### PR TITLE
feat(sql): add `schema` param to `FindOptions` and QB

### DIFF
--- a/docs/docs/entity-manager.md
+++ b/docs/docs/entity-manager.md
@@ -288,6 +288,7 @@ export interface FindOptions {
   orderBy?: { [k: string]: QueryOrder };
   limit?: number;
   offset?: number;
+  schema?: string;
 }
 ```
 

--- a/docs/docs/multiple-schemas.md
+++ b/docs/docs/multiple-schemas.md
@@ -21,3 +21,17 @@ export class Bar { ... }
 Then use those entities as usual. Resulting SQL queries will use this `tableName` value as a 
 table name so as long as your connection has access to given schema, everything should work 
 as expected.
+
+You can also query for entity in specific schema via `EntityManager`, `EntityRepository` or 
+`QueryBuilder`:
+
+```typescript
+const user = await em.findOne(User, { ... }, { schema: 'client-123' });
+```
+
+To create entity in specific schema, you will need to use `QueryBuilder`:
+
+```typescript
+const qb = em.createQueryBuilder(User);
+await qb.insert({ email: 'foo@bar.com' }).withSchema('client-123');
+```

--- a/docs/docs/query-builder.md
+++ b/docs/docs/query-builder.md
@@ -258,6 +258,7 @@ qb.groupBy(fields: string | string[]): QueryBuilder;
 qb.having(cond: Record<string, any>): QueryBuilder;
 qb.limit(limit: number, offset?: number): QueryBuilder;
 qb.offset(offset: number): QueryBuilder;
+qb.withSchema(schema?: string): QueryBuilder;
 qb.execute<T>(method: 'all' | 'get' | 'run' = 'all', mapResults = true): T;
 qb.getResult<T>(): T[];
 qb.getSingleResult<T>(): T;

--- a/docs/docs/repositories.md
+++ b/docs/docs/repositories.md
@@ -76,6 +76,7 @@ export interface FindOptions {
   orderBy?: { [k: string]: QueryOrder };
   limit?: number;
   offset?: number;
+  schema?: string;
 }
 ```
 

--- a/lib/drivers/DatabaseDriver.ts
+++ b/lib/drivers/DatabaseDriver.ts
@@ -1,11 +1,10 @@
-import { IDatabaseDriver } from './IDatabaseDriver';
+import { FindOneOptions, FindOptions, IDatabaseDriver } from './IDatabaseDriver';
 import { EntityData, EntityMetadata, EntityProperty, FilterQuery, AnyEntity, Primary, Dictionary } from '../typings';
 import { MetadataStorage } from '../metadata';
 import { Connection, QueryResult, Transaction } from '../connections';
 import { Configuration, ConnectionOptions, Utils } from '../utils';
 import { QueryOrder, QueryOrderMap } from '../query';
 import { Platform } from '../platforms';
-import { LockMode } from '../unit-of-work';
 
 export abstract class DatabaseDriver<C extends Connection> implements IDatabaseDriver<C> {
 
@@ -18,9 +17,9 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
   protected constructor(protected readonly config: Configuration,
                         protected readonly dependencies: string[]) { }
 
-  abstract async find<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, populate?: string[], orderBy?: QueryOrderMap, fields?: string[], limit?: number, offset?: number, ctx?: Transaction): Promise<T[]>;
+  abstract async find<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, options?: FindOptions, ctx?: Transaction): Promise<T[]>;
 
-  abstract async findOne<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, populate: string[], orderBy?: QueryOrderMap, fields?: string[], lockMode?: LockMode, ctx?: Transaction): Promise<T | null>;
+  abstract async findOne<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions, ctx?: Transaction): Promise<T | null>;
 
   abstract async nativeInsert<T extends AnyEntity<T>>(entityName: string, data: EntityData<T>, ctx?: Transaction): Promise<QueryResult>;
 

--- a/lib/drivers/IDatabaseDriver.ts
+++ b/lib/drivers/IDatabaseDriver.ts
@@ -2,8 +2,8 @@ import { EntityData, EntityMetadata, EntityProperty, AnyEntity, FilterQuery, Pri
 import { Connection, QueryResult, Transaction } from '../connections';
 import { QueryOrderMap } from '../query';
 import { Platform } from '../platforms';
-import { LockMode } from '../unit-of-work';
 import { MetadataStorage } from '../metadata';
+import { LockMode } from '../unit-of-work';
 
 export interface IDatabaseDriver<C extends Connection = Connection> {
 
@@ -18,12 +18,12 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   /**
    * Finds selection of entities
    */
-  find<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, populate?: string[], orderBy?: QueryOrderMap, fields?: string[], limit?: number, offset?: number, ctx?: Transaction): Promise<T[]>;
+  find<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, options?: FindOptions, ctx?: Transaction): Promise<T[]>;
 
   /**
    * Finds single entity (table row, document)
    */
-  findOne<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, populate?: string[], orderBy?: QueryOrderMap, fields?: string[], lockMode?: LockMode, ctx?: Transaction): Promise<T | null>;
+  findOne<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions, ctx?: Transaction): Promise<T | null>;
 
   nativeInsert<T extends AnyEntity<T>>(entityName: string, data: EntityData<T>, ctx?: Transaction): Promise<QueryResult>;
 
@@ -52,4 +52,24 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
    */
   getDependencies(): string[];
 
+}
+
+export interface FindOptions {
+  populate?: string[] | boolean;
+  orderBy?: QueryOrderMap;
+  limit?: number;
+  offset?: number;
+  refresh?: boolean;
+  fields?: string[];
+  schema?: string;
+}
+
+export interface FindOneOptions {
+  populate?: string[] | boolean;
+  orderBy?: QueryOrderMap;
+  lockMode?: LockMode;
+  lockVersion?: number | Date;
+  refresh?: boolean;
+  fields?: string[];
+  schema?: string;
 }

--- a/lib/entity/EntityRepository.ts
+++ b/lib/entity/EntityRepository.ts
@@ -1,7 +1,7 @@
-import { EntityManager, FindOneOptions, FindOneOrFailOptions, FindOptions } from '../EntityManager';
+import { EntityManager, FindOneOrFailOptions } from '../EntityManager';
 import { EntityData, EntityName, AnyEntity, Primary } from '../typings';
 import { QueryBuilder, QueryOrderMap } from '../query';
-import { FilterQuery, IdentifiedReference, Reference } from '..';
+import { FilterQuery, FindOneOptions, FindOptions, IdentifiedReference, Reference } from '..';
 
 export class EntityRepository<T extends AnyEntity<T>> {
 

--- a/lib/query/QueryBuilder.ts
+++ b/lib/query/QueryBuilder.ts
@@ -26,6 +26,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
   private finalized = false;
   private _joins: Record<string, JoinOptions> = {};
   private _aliasMap: Record<string, string> = {};
+  private _schema?: string;
   private _cond: Dictionary = {};
   private _data!: Dictionary;
   private _orderBy: QueryOrderMap = {};
@@ -176,6 +177,12 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     return this;
   }
 
+  withSchema(schema?: string): this {
+    this._schema = schema;
+
+    return this;
+  }
+
   setLockMode(mode?: LockMode): this {
     if ([LockMode.NONE, LockMode.PESSIMISTIC_READ, LockMode.PESSIMISTIC_WRITE].includes(mode!) && !this.context) {
       throw ValidationError.transactionRequired();
@@ -269,7 +276,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     Object.assign(qb, this);
 
     // clone array/object properties
-    const properties = ['flags', '_fields', '_populate', '_populateMap', '_joins', '_aliasMap', '_cond', '_data', '_orderBy'];
+    const properties = ['flags', '_fields', '_populate', '_populateMap', '_joins', '_aliasMap', '_cond', '_data', '_orderBy', '_schema'];
     properties.forEach(prop => (qb as any)[prop] = Utils.copy(this[prop as keyof this]));
     qb.finalized = false;
 
@@ -356,6 +363,10 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
 
   private getQueryBase(): KnexQueryBuilder {
     const qb = this.getKnex();
+
+    if (this._schema) {
+      qb.withSchema(this._schema);
+    }
 
     switch (this.type) {
       case QueryType.SELECT:

--- a/lib/unit-of-work/ChangeSetPersister.ts
+++ b/lib/unit-of-work/ChangeSetPersister.ts
@@ -74,7 +74,7 @@ export class ChangeSetPersister {
     }
 
     if (meta.versionProperty && [ChangeSetType.CREATE, ChangeSetType.UPDATE].includes(changeSet.type)) {
-      const e = await this.driver.findOne<T>(meta.name, changeSet.entity.__primaryKey as {}, [], {}, [meta.versionProperty], undefined, ctx);
+      const e = await this.driver.findOne<T>(meta.name, changeSet.entity.__primaryKey, { populate: [meta.versionProperty] }, ctx);
       changeSet.entity[meta.versionProperty] = e![meta.versionProperty] as any;
     }
   }

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -889,13 +889,14 @@ describe('QueryBuilder', () => {
     expect(qb3.getParams()).toEqual(['My Publisher 1']);
 
     const qb4 = orm.em.createQueryBuilder(Author2);
+    qb4.withSchema('test123');
     qb4.select('*').where({ books: { publisher: { tests: { name: 'Test 2' } } } }).orderBy({ books: { publisher: { tests: { name: QueryOrder.DESC } } } });
     expect(qb4.getQuery()).toEqual('select `e0`.* ' +
-      'from `author2` as `e0` ' +
-      'left join `book2` as `e1` on `e0`.`id` = `e1`.`author_id` ' +
-      'left join `publisher2` as `e2` on `e1`.`publisher_id` = `e2`.`id` ' +
-      'left join `publisher2_to_test2` as `e4` on `e2`.`id` = `e4`.`publisher2_id` ' +
-      'left join `test2` as `e3` on `e4`.`test2_id` = `e3`.`id` ' +
+      'from `test123`.`author2` as `e0` ' +
+      'left join `test123`.`book2` as `e1` on `e0`.`id` = `e1`.`author_id` ' +
+      'left join `test123`.`publisher2` as `e2` on `e1`.`publisher_id` = `e2`.`id` ' +
+      'left join `test123`.`publisher2_to_test2` as `e4` on `e2`.`id` = `e4`.`publisher2_id` ' +
+      'left join `test123`.`test2` as `e3` on `e4`.`test2_id` = `e3`.`id` ' +
       'where `e3`.`name` = ? order by `e3`.`name` desc');
     expect(qb4.getParams()).toEqual(['Test 2']);
 
@@ -1018,8 +1019,8 @@ describe('QueryBuilder', () => {
     expect(qb2.getParams()).toEqual([2359, 'test 123', true]);
 
     const qb3 = orm.em.createQueryBuilder(BookTag2);
-    qb3.insert({ books: 123 });
-    expect(qb3.getQuery()).toEqual('insert into `book_tag2` (`books`) values (?)');
+    qb3.insert({ books: 123 }).withSchema('test123');
+    expect(qb3.getQuery()).toEqual('insert into `test123`.`book_tag2` (`books`) values (?)');
     expect(qb3.getParams()).toEqual([123]);
   });
 
@@ -1032,10 +1033,11 @@ describe('QueryBuilder', () => {
 
   test('update query with entity in data', async () => {
     const qb = orm.em.createQueryBuilder(Publisher2);
+    qb.withSchema('test123');
     const test = Test2.create('test');
     test.id = 321;
     qb.update({ name: 'test 123', test }).where({ id: 123, type: PublisherType.LOCAL });
-    expect(qb.getQuery()).toEqual('update `publisher2` set `name` = ?, `test` = ? where `id` = ? and `type` = ?');
+    expect(qb.getQuery()).toEqual('update `test123`.`publisher2` set `name` = ?, `test` = ? where `id` = ? and `type` = ?');
     expect(qb.getParams()).toEqual(['test 123', 321, 123, PublisherType.LOCAL]);
   });
 


### PR DESCRIPTION
Now one can also query for entity in specific schema via `EntityManager`, `EntityRepository` or
`QueryBuilder`:

```typescript
const user = await em.findOne(User, { ... }, { schema: 'client-123' });
```

To create entity in specific schema, we will need to use `QueryBuilder`:

```typescript
const qb = em.createQueryBuilder(User);
await qb.insert({ email: 'foo@bar.com' }).withSchema('client-123');
```

Closes #284