### PR TITLE
test: 'fix' memory leak in graceful-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,10 @@
   "homepage": "https://mikro-orm.io",
   "scripts": {
     "build": "rimraf dist && tsc",
-    "test": "jest --runInBand",
-    "coverage": "rimraf temp tests/generated-entities && jest --runInBand --coverage",
+    "pretest": "node tests/pre-test",
+    "test": "node --expose-gc ./node_modules/.bin/jest --runInBand --logHeapUsage",
+    "posttest": "node tests/post-test",
+    "coverage": "rimraf temp tests/generated-entities && yarn test --coverage",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "lint": "tslint -p ."
   },

--- a/tests/post-test.js
+++ b/tests/post-test.js
@@ -1,0 +1,13 @@
+const { writeFileSync, readFileSync, existsSync, unlinkSync } = require('fs');
+
+/**
+ * This un-patches the graceful-fs library which is causing memory leaks when running via jest
+ */
+const path = process.cwd() + '/node_modules/graceful-fs/graceful-fs.js';
+const backup = process.cwd() + '/node_modules/graceful-fs/graceful-fs.js.backup';
+
+if (existsSync(backup)) {
+  const original = readFileSync(backup);
+  writeFileSync(path, original);
+  unlinkSync(backup);
+}

--- a/tests/pre-test.js
+++ b/tests/pre-test.js
@@ -1,0 +1,11 @@
+const { writeFileSync, readFileSync } = require('fs');
+
+/**
+ * This patches the graceful-fs library which is causing memory leaks when running via jest
+ */
+const replacement = `const fs = require('fs'); module.exports = Object.assign(fs, { gracefulify: () => {} });`;
+const path = process.cwd() + '/node_modules/graceful-fs/graceful-fs.js';
+const backup = process.cwd() + '/node_modules/graceful-fs/graceful-fs.js.backup';
+const original = readFileSync(path);
+writeFileSync(backup, original);
+writeFileSync(path, replacement);


### PR DESCRIPTION
`graceful-fs` and `jest` does not like each other, so this removes the `graceful-fs` implementation before running tests and adds it back afterwards.

https://github.com/facebook/jest/issues/6399
https://github.com/facebook/jest/issues/6814
https://github.com/isaacs/node-graceful-fs/issues/102