### PR TITLE
feat(core): simplify entity definition and rework typings of FilterQuery

### DIFF
--- a/docs/custom-driver.md
+++ b/docs/custom-driver.md
@@ -98,12 +98,12 @@ export class MyCustomSchemaHelper extends DatabaseDriver {
   protected readonly platform = new MyCustomPlatform;
 
   // and implement abstract methods
-  find<T extends IEntity>(entityName: string, where: FilterQuery<T>, populate?: string[], orderBy?: Record<string, QueryOrder>, limit?: number, offset?: number): Promise<T[]>;
-  findOne<T extends IEntity>(entityName: string, where: FilterQuery<T> | string, populate: string[]): Promise<T | null>;
-  nativeInsert<T extends IEntityType<T>>(entityName: string, data: EntityData<T>): Promise<QueryResult>;
-  nativeUpdate<T extends IEntity>(entityName: string, where: FilterQuery<IEntity> | IPrimaryKey, data: EntityData<T>): Promise<QueryResult>;
-  nativeDelete<T extends IEntity>(entityName: string, where: FilterQuery<IEntity> | IPrimaryKey): Promise<QueryResult>;
-  count<T extends IEntity>(entityName: string, where: FilterQuery<T>): Promise<number>;
+  find<T extends AnyEntity>(entityName: string, where: FilterQuery<T>, populate?: string[], orderBy?: Record<string, QueryOrder>, limit?: number, offset?: number): Promise<T[]>;
+  findOne<T extends AnyEntity>(entityName: string, where: FilterQuery<T> | string, populate: string[]): Promise<T | null>;
+  nativeInsert<T extends AnyEntityType<T>>(entityName: string, data: EntityData<T>): Promise<QueryResult>;
+  nativeUpdate<T extends AnyEntity>(entityName: string, where: FilterQuery<T> | IPrimaryKey, data: EntityData<T>): Promise<QueryResult>;
+  nativeDelete<T extends AnyEntity>(entityName: string, where: FilterQuery<T> | IPrimaryKey): Promise<QueryResult>;
+  count<T extends AnyEntity>(entityName: string, where: FilterQuery<T>): Promise<number>;
 
 }
 ```

--- a/docs/defining-entities.md
+++ b/docs/defining-entities.md
@@ -42,13 +42,13 @@ export class Book {
 
 }
 
-export interface Book extends IEntity<string> { }
+export interface Book extends AnyEntity<string> { }
 ```
 
-You will need to extend Book's interface with `IEntity`. The interface represents internal 
+You will need to extend Book's interface with `AnyEntity`. The interface represents internal 
 methods added to your entity's prototype via `@Entity` decorator.
 
-> `IEntity` is generic interface, its type parameter depends on data type of normalized primary
+> `AnyEntity` is generic interface, its type parameter depends on data type of normalized primary
 > key produced by used driver. SQL drivers usually use `number` and Mongo driver uses `string`.
 > This type default to union type `number | string`. Keep in mind that you have to worry about 
 > this only when you define your primary key as `_id` instead of `id`.
@@ -107,7 +107,7 @@ export class Author {
 
 }
 
-export interface Author extends IEntity { }
+export interface Author extends AnyEntity { }
 ```
 
 More information about modelling relationships can be found on [modelling relationships page](relationships.md).

--- a/docs/entity-constructors.md
+++ b/docs/entity-constructors.md
@@ -36,7 +36,7 @@ export class Book {
 
 }
 
-export interface Book extends IEntity { }
+export interface Book extends AnyEntity { }
 ```
 
 [&larr; Back to table of contents](index.md#table-of-contents)

--- a/docs/entity-helper.md
+++ b/docs/entity-helper.md
@@ -3,11 +3,11 @@
 
 # EntityHelper and Decorated Entities
 
-## Updating Entity Values with IEntity.assign()
+## Updating Entity Values with Entity.assign()
 
 When you want to update entity based on user input, you will usually have just plain
 string ids of entity relations as user input. Normally you would need to use 
-`EntityManager.getReference()` to create references from each id first, and then
+`em.getReference()` to create references from each id first, and then
 use those references to update entity relations:
 
 ```typescript
@@ -16,7 +16,7 @@ const book = new Book('Book', jon);
 book.author = orm.em.getReference<Author>(Author, '...id...');
 ```
 
-Same result can be easily achieved with `IEntity.assign()`:
+Same result can be easily achieved with `Entity.assign()`:
 
 ```typescript
 book.assign({ 
@@ -28,7 +28,7 @@ console.log(book.author); // instance of Author with id: '...id...'
 console.log(book.author.id); // '...id...'
 ```
 
-By default, `IEntity.assign(data)` behaves same way as `Object.assign(entity, data)`, 
+By default, `Entity.assign(data)` behaves same way as `Object.assign(entity, data)`, 
 e.g. it does not merge things recursively. To enable deep merging of object properties, 
 use second parameter to enable `mergeObjects` flag:
 

--- a/docs/entity-manager.md
+++ b/docs/entity-manager.md
@@ -205,7 +205,7 @@ try {
 
 ## Type of Fetched Entities
 
-Both `EntityManager.find` and `EntityManager.findOne()` methods have generic return types.
+Both `em.find` and `em.findOne()` methods have generic return types.
 All of following examples are equal and will let typescript correctly infer the entity type:
 
 ```typescript
@@ -229,12 +229,12 @@ or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/
 
 ## EntityManager API
 
-#### `getRepository<T extends IEntity>(entityName: string | EntityClass<T>): EntityRepository<T>`
+#### `getRepository<T extends AnyEntity>(entityName: string | EntityClass<T>): EntityRepository<T>`
 
 Returns `EntityRepository` for given entity, respects `customRepository` option of `@Entity`
 and `entityRepository` option of `MikroORM.init()`.
 
-#### `find<T extends IEntity>(entityName: string | EntityClass<T>, where: FilterQuery<T>, options?: FindOptions): Promise<T[]>`
+#### `find<T extends AnyEntity>(entityName: string | EntityClass<T>, where: FilterQuery<T>, options?: FindOptions): Promise<T[]>`
 
 Returns array of entities found for given condition. You can specify `FindOptions` to request
 population of referenced entities or control the pagination:
@@ -250,27 +250,27 @@ export interface FindOptions {
 
 ---
 
-#### `find<T extends IEntity>(entityName: string | EntityClass<T>, where: FilterQuery<T>, populate?: string[], orderBy?: { [k: string]: QueryOrder }, limit?: number, offset?: number): Promise<T[]>`
+#### `find<T extends AnyEntity>(entityName: string | EntityClass<T>, where: FilterQuery<T>, populate?: string[], orderBy?: { [k: string]: QueryOrder }, limit?: number, offset?: number): Promise<T[]>`
 
 Same as previous `find` method, just with dedicated parameters for `populate`, `orderBy`, `limit`
 and `offset`.
 
 ---
 
-#### `findAndCount<T extends IEntity>(entityName: string | EntityClass<T>, where: FilterQuery<T>, populate?: string[], orderBy?: { [k: string]: QueryOrder }, limit?: number, offset?: number): Promise<[T[], number]>`
+#### `findAndCount<T extends AnyEntity>(entityName: string | EntityClass<T>, where: FilterQuery<T>, populate?: string[], orderBy?: { [k: string]: QueryOrder }, limit?: number, offset?: number): Promise<[T[], number]>`
 
 Combination of `find` and `count` methods. 
 
 ---
 
-#### `findOne<T extends IEntity>(entityName: string | EntityClass<T>, where: FilterQuery<T> | IPrimaryKey, populate?: string[]): Promise<T | null>`
+#### `findOne<T extends AnyEntity>(entityName: string | EntityClass<T>, where: FilterQuery<T> | IPrimaryKey, populate?: string[]): Promise<T | null>`
 
 Finds an entity by given `where` condition. You can use primary key as `where` value, then
 if the entity is already managed, no database call will be made. 
 
 ---
 
-#### `findOneOrFail<T extends IEntity>(entityName: string | EntityClass<T>, where: FilterQuery<T> | IPrimaryKey, populate?: string[]): Promise<T>`
+#### `findOneOrFail<T extends AnyEntity>(entityName: string | EntityClass<T>, where: FilterQuery<T> | IPrimaryKey, populate?: string[]): Promise<T>`
 
 Just like `findOne`, but throws when entity not found, so it always resolves to given entity. 
 You can customize the error either globally via `findOneOrFailHandler` option, or locally via 
@@ -278,21 +278,21 @@ You can customize the error either globally via `findOneOrFailHandler` option, o
 
 ---
 
-#### `merge<T extends IEntity>(entityName: string | EntityClass<T>, data: EntityData<T>): T`
+#### `merge<T extends AnyEntity>(entityName: string | EntityClass<T>, data: EntityData<T>): T`
 
 Adds given entity to current Identity Map. After merging, entity becomes managed. 
 This is useful when you want to work with cached entities. 
 
 ---
 
-#### `map<T extends IEntity>(entityName: string | EntityClass<T>, data: EntityData<T>): T`
+#### `map<T extends AnyEntity>(entityName: string | EntityClass<T>, data: EntityData<T>): T`
 
 Maps raw DB result to entity, adding it to current Identity Map. Equivalent to 
-`IDatabaseDriver.mapResult()` followed by `EntityManager.merge()`.
+`IDatabaseDriver.mapResult()` followed by `em.merge()`.
 
 ---
 
-#### `getReference<T extends IEntity>(entityName: string | EntityClass<T>, id: string): T`
+#### `getReference<T extends AnyEntity>(entityName: string | EntityClass<T>, id: string): T`
 
 Gets a reference to the entity identified by the given type and identifier without actually 
 loading it, if the entity is not yet loaded.
@@ -305,7 +305,7 @@ Gets count of entities matching the `where` condition.
 
 ---
 
-#### `persist(entity: IEntity | IEntity[], flush?: boolean): void | Promise<void>`
+#### `persist(entity: AnyEntity | AnyEntity[], flush?: boolean): void | Promise<void>`
 
 Tells the EntityManager to make an instance managed and persistent. The entity will be 
 entered into the database at or before transaction commit or as a result of the flush 
@@ -314,13 +314,13 @@ configuration option.
 
 ---
 
-#### `persistAndFlush(entity: IEntity | IEntity[]): Promise<void>`
+#### `persistAndFlush(entity: AnyEntity | AnyEntity[]): Promise<void>`
 
 Shortcut for `persist` & `flush`.
 
 ---
 
-#### `persistLater(entity: IEntity | IEntity[]): void`
+#### `persistLater(entity: AnyEntity | AnyEntity[]): void`
 
 Shortcut for just `persist`, without flushing. 
 
@@ -332,7 +332,7 @@ Flushes all changes to objects that have been queued up to now to the database.
 
 ---
 
-#### `remove(entityName: string | EntityClass<T>, where: IEntity | FilterQuery<T> | IPrimaryKey, flush?: boolean): Promise<number>`
+#### `remove(entityName: string | EntityClass<T>, where: AnyEntity | FilterQuery<T> | IPrimaryKey, flush?: boolean): Promise<number>`
 
 When provided entity instance as `where` value, then it calls `removeEntity(entity, flush)`, 
 otherwise it fires delete query with given `where` condition. 
@@ -341,7 +341,7 @@ This method fires `beforeDelete` and `afterDelete` hooks only if you provide ent
 
 ---
 
-#### `removeEntity(entity: IEntity, flush?: boolean): Promise<number>`
+#### `removeEntity(entity: AnyEntity, flush?: boolean): Promise<number>`
 
 Removes an entity instance. A removed entity will be removed from the database at or before 
 transaction commit or as a result of the flush operation. You can control immediate flushing 
@@ -351,13 +351,13 @@ This method fires `beforeDelete` and `afterDelete` hooks.
 
 ---
 
-#### `removeAndFlush(entity: IEntity): Promise<void>`
+#### `removeAndFlush(entity: AnyEntity): Promise<void>`
 
 Shortcut for `removeEntity` & `flush`.
 
 ---
 
-#### `removeLater(entity: IEntity): void`
+#### `removeLater(entity: AnyEntity): void`
 
 Shortcut for `removeEntity` without flushing. 
 

--- a/docs/entity-references.md
+++ b/docs/entity-references.md
@@ -147,7 +147,7 @@ console.log(book.author.id); // ok, returns string PK
 console.log(book.author._id); // ok, returns ObjectId PK
 ```
 
-> As opposed to `IEntity.init()` which always refreshes the entity, `Reference.load()` 
+> As opposed to `Entity.init()` which always refreshes the entity, `Reference.load()` 
 > method will query the database only if the entity is not already loaded in Identity Map. 
 
 [&larr; Back to table of contents](index.md#table-of-contents)

--- a/docs/identity-map.md
+++ b/docs/identity-map.md
@@ -15,7 +15,7 @@ const authors = await authorRepository.findAll(['books']);
 console.log(jon === authors[0]); // true
 ```
 
-If you want to clear this identity map cache, you can do so via `EntityManager.clear()` method:
+If you want to clear this identity map cache, you can do so via `em.clear()` method:
 
 ```typescript
 orm.em.clear();

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ compatible with Vanilla JavaScript.
   - [Smart Query Conditions](query-conditions.md)
   - [Using `QueryBuilder`](query-builder.md)
   - [Serializing](serializing.md)
-  - [Updating Entity Values with `IEntity.assign()`](entity-helper.md)
+  - [Updating Entity Values with `Entity.assign()`](entity-helper.md)
   - [Property Validation](property-validation.md)
   - [Lifecycle Hooks](lifecycle-hooks.md)
   - [Naming Strategy](naming-strategy.md)

--- a/docs/query-conditions.md
+++ b/docs/query-conditions.md
@@ -67,7 +67,7 @@ will be converted automatically:
 const res = await orm.em.find(Author, { favouriteBook: [1, 2, 7] });
 ```
 
-For primary key lookup, you can provide the array directly to `EntityManager.find()`:
+For primary key lookup, you can provide the array directly to `em.find()`:
 
 ```typescript
 const res = await orm.em.find(Author, [1, 2, 7]);

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -54,7 +54,7 @@ export class Author {
 Note that we need to pass that repository reference inside a callback so we will not run
 into circular dependency issues when using entity references inside that repository.
 
-Now you can access your custom repository via `EntityManager.getRepository()` method.
+Now you can access your custom repository via `em.getRepository()` method.
 
 > You can also register custom base repository (for all entities where you do not specify 
 `customRepository`) globally, via `MikroORM.init({ entityRepository: CustomBaseRepository })`
@@ -142,7 +142,7 @@ Gets count of entities matching the `where` condition.
 
 ---
 
-#### `persist(entity: IEntity | IEntity[], flush?: boolean): Promise<void>`
+#### `persist(entity: AnyEntity | AnyEntity[], flush?: boolean): Promise<void>`
 
 Tells the EntityManager to make an instance managed and persistent. The entity will be 
 entered into the database at or before transaction commit or as a result of the flush 
@@ -151,13 +151,13 @@ configuration option.
 
 ---
 
-#### `persistAndFlush(entity: IEntity | IEntity[]): Promise<void>`
+#### `persistAndFlush(entity: AnyEntity | AnyEntity[]): Promise<void>`
 
 Shortcut for `persist` & `flush`.
 
 ---
 
-#### `persistLater(entity: IEntity | IEntity[]): void`
+#### `persistLater(entity: AnyEntity | AnyEntity[]): void`
 
 Shortcut for just `persist`, without flushing. 
 
@@ -169,7 +169,7 @@ Flushes all changes to objects that have been queued up to now to the database.
 
 ---
 
-#### `remove(where: IEntity | FilterQuery<T>, flush?: boolean): Promise<number>`
+#### `remove(where: AnyEntity | FilterQuery<T>, flush?: boolean): Promise<number>`
 
 When provided entity instance as `where` value, then it calls `removeEntity(entity, flush)`, 
 otherwise it fires delete query with given `where` condition. 
@@ -178,7 +178,7 @@ This method fires `beforeDelete` and `afterDelete` hooks only if you provide ent
 
 ---
 
-#### `removeAndFlush(entity: IEntity): Promise<void>`
+#### `removeAndFlush(entity: AnyEntity): Promise<void>`
 
 Shortcut for `removeEntity` & `flush`.
 
@@ -186,7 +186,7 @@ This method fires `beforeDelete` and `afterDelete` hooks.
 
 ---
 
-#### `removeLater(entity: IEntity): void`
+#### `removeLater(entity: AnyEntity): void`
 
 Shortcut for `removeEntity` without flushing. 
 

--- a/docs/serializing.md
+++ b/docs/serializing.md
@@ -6,8 +6,8 @@
 By default, all entities are monkey patched with `toObject()` and `toJSON` methods:
 
 ```typescript
-export interface IEntity<K = number | string> {
-  toObject(parent?: IEntity, isCollection?: boolean): Record<string, any>;
+export interface AnyEntity<K = number | string> {
+  toObject(parent?: AnyEntity, isCollection?: boolean): Record<string, any>;
   toJSON(...args: any[]): Record<string, any>;
   // ...
 }
@@ -62,8 +62,8 @@ console.log(book.toJSON().hiddenField); // undefined
 
 The opposite situation where you want to define a property that lives only in memory (is 
 not persisted into database) can be solved by defining your property as `persist: false`. 
-Such property can be assigned via one of `IEntity.assign()`, `EntityManager.create()` and 
-`EntityManager.merge()`. It will be also part of serialized result. 
+Such property can be assigned via one of `Entity.assign()`, `em.create()` and 
+`em.merge()`. It will be also part of serialized result. 
 
 This can be handle when dealing with additional values selected via `QueryBuilder` or 
 MongoDB's aggregations.

--- a/docs/usage-with-mongo.md
+++ b/docs/usage-with-mongo.md
@@ -62,9 +62,9 @@ boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/na
 methods:
 
 ```typescript
-EntityManager.nativeInsert<T extends IEntity>(entityName: string, data: any): Promise<IPrimaryKey>;
-EntityManager.nativeUpdate<T extends IEntity>(entityName: string, where: FilterQuery<T>, data: any): Promise<number>;
-EntityManager.nativeDelete<T extends IEntity>(entityName: string, where: FilterQuery<T> | any): Promise<number>;
+em.nativeInsert<T extends AnyEntity>(entityName: string, data: any): Promise<IPrimaryKey>;
+em.nativeUpdate<T extends AnyEntity>(entityName: string, where: FilterQuery<T>, data: any): Promise<number>;
+em.nativeDelete<T extends AnyEntity>(entityName: string, where: FilterQuery<T> | any): Promise<number>;
 ```
 
 Those methods execute native driver methods like Mongo's `insertOne/updateMany/deleteMany` collection methods respectively. 
@@ -82,7 +82,7 @@ EntityRepository.nativeDelete(where: FilterQuery<T> | any): Promise<number>;
 There is also shortcut for calling `aggregate` method:
 
 ```typescript
-EntityManager.aggregate(entityName: string, pipeline: any[]): Promise<any[]>;
+em.aggregate(entityName: string, pipeline: any[]): Promise<any[]>;
 EntityRepository.aggregate(pipeline: any[]): Promise<any[]>;
 ```
 

--- a/docs/usage-with-sql.md
+++ b/docs/usage-with-sql.md
@@ -117,15 +117,12 @@ For more examples of how to work with `QueryBuilder`, take a look at `QueryBuild
 
 ## Transactions
 
-When you call `EntityManager#flush()`, all computed changes are queried [inside a database
+When you call `em.flush()`, all computed changes are queried [inside a database
 transaction](unit-of-work.md) by default, so you do not have to handle transactions manually. 
 
-When you need to explicitly handle the transaction, you can use `beginTransaction/commit/rollback` 
-methods on both `MySqlDriver` and their shortcuts on `EntityManager`. 
-
-You can also use `EntityManager.transactional(cb)` helper to run callback in transaction. It will
-provide forked `EntityManager` as a parameter with clear clear isolated identity map - please use that
-to make changes. 
+When you need to explicitly handle the transaction, you can use `em.transactional(cb)` 
+to run callback in transaction. It will provide forked `EntityManager` as a parameter 
+with clear isolated identity map - please use that to make changes. 
 
 ```typescript
 // if an error occurs inside the callback, all db queries from inside the callback will be rolled back
@@ -135,14 +132,7 @@ await orm.em.transactional(async (em: EntityManager) => {
 });
 ```
 
-```typescript
-EntityManager.beginTransaction(): Promise<void>;
-EntityManager.commit(): Promise<void>;
-EntityManager.rollback(): Promise<void>;
-EntityManager.transactional(cb: (em: EntityManager) => Promise<any>): Promise<any>;
-```
-
-## LIKE queries
+## LIKE Queries
 
 SQL do support LIKE queries via native JS regular expressions:
 
@@ -157,7 +147,7 @@ const authors = await orm.em.find(Author2, { email: /exa.*le\.c.m$/ });
 console.log(authors); // all 3 authors found
 ```
 
-## Native collection methods
+## Native Collection Methods
 
 Sometimes you need to perform some bulk operation, or you just want to populate your
 database with initial fixtures. Using ORM for such operations can bring unnecessary
@@ -165,9 +155,9 @@ boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/na
 methods:
 
 ```typescript
-EntityManager.nativeInsert<T extends IEntity>(entityName: string, data: any): Promise<IPrimaryKey>;
-EntityManager.nativeUpdate<T extends IEntity>(entityName: string, where: FilterQuery<T>, data: any): Promise<number>;
-EntityManager.nativeDelete<T extends IEntity>(entityName: string, where: FilterQuery<T> | any): Promise<number>;
+em.nativeInsert<T extends AnyEntity>(entityName: string, data: any): Promise<IPrimaryKey>;
+em.nativeUpdate<T extends AnyEntity>(entityName: string, where: FilterQuery<T>, data: any): Promise<number>;
+em.nativeDelete<T extends AnyEntity>(entityName: string, where: FilterQuery<T> | any): Promise<number>;
 ```
 
 Those methods execute native SQL queries generated via `QueryBuilder` based on entity 

--- a/lib/cli/CLIHelper.ts
+++ b/lib/cli/CLIHelper.ts
@@ -9,6 +9,7 @@ import { ClearCacheCommand } from './ClearCacheCommand';
 import { GenerateEntitiesCommand } from './GenerateEntitiesCommand';
 import { SchemaCommandFactory } from './SchemaCommandFactory';
 import { DebugCommand } from './DebugCommand';
+import { Dictionary } from '../types';
 
 export class CLIHelper {
 
@@ -85,7 +86,7 @@ export class CLIHelper {
     }
   }
 
-  static async getPackageConfig(): Promise<Record<string, any>> {
+  static async getPackageConfig(): Promise<Dictionary> {
     if (await pathExists(process.cwd() + '/package.json')) {
       return require(process.cwd() + '/package.json');
     }

--- a/lib/connections/AbstractSqlConnection.ts
+++ b/lib/connections/AbstractSqlConnection.ts
@@ -3,7 +3,7 @@ import { readFile } from 'fs-extra';
 
 import { Connection, QueryResult } from './Connection';
 import { Utils } from '../utils';
-import { EntityData, IEntity } from '../decorators';
+import { EntityData, AnyEntity } from '../types';
 
 export abstract class AbstractSqlConnection extends Connection {
 
@@ -40,7 +40,7 @@ export abstract class AbstractSqlConnection extends Connection {
     });
   }
 
-  async execute<T extends QueryResult | EntityData<IEntity> | EntityData<IEntity>[] = EntityData<IEntity>[]>(queryOrKnex: string | QueryBuilder | Raw, params: any[] = [], method: 'all' | 'get' | 'run' = 'all'): Promise<T> {
+  async execute<T extends QueryResult | EntityData<AnyEntity> | EntityData<AnyEntity>[] = EntityData<AnyEntity>[]>(queryOrKnex: string | QueryBuilder | Raw, params: any[] = [], method: 'all' | 'get' | 'run' = 'all'): Promise<T> {
     if (Utils.isObject<QueryBuilder | Raw>(queryOrKnex)) {
       return await this.executeKnex(queryOrKnex, method);
     }

--- a/lib/connections/Connection.ts
+++ b/lib/connections/Connection.ts
@@ -5,6 +5,7 @@ import highlight from 'cli-highlight';
 
 import { Configuration, ConnectionOptions, Utils } from '../utils';
 import { MetadataStorage } from '../metadata';
+import { Dictionary } from '../types';
 
 export abstract class Connection {
 
@@ -96,7 +97,7 @@ export abstract class Connection {
 export interface QueryResult {
   affectedRows: number;
   insertId: number;
-  row?: Record<string, any>;
+  row?: Dictionary;
 }
 
 export interface ConnectionConfig {

--- a/lib/decorators/Entity.ts
+++ b/lib/decorators/Entity.ts
@@ -1,14 +1,10 @@
 import { MetadataStorage } from '../metadata';
-import { EntityManager } from '../EntityManager';
-import { IPrimaryKey } from './PrimaryKey';
-import { AssignOptions, Cascade, Collection, EntityRepository, ReferenceType } from '../entity';
+import { EntityRepository } from '../entity';
 import { Utils } from '../utils';
-import { QueryOrder } from '../query';
-import { LockMode } from '../unit-of-work';
-import { Constructor } from '../drivers';
+import { AnyEntity, Constructor } from '../types';
 
-export function Entity(options: EntityOptions = {}): Function {
-  return function <T extends { new(...args: any[]): IEntity }>(target: T) {
+export function Entity(options: EntityOptions<any> = {}): Function {
+  return function <T extends { new(...args: any[]): AnyEntity<T> }>(target: T) {
     const meta = MetadataStorage.getMetadata(target.name);
     Utils.merge(meta, options);
     meta.name = target.name;
@@ -20,94 +16,7 @@ export function Entity(options: EntityOptions = {}): Function {
   };
 }
 
-export type EntityOptions = {
+export type EntityOptions<T extends AnyEntity<T>> = {
   collection?: string;
-  customRepository?: () => Constructor<EntityRepository<IEntity>>;
+  customRepository?: () => Constructor<EntityRepository<T>>;
 };
-
-export interface IEntity<K = number | string> {
-  id: K;
-  isInitialized(): boolean;
-  populated(populated?: boolean): void;
-  init(populated?: boolean, lockMode?: LockMode): Promise<this>;
-  toObject(ignoreFields?: string[]): Record<string, any>;
-  toJSON(...args: any[]): Record<string, any>;
-  assign(data: any, options?: AssignOptions | boolean): this;
-  __uuid: string;
-  __meta: EntityMetadata;
-  __em: EntityManager;
-  __initialized?: boolean;
-  __populated: boolean;
-  __lazyInitialized: boolean;
-  __primaryKey: K;
-  __primaryKeyField: string & keyof IEntity;
-  __serializedPrimaryKey: string & keyof IEntity;
-  __serializedPrimaryKeyField: string;
-}
-
-export type IEntityType<T> = { [k in keyof T]: IEntity | Collection<IEntity> | any; } & IEntity;
-
-export type EntityClass<T extends IEntityType<T>> = Constructor<T> & Function & { prototype: T };
-
-export type EntityClassGroup<T extends IEntityType<T>> = {
-  entity: EntityClass<T>;
-  schema: EntityMetadata<T>;
-};
-
-export type EntityName<T extends IEntityType<T>> = string | EntityClass<T>;
-
-export type EntityData<T extends IEntityType<T>> = { [P in keyof T]?: T[P] | IPrimaryKey; } & Record<string, any>;
-
-export interface EntityProperty<T extends IEntityType<T> = any> {
-  name: string & keyof T;
-  entity: () => EntityName<T>;
-  type: string;
-  columnType: string;
-  primary: boolean;
-  length?: any;
-  reference: ReferenceType;
-  wrappedReference?: boolean;
-  fieldName: string;
-  default?: any;
-  unique?: boolean;
-  nullable?: boolean;
-  unsigned: boolean;
-  persist?: boolean;
-  hidden?: boolean;
-  version?: boolean;
-  eager?: boolean;
-  setter?: boolean;
-  getter?: boolean;
-  getterName?: keyof T;
-  cascade: Cascade[];
-  orphanRemoval?: boolean;
-  onUpdate?: () => any;
-  owner: boolean;
-  inversedBy: string;
-  mappedBy: string;
-  orderBy?: { [field: string]: QueryOrder };
-  pivotTable: string;
-  joinColumn: string;
-  inverseJoinColumn: string;
-  referenceColumnName: string;
-  referencedTableName: string;
-}
-
-export type HookType = 'onInit' | 'beforeCreate' | 'afterCreate' | 'beforeUpdate' | 'afterUpdate' | 'beforeDelete' | 'afterDelete';
-
-export interface EntityMetadata<T extends IEntityType<T> = any> {
-  name: string;
-  className: string;
-  constructorParams: (keyof T & string)[];
-  toJsonParams: string[];
-  extends: string;
-  collection: string;
-  path: string;
-  primaryKey: keyof T & string;
-  versionProperty: keyof T & string;
-  serializedPrimaryKey: keyof T & string;
-  properties: { [K in keyof T & string]: EntityProperty<T> };
-  customRepository: () => Constructor<EntityRepository<T>>;
-  hooks: Partial<Record<HookType, (string & keyof T)[]>>;
-  prototype: T;
-}

--- a/lib/decorators/ManyToMany.ts
+++ b/lib/decorators/ManyToMany.ts
@@ -1,15 +1,15 @@
 import { ReferenceOptions } from './Property';
-import { EntityName, EntityProperty, IEntity, IEntityType } from './Entity';
 import { MetadataStorage } from '../metadata';
 import { Utils } from '../utils';
 import { Cascade, ReferenceType } from '../entity';
+import { EntityName, EntityProperty, AnyEntity } from '../types';
 
-export function ManyToMany<T extends IEntityType<T>>(
+export function ManyToMany<T extends AnyEntity<T>>(
   entity: ManyToManyOptions<T> | string | (() => EntityName<T>),
   mappedBy?: (string & keyof T) | ((e: T) => any),
   options: Partial<ManyToManyOptions<T>> = {},
 ) {
-  return function (target: IEntity, propertyName: string) {
+  return function (target: AnyEntity, propertyName: string) {
     options = Utils.isObject<ManyToManyOptions<T>>(entity) ? entity : { ...options, entity, mappedBy };
 
     if (options.owner) {
@@ -32,7 +32,7 @@ export function ManyToMany<T extends IEntityType<T>>(
   };
 }
 
-export interface ManyToManyOptions<T extends IEntityType<T>> extends ReferenceOptions<T> {
+export interface ManyToManyOptions<T extends AnyEntity<T>> extends ReferenceOptions<T> {
   entity: string | (() => EntityName<T>);
   owner?: boolean;
   inversedBy?: (string & keyof T) | ((e: T) => any);

--- a/lib/decorators/ManyToOne.ts
+++ b/lib/decorators/ManyToOne.ts
@@ -1,14 +1,14 @@
 import { ReferenceOptions } from './Property';
-import { EntityName, EntityProperty, IEntity, IEntityType } from './Entity';
 import { MetadataStorage } from '../metadata';
 import { Utils } from '../utils';
 import { Cascade, ReferenceType } from '../entity';
+import { EntityName, EntityProperty, AnyEntity } from '../types';
 
-export function ManyToOne<T extends IEntityType<T>>(
+export function ManyToOne<T extends AnyEntity<T>>(
   entity: ManyToOneOptions<T> | string | ((e?: any) => EntityName<T>) = {},
   options: Partial<ManyToOneOptions<T>> = {},
 ) {
-  return function (target: IEntity, propertyName: string) {
+  return function (target: AnyEntity, propertyName: string) {
     options = Utils.isObject<ManyToOneOptions<T>>(entity) ? entity : { ...options, entity };
 
     if ((options as any).fk) {
@@ -24,7 +24,7 @@ export function ManyToOne<T extends IEntityType<T>>(
   };
 }
 
-export interface ManyToOneOptions<T extends IEntityType<T>> extends ReferenceOptions<T> {
+export interface ManyToOneOptions<T extends AnyEntity<T>> extends ReferenceOptions<T> {
   entity?: string | (() => EntityName<T>);
   inversedBy?: (string & keyof T) | ((e: T) => any);
   wrappedReference?: boolean;

--- a/lib/decorators/OneToMany.ts
+++ b/lib/decorators/OneToMany.ts
@@ -1,11 +1,11 @@
 import { ReferenceOptions } from './Property';
-import { EntityName, EntityProperty, IEntity, IEntityType } from './Entity';
 import { MetadataStorage } from '../metadata';
 import { Utils } from '../utils';
 import { Cascade, ReferenceType } from '../entity';
 import { QueryOrder } from '../query';
+import { EntityName, EntityProperty, AnyEntity } from '../types';
 
-export function OneToMany<T extends IEntityType<T>>(
+export function OneToMany<T extends AnyEntity<T>>(
   entity: OneToManyOptions<T> | string | ((e?: any) => EntityName<T>),
   mappedBy?: (string & keyof T) | ((e: T) => any),
   options: Partial<OneToManyOptions<T>> = {},
@@ -13,13 +13,13 @@ export function OneToMany<T extends IEntityType<T>>(
   return createOneToDecorator(entity, mappedBy, options, ReferenceType.ONE_TO_MANY);
 }
 
-export function createOneToDecorator<T extends IEntityType<T>>(
+export function createOneToDecorator<T extends AnyEntity<T>>(
   entity?: OneToManyOptions<T> | string | ((e?: any) => EntityName<T>),
   mappedBy?: (string & keyof T) | ((e: T) => any),
   options?: Partial<OneToManyOptions<T>>,
   reference?: ReferenceType,
 ) {
-  return function (target: IEntity, propertyName: string) {
+  return function (target: AnyEntity, propertyName: string) {
     options = Utils.isObject<OneToManyOptions<T>>(entity) ? entity : { ...options, entity, mappedBy };
     const meta = MetadataStorage.getMetadata(target.constructor.name);
     Utils.lookupPathFromDecorator(meta);
@@ -55,7 +55,7 @@ export function createOneToDecorator<T extends IEntityType<T>>(
   };
 }
 
-export type OneToManyOptions<T extends IEntityType<T>> = ReferenceOptions<T> & {
+export type OneToManyOptions<T extends AnyEntity<T>> = ReferenceOptions<T> & {
   entity: string | (() => EntityName<T>);
   orphanRemoval?: boolean;
   orderBy?: { [field: string]: QueryOrder };

--- a/lib/decorators/OneToOne.ts
+++ b/lib/decorators/OneToOne.ts
@@ -1,8 +1,9 @@
-import { EntityName, IEntityType } from './Entity';
+
 import { ReferenceType } from '../entity';
 import { createOneToDecorator, OneToManyOptions } from './OneToMany';
+import { EntityName, AnyEntity } from '../types';
 
-export function OneToOne<T extends IEntityType<T>>(
+export function OneToOne<T extends AnyEntity<T>>(
   entity?: OneToOneOptions<T> | string | ((e?: any) => EntityName<T>),
   mappedBy?: (string & keyof T) | ((e: T) => any),
   options: Partial<OneToOneOptions<T>> = {},
@@ -10,7 +11,7 @@ export function OneToOne<T extends IEntityType<T>>(
   return createOneToDecorator<T>(entity as string, mappedBy, options, ReferenceType.ONE_TO_ONE);
 }
 
-export interface OneToOneOptions<T extends IEntityType<T>> extends Partial<Omit<OneToManyOptions<T>, 'orderBy'>> {
+export interface OneToOneOptions<T extends AnyEntity<T>> extends Partial<Omit<OneToManyOptions<T>, 'orderBy'>> {
   owner?: boolean;
   inversedBy?: (string & keyof T) | ((e: T) => any);
   wrappedReference?: boolean;

--- a/lib/decorators/Property.ts
+++ b/lib/decorators/Property.ts
@@ -1,10 +1,11 @@
-import { EntityName, EntityProperty, IEntity, IEntityType } from './Entity';
+
 import { MetadataStorage } from '../metadata';
 import { Utils } from '../utils';
 import { Cascade, ReferenceType } from '../entity';
+import { EntityName, EntityProperty, AnyEntity } from '../types';
 
 export function Property(options: PropertyOptions = {}): Function {
-  return function (target: IEntity, propertyName: string) {
+  return function (target: AnyEntity, propertyName: string) {
     const meta = MetadataStorage.getMetadata(target.constructor.name);
     Utils.lookupPathFromDecorator(meta);
     options.name = options.name || propertyName;
@@ -40,7 +41,7 @@ export type PropertyOptions = {
   version?: boolean;
 };
 
-export interface ReferenceOptions<T extends IEntityType<T>> extends PropertyOptions {
+export interface ReferenceOptions<T extends AnyEntity<T>> extends PropertyOptions {
   entity?: string | (() => EntityName<T>);
   cascade?: Cascade[];
   eager?: boolean;

--- a/lib/decorators/Repository.ts
+++ b/lib/decorators/Repository.ts
@@ -1,9 +1,8 @@
-import { EntityClass, IEntity } from './Entity';
+import { AnyEntity, Constructor, EntityClass } from '../types';
 import { EntityRepository } from '../entity';
 import { MetadataStorage } from '../metadata';
-import { Constructor } from '../drivers';
 
-export function Repository<T extends IEntity>(entity: EntityClass<T>) {
+export function Repository<T extends AnyEntity>(entity: EntityClass<T>) {
   return function (target: Constructor<EntityRepository<T>>) {
     const meta = MetadataStorage.getMetadata(entity.name);
     meta.customRepository = () => target;

--- a/lib/decorators/SerializedPrimaryKey.ts
+++ b/lib/decorators/SerializedPrimaryKey.ts
@@ -3,16 +3,16 @@ import { ReferenceType } from '../entity';
 import { EntityProperty, AnyEntity, PropertyOptions } from '.';
 import { Utils } from '../utils';
 
-export function PrimaryKey(options: PrimaryKeyOptions = {}): Function {
+export function SerializedPrimaryKey(options: SerializedPrimaryKeyOptions = {}): Function {
   return function (target: AnyEntity, propertyName: string) {
     const meta = MetadataStorage.getMetadata(target.constructor.name);
     options.name = propertyName;
-    meta.primaryKey = propertyName;
-    meta.properties[propertyName] = Object.assign({ reference: ReferenceType.SCALAR, primary: true }, options) as EntityProperty;
+    meta.serializedPrimaryKey = propertyName;
+    meta.properties[propertyName] = Object.assign({ reference: ReferenceType.SCALAR }, options) as EntityProperty;
     Utils.lookupPathFromDecorator(meta);
   };
 }
 
-export interface PrimaryKeyOptions extends PropertyOptions {
+export interface SerializedPrimaryKeyOptions extends PropertyOptions {
   type?: any;
 }

--- a/lib/decorators/hooks.ts
+++ b/lib/decorators/hooks.ts
@@ -1,5 +1,5 @@
 import { MetadataStorage } from '../metadata';
-import { HookType } from './Entity';
+import { HookType } from '../types';
 
 export function BeforeCreate() {
   return hook('beforeCreate');

--- a/lib/decorators/index.ts
+++ b/lib/decorators/index.ts
@@ -1,4 +1,5 @@
 export * from './PrimaryKey';
+export * from './SerializedPrimaryKey';
 export * from './Entity';
 export * from './OneToOne';
 export * from './ManyToOne';
@@ -7,3 +8,4 @@ export { OneToMany, OneToManyOptions } from './OneToMany';
 export * from './Property';
 export * from './Repository';
 export * from './hooks';
+export * from '../types';

--- a/lib/drivers/IDatabaseDriver.ts
+++ b/lib/drivers/IDatabaseDriver.ts
@@ -1,4 +1,4 @@
-import { EntityData, EntityMetadata, EntityProperty, IEntity, IEntityType, IPrimaryKey } from '../decorators';
+import { EntityData, EntityMetadata, EntityProperty, AnyEntity, FilterQuery, Primary } from '../types';
 import { Connection, QueryResult, Transaction } from '../connections';
 import { QueryOrderMap } from '../query';
 import { Platform } from '../platforms';
@@ -16,29 +16,29 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   /**
    * Finds selection of entities
    */
-  find<T extends IEntity>(entityName: string, where: FilterQuery<T>, populate?: string[], orderBy?: QueryOrderMap, fields?: string[], limit?: number, offset?: number, ctx?: Transaction): Promise<T[]>;
+  find<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, populate?: string[], orderBy?: QueryOrderMap, fields?: string[], limit?: number, offset?: number, ctx?: Transaction): Promise<T[]>;
 
   /**
    * Finds single entity (table row, document)
    */
-  findOne<T extends IEntity>(entityName: string, where: FilterQuery<T> | IPrimaryKey, populate?: string[], orderBy?: QueryOrderMap, fields?: string[], lockMode?: LockMode, ctx?: Transaction): Promise<T | null>;
+  findOne<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, populate?: string[], orderBy?: QueryOrderMap, fields?: string[], lockMode?: LockMode, ctx?: Transaction): Promise<T | null>;
 
-  nativeInsert<T extends IEntity>(entityName: string, data: EntityData<T>, ctx?: Transaction): Promise<QueryResult>;
+  nativeInsert<T extends AnyEntity<T>>(entityName: string, data: EntityData<T>, ctx?: Transaction): Promise<QueryResult>;
 
-  nativeUpdate<T extends IEntity>(entityName: string, where: FilterQuery<T> | IPrimaryKey, data: EntityData<T>, ctx?: Transaction): Promise<QueryResult>;
+  nativeUpdate<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, data: EntityData<T>, ctx?: Transaction): Promise<QueryResult>;
 
-  nativeDelete<T extends IEntity>(entityName: string, where: FilterQuery<T> | IPrimaryKey, ctx?: Transaction): Promise<QueryResult>;
+  nativeDelete<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, ctx?: Transaction): Promise<QueryResult>;
 
-  count<T extends IEntity>(entityName: string, where: FilterQuery<T>, ctx?: Transaction): Promise<number>;
+  count<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, ctx?: Transaction): Promise<number>;
 
   aggregate(entityName: string, pipeline: any[]): Promise<any[]>;
 
-  mapResult<T extends IEntityType<T>>(result: EntityData<T>, meta: EntityMetadata): T | null;
+  mapResult<T extends AnyEntity<T>>(result: EntityData<T>, meta: EntityMetadata): T | null;
 
   /**
    * When driver uses pivot tables for M:N, this method will load identifiers for given collections from them
    */
-  loadFromPivotTable<T extends IEntity>(prop: EntityProperty, owners: IPrimaryKey[], ctx?: Transaction): Promise<Record<string, T[]>>;
+  loadFromPivotTable<T extends AnyEntity<T>>(prop: EntityProperty, owners: Primary<T>[], ctx?: Transaction): Promise<Record<string, T[]>>;
 
   getPlatform(): Platform;
 
@@ -51,13 +51,3 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   getDependencies(): string[];
 
 }
-
-export type DeepPartial<T> = {
-  [P in keyof T]?: T[P] extends (infer U)[]
-    ? DeepPartial<U>[]
-    : T[P] extends ReadonlyArray<infer U>
-      ? ReadonlyArray<DeepPartial<U>>
-      : DeepPartial<T[P]>
-};
-
-export type FilterQuery<T> = DeepPartial<T> | Record<string, any>;

--- a/lib/drivers/index.ts
+++ b/lib/drivers/index.ts
@@ -1,3 +1,4 @@
 export * from './IDatabaseDriver';
 export * from './DatabaseDriver';
 export * from './AbstractSqlDriver';
+export { Constructor } from '../types';

--- a/lib/entity/ArrayCollection.ts
+++ b/lib/entity/ArrayCollection.ts
@@ -1,15 +1,16 @@
-import { EntityProperty, IEntityType, IPrimaryKey } from '../decorators';
+import { Dictionary, EntityProperty, AnyEntity, IPrimaryKey, Primary } from '../types';
 import { ReferenceType } from './enums';
 import { Collection } from './Collection';
+import { wrap } from './EntityHelper';
 
-export class ArrayCollection<T extends IEntityType<T>> {
+export class ArrayCollection<T extends AnyEntity<T>> {
 
   [k: number]: T;
 
   protected readonly items: T[] = [];
   private _property: EntityProperty;
 
-  constructor(readonly owner: IEntityType<any>, items?: T[]) {
+  constructor(readonly owner: AnyEntity, items?: T[]) {
     if (items) {
       this.items = items;
       Object.assign(this, items);
@@ -20,25 +21,25 @@ export class ArrayCollection<T extends IEntityType<T>> {
     return [...this.items];
   }
 
-  toArray(): Record<string, any>[] {
+  toArray(): Dictionary[] {
     return this.getItems().map(item => {
-      const meta = this.owner.__em.getMetadata().get(item.constructor.name);
+      const meta = wrap(this.owner).__em.getMetadata().get(item.constructor.name);
       const args = [...meta.toJsonParams.map(() => undefined), [this.property.name]];
 
-      return item.toJSON(...args);
+      return wrap(item).toJSON(...args);
     });
   }
 
-  getIdentifiers(field?: string): IPrimaryKey[] {
+  getIdentifiers<U extends IPrimaryKey = Primary<T> & IPrimaryKey>(field?: string): U[] {
     const items = this.getItems();
 
     if (items.length === 0) {
       return [];
     }
 
-    field = field || this.items[0].__serializedPrimaryKeyField;
+    field = field || wrap(this.items[0]).__meta.serializedPrimaryKey;
 
-    return this.getItems().map(i => i[field as keyof T]);
+    return this.getItems().map(i => i[field as keyof T]) as unknown as U[];
   }
 
   add(...items: T[]): void {
@@ -59,7 +60,7 @@ export class ArrayCollection<T extends IEntityType<T>> {
 
   remove(...items: T[]): void {
     for (const item of items) {
-      const idx = this.items.findIndex(i => i.__serializedPrimaryKey === item.__serializedPrimaryKey);
+      const idx = this.items.findIndex(i => wrap(i).__serializedPrimaryKey === wrap(item).__serializedPrimaryKey);
 
       if (idx !== -1) {
         delete this[this.items.length - 1]; // remove last item
@@ -78,7 +79,7 @@ export class ArrayCollection<T extends IEntityType<T>> {
   contains(item: T): boolean {
     return !!this.items.find(i => {
       const objectIdentity = i === item;
-      const primaryKeyIdentity = !!i.__primaryKey && !!item.__primaryKey && i.__serializedPrimaryKey === item.__serializedPrimaryKey;
+      const primaryKeyIdentity = !!wrap(i).__primaryKey && !!wrap(item).__primaryKey && wrap(i).__serializedPrimaryKey === wrap(item).__serializedPrimaryKey;
 
       return objectIdentity || primaryKeyIdentity;
     });
@@ -107,18 +108,18 @@ export class ArrayCollection<T extends IEntityType<T>> {
   }
 
   protected propagateToInverseSide(item: T, method: 'add' | 'remove'): void {
-    const collection = item[this.property.inversedBy as keyof T] as Collection<T>;
+    const collection = item[this.property.inversedBy as keyof T] as unknown as Collection<T>;
 
     if (this.shouldPropagateToCollection(collection, method)) {
-      collection[method](this.owner);
+      collection[method](this.owner as T);
     }
   }
 
   protected propagateToOwningSide(item: T, method: 'add' | 'remove'): void {
-    const collection = item[this.property.mappedBy as keyof T] as Collection<T>;
+    const collection = item[this.property.mappedBy as keyof T] as unknown as Collection<T>;
 
     if (this.property.reference === ReferenceType.MANY_TO_MANY && this.shouldPropagateToCollection(collection, method)) {
-      collection[method](this.owner);
+      collection[method](this.owner as T);
     } else if (this.property.reference === ReferenceType.ONE_TO_MANY) {
       const value = method === 'add' ? this.owner : null;
       item[this.property.mappedBy as keyof T] = value as T[keyof T];
@@ -131,16 +132,16 @@ export class ArrayCollection<T extends IEntityType<T>> {
     }
 
     if (method === 'add') {
-      return !collection.contains(this.owner);
+      return !collection.contains(this.owner as T);
     }
 
     // remove
-    return collection.contains(this.owner);
+    return collection.contains(this.owner as T);
   }
 
   protected get property() {
     if (!this._property) {
-      const meta = this.owner.__em.getMetadata().get(this.owner.constructor.name);
+      const meta = wrap(this.owner).__em.getMetadata().get(this.owner.constructor.name);
       const field = Object.keys(meta.properties).find(k => this.owner[k] === this);
       this._property = meta.properties[field!];
     }

--- a/lib/entity/EntityHelper.ts
+++ b/lib/entity/EntityHelper.ts
@@ -1,39 +1,40 @@
 import { v4 as uuid } from 'uuid';
 import { EntityManager } from '../EntityManager';
-import { EntityClass, EntityData, EntityMetadata, IEntity, IEntityType, IPrimaryKey } from '../decorators';
+import { EntityData, EntityMetadata, AnyEntity, IWrappedEntity, Primary, WrappedEntity } from '../types';
 import { EntityTransformer } from './EntityTransformer';
 import { AssignOptions, EntityAssigner } from './EntityAssigner';
 import { LockMode } from '../unit-of-work';
 
 export class EntityHelper {
 
-  static async init(entity: IEntity, populated = true, lockMode?: LockMode): Promise<IEntity> {
-    await entity.__em.findOne(entity.constructor.name, entity.__primaryKey, { refresh: true, lockMode });
-    entity.populated(populated);
+  static async init<T extends AnyEntity<T>>(entity: T, populated = true, lockMode?: LockMode): Promise<T> {
+    await wrap(entity).__em.findOne(entity.constructor.name, entity, { refresh: true, lockMode });
+    wrap(entity).populated(populated);
     Object.defineProperty(entity, '__lazyInitialized', { value: true, writable: true });
 
     return entity;
   }
 
-  static decorate<T extends IEntityType<T>>(meta: EntityMetadata<T>, em: EntityManager): void {
+  static decorate<T extends AnyEntity<T>>(meta: EntityMetadata<T>, em: EntityManager): void {
     const pk = meta.properties[meta.primaryKey];
 
-    if (pk.name === '_id' && !meta.properties.id) {
+    if (pk.name === '_id') {
       EntityHelper.defineIdProperty(meta, em);
     }
 
     EntityHelper.defineBaseProperties(meta, em);
     EntityHelper.definePrimaryKeyProperties(meta);
+    const prototype = meta.prototype as IWrappedEntity<T, keyof T> & T;
 
-    if (!meta.prototype.assign) { // assign can be overridden
-      meta.prototype.assign = function (data: EntityData<T>, options?: AssignOptions): T {
-        return EntityAssigner.assign(this, data, options);
+    if (!prototype.assign) { // assign can be overridden
+      prototype.assign = function (this: T, data: EntityData<T>, options?: AssignOptions): IWrappedEntity<T, keyof T> & T {
+        return EntityAssigner.assign<T>(this, data, options) as IWrappedEntity<T, keyof T> & T;
       };
     }
 
-    if (!meta.prototype.toJSON) { // toJSON can be overridden
-      meta.prototype.toJSON = function (...args: any[]) {
-        return EntityTransformer.toObject(this, ...args.slice(meta.toJsonParams.length));
+    if (!prototype.toJSON) { // toJSON can be overridden
+      prototype.toJSON = function (this: T, ...args: any[]) {
+        return EntityTransformer.toObject<T>(this, ...args.slice(meta.toJsonParams.length));
       };
     }
   }
@@ -41,7 +42,7 @@ export class EntityHelper {
   /**
    * defines magic id property getter/setter if PK property is `_id` and there is no `id` property defined
    */
-  private static defineIdProperty<T extends IEntityType<T>>(meta: EntityMetadata<T>, em: EntityManager): void {
+  private static defineIdProperty<T extends AnyEntity<T>>(meta: EntityMetadata<T>, em: EntityManager): void {
     Object.defineProperty(meta.prototype, 'id', {
       get(): string | null {
         return this._id ? em.getDriver().getPlatform().normalizePrimaryKey<string>(this._id) : null;
@@ -52,7 +53,7 @@ export class EntityHelper {
     });
   }
 
-  private static defineBaseProperties<T extends IEntityType<T>>(meta: EntityMetadata<T>, em: EntityManager) {
+  private static defineBaseProperties<T extends AnyEntity<T>>(meta: EntityMetadata<T>, em: EntityManager) {
     Object.defineProperties(meta.prototype, {
       __populated: { value: false, writable: true },
       __lazyInitialized: { value: false, writable: true },
@@ -70,41 +71,50 @@ export class EntityHelper {
       },
     });
 
-    meta.prototype.isInitialized = function () {
+    const prototype = meta.prototype as IWrappedEntity<T, keyof T> & T;
+
+    prototype.isInitialized = function (this: IWrappedEntity<T, keyof T>) {
       return this.__initialized !== false;
     };
 
-    meta.prototype.populated = function (populated = true) {
+    prototype.populated = function (this: T, populated: boolean = true) {
       Object.defineProperty(this, '__populated', { value: populated, writable: true });
     };
 
-    meta.prototype.toObject = function (ignoreFields: string[] = []) {
+    prototype.toObject = function (this: T, ignoreFields: string[] = []) {
       return EntityTransformer.toObject(this, ignoreFields);
     };
 
-    meta.prototype.init = function (populated = true) {
-      return EntityHelper.init(this, populated) as Promise<EntityClass<T> & T>;
+    prototype.init = function (this: T, populated: boolean = true): Promise<IWrappedEntity<T, keyof T> & T> {
+      return EntityHelper.init<T>(this as T, populated) as Promise<IWrappedEntity<T, keyof T> & T>;
     };
   }
 
-  private static definePrimaryKeyProperties<T extends IEntityType<T>>(meta: EntityMetadata<T>) {
+  private static definePrimaryKeyProperties<T extends AnyEntity<T>>(meta: EntityMetadata<T>) {
     Object.defineProperties(meta.prototype, {
       __primaryKeyField: { value: meta.primaryKey },
       __primaryKey: {
-        get(): IPrimaryKey {
+        get(): Primary<T> {
           return this[meta.primaryKey];
         },
-        set(id: IPrimaryKey): void {
+        set(id: Primary<T>): void {
           this[meta.primaryKey] = id;
         },
       },
       __serializedPrimaryKeyField: { value: meta.serializedPrimaryKey },
       __serializedPrimaryKey: {
-        get(): IPrimaryKey {
+        get(): Primary<T> {
           return this[meta.serializedPrimaryKey];
         },
       },
     });
   }
 
+}
+
+/**
+ * wraps entity type with AnyEntity internal properties and helpers like init/isInitialized/populated/toJSON
+ */
+export function wrap<T>(entity: T): T & WrappedEntity<T, keyof T> {
+  return entity as T & WrappedEntity<T, keyof T>;
 }

--- a/lib/entity/EntityIdentifier.ts
+++ b/lib/entity/EntityIdentifier.ts
@@ -1,4 +1,4 @@
-import { IPrimaryKey } from '../decorators';
+import { IPrimaryKey } from '../types';
 
 export class EntityIdentifier {
 
@@ -8,7 +8,7 @@ export class EntityIdentifier {
     this.value = value;
   }
 
-  getValue<T = IPrimaryKey>(): T {
+  getValue<T extends IPrimaryKey = IPrimaryKey>(): T {
     return this.value as T;
   }
 

--- a/lib/entity/EntityRepository.ts
+++ b/lib/entity/EntityRepository.ts
@@ -1,22 +1,22 @@
 import { EntityManager, FindOneOptions, FindOneOrFailOptions, FindOptions } from '../EntityManager';
-import { EntityData, EntityName, IEntity, IEntityType, IPrimaryKey } from '../decorators';
+import { EntityData, EntityName, AnyEntity, Primary } from '../types';
 import { QueryBuilder, QueryOrderMap } from '../query';
 import { FilterQuery, IdentifiedReference, Reference } from '..';
 
-export class EntityRepository<T extends IEntityType<T>> {
+export class EntityRepository<T extends AnyEntity<T>> {
 
   constructor(private readonly em: EntityManager,
               protected readonly entityName: EntityName<T>) { }
 
-  persist(entity: T | IEntity[], flush = this.em.config.get('autoFlush')): void | Promise<void> {
+  persist(entity: AnyEntity | AnyEntity[], flush = this.em.config.get('autoFlush')): void | Promise<void> {
     return this.em.persist(entity, flush);
   }
 
-  async persistAndFlush(entity: IEntity | IEntity[]): Promise<void> {
+  async persistAndFlush(entity: AnyEntity | AnyEntity[]): Promise<void> {
     await this.em.persistAndFlush(entity);
   }
 
-  persistLater(entity: IEntity | IEntity[]): void {
+  persistLater(entity: AnyEntity | AnyEntity[]): void {
     this.em.persistLater(entity);
   }
 
@@ -24,27 +24,27 @@ export class EntityRepository<T extends IEntityType<T>> {
     return this.em.createQueryBuilder(this.entityName, alias);
   }
 
-  async findOne(where: FilterQuery<T> | IPrimaryKey, populate?: string[] | boolean, orderBy?: QueryOrderMap): Promise<T | null>; // tslint:disable-next-line:lines-between-class-members
-  async findOne(where: FilterQuery<T> | IPrimaryKey, populate?: FindOneOptions, orderBy?: QueryOrderMap): Promise<T | null>; // tslint:disable-next-line:lines-between-class-members
-  async findOne(where: FilterQuery<T> | IPrimaryKey, populate: string[] | boolean | FindOneOptions = [], orderBy?: QueryOrderMap): Promise<T | null> {
+  async findOne(where: FilterQuery<T>, populate?: string[] | boolean, orderBy?: QueryOrderMap): Promise<T | null>; // tslint:disable-next-line:lines-between-class-members
+  async findOne(where: FilterQuery<T>, populate?: FindOneOptions, orderBy?: QueryOrderMap): Promise<T | null>; // tslint:disable-next-line:lines-between-class-members
+  async findOne(where: FilterQuery<T>, populate: string[] | boolean | FindOneOptions = [], orderBy?: QueryOrderMap): Promise<T | null> {
     return this.em.findOne<T>(this.entityName, where, populate as string[], orderBy);
   }
 
-  async findOneOrFail(where: FilterQuery<T> | IPrimaryKey, populate?: string[] | boolean, orderBy?: QueryOrderMap): Promise<T>; // tslint:disable-next-line:lines-between-class-members
-  async findOneOrFail(where: FilterQuery<T> | IPrimaryKey, populate?: FindOneOrFailOptions, orderBy?: QueryOrderMap): Promise<T>; // tslint:disable-next-line:lines-between-class-members
-  async findOneOrFail(where: FilterQuery<T> | IPrimaryKey, populate: string[] | boolean | FindOneOrFailOptions = [], orderBy?: QueryOrderMap): Promise<T> {
+  async findOneOrFail(where: FilterQuery<T>, populate?: string[] | boolean, orderBy?: QueryOrderMap): Promise<T>; // tslint:disable-next-line:lines-between-class-members
+  async findOneOrFail(where: FilterQuery<T>, populate?: FindOneOrFailOptions, orderBy?: QueryOrderMap): Promise<T>; // tslint:disable-next-line:lines-between-class-members
+  async findOneOrFail(where: FilterQuery<T>, populate: string[] | boolean | FindOneOrFailOptions = [], orderBy?: QueryOrderMap): Promise<T> {
     return this.em.findOneOrFail<T>(this.entityName, where, populate as string[], orderBy);
   }
 
-  async find(where: FilterQuery<T> | IPrimaryKey, options?: FindOptions): Promise<T[]>; // tslint:disable-next-line:lines-between-class-members
-  async find(where: FilterQuery<T> | IPrimaryKey, populate?: string[] | boolean, orderBy?: QueryOrderMap, limit?: number, offset?: number): Promise<T[]>; // tslint:disable-next-line:lines-between-class-members
-  async find(where: FilterQuery<T> | IPrimaryKey, populate: string[] | boolean | FindOptions = [], orderBy: QueryOrderMap = {}, limit?: number, offset?: number): Promise<T[]> {
+  async find(where: FilterQuery<T>, options?: FindOptions): Promise<T[]>; // tslint:disable-next-line:lines-between-class-members
+  async find(where: FilterQuery<T>, populate?: string[] | boolean, orderBy?: QueryOrderMap, limit?: number, offset?: number): Promise<T[]>; // tslint:disable-next-line:lines-between-class-members
+  async find(where: FilterQuery<T>, populate: string[] | boolean | FindOptions = [], orderBy: QueryOrderMap = {}, limit?: number, offset?: number): Promise<T[]> {
     return this.em.find<T>(this.entityName, where as FilterQuery<T>, populate as string[], orderBy, limit, offset);
   }
 
-  async findAndCount(where: FilterQuery<T> | IPrimaryKey, options?: FindOptions): Promise<[T[], number]>; // tslint:disable-next-line:lines-between-class-members
-  async findAndCount(where: FilterQuery<T> | IPrimaryKey, populate?: string[] | boolean, orderBy?: QueryOrderMap, limit?: number, offset?: number): Promise<[T[], number]>; // tslint:disable-next-line:lines-between-class-members
-  async findAndCount(where: FilterQuery<T> | IPrimaryKey, populate: string[] | boolean | FindOptions = [], orderBy: QueryOrderMap = {}, limit?: number, offset?: number): Promise<[T[], number]> {
+  async findAndCount(where: FilterQuery<T>, options?: FindOptions): Promise<[T[], number]>; // tslint:disable-next-line:lines-between-class-members
+  async findAndCount(where: FilterQuery<T>, populate?: string[] | boolean, orderBy?: QueryOrderMap, limit?: number, offset?: number): Promise<[T[], number]>; // tslint:disable-next-line:lines-between-class-members
+  async findAndCount(where: FilterQuery<T>, populate: string[] | boolean | FindOptions = [], orderBy: QueryOrderMap = {}, limit?: number, offset?: number): Promise<[T[], number]> {
     return this.em.findAndCount<T>(this.entityName, where as FilterQuery<T>, populate as string[], orderBy, limit, offset);
   }
 
@@ -54,15 +54,15 @@ export class EntityRepository<T extends IEntityType<T>> {
     return this.em.find<T>(this.entityName, {}, populate as string[], orderBy, limit, offset);
   }
 
-  remove(where: T | FilterQuery<T> | IPrimaryKey, flush = this.em.config.get('autoFlush')): void | Promise<number> {
+  remove(where: T | FilterQuery<T>, flush = this.em.config.get('autoFlush')): void | Promise<number> {
     return this.em.remove(this.entityName, where, flush);
   }
 
-  async removeAndFlush(entity: IEntity): Promise<void> {
+  async removeAndFlush(entity: AnyEntity): Promise<void> {
     await this.em.removeAndFlush(entity);
   }
 
-  removeLater(entity: IEntity): void {
+  removeLater(entity: AnyEntity): void {
     this.em.removeLater(entity);
   }
 
@@ -70,8 +70,8 @@ export class EntityRepository<T extends IEntityType<T>> {
     return this.em.flush();
   }
 
-  async nativeInsert(data: EntityData<T>): Promise<IPrimaryKey> {
-    return this.em.nativeInsert(this.entityName, data);
+  async nativeInsert(data: EntityData<T>): Promise<Primary<T>> {
+    return this.em.nativeInsert<T>(this.entityName, data);
   }
 
   async nativeUpdate(where: FilterQuery<T>, data: EntityData<T>): Promise<number> {
@@ -93,12 +93,12 @@ export class EntityRepository<T extends IEntityType<T>> {
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<PK extends keyof T>(id: IPrimaryKey, wrapped: true): IdentifiedReference<T, PK>; // tslint:disable-next-line:lines-between-class-members
-  getReference(id: IPrimaryKey): T; // tslint:disable-next-line:lines-between-class-members
-  getReference(id: IPrimaryKey, wrapped: false): T; // tslint:disable-next-line:lines-between-class-members
-  getReference(id: IPrimaryKey, wrapped: true): Reference<T>; // tslint:disable-next-line:lines-between-class-members
-  getReference(id: IPrimaryKey, wrapped: boolean): T | Reference<T>; // tslint:disable-next-line:lines-between-class-members
-  getReference(id: IPrimaryKey, wrapped = false): T | Reference<T> {
+  getReference<PK extends keyof T>(id: Primary<T>, wrapped: true): IdentifiedReference<T, PK>;
+  getReference<PK extends keyof T = keyof T>(id: Primary<T>): T;
+  getReference<PK extends keyof T = keyof T>(id: Primary<T>, wrapped: false): T;
+  getReference<PK extends keyof T = keyof T>(id: Primary<T>, wrapped: true): Reference<T>;
+  getReference<PK extends keyof T = keyof T>(id: Primary<T>, wrapped: boolean): T | Reference<T>;
+  getReference<PK extends keyof T = keyof T>(id: Primary<T>, wrapped = false): T | Reference<T> {
     return this.em.getReference<T>(this.entityName, id, wrapped);
   }
 
@@ -114,7 +114,7 @@ export class EntityRepository<T extends IEntityType<T>> {
   }
 
   async count(where: FilterQuery<T> = {}): Promise<number> {
-    return this.em.count(this.entityName, where);
+    return this.em.count<T>(this.entityName, where);
   }
 
 }

--- a/lib/entity/EntityTransformer.ts
+++ b/lib/entity/EntityTransformer.ts
@@ -1,61 +1,63 @@
 import { Utils } from '../utils';
 import { ArrayCollection } from './ArrayCollection';
 import { Collection } from './Collection';
-import { EntityData, EntityMetadata, IEntity, IEntityType } from '../decorators';
+import { EntityData, EntityMetadata, EntityProperty, AnyEntity, IPrimaryKey } from '../types';
 import { Reference } from './Reference';
+import { wrap } from './EntityHelper';
 
 export class EntityTransformer {
 
-  static toObject<T extends IEntityType<T>>(entity: T, ignoreFields: string[] = []): EntityData<T> {
-    const platform = entity.__em.getDriver().getPlatform();
-    const pk = platform.getSerializedPrimaryKeyField(entity.__primaryKeyField);
-    const meta = entity.__em.getMetadata().get<T>(entity.constructor.name);
+  static toObject<T extends AnyEntity<T>>(entity: T, ignoreFields: string[] = []): EntityData<T> {
+    const wrapped = wrap(entity);
+    const platform = wrapped.__em.getDriver().getPlatform();
+    const pk = platform.getSerializedPrimaryKeyField(wrapped.__meta.primaryKey);
+    const meta = wrapped.__meta;
     const pkProp = meta.properties[meta.primaryKey];
-    const ret = (entity.__primaryKey && !pkProp.hidden ? { [pk]: platform.normalizePrimaryKey(entity.__primaryKey) } : {}) as EntityData<T>;
+    const ret = (wrapped.__primaryKey && !pkProp.hidden ? { [pk]: platform.normalizePrimaryKey(wrapped.__primaryKey as IPrimaryKey) } : {}) as EntityData<T>;
 
-    if (!entity.isInitialized() && entity.__primaryKey) {
+    if (!wrapped.isInitialized() && wrapped.__primaryKey) {
       return ret;
     }
 
     // normal properties
     Object.keys(entity)
-      .filter(prop => this.isVisible(meta, prop as keyof T & string, entity, ignoreFields))
+      .filter(prop => this.isVisible(meta, prop as keyof T & string, ignoreFields))
       .map(prop => [prop, EntityTransformer.processProperty<T>(prop as keyof T, entity, ignoreFields)])
       .filter(([, value]) => typeof value !== 'undefined')
-      .forEach(([prop, value]) => ret[prop!] = value);
+      .forEach(([prop, value]) => ret[prop! as keyof T] = value as T[keyof T]);
 
     // decorated getters
-    Object.values(meta.properties)
+    Object.values<EntityProperty<T>>(meta.properties)
       .filter(prop => prop.getter && !prop.hidden && typeof entity[prop.name] !== 'undefined')
       .forEach(prop => ret[prop.name] = entity[prop.name]);
 
     // decorated get methods
-    Object.values(meta.properties)
-      .filter(prop => prop.getterName && !prop.hidden && entity[prop.getterName] as object instanceof Function)
-      .forEach(prop => ret[prop.name] = entity[prop.getterName!]());
+    Object.values<EntityProperty<T>>(meta.properties)
+      .filter(prop => prop.getterName && !prop.hidden && entity[prop.getterName] as unknown instanceof Function)
+      .forEach(prop => ret[prop.name] = (entity[prop.getterName!] as unknown as () => void)());
 
     return ret;
   }
 
-  private static isVisible<T extends IEntityType<T>>(meta: EntityMetadata<T>, prop: keyof T & string, entity: T, ignoreFields: string[]): boolean {
+  private static isVisible<T extends AnyEntity<T>>(meta: EntityMetadata<T>, prop: keyof T & string, ignoreFields: string[]): boolean {
     const hidden = meta.properties[prop] && !meta.properties[prop].hidden;
-    return hidden && prop !== entity.__primaryKeyField && !prop.startsWith('_') && !ignoreFields.includes(prop);
+    return hidden && prop !== meta.primaryKey && !prop.startsWith('_') && !ignoreFields.includes(prop);
   }
 
-  private static processProperty<T extends IEntityType<T>>(prop: keyof T, entity: T, ignoreFields: string[]): T[keyof T] | undefined {
-    if (entity[prop] as object instanceof ArrayCollection) {
+  private static processProperty<T extends AnyEntity<T>>(prop: keyof T, entity: T, ignoreFields: string[]): T[keyof T] | undefined {
+    if (entity[prop] as unknown instanceof ArrayCollection) {
       return EntityTransformer.processCollection(prop, entity);
     }
 
-    if (Utils.isEntity(entity[prop]) || entity[prop] as object instanceof Reference) {
+    if (Utils.isEntity(entity[prop]) || entity[prop] as unknown instanceof Reference) {
       return EntityTransformer.processEntity(prop, entity, ignoreFields);
     }
 
     return entity[prop];
   }
 
-  private static processEntity<T extends IEntityType<T>>(prop: keyof T, entity: T, ignoreFields: string[]): T[keyof T] | undefined {
-    const child = entity[prop] as IEntity | Reference<T>;
+  private static processEntity<T extends AnyEntity<T>>(prop: keyof T, entity: T, ignoreFields: string[]): T[keyof T] | undefined {
+    const child = wrap(entity[prop] as unknown as T | Reference<T>);
     const platform = child.__em.getDriver().getPlatform();
 
     if (child.isInitialized() && child.__populated && child !== entity && !child.__lazyInitialized) {
@@ -63,18 +65,18 @@ export class EntityTransformer {
       return child.toJSON(...args) as T[keyof T];
     }
 
-    return platform.normalizePrimaryKey(child.__primaryKey);
+    return platform.normalizePrimaryKey(child.__primaryKey as IPrimaryKey) as unknown as T[keyof T];
   }
 
-  private static processCollection<T extends IEntityType<T>>(prop: keyof T, entity: T): T[keyof T] | undefined {
-    const col = entity[prop] as Collection<IEntity>;
+  private static processCollection<T extends AnyEntity<T>>(prop: keyof T, entity: T): T[keyof T] | undefined {
+    const col = entity[prop] as unknown as Collection<AnyEntity>;
 
     if (col.isInitialized(true) && col.shouldPopulate()) {
-      return col.toArray() as T[keyof T];
+      return col.toArray() as unknown as T[keyof T];
     }
 
     if (col.isInitialized()) {
-      return col.getIdentifiers() as T[keyof T];
+      return col.getIdentifiers() as unknown as T[keyof T];
     }
   }
 

--- a/lib/hydration/Hydrator.ts
+++ b/lib/hydration/Hydrator.ts
@@ -1,5 +1,5 @@
-import { IDatabaseDriver } from '..';
-import { EntityData, EntityMetadata, EntityProperty, IEntityType } from '../decorators';
+import { IDatabaseDriver, wrap } from '..';
+import { EntityData, EntityMetadata, EntityProperty, AnyEntity } from '../types';
 import { EntityFactory } from '../entity';
 
 export abstract class Hydrator {
@@ -7,18 +7,18 @@ export abstract class Hydrator {
   constructor(protected readonly factory: EntityFactory,
               protected readonly driver: IDatabaseDriver) { }
 
-  hydrate<T extends IEntityType<T>>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>): void {
+  hydrate<T extends AnyEntity<T>>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>): void {
     if (data[meta.primaryKey]) {
-      entity.__primaryKey = data[meta.primaryKey];
+      wrap(entity).__primaryKey = data[meta.primaryKey];
     }
 
     // then process user defined properties (ignore not defined keys in `data`)
-    Object.values(meta.properties).forEach(prop => {
+    Object.values<EntityProperty>(meta.properties).forEach(prop => {
       const value = data[prop.name];
       this.hydrateProperty(entity, prop, value);
     });
   }
 
-  protected abstract hydrateProperty<T extends IEntityType<T>>(entity: T, prop: EntityProperty, value: EntityData<T>[any]): void;
+  protected abstract hydrateProperty<T extends AnyEntity<T>>(entity: T, prop: EntityProperty, value: EntityData<T>[any]): void;
 
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,7 @@
+export {
+  Constructor, Dictionary, PrimaryKeyType, Primary, IPrimaryKey, FilterQuery, IWrappedEntity, EntityName, EntityData,
+  AnyEntity, WrappedEntity, IdEntity, UuidEntity, MongoEntity, EntityProperty, EntityMetadata,
+} from './types';
 export * from './MikroORM';
 export * from './entity';
 export * from './EntityManager';
@@ -16,8 +20,8 @@ export * from './metadata/JavaScriptMetadataProvider';
 export * from './metadata/TypeScriptMetadataProvider';
 export * from './cache';
 export {
-  Entity, IEntity, EntityOptions, OneToMany, OneToManyOptions, OneToOne, OneToOneOptions, ManyToOne, ManyToOneOptions,
-  ManyToMany, ManyToManyOptions, Property, PropertyOptions, IPrimaryKey, PrimaryKey, PrimaryKeyOptions, Repository,
+  Entity, EntityOptions, OneToMany, OneToManyOptions, OneToOne, OneToOneOptions, ManyToOne, ManyToOneOptions,
+  ManyToMany, ManyToManyOptions, Property, PropertyOptions, PrimaryKey, PrimaryKeyOptions, Repository,
 } from './decorators';
 export * from './decorators/hooks';
 export * from './query/enums';

--- a/lib/metadata/JavaScriptMetadataProvider.ts
+++ b/lib/metadata/JavaScriptMetadataProvider.ts
@@ -1,5 +1,5 @@
 import { MetadataProvider } from './MetadataProvider';
-import { EntityMetadata, EntityProperty } from '../decorators';
+import { EntityMetadata, EntityProperty } from '../types';
 import { Utils } from '../utils';
 import { Cascade, ReferenceType } from '../entity';
 
@@ -30,7 +30,7 @@ export class JavaScriptMetadataProvider extends MetadataProvider {
       if (Utils.isObject(prop)) {
         Object.entries(prop).forEach(([attribute, value]) => {
           if (!(attribute in meta.properties[name])) {
-            meta.properties[name][attribute as keyof EntityProperty] = value;
+            meta.properties[name][attribute] = value;
           }
         });
       }

--- a/lib/metadata/MetadataDiscovery.ts
+++ b/lib/metadata/MetadataDiscovery.ts
@@ -2,7 +2,7 @@ import { extname } from 'path';
 import globby from 'globby';
 import chalk from 'chalk';
 
-import { EntityClass, EntityClassGroup, EntityMetadata, EntityProperty, IEntityType } from '../decorators';
+import { EntityClass, EntityClassGroup, EntityMetadata, EntityProperty, AnyEntity } from '../types';
 import { Configuration, Logger, Utils, ValidationError } from '../utils';
 import { MetadataValidator } from './MetadataValidator';
 import { MetadataStorage } from './MetadataStorage';
@@ -83,7 +83,7 @@ export class MetadataDiscovery {
     }
   }
 
-  private prepare<T extends IEntityType<T>>(entity: EntityClass<T> | EntityClassGroup<T>): EntityClass<T> {
+  private prepare<T extends AnyEntity<T>>(entity: EntityClass<T> | EntityClassGroup<T>): EntityClass<T> {
     // save path to entity from schema
     if ('entity' in entity && 'schema' in entity) {
       const schema = entity.schema;
@@ -96,7 +96,7 @@ export class MetadataDiscovery {
     return entity;
   }
 
-  private async discoverEntity<T extends IEntityType<T>>(entity: EntityClass<T> | EntityClassGroup<T>, path?: string): Promise<void> {
+  private async discoverEntity<T extends AnyEntity<T>>(entity: EntityClass<T> | EntityClassGroup<T>, path?: string): Promise<void> {
     entity = this.prepare(entity);
     this.logger.log('discovery', `- processing entity ${chalk.cyan(entity.name)}`);
 
@@ -125,7 +125,7 @@ export class MetadataDiscovery {
     this.discovered.push(meta);
   }
 
-  private async saveToCache<T extends IEntityType<T>>(meta: EntityMetadata, entity: EntityClass<T>): Promise<void> {
+  private async saveToCache<T extends AnyEntity<T>>(meta: EntityMetadata, entity: EntityClass<T>): Promise<void> {
     const copy = Object.assign({}, meta);
     delete copy.prototype;
 

--- a/lib/metadata/MetadataProvider.ts
+++ b/lib/metadata/MetadataProvider.ts
@@ -1,4 +1,4 @@
-import { EntityMetadata } from '../decorators';
+import { EntityMetadata } from '../types';
 import { Configuration, Utils } from '../utils';
 
 export abstract class MetadataProvider {

--- a/lib/metadata/MetadataStorage.ts
+++ b/lib/metadata/MetadataStorage.ts
@@ -1,4 +1,4 @@
-import { EntityMetadata, IEntityType } from '../decorators';
+import { EntityMetadata, AnyEntity } from '../types';
 import { Utils, ValidationError } from '../utils';
 import { EntityManager } from '../EntityManager';
 import { EntityHelper } from '../entity';
@@ -13,8 +13,8 @@ export class MetadataStorage {
   }
 
   static getMetadata(): Record<string, EntityMetadata>; // tslint:disable-next-line:lines-between-class-members
-  static getMetadata<T extends IEntityType<T> = any>(entity: string): EntityMetadata<T>; // tslint:disable-next-line:lines-between-class-members
-  static getMetadata<T extends IEntityType<T> = any>(entity?: string): Record<string, EntityMetadata> | EntityMetadata<T> {
+  static getMetadata<T extends AnyEntity<T> = any>(entity: string): EntityMetadata<T>; // tslint:disable-next-line:lines-between-class-members
+  static getMetadata<T extends AnyEntity<T> = any>(entity?: string): Record<string, EntityMetadata> | EntityMetadata<T> {
     if (entity && !MetadataStorage.metadata[entity]) {
       MetadataStorage.metadata[entity] = { properties: {}, hooks: {} } as EntityMetadata;
     }
@@ -34,7 +34,7 @@ export class MetadataStorage {
     return this.metadata;
   }
 
-  get<T extends IEntityType<T> = any>(entity: string, init = false, validate = true): EntityMetadata<T> {
+  get<T extends AnyEntity<T> = any>(entity: string, init = false, validate = true): EntityMetadata<T> {
     if (entity && !this.metadata[entity] && validate && !init) {
       throw ValidationError.missingMetadata(entity);
     }

--- a/lib/metadata/MetadataValidator.ts
+++ b/lib/metadata/MetadataValidator.ts
@@ -1,4 +1,4 @@
-import { EntityMetadata, EntityProperty } from '../decorators';
+import { EntityMetadata, EntityProperty } from '../types';
 import { Utils, ValidationError } from '../utils';
 import { ReferenceType } from '../entity';
 import { MetadataStorage } from './MetadataStorage';

--- a/lib/metadata/TypeScriptMetadataProvider.ts
+++ b/lib/metadata/TypeScriptMetadataProvider.ts
@@ -2,7 +2,7 @@ import { Project, PropertyDeclaration, SourceFile } from 'ts-morph';
 import { pathExists } from 'fs-extra';
 
 import { MetadataProvider } from './MetadataProvider';
-import { EntityMetadata, EntityProperty } from '../decorators';
+import { EntityMetadata, EntityProperty } from '../types';
 import { Utils } from '../utils';
 
 export class TypeScriptMetadataProvider extends MetadataProvider {

--- a/lib/platforms/MongoPlatform.ts
+++ b/lib/platforms/MongoPlatform.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from 'mongodb';
 import { Platform } from './Platform';
 import { MongoNamingStrategy, NamingStrategy } from '../naming-strategy';
-import { IPrimaryKey } from '../decorators';
+import { IPrimaryKey, Primary } from '../types';
 import { SchemaHelper } from '../schema';
 
 export class MongoPlatform extends Platform {
@@ -20,7 +20,7 @@ export class MongoPlatform extends Platform {
     return MongoNamingStrategy;
   }
 
-  normalizePrimaryKey<T = number | string>(data: IPrimaryKey | ObjectId): T {
+  normalizePrimaryKey<T = number | string>(data: Primary<T> | IPrimaryKey | ObjectId): T {
     if (data instanceof ObjectId) {
       return data.toHexString() as unknown as T;
     }

--- a/lib/platforms/Platform.ts
+++ b/lib/platforms/Platform.ts
@@ -1,5 +1,5 @@
 import { NamingStrategy, UnderscoreNamingStrategy } from '../naming-strategy';
-import { IPrimaryKey } from '../decorators';
+import { IPrimaryKey, Primary } from '../types';
 import { SchemaHelper } from '../schema';
 
 export abstract class Platform {
@@ -37,7 +37,7 @@ export abstract class Platform {
   /**
    * Normalizes primary key wrapper to scalar value (e.g. mongodb's ObjectId to string)
    */
-  normalizePrimaryKey<T = number | string>(data: IPrimaryKey): T {
+  normalizePrimaryKey<T extends number | string = number | string>(data: Primary<T> | IPrimaryKey): T {
     return data as T;
   }
 

--- a/lib/query/CriteriaNode.ts
+++ b/lib/query/CriteriaNode.ts
@@ -1,5 +1,5 @@
 import { inspect } from 'util';
-import { EntityProperty } from '../decorators';
+import { Dictionary, EntityProperty } from '../types';
 import { MetadataStorage } from '../metadata';
 import { QueryBuilderHelper } from './QueryBuilderHelper';
 import { Utils } from '../utils';
@@ -105,7 +105,7 @@ export class ScalarCriteriaNode extends CriteriaNode {
       const nestedAlias = qb.getAliasForEntity(this.entityName, this) || qb.getNextAlias();
       const field = `${alias}.${this.prop!.name}`;
 
-      if (this.prop!.reference === ReferenceType.MANY_TO_MANY) { // TODO might not be enough, maybe check payload for operator/scalar?
+      if (this.prop!.reference === ReferenceType.MANY_TO_MANY) {
         qb.join(field, nestedAlias, undefined, 'pivotJoin');
       } else {
         qb.leftJoin(field, nestedAlias);
@@ -150,7 +150,7 @@ export class ArrayCriteriaNode extends CriteriaNode {
 
 export class ObjectCriteriaNode extends CriteriaNode {
 
-  static create(metadata: MetadataStorage, entityName: string, payload: Record<string, any>, parent?: CriteriaNode, key?: string): ObjectCriteriaNode {
+  static create(metadata: MetadataStorage, entityName: string, payload: Dictionary, parent?: CriteriaNode, key?: string): ObjectCriteriaNode {
     const node = new ObjectCriteriaNode(metadata, entityName, parent, key);
     const meta = metadata.get(entityName, false, false);
     node.payload = Object.keys(payload).reduce((o, item) => {

--- a/lib/query/QueryBuilderHelper.ts
+++ b/lib/query/QueryBuilderHelper.ts
@@ -2,7 +2,7 @@ import Knex, { JoinClause, QueryBuilder as KnexQueryBuilder, Raw } from 'knex';
 import { inspect } from 'util';
 
 import { Utils, ValidationError } from '../utils';
-import { EntityMetadata, EntityProperty } from '../decorators';
+import { Dictionary, EntityMetadata, EntityProperty } from '../types';
 import { FlatQueryOrderMap, QueryOrderNumeric, QueryType } from './enums';
 import { Platform } from '../platforms';
 import { JoinOptions } from './QueryBuilder';
@@ -83,7 +83,7 @@ export class QueryBuilderHelper {
     return data;
   }
 
-  joinOneToReference(prop: EntityProperty, ownerAlias: string, alias: string, type: 'leftJoin' | 'innerJoin' | 'pivotJoin', cond: Record<string, any> = {}): JoinOptions {
+  joinOneToReference(prop: EntityProperty, ownerAlias: string, alias: string, type: 'leftJoin' | 'innerJoin' | 'pivotJoin', cond: Dictionary = {}): JoinOptions {
     const meta = this.metadata.get(prop.type);
     const prop2 = meta.properties[prop.mappedBy || prop.inversedBy];
 
@@ -96,7 +96,7 @@ export class QueryBuilderHelper {
     };
   }
 
-  joinManyToOneReference(prop: EntityProperty, ownerAlias: string, alias: string, type: 'leftJoin' | 'innerJoin' | 'pivotJoin', cond: Record<string, any> = {}): JoinOptions {
+  joinManyToOneReference(prop: EntityProperty, ownerAlias: string, alias: string, type: 'leftJoin' | 'innerJoin' | 'pivotJoin', cond: Dictionary = {}): JoinOptions {
     return {
       prop, type, cond, ownerAlias, alias,
       table: this.getTableName(prop.type),
@@ -105,7 +105,7 @@ export class QueryBuilderHelper {
     };
   }
 
-  joinManyToManyReference(prop: EntityProperty, ownerAlias: string, alias: string, pivotAlias: string, type: 'leftJoin' | 'innerJoin' | 'pivotJoin', cond: Record<string, any>): Record<string, JoinOptions> {
+  joinManyToManyReference(prop: EntityProperty, ownerAlias: string, alias: string, pivotAlias: string, type: 'leftJoin' | 'innerJoin' | 'pivotJoin', cond: Dictionary): Record<string, JoinOptions> {
     const join = {
       prop, type, cond, ownerAlias,
       alias: pivotAlias,
@@ -141,7 +141,7 @@ export class QueryBuilderHelper {
     return ret;
   }
 
-  joinPivotTable(field: string, prop: EntityProperty, ownerAlias: string, alias: string, type: 'leftJoin' | 'innerJoin' | 'pivotJoin', cond: Record<string, any> = {}): JoinOptions {
+  joinPivotTable(field: string, prop: EntityProperty, ownerAlias: string, alias: string, type: 'leftJoin' | 'innerJoin' | 'pivotJoin', cond: Dictionary = {}): JoinOptions {
     const prop2 = this.metadata.get(field).properties[prop.mappedBy || prop.inversedBy];
 
     return {
@@ -281,7 +281,7 @@ export class QueryBuilderHelper {
     qb[m](this.mapper(key, type), replacement, cond[key][op]);
   }
 
-  private appendJoinClause(clause: JoinClause, cond: Record<string, any>, operator?: '$and' | '$or'): void {
+  private appendJoinClause(clause: JoinClause, cond: Dictionary, operator?: '$and' | '$or'): void {
     Object.keys(cond).forEach(k => {
       if (k === '$and' || k === '$or') {
         const method = operator === '$or' ? 'orOn' : 'andOn';

--- a/lib/schema/EntityGenerator.ts
+++ b/lib/schema/EntityGenerator.ts
@@ -1,9 +1,9 @@
 import { CodeBlockWriter, Project, QuoteKind, SourceFile } from 'ts-morph';
 import { ensureDir, writeFile } from 'fs-extra';
 
-import { AbstractSqlDriver, Configuration, DatabaseSchema, Utils } from '..';
+import { AbstractSqlDriver, Configuration, DatabaseSchema, Dictionary, Utils } from '..';
 import { Platform } from '../platforms';
-import { EntityProperty } from '../decorators';
+import { EntityProperty } from '../types';
 import { Column, DatabaseTable } from './DatabaseTable';
 
 export class EntityGenerator {
@@ -99,7 +99,7 @@ export class EntityGenerator {
     return `${decorator}({ ${Object.entries(options).map(([opt, val]) => `${opt}: ${val}`).join(', ')} })`;
   }
 
-  private getCommonDecoratorOptions(column: Column, options: Record<string, any>, defaultValue: any, columnType?: string) {
+  private getCommonDecoratorOptions(column: Column, options: Dictionary, defaultValue: any, columnType?: string) {
     if (columnType) {
       options.columnType = `'${columnType}'`;
     }
@@ -113,7 +113,7 @@ export class EntityGenerator {
     }
   }
 
-  private getScalarPropertyDecoratorOptions(type: string, column: Column, options: Record<string, any>, prop: string, columnType?: string): void {
+  private getScalarPropertyDecoratorOptions(type: string, column: Column, options: Dictionary, prop: string, columnType?: string): void {
     const defaultColumnType = this.helper.getTypeDefinition({
       type,
       length: column.maxLength,
@@ -132,7 +132,7 @@ export class EntityGenerator {
     }
   }
 
-  private getForeignKeyDecoratorOptions(options: Record<string, any>, column: Column, prop: string) {
+  private getForeignKeyDecoratorOptions(options: Dictionary, column: Column, prop: string) {
     options.entity = `() => ${this.namingStrategy.getClassName(column.fk.referencedTableName, '_')}`;
 
     if (column.name !== this.namingStrategy.joinKeyColumnName(prop, column.fk.referencedColumnName)) {

--- a/lib/schema/MySqlSchemaHelper.ts
+++ b/lib/schema/MySqlSchemaHelper.ts
@@ -1,6 +1,6 @@
 import { MySqlTableBuilder } from 'knex';
 import { IsSame, SchemaHelper } from './SchemaHelper';
-import { EntityProperty } from '../decorators';
+import { EntityProperty } from '../types';
 import { AbstractSqlConnection } from '../connections/AbstractSqlConnection';
 import { Column } from './DatabaseTable';
 

--- a/lib/schema/PostgreSqlSchemaHelper.ts
+++ b/lib/schema/PostgreSqlSchemaHelper.ts
@@ -1,5 +1,5 @@
 import { IsSame, SchemaHelper } from './SchemaHelper';
-import { EntityProperty } from '../decorators';
+import { EntityProperty } from '../types';
 import { AbstractSqlConnection } from '../connections/AbstractSqlConnection';
 import { Column } from './DatabaseTable';
 

--- a/lib/schema/SchemaGenerator.ts
+++ b/lib/schema/SchemaGenerator.ts
@@ -1,6 +1,6 @@
 import { ColumnBuilder, SchemaBuilder, TableBuilder } from 'knex';
 import { AbstractSqlDriver, Cascade, DatabaseSchema, IsSame, ReferenceType, Utils } from '..';
-import { EntityMetadata, EntityProperty } from '../decorators';
+import { EntityMetadata, EntityProperty } from '../types';
 import { Platform } from '../platforms';
 import { MetadataStorage } from '../metadata';
 import { Column, DatabaseTable } from './DatabaseTable';

--- a/lib/schema/SchemaHelper.ts
+++ b/lib/schema/SchemaHelper.ts
@@ -1,5 +1,5 @@
 import { TableBuilder } from 'knex';
-import { EntityProperty } from '../decorators';
+import { Dictionary, EntityProperty } from '../types';
 import { AbstractSqlConnection } from '../connections/AbstractSqlConnection';
 import { Column, Index } from './DatabaseTable';
 import { ReferenceType } from '../entity';
@@ -68,7 +68,7 @@ export abstract class SchemaHelper {
     return ret;
   }
 
-  async getForeignKeys(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<Record<string, any>> {
+  async getForeignKeys(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<Dictionary> {
     const fks = await connection.execute<any[]>(this.getForeignKeysSQL(tableName, schemaName));
     return this.mapForeignKeys(fks);
   }
@@ -93,7 +93,7 @@ export abstract class SchemaHelper {
     throw new Error('Not supported by given driver');
   }
 
-  mapForeignKeys(fks: any[]): Record<string, any> {
+  mapForeignKeys(fks: any[]): Dictionary {
     return fks.reduce((ret, fk: any) => {
       ret[fk.column_name] = {
         columnName: fk.column_name,

--- a/lib/schema/SqliteSchemaHelper.ts
+++ b/lib/schema/SqliteSchemaHelper.ts
@@ -1,5 +1,5 @@
 import { IsSame, SchemaHelper } from './SchemaHelper';
-import { EntityProperty } from '../decorators';
+import { Dictionary, EntityProperty } from '../types';
 import { AbstractSqlConnection } from '../connections/AbstractSqlConnection';
 import { Column } from './DatabaseTable';
 
@@ -57,7 +57,7 @@ export class SqliteSchemaHelper extends SchemaHelper {
     }));
   }
 
-  async getPrimaryKeys(connection: AbstractSqlConnection, indexes: Record<string, any>, tableName: string, schemaName?: string): Promise<string[]> {
+  async getPrimaryKeys(connection: AbstractSqlConnection, indexes: Dictionary, tableName: string, schemaName?: string): Promise<string[]> {
     const sql = `pragma table_info(\`${tableName}\`)`;
     const cols = await connection.execute<{ pk: number; name: string }[]>(sql);
 
@@ -92,7 +92,7 @@ export class SqliteSchemaHelper extends SchemaHelper {
     return `pragma foreign_key_list(\`${tableName}\`)`;
   }
 
-  mapForeignKeys(fks: any[]): Record<string, any> {
+  mapForeignKeys(fks: any[]): Dictionary {
     return fks.reduce((ret, fk: any) => {
       ret[fk.from] = {
         columnName: fk.from,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,147 @@
+import { QueryOrder } from './query';
+import { AssignOptions, Cascade, Collection, EntityRepository, ReferenceType } from './entity';
+import { EntityManager } from './EntityManager';
+import { LockMode } from './unit-of-work';
+
+export type Constructor<T> = new (...args: any[]) => T;
+export type Dictionary<T = any> = { [k: string]: T };
+
+export type PartialEntityProperty<T, P extends keyof T> = null | (T extends Date | RegExp ? T : T[P] | (true extends IsEntity<T[P]> ? PartialEntity<T[P]> | Primary<T[P]> : never));
+export type PartialEntity<T> = { [P in keyof T]?: PartialEntityProperty<T, P> };
+
+export type DeepPartialEntity<T> = {
+  [P in keyof T]?: null | (T[P] extends (infer U)[]
+    ? DeepPartialEntity<U>[]
+    : T[P] extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartialEntity<U>>
+      : T extends Date | RegExp
+        ? T
+        : DeepPartialEntity<T[P]> | PartialEntity<T[P]> | Primary<T[P]>)
+};
+
+export const PrimaryKeyType = Symbol('PrimaryKeyType');
+export type Primary<T> = T extends { [PrimaryKeyType]: infer PK }
+  ? PK : T extends { _id: infer PK }
+  ? PK | string : T extends { uuid: infer PK }
+  ? PK : T extends { id: infer PK }
+  ? PK : never;
+export type IPrimaryKeyValue = number | string | { toHexString(): string };
+export type IPrimaryKey<T extends IPrimaryKeyValue = IPrimaryKeyValue> = T;
+
+export type IsEntity<T> = T extends { [PrimaryKeyType]: any } | { _id: any } | { uuid: string } | { id: number | string } ? true : never;
+
+export type UnionOfArrays<T> = T extends infer T1 | infer T2 | infer T3 | infer T4 | infer T5 | infer T6 | infer T7 | infer T8 | infer T9 | infer T10
+  ? T1[] | T2[] | T3[] | T4[] | T5[] | T6[] | T7[] | T8[] | T9[] | T10[] : T extends infer T1 | infer T2 | infer T3 | infer T4 | infer T5 | infer T6 | infer T7 | infer T8 | infer T9
+  ? T1[] | T2[] | T3[] | T4[] | T5[] | T6[] | T7[] | T8[] | T9[] : T extends infer T1 | infer T2 | infer T3 | infer T4 | infer T5 | infer T6 | infer T7 | infer T8
+  ? T1[] | T2[] | T3[] | T4[] | T5[] | T6[] | T7[] | T8[] : T extends infer T1 | infer T2 | infer T3 | infer T4 | infer T5 | infer T6 | infer T7
+  ? T1[] | T2[] | T3[] | T4[] | T5[] | T6[] | T7[] : T extends infer T1 | infer T2 | infer T3 | infer T4 | infer T5 | infer T6
+  ? T1[] | T2[] | T3[] | T4[] | T5[] | T6[] : T extends infer T1 | infer T2 | infer T3 | infer T4 | infer T5
+  ? T1[] | T2[] | T3[] | T4[] | T5[] : T extends infer T1 | infer T2 | infer T3 | infer T4
+  ? T1[] | T2[] | T3[] | T4[] : T extends infer T1 | infer T2 | infer T3
+  ? T1[] | T2[] | T3[] : T extends infer T1 | infer T2
+  ? T1[] | T2[] : T extends infer T1
+  ? T1[] : never;
+export type OneOrArray<T> = T | UnionOfArrays<T>;
+export type GroupOperatorMap<T> = { $and?: UnionOfArrays<Query<T>>; $or?: UnionOfArrays<Query<T>> };
+export type OperatorMap<T> = {
+  $and?: Query<T>[];
+  $or?: Query<T>[];
+  $eq?: Query<T>;
+  $ne?: Query<T>;
+  $in?: Query<T>[];
+  $nin?: Query<T>[];
+  $not?: Query<T>;
+  $gt?: Query<T>;
+  $gte?: Query<T>;
+  $lt?: Query<T>;
+  $lte?: Query<T>;
+};
+export type StringProp<T> = T extends string ? string | RegExp : never;
+export type EntityOrPrimary<T> = true extends IsEntity<T> ? DeepPartialEntity<T> | PartialEntity<T> | Primary<T> | T : never;
+export type CollectionItem<T> = T extends Collection<infer K> ? EntityOrPrimary<K> : never;
+export type FilterValue<T> = T | OperatorMap<T> | StringProp<T> | OneOrArray<CollectionItem<T> | EntityOrPrimary<T>>;
+export type Query<T> = true extends IsEntity<T>
+  ? { [K in keyof T]?: Query<T[K]> | FilterValue<T[K]> | null } | FilterValue<T>
+  : T extends Collection<infer K> ? FilterValue<K> : FilterValue<T>;
+export type FilterQuery<T> = GroupOperatorMap<Query<T>> | Query<T> | { [PrimaryKeyType]?: any };
+
+export interface IWrappedEntity<T, PK extends keyof T> {
+  isInitialized(): boolean;
+  populated(populated?: boolean): void;
+  init(populated?: boolean, lockMode?: LockMode): Promise<this>;
+  toObject(ignoreFields?: string[]): Dictionary;
+  toJSON(...args: any[]): Dictionary;
+  assign(data: any, options?: AssignOptions | boolean): this;
+  __uuid: string;
+  __meta: EntityMetadata;
+  __em: EntityManager;
+  __initialized?: boolean;
+  __populated: boolean;
+  __lazyInitialized: boolean;
+  __primaryKey: T[PK] & Primary<T>;
+  __serializedPrimaryKey: string & keyof T;
+}
+
+export type AnyEntity<T = any, PK extends keyof T = keyof T> = { [K in PK]?: T[K] } & { [PrimaryKeyType]?: T[PK] };
+export type WrappedEntity<T, PK extends keyof T> = IWrappedEntity<T, PK> & AnyEntity<T, PK>;
+export type IdEntity<T extends { id: number | string }> = AnyEntity<T, 'id'>;
+export type UuidEntity<T extends { uuid: string }> = AnyEntity<T, 'uuid'>;
+export type MongoEntity<T extends { _id: IPrimaryKey; id: string }> = AnyEntity<T, 'id' | '_id'>;
+export type EntityClass<T extends AnyEntity<T>> = Function & { prototype: T };
+export type EntityClassGroup<T extends AnyEntity<T>> = { entity: EntityClass<T>; schema: EntityMetadata<T> };
+export type EntityName<T extends AnyEntity<T>> = string | EntityClass<T>;
+export type EntityData<T extends AnyEntity<T>> = { [K in keyof T]?: T[K] | Primary<T[K]> | CollectionItem<T[K]>[] } & Dictionary;
+
+export interface EntityProperty<T extends AnyEntity<T> = any> {
+  name: string & keyof T;
+  entity: () => EntityName<T>;
+  type: string;
+  columnType: string;
+  primary: boolean;
+  length?: any;
+  reference: ReferenceType;
+  wrappedReference?: boolean;
+  fieldName: string;
+  default?: any;
+  unique?: boolean;
+  nullable?: boolean;
+  unsigned: boolean;
+  persist?: boolean;
+  hidden?: boolean;
+  version?: boolean;
+  eager?: boolean;
+  setter?: boolean;
+  getter?: boolean;
+  getterName?: keyof T;
+  cascade: Cascade[];
+  orphanRemoval?: boolean;
+  onUpdate?: () => any;
+  owner: boolean;
+  inversedBy: string;
+  mappedBy: string;
+  orderBy?: { [field: string]: QueryOrder };
+  pivotTable: string;
+  joinColumn: string;
+  inverseJoinColumn: string;
+  referenceColumnName: string;
+  referencedTableName: string;
+}
+
+export type HookType = 'onInit' | 'beforeCreate' | 'afterCreate' | 'beforeUpdate' | 'afterUpdate' | 'beforeDelete' | 'afterDelete';
+
+export interface EntityMetadata<T extends AnyEntity<T> = any> {
+  name: string;
+  className: string;
+  constructorParams: (keyof T & string)[];
+  toJsonParams: string[];
+  extends: string;
+  collection: string;
+  path: string;
+  primaryKey: keyof T & string;
+  versionProperty: keyof T & string;
+  serializedPrimaryKey: keyof T & string;
+  properties: { [K in keyof T & string]: EntityProperty<T> };
+  customRepository: () => Constructor<EntityRepository<T>>;
+  hooks: Partial<Record<HookType, (string & keyof T)[]>>;
+  prototype: T;
+}

--- a/lib/unit-of-work/ChangeSet.ts
+++ b/lib/unit-of-work/ChangeSet.ts
@@ -1,10 +1,10 @@
-import { EntityData, IEntityType } from '../decorators';
+import { EntityData, AnyEntity, WrappedEntity, Primary } from '../types';
 
-export interface ChangeSet<T extends IEntityType<T>> {
+export interface ChangeSet<T extends AnyEntity<T>> {
   name: string;
   collection: string;
   type: ChangeSetType;
-  entity: T;
+  entity: T & WrappedEntity<T, Primary<T> & keyof T>;
   payload: EntityData<T>;
 }
 

--- a/lib/unit-of-work/ChangeSetPersister.ts
+++ b/lib/unit-of-work/ChangeSetPersister.ts
@@ -1,8 +1,8 @@
 import { MetadataStorage } from '../metadata';
-import { EntityMetadata, EntityProperty, IEntityType } from '../decorators';
-import { EntityIdentifier } from '../entity';
+import { EntityMetadata, EntityProperty, AnyEntity, IPrimaryKey } from '../types';
+import { EntityIdentifier, wrap } from '../entity';
 import { ChangeSet, ChangeSetType } from './ChangeSet';
-import { IDatabaseDriver, Transaction } from '..';
+import { FilterQuery, IDatabaseDriver, Transaction } from '..';
 import { QueryResult } from '../connections';
 import { ValidationError } from '../utils';
 
@@ -12,7 +12,7 @@ export class ChangeSetPersister {
               private readonly identifierMap: Record<string, EntityIdentifier>,
               private readonly metadata: MetadataStorage) { }
 
-  async persistToDatabase<T extends IEntityType<T>>(changeSet: ChangeSet<T>, ctx?: Transaction): Promise<void> {
+  async persistToDatabase<T extends AnyEntity<T>>(changeSet: ChangeSet<T>, ctx?: Transaction): Promise<void> {
     const meta = this.metadata.get(changeSet.name);
 
     // process references first
@@ -24,11 +24,11 @@ export class ChangeSetPersister {
     await this.persistEntity(changeSet, meta, ctx);
   }
 
-  private async persistEntity<T extends IEntityType<T>>(changeSet: ChangeSet<T>, meta: EntityMetadata<T>, ctx?: Transaction): Promise<void> {
+  private async persistEntity<T extends AnyEntity<T>>(changeSet: ChangeSet<T>, meta: EntityMetadata<T>, ctx?: Transaction): Promise<void> {
     let res: QueryResult | undefined;
 
     if (changeSet.type === ChangeSetType.DELETE) {
-      await this.driver.nativeDelete(changeSet.name, changeSet.entity.__primaryKey, ctx);
+      await this.driver.nativeDelete(changeSet.name, changeSet.entity.__primaryKey as {}, ctx);
     } else if (changeSet.type === ChangeSetType.UPDATE) {
       res = await this.updateEntity(meta, changeSet, ctx);
       this.mapReturnedValues(changeSet.entity, res, meta);
@@ -39,45 +39,45 @@ export class ChangeSetPersister {
     } else { // ChangeSetType.CREATE without primary key
       res = await this.driver.nativeInsert(changeSet.name, changeSet.payload, ctx);
       this.mapReturnedValues(changeSet.entity, res, meta);
-      changeSet.entity.__primaryKey = changeSet.entity.__primaryKey || res.insertId;
-      this.identifierMap[changeSet.entity.__uuid].setValue(changeSet.entity.__primaryKey);
+      wrap(changeSet.entity).__primaryKey = changeSet.entity.__primaryKey || res.insertId as any;
+      this.identifierMap[changeSet.entity.__uuid].setValue(changeSet.entity.__primaryKey as IPrimaryKey);
       delete changeSet.entity.__initialized;
     }
 
     await this.processOptimisticLock(meta, changeSet, res, ctx);
   }
 
-  private async updateEntity<T extends IEntityType<T>>(meta: EntityMetadata<T>, changeSet: ChangeSet<T>, ctx?: Transaction): Promise<QueryResult> {
+  private async updateEntity<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSet: ChangeSet<T>, ctx?: Transaction): Promise<QueryResult> {
     if (!meta.versionProperty || !changeSet.entity[meta.versionProperty]) {
-      return this.driver.nativeUpdate(changeSet.name, changeSet.entity.__primaryKey, changeSet.payload, ctx);
+      return this.driver.nativeUpdate(changeSet.name, changeSet.entity.__primaryKey as {}, changeSet.payload, ctx);
     }
 
     const cond = {
-      [changeSet.entity.__primaryKeyField]: changeSet.entity.__primaryKey,
+      [changeSet.entity.__meta.primaryKey]: changeSet.entity.__primaryKey,
       [meta.versionProperty]: changeSet.entity[meta.versionProperty],
-    };
+    } as FilterQuery<T>;
 
     return this.driver.nativeUpdate(changeSet.name, cond, changeSet.payload, ctx);
   }
 
-  private async processOptimisticLock<T extends IEntityType<T>>(meta: EntityMetadata<T>, changeSet: ChangeSet<T>, res: QueryResult | undefined, ctx?: Transaction) {
+  private async processOptimisticLock<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSet: ChangeSet<T>, res: QueryResult | undefined, ctx?: Transaction) {
     if (meta.versionProperty && changeSet.type === ChangeSetType.UPDATE && res && !res.affectedRows) {
       throw ValidationError.lockFailed(changeSet.entity);
     }
 
     if (meta.versionProperty && [ChangeSetType.CREATE, ChangeSetType.UPDATE].includes(changeSet.type)) {
-      const e = await this.driver.findOne<T>(meta.name, changeSet.entity.__primaryKey, [], {}, [meta.versionProperty], undefined, ctx);
-      changeSet.entity[meta.versionProperty as keyof T] = e![meta.versionProperty] as T[keyof T];
+      const e = await this.driver.findOne<T>(meta.name, changeSet.entity.__primaryKey as {}, [], {}, [meta.versionProperty], undefined, ctx);
+      changeSet.entity[meta.versionProperty] = e![meta.versionProperty] as any;
     }
   }
 
-  private processReference<T extends IEntityType<T>>(changeSet: ChangeSet<T>, prop: EntityProperty): void {
+  private processReference<T extends AnyEntity<T>>(changeSet: ChangeSet<T>, prop: EntityProperty): void {
     const value = changeSet.payload[prop.name];
 
     if (value instanceof EntityIdentifier) {
       changeSet.payload[prop.name as keyof T] = value.getValue();
     } else if (Array.isArray(value) && value.some(item => item as object instanceof EntityIdentifier)) {
-      changeSet.payload[prop.name as keyof T] = value.map(item => item instanceof EntityIdentifier ? item.getValue() : item) as T[keyof T];
+      changeSet.payload[prop.name as keyof T] = value.map(item => item instanceof EntityIdentifier ? item.getValue() : item) as unknown as T[keyof T];
     }
 
     if (prop.onUpdate) {
@@ -85,9 +85,9 @@ export class ChangeSetPersister {
     }
   }
 
-  private mapReturnedValues<T extends IEntityType<T>>(entity: T, res: QueryResult, meta: EntityMetadata<T>): void {
+  private mapReturnedValues<T extends AnyEntity<T>>(entity: T, res: QueryResult, meta: EntityMetadata<T>): void {
     if (res.row && Object.keys(res.row).length > 0) {
-      Object.values(meta.properties).forEach(prop => {
+      Object.values<EntityProperty>(meta.properties).forEach(prop => {
         if (res.row![prop.fieldName]) {
           entity[prop.name as keyof T] = res.row![prop.fieldName] as T[keyof T];
         }

--- a/lib/utils/Configuration.ts
+++ b/lib/utils/Configuration.ts
@@ -5,11 +5,11 @@ import { NamingStrategy } from '../naming-strategy';
 import { CacheAdapter, FileCacheAdapter, NullCacheAdapter } from '../cache';
 import { MetadataProvider, TypeScriptMetadataProvider } from '../metadata';
 import { EntityFactory, EntityRepository } from '../entity';
-import { EntityClass, EntityClassGroup, EntityName, EntityOptions, IEntity, IPrimaryKey } from '../decorators';
+import { Dictionary, EntityClass, EntityClassGroup, EntityName, AnyEntity, IPrimaryKey } from '../types';
 import { Hydrator, ObjectHydrator } from '../hydration';
 import { Logger, LoggerNamespace, Utils, ValidationError } from '../utils';
 import { EntityManager } from '../EntityManager';
-import { IDatabaseDriver } from '..';
+import { EntityOptions, IDatabaseDriver } from '..';
 import { Platform } from '../platforms';
 
 export class Configuration {
@@ -26,7 +26,7 @@ export class Configuration {
     strict: false,
     // tslint:disable-next-line:no-console
     logger: console.log.bind(console),
-    findOneOrFailHandler: (entityName: string, where: Record<string, any> | IPrimaryKey) => ValidationError.findOneFailed(entityName, where),
+    findOneOrFailHandler: (entityName: string, where: Dictionary | IPrimaryKey) => ValidationError.findOneFailed(entityName, where),
     baseDir: process.cwd(),
     entityRepository: EntityRepository,
     hydrator: ObjectHydrator,
@@ -62,7 +62,7 @@ export class Configuration {
   private readonly logger: Logger;
   private readonly driver: IDatabaseDriver;
   private readonly platform: Platform;
-  private readonly cache: Record<string, any> = {};
+  private readonly cache: Dictionary = {};
   private readonly highlightTheme: Theme;
 
   constructor(options: Options, validate = true) {
@@ -121,7 +121,7 @@ export class Configuration {
     return this.cached(this.options.cache.adapter!, this.options.cache.options, this.options.baseDir, this.options.cache.pretty);
   }
 
-  getRepositoryClass(customRepository: EntityOptions['customRepository']): MikroORMOptions['entityRepository'] {
+  getRepositoryClass(customRepository: EntityOptions<AnyEntity>['customRepository']): MikroORMOptions['entityRepository'] {
     if (customRepository) {
       return customRepository();
     }
@@ -196,7 +196,7 @@ export interface ConnectionOptions {
 }
 
 export interface MikroORMOptions extends ConnectionOptions {
-  entities: (EntityClass<IEntity> | EntityClassGroup<IEntity>)[];
+  entities: (EntityClass<AnyEntity> | EntityClassGroup<AnyEntity>)[];
   entitiesDirs: string[];
   entitiesDirsTs: string[];
   warnWhenNoEntities: boolean;
@@ -206,11 +206,11 @@ export interface MikroORMOptions extends ConnectionOptions {
   driver?: { new (config: Configuration): IDatabaseDriver };
   namingStrategy?: { new (): NamingStrategy };
   hydrator: { new (factory: EntityFactory, driver: IDatabaseDriver): Hydrator };
-  entityRepository: { new (em: EntityManager, entityName: EntityName<IEntity>): EntityRepository<IEntity> };
+  entityRepository: { new (em: EntityManager, entityName: EntityName<AnyEntity>): EntityRepository<AnyEntity> };
   replicas?: Partial<ConnectionOptions>[];
   strict: boolean;
   logger: (message: string) => void;
-  findOneOrFailHandler: (entityName: string, where: Record<string, any> | IPrimaryKey) => Error;
+  findOneOrFailHandler: (entityName: string, where: Dictionary | IPrimaryKey) => Error;
   debug: boolean | LoggerNamespace[];
   highlight: boolean;
   highlightTheme?: Record<string, string | string[]>;
@@ -220,7 +220,7 @@ export interface MikroORMOptions extends ConnectionOptions {
     enabled?: boolean;
     pretty?: boolean;
     adapter?: { new (...params: any[]): CacheAdapter };
-    options?: Record<string, any>;
+    options?: Dictionary;
   };
   metadataProvider: { new (config: Configuration): MetadataProvider };
 }

--- a/lib/utils/ValidationError.ts
+++ b/lib/utils/ValidationError.ts
@@ -1,10 +1,10 @@
 import { inspect } from 'util';
-import { EntityMetadata, EntityProperty, IEntity, IPrimaryKey } from '../decorators';
+import { Dictionary, EntityMetadata, EntityProperty, AnyEntity, IPrimaryKey } from '../types';
 import { Utils } from './Utils';
 
-export class ValidationError extends Error {
+export class ValidationError<T extends AnyEntity = AnyEntity> extends Error {
 
-  constructor(message: string, private readonly entity?: IEntity) {
+  constructor(message: string, private readonly entity?: T) {
     super(message);
     Error.captureStackTrace(this, this.constructor);
 
@@ -12,18 +12,18 @@ export class ValidationError extends Error {
     this.message = message;
   }
 
-  getEntity(): IEntity | undefined {
+  getEntity(): AnyEntity | undefined {
     return this.entity;
   }
 
-  static fromWrongPropertyType(entity: IEntity, property: string, expectedType: string, givenType: string, givenValue: string): ValidationError {
+  static fromWrongPropertyType(entity: AnyEntity, property: string, expectedType: string, givenType: string, givenValue: string): ValidationError {
     const entityName = entity.constructor.name;
     const msg = `Trying to set ${entityName}.${property} of type '${expectedType}' to '${givenValue}' of type '${givenType}'`;
 
     return new ValidationError(msg);
   }
 
-  static fromCollectionNotInitialized(entity: IEntity, prop: EntityProperty): ValidationError {
+  static fromCollectionNotInitialized(entity: AnyEntity, prop: EntityProperty): ValidationError {
     const entityName = entity.constructor.name;
     const msg = `${entityName}.${prop.name} is not initialized, define it as '${prop.name} = new Collection<${prop.type}>(this);'`;
 
@@ -73,7 +73,7 @@ export class ValidationError extends Error {
     return new ValidationError('An open transaction is required for this operation');
   }
 
-  static entityNotManaged(entity: IEntity): ValidationError {
+  static entityNotManaged(entity: AnyEntity): ValidationError {
     return new ValidationError(`Entity ${entity.constructor.name} is not managed. An entity is managed if its fetched from the database or registered as new through EntityManager.persist()`);
   }
 
@@ -90,14 +90,14 @@ export class ValidationError extends Error {
     return new ValidationError(`Version property ${meta.name}.${prop.name} has unsupported type '${prop.type}'. Only 'number' and 'Date' are allowed.`);
   }
 
-  static lockFailed(entityOrName: IEntity | string): ValidationError {
+  static lockFailed(entityOrName: AnyEntity | string): ValidationError {
     const name = Utils.isString(entityOrName) ? entityOrName : entityOrName.constructor.name;
     const entity = Utils.isString(entityOrName) ? undefined : entityOrName;
 
     return new ValidationError(`The optimistic lock on entity ${name} failed`, entity);
   }
 
-  static lockFailedVersionMismatch(entity: IEntity, expectedLockVersion: number | Date, actualLockVersion: number | Date): ValidationError {
+  static lockFailedVersionMismatch(entity: AnyEntity, expectedLockVersion: number | Date, actualLockVersion: number | Date): ValidationError {
     expectedLockVersion = expectedLockVersion instanceof Date ? expectedLockVersion.getTime() : expectedLockVersion;
     actualLockVersion = actualLockVersion instanceof Date ? actualLockVersion.getTime() : actualLockVersion;
 
@@ -116,7 +116,7 @@ export class ValidationError extends Error {
     return new ValidationError(`Entity '${name}' not found in ${path}`);
   }
 
-  static findOneFailed(name: string, where: Record<string, any> | IPrimaryKey): ValidationError {
+  static findOneFailed(name: string, where: Dictionary | IPrimaryKey): ValidationError {
     return new ValidationError(`${name} not found (${inspect(where)})`);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mikro-orm",
-  "version": "3.0.0-alpha.22",
+  "version": "3.0.0-alpha.23",
   "description": "TypeScript ORM for Node.js based on Data Mapper, Unit of Work and Identity Map patterns. Supports MongoDB, MySQL, PostgreSQL and SQLite databases as well as usage with vanilla JavaScript.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -13,6 +13,7 @@
     "mongo",
     "mongodb",
     "mysql",
+    "mariadb",
     "postgresql",
     "sqlite",
     "sqlite3",
@@ -94,7 +95,7 @@
     "globby": "^10.0.0",
     "knex": "^0.19.0",
     "ts-morph": "^4.0.0",
-    "typescript": "^3.5.0",
+    "typescript": "^3.6.3",
     "uuid": "^3.3.2",
     "yargonaut": "^1.1.4",
     "yargs": "^13.3.0"
@@ -134,6 +135,7 @@
     "@types/node": "^12.7.5",
     "@types/pg": "^7.11.1",
     "@types/uuid": "^3.4.5",
+    "conditional-type-checks": "^1.0.1",
     "coveralls": "^3.0.6",
     "husky": "^3.0.5",
     "jest": "^24.9.0",
@@ -146,7 +148,7 @@
     "semantic-release": "^15.13.24",
     "sqlite3": "^4.1.0",
     "ts-jest": "^24.1.0",
-    "ts-node": "^8.3.0",
+    "ts-node": "^8.4.1",
     "tslint": "^5.20.0",
     "tslint-eslint-rules": "^5.4.0",
     "tslint-lines-between-class-members": "^1.3.6"

--- a/tests/EntityFactory.test.ts
+++ b/tests/EntityFactory.test.ts
@@ -1,6 +1,6 @@
 import { ObjectId } from 'mongodb';
 import { Book, Author, Publisher, Test } from './entities';
-import { MikroORM, Collection, Utils } from '../lib';
+import { MikroORM, Collection } from '../lib';
 import { EntityFactory, ReferenceType } from '../lib/entity';
 import { initORMMongo, wipeDatabase } from './bootstrap';
 import { MetadataDiscovery } from '../lib/metadata';

--- a/tests/EntityHelper.mysql.test.ts
+++ b/tests/EntityHelper.mysql.test.ts
@@ -1,4 +1,4 @@
-import { MikroORM } from '../lib';
+import { MikroORM, wrap } from '../lib';
 import { initORMMySql, wipeDatabaseMySql } from './bootstrap';
 import { Author2, Book2, BookTag2 } from './entities-sql';
 import { MetadataDiscovery } from '../lib/metadata';
@@ -20,13 +20,13 @@ describe('EntityHelperMySql', () => {
     await orm.em.persistAndFlush(book);
     expect(book.title).toBe('Book2');
     expect(book.author).toBe(jon);
-    book.assign({ title: 'Better Book2 1', author: god, notExisting: true });
+    wrap(book).assign({ title: 'Better Book2 1', author: god, notExisting: true });
     expect(book.author).toBe(god);
     expect((book as any).notExisting).toBe(true);
     await orm.em.persistAndFlush(god);
-    book.assign({ title: 'Better Book2 2', author: god.id });
+    wrap(book).assign({ title: 'Better Book2 2', author: god.id });
     expect(book.author).toBe(god);
-    book.assign({ title: 'Better Book2 3', author: jon.id });
+    wrap(book).assign({ title: 'Better Book2 3', author: jon.id });
     expect(book.title).toBe('Better Book2 3');
     expect(book.author).toBe(jon);
   });
@@ -43,13 +43,13 @@ describe('EntityHelperMySql', () => {
     book.tags.add(tag2);
     book.tags.add(tag3);
     await orm.em.persistAndFlush(book);
-    book.assign({ tags: [other.id] });
+    wrap(book).assign({ tags: [other.id] });
     expect(book.tags.getIdentifiers()).toMatchObject([other.id]);
-    book.assign({ tags: [] });
+    wrap(book).assign({ tags: [] });
     expect(book.tags.getIdentifiers()).toMatchObject([]);
-    book.assign({ tags: [tag1.id, tag3.id] });
+    wrap(book).assign({ tags: [tag1.id, tag3.id] });
     expect(book.tags.getIdentifiers()).toMatchObject([tag1.id, tag3.id]);
-    book.assign({ tags: [tag2] });
+    wrap(book).assign({ tags: [tag2] });
     expect(book.tags.getIdentifiers()).toMatchObject([tag2.id]);
   });
 
@@ -57,14 +57,14 @@ describe('EntityHelperMySql', () => {
     const jon = new Author2('Jon Snow', 'snow@wall.st');
     const book = new Book2('Book2', jon);
     book.meta = { items: 5, category: 'test' };
-    book.assign({ meta: { items: 3, category: 'foo' } });
+    wrap(book).assign({ meta: { items: 3, category: 'foo' } });
     expect(book.meta).toEqual({ items: 3, category: 'foo' });
-    book.assign({ meta: { category: 'bar' } }, { mergeObjects: true });
+    wrap(book).assign({ meta: { category: 'bar' } }, { mergeObjects: true });
     expect(book.meta).toEqual({ items: 3, category: 'bar' });
-    book.assign({ meta: { category: 'bar' } });
+    wrap(book).assign({ meta: { category: 'bar' } });
     expect(book.meta).toEqual({ category: 'bar' });
     jon.identities = ['1', '2'];
-    jon.assign({ identities: ['3', '4'] }, { mergeObjects: true });
+    wrap(jon).assign({ identities: ['3', '4'] }, { mergeObjects: true });
     expect(jon.identities).toEqual(['3', '4']);
   });
 

--- a/tests/EntityManager.sqlite.test.ts
+++ b/tests/EntityManager.sqlite.test.ts
@@ -1,9 +1,8 @@
 import { unlinkSync } from 'fs';
-import { Collection, EntityManager, JavaScriptMetadataProvider, LockMode, MikroORM, QueryOrder, Utils } from '../lib';
+import { Collection, EntityManager, EntityMetadata, JavaScriptMetadataProvider, LockMode, MikroORM, QueryOrder, Utils } from '../lib';
 import { initORMSqlite, wipeDatabaseSqlite } from './bootstrap';
 import { SqliteDriver } from '../lib/drivers/SqliteDriver';
 import { Logger, ValidationError } from '../lib/utils';
-import { EntityMetadata } from '../lib/decorators';
 
 const { Author3 } = require('./entities-js').Author3;
 const { Book3 } = require('./entities-js').Book3;
@@ -38,7 +37,7 @@ describe('EntityManagerSqlite', () => {
 
   test('should return sqlite driver', async () => {
     const driver = orm.em.getDriver<SqliteDriver>();
-    expect(driver instanceof SqliteDriver).toBe(true);
+    expect(driver).toBeInstanceOf(SqliteDriver);
     expect(await driver.findOne(Book3.name, { title: '123' })).toBeNull();
     expect(await driver.nativeInsert(BookTag3.name, { name: 'tag', books: [1] })).not.toBeNull();
     await expect(driver.getConnection().execute('select 1 as count')).resolves.toEqual([{ count: 1 }]);
@@ -67,7 +66,7 @@ describe('EntityManagerSqlite', () => {
   });
 
   test('should convert entity to PK when trying to search by entity', async () => {
-    const repo = orm.em.getRepository(Author3);
+    const repo = orm.em.getRepository<any>(Author3);
     const author = new Author3('name', 'email');
     await repo.persistAndFlush(author);
     const a = await repo.findOne(author);
@@ -288,7 +287,7 @@ describe('EntityManagerSqlite', () => {
     await orm.em.persist(bible, true);
     orm.em.clear();
 
-    const ref = orm.em.getReference(Author3, god.id);
+    const ref = orm.em.getReference<any>(Author3, god.id);
     expect(ref.isInitialized()).toBe(false);
     const newGod = await orm.em.findOne(Author3, god.id);
     expect(ref).toBe(newGod);
@@ -348,7 +347,7 @@ describe('EntityManagerSqlite', () => {
     await orm.em.persistAndFlush(test);
     orm.em.clear();
 
-    const proxy = orm.em.getReference(Test3, test.id);
+    const proxy = orm.em.getReference<any>(Test3, test.id);
     await orm.em.lock(proxy, LockMode.OPTIMISTIC, 1);
     expect(proxy.isInitialized()).toBe(true);
   });
@@ -823,18 +822,18 @@ describe('EntityManagerSqlite', () => {
     await orm.em.persist([b1, b2, b3], true);
     orm.em.clear();
 
-    const a1 = (await orm.em.findOne(Author3, { 'id:ne': 10 }))!;
+    const a1 = (await orm.em.findOne<any>(Author3, { 'id:ne': 10 }))!;
     expect(a1).not.toBeNull();
     expect(a1.id).toBe(author.id);
-    const a2 = (await orm.em.findOne(Author3, { 'id>=': 1 }))!;
+    const a2 = (await orm.em.findOne<any>(Author3, { 'id>=': 1 }))!;
     expect(a2).not.toBeNull();
     expect(a2.id).toBe(author.id);
-    const a3 = (await orm.em.findOne(Author3, { 'id:nin': [2, 3, 4] }))!;
+    const a3 = (await orm.em.findOne<any>(Author3, { 'id:nin': [2, 3, 4] }))!;
     expect(a3).not.toBeNull();
     expect(a3.id).toBe(author.id);
-    const a4 = (await orm.em.findOne(Author3, { 'id:in': [] }))!;
+    const a4 = (await orm.em.findOne<any>(Author3, { 'id:in': [] }))!;
     expect(a4).toBeNull();
-    const a5 = (await orm.em.findOne(Author3, { 'id:nin': [] }))!;
+    const a5 = (await orm.em.findOne<any>(Author3, { 'id:nin': [] }))!;
     expect(a5).not.toBeNull();
     expect(a5.id).toBe(author.id);
   });

--- a/tests/EntityRepository.test.ts
+++ b/tests/EntityRepository.test.ts
@@ -1,4 +1,4 @@
-import { EntityRepository, EntityManager, IEntity, Configuration, QueryOrder } from '../lib';
+import { EntityRepository, EntityManager, Configuration, QueryOrder, AnyEntity } from '../lib';
 import { Publisher } from './entities';
 
 const methods = {
@@ -40,10 +40,10 @@ describe('EntityRepository', () => {
     expect(methods.persistAndFlush.mock.calls[0]).toEqual([e]);
     repo.persistLater(e);
     expect(methods.persistLater.mock.calls[0]).toEqual([e]);
-    await repo.find({ foo: 'bar' });
-    expect(methods.find.mock.calls[0]).toEqual([Publisher, { foo: 'bar' }, [], {}, undefined, undefined]);
-    await repo.findAndCount({ foo: 'bar' });
-    expect(methods.findAndCount.mock.calls[0]).toEqual([Publisher, { foo: 'bar' }, [], {}, undefined, undefined]);
+    await repo.find({ name: 'bar' });
+    expect(methods.find.mock.calls[0]).toEqual([Publisher, { name: 'bar' }, [], {}, undefined, undefined]);
+    await repo.findAndCount({ name: 'bar' });
+    expect(methods.findAndCount.mock.calls[0]).toEqual([Publisher, { name: 'bar' }, [], {}, undefined, undefined]);
     await repo.findOne('bar');
     expect(methods.findOne.mock.calls[0]).toEqual([Publisher, 'bar', [], undefined]);
     await repo.findOneOrFail('bar');
@@ -52,7 +52,7 @@ describe('EntityRepository', () => {
     expect(methods.createQueryBuilder.mock.calls[0]).toEqual([Publisher, undefined]);
     await repo.remove('bar');
     expect(methods.remove.mock.calls[0]).toEqual([Publisher, 'bar', true]);
-    const entity = {} as IEntity;
+    const entity = {} as AnyEntity;
     await repo.removeAndFlush(entity);
     expect(methods.removeAndFlush.mock.calls[0]).toEqual([entity]);
     repo.removeLater(entity);
@@ -60,14 +60,14 @@ describe('EntityRepository', () => {
     await repo.create({ name: 'bar' });
     expect(methods.create.mock.calls[0]).toEqual([Publisher, { name: 'bar' }]);
 
-    await repo.nativeInsert({ foo: 'bar' });
-    expect(methods.nativeInsert.mock.calls[0]).toEqual([Publisher, { foo: 'bar' }]);
-    await repo.nativeUpdate({ foo: 'bar' }, { foo: 'baz' });
-    expect(methods.nativeUpdate.mock.calls[0]).toEqual([Publisher, { foo: 'bar' }, { foo: 'baz' }]);
-    await repo.nativeDelete({ foo: 'bar' });
-    expect(methods.nativeDelete.mock.calls[0]).toEqual([Publisher, { foo: 'bar' }]);
-    await repo.aggregate([{ foo: 'bar' }]);
-    expect(methods.aggregate.mock.calls[0]).toEqual([Publisher, [{ foo: 'bar' }]]);
+    await repo.nativeInsert({ name: 'bar' });
+    expect(methods.nativeInsert.mock.calls[0]).toEqual([Publisher, { name: 'bar' }]);
+    await repo.nativeUpdate({ name: 'bar' }, { name: 'baz' });
+    expect(methods.nativeUpdate.mock.calls[0]).toEqual([Publisher, { name: 'bar' }, { name: 'baz' }]);
+    await repo.nativeDelete({ name: 'bar' });
+    expect(methods.nativeDelete.mock.calls[0]).toEqual([Publisher, { name: 'bar' }]);
+    await repo.aggregate([{ name: 'bar' }]);
+    expect(methods.aggregate.mock.calls[0]).toEqual([Publisher, [{ name: 'bar' }]]);
   });
 
   test('find() supports calling with config object', async () => {
@@ -78,8 +78,8 @@ describe('EntityRepository', () => {
       offset: 321,
     };
     methods.find.mock.calls = [];
-    await repo.find({ foo: 'bar' }, options);
-    expect(methods.find.mock.calls[0]).toEqual([Publisher, { foo: 'bar' }, options, {}, undefined, undefined]);
+    await repo.find({ name: 'bar' }, options);
+    expect(methods.find.mock.calls[0]).toEqual([Publisher, { name: 'bar' }, options, {}, undefined, undefined]);
   });
 
   test('findOne() supports calling with config object', async () => {
@@ -88,8 +88,8 @@ describe('EntityRepository', () => {
       orderBy: { test: QueryOrder.DESC },
     };
     methods.findOne.mock.calls = [];
-    await repo.findOne({ foo: 'bar' }, options);
-    expect(methods.findOne.mock.calls[0]).toEqual([Publisher, { foo: 'bar' }, options, undefined]);
+    await repo.findOne({ name: 'bar' }, options);
+    expect(methods.findOne.mock.calls[0]).toEqual([Publisher, { name: 'bar' }, options, undefined]);
   });
 
   test('findOneOrFail() supports calling with config object', async () => {
@@ -99,8 +99,8 @@ describe('EntityRepository', () => {
       handler: () => new Error('Test'),
     };
     methods.findOneOrFail.mock.calls = [];
-    await repo.findOneOrFail({ foo: 'bar' }, options);
-    expect(methods.findOneOrFail.mock.calls[0]).toEqual([Publisher, { foo: 'bar' }, options, undefined]);
+    await repo.findOneOrFail({ name: 'bar' }, options);
+    expect(methods.findOneOrFail.mock.calls[0]).toEqual([Publisher, { name: 'bar' }, options, undefined]);
   });
 
 });

--- a/tests/RequestContext.test.ts
+++ b/tests/RequestContext.test.ts
@@ -1,4 +1,4 @@
-import { RequestContext, MikroORM } from '../lib';
+import { RequestContext, MikroORM, wrap } from '../lib';
 import { initORMMongo, wipeDatabase } from './bootstrap';
 import { Author, Book } from './entities';
 
@@ -34,7 +34,7 @@ describe('RequestContext', () => {
         const em = RequestContext.getEntityManager()!;
         const jon = await em.findOne(Author, author.id, ['favouriteBook']);
         expect(jon!.favouriteBook).toBeInstanceOf(Book);
-        expect(jon!.favouriteBook.isInitialized()).toBe(true);
+        expect(wrap(jon!.favouriteBook).isInitialized()).toBe(true);
         expect(jon!.favouriteBook.title).toBe('Bible');
         resolve();
       });

--- a/tests/SchemaGenerator.test.ts
+++ b/tests/SchemaGenerator.test.ts
@@ -28,7 +28,7 @@ describe('SchemaGenerator', () => {
     const orm = await initORMMySql();
     orm.em.getConnection().execute('drop table if exists new_table');
     const meta = orm.getMetadata();
-    const generator = new SchemaGenerator(orm.em.getDriver(), meta);
+    const generator = orm.getSchemaGenerator();
 
     const newTableMeta = {
       properties: {
@@ -163,7 +163,7 @@ describe('SchemaGenerator', () => {
     const orm = await initORMPostgreSql();
     orm.em.getConnection().execute('drop table if exists new_table cascade');
     const meta = orm.getMetadata();
-    const generator = new SchemaGenerator(orm.em.getDriver(), meta);
+    const generator = orm.getSchemaGenerator();
 
     const newTableMeta = {
       properties: {

--- a/tests/SmartQueryHelper.test.ts
+++ b/tests/SmartQueryHelper.test.ts
@@ -67,6 +67,10 @@ describe('SmartQueryHelper', () => {
     });
   });
 
+  test('processWhere returns empty object for undefined condition', async () => {
+    expect(SmartQueryHelper.processWhere(undefined as any, 'id')).toEqual({});
+  });
+
   test('test entity conversion to PK', async () => {
     const test = Test2.create('t123');
     test.id = 123;
@@ -87,11 +91,11 @@ describe('SmartQueryHelper', () => {
     const book1 = new Book2('b1', author);
     const book2 = new Book2('b2', author);
     const book3 = new Book2('b3', author);
-    expect(SmartQueryHelper.processWhere([1, 2, 3], 'uuid')).toEqual({ uuid: { $in: [1, 2, 3] } });
-    expect(SmartQueryHelper.processWhere([book1, book2, book3], 'uuid')).toEqual({ uuid: { $in: [book1.uuid, book2.uuid, book3.uuid] } });
-    expect(SmartQueryHelper.processWhere({ arr: [1, 2, 3] }, 'id')).toEqual({ arr: { $in: [1, 2, 3] } });
-    expect(SmartQueryHelper.processWhere({ $or: [{ arr: [1, 2, 3] }, { arr: [7, 8, 9] }] }, 'id')).toEqual({
-      $or: [{ arr: { $in: [1, 2, 3] } }, { arr: { $in: [7, 8, 9] } }],
+    expect(SmartQueryHelper.processWhere<Author2>([1, 2, 3], 'uuid')).toEqual({ uuid: { $in: [1, 2, 3] } });
+    expect(SmartQueryHelper.processWhere<Book2>([book1, book2, book3], 'uuid')).toEqual({ uuid: { $in: [book1.uuid, book2.uuid, book3.uuid] } });
+    expect(SmartQueryHelper.processWhere<Author2>({ favouriteBook: ['1', '2', '3'] }, 'id')).toEqual({ favouriteBook: { $in: ['1', '2', '3'] } });
+    expect(SmartQueryHelper.processWhere<Book2>({ $or: [{ author: [1, 2, 3] }, { author: [7, 8, 9] }] }, 'id')).toEqual({
+      $or: [{ author: { $in: [1, 2, 3] } }, { author: { $in: [7, 8, 9] } }],
     });
   });
 

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -1,8 +1,7 @@
 import { ObjectId } from 'mongodb';
-import { Collection, MikroORM, Utils } from '../lib';
+import { Collection, EntityMetadata, MikroORM, Utils } from '../lib';
 import { Author, Book } from './entities';
 import { initORMMongo, wipeDatabase } from './bootstrap';
-import { EntityMetadata } from '../lib/decorators';
 
 class Test {}
 

--- a/tests/decorators.test.ts
+++ b/tests/decorators.test.ts
@@ -1,22 +1,17 @@
-import { IEntity, ManyToMany, ManyToOne, OneToMany, OneToOne, Property } from '../lib';
+import { AnyEntity, ManyToMany, ManyToOne, OneToMany, OneToOne, Property } from '../lib';
 import { Test } from './entities';
 import { MetadataStorage } from '../lib/metadata';
 import { ReferenceType } from '../lib/entity';
 
-class Test2 {}
-interface Test2 extends IEntity<string> { }
+class Test2 implements AnyEntity<Test2> {}
 
-class Test3 {}
-interface Test3 extends IEntity<string> { }
+class Test3 implements AnyEntity<Test3> {}
 
-class Test4 {}
-interface Test4 extends IEntity<string> { }
+class Test4 implements AnyEntity<Test4> {}
 
-class Test5 {}
-interface Test5 extends IEntity<string> { }
+class Test5 implements AnyEntity<Test5> {}
 
-class Test6 {}
-interface Test6 extends IEntity<string> { }
+class Test6 implements AnyEntity<Test6> {}
 
 describe('decorators', () => {
 

--- a/tests/entities-1/dup1.model.ts
+++ b/tests/entities-1/dup1.model.ts
@@ -1,15 +1,17 @@
 import { ObjectId } from 'mongodb';
-import { Entity, IEntity, PrimaryKey, Property } from '../../lib';
+import { Entity, MongoEntity, PrimaryKey, Property } from '../../lib';
+import { SerializedPrimaryKey } from '../../lib/decorators';
 
 @Entity()
-export class Dup1 {
+export class Dup1 implements MongoEntity<Dup1> {
 
   @PrimaryKey()
   _id: ObjectId;
+
+  @SerializedPrimaryKey()
+  id: string;
 
   @Property()
   name: string;
 
 }
-
-export interface Dup1 extends IEntity<string> { }

--- a/tests/entities-1/dup2.model.ts
+++ b/tests/entities-1/dup2.model.ts
@@ -1,16 +1,18 @@
 import { ObjectId } from 'mongodb';
-import { Entity, IEntity, OneToOne, PrimaryKey } from '../../lib';
+import { Entity, MongoEntity, OneToOne, PrimaryKey } from '../../lib';
 import { Dup1 } from './dup1.model';
+import { SerializedPrimaryKey } from '../../lib/decorators';
 
 @Entity()
-export class Dup2 {
+export class Dup2 implements MongoEntity<Dup2> {
 
   @PrimaryKey()
   _id: ObjectId;
+
+  @SerializedPrimaryKey()
+  id: string;
 
   @OneToOne({ owner: true })
   dup1: Dup1;
 
 }
-
-export interface Dup2 extends IEntity<string> { }

--- a/tests/entities-2/dup1.model.ts
+++ b/tests/entities-2/dup1.model.ts
@@ -1,15 +1,17 @@
 import { ObjectId } from 'mongodb';
-import { Entity, IEntity, PrimaryKey, Property } from '../../lib';
+import { Entity, MongoEntity, PrimaryKey, Property } from '../../lib';
+import { SerializedPrimaryKey } from '../../lib/decorators';
 
 @Entity()
-export class Dup1 {
+export class Dup1 implements MongoEntity<Dup1> {
 
   @PrimaryKey()
   _id: ObjectId;
+
+  @SerializedPrimaryKey()
+  id: string;
 
   @Property()
   name: string;
 
 }
-
-export interface Dup1 extends IEntity<string> { }

--- a/tests/entities-2/dup2.model.ts
+++ b/tests/entities-2/dup2.model.ts
@@ -1,16 +1,18 @@
 import { ObjectId } from 'mongodb';
-import { Entity, IEntity, OneToOne, PrimaryKey } from '../../lib';
+import { Entity, MongoEntity, OneToOne, PrimaryKey } from '../../lib';
 import { Dup1 } from './dup1.model';
+import { SerializedPrimaryKey } from '../../lib/decorators';
 
 @Entity()
-export class Dup2 {
+export class Dup2 implements MongoEntity<Dup2> {
 
   @PrimaryKey()
   _id: ObjectId;
+
+  @SerializedPrimaryKey()
+  id: string;
 
   @OneToOne({ owner: true })
   dup1: Dup1;
 
 }
-
-export interface Dup2 extends IEntity<string> { }

--- a/tests/entities-3/bad-name.model.ts
+++ b/tests/entities-3/bad-name.model.ts
@@ -1,14 +1,16 @@
-import { Entity, IEntity, PrimaryKey, Property } from '../../lib';
+import { Entity, MongoEntity, PrimaryKey, Property } from '../../lib';
+import { SerializedPrimaryKey } from '../../lib/decorators';
 
 @Entity()
-export class Test {
+export class Test implements MongoEntity<Test> {
 
   @PrimaryKey({ type: 'ObjectId' })
   _id: any;
+
+  @SerializedPrimaryKey()
+  id: string;
 
   @Property({ type: 'string' })
   name: any;
 
 }
-
-export interface Test extends IEntity<string> { }

--- a/tests/entities-sql/BaseEntity2.ts
+++ b/tests/entities-sql/BaseEntity2.ts
@@ -1,8 +1,8 @@
-import { BeforeCreate, Collection, IEntity, PrimaryKey, Property } from '../../lib';
+import { BeforeCreate, Collection, IdEntity, PrimaryKey, Property } from '../../lib';
 import { MetadataStorage } from '../../lib/metadata';
 import { ReferenceType } from '../../lib/entity';
 
-export abstract class BaseEntity2 {
+export abstract class BaseEntity2 implements IdEntity<BaseEntity2> {
 
   @PrimaryKey()
   id: number;
@@ -27,5 +27,3 @@ export abstract class BaseEntity2 {
   }
 
 }
-
-export interface BaseEntity2 extends IEntity<number> { }

--- a/tests/entities-sql/BaseEntity22.ts
+++ b/tests/entities-sql/BaseEntity22.ts
@@ -1,8 +1,10 @@
-import { Collection, IEntity } from '../../lib';
-import { MetadataStorage } from '../../lib/metadata/MetadataStorage';
-import { ReferenceType } from '../../lib/entity/enums';
+import { Collection, IdEntity, AnyEntity } from '../../lib';
+import { MetadataStorage } from '../../lib/metadata';
+import { ReferenceType } from '../../lib/entity';
 
-export abstract class BaseEntity22 {
+export abstract class BaseEntity22 implements AnyEntity<BaseEntity22, 'id'> {
+
+  abstract id: number;
 
   constructor() {
     const meta = MetadataStorage.getMetadata(this.constructor.name);
@@ -10,11 +12,9 @@ export abstract class BaseEntity22 {
 
     Object.keys(props).forEach(prop => {
       if ([ReferenceType.ONE_TO_MANY, ReferenceType.MANY_TO_MANY].includes(props[prop].reference)) {
-        (this as any)[prop] = new Collection(this);
+        (this as any)[prop] = new Collection(this as AnyEntity);
       }
     });
   }
 
 }
-
-export interface BaseEntity22 extends IEntity<number> { }

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -1,12 +1,12 @@
 import { v4 } from 'uuid';
-import { Cascade, Collection, Entity, IEntity, ManyToMany, ManyToOne, OneToOne, PrimaryKey, Property } from '../../lib';
+import { Cascade, Collection, Entity, ManyToMany, ManyToOne, OneToOne, PrimaryKey, Property, UuidEntity } from '../../lib';
 import { Publisher2 } from './Publisher2';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Test2 } from './Test2';
 
 @Entity()
-export class Book2 {
+export class Book2 implements UuidEntity<Book2> {
 
   @PrimaryKey({ fieldName: 'uuid_pk', length: 36 })
   uuid = v4();
@@ -47,8 +47,6 @@ export class Book2 {
   }
 
 }
-
-export interface Book2 extends IEntity<string> { }
 
 export interface Book2Meta {
   category: string;

--- a/tests/entities-sql/FooBar2.ts
+++ b/tests/entities-sql/FooBar2.ts
@@ -1,9 +1,9 @@
-import { Entity, OneToOne, PrimaryKey, Property } from '../../lib';
+import { Entity, IdEntity, OneToOne, PrimaryKey, Property } from '../../lib';
 import { BaseEntity22 } from './BaseEntity22';
 import { FooBaz2 } from './FooBaz2';
 
 @Entity()
-export class FooBar2 extends BaseEntity22 {
+export class FooBar2 extends BaseEntity22 implements IdEntity<FooBar2> {
 
   @PrimaryKey()
   id: number;
@@ -14,7 +14,7 @@ export class FooBar2 extends BaseEntity22 {
   @OneToOne({ orphanRemoval: true })
   baz: FooBaz2;
 
-  @OneToOne({ owner: true })
+  @OneToOne()
   fooBar: FooBar2;
 
   @Property({ version: true, length: 3 })

--- a/tests/entities-sql/FooBaz2.ts
+++ b/tests/entities-sql/FooBaz2.ts
@@ -1,8 +1,8 @@
-import { Entity, IEntity, OneToOne, PrimaryKey, Property } from '../../lib';
+import { Entity, IdEntity, OneToOne, PrimaryKey, Property } from '../../lib';
 import { FooBar2 } from './FooBar2';
 
 @Entity()
-export class FooBaz2 {
+export class FooBaz2 implements IdEntity<FooBaz2> {
 
   @PrimaryKey()
   id: number;
@@ -21,5 +21,3 @@ export class FooBaz2 {
   }
 
 }
-
-export interface FooBaz2 extends IEntity<number> { }

--- a/tests/entities-sql/Label2.ts
+++ b/tests/entities-sql/Label2.ts
@@ -1,4 +1,4 @@
-import { Entity, IEntity, PrimaryKey, Property } from '../../lib';
+import { Entity, AnyEntity, PrimaryKey, Property } from '../../lib';
 import { v4 } from 'uuid';
 
 @Entity()
@@ -16,4 +16,4 @@ export class Label2 {
 
 }
 
-export interface Label2 extends IEntity<string> { }
+export interface Label2 extends AnyEntity<string> { }

--- a/tests/entities-sql/Test2.ts
+++ b/tests/entities-sql/Test2.ts
@@ -1,8 +1,8 @@
-import { Entity, IEntity, OneToOne, PrimaryKey, Property } from '../../lib';
+import { Entity, IdEntity, OneToOne, PrimaryKey, Property } from '../../lib';
 import { Book2 } from './Book2';
 
 @Entity()
-export class Test2 {
+export class Test2 implements IdEntity<Test2> {
 
   @PrimaryKey()
   id: number;
@@ -29,5 +29,3 @@ export class Test2 {
   }
 
 }
-
-export interface Test2 extends IEntity<number> { }

--- a/tests/entities/Author.ts
+++ b/tests/entities/Author.ts
@@ -1,6 +1,6 @@
 import {
   AfterCreate, AfterDelete, AfterUpdate, BeforeCreate, BeforeDelete, BeforeUpdate,
-  Cascade, Collection, Entity, EntityAssigner, ManyToMany, ManyToOne, OneToMany, Property,
+  Cascade, Collection, Entity, EntityAssigner, ManyToMany, ManyToOne, OneToMany, Property, wrap,
 } from '../../lib';
 
 import { Book } from './Book';
@@ -106,7 +106,7 @@ export class Author extends BaseEntity {
   }
 
   toJSON(strict = true, strip = ['id', 'email'], ...args: any[]): { [p: string]: any } {
-    const o = this.toObject(...args);
+    const o = wrap(this).toObject(...args);
     o.fooBar = 123;
 
     if (strict) {

--- a/tests/entities/BaseEntity.ts
+++ b/tests/entities/BaseEntity.ts
@@ -1,10 +1,14 @@
-import { BeforeCreate, IEntity, PrimaryKey, Property } from '../../lib';
 import { ObjectId } from 'bson';
+import { BeforeCreate, MongoEntity, PrimaryKey, Property } from '../../lib';
+import { SerializedPrimaryKey } from '../../lib/decorators';
 
-export abstract class BaseEntity {
+export abstract class BaseEntity implements MongoEntity<BaseEntity> {
 
   @PrimaryKey()
   _id: ObjectId;
+
+  @SerializedPrimaryKey()
+  id: string;
 
   @Property()
   createdAt = new Date();
@@ -24,5 +28,3 @@ export abstract class BaseEntity {
   }
 
 }
-
-export interface BaseEntity extends IEntity<string> { }

--- a/tests/entities/BaseEntity3.ts
+++ b/tests/entities/BaseEntity3.ts
@@ -1,11 +1,13 @@
-import { IEntity, PrimaryKey } from '../../lib';
 import { ObjectId } from 'bson';
+import { MongoEntity, PrimaryKey } from '../../lib';
+import { SerializedPrimaryKey } from '../../lib/decorators';
 
-export abstract class BaseEntity3 {
+export abstract class BaseEntity3 implements MongoEntity<BaseEntity3> {
 
   @PrimaryKey()
   _id: ObjectId;
 
-}
+  @SerializedPrimaryKey()
+  id: string;
 
-export interface BaseEntity3 extends IEntity<string> { }
+}

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -1,5 +1,15 @@
 import { ObjectId } from 'mongodb';
-import { Cascade, Collection, Entity, IdentifiedReference, ManyToMany, ManyToOne, PrimaryKey, Property } from '../../lib';
+import {
+  Cascade,
+  Collection,
+  Entity,
+  IdentifiedReference,
+  ManyToMany,
+  ManyToOne,
+  PrimaryKey,
+  Property,
+  wrap,
+} from '../../lib';
 import { Publisher } from './Publisher';
 import { Author } from './Author';
 import { BookTag } from './book-tag';
@@ -39,7 +49,7 @@ export class Book extends BaseEntity3 {
   }
 
   toJSON(strict = true, strip = ['metaObject', 'metaArray', 'metaArrayOfStrings'], ...args: any[]): { [p: string]: any } {
-    const o = this.toObject(...args);
+    const o = wrap(this).toObject(...args);
 
     if (strict) {
       strip.forEach(k => delete o[k]);

--- a/tests/entities/FooBar.ts
+++ b/tests/entities/FooBar.ts
@@ -1,12 +1,16 @@
 import { ObjectId } from 'mongodb';
-import { Entity, IEntity, OneToOne, PrimaryKey, Property } from '../../lib';
+import { Entity, MongoEntity, OneToOne, PrimaryKey, Property } from '../../lib';
 import { FooBaz } from './FooBaz';
+import { SerializedPrimaryKey } from '../../lib/decorators';
 
 @Entity()
-export class FooBar {
+export class FooBar implements MongoEntity<FooBar> {
 
   @PrimaryKey()
   _id: ObjectId;
+
+  @SerializedPrimaryKey()
+  id: string;
 
   @Property()
   name: string;
@@ -25,5 +29,3 @@ export class FooBar {
   }
 
 }
-
-export interface FooBar extends IEntity<string> { }

--- a/tests/entities/FooBaz.ts
+++ b/tests/entities/FooBaz.ts
@@ -1,13 +1,17 @@
 import { ObjectId } from 'mongodb';
-import { Entity, IEntity, ManyToOne, OneToOne, PrimaryKey, Property } from '../../lib';
+import { Entity, ManyToOne, MongoEntity, OneToOne, PrimaryKey, Property } from '../../lib';
 import { FooBar } from './FooBar';
 import { Book } from './Book';
+import { SerializedPrimaryKey } from '../../lib/decorators';
 
 @Entity()
-export class FooBaz {
+export class FooBaz implements MongoEntity<FooBaz> {
 
   @PrimaryKey()
   _id: ObjectId;
+
+  @SerializedPrimaryKey()
+  id: string;
 
   @Property()
   name: string;
@@ -26,5 +30,3 @@ export class FooBaz {
   }
 
 }
-
-export interface FooBaz extends IEntity<string> { }

--- a/tests/entities/Publisher.ts
+++ b/tests/entities/Publisher.ts
@@ -1,13 +1,17 @@
 import { ObjectId } from 'mongodb';
-import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, Property, IEntity, BeforeCreate } from '../../lib';
+import { Collection, Entity, ManyToMany, MongoEntity, OneToMany, PrimaryKey, Property, BeforeCreate } from '../../lib';
 import { Book } from './Book';
 import { Test } from './test.model';
+import { SerializedPrimaryKey } from '../../lib/decorators';
 
 @Entity()
-export class Publisher {
+export class Publisher implements MongoEntity<Publisher> {
 
   @PrimaryKey()
   _id: ObjectId;
+
+  @SerializedPrimaryKey()
+  id: string;
 
   @Property()
   name: string;
@@ -32,8 +36,6 @@ export class Publisher {
   }
 
 }
-
-export interface Publisher extends IEntity<string> { }
 
 export enum PublisherType {
   LOCAL = 'local',

--- a/tests/entities/book-tag.ts
+++ b/tests/entities/book-tag.ts
@@ -1,12 +1,16 @@
 import { ObjectId } from 'mongodb';
-import { Collection, Entity, ManyToMany, PrimaryKey, Property, IEntity } from '../../lib';
+import { Collection, Entity, ManyToMany, PrimaryKey, Property, MongoEntity } from '../../lib';
 import { Book } from './Book';
+import { SerializedPrimaryKey } from '../../lib/decorators';
 
 @Entity()
-export class BookTag {
+export class BookTag implements MongoEntity<BookTag> {
 
   @PrimaryKey()
   _id: ObjectId;
+
+  @SerializedPrimaryKey()
+  id: string;
 
   @Property()
   name: string;
@@ -19,5 +23,3 @@ export class BookTag {
   }
 
 }
-
-export interface BookTag extends IEntity { }

--- a/tests/entities/test.model.ts
+++ b/tests/entities/test.model.ts
@@ -1,10 +1,14 @@
-import { Entity, IEntity, PrimaryKey, Property } from '../../lib';
+import { Entity, MongoEntity, PrimaryKey, Property } from '../../lib';
+import { SerializedPrimaryKey } from '../../lib/decorators';
 
 @Entity()
-export class Test {
+export class Test implements MongoEntity<Test> {
 
   @PrimaryKey({ type: 'ObjectId' })
   _id: any;
+
+  @SerializedPrimaryKey()
+  id: string;
 
   @Property({ type: 'string' })
   name: any;
@@ -29,5 +33,3 @@ export class Test {
   }
 
 }
-
-export interface Test extends IEntity<string> { }

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,0 +1,247 @@
+import { assert, Has, IsExact, IsNever } from 'conditional-type-checks';
+import { ObjectId } from 'mongodb';
+import {
+  CollectionItem, DeepPartialEntity, EntityOrPrimary, FilterQuery, FilterValue, OneOrArray, OperatorMap, PartialEntity,
+  Primary, PrimaryKeyType, Query, StringProp,
+} from '../lib/types';
+import { Author2, Book2, BookTag2 } from './entities-sql';
+import { Author, Book } from './entities';
+import { Collection } from '../lib/entity';
+
+type IsAssignable<T, Expected> = Expected extends T ? true : false;
+
+describe('check typings', () => {
+
+  test('Primary', async () => {
+    assert<IsExact<Primary<Book2>, string>>(true);
+    assert<IsExact<Primary<Book2>, number>>(false);
+    assert<IsExact<Primary<Author2>, number>>(true);
+    assert<IsExact<Primary<Author2>, string>>(false);
+
+    // PrimaryKeyType symbol has priority
+    type Test = { _id: ObjectId; id: string; uuid: number; [PrimaryKeyType]: Date };
+    assert<IsExact<Primary<Test>, Date>>(true);
+    assert<IsExact<Primary<Test>, ObjectId>>(false);
+    assert<IsExact<Primary<Test>, string>>(false);
+    assert<IsExact<Primary<Test>, number>>(false);
+
+    // object id allows string
+    assert<IsExact<Primary<Author>, ObjectId | string>>(true);
+    assert<IsExact<Primary<Author>, number>>(false);
+  });
+
+  test('EntityOrPrimary', async () => {
+    assert<IsExact<EntityOrPrimary<Book2>, PartialEntity<Book2> | DeepPartialEntity<Book2> | string>>(true);
+    assert<Has<EntityOrPrimary<Book2>, { title: string }>>(true);
+    assert<Has<EntityOrPrimary<Book2>, { name: string }>>(false);
+    assert<Has<EntityOrPrimary<Book2>, { born: Date }>>(false);
+    assert<IsExact<EntityOrPrimary<Author2>, PartialEntity<Author2> | DeepPartialEntity<Author2> | number>>(true);
+    assert<Has<EntityOrPrimary<Author2>, string>>(false);
+    assert<Has<EntityOrPrimary<Author2>, { born?: Date }>>(true);
+    assert<Has<EntityOrPrimary<Author2>, { name: string }>>(true);
+    assert<Has<EntityOrPrimary<Author2>, { name: null }>>(false);
+  });
+
+  test('OneOrArray', async () => {
+    assert<IsExact<OneOrArray<string>, string | string[]>>(true);
+    assert<IsExact<OneOrArray<number>, number | number[]>>(true);
+    assert<IsExact<OneOrArray<EntityOrPrimary<Author2>>, number | number[] | DeepPartialEntity<Author2> | DeepPartialEntity<Author2>[] | PartialEntity<Author2> | PartialEntity<Author2>[]>>(true);
+    assert<IsExact<OneOrArray<Author2>, Author2 | Author2[]>>(true);
+    assert<IsExact<OneOrArray<string | number>, string | number | string[] | number[]>>(true);
+    assert<IsExact<OneOrArray<EntityOrPrimary<Author2>>, Author2 | Author2[] | number | number[] | DeepPartialEntity<Author2> | PartialEntity<Author2> | DeepPartialEntity<Author2>[] | PartialEntity<Author2>[]>>(true);
+    assert<Has<OneOrArray<EntityOrPrimary<Author2>>, number[]>>(true);
+  });
+
+  test('StringProp', async () => {
+    assert<IsExact<StringProp<string>, string | RegExp>>(true);
+    assert<IsNever<StringProp<number>>>(true);
+    assert<IsNever<StringProp<number>>>(true);
+    assert<IsNever<StringProp<Date>>>(true);
+  });
+
+  test('CollectionItem', async () => {
+    assert<IsExact<CollectionItem<Author2['books']>, EntityOrPrimary<Book2>>>(true);
+    assert<Has<CollectionItem<Author2['books']>, string>>(true);
+    assert<Has<CollectionItem<Author['books']>, ObjectId>>(true);
+    assert<Has<CollectionItem<Collection<Book2>>, string>>(true);
+    assert<Has<CollectionItem<Collection<Book>>, ObjectId>>(true);
+    assert<Has<CollectionItem<Collection<Book>>, Book>>(true);
+    assert<IsNever<CollectionItem<number>>>(true);
+    assert<IsNever<CollectionItem<string>>>(true);
+    assert<IsNever<CollectionItem<Book>>>(true);
+    assert<IsNever<CollectionItem<Book2>>>(true);
+    assert<IsNever<CollectionItem<Date>>>(true);
+    assert<Has<CollectionItem<Collection<Author2>>, number[]>>(false);
+  });
+
+  test('FilterValue', async () => {
+    assert<IsExact<FilterValue<string>, RegExp | string | OperatorMap<string>>>(true); // strings allow regexps
+    assert<IsExact<FilterValue<number>, number | OperatorMap<number>>>(true);
+    assert<Has<FilterValue<string>, number>>(false);
+    assert<IsExact<FilterValue<Date>, Date | OperatorMap<Date>>>(true);
+    assert<IsExact<FilterValue<RegExp>, RegExp | OperatorMap<RegExp>>>(true);
+
+    // require specific type
+    assert<Has<FilterValue<number>, string>>(false);
+    assert<Has<FilterValue<Date>, string>>(false);
+    assert<Has<FilterValue<Date>, number>>(false);
+
+    // allows collection item
+    assert<Has<FilterValue<Collection<Book2>>, string>>(true);
+    assert<Has<FilterValue<Collection<Author2>>, number>>(true);
+    assert<Has<FilterValue<Collection<Author2>>, string>>(false);
+    assert<Has<FilterValue<Collection<Author2>>, Author2>>(true);
+    assert<Has<FilterValue<Collection<Author2>>, string[]>>(false);
+    assert<Has<OneOrArray<EntityOrPrimary<Author2>>, number[]>>(true);
+    assert<Has<FilterValue<Collection<Author2>>, number[]>>(true);
+    assert<Has<FilterValue<Collection<Author2>>, Author2[]>>(true);
+    assert<Has<FilterValue<Collection<Author2>>, Book2[]>>(false);
+    assert<Has<FilterValue<Author['books']>, ObjectId>>(true);
+    assert<Has<FilterValue<Collection<Book2>>, string>>(true);
+    assert<Has<FilterValue<Collection<Book>>, ObjectId>>(true);
+
+    // allows entity/pk and arrays of entity/pk
+    assert<Has<FilterValue<Author2>, Author2[]>>(true);
+    assert<Has<FilterValue<Author2>, number[]>>(true);
+    assert<Has<FilterValue<Author2>, Author2>>(true);
+    assert<Has<FilterValue<Author2>, number>>(true);
+
+    // date requires date
+    assert<Has<FilterValue<Author['born']>, Date>>(true);
+    assert<Has<FilterValue<Author['born']>, number>>(false);
+    assert<Has<FilterValue<Author['born']>, string>>(false);
+  });
+
+  test('Query', async () => {
+    assert<Has<Query<Author['born']>, Date>>(true);
+    assert<Has<Query<Author['born']>, number>>(false);
+    assert<Has<Query<Author['born']>, string>>(false);
+    assert<Has<Query<Author>, { born?: Date }>>(true);
+    assert<Has<Query<Author>, { born?: number }>>(false);
+    assert<Has<Query<Author>, { born?: string }>>(false);
+    assert<IsAssignable<Query<Author2>, { favouriteBook: string }>>(true);
+    assert<IsAssignable<Query<Author2>, { favouriteBook: null }>>(true);
+    assert<IsAssignable<Query<Author2>, { favouriteBook: number }>>(false);
+    assert<IsAssignable<Query<Author2>, { favouriteBook: { author: number } }>>(true);
+    assert<IsAssignable<Query<Author2>, { favouriteBook: { author: null } }>>(true);
+    assert<IsAssignable<Query<Author2>, { favouriteBook: { author: string } }>>(false);
+    assert<Has<Query<Author2>, Author2>>(true);
+    assert<Has<Query<Author2>, number>>(true);
+    assert<Has<Query<Author2>, string>>(false);
+    assert<Has<Query<Author2>, Author2[]>>(true);
+    assert<Has<Query<Author2>, { books: { author: { born?: string } }; favouriteBook: null }>>(false);
+    assert<Has<Query<Author2>, { books: { author: { born?: number } }; favouriteBook: null }>>(false);
+    assert<Has<Query<Book2>, { author: { born?: Date } }>>(true);
+    assert<Has<Query<Book2>, { author: { born?: string } }>>(false);
+    assert<Has<Query<Book2>, { author: { born?: number } }>>(false);
+    assert<IsAssignable<Query<Author2>, { favouriteBook: { author: { born: Date } } }>>(true);
+    assert<IsAssignable<Query<Author2>, { favouriteBook: { author: { books: string[] } } }>>(true);
+    assert<IsAssignable<Query<Book2>, { author: { books: string[] } }>>(true);
+    assert<IsAssignable<Query<Author2>, { books: { author: { born: Date } } }>>(true);
+    assert<IsAssignable<Query<Author2>, { books: { author: { born: null } } }>>(true);
+    assert<IsAssignable<Query<Author2>, { favouriteBook: null }>>(true);
+    assert<IsAssignable<Query<Author2>, { favouriteBook: string }>>(true);
+    assert<Has<Query<Author2>, { favouriteBook: number }>>(false);
+    assert<Has<Query<Book2>, { author: { born?: Date }; favouriteBook: string }>>(false); // favouriteBook does not exist on Book2
+    assert<IsAssignable<Query<Book2>, { author: { books: { publisher: number } } }>>(true);
+    assert<IsAssignable<Query<Book2>, { author: { books: { publisher: null } } }>>(true);
+    assert<Has<Query<Author2>, { favouriteBook: Query<Book2> }>>(true);
+    assert<IsAssignable<Query<Author2>, { books: FilterValue<Book2> }>>(true);
+    assert<IsAssignable<Query<Author2>, { books: string }>>(true);
+    assert<IsAssignable<Query<Author2>, { books: string[] }>>(true);
+    assert<IsAssignable<Query<Author2>, { books: Book2 }>>(true);
+    assert<IsAssignable<Query<Author2>, { books: Book2[] }>>(true);
+    assert<IsAssignable<Query<Author2>, { books: null }>>(true);
+    assert<IsAssignable<Query<Author2>, { books: { author: Author2 }; favouriteBook: Book2 }>>(true);
+    assert<IsAssignable<Query<Author2>, { books: { author: { born: Date } }; favouriteBook: null }>>(true);
+    assert<IsAssignable<Query<Author2>, { books: { author: { born: Date } }; favouriteBook: Book2 }>>(true);
+    assert<IsAssignable<Query<Author2>, { books: { author: { born: Date } }; favouriteBook: null }>>(true);
+    assert<IsAssignable<Query<Author2>, { books: { author: { born: Date } }; favouriteBook: { title: null } }>>(true);
+
+    // hard to test this before support to test assign-ability is exposed TS compiler api
+    // @see https://github.com/microsoft/TypeScript/pull/33263/files#diff-c3ed224e4daa84352f7f1abcd23e8ccaR525-R527
+    // assert<IsAssignable<Query<Book2>, { author: { books: { publisher: string } } }>>(false); // should pass
+    // const t1: Query<Book2> = { author: { books: { publisher: 1 } } }; // ok
+    // const t2: Query<Book2> = { author: { books: { publisher: '1' } } }; // ok, should fail
+    // assert<Has<Query<Author2>, { age: { $gte: number } }>>(true); // should pass
+    // assert<IsAssignable<Query<Author2>, { books: { author: { born: number } }; favouriteBook: null }>>(false); // hard to test failures
+    // assert<IsAssignable<Query<Author2>, { books: { author: { born: string } }; favouriteBook: null }>>(false); // hard to test failures
+  });
+
+  test('FilterQuery', async () => {
+    assert<Has<FilterQuery<Author2>, number>>(true);
+    assert<Has<FilterQuery<Author2>, number[]>>(true);
+    assert<Has<FilterQuery<Author2>, string>>(false);
+    assert<Has<FilterQuery<Author2>, number[]>>(true);
+
+    assert<IsAssignable<FilterQuery<Book2>, { author: 123 }>>(true);
+    assert<IsAssignable<FilterQuery<Author2>, { favouriteBook: null }>>(true);
+    assert<IsAssignable<FilterQuery<Author2>, { books: { author: { name: 'asd' } } }>>(true);
+    assert<IsAssignable<FilterQuery<Author2>, { books: { author: Author2 } }>>(true);
+    assert<IsAssignable<FilterQuery<Author2>, { books: { author: 123 } }>>(true);
+    // assert<IsAssignable<FilterQuery<Author2>, { books: { author: '123' } }>>(false); // hard to test failures
+
+    assert<IsAssignable<FilterQuery<Author2>, { books: { title: '123' }; favouriteBook: null }>>(true);
+    // assert<IsAssignable<FilterQuery<Author2>, { books: { title: 123 }; favouriteBook: null }>>(false); // hard to test failures
+    // assert<IsAssignable<FilterQuery<Author2>, { books: { title: Date }; favouriteBook: null }>>(false); // hard to test failures
+
+    assert<IsAssignable<FilterQuery<Author2>, { born: Date }>>(true);
+    // assert<IsAssignable<FilterQuery<Author2>, { born: number }>>(false); // hard to test failures
+    // assert<IsAssignable<FilterQuery<Author2>, { born: string }>>(false); // hard to test failures
+
+    assert<IsAssignable<FilterQuery<Author2>, { age: { $in: [1] } }>>(true);
+    // assert<IsAssignable<FilterQuery<Author2>, { age: { $in: ['1'] } }>>(false); // hard to test failures
+    // assert<IsAssignable<FilterQuery<Author2>, { age: { $gta: ['1'] } }>>(false); // hard to test failures
+
+    assert<IsAssignable<FilterQuery<Author2>, { age: { $gte: number } }>>(true);
+    assert<IsAssignable<FilterQuery<Author2>, { age: { $gte: number }; born: { $lt: Date }; $and: [{ name: { $ne: 'John' } }, { name: { $in: ['Ben', 'Paul'] } }] }>>(true);
+    assert<Has<FilterQuery<Author2>, { favouriteBook: Book2 }>>(true);
+    assert<IsAssignable<FilterQuery<Author2>, { $and: [{ favouriteBook: Book2 }, { name: string }] }>>(true);
+    assert<IsAssignable<FilterQuery<Author2>, { $and: [{ favouriteBook: { title: string } }, { name: string }] }>>(true);
+    assert<IsAssignable<FilterQuery<Author2>, { $and: [{ favouriteBook: string }, { name: string }] }>>(true);
+    assert<Has<FilterQuery<Author2>, Author2>>(true);
+    assert<Has<FilterQuery<Author2>, number>>(true);
+    assert<Has<FilterQuery<Author2>, { favouriteBook: Query<Book2> }>>(true);
+    assert<Has<FilterQuery<Book2>, { author: { favouriteBook: Query<Book2> } }>>(true);
+    assert<Has<FilterQuery<Book2>, { author: { favouriteBook: { title: string } } }>>(true);
+    assert<IsAssignable<FilterQuery<Book2>, { author: { favouriteBook: { tags: FilterValue<BookTag2> } } }>>(true);
+    assert<IsAssignable<FilterQuery<Book2>, { author: { favouriteBook: { tags: BookTag2[] } } }>>(true);
+    assert<IsAssignable<FilterQuery<Book2>, { author: { favouriteBook: { tags: number[] } } }>>(true);
+  });
+
+  test('FilterQuery ok assignments', async () => {
+    let ok01: FilterQuery<Author2>;
+    ok01 = {};
+    ok01 = { born: new Date() };
+    ok01 = { born: { $gte: new Date() } };
+    ok01 = { age: { $gte: 1 } };
+    ok01 = { favouriteBook: '1' };
+    ok01 = { favouriteBook: ['1', '2'] };
+    ok01 = { favouriteBook: null };
+    ok01 = { books: { author: { born: new Date() } }, favouriteBook: null };
+    ok01 = { books: { author: { born: new Date() } } };
+    ok01 = { books: { author: { born: new Date() } }, favouriteBook: {} as Book2 };
+  });
+
+  // there is no way to test this currently, uncomment to check they all fail
+  // test('FilterQuery bad assignments', async () => {
+  //   let fail01: FilterQuery<Author2>;
+  //   fail01 = { books: { author: { born: 123 } }, favouriteBook: null };
+  //   fail01 = { born: 123 };
+  //   fail01 = { books: { author: { born: 123 } }, favouriteBook: null };
+  //   fail01 = { books: { author: { born: '123' } }, favouriteBook: null };
+  //   fail01 = { age: { $gta: 1 } };
+  //   fail01 = { ago: { $gte: 1 } };
+  //   fail01 = { ago: { $gta: 1 } };
+  //   fail01 = { favouriteBook: 1 };
+  //   fail01 = { favouriteBook: 1 };
+  //   fail01 = { favouriteBook: [1, '2'] };
+  //   fail01 = { favouriteBook: [1, 2] };
+  //
+  //   let fail02: FilterQuery<Book2>;
+  //   fail02 = { author: { born: 123 } };
+  //   fail02 = { author: { born: '123' } };
+  //   fail02 = { author: { born: { $or: ['123'] } } };
+  // });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1663,6 +1663,11 @@ concat-stream@^1.5.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+conditional-type-checks@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/conditional-type-checks/-/conditional-type-checks-1.0.1.tgz#0905a8631ea11bf155e7a6edb6d6b55c2e50520e"
+  integrity sha512-+O/IE/QGjXzdk4ttJFLRQm8pofQE0KZZmgcamquUGhHfaZt0UTZMlklqW0J9tWO8HQvC70cPahEAVMwSfeqtuQ==
+
 config-chain@^1.1.12:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
@@ -7441,10 +7446,10 @@ ts-morph@^4.0.0:
     multimatch "^4.0.0"
     typescript "^3.0.1"
 
-ts-node@^8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.3.0.tgz#e4059618411371924a1fb5f3b125915f324efb57"
-  integrity sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==
+ts-node@^8.4.1:
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.4.1.tgz#270b0dba16e8723c9fa4f9b4775d3810fd994b4f"
+  integrity sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==
   dependencies:
     arg "^4.1.0"
     diff "^4.0.1"
@@ -7543,10 +7548,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.0.1, typescript@^3.5.0:
+typescript@^3.0.1:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+
+typescript@^3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
+  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
 
 uglify-js@^3.1.4:
   version "3.6.0"


### PR DESCRIPTION
Now it is no longer needed to merge entities with `IEntity` interface, that was polluting entity's interface with internal methods.
New interfaces `IdentifiedEntity<T>`, `UuidEntity<T>` and `MongoEntity<T>` are introduced, that should be implemented by entities. They
are not adding any new properties or methods, keeping the entity's interface clean.

This also introduces new strictly typed `FilterQuery<T>` implementation based on information provided by those new interfaces (type of primary key
in particular). It is not used in query builder, as there string keys needs to be supported for aliasing to work (`{ 'a.books': 1 }`). 

**BREAKING CHANGES:**
`IEntity` interface no longer has public methods like `toJSON()`, `toObject()` or `init()`. One can use `wrap()` method provided by ORM that
will enhance property type when needed with those methods (`await wrap(book.author).init()`). To keep all methods available on the
entity, you can still use interface merging with `WrappedEntity<T, PK>` that both extends `IEntity<T, PK>` and defines all those methods. 
FilterQuery now does not allow using smart query operators. You can either cast your condition as any or use object syntax instead
(instead of `{ 'age:gte': 18 }` use `{ age: { $gte: 18 } }`).

Closes #124, #171