### PR TITLE
feat(core): add support for custom types

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,16 +9,13 @@ discuss specifics.
 
 ## Planned features
 
-- Association scopes
-- Value transformers (e.g. mapping of `Date` object to formatted string)
+- Association scopes/filters ([hibernate docs](https://docs.jboss.org/hibernate/orm/3.6/reference/en-US/html/filters.html))
 - Schema sync (allow automatic synchronization during development)
-- Migrations via `umzug`
-- Improved support for data types like date, time, timestamp
 - Support for RegExp search in SQL drivers
 - Collection expressions - support querying parts of collection
 - Collection pagination
 - Composite primary keys
 - Map collections
-- Single table inheritance #33
-- Embedded entities (allow in-lining child entity into parent one with prefixed keys)
+- Single table inheritance ([#33](https://github.com/mikro-orm/mikro-orm/issues/33))
+- Embedded entities (allow in-lining child entity into parent one with prefixed keys, or maybe as serialized JSON)
 - Slow query log

--- a/docs/docs/custom-types.md
+++ b/docs/docs/custom-types.md
@@ -1,0 +1,83 @@
+---
+title: Custom Types
+---
+
+You can define custom types by extending `Type` abstract class. It has 4 optional methods:
+
+- `convertToDatabaseValue(value: any, platform: Platform): any`
+
+  Converts a value from its JS representation to its database representation of this type.
+  By default returns unchanged `value`.
+
+- `convertToJSValue(value: any, platform: Platform): any`
+
+  Converts a value from its database representation to its JS representation of this type.
+  By default returns unchanged `value`.
+
+- `toJSON(value: any, platform: Platform): any`
+
+  Converts a value from its JS representation to its serialized JSON form of this type.
+  By default converts to the database value.
+  
+- `getColumnType(prop: EntityProperty, platform: Platform): string`
+
+  Gets the SQL declaration snippet for a field of this type.
+  By default returns `columnType` of given property.
+
+> `DateType` and `TimeType` types are already implemented in the ORM.
+
+```typescript
+import { Type, Platform, EntityProperty, ValidationError } from 'mikro-orm';
+
+export class DateType extends Type {
+
+  convertToDatabaseValue(value: any, platform: Platform): any {
+    if (value instanceof Date) {
+      return value.toISOString().substr(0, 10);
+    }
+
+    if (!value || value.toString().match(/^\d{4}-\d{2}-\d{2}$/)) {
+      return value;
+    }
+
+    throw ValidationError.invalidType(DateType, value, 'JS');
+  }
+
+  convertToJSValue(value: any, platform: Platform): any {
+    if (!value || value instanceof Date) {
+      return value;
+    }
+
+    const date = new Date(value);
+
+    if (date.toString() === 'Invalid Date') {
+      throw ValidationError.invalidType(DateType, value, 'database');
+    }
+
+    return date;
+  }
+
+  getColumnType(prop: EntityProperty, platform: Platform) {
+    return `date(${prop.length})`;
+  }
+
+}
+```
+
+Then you can use this type when defining your entity properties:
+
+```typescript
+@Entity()
+export class FooBar implements IdEntity<FooBar> {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property({ type: DateType, length: 3 })
+  born?: Date;
+
+}
+```

--- a/docs/docs/decorators.md
+++ b/docs/docs/decorators.md
@@ -31,7 +31,7 @@ extend the `@Property()` decorator, so you can also use its parameters there.
 | Parameter | Type | Optional | Description |
 |-----------|------|----------|-------------|
 | `fieldName` | `string` | yes | Override default property name (see [Naming Strategy](naming-strategy.md)). |
-| `type` | `string` | yes | Explicitly specify the runtime type (see [Metadata Providers](metadata-providers.md)). |
+| `type` | `string` &#124; `Type` | yes | Explicitly specify the runtime type (see [Metadata Providers](metadata-providers.md) and [Custom Types](custom-types.md)). |
 | `onUpdate` | `() => any` | yes | Automatically update the property value every time entity gets updated. |
 | `persist` | `boolean` | yes | Set to `false` to define [Shadow Property](serializing.md#shadow-properties). |
 | `hidden` | `boolean` | yes | Set to `true` to omit the property when [Serializing](serializing.md). |

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -168,6 +168,29 @@ export const enum UserStatus {
 }
 ``` 
 
+## Custom Types
+
+You can define custom types by extending `Type` abstract class. It has 4 optional methods:
+
+- `convertToDatabaseValue(value: any, platform: Platform): any`
+
+  Converts a value from its JS representation to its database representation of this type.
+
+- `convertToJSValue(value: any, platform: Platform): any`
+
+  Converts a value from its database representation to its JS representation of this type.
+
+- `toJSON(value: any, platform: Platform): any`
+
+  Converts a value from its JS representation to its serialized JSON form of this type.
+  By default converts to the database value.
+  
+- `getColumnType(prop: EntityProperty, platform: Platform): string`
+
+  Gets the SQL declaration snippet for a field of this type.
+
+More information can be found in [Custom Types](custom-types.md) section.
+
 ## Virtual Properties
 
 You can define your properties as virtual, either as a method, or via JavaScript `get/set`.

--- a/lib/connections/PostgreSqlConnection.ts
+++ b/lib/connections/PostgreSqlConnection.ts
@@ -16,7 +16,7 @@ export class PostgreSqlConnection extends AbstractSqlConnection {
     const ret: PgConnectionConfig = super.getConnectionOptions();
 
     if (this.config.get('forceUtcTimezone')) {
-      types.setTypeParser(1114, str => new Date(str + 'Z')); // 1114 is OID for timestamp in Postgres
+      [1082, 1083, 1114].forEach(oid => types.setTypeParser(oid, str => new Date(str + 'Z'))); // date, time, timestamp types
       (defaults as any).parseInputDatesAsUTC = true;
     }
 

--- a/lib/entity/EntityAssigner.ts
+++ b/lib/entity/EntityAssigner.ts
@@ -16,6 +16,7 @@ export class EntityAssigner {
     const em = options.em || wrap(entity).__em;
     const meta = wrap(entity).__internal.metadata.get(entity.constructor.name);
     const validator = wrap(entity).__internal.validator;
+    const platform = wrap(entity).__internal.platform;
     const props = meta.properties;
 
     Object.keys(data).forEach(prop => {
@@ -23,7 +24,11 @@ export class EntityAssigner {
         return;
       }
 
-      const value = data[prop as keyof EntityData<T>];
+      let value = data[prop as keyof EntityData<T>];
+
+      if (props[prop] && props[prop].customType) {
+        value = props[prop].customType.convertToJSValue(value, platform);
+      }
 
       if (props[prop] && [ReferenceType.MANY_TO_ONE, ReferenceType.ONE_TO_ONE].includes(props[prop].reference) && value && EntityAssigner.validateEM(em)) {
         return EntityAssigner.assignReference<T>(entity, value, props[prop], em!);

--- a/lib/hydration/ObjectHydrator.ts
+++ b/lib/hydration/ObjectHydrator.ts
@@ -26,6 +26,10 @@ export class ObjectHydrator extends Hydrator {
       return;
     }
 
+    if (prop.customType) {
+      value = prop.customType.convertToJSValue(value, this.em.getDriver().getPlatform());
+    }
+
     entity[prop.name as keyof T] = value;
   }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -14,6 +14,7 @@ export * from './query/QueryBuilder';
 export * from './drivers';
 export * from './connections';
 export * from './platforms';
+export * from './types';
 export * from './naming-strategy';
 export * from './metadata/MetadataProvider';
 export * from './metadata/JavaScriptMetadataProvider';

--- a/lib/metadata/MetadataDiscovery.ts
+++ b/lib/metadata/MetadataDiscovery.ts
@@ -8,6 +8,7 @@ import { MetadataValidator } from './MetadataValidator';
 import { MetadataStorage } from './MetadataStorage';
 import { Cascade, ReferenceType } from '../entity';
 import { Platform } from '../platforms';
+import { Type } from '../types';
 
 export class MetadataDiscovery {
 
@@ -238,6 +239,7 @@ export class MetadataDiscovery {
     Object.values(meta.properties).forEach(prop => {
       this.applyNamingStrategy(meta, prop);
       this.initVersionProperty(meta, prop);
+      this.initCustomType(prop);
       this.initColumnType(prop, meta.path);
     });
     meta.serializedPrimaryKey = this.platform.getSerializedPrimaryKeyField(meta.primaryKey);
@@ -408,6 +410,17 @@ export class MetadataDiscovery {
 
     meta.versionProperty = prop.name;
     prop.default = this.getDefaultVersionValue(prop);
+  }
+
+  private initCustomType(prop: EntityProperty): void {
+    if (Object.getPrototypeOf(prop.type) === Type) {
+      prop.customType = Type.getType(prop.type as any);
+    }
+
+    if (prop.customType) {
+      prop.type = prop.customType.constructor.name;
+      prop.columnType = prop.customType.getColumnType(prop, this.platform);
+    }
   }
 
   private initColumnType(prop: EntityProperty, path?: string): void {

--- a/lib/platforms/Platform.ts
+++ b/lib/platforms/Platform.ts
@@ -66,4 +66,12 @@ export abstract class Platform {
     return 'current_timestamp' + (length ? `(${length})` : '');
   }
 
+  getDateTypeDeclarationSQL(length: number): string {
+    return 'date' + (length ? `(${length})` : '');
+  }
+
+  getTimeTypeDeclarationSQL(length: number): string {
+    return 'time' + (length ? `(${length})` : '');
+  }
+
 }

--- a/lib/platforms/PostgreSqlPlatform.ts
+++ b/lib/platforms/PostgreSqlPlatform.ts
@@ -17,4 +17,8 @@ export class PostgreSqlPlatform extends Platform {
     return `current_timestamp(${length})`;
   }
 
+  getTimeTypeDeclarationSQL(): string {
+    return 'time(0)';
+  }
+
 }

--- a/lib/types/DateType.ts
+++ b/lib/types/DateType.ts
@@ -1,0 +1,38 @@
+import { Type } from './Type';
+import { Platform } from '../platforms';
+import { EntityProperty } from '../typings';
+import { ValidationError } from '../utils';
+
+export class DateType extends Type {
+
+  convertToDatabaseValue(value: any, platform: Platform): any {
+    if (value instanceof Date) {
+      return value.toISOString().substr(0, 10);
+    }
+
+    if (!value || value.toString().match(/^\d{4}-\d{2}-\d{2}$/)) {
+      return value;
+    }
+
+    throw ValidationError.invalidType(DateType, value, 'JS');
+  }
+
+  convertToJSValue(value: any, platform: Platform): any {
+    if (!value || value instanceof Date) {
+      return value;
+    }
+
+    const date = new Date(value);
+
+    if (date.toString() === 'Invalid Date') {
+      throw ValidationError.invalidType(DateType, value, 'database');
+    }
+
+    return date;
+  }
+
+  getColumnType(prop: EntityProperty, platform: Platform) {
+    return platform.getDateTypeDeclarationSQL(prop.length);
+  }
+
+}

--- a/lib/types/TimeType.ts
+++ b/lib/types/TimeType.ts
@@ -1,0 +1,20 @@
+import { Type } from './Type';
+import { Platform } from '../platforms';
+import { EntityProperty } from '../typings';
+import { ValidationError } from '../utils';
+
+export class TimeType extends Type {
+
+  convertToDatabaseValue(value: any, platform: Platform): any {
+    if (value && !value.toString().match(/^\d{2,}:(?:[0-5]\d):(?:[0-5]\d)$/)) {
+      throw ValidationError.invalidType(TimeType, value, 'JS');
+    }
+
+    return super.convertToDatabaseValue(value, platform);
+  }
+
+  getColumnType(prop: EntityProperty, platform: Platform) {
+    return platform.getTimeTypeDeclarationSQL(prop.length);
+  }
+
+}

--- a/lib/types/Type.ts
+++ b/lib/types/Type.ts
@@ -1,0 +1,47 @@
+import { Platform } from '../platforms';
+import { Constructor, EntityProperty } from '../typings';
+
+export abstract class Type {
+
+  private static readonly types = new Map();
+
+  /**
+   * Converts a value from its JS representation to its database representation of this type.
+   */
+  convertToDatabaseValue(value: any, platform: Platform): any {
+    return value;
+  }
+
+  /**
+   * Converts a value from its database representation to its JS representation of this type.
+   */
+  convertToJSValue(value: any, platform: Platform): any {
+    return value;
+  }
+
+  /**
+   * Converts a value from its JS representation to its serialized JSON form of this type.
+   * By default converts to the database value.
+   */
+  toJSON(value: any, platform: Platform): any {
+    return this.convertToDatabaseValue(value, platform);
+  }
+
+  /**
+   * Gets the SQL declaration snippet for a field of this type.
+   */
+  getColumnType(prop: EntityProperty, platform: Platform): string {
+    return prop.columnType;
+  }
+
+  static getType(cls: Constructor<Type>): Type {
+    const key = cls.name;
+
+    if (!Type.types.has(key)) {
+      Type.types.set(key, new cls());
+    }
+
+    return Type.types.get(key);
+  }
+
+}

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,0 +1,3 @@
+export * from './Type';
+export * from './DateType';
+export * from './TimeType';

--- a/lib/typings.ts
+++ b/lib/typings.ts
@@ -12,6 +12,7 @@ import { EntityManager } from './EntityManager';
 import { LockMode } from './unit-of-work';
 import { Platform } from './platforms';
 import { MetadataStorage } from './metadata';
+import { Type } from './types';
 
 export type Constructor<T> = new (...args: any[]) => T;
 export type Dictionary<T = any> = { [k: string]: T };
@@ -111,6 +112,7 @@ export interface EntityProperty<T extends AnyEntity<T> = any> {
   entity: () => EntityName<T>;
   type: string;
   columnType: string;
+  customType: Type;
   primary: boolean;
   length?: any;
   reference: ReferenceType;

--- a/lib/unit-of-work/ChangeSetComputer.ts
+++ b/lib/unit-of-work/ChangeSetComputer.ts
@@ -34,11 +34,14 @@ export class ChangeSetComputer {
   }
 
   private computePayload<T extends AnyEntity<T>>(entity: T): EntityData<T> {
-    if (this.originalEntityData[wrap(entity).__uuid]) {
-      return Utils.diffEntities<T>(this.originalEntityData[wrap(entity).__uuid] as T, entity, this.metadata);
+    const wrapped = wrap(entity);
+    const platform = wrapped.__internal.platform;
+
+    if (this.originalEntityData[wrapped.__uuid]) {
+      return Utils.diffEntities<T>(this.originalEntityData[wrapped.__uuid] as T, entity, this.metadata, platform);
     }
 
-    return Utils.prepareEntity(entity, this.metadata);
+    return Utils.prepareEntity(entity, this.metadata, platform);
   }
 
   private processReference<T extends AnyEntity<T>>(changeSet: ChangeSet<T>, prop: EntityProperty<T>): void {

--- a/lib/unit-of-work/UnitOfWork.ts
+++ b/lib/unit-of-work/UnitOfWork.ts
@@ -41,7 +41,7 @@ export class UnitOfWork {
     this.identityMap[`${wrapped.constructor.name}-${wrapped.__serializedPrimaryKey}`] = wrapped;
 
     if (!this.originalEntityData[wrapped.__uuid] || mergeData) {
-      this.originalEntityData[wrapped.__uuid] = Utils.prepareEntity(entity, this.metadata);
+      this.originalEntityData[wrapped.__uuid] = Utils.prepareEntity(entity, this.metadata, this.platform);
     }
 
     this.cascade(entity, Cascade.MERGE, visited);
@@ -204,7 +204,7 @@ export class UnitOfWork {
     if (changeSet) {
       this.changeSets.push(changeSet);
       this.cleanUpStack(this.persistStack, wrapped);
-      this.originalEntityData[wrapped.__uuid] = Utils.prepareEntity(entity, this.metadata);
+      this.originalEntityData[wrapped.__uuid] = Utils.prepareEntity(entity, this.metadata, this.platform);
     }
   }
 
@@ -266,7 +266,7 @@ export class UnitOfWork {
       await Utils.runSerial(hooks[type]!, hook => (entity[hook] as unknown as () => Promise<any>)());
 
       if (payload) {
-        Object.assign(payload, Utils.diffEntities(copy, entity, this.metadata));
+        Object.assign(payload, Utils.diffEntities(copy, entity, this.metadata, this.platform));
       }
     }
   }

--- a/lib/utils/ValidationError.ts
+++ b/lib/utils/ValidationError.ts
@@ -1,6 +1,7 @@
 import { inspect } from 'util';
-import { Dictionary, EntityMetadata, EntityProperty, AnyEntity, IPrimaryKey } from '../typings';
+import { Dictionary, EntityMetadata, EntityProperty, AnyEntity, IPrimaryKey, Constructor } from '../typings';
 import { Utils } from './Utils';
+import { Type } from '../types';
 
 export class ValidationError<T extends AnyEntity = AnyEntity> extends Error {
 
@@ -126,6 +127,16 @@ export class ValidationError<T extends AnyEntity = AnyEntity> extends Error {
 
   static invalidPropertyName(entityName: string, invalid: string): ValidationError {
     return new ValidationError(`Entity '${entityName}' does not have property '${invalid}'`);
+  }
+
+  static invalidType(type: Constructor<Type>, value: any, mode: string): ValidationError {
+    const valueType = Utils.getObjectType(value);
+
+    if (value instanceof Date) {
+      value = value.toISOString();
+    }
+
+    return new ValidationError(`Could not convert ${mode} value '${value}' of type '${valueType}' to type ${type.name}`);
   }
 
   private static fromMessage(meta: EntityMetadata, prop: EntityProperty, message: string): ValidationError {

--- a/tests/EntityManager.mariadb.test.ts
+++ b/tests/EntityManager.mariadb.test.ts
@@ -68,7 +68,7 @@ describe('EntityManagerMariaDb', () => {
     await orm.em.persistAndFlush(bible);
 
     const author = new Author2('Jon Snow', 'snow@wall.st');
-    author.born = new Date();
+    author.born = new Date('1990-03-23');
     author.favouriteBook = bible;
 
     const publisher = new Publisher2('7K publisher', PublisherType.GLOBAL);
@@ -133,7 +133,7 @@ describe('EntityManagerMariaDb', () => {
         { author: jon.id, publisher: publisher.id, title: 'My Life on The Wall, part 3' },
       ],
       favouriteBook: { author: god.id, title: 'Bible' },
-      born: jon.born,
+      // born: '1990-03-23', // mariadb driver currently does not work with forced UTC timezone
       email: 'snow@wall.st',
       name: 'Jon Snow',
     });

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -28,7 +28,7 @@ describe('EntityManagerMongo', () => {
     await orm.em.persistAndFlush(bible);
 
     const author = new Author('Jon Snow', 'snow@wall.st');
-    author.born = new Date();
+    author.born = new Date('2000-01-01');
     author.favouriteBook = bible;
 
     const publisher = new Publisher('7K publisher', PublisherType.GLOBAL);
@@ -92,7 +92,7 @@ describe('EntityManagerMongo', () => {
         { author: jon.id, publisher: publisher.id, title: 'My Life on The Wall, part 3' },
       ],
       favouriteBook: { author: god.id, title: 'Bible' },
-      born: jon.born,
+      born: '2000-01-01',
       name: 'Jon Snow',
       foo: 'bar',
     });
@@ -502,14 +502,14 @@ describe('EntityManagerMongo', () => {
     expect(author.name).toBe('Jon Snow');
   });
 
-  test('populate ManyToOne relation', async () => {
+  test('populate ManyToOne relation via init()', async () => {
     const authorRepository = orm.em.getRepository(Author);
     const god = new Author('God', 'hello@heaven.god');
     const bible = new Book('Bible', god);
     await orm.em.persistAndFlush(bible);
 
     let jon = new Author('Jon Snow', 'snow@wall.st');
-    jon.born = new Date();
+    jon.born = new Date('1990-03-23');
     jon.favouriteBook = bible;
     await orm.em.persistAndFlush(jon);
     orm.em.clear();
@@ -517,6 +517,7 @@ describe('EntityManagerMongo', () => {
     jon = (await authorRepository.findOne(jon.id))!;
     expect(jon).not.toBeNull();
     expect(jon.name).toBe('Jon Snow');
+    expect(jon.born).toEqual(new Date('1990-03-23'));
     expect(jon.favouriteBook).toBeInstanceOf(Book);
     expect(wrap(jon.favouriteBook).isInitialized()).toBe(false);
 

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -289,7 +289,8 @@ describe('EntityManagerMySql', () => {
     await orm.em.persistAndFlush(bible);
 
     const author = new Author2('Jon Snow', 'snow@wall.st');
-    author.born = new Date();
+    author.born = new Date('1990-03-23');
+    author.bornTime = '00:23:59';
     author.favouriteBook = bible;
 
     const publisher = new Publisher2('7K publisher', PublisherType.GLOBAL);
@@ -356,7 +357,8 @@ describe('EntityManagerMySql', () => {
         { author: jon.id, publisher: publisher.id, title: 'My Life on The Wall, part 3' },
       ],
       favouriteBook: { author: god.id, title: 'Bible' },
-      born: jon.born,
+      born: '1990-03-23',
+      bornTime: '00:23:59',
       email: 'snow@wall.st',
       name: 'Jon Snow',
     });
@@ -1323,7 +1325,7 @@ describe('EntityManagerMySql', () => {
     author2.favouriteBook = book;
     author2.version = 123;
     await orm.em.persistAndFlush([author1, author2, book]);
-    const diff = Utils.diffEntities(author1, author2, orm.getMetadata());
+    const diff = Utils.diffEntities(author1, author2, orm.getMetadata(), orm.em.getDriver().getPlatform());
     expect(diff).toMatchObject({ name: 'Name 2', favouriteBook: book.uuid });
     expect(typeof diff.favouriteBook).toBe('string');
     expect(diff.favouriteBook).toBe(book.uuid);
@@ -1523,7 +1525,7 @@ describe('EntityManagerMySql', () => {
 
   test('partial selects', async () => {
     const author = new Author2('Jon Snow', 'snow@wall.st');
-    author.born = new Date();
+    author.born = new Date('1990-03-23');
     await orm.em.persistAndFlush(author);
     orm.em.clear();
 
@@ -1600,7 +1602,7 @@ describe('EntityManagerMySql', () => {
     Object.assign(orm.em.config, { logger });
 
     let author = new Author2('Jon Snow', 'snow@wall.st');
-    author.born = new Date();
+    author.born = new Date('1990-03-23');
     author.books.add(new Book2('B', author));
     await orm.em.persistAndFlush(author);
     expect(mock.mock.calls[0][0]).toMatch(/begin.*via write connection '127\.0\.0\.1'/);

--- a/tests/EntityManager.sqlite.test.ts
+++ b/tests/EntityManager.sqlite.test.ts
@@ -176,7 +176,7 @@ describe('EntityManagerSqlite', () => {
     await orm.em.persist(bible, true);
 
     const author = new Author3('Jon Snow', 'snow@wall.st');
-    author.born = new Date();
+    author.born = new Date('1990-03-23');
     author.favouriteBook = bible;
 
     const publisher = new Publisher3('7K publisher', 'global');
@@ -237,7 +237,7 @@ describe('EntityManagerSqlite', () => {
         { author: jon.id, publisher: publisher.id, title: 'My Life on The Wall, part 3' },
       ],
       favouriteBook: { author: god.id, title: 'Bible' },
-      born: jon.born,
+      born: '1990-03-23',
       email: 'snow@wall.st',
       name: 'Jon Snow',
     });
@@ -523,7 +523,7 @@ describe('EntityManagerSqlite', () => {
     await orm.em.persist(bible, true);
 
     let jon = new Author3('Jon Snow', 'snow@wall.st');
-    jon.born = new Date();
+    jon.born = new Date('1990-03-23');
     jon.favouriteBook = bible;
     await orm.em.persist(jon, true);
     orm.em.clear();
@@ -811,7 +811,7 @@ describe('EntityManagerSqlite', () => {
     author2.favouriteBook = book;
     author2.version = 123;
     await orm.em.persist([author1, author2, book], true);
-    const diff = Utils.diffEntities(author1, author2, orm.getMetadata());
+    const diff = Utils.diffEntities(author1, author2, orm.getMetadata(), orm.em.getDriver().getPlatform());
     expect(diff).toMatchObject({ name: 'Name 2', favouriteBook: book.id });
     expect(typeof diff.favouriteBook).toBe('number');
   });
@@ -842,14 +842,14 @@ describe('EntityManagerSqlite', () => {
 
   test('datetime is stored in correct timezone', async () => {
     const author = new Author3('n', 'e');
-    author.born = new Date('2000-01-01T00:00:00Z');
+    author.createdAt = new Date('2000-01-01T00:00:00Z');
     await orm.em.persistAndFlush(author);
     orm.em.clear();
 
-    const res = await orm.em.getConnection().execute<{ born: number }[]>(`select born as born from author3 where id = ${author.id}`);
-    expect(res[0].born).toBe(+author.born);
+    const res = await orm.em.getConnection().execute<{ created_at: number }[]>(`select created_at as created_at from author3 where id = ${author.id}`);
+    expect(res[0].created_at).toBe(+author.createdAt);
     const a = await orm.em.findOneOrFail<any>(Author3, author.id);
-    expect(+a.born!).toBe(+author.born);
+    expect(+a.createdAt!).toBe(+author.createdAt);
   });
 
   afterAll(async () => {

--- a/tests/SchemaGenerator.test.ts
+++ b/tests/SchemaGenerator.test.ts
@@ -328,7 +328,6 @@ describe('SchemaGenerator', () => {
     meta.set('NewTable', newTableMeta);
     const authorMeta = meta.get('Author2');
     authorMeta.properties.termsAccepted.default = false;
-    const now = Date.now();
     await expect(generator.getUpdateSchemaSQL(false)).resolves.toMatchSnapshot('postgres-update-schema-create-table');
     await generator.updateSchema();
 

--- a/tests/UnitOfWork.test.ts
+++ b/tests/UnitOfWork.test.ts
@@ -24,15 +24,16 @@ describe('UnitOfWork', () => {
     expect(() => computer.computeChangeSet(author)).toThrowError(`Trying to set Author.name of type 'string' to '111' of type 'number'`);
 
     // string date with unknown format will throw
-    Object.assign(author, { name: '333', email: '444', born: 'asd' });
-    expect(() => computer.computeChangeSet(author)).toThrowError(`Trying to set Author.born of type 'date' to 'asd' of type 'string'`);
+    Object.assign(author, { name: '333', email: '444', createdAt: 'asd' });
+    expect(() => computer.computeChangeSet(author)).toThrowError(`Trying to set Author.createdAt of type 'date' to 'asd' of type 'string'`);
+    delete author.createdAt;
 
     // number bool with other value than 0/1 will throw
     Object.assign(author, { termsAccepted: 2 });
     expect(() => computer.computeChangeSet(author)).toThrowError(`Trying to set Author.termsAccepted of type 'boolean' to '2' of type 'number'`);
 
     // string date with correct format will be auto-corrected
-    Object.assign(author, { name: '333', email: '444', born: '2018-01-01', termsAccepted: 1 });
+    Object.assign(author, { name: '333', email: '444', createdAt: '2018-01-01', termsAccepted: 1 });
     let changeSet = computer.computeChangeSet(author)!;
     expect(typeof changeSet.payload.name).toBe('string');
     expect(changeSet.payload.name).toBe('333');
@@ -40,17 +41,17 @@ describe('UnitOfWork', () => {
     expect(changeSet.payload.email).toBe('444');
     expect(typeof changeSet.payload.termsAccepted).toBe('boolean');
     expect(changeSet.payload.termsAccepted).toBe(true);
-    expect(changeSet.payload.born instanceof Date).toBe(true);
+    expect(changeSet.payload.createdAt instanceof Date).toBe(true);
 
     // Date object will be ok
-    Object.assign(author, { born: new Date() });
+    Object.assign(author, { createdAt: new Date() });
     changeSet = (await computer.computeChangeSet(author))!;
-    expect(changeSet.payload.born instanceof Date).toBe(true);
+    expect(changeSet.payload.createdAt instanceof Date).toBe(true);
 
     // null will be ok
-    Object.assign(author, { born: null });
+    Object.assign(author, { createdAt: null });
     changeSet = (await computer.computeChangeSet(author))!;
-    expect(changeSet.payload.born).toBeNull();
+    expect(changeSet.payload.createdAt).toBeNull();
 
     // string number with correct format will be auto-corrected
     Object.assign(author, { age: '21' });
@@ -76,8 +77,8 @@ describe('UnitOfWork', () => {
     const author = new Author('test', 'test');
 
     // string date with correct format will not be auto-corrected in strict mode
-    const payload = { name: '333', email: '444', born: '2018-01-01', termsAccepted: 1 };
-    expect(() => validator.validate(author, payload, orm.getMetadata().get(Author.name))).toThrowError(`Trying to set Author.born of type 'date' to '2018-01-01' of type 'string'`);
+    const payload = { name: '333', email: '444', createdAt: '2018-01-01', termsAccepted: 1 };
+    expect(() => validator.validate(author, payload, orm.getMetadata().get(Author.name))).toThrowError(`Trying to set Author.createdAt of type 'date' to '2018-01-01' of type 'string'`);
   });
 
   test('changeSet is null for empty payload', async () => {

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -90,7 +90,7 @@ describe('Utils', () => {
     author1.books = new Collection<Book>(author1);
     const author2 = new Author('Name 2', 'e-mail');
     author2.books = new Collection<Book>(author2);
-    expect(Utils.diffEntities(author1, author2, orm.getMetadata()).books).toBeUndefined();
+    expect(Utils.diffEntities(author1, author2, orm.getMetadata(), orm.em.getDriver().getPlatform()).books).toBeUndefined();
   });
 
   test('prepareEntity changes entity to string id', async () => {
@@ -100,7 +100,7 @@ describe('Utils', () => {
     author2.favouriteBook = book;
     author2.version = 123;
     await orm.em.persistAndFlush(author2);
-    const diff = Utils.diffEntities(author1, author2, orm.getMetadata());
+    const diff = Utils.diffEntities(author1, author2, orm.getMetadata(), orm.em.getDriver().getPlatform());
     expect(diff).toMatchObject({ name: 'Name 2', favouriteBook: book._id });
     expect(diff.favouriteBook instanceof ObjectId).toBe(true);
   });
@@ -109,7 +109,7 @@ describe('Utils', () => {
     const author = new Author('Name 1', 'e-mail');
     author.version = 123;
     author.versionAsString = 'v123';
-    const o = Utils.prepareEntity(author, orm.getMetadata());
+    const o = Utils.prepareEntity(author, orm.getMetadata(), orm.em.getDriver().getPlatform());
     expect(o.version).toBeUndefined();
     expect(o.versionAsString).toBeUndefined();
   });

--- a/tests/__snapshots__/EntityGenerator.test.ts.snap
+++ b/tests/__snapshots__/EntityGenerator.test.ts.snap
@@ -35,8 +35,11 @@ export class Author2 {
   @Property({ nullable: true })
   identities?: object;
 
-  @Property({ nullable: true })
-  born?: Date;
+  @Property({ columnType: 'date', nullable: true })
+  born?: string;
+
+  @Property({ columnType: 'time', nullable: true })
+  bornTime?: string;
 
   @ManyToOne({ entity: () => Book2, nullable: true })
   favouriteBook?: Book2;
@@ -309,8 +312,11 @@ export class Author2 {
   @Property({ nullable: true })
   identities?: object;
 
-  @Property({ type: 'timestamp', nullable: true })
+  @Property({ type: 'date', nullable: true })
   born?: Date;
+
+  @Property({ type: 'time', nullable: true })
+  bornTime?: Date;
 
   @ManyToOne({ entity: () => Book2, nullable: true })
   favouriteBook?: Book2;
@@ -589,8 +595,11 @@ export class Author3 {
   @Property({ nullable: true })
   identities?: string;
 
-  @Property({ nullable: true })
-  born?: Date;
+  @Property({ columnType: 'date', nullable: true })
+  born?: string;
+
+  @Property({ columnType: 'time', nullable: true })
+  bornTime?: string;
 
   @ManyToOne({ entity: () => Book3, nullable: true })
   favouriteBook?: Book3;

--- a/tests/__snapshots__/SchemaGenerator.test.ts.snap
+++ b/tests/__snapshots__/SchemaGenerator.test.ts.snap
@@ -4,7 +4,7 @@ exports[`SchemaGenerator generate schema from metadata [mysql]: mysql-create-sch
 "set names utf8;
 set foreign_key_checks = 0;
 
-create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null, \`terms_accepted\` tinyint(1) not null default 0, \`optional\` tinyint(1) null, \`identities\` json null, \`born\` datetime null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8 engine = InnoDB;
+create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null, \`terms_accepted\` tinyint(1) not null default 0, \`optional\` tinyint(1) null, \`identities\` json null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8 engine = InnoDB;
 alter table \`author2\` add unique \`author2_email_unique\`(\`email\`);
 alter table \`author2\` add index \`author2_favourite_book_uuid_pk_index\`(\`favourite_book_uuid_pk\`);
 alter table \`author2\` add index \`author2_favourite_author_id_index\`(\`favourite_author_id\`);
@@ -22,7 +22,7 @@ create table \`test2\` (\`id\` int unsigned not null auto_increment primary key,
 alter table \`test2\` add unique \`test2_book_uuid_pk_unique\`(\`book_uuid_pk\`);
 alter table \`test2\` add index \`test2_book_uuid_pk_index\`(\`book_uuid_pk\`);
 
-create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
+create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp) default character set utf8 engine = InnoDB;
 alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
 alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
 alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
@@ -121,7 +121,7 @@ drop table if exists \`book2_to_book_tag2\`;
 drop table if exists \`book_to_tag_unordered\`;
 drop table if exists \`publisher2_to_test2\`;
 
-create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null, \`terms_accepted\` tinyint(1) not null default 0, \`optional\` tinyint(1) null, \`identities\` json null, \`born\` datetime null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8 engine = InnoDB;
+create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null, \`terms_accepted\` tinyint(1) not null default 0, \`optional\` tinyint(1) null, \`identities\` json null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8 engine = InnoDB;
 alter table \`author2\` add unique \`author2_email_unique\`(\`email\`);
 alter table \`author2\` add index \`author2_favourite_book_uuid_pk_index\`(\`favourite_book_uuid_pk\`);
 alter table \`author2\` add index \`author2_favourite_author_id_index\`(\`favourite_author_id\`);
@@ -139,7 +139,7 @@ create table \`test2\` (\`id\` int unsigned not null auto_increment primary key,
 alter table \`test2\` add unique \`test2_book_uuid_pk_unique\`(\`book_uuid_pk\`);
 alter table \`test2\` add index \`test2_book_uuid_pk_index\`(\`book_uuid_pk\`);
 
-create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
+create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp) default character set utf8 engine = InnoDB;
 alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
 alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
 alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
@@ -220,7 +220,7 @@ exports[`SchemaGenerator generate schema from metadata [postgres]: postgres-crea
 "set names 'utf8';
 set session_replication_role = 'replica';
 
-create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"updated_at\\" timestamptz(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int4 null, \\"terms_accepted\\" bool not null default 0, \\"optional\\" bool null, \\"identities\\" json null, \\"born\\" timestamptz(0) null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int4 null);
+create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"updated_at\\" timestamptz(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int4 null, \\"terms_accepted\\" bool not null default 0, \\"optional\\" bool null, \\"identities\\" json null, \\"born\\" date null, \\"born_time\\" time(0) null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int4 null);
 alter table \\"author2\\" add constraint \\"author2_email_unique\\" unique (\\"email\\");
 
 create table \\"book2\\" (\\"uuid_pk\\" varchar(36) not null, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"title\\" varchar(255) null, \\"perex\\" text null, \\"price\\" float null, \\"double\\" double null, \\"meta\\" json null, \\"author_id\\" int4 not null, \\"publisher_id\\" int4 null);
@@ -233,7 +233,7 @@ create table \\"publisher2\\" (\\"id\\" serial primary key, \\"name\\" varchar(2
 create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"version\\" int4 not null default 1);
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_unique\\" unique (\\"book_uuid_pk\\");
 
-create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int4 null, \\"foo_bar_id\\" int4 null, \\"version\\" timestamptz(3) not null default current_timestamp(3));
+create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int4 null, \\"foo_bar_id\\" int4 null, \\"version\\" timestamptz(0) not null default current_timestamp(0));
 alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_unique\\" unique (\\"baz_id\\");
 alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_unique\\" unique (\\"foo_bar_id\\");
 
@@ -325,7 +325,7 @@ drop table if exists \\"book2_to_book_tag2\\" cascade;
 drop table if exists \\"book_to_tag_unordered\\" cascade;
 drop table if exists \\"publisher2_to_test2\\" cascade;
 
-create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"updated_at\\" timestamptz(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int4 null, \\"terms_accepted\\" bool not null default 0, \\"optional\\" bool null, \\"identities\\" json null, \\"born\\" timestamptz(0) null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int4 null);
+create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"updated_at\\" timestamptz(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int4 null, \\"terms_accepted\\" bool not null default 0, \\"optional\\" bool null, \\"identities\\" json null, \\"born\\" date null, \\"born_time\\" time(0) null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int4 null);
 alter table \\"author2\\" add constraint \\"author2_email_unique\\" unique (\\"email\\");
 
 create table \\"book2\\" (\\"uuid_pk\\" varchar(36) not null, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"title\\" varchar(255) null, \\"perex\\" text null, \\"price\\" float null, \\"double\\" double null, \\"meta\\" json null, \\"author_id\\" int4 not null, \\"publisher_id\\" int4 null);
@@ -338,7 +338,7 @@ create table \\"publisher2\\" (\\"id\\" serial primary key, \\"name\\" varchar(2
 create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"version\\" int4 not null default 1);
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_unique\\" unique (\\"book_uuid_pk\\");
 
-create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int4 null, \\"foo_bar_id\\" int4 null, \\"version\\" timestamptz(3) not null default current_timestamp(3));
+create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int4 null, \\"foo_bar_id\\" int4 null, \\"version\\" timestamptz(0) not null default current_timestamp(0));
 alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_unique\\" unique (\\"baz_id\\");
 alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_unique\\" unique (\\"foo_bar_id\\");
 
@@ -405,7 +405,7 @@ set session_replication_role = 'origin';
 exports[`SchemaGenerator generate schema from metadata [sqlite]: sqlite-create-schema-dump 1`] = `
 "pragma foreign_keys = off;
 
-create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` varchar null, \`born\` datetime null);
+create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` varchar null, \`born\` date(3) null, \`born_time\` time(3) null);
 create unique index \`author3_email_unique\` on \`author3\` (\`email\`);
 
 create table \`book3\` (\`id\` integer not null primary key autoincrement, \`title\` varchar not null);
@@ -481,7 +481,7 @@ drop table if exists \`test3\`;
 drop table if exists \`book3_to_book_tag3\`;
 drop table if exists \`publisher3_to_test3\`;
 
-create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` varchar null, \`born\` datetime null);
+create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` varchar null, \`born\` date(3) null, \`born_time\` time(3) null);
 create unique index \`author3_email_unique\` on \`author3\` (\`email\`);
 
 create table \`book3\` (\`id\` integer not null primary key autoincrement, \`title\` varchar not null);

--- a/tests/entities-js/Author3.js
+++ b/tests/entities-js/Author3.js
@@ -1,4 +1,4 @@
-const { Collection, ReferenceType } = require('../../lib');
+const { Collection, DateType, TimeType, ReferenceType } = require('../../lib');
 const { BaseEntity4 } = require('./index').BaseEntity4;
 
 /**
@@ -11,6 +11,7 @@ const { BaseEntity4 } = require('./index').BaseEntity4;
  * @property {boolean} termsAccepted
  * @property {string[]} identities
  * @property {Date} born
+ * @property {string} bornTime
  * @property {Collection<Book3>} books
  * @property {Book3} favouriteBook
  * @property {number} version
@@ -91,8 +92,14 @@ const schema = {
       nullable: true,
     },
     born: {
-      type: 'Date',
+      type: DateType,
       nullable: true,
+      length: 3,
+    },
+    bornTime: {
+      type: TimeType,
+      nullable: true,
+      length: 3,
     },
     books: {
       reference: ReferenceType.ONE_TO_MANY,

--- a/tests/entities-sql/Author2.ts
+++ b/tests/entities-sql/Author2.ts
@@ -1,6 +1,6 @@
 import {
   AfterCreate, AfterDelete, AfterUpdate, BeforeCreate, BeforeDelete, BeforeUpdate,
-  Collection, Entity, OneToMany, Property, ManyToOne, QueryOrder, OnInit, ManyToMany,
+  Collection, Entity, OneToMany, Property, ManyToOne, QueryOrder, OnInit, ManyToMany, DateType, TimeType,
 } from '../../lib';
 
 import { Book2 } from './Book2';
@@ -36,8 +36,11 @@ export class Author2 extends BaseEntity2 {
   @Property({ nullable: true })
   identities?: string[];
 
-  @Property({ length: 0, nullable: true })
+  @Property({ type: DateType, nullable: true })
   born?: Date;
+
+  @Property({ type: TimeType, nullable: true })
+  bornTime?: string;
 
   @OneToMany({ entity: () => Book2, mappedBy: 'author', orderBy: { title: QueryOrder.ASC } })
   books!: Collection<Book2>;

--- a/tests/entities-sql/FooBar2.ts
+++ b/tests/entities-sql/FooBar2.ts
@@ -17,7 +17,7 @@ export class FooBar2 extends BaseEntity22 implements IdEntity<FooBar2> {
   @OneToOne({ nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ version: true, length: 3 })
+  @Property({ version: true, length: 0 })
   version!: Date;
 
   static create(name: string) {

--- a/tests/entities/Author.ts
+++ b/tests/entities/Author.ts
@@ -1,5 +1,5 @@
 import {
-  AfterCreate, AfterDelete, AfterUpdate, BeforeCreate, BeforeDelete, BeforeUpdate,
+  AfterCreate, AfterDelete, AfterUpdate, BeforeCreate, BeforeDelete, BeforeUpdate, DateType,
   Cascade, Collection, Entity, EntityAssigner, ManyToMany, ManyToOne, OneToMany, Property, wrap,
 } from '../../lib';
 
@@ -31,7 +31,7 @@ export class Author extends BaseEntity {
   @Property({ fieldName: 'identitiesArray' })
   identities?: string[];
 
-  @Property()
+  @Property({ type: DateType })
   born?: Date;
 
   @OneToMany(() => Book, book => book.author, { referenceColumnName: '_id', cascade: [Cascade.PERSIST], orphanRemoval: true })

--- a/tests/mysql-schema.sql
+++ b/tests/mysql-schema.sql
@@ -14,7 +14,7 @@ drop table if exists `book2_to_book_tag2`;
 drop table if exists `book_to_tag_unordered`;
 drop table if exists `publisher2_to_test2`;
 
-create table `author2` (`id` int unsigned not null auto_increment primary key, `created_at` datetime(3) not null default current_timestamp(3), `updated_at` datetime(3) not null default current_timestamp(3), `name` varchar(255) not null, `email` varchar(255) not null, `age` int(11) null, `terms_accepted` tinyint(1) not null default 0, `optional` tinyint(1) null, `identities` json null, `born` datetime null, `favourite_book_uuid_pk` varchar(36) null, `favourite_author_id` int(11) unsigned null) default character set utf8 engine = InnoDB;
+create table `author2` (`id` int unsigned not null auto_increment primary key, `created_at` datetime(3) not null default current_timestamp(3), `updated_at` datetime(3) not null default current_timestamp(3), `name` varchar(255) not null, `email` varchar(255) not null, `age` int(11) null, `terms_accepted` tinyint(1) not null default 0, `optional` tinyint(1) null, `identities` json null, `born` date null, `born_time` time null, `favourite_book_uuid_pk` varchar(36) null, `favourite_author_id` int(11) unsigned null) default character set utf8 engine = InnoDB;
 alter table `author2` add unique `author2_email_unique`(`email`);
 alter table `author2` add index `author2_favourite_book_uuid_pk_index`(`favourite_book_uuid_pk`);
 alter table `author2` add index `author2_favourite_author_id_index`(`favourite_author_id`);

--- a/tests/postgre-schema.sql
+++ b/tests/postgre-schema.sql
@@ -15,7 +15,7 @@ drop table if exists "book_to_tag_unordered" cascade;
 drop table if exists "publisher2_to_test2" cascade;
 drop table if exists "label2" cascade;
 
-create table "author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), "updated_at" timestamptz(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int4 null, "terms_accepted" bool not null default false, "optional" bool null, "identities" json null, "born" timestamp(0) null, "favourite_book_uuid_pk" varchar(36) null, "favourite_author_id" int4 null);
+create table "author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), "updated_at" timestamptz(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int4 null, "terms_accepted" bool not null default false, "optional" bool null, "identities" json null, "born" date null, "born_time" time(0) without time zone null, "favourite_book_uuid_pk" varchar(36) null, "favourite_author_id" int4 null);
 alter table "author2" add constraint "author2_email_unique" unique ("email");
 
 create table "book2" ("uuid_pk" character varying(36) not null, "created_at" timestamptz(3) not null default current_timestamp(3), "title" varchar(255) null, "perex" text null, "price" float null, "double" double precision null, "meta" json null, "author_id" int4 not null, "publisher_id" int4 null, "foo" varchar(255) null);

--- a/tests/sqlite-schema.sql
+++ b/tests/sqlite-schema.sql
@@ -8,7 +8,7 @@ drop table if exists `test3`;
 drop table if exists `book3_to_book_tag3`;
 drop table if exists `publisher3_to_test3`;
 
-create table `author3` (`id` integer not null primary key autoincrement, `created_at` datetime null, `updated_at` datetime null, `name` varchar not null, `email` varchar not null, `age` integer null, `terms_accepted` integer not null default 0, `identities` varchar null, `born` datetime null);
+create table `author3` (`id` integer not null primary key autoincrement, `created_at` datetime null, `updated_at` datetime null, `name` varchar not null, `email` varchar not null, `age` integer null, `terms_accepted` integer not null default 0, `identities` varchar null, `born` date null, `born_time` time null);
 create unique index `author3_email_unique` on `author3` (`email`);
 
 create table `book3` (`id` integer not null primary key autoincrement, `title` varchar not null, `foo` varchar null);

--- a/tests/types/DateType.test.ts
+++ b/tests/types/DateType.test.ts
@@ -1,0 +1,30 @@
+import { DateType } from '../../lib/types';
+import { MongoPlatform } from '../../lib/platforms/MongoPlatform';
+
+describe('DateType', () => {
+
+  const type = new DateType();
+  const platform = new MongoPlatform();
+
+  test('convertToDatabaseValue', () => {
+    expect(type.convertToDatabaseValue('2000-01-01', platform)).toBe('2000-01-01');
+    expect(type.convertToDatabaseValue(new Date('2000-01-01'), platform)).toBe('2000-01-01');
+    expect(type.convertToDatabaseValue(null, platform)).toBe(null);
+    expect(type.convertToDatabaseValue(undefined, platform)).toBe(undefined);
+    expect(() => type.convertToDatabaseValue(1, platform)).toThrowError(`Could not convert JS value '1' of type 'number' to type DateType`);
+  });
+
+  test('convertToJSValue', () => {
+    const date = new Date('2000-01-01Z');
+    expect(type.convertToJSValue('2000-01-01', platform)).toEqual(date);
+    expect(type.convertToJSValue(new Date('2000-01-01'), platform)).toEqual(date);
+    expect(type.convertToJSValue(null, platform)).toBe(null);
+    expect(type.convertToJSValue(undefined, platform)).toBe(undefined);
+    expect(() => type.convertToJSValue('asd', platform)).toThrowError(`Could not convert database value 'asd' of type 'string' to type DateType`);
+  });
+
+  test('getColumnType', () => {
+    expect(type.getColumnType({ columnType: 'asd' } as any, platform)).toBe('date');
+  });
+
+});

--- a/tests/types/TimeType.test.ts
+++ b/tests/types/TimeType.test.ts
@@ -1,0 +1,22 @@
+import { TimeType } from '../../lib/types';
+import { MongoPlatform } from '../../lib/platforms/MongoPlatform';
+
+describe('TimeType', () => {
+
+  const type = new TimeType();
+  const platform = new MongoPlatform();
+
+  test('convertToDatabaseValue', () => {
+    expect(type.convertToDatabaseValue('00:00:01', platform)).toBe('00:00:01');
+    expect(type.convertToDatabaseValue(null, platform)).toBe(null);
+    expect(type.convertToDatabaseValue(undefined, platform)).toBe(undefined);
+    expect(() => type.convertToDatabaseValue(1, platform)).toThrowError(`Could not convert JS value '1' of type 'number' to type TimeType`);
+    expect(() => type.convertToDatabaseValue('2000-01-01', platform)).toThrowError(`Could not convert JS value '2000-01-01' of type 'string' to type TimeType`);
+    expect(() => type.convertToDatabaseValue(new Date('2000-01-01'), platform)).toThrowError(`Could not convert JS value '2000-01-01T00:00:00.000Z' of type 'date' to type TimeType`);
+  });
+
+  test('getColumnType', () => {
+    expect(type.getColumnType({ columnType: 'asd' } as any, platform)).toBe('time');
+  });
+
+});

--- a/tests/types/Type.test.ts
+++ b/tests/types/Type.test.ts
@@ -1,0 +1,27 @@
+import { Type } from '../../lib/types';
+import { MongoPlatform } from '../../lib/platforms/MongoPlatform';
+
+class TestType extends Type { }
+
+describe('Type', () => {
+
+  const type = new TestType();
+  const platform = new MongoPlatform();
+
+  test('convertToDatabaseValue', () => {
+    expect(type.convertToDatabaseValue('asd', platform)).toBe('asd');
+    expect(type.convertToDatabaseValue(null, platform)).toBe(null);
+    expect(type.convertToDatabaseValue(undefined, platform)).toBe(undefined);
+  });
+
+  test('convertToJSValue', () => {
+    expect(type.convertToJSValue('asd', platform)).toBe('asd');
+    expect(type.convertToJSValue(null, platform)).toBe(null);
+    expect(type.convertToJSValue(undefined, platform)).toBe(undefined);
+  });
+
+  test('getColumnType', () => {
+    expect(type.getColumnType({ columnType: 'asd' } as any, platform)).toBe('asd');
+  });
+
+});


### PR DESCRIPTION
Now it is possible to implement custom types by extending `Type` class. There are few existing types that one can use, like `DateType` that stores the value in `date` column type in sql (or string in mongo) and converts it to the runtime `Date` value.

```typescript
@Property({ type: DateType })
born?: Date;
```