### PR TITLE
feat(core): add `refresh` parameter to `FindOptions`

### DIFF
--- a/lib/EntityManager.ts
+++ b/lib/EntityManager.ts
@@ -73,12 +73,12 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     const ret: T[] = [];
 
     for (const data of results) {
-      const entity = this.merge<T>(entityName, data);
+      const entity = this.merge<T>(entityName, data, options.refresh);
       ret.push(entity);
     }
 
     const unique = Utils.unique(ret);
-    await this.entityLoader.populate(entityName, unique, options.populate || [], where, options.orderBy || {});
+    await this.entityLoader.populate(entityName, unique, options.populate || [], where, options.orderBy || {}, options.refresh);
 
     return unique;
   }
@@ -393,7 +393,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       await this.lock(entity, options.lockMode, options.lockVersion);
     }
 
-    await this.entityLoader.populate(entity.constructor.name, [entity], options.populate || [], where, options.orderBy || {});
+    await this.entityLoader.populate(entity.constructor.name, [entity], options.populate || [], where, options.orderBy || {}, options.refresh);
 
     return entity;
   }
@@ -409,6 +409,7 @@ export interface FindOptions {
   orderBy?: QueryOrderMap;
   limit?: number;
   offset?: number;
+  refresh?: boolean;
   fields?: string[];
 }
 

--- a/lib/entity/EntityAssigner.ts
+++ b/lib/entity/EntityAssigner.ts
@@ -60,7 +60,11 @@ export class EntityAssigner {
     const prop2 = meta2.properties[prop.inversedBy || prop.mappedBy];
 
     if (prop2 && !entity[prop.name][prop2.name]) {
-      entity[prop.name][prop2.name] = Utils.wrapReference(entity, prop2);
+      if (entity[prop.name] instanceof Reference) {
+        entity[prop.name].unwrap()[prop2.name] = Utils.wrapReference(entity, prop2);
+      } else {
+        entity[prop.name][prop2.name] = Utils.wrapReference(entity, prop2);
+      }
     }
   }
 

--- a/lib/utils/Utils.ts
+++ b/lib/utils/Utils.ts
@@ -187,12 +187,20 @@ export class Utils {
     return null;
   }
 
-  static isEntity<T = AnyEntity>(data: any): data is T {
+  static isEntity<T = AnyEntity>(data: any, allowReference = false): data is T {
+    if (allowReference && Utils.isReference(data)) {
+      return true;
+    }
+
     return Utils.isObject(data) && !!data.__entity;
   }
 
   static isReference<T extends AnyEntity<T>>(data: any): data is Reference<T> {
     return data instanceof Reference;
+  }
+
+  static unwrapReference<T extends AnyEntity<T>>(ref: T | Reference<T>): T {
+    return Utils.isReference<T>(ref) ? (ref as Reference<T>).unwrap() : ref;
   }
 
   static isObjectID(key: any) {

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -1,6 +1,6 @@
 import { v4 } from 'uuid';
-import { Collection, Configuration, EntityManager, LockMode, MikroORM, QueryOrder, Utils, wrap } from '../lib';
-import { Author2, Book2, BookTag2, FooBar2, Publisher2, PublisherType, Test2 } from './entities-sql';
+import { Collection, Configuration, EntityManager, LockMode, MikroORM, QueryOrder, Reference, Utils, wrap } from '../lib';
+import { Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, PublisherType, Test2 } from './entities-sql';
 import { initORMPostgreSql, wipeDatabasePostgreSql } from './bootstrap';
 import { PostgreSqlDriver } from '../lib/drivers/PostgreSqlDriver';
 import { Logger, ValidationError } from '../lib/utils';
@@ -565,7 +565,7 @@ describe('EntityManagerPostgre', () => {
     expect(author.name).toBe('Jon Snow');
   });
 
-  test('populate ManyToOne relation', async () => {
+  test('populate ManyToOne relation via init()', async () => {
     const authorRepository = orm.em.getRepository(Author2);
     const god = new Author2('God', 'hello@heaven.god');
     const bible = new Book2('Bible', god);
@@ -587,6 +587,65 @@ describe('EntityManagerPostgre', () => {
     expect(jon.favouriteBook).toBeInstanceOf(Book2);
     expect(wrap(jon.favouriteBook).isInitialized()).toBe(true);
     expect(jon.favouriteBook!.title).toBe('Bible');
+  });
+
+  test('populate OneToOne relation', async () => {
+    const bar = FooBar2.create('bar');
+    const baz = new FooBaz2('baz');
+    bar.baz = baz;
+    await orm.em.persistAndFlush(bar);
+    orm.em.clear();
+
+    const b1 = (await orm.em.findOne(FooBar2, { id: bar.id }, { populate: ['baz'], refresh: true }))!;
+    expect(b1.baz).toBeInstanceOf(FooBaz2);
+    expect(b1.baz!.id).toBe(baz.id);
+    expect(wrap(b1).toJSON()).toMatchObject({ baz: wrap(baz).toJSON() });
+  });
+
+  test('populate OneToOne relation on inverse side', async () => {
+    const bar = FooBar2.create('bar');
+    const baz = new FooBaz2('baz');
+    bar.baz = baz;
+    await orm.em.persistAndFlush(bar);
+    orm.em.clear();
+
+    const mock = jest.fn();
+    const logger = new Logger(mock, true);
+    Object.assign(orm.em.config, { logger });
+
+    // autoJoinOneToOneOwner: false
+    const b0 = await orm.em.findOneOrFail(FooBaz2, { id: baz.id });
+    expect(mock.mock.calls[0][0]).toMatch('select "e0".* from "foo_baz2" as "e0" where "e0"."id" = $1 limit $2');
+    expect(b0.bar).toBeUndefined();
+    orm.em.clear();
+
+    const b1 = await orm.em.findOneOrFail(FooBaz2, { id: baz.id }, ['bar']);
+    expect(mock.mock.calls[1][0]).toMatch('select "e0".*, "e1"."id" as "bar_id" from "foo_baz2" as "e0" left join "foo_bar2" as "e1" on "e0"."id" = "e1"."baz_id" where "e0"."id" = $1 limit $2');
+    expect(mock.mock.calls[2][0]).toMatch('select "e0".* from "foo_bar2" as "e0" where "e0"."baz_id" in ($1) order by "e0"."baz_id" asc');
+    expect(b1.bar).toBeInstanceOf(FooBar2);
+    expect(b1.bar!.id).toBe(bar.id);
+    expect(wrap(b1).toJSON()).toMatchObject({ bar: wrap(bar).toJSON() });
+    orm.em.clear();
+
+    const b2 = await orm.em.findOneOrFail(FooBaz2, { bar: bar.id }, ['bar']);
+    expect(mock.mock.calls[3][0]).toMatch('select "e0".*, "e1"."id" as "bar_id" from "foo_baz2" as "e0" left join "foo_bar2" as "e1" on "e0"."id" = "e1"."baz_id" where "e1"."id" = $1 limit $2');
+    expect(mock.mock.calls[4][0]).toMatch('select "e0".* from "foo_bar2" as "e0" where "e0"."baz_id" in ($1) order by "e0"."baz_id" asc');
+    expect(b2.bar).toBeInstanceOf(FooBar2);
+    expect(b2.bar!.id).toBe(bar.id);
+    expect(wrap(b2).toJSON()).toMatchObject({ bar: wrap(bar).toJSON() });
+  });
+
+  test('populate OneToOne relation with uuid PK', async () => {
+    const author = new Author2('name', 'email');
+    const book = new Book2('b1', author);
+    const test = Test2.create('t');
+    test.book = book;
+    await orm.em.persistAndFlush(test);
+    orm.em.clear();
+
+    const b1 = (await orm.em.findOne(Book2, { test: test.id }, ['test']))!;
+    expect(b1.uuid).not.toBeNull();
+    expect(wrap(b1).toJSON()).toMatchObject({ test: wrap(test).toJSON() });
   });
 
   test('many to many relation', async () => {

--- a/tests/issues/GH222.test.ts
+++ b/tests/issues/GH222.test.ts
@@ -1,19 +1,7 @@
-import {
-  Collection,
-  Entity,
-  IdEntity,
-  ManyToOne,
-  MikroORM,
-  OneToMany,
-  OneToOne,
-  PrimaryKey,
-  Property,
-  ReflectMetadataProvider,
-  wrap,
-} from '../../lib';
+import { Collection, Entity, IdEntity, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, Property, ReflectMetadataProvider, wrap } from '../../lib';
 import { BASE_DIR } from '../bootstrap';
 import { SqliteDriver } from '../../lib/drivers/SqliteDriver';
-import { unlinkSync } from "fs";
+import { unlinkSync } from 'fs';
 
 @Entity()
 export class A implements IdEntity<A> {

--- a/tests/issues/GH269.test.ts
+++ b/tests/issues/GH269.test.ts
@@ -1,0 +1,126 @@
+import { Entity, IdentifiedReference, IdEntity, MikroORM, OneToOne, PrimaryKey, ReflectMetadataProvider, Property, wrap, Reference } from '../../lib';
+import { BASE_DIR } from '../bootstrap';
+import { SqliteDriver } from '../../lib/drivers/SqliteDriver';
+import { unlinkSync } from 'fs';
+
+@Entity()
+export class A implements IdEntity<A> {
+
+  @PrimaryKey({ type: 'number' })
+  id!: number;
+
+  @OneToOne({ entity: () => B, inversedBy: 'a', wrappedReference: true, nullable: true })
+  b?: IdentifiedReference<B>;
+
+  @Property()
+  name!: string;
+
+}
+
+@Entity()
+export class B implements IdEntity<B> {
+
+  @PrimaryKey({ type: 'number' })
+  id!: number;
+
+  @OneToOne({ entity: () => A, mappedBy: 'b', wrappedReference: true, nullable: true })
+  a?: IdentifiedReference<A>;
+
+  @Property()
+  name!: string;
+
+}
+
+describe('GH issue 269', () => {
+
+  let orm: MikroORM<SqliteDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [A, B],
+      dbName: BASE_DIR + '/../temp/mikro_orm_test_gh269.db',
+      debug: false,
+      type: 'sqlite',
+      metadataProvider: ReflectMetadataProvider,
+      autoJoinOneToOneOwner: false,
+      cache: { enabled: false },
+    });
+    await orm.getSchemaGenerator().dropSchema();
+    await orm.getSchemaGenerator().createSchema();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+    unlinkSync(orm.config.get('dbName'));
+  });
+
+  test('1:1 populates owner even with autoJoinOneToOneOwner: false', async () => {
+    const em = orm.em.fork();
+    const a = new A();
+    a.id = 1;
+    a.name = 'my name is a';
+    const b = new B();
+    b.id = 1;
+    a.b = wrap(b).toReference();
+    b.name = 'my name is b';
+    b.a = wrap(a).toReference();
+    await em.persistAndFlush([a, b]);
+    em.clear();
+
+    const bb = await em.findOneOrFail(B, b.id, ['a']);
+    expect(bb.name).toBe('my name is b');
+    expect(bb.a).toBeInstanceOf(Reference);
+    expect(bb.a!.isInitialized()).toBe(true);
+    expect(bb.a!.unwrap().name).toBe('my name is a');
+    expect(bb.a!.unwrap().b).toBeInstanceOf(Reference);
+    expect(bb.a!.unwrap().b!.isInitialized()).toBe(true);
+  });
+
+  test('1:1 populates owner even with autoJoinOneToOneOwner: false and when already loaded', async () => {
+    const em = orm.em.fork();
+    const a = new A();
+    a.id = 2;
+    a.name = 'my name is a';
+    const b = new B();
+    b.id = 2;
+    a.b = wrap(b).toReference();
+    b.name = 'my name is b';
+    b.a = wrap(a).toReference();
+    await em.persistAndFlush([a, b]);
+    em.clear();
+
+    const bb0 = await em.findOneOrFail(B, b.id); // load first so it is already in IM
+    expect(bb0.a).toBeUndefined();
+    const bb = await em.findOneOrFail(B, b.id, ['a']);
+    expect(bb).toBe(bb0);
+    expect(bb.name).toBe('my name is b');
+    expect(bb.a).toBeInstanceOf(Reference);
+    expect(bb.a!.isInitialized()).toBe(true);
+    expect(bb.a!.unwrap().name).toBe('my name is a');
+    expect(bb.a!.unwrap().b).toBeInstanceOf(Reference);
+    expect(bb.a!.unwrap().b!.isInitialized()).toBe(true);
+  });
+
+  test('1:1 populates inverse even with autoJoinOneToOneOwner: false', async () => {
+    const em = orm.em.fork();
+    const a = new A();
+    a.id = 3;
+    a.name = 'my name is a';
+    const b = new B();
+    b.id = 3;
+    a.b = wrap(b).toReference();
+    b.name = 'my name is b';
+    b.a = wrap(a).toReference();
+    await em.persistAndFlush([a, b]);
+    em.clear();
+
+    const aa = await em.findOneOrFail(A, a.id, ['b']);
+    expect(aa.name).toBe('my name is a');
+    expect(aa.b).toBeInstanceOf(Reference);
+    expect(aa.b!.isInitialized()).toBe(true);
+    expect(aa.b!.unwrap().name).toBe('my name is b');
+    expect(aa.b!.unwrap().a).toBeInstanceOf(Reference);
+    expect(aa.b!.unwrap().a!.isInitialized()).toBe(true);
+  });
+
+});


### PR DESCRIPTION
This also fixes loading of 1:1 owners via populate when `autoJoinOneToOneOwner` option is disabled.

Closes #269