### PR TITLE
Fixes for tests on windows.

### DIFF
--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -181,11 +181,11 @@ describe('Utils', () => {
   });
 
   test('absolutePath', () => {
-    expect(Utils.absolutePath('./test')).toBe(process.cwd() + '/test');
-    expect(Utils.absolutePath('test')).toBe(process.cwd() + '/test');
-    expect(Utils.absolutePath(process.cwd() + '/tests/')).toBe(process.cwd() + '/tests');
-    expect(Utils.absolutePath('./tests/cli')).toBe(process.cwd() + '/tests/cli');
-    expect(Utils.absolutePath('')).toBe(process.cwd());
+    expect(Utils.absolutePath('./test')).toBe(Utils.normalizePath(process.cwd() + '/test'));
+    expect(Utils.absolutePath('test')).toBe(Utils.normalizePath(process.cwd() + '/test'));
+    expect(Utils.absolutePath(process.cwd() + '/tests/')).toBe(Utils.normalizePath(process.cwd() + '/tests'));
+    expect(Utils.absolutePath('./tests/cli')).toBe(Utils.normalizePath(process.cwd() + '/tests/cli'));
+    expect(Utils.absolutePath('')).toBe(Utils.normalizePath(process.cwd()));
   });
 
   test('pathExists wrapper', async () => {

--- a/tests/cli/DebugCommand.test.ts
+++ b/tests/cli/DebugCommand.test.ts
@@ -28,7 +28,7 @@ describe('DebugCommand', () => {
     expect(dump.mock.calls).toEqual([
       ['Current MikroORM CLI configuration'],
       [' - searched config paths:'],
-      [`   - ${process.cwd()}/path/orm-config.ts (found)`],
+      [`   - ${Utils.normalizePath(process.cwd() + '/path/orm-config.ts') } (found)`],
       [' - configuration found'],
     ]);
 
@@ -42,11 +42,11 @@ describe('DebugCommand', () => {
       ['Current MikroORM CLI configuration'],
       [' - ts-node enabled'],
       [' - searched config paths:'],
-      [`   - ${process.cwd()}/path/orm-config.ts (found)`],
+      [`   - ${Utils.normalizePath(process.cwd() + '/path/orm-config.ts') } (found)`],
       [' - configuration found'],
       [' - will use `entitiesDirs` paths:'],
-      [`   - ${process.cwd()}/entities-1 (found)`],
-      [`   - ${process.cwd()}/entities-2 (not found)`],
+      [`   - ${Utils.normalizePath(process.cwd() + '/entities-1') } (found)`],
+      [`   - ${Utils.normalizePath(process.cwd() + '/entities-2') } (not found)`],
     ]);
 
     getConfiguration.mockResolvedValue(new Configuration({ entities: [FooBar, FooBaz] } as any, false));
@@ -57,7 +57,7 @@ describe('DebugCommand', () => {
       ['Current MikroORM CLI configuration'],
       [' - ts-node enabled'],
       [' - searched config paths:'],
-      [`   - ${process.cwd()}/path/orm-config.ts (found)`],
+      [`   - ${Utils.normalizePath(process.cwd() + '/path/orm-config.ts') } (found)`],
       [' - configuration found'],
       [' - will use `entities` array (contains 2 items)'],
     ]);
@@ -70,7 +70,7 @@ describe('DebugCommand', () => {
       ['Current MikroORM CLI configuration'],
       [' - ts-node enabled'],
       [' - searched config paths:'],
-      [`   - ${process.cwd()}/path/orm-config.ts (found)`],
+      [`   - ${Utils.normalizePath(process.cwd() + '/path/orm-config.ts') } (found)`],
       ['- configuration not found (test error message)'],
     ]);
 
@@ -82,7 +82,7 @@ describe('DebugCommand', () => {
       ['Current MikroORM CLI configuration'],
       [' - ts-node enabled'],
       [' - searched config paths:'],
-      [`   - ${process.cwd()}/path/orm-config.ts (not found)`],
+      [`   - ${Utils.normalizePath(process.cwd() + '/path/orm-config.ts') } (not found)`],
       [' - configuration found'],
       [' - will use `entities` array (contains 2 items)'],
     ]);


### PR DESCRIPTION
Added Utils.normalizePath to fix errors with running tests on windows. As this function is tested seperately, I assume that it's working correctly.

Example errors:
    - (expected)    "   - C:\\Users\\XX\\Repositories\\mikro-orm/path/orm-config.ts (found)",
    + (received)"   - C:/Users/AW/Repositories/mikro-orm/path/orm-config.ts (found)",