### PR TITLE
feat(mongodb): add support for indexes in mongo driver

### DIFF
--- a/docs/docs/usage-with-mongo.md
+++ b/docs/docs/usage-with-mongo.md
@@ -85,6 +85,28 @@ const orm = await MikroORM.init({
 await orm.em.getDriver().createCollections();
 ```
 
+## Indexes
+
+Starting with v3.4, MongoDB driver supports indexes and unique constraints. You can 
+use `@Index()` and `@Unique()` as described in [Defining Entities section](defining-entities.md#indexes).
+To automatically create new indexes when initializing the ORM, you need to enable
+`ensureIndexes` option. 
+
+```typescript
+const orm = await MikroORM.init({
+  entitiesDirs: ['entities'], // relative to `baseDir`
+  dbName: 'my-db-name',
+  type: 'mongo',
+  ensureIndexes: true, // defaults to false
+});
+``` 
+
+Alternatively you can call `ensureIndexes()` method on the `MongoDriver`:
+
+```typescript
+await orm.em.getDriver().ensureIndexes();
+```
+
 ## Native collection methods
 
 Sometimes you need to perform some bulk operation, or you just want to populate your

--- a/lib/MikroORM.ts
+++ b/lib/MikroORM.ts
@@ -38,6 +38,10 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
     orm.driver.setMetadata(orm.metadata);
     await orm.connect();
 
+    if (orm.config.get('ensureIndexes')) {
+      await orm.driver.ensureIndexes();
+    }
+
     return orm;
   }
 

--- a/lib/connections/MongoConnection.ts
+++ b/lib/connections/MongoConnection.ts
@@ -32,6 +32,10 @@ export class MongoConnection extends Connection {
     return this.db.createCollection(this.getCollectionName(name));
   }
 
+  dropCollection(name: EntityName<AnyEntity>): Promise<boolean> {
+    return this.db.dropCollection(this.getCollectionName(name));
+  }
+
   getDefaultClientUrl(): string {
     return 'mongodb://127.0.0.1:27017';
   }
@@ -54,6 +58,10 @@ export class MongoConnection extends Connection {
     const match = clientUrl.match(/^(\w+):\/\/((.*@.+)|.+)$/);
 
     return match ? `${match[1]}://${options.auth ? options.auth.user + ':*****@' : ''}${match[2]}` : clientUrl;
+  }
+
+  getDb(): Db {
+    return this.db;
   }
 
   async execute(query: string): Promise<any> {

--- a/lib/drivers/DatabaseDriver.ts
+++ b/lib/drivers/DatabaseDriver.ts
@@ -97,6 +97,10 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     return this.dependencies;
   }
 
+  async ensureIndexes(): Promise<void> {
+    throw new Error(`${this.constructor.name} does not use ensureIndexes`);
+  }
+
   protected getPivotOrderBy(prop: EntityProperty, orderBy?: QueryOrderMap): QueryOrderMap {
     if (orderBy) {
       return orderBy;

--- a/lib/drivers/IDatabaseDriver.ts
+++ b/lib/drivers/IDatabaseDriver.ts
@@ -46,6 +46,8 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
 
   setMetadata(metadata: MetadataStorage): void;
 
+  ensureIndexes(): Promise<void>;
+
   /**
    * Returns name of the underlying database dependencies (e.g. `mongodb` or `mysql2`)
    * for SQL drivers it also returns `knex` in the array as connectors are not used directly there

--- a/lib/utils/Configuration.ts
+++ b/lib/utils/Configuration.ts
@@ -38,6 +38,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     autoJoinOneToOneOwner: true,
     propagateToOneOwner: true,
     forceUtcTimezone: false,
+    ensureIndexes: false,
     tsNode: false,
     debug: false,
     verbose: false,
@@ -285,6 +286,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
   autoJoinOneToOneOwner: boolean;
   propagateToOneOwner: boolean;
   forceUtcTimezone: boolean;
+  ensureIndexes: boolean;
   hydrator: { new (factory: EntityFactory, em: EntityManager): Hydrator };
   entityRepository: { new (em: EntityManager, entityName: EntityName<AnyEntity>): EntityRepository<AnyEntity> };
   replicas?: Partial<ConnectionOptions>[];

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -487,6 +487,24 @@ describe('EntityManagerMongo', () => {
     expect(driver.getConnection().getCollection(BookTag.name).collectionName).toBe('book-tag');
   });
 
+  test('ensure indexes', async () => {
+    await orm.em.getDriver().ensureIndexes();
+    const conn = orm.em.getDriver().getConnection('write');
+    const authorInfo = await conn.getCollection('author').indexInformation();
+    const bookInfo = await conn.getCollection('books-table').indexInformation();
+    expect(authorInfo).toEqual({
+      _id_: [['_id', 1]],
+      born_1: [['born', 1]],
+      email_1: [['email', 1]],
+      custom_idx_1: [['name', 1], ['email', 1]],
+    });
+    expect(bookInfo).toEqual({
+      _id_: [['_id', 1]],
+      publisher_idx: [['publisher', 1]],
+      title_1_author_1: [['title', 1], ['author', 1]],
+    });
+  });
+
   test('should use user and password as connection options', async () => {
     const config = new Configuration({ user: 'usr', password: 'pw' } as any, false);
     const connection = new MongoConnection(config);

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -71,6 +71,7 @@ describe('EntityManagerMySql', () => {
     expect(driver.getPlatform().denormalizePrimaryKey(1)).toBe(1);
     expect(driver.getPlatform().denormalizePrimaryKey('1')).toBe('1');
     await expect(driver.find(BookTag2.name, { books: { $in: [1] } })).resolves.not.toBeNull();
+    await expect(driver.ensureIndexes()).rejects.toThrowError('MySqlDriver does not use ensureIndexes');
   });
 
   test('driver appends errored query', async () => {

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -38,12 +38,14 @@ export async function initORMMongo() {
     highlight: false,
     logger: i => i,
     type: 'mongo',
+    ensureIndexes: true,
     implicitTransactions: true,
     cache: { pretty: true },
   });
 
   // create collections first so we can use transactions
-  await orm.em.getDriver().createCollections();
+  await orm.em.getDriver().dropCollections();
+  await orm.em.getDriver().ensureIndexes();
 
   return orm;
 }

--- a/tests/entities/Author.ts
+++ b/tests/entities/Author.ts
@@ -1,6 +1,6 @@
 import {
   AfterCreate, AfterDelete, AfterUpdate, BeforeCreate, BeforeDelete, BeforeUpdate, DateType,
-  Cascade, Collection, Entity, EntityAssigner, ManyToMany, ManyToOne, OneToMany, Property, wrap,
+  Cascade, Collection, Entity, EntityAssigner, ManyToMany, ManyToOne, OneToMany, Property, wrap, Index, Unique,
 } from '../../lib';
 
 import { Book } from './Book';
@@ -8,6 +8,7 @@ import { AuthorRepository } from '../repositories/AuthorRepository';
 import { BaseEntity } from './BaseEntity';
 
 @Entity({ customRepository: () => AuthorRepository })
+@Index({ name: 'custom_idx_1', properties: ['name', 'email'] })
 export class Author extends BaseEntity {
 
   static beforeDestroyCalled = 0;
@@ -16,6 +17,7 @@ export class Author extends BaseEntity {
   @Property()
   name: string;
 
+  @Unique()
   @Property()
   email: string;
 
@@ -32,6 +34,7 @@ export class Author extends BaseEntity {
   identities?: string[];
 
   @Property({ type: DateType })
+  @Index()
   born?: Date;
 
   @OneToMany(() => Book, book => book.author, { referenceColumnName: '_id', cascade: [Cascade.PERSIST], orphanRemoval: true })

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -1,11 +1,12 @@
 import { ObjectId } from 'mongodb';
-import { Cascade, Collection, Entity, IdentifiedReference, ManyToMany, ManyToOne, PrimaryKey, Property, wrap } from '../../lib';
+import { Cascade, Collection, Entity, IdentifiedReference, Index, ManyToMany, ManyToOne, PrimaryKey, Property, Unique, wrap } from '../../lib';
 import { Publisher } from './Publisher';
 import { Author } from './Author';
 import { BookTag } from './book-tag';
 import { BaseEntity3 } from './BaseEntity3';
 
 @Entity({ tableName: 'books-table' })
+@Unique({ properties: ['title', 'author'] })
 export class Book extends BaseEntity3 {
 
   @PrimaryKey()
@@ -18,6 +19,7 @@ export class Book extends BaseEntity3 {
   author: Author;
 
   @ManyToOne(() => Publisher, { cascade: [Cascade.PERSIST, Cascade.REMOVE] })
+  @Index({ name: 'publisher_idx' })
   publisher!: IdentifiedReference<Publisher, '_id' | 'id'>;
 
   @ManyToMany()


### PR DESCRIPTION
MongoDB driver now supports indexes and unique constraints. You can use `@Index()` and `@Unique()`.
To automatically create new indexes when initializing the ORM, you need to enable `ensureIndexes` option.

```typescript
const orm = await MikroORM.init({
  entitiesDirs: ['entities'], // relative to `baseDir`
  dbName: 'my-db-name',
  type: 'mongo',
  ensureIndexes: true, // defaults to false
});
```

Alternatively you can call `ensureIndexes()` method on the `MongoDriver`:

```typescript
await orm.em.getDriver().ensureIndexes();
```

Closes #159