### PR TITLE
Add support for alternative loading strategies

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -3,7 +3,7 @@ import { v4 as uuid } from 'uuid';
 import { Configuration, RequestContext, Utils, ValidationError, SmartQueryHelper } from './utils';
 import { EntityAssigner, EntityFactory, EntityLoader, EntityRepository, EntityValidator, IdentifiedReference, Reference, ReferenceType, wrap } from './entity';
 import { LockMode, UnitOfWork } from './unit-of-work';
-import { IDatabaseDriver, FindOneOptions, FindOptions, EntityManagerType, PopulateOptions, Populate } from './drivers';
+import { IDatabaseDriver, FindOneOptions, FindOptions, EntityManagerType, Populate, PopulateOptions } from './drivers';
 import { EntityData, EntityMetadata, EntityName, AnyEntity, IPrimaryKey, FilterQuery, Primary, Dictionary } from './typings';
 import { QueryOrderMap } from './enums';
 import { MetadataStorage } from './metadata';

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -598,20 +598,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     if (Array.isArray(populate)) {
       return populate.map(field => {
         if (Utils.isString(field)) {
-          const relation = meta.properties[field];
-
-          // If no relation is found, we assume that the relation is invalid and don't attempt to get the strategy.
-          // By returning a field/relation that doesn't exist, validation code will handle that error upstream.
-          if (!relation) {
-            return {
-              field,
-            };
-          }
-
-          return {
-            field,
-            strategy: relation.strategy,
-          };
+          const strategy = meta.properties[field]?.strategy;
+          return { field, strategy };
         }
 
         return field;

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -3,7 +3,7 @@ import { v4 as uuid } from 'uuid';
 import { Configuration, RequestContext, Utils, ValidationError, SmartQueryHelper } from './utils';
 import { EntityAssigner, EntityFactory, EntityLoader, EntityRepository, EntityValidator, IdentifiedReference, Reference, ReferenceType, wrap } from './entity';
 import { LockMode, UnitOfWork } from './unit-of-work';
-import { IDatabaseDriver, FindOneOptions, FindOptions, EntityManagerType } from './drivers';
+import { IDatabaseDriver, FindOneOptions, FindOptions, EntityManagerType, PopulateOptions, Populate } from './drivers';
 import { EntityData, EntityMetadata, EntityName, AnyEntity, IPrimaryKey, FilterQuery, Primary, Dictionary } from './typings';
 import { QueryOrderMap } from './enums';
 import { MetadataStorage } from './metadata';
@@ -83,7 +83,9 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     this.validator.validateParams(where);
     const options = Utils.isObject<FindOptions>(populate) ? populate : { populate, orderBy, limit, offset };
     options.orderBy = options.orderBy || {};
-    const results = await this.driver.find<T>(entityName, where, { ...options, populate: this.preparePopulate(options.populate) }, this.transactionContext);
+    const preparedPopulate = this.preparePopulate(entityName, options.populate);
+    const opts = { ...options, populate: preparedPopulate };
+    const results = await this.driver.find<T>(entityName, where, opts, this.transactionContext);
 
     if (results.length === 0) {
       return [];
@@ -97,7 +99,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     const unique = Utils.unique(ret);
-    await this.entityLoader.populate<T>(entityName, unique, options.populate || [], where, options.orderBy, options.refresh);
+    await this.entityLoader.populate<T>(entityName, unique, preparedPopulate, where, options.orderBy, options.refresh);
 
     return unique;
   }
@@ -155,7 +157,10 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     this.validator.validateParams(where);
-    const data = await this.driver.findOne(entityName, where, { ...options, populate: this.preparePopulate(options.populate) }, this.transactionContext);
+    const preparedPopulate = this.preparePopulate(entityName, options.populate);
+    options.populate = preparedPopulate;
+
+    const data = await this.driver.findOne(entityName, where, { ...options, populate: preparedPopulate }, this.transactionContext);
 
     if (!data) {
       return null;
@@ -494,7 +499,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     return ret;
   }
 
-  async populate<T extends AnyEntity<T>, K extends T | T[]>(entities: K, populate: string | string[] | boolean, where: FilterQuery<T> = {}, orderBy: QueryOrderMap = {}, refresh = false, validate = true): Promise<K> {
+  async populate<T extends AnyEntity<T>, K extends T | T[]>(entities: K, populate: string | Populate, where: FilterQuery<T> = {}, orderBy: QueryOrderMap = {}, refresh = false, validate = true): Promise<K> {
     const entitiesArray = Utils.asArray(entities);
 
     if (entitiesArray.length === 0) {
@@ -502,7 +507,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     const entityName = entitiesArray[0].constructor.name;
-    await this.entityLoader.populate(entityName, entitiesArray, populate, where, orderBy, refresh, validate);
+    const preparedPopulate = this.preparePopulate(entityName, populate);
+    await this.entityLoader.populate(entityName, entitiesArray, preparedPopulate, where, orderBy, refresh, validate);
 
     return entities;
   }
@@ -579,13 +585,49 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       await this.lock(entity, options.lockMode, options.lockVersion);
     }
 
-    await this.entityLoader.populate(entityName, [entity], options.populate || [], where, options.orderBy || {}, options.refresh);
+    const preparedPopulate = this.preparePopulate(entityName, options.populate);
+
+    await this.entityLoader.populate(entityName, [entity], preparedPopulate, where, options.orderBy || {}, options.refresh);
 
     return entity;
   }
 
-  private preparePopulate(populate?: string[] | boolean) {
-    return Array.isArray(populate) ? populate : [];
+  private preparePopulate(entityName: string, populate?: string | Populate): PopulateOptions[] {
+    const meta = this.metadata.get(entityName);
+
+    if (Array.isArray(populate)) {
+      return populate.map(field => {
+        if (Utils.isString(field)) {
+          const relation = meta.properties[field];
+
+          // If no relation is found, we assume that the relation is invalid and don't attempt to get the strategy.
+          // By returning a field/relation that doesn't exist, validation code will handle that error upstream.
+          if (!relation) {
+            return {
+              field,
+            };
+          }
+
+          return {
+            field,
+            strategy: relation.strategy,
+          };
+        }
+
+        return field;
+      });
+    }
+
+    if (Utils.isString(populate)) {
+      const relation = meta.properties[populate];
+
+      return [{
+        field: populate,
+        strategy: relation.strategy,
+      }];
+    }
+
+    return [];
   }
 
 }

--- a/packages/core/src/decorators/Property.ts
+++ b/packages/core/src/decorators/Property.ts
@@ -1,6 +1,6 @@
 import { MetadataStorage } from '../metadata';
 import { Utils } from '../utils';
-import { Cascade, EntityValidator, ReferenceType } from '../entity';
+import { Cascade, EntityValidator, ReferenceType, LoadStrategy } from '../entity';
 import { EntityName, EntityProperty, AnyEntity, Constructor } from '../typings';
 import { Type } from '../types';
 
@@ -59,4 +59,5 @@ export interface ReferenceOptions<T extends AnyEntity<T>> extends PropertyOption
   entity?: string | (() => EntityName<T>);
   cascade?: Cascade[];
   eager?: boolean;
+  strategy?: LoadStrategy;
 }

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -1,4 +1,4 @@
-import { EntityManagerType, FindOneOptions, FindOptions, IDatabaseDriver } from './IDatabaseDriver';
+import { EntityManagerType, FindOneOptions, FindOptions, IDatabaseDriver, PopulateOptions } from './IDatabaseDriver';
 import { EntityData, EntityMetadata, EntityProperty, FilterQuery, AnyEntity, Dictionary, Primary } from '../typings';
 import { MetadataStorage } from '../metadata';
 import { Connection, QueryResult, Transaction } from '../connections';
@@ -51,7 +51,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     await this.nativeUpdate<T>(coll.owner.constructor.name, wrap(coll.owner, true).__primaryKey, data, ctx);
   }
 
-  mapResult<T extends AnyEntity<T>>(result: EntityData<T>, meta: EntityMetadata): T | null {
+  mapResult<T extends AnyEntity<T>>(result: EntityData<T>, meta: EntityMetadata, populate: PopulateOptions[] = []): T | null {
     if (!result || !meta) {
       return null;
     }

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -4,7 +4,7 @@ import { QueryOrderMap, QueryFlag } from '../enums';
 import { Platform } from '../platforms';
 import { MetadataStorage } from '../metadata';
 import { LockMode } from '../unit-of-work';
-import { Collection } from '../entity';
+import { Collection, LoadStrategy } from '../entity';
 import { EntityManager } from '../index';
 import { DriverException } from '../exceptions';
 
@@ -46,7 +46,7 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
 
   aggregate(entityName: string, pipeline: any[]): Promise<any[]>;
 
-  mapResult<T extends AnyEntity<T>>(result: EntityData<T>, meta: EntityMetadata): T | null;
+  mapResult<T extends AnyEntity<T>>(result: EntityData<T>, meta: EntityMetadata, populate?: PopulateOptions[]): T | null;
 
   /**
    * When driver uses pivot tables for M:N, this method will load identifiers for given collections from them
@@ -75,7 +75,7 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
 }
 
 export interface FindOptions {
-  populate?: string[] | boolean;
+  populate?: Populate;
   orderBy?: QueryOrderMap;
   limit?: number;
   offset?: number;
@@ -87,7 +87,7 @@ export interface FindOptions {
 }
 
 export interface FindOneOptions {
-  populate?: string[] | boolean;
+  populate?: Populate;
   orderBy?: QueryOrderMap;
   groupBy?: string | string[];
   lockMode?: LockMode;
@@ -97,3 +97,10 @@ export interface FindOneOptions {
   schema?: string;
   flags?: QueryFlag[];
 }
+
+export type Populate = (string | PopulateOptions)[] | boolean;
+
+export type PopulateOptions = {
+  field: string;
+  strategy?: LoadStrategy;
+};

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -16,7 +16,7 @@ export class EntityLoader {
   constructor(private readonly em: EntityManager) { }
 
   async populate<T extends AnyEntity<T>>(entityName: string, entities: T[], populate: PopulateOptions[] | boolean, where: FilterQuery<T> = {}, orderBy: QueryOrderMap = {}, refresh = false, validate = true, lookup = true): Promise<void> {
-    if (entities.length === 0 || populate === false || (Array.isArray(populate) && populate.length > 0)) {
+    if (entities.length === 0 || populate === false) {
       return;
     }
 

--- a/packages/core/src/entity/enums.ts
+++ b/packages/core/src/entity/enums.ts
@@ -13,3 +13,8 @@ export enum Cascade {
   REMOVE = 'remove',
   ALL = 'all',
 }
+
+export enum LoadStrategy {
+  SELECT_IN = 'select-in',
+  JOINED = 'joined'
+}

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -102,10 +102,7 @@ export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntit
   }
 
   addManyToOne<K = object>(name: string & keyof T, type: TypeType, options: ManyToOneOptions<K>): void {
-    const prop = {
-      ...this.defaultRelationshipConfig(ReferenceType.MANY_TO_ONE),
-      ...options,
-    };
+    const prop = this.createProperty(ReferenceType.MANY_TO_ONE, options);
     Utils.defaultValue(prop, 'nullable', prop.cascade.includes(Cascade.REMOVE) || prop.cascade.includes(Cascade.ALL));
     this.addProperty(name, type, prop);
   }
@@ -121,26 +118,17 @@ export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntit
       Utils.renameKey(options, 'mappedBy', 'inversedBy');
     }
 
-    const prop = {
-      ...this.defaultRelationshipConfig(ReferenceType.MANY_TO_MANY),
-      ...options,
-    };
+    const prop = this.createProperty(ReferenceType.MANY_TO_MANY, options);
     this.addProperty(name, type, prop);
   }
 
   addOneToMany<K = object>(name: string & keyof T, type: TypeType, options: OneToManyOptions<K>): void {
-    const prop = {
-      ...this.defaultRelationshipConfig(ReferenceType.ONE_TO_MANY),
-      ...options,
-    };
+    const prop = this.createProperty(ReferenceType.ONE_TO_MANY, options);
     this.addProperty(name, type, prop);
   }
 
   addOneToOne<K = object>(name: string & keyof T, type: TypeType, options: OneToOneOptions<K>): void {
-    const prop = {
-      ...this.defaultRelationshipConfig(ReferenceType.ONE_TO_ONE),
-      ...options,
-    };
+    const prop = this.createProperty(ReferenceType.ONE_TO_ONE, options) as EntityProperty;
     Utils.defaultValue(prop, 'nullable', prop.cascade.includes(Cascade.REMOVE) || prop.cascade.includes(Cascade.ALL));
     Utils.defaultValue(prop, 'owner', !!prop.inversedBy || !prop.mappedBy);
     Utils.defaultValue(prop, 'unique', prop.owner);
@@ -289,11 +277,12 @@ export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntit
     return type;
   }
 
-  private defaultRelationshipConfig(reference: ReferenceType) {
+  private createProperty(reference: ReferenceType, options: PropertyOptions | EntityProperty = {}) {
     return {
       reference,
       cascade: [Cascade.PERSIST, Cascade.MERGE],
       strategy: LoadStrategy.SELECT_IN,
+      ...options,
     };
   }
 

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1,5 +1,5 @@
 import { QueryOrder } from './enums';
-import { AssignOptions, Cascade, Collection, EntityRepository, EntityValidator, IdentifiedReference, Reference, ReferenceType } from './entity';
+import { AssignOptions, Cascade, Collection, EntityRepository, EntityValidator, IdentifiedReference, Reference, ReferenceType, LoadStrategy } from './entity';
 import { EntityManager } from './EntityManager';
 import { LockMode } from './unit-of-work';
 import { Platform } from './platforms';
@@ -134,6 +134,7 @@ export interface EntityProperty<T extends AnyEntity<T> = any> {
   onUpdate?: () => any;
   onDelete?: 'cascade' | 'no action' | 'set null' | 'set default' | string;
   onUpdateIntegrity?: 'cascade' | 'no action' | 'set null' | 'set default' | string;
+  strategy?: LoadStrategy;
   owner: boolean;
   inversedBy: string;
   mappedBy: string;

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -75,7 +75,11 @@ export class ChangeSetPersister {
     }
 
     if (meta.versionProperty && [ChangeSetType.CREATE, ChangeSetType.UPDATE].includes(changeSet.type)) {
-      const e = await this.driver.findOne<T>(meta.name, wrap(changeSet.entity, true).__primaryKey, { populate: [meta.versionProperty] }, ctx);
+      const e = await this.driver.findOne<T>(meta.name, wrap(changeSet.entity, true).__primaryKey, {
+        populate: [{
+          field: meta.versionProperty,
+        }],
+      }, ctx);
       (changeSet.entity as T)[meta.versionProperty] = e![meta.versionProperty];
     }
   }

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -106,11 +106,12 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
   }
 
   mapResult<T extends AnyEntity<T>>(result: EntityData<T>, meta: EntityMetadata, populate: PopulateOptions[] = []): T | null {
-    const ret = super.mapResult(result, meta, populate);
+    const ret = super.mapResult(result, meta);
 
     if (!ret) {
       return null;
     }
+
     const joinedLoads = this.joinedLoads(meta, populate);
 
     joinedLoads.forEach((relationName, index) => {
@@ -123,7 +124,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
       Object.values(properties)
         .filter(({ reference }) => reference === ReferenceType.SCALAR)
         .forEach(prop => {
-          const aliasedProp = this.getAliasedField(prop.fieldNames[0], relationName, index).as;
+          const aliasedProp = this.getAliasedField(prop.fieldNames[0], relationName, index).alias;
 
           if (aliasedProp in ret) {
             relationPojo[prop.name] = ret[aliasedProp];
@@ -268,11 +269,11 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
       return populate;
     }
 
-    const relationToPopulate = populate.map(({ field }) => field);
+    const relationsToPopulate = populate.map(({ field }) => field);
 
     const toPopulate: PopulateOptions[] = Object.values(meta.properties)
       .filter(prop => {
-        return prop.reference === ReferenceType.ONE_TO_ONE && !prop.owner && !relationToPopulate.includes(prop.name);
+        return prop.reference === ReferenceType.ONE_TO_ONE && !prop.owner && !relationsToPopulate.includes(prop.name);
       })
       .map(prop => ({ field: prop.name, strategy: prop.strategy }));
 
@@ -308,12 +309,12 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
 
   protected getAliasedField(field: string, schema: string, index = 0){
     const tableAlias = schema.charAt(0);
-    const as = `${tableAlias}${index}_${field}`;
+    const alias = `${tableAlias}${index}_${field}`;
 
     return {
       field,
       schema,
-      as,
+      alias,
     };
   }
 
@@ -326,8 +327,8 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
 
     // alias all fields in the primary table
     Object.values(meta.properties)
-      .filter((prop) => prop.reference === ReferenceType.SCALAR && prop.persist !== false)
-      .forEach((prop) => {
+      .filter(prop => prop.reference === ReferenceType.SCALAR && prop.persist !== false)
+      .forEach(prop => {
         selects.push(prop.fieldNames[0]);
         queryBuilder.addSelect(prop.fieldNames[0]);
       });
@@ -339,8 +340,8 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
       Object.values(properties)
         .filter(prop => prop.reference === ReferenceType.SCALAR && prop.persist !== false)
         .forEach(prop => {
-          const { field, schema, as } = this.getAliasedField(prop.fieldNames[0], relationName, index);
-          selects.push(this.getRefForField(field, schema, as));
+          const { field, schema, alias } = this.getAliasedField(prop.fieldNames[0], relationName, index);
+          selects.push(this.getRefForField(field, schema, alias));
           queryBuilder.join(relationName, relationName);
         });
     });

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -96,7 +96,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
 
     Utils.asArray(options.flags).forEach(flag => qb.setFlag(flag));
 
-    const result = await this.rethrow(qb.execute('all'));
+    const result = await this.rethrow(qb.execute(method));
 
     if (Array.isArray(result)) {
       return this.processJoinedLoads(result, joinedLoads) as unknown as T;
@@ -285,8 +285,12 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
       .map(({ field }) => field);
   }
 
-  protected processJoinedLoads<T extends AnyEntity<T>>(results: object[], joinedLoads: string[]): T {
-    return results.reduce((accumulator, value) => {
+  protected processJoinedLoads<T extends AnyEntity<T>>(result: object[], joinedLoads: string[]): T | null {
+    if (result.length === 0) {
+      return null;
+    }
+
+    return result.reduce((accumulator, value) => {
       joinedLoads.forEach(relationName => {
         if (relationName in value) {
           const relation = value[relationName];

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -322,10 +322,6 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     return qb;
   }
 
-  getRefForField(field: string, schema: string, as: string) {
-    return this.knex.ref(field).withSchema(schema).as(as);
-  }
-
   private joinReference(field: string, alias: string, cond: Dictionary, type: 'leftJoin' | 'innerJoin' | 'pivotJoin', path?: string): string[] {
     const [fromAlias, fromField] = this.helper.splitField(field);
     const entityName = this._aliasMap[fromAlias];

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -1,7 +1,7 @@
-import { QueryBuilder as KnexQueryBuilder, Raw, Transaction, Value } from 'knex';
+import Knex, { QueryBuilder as KnexQueryBuilder, Raw, Transaction, Value, Ref } from 'knex';
 import {
   AnyEntity, Dictionary, EntityMetadata, EntityProperty, FlatQueryOrderMap, GroupOperator, LockMode, MetadataStorage, QBFilterQuery, QueryFlag,
-  QueryOrderMap, ReferenceType, SmartQueryHelper, Utils, ValidationError,
+  QueryOrderMap, ReferenceType, SmartQueryHelper, Utils, ValidationError, PopulateOptions,
 } from '@mikro-orm/core';
 import { QueryType } from './enums';
 import { AbstractSqlDriver, QueryBuilderHelper } from '../index';
@@ -14,8 +14,8 @@ import { SqlEntityManager } from '../SqlEntityManager';
 export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
 
   type!: QueryType;
-  _fields?: (string | KnexQueryBuilder)[];
-  _populate: string[] = [];
+  _fields?: Field[];
+  _populate: PopulateOptions[] = [];
   _populateMap: Dictionary<string> = {};
 
   private aliasCounter = 1;
@@ -45,7 +45,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
               private readonly connectionType?: 'read' | 'write',
               private readonly em?: SqlEntityManager) { }
 
-  select(fields: string | KnexQueryBuilder | (string | KnexQueryBuilder)[], distinct = false): this {
+  select(fields: Field | Field[], distinct = false): this {
     this._fields = Utils.asArray(fields);
 
     if (distinct) {
@@ -167,8 +167,9 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
   /**
    * @internal
    */
-  populate(populate: string[]): this {
+  populate(populate: PopulateOptions[]): this {
     this._populate = populate;
+
     return this;
   }
 
@@ -265,10 +266,10 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     }
 
     if (method === 'all' && Array.isArray(res)) {
-      return res.map(r => this.driver.mapResult(r, meta)) as unknown as U;
+      return res.map(r => this.driver.mapResult(r, meta, this._populate)) as unknown as U;
     }
 
-    return this.driver.mapResult(res, meta) as unknown as U;
+    return this.driver.mapResult(res, meta, this._populate) as unknown as U;
   }
 
   async getResult(): Promise<T[]> {
@@ -321,6 +322,10 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     return qb;
   }
 
+  getRefForField(field: string, schema: string, as: string) {
+    return this.knex.ref(field).withSchema(schema).as(as);
+  }
+
   private joinReference(field: string, alias: string, cond: Dictionary, type: 'leftJoin' | 'innerJoin' | 'pivotJoin', path?: string): string[] {
     const [fromAlias, fromField] = this.helper.splitField(field);
     const entityName = this._aliasMap[fromAlias];
@@ -349,8 +354,8 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     return ret;
   }
 
-  private prepareFields<T extends string | Raw = string | Raw>(fields: (string | KnexQueryBuilder)[], type: 'where' | 'groupBy' | 'sub-query' = 'where'): T[] {
-    const ret: (string | KnexQueryBuilder)[] = [];
+  private prepareFields<T extends string | Raw = string | Raw>(fields: Field[], type: 'where' | 'groupBy' | 'sub-query' = 'where'): T[] {
+    const ret: Field[] = [];
 
     fields.forEach(f => {
       if (!Utils.isString(f)) {
@@ -441,7 +446,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     }
 
     const meta = this.metadata.get(this.entityName, false, false);
-    this._populate.forEach(field => {
+    this._populate.forEach(({ field }) => {
       const [fromAlias, fromField] = this.helper.splitField(field);
       const aliasedField = `${fromAlias}.${fromField}`;
 
@@ -520,6 +525,12 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
   }
 
 }
+
+type KnexStringRef = Ref<string, {
+  [alias: string]: string;
+}>;
+
+export type Field = string | KnexStringRef | KnexQueryBuilder;
 
 export interface JoinOptions {
   table: string;

--- a/tests/JoinedLoads.test.ts
+++ b/tests/JoinedLoads.test.ts
@@ -1,0 +1,59 @@
+import { MikroORM, Logger } from '@mikro-orm/core';
+import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { initORMPostgreSql, wipeDatabasePostgreSql } from './bootstrap';
+import { Author2, Book2 } from './entities-sql';
+
+describe('Joined loading', () => {
+
+  let orm: MikroORM<PostgreSqlDriver>;
+
+  beforeAll(async () => orm = await initORMPostgreSql());
+  beforeEach(async () => wipeDatabasePostgreSql(orm.em));
+
+  afterAll(async () => orm.close(true));
+
+  test('populate OneToMany with joined strategy', async () => {
+    const author2 = new Author2('Albert Camus', 'albert.camus@email.com');
+    const stranger = new Book2('The Stranger', author2);
+    const fall = new Book2('The Fall', author2);
+
+    author2.books.add(stranger, fall);
+
+    await orm.em.persistAndFlush(author2);
+    orm.em.clear();
+
+    const a2 = await orm.em.findOneOrFail(Author2, {
+      id: author2.id,
+    }, {
+      populate: ['books', 'following'],
+    });
+
+    expect(a2.books).toHaveLength(2);
+    expect(a2.books[0].title).toEqual('The Stranger');
+    expect(a2.books[1].title).toEqual('The Fall');
+  });
+
+  test('should only fire one query', async () => {
+    const author2 = new Author2('Albert Camus', 'albert.camus@email.com');
+    const stranger = new Book2('The Stranger', author2);
+    const fall = new Book2('The Fall', author2);
+
+    author2.books.add(stranger, fall);
+
+    await orm.em.persistAndFlush(author2);
+    orm.em.clear();
+
+    const mock = jest.fn();
+    const logger = new Logger(mock, true);
+    Object.assign(orm.em.config, { logger });
+
+    await orm.em.findOneOrFail(Author2, {
+      id: author2.id,
+    }, {
+      populate: ['books'],
+    });
+
+    expect(mock.mock.calls.length).toBe(1);
+    expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."created_at", "e0"."updated_at", "e0"."name", "e0"."email", "e0"."age", "e0"."terms_accepted", "e0"."optional", "e0"."identities", "e0"."born", "e0"."born_time", "books"."uuid_pk" as "b0_uuid_pk", "books"."created_at" as "b0_created_at", "books"."title" as "b0_title", "books"."perex" as "b0_perex", "books"."price" as "b0_price", "books"."double" as "b0_double", "books"."meta" as "b0_meta" from "author2" as "e0" inner join "book2" as "books" on "e0"."id" = "books"."author_id" where "e0"."id" = $1');
+  });
+});

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -457,7 +457,7 @@ describe('QueryBuilder', () => {
 
   test('select by m:n inverse side (that is not defined as property) via populate', async () => {
     const qb = orm.em.createQueryBuilder(Test2);
-    qb.select('*').populate([{ field: 'publisher2_tests' }]).where({ 'publisher2_to_test2.Publisher2_owner': { $in: [ 1, 2 ] } }).orderBy({ 'publisher2_to_test2.id': QueryOrder.ASC });
+    qb.select('*').populate([{ field: 'publisher2_tests' }]).where({ 'publisher2_tests.Publisher2_owner': { $in: [ 1, 2 ] } }).orderBy({ 'publisher2_tests.id': QueryOrder.ASC });
     let sql = 'select `e0`.*, `e1`.`test2_id`, `e1`.`publisher2_id` from `test2` as `e0` ';
     sql += 'left join `publisher2_tests` as `e1` on `e0`.`id` = `e1`.`test2_id` ';
     sql += 'where `e1`.`publisher2_id` in (?, ?) ';
@@ -468,7 +468,7 @@ describe('QueryBuilder', () => {
 
   test('select by m:n self reference owner', async () => {
     const qb = orm.em.createQueryBuilder(Author2);
-    qb.select('*').populate([{ field: 'author2_following' }]).where({ 'author2_to_author2.Author2_owner': { $in: [ 1, 2 ] } });
+    qb.select('*').populate([{ field: 'author2_following' }]).where({ 'author2_following.Author2_owner': { $in: [ 1, 2 ] } });
     let sql = 'select `e0`.*, `e1`.`author2_2_id`, `e1`.`author2_1_id` from `author2` as `e0` ';
     sql += 'left join `author2_following` as `e1` on `e0`.`id` = `e1`.`author2_2_id` ';
     sql += 'where `e1`.`author2_1_id` in (?, ?)';
@@ -478,7 +478,7 @@ describe('QueryBuilder', () => {
 
   test('select by m:n self reference inverse', async () => {
     const qb = orm.em.createQueryBuilder(Author2);
-    qb.select('*').populate([{ field: 'author2_following' }]).where({ 'author2_to_author2.Author2_inverse': { $in: [ 1, 2 ] } });
+    qb.select('*').populate([{ field: 'author2_following' }]).where({ 'author2_following.Author2_inverse': { $in: [ 1, 2 ] } });
     let sql = 'select `e0`.*, `e1`.`author2_1_id`, `e1`.`author2_2_id` from `author2` as `e0` ';
     sql += 'left join `author2_following` as `e1` on `e0`.`id` = `e1`.`author2_1_id` ';
     sql += 'where `e1`.`author2_2_id` in (?, ?)';
@@ -488,7 +488,7 @@ describe('QueryBuilder', () => {
 
   test('select by m:n with composite keys', async () => {
     const qb = orm.em.createQueryBuilder(User2);
-    qb.select('*').populate([{ field: 'user2_cars' }]).where({ 'user2_to_car2.Car2_inverse': { $in: [ [1, 2], [3, 4] ] } });
+    qb.select('*').populate([{ field: 'user2_cars' }]).where({ 'user2_cars.Car2_inverse': { $in: [ [1, 2], [3, 4] ] } });
     const sql = 'select `e0`.*, `e1`.`user2_first_name`, `e1`.`user2_last_name`, `e1`.`car2_name`, `e1`.`car2_year` ' +
       'from `user2` as `e0` left join `user2_cars` as `e1` on `e0`.`first_name` = `e1`.`user2_first_name` and `e0`.`last_name` = `e1`.`user2_last_name` ' +
       'where (`e1`.`car2_name`, `e1`.`car2_year`) in ((?, ?), (?, ?))';

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -397,7 +397,7 @@ describe('QueryBuilder', () => {
 
   test('select by 1:1 inversed', async () => {
     const qb = orm.em.createQueryBuilder(FooBaz2);
-    qb.select('*').where({ id: 123 }).populate(['bar']);
+    qb.select('*').where({ id: 123 }).populate([{ field: 'bar' }]);
     expect(qb.getQuery()).toEqual('select `e0`.*, `e1`.`id` as `bar_id` from `foo_baz2` as `e0` left join `foo_bar2` as `e1` on `e0`.`id` = `e1`.`baz_id` where `e0`.`id` = ?');
     expect(qb.getParams()).toEqual([123]);
   });
@@ -411,7 +411,7 @@ describe('QueryBuilder', () => {
 
   test('select by 1:1 inversed with populate', async () => {
     const qb = orm.em.createQueryBuilder(FooBaz2);
-    qb.select('*').where({ id: 123 }).populate(['bar']);
+    qb.select('*').where({ id: 123 }).populate([{ field: 'bar' }]);
     expect(qb.getQuery()).toEqual('select `e0`.*, `e1`.`id` as `bar_id` from `foo_baz2` as `e0` left join `foo_bar2` as `e1` on `e0`.`id` = `e1`.`baz_id` where `e0`.`id` = ?');
     expect(qb.getParams()).toEqual([123]);
   });
@@ -425,14 +425,14 @@ describe('QueryBuilder', () => {
 
   test('select by 1:1 inversed with populate (uuid pk)', async () => {
     const qb = orm.em.createQueryBuilder(Book2);
-    qb.select('*').where({ test: 123 }).populate(['test']);
+    qb.select('*').where({ test: 123 }).populate([{ field: 'test' }]);
     expect(qb.getQuery()).toEqual('select `e0`.*, `e1`.`id` as `test_id` from `book2` as `e0` left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` where `e1`.`id` = ?');
     expect(qb.getParams()).toEqual([123]);
   });
 
   test('select by 1:1 inversed with populate() before where() (uuid pk)', async () => {
     const qb = orm.em.createQueryBuilder(Book2);
-    qb.select('*').populate(['test']).where({ test: 123 });
+    qb.select('*').populate([{ field: 'test' }]).where({ test: 123 });
     expect(qb.getQuery()).toEqual('select `e0`.*, `e1`.`id` as `test_id` from `book2` as `e0` left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` where `e1`.`id` = ?');
     expect(qb.getParams()).toEqual([123]);
   });
@@ -457,7 +457,7 @@ describe('QueryBuilder', () => {
 
   test('select by m:n inverse side (that is not defined as property) via populate', async () => {
     const qb = orm.em.createQueryBuilder(Test2);
-    qb.select('*').populate(['publisher2_tests']).where({ 'publisher2_tests.Publisher2_owner': { $in: [ 1, 2 ] } }).orderBy({ 'publisher2_tests.id': QueryOrder.ASC });
+    qb.select('*').populate([{ field: 'publisher2_tests' }]).where({ 'publisher2_to_test2.Publisher2_owner': { $in: [ 1, 2 ] } }).orderBy({ 'publisher2_to_test2.id': QueryOrder.ASC });
     let sql = 'select `e0`.*, `e1`.`test2_id`, `e1`.`publisher2_id` from `test2` as `e0` ';
     sql += 'left join `publisher2_tests` as `e1` on `e0`.`id` = `e1`.`test2_id` ';
     sql += 'where `e1`.`publisher2_id` in (?, ?) ';
@@ -468,7 +468,7 @@ describe('QueryBuilder', () => {
 
   test('select by m:n self reference owner', async () => {
     const qb = orm.em.createQueryBuilder(Author2);
-    qb.select('*').populate(['author2_following']).where({ 'author2_following.Author2_owner': { $in: [ 1, 2 ] } });
+    qb.select('*').populate([{ field: 'author2_following' }]).where({ 'author2_to_author2.Author2_owner': { $in: [ 1, 2 ] } });
     let sql = 'select `e0`.*, `e1`.`author2_2_id`, `e1`.`author2_1_id` from `author2` as `e0` ';
     sql += 'left join `author2_following` as `e1` on `e0`.`id` = `e1`.`author2_2_id` ';
     sql += 'where `e1`.`author2_1_id` in (?, ?)';
@@ -478,7 +478,7 @@ describe('QueryBuilder', () => {
 
   test('select by m:n self reference inverse', async () => {
     const qb = orm.em.createQueryBuilder(Author2);
-    qb.select('*').populate(['author2_following']).where({ 'author2_following.Author2_inverse': { $in: [ 1, 2 ] } });
+    qb.select('*').populate([{ field: 'author2_following' }]).where({ 'author2_to_author2.Author2_inverse': { $in: [ 1, 2 ] } });
     let sql = 'select `e0`.*, `e1`.`author2_1_id`, `e1`.`author2_2_id` from `author2` as `e0` ';
     sql += 'left join `author2_following` as `e1` on `e0`.`id` = `e1`.`author2_1_id` ';
     sql += 'where `e1`.`author2_2_id` in (?, ?)';
@@ -488,7 +488,7 @@ describe('QueryBuilder', () => {
 
   test('select by m:n with composite keys', async () => {
     const qb = orm.em.createQueryBuilder(User2);
-    qb.select('*').populate(['user2_cars']).where({ 'user2_cars.Car2_inverse': { $in: [ [1, 2], [3, 4] ] } });
+    qb.select('*').populate([{ field: 'user2_cars' }]).where({ 'user2_to_car2.Car2_inverse': { $in: [ [1, 2], [3, 4] ] } });
     const sql = 'select `e0`.*, `e1`.`user2_first_name`, `e1`.`user2_last_name`, `e1`.`car2_name`, `e1`.`car2_year` ' +
       'from `user2` as `e0` left join `user2_cars` as `e1` on `e0`.`first_name` = `e1`.`user2_first_name` and `e0`.`last_name` = `e1`.`user2_last_name` ' +
       'where (`e1`.`car2_name`, `e1`.`car2_year`) in ((?, ?), (?, ?))';
@@ -498,7 +498,7 @@ describe('QueryBuilder', () => {
 
   test('select by m:n with unknown populate ignored', async () => {
     const qb = orm.em.createQueryBuilder(Test2);
-    qb.select('*').populate(['not_existing']);
+    qb.select('*').populate([{ field: 'not_existing' }]);
     expect(qb.getQuery()).toEqual('select `e0`.* from `test2` as `e0`');
     expect(qb.getParams()).toEqual([]);
   });
@@ -890,7 +890,7 @@ describe('QueryBuilder', () => {
 
   test('select with populate and join of 1:m', async () => {
     const qb = orm.em.createQueryBuilder(Author2);
-    qb.select('*').populate(['books']).leftJoin('books', 'b');
+    qb.select('*').populate([{ field: 'books' }]).leftJoin('books', 'b');
     expect(qb.getQuery()).toEqual('select `e0`.* ' +
       'from `author2` as `e0` ' +
       'left join `book2` as `b` on `e0`.`id` = `b`.`author_id`');
@@ -898,7 +898,7 @@ describe('QueryBuilder', () => {
 
   test('select with populate and join of m:n', async () => {
     const qb = orm.em.createQueryBuilder(Book2);
-    qb.select('*').populate(['tags']).leftJoin('tags', 't');
+    qb.select('*').populate([{ field: 'tags' }]).leftJoin('tags', 't');
     expect(qb.getQuery()).toEqual('select `e0`.*, `e1`.`book2_uuid_pk`, `e1`.`book_tag2_id` ' +
       'from `book2` as `e0` ' +
       'left join `book2_tags` as `e1` on `e0`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +

--- a/tests/entities-sql/Author2.ts
+++ b/tests/entities-sql/Author2.ts
@@ -1,6 +1,6 @@
 import {
   AfterCreate, AfterDelete, AfterUpdate, BeforeCreate, BeforeDelete, BeforeUpdate, Collection, Entity, OneToMany, Property, ManyToOne,
-  QueryOrder, OnInit, ManyToMany, DateType, TimeType, Index, Unique, OneToOne, Cascade,
+  QueryOrder, OnInit, ManyToMany, DateType, TimeType, Index, Unique, OneToOne, Cascade, LoadStrategy,
 } from '@mikro-orm/core';
 
 import { Book2 } from './Book2';
@@ -48,7 +48,12 @@ export class Author2 extends BaseEntity2 {
   @Property({ type: TimeType, index: 'born_time_idx', nullable: true })
   bornTime?: string;
 
-  @OneToMany({ entity: () => Book2, mappedBy: 'author', orderBy: { title: QueryOrder.ASC } })
+  @OneToMany({
+    entity: () => Book2,
+    mappedBy: 'author',
+    orderBy: { title: QueryOrder.ASC },
+    strategy: LoadStrategy.JOINED,
+  })
   books!: Collection<Book2>;
 
   @OneToOne({ entity: () => Address2, mappedBy: address => address.author, cascade: [Cascade.ALL] })


### PR DESCRIPTION
This adds support for alternate load strategies. As of now, only one additional strategy is supported: `joined`. Currently, the only way to specify the strategy is on on the decorator for the relationship:

```ts
@Entity()
export class Author2 {
  @OneToMany({
    entity: () => Book2,
    mappedBy: 'author',
    orderBy: { title: QueryOrder.ASC },
    strategy: LoadStrategy.JOINED, // new property
  })
  books!: Collection<Book2>;
}
```
---

- [ ] Tests
- [ ] Docs
- [ ] Cleanup

Closes #440