### PR TITLE
Update configuration.md

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -10,6 +10,9 @@ entities in selected folders.
 ```typescript
 MikroORM.init({
   entities: [Author, Book, Publisher, BookTag],
+  discovery: {
+    requireEntitiesArray: true, // force usage of `entities` instead of `entitiesDirs`
+  }
 });
 ```
 


### PR DESCRIPTION
if you want find entity in entities, `discovery.requireEntitiesArray` config is required.
I spent an hour to find out why I have set the entites but the mikro-rom still requires the file, hope this can save time for others