### PR TITLE
feat(core): allow for the number zero as a primary key

### DIFF
--- a/lib/entity/EntityAssigner.ts
+++ b/lib/entity/EntityAssigner.ts
@@ -31,7 +31,8 @@ export class EntityAssigner {
         value = props[prop].customType.convertToJSValue(value, platform);
       }
 
-      if (props[prop] && [ReferenceType.MANY_TO_ONE, ReferenceType.ONE_TO_ONE].includes(props[prop].reference) && value && EntityAssigner.validateEM(em)) {
+      // tslint:disable-next-line:triple-equals - Really want the double equals here to pass for both null and undefined and allow for keys of numeric 0
+      if (props[prop] && [ReferenceType.MANY_TO_ONE, ReferenceType.ONE_TO_ONE].includes(props[prop].reference) && value != null && EntityAssigner.validateEM(em)) {
         return EntityAssigner.assignReference<T>(entity, value, props[prop], em!);
       }
 

--- a/lib/entity/EntityFactory.ts
+++ b/lib/entity/EntityFactory.ts
@@ -55,7 +55,8 @@ export class EntityFactory {
   private createEntity<T extends AnyEntity<T>>(data: EntityData<T>, meta: EntityMetadata<T>): T {
     const Entity = this.metadata.get<T>(meta.name).class;
 
-    if (!data[meta.primaryKey]) {
+    // tslint:disable-next-line:triple-equals - Really want the double equals here to pass for both null and undefined and allow for keys of numeric 0
+    if (data[meta.primaryKey] == null) {
       const params = this.extractConstructorParams<T>(meta, data);
       meta.constructorParams.forEach(prop => delete data[prop]);
 
@@ -80,7 +81,8 @@ export class EntityFactory {
     const platform = this.driver.getPlatform();
     const pk = platform.getSerializedPrimaryKeyField(meta.primaryKey);
 
-    if (data[pk] || data[meta.primaryKey]) {
+    // tslint:disable-next-line:triple-equals - Really want the double equals here to pass for both null and undefined and allow for keys of numeric 0
+    if (data[pk] != null || data[meta.primaryKey] != null) {
       const id = platform.denormalizePrimaryKey(data[pk] || data[meta.primaryKey]);
       delete data[pk];
       data[meta.primaryKey as keyof T] = id as Primary<T> & T[keyof T];

--- a/lib/entity/EntityTransformer.ts
+++ b/lib/entity/EntityTransformer.ts
@@ -13,9 +13,11 @@ export class EntityTransformer {
     const pk = platform.getSerializedPrimaryKeyField(wrapped.__meta.primaryKey);
     const meta = wrapped.__meta;
     const pkProp = meta.properties[meta.primaryKey];
-    const ret = (wrapped.__primaryKey && !pkProp.hidden ? { [pk]: platform.normalizePrimaryKey(wrapped.__primaryKey as IPrimaryKey) } : {}) as EntityData<T>;
+    // tslint:disable-next-line:triple-equals Really want the double not equals here to allow for keys of numeric 0 but not allow for null nor undefined
+    const ret = (wrapped.__primaryKey != null && !pkProp.hidden ? { [pk]: platform.normalizePrimaryKey(wrapped.__primaryKey as IPrimaryKey) } : {}) as EntityData<T>;
 
-    if ((!wrapped.isInitialized() && wrapped.__primaryKey) || visited.includes(wrap(entity).__uuid)) {
+    // tslint:disable-next-line:triple-equals Really want the double not equals here to allow for keys of numeric 0 but not allow for null nor undefined
+    if ((!wrapped.isInitialized() && wrapped.__primaryKey != null) || visited.includes(wrap(entity).__uuid)) {
       return ret;
     }
 

--- a/lib/entity/EntityValidator.ts
+++ b/lib/entity/EntityValidator.ts
@@ -70,7 +70,8 @@ export class EntityValidator {
   }
 
   validatePrimaryKey<T extends AnyEntity<T>>(entity: EntityData<T>, meta: EntityMetadata): void {
-    if (!entity || (!entity[meta.primaryKey] && !entity[meta.serializedPrimaryKey])) {
+    // tslint:disable-next-line:triple-equals - Want fuzzy equals to catch both null and undefined and allow for primary keys with the number 0
+    if (!entity || (entity[meta.primaryKey] == null && entity[meta.serializedPrimaryKey] == null )) {
       throw ValidationError.fromMergeWithoutPK(meta);
     }
   }

--- a/lib/unit-of-work/ChangeSetComputer.ts
+++ b/lib/unit-of-work/ChangeSetComputer.ts
@@ -72,7 +72,8 @@ export class ChangeSetComputer {
     const pk = this.metadata.get(prop.type).primaryKey;
     const entity = changeSet.entity[prop.name] as unknown as T;
 
-    if (!entity[pk]) {
+    // tslint:disable-next-line:triple-equals - Really want the double equals here to pass for both null and undefined and allow for keys of numeric 0
+    if (entity[pk] == null) {
       changeSet.payload[prop.name] = this.identifierMap[wrap(entity).__uuid];
     }
   }

--- a/lib/unit-of-work/ChangeSetPersister.ts
+++ b/lib/unit-of-work/ChangeSetPersister.ts
@@ -32,14 +32,16 @@ export class ChangeSetPersister {
     } else if (changeSet.type === ChangeSetType.UPDATE) {
       res = await this.updateEntity(meta, changeSet, ctx);
       this.mapReturnedValues(changeSet.entity, res, meta);
-    } else if (changeSet.entity.__primaryKey) { // ChangeSetType.CREATE with primary key
+      // tslint:disable-next-line:triple-equals Really want the double not equals here to allow for keys of numeric 0 but not allow for null nor undefined
+    } else if (changeSet.entity.__primaryKey != null) { // ChangeSetType.CREATE with primary key
       res = await this.driver.nativeInsert(changeSet.name, changeSet.payload, ctx);
       this.mapReturnedValues(changeSet.entity, res, meta);
       delete changeSet.entity.__initialized;
     } else { // ChangeSetType.CREATE without primary key
       res = await this.driver.nativeInsert(changeSet.name, changeSet.payload, ctx);
       this.mapReturnedValues(changeSet.entity, res, meta);
-      wrap(changeSet.entity).__primaryKey = changeSet.entity.__primaryKey || res.insertId as any;
+      // tslint:disable-next-line:triple-equals Really want the double not equals here to allow for keys of numeric 0 but not allow for null nor undefined
+      wrap(changeSet.entity).__primaryKey = changeSet.entity.__primaryKey != null ? changeSet.entity.__primaryKey : res.insertId as any;
       this.identifierMap[changeSet.entity.__uuid].setValue(changeSet.entity.__primaryKey as IPrimaryKey);
       delete changeSet.entity.__initialized;
     }

--- a/lib/unit-of-work/UnitOfWork.ts
+++ b/lib/unit-of-work/UnitOfWork.ts
@@ -35,7 +35,8 @@ export class UnitOfWork {
     const wrapped = wrap(entity);
     Object.defineProperty(wrapped, '__em', { value: this.em, writable: true });
 
-    if (!wrapped.__primaryKey) {
+    // tslint:disable-next-line:triple-equals - Really want the double equals here to pass for both null and undefined and allow for keys of numeric 0
+    if (wrapped.__primaryKey == null) {
       return;
     }
 
@@ -76,7 +77,8 @@ export class UnitOfWork {
       return;
     }
 
-    if (!wrap(entity).__primaryKey) {
+    // tslint:disable-next-line:triple-equals - Really want the double equals here to pass for both null and undefined and allow for keys of numeric 0
+    if (wrap(entity).__primaryKey == null) {
       this.identifierMap[wrap(entity).__uuid] = new EntityIdentifier();
     }
 
@@ -186,7 +188,8 @@ export class UnitOfWork {
       return;
     }
 
-    if (!wrapped.__primaryKey && !this.identifierMap[wrapped.__uuid]) {
+    // tslint:disable-next-line:triple-equals - Really want the double equals here to pass for both null and undefined and allow for keys of numeric 0
+    if (wrapped.__primaryKey == null && !this.identifierMap[wrapped.__uuid]) {
       this.identifierMap[wrapped.__uuid] = new EntityIdentifier();
     }
 

--- a/lib/utils/Utils.ts
+++ b/lib/utils/Utils.ts
@@ -156,7 +156,8 @@ export class Utils {
     const pk = () => metadata.get(prop.type).primaryKey;
     const collection = entity[prop.name] as unknown instanceof ArrayCollection;
     const noPkRef = Utils.isEntity(entity[prop.name]) && !entity[prop.name][pk()];
-    const noPkProp = prop.primary && !entity[prop.name];
+    // tslint:disable-next-line:triple-equals Really want the double equals here to allow for keys of numeric 0 but not allow for null nor undefined
+    const noPkProp = prop.primary && entity[prop.name] == null;
     const inverse = prop.reference === ReferenceType.ONE_TO_ONE && !prop.owner;
 
     // bidirectional 1:1 and m:1 fields are defined as setters, we need to check for `undefined` explicitly

--- a/tests/EntityFactory.mysql.test.ts
+++ b/tests/EntityFactory.mysql.test.ts
@@ -1,0 +1,38 @@
+import {
+  Collection,
+  EntityFactory,
+  MikroORM,
+} from '../lib';
+import { Publisher2 } from './entities-sql';
+import { initORMMySql, wipeDatabaseMySql } from './bootstrap';
+import { MySqlDriver } from '../lib/drivers/MySqlDriver';
+import { MetadataDiscovery } from '../lib/metadata';
+
+describe('EntityFactoryMySql', () => {
+
+  let orm: MikroORM<MySqlDriver>;
+  let factory: EntityFactory;
+
+  beforeAll(async () => {
+    orm = await initORMMySql();
+    await new MetadataDiscovery(orm.getMetadata(), orm.em.getDriver().getPlatform(), orm.config).discover();
+    factory = new EntityFactory(orm.em.getUnitOfWork(), orm.em);
+  });
+  beforeEach(async () => wipeDatabaseMySql(orm.em));
+
+  test('should support a primary key value of 0', async () => {
+    const p1 = new Publisher2(); // calls constructor, so uses default name
+    expect(p1.name).toBe('asd');
+    expect(p1).toBeInstanceOf(Publisher2);
+    expect(p1.books).toBeInstanceOf(Collection);
+    expect(p1.tests).toBeInstanceOf(Collection);
+    const p2 = factory.create(Publisher2, { id: 0 }); // shouldn't call constructor
+    expect(p2).toBeInstanceOf(Publisher2);
+    expect(p2.name).toBeUndefined();
+    expect(p2.books).toBeInstanceOf(Collection);
+    expect(p2.tests).toBeInstanceOf(Collection);
+  });
+
+  afterAll(async () => orm.close(true));
+
+});

--- a/tests/__snapshots__/EntityGenerator.test.ts.snap
+++ b/tests/__snapshots__/EntityGenerator.test.ts.snap
@@ -185,10 +185,46 @@ export class FooBar2 {
 
 }
 ",
+  "import { Entity, OneToOne, PrimaryKey, Property } from 'mikro-orm';
+import { FooBazPk0 } from './FooBazPk0';
+
+@Entity()
+export class FooBarPk0 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 255 })
+  name!: string;
+
+  @OneToOne({ entity: () => FooBazPk0, nullable: true })
+  baz?: FooBazPk0;
+
+  @Property({ length: 3, default: \`current_timestamp(3)\` })
+  version!: Date;
+
+}
+",
   "import { Entity, PrimaryKey, Property } from 'mikro-orm';
 
 @Entity()
 export class FooBaz2 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 255 })
+  name!: string;
+
+  @Property({ length: 3, default: \`current_timestamp(3)\` })
+  version!: Date;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from 'mikro-orm';
+
+@Entity()
+export class FooBazPk0 {
 
   @PrimaryKey()
   id!: number;

--- a/tests/__snapshots__/SchemaGenerator.test.ts.snap
+++ b/tests/__snapshots__/SchemaGenerator.test.ts.snap
@@ -38,6 +38,11 @@ alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\
 
 create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
 
+create table \`foo_bar_pk0\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp) default character set utf8 engine = InnoDB;
+alter table \`foo_bar_pk0\` add index \`foo_bar_pk0_baz_id_index\`(\`baz_id\`);
+
+create table \`foo_baz_pk0\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
+
 create table \`author_to_friend\` (\`author2_1_id\` int(11) unsigned not null, \`author2_2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table \`author_to_friend\` add index \`author_to_friend_author2_1_id_index\`(\`author2_1_id\`);
 alter table \`author_to_friend\` add index \`author_to_friend_author2_2_id_index\`(\`author2_2_id\`);
@@ -72,6 +77,8 @@ alter table \`test2\` add constraint \`test2_book_uuid_pk_foreign\` foreign key 
 alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;
 alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;
 
+alter table \`foo_bar_pk0\` add constraint \`foo_bar_pk0_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz_pk0\` (\`id\`) on update cascade on delete set null;
+
 alter table \`author_to_friend\` add constraint \`author_to_friend_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 
@@ -102,6 +109,8 @@ drop table if exists \`publisher2\`;
 drop table if exists \`test2\`;
 drop table if exists \`foo_bar2\`;
 drop table if exists \`foo_baz2\`;
+drop table if exists \`foo_bar_pk0\`;
+drop table if exists \`foo_baz_pk0\`;
 drop table if exists \`author_to_friend\`;
 drop table if exists \`author2_to_author2\`;
 drop table if exists \`book2_to_book_tag2\`;
@@ -123,6 +132,8 @@ drop table if exists \`publisher2\`;
 drop table if exists \`test2\`;
 drop table if exists \`foo_bar2\`;
 drop table if exists \`foo_baz2\`;
+drop table if exists \`foo_bar_pk0\`;
+drop table if exists \`foo_baz_pk0\`;
 drop table if exists \`author_to_friend\`;
 drop table if exists \`author2_to_author2\`;
 drop table if exists \`book2_to_book_tag2\`;
@@ -163,6 +174,11 @@ alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\
 
 create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
 
+create table \`foo_bar_pk0\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp) default character set utf8 engine = InnoDB;
+alter table \`foo_bar_pk0\` add index \`foo_bar_pk0_baz_id_index\`(\`baz_id\`);
+
+create table \`foo_baz_pk0\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
+
 create table \`author_to_friend\` (\`author2_1_id\` int(11) unsigned not null, \`author2_2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table \`author_to_friend\` add index \`author_to_friend_author2_1_id_index\`(\`author2_1_id\`);
 alter table \`author_to_friend\` add index \`author_to_friend_author2_2_id_index\`(\`author2_2_id\`);
@@ -196,6 +212,8 @@ alter table \`test2\` add constraint \`test2_book_uuid_pk_foreign\` foreign key 
 
 alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;
 alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;
+
+alter table \`foo_bar_pk0\` add constraint \`foo_bar_pk0_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz_pk0\` (\`id\`) on update cascade on delete set null;
 
 alter table \`author_to_friend\` add constraint \`author_to_friend_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
@@ -733,6 +751,11 @@ alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\
 
 create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
 
+create table \`foo_bar_pk0\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp) default character set utf8 engine = InnoDB;
+alter table \`foo_bar_pk0\` add index \`foo_bar_pk0_baz_id_index\`(\`baz_id\`);
+
+create table \`foo_baz_pk0\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
+
 create table \`author_to_friend\` (\`author2_1_id\` int(11) unsigned not null, \`author2_2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table \`author_to_friend\` add index \`author_to_friend_author2_1_id_index\`(\`author2_1_id\`);
 alter table \`author_to_friend\` add index \`author_to_friend_author2_2_id_index\`(\`author2_2_id\`);
@@ -766,6 +789,8 @@ alter table \`test2\` add constraint \`test2_book_uuid_pk_foreign\` foreign key 
 
 alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;
 alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;
+
+alter table \`foo_bar_pk0\` add constraint \`foo_bar_pk0_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz_pk0\` (\`id\`) on update cascade on delete set null;
 
 alter table \`author_to_friend\` add constraint \`author_to_friend_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
 import { EntityManager, JavaScriptMetadataProvider, MikroORM, ReflectMetadataProvider } from '../lib';
 import { Author, Book, BookTag, Publisher, Test } from './entities';
-import { Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, Test2, Label2 } from './entities-sql';
+import { Author2, Book2, BookTag2, FooBar2, FooBaz2, FooBarPk0, FooBazPk0, Publisher2, Test2, Label2 } from './entities-sql';
 import { SqliteDriver } from '../lib/drivers/SqliteDriver';
 import { BaseEntity2 } from './entities-sql/BaseEntity2';
 import { BaseEntity22 } from './entities-sql/BaseEntity22';
@@ -52,7 +52,7 @@ export async function initORMMongo() {
 
 export async function initORMMySql<D extends MySqlDriver | MariaDbDriver = MySqlDriver>(type: 'mysql' | 'mariadb' = 'mysql') {
   let orm = await MikroORM.init<D>({
-    entities: [Author2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, BaseEntity2, BaseEntity22],
+    entities: [Author2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, FooBarPk0, FooBazPk0, BaseEntity2, BaseEntity22],
     discovery: { tsConfigPath: BASE_DIR + '/tsconfig.test.json' },
     clientUrl: `mysql://root@127.0.0.1:3306/mikro_orm_test`,
     port: 3307,
@@ -163,6 +163,8 @@ export async function wipeDatabaseMySql(em: EntityManager) {
   await em.createQueryBuilder(BookTag2).truncate().execute();
   await em.createQueryBuilder(Publisher2).truncate().execute();
   await em.createQueryBuilder(Test2).truncate().execute();
+  await em.createQueryBuilder(FooBazPk0).truncate().execute();
+  await em.createQueryBuilder(FooBarPk0).truncate().execute();
   await em.createQueryBuilder('author2_to_author2').truncate().execute();
   await em.createQueryBuilder('book2_to_book_tag2').truncate().execute();
   await em.createQueryBuilder('book_to_tag_unordered').truncate().execute();

--- a/tests/entities-sql/FooBarPk0.ts
+++ b/tests/entities-sql/FooBarPk0.ts
@@ -1,0 +1,27 @@
+import { Entity, ManyToOne, PrimaryKey, Property } from '../../lib';
+import { BaseEntity22 } from './BaseEntity22';
+import { FooBazPk0 } from './FooBazPk0';
+
+@Entity()
+export class FooBarPk0 extends BaseEntity22 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @ManyToOne({ nullable: true })
+  baz?: FooBazPk0;
+
+  @Property({ version: true, length: 0 })
+  version!: Date;
+
+  static create(name: string) {
+    const bar = new FooBarPk0();
+    bar.name = name;
+
+    return bar;
+  }
+
+}

--- a/tests/entities-sql/FooBazPk0.ts
+++ b/tests/entities-sql/FooBazPk0.ts
@@ -1,0 +1,30 @@
+import { Cascade, Collection, Entity, OneToMany, PrimaryKey, Property } from '../../lib';
+import { FooBarPk0 } from './FooBarPk0';
+
+@Entity()
+export class FooBazPk0 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name: string;
+
+  @OneToMany(() => FooBarPk0, 'baz', { hidden: true })
+  bars = new Collection<FooBarPk0>(this);
+
+  @Property({ version: true })
+  version!: Date;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  static create(id: number, name: string) {
+    const baz = new FooBazPk0(name);
+    baz.id = id;
+
+    return baz;
+  }
+
+}

--- a/tests/entities-sql/index.ts
+++ b/tests/entities-sql/index.ts
@@ -5,4 +5,6 @@ export * from './Publisher2';
 export * from './Test2';
 export * from './FooBar2';
 export * from './FooBaz2';
+export * from './FooBarPk0';
+export * from './FooBazPk0';
 export * from './Label2';

--- a/tests/mysql-schema.sql
+++ b/tests/mysql-schema.sql
@@ -8,6 +8,8 @@ drop table if exists `publisher2`;
 drop table if exists `test2`;
 drop table if exists `foo_bar2`;
 drop table if exists `foo_baz2`;
+drop table if exists `foo_bar_pk0`;
+drop table if exists `foo_baz_pk0`;
 drop table if exists `author_to_friend`;
 drop table if exists `author2_to_author2`;
 drop table if exists `book2_to_book_tag2`;
@@ -44,7 +46,13 @@ alter table `foo_bar2` add index `foo_bar2_baz_id_index`(`baz_id`);
 alter table `foo_bar2` add unique `foo_bar2_foo_bar_id_unique`(`foo_bar_id`);
 alter table `foo_bar2` add index `foo_bar2_foo_bar_id_index`(`foo_bar_id`);
 
+create table `foo_bar_pk0` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) not null, `baz_id` int(11) unsigned null, `version` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
+alter table `foo_bar_pk0` add unique `foo_bar_pk0_baz_id_unique`(`baz_id`);
+alter table `foo_bar_pk0` add index `foo_bar_pk0_baz_id_index`(`baz_id`);
+
 create table `foo_baz2` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) not null, `version` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
+
+create table `foo_baz_pk0` (`id` int unsigned not null primary key, `name` varchar(255) not null, `version` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
 
 create table `author_to_friend` (`author2_1_id` int(11) unsigned not null, `author2_2_id` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table `author_to_friend` add index `author_to_friend_author2_1_id_index`(`author2_1_id`);
@@ -80,6 +88,8 @@ alter table `test2` add constraint `test2_foo___bar_foreign` foreign key (`foo__
 
 alter table `foo_bar2` add constraint `foo_bar2_baz_id_foreign` foreign key (`baz_id`) references `foo_baz2` (`id`) on update cascade on delete set null;
 alter table `foo_bar2` add constraint `foo_bar2_foo_bar_id_foreign` foreign key (`foo_bar_id`) references `foo_bar2` (`id`) on update cascade on delete set null;
+
+alter table `foo_bar_pk0` add constraint `foo_bar_pk0_baz_id_foreign` foreign key (`baz_id`) references `foo_baz_pk0` (`id`) on update cascade on delete set null;
 
 alter table `author_to_friend` add constraint `author_to_friend_author2_1_id_foreign` foreign key (`author2_1_id`) references `author2` (`id`) on update cascade on delete cascade;
 alter table `author_to_friend` add constraint `author_to_friend_author2_2_id_foreign` foreign key (`author2_2_id`) references `author2` (`id`) on update cascade on delete cascade;


### PR DESCRIPTION
There are some cases where an entity will have a primary key of 0.
Our use case is a table of static statuses that are pervasive
throughout our application. We add the rows when we generate the
schema, not through the ORM. We only want to map relationships
to those statuses with the ORM. Some of these statuses start with
the id of 0 versus 1. Previous to this fix, there were generic
falsy checks that would take a primary key with a value of 0 as
if the primary key was not set. This fix makes those checks
specific for both null and undefined values.

BREAKING CHANGE: entities that were using a primary key of 0 to
signify that the primary key was not defined will now interpret
the zero to be the actual primary key.

To migrate, no longer default the primary key to 0. Use null
and undefined to signify a primary key that is not defined.