### PR TITLE
feat(core): use composite PK in many to many relations

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -127,6 +127,20 @@ books = new Collection<Book>(this);
 books = new Collection<Book>(this);
 ```
 
+### Forcing fixed order of collection items
+
+> Since v3 many to many collections does not require having auto increment primary key, that 
+> was used to ensure fixed order of collection items.
+
+To preserve fixed order of collections, you can use `fixedOrder: true` attribute, which will 
+start ordering by `id` column. Schema generator will convert the pivot table to have auto increment
+primary key `id`. You can also change the order column name via `fixedOrderColumn: 'order'`. 
+
+You can also specify default ordering via `orderBy: { ... }` attribute. This will be used when
+you fully populate the collection including its items, as it orders by the referenced entity 
+properties instead of pivot table columns (which `fixedOrderColumn` is). On the other hand, 
+`fixedOrder` is used to maintain the insert order of items instead of ordering by some property. 
+
 ## Propagation of Collection's add() and remove() operations
 
 When you use one of `Collection.add()` method, the item is added to given collection, 

--- a/docs/query-builder.md
+++ b/docs/query-builder.md
@@ -234,6 +234,7 @@ console.log(qb.getQuery()); // for MySQL
 
 ```typescript
 qb.select(fields: string | string[], distinct?: boolean): QueryBuilder;
+qb.addSelect(fields: string | string[]): QueryBuilder;
 qb.insert(data: Record<string, any>): QueryBuilder;
 qb.update(data: Record<string, any>): QueryBuilder;
 qb.delete(cond: Record<string, any>): QueryBuilder;

--- a/docs/upgrading-v2-to-v3.md
+++ b/docs/upgrading-v2-to-v3.md
@@ -71,11 +71,17 @@ In postgres driver, it used to be required to pass parameters as indexed dollar 
 ($1, $2, ...), while now knex requires the placeholder to be simple question mark (`?`), 
 like in other dialects, so this is now unified with other drivers.
 
-## SchemaGenerator.generate() is now async
+## ManyToMany now uses composite primary key
 
-If you used `SchemaGenerator`, now there is CLI tool you can use instead. Learn more 
-in [SchemaGenerator docs](schema-generator.md). To setup CLI, take a look at 
-[installation section](installation.md).
+Previously it was required to have autoincrement primary key for m:n pivot tables. Now this 
+has changed. By default, only foreign columns are required and composite key over both of them
+is used as primary key.
+
+To preserve stable order of collections, you can force previous behaviour by defining the 
+m:n property as `fixedOrder: true`, which will start ordering by `id` column. You can also 
+override the order column name via `fixedOrderColumn: 'order'`. 
+
+You can also specify default ordering via `orderBy: { ... }` attribute.
 
 ## Strict FilterQuery and smart query conditions
 
@@ -90,6 +96,16 @@ option. `true`/`false` will enable/disable all namespaces.
 
 Available logger namespaces: `'query' | 'query-params' | 'discovery' | 'info'`.
 
+## Removed deprecated fk option from 1:m and m:1 decorators 
+
+Use `mappedBy`/`inversedBy` instead.
+
+## SchemaGenerator.generate() is now async
+
+If you used `SchemaGenerator`, now there is CLI tool you can use instead. Learn more 
+in [SchemaGenerator docs](schema-generator.md). To setup CLI, take a look at 
+[installation section](installation.md).
+
 ## New method on NamingStrategy interface
 
 `getClassName()` is used to find entity class name based on its file name. Now users can 
@@ -97,7 +113,3 @@ override the default implementation to accommodate their specific needs.
 
 If you used custom naming strategy, you will either need to implement this method yourself, 
 or extend `AbstractNamingStrategy`.
-
-## Removed deprecated fk option from 1:m and m:1 decorators 
-
-Use `mappedBy`/`inversedBy` instead.

--- a/lib/EntityManager.ts
+++ b/lib/EntityManager.ts
@@ -79,7 +79,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
 
     await this.entityLoader.populate(entityName, ret, options.populate || [], where, options.orderBy || {});
 
-    return ret;
+    return Utils.unique(ret);
   }
 
   async findAndCount<T extends AnyEntity<T>>(entityName: EntityName<T>, where: FilterQuery<T>, options?: FindOptions): Promise<[T[], number]>;

--- a/lib/decorators/ManyToMany.ts
+++ b/lib/decorators/ManyToMany.ts
@@ -12,6 +12,11 @@ export function ManyToMany<T extends AnyEntity<T>>(
 ) {
   return function (target: AnyEntity, propertyName: string) {
     options = Utils.isObject<ManyToManyOptions<T>>(entity) ? entity : { ...options, entity, mappedBy };
+    options.fixedOrder = options.fixedOrder || !!options.fixedOrderColumn;
+
+    if (!options.owner && !options.inversedBy && !options.mappedBy) {
+      options.owner = true;
+    }
 
     if (options.owner) {
       Utils.renameKey(options, 'mappedBy', 'inversedBy');
@@ -22,10 +27,6 @@ export function ManyToMany<T extends AnyEntity<T>>(
 
     if (!options.entity) {
       throw new Error(`'@ManyToMany({ entity: string | Function })' is required in '${target.constructor.name}.${propertyName}'`);
-    }
-
-    if (!options.owner && !options.inversedBy && !options.mappedBy) {
-      options.owner = true;
     }
 
     const property = { name: propertyName, reference: ReferenceType.MANY_TO_MANY, owner: !!options.inversedBy, cascade: [Cascade.PERSIST, Cascade.MERGE] } as EntityProperty<T>;
@@ -39,6 +40,8 @@ export interface ManyToManyOptions<T extends AnyEntity<T>> extends ReferenceOpti
   inversedBy?: (string & keyof T) | ((e: T) => any);
   mappedBy?: (string & keyof T) | ((e: T) => any);
   orderBy?: { [field: string]: QueryOrder };
+  fixedOrder?: boolean;
+  fixedOrderColumn?: string;
   pivotTable?: string;
   joinColumn?: string;
   inverseJoinColumn?: string;

--- a/lib/decorators/ManyToOne.ts
+++ b/lib/decorators/ManyToOne.ts
@@ -28,4 +28,5 @@ export interface ManyToOneOptions<T extends AnyEntity<T>> extends ReferenceOptio
   entity?: string | (() => EntityName<T>);
   inversedBy?: (string & keyof T) | ((e: T) => any);
   wrappedReference?: boolean;
+  primary?: boolean;
 }

--- a/lib/decorators/OneToOne.ts
+++ b/lib/decorators/OneToOne.ts
@@ -15,4 +15,5 @@ export interface OneToOneOptions<T extends AnyEntity<T>> extends Partial<Omit<On
   owner?: boolean;
   inversedBy?: (string & keyof T) | ((e: T) => any);
   wrappedReference?: boolean;
+  primary?: boolean;
 }

--- a/lib/entity/EntityLoader.ts
+++ b/lib/entity/EntityLoader.ts
@@ -130,7 +130,6 @@ export class EntityLoader {
   }
 
   private async findChildrenFromPivotTable<T extends AnyEntity<T>>(filtered: T[], prop: EntityProperty, field: keyof T, where?: FilterQuery<T>, orderBy?: QueryOrderMap): Promise<AnyEntity[]> {
-    orderBy = orderBy || prop.orderBy;
     const map = await this.driver.loadFromPivotTable(prop, filtered.map(e => wrap(e).__primaryKey) as Primary<T>[], where, orderBy, this.em.getTransactionContext());
     const children: AnyEntity[] = [];
 

--- a/lib/metadata/MetadataValidator.ts
+++ b/lib/metadata/MetadataValidator.ts
@@ -60,11 +60,6 @@ export class MetadataValidator {
   }
 
   private validateBidirectional(meta: EntityMetadata, prop: EntityProperty, metadata: MetadataStorage): void {
-    // 1:1 reference either is owner or has `mappedBy`
-    if (!prop.owner && !prop.mappedBy && !prop.inversedBy) {
-      throw ValidationError.fromMissingOwnership(meta, prop);
-    }
-
     if (prop.inversedBy) {
       const inverse = metadata.get(prop.type).properties[prop.inversedBy];
       this.validateOwningSide(meta, prop, inverse);

--- a/lib/query/CriteriaNode.ts
+++ b/lib/query/CriteriaNode.ts
@@ -116,7 +116,7 @@ export class ScalarCriteriaNode extends CriteriaNode {
       }
 
       if (this.prop!.reference === ReferenceType.ONE_TO_ONE) {
-        qb._fields!.push(field);
+        qb.addSelect(field);
       }
     }
 

--- a/lib/query/QueryBuilder.ts
+++ b/lib/query/QueryBuilder.ts
@@ -56,6 +56,10 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     return this.init(QueryType.SELECT);
   }
 
+  addSelect(fields: string | string[]): this {
+    return this.select([...Utils.asArray(this._fields), ...Utils.asArray(fields)]);
+  }
+
   insert(data: any): this {
     return this.init(QueryType.INSERT, data);
   }

--- a/lib/query/QueryBuilderHelper.ts
+++ b/lib/query/QueryBuilderHelper.ts
@@ -350,10 +350,10 @@ export class QueryBuilderHelper {
   }
 
   finalize(type: QueryType, qb: KnexQueryBuilder, meta?: EntityMetadata): void {
-    const useReturningStatement = type === QueryType.INSERT && this.platform.usesReturningStatement();
+    const useReturningStatement = type === QueryType.INSERT && this.platform.usesReturningStatement() && meta && !meta.compositePK;
 
-    if (useReturningStatement && meta) {
-      const returningProps = Object.values(meta.properties).filter(prop => prop.primary || prop.default);
+    if (useReturningStatement) {
+      const returningProps = Object.values(meta!.properties).filter(prop => prop.primary || prop.default);
       qb.returning(returningProps.map(prop => prop.fieldName));
     }
   }

--- a/lib/schema/DatabaseTable.ts
+++ b/lib/schema/DatabaseTable.ts
@@ -21,7 +21,7 @@ export class DatabaseTable {
     this.columns = cols.reduce((o, v) => {
       const index = indexes[v.name] || [];
       v.primary = pks.includes(v.name);
-      v.unique = index.some(i => i.unique);
+      v.unique = index.some(i => i.unique && !i.primary);
       v.fk = fks[v.name];
       v.indexes = index.filter(i => !i.primary);
       o[v.name] = v;

--- a/lib/schema/EntityGenerator.ts
+++ b/lib/schema/EntityGenerator.ts
@@ -157,19 +157,23 @@ export class EntityGenerator {
     if (!(cascade.length === 2 && cascade.includes('Cascade.PERSIST') && cascade.includes('Cascade.MERGE'))) {
       options.cascade = `[${cascade.sort().join(', ')}]`;
     }
+
+    if (column.primary) {
+      options.primary = true;
+    }
   }
 
   private getDecoratorType(column: Column): string {
-    if (column.primary) {
-      return '@PrimaryKey';
-    }
-
     if (column.fk && column.unique) {
       return '@OneToOne';
     }
 
     if (column.fk) {
       return '@ManyToOne';
+    }
+
+    if (column.primary) {
+      return '@PrimaryKey';
     }
 
     return '@Property';

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -122,6 +122,8 @@ export interface EntityProperty<T extends AnyEntity<T> = any> {
   inversedBy: string;
   mappedBy: string;
   orderBy?: { [field: string]: QueryOrder };
+  fixedOrder?: boolean;
+  fixedOrderColumn?: string;
   pivotTable: string;
   joinColumn: string;
   inverseJoinColumn: string;
@@ -141,6 +143,8 @@ export interface EntityMetadata<T extends AnyEntity<T> = any> {
   collection: string;
   path: string;
   primaryKey: keyof T & string;
+  primaryKeys: (keyof T & string)[];
+  compositePK: boolean;
   versionProperty: keyof T & string;
   serializedPrimaryKey: keyof T & string;
   properties: { [K in keyof T & string]: EntityProperty<T> };

--- a/lib/utils/ValidationError.ts
+++ b/lib/utils/ValidationError.ts
@@ -57,10 +57,6 @@ export class ValidationError<T extends AnyEntity = AnyEntity> extends Error {
     return new ValidationError(`Both ${meta.name}.${prop.name} and ${prop.type}.${prop[key]} are defined as ${type} sides, use '${other}' on one of them`);
   }
 
-  static fromMissingOwnership(meta: EntityMetadata, prop: EntityProperty): ValidationError {
-    return ValidationError.fromMessage(meta, prop, `needs to have one of 'owner', 'mappedBy' or 'inversedBy' attributes`);
-  }
-
   static fromMergeWithoutPK(meta: EntityMetadata): void {
     throw new ValidationError(`You cannot merge entity '${meta.name}' without identifier!`);
   }

--- a/tests/EntityGenerator.test.ts
+++ b/tests/EntityGenerator.test.ts
@@ -1,6 +1,8 @@
 import { pathExists, remove } from 'fs-extra';
-import { initORMMongo, initORMMySql, initORMPostgreSql, initORMSqlite } from './bootstrap';
+import { initORMMySql, initORMPostgreSql, initORMSqlite } from './bootstrap';
 import { EntityGenerator } from '../lib/schema/EntityGenerator';
+import { MongoDriver } from '../lib/drivers/MongoDriver';
+import { Configuration, MikroORM } from '../lib';
 
 describe('EntityGenerator', () => {
 
@@ -41,10 +43,8 @@ describe('EntityGenerator', () => {
   });
 
   test('not supported [mongodb]', async () => {
-    const orm = await initORMMongo();
-    expect(() => orm.getEntityGenerator()).toThrowError('Not supported by given driver');
-
-    await orm.close(true);
+    const mongoOrm = Object.create(MikroORM.prototype, { driver: new MongoDriver(new Configuration({} as any, false)) } as any);
+    expect(() => mongoOrm.getEntityGenerator()).toThrowError('Not supported by given driver');
   });
 
 });

--- a/tests/EntityHelper.mysql.test.ts
+++ b/tests/EntityHelper.mysql.test.ts
@@ -40,9 +40,7 @@ describe('EntityHelperMySql', () => {
     const tag1 = new BookTag2('tag 1');
     const tag2 = new BookTag2('tag 2');
     const tag3 = new BookTag2('tag 3');
-    book.tags.add(tag1);
-    book.tags.add(tag2);
-    book.tags.add(tag3);
+    book.tags.add(tag1, tag2, tag3);
     await orm.em.persistAndFlush(book);
     wrap(book).assign({ tags: [other.id] });
     expect(book.tags.getIdentifiers()).toMatchObject([other.id]);

--- a/tests/MetadataValidator.test.ts
+++ b/tests/MetadataValidator.test.ts
@@ -35,8 +35,6 @@ describe('MetadataValidator', () => {
 
     // many to many inversedBy
     meta.Book = { name: 'Book', properties: {} };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrowError(`Author.books needs to have one of 'owner', 'mappedBy' or 'inversedBy' attributes`);
-
     meta.Author.properties.books = { name: 'books', reference: ReferenceType.MANY_TO_MANY, type: 'Book', inversedBy: 'bar' };
     expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrowError(`Author.books has unknown 'inversedBy' reference: Book.bar`);
 
@@ -67,8 +65,6 @@ describe('MetadataValidator', () => {
 
     // one to one inversedBy
     meta.Bar = { name: 'Bar', properties: {} };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Foo')).toThrowError(`Foo.bar needs to have one of 'owner', 'mappedBy' or 'inversedBy' attributes`);
-
     meta.Foo.properties.bar = { name: 'bar', reference: ReferenceType.ONE_TO_ONE, type: 'Bar', inversedBy: 'bar' };
     expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Foo')).toThrowError(`Foo.bar has unknown 'inversedBy' reference: Bar.bar`);
 

--- a/tests/SchemaGenerator.test.ts
+++ b/tests/SchemaGenerator.test.ts
@@ -1,7 +1,9 @@
-import { initORMMongo, initORMMySql, initORMPostgreSql, initORMSqlite } from './bootstrap';
+import { initORMMySql, initORMPostgreSql, initORMSqlite } from './bootstrap';
 import { SchemaGenerator } from '../lib/schema';
 import { ReferenceType } from '../lib/entity';
-import { Utils } from '../lib/utils';
+import { Configuration, Utils } from '../lib/utils';
+import { MikroORM } from '../lib';
+import { MongoDriver } from '../lib/drivers/MongoDriver';
 
 describe('SchemaGenerator', () => {
 
@@ -256,10 +258,8 @@ describe('SchemaGenerator', () => {
   });
 
   test('not supported [mongodb]', async () => {
-    const orm = await initORMMongo();
-    expect(() => orm.getSchemaGenerator()).toThrowError('Not supported by given driver');
-
-    await orm.close(true);
+    const mongoOrm = Object.create(MikroORM.prototype, { driver: new MongoDriver(new Configuration({} as any, false)) } as any);
+    expect(() => mongoOrm.getSchemaGenerator()).toThrowError('Not supported by given driver');
   });
 
 });

--- a/tests/__snapshots__/EntityGenerator.test.ts.snap
+++ b/tests/__snapshots__/EntityGenerator.test.ts.snap
@@ -90,7 +90,7 @@ import { BookTag2 } from './BookTag2';
 export class Book2ToBookTag2 {
 
     @PrimaryKey()
-    id: number;
+    order: number;
 
     @ManyToOne({ entity: () => Book2, cascade: [Cascade.ALL] })
     book2: Book2;
@@ -110,6 +110,21 @@ export class BookTag2 {
 
     @Property({ length: 50 })
     name: string;
+
+}
+",
+  "import { Cascade, Entity, ManyToOne } from 'mikro-orm';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
+
+@Entity()
+export class BookToTagUnordered {
+
+    @ManyToOne({ entity: () => Book2, cascade: [Cascade.ALL], primary: true })
+    book2: Book2;
+
+    @ManyToOne({ entity: () => BookTag2, cascade: [Cascade.ALL], primary: true })
+    bookTag2: BookTag2;
 
 }
 ",
@@ -306,7 +321,7 @@ import { BookTag2 } from './BookTag2';
 export class Book2ToBookTag2 {
 
     @PrimaryKey()
-    id: number;
+    order: number;
 
     @ManyToOne({ entity: () => Book2, cascade: [Cascade.ALL] })
     book2: Book2;
@@ -326,6 +341,21 @@ export class BookTag2 {
 
     @Property({ length: 50 })
     name: string;
+
+}
+",
+  "import { Cascade, Entity, ManyToOne } from 'mikro-orm';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
+
+@Entity()
+export class BookToTagUnordered {
+
+    @ManyToOne({ entity: () => Book2, cascade: [Cascade.ALL], primary: true })
+    book2: Book2;
+
+    @ManyToOne({ entity: () => BookTag2, cascade: [Cascade.ALL], primary: true })
+    bookTag2: BookTag2;
 
 }
 ",

--- a/tests/__snapshots__/SchemaGenerator.test.ts.snap
+++ b/tests/__snapshots__/SchemaGenerator.test.ts.snap
@@ -30,9 +30,14 @@ alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`)
 
 create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
 
-create table \`book2_to_book_tag2\` (\`id\` int unsigned not null auto_increment primary key, \`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
+create table \`book2_to_book_tag2\` (\`order\` int unsigned not null auto_increment primary key, \`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table \`book2_to_book_tag2\` add index \`book2_to_book_tag2_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
 alter table \`book2_to_book_tag2\` add index \`book2_to_book_tag2_book_tag2_id_index\`(\`book_tag2_id\`);
+
+create table \`book_to_tag_unordered\` (\`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
+alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
+alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book_tag2_id_index\`(\`book_tag2_id\`);
+alter table \`book_to_tag_unordered\` add primary key \`book_to_tag_unordered_pkey\`(\`book2_uuid_pk\`, \`book_tag2_id\`);
 
 create table \`publisher2_to_test2\` (\`id\` int unsigned not null auto_increment primary key, \`publisher2_id\` int(11) unsigned not null, \`test2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table \`publisher2_to_test2\` add index \`publisher2_to_test2_publisher2_id_index\`(\`publisher2_id\`);
@@ -51,6 +56,9 @@ alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign 
 
 alter table \`book2_to_book_tag2\` add constraint \`book2_to_book_tag2_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;
 alter table \`book2_to_book_tag2\` add constraint \`book2_to_book_tag2_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`book_to_tag_unordered\` add constraint \`book_to_tag_unordered_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;
+alter table \`book_to_tag_unordered\` add constraint \`book_to_tag_unordered_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;
 
 alter table \`publisher2_to_test2\` add constraint \`publisher2_to_test2_publisher2_id_foreign\` foreign key (\`publisher2_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
 alter table \`publisher2_to_test2\` add constraint \`publisher2_to_test2_test2_id_foreign\` foreign key (\`test2_id\`) references \`test2\` (\`id\`) on update cascade on delete cascade;
@@ -71,6 +79,7 @@ drop table if exists \`test2\`;
 drop table if exists \`foo_bar2\`;
 drop table if exists \`foo_baz2\`;
 drop table if exists \`book2_to_book_tag2\`;
+drop table if exists \`book_to_tag_unordered\`;
 drop table if exists \`publisher2_to_test2\`;
 
 set foreign_key_checks = 1;
@@ -89,6 +98,7 @@ drop table if exists \`test2\`;
 drop table if exists \`foo_bar2\`;
 drop table if exists \`foo_baz2\`;
 drop table if exists \`book2_to_book_tag2\`;
+drop table if exists \`book_to_tag_unordered\`;
 drop table if exists \`publisher2_to_test2\`;
 
 create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null, \`terms_accepted\` tinyint(1) not null default 0, \`identities\` json null, \`born\` datetime null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8 engine = InnoDB;
@@ -117,9 +127,14 @@ alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`)
 
 create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
 
-create table \`book2_to_book_tag2\` (\`id\` int unsigned not null auto_increment primary key, \`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
+create table \`book2_to_book_tag2\` (\`order\` int unsigned not null auto_increment primary key, \`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table \`book2_to_book_tag2\` add index \`book2_to_book_tag2_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
 alter table \`book2_to_book_tag2\` add index \`book2_to_book_tag2_book_tag2_id_index\`(\`book_tag2_id\`);
+
+create table \`book_to_tag_unordered\` (\`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
+alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
+alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book_tag2_id_index\`(\`book_tag2_id\`);
+alter table \`book_to_tag_unordered\` add primary key \`book_to_tag_unordered_pkey\`(\`book2_uuid_pk\`, \`book_tag2_id\`);
 
 create table \`publisher2_to_test2\` (\`id\` int unsigned not null auto_increment primary key, \`publisher2_id\` int(11) unsigned not null, \`test2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table \`publisher2_to_test2\` add index \`publisher2_to_test2_publisher2_id_index\`(\`publisher2_id\`);
@@ -138,6 +153,9 @@ alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign 
 
 alter table \`book2_to_book_tag2\` add constraint \`book2_to_book_tag2_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;
 alter table \`book2_to_book_tag2\` add constraint \`book2_to_book_tag2_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`book_to_tag_unordered\` add constraint \`book_to_tag_unordered_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;
+alter table \`book_to_tag_unordered\` add constraint \`book_to_tag_unordered_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;
 
 alter table \`publisher2_to_test2\` add constraint \`publisher2_to_test2_publisher2_id_foreign\` foreign key (\`publisher2_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
 alter table \`publisher2_to_test2\` add constraint \`publisher2_to_test2_test2_id_foreign\` foreign key (\`test2_id\`) references \`test2\` (\`id\`) on update cascade on delete cascade;
@@ -188,7 +206,10 @@ create table \\"foo_baz2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255
 create table \\"label2\\" (\\"uuid\\" uuid not null, \\"name\\" varchar(255) not null);
 alter table \\"label2\\" add constraint \\"label2_pkey\\" primary key (\\"uuid\\");
 
-create table \\"book2_to_book_tag2\\" (\\"id\\" serial primary key, \\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" int4 not null);
+create table \\"book2_to_book_tag2\\" (\\"order\\" serial primary key, \\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" int4 not null);
+
+create table \\"book_to_tag_unordered\\" (\\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" int4 not null);
+alter table \\"book_to_tag_unordered\\" add constraint \\"book_to_tag_unordered_pkey\\" primary key (\\"book2_uuid_pk\\", \\"book_tag2_id\\");
 
 create table \\"publisher2_to_test2\\" (\\"id\\" serial primary key, \\"publisher2_id\\" int4 not null, \\"test2_id\\" int4 not null);
 
@@ -205,6 +226,9 @@ alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_foreign\\" fore
 
 alter table \\"book2_to_book_tag2\\" add constraint \\"book2_to_book_tag2_book2_uuid_pk_foreign\\" foreign key (\\"book2_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update cascade on delete cascade;
 alter table \\"book2_to_book_tag2\\" add constraint \\"book2_to_book_tag2_book_tag2_id_foreign\\" foreign key (\\"book_tag2_id\\") references \\"book_tag2\\" (\\"id\\") on update cascade on delete cascade;
+
+alter table \\"book_to_tag_unordered\\" add constraint \\"book_to_tag_unordered_book2_uuid_pk_foreign\\" foreign key (\\"book2_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update cascade on delete cascade;
+alter table \\"book_to_tag_unordered\\" add constraint \\"book_to_tag_unordered_book_tag2_id_foreign\\" foreign key (\\"book_tag2_id\\") references \\"book_tag2\\" (\\"id\\") on update cascade on delete cascade;
 
 alter table \\"publisher2_to_test2\\" add constraint \\"publisher2_to_test2_publisher2_id_foreign\\" foreign key (\\"publisher2_id\\") references \\"publisher2\\" (\\"id\\") on update cascade on delete cascade;
 alter table \\"publisher2_to_test2\\" add constraint \\"publisher2_to_test2_test2_id_foreign\\" foreign key (\\"test2_id\\") references \\"test2\\" (\\"id\\") on update cascade on delete cascade;
@@ -226,6 +250,7 @@ drop table if exists \\"foo_bar2\\" cascade;
 drop table if exists \\"foo_baz2\\" cascade;
 drop table if exists \\"label2\\" cascade;
 drop table if exists \\"book2_to_book_tag2\\" cascade;
+drop table if exists \\"book_to_tag_unordered\\" cascade;
 drop table if exists \\"publisher2_to_test2\\" cascade;
 
 set session_replication_role = 'origin';
@@ -245,6 +270,7 @@ drop table if exists \\"foo_bar2\\" cascade;
 drop table if exists \\"foo_baz2\\" cascade;
 drop table if exists \\"label2\\" cascade;
 drop table if exists \\"book2_to_book_tag2\\" cascade;
+drop table if exists \\"book_to_tag_unordered\\" cascade;
 drop table if exists \\"publisher2_to_test2\\" cascade;
 
 create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"updated_at\\" timestamptz(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int4 null, \\"terms_accepted\\" bool not null default 0, \\"identities\\" json null, \\"born\\" timestamptz(0) null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int4 null);
@@ -269,7 +295,10 @@ create table \\"foo_baz2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255
 create table \\"label2\\" (\\"uuid\\" uuid not null, \\"name\\" varchar(255) not null);
 alter table \\"label2\\" add constraint \\"label2_pkey\\" primary key (\\"uuid\\");
 
-create table \\"book2_to_book_tag2\\" (\\"id\\" serial primary key, \\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" int4 not null);
+create table \\"book2_to_book_tag2\\" (\\"order\\" serial primary key, \\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" int4 not null);
+
+create table \\"book_to_tag_unordered\\" (\\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" int4 not null);
+alter table \\"book_to_tag_unordered\\" add constraint \\"book_to_tag_unordered_pkey\\" primary key (\\"book2_uuid_pk\\", \\"book_tag2_id\\");
 
 create table \\"publisher2_to_test2\\" (\\"id\\" serial primary key, \\"publisher2_id\\" int4 not null, \\"test2_id\\" int4 not null);
 
@@ -286,6 +315,9 @@ alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_foreign\\" fore
 
 alter table \\"book2_to_book_tag2\\" add constraint \\"book2_to_book_tag2_book2_uuid_pk_foreign\\" foreign key (\\"book2_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update cascade on delete cascade;
 alter table \\"book2_to_book_tag2\\" add constraint \\"book2_to_book_tag2_book_tag2_id_foreign\\" foreign key (\\"book_tag2_id\\") references \\"book_tag2\\" (\\"id\\") on update cascade on delete cascade;
+
+alter table \\"book_to_tag_unordered\\" add constraint \\"book_to_tag_unordered_book2_uuid_pk_foreign\\" foreign key (\\"book2_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update cascade on delete cascade;
+alter table \\"book_to_tag_unordered\\" add constraint \\"book_to_tag_unordered_book_tag2_id_foreign\\" foreign key (\\"book_tag2_id\\") references \\"book_tag2\\" (\\"id\\") on update cascade on delete cascade;
 
 alter table \\"publisher2_to_test2\\" add constraint \\"publisher2_to_test2_publisher2_id_foreign\\" foreign key (\\"publisher2_id\\") references \\"publisher2\\" (\\"id\\") on update cascade on delete cascade;
 alter table \\"publisher2_to_test2\\" add constraint \\"publisher2_to_test2_test2_id_foreign\\" foreign key (\\"test2_id\\") references \\"test2\\" (\\"id\\") on update cascade on delete cascade;

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -69,7 +69,7 @@ export async function initORMMySql<D extends MySqlDriver | MariaDbDriver = MySql
 
 export async function initORMPostgreSql() {
   const orm = await MikroORM.init<PostgreSqlDriver>({
-    entities: [Author2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, BaseEntity2, BaseEntity22, Label2],
+    entities: [Author2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, Label2, BaseEntity2, BaseEntity22],
     tsConfigPath: BASE_DIR + '/tsconfig.test.json',
     dbName: `mikro_orm_test`,
     baseDir: BASE_DIR,
@@ -124,6 +124,7 @@ export async function wipeDatabaseMySql(em: EntityManager) {
   await em.createQueryBuilder(Publisher2).truncate().execute();
   await em.createQueryBuilder(Test2).truncate().execute();
   await em.createQueryBuilder('book2_to_book_tag2').truncate().execute();
+  await em.createQueryBuilder('book_to_tag_unordered').truncate().execute();
   await em.createQueryBuilder('publisher2_to_test2').truncate().execute();
   await em.getConnection().execute('set foreign_key_checks = 1');
   em.clear();
@@ -137,6 +138,7 @@ export async function wipeDatabasePostgreSql(em: EntityManager) {
   await em.createQueryBuilder(Publisher2).truncate().execute();
   await em.createQueryBuilder(Test2).truncate().execute();
   await em.createQueryBuilder('book2_to_book_tag2').truncate().execute();
+  await em.createQueryBuilder('book_to_tag_unordered').truncate().execute();
   await em.createQueryBuilder('publisher2_to_test2').truncate().execute();
   await em.getConnection().execute(`set session_replication_role = 'origin'`);
   em.clear();

--- a/tests/entities-js/Book3.js
+++ b/tests/entities-js/Book3.js
@@ -41,6 +41,7 @@ const schema = {
     tags: {
       reference: 'm:n',
       owner: true,
+      fixedOrder: true,
       inversedBy: 'books',
       type: 'BookTag3',
     },

--- a/tests/entities-js/Publisher3.js
+++ b/tests/entities-js/Publisher3.js
@@ -32,7 +32,7 @@ const schema = {
     },
     tests: {
       reference: 'm:n',
-      owner: true,
+      fixedOrder: true,
       type: 'Test3',
     },
     type: {

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -38,8 +38,11 @@ export class Book2 implements UuidEntity<Book2> {
   @OneToOne({ cascade: [], mappedBy: 'book' })
   test?: Test2;
 
-  @ManyToMany({ entity: () => BookTag2, inversedBy: 'books', cascade: [], orderBy: { name: QueryOrder.ASC } })
+  @ManyToMany({ entity: () => BookTag2, cascade: [], fixedOrderColumn: 'order' })
   tags = new Collection<BookTag2>(this);
+
+  @ManyToMany(() => BookTag2, undefined, { pivotTable: 'book_to_tag_unordered', orderBy: { name: QueryOrder.ASC } })
+  tagsUnordered = new Collection<BookTag2>(this);
 
   constructor(title: string, author: Author2) {
     this.title = title;

--- a/tests/entities-sql/BookTag2.ts
+++ b/tests/entities-sql/BookTag2.ts
@@ -8,8 +8,11 @@ export class BookTag2 extends BaseEntity2 {
   @Property({ length: 50 })
   name: string;
 
-  @ManyToMany({ entity: () => Book2, mappedBy: 'tags' })
+  @ManyToMany(() => Book2, book => book.tags)
   books!: Collection<Book2>;
+
+  @ManyToMany(() => Book2, book => book.tagsUnordered)
+  booksUnordered!: Collection<Book2>;
 
   constructor(name: string) {
     super();

--- a/tests/entities-sql/Publisher2.ts
+++ b/tests/entities-sql/Publisher2.ts
@@ -12,7 +12,7 @@ export class Publisher2 extends BaseEntity2 {
   @OneToMany({ entity: () => Book2, mappedBy: 'publisher' })
   books!: Collection<Book2>;
 
-  @ManyToMany({ entity: () => Test2, owner: true })
+  @ManyToMany({ entity: () => Test2, fixedOrder: true })
   tests!: Collection<Test2>;
 
   @Property({ type: 'string', length: 10 })

--- a/tests/mysql-schema.sql
+++ b/tests/mysql-schema.sql
@@ -9,6 +9,7 @@ drop table if exists `test2`;
 drop table if exists `foo_bar2`;
 drop table if exists `foo_baz2`;
 drop table if exists `book2_to_book_tag2`;
+drop table if exists `book_to_tag_unordered`;
 drop table if exists `publisher2_to_test2`;
 
 create table `author2` (`id` int unsigned not null auto_increment primary key, `created_at` datetime(3) not null default current_timestamp(3), `updated_at` datetime(3) not null default current_timestamp(3), `name` varchar(255) not null, `email` varchar(255) not null, `age` int(11) null, `terms_accepted` tinyint(1) not null default 0, `identities` json null, `born` datetime null, `favourite_book_uuid_pk` varchar(36) null, `favourite_author_id` int(11) unsigned null) default character set utf8 engine = InnoDB;
@@ -39,11 +40,16 @@ alter table `foo_bar2` add index `foo_bar2_foo_bar_id_index`(`foo_bar_id`);
 
 create table `foo_baz2` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) not null, `version` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
 
-create table `book2_to_book_tag2` (`id` int unsigned not null auto_increment primary key, `book2_uuid_pk` varchar(36) not null, `book_tag2_id` int(11) unsigned not null) default character set utf8 engine = InnoDB;
+create table `book2_to_book_tag2` (`order` int unsigned not null auto_increment primary key, `book2_uuid_pk` varchar(36) not null, `book_tag2_id` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table `book2_to_book_tag2` add index `book2_to_book_tag2_book2_uuid_pk_index`(`book2_uuid_pk`);
 alter table `book2_to_book_tag2` add index `book2_to_book_tag2_book_tag2_id_index`(`book_tag2_id`);
 
-create table `publisher2_to_test2` (`id` int unsigned not null auto_increment primary key, `publisher2_id` int(11) unsigned not null, `test2_id` int(11) unsigned not null) default character set utf8 engine = InnoDB;
+create table `book_to_tag_unordered` (`book2_uuid_pk` varchar(36) not null, `book_tag2_id` int(11) unsigned not null) default character set utf8 engine = InnoDB;
+alter table `book_to_tag_unordered` add index `book_to_tag_unordered_book2_uuid_pk_index`(`book2_uuid_pk`);
+alter table `book_to_tag_unordered` add index `book_to_tag_unordered_book_tag2_id_index`(`book_tag2_id`);
+alter table `book_to_tag_unordered` add primary key `book_to_tag_unordered_pkey`(`book2_uuid_pk`, `book_tag2_id`);
+
+create table `publisher2_to_test2` (`id` int unsigned not null auto_increment  primary key, `publisher2_id` int(11) unsigned not null, `test2_id` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table `publisher2_to_test2` add index `publisher2_to_test2_publisher2_id_index`(`publisher2_id`);
 alter table `publisher2_to_test2` add index `publisher2_to_test2_test2_id_index`(`test2_id`);
 
@@ -61,6 +67,9 @@ alter table `foo_bar2` add constraint `foo_bar2_foo_bar_id_foreign` foreign key 
 
 alter table `book2_to_book_tag2` add constraint `book2_to_book_tag2_book2_uuid_pk_foreign` foreign key (`book2_uuid_pk`) references `book2` (`uuid_pk`) on update cascade on delete cascade;
 alter table `book2_to_book_tag2` add constraint `book2_to_book_tag2_book_tag2_id_foreign` foreign key (`book_tag2_id`) references `book_tag2` (`id`) on update cascade on delete cascade;
+
+alter table `book_to_tag_unordered` add constraint `book_to_tag_unordered_book2_uuid_pk_foreign` foreign key (`book2_uuid_pk`) references `book2` (`uuid_pk`) on update cascade on delete cascade;
+alter table `book_to_tag_unordered` add constraint `book_to_tag_unordered_book_tag2_id_foreign` foreign key (`book_tag2_id`) references `book_tag2` (`id`) on update cascade on delete cascade;
 
 alter table `publisher2_to_test2` add constraint `publisher2_to_test2_publisher2_id_foreign` foreign key (`publisher2_id`) references `publisher2` (`id`) on update cascade on delete cascade;
 alter table `publisher2_to_test2` add constraint `publisher2_to_test2_test2_id_foreign` foreign key (`test2_id`) references `test2` (`id`) on update cascade on delete cascade;

--- a/tests/postgre-schema.sql
+++ b/tests/postgre-schema.sql
@@ -9,6 +9,7 @@ drop table if exists "test2" cascade;
 drop table if exists "foo_bar2" cascade;
 drop table if exists "foo_baz2" cascade;
 drop table if exists "book2_to_book_tag2" cascade;
+drop table if exists "book_to_tag_unordered" cascade;
 drop table if exists "publisher2_to_test2" cascade;
 drop table if exists "label2" cascade;
 
@@ -31,7 +32,9 @@ alter table "foo_bar2" add constraint "foo_bar2_foo_bar_id_unique" unique ("foo_
 
 create table "foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
 
-create table "book2_to_book_tag2" ("id" serial primary key, "book2_uuid_pk" varchar(36) not null, "book_tag2_id" int4 not null);
+create table "book2_to_book_tag2" ("order" serial primary key, "book2_uuid_pk" varchar(36) not null, "book_tag2_id" int4 not null);
+
+create table "book_to_tag_unordered" ("book2_uuid_pk" varchar(36) not null, "book_tag2_id" int4 not null, primary key ("book2_uuid_pk", "book_tag2_id"));
 
 create table "publisher2_to_test2" ("id" serial primary key, "publisher2_id" int4 not null, "test2_id" int4 not null);
 
@@ -48,6 +51,9 @@ alter table "foo_bar2" add constraint "foo_bar2_foo_bar_id_foreign" foreign key 
 
 alter table "book2_to_book_tag2" add constraint "book2_to_book_tag2_book2_uuid_pk_foreign" foreign key ("book2_uuid_pk") references "book2" ("uuid_pk") on update cascade on delete cascade;
 alter table "book2_to_book_tag2" add constraint "book2_to_book_tag2_book_tag2_id_foreign" foreign key ("book_tag2_id") references "book_tag2" ("id") on update cascade on delete cascade;
+
+alter table "book_to_tag_unordered" add constraint "book_to_tag_unordered_book2_uuid_pk_foreign" foreign key ("book2_uuid_pk") references "book2" ("uuid_pk") on update cascade on delete cascade;
+alter table "book_to_tag_unordered" add constraint "book_to_tag_unordered_book_tag2_id_foreign" foreign key ("book_tag2_id") references "book_tag2" ("id") on update cascade on delete cascade;
 
 alter table "publisher2_to_test2" add constraint "publisher2_to_test2_publisher2_id_foreign" foreign key ("publisher2_id") references "publisher2" ("id") on update cascade on delete cascade;
 alter table "publisher2_to_test2" add constraint "publisher2_to_test2_test2_id_foreign" foreign key ("test2_id") references "test2" ("id") on update cascade on delete cascade;


### PR DESCRIPTION
Previously it was required to have autoincrement primary key for m:n pivot tables. Now this
has changed. By default, only foreign columns are required and composite key over both of them
is used as primary key.

**BREAKING CHANGE:**
M:N collection items no longer have fixed order by default. To preserve stable order of collections,
you can force previous behaviour by defining the m:n property as `fixedOrder: true`, which will start
ordering by `id` column. You can also override the order column name via `fixedOrderColumn: 'order'`.

You can also specify default ordering via `orderBy: { ... }` attribute.

Closes #121