### PR TITLE
fix(utils): Treat ObjectIds and Buffers as scalars

### DIFF
--- a/lib/utils/Utils.ts
+++ b/lib/utils/Utils.ts
@@ -71,7 +71,7 @@ export class Utils {
 
     if (Utils.isObject(target) && Utils.isObject(source)) {
       Object.entries(source).forEach(([key, value]) => {
-        if (Utils.isObject(value, [Date, RegExp])) {
+        if (Utils.isObject(value, [Date, RegExp, Buffer])) {
           if (!(key in target)) {
             Object.assign(target, { [key]: {} });
           }

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -72,6 +72,11 @@ describe('Utils', () => {
     expect(Utils.merge('a', 'b')).toEqual('a');
   });
 
+  test('merge Buffers', () => {
+    const buffer = Buffer.from('Test buffer');
+    expect(Utils.merge({}, {a: buffer})).toEqual({a: buffer});
+  });
+
   test('diff', () => {
     expect(Utils.diff({a: 'a', b: 'c'}, {a: 'b', b: 'c'})).toEqual({a: 'b'});
     expect(Utils.diff({a: 'a', b: 'c', c: {d: 'e', f: ['i', 'h']}}, {a: 'b', b: 'c', c: {d: 'e', f: ['g', 'h']}})).toEqual({a: 'b', c: {d: 'e', f: ['g', 'h']}});


### PR DESCRIPTION
Merge would convert Buffers into Objects with integer keys, which prevented ObjectIds from being persisted to MongoDB if EntityAssigner.assign was used with mergeObjects.

Closes #365