### PR TITLE
Webpack fixes

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -136,6 +136,11 @@ module.exports = {
   module: {
     rules: [
       { test: /\.ts$/, loader: 'ts-loader' },
+      {
+            test: /\.mjs$/,
+            include: /node_modules/,
+            type: "javascript/auto"
+      }
     ],
   },
   plugins: [


### PR DESCRIPTION
Fix for errors thrown when using Webpack (a MikroORM dependency, acorn, added mjs files which webpack can't load correctly and aren't needed during Webpack runtime).