### PR TITLE
perf(core): do not cascade persist entity references

### DIFF
--- a/docs/docs/upgrading-v2-to-v3.md
+++ b/docs/docs/upgrading-v2-to-v3.md
@@ -82,6 +82,19 @@ override the order column name via `fixedOrderColumn: 'order'`.
 
 You can also specify default ordering via `orderBy: { ... }` attribute.
 
+## Entity references now don't have instantiated collections
+
+Previously all entity instances, including entity references (not fully loaded entities where
+we know only the primary key), had instantiated collection classes. Now only initialized entities
+have them.
+
+```typescript
+const book = em.getReference(Book, 1);
+console.log(book.tags); // undefined
+await book.init();
+console.log(book.tags); // instance of Collection (not initialized)
+```
+
 ## EntityAssigner.assign() requires EM for new entities
 
 Previously all entities had internal reference to the root EM - the one created when 

--- a/lib/entity/ArrayCollection.ts
+++ b/lib/entity/ArrayCollection.ts
@@ -127,7 +127,7 @@ export class ArrayCollection<T extends AnyEntity<T>> {
   }
 
   protected shouldPropagateToCollection(collection: Collection<T>, method: 'add' | 'remove'): boolean {
-    if (!collection.isInitialized()) {
+    if (!collection || !collection.isInitialized()) {
       return false;
     }
 

--- a/lib/entity/EntityFactory.ts
+++ b/lib/entity/EntityFactory.ts
@@ -31,9 +31,9 @@ export class EntityFactory {
     }
 
     const entity = this.createEntity(data, meta);
-    this.hydrator.hydrate(entity, meta, data, newEntity);
 
     if (initialized) {
+      this.hydrator.hydrate(entity, meta, data, newEntity);
       delete entity.__initialized;
     } else {
       entity.__initialized = initialized;

--- a/tests/EntityFactory.test.ts
+++ b/tests/EntityFactory.test.ts
@@ -45,6 +45,7 @@ describe('EntityFactory', () => {
     expect(ref._id).toBeInstanceOf(ObjectId);
     expect(ref.id).toBe('5b0d19b28b21c648c2c8a600');
     expect(ref.title).toBeUndefined();
+    expect(ref.tags).toBeUndefined();
     expect(ref.toJSON()).toEqual({ id: '5b0d19b28b21c648c2c8a600' });
   });
 
@@ -57,7 +58,7 @@ describe('EntityFactory', () => {
   });
 
   test('entity ctor can have different params than props', async () => {
-    const entity = factory.create(Test, { name: 'test' }, false);
+    const entity = factory.create(Test, { name: 'test' });
     expect(entity).toBeInstanceOf(Test);
     expect(entity._id).toBeUndefined();
     expect(entity.name).toBe('test');

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -1056,6 +1056,17 @@ describe('EntityManagerMongo', () => {
     expect(tags[0].books[0].author.books.isInitialized(true)).toBe(true);
   });
 
+  test('reference has no collection initialized', async () => {
+    const book1 = new Book('t', new Author('a', 'e'));
+    await orm.em.fork().persistAndFlush(book1);
+    const book = orm.em.getReference(Book, book1.id);
+    expect(book.tags).toBeUndefined();
+    await wrap(book).init();
+    expect(book.tags).not.toBeUndefined();
+    expect(book.tags).toBeInstanceOf(Collection);
+    expect(book.tags.isInitialized()).toBe(true);
+  });
+
   test('populating one to many relation', async () => {
     let author = new Author('Jon Snow', 'snow@wall.st');
     const book1 = new Book('My Life on The Wall, part 1', author);


### PR DESCRIPTION
Persist is now cascaded only to initialized entities. Previously all entities and all their properties
were cascaded, which was unnecessary overhead.

Previously all entity instances, including entity references (not fully loaded entities where
we know only the primary key), had instantiated collection classes. Now only initialized entities
have them.

BREAKING CHANGE:
Entity references (not initialized entities) now don't have instantiated collections.

```typescript
const book = em.getReference(Book, 1);
console.log(book.tags); // undefined
await book.init();
console.log(book.tags); // instance of Collection (not initialized)
```