### PR TITLE
fix(utils): lookupPathFromDecorator() incorrect processing of stack t…

### DIFF
--- a/lib/utils/Utils.ts
+++ b/lib/utils/Utils.ts
@@ -338,7 +338,15 @@ export class Utils {
       line++;
     }
 
-    meta.path = Utils.normalizePath(stack[line].match(/\((.*):\d+:\d+\)/)![1]);
+    if (stack[line].match(/\(.+\)/i)) {
+      meta.path = Utils.normalizePath(
+        stack[line].match(/\((.*):\d+:\d+\)/)![1],
+      );
+    } else {
+      meta.path = Utils.normalizePath(
+        stack[line].match(/at\s*(.*):\d+:\d+$/)![1],
+      );
+    }
 
     return meta.path;
   }


### PR DESCRIPTION
…race

Related to https://github.com/mikro-orm/mikro-orm/issues/118.
It appears that the `lookupFromDecorator` method expects each stack trace line to contain the file path inside parentheses. However it seems not to be always the case. On one of my project, when I log `stack[line]` this is what it outputs: `     at /long/path/to/entity.file.ts:x:y`.  
Naturally this would cause the lookup method to crash.