### PR TITLE
Update web pack documentation

### DIFF
--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -119,6 +119,7 @@ await MikroORM.init({
     // ...
     entities: await getEntities(),
     cache: { enabled: false },
+    discovery: { alwaysAnalyseProperties: false } //since rc-4
     // ...
 });
 


### PR DESCRIPTION
This option must be disabled to prevent the metadata analysers from running else web pack builds will fail on start.