### PR TITLE
fix(.npmignore): Ignore MongoDB data directory

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,4 +6,5 @@
 /temp
 /yarn-error.log
 /mikro_orm_test.db
+/data
 /.*


### PR DESCRIPTION
mikro-orm is currently published with 920 MB of test data left over from run-rs. Adding /data to .npmignore excludes this test data from the published package and greatly reduces the installation footprint.

I'm unsure how to add a test for this, if it's even reasonably possible. I saw tests requested as part of the pull request guidelines, so let me know if there's anything I ought to do in that regard.

I've only been working with mikro-orm for a short while now, and I'm really liking it so far. Keep up the good work, and I'm happy to have the opportunity to contribute!