### PR TITLE
feat(core): rework commit logic of UoW to ensure right query order

### DIFF
--- a/lib/EntityManager.ts
+++ b/lib/EntityManager.ts
@@ -546,7 +546,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Gets the transaction context (driver dependent object used to make sure queries are executed on same connection).
    */
-  getTransactionContext<T extends Transaction = Transaction>(): T {
+  getTransactionContext<T extends Transaction = Transaction>(): T | undefined {
     return this.transactionContext as T;
   }
 

--- a/lib/typings.ts
+++ b/lib/typings.ts
@@ -84,6 +84,7 @@ export interface IWrappedEntity<T, PK extends keyof T> {
   __uuid: string;
   __meta: EntityMetadata<T>;
   __internal: { platform: Platform; metadata: MetadataStorage; validator: EntityValidator };
+  __data: Dictionary;
   __em?: EntityManager;
   __initialized?: boolean;
   __populated: boolean;

--- a/lib/unit-of-work/ChangeSet.ts
+++ b/lib/unit-of-work/ChangeSet.ts
@@ -6,6 +6,7 @@ export interface ChangeSet<T extends AnyEntity<T>> {
   type: ChangeSetType;
   entity: T & WrappedEntity<T, Primary<T> & keyof T>;
   payload: EntityData<T>;
+  persisted: boolean;
 }
 
 export enum ChangeSetType {

--- a/lib/unit-of-work/CommitOrderCalculator.ts
+++ b/lib/unit-of-work/CommitOrderCalculator.ts
@@ -1,0 +1,125 @@
+import { Dictionary } from '../typings';
+
+/**
+ * CommitOrderCalculator implements topological sorting, which is an ordering
+ * algorithm for directed graphs (DG) and/or directed acyclic graphs (DAG) by
+ * using a depth-first searching (DFS) to traverse the graph built in memory.
+ * This algorithm have a linear running time based on nodes (V) and dependency
+ * between the nodes (E), resulting in a computational complexity of O(V + E).
+ *
+ * Based on https://github.com/doctrine/orm/blob/master/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
+ */
+export class CommitOrderCalculator {
+
+  /** Matrix of nodes, keys are provided hashes and values are the node definition objects. */
+  private nodes: Dictionary<Node> = {};
+
+  /** Volatile variable holding calculated nodes during sorting process. */
+  private sortedNodeList: string[] = [];
+
+  /**
+   * Checks for node existence in graph.
+   */
+  hasNode(hash: string): boolean {
+    return hash in this.nodes;
+  }
+
+  /**
+   * Adds a new node to the graph, assigning its hash.
+   */
+  addNode(hash: string): void {
+    this.nodes[hash] = { hash, state: NodeState.NOT_VISITED, dependencies: {} };
+  }
+
+  /**
+   * Adds a new dependency (edge) to the graph using their hashes.
+   */
+  addDependency(from: string, to: string, weight: number): void {
+    this.nodes[from].dependencies[to] = { from, to, weight };
+  }
+
+  /**
+   * Return a valid order list of all current nodes.
+   * The desired topological sorting is the reverse post order of these searches.
+   *
+   * @internal Highly performance-sensitive method.
+   */
+  sort(): string[] {
+    for (const vertex of Object.values(this.nodes)) {
+      if (vertex.state !== NodeState.NOT_VISITED) {
+        continue;
+      }
+
+      this.visit(vertex);
+    }
+
+    const sortedList = this.sortedNodeList.reverse();
+    this.nodes = {};
+    this.sortedNodeList = [];
+
+    return sortedList;
+  }
+
+  /**
+   * Visit a given node definition for reordering.
+   *
+   * @internal Highly performance-sensitive method.
+   */
+  private visit(node: Node): void {
+    node.state = NodeState.IN_PROGRESS;
+
+    for (const edge of Object.values(node.dependencies)) {
+      const target = this.nodes[edge.to];
+
+      switch (target.state) {
+        case NodeState.VISITED: break; // Do nothing, since node was already visited
+        case NodeState.IN_PROGRESS: this.visitOpenNode(node, target, edge); break;
+        case NodeState.NOT_VISITED: this.visit(target);
+      }
+    }
+
+    if (node.state as unknown !== NodeState.VISITED) {
+      node.state = NodeState.VISITED;
+      this.sortedNodeList.push(node.hash);
+    }
+  }
+
+  /**
+   * Visits all target's dependencies if in cycle with given node
+   */
+  private visitOpenNode(node: Node, target: Node, edge: Edge): void {
+    if (!target.dependencies[node.hash] || target.dependencies[node.hash].weight >= edge.weight) {
+      return;
+    }
+
+    for (const edge of Object.values(target.dependencies)) {
+      const targetNode = this.nodes[edge.to];
+
+      if (targetNode.state === NodeState.NOT_VISITED) {
+        this.visit(targetNode);
+      }
+    }
+
+    target.state = NodeState.VISITED;
+    this.sortedNodeList.push(target.hash);
+  }
+
+}
+
+export const enum NodeState {
+  NOT_VISITED = 0,
+  IN_PROGRESS = 1,
+  VISITED = 2,
+}
+
+export interface Node {
+  hash: string;
+  state: NodeState;
+  dependencies: Dictionary<Edge>;
+}
+
+export interface Edge {
+  from: string;
+  to: string;
+  weight: number;
+}

--- a/lib/unit-of-work/index.ts
+++ b/lib/unit-of-work/index.ts
@@ -2,4 +2,5 @@ export * from './enums';
 export * from './ChangeSet';
 export * from './ChangeSetComputer';
 export * from './ChangeSetPersister';
+export * from './CommitOrderCalculator';
 export * from './UnitOfWork';

--- a/tests/CommitOrderCalculatorTest.test.ts
+++ b/tests/CommitOrderCalculatorTest.test.ts
@@ -1,0 +1,79 @@
+import { CommitOrderCalculator } from '../lib/unit-of-work';
+
+describe('CommitOrderCalculator', () => {
+
+  const calc = new CommitOrderCalculator();
+
+  test('Commit ordering 1', async () => {
+    calc.addNode('1');
+    calc.addNode('2');
+    calc.addNode('3');
+    calc.addNode('4');
+    calc.addNode('5');
+
+    calc.addDependency('1', '2', 1);
+    calc.addDependency('2', '3', 1);
+    calc.addDependency('3', '4', 1);
+    calc.addDependency('5', '1', 1);
+
+    const sorted = calc.sort();
+    const correctOrder = ['5', '1', '2', '3', '4'];
+    expect(sorted).toEqual(correctOrder);
+  });
+
+  test('Commit ordering 2', async () => {
+    calc.addNode('1');
+    calc.addNode('2');
+
+    calc.addDependency('1', '2', 0);
+    calc.addDependency('2', '1', 1);
+
+    const sorted = calc.sort();
+    const correctOrder = ['2', '1'];
+    expect(sorted).toEqual(correctOrder);
+  });
+
+  test('Commit ordering 3', async () => {
+    calc.addNode('1');
+    calc.addNode('2');
+    calc.addNode('3');
+    calc.addNode('4');
+
+    calc.addDependency('4', '1', 1);
+    calc.addDependency('1', '2', 1);
+    calc.addDependency('4', '3', 1);
+    calc.addDependency('1', '4', 0);
+
+    // There are multiple valid ordering for this constellation, but
+    // the class4, class1, class2 ordering is important to break the cycle
+    // on the nullable link.
+    const correctOrders = [
+      ['4', '1', '2', '3'],
+      ['4', '1', '3', '2'],
+      ['4', '3', '1', '2'],
+    ];
+    const sorted = calc.sort();
+    expect(correctOrders).toContainEqual(sorted);
+  });
+
+  test('Commit ordering 4', async () => {
+    calc.addNode('1');
+    calc.addNode('2');
+    calc.addNode('3');
+    calc.addNode('4');
+    calc.addNode('5');
+
+    calc.addDependency('1', '2', 0.5);
+    calc.addDependency('1', '3', 0.5);
+    calc.addDependency('1', '4', 0);
+    calc.addDependency('2', '3', 0.5);
+    calc.addDependency('3', '1', 1);
+    calc.addDependency('4', '5', 1);
+    calc.addDependency('5', '3', 1);
+
+    const sorted = calc.sort();
+    const correctOrder = ['2', '3', '1', '4', '5'];
+    expect(sorted).toEqual(correctOrder);
+  });
+
+});

--- a/tests/EntityFactory.test.ts
+++ b/tests/EntityFactory.test.ts
@@ -124,6 +124,13 @@ describe('EntityFactory', () => {
     expect(p1.tests).toBeInstanceOf(Collection);
   });
 
+  test('create return entity without hydrating it if it is already an entity', async () => {
+    const p1 = new Publisher();
+    expect(p1.name).toBe('asd');
+    const p2 = factory.create(Publisher, p1);
+    expect(p2).toBe(p1);
+  });
+
   test('create should ignore invalid reference values', async () => {
     const a = factory.create(Author, { favouriteAuthor: false } as any);
     expect(a).toBeInstanceOf(Author);

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -591,9 +591,13 @@ describe('EntityManagerMongo', () => {
     expect(book.tags.getItems()[0]).toBeInstanceOf(BookTag);
     expect(book.tags.getItems()[0]._id).toBeDefined();
     expect(wrap(book.tags.getItems()[0]).isInitialized()).toBe(false);
+    const initSpy = jest.spyOn(Collection.prototype, 'init');
     const items2 = await book.tags.loadItems();
+    expect(initSpy).toBeCalledTimes(1);
     expect(book.tags.getItems()).toEqual(items2);
-    expect(wrap(book.tags.getItems()[0]).isInitialized()).toBe(true);
+    const items3 = await book.tags.loadItems();
+    expect(initSpy).toBeCalledTimes(1);
+    expect(items3).toEqual(items2);
 
     // test collection CRUD
     // remove

--- a/tests/EntityManager.sqlite2.test.ts
+++ b/tests/EntityManager.sqlite2.test.ts
@@ -131,7 +131,7 @@ describe('EntityManagerSqlite2', () => {
     const bible = orm.em.create<Book4>('Book4', { title: 'Bible', author: god });
     expect(bible.author).toBe(god);
     bible.author = god;
-    await orm.em.persist(bible, true);
+    await orm.em.persistAndFlush(bible);
 
     const author = orm.em.create<Author4>('Author4', { name: 'Jon Snow', email: 'snow@wall.st' });
     author.born = new Date('1990-03-23');

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -128,6 +128,7 @@ export async function initORMSqlite2() {
     logger: i => i,
     cache: { pretty: true },
   });
+  await orm.getSchemaGenerator().dropSchema();
   await orm.getSchemaGenerator().createSchema();
 
   return orm;


### PR DESCRIPTION
- uses topological sorting to find correct order of entities when persisting to ensure FK availability
- postpones m:n collection updates (removes them from entity change sets)
- changes the logic when extra updates are used