### PR TITLE
feat(sql): add support for sub-queries

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,12 +24,13 @@ discuss specifics.
 - [x] Allow adding items to not initialized collections
 - [x] Use absolute path to entity file in static MetadataStorage keys (fix for 'Multiple property decorators' validation issues)
 - [x] Embedded entities (allow in-lining child entity into parent one with prefixed keys)
+- [x] Use `jsonb` as default for object columns in postgres
+- [x] Support subqueries in QB
 - [ ] Association scopes/filters ([hibernate docs](https://docs.jboss.org/hibernate/orm/3.6/reference/en-US/html/filters.html))
 - [ ] Support external hooks when using EntitySchema (hooks outside of entity)
 - [ ] Support multiple M:N with same properties without manually specifying `pivotTable`
 - [ ] Cache metadata only with ts-morph provider
 - [ ] Diffing entity level indexes in schema generator
-- [ ] Support subqueries in QB
 - [ ] Support computed properties
 - [ ] Add `groupBy` and `distinct` to `FindOptions` and `FindOneOptions`
 - [ ] Paginator helper or something similar ([doctrine docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/pagination.html))
@@ -46,7 +47,6 @@ discuss specifics.
 - [x] Remove `autoFlush` option
 - [x] Drop default value for platform `type` (currently defaults to `mongodb`)
 - [x] Remove `IdEntity/UuidEntity/MongoEntity` interfaces
-- [x] Use `jsonb` as default for object columns in postgres
 
 ## Docs
 

--- a/packages/knex/src/query/CriteriaNode.ts
+++ b/packages/knex/src/query/CriteriaNode.ts
@@ -38,7 +38,7 @@ export class CriteriaNode {
       return ArrayCriteriaNode.create(metadata, entityName, payload, parent, key);
     }
 
-    if (Utils.isObject(payload) && !scalar) {
+    if (Utils.isPlainObject(payload) && !scalar) {
       return ObjectCriteriaNode.create(metadata, entityName, payload, parent, key);
     }
 

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -12,6 +12,7 @@ export class QueryBuilderHelper {
   constructor(private readonly entityName: string,
               private readonly alias: string,
               private readonly aliasMap: Dictionary<string>,
+              private readonly subQueries: Dictionary<string>,
               private readonly metadata: MetadataStorage,
               private readonly knex: Knex,
               private readonly platform: Platform) { }
@@ -247,7 +248,7 @@ export class QueryBuilderHelper {
       return void qb[m](this.mapper(key, type), 'like', this.getRegExpParam(cond[key]));
     }
 
-    if (Utils.isObject(cond[key]) && !(cond[key] instanceof Date)) {
+    if (Utils.isPlainObject(cond[key]) || cond[key] instanceof RegExp) {
       return this.processObjectSubCondition(cond, key, qb, method, m, type);
     }
 
@@ -256,6 +257,10 @@ export class QueryBuilderHelper {
     }
 
     const op = cond[key] === null ? 'is' : '=';
+
+    if (this.subQueries[key]) {
+      return void qb[m](this.knex.raw(`(${this.subQueries[key]})`), op, cond[key]);
+    }
 
     qb[m](this.mapper(key, type, cond[key]), op, cond[key]);
   }
@@ -307,6 +312,10 @@ export class QueryBuilderHelper {
       value[op] = this.knex.raw(`(${fields.map(() => '?').join(', ')})`, value[op]);
     }
 
+    if (this.subQueries[key]) {
+      return void qb[m](this.knex.raw(`(${this.subQueries[key]})`), replacement, value[op]);
+    }
+
     qb[m](this.mapper(key, type), replacement, value[op]);
   }
 
@@ -342,14 +351,14 @@ export class QueryBuilderHelper {
     });
   }
 
-  private appendJoinSubClause(clause: JoinClause, cond: any, key: string, operator?: '$and' | '$or'): void {
+  private appendJoinSubClause(clause: JoinClause, cond: Dictionary, key: string, operator?: '$and' | '$or'): void {
     const m = operator === '$or' ? 'orOn' : 'andOn';
 
     if (cond[key] instanceof RegExp) {
       return void clause[m](this.mapper(key), 'like', this.knex.raw('?', this.getRegExpParam(cond[key])));
     }
 
-    if (Utils.isObject(cond[key]) && !(cond[key] instanceof Date)) {
+    if (Utils.isPlainObject(cond[key])) {
       return this.processObjectSubClause(cond, key, clause, m);
     }
 

--- a/tests/entities-sql/Author2.ts
+++ b/tests/entities-sql/Author2.ts
@@ -78,6 +78,9 @@ export class Author2 extends BaseEntity2 {
   @Property({ persist: false })
   code!: string;
 
+  @Property({ persist: false })
+  booksTotal!: number;
+
   constructor(name: string, email: string) {
     super();
     this.name = name;


### PR DESCRIPTION
You can use sub-queries in selects or in where conditions. To select subquery, use `qb.as(alias)` method:

```typescript
const knex = orm.em.getKnex();
const qb1 = orm.em.createQueryBuilder(Book2, 'b').count('b.uuid', true).where({ author: knex.ref('a.id') }).as('Author2.booksTotal');
const qb2 = orm.em.createQueryBuilder(Author2, 'a');
qb2.select(['*', qb1]).orderBy({ booksTotal: 'desc' });

console.log(qb2.getQuery());
// select `a`.*, (select count(distinct `b`.`uuid_pk`) as `count` from `book2` as `b` where `b`.`author_id` = `a`.`id`) as `books_total` from `author2` as `a` order by `books_total` desc
```

When you want to filter by sub-query, you will need to register it first via `qb.withSubquery()`:

> The dynamic property (`booksTotal`) needs to be defined at the entity level (as `persist: false`).
> You always need to use prefix in the `qb.withSchema()` (so `a.booksTotal`).

```typescript
const knex = orm.em.getKnex();
const qb1 = orm.em.createQueryBuilder(Book2, 'b').count('b.uuid', true).where({ author: knex.ref('a.id') }).getKnexQuery();
const qb2 = orm.em.createQueryBuilder(Author2, 'a');
qb2.select('*').withSubQuery(qb1, 'a.booksTotal').where({ 'a.booksTotal': { $in: [1, 2, 3] } });

console.log(qb2.getQuery());
// select `a`.* from `author2` as `a` where (select count(distinct `b`.`uuid_pk`) as `count` from `book2` as `b` where `b`.`author_id` = `a`.`id`) in (?, ?, ?)
```