### PR TITLE
WIP: Fix for using globs

### DIFF
--- a/lib/metadata/TypeScriptMetadataProvider.ts
+++ b/lib/metadata/TypeScriptMetadataProvider.ts
@@ -1,4 +1,3 @@
-import { isAbsolute } from 'path';
 import { Project, SourceFile } from 'ts-morph';
 import { pathExists } from 'fs-extra';
 

--- a/lib/utils/Utils.ts
+++ b/lib/utils/Utils.ts
@@ -244,7 +244,7 @@ export class Utils {
   }
 
   static toAbsolutePath(dir: string, baseDir: string) {
-    if (!isAbsolute(dir)) {
+    if (isAbsolute(dir)) {
       return Utils.normalizePath(dir);
     } else {
       return Utils.normalizePath(baseDir, dir);

--- a/lib/utils/Utils.ts
+++ b/lib/utils/Utils.ts
@@ -1,3 +1,4 @@
+import { normalize, join } from 'path';
 import * as fastEqual from 'fast-deep-equal';
 import * as clone from 'clone';
 
@@ -6,7 +7,6 @@ import { EntityData, EntityMetadata, EntityProperty, IEntity, IEntityType, IPrim
 import { ArrayCollection, Collection, ReferenceType } from '../entity';
 
 export class Utils {
-
   static isDefined(data: any): data is object {
     return typeof data !== 'undefined';
   }
@@ -32,7 +32,7 @@ export class Utils {
   }
 
   static flatten<T>(arrays: T[][]): T[] {
-    return [].concat(...arrays as any[]);
+    return [].concat(...(arrays as any[]));
   }
 
   static merge(target: any, ...sources: any[]): any {
@@ -88,12 +88,12 @@ export class Utils {
       const pk = () => metadata[prop.type].primaryKey;
       const name = prop.name as keyof T;
 
-      if (e[name] as any instanceof ArrayCollection || (Utils.isEntity(e[name]) && !e[name][pk()])) {
+      if ((e[name] as any) instanceof ArrayCollection || (Utils.isEntity(e[name]) && !e[name][pk()])) {
         return delete ret[name];
       }
 
       if (Utils.isEntity(e[name])) {
-        return ret[prop.name] = ret[prop.name][pk()];
+        return (ret[prop.name] = ret[prop.name][pk()]);
       }
     });
 
@@ -127,7 +127,7 @@ export class Utils {
   }
 
   static getParamNames(func: Function | string): string[] {
-    const STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
+    const STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/gm;
     const ARGUMENT_NAMES = /([^\s,]+)/g;
     const fnStr = func.toString().replace(STRIP_COMMENTS, ''); // strip comments
     let paramsStr = fnStr.slice(fnStr.indexOf('(') + 1, fnStr.indexOf(')')); // extract params
@@ -240,7 +240,6 @@ export class Utils {
   }
 
   static normalizePath(...parts: string[]): string {
-    return parts.join('/').replace(/\\/g, '/');
+    return normalize(join(...parts));
   }
-
 }

--- a/lib/utils/Utils.ts
+++ b/lib/utils/Utils.ts
@@ -1,4 +1,4 @@
-import { normalize, join } from 'path';
+import { normalize, join, isAbsolute } from 'path';
 import * as fastEqual from 'fast-deep-equal';
 import * as clone from 'clone';
 
@@ -241,5 +241,13 @@ export class Utils {
 
   static normalizePath(...parts: string[]): string {
     return normalize(join(...parts));
+  }
+
+  static toAbsolutePath(dir: string, baseDir: string) {
+    if (!isAbsolute(dir)) {
+      return Utils.normalizePath(dir);
+    } else {
+      return Utils.normalizePath(baseDir, dir);
+    }
   }
 }

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -27,6 +27,14 @@ describe('MikroORM', () => {
     await expect(MikroORM.init({ dbName: 'test', baseDir: BASE_DIR, entities: [FooBaz2], cache: { enabled: false }, entitiesDirsTs: ['entities'] })).rejects.toThrowError(error);
   });
 
+  test('should work with globs', async () => {
+    // todo: confirm that entities are loaded correctly
+    await expect(MikroORM.init({ dbName: 'test', baseDir: BASE_DIR, entitiesDirs: ['./entities-nested/**/entities'], cache: { enabled: false }, entitiesDirsTs: ['./entities-nested/**/entities'] })).not.toThrowError();
+    await expect(MikroORM.init({ dbName: 'test', baseDir: BASE_DIR, entitiesDirs: ['entities-nested/**/entities'], cache: { enabled: false }, entitiesDirsTs: ['entities-nested/**/entities'] })).not.toThrowError();
+    await expect(MikroORM.init({ dbName: 'test', baseDir: BASE_DIR, entitiesDirs: ['entities-nested/**/entities/'], cache: { enabled: false }, entitiesDirsTs: ['entities-nested/**/entities/'] })).not.toThrowError();
+    await expect(MikroORM.init({ dbName: 'test', baseDir: BASE_DIR, entitiesDirs: ['./entities-nested/**/entities'], cache: { enabled: false } })).not.toThrowError();
+  });
+
   test('should init itself with entity manager', async () => {
     const orm = await MikroORM.init({
       entitiesDirs: ['entities'],

--- a/tests/entities-nested/Author/entities/Author.ts
+++ b/tests/entities-nested/Author/entities/Author.ts
@@ -1,0 +1,125 @@
+import {
+  AfterCreate,
+  AfterDelete,
+  AfterUpdate,
+  BeforeCreate,
+  BeforeDelete,
+  BeforeUpdate,
+  Cascade,
+  Collection,
+  Entity,
+  EntityAssigner,
+  ManyToMany,
+  ManyToOne,
+  OneToMany,
+  Property
+} from '../../../../lib';
+
+import { Book } from '../../Book/entities/Book';
+import { AuthorRepository } from '../../../repositories/AuthorRepository';
+import { BaseEntity } from '../../entities/BaseEntity';
+
+@Entity({ customRepository: () => AuthorRepository })
+export class Author extends BaseEntity {
+  static beforeDestroyCalled = 0;
+  static afterDestroyCalled = 0;
+
+  @Property()
+  name: string;
+
+  @Property()
+  email: string;
+
+  @Property()
+  age: number;
+
+  @Property()
+  termsAccepted = false;
+
+  @Property({ fieldName: 'identitiesArray' })
+  identities: string[];
+
+  @Property()
+  born: Date;
+
+  @OneToMany({
+    entity: () => Book,
+    fk: 'author',
+    referenceColumnName: '_id',
+    cascade: [Cascade.PERSIST],
+    orphanRemoval: true
+  })
+  books = new Collection<Book>(this);
+
+  @ManyToMany({ entity: () => Author, owner: true })
+  friends: Collection<Author> = new Collection<Author>(this);
+
+  @ManyToOne()
+  favouriteBook: Book;
+
+  @ManyToOne()
+  favouriteAuthor: Author;
+
+  @Property({ persist: false })
+  version: number;
+
+  @Property({ persist: false })
+  versionAsString: string;
+
+  constructor(name: string, email: string) {
+    super();
+    this.name = name;
+    this.email = email;
+    this.foo = 'bar';
+  }
+
+  @BeforeCreate()
+  beforeCreate() {
+    this.version = 1;
+  }
+
+  @BeforeCreate()
+  beforeCreate2() {
+    // do sth else
+  }
+
+  @AfterCreate()
+  afterCreate() {
+    this.versionAsString = 'v' + this.version;
+  }
+
+  @BeforeUpdate()
+  beforeUpdate() {
+    this.version += 1;
+  }
+
+  @AfterUpdate()
+  afterUpdate() {
+    this.versionAsString = 'v' + this.version;
+  }
+
+  @BeforeDelete()
+  beforeDelete() {
+    Author.beforeDestroyCalled += 1;
+  }
+
+  @AfterDelete()
+  afterDelete() {
+    Author.afterDestroyCalled += 1;
+  }
+
+  assign(data: any): void {
+    EntityAssigner.assign(this, data);
+  }
+
+  toJSON(strict = true, strip = ['id', 'email'], ...args: any[]): { [p: string]: any } {
+    const o = this.toObject(...args);
+    o.fooBar = 123;
+
+    if (strict) {
+      strip.forEach(k => delete o[k]);
+    }
+
+    return o;
+  }
+}

--- a/tests/entities-nested/Book/entities/Book.ts
+++ b/tests/entities-nested/Book/entities/Book.ts
@@ -1,0 +1,53 @@
+import { ObjectID } from 'mongodb';
+import { Cascade, Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '../../../../lib';
+import { Publisher } from '../../entities/Publisher';
+import { Author } from '../../Author/entities/Author';
+import { BookTag } from '../../entities/book-tag';
+import { BaseEntity3 } from '../../entities/BaseEntity3';
+
+@Entity({ collection: 'books-table' })
+export class Book extends BaseEntity3 {
+  @PrimaryKey()
+  _id: ObjectID;
+
+  @Property()
+  title: string;
+
+  @ManyToOne()
+  author: Author;
+
+  @ManyToOne({ cascade: [Cascade.PERSIST, Cascade.REMOVE] })
+  publisher: Publisher;
+
+  @ManyToMany({ entity: () => BookTag.name, inversedBy: 'books' })
+  tags = new Collection<BookTag>(this);
+
+  @Property()
+  metaObject: object;
+
+  @Property()
+  metaArray: any[];
+
+  @Property()
+  metaArrayOfStrings: string[];
+
+  constructor(title: string, author?: Author) {
+    super();
+    this.title = title;
+    this.author = author as Author;
+  }
+
+  toJSON(
+    strict = true,
+    strip = ['metaObject', 'metaArray', 'metaArrayOfStrings'],
+    ...args: any[]
+  ): { [p: string]: any } {
+    const o = this.toObject(...args);
+
+    if (strict) {
+      strip.forEach(k => delete o[k]);
+    }
+
+    return o;
+  }
+}

--- a/tests/entities-nested/entities/BaseEntity.ts
+++ b/tests/entities-nested/entities/BaseEntity.ts
@@ -1,0 +1,18 @@
+import { ObjectID } from 'bson';
+import { IEntity, PrimaryKey, Property } from '../../../lib';
+
+export abstract class BaseEntity {
+  @PrimaryKey()
+  _id: ObjectID;
+
+  @Property()
+  createdAt = new Date();
+
+  @Property({ onUpdate: () => new Date() })
+  updatedAt = new Date();
+
+  @Property()
+  foo: string;
+}
+
+export interface BaseEntity extends IEntity<string> {}

--- a/tests/entities-nested/entities/BaseEntity3.ts
+++ b/tests/entities-nested/entities/BaseEntity3.ts
@@ -1,0 +1,9 @@
+import { ObjectID } from 'bson';
+import { IEntity, PrimaryKey } from '../../../lib';
+
+export abstract class BaseEntity3 {
+  @PrimaryKey()
+  _id: ObjectID;
+}
+
+export interface BaseEntity3 extends IEntity<string> {}

--- a/tests/entities-nested/entities/FooBar.ts
+++ b/tests/entities-nested/entities/FooBar.ts
@@ -1,0 +1,27 @@
+import { ObjectID } from 'mongodb';
+import { Entity, IEntity, OneToOne, PrimaryKey, Property } from '../../../lib';
+import { FooBaz } from './FooBaz';
+
+@Entity()
+export class FooBar {
+  @PrimaryKey()
+  _id: ObjectID;
+
+  @Property()
+  name: string;
+
+  @OneToOne({ inversedBy: 'bar', orphanRemoval: true })
+  baz: FooBaz | null;
+
+  @OneToOne({ owner: true })
+  fooBar: FooBar;
+
+  static create(name: string) {
+    const bar = new FooBar();
+    bar.name = name;
+
+    return bar;
+  }
+}
+
+export interface FooBar extends IEntity<string> {}

--- a/tests/entities-nested/entities/FooBaz.ts
+++ b/tests/entities-nested/entities/FooBaz.ts
@@ -1,0 +1,24 @@
+import { ObjectID } from 'mongodb';
+import { Entity, IEntity, OneToOne, PrimaryKey, Property } from '../../../lib';
+import { FooBar } from './FooBar';
+
+@Entity()
+export class FooBaz {
+  @PrimaryKey()
+  _id: ObjectID;
+
+  @Property()
+  name: string;
+
+  @OneToOne({ mappedBy: 'baz' })
+  bar: FooBar;
+
+  static create(name: string) {
+    const baz = new FooBaz();
+    baz.name = name;
+
+    return baz;
+  }
+}
+
+export interface FooBaz extends IEntity<string> {}

--- a/tests/entities-nested/entities/Publisher.ts
+++ b/tests/entities-nested/entities/Publisher.ts
@@ -1,0 +1,39 @@
+import { ObjectID } from 'mongodb';
+import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, Property, IEntity, BeforeCreate } from '../../../lib';
+import { Book } from '../Book/entities/Book';
+import { Test } from './test.model';
+
+@Entity()
+export class Publisher {
+  @PrimaryKey()
+  _id: ObjectID;
+
+  @Property()
+  name: string;
+
+  @OneToMany({ entity: () => Book.name, fk: 'publisher' })
+  books = new Collection<Book>(this);
+
+  @ManyToMany({ entity: () => Test.name, owner: true })
+  tests = new Collection<Test>(this);
+
+  @Property()
+  type: PublisherType = PublisherType.LOCAL;
+
+  constructor(name: string = 'asd', type: PublisherType = PublisherType.LOCAL) {
+    this.name = name;
+    this.type = type;
+  }
+
+  @BeforeCreate()
+  beforeCreate() {
+    // do sth
+  }
+}
+
+export interface Publisher extends IEntity {}
+
+export enum PublisherType {
+  LOCAL = 'local',
+  GLOBAL = 'global'
+}

--- a/tests/entities-nested/entities/book-tag.ts
+++ b/tests/entities-nested/entities/book-tag.ts
@@ -1,0 +1,21 @@
+import { ObjectID } from 'mongodb';
+import { Collection, Entity, ManyToMany, PrimaryKey, Property, IEntity } from '../../../lib';
+import { Book } from '../Book/entities/Book';
+
+@Entity()
+export class BookTag {
+  @PrimaryKey()
+  _id: ObjectID;
+
+  @Property()
+  name: string;
+
+  @ManyToMany({ entity: () => Book.name, mappedBy: 'tags' })
+  books: Collection<Book> = new Collection<Book>(this);
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+
+export interface BookTag extends IEntity {}

--- a/tests/entities-nested/entities/index.ts
+++ b/tests/entities-nested/entities/index.ts
@@ -1,0 +1,5 @@
+export * from './Author/entities/Author';
+export * from './Book/entities/Book';
+export * from './book-tag';
+export * from './Publisher';
+export * from './test.model';

--- a/tests/entities-nested/entities/test.model.ts
+++ b/tests/entities-nested/entities/test.model.ts
@@ -1,0 +1,22 @@
+import { Entity, IEntity, PrimaryKey, Property } from '../../../lib';
+
+@Entity()
+export class Test {
+  @PrimaryKey({ type: 'ObjectID' })
+  _id: any;
+
+  @Property({ type: 'string' })
+  name: any;
+
+  @Property({ hidden: true })
+  hiddenField = Date.now();
+
+  static create(name: string) {
+    const t = new Test();
+    t.name = name;
+
+    return t;
+  }
+}
+
+export interface Test extends IEntity<string> {}


### PR DESCRIPTION
This fixes issues with using globs for entity dirs

<details> 
  <summary><h3>Click here for all of my investigation / rambling</h3></summary>
   <span>


```
0|server  | Error saving recipe TypeError: Cannot read property 'name' of undefined
0|server  |     at Function.className (/home/coder/project/packages/server/node_modules/mikro-orm/dist/utils/Utils.js:156:28)
0|server  |     at MongoConnection.getCollectionName (/home/coder/project/packages/server/node_modules/mikro-orm/dist/connections/MongoConnection.js:153:26)
0|server  |     at MongoConnection.getCollection (/home/coder/project/packages/server/node_modules/mikro-orm/dist/connections/MongoConnection.js:19:36)
0|server  |     at MongoConnection.insertOne (/home/coder/project/packages/server/node_modules/mikro-orm/dist/connections/MongoConnection.js:84:28)
0|server  |     at MongoDriver.nativeInsert (/home/coder/project/packages/server/node_modules/mikro-orm/dist/drivers/MongoDriver.js:33:32)
0|server  |     at ChangeSetPersister.persistEntity (/home/coder/project/packages/server/node_modules/mikro-orm/dist/unit-of-work/ChangeSetPersister.js:37:37)
0|server  |     at ChangeSetPersister.persistToDatabase (/home/coder/project/packages/server/node_modules/mikro-orm/dist/unit-of-work/ChangeSetPersister.js:20:20)
0|server  |     at UnitOfWork.commitChangeSet (/home/coder/project/packages/server/node_modules/mikro-orm/dist/unit-of-work/UnitOfWork.js:200:35)
0|server  |     at processTicksAndRejections (internal/process/task_queues.js:86:5)
```

I added a log for 

https://github.com/B4nan/mikro-orm/blob/master/lib/connections/MongoConnection.ts#L181-L184
```
  private getCollectionName(name: EntityName<IEntity>): string {
    name = Utils.className(name);
    console.log(this.metadata)
    return this.metadata[name] ? this.metadata[name].collection : name;
  }
```
```
0|server  |   Recipe:
0|server  |    { properties:
0|server  |       { _id: [Object],
0|server  |         createdAt: [Object],
0|server  |         updatedAt: [Object],
0|server  |         name: [Object],
0|server  |         description: [Object] },
0|server  |      primaryKey: '_id',
0|server  |      path:
0|server  |       '/home/coder/project/packages/server/src/Recipe/entities/recipe.entity.ts',
0|server  |      name: 'Recipe',
0|server  |      constructorParams: [],
0|server  |      extends: undefined },
```

This fails because there is an entry in metadata for the entity, but the collection property isn't set. 

### Workaround? Maybe?

If I specify the collection on the entity
```typescript
@Entity({ collection: "Recipe" })
export class Recipe {
//...
```
Here's the metadata now
```
0|server  |   Recipe:
0|server  |    { properties:
0|server  |       { _id: [Object],
0|server  |         createdAt: [Object],
0|server  |         updatedAt: [Object],
0|server  |         name: [Object],
0|server  |         description: [Object] },
0|server  |      primaryKey: '_id',
0|server  |      path:
0|server  |       '/home/coder/project/packages/server/src/Recipe/entities/recipe.entity.ts',
0|server  |      collection: 'Recipe',
0|server  |      name: 'Recipe',
0|server  |      constructorParams: [],
0|server  |      extends: undefined },
```

But then I get another error:
```
Error saving recipe TypeError: Cannot read property 'name' of undefined
0|server  |     at Function.fromMergeWithoutPK (/home/coder/project/packages/server/node_modules/mikro-orm/dist/utils/ValidationError.js:49:68)
0|server  |     at EntityValidator.validatePrimaryKey (/home/coder/project/packages/server/node_modules/mikro-orm/dist/entity/EntityValidator.js:55:43)
0|server  |     at EntityManager.merge (/home/coder/project/packages/server/node_modules/mikro-orm/dist/EntityManager.js:154:20)
0|server  |     at UnitOfWork.commitChangeSet (/home/coder/project/packages/server/node_modules/mikro-orm/dist/unit-of-work/UnitOfWork.js:203:17)
0|server  |     at processTicksAndRejections (internal/process/task_queues.js:86:5
```

https://github.com/B4nan/mikro-orm/blob/master/lib/entity/EntityValidator.ts#L66-L70
```typescript
  validatePrimaryKey<T extends IEntityType<T>>(entity: EntityData<T>, meta: EntityMetadata): void {
    if (!entity || (!entity[meta.primaryKey] && !entity[meta.serializedPrimaryKey])) {
      throw ValidationError.fromMergeWithoutPK(meta);
    }
  }
```

Here's my entity (console.logged from EntityRepository#GetRepository) It doesn't have an _id, so it fails this check.

```
0|server  |   Recipe {
0|server  |   createdAt: 2019-08-01T17:09:13.160Z,
0|server  |   updatedAt: 2019-08-01T17:09:13.160Z,
0|server  |   name: 'My Recipe',
0|server  |   description: 'Some cool recipe Created: 1564679353160' }
```





## More Logs!!!

```
0|server  | Getting Unit of work: 
0|server  | Insert one into :  Recipe string
0|server  | Get Collection Name for:  Recipe string
0|server  | Get Collection Name for classname:  Recipe string
0|server  | metdata:  true { BaseEntity:
0|server  |    { properties: { _id: [Object], createdAt: [Object], updatedAt: [Object] },
0|server  |      primaryKey: '_id',
0|server  |      path:
0|server  |       '/home/coder/project/packages/server/src/shared/entities/BaseEntity.ts' },
0|server  |   Recipe:
0|server  |    { properties:
0|server  |       { _id: [Object],
0|server  |         createdAt: [Object],
0|server  |         updatedAt: [Object],
0|server  |         name: [Object],
0|server  |         description: [Object] },
0|server  |      primaryKey: '_id',
0|server  |      path:
0|server  |       '/home/coder/project/packages/server/src/Recipe/entities/recipe.entity.ts',
0|server  |      collection: 'Recipe',
0|server  |      name: 'Recipe',
0|server  |      constructorParams: [],
0|server  |      extends: undefined },
0|server  |   User:
0|server  |    { properties:
0|server  |       { username: [Object],
0|server  |         allServices: [Object],
0|server  |         emails: [Object],
0|server  |         deactivated: [Object],
0|server  |         recipes: [Object] },
0|server  |      path:
0|server  |       '/home/coder/project/packages/server/src/User/entities/user.entity.ts',
0|server  |      name: 'User',
0|server  |      constructorParams: [],
0|server  |      extends: 'BaseEntity' } }
0|server  | CollectionName:  Recipe string
0|server  | Get Collection Name for:  Recipe string
0|server  | Get Collection Name for classname:  Recipe string
0|server  | metdata:  true { BaseEntity:
0|server  |    { properties: { _id: [Object], createdAt: [Object], updatedAt: [Object] },
0|server  |      primaryKey: '_id',
0|server  |      path:
0|server  |       '/home/coder/project/packages/server/src/shared/entities/BaseEntity.ts' },
0|server  |   Recipe:
0|server  |    { properties:
0|server  |       { _id: [Object],
0|server  |         createdAt: [Object],
0|server  |         updatedAt: [Object],
0|server  |         name: [Object],
0|server  |         description: [Object] },
0|server  |      primaryKey: '_id',
0|server  |      path:
0|server  |       '/home/coder/project/packages/server/src/Recipe/entities/recipe.entity.ts',
0|server  |      collection: 'Recipe',
0|server  |      name: 'Recipe',
0|server  |      constructorParams: [],
0|server  |      extends: undefined },
0|server  |   User:
0|server  |    { properties:
0|server  |       { username: [Object],
0|server  |         allServices: [Object],
0|server  |         emails: [Object],
0|server  |         deactivated: [Object],
0|server  |         recipes: [Object] },
0|server  |      path:
0|server  |       '/home/coder/project/packages/server/src/User/entities/user.entity.ts',
0|server  |      name: 'User',
0|server  |      constructorParams: [],
0|server  |      extends: 'BaseEntity' } }
0|server  | Merging Entity Recipe {
0|server  |   createdAt: 2019-08-01T17:27:29.960Z,
0|server  |   updatedAt: 2019-08-01T17:27:29.963Z,
0|server  |   name: 'My Recipe',
0|server  |   description: 'Some cool recipe Created: 1564680449959',
0|server  |   __primaryKey: 5d4321011bb0124e0584efed }  With data undefined
0|server  | Entity Classname is  My Recipe string metadata:  false undefined
0|server  | Throwing merge without PK for entity undefined and Meta undefined
0|server  | Error saving recipe TypeError: Cannot read property 'name' of undefined
0|server  |     at Function.fromMergeWithoutPK (/home/coder/project/packages/server/node_modules/mikro-orm/dist/utils/ValidationError.js:49:68)
0|server  |     at EntityValidator.validatePrimaryKey (/home/coder/project/packages/server/node_modules/mikro-orm/dist/entity/EntityValidator.js:60:37)
0|server  |     at EntityManager.merge (/home/coder/project/packages/server/node_modules/mikro-orm/dist/EntityManager.js:164:20)
0|server  |     at UnitOfWork.commitChangeSet (/home/coder/project/packages/server/node_modules/mikro-orm/dist/unit-of-work/UnitOfWork.js:203:17)
0|server  |     at processTicksAndRejections (internal/process/task_queues.js:86:5)
```

### Stack
It looks like that got us a little further (modified it in node_modules)

but now we get this error (again)
```
Error saving recipe TypeError: Cannot read property 'name' of undefined
    at Function.fromMergeWithoutPK (/home/coder/project/packages/server/node_modules/mikro-orm/dist/utils/ValidationError.js:49:68)
    at EntityValidator.validatePrimaryKey (/home/coder/project/packages/server/node_modules/mikro-orm/dist/entity/EntityValidator.js:55:43)
    at EntityManager.merge (/home/coder/project/packages/server/node_modules/mikro-orm/dist/EntityManager.js:139:24)
    at UnitOfWork.commitChangeSet (/home/coder/project/packages/server/node_modules/mikro-orm/dist/unit-of-work/UnitOfWork.js:192:25)
    at processTicksAndRejections (internal/process/task_queues.js:86:5)
```

This is called from
https://github.com/B4nan/mikro-orm/blob/master/lib/unit-of-work/UnitOfWork.ts#L240-L244


### Conclusion 1

**EntityManager#merge - When creating an entity with data only `const recipe = await this.recipeRepository.create({ ...recipeInput, description });` it will be called with the data, which won't be an entity, which won't have an ID and will fail merge**



# Problem two
If I use new Recipe, Object.assign and then persistAndFlush, it correctly creates an ID in the __primaryKey property. But still doesn't work
```
Merging Entity Recipe {
0|server  |   createdAt: 2019-08-01T17:41:46.322Z,
0|server  |   updatedAt: 2019-08-01T17:41:46.325Z,
0|server  |   name: 'My Recipe',
0|server  |   description: 'Some cool recipe Created: 1564681306322',
0|server  |   __primaryKey: 5d43245aec82af4f3c8a569c }  With data undefined
0|server  | Entity Classname is  My Recipe string metadata:  false undefined
0|server  | Throwing merge without PK for entity undefined and Meta undefined
```

```typescript
const recipe = new Recipe();
    const description = recipeInput.description + " Created: " + Date.now();
    Object.assign(recipe, recipeInput, { description });
    // const recipe = await this.recipeRepository.create({ ...recipeInput, description });
    console.log("before persist and flush recipe", recipe, "typeof", typeof recipe);
    await this.recipeRepository.persistAndFlush(recipe);
    console.log("after persist and flush recipe", recipe);
    recipe.description = "goo";
    console.log("after set description recipe", recipe);
    try {
      await this.recipeRepository.persistAndFlush(recipe);
    } catch (e) {
      console.log("Error saving recipe", e);
    }
    console.log("Recipe Saved", recipe);
    return recipe;
```

#### Stack
persistAndFlush -> EntityManager#flush -> UnitOfWork#commit -> UnitOfWork$commitChangeSet -> ChangeSetPersister#persistToDatabase -< persistEntity#ChangeSetPersister -> MongoDriver#nativeInsert -> MongoConnection#insertOne -> MongoConnection#getCollectionName
![image](uploads/15250ceeb019306bded686fe94a2d606/image.png)

![image](uploads/505f2615e665641aae2a46274af7334a/image.png)


Now we have `undefined` as the `collection` and we call two more lines, then we call `this.getCollection` with undefined

![image](uploads/c5bf05888b9766da129debcc18e0f077/image.png)

Which calls collectionName again, on undefined

![image](uploads/431315fc2718193733e2f82f2096d3de/image.png)

which calls className on undefined `name = utils_1.Utils.className(name);`

### Conclusion 2
**getCollectionName fails if the metadata doesn't have a collection**

#### Fixes?
I think the failure is correct. If you pass in undefined `collection` to `getCollectionName` it should probably fail.

But returning undefined from getCollectionName in the first place seems wrong. We should probably change this line from:
```typescript
return this.metadata[name] ? this.metadata[name].collection : name;
```

to
```typescript
return (this.metadata[name] && this.metadata[name].collection) ? this.metadata[name].collection : name;
```
or, IMO a little bit cleaner
```typescript
return (this.metadata[name] && this.metadata[name].collection) || name;
```

But, the root cause might be, why is collection null in the first place??


# More problems


Ugh.... Okay lets run the example in nestjs-mikro-orm. That seems to work for both SQLLite and mongodb. 

What's the difference??
Version:
2.7.1
my version
2.7.4

okay, so let's try using 2.7.1....
We get an error because `./**/entities/` is not a directory... interesting, so glob patterns was added since 2.7.1?? 

So let's try an entities directory. If the only change I make is move recipe.entity.ts to an `./entities/` folder, it works perfectly....... UGH! So there's an issue with loading the files with globby.

  </span>
</details>