### PR TITLE
feat(mapping): add support for embeddables

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@ discuss specifics.
 - [x] Single table inheritance ([#33](https://github.com/mikro-orm/mikro-orm/issues/33))
 - [x] Allow adding items to not initialized collections
 - [x] Use absolute path to entity file in static MetadataStorage keys (fix for 'Multiple property decorators' validation issues)
-- [ ] Embedded entities (allow in-lining child entity into parent one with prefixed keys, or maybe as serialized JSON)
+- [x] Embedded entities (allow in-lining child entity into parent one with prefixed keys)
 - [ ] Association scopes/filters ([hibernate docs](https://docs.jboss.org/hibernate/orm/3.6/reference/en-US/html/filters.html))
 - [ ] Support external hooks when using EntitySchema (hooks outside of entity)
 - [ ] Support multiple M:N with same properties without manually specifying `pivotTable`

--- a/docs/docs/embeddables.md
+++ b/docs/docs/embeddables.md
@@ -1,0 +1,103 @@
+---
+title: Separating Concerns using Embeddables
+sidebar_label: Embeddables
+---
+
+> Support for embeddables was added in version 4.0
+
+Embeddables are classes which are not entities themselves, but are embedded in 
+entities and can also be queried. You'll mostly want to use them to reduce 
+duplication or separating concerns. Value objects such as date range or address 
+are the primary use case for this feature.
+
+> Embeddables needs to be discovered just like regular entities, don't forget to 
+> add them to the list of entities when initializing the ORM.
+
+Embeddables can only contain properties with basic `@Property()` mapping.
+
+For the purposes of this tutorial, we will assume that you have a `User` class in 
+your application and you would like to store an address in the `User` class. We will 
+model the `Address` class as an embeddable instead of simply adding the respective 
+columns to the `User` class.
+
+```typescript
+@Entity()
+export class User {
+
+  @Embedded()
+  address!: Address;
+
+}
+
+@Embeddable()
+export class Address {
+  
+  @Property()
+  street!: string;
+
+  @Property()
+  postalCode!: string;
+
+  @Property()
+  city!: string;
+
+  @Property()
+  country!: string;
+
+}
+```
+
+> When using ReflectMetadataProvider, you might need to provide the class in decorator options:
+> `@Embedded(() => Address)` or `@Embedded({ entity: () => Address })`.
+
+In terms of your database schema, MikroORM will automatically inline all columns from 
+the `Address` class into the table of the `User` class, just as if you had declared 
+them directly there.
+
+## Initializing embeddables
+
+In case all fields in the embeddable are nullable, you might want to initialize the 
+embeddable, to avoid getting a null value instead of the embedded object.
+
+```typescript
+@Embedded()
+address = new Address();
+```
+
+## Column Prefixing
+
+By default, MikroORM names your columns by prefixing them, using the value object name.
+
+Following the example above, your columns would be named as `address_street`, 
+`address_postal_code`...
+
+You can change this behaviour to meet your needs by changing the `prefix` attribute 
+in the `@Embedded()` notation.
+
+The following example shows you how to set your prefix to `myPrefix_`:
+
+```typescript
+@Entity()
+export class User {
+
+  @Embedded({ prefix: 'myPrefix_' })
+  address!: Address;
+
+}
+```
+
+To have MikroORM drop the prefix and use the value object's property name directly, 
+set `prefix: false`:
+
+```typescript
+@Entity()
+export class User {
+
+  @Embedded({ entity: () => Address, prefix: false })
+  address!: Address;
+
+}
+```
+
+> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/embeddables.html)
+> as the behaviour here is pretty much the same.

--- a/packages/core/src/decorators/Embeddable.ts
+++ b/packages/core/src/decorators/Embeddable.ts
@@ -1,0 +1,13 @@
+import { AnyEntity } from '../typings';
+import { MetadataStorage } from '../metadata';
+
+export function Embeddable(): Function {
+  return function <T extends { new(...args: any[]): AnyEntity<T> }>(target: T) {
+    const meta = MetadataStorage.getMetadataFromDecorator(target);
+    meta.class = target;
+    meta.name = target.name;
+    meta.embeddable = true;
+
+    return target;
+  };
+}

--- a/packages/core/src/decorators/Embedded.ts
+++ b/packages/core/src/decorators/Embedded.ts
@@ -1,0 +1,21 @@
+import { AnyEntity, EntityProperty } from '../typings';
+import { MetadataStorage } from '../metadata';
+import { ReferenceType } from '../entity/enums';
+import { Utils } from '../utils';
+
+export function Embedded(options: EmbeddedOptions | (() => AnyEntity) = {}): Function {
+  return function (target: AnyEntity, propertyName: string) {
+    const meta = MetadataStorage.getMetadataFromDecorator(target.constructor);
+    options = options instanceof Function ? { entity: options } : options;
+    Utils.defaultValue(options, 'prefix', true);
+    const property = { name: propertyName, reference: ReferenceType.EMBEDDED } as EntityProperty;
+    meta.properties[propertyName] = Object.assign(property, options);
+  };
+}
+
+export type EmbeddedOptions = {
+  entity?: string | (() => AnyEntity);
+  type?: string;
+  prefix?: string | boolean;
+  nullable?: boolean;
+};

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -8,4 +8,6 @@ export * from './Property';
 export * from './Enum';
 export * from './Indexed';
 export * from './Repository';
+export * from './Embeddable';
+export * from './Embedded';
 export * from './hooks';

--- a/packages/core/src/entity/EntityHelper.ts
+++ b/packages/core/src/entity/EntityHelper.ts
@@ -36,6 +36,10 @@ export class EntityHelper {
   }
 
   static decorate<T extends AnyEntity<T>>(meta: EntityMetadata<T>, em: EntityManager): void {
+    if (meta.embeddable) {
+      return;
+    }
+
     const pk = meta.properties[meta.primaryKeys[0]];
 
     if (pk.name === '_id') {

--- a/packages/core/src/entity/enums.ts
+++ b/packages/core/src/entity/enums.ts
@@ -4,6 +4,7 @@ export enum ReferenceType {
   ONE_TO_MANY = '1:m',
   MANY_TO_ONE = 'm:1',
   MANY_TO_MANY = 'm:n',
+  EMBEDDED = 'embedded',
 }
 
 export enum Cascade {

--- a/packages/core/src/hydration/Hydrator.ts
+++ b/packages/core/src/hydration/Hydrator.ts
@@ -15,11 +15,15 @@ export abstract class Hydrator {
       meta = metadata.get(entity.constructor.name);
     }
 
-    for (const prop of Object.values<EntityProperty>(meta.properties).filter(prop => !prop.inherited && root.discriminatorColumn !== prop.name)) {
-      this.hydrateProperty(entity, prop, data[prop.name], newEntity);
+    const props = Object.values<EntityProperty>(meta.properties).filter(prop => {
+      return !prop.inherited && root.discriminatorColumn !== prop.name && !prop.embedded;
+    });
+
+    for (const prop of props) {
+      this.hydrateProperty(entity, prop, data, newEntity);
     }
   }
 
-  protected abstract hydrateProperty<T extends AnyEntity<T>>(entity: T, prop: EntityProperty, value: EntityData<T>[any], newEntity: boolean): void;
+  protected abstract hydrateProperty<T extends AnyEntity<T>>(entity: T, prop: EntityProperty, value: EntityData<T>, newEntity: boolean): void;
 
 }

--- a/packages/core/src/metadata/MetadataValidator.ts
+++ b/packages/core/src/metadata/MetadataValidator.ts
@@ -9,7 +9,7 @@ export class MetadataValidator {
     const meta = metadata.get(name);
 
     // entities have PK
-    if (!meta.primaryKeys || meta.primaryKeys.length === 0) {
+    if (!meta.embeddable && (!meta.primaryKeys || meta.primaryKeys.length === 0)) {
       throw ValidationError.fromMissingPrimaryKey(meta);
     }
 

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -19,7 +19,7 @@ export type DeepPartialEntity<T> = {
       ? readonly DeepPartialEntity<U>[]
       : T extends Date | RegExp
         ? T
-        : DeepPartialEntity<T[P]> | PartialEntity<T[P]> | Primary<T[P]>)
+        : DeepPartialEntity<T[P]> | PartialEntity<T[P]> | Primary<T[P]> | OperatorMap<T[P]> | StringProp<T[P]>)
 };
 
 export const PrimaryKeyType = Symbol('PrimaryKeyType');
@@ -55,7 +55,7 @@ export type StringProp<T> = T extends string ? string | RegExp : never;
 export type EntityOrPrimary<T> = true extends IsScalar<T> ? never : DeepPartialEntity<ReferencedEntity<T>> | PartialEntity<ReferencedEntity<T>> | Primary<ReferencedEntity<T>> | ReferencedEntity<T>;
 export type CollectionItem<T> = T extends Collection<infer K> ? EntityOrPrimary<K> : never;
 export type ReferencedEntity<T> = T extends Reference<infer K> ? K : T;
-export type FilterValue<T> =  T | OperatorMap<T> | StringProp<T> | OneOrArray<CollectionItem<T> | EntityOrPrimary<T>> | null;
+export type FilterValue<T> = T | OperatorMap<T> | StringProp<T> | OneOrArray<CollectionItem<T> | EntityOrPrimary<T>> | null;
 export type Query<T> = true extends IsEntity<T>
   ? { [K in keyof T]?: Query<ReferencedEntity<T[K]>> | FilterValue<ReferencedEntity<T[K]>> | null } | FilterValue<ReferencedEntity<T>>
   : T extends Collection<infer K>
@@ -109,6 +109,10 @@ export interface EntityProperty<T extends AnyEntity<T> = any> {
   wrappedReference?: boolean;
   fieldNames: string[];
   default?: any;
+  prefix?: string | boolean;
+  embedded?: [string, string];
+  embeddable: Constructor<T>;
+  embeddedProps: Dictionary<EntityProperty>;
   index?: boolean | string;
   unique?: boolean | string;
   nullable?: boolean;
@@ -152,6 +156,7 @@ export interface EntityMetadata<T extends AnyEntity<T> = any> {
   discriminatorColumn?: string;
   discriminatorValue?: string;
   discriminatorMap?: Dictionary<string>;
+  embeddable: boolean;
   constructorParams: string[];
   toJsonParams: string[];
   extends: string;

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -13,6 +13,7 @@ import { MetadataStorage } from '../metadata';
 import { AnyEntity, Dictionary, EntityData, EntityMetadata, EntityProperty, Primary } from '../typings';
 import { ArrayCollection, Collection, Reference, ReferenceType, wrap } from '../entity';
 import { Platform } from '../platforms';
+import { GroupOperator, QueryOperator } from '../enums';
 
 export class Utils {
 
@@ -147,6 +148,12 @@ export class Utils {
     Object.values<EntityProperty<T>>(meta.properties).forEach(prop => {
       if (Utils.shouldIgnoreProperty(entity, prop, root)) {
         return;
+      }
+
+      if (prop.reference === ReferenceType.EMBEDDED) {
+        return Object.values<EntityProperty>(meta.properties).filter(p => p.embedded?.[0] === prop.name).forEach(childProp => {
+          ret[childProp.name as keyof T] = entity[prop.name][childProp.embedded![1]];
+        });
       }
 
       if (Utils.isEntity(entity[prop.name], true)) {
@@ -590,6 +597,14 @@ export class Utils {
 
   static flatten<T>(arrays: T[][]): T[] {
     return ([] as T[]).concat.apply([], arrays);
+  }
+
+  static isOperator(key: string, includeGroupOperators = true): boolean {
+    if (!includeGroupOperators) {
+      return !!QueryOperator[key];
+    }
+
+    return !!GroupOperator[key] || !!QueryOperator[key];
   }
 
 }

--- a/packages/core/src/utils/ValidationError.ts
+++ b/packages/core/src/utils/ValidationError.ts
@@ -167,6 +167,10 @@ export class ValidationError<T extends AnyEntity = AnyEntity> extends Error {
     return new ValidationError(`Composite key required for entity ${meta.className}.`);
   }
 
+  static cannotUseOperatorsInsideEmbeddables(className: string, propName: string, payload: Dictionary): ValidationError {
+    return new ValidationError(`Using operators inside embeddables is not allowed, move the operator above. (property: ${className}.${propName}, payload: ${inspect(payload)})`);
+  }
+
   private static fromMessage(meta: EntityMetadata, prop: EntityProperty, message: string): ValidationError {
     return new ValidationError(`${meta.className}.${prop.name} ${message}`);
   }

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -4,7 +4,7 @@ import {
   Configuration, Utils, Collection, FindOneOptions, FindOptions, ReferenceType, wrap, DatabaseDriver, QueryResult,
   Transaction, EntityManager, IDatabaseDriver, EntityManagerType, LockMode,
 } from '@mikro-orm/core';
-import { AbstractSqlConnection, AbstractSqlPlatform, QueryBuilder, QueryBuilderHelper } from './index';
+import { AbstractSqlConnection, AbstractSqlPlatform, QueryBuilder } from './index';
 import { SqlEntityManager } from './SqlEntityManager';
 
 export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = AbstractSqlConnection> extends DatabaseDriver<C> {
@@ -159,7 +159,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     const meta = this.metadata.get(prop.type);
     const cond = { [`${prop.pivotTable}.${pivotProp2.name}`]: { $in: meta.compositePK ? owners : owners.map(o => o[0]) } };
 
-    if (!Utils.isEmpty(where) && Object.keys(where as Dictionary).every(k => QueryBuilderHelper.isOperator(k, false))) {
+    if (!Utils.isEmpty(where) && Object.keys(where as Dictionary).every(k => Utils.isOperator(k, false))) {
       where = cond;
     } else {
       where = { ...where, ...cond };

--- a/packages/knex/src/query/CriteriaNode.ts
+++ b/packages/knex/src/query/CriteriaNode.ts
@@ -23,7 +23,7 @@ export class CriteriaNode {
       Utils.splitPrimaryKeys(key).forEach(k => {
         this.prop = meta.properties[k];
 
-        if (validate && !this.prop && !k.includes('.') && !QueryBuilderHelper.isOperator(k) && !QueryBuilderHelper.isCustomExpression(k)) {
+        if (validate && !this.prop && !k.includes('.') && !Utils.isOperator(k) && !QueryBuilderHelper.isCustomExpression(k)) {
           throw new Error(`Trying to query by not existing property ${entityName}.${k}`);
         }
       });
@@ -58,7 +58,7 @@ export class CriteriaNode {
     const composite = this.prop && this.prop.joinColumns ? this.prop.joinColumns.length > 1 : false;
     const customExpression = QueryBuilderHelper.isCustomExpression(this.key!);
     const scalar = Utils.isPrimaryKey(payload) || payload instanceof RegExp || payload instanceof Date || customExpression;
-    const operator = Utils.isObject(payload) && Object.keys(payload).every(k => QueryBuilderHelper.isOperator(k, false));
+    const operator = Utils.isObject(payload) && Object.keys(payload).every(k => Utils.isOperator(k, false));
 
     if (composite) {
       return true;

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -2,7 +2,7 @@ import Knex, { JoinClause, QueryBuilder as KnexQueryBuilder, Raw } from 'knex';
 import { inspect } from 'util';
 import {
   Utils, ValidationError, Dictionary, EntityMetadata, EntityProperty, FlatQueryOrderMap, QueryOrderNumeric,
-  Platform, ReferenceType, LockMode, MetadataStorage, QueryOperator, GroupOperator,
+  Platform, ReferenceType, LockMode, MetadataStorage, QueryOperator,
 } from '@mikro-orm/core';
 import { QueryType } from './enums';
 import { JoinOptions } from './QueryBuilder';
@@ -448,14 +448,6 @@ export class QueryBuilderHelper {
     }
 
     qb.update(versionProperty.fieldNames[0], this.knex.raw(sql));
-  }
-
-  static isOperator(key: string, includeGroupOperators = true): boolean {
-    if (!includeGroupOperators) {
-      return !!QueryOperator[key];
-    }
-
-    return !!GroupOperator[key] || !!QueryOperator[key];
   }
 
   static isCustomExpression(field: string): boolean {

--- a/packages/knex/src/schema/SchemaGenerator.ts
+++ b/packages/knex/src/schema/SchemaGenerator.ts
@@ -42,7 +42,7 @@ export class SchemaGenerator {
   }
 
   async getCreateSchemaSQL(wrap = true): Promise<string> {
-    const metadata = Object.values(this.metadata.getAll()).filter(meta => !meta.discriminatorValue);
+    const metadata = Object.values(this.metadata.getAll()).filter(meta => !meta.discriminatorValue && !meta.embeddable);
     let ret = '';
 
     for (const meta of metadata) {

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -1,7 +1,7 @@
 import { ClientSession, ObjectId } from 'mongodb';
 import {
   DatabaseDriver, EntityData, AnyEntity, FilterQuery, EntityMetadata, EntityProperty, Configuration, Utils, ReferenceType,
-  FindOneOptions, FindOptions, QueryResult, Transaction, IDatabaseDriver, EntityManager, EntityManagerType, Dictionary,
+  FindOneOptions, FindOptions, QueryResult, Transaction, IDatabaseDriver, EntityManager, EntityManagerType, Dictionary, ValidationError,
 } from '@mikro-orm/core';
 import { MongoConnection } from './MongoConnection';
 import { MongoPlatform } from './MongoPlatform';
@@ -160,10 +160,39 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     })];
   }
 
+  private inlineEmbeddables<T>(meta: EntityMetadata<T>, data: T): void {
+    Object.keys(data).forEach(k => {
+      if (Utils.isOperator(k)) {
+        Utils.asArray(data[k]).forEach(payload => this.inlineEmbeddables(meta, payload));
+      }
+    });
+
+    Object.values<EntityProperty>(meta.properties).forEach(prop => {
+      if (prop.reference === ReferenceType.EMBEDDED && Utils.isObject(data[prop.name])) {
+        const props = prop.embeddedProps;
+
+        Object.keys(data[prop.name]).forEach(kk => {
+          const operator = Object.keys(data[prop.name]).some(f => Utils.isOperator(f));
+
+          if (operator) {
+            throw ValidationError.cannotUseOperatorsInsideEmbeddables(meta.name, prop.name, data);
+          }
+
+          data[props[kk].name] = data[prop.name][props[kk].embedded![1]];
+        });
+        delete data[prop.name];
+      }
+    });
+  }
+
   private renameFields<T>(entityName: string, data: T): T {
     data = Object.assign({}, data); // copy first
     Utils.renameKey(data, 'id', '_id');
     const meta = this.metadata.get(entityName, false, false);
+
+    if (meta) {
+      this.inlineEmbeddables(meta, data);
+    }
 
     Object.keys(data).forEach(k => {
       if (meta?.properties[k]) {

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -8,7 +8,6 @@ import { AuthorRepository } from './repositories/AuthorRepository';
 import { initORMMongo, wipeDatabase } from './bootstrap';
 import FooBar from './entities/FooBar';
 import { FooBaz } from './entities/FooBaz';
-import { Author2, Book2, BookTag2 } from './entities-sql';
 
 describe('EntityManagerMongo', () => {
 

--- a/tests/__snapshots__/embedded-entities.mysql.test.ts.snap
+++ b/tests/__snapshots__/embedded-entities.mysql.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`embedded entities in mysql schema: embeddables 1`] = `
+"create table \`user\` (\`id\` int unsigned not null auto_increment primary key, \`address1_street\` varchar(255) not null, \`address1_postal_code\` varchar(255) not null, \`address1_city\` varchar(255) not null, \`address1_country\` varchar(255) not null, \`addr_street\` varchar(255) null, \`addr_postal_code\` varchar(255) null, \`addr_city\` varchar(255) null, \`addr_country\` varchar(255) null, \`street\` varchar(255) not null, \`postal_code\` varchar(255) not null, \`city\` varchar(255) not null, \`country\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+
+"
+`;

--- a/tests/embedded-entities.mongo.test.ts
+++ b/tests/embedded-entities.mongo.test.ts
@@ -1,0 +1,190 @@
+import { Embeddable, Embedded, Entity, Logger, MikroORM, PrimaryKey, Property, ReferenceType, SerializedPrimaryKey } from '@mikro-orm/core';
+import { ObjectId, MongoDriver } from '@mikro-orm/mongodb';
+
+@Embeddable()
+class Address1 {
+
+  @Property()
+  street?: string;
+
+  @Property()
+  postalCode?: string;
+
+  @Property()
+  city?: string;
+
+  @Property()
+  country?: string;
+
+  constructor(street?: string, postalCode?: string, city?: string, country?: string) {
+    this.street = street;
+    this.postalCode = postalCode;
+    this.city = city;
+    this.country = country;
+  }
+
+}
+
+@Embeddable()
+class Address2 {
+
+  @Property()
+  street!: string;
+
+  @Property()
+  postalCode?: string;
+
+  @Property()
+  city!: string;
+
+  @Property()
+  country!: string;
+
+  constructor(street: string, city: string, country: string, postalCode?: string) {
+    this.street = street;
+    this.city = city;
+    this.country = country;
+    this.postalCode = postalCode;
+  }
+
+}
+
+@Entity()
+class User {
+
+  @PrimaryKey({ type: 'ObjectId' })
+  _id!: ObjectId;
+
+  @SerializedPrimaryKey()
+  id!: string;
+
+  @Embedded(() => Address1)
+  address1!: Address1;
+
+  @Embedded( { entity: () => Address2, prefix: 'addr_', nullable: true })
+  address2?: Address2;
+
+  @Embedded( { entity: () => Address1, prefix: false })
+  address3 = new Address1();
+
+}
+
+describe('embedded entities in mongo', () => {
+
+  let orm: MikroORM<MongoDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Address1, Address2, User],
+      clientUrl: 'mongodb://localhost:27017,localhost:27018,localhost:27019/mikro-orm-test-embeddables?replicaSet=rs0',
+      type: 'mongo',
+      cache: { enabled: false },
+    });
+  });
+
+  afterAll(async () => {
+    await orm.em.getDriver().dropCollections();
+    await orm.close(true);
+  });
+
+  test('metadata', async () => {
+    expect(orm.getMetadata().get('Address1').embeddable).toBe(true);
+    expect(orm.getMetadata().get('Address1').properties).toMatchObject({
+      street: { name: 'street', type: 'string' },
+      postalCode: { name: 'postalCode', type: 'string' },
+      city: { name: 'city', type: 'string' },
+      country: { name: 'country', type: 'string' },
+    });
+    expect(orm.getMetadata().get('User').properties.address1).toMatchObject({
+      name: 'address1',
+      reference: ReferenceType.EMBEDDED,
+      type: 'Address1',
+    });
+    expect(orm.getMetadata().get('User').properties.address1_street).toMatchObject({
+      name: 'address1_street',
+      reference: ReferenceType.SCALAR,
+      type: 'string',
+    });
+    expect(orm.getMetadata().get('User').properties.address2).toMatchObject({
+      name: 'address2',
+      reference: ReferenceType.EMBEDDED,
+      type: 'Address2',
+    });
+    expect(orm.getMetadata().get('User').properties.addr_street).toMatchObject({
+      name: 'addr_street',
+      reference: ReferenceType.SCALAR,
+      type: 'string',
+      nullable: true,
+    });
+    expect(orm.getMetadata().get('User').properties.address3).toMatchObject({
+      name: 'address3',
+      reference: ReferenceType.EMBEDDED,
+      type: 'Address1',
+    });
+    expect(orm.getMetadata().get('User').properties.street).toMatchObject({
+      name: 'street',
+      reference: ReferenceType.SCALAR,
+      type: 'string',
+    });
+  });
+
+  test('persist and load', async () => {
+    const user = new User();
+    user.address1 = new Address1('Downing street 10', '123', 'London 1', 'UK 1');
+    user.address2 = new Address2('Downing street 11', 'London 2', 'UK 2');
+    user.address3 = new Address1('Downing street 12', '789', 'London 3', 'UK 3');
+
+    const mock = jest.fn();
+    const logger = new Logger(mock, true);
+    Object.assign(orm.config, { logger });
+    orm.config.set('highlight', false);
+    await orm.em.persistAndFlush(user);
+    orm.em.clear();
+    expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('user').insertOne({ address1_street: 'Downing street 10', address1_postalCode: '123', address1_city: 'London 1', address1_country: 'UK 1', addr_street: 'Downing street 11', addr_postalCode: undefined, addr_city: 'London 2', addr_country: 'UK 2', street: 'Downing street 12', postalCode: '789', city: 'London 3', country: 'UK 3' }, { session: undefined });`);
+
+    const u = await orm.em.findOneOrFail(User, user.id);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('user'\)\.find\({ _id: .* }, { session: undefined }\)\.limit\(1\).toArray\(\);/);
+    expect(u.address1).toBeInstanceOf(Address1);
+    expect(u.address1).toEqual({
+      street: 'Downing street 10',
+      postalCode: '123',
+      city: 'London 1',
+      country: 'UK 1',
+    });
+    expect(u.address2).toBeInstanceOf(Address2);
+    expect(u.address2).toEqual({
+      street: 'Downing street 11',
+      postalCode: null,
+      city: 'London 2',
+      country: 'UK 2',
+    });
+    expect(u.address3).toBeInstanceOf(Address1);
+    expect(u.address3).toEqual({
+      street: 'Downing street 12',
+      postalCode: '789',
+      city: 'London 3',
+      country: 'UK 3',
+    });
+
+    u.address2!.postalCode = '111';
+    await orm.em.flush();
+    expect(mock.mock.calls[2][0]).toMatch(/db\.getCollection\('user'\)\.updateMany\({ _id: .* }, { '\$set': { addr_postalCode: '111' } }, { session: undefined }\);/);
+    orm.em.clear();
+
+    const u1 = await orm.em.findOneOrFail(User, { address1: { city: 'London 1', postalCode: '123' } });
+    expect(mock.mock.calls[3][0]).toMatch(/db\.getCollection\('user'\)\.find\({ address1_city: 'London 1', address1_postalCode: '123' }, { session: undefined }\)\.limit\(1\).toArray\(\);/);
+    expect(u1.address1.city).toBe('London 1');
+    expect(u1.address1.postalCode).toBe('123');
+    const u2 = await orm.em.findOneOrFail(User, { address1: { city: /^London/ } });
+    expect(mock.mock.calls[4][0]).toMatch(/db\.getCollection\('user'\)\.find\({ address1_city: \/\^London\/ }, { session: undefined }\)\.limit\(1\).toArray\(\);/);
+    expect(u2.address1.city).toBe('London 1');
+    expect(u2.address1.postalCode).toBe('123');
+    expect(u2).toBe(u1);
+    const u3 = await orm.em.findOneOrFail(User, { $or: [{ address1: { city: 'London 1' } }, { address1: { city: 'Berlin' } }] });
+    expect(mock.mock.calls[5][0]).toMatch(/db\.getCollection\('user'\)\.find\({ '\$or': \[ { address1_city: 'London 1' }, { address1_city: 'Berlin' } ] }, { session: undefined }\)\.limit\(1\).toArray\(\);/);
+    expect(u3).toBe(u1);
+    const err = `Using operators inside embeddables is not allowed, move the operator above. (property: User.address1, payload: { address1: { '$or': [ [Object], [Object] ] } })`;
+    await expect(orm.em.findOneOrFail(User, { address1: { $or: [{ city: 'London 1' }, { city: 'Berlin' }] } })).rejects.toThrowError(err);
+  });
+
+});

--- a/tests/embedded-entities.mysql.test.ts
+++ b/tests/embedded-entities.mysql.test.ts
@@ -1,0 +1,228 @@
+import { Embeddable, Embedded, Entity, Logger, MikroORM, PrimaryKey, Property, ReferenceType, wrap } from '@mikro-orm/core';
+import { MySqlDriver } from '@mikro-orm/mysql';
+
+@Embeddable()
+class Address1 {
+
+  @Property()
+  street?: string;
+
+  @Property()
+  postalCode?: string;
+
+  @Property()
+  city?: string;
+
+  @Property()
+  country?: string;
+
+  constructor(street?: string, postalCode?: string, city?: string, country?: string) {
+    this.street = street;
+    this.postalCode = postalCode;
+    this.city = city;
+    this.country = country;
+  }
+
+}
+
+@Embeddable()
+class Address2 {
+
+  @Property()
+  street!: string;
+
+  @Property()
+  postalCode?: string;
+
+  @Property()
+  city!: string;
+
+  @Property()
+  country!: string;
+
+  constructor(street: string, city: string, country: string, postalCode?: string) {
+    this.street = street;
+    this.city = city;
+    this.country = country;
+    this.postalCode = postalCode;
+  }
+
+}
+
+@Entity()
+class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Embedded()
+  address1!: Address1;
+
+  @Embedded( { prefix: 'addr_', nullable: true })
+  address2?: Address2;
+
+  @Embedded( { prefix: false })
+  address3: Address1 = new Address1();
+
+}
+
+describe('embedded entities in mysql', () => {
+
+  let orm: MikroORM<MySqlDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Address1, Address2, User],
+      dbName: `mikro_orm_test_embeddables`,
+      type: 'mysql',
+      port: 3307,
+      cache: { enabled: false },
+    });
+    await orm.getSchemaGenerator().ensureDatabase();
+    await orm.getSchemaGenerator().createSchema();
+  });
+
+  afterAll(async () => {
+    await orm.getSchemaGenerator().dropSchema();
+    await orm.close(true);
+  });
+
+  test('metadata', async () => {
+    expect(orm.getMetadata().get('Address1').embeddable).toBe(true);
+    expect(orm.getMetadata().get('Address1').properties).toMatchObject({
+      street: { name: 'street', type: 'string' },
+      postalCode: { name: 'postalCode', type: 'string' },
+      city: { name: 'city', type: 'string' },
+      country: { name: 'country', type: 'string' },
+    });
+    expect(orm.getMetadata().get('User').properties.address1).toMatchObject({
+      name: 'address1',
+      reference: ReferenceType.EMBEDDED,
+      type: 'Address1',
+    });
+    expect(orm.getMetadata().get('User').properties.address1_street).toMatchObject({
+      name: 'address1_street',
+      reference: ReferenceType.SCALAR,
+      type: 'string',
+    });
+    expect(orm.getMetadata().get('User').properties.address2).toMatchObject({
+      name: 'address2',
+      reference: ReferenceType.EMBEDDED,
+      type: 'Address2',
+    });
+    expect(orm.getMetadata().get('User').properties.addr_street).toMatchObject({
+      name: 'addr_street',
+      reference: ReferenceType.SCALAR,
+      type: 'string',
+      nullable: true,
+    });
+    expect(orm.getMetadata().get('User').properties.address3).toMatchObject({
+      name: 'address3',
+      reference: ReferenceType.EMBEDDED,
+      type: 'Address1',
+    });
+    expect(orm.getMetadata().get('User').properties.street).toMatchObject({
+      name: 'street',
+      reference: ReferenceType.SCALAR,
+      type: 'string',
+    });
+  });
+
+  test('schema', async () => {
+    await expect(orm.getSchemaGenerator().getCreateSchemaSQL(false)).resolves.toMatchSnapshot('embeddables');
+  });
+
+  test('persist and load', async () => {
+    const user = new User();
+    user.address1 = new Address1('Downing street 10', '123', 'London 1', 'UK 1');
+    user.address2 = new Address2('Downing street 11', 'London 2', 'UK 2');
+    user.address3 = new Address1('Downing street 12', '789', 'London 3', 'UK 3');
+
+    const mock = jest.fn();
+    const logger = new Logger(mock, true);
+    Object.assign(orm.config, { logger });
+    orm.config.set('highlight', false);
+    await orm.em.persistAndFlush(user);
+    orm.em.clear();
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch('insert into `user` (`addr_city`, `addr_country`, `addr_postal_code`, `addr_street`, `address1_city`, `address1_country`, `address1_postal_code`, `address1_street`, `city`, `country`, `postal_code`, `street`) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
+    expect(mock.mock.calls[2][0]).toMatch('commit');
+
+    const u = await orm.em.findOneOrFail(User, user.id);
+    expect(mock.mock.calls[3][0]).toMatch('select `e0`.* from `user` as `e0` where `e0`.`id` = ? limit ?');
+    expect(u.address1).toBeInstanceOf(Address1);
+    expect(u.address1).toEqual({
+      street: 'Downing street 10',
+      postalCode: '123',
+      city: 'London 1',
+      country: 'UK 1',
+    });
+    expect(u.address2).toBeInstanceOf(Address2);
+    expect(u.address2).toEqual({
+      street: 'Downing street 11',
+      postalCode: null,
+      city: 'London 2',
+      country: 'UK 2',
+    });
+    expect(u.address3).toBeInstanceOf(Address1);
+    expect(u.address3).toEqual({
+      street: 'Downing street 12',
+      postalCode: '789',
+      city: 'London 3',
+      country: 'UK 3',
+    });
+
+    u.address2!.postalCode = '111';
+    await orm.em.flush();
+    expect(mock.mock.calls[4][0]).toMatch('begin');
+    expect(mock.mock.calls[5][0]).toMatch('update `user` set `addr_postal_code` = ? where `id` = ?');
+    expect(mock.mock.calls[6][0]).toMatch('commit');
+    orm.em.clear();
+
+    const u1 = await orm.em.findOneOrFail(User, { address1: { city: 'London 1', postalCode: '123' } });
+    expect(mock.mock.calls[7][0]).toMatch('select `e0`.* from `user` as `e0` where `e0`.`address1_city` = ? and `e0`.`address1_postal_code` = ? limit ?');
+    expect(u1.address1.city).toBe('London 1');
+    expect(u1.address1.postalCode).toBe('123');
+    const u2 = await orm.em.findOneOrFail(User, { address1: { city: /^London/ } });
+    expect(mock.mock.calls[8][0]).toMatch('select `e0`.* from `user` as `e0` where `e0`.`address1_city` like ? limit ?');
+    expect(u2.address1.city).toBe('London 1');
+    expect(u2.address1.postalCode).toBe('123');
+    expect(u2).toBe(u1);
+    const u3 = await orm.em.findOneOrFail(User, { $or: [{ address1: { city: 'London 1' } }, { address1: { city: 'Berlin' } }] });
+    expect(mock.mock.calls[8][0]).toMatch('select `e0`.* from `user` as `e0` where `e0`.`address1_city` like ? limit ?');
+    expect(u3).toBe(u1);
+    const err = `Using operators inside embeddables is not allowed, move the operator above. (property: User.address1, payload: { address1: { '$or': [ [Object], [Object] ] } })`;
+    await expect(orm.em.findOneOrFail(User, { address1: { $or: [{ city: 'London 1' }, { city: 'Berlin' }] } })).rejects.toThrowError(err);
+  });
+
+  test('assign', async () => {
+    const user = new User();
+    wrap(user).assign({
+      address1: { street: 'Downing street 10', postalCode: '123', city: 'London 1', country: 'UK 1' },
+      address2: { street: 'Downing street 11', city: 'London 2', country: 'UK 2' },
+      address3: { street: 'Downing street 12', postalCode: '789', city: 'London 3', country: 'UK 3' },
+    }, { em: orm.em });
+
+    expect(user.address1).toBeInstanceOf(Address1);
+    expect(user.address1).toEqual({
+      street: 'Downing street 10',
+      postalCode: '123',
+      city: 'London 1',
+      country: 'UK 1',
+    });
+    expect(user.address2).toBeInstanceOf(Address2);
+    expect(user.address2).toEqual({
+      street: 'Downing street 11',
+      city: 'London 2',
+      country: 'UK 2',
+    });
+    expect(user.address3).toBeInstanceOf(Address1);
+    expect(user.address3).toEqual({
+      street: 'Downing street 12',
+      postalCode: '789',
+      city: 'London 3',
+      country: 'UK 3',
+    });
+  });
+
+});


### PR DESCRIPTION
Embeddables are classes which are not entities themselves, but are embedded in entities.

```typescript
@Embeddable()
class Address {

  @Property()
  street!: string;

  @Property()
  city!: string;

  @Property()
  country!: string;

}

@entity()
class User {

  @PrimaryKey()
  id!: number;

  @Embedded(() => Address)
  address!: Address;

}
```