### PR TITLE
feat(core): allow adding items to not initialized collections

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ discuss specifics.
 - [ ] Single table inheritance ([#33](https://github.com/mikro-orm/mikro-orm/issues/33))
 - [ ] Embedded entities (allow in-lining child entity into parent one with prefixed keys, or maybe as serialized JSON)
 - [ ] Support external hooks when using EntitySchema (hooks outside of entity)
-- [ ] Allow adding items to not initialized collections
+- [x] Allow adding items to not initialized collections
 - [ ] Support multiple M:N with same properties without manually specifying `pivotTable`
 - [ ] Cache metadata only with ts-morph provider
 - [ ] Diffing entity level indexes in schema generator
@@ -38,7 +38,7 @@ discuss specifics.
 - [x] Require node 10+
 - [x] Require TS 3.7 or newer
 - [x] Split into multiple packages (core, driver packages, TS support, SQL support, CLI)
-- [ ] Drop default value for db `type` (currently defaults to `mongodb`)
+- [ ] Drop default value for platform `type` (currently defaults to `mongodb`)
 - [x] Remove `autoFlush` option
 - [ ] Remove `IdEntity/UuidEntity/MongoEntity` interfaces
 - [ ] Rename `wrappedReference` to `reference` (keep `wrappedReference` supported)

--- a/packages/core/src/entity/ArrayCollection.ts
+++ b/packages/core/src/entity/ArrayCollection.ts
@@ -48,7 +48,7 @@ export class ArrayCollection<T extends AnyEntity<T>, O extends AnyEntity<O>> {
 
   add(...items: T[]): void {
     for (const item of items) {
-      if (!this.contains(item)) {
+      if (!this.contains(item, false)) {
         this.items.push(item);
         this.propagate(item, 'add');
       }
@@ -86,7 +86,7 @@ export class ArrayCollection<T extends AnyEntity<T>, O extends AnyEntity<O>> {
     this.remove(...this.items);
   }
 
-  contains(item: T): boolean {
+  contains(item: T, check?: boolean): boolean {
     return !!this.items.find(i => {
       const objectIdentity = i === item;
       const primaryKeyIdentity = !!wrap(i).__primaryKey && !!wrap(item).__primaryKey && wrap(i).__serializedPrimaryKey === wrap(item).__serializedPrimaryKey;
@@ -149,16 +149,16 @@ export class ArrayCollection<T extends AnyEntity<T>, O extends AnyEntity<O>> {
   }
 
   protected shouldPropagateToCollection(collection: Collection<O, T>, method: 'add' | 'remove'): boolean {
-    if (!collection || !collection.isInitialized()) {
+    if (!collection) {
       return false;
     }
 
     if (method === 'add') {
-      return !collection.contains(this.owner);
+      return !collection.contains(this.owner, false);
     }
 
     // remove
-    return collection.contains(this.owner);
+    return collection.contains(this.owner, false);
   }
 
 }

--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -33,8 +33,11 @@ export class Collection<T extends AnyEntity<T>, O extends AnyEntity<O> = AnyEnti
   /**
    * Returns the items (the collection must be initialized)
    */
-  getItems(): T[] {
-    this.checkInitialized();
+  getItems(check = true): T[] {
+    if (check) {
+      this.checkInitialized();
+    }
+
     return super.getItems();
   }
 
@@ -79,8 +82,11 @@ export class Collection<T extends AnyEntity<T>, O extends AnyEntity<O> = AnyEnti
     }
   }
 
-  contains(item: T): boolean {
-    this.checkInitialized();
+  contains(item: T, check = true): boolean {
+    if (check) {
+      this.checkInitialized();
+    }
+
     return super.contains(item);
   }
 
@@ -206,7 +212,10 @@ export class Collection<T extends AnyEntity<T>, O extends AnyEntity<O> = AnyEnti
   }
 
   private modify(method: 'add' | 'remove', items: T[]): void {
-    this.checkInitialized();
+    if (method === 'remove') {
+      this.checkInitialized();
+    }
+
     this.validateModification(items);
     super[method](...items);
     this.setDirty();
@@ -249,7 +258,7 @@ export class Collection<T extends AnyEntity<T>, O extends AnyEntity<O> = AnyEnti
     // throw if we are modifying inverse side of M:N collection when owning side is initialized (would be ignored when persisting)
     const manyToManyInverse = this.property.reference === ReferenceType.MANY_TO_MANY && this.property.mappedBy;
 
-    if (manyToManyInverse && items.find(item => !item[this.property.mappedBy] || !item[this.property.mappedBy].isInitialized())) {
+    if (manyToManyInverse && items.find(item => !wrap(item).isInitialized() || !item[this.property.mappedBy])) {
       throw ValidationError.cannotModifyInverseCollection(this.owner, this.property);
     }
   }

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -235,7 +235,7 @@ export class UnitOfWork {
       return;
     }
 
-    reference.getItems()
+    reference.getItems(false)
       .filter(item => !this.originalEntityData[wrap(item).__uuid])
       .forEach(item => this.findNewEntities(item, visited));
   }
@@ -343,13 +343,16 @@ export class UnitOfWork {
     const collection = reference as Collection<AnyEntity>;
     const requireFullyInitialized = type === Cascade.PERSIST; // only cascade persist needs fully initialized items
 
-    if ([ReferenceType.ONE_TO_MANY, ReferenceType.MANY_TO_MANY].includes(prop.reference) && collection && collection.isInitialized(requireFullyInitialized)) {
-      collection.getItems().forEach(item => this.cascade(item, type, visited, options));
+    if ([ReferenceType.ONE_TO_MANY, ReferenceType.MANY_TO_MANY].includes(prop.reference) && collection) {
+      collection
+        .getItems(false)
+        .filter(item => !requireFullyInitialized || wrap(item).isInitialized())
+        .forEach(item => this.cascade(item, type, visited, options));
     }
   }
 
   private isCollectionSelfReferenced(collection: Collection<AnyEntity>, visited: AnyEntity[]): boolean {
-    const filtered = collection.getItems().filter(item => !this.originalEntityData[wrap(item).__uuid]);
+    const filtered = collection.getItems(false).filter(item => !this.originalEntityData[wrap(item).__uuid]);
     return filtered.some(items => visited.includes(items));
   }
 

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -138,7 +138,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     const meta = wrap(coll.owner).__meta;
     const pks = wrap(coll.owner).__primaryKeys;
     const snapshot = coll.getSnapshot().map(item => wrap(item).__primaryKeys);
-    const current = coll.getItems().map(item => wrap(item).__primaryKeys);
+    const current = coll.getItems(false).map(item => wrap(item).__primaryKeys);
     const deleteDiff = snapshot.filter(item => !current.includes(item));
     const insertDiff = current.filter(item => !snapshot.includes(item));
     const target = snapshot.filter(item => current.includes(item)).concat(...insertDiff);

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -913,7 +913,6 @@ describe('EntityManagerMySql', () => {
     expect(tags[0].books.isInitialized()).toBe(false);
     expect(tags[0].books.isDirty()).toBe(false);
     expect(() => tags[0].books.getItems()).toThrowError(/Collection<Book2> of entity BookTag2\[\d+] not initialized/);
-    expect(() => tags[0].books.add(book1)).toThrowError(/Collection<Book2> of entity BookTag2\[\d+] not initialized/);
     expect(() => tags[0].books.remove(book1, book2)).toThrowError(/Collection<Book2> of entity BookTag2\[\d+] not initialized/);
     expect(() => tags[0].books.removeAll()).toThrowError(/Collection<Book2> of entity BookTag2\[\d+] not initialized/);
     expect(() => tags[0].books.contains(book1)).toThrowError(/Collection<Book2> of entity BookTag2\[\d+] not initialized/);
@@ -1847,6 +1846,56 @@ describe('EntityManagerMySql', () => {
     expect(mock.mock.calls[0][0]).toMatch('begin');
     expect(mock.mock.calls[1][0]).toMatch('delete from `foo_baz2` where `id` = ?');
     expect(mock.mock.calls[2][0]).toMatch('commit');
+  });
+
+  test('adding items to not initialized collection', async () => {
+    const god = new Author2('God', 'hello@heaven.god');
+    const b1 = new Book2('Bible 1', god);
+    await orm.em.persistAndFlush(b1);
+    orm.em.clear();
+
+    const a = await orm.em.findOneOrFail(Author2, god.id);
+    expect(a.books.isInitialized()).toBe(false);
+    const b2 = new Book2('Bible 2', a);
+    const b3 = new Book2('Bible 3', a);
+    a.books.add(b2, b3);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const a2 = await orm.em.findOneOrFail(Author2, god.id, ['books']);
+    expect(a2.books.count()).toBe(3);
+    expect(a2.books.getIdentifiers()).toEqual([b1.uuid, b2.uuid, b3.uuid]);
+
+    const tag1 = new BookTag2('silly');
+    const tag2 = new BookTag2('funny');
+    const tag3 = new BookTag2('sick');
+    const tag4 = new BookTag2('strange');
+    let tag5 = new BookTag2('sexy');
+    a2.books[0].tags.add(tag1);
+    a2.books[1].tags.add(tag1);
+    a2.books[2].tags.add(tag5);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const a3 = await orm.em.findOneOrFail(Author2, god.id, ['books']);
+    tag5 = orm.em.getReference(BookTag2, tag5.id);
+    a3.books[0].tags.add(tag3);
+    a3.books[1].tags.add(tag2, tag5);
+    a3.books[2].tags.add(tag4);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const a4 = await orm.em.findOneOrFail(Author2, god.id, ['books.tags']);
+    expect(a4.books[0].tags.getIdentifiers()).toEqual([tag1.id, tag3.id]);
+    expect(a4.books[1].tags.getIdentifiers()).toEqual([tag1.id, tag2.id, tag5.id]);
+    expect(a4.books[2].tags.getIdentifiers()).toEqual([tag5.id, tag4.id]);
+    orm.em.clear();
+
+    const tag = await orm.em.findOneOrFail(BookTag2, tag1.id);
+    const book = await orm.em.findOneOrFail(Book2, b3.uuid);
+    tag.books.add(book);
+    await orm.em.flush();
+    orm.em.clear();
   });
 
   afterAll(async () => orm.close(true));

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -706,7 +706,6 @@ describe('EntityManagerPostgre', () => {
     expect(tags[0].books.isInitialized()).toBe(false);
     expect(tags[0].books.isDirty()).toBe(false);
     expect(() => tags[0].books.getItems()).toThrowError(/Collection<Book2> of entity BookTag2\[\d+] not initialized/);
-    expect(() => tags[0].books.add(book1)).toThrowError(/Collection<Book2> of entity BookTag2\[\d+] not initialized/);
     expect(() => tags[0].books.remove(book1, book2)).toThrowError(/Collection<Book2> of entity BookTag2\[\d+] not initialized/);
     expect(() => tags[0].books.removeAll()).toThrowError(/Collection<Book2> of entity BookTag2\[\d+] not initialized/);
     expect(() => tags[0].books.contains(book1)).toThrowError(/Collection<Book2> of entity BookTag2\[\d+] not initialized/);

--- a/tests/EntityManager.sqlite.test.ts
+++ b/tests/EntityManager.sqlite.test.ts
@@ -582,7 +582,6 @@ describe('EntityManagerSqlite', () => {
     expect(tags[0].books.isInitialized()).toBe(false);
     expect(tags[0].books.isDirty()).toBe(false);
     expect(() => tags[0].books.getItems()).toThrowError(/Collection<Book3> of entity BookTag3\[\d+] not initialized/);
-    expect(() => tags[0].books.add(book1)).toThrowError(/Collection<Book3> of entity BookTag3\[\d+] not initialized/);
     expect(() => tags[0].books.remove(book1, book2)).toThrowError(/Collection<Book3> of entity BookTag3\[\d+] not initialized/);
     expect(() => tags[0].books.removeAll()).toThrowError(/Collection<Book3> of entity BookTag3\[\d+] not initialized/);
     expect(() => tags[0].books.contains(book1)).toThrowError(/Collection<Book3> of entity BookTag3\[\d+] not initialized/);

--- a/tests/EntityManager.sqlite2.test.ts
+++ b/tests/EntityManager.sqlite2.test.ts
@@ -541,7 +541,6 @@ describe('EntityManagerSqlite2', () => {
     expect(tags[0].books.isInitialized()).toBe(false);
     expect(tags[0].books.isDirty()).toBe(false);
     expect(() => tags[0].books.getItems()).toThrowError(/Collection<Book4> of entity BookTag4\[\d+] not initialized/);
-    expect(() => tags[0].books.add(book1)).toThrowError(/Collection<Book4> of entity BookTag4\[\d+] not initialized/);
     expect(() => tags[0].books.remove(book1, book2)).toThrowError(/Collection<Book4> of entity BookTag4\[\d+] not initialized/);
     expect(() => tags[0].books.removeAll()).toThrowError(/Collection<Book4> of entity BookTag4\[\d+] not initialized/);
     expect(() => tags[0].books.contains(book1)).toThrowError(/Collection<Book4> of entity BookTag4\[\d+] not initialized/);


### PR DESCRIPTION
Works for both 1:m and m:n collections.

```typescript
const a = await orm.em.findOneOrFail(Author2, god.id);
console.log(a.books.isInitialized()); // false
const b2 = new Book2('Bible 2', a);
const b3 = new Book2('Bible 3', a);
a.books.add(b2, b3);
await orm.em.flush();
```