### PR TITLE
fix(core): do not set EM to entity until merging [BC]

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,7 +6,7 @@ checks:
       threshold: 500
   method-lines:
     config:
-      threshold: 30
+      threshold: 50
   method-count:
     config:
       threshold: 40

--- a/docs/docs/entity-helper.md
+++ b/docs/docs/entity-helper.md
@@ -30,6 +30,19 @@ console.log(book.author); // instance of Author with id: '...id...'
 console.log(book.author.id); // '...id...'
 ```
 
+To use `entity.assign()` on not managed entities, you need to provide `EntityManager` 
+instance explicitly: 
+
+```typescript
+import { wrap } from 'mikro-orm';
+
+const book = new Book();
+wrap(book).assign({ 
+  title: 'Better Book 1', 
+  author: '...id...',
+}, { em: orm.em });
+```
+
 By default, `entity.assign(data)` behaves same way as `Object.assign(entity, data)`, 
 e.g. it does not merge things recursively. To enable deep merging of object properties, 
 use second parameter to enable `mergeObjects` flag:

--- a/docs/docs/upgrading-v2-to-v3.md
+++ b/docs/docs/upgrading-v2-to-v3.md
@@ -82,6 +82,20 @@ override the order column name via `fixedOrderColumn: 'order'`.
 
 You can also specify default ordering via `orderBy: { ... }` attribute.
 
+## EntityAssigner.assign() requires EM for new entities
+
+Previously all entities had internal reference to the root EM - the one created when 
+initializing the ORM. Now only managed entities (those merged to the EM, e.g. loaded 
+from the database) have this internal reference. 
+
+To use `assign()` method on new (not managed) entities, you need to provide the `em`
+parameter:
+
+```typescript
+const book = new Book();
+wrap(book).assign(data, { em: orm.em });
+```
+
 ## Strict FilterQuery and smart query conditions
 
 `FilterQuery` now does not allow using smart query operators. You can either cast your condition 

--- a/lib/entity/ArrayCollection.ts
+++ b/lib/entity/ArrayCollection.ts
@@ -23,7 +23,7 @@ export class ArrayCollection<T extends AnyEntity<T>> {
 
   toArray(): Dictionary[] {
     return this.getItems().map(item => {
-      const meta = wrap(this.owner).__em.getMetadata().get(item.constructor.name);
+      const meta = wrap(this.owner).__internal.metadata.get(item.constructor.name);
       const args = [...meta.toJsonParams.map(() => undefined), [this.property.name]];
 
       return wrap(item).toJSON(...args);
@@ -141,7 +141,7 @@ export class ArrayCollection<T extends AnyEntity<T>> {
 
   protected get property() {
     if (!this._property) {
-      const meta = wrap(this.owner).__em.getMetadata().get(this.owner.constructor.name);
+      const meta = wrap(this.owner).__meta;
       const field = Object.keys(meta.properties).find(k => this.owner[k] === this);
       this._property = meta.properties[field!];
     }

--- a/lib/entity/EntityFactory.ts
+++ b/lib/entity/EntityFactory.ts
@@ -1,20 +1,20 @@
-import { Configuration, Utils } from '../utils';
+import { Utils } from '../utils';
 import { AnyEntity, Constructor, EntityData, EntityMetadata, EntityName, Primary } from '../types';
-import { MetadataStorage } from '../metadata';
 import { UnitOfWork } from '../unit-of-work';
 import { ReferenceType } from './enums';
-import { IDatabaseDriver } from '..';
+import { EntityManager } from '..';
 
 export const SCALAR_TYPES = ['string', 'number', 'boolean', 'Date'];
 
 export class EntityFactory {
 
-  private readonly hydrator = this.config.getHydrator(this);
+  private readonly driver = this.em.getDriver();
+  private readonly config = this.em.config;
+  private readonly metadata = this.em.getMetadata();
+  private readonly hydrator = this.config.getHydrator(this, this.em);
 
   constructor(private readonly unitOfWork: UnitOfWork,
-              private readonly driver: IDatabaseDriver,
-              private readonly config: Configuration,
-              private readonly metadata: MetadataStorage) { }
+              private readonly em: EntityManager) { }
 
   create<T extends AnyEntity<T>>(entityName: EntityName<T>, data: EntityData<T>, initialized = true, newEntity = false): T {
     entityName = Utils.className(entityName);

--- a/lib/entity/Reference.ts
+++ b/lib/entity/Reference.ts
@@ -1,6 +1,9 @@
 import { Dictionary, EntityMetadata, AnyEntity, Primary } from '../types';
 import { EntityManager } from '../EntityManager';
 import { wrap } from './EntityHelper';
+import { Platform } from '../platforms';
+import { MetadataStorage } from '../metadata';
+import { EntityValidator } from './EntityValidator';
 
 export type IdentifiedReference<T extends AnyEntity<T>, PK extends keyof T = 'id' & keyof T> = { [K in PK]: T[K] } & Reference<T>;
 
@@ -78,8 +81,12 @@ export class Reference<T extends AnyEntity<T>> {
     return wrap(this.entity).__uuid;
   }
 
-  get __em(): EntityManager {
+  get __em(): EntityManager | undefined {
     return wrap(this.entity).__em;
+  }
+
+  get __internal(): { platform: Platform; metadata: MetadataStorage; validator: EntityValidator } {
+    return wrap(this.entity).__internal;
   }
 
   get __meta(): EntityMetadata {

--- a/lib/hydration/Hydrator.ts
+++ b/lib/hydration/Hydrator.ts
@@ -1,11 +1,11 @@
-import { IDatabaseDriver, wrap } from '..';
+import { EntityManager, wrap } from '..';
 import { EntityData, EntityMetadata, EntityProperty, AnyEntity } from '../types';
 import { EntityFactory } from '../entity';
 
 export abstract class Hydrator {
 
   constructor(protected readonly factory: EntityFactory,
-              protected readonly driver: IDatabaseDriver) { }
+              protected readonly em: EntityManager) { }
 
   hydrate<T extends AnyEntity<T>>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, newEntity: boolean): void {
     if (data[meta.primaryKey]) {

--- a/lib/hydration/ObjectHydrator.ts
+++ b/lib/hydration/ObjectHydrator.ts
@@ -1,6 +1,6 @@
 import { EntityData, EntityProperty, AnyEntity, Primary } from '../types';
 import { Hydrator } from './Hydrator';
-import { Collection, EntityAssigner, ReferenceType, wrap } from '../entity';
+import { Collection, EntityAssigner, ReferenceType } from '../entity';
 import { Utils } from '../utils';
 
 export class ObjectHydrator extends Hydrator {
@@ -42,7 +42,7 @@ export class ObjectHydrator extends Hydrator {
       const items = value.map((value: Primary<T> | EntityData<T>) => this.createCollectionItem(prop, value));
       entity[prop.name as keyof T] = new Collection<AnyEntity>(entity, items) as unknown as T[keyof T];
     } else if (!entity[prop.name as keyof T]) {
-      const items = this.driver.getPlatform().usesPivotTable() ? undefined : [];
+      const items = this.em.getDriver().getPlatform().usesPivotTable() ? undefined : [];
       entity[prop.name as keyof T] = new Collection<AnyEntity>(entity, items, newEntity) as unknown as T[keyof T];
     }
   }
@@ -75,7 +75,7 @@ export class ObjectHydrator extends Hydrator {
     }
 
     const child = this.factory.create(prop.type, value as EntityData<T>);
-    wrap(child).__em.merge(child);
+    this.em.merge(child);
 
     return child;
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,7 +1,17 @@
 import { QueryOrder } from './query';
-import { AssignOptions, Cascade, Collection, EntityRepository, IdentifiedReference, ReferenceType } from './entity';
+import {
+  AssignOptions,
+  Cascade,
+  Collection,
+  EntityRepository,
+  EntityValidator,
+  IdentifiedReference,
+  ReferenceType,
+} from './entity';
 import { EntityManager } from './EntityManager';
 import { LockMode } from './unit-of-work';
+import { Platform } from './platforms';
+import { MetadataStorage } from './metadata';
 
 export type Constructor<T> = new (...args: any[]) => T;
 export type Dictionary<T = any> = { [k: string]: T };
@@ -77,7 +87,8 @@ export interface IWrappedEntity<T, PK extends keyof T> {
   assign(data: any, options?: AssignOptions | boolean): this;
   __uuid: string;
   __meta: EntityMetadata;
-  __em: EntityManager;
+  __internal: { platform: Platform; metadata: MetadataStorage; validator: EntityValidator };
+  __em?: EntityManager;
   __initialized?: boolean;
   __populated: boolean;
   __lazyInitialized: boolean;

--- a/lib/unit-of-work/ChangeSetComputer.ts
+++ b/lib/unit-of-work/ChangeSetComputer.ts
@@ -75,9 +75,9 @@ export class ChangeSetComputer {
   private processOneToOne<T extends AnyEntity<T>>(prop: EntityProperty<T>, changeSet: ChangeSet<T>): void {
     // check diff, if we had a value on 1:1 before and now it changed (nulled or replaced), we need to trigger orphan removal)
     const data = this.originalEntityData[changeSet.entity.__uuid] as EntityData<T>;
+    const em = changeSet.entity.__em;
 
-    if (prop.orphanRemoval && data && data[prop.name] && prop.name in changeSet.payload) {
-      const em = changeSet.entity.__em;
+    if (prop.orphanRemoval && data && data[prop.name] && prop.name in changeSet.payload && em) {
       const orphan = em.getReference(prop.type, data[prop.name] as Primary<T>);
       em.getUnitOfWork().scheduleOrphanRemoval(orphan);
     }

--- a/lib/unit-of-work/UnitOfWork.ts
+++ b/lib/unit-of-work/UnitOfWork.ts
@@ -32,6 +32,7 @@ export class UnitOfWork {
 
   merge<T extends AnyEntity<T>>(entity: T, visited: AnyEntity[] = [], mergeData = true): void {
     const wrapped = wrap(entity);
+    wrapped.__em = this.em;
 
     if (!wrapped.__primaryKey) {
       return;
@@ -392,7 +393,6 @@ export class UnitOfWork {
       const collection = new Collection<AnyEntity>(entity);
       entity[prop.name as keyof T] = collection as unknown as T[keyof T];
       collection.set(reference as AnyEntity[]);
-      collection.setDirty();
     }
   }
 

--- a/lib/utils/Configuration.ts
+++ b/lib/utils/Configuration.ts
@@ -123,9 +123,9 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     return this.cached(this.options.namingStrategy || this.platform.getNamingStrategy());
   }
 
-  getHydrator(factory: EntityFactory): Hydrator {
+  getHydrator(factory: EntityFactory, em: EntityManager): Hydrator {
     // Hydrator cannot be cached as it would have reference to wrong factory
-    return new this.options.hydrator(factory, this.driver);
+    return new this.options.hydrator(factory, em);
   }
 
   getMetadataProvider(): MetadataProvider {
@@ -236,7 +236,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
   namingStrategy?: { new (): NamingStrategy };
   autoJoinOneToOneOwner: boolean;
   forceUtcTimezone: boolean;
-  hydrator: { new (factory: EntityFactory, driver: IDatabaseDriver): Hydrator };
+  hydrator: { new (factory: EntityFactory, em: EntityManager): Hydrator };
   entityRepository: { new (em: EntityManager, entityName: EntityName<AnyEntity>): EntityRepository<AnyEntity> };
   replicas?: Partial<ConnectionOptions>[];
   strict: boolean;

--- a/lib/utils/ValidationError.ts
+++ b/lib/utils/ValidationError.ts
@@ -73,6 +73,10 @@ export class ValidationError<T extends AnyEntity = AnyEntity> extends Error {
     return new ValidationError(`Entity ${entity.constructor.name} is not managed. An entity is managed if its fetched from the database or registered as new through EntityManager.persist()`);
   }
 
+  static notEntity(owner: AnyEntity, prop: EntityProperty, data: any): ValidationError {
+    return new ValidationError(`Entity of type ${prop.type} expected for property ${owner.constructor.name}.${prop.name}, ${inspect(data)} of type ${Utils.getObjectType(data)} given. If you are using Object.assign(entity, data), use wrap(entity).assign(data, { em }) instead.`);
+  }
+
   static notVersioned(meta: EntityMetadata): ValidationError {
     return new ValidationError(`Cannot obtain optimistic lock on unversioned entity ${meta.name}`);
   }

--- a/tests/EntityFactory.test.ts
+++ b/tests/EntityFactory.test.ts
@@ -15,7 +15,7 @@ describe('EntityFactory', () => {
   beforeAll(async () => {
     orm = await initORMMongo();
     await new MetadataDiscovery(orm.getMetadata(), orm.em.getDriver().getPlatform(), orm.config).discover();
-    factory = new EntityFactory(orm.em.getUnitOfWork(), orm.em.getDriver(), orm.config, orm.getMetadata());
+    factory = new EntityFactory(orm.em.getUnitOfWork(), orm.em);
     expect(orm.em.config.getNamingStrategy().referenceColumnName()).toBe('_id');
   });
   beforeEach(async () => wipeDatabase(orm.em));

--- a/tests/EntityManager.mariadb.test.ts
+++ b/tests/EntityManager.mariadb.test.ts
@@ -1,6 +1,6 @@
 import { v4 } from 'uuid';
 
-import { Collection, EntityManager, MikroORM, QueryOrder, wrap } from '../lib';
+import { Collection, EntityManager, MikroORM, QueryOrder, Reference, wrap } from '../lib';
 import { Author2, Book2, BookTag2, Publisher2, PublisherType } from './entities-sql';
 import { initORMMySql, wipeDatabaseMySql } from './bootstrap';
 import { MariaDbDriver } from '../lib/drivers/MariaDbDriver';
@@ -76,13 +76,13 @@ describe('EntityManagerMariaDb', () => {
     // as we order by Book.createdAt when populating collection, we need to make sure values will be sequential
     const book1 = new Book2('My Life on The Wall, part 1', author);
     book1.createdAt = new Date(Date.now() + 1);
-    book1.publisher = publisher;
+    book1.publisher = wrap(publisher).toReference();
     const book2 = new Book2('My Life on The Wall, part 2', author);
     book2.createdAt = new Date(Date.now() + 2);
-    book2.publisher = publisher;
+    book2.publisher = wrap(publisher).toReference();
     const book3 = new Book2('My Life on The Wall, part 3', author);
     book3.createdAt = new Date(Date.now() + 3);
-    book3.publisher = publisher;
+    book3.publisher = wrap(publisher).toReference();
 
     const repo = orm.em.getRepository(Book2);
     repo.persist(book1);
@@ -151,8 +151,9 @@ describe('EntityManagerMariaDb', () => {
 
         expect(book.author).toBeInstanceOf(Author2);
         expect(wrap(book.author).isInitialized()).toBe(true);
-        expect(book.publisher).toBeInstanceOf(Publisher2);
-        expect(wrap(book.publisher).isInitialized()).toBe(false);
+        expect(book.publisher).toBeInstanceOf(Reference);
+        expect(book.publisher!.unwrap()).toBeInstanceOf(Publisher2);
+        expect(book.publisher!.isInitialized()).toBe(false);
       }
     }
 

--- a/tests/entities-js/BaseEntity4.js
+++ b/tests/entities-js/BaseEntity4.js
@@ -6,8 +6,7 @@ const { Collection, ReferenceType } = require('../../lib');
 class BaseEntity4 {
 
   constructor() {
-    const meta = this['__em'].getMetadata().get(this.constructor.name);
-    const props = meta.properties;
+    const props = this['__meta'].properties;
 
     Object.keys(props).forEach(prop => {
       if ([ReferenceType.ONE_TO_MANY, ReferenceType.MANY_TO_MANY].includes(props[prop].reference)) {

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -1,5 +1,5 @@
 import { v4 } from 'uuid';
-import { Cascade, Collection, Entity, ManyToMany, ManyToOne, OneToOne, PrimaryKey, Property, QueryOrder, UuidEntity } from '../../lib';
+import { Cascade, Collection, Entity, IdentifiedReference, ManyToMany, ManyToOne, OneToOne, PrimaryKey, Property, QueryOrder, UuidEntity } from '../../lib';
 import { Publisher2 } from './Publisher2';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
@@ -32,8 +32,8 @@ export class Book2 implements UuidEntity<Book2> {
   @ManyToOne({ entity: 'Author2', cascade: [] })
   author: Author2;
 
-  @ManyToOne({ cascade: [Cascade.PERSIST, Cascade.REMOVE], nullable: true })
-  publisher?: Publisher2;
+  @ManyToOne(() => Publisher2, { cascade: [Cascade.PERSIST, Cascade.REMOVE], nullable: true, wrappedReference: true })
+  publisher?: IdentifiedReference<Publisher2>;
 
   @OneToOne({ cascade: [], mappedBy: 'book', nullable: true })
   test?: Test2;


### PR DESCRIPTION
Previously all entities had internal reference to the root EM - the one created when
initializing the ORM. Now only managed entities (those merged to the EM, e.g. loaded
from the database) have this internal reference.

To use `assign()` method on new (not managed) entities, you need to provide the `em`
parameter:

```typescript
const book = new Book();
wrap(book).assign(data, { em: orm.em });
```

Closes: #267