### PR TITLE
feat(core): add support for read connections

### DIFF
--- a/lib/EntityManager.ts
+++ b/lib/EntityManager.ts
@@ -1,7 +1,7 @@
 import { Configuration, RequestContext, Utils, ValidationError } from './utils';
 import { EntityAssigner, EntityFactory, EntityLoader, EntityRepository, EntityValidator, ReferenceType } from './entity';
 import { LockMode, UnitOfWork } from './unit-of-work';
-import { FilterQuery, IDatabaseDriver } from './drivers';
+import { AbstractSqlDriver, FilterQuery, IDatabaseDriver } from './drivers';
 import { EntityData, EntityMetadata, EntityName, IEntity, IEntityType, IPrimaryKey } from './decorators';
 import { QueryBuilder, QueryOrderMap, SmartQueryHelper } from './query';
 import { MetadataStorage } from './metadata';
@@ -24,8 +24,8 @@ export class EntityManager {
     return this.driver as D;
   }
 
-  getConnection<C extends Connection = Connection>(): C {
-    return this.driver.getConnection() as C;
+  getConnection<C extends Connection = Connection>(type?: 'read' | 'write'): C {
+    return this.driver.getConnection(type) as C;
   }
 
   getRepository<T extends IEntityType<T>>(entityName: EntityName<T>): EntityRepository<T> {
@@ -44,9 +44,9 @@ export class EntityManager {
     return this.validator;
   }
 
-  createQueryBuilder(entityName: EntityName<IEntity>, alias?: string): QueryBuilder {
+  createQueryBuilder(entityName: EntityName<IEntity>, alias?: string, type?: 'read' | 'write'): QueryBuilder {
     entityName = Utils.className(entityName);
-    return new QueryBuilder(entityName, this.metadata, this.driver, this.transactionContext, alias);
+    return new QueryBuilder(entityName, this.metadata, this.driver as AbstractSqlDriver, this.transactionContext, alias, type);
   }
 
   async find<T extends IEntityType<T>>(entityName: EntityName<T>, where?: FilterQuery<T>, options?: FindOptions): Promise<T[]>;

--- a/lib/MikroORM.ts
+++ b/lib/MikroORM.ts
@@ -45,8 +45,7 @@ export class MikroORM {
   }
 
   async connect(): Promise<IDatabaseDriver> {
-    const connection = this.driver.getConnection();
-    await connection.connect();
+    const connection = await this.driver.connect();
     const clientUrl = connection.getClientUrl();
     const dbName = this.config.get('dbName');
     this.logger.log('info', `MikroORM successfully connected to database ${chalk.green(dbName)}${clientUrl ? ' on ' + chalk.green(clientUrl) : ''}`);
@@ -59,7 +58,7 @@ export class MikroORM {
   }
 
   async close(force = false): Promise<void> {
-    return this.driver.getConnection().close(force);
+    return this.driver.close(force);
   }
 
   getMetadata(): MetadataStorage {

--- a/lib/drivers/AbstractSqlDriver.ts
+++ b/lib/drivers/AbstractSqlDriver.ts
@@ -93,7 +93,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
   }
 
   protected createQueryBuilder(entityName: string, ctx?: Transaction): QueryBuilder {
-    return new QueryBuilder(entityName, this.metadata, this, ctx);
+    return new QueryBuilder(entityName, this.metadata, this, ctx, undefined, ctx ? 'write' : 'read');
   }
 
   protected extractManyToMany<T extends IEntityType<T>>(entityName: string, data: EntityData<T>): EntityData<T> {

--- a/lib/drivers/IDatabaseDriver.ts
+++ b/lib/drivers/IDatabaseDriver.ts
@@ -7,7 +7,11 @@ import { MetadataStorage } from '../metadata';
 
 export interface IDatabaseDriver<C extends Connection = Connection> {
 
-  getConnection(): C;
+  connect(): Promise<C>;
+
+  close(force?: boolean): Promise<void>;
+
+  getConnection(type?: 'read' | 'write'): C;
 
   /**
    * Finds selection of entities

--- a/lib/drivers/MongoDriver.ts
+++ b/lib/drivers/MongoDriver.ts
@@ -15,7 +15,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
 
   async find<T extends IEntityType<T>>(entityName: string, where: FilterQuery<T>, populate: string[], orderBy: QueryOrderMap, limit: number, offset: number): Promise<T[]> {
     where = this.renameFields(entityName, where);
-    const res = await this.connection.find<T>(entityName, where, orderBy, limit, offset);
+    const res = await this.getConnection('read').find<T>(entityName, where, orderBy, limit, offset);
 
     return res.map((r: T) => this.mapResult<T>(r, this.metadata.get(entityName))!);
   }
@@ -26,19 +26,19 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     }
 
     where = this.renameFields(entityName, where) as FilterQuery<T>;
-    const res = await this.connection.find<T>(entityName, where, orderBy, 1, undefined, fields);
+    const res = await this.getConnection('read').find<T>(entityName, where, orderBy, 1, undefined, fields);
 
     return this.mapResult<T>(res[0], this.metadata.get(entityName));
   }
 
   async count<T extends IEntityType<T>>(entityName: string, where: FilterQuery<T>): Promise<number> {
     where = this.renameFields(entityName, where);
-    return this.connection.countDocuments<T>(entityName, where);
+    return this.getConnection('read').countDocuments<T>(entityName, where);
   }
 
   async nativeInsert<T extends IEntityType<T>>(entityName: string, data: EntityData<T>): Promise<QueryResult> {
     data = this.renameFields(entityName, data);
-    return this.connection.insertOne<EntityData<T>>(entityName, data);
+    return this.getConnection('write').insertOne<EntityData<T>>(entityName, data);
   }
 
   async nativeUpdate<T extends IEntityType<T>>(entityName: string, where: FilterQuery<T> | IPrimaryKey, data: EntityData<T>): Promise<QueryResult> {
@@ -49,7 +49,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     where = this.renameFields(entityName, where) as FilterQuery<T>;
     data = this.renameFields(entityName, data);
 
-    return this.connection.updateMany<T>(entityName, where, data);
+    return this.getConnection('write').updateMany<T>(entityName, where, data);
   }
 
   async nativeDelete<T extends IEntityType<T>>(entityName: string, where: FilterQuery<T> | IPrimaryKey): Promise<QueryResult> {
@@ -59,11 +59,11 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
 
     where = this.renameFields(entityName, where) as FilterQuery<T>;
 
-    return this.connection.deleteMany<T>(entityName, where);
+    return this.getConnection('write').deleteMany<T>(entityName, where);
   }
 
   async aggregate(entityName: string, pipeline: any[]): Promise<any[]> {
-    return this.connection.aggregate(entityName, pipeline);
+    return this.getConnection('read').aggregate(entityName, pipeline);
   }
 
   private renameFields(entityName: string, data: any): any {

--- a/lib/drivers/MySqlDriver.ts
+++ b/lib/drivers/MySqlDriver.ts
@@ -5,6 +5,7 @@ import { MySqlPlatform } from '../platforms/MySqlPlatform';
 export class MySqlDriver extends AbstractSqlDriver<MySqlConnection> {
 
   protected readonly connection = new MySqlConnection(this.config);
+  protected readonly replicas = this.createReplicas(conf => new MySqlConnection(this.config, conf, 'read'));
   protected readonly platform = new MySqlPlatform();
 
 }

--- a/lib/unit-of-work/UnitOfWork.ts
+++ b/lib/unit-of-work/UnitOfWork.ts
@@ -102,7 +102,7 @@ export class UnitOfWork {
     const promise = async (tx: Transaction) => await Utils.runSerial(this.changeSets, changeSet => this.commitChangeSet(changeSet, tx));
 
     if (runInTransaction) {
-      await this.em.getConnection().transactional(trx => promise(trx));
+      await this.em.getConnection('write').transactional(trx => promise(trx));
     } else {
       await promise(this.em.getTransactionContext());
     }

--- a/lib/utils/Configuration.ts
+++ b/lib/utils/Configuration.ts
@@ -31,6 +31,7 @@ export class Configuration {
     hydrator: ObjectHydrator,
     tsNode: false,
     debug: false,
+    verbose: false,
     cache: {
       enabled: true,
       adapter: FileCacheAdapter,
@@ -75,8 +76,8 @@ export class Configuration {
     this.init();
   }
 
-  get<T extends keyof MikroORMOptions, U extends MikroORMOptions[T]>(key: T, defaultValue?: U): MikroORMOptions[T] {
-    return (Utils.isDefined(this.options[key]) ? this.options[key] : defaultValue) as MikroORMOptions[T];
+  get<T extends keyof MikroORMOptions, U extends MikroORMOptions[T]>(key: T, defaultValue?: U): U {
+    return (Utils.isDefined(this.options[key]) ? this.options[key] : defaultValue) as U;
   }
 
   set<T extends keyof MikroORMOptions, U extends MikroORMOptions[T]>(key: T, value: U): void {
@@ -172,8 +173,19 @@ export class Configuration {
 
 }
 
-export interface MikroORMOptions {
+export interface ConnectionOptions {
+  name?: string;
   dbName: string;
+  clientUrl?: string;
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+  multipleStatements?: boolean; // for mysql driver
+  pool: PoolConfig;
+}
+
+export interface MikroORMOptions extends ConnectionOptions {
   entities: (EntityClass<IEntity> | EntityClassGroup<IEntity>)[];
   entitiesDirs: string[];
   entitiesDirsTs: string[];
@@ -185,13 +197,7 @@ export interface MikroORMOptions {
   namingStrategy?: { new (): NamingStrategy };
   hydrator: { new (factory: EntityFactory, driver: IDatabaseDriver): Hydrator };
   entityRepository: { new (em: EntityManager, entityName: EntityName<IEntity>): EntityRepository<IEntity> };
-  clientUrl?: string;
-  host?: string;
-  port?: number;
-  user?: string;
-  password?: string;
-  multipleStatements?: boolean; // for mysql driver
-  pool: PoolConfig;
+  replicas?: Partial<ConnectionOptions>[];
   strict: boolean;
   logger: (message: string) => void;
   debug: boolean | LoggerNamespace[];

--- a/lib/utils/Utils.ts
+++ b/lib/utils/Utils.ts
@@ -269,4 +269,8 @@ export class Utils {
     }, [] as T[]);
   }
 
+  static randomInt(min: number, max: number): number {
+    return Math.round(Math.random() * (max - min)) + min;
+  }
+
 }

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -1211,6 +1211,52 @@ describe('EntityManagerMySql', () => {
     }
 
     expect(mock.mock.calls[2][0]).toMatch('commit');
+    orm.em.config.set('highlight', false);
+  });
+
+  test('read replicas', async () => {
+    const mock = jest.fn();
+    const logger = new Logger(mock, true);
+    Object.assign(orm.em.config, { logger });
+
+    let author = new Author2('Jon Snow', 'snow@wall.st');
+    author.born = new Date();
+    author.books.add(new Book2('B', author));
+    await orm.em.persistAndFlush(author);
+    expect(mock.mock.calls[0][0]).toMatch(/begin.*via write connection '127\.0\.0\.1'/);
+    expect(mock.mock.calls[1][0]).toMatch(/insert into `author2`.*via write connection '127\.0\.0\.1'/);
+    expect(mock.mock.calls[2][0]).toMatch(/insert into `book2`.*via write connection '127\.0\.0\.1'/);
+    expect(mock.mock.calls[3][0]).toMatch(/commit.*via write connection '127\.0\.0\.1'/);
+
+    orm.em.clear();
+    author = (await orm.em.findOne(Author2, author))!;
+    await orm.em.findOne(Author2, author, { refresh: true });
+    await orm.em.findOne(Author2, author, { refresh: true });
+    expect(mock.mock.calls[4][0]).toMatch(/select `e0`.* from `author2` as `e0` where `e0`.`id` = \? limit \?.*via read connection 'read-\d'/);
+    expect(mock.mock.calls[5][0]).toMatch(/select `e0`.* from `author2` as `e0` where `e0`.`id` = \? limit \?.*via read connection 'read-\d'/);
+    expect(mock.mock.calls[6][0]).toMatch(/select `e0`.* from `author2` as `e0` where `e0`.`id` = \? limit \?.*via read connection 'read-\d'/);
+
+    author.name = 'Jon Blow';
+    await orm.em.flush();
+    expect(mock.mock.calls[7][0]).toMatch(/begin.*via write connection '127\.0\.0\.1'/);
+    expect(mock.mock.calls[8][0]).toMatch(/update `author2` set `name` = \?, `updated_at` = \? where `id` = \?.*via write connection '127\.0\.0\.1'/);
+    expect(mock.mock.calls[9][0]).toMatch(/commit.*via write connection '127\.0\.0\.1'/);
+
+    const qb = orm.em.createQueryBuilder(Author2, 'a', 'write');
+    await qb.select('*').where({ name: /.*Blow/ }).execute();
+    expect(mock.mock.calls[10][0]).toMatch(/select `a`.* from `author2` as `a` where `a`.`name` like \?.*via write connection '127\.0\.0\.1'/);
+
+    await orm.em.transactional(async em => {
+      const book = await em.findOne(Book2, { title: 'B' });
+      author.name = 'Jon Flow';
+      author.favouriteBook = book!;
+      await em.flush();
+    });
+
+    expect(mock.mock.calls[11][0]).toMatch(/begin.*via write connection '127\.0\.0\.1'/);
+    expect(mock.mock.calls[12][0]).toMatch(/select `e0`.* from `book2` as `e0` where `e0`.`title` = \?.*via write connection '127\.0\.0\.1'/);
+    expect(mock.mock.calls[13][0]).toMatch(/update `author2` set `name` = \?, `favourite_book_uuid_pk` = \?, `updated_at` = \? where `id` = \?.*via write connection '127\.0\.0\.1'/);
+    expect(mock.mock.calls[14][0]).toMatch(/commit.*via write connection '127\.0\.0\.1'/);
   });
 
   afterAll(async () => orm.close(true));

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -55,6 +55,7 @@ export async function initORMMySql() {
     logger: i => i,
     multipleStatements: true,
     type: 'mysql',
+    replicas: [{ name: 'read-1' }, { name: 'read-2' }], // create two read replicas with same configuration, just for testing purposes
   });
 
   const connection = orm.em.getConnection<MySqlConnection>();


### PR DESCRIPTION
Now users can specify multiple read connections via `replicas` option. You can provide only fields that differ from master connection, rest will be taken from it.

By default select queries will use random read connection if not inside transaction. You can specify connection type manually in `EntityManager.getConnection(type: 'read' | 'write')`.

Closes #77