### PR TITLE
fix(schema): rework enum handling in schema generator

### DIFF
--- a/lib/connections/PostgreSqlConnection.ts
+++ b/lib/connections/PostgreSqlConnection.ts
@@ -1,10 +1,15 @@
 import { PgConnectionConfig } from 'knex';
 import { types, defaults } from 'pg';
 import { AbstractSqlConnection } from './AbstractSqlConnection';
+import { Dictionary } from '../typings';
+
+const TableCompiler_PG = require('knex/lib/dialects/postgres/schema/tablecompiler.js');
+const TableCompiler = require('knex/lib/schema/tablecompiler.js');
 
 export class PostgreSqlConnection extends AbstractSqlConnection {
 
   async connect(): Promise<void> {
+    this.patchKnex();
     this.client = this.createKnexClient('pg');
   }
 
@@ -38,6 +43,74 @@ export class PostgreSqlConnection extends AbstractSqlConnection {
       insertId: res.rows[0] ? res.rows[0].id : 0,
       row: res.rows[0],
     } as unknown as T;
+  }
+
+  /**
+   * monkey patch knex' postgres dialect so it correctly handles column updates (especially enums)
+   */
+  private patchKnex(): void {
+    const that = this;
+
+    TableCompiler_PG.prototype.addColumns = function (this: typeof TableCompiler_PG, columns: Dictionary[], prefix: string, colCompilers: Dictionary[]) {
+      if (prefix !== this.alterColumnsPrefix) {
+        // base class implementation for normal add
+        return TableCompiler.prototype.addColumns.call(this, columns, prefix);
+      }
+
+      // alter columns
+      for (const col of colCompilers) {
+        that.addColumn.call(this, col, that);
+      }
+    };
+  }
+
+  private addColumn(this: typeof TableCompiler_PG, col: Dictionary, that: PostgreSqlConnection): void {
+    const quotedTableName = this.tableName();
+    const type = col.getColumnType();
+    const colName = this.client.wrapIdentifier(col.getColumnName(), col.columnBuilder.queryContext());
+    const constraintName = `${this.tableNameRaw}_${col.getColumnName()}_check`;
+    this.pushQuery({ sql: `alter table ${quotedTableName} drop constraint if exists "${constraintName}"`, bindings: [] });
+
+    if (col.type === 'enu') {
+      this.pushQuery({ sql: `alter table ${quotedTableName} alter column ${colName} type text using (${colName}::text)`, bindings: [] });
+      this.pushQuery({ sql: `alter table ${quotedTableName} add constraint "${constraintName}" ${type.replace(/^text /, '')}`, bindings: [] });
+    } else {
+      this.pushQuery({ sql: `alter table ${quotedTableName} alter column ${colName} type ${type} using (${colName}::${type})`, bindings: [] });
+    }
+
+    that.alterColumnDefault.call(this, col, colName);
+    that.alterColumnNullable.call(this, col, colName);
+  }
+
+  private alterColumnNullable(this: typeof TableCompiler_PG, col: Dictionary, colName: string): void {
+    const quotedTableName = this.tableName();
+    const nullable = col.modified.nullable;
+
+    if (!nullable) {
+      return;
+    }
+
+    if (nullable[0] === false) {
+      this.pushQuery({ sql: `alter table ${quotedTableName} alter column ${colName} set not null`, bindings: [] });
+    } else {
+      this.pushQuery({ sql: `alter table ${quotedTableName} alter column ${colName} drop not null`, bindings: [] });
+    }
+  }
+
+  private alterColumnDefault(this: typeof TableCompiler_PG, col: Dictionary, colName: string): void {
+    const quotedTableName = this.tableName();
+    const defaultTo = col.modified.defaultTo;
+
+    if (!defaultTo) {
+      return;
+    }
+
+    if (defaultTo[0] === null) {
+      this.pushQuery({ sql: `alter table ${quotedTableName} alter column ${colName} drop default`, bindings: [] });
+    } else {
+      const modifier = col.defaultTo.apply(col, defaultTo);
+      this.pushQuery({ sql: `alter table ${quotedTableName} alter column ${colName} set ${modifier}`, bindings: [] });
+    }
   }
 
 }

--- a/lib/connections/SqliteConnection.ts
+++ b/lib/connections/SqliteConnection.ts
@@ -2,8 +2,6 @@ import { ensureDir, readFile } from 'fs-extra';
 import { dirname } from 'path';
 import { Config } from 'knex';
 
-const Bluebird = require('bluebird');
-
 import { AbstractSqlConnection } from './AbstractSqlConnection';
 
 export class SqliteConnection extends AbstractSqlConnection {
@@ -71,7 +69,7 @@ export class SqliteConnection extends AbstractSqlConnection {
     dialect.prototype._query = (connection: any, obj: any) => {
       const callMethod = this.getCallMethod(obj);
 
-      return new Bluebird((resolve: any, reject: any) => {
+      return new Promise((resolve: any, reject: any) => {
         /* istanbul ignore if */
         if (!connection || !connection[callMethod]) {
           return reject(new Error(`Error calling ${callMethod} on connection.`));

--- a/lib/schema/DatabaseSchema.ts
+++ b/lib/schema/DatabaseSchema.ts
@@ -36,7 +36,8 @@ export class DatabaseSchema {
       const indexes = await helper.getIndexes(connection, t.table_name, t.schema_name);
       const pks = await helper.getPrimaryKeys(connection, indexes, t.table_name, t.schema_name);
       const fks = await helper.getForeignKeys(connection, t.table_name, t.schema_name);
-      table.init(cols, indexes, pks, fks);
+      const enums = await helper.getEnumDefinitions(connection, t.table_name, t.schema_name);
+      table.init(cols, indexes, pks, fks, enums);
     }
 
     return schema;

--- a/lib/schema/DatabaseTable.ts
+++ b/lib/schema/DatabaseTable.ts
@@ -35,7 +35,7 @@ export class DatabaseTable {
     }, {} as Dictionary<Index[]>);
   }
 
-  init(cols: Column[], indexes: Index[], pks: string[], fks: Dictionary<ForeignKey>): void {
+  init(cols: Column[], indexes: Index[], pks: string[], fks: Dictionary<ForeignKey>, enums: Dictionary<string[]>): void {
     this.indexes = indexes;
     this.foreignKeys = fks;
 
@@ -51,10 +51,11 @@ export class DatabaseTable {
       v.fk = fks[v.name];
       v.indexes = index.filter(i => !i.primary && !i.composite);
       v.defaultValue = v.defaultValue && v.defaultValue.toString().startsWith('nextval(') ? null : v.defaultValue;
+      v.enumItems = enums[v.name] || [];
       o[v.name] = v;
 
       return o;
-    }, {} as any);
+    }, {} as Dictionary<Column>);
   }
 
   getEntityDeclaration(namingStrategy: NamingStrategy, schemaHelper: SchemaHelper): EntityMetadata {
@@ -180,6 +181,7 @@ export interface Column {
   nullable: boolean;
   maxLength: number;
   defaultValue: string | null;
+  enumItems: string[];
 }
 
 export interface ForeignKey {

--- a/lib/schema/PostgreSqlSchemaHelper.ts
+++ b/lib/schema/PostgreSqlSchemaHelper.ts
@@ -1,5 +1,5 @@
 import { IsSame, SchemaHelper } from './SchemaHelper';
-import { EntityProperty } from '../typings';
+import { Dictionary, EntityProperty } from '../typings';
 import { AbstractSqlConnection } from '../connections/AbstractSqlConnection';
 import { Column, Index } from './DatabaseTable';
 
@@ -8,18 +8,18 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
   static readonly TYPES = {
     boolean: ['bool', 'boolean'],
     number: ['int4', 'integer', 'int2', 'int', 'float', 'float8', 'double', 'double precision', 'bigint', 'smallint', 'decimal', 'numeric', 'real'],
+    string: ['varchar(?)', 'character varying', 'text', 'character', 'char', 'uuid', 'bigint', 'int8', 'enum'],
     float: ['float'],
     double: ['double precision', 'float8'],
     tinyint: ['int2'],
     smallint: ['int2'],
-    string: ['varchar(?)', 'character varying', 'text', 'character', 'char', 'uuid', 'enum', 'bigint', 'int8'],
+    text: ['text'],
     Date: ['timestamptz(?)', 'timestamp(?)', 'datetime(?)', 'timestamp with time zone', 'timestamp without time zone', 'datetimetz', 'time', 'date', 'timetz', 'datetz'],
     date: ['timestamptz(?)', 'timestamp(?)', 'datetime(?)', 'timestamp with time zone', 'timestamp without time zone', 'datetimetz', 'time', 'date', 'timetz', 'datetz'],
-    text: ['text'],
     object: ['json'],
     json: ['json'],
     uuid: ['uuid'],
-    enum: ['enum'],
+    enum: ['text'], // enums are implemented as text columns with check constraints
   };
 
   static readonly DEFAULT_TYPE_LENGTHS = {
@@ -109,6 +109,24 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
         and kcu.ordinal_position = rel_kcu.ordinal_position
       where tco.table_name = '${tableName}' and tco.table_schema = '${schemaName}' and tco.constraint_schema = '${schemaName}' and tco.constraint_type = 'FOREIGN KEY'
       order by kcu.table_schema, kcu.table_name, kcu.ordinal_position`;
+  }
+
+  async getEnumDefinitions(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<Dictionary> {
+    const sql = `select conrelid::regclass as table_from, conname, pg_get_constraintdef(c.oid) as enum_def
+      from pg_constraint c join pg_namespace n on n.oid = c.connamespace
+      where contype = 'c' and conrelid = '${schemaName}.${tableName}'::regclass order by contype`;
+    const enums = await connection.execute<any[]>(sql);
+
+    return enums.reduce((o, item) => {
+      // check constraints are defined as one of:
+      // `CHECK ((type = ANY (ARRAY['local'::text, 'global'::text])))`
+      // `CHECK (((enum_test)::text = ANY ((ARRAY['a'::character varying, 'b'::character varying, 'c'::character varying])::text[])))`
+      const m1 = item.enum_def.match(/check \(\(\((\w+)\)::/i) || item.enum_def.match(/check \(\((\w+) = any/i);
+      const m2 = item.enum_def.match(/\(array\[(.*)]\)/i);
+      o[m1[1]] = m2[1].split(',').map((item: string) => item.trim().match(/^'(.*)'/)![1]);
+
+      return o;
+    }, {} as Dictionary<string>);
   }
 
   normalizeDefaultValue(defaultValue: string, length: number) {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "fast-deep-equal": "^3.1.1",
     "fs-extra": "^8.1.0",
     "globby": "^10.0.0",
-    "knex": "^0.20.12",
+    "knex": "^0.20.13",
     "reflect-metadata": "^0.1.13",
     "ts-morph": "^4.3.3",
     "umzug": "^2.2.0",

--- a/tests/Migrator.test.ts
+++ b/tests/Migrator.test.ts
@@ -48,7 +48,6 @@ describe('Migrator', () => {
   });
 
   test('generate schema migration', async () => {
-    orm.em.getConnection().execute('drop table if exists new_table');
     const dateMock = jest.spyOn(Date.prototype, 'toISOString');
     dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
     const migrator = orm.getMigrator();

--- a/tests/__snapshots__/SchemaGenerator.test.ts.snap
+++ b/tests/__snapshots__/SchemaGenerator.test.ts.snap
@@ -1128,7 +1128,7 @@ alter table \`new_table\` add \`id\` int unsigned not null auto_increment primar
 `;
 
 exports[`SchemaGenerator update schema [mysql]: mysql-update-schema-alter-column 1`] = `
-"alter table \`author2\` modify \`age\` int(11) null default 42, modify \`born\` int not null default 42;
+"alter table \`author2\` modify \`age\` int(11) default 42, modify \`born\` int not null default 42;
 alter table \`author2\` drop foreign key \`author2_favourite_author_id_foreign\`;
 alter table \`author2\` drop index \`author2_favourite_author_id_index\`;
 alter table \`author2\` add constraint \`author2_favourite_author_id_foreign\` foreign key (\`favourite_author_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;
@@ -1192,13 +1192,11 @@ alter table \\"new_table\\" add column \\"id\\" serial primary key, add column \
 `;
 
 exports[`SchemaGenerator update schema [postgres]: postgres-update-schema-alter-column 1`] = `
-"alter table \\"author2\\" alter column \\"name\\" drop default;
-alter table \\"author2\\" alter column \\"name\\" drop not null;
+"alter table \\"author2\\" drop constraint if exists \\"author2_name_check\\";
 alter table \\"author2\\" alter column \\"name\\" type int4 using (\\"name\\"::int4);
 alter table \\"author2\\" alter column \\"name\\" set default 42;
-alter table \\"author2\\" alter column \\"name\\" set not null;
-alter table \\"author2\\" alter column \\"age\\" drop default;
-alter table \\"author2\\" alter column \\"age\\" drop not null;
+alter table \\"author2\\" alter column \\"name\\" drop not null;
+alter table \\"author2\\" drop constraint if exists \\"author2_age_check\\";
 alter table \\"author2\\" alter column \\"age\\" type int4 using (\\"age\\"::int4);
 alter table \\"author2\\" alter column \\"age\\" set default 42;
 alter table \\"author2\\" drop constraint \\"author2_favourite_author_id_foreign\\";
@@ -1218,7 +1216,11 @@ create table \\"new_table\\" (\\"id\\" serial primary key, \\"created_at\\" time
 `;
 
 exports[`SchemaGenerator update schema [postgres]: postgres-update-schema-drop-column 1`] = `
-"alter table \\"author2\\" drop constraint \\"author2_favourite_book_uuid_pk_foreign\\";
+"alter table \\"author2\\" drop constraint if exists \\"author2_name_check\\";
+alter table \\"author2\\" alter column \\"name\\" type int4 using (\\"name\\"::int4);
+alter table \\"author2\\" alter column \\"name\\" drop default;
+alter table \\"author2\\" alter column \\"name\\" set not null;
+alter table \\"author2\\" drop constraint \\"author2_favourite_book_uuid_pk_foreign\\";
 alter table \\"author2\\" drop column \\"favourite_book_uuid_pk\\";
 
 alter table \\"new_table\\" drop column \\"id\\";
@@ -1241,6 +1243,71 @@ exports[`SchemaGenerator update schema [postgres]: postgres-update-schema-rename
 
 alter table \\"author2\\" rename column \\"favourite_author_id\\" to \\"favourite_writer_id\\";
 
+
+"
+`;
+
+exports[`SchemaGenerator update schema enums [mysql]: mysql-update-schema-enums-1 1`] = `
+"alter table \`book2\` drop \`foo\`;
+
+alter table \`test2\` drop foreign key \`test2_foo___bar_foreign\`;
+alter table \`test2\` drop index \`test2_foo___bar_unique\`;
+alter table \`test2\` drop index \`test2_foo___bar_index\`;
+alter table \`test2\` drop \`foo___bar\`;
+alter table \`test2\` drop \`foo___baz\`;
+
+create table \`new_table\` (\`id\` int unsigned not null auto_increment primary key, \`enum_test\` varchar(255) not null) default character set utf8 engine = InnoDB;
+
+"
+`;
+
+exports[`SchemaGenerator update schema enums [mysql]: mysql-update-schema-enums-2 1`] = `
+"alter table \`new_table\` modify \`enum_test\` enum('a', 'b');
+
+"
+`;
+
+exports[`SchemaGenerator update schema enums [mysql]: mysql-update-schema-enums-3 1`] = `
+"alter table \`new_table\` modify \`enum_test\` enum('a', 'b', 'c') not null;
+
+"
+`;
+
+exports[`SchemaGenerator update schema enums [mysql]: mysql-update-schema-enums-4 1`] = `
+"alter table \`new_table\` modify \`enum_test\` int;
+
+"
+`;
+
+exports[`SchemaGenerator update schema enums [postgres]: postgres-update-schema-enums-1 1`] = `
+"alter table \\"book2\\" drop column \\"foo\\";
+
+alter table \\"test2\\" drop column \\"path\\";
+
+create table \\"new_table\\" (\\"id\\" serial primary key, \\"enum_test\\" varchar(255) not null);
+
+"
+`;
+
+exports[`SchemaGenerator update schema enums [postgres]: postgres-update-schema-enums-2 1`] = `
+"alter table \\"new_table\\" drop constraint if exists \\"new_table_enum_test_check\\";
+alter table \\"new_table\\" alter column \\"enum_test\\" type text using (\\"enum_test\\"::text);
+alter table \\"new_table\\" add constraint \\"new_table_enum_test_check\\" check (\\"enum_test\\" in ('a', 'b'));
+
+"
+`;
+
+exports[`SchemaGenerator update schema enums [postgres]: postgres-update-schema-enums-3 1`] = `
+"alter table \\"new_table\\" drop constraint if exists \\"new_table_enum_test_check\\";
+alter table \\"new_table\\" alter column \\"enum_test\\" type text using (\\"enum_test\\"::text);
+alter table \\"new_table\\" add constraint \\"new_table_enum_test_check\\" check (\\"enum_test\\" in ('a', 'b', 'c'));
+
+"
+`;
+
+exports[`SchemaGenerator update schema enums [postgres]: postgres-update-schema-enums-4 1`] = `
+"alter table \\"new_table\\" drop constraint if exists \\"new_table_enum_test_check\\";
+alter table \\"new_table\\" alter column \\"enum_test\\" type int4 using (\\"enum_test\\"::int4);
 
 "
 `;

--- a/tests/mysql-schema.sql
+++ b/tests/mysql-schema.sql
@@ -20,6 +20,7 @@ drop table if exists `book2_to_book_tag2`;
 drop table if exists `book_to_tag_unordered`;
 drop table if exists `publisher2_to_test2`;
 drop table if exists `user2_to_car2`;
+drop table if exists `new_table`;
 
 create table `author2` (`id` int unsigned not null auto_increment primary key, `created_at` datetime(3) not null default current_timestamp(3), `updated_at` datetime(3) not null default current_timestamp(3), `name` varchar(255) not null, `email` varchar(255) not null, `age` int(11) null, `terms_accepted` tinyint(1) not null default false, `optional` tinyint(1) null, `identities` json null, `born` date null, `born_time` time null, `favourite_book_uuid_pk` varchar(36) null, `favourite_author_id` int(11) unsigned null) default character set utf8 engine = InnoDB;
 alter table `author2` add unique `custom_email_unique_name`(`email`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4686,10 +4686,10 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-knex@^0.20.12:
-  version "0.20.12"
-  resolved "https://registry.yarnpkg.com/knex/-/knex-0.20.12.tgz#33e576fb53b624c6cf346f7a4c81f0a1e06191fc"
-  integrity sha512-pxJBsfW9EGfc1l5ObD5+91/gveDXZZrx35kW+2tihJYpsAqUoqAnUT2v0xBQrWTDlt3Tifg9Gt84P/0abomPrA==
+knex@^0.20.13:
+  version "0.20.13"
+  resolved "https://registry.yarnpkg.com/knex/-/knex-0.20.13.tgz#056c310d963f7efce1b3c7397576add1323f1146"
+  integrity sha512-YVl//Te0G5suc+d9KyeI6WuhtgVlxu6HXYQB+WqrccFkSZAbHqlqZlUMogYG3UoVq69c3kiFbbxgUNkrO0PVfg==
   dependencies:
     colorette "1.1.0"
     commander "^4.1.1"


### PR DESCRIPTION
String enums are now discovered properly, and we diff the actual enum items to know whether something changed.
This also fixes postgres enum altering that produced invalid query.

Postgres dialect in knex is now monkey patched to have control over how column alters are working.
Now only necessary queries should be made (so no `drop null` followed by `set null`, etc).

Closes #397
Closes #432