### PR TITLE
feat(core): do not require entity attribute in collection decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ export class MongoBook implements MongoEntity<MongoBook> {
   @ManyToOne()
   author: Author;
 
-  @ManyToMany(() => BookTag, tag => tag.books, { owner: true })
+  @ManyToMany()
   tags = new Collection<BookTag>(this);
 
   constructor(title: string, author: Author) {

--- a/docs/defining-entities.md
+++ b/docs/defining-entities.md
@@ -32,7 +32,7 @@ export class Book implements IdEntity<Book> {
   @ManyToOne(() => Publisher) // or you can specify the entity as class reference or string name
   publisher?: Publisher;
 
-  @ManyToMany(() => BookTag, tag => tag.books, { owner: true })
+  @ManyToMany() // owning side can be simple as this!
   tags = new Collection<BookTag>(this);
 
   constructor(title: string, author: Author) {
@@ -95,6 +95,9 @@ export class Author implements MongoEntity<Author> {
 
   @OneToMany(() => Book, book => book.author)
   books = new Collection<Book>(this);
+
+  @ManyToMany()
+  friends = new Collection<Author>(this);
 
   @ManyToOne()
   favouriteBook: Book;

--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -62,7 +62,7 @@ export class Author implements IdEntity<Author> {
   @OneToMany('Book', 'author')
   books2 = new Collection<Book>(this);
 
-  @OneToMany({ entity: () => Book, mappedBy: book => book.author })
+  @OneToMany({ mappedBy: book => book.author }) // referenced entity type can be sniffer too
   books3 = new Collection<Book>(this);
 
   @OneToMany({ entity: () => Book, mappedBy: 'author', orphanRemoval: true })
@@ -137,7 +137,7 @@ Here are examples of how you can define ManyToMany relationship:
 export class Book implements IdEntity<Book> {
 
   // when none of `owner/inverseBy/mappedBy` is provided, it will be considered owning side
-  @ManyToMany(() => BookTag)
+  @ManyToMany()
   tags1 = new Collection<BookTag>(this);
 
   @ManyToMany(() => BookTag, 'books', { owner: true })

--- a/lib/decorators/ManyToMany.ts
+++ b/lib/decorators/ManyToMany.ts
@@ -6,7 +6,7 @@ import { EntityName, EntityProperty, AnyEntity } from '../types';
 import { QueryOrder } from '../query';
 
 export function ManyToMany<T extends AnyEntity<T>>(
-  entity: ManyToManyOptions<T> | string | (() => EntityName<T>),
+  entity?: ManyToManyOptions<T> | string | (() => EntityName<T>),
   mappedBy?: (string & keyof T) | ((e: T) => any),
   options: Partial<ManyToManyOptions<T>> = {},
 ) {
@@ -24,18 +24,13 @@ export function ManyToMany<T extends AnyEntity<T>>(
 
     const meta = MetadataStorage.getMetadata(target.constructor.name);
     Utils.lookupPathFromDecorator(meta);
-
-    if (!options.entity) {
-      throw new Error(`'@ManyToMany({ entity: string | Function })' is required in '${target.constructor.name}.${propertyName}'`);
-    }
-
     const property = { name: propertyName, reference: ReferenceType.MANY_TO_MANY, owner: !!options.inversedBy, cascade: [Cascade.PERSIST, Cascade.MERGE] } as EntityProperty<T>;
     meta.properties[propertyName] = Object.assign(property, options);
   };
 }
 
 export interface ManyToManyOptions<T extends AnyEntity<T>> extends ReferenceOptions<T> {
-  entity: string | (() => EntityName<T>);
+  entity?: string | (() => EntityName<T>);
   owner?: boolean;
   inversedBy?: (string & keyof T) | ((e: T) => any);
   mappedBy?: (string & keyof T) | ((e: T) => any);

--- a/lib/decorators/OneToMany.ts
+++ b/lib/decorators/OneToMany.ts
@@ -25,10 +25,6 @@ export function createOneToDecorator<T extends AnyEntity<T>>(
     Utils.lookupPathFromDecorator(meta);
 
     if (reference === ReferenceType.ONE_TO_MANY) {
-      if (!options.entity) {
-        throw new Error(`'@OneToMany({ entity: string | Function })' is required in '${target.constructor.name}.${propertyName}'`);
-      }
-
       if ((options as any).fk) {
         throw new Error(`@OneToMany({ fk })' is deprecated, use 'mappedBy' instead in '${target.constructor.name}.${propertyName}'`);
       }
@@ -56,7 +52,7 @@ export function createOneToDecorator<T extends AnyEntity<T>>(
 }
 
 export type OneToManyOptions<T extends AnyEntity<T>> = ReferenceOptions<T> & {
-  entity: string | (() => EntityName<T>);
+  entity?: string | (() => EntityName<T>);
   orphanRemoval?: boolean;
   orderBy?: { [field: string]: QueryOrder };
   joinColumn?: string;

--- a/lib/metadata/TypeScriptMetadataProvider.ts
+++ b/lib/metadata/TypeScriptMetadataProvider.ts
@@ -44,7 +44,8 @@ export class TypeScriptMetadataProvider extends MetadataProvider {
       prop.nullable = true;
     }
 
-    this.processReferenceWrapper(prop);
+    this.processWrapper(prop, 'IdentifiedReference');
+    this.processWrapper(prop, 'Collection');
   }
 
   private async readTypeFromSource(file: string, name: string, prop: EntityProperty): Promise<{ type: string; optional?: boolean }> {
@@ -71,11 +72,16 @@ export class TypeScriptMetadataProvider extends MetadataProvider {
     return source;
   }
 
-  private processReferenceWrapper(prop: EntityProperty): void {
-    const m = prop.type.match(/^IdentifiedReference<(\w+),?.*>$/);
+  private processWrapper(prop: EntityProperty, wrapper: string): void {
+    const m = prop.type.match(new RegExp(`^${wrapper}<(\\w+),?.*>$`));
 
-    if (m) {
-      prop.type = m[1];
+    if (!m) {
+      return;
+    }
+
+    prop.type = m[1];
+
+    if (wrapper === 'IdentifiedReference') {
       prop.wrappedReference = true;
     }
   }

--- a/tests/decorators.test.ts
+++ b/tests/decorators.test.ts
@@ -16,8 +16,6 @@ class Test6 implements AnyEntity<Test6> {}
 describe('decorators', () => {
 
   test('ManyToMany', () => {
-    expect(() => ManyToMany({} as any)(new Test(), 'test')).toThrowError(`@ManyToMany({ entity: string | Function })' is required in 'Test.test`);
-
     const storage = MetadataStorage.getMetadata();
     ManyToMany({ entity: () => Test })(new Test2(), 'test0');
     expect(storage.Test2.properties.test0).toMatchObject({
@@ -61,7 +59,6 @@ describe('decorators', () => {
   });
 
   test('OneToMany', () => {
-    expect(() => OneToMany({} as any)(new Test(), 'test')).toThrowError(`@OneToMany({ entity: string | Function })' is required in 'Test.test`);
     expect(() => OneToMany({ entity: () => Test, fk: 'test' } as any)(new Test(), 'test')).toThrowError(`@OneToMany({ fk })' is deprecated, use 'mappedBy' instead in 'Test.test`);
 
     const storage = MetadataStorage.getMetadata();

--- a/tests/entities-sql/Author2.ts
+++ b/tests/entities-sql/Author2.ts
@@ -36,7 +36,7 @@ export class Author2 extends BaseEntity2 {
   @Property({ length: 0 })
   born?: Date;
 
-  @OneToMany('Book2', 'author', { orderBy: { title: QueryOrder.ASC } })
+  @OneToMany({ mappedBy: 'author', orderBy: { title: QueryOrder.ASC } })
   books!: Collection<Book2>;
 
   @ManyToOne()

--- a/tests/entities-sql/FooBaz2.ts
+++ b/tests/entities-sql/FooBaz2.ts
@@ -10,7 +10,7 @@ export class FooBaz2 implements IdEntity<FooBaz2> {
   @Property()
   name: string;
 
-  @OneToOne(() => FooBar2, 'baz')
+  @OneToOne({ mappedBy: 'baz' })
   bar?: FooBar2;
 
   @Property({ version: true })

--- a/tests/entities-sql/Publisher2.ts
+++ b/tests/entities-sql/Publisher2.ts
@@ -9,10 +9,10 @@ export class Publisher2 extends BaseEntity2 {
   @Property()
   name: string;
 
-  @OneToMany({ entity: () => Book2, mappedBy: 'publisher' })
+  @OneToMany({ mappedBy: 'publisher' })
   books!: Collection<Book2>;
 
-  @ManyToMany({ entity: () => Test2, fixedOrder: true })
+  @ManyToMany({ fixedOrder: true })
   tests!: Collection<Test2>;
 
   @Property({ type: 'string', length: 10 })

--- a/tests/entities-sql/Test2.ts
+++ b/tests/entities-sql/Test2.ts
@@ -10,7 +10,7 @@ export class Test2 implements IdEntity<Test2> {
   @Property()
   name?: string;
 
-  @OneToOne({ cascade: [], inversedBy: 'test' })
+  @OneToOne({ entity: 'Book2', cascade: [], inversedBy: 'test' })
   book?: Book2;
 
   @Property({ version: true })

--- a/tests/entities/Author.ts
+++ b/tests/entities/Author.ts
@@ -34,7 +34,7 @@ export class Author extends BaseEntity {
   @OneToMany(() => Book, book => book.author, { referenceColumnName: '_id', cascade: [Cascade.PERSIST], orphanRemoval: true })
   books = new Collection<Book>(this);
 
-  @ManyToMany(() => Author)
+  @ManyToMany()
   friends: Collection<Author> = new Collection<Author>(this);
 
   @ManyToOne()

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -30,7 +30,7 @@ export class Book extends BaseEntity3 {
   @ManyToOne({ cascade: [Cascade.PERSIST, Cascade.REMOVE] })
   publisher!: IdentifiedReference<Publisher, '_id' | 'id'>;
 
-  @ManyToMany(() => BookTag)
+  @ManyToMany()
   tags = new Collection<BookTag>(this);
 
   @Property()

--- a/tests/entities/Publisher.ts
+++ b/tests/entities/Publisher.ts
@@ -16,10 +16,10 @@ export class Publisher implements MongoEntity<Publisher> {
   @Property()
   name: string;
 
-  @OneToMany({ entity: () => Book.name, mappedBy: 'publisher' })
+  @OneToMany({ mappedBy: 'publisher' })
   books = new Collection<Book>(this);
 
-  @ManyToMany({ entity: () => Test.name, owner: true, eager: true })
+  @ManyToMany({ eager: true })
   tests = new Collection<Test>(this);
 
   @Property()


### PR DESCRIPTION
Now the type from `prop: Collection<MyEntity>` is sniffed via reflection, so you do not have to define `entity` or `type` attributes in collection decorators (`@ManyToMany` and `@OneToMany`).