### PR TITLE
feat(mongo): add support for mongodb text indexes

### DIFF
--- a/docs/docs/usage-with-mongo.md
+++ b/docs/docs/usage-with-mongo.md
@@ -121,6 +121,10 @@ await orm.em.getDriver().ensureIndexes();
 > 
 > `@Unique({ options: { partialFilterExpression: { name: { $exists: true } } }})`
 
+> You can also create text indexes by passing `type` parameter:
+> 
+> `@Index({ properties: ['name', 'caption'], type: 'text' })`
+
 ## Native collection methods
 
 Sometimes you need to perform some bulk operation, or you just want to populate your

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -502,6 +502,7 @@ describe('EntityManagerMongo', () => {
     expect(bookInfo.reduce((o: any, i: any) => { o[i.name] = i; return o; }, {} as any)).toMatchObject({
       _id_: { key: { _id: 1 }, name: '_id_' },
       publisher_idx: { key: { publisher: 1 }, name: 'publisher_idx' },
+      title_text: { key: { _fts: 'text', _ftsx: 1 }, weights: { title: 1 } },
       title_1_author_1: { key: { title: 1, author: 1 }, name: 'title_1_author_1', unique: true },
     });
   });

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -7,6 +7,7 @@ import { BaseEntity3 } from './BaseEntity3';
 
 @Entity({ tableName: 'books-table' })
 @Unique({ properties: ['title', 'author'] })
+@Index({ properties: 'title', type: 'text' })
 export class Book extends BaseEntity3 {
 
   @PrimaryKey()


### PR DESCRIPTION
Added support for text indexes in MongoDB.
Added text index test.

Closes #479 