### PR TITLE
feat(core): propagate changes to 1:1 and m:1 relations

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -186,6 +186,26 @@ MikroORM.init({
 });
 ```
 
+## Propagation of 1:1 and m:1 owners
+
+MikroORM defines getter and setter for every owning side of m:1 and 1:1 relation. This is 
+then used for propagation of changes to the inverse side of bi-directional relations.
+
+```typescript
+const author = new Author('n', 'e');
+const book = new Book('t');
+book.author = author;
+console.log(author.books.contains(book)); // true
+```
+
+You can disable this behaviour via `propagateToOneOwner` option.
+
+```typescript
+MikroORM.init({
+  propagateToOneOwner: false,
+});
+```
+
 ## Forcing UTC Timezone
 
 Use `forceUtcTimezone` option to force the `Date`s to be saved in UTC in datetime columns 

--- a/docs/docs/propagation.md
+++ b/docs/docs/propagation.md
@@ -1,0 +1,51 @@
+---
+title: Propagation
+---
+
+By default MikroORM will propagate all changes made to one side of bi-directional relations
+to the other side, keeping them in sync. This works for all relations, including M:1 and 1:1.
+As part of the discovery process, all M:1 and 1:1 properties are re-defined as getter/setter.
+
+```typescript
+const author = new Author(...);
+const book = new Book(...);
+book.author = author;
+console.log(author.books.contains(book)); // true
+```
+
+> You can disable this behaviour via `propagateToOneOwner` option.
+
+## Propagation of Collection's add() and remove() operations
+
+When you use one of `Collection.add()` method, the item is added to given collection, 
+and this action is also propagated to its counterpart. 
+
+```typescript
+// one to many
+const author = new Author(...);
+const book = new Book(...);
+
+author.books.add(book);
+console.log(book.author); // author will be set thanks to the propagation
+```
+
+For M:N this works in both ways, either from owning side, or from inverse side. 
+
+```typescript
+// many to many works both from owning side and from inverse side
+const book = new Book(...);
+const tag = new BookTag(...);
+
+book.tags.add(tag);
+console.log(tag.books.contains(book)); // true
+
+tag.books.add(book);
+console.log(book.tags.contains(tag)); // true
+``` 
+
+> Collections on both sides have to be initialized, otherwise propagation won't work.
+
+> Although this propagation works also for M:N inverse side, you should always use owning
+> side to manipulate the collection.
+
+Same applies for `Collection.remove()`.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -22,6 +22,7 @@ module.exports = {
       'nested-populate',
       'query-conditions',
       'query-builder',
+      'propagation',
       'serializing',
       'entity-helper',
       'property-validation',

--- a/lib/unit-of-work/ChangeSetComputer.ts
+++ b/lib/unit-of-work/ChangeSetComputer.ts
@@ -50,7 +50,7 @@ export class ChangeSetComputer {
     const isToOneOwner = prop.reference === ReferenceType.MANY_TO_ONE || (prop.reference === ReferenceType.ONE_TO_ONE && prop.owner);
 
     if (prop.reference === ReferenceType.MANY_TO_MANY && prop.owner && (changeSet.entity[prop.name] as unknown as Collection<T>).isDirty()) {
-      this.collectionUpdates.push(changeSet.entity[prop.name] as unknown as Collection<T> as Collection<AnyEntity>);
+      this.collectionUpdates.push(changeSet.entity[prop.name] as unknown as Collection<AnyEntity>);
     } else if (isToOneOwner && changeSet.entity[prop.name]) {
       this.processManyToOne(prop, changeSet);
     }

--- a/lib/utils/Configuration.ts
+++ b/lib/utils/Configuration.ts
@@ -36,6 +36,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     entityRepository: EntityRepository,
     hydrator: ObjectHydrator,
     autoJoinOneToOneOwner: true,
+    propagateToOneOwner: true,
     forceUtcTimezone: false,
     tsNode: false,
     debug: false,
@@ -269,6 +270,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
   driverOptions: Dictionary;
   namingStrategy?: { new (): NamingStrategy };
   autoJoinOneToOneOwner: boolean;
+  propagateToOneOwner: boolean;
   forceUtcTimezone: boolean;
   hydrator: { new (factory: EntityFactory, em: EntityManager): Hydrator };
   entityRepository: { new (em: EntityManager, entityName: EntityName<AnyEntity>): EntityRepository<AnyEntity> };

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -125,6 +125,7 @@ export async function initORMSqlite2() {
     driver: SqliteDriver,
     debug: ['query'],
     highlight: false,
+    propagateToOneOwner: false,
     logger: i => i,
     cache: { pretty: true },
   });

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -1,15 +1,5 @@
 import { ObjectId } from 'mongodb';
-import {
-  Cascade,
-  Collection,
-  Entity,
-  IdentifiedReference,
-  ManyToMany,
-  ManyToOne,
-  PrimaryKey,
-  Property,
-  wrap,
-} from '../../lib';
+import { Cascade, Collection, Entity, IdentifiedReference, ManyToMany, ManyToOne, PrimaryKey, Property, wrap } from '../../lib';
 import { Publisher } from './Publisher';
 import { Author } from './Author';
 import { BookTag } from './book-tag';

--- a/tests/issues/GH269.test.ts
+++ b/tests/issues/GH269.test.ts
@@ -74,6 +74,16 @@ describe('GH issue 269', () => {
     expect(bb.a!.unwrap().name).toBe('my name is a');
     expect(bb.a!.unwrap().b).toBeInstanceOf(Reference);
     expect(bb.a!.unwrap().b!.isInitialized()).toBe(true);
+
+    const a2 = new A();
+    const b2 = new B();
+    a2.name = 'a2';
+    b2.name = 'b2';
+    b2.a = Reference.create(a2);
+    const spy = jest.spyOn(Reference.prototype, 'set');
+    b.a = b2.a;
+    expect(b.a!.unwrap().b!.unwrap()).toBe(b);
+    expect(spy).toBeCalledTimes(1);
   });
 
   test('1:1 populates owner even with autoJoinOneToOneOwner: false and when already loaded', async () => {

--- a/tests/issues/GH302.test.ts
+++ b/tests/issues/GH302.test.ts
@@ -1,16 +1,4 @@
-import {
-  Entity,
-  IdentifiedReference,
-  IdEntity,
-  MikroORM,
-  OneToOne,
-  PrimaryKey,
-  ReflectMetadataProvider,
-  Property,
-  wrap,
-  Reference,
-  ManyToOne, OneToMany, Collection,
-} from '../../lib';
+import { Entity, IdentifiedReference, IdEntity, MikroORM, PrimaryKey, ReflectMetadataProvider, Property, Reference, ManyToOne, OneToMany, Collection } from '../../lib';
 import { BASE_DIR } from '../bootstrap';
 import { SqliteDriver } from '../../lib/drivers/SqliteDriver';
 import { unlinkSync } from 'fs';


### PR DESCRIPTION
MikroORM now defines getter and setter for every owning side of m:1 and 1:1 relation. This is
then used for propagation of changes to the inverse side of bi-directional relations.

```typescript
const author = new Author('n', 'e');
const book = new Book('t');
book.author = author;
console.log(author.books.contains(book)); // true
```

Closes #307