### PR TITLE
feat(core): add support for single table inheritance

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,11 +19,12 @@ discuss specifics.
 
 ## Planned changes for v4
 
+- [x] Single table inheritance ([#33](https://github.com/mikro-orm/mikro-orm/issues/33))
+- [x] Allow adding items to not initialized collections
+- [x] Use absolute path to entity file in static MetadataStorage keys (fix for 'Multiple property decorators' validation issues)
 - [ ] Association scopes/filters ([hibernate docs](https://docs.jboss.org/hibernate/orm/3.6/reference/en-US/html/filters.html))
-- [ ] Single table inheritance ([#33](https://github.com/mikro-orm/mikro-orm/issues/33))
 - [ ] Embedded entities (allow in-lining child entity into parent one with prefixed keys, or maybe as serialized JSON)
 - [ ] Support external hooks when using EntitySchema (hooks outside of entity)
-- [x] Allow adding items to not initialized collections
 - [ ] Support multiple M:N with same properties without manually specifying `pivotTable`
 - [ ] Cache metadata only with ts-morph provider
 - [ ] Diffing entity level indexes in schema generator
@@ -31,15 +32,16 @@ discuss specifics.
 - [ ] Support computed properties
 - [ ] Add `groupBy` and `distinct` to `FindOptions` and `FindOneOptions`
 - [ ] Paginator helper or something similar ([doctrine docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/pagination.html))
-- [x] Use absolute path to entity file in static MetadataStorage keys
+- [ ] Use custom errors for specific cases (unique constraint violation, db not accessible, ...)
+- [ ] Add custom types for blob, array, json
 
 ## Planned breaking changes for v4
 
 - [x] Require node 10+
 - [x] Require TS 3.7 or newer
 - [x] Split into multiple packages (core, driver packages, TS support, SQL support, CLI)
-- [ ] Drop default value for platform `type` (currently defaults to `mongodb`)
 - [x] Remove `autoFlush` option
+- [ ] Drop default value for platform `type` (currently defaults to `mongodb`)
 - [ ] Remove `IdEntity/UuidEntity/MongoEntity` interfaces
 - [ ] Rename `wrappedReference` to `reference` (keep `wrappedReference` supported)
 - [ ] Use `bigint` type natively in `BigIntType`

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -363,7 +363,9 @@ add any suffix behind the dot, not just `.model.ts` or `.entity.ts`.
 ## Using BaseEntity
 
 You can define your own base entity with properties that you require on all entities, like
-primary key and created/updated time. 
+primary key and created/updated time. Single table inheritance is also supported.
+
+Read more about this topic in [Inheritance Mapping](inheritance-mapping.md) section.
 
 > If you are initializing the ORM via `entities` option, you need to specify all your
 > base entities as well.

--- a/docs/docs/inheritance-mapping.md
+++ b/docs/docs/inheritance-mapping.md
@@ -1,0 +1,138 @@
+---
+title: Inheritance Mapping
+---
+
+# Mapped Superclasses
+
+A mapped superclass is an abstract or concrete class that provides persistent entity state and 
+mapping information for its subclasses, but which is not itself an entity. Typically, the purpose 
+of such a mapped superclass is to define state and mapping information that is common to multiple 
+entity classes.
+
+Mapped superclasses, just as regular, non-mapped classes, can appear in the middle of an otherwise 
+mapped inheritance hierarchy (through Single Table Inheritance).
+
+> A mapped superclass cannot be an entity, it is not query-able and persistent relationships defined 
+> by a mapped superclass must be unidirectional (with an owning side only). This means that One-To-Many 
+> associations are not possible on a mapped superclass at all. Furthermore Many-To-Many associations 
+> are only possible if the mapped superclass is only used in exactly one entity at the moment. For 
+> further support of inheritance, the single table inheritance features have to be used.
+
+```typescript
+// do not use @Entity decorator on base classes
+export abstract class Person {
+
+  @Property()
+  mapped1!: number;
+
+  @Property()
+  mapped2!: string;
+ 
+  @OneToOne()
+  toothbrush!: Toothbrush;
+
+  // ... more fields and methods
+}
+
+@Entity()
+export class Employee extends Person {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  // ... more fields and methods
+
+}
+
+@Entity()
+export class Toothbrush {
+  
+  @PrimaryKey()
+  id!: number;
+
+  // ... more fields and methods
+
+}
+```
+
+The DDL for the corresponding database schema would look something like this (this is for SQLite):
+
+```sql
+create table `employee` (
+  `id` int unsigned not null auto_increment primary key,
+  `name` varchar(255) not null, `mapped1` integer not null,
+  `mapped2` varchar(255) not null,
+  `toothbrush_id` integer not null
+);
+```
+
+As you can see from this DDL snippet, there is only a single table for the entity 
+subclass. All the mappings from the mapped superclass were inherited to the subclass 
+as if they had been defined on that class directly.
+
+# Single Table Inheritance
+
+> Support for STI was added in version 4.0
+
+[Single Table Inheritance](https://martinfowler.com/eaaCatalog/singleTableInheritance.html) 
+is an inheritance mapping strategy where all classes of a hierarchy are mapped to a single 
+database table. In order to distinguish which row represents which type in the hierarchy 
+a so-called discriminator column is used.
+
+```typescript
+@Entity({
+  discriminatorColumn: 'discr',
+  discriminatorMap: { person: 'Person', employee: 'Employee' },
+})
+export class Person {
+  // ...
+}
+
+@Entity()
+export class Employee extends Person {
+  // ...
+}
+```
+
+Things to note:
+
+- The `discriminatorColumn` option must be specified on the topmost class that is 
+  part of the mapped entity hierarchy.
+- The `discriminatorMap` specifies which values of the discriminator column identify 
+  a row as being of a certain type. In the case above a value of `person` identifies
+  a row as being of type `Person` and `employee` identifies a row as being of type 
+  `Employee`.
+- All entity classes that is part of the mapped entity hierarchy (including the topmost 
+  class) should be specified in the `discriminatorMap`. In the case above `Person` class
+  included.
+- If no discriminator map is provided, then the map is generated automatically. 
+  The automatically generated discriminator map contains the table names that would be
+  otherwise used in case of regular entities. 
+
+## Design-time considerations
+
+This mapping approach works well when the type hierarchy is fairly simple and stable. 
+Adding a new type to the hierarchy and adding fields to existing supertypes simply 
+involves adding new columns to the table, though in large deployments this may have 
+an adverse impact on the index and column layout inside the database.
+
+## Performance impact
+
+This strategy is very efficient for querying across all types in the hierarchy or 
+for specific types. No table joins are required, only a WHERE clause listing the 
+type identifiers. In particular, relationships involving types that employ this 
+mapping strategy are very performing.
+
+## SQL Schema considerations
+
+For Single-Table-Inheritance to work in scenarios where you are using either a legacy 
+database schema or a self-written database schema you have to make sure that all 
+columns that are not in the root entity but in any of the different sub-entities 
+has to allow null values. Columns that have NOT NULL constraints have to be on the 
+root entity of the single-table inheritance hierarchy.
+
+> This part of documentation is highly inspired by [doctrine docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/inheritance-mapping.html)
+> as the behaviour here is pretty much the same.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -31,6 +31,7 @@ module.exports = {
       'naming-strategy',
       'custom-types',
       'entity-schema',
+      'inheritance-mapping',
       'metadata-providers',
       'metadata-cache',
       'debugging',

--- a/packages/core/src/decorators/Entity.ts
+++ b/packages/core/src/decorators/Entity.ts
@@ -1,7 +1,7 @@
 import { MetadataStorage } from '../metadata';
 import { EntityRepository } from '../entity';
 import { Utils } from '../utils';
-import { AnyEntity, Constructor } from '../typings';
+import { AnyEntity, Constructor, Dictionary } from '../typings';
 
 export function Entity(options: EntityOptions<any> = {}): Function {
   return function <T extends { new(...args: any[]): AnyEntity<T> }>(target: T) {
@@ -17,5 +17,8 @@ export function Entity(options: EntityOptions<any> = {}): Function {
 export type EntityOptions<T extends AnyEntity<T>> = {
   tableName?: string;
   collection?: string;
+  discriminatorColumn?: string;
+  discriminatorMap?: Dictionary<string>;
+  discriminatorValue?: string;
   customRepository?: () => Constructor<EntityRepository<T>>;
 };

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -16,12 +16,17 @@ export class EntityAssigner {
     const options = (typeof onlyProperties === 'boolean' ? { onlyProperties } : onlyProperties);
     const em = options.em || wrap(entity).__em;
     const meta = wrap(entity).__internal.metadata.get(entity.constructor.name);
+    const root = Utils.getRootEntity(wrap(entity).__internal.metadata, meta);
     const validator = wrap(entity).__internal.validator;
     const platform = wrap(entity).__internal.platform;
     const props = meta.properties;
 
     Object.keys(data).forEach(prop => {
       if (options.onlyProperties && !(prop in props)) {
+        return;
+      }
+
+      if (props[prop]?.inherited || root.discriminatorColumn === prop) {
         return;
       }
 

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -63,7 +63,16 @@ export class EntityFactory {
   }
 
   private createEntity<T extends AnyEntity<T>>(data: EntityData<T>, meta: EntityMetadata<T>): T {
-    const Entity = this.metadata.get<T>(meta.name).class;
+    const root = Utils.getRootEntity(this.metadata, meta);
+
+    if (root.discriminatorColumn) {
+      const value = data[root.discriminatorColumn];
+      delete data[root.discriminatorColumn];
+      const type = root.discriminatorMap![value];
+      meta = type ? this.metadata.get(type) : meta;
+    }
+
+    const Entity = meta.class;
     const pks = Utils.getOrderedPrimaryKeys<T>(data, meta);
 
     if (meta.primaryKeys.some(pk => !Utils.isDefined(data[pk as keyof T], true))) {

--- a/packages/core/src/entity/EntityValidator.ts
+++ b/packages/core/src/entity/EntityValidator.ts
@@ -28,7 +28,11 @@ export class EntityValidator {
         return;
       }
 
-      payload[prop] = entity[prop as keyof T] = this.validateProperty(property, payload[prop], entity);
+      payload[prop] = this.validateProperty(property, payload[prop], entity);
+
+      if (entity[prop]) {
+        entity[prop] = payload[prop];
+      }
     });
   }
 

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -30,8 +30,12 @@ export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntit
 
   constructor(meta: Metadata<T, U> | EntityMetadata<T>, internal = false) {
     meta.name = meta.class ? meta.class.name : meta.name;
-    Utils.renameKey(meta, 'tableName', 'collection');
-    meta.tableName = meta.collection;
+
+    if (meta.tableName || meta.collection) {
+      Utils.renameKey(meta, 'tableName', 'collection');
+      meta.tableName = meta.collection;
+    }
+
     Object.assign(this._meta, { className: meta.name, properties: {}, hooks: {}, indexes: [], uniques: [] }, meta);
     this.internal = internal;
   }

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -103,6 +103,7 @@ export interface EntityProperty<T extends AnyEntity<T> = any> {
   customType: Type;
   primary: boolean;
   serializedPrimaryKey: boolean;
+  discriminator?: boolean;
   length?: any;
   reference: ReferenceType;
   wrappedReference?: boolean;
@@ -111,6 +112,7 @@ export interface EntityProperty<T extends AnyEntity<T> = any> {
   index?: boolean | string;
   unique?: boolean | string;
   nullable?: boolean;
+  inherited?: boolean;
   unsigned: boolean;
   persist?: boolean;
   hidden?: boolean;
@@ -147,6 +149,9 @@ export interface EntityMetadata<T extends AnyEntity<T> = any> {
   className: string;
   tableName: string;
   pivotTable: boolean;
+  discriminatorColumn?: string;
+  discriminatorValue?: string;
+  discriminatorMap?: Dictionary<string>;
   constructorParams: string[];
   toJsonParams: string[];
   extends: string;

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -39,7 +39,8 @@ export class UnitOfWork {
       return;
     }
 
-    this.identityMap[`${wrapped.constructor.name}-${wrapped.__serializedPrimaryKey}`] = wrapped;
+    const root = Utils.getRootEntity(this.metadata, wrapped.__meta);
+    this.identityMap[`${root.name}-${wrapped.__serializedPrimaryKey}`] = wrapped;
 
     if (mergeData || !this.originalEntityData[wrapped.__uuid]) {
       this.originalEntityData[wrapped.__uuid] = Utils.prepareEntity(entity, this.metadata, this.platform);
@@ -52,8 +53,9 @@ export class UnitOfWork {
    * Returns entity from the identity map. For composite keys, you need to pass an array of PKs in the same order as they are defined in `meta.primaryKeys`.
    */
   getById<T extends AnyEntity<T>>(entityName: string, id: Primary<T> | Primary<T>[]): T {
+    const root = Utils.getRootEntity(this.metadata, this.metadata.get(entityName));
     const hash = Utils.getPrimaryKeyHash(Utils.asArray(id) as string[]);
-    const token = `${entityName}-${hash}`;
+    const token = `${root.name}-${hash}`;
 
     return this.identityMap[token] as T;
   }
@@ -145,7 +147,8 @@ export class UnitOfWork {
   }
 
   unsetIdentity(entity: AnyEntity): void {
-    delete this.identityMap[`${entity.constructor.name}-${wrap(entity).__serializedPrimaryKey}`];
+    const root = Utils.getRootEntity(this.metadata, wrap(entity).__meta);
+    delete this.identityMap[`${root.name}-${wrap(entity).__serializedPrimaryKey}`];
     delete this.identifierMap[wrap(entity).__uuid];
     delete this.originalEntityData[wrap(entity).__uuid];
   }

--- a/tests/__snapshots__/EntityGenerator.test.ts.snap
+++ b/tests/__snapshots__/EntityGenerator.test.ts.snap
@@ -99,6 +99,41 @@ export class AuthorToFriend {
 
 }
 ",
+  "import { Entity, Index, ManyToOne, OneToOne, PrimaryKey, Property } from 'mikro-orm';
+
+@Entity()
+export class BaseUser2 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 100 })
+  firstName!: string;
+
+  @Property({ length: 100 })
+  lastName!: string;
+
+  @Index({ name: 'base_user2_type_index' })
+  @Property({ columnType: 'enum' })
+  type!: string;
+
+  @Property({ nullable: true })
+  employeeProp?: number;
+
+  @Property({ length: 255, nullable: true })
+  managerProp?: string;
+
+  @Property({ length: 255, nullable: true })
+  ownerProp?: string;
+
+  @ManyToOne({ entity: () => BaseUser2, nullable: true, index: 'base_user2_favourite_employee_id_index' })
+  favouriteEmployee?: BaseUser2;
+
+  @OneToOne({ entity: () => BaseUser2, nullable: true, index: 'base_user2_favourite_manager_id_index', unique: 'base_user2_favourite_manager_id_unique' })
+  favouriteManager?: BaseUser2;
+
+}
+",
   "import { Cascade, Entity, ManyToOne, PrimaryKey, Property } from 'mikro-orm';
 import { Author2 } from './Author2';
 import { Publisher2 } from './Publisher2';

--- a/tests/__snapshots__/SchemaGenerator.test.ts.snap
+++ b/tests/__snapshots__/SchemaGenerator.test.ts.snap
@@ -65,6 +65,12 @@ alter table \`user2\` add index \`user2_first_name_index\`(\`first_name\`);
 alter table \`user2\` add index \`user2_last_name_index\`(\`last_name\`);
 alter table \`user2\` add primary key \`user2_pkey\`(\`first_name\`, \`last_name\`);
 
+create table \`base_user2\` (\`id\` int unsigned not null auto_increment primary key, \`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`type\` enum('employee', 'manager', 'owner') not null, \`employee_prop\` int(11) null, \`manager_prop\` varchar(255) null, \`owner_prop\` varchar(255) null, \`favourite_employee_id\` int(11) unsigned null, \`favourite_manager_id\` int(11) unsigned null) default character set utf8 engine = InnoDB;
+alter table \`base_user2\` add index \`base_user2_type_index\`(\`type\`);
+alter table \`base_user2\` add index \`base_user2_favourite_employee_id_index\`(\`favourite_employee_id\`);
+alter table \`base_user2\` add index \`base_user2_favourite_manager_id_index\`(\`favourite_manager_id\`);
+alter table \`base_user2\` add unique \`base_user2_favourite_manager_id_unique\`(\`favourite_manager_id\`);
+
 create table \`author_to_friend\` (\`author2_1_id\` int(11) unsigned not null, \`author2_2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table \`author_to_friend\` add index \`author_to_friend_author2_1_id_index\`(\`author2_1_id\`);
 alter table \`author_to_friend\` add index \`author_to_friend_author2_2_id_index\`(\`author2_2_id\`);
@@ -114,6 +120,9 @@ alter table \`configuration2\` add constraint \`configuration2_test_id_foreign\`
 alter table \`car_owner2\` add constraint \`car_owner2_car_name_foreign\` foreign key (\`car_name\`) references \`car2\` (\`name\`) on update cascade;
 alter table \`car_owner2\` add constraint \`car_owner2_car_year_foreign\` foreign key (\`car_year\`) references \`car2\` (\`year\`) on update cascade;
 
+alter table \`base_user2\` add constraint \`base_user2_favourite_employee_id_foreign\` foreign key (\`favourite_employee_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
+alter table \`base_user2\` add constraint \`base_user2_favourite_manager_id_foreign\` foreign key (\`favourite_manager_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
+
 alter table \`author_to_friend\` add constraint \`author_to_friend_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 
@@ -155,6 +164,7 @@ drop table if exists \`configuration2\`;
 drop table if exists \`car2\`;
 drop table if exists \`car_owner2\`;
 drop table if exists \`user2\`;
+drop table if exists \`base_user2\`;
 drop table if exists \`author_to_friend\`;
 drop table if exists \`author2_to_author2\`;
 drop table if exists \`book2_to_book_tag2\`;
@@ -183,6 +193,7 @@ drop table if exists \`configuration2\`;
 drop table if exists \`car2\`;
 drop table if exists \`car_owner2\`;
 drop table if exists \`user2\`;
+drop table if exists \`base_user2\`;
 drop table if exists \`author_to_friend\`;
 drop table if exists \`author2_to_author2\`;
 drop table if exists \`book2_to_book_tag2\`;
@@ -251,6 +262,12 @@ alter table \`user2\` add index \`user2_first_name_index\`(\`first_name\`);
 alter table \`user2\` add index \`user2_last_name_index\`(\`last_name\`);
 alter table \`user2\` add primary key \`user2_pkey\`(\`first_name\`, \`last_name\`);
 
+create table \`base_user2\` (\`id\` int unsigned not null auto_increment primary key, \`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`type\` enum('employee', 'manager', 'owner') not null, \`employee_prop\` int(11) null, \`manager_prop\` varchar(255) null, \`owner_prop\` varchar(255) null, \`favourite_employee_id\` int(11) unsigned null, \`favourite_manager_id\` int(11) unsigned null) default character set utf8 engine = InnoDB;
+alter table \`base_user2\` add index \`base_user2_type_index\`(\`type\`);
+alter table \`base_user2\` add index \`base_user2_favourite_employee_id_index\`(\`favourite_employee_id\`);
+alter table \`base_user2\` add index \`base_user2_favourite_manager_id_index\`(\`favourite_manager_id\`);
+alter table \`base_user2\` add unique \`base_user2_favourite_manager_id_unique\`(\`favourite_manager_id\`);
+
 create table \`author_to_friend\` (\`author2_1_id\` int(11) unsigned not null, \`author2_2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table \`author_to_friend\` add index \`author_to_friend_author2_1_id_index\`(\`author2_1_id\`);
 alter table \`author_to_friend\` add index \`author_to_friend_author2_2_id_index\`(\`author2_2_id\`);
@@ -299,6 +316,9 @@ alter table \`configuration2\` add constraint \`configuration2_test_id_foreign\`
 
 alter table \`car_owner2\` add constraint \`car_owner2_car_name_foreign\` foreign key (\`car_name\`) references \`car2\` (\`name\`) on update cascade;
 alter table \`car_owner2\` add constraint \`car_owner2_car_year_foreign\` foreign key (\`car_year\`) references \`car2\` (\`year\`) on update cascade;
+
+alter table \`base_user2\` add constraint \`base_user2_favourite_employee_id_foreign\` foreign key (\`favourite_employee_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
+alter table \`base_user2\` add constraint \`base_user2_favourite_manager_id_foreign\` foreign key (\`favourite_manager_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
 
 alter table \`author_to_friend\` add constraint \`author_to_friend_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
@@ -914,6 +934,12 @@ alter table \`user2\` add index \`user2_first_name_index\`(\`first_name\`);
 alter table \`user2\` add index \`user2_last_name_index\`(\`last_name\`);
 alter table \`user2\` add primary key \`user2_pkey\`(\`first_name\`, \`last_name\`);
 
+create table \`base_user2\` (\`id\` int unsigned not null auto_increment primary key, \`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`type\` enum('employee', 'manager', 'owner') not null, \`employee_prop\` int(11) null, \`manager_prop\` varchar(255) null, \`owner_prop\` varchar(255) null, \`favourite_employee_id\` int(11) unsigned null, \`favourite_manager_id\` int(11) unsigned null) default character set utf8 engine = InnoDB;
+alter table \`base_user2\` add index \`base_user2_type_index\`(\`type\`);
+alter table \`base_user2\` add index \`base_user2_favourite_employee_id_index\`(\`favourite_employee_id\`);
+alter table \`base_user2\` add index \`base_user2_favourite_manager_id_index\`(\`favourite_manager_id\`);
+alter table \`base_user2\` add unique \`base_user2_favourite_manager_id_unique\`(\`favourite_manager_id\`);
+
 create table \`author_to_friend\` (\`author2_1_id\` int(11) unsigned not null, \`author2_2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table \`author_to_friend\` add index \`author_to_friend_author2_1_id_index\`(\`author2_1_id\`);
 alter table \`author_to_friend\` add index \`author_to_friend_author2_2_id_index\`(\`author2_2_id\`);
@@ -962,6 +988,9 @@ alter table \`configuration2\` add constraint \`configuration2_test_id_foreign\`
 
 alter table \`car_owner2\` add constraint \`car_owner2_car_name_foreign\` foreign key (\`car_name\`) references \`car2\` (\`name\`) on update cascade;
 alter table \`car_owner2\` add constraint \`car_owner2_car_year_foreign\` foreign key (\`car_year\`) references \`car2\` (\`year\`) on update cascade;
+
+alter table \`base_user2\` add constraint \`base_user2_favourite_employee_id_foreign\` foreign key (\`favourite_employee_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
+alter table \`base_user2\` add constraint \`base_user2_favourite_manager_id_foreign\` foreign key (\`favourite_manager_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
 
 alter table \`author_to_friend\` add constraint \`author_to_friend_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -8,7 +8,10 @@ import { MariaDbDriver } from '@mikro-orm/mariadb';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 
 import { Author, Book, BookTag, Publisher, Test } from './entities';
-import { Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, Test2, Label2, Configuration2, Address2, FooParam2, Car2, CarOwner2, User2 } from './entities-sql';
+import {
+  Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, Test2, Label2, Configuration2, Address2, FooParam2,
+  Car2, CarOwner2, User2, BaseUser2, Employee2, Manager2, CompanyOwner2,
+} from './entities-sql';
 import { BaseEntity2 } from './entities-sql/BaseEntity2';
 import { BaseEntity22 } from './entities-sql/BaseEntity22';
 import { FooBaz } from './entities/FooBaz';
@@ -51,7 +54,10 @@ export async function initORMMongo() {
 
 export async function initORMMySql<D extends MySqlDriver | MariaDbDriver = MySqlDriver>(type: 'mysql' | 'mariadb' = 'mysql') {
   let orm = await MikroORM.init<AbstractSqlDriver>({
-    entities: [Author2, Address2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, FooParam2, Configuration2, BaseEntity2, BaseEntity22, Car2, CarOwner2, User2],
+    entities: [
+      Author2, Address2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, FooParam2, Configuration2, BaseEntity2, BaseEntity22,
+      Car2, CarOwner2, User2, BaseUser2, Employee2, Manager2, CompanyOwner2,
+    ],
     discovery: { tsConfigPath: BASE_DIR + '/tsconfig.test.json' },
     clientUrl: `mysql://root@127.0.0.1:3306/mikro_orm_test`,
     port: type === 'mysql' ? 3307 : 3309,
@@ -172,6 +178,7 @@ export async function wipeDatabaseMySql(em: SqlEntityManager) {
   await em.createQueryBuilder(Configuration2).truncate().execute();
   await em.createQueryBuilder(Car2).truncate().execute();
   await em.createQueryBuilder(CarOwner2).truncate().execute();
+  await em.createQueryBuilder(BaseUser2).truncate().execute();
   await em.createQueryBuilder('author2_to_author2').truncate().execute();
   await em.createQueryBuilder('book2_to_book_tag2').truncate().execute();
   await em.createQueryBuilder('book_to_tag_unordered').truncate().execute();

--- a/tests/entities-sql/Address2.ts
+++ b/tests/entities-sql/Address2.ts
@@ -1,4 +1,4 @@
-import { Entity, Property, OneToOne, Index } from '@mikro-orm/core';
+import { Entity, Property, OneToOne } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
 @Entity()

--- a/tests/entities-sql/BaseUser2.ts
+++ b/tests/entities-sql/BaseUser2.ts
@@ -1,0 +1,39 @@
+import { AfterCreate, AfterUpdate, Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({
+  discriminatorColumn: 'type',
+  discriminatorMap: {
+    employee: 'Employee2',
+    manager: 'Manager2',
+    owner: 'CompanyOwner2',
+  },
+})
+export abstract class BaseUser2 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 100 })
+  firstName: string;
+
+  @Property({ length: 100 })
+  lastName: string;
+
+  baseState?: string;
+
+  constructor(firstName: string, lastName: string) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+  }
+
+  @AfterCreate()
+  afterCreate1() {
+    this.baseState = 'created';
+  }
+
+  @AfterUpdate()
+  afterUpdate1() {
+    this.baseState = 'updated';
+  }
+
+}

--- a/tests/entities-sql/CompanyOwner2.ts
+++ b/tests/entities-sql/CompanyOwner2.ts
@@ -1,0 +1,29 @@
+import { AfterCreate, AfterUpdate, Entity, ManyToOne, OneToOne, Property } from '@mikro-orm/core';
+import { Manager2 } from './Manager2';
+import { Employee2 } from './Employee2';
+
+@Entity()
+export class CompanyOwner2 extends Manager2 {
+
+  @Property()
+  ownerProp!: string;
+
+  @ManyToOne(() => Employee2)
+  favouriteEmployee?: Employee2;
+
+  @OneToOne(() => Manager2)
+  favouriteManager?: Manager2;
+
+  state?: string;
+
+  @AfterCreate()
+  afterCreate2() {
+    this.state = 'created';
+  }
+
+  @AfterUpdate()
+  afterUpdate2() {
+    this.state = 'updated';
+  }
+
+}

--- a/tests/entities-sql/Employee2.ts
+++ b/tests/entities-sql/Employee2.ts
@@ -1,0 +1,11 @@
+import { Entity, Property } from '@mikro-orm/core';
+import { BaseUser2 } from './BaseUser2';
+
+@Entity()
+export class Employee2 extends BaseUser2 {
+
+  @Property()
+  employeeProp!: number;
+
+}
+

--- a/tests/entities-sql/Manager2.ts
+++ b/tests/entities-sql/Manager2.ts
@@ -1,0 +1,10 @@
+import { Entity, Property } from '@mikro-orm/core';
+import { BaseUser2 } from './BaseUser2';
+
+@Entity()
+export class Manager2 extends BaseUser2 {
+
+  @Property()
+  managerProp!: string;
+
+}

--- a/tests/entities-sql/index.ts
+++ b/tests/entities-sql/index.ts
@@ -12,3 +12,7 @@ export * from './Address2';
 export * from './Car2';
 export * from './CarOwner2';
 export * from './User2';
+export * from './BaseUser2';
+export * from './Employee2';
+export * from './Manager2';
+export * from './CompanyOwner2';

--- a/tests/mysql-schema.sql
+++ b/tests/mysql-schema.sql
@@ -14,6 +14,7 @@ drop table if exists `configuration2`;
 drop table if exists `car2`;
 drop table if exists `car_owner2`;
 drop table if exists `user2`;
+drop table if exists `base_user2`;
 drop table if exists `author_to_friend`;
 drop table if exists `author2_to_author2`;
 drop table if exists `book2_to_book_tag2`;
@@ -85,6 +86,12 @@ alter table `user2` add index `user2_first_name_index`(`first_name`);
 alter table `user2` add index `user2_last_name_index`(`last_name`);
 alter table `user2` add primary key `user2_pkey`(`first_name`, `last_name`);
 
+create table `base_user2` (`id` int unsigned not null auto_increment primary key, `first_name` varchar(100) not null, `last_name` varchar(100) not null, `type` enum('employee', 'manager', 'owner') not null, `employee_prop` int(11) null, `manager_prop` varchar(255) null, `owner_prop` varchar(255) null, `favourite_employee_id` int(11) unsigned null, `favourite_manager_id` int(11) unsigned null) default character set utf8 engine = InnoDB;
+alter table `base_user2` add index `base_user2_type_index`(`type`);
+alter table `base_user2` add index `base_user2_favourite_employee_id_index`(`favourite_employee_id`);
+alter table `base_user2` add index `base_user2_favourite_manager_id_index`(`favourite_manager_id`);
+alter table `base_user2` add unique `base_user2_favourite_manager_id_unique`(`favourite_manager_id`);
+
 create table `author_to_friend` (`author2_1_id` int(11) unsigned not null, `author2_2_id` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table `author_to_friend` add index `author_to_friend_author2_1_id_index`(`author2_1_id`);
 alter table `author_to_friend` add index `author_to_friend_author2_2_id_index`(`author2_2_id`);
@@ -134,6 +141,9 @@ alter table `configuration2` add constraint `configuration2_test_id_foreign` for
 
 alter table `car_owner2` add constraint `car_owner2_car_name_foreign` foreign key (`car_name`) references `car2` (`name`) on update cascade;
 alter table `car_owner2` add constraint `car_owner2_car_year_foreign` foreign key (`car_year`) references `car2` (`year`) on update cascade;
+
+alter table `base_user2` add constraint `base_user2_favourite_employee_id_foreign` foreign key (`favourite_employee_id`) references `base_user2` (`id`) on update cascade on delete set null;
+alter table `base_user2` add constraint `base_user2_favourite_manager_id_foreign` foreign key (`favourite_manager_id`) references `base_user2` (`id`) on update cascade on delete set null;
 
 alter table `author_to_friend` add constraint `author_to_friend_author2_1_id_foreign` foreign key (`author2_1_id`) references `author2` (`id`) on update cascade on delete cascade;
 alter table `author_to_friend` add constraint `author_to_friend_author2_2_id_foreign` foreign key (`author2_2_id`) references `author2` (`id`) on update cascade on delete cascade;

--- a/tests/single-table-inheritance.mysql.test.ts
+++ b/tests/single-table-inheritance.mysql.test.ts
@@ -1,0 +1,151 @@
+import { Dictionary, MetadataDiscovery, MetadataStorage, MikroORM, ReferenceType, wrap } from '@mikro-orm/core';
+import { MySqlDriver } from '@mikro-orm/mysql';
+import { BaseUser2, CompanyOwner2, Employee2, Manager2 } from './entities-sql';
+import { initORMMySql, wipeDatabaseMySql } from './bootstrap';
+
+describe('single table inheritance in mysql', () => {
+
+  let orm: MikroORM<MySqlDriver>;
+
+  beforeAll(async () => orm = await initORMMySql());
+  beforeEach(async () => wipeDatabaseMySql(orm.em));
+
+  async function createEntities() {
+    const employee1 = new Employee2('Emp', '1');
+    employee1.employeeProp = 1;
+    const employee2 = new Employee2('Emp', '2');
+    employee2.employeeProp = 2;
+    const manager = new Manager2('Man', '3');
+    manager.managerProp = 'i am manager';
+    const owner = new CompanyOwner2('Bruce', 'Almighty');
+    owner.ownerProp = 'i am owner';
+    owner.managerProp = 'i said i am owner';
+    owner.favouriteEmployee = employee2;
+    owner.favouriteManager = manager;
+
+    expect((owner as any).type).not.toBeDefined();
+    await orm.em.persistAndFlush([owner, employee1]);
+    orm.em.clear();
+
+    expect(owner.state).toBe('created');
+    expect(owner.baseState).toBe('created');
+    expect((owner as any).type).not.toBeDefined();
+  }
+
+  test('check metadata', async () => {
+    expect(orm.getMetadata().get('BaseUser2').hooks).toEqual({
+      afterCreate: ['afterCreate1'],
+      afterUpdate: ['afterUpdate1'],
+    });
+    expect(orm.getMetadata().get('Employee2').hooks).toEqual({
+      afterCreate: ['afterCreate1'],
+      afterUpdate: ['afterUpdate1'],
+    });
+    expect(orm.getMetadata().get('Manager2').hooks).toEqual({
+      afterCreate: ['afterCreate1'],
+      afterUpdate: ['afterUpdate1'],
+    });
+    expect(orm.getMetadata().get('CompanyOwner2').hooks).toEqual({
+      afterCreate: ['afterCreate1', 'afterCreate2'],
+      afterUpdate: ['afterUpdate1', 'afterUpdate2'],
+    });
+  });
+
+  test('persisting and loading STI entities', async () => {
+    await createEntities();
+    const users = await orm.em.find(BaseUser2, {}, { orderBy: { lastName: 'asc', firstName: 'asc' } });
+    expect(users).toHaveLength(4);
+    expect(users[0]).toBeInstanceOf(Employee2);
+    expect(users[1]).toBeInstanceOf(Employee2);
+    expect(users[2]).toBeInstanceOf(Manager2);
+    expect(users[3]).toBeInstanceOf(CompanyOwner2);
+    expect((users[3] as CompanyOwner2).favouriteEmployee).toBeInstanceOf(Employee2);
+    expect((users[3] as CompanyOwner2).favouriteManager).toBeInstanceOf(Manager2);
+    expect(users[0]).toEqual({
+      id: 2,
+      firstName: 'Emp',
+      lastName: '1',
+      employeeProp: 1,
+    });
+    expect((users[0] as any).type).not.toBeDefined();
+    expect(users[1]).toEqual({
+      id: 1,
+      firstName: 'Emp',
+      lastName: '2',
+      employeeProp: 2,
+    });
+    expect(users[2]).toEqual({
+      id: 3,
+      firstName: 'Man',
+      lastName: '3',
+      managerProp: 'i am manager',
+    });
+    expect(users[3]).toEqual({
+      id: 4,
+      firstName: 'Bruce',
+      lastName: 'Almighty',
+      managerProp: 'i said i am owner',
+      ownerProp: 'i am owner',
+      favouriteEmployee: users[1],
+      favouriteManager: users[2],
+    });
+
+    expect(Object.keys(orm.em.getUnitOfWork().getIdentityMap())).toEqual(['BaseUser2-2', 'BaseUser2-1', 'BaseUser2-3', 'BaseUser2-4']);
+
+    const o = await orm.em.findOneOrFail(CompanyOwner2, 4);
+    expect(o.state).toBeUndefined();
+    expect(o.baseState).toBeUndefined();
+    o.firstName = 'Changed';
+    await orm.em.flush();
+    expect(o.state).toBe('updated');
+    expect(o.baseState).toBe('updated');
+  });
+
+  test('STI in m:1 and 1:1 relations', async () => {
+    await createEntities();
+    const owner = await orm.em.findOneOrFail(CompanyOwner2, { firstName: 'Bruce' });
+    expect(owner).toBeInstanceOf(CompanyOwner2);
+    expect(owner.favouriteEmployee).toBeInstanceOf(Employee2);
+    expect(wrap(owner.favouriteEmployee).isInitialized()).toBe(false);
+    await wrap(owner.favouriteEmployee).init();
+    expect(wrap(owner.favouriteEmployee).isInitialized()).toBe(true);
+    expect(owner.favouriteManager).toBeInstanceOf(Manager2);
+    expect(wrap(owner.favouriteManager).isInitialized()).toBe(false);
+    await wrap(owner.favouriteManager).init();
+    expect(wrap(owner.favouriteManager).isInitialized()).toBe(true);
+  });
+
+  test('generated discriminator map', async () => {
+    const storage = new MetadataStorage({
+      A: { name: 'A', className: 'A', primaryKeys: ['id'], discriminatorColumn: 'type', properties: { id: { name: 'id', type: 'string', reference: ReferenceType.SCALAR } } },
+      B: { name: 'B', className: 'B', primaryKeys: ['id'], extends: 'A', properties: { id: { name: 'id', type: 'string', reference: ReferenceType.SCALAR } } },
+      C: { name: 'C', className: 'C', primaryKeys: ['id'], extends: 'A', properties: { id: { name: 'id', type: 'string', reference: ReferenceType.SCALAR } } },
+    } as Dictionary);
+    class A {
+
+      toJSON(a: string, b: string) {
+        //
+      }
+
+    }
+    class B {}
+    class C {}
+    orm.config.set('entities', [A, B, C]);
+    const discovery = new MetadataDiscovery(storage, orm.em.getDriver().getPlatform(), orm.config);
+    const discovered = await discovery.discover();
+    expect(discovered.get('A').discriminatorMap).toEqual({ a: 'A', b: 'B', c: 'C' });
+    expect(discovered.get('A').properties.type).toMatchObject({
+      name: 'type',
+      enum: true,
+      type: 'string',
+      index: true,
+      items: ['a', 'b', 'c'],
+    });
+    expect(discovered.get('A').discriminatorValue).toBe('a');
+    expect(discovered.get('B').discriminatorValue).toBe('b');
+    expect(discovered.get('C').discriminatorValue).toBe('c');
+  });
+
+  afterAll(async () => orm.close(true));
+
+});


### PR DESCRIPTION
```typescript
@Entity({
  discriminatorColumn: 'discr',
  discriminatorMap: { person: 'Person', employee: 'Employee' },
})
export class Person {
  // ...
}

@Entity()
export class Employee extends Person {
  // ...
}
```

Closes #33