### PR TITLE
feat(sql): use collection snapshots to compute precise diff

### DIFF
--- a/lib/drivers/IDatabaseDriver.ts
+++ b/lib/drivers/IDatabaseDriver.ts
@@ -4,6 +4,7 @@ import { QueryOrderMap } from '../query';
 import { Platform } from '../platforms';
 import { MetadataStorage } from '../metadata';
 import { LockMode } from '../unit-of-work';
+import { Collection } from '../entity';
 
 export interface IDatabaseDriver<C extends Connection = Connection> {
 
@@ -30,6 +31,8 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   nativeUpdate<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, data: EntityData<T>, ctx?: Transaction): Promise<QueryResult>;
 
   nativeDelete<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, ctx?: Transaction): Promise<QueryResult>;
+
+  syncCollection<T extends AnyEntity<T>>(collection: Collection<T>, ctx?: Transaction): Promise<void>;
 
   count<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, ctx?: Transaction): Promise<number>;
 

--- a/lib/unit-of-work/ChangeSetPersister.ts
+++ b/lib/unit-of-work/ChangeSetPersister.ts
@@ -1,6 +1,6 @@
 import { MetadataStorage } from '../metadata';
-import { AnyEntity, Dictionary, EntityData, EntityMetadata, EntityProperty, IPrimaryKey } from '../typings';
-import { Collection, EntityIdentifier, wrap } from '../entity';
+import { AnyEntity, Dictionary, EntityMetadata, EntityProperty, IPrimaryKey } from '../typings';
+import { EntityIdentifier, wrap } from '../entity';
 import { ChangeSet, ChangeSetType } from './ChangeSet';
 import { FilterQuery, IDatabaseDriver, Transaction } from '..';
 import { QueryResult } from '../connections';
@@ -22,13 +22,6 @@ export class ChangeSetPersister {
 
     // persist the entity itself
     await this.persistEntity(changeSet, meta, ctx);
-  }
-
-  async persistCollectionToDatabase<T extends AnyEntity<T>>(coll: Collection<T>, ctx?: Transaction): Promise<void> {
-    const pk = this.metadata.get(coll.property.type).primaryKey;
-    const data = { [coll.property.name]: coll.getIdentifiers(pk) } as EntityData<T>;
-    await this.driver.nativeUpdate(coll.owner.constructor.name, wrap(coll.owner).__primaryKey, data, ctx);
-    coll.setDirty(false);
   }
 
   private async persistEntity<T extends AnyEntity<T>>(changeSet: ChangeSet<T>, meta: EntityMetadata<T>, ctx?: Transaction): Promise<void> {

--- a/lib/unit-of-work/UnitOfWork.ts
+++ b/lib/unit-of-work/UnitOfWork.ts
@@ -424,7 +424,8 @@ export class UnitOfWork {
     }
 
     for (const coll of this.collectionUpdates) {
-      await this.changeSetPersister.persistCollectionToDatabase(coll, tx);
+      await this.em.getDriver().syncCollection(coll, tx);
+      coll.takeSnapshot();
     }
   }
 

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -1221,9 +1221,9 @@ describe('EntityManagerMongo', () => {
   test('many to many collection does have fixed order', async () => {
     const repo = orm.em.getRepository(Publisher);
     const publisher = new Publisher();
-    const t1 = Test.create('t1');
-    const t2 = Test.create('t2');
-    const t3 = Test.create('t3');
+    let t1 = Test.create('t1');
+    let t2 = Test.create('t2');
+    let t3 = Test.create('t3');
     await orm.em.persistAndFlush([t1, t2, t3]);
     publisher.tests.add(t2, t1, t3);
     await repo.persistAndFlush(publisher);
@@ -1235,6 +1235,15 @@ describe('EntityManagerMongo', () => {
 
     await ent.tests.init();
     await expect(ent.tests.getIdentifiers('id')).toEqual([t2.id, t1.id, t3.id]);
+
+    [t1, t2, t3] = ent.tests.getItems();
+    ent.tests.set([t3, t2, t1]);
+    await repo.flush();
+    orm.em.clear();
+
+    const ent1 = (await repo.findOne(publisher.id))!;
+    await expect(ent1.tests.count()).toBe(3);
+    await expect(ent1.tests.getIdentifiers('id')).toEqual([t3.id, t2.id, t1.id]);
   });
 
   test('collection allows custom where and orderBy', async () => {


### PR DESCRIPTION
When updating m:n collections, snapshots are now used to compute the exact different with the current state.
This means that we now execute only the queries that are needed (e.g. if we only append 1 item, we do not
clear the whole collection and insert everything as it was before, but rather fire 1 precise query for the
missing item).