### PR TITLE
refactor(core): do not define methods directly on the entity prototype

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,6 @@ discuss specifics.
 - [ ] Paginator helper or something similar ([doctrine docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/pagination.html))
 - [ ] Use custom errors for specific cases (unique constraint violation, db not accessible, ...)
 - [ ] Add custom types for blob, array, json
-- [ ] Do not define internal methods like `init` directly on the entity prototype ([#506](https://github.com/mikro-orm/mikro-orm/issues/506))
 - [ ] Lazy scalar properties (allow having props that won't be loaded by default, but can be populated)
 
 ## Planned breaking changes for v4
@@ -47,6 +46,7 @@ discuss specifics.
 - [x] Remove `autoFlush` option
 - [x] Drop default value for platform `type` (currently defaults to `mongodb`)
 - [x] Remove `IdEntity/UuidEntity/MongoEntity` interfaces
+- [x] Do not define internal methods like `init` directly on the entity prototype ([#506](https://github.com/mikro-orm/mikro-orm/issues/506))
 
 ## Docs
 

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -468,11 +468,18 @@ export class Book {
 }
 ```
 
-### Using WrappedEntity interface
+### Using BaseEntity (previously WrappedEntity)
+
+From v4 `BaseEntity` class is provided with `init`, `isInitialized`, `assign`
+and other methods that are otherwise available via the `wrap()` helper.
+
+> Usage of `BaseEntity` is optional.
 
 ```typescript
+import { BaseEntity } from '@mikro-orm/core';
+
 @Entity()
-export class Book {
+export class Book extends BaseEntity {
 
   @PrimaryKey()
   id!: number;
@@ -485,7 +492,8 @@ export class Book {
 
 }
 
-export interface Book extends WrappedEntity<Book, 'id'> { };
+const book = new Book();
+console.log(book.isInitialized()); // true
 ```
 
 With your entities set up, you can start [using entity manager](entity-manager.md) and 

--- a/docs/docs/entity-helper.md
+++ b/docs/docs/entity-helper.md
@@ -61,40 +61,40 @@ console.log(book.meta); // { foo: 4 }
 
 ## `WrappedEntity` and `wrap()` helper
 
-`IWrappedEntity` is interface that defines helper methods as well as some internal 
-properties provided by the ORM:
+`IWrappedEntity` is an interface that defines public helper methods provided 
+by the ORM:
 
 ```typescript
 interface IWrappedEntity<T, PK extends keyof T> {
   isInitialized(): boolean;
   populated(populated?: boolean): void;
-  init(populated?: boolean, lockMode?: LockMode): Promise<this>;
+  init(populated?: boolean, lockMode?: LockMode): Promise<T>;
   toReference(): IdentifiedReference<T, PK>;
   toObject(ignoreFields?: string[]): Dictionary;
   toJSON(...args: any[]): Dictionary;
-  assign(data: any, options?: AssignOptions | boolean): this;
-  __uuid: string;
-  __meta: EntityMetadata;
-  __em: EntityManager;
-  __initialized?: boolean;
-  __populated: boolean;
-  __lazyInitialized: boolean;
-  __primaryKey: T[PK] & Primary<T>;
-  __serializedPrimaryKey: string & keyof T;
+  assign(data: any, options?: AssignOptions | boolean): T;
 }
 ```
 
+There are two ways to access those methods. You can either extend `BaseEntity` 
+(exported from `@mikro-orm/core`), that defines those methods, or use the 
+`wrap()` helper to access `WrappedEntity` instance, where those methods
+exist.
+
 Users can choose whether they are fine with polluting the entity interface with 
-those additional methods and properties, or they want to keep the interface clean 
+those additional methods, or they want to keep the interface clean 
 and use the `wrap(entity)` helper method instead to access them. 
 
-To keep all methods available on the entity, you can use interface merging with 
-`WrappedEntity<T, PK>` that both extends `AnyEntity<T, PK>` and defines all those methods.
+> Since v4 `wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is 
+> being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...),
+> if you want to access internal properties like `__meta` or `__em`, you need to explicitly
+> ask for the helper via `wrap(entity, true)`.
 
 ```typescript
+import { BaseEntity } from '@mikro-orm/core';
+
 @Entity()
-export class Book { ... }
-export interface Book extends WrappedEntity<Book, 'id'> { }
+export class Book extends BaseEntity<Book, 'id'> { ... }
 ```
 
 Then you can work with those methods directly:
@@ -103,4 +103,17 @@ Then you can work with those methods directly:
 book.meta = { foo: 1, bar: 2 };
 book.assign({ meta: { foo: 3 } }, { mergeObjects: true });
 console.log(book.meta); // { foo: 3, bar: 2 }
+```
+
+### Accessing internal prefixed properties
+
+Previously it was possible to access internal properties like `__meta` or `__em` 
+from the `wrap()` helper. Now to access them, you need to use second parameter of
+wrap:
+
+```typescript
+@Entity()
+export class Author { ... }
+
+console.log(wrap(author, true).__meta);
 ```

--- a/docs/docs/property-validation.md
+++ b/docs/docs/property-validation.md
@@ -9,39 +9,39 @@ when persisting the entity.
 
 ```typescript
 // number instead of string will throw
-const author = new Author('test', 'test') as WrappedEntity<Author>;
-author.assign({ name: 111, email: 222 });
+const author = new Author('test', 'test');
+wrap(author).assign({ name: 111, email: 222 });
 await orm.em.persistAndFlush(author); // throws "Validation error: trying to set Author.name of type 'string' to '111' of type 'number'"
 
 // string date with unknown format will throw
-author.assign(author, { name: '333', email: '444', born: 'asd' });
+wrap(author).assign(author, { name: '333', email: '444', born: 'asd' });
 await orm.em.persistAndFlush(author); // throws "Validation error: trying to set Author.born of type 'date' to 'asd' of type 'string'"
 
 // string date with correct format will be auto-corrected
-author.assign({ name: '333', email: '444', born: '2018-01-01' });
+wrap(author).assign({ name: '333', email: '444', born: '2018-01-01' });
 await orm.em.persistAndFlush(author);
 console.log(author.born).toBe(true); // instance of Date
 
 // Date object will be ok
-author.assign({ born: new Date() });
+wrap(author).assign({ born: new Date() });
 await orm.em.persistAndFlush(author);
 console.log(author.born).toBe(true); // instance of Date
 
 // null will be ok
-author.assign({ born: null });
+wrap(author).assign({ born: null });
 await orm.em.persistAndFlush(author);
 console.log(author.born); // null
 
 // string number with correct format will be auto-corrected
-author.assign({ age: '21' });
+wrap(author).assign({ age: '21' });
 await orm.em.persistAndFlush(author);
 console.log(author.age); // number 21
 
 // string instead of number with will throw
-author.assign({ age: 'asd' });
+wrap(author).assign({ age: 'asd' });
 await orm.em.persistAndFlush(author); // throws "Validation error: trying to set Author.age of type 'number' to 'asd' of type 'string'"
-author.assign({ age: new Date() });
+wrap(author).assign({ age: new Date() });
 await orm.em.persistAndFlush(author); // throws "Validation error: trying to set Author.age of type 'number' to '2019-01-17T21:14:23.875Z' of type 'date'"
-author.assign({ age: false });
+wrap(author).assign({ age: false });
 await orm.em.persistAndFlush(author); // throws "Validation error: trying to set Author.age of type 'number' to 'false' of type 'boolean'"
 ```

--- a/docs/docs/upgrading-v3-to-v4.md
+++ b/docs/docs/upgrading-v3-to-v4.md
@@ -22,6 +22,21 @@ TODO multiple packages
 
 TODO QB getter, knex getter, aggregate...
 
+## Changes in `wrap()` helper and `WrappedEntity` interface
+
+Previously all the methods and properties of `WrappedEntity` interface were
+added to the entity prototype during discovery. In v4 there is only one property
+added: `__helper: WrappedEntity`. `WrappedEntity` has been converted to actual class.
+
+`wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is 
+being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...),
+if you want to access internal properties like `__meta` or `__em`, you need to explicitly
+ask for the helper via `wrap(entity, true)`.
+
+Instead of interface merging with `WrappedEntity`, one can now use classic inheritance,
+by extending `BaseEntity` exported from `@mikro-orm/core`. If you do so, `wrap(entity)` 
+will return your entity. 
+
 ## `autoFlush` option has been removed
 
 The `flush` parameter of `persist()` and `remove()` methods is still there, but you

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "build": "lerna run build",
     "pub": "lerna publish",
     "test": "jest --runInBand",
+    "tsc-check-tests": " tsc --noEmit --project tests/tsconfig.json",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 1",
     "coverage": "rimraf temp tests/generated-entities && yarn test --coverage",
     "coveralls": "cat ./coverage/lcov.info | coveralls",

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -48,7 +48,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
   async syncCollection<T extends AnyEntity<T>, O extends AnyEntity<O>>(coll: Collection<T, O>, ctx?: Transaction): Promise<void> {
     const pk = this.metadata.get(coll.property.type).primaryKeys[0];
     const data = { [coll.property.name]: coll.getIdentifiers(pk) } as EntityData<T>;
-    await this.nativeUpdate<T>(coll.owner.constructor.name, wrap(coll.owner).__primaryKey, data, ctx);
+    await this.nativeUpdate<T>(coll.owner.constructor.name, wrap(coll.owner, true).__primaryKey, data, ctx);
   }
 
   mapResult<T extends AnyEntity<T>>(result: EntityData<T>, meta: EntityMetadata): T | null {

--- a/packages/core/src/entity/ArrayCollection.ts
+++ b/packages/core/src/entity/ArrayCollection.ts
@@ -1,7 +1,7 @@
 import { AnyEntity, Dictionary, EntityProperty, IPrimaryKey, Primary } from '../typings';
 import { ReferenceType } from './enums';
 import { Collection } from './Collection';
-import { wrap } from './EntityHelper';
+import { wrap } from './wrap';
 
 export class ArrayCollection<T extends AnyEntity<T>, O extends AnyEntity<O>> {
 
@@ -27,7 +27,7 @@ export class ArrayCollection<T extends AnyEntity<T>, O extends AnyEntity<O>> {
 
   toArray(): Dictionary[] {
     return this.getItems().map(item => {
-      const meta = wrap(this.owner).__internal.metadata.get(item.constructor.name);
+      const meta = wrap(item, true).__meta;
       const args = [...meta.toJsonParams.map(() => undefined), [this.property.name]];
 
       return wrap(item).toJSON(...args);
@@ -41,7 +41,7 @@ export class ArrayCollection<T extends AnyEntity<T>, O extends AnyEntity<O>> {
       return [];
     }
 
-    field = field || wrap(this.items[0]).__meta.serializedPrimaryKey;
+    field = field || wrap(this.items[0], true).__meta.serializedPrimaryKey;
 
     return this.getItems().map(i => i[field as keyof T]) as unknown as U[];
   }
@@ -70,7 +70,7 @@ export class ArrayCollection<T extends AnyEntity<T>, O extends AnyEntity<O>> {
 
   remove(...items: T[]): void {
     for (const item of items) {
-      const idx = this.items.findIndex(i => wrap(i).__serializedPrimaryKey === wrap(item).__serializedPrimaryKey);
+      const idx = this.items.findIndex(i => wrap(i, true).__serializedPrimaryKey === wrap(item, true).__serializedPrimaryKey);
 
       if (idx !== -1) {
         delete this[this.items.length - 1]; // remove last item
@@ -89,7 +89,7 @@ export class ArrayCollection<T extends AnyEntity<T>, O extends AnyEntity<O>> {
   contains(item: T, check?: boolean): boolean {
     return !!this.items.find(i => {
       const objectIdentity = i === item;
-      const primaryKeyIdentity = !!wrap(i).__primaryKey && !!wrap(item).__primaryKey && wrap(i).__serializedPrimaryKey === wrap(item).__serializedPrimaryKey;
+      const primaryKeyIdentity = !!wrap(i, true).__primaryKey && !!wrap(item, true).__primaryKey && wrap(i, true).__serializedPrimaryKey === wrap(item, true).__serializedPrimaryKey;
 
       return objectIdentity || primaryKeyIdentity;
     });
@@ -114,7 +114,7 @@ export class ArrayCollection<T extends AnyEntity<T>, O extends AnyEntity<O>> {
    */
   get property(): EntityProperty {
     if (!this._property) {
-      const meta = wrap(this.owner).__meta;
+      const meta = wrap(this.owner, true).__meta;
       const field = Object.keys(meta.properties).find(k => this.owner[k] === this);
       this._property = meta.properties[field!];
     }

--- a/packages/core/src/entity/BaseEntity.ts
+++ b/packages/core/src/entity/BaseEntity.ts
@@ -1,0 +1,36 @@
+import { wrap } from './wrap';
+import { IdentifiedReference, Reference } from './Reference';
+import { Dictionary, EntityData, IWrappedEntity } from '../typings';
+import { AssignOptions, EntityAssigner } from './EntityAssigner';
+
+export abstract class BaseEntity<T, PK extends keyof T> implements IWrappedEntity<T, PK> {
+
+  isInitialized(): boolean {
+    return wrap(this, true).isInitialized();
+  }
+
+  populated(populated = true): void {
+    wrap(this, true).populated(populated);
+  }
+
+  toReference(): IdentifiedReference<T, PK> {
+    return Reference.create<T, PK>(this as unknown as T);
+  }
+
+  toObject(ignoreFields: string[] = []): EntityData<T> {
+    return wrap(this, true).toObject(ignoreFields) as EntityData<T>;
+  }
+
+  toJSON(...args: any[]): EntityData<T> & Dictionary {
+    return this.toObject(...args);
+  }
+
+  assign(data: EntityData<T>, options?: AssignOptions): T {
+    return EntityAssigner.assign(this as unknown as T, data, options);
+  }
+
+  init(populated = true): Promise<T> {
+    return wrap(this as unknown as T, true).init(populated);
+  }
+
+}

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -6,7 +6,7 @@ import { AnyEntity, EntityData, EntityMetadata, EntityProperty } from '../typing
 import { Utils } from '../utils';
 import { ReferenceType } from './enums';
 import { Reference } from './Reference';
-import { wrap } from './EntityHelper';
+import { wrap } from './wrap';
 
 export class EntityAssigner {
 
@@ -14,11 +14,12 @@ export class EntityAssigner {
   static assign<T extends AnyEntity<T>>(entity: T, data: EntityData<T>, onlyProperties?: boolean): T;
   static assign<T extends AnyEntity<T>>(entity: T, data: EntityData<T>, onlyProperties: AssignOptions | boolean = false): T {
     const options = (typeof onlyProperties === 'boolean' ? { onlyProperties } : onlyProperties);
-    const em = options.em || wrap(entity).__em;
-    const meta = wrap(entity).__internal.metadata.get(entity.constructor.name);
-    const root = Utils.getRootEntity(wrap(entity).__internal.metadata, meta);
-    const validator = wrap(entity).__internal.validator;
-    const platform = wrap(entity).__internal.platform;
+    const wrapped = wrap(entity, true);
+    const em = options.em || wrapped.__em;
+    const meta = wrapped.__internal.metadata.get(entity.constructor.name);
+    const root = Utils.getRootEntity(wrapped.__internal.metadata, meta);
+    const validator = wrapped.__internal.validator;
+    const platform = wrapped.__internal.platform;
     const props = meta.properties;
 
     Object.keys(data).forEach(prop => {
@@ -75,7 +76,7 @@ export class EntityAssigner {
       return;
     }
 
-    const meta2 = entity[prop.name].__meta as EntityMetadata;
+    const meta2 = wrap(entity[prop.name], true).__meta as EntityMetadata;
     const prop2 = meta2.properties[prop.inversedBy || prop.mappedBy];
 
     if (prop2 && !entity[prop.name][prop2.name]) {

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -2,7 +2,7 @@ import { Utils } from '../utils';
 import { AnyEntity, EntityData, EntityMetadata, EntityName, Primary } from '../typings';
 import { UnitOfWork } from '../unit-of-work';
 import { ReferenceType } from './enums';
-import { EntityManager } from '..';
+import { EntityManager, wrap } from '..';
 
 export const SCALAR_TYPES = ['string', 'number', 'boolean', 'Date'];
 
@@ -25,16 +25,13 @@ export class EntityFactory {
     const meta = this.metadata.get(entityName);
     meta.primaryKeys.forEach(pk => this.denormalizePrimaryKey(data, pk));
     const entity = this.createEntity(data, meta);
+    const wrapped = wrap(entity, true);
 
     if (initialized && !Utils.isEntity(data)) {
       this.hydrator.hydrate(entity, meta, data, newEntity);
     }
 
-    if (initialized) {
-      delete entity.__initialized;
-    } else {
-      entity.__initialized = initialized;
-    }
+    wrapped.__initialized = !!initialized;
 
     this.runHooks(entity, meta);
 

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -5,7 +5,7 @@ import { Utils, ValidationError } from '../utils';
 import { Collection } from './Collection';
 import { QueryOrder, QueryOrderMap } from '../enums';
 import { Reference } from './Reference';
-import { wrap } from './EntityHelper';
+import { wrap } from './wrap';
 
 export class EntityLoader {
 
@@ -53,7 +53,7 @@ export class EntityLoader {
     // set populate flag
     entities.forEach(entity => {
       if (Utils.isEntity(entity[field], true) || entity[field] as unknown instanceof Collection) {
-        wrap(entity[field]).populated();
+        wrap(entity[field], true).populated();
       }
     });
 
@@ -114,7 +114,7 @@ export class EntityLoader {
       return [];
     }
 
-    const ids = Utils.unique(children.map(e => Utils.getPrimaryKeyValues(e, wrap(e).__meta.primaryKeys, true)));
+    const ids = Utils.unique(children.map(e => Utils.getPrimaryKeyValues(e, wrap(e, true).__meta.primaryKeys, true)));
     where = { [fk]: { $in: ids }, ...where };
     orderBy = orderBy || prop.orderBy || { [fk]: QueryOrder.ASC };
 
@@ -147,11 +147,11 @@ export class EntityLoader {
   }
 
   private async findChildrenFromPivotTable<T extends AnyEntity<T>>(filtered: T[], prop: EntityProperty, field: keyof T, refresh: boolean, where?: FilterQuery<T>, orderBy?: QueryOrderMap): Promise<AnyEntity[]> {
-    const map = await this.driver.loadFromPivotTable(prop, filtered.map(e => wrap(e).__primaryKeys), where, orderBy, this.em.getTransactionContext());
+    const map = await this.driver.loadFromPivotTable(prop, filtered.map(e => wrap(e, true).__primaryKeys), where, orderBy, this.em.getTransactionContext());
     const children: AnyEntity[] = [];
 
     for (const entity of filtered) {
-      const items = map[wrap(entity).__serializedPrimaryKey].map(item => this.em.merge(prop.type, item, refresh));
+      const items = map[wrap(entity, true).__serializedPrimaryKey as string].map(item => this.em.merge(prop.type, item, refresh));
       (entity[field] as unknown as Collection<AnyEntity>).hydrate(items);
       children.push(...items);
     }
@@ -181,7 +181,7 @@ export class EntityLoader {
       return entities.filter(e => e[field]);
     }
 
-    return entities.filter(e => e[field] && !(e[field] as unknown as Collection<AnyEntity>).isInitialized(true));
+    return entities.filter(e => Utils.isCollection(e[field]) && !(e[field] as unknown as Collection<AnyEntity>).isInitialized(true));
   }
 
   private filterReferences<T extends AnyEntity<T>>(entities: T[], field: keyof T, refresh: boolean): T[keyof T][] {
@@ -191,7 +191,7 @@ export class EntityLoader {
       return children.map(e => Utils.unwrapReference(e[field]));
     }
 
-    return children.filter(e => !(e[field] as AnyEntity).isInitialized()).map(e => Utils.unwrapReference(e[field]));
+    return children.filter(e => !wrap(e[field], true).isInitialized()).map(e => Utils.unwrapReference(e[field]));
   }
 
   private lookupAllRelationships(entityName: string, prefix = '', visited: string[] = []): string[] {

--- a/packages/core/src/entity/EntityValidator.ts
+++ b/packages/core/src/entity/EntityValidator.ts
@@ -2,7 +2,7 @@ import { SCALAR_TYPES } from './EntityFactory';
 import { EntityData, EntityMetadata, EntityProperty, FilterQuery, AnyEntity } from '../typings';
 import { Utils, ValidationError } from '../utils';
 import { ReferenceType } from './enums';
-import { wrap } from './EntityHelper';
+import { wrap } from './wrap';
 
 export class EntityValidator {
 

--- a/packages/core/src/entity/Reference.ts
+++ b/packages/core/src/entity/Reference.ts
@@ -1,9 +1,9 @@
 import { Dictionary, EntityMetadata, AnyEntity, Primary } from '../typings';
 import { EntityManager } from '../EntityManager';
-import { wrap } from './EntityHelper';
 import { Platform } from '../platforms';
 import { MetadataStorage } from '../metadata';
 import { EntityValidator } from './EntityValidator';
+import { wrap } from './wrap';
 
 export type IdentifiedReference<T extends AnyEntity<T>, PK extends keyof T = 'id' & keyof T> = { [K in PK]: T[K] } & Reference<T>;
 
@@ -11,7 +11,7 @@ export class Reference<T extends AnyEntity<T>> {
 
   constructor(private entity: T) {
     this.set(entity);
-    const wrapped = wrap(this.entity);
+    const wrapped = wrap(this.entity, true);
 
     wrapped.__meta.primaryKeys.forEach(primaryKey => {
       Object.defineProperty(this, primaryKey, {
@@ -24,7 +24,7 @@ export class Reference<T extends AnyEntity<T>> {
     if (wrapped.__meta.serializedPrimaryKey && wrapped.__meta.primaryKeys[0] !== wrapped.__meta.serializedPrimaryKey) {
       Object.defineProperty(this, wrapped.__meta.serializedPrimaryKey, {
         get() {
-          return wrap(this.entity).__serializedPrimaryKey;
+          return wrap(this.entity, true).__serializedPrimaryKey;
         },
       });
     }
@@ -43,7 +43,7 @@ export class Reference<T extends AnyEntity<T>> {
       return this.entity;
     }
 
-    return wrap(this.entity).init();
+    return wrap(this.entity, true).init();
   }
 
   async get<K extends keyof T>(prop: K): Promise<T[K]> {
@@ -76,11 +76,11 @@ export class Reference<T extends AnyEntity<T>> {
   }
 
   isInitialized(): boolean {
-    return wrap(this.entity).isInitialized();
+    return wrap(this.entity, true).isInitialized();
   }
 
   populated(populated?: boolean): void {
-    wrap(this.entity).populated!(populated);
+    wrap(this.entity, true).populated!(populated);
   }
 
   toJSON(...args: any[]): Dictionary {
@@ -88,35 +88,35 @@ export class Reference<T extends AnyEntity<T>> {
   }
 
   get __primaryKey(): Primary<T> {
-    return wrap(this.entity).__primaryKey as Primary<T>;
+    return wrap(this.entity, true).__primaryKey as Primary<T>;
   }
 
   get __primaryKeys(): Primary<T>[] {
-    return wrap(this.entity).__primaryKeys;
+    return wrap(this.entity, true).__primaryKeys;
   }
 
   get __uuid(): string {
-    return wrap(this.entity).__uuid;
+    return wrap(this.entity, true).__uuid;
   }
 
   get __em(): EntityManager | undefined {
-    return wrap(this.entity).__em;
+    return wrap(this.entity, true).__em;
   }
 
   get __internal(): { platform: Platform; metadata: MetadataStorage; validator: EntityValidator } {
-    return wrap(this.entity).__internal;
+    return wrap(this.entity, true).__internal;
   }
 
   get __meta(): EntityMetadata {
-    return wrap(this.entity).__meta;
+    return wrap(this.entity, true).__meta;
   }
 
   get __populated(): boolean {
-    return wrap(this.entity).__populated;
+    return wrap(this.entity, true).__populated;
   }
 
   get __lazyInitialized(): boolean {
-    return wrap(this.entity).__lazyInitialized;
+    return wrap(this.entity, true).__lazyInitialized;
   }
 
 }

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -1,0 +1,95 @@
+import { v4 as uuid } from 'uuid';
+import { EntityManager } from '../EntityManager';
+import { Platform } from '../platforms';
+import { MetadataStorage } from '../metadata';
+import { EntityValidator } from './EntityValidator';
+import { Dictionary, EntityData, EntityMetadata, Primary } from '../typings';
+import { IdentifiedReference, Reference } from './Reference';
+import { EntityTransformer } from './EntityTransformer';
+import { AssignOptions, EntityAssigner } from './EntityAssigner';
+import { EntityHelper } from './EntityHelper';
+import { Utils } from '../utils';
+import { wrap } from './wrap';
+
+export class WrappedEntity<T, PK extends keyof T> {
+
+  __initialized = true;
+  __populated = false;
+  __lazyInitialized = false;
+  __em?: EntityManager;
+
+  readonly __uuid = uuid();
+  readonly __internal: {
+    platform: Platform;
+    metadata: MetadataStorage;
+    validator: EntityValidator;
+  };
+
+  constructor(private readonly entity: T,
+              readonly __meta: EntityMetadata<T>,
+              em: EntityManager) {
+    this.__internal = {
+      platform: em.getDriver().getPlatform(),
+      metadata: em.getMetadata(),
+      validator: em.getValidator(),
+    };
+  }
+
+  isInitialized(): boolean {
+    return this.__initialized;
+  }
+
+  populated(populated = true): void {
+    this.__populated = populated;
+  }
+
+  toReference(): IdentifiedReference<T, PK> {
+    return Reference.create<T, PK>(this.entity);
+  }
+
+  toObject(ignoreFields: string[] = []): EntityData<T> {
+    return EntityTransformer.toObject(this.entity, ignoreFields) as EntityData<T>;
+  }
+
+  toJSON(...args: any[]): EntityData<T> & Dictionary {
+    // toJSON methods is added to thee prototype during discovery to support automatic serialization via JSON.stringify()
+    return (this.entity as Dictionary).toJSON(...args);
+  }
+
+  assign(data: EntityData<T>, options?: AssignOptions): T {
+    if ('assign' in this.entity) {
+      return (this.entity as Dictionary).assign(data, options);
+    }
+
+    return EntityAssigner.assign(this.entity, data, options);
+  }
+
+  init(populated = true): Promise<T> {
+    return EntityHelper.init<T>(this.entity, populated) as Promise<T>;
+  }
+
+  get __primaryKey(): Primary<T> {
+    return Utils.getPrimaryKeyValue(this.entity, this.__meta.primaryKeys);
+  }
+
+  set __primaryKey(id: Primary<T>) {
+    this.entity[this.__meta.primaryKeys[0] as string] = id;
+  }
+
+  get __primaryKeys(): Primary<T>[] {
+    return Utils.getPrimaryKeyValues(this.entity, this.__meta.primaryKeys);
+  }
+
+  get __serializedPrimaryKey(): Primary<T> | string {
+    if (this.__meta.compositePK) {
+      return Utils.getCompositeKeyHash(this.entity, this.__meta);
+    }
+
+    if (Utils.isEntity(this.entity[this.__meta.serializedPrimaryKey])) {
+      return wrap(this.entity[this.__meta.serializedPrimaryKey], true).__serializedPrimaryKey as string;
+    }
+
+    return this.entity[this.__meta.serializedPrimaryKey] as unknown as string;
+  }
+
+}

--- a/packages/core/src/entity/index.ts
+++ b/packages/core/src/entity/index.ts
@@ -10,3 +10,6 @@ export * from './ArrayCollection';
 export * from './Collection';
 export * from './EntityLoader';
 export * from './Reference';
+export * from './wrap';
+export * from './BaseEntity';
+export * from './WrappedEntity';

--- a/packages/core/src/entity/wrap.ts
+++ b/packages/core/src/entity/wrap.ts
@@ -1,0 +1,36 @@
+import { Dictionary, IWrappedEntity, IWrappedEntityInternal } from '../typings';
+import { ArrayCollection } from './ArrayCollection';
+import { Reference } from './Reference';
+import { Utils } from '../utils';
+import { WrappedEntity } from './WrappedEntity';
+import { BaseEntity } from './BaseEntity';
+
+/**
+ * returns WrappedEntity instance associated with this entity. This includes all the internal properties like `__meta` or `__em`.
+ */
+export function wrap<T>(entity: T, preferHelper: true): IWrappedEntityInternal<T, keyof T>;
+
+/**
+ * wraps entity type with WrappedEntity internal properties and helpers like init/isInitialized/populated/toJSON
+ */
+export function wrap<T>(entity: T, preferHelper?: false): IWrappedEntity<T, keyof T>;
+
+/**
+ * wraps entity type with WrappedEntity internal properties and helpers like init/isInitialized/populated/toJSON
+ * use `preferHelper = true` to have access to the internal `__` properties like `__meta` or `__em`
+ */
+export function wrap<T>(entity: T, preferHelper = false): IWrappedEntity<T, keyof T> | IWrappedEntityInternal<T, keyof T> {
+  if (entity instanceof BaseEntity && !preferHelper) {
+    return entity as IWrappedEntity<T, keyof T>;
+  }
+
+  if (entity instanceof ArrayCollection) {
+    return entity as unknown as WrappedEntity<T, keyof T>;
+  }
+
+  if (entity instanceof Reference) {
+    entity = Utils.unwrapReference(entity);
+  }
+
+  return (entity as Dictionary).__helper;
+}

--- a/packages/core/src/hydration/ObjectHydrator.ts
+++ b/packages/core/src/hydration/ObjectHydrator.ts
@@ -38,7 +38,7 @@ export class ObjectHydrator extends Hydrator {
   private hydrateEmbeddable<T extends AnyEntity<T>>(entity: T, prop: EntityProperty, data: EntityData<T>): void {
     const value: Dictionary = {};
 
-    Object.values<EntityProperty>(wrap(entity).__meta.properties).filter(p => p.embedded?.[0] === prop.name).forEach(childProp => {
+    Object.values<EntityProperty>(wrap(entity, true).__meta.properties).filter(p => p.embedded?.[0] === prop.name).forEach(childProp => {
       value[childProp.embedded![1]] = data[childProp.name];
     });
 
@@ -95,7 +95,7 @@ export class ObjectHydrator extends Hydrator {
 
     const child = this.factory.create(prop.type, value as EntityData<T>);
 
-    if (wrap(child).__primaryKey) {
+    if (wrap(child, true).__primaryKey) {
       this.em.merge(child);
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 export {
   Constructor, Dictionary, PrimaryKeyType, Primary, IPrimaryKey, FilterQuery, IWrappedEntity, EntityName, EntityData,
-  AnyEntity, WrappedEntity, EntityProperty, EntityMetadata, QBFilterQuery,
+  AnyEntity, EntityProperty, EntityMetadata, QBFilterQuery,
 } from './typings';
 export * from './enums';
 export * from './MikroORM';

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -1,9 +1,9 @@
-import { AnyEntity, Constructor, Dictionary, EntityMetadata, EntityName, EntityProperty } from '../typings';
+import { AnyEntity, Constructor, Dictionary, EntityMetadata, EntityName, EntityProperty, NonFunctionPropertyNames } from '../typings';
 import {
   EmbeddedOptions, EnumOptions, IndexOptions, ManyToManyOptions, ManyToOneOptions, OneToManyOptions, OneToOneOptions, PrimaryKeyOptions, PropertyOptions,
   SerializedPrimaryKeyOptions, UniqueOptions,
 } from '../decorators';
-import { Cascade, Collection, EntityRepository, ReferenceType } from '../entity';
+import { BaseEntity, Cascade, Collection, EntityRepository, ReferenceType } from '../entity';
 import { Type } from '../types';
 import { Utils } from '../utils';
 
@@ -18,7 +18,6 @@ type Property<T> =
   | ({ reference: ReferenceType.EMBEDDED | 'embedded' } & TypeDef<T> & EmbeddedOptions & PropertyOptions)
   | ({ enum: true } & EnumOptions)
   | (TypeDef<T> & PropertyOptions);
-type NonFunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T];
 type PropertyKey<T, U> = NonFunctionPropertyNames<Omit<T, keyof U>>;
 type Metadata<T, U> =
   & Omit<Partial<EntityMetadata<T>>, 'name' | 'properties'>
@@ -163,7 +162,10 @@ export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntit
     this._meta.className = proto.name;
     this._meta.constructorParams = Utils.getParamNames(proto, 'constructor');
     this._meta.toJsonParams = Utils.getParamNames(proto, 'toJSON').filter(p => p !== '...args');
-    this._meta.extends = this._meta.extends || Object.getPrototypeOf(proto).name || undefined;
+
+    if (Object.getPrototypeOf(proto) !== BaseEntity) {
+      this._meta.extends = this._meta.extends || Object.getPrototypeOf(proto).name || undefined;
+    }
   }
 
   get meta() {

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -8,6 +8,7 @@ import { Type } from './types';
 
 export type Constructor<T> = new (...args: any[]) => T;
 export type Dictionary<T = any> = { [k: string]: T };
+export type NonFunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T];
 
 export type PartialEntityProperty<T, P extends keyof T> = null | (T extends Date | RegExp ? T : T[P] | (true extends IsEntity<T[P]> ? PartialEntity<T[P]> | Primary<T[P]> : never));
 export type PartialEntity<T> = T extends Reference<infer U> ? { [P in keyof U]?: PartialEntityProperty<U, P> } : { [P in keyof T]?: PartialEntityProperty<T, P> };
@@ -67,11 +68,14 @@ export type QBFilterQuery<T = any> = FilterQuery<T> & Dictionary;
 export interface IWrappedEntity<T, PK extends keyof T> {
   isInitialized(): boolean;
   populated(populated?: boolean): void;
-  init(populated?: boolean, lockMode?: LockMode): Promise<this>;
+  init(populated?: boolean, lockMode?: LockMode): Promise<T>;
   toReference(): IdentifiedReference<T, PK>;
   toObject(ignoreFields?: string[]): Dictionary;
   toJSON(...args: any[]): Dictionary;
-  assign(data: any, options?: AssignOptions | boolean): this;
+  assign(data: any, options?: AssignOptions | boolean): T;
+}
+
+export interface IWrappedEntityInternal<T, PK extends keyof T> extends IWrappedEntity<T, PK> {
   __uuid: string;
   __meta: EntityMetadata<T>;
   __internal: { platform: Platform; metadata: MetadataStorage; validator: EntityValidator };
@@ -86,7 +90,6 @@ export interface IWrappedEntity<T, PK extends keyof T> {
 }
 
 export type AnyEntity<T = any, PK extends keyof T = keyof T> = { [K in PK]?: T[K] } & { [PrimaryKeyType]?: T[PK] };
-export type WrappedEntity<T, PK extends keyof T> = IWrappedEntity<T, PK> & AnyEntity<T, PK>;
 export type EntityClass<T extends AnyEntity<T>> = Function & { prototype: T };
 export type EntityClassGroup<T extends AnyEntity<T>> = { entity: EntityClass<T>; schema: EntityMetadata<T> | EntitySchema<T> };
 export type EntityName<T extends AnyEntity<T>> = string | EntityClass<T>;

--- a/packages/core/src/unit-of-work/ChangeSet.ts
+++ b/packages/core/src/unit-of-work/ChangeSet.ts
@@ -1,10 +1,10 @@
-import { EntityData, AnyEntity, WrappedEntity, Primary } from '../typings';
+import { EntityData, AnyEntity } from '../typings';
 
 export interface ChangeSet<T extends AnyEntity<T>> {
   name: string;
   collection: string;
   type: ChangeSetType;
-  entity: T & WrappedEntity<T, Primary<T> & keyof T>;
+  entity: T;
   payload: EntityData<T>;
   persisted: boolean;
 }

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -26,21 +26,22 @@ export class ChangeSetPersister {
 
   private async persistEntity<T extends AnyEntity<T>>(changeSet: ChangeSet<T>, meta: EntityMetadata<T>, ctx?: Transaction): Promise<void> {
     let res: QueryResult | undefined;
+    const wrapped = wrap(changeSet.entity, true);
 
     if (changeSet.type === ChangeSetType.DELETE) {
-      await this.driver.nativeDelete(changeSet.name, changeSet.entity.__primaryKey as {}, ctx);
+      await this.driver.nativeDelete(changeSet.name, wrapped.__primaryKey as {}, ctx);
     } else if (changeSet.type === ChangeSetType.UPDATE) {
       res = await this.updateEntity(meta, changeSet, ctx);
       this.mapReturnedValues(changeSet.entity, res, meta);
-    } else if (Utils.isDefined(changeSet.entity.__primaryKey, true)) { // ChangeSetType.CREATE with primary key
+    } else if (Utils.isDefined(wrapped.__primaryKey, true)) { // ChangeSetType.CREATE with primary key
       res = await this.driver.nativeInsert(changeSet.name, changeSet.payload, ctx);
       this.mapReturnedValues(changeSet.entity, res, meta);
-      delete changeSet.entity.__initialized;
+      wrapped.__initialized = true;
     } else { // ChangeSetType.CREATE without primary key
       res = await this.driver.nativeInsert(changeSet.name, changeSet.payload, ctx);
       this.mapReturnedValues(changeSet.entity, res, meta);
       this.mapPrimaryKey(meta, res, changeSet);
-      delete changeSet.entity.__initialized;
+      wrapped.__initialized = true;
     }
 
     await this.processOptimisticLock(meta, changeSet, res, ctx);
@@ -50,13 +51,14 @@ export class ChangeSetPersister {
   private mapPrimaryKey<T>(meta: EntityMetadata<T>, res: QueryResult, changeSet: ChangeSet<T>): void {
     const prop = meta.properties[meta.primaryKeys[0]];
     const insertId = prop.customType ? prop.customType.convertToJSValue(res.insertId, this.driver.getPlatform()) : res.insertId;
-    wrap(changeSet.entity).__primaryKey = Utils.isDefined(changeSet.entity.__primaryKey, true) ? changeSet.entity.__primaryKey : insertId;
-    this.identifierMap[changeSet.entity.__uuid].setValue(changeSet.entity[prop.name] as unknown as IPrimaryKey);
+    const wrapped = wrap(changeSet.entity, true);
+    wrapped.__primaryKey = Utils.isDefined(wrapped.__primaryKey, true) ? wrapped.__primaryKey : insertId;
+    this.identifierMap[wrapped.__uuid].setValue(changeSet.entity[prop.name] as unknown as IPrimaryKey);
   }
 
   private async updateEntity<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSet: ChangeSet<T>, ctx?: Transaction): Promise<QueryResult> {
     if (!meta.versionProperty || !changeSet.entity[meta.versionProperty]) {
-      return this.driver.nativeUpdate(changeSet.name, changeSet.entity.__primaryKey as {}, changeSet.payload, ctx);
+      return this.driver.nativeUpdate(changeSet.name, wrap(changeSet.entity, true).__primaryKey as {}, changeSet.payload, ctx);
     }
 
     const cond = {
@@ -73,7 +75,7 @@ export class ChangeSetPersister {
     }
 
     if (meta.versionProperty && [ChangeSetType.CREATE, ChangeSetType.UPDATE].includes(changeSet.type)) {
-      const e = await this.driver.findOne<T>(meta.name, changeSet.entity.__primaryKey, { populate: [meta.versionProperty] }, ctx);
+      const e = await this.driver.findOne<T>(meta.name, wrap(changeSet.entity, true).__primaryKey, { populate: [meta.versionProperty] }, ctx);
       (changeSet.entity as T)[meta.versionProperty] = e![meta.versionProperty];
     }
   }

--- a/packages/core/src/utils/SmartQueryHelper.ts
+++ b/packages/core/src/utils/SmartQueryHelper.ts
@@ -76,11 +76,13 @@ export class SmartQueryHelper {
   }
 
   private static processEntity(entity: AnyEntity, root?: boolean): any {
-    if (root || wrap(entity).__meta.compositePK) {
-      return entity.__primaryKey;
+    const wrapped = wrap(entity, true);
+
+    if (root || wrapped.__meta.compositePK) {
+      return wrapped.__primaryKey;
     }
 
-    return Utils.getPrimaryKeyCond(entity, wrap(entity).__meta.primaryKeys);
+    return Utils.getPrimaryKeyCond(entity, wrapped.__meta.primaryKeys);
   }
 
   private static processExpression<T>(expr: string, value: T): Dictionary<T> {

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -182,7 +182,7 @@ export class Utils {
     }
 
     const collection = entity[prop.name] as unknown instanceof ArrayCollection;
-    const noPkRef = Utils.isEntity(entity[prop.name]) && !wrap(entity[prop.name]).__primaryKeys.every(pk => pk);
+    const noPkRef = Utils.isEntity(entity[prop.name]) && !wrap(entity[prop.name], true).__primaryKeys.every(pk => pk);
     const noPkProp = prop.primary && !Utils.isDefined(entity[prop.name], true);
     const inverse = prop.reference === ReferenceType.ONE_TO_ONE && !prop.owner;
     const discriminator = prop.name === root.discriminatorColumn;
@@ -278,7 +278,7 @@ export class Utils {
     }
 
     if (Utils.isEntity(data) && !meta) {
-      meta = wrap(data).__meta;
+      meta = wrap(data, true).__meta;
     }
 
     if (Utils.isObject(data) && meta) {
@@ -295,7 +295,7 @@ export class Utils {
   static getCompositeKeyHash<T>(entity: T, meta: EntityMetadata<T>): string {
     const pks = meta.primaryKeys.map(pk => {
       if (Utils.isEntity(entity[pk], true)) {
-        return wrap(entity[pk]).__serializedPrimaryKey;
+        return wrap(entity[pk], true).__serializedPrimaryKey;
       }
 
       return entity[pk];
@@ -318,7 +318,7 @@ export class Utils {
     }
 
     if (Utils.isEntity(entity[primaryKeys[0]])) {
-      return wrap(entity[primaryKeys[0]]).__primaryKey;
+      return wrap(entity[primaryKeys[0]], true).__primaryKey;
     }
 
     return entity[primaryKeys[0]];
@@ -327,7 +327,7 @@ export class Utils {
   static getPrimaryKeyValues<T extends AnyEntity<T>>(entity: T, primaryKeys: string[], allowScalar = false) {
     if (allowScalar && primaryKeys.length === 1) {
       if (Utils.isEntity(entity[primaryKeys[0]])) {
-        return wrap(entity[primaryKeys[0]]).__primaryKey;
+        return wrap(entity[primaryKeys[0]], true).__primaryKey;
       }
 
       return entity[primaryKeys[0]];
@@ -335,7 +335,7 @@ export class Utils {
 
     return primaryKeys.map(pk => {
       if (Utils.isEntity(entity[pk])) {
-        return wrap(entity[pk]).__primaryKey;
+        return wrap(entity[pk], true).__primaryKey;
       }
 
       return entity[pk];

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -135,10 +135,11 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
   }
 
   async syncCollection<T extends AnyEntity<T>, O extends AnyEntity<O>>(coll: Collection<T, O>, ctx?: Transaction): Promise<void> {
-    const meta = wrap(coll.owner).__meta;
-    const pks = wrap(coll.owner).__primaryKeys;
-    const snapshot = coll.getSnapshot().map(item => wrap(item).__primaryKeys);
-    const current = coll.getItems(false).map(item => wrap(item).__primaryKeys);
+    const wrapped = wrap(coll.owner, true);
+    const meta = wrapped.__meta;
+    const pks = wrapped.__primaryKeys;
+    const snapshot = coll.getSnapshot().map(item => wrap(item, true).__primaryKeys);
+    const current = coll.getItems(false).map(item => wrap(item, true).__primaryKeys);
     const deleteDiff = snapshot.filter(item => !current.includes(item));
     const insertDiff = current.filter(item => !snapshot.includes(item));
     const target = snapshot.filter(item => current.includes(item)).concat(...insertDiff);
@@ -271,7 +272,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
 
   async lockPessimistic<T extends AnyEntity<T>>(entity: T, mode: LockMode, ctx?: Transaction): Promise<void> {
     const qb = this.createQueryBuilder(entity.constructor.name, ctx);
-    const meta = wrap(entity).__meta;
+    const meta = wrap(entity, true).__meta;
     const cond = Utils.getPrimaryKeyCond(entity, meta.primaryKeys);
     await qb.select('1').where(cond).setLockMode(mode).execute();
   }

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -1499,13 +1499,13 @@ describe('EntityManagerMongo', () => {
     bar.baz = baz1;
     await orm.em.persistAndFlush(bar);
     // @ts-ignore
-    expect(orm.em.getUnitOfWork().originalEntityData[bar.__uuid].baz).toEqual(baz1._id);
+    expect(orm.em.getUnitOfWork().originalEntityData[wrap(bar, true).__uuid].baz).toEqual(baz1._id);
 
     // replacing reference with value will trigger orphan removal
     bar.baz = baz2;
     await orm.em.persistAndFlush(bar);
     // @ts-ignore
-    expect(orm.em.getUnitOfWork().originalEntityData[bar.__uuid].baz).toEqual(baz2._id);
+    expect(orm.em.getUnitOfWork().originalEntityData[wrap(bar, true).__uuid].baz).toEqual(baz2._id);
     await expect(orm.em.findOne(FooBaz, baz1)).resolves.toBeNull();
     await expect(orm.em.findOne(FooBaz, baz2)).resolves.not.toBeNull();
 
@@ -1708,6 +1708,22 @@ describe('EntityManagerMongo', () => {
     expect(ref4.isInitialized()).toBe(true);
     expect(ref4.getProperty('name')).toBe('God');
     await expect(ref4.get('email')).resolves.toBe('hello@heaven.god');
+    expect(ref4.__populated).toBe(true);
+    ref4.populated(false);
+    expect(ref4.__populated).toBe(false);
+    ref4.populated();
+    expect(ref4.__populated).toBe(true);
+    expect(ref4.__lazyInitialized).toBe(true);
+    expect(ref4.__internal).toBeDefined();
+    expect(ref4.__em).toBeDefined();
+    expect(ref4.__uuid).toBeDefined();
+    expect(ref4.toJSON()).toMatchObject({
+      name: 'God',
+    });
+
+    // const wrapped = wrap(ref4);
+    // console.log(wrapped);
+    // expect(wrapped).toBe(ref4);
   });
 
   test('find and count', async () => {

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -219,8 +219,8 @@ describe('EntityManagerMySql', () => {
     const repo = orm.em.getRepository(FooBar2);
     const a = await repo.findOne(fooBar.id, ['baz']);
     expect(wrap(a!.baz).isInitialized()).toBe(true);
-    expect(wrap(a!.baz).id).toBe(0);
-    expect(wrap(a!.baz).name).toBe('testBaz');
+    expect(a!.baz!.id).toBe(0);
+    expect(a!.baz!.name).toBe('testBaz');
   });
 
   test('inverse side of 1:1 is ignored in change set', async () => {

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -601,10 +601,10 @@ describe('EntityManagerPostgre', () => {
 
     const em2 = orm.em.fork();
     const bible2 = await em2.findOneOrFail(Book2, { uuid: bible.uuid });
-    expect(wrap(bible2).__em!.id).toBe(em2.id);
-    expect(wrap(bible2.publisher).__em!.id).toBe(em2.id);
+    expect(wrap(bible2, true).__em!.id).toBe(em2.id);
+    expect(wrap(bible2.publisher, true).__em!.id).toBe(em2.id);
     const publisher2 = await bible2.publisher!.load();
-    expect(wrap(publisher2).__em!.id).toBe(em2.id);
+    expect(wrap(publisher2, true).__em!.id).toBe(em2.id);
   });
 
   test('populate OneToOne relation', async () => {

--- a/tests/EntityManager.sqlite.test.ts
+++ b/tests/EntityManager.sqlite.test.ts
@@ -1,5 +1,5 @@
 import { unlinkSync } from 'fs';
-import { Collection, EntityManager, EntityMetadata, JavaScriptMetadataProvider, LockMode, MikroORM, QueryOrder, Utils, Logger, ValidationError } from '@mikro-orm/core';
+import { Collection, EntityManager, EntityMetadata, JavaScriptMetadataProvider, LockMode, MikroORM, QueryOrder, Utils, Logger, ValidationError, wrap } from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
 import { initORMSqlite, wipeDatabaseSqlite } from './bootstrap';
@@ -666,7 +666,7 @@ describe('EntityManagerSqlite', () => {
     expect(publishers[0].tests.isDirty()).toBe(false);
     expect(publishers[0].tests.count()).toBe(0);
     await publishers[0].tests.init(); // empty many to many on owning side should not make db calls
-    expect(publishers[1].tests.getItems()[0].isInitialized()).toBe(true);
+    expect(wrap(publishers[1].tests.getItems()[0]).isInitialized()).toBe(true);
   });
 
   test('populating many to many relation on inverse side', async () => {

--- a/tests/entities-js/BaseEntity4.js
+++ b/tests/entities-js/BaseEntity4.js
@@ -1,12 +1,13 @@
-const { Collection, ReferenceType } = require('@mikro-orm/core');
+const { Collection, BaseEntity, ReferenceType, wrap } = require('@mikro-orm/core');
 
 /**
  * @property {number} id
  */
-class BaseEntity4 {
+class BaseEntity4 extends BaseEntity {
 
   constructor() {
-    const props = this['__meta'].properties;
+    super();
+    const props = wrap(this, true).__meta.properties;
 
     Object.keys(props).forEach(prop => {
       if ([ReferenceType.ONE_TO_MANY, ReferenceType.MANY_TO_MANY].includes(props[prop].reference)) {

--- a/tests/entities-schema/User4.ts
+++ b/tests/entities-schema/User4.ts
@@ -1,4 +1,4 @@
-import { EntitySchema } from '../../lib/schema';
+import { EntitySchema } from '@mikro-orm/core';
 
 export class User4 {
 

--- a/tests/entities-sql/BaseEntity2.ts
+++ b/tests/entities-sql/BaseEntity2.ts
@@ -9,7 +9,7 @@ export abstract class BaseEntity2 {
   hookTest = false;
 
   protected constructor() {
-    const props = wrap(this).__meta.properties;
+    const props = wrap(this, true).__meta.properties;
 
     Object.keys(props).forEach(prop => {
       if ([ReferenceType.ONE_TO_MANY, ReferenceType.MANY_TO_MANY].includes(props[prop].reference)) {

--- a/tests/entities-sql/BaseEntity22.ts
+++ b/tests/entities-sql/BaseEntity22.ts
@@ -5,7 +5,7 @@ export abstract class BaseEntity22 {
   abstract id: number;
 
   constructor() {
-    const props = wrap(this).__meta.properties;
+    const props = wrap(this, true).__meta.properties;
 
     Object.keys(props).forEach(prop => {
       if ([ReferenceType.ONE_TO_MANY, ReferenceType.MANY_TO_MANY].includes(props[prop].reference)) {

--- a/tests/entities-sql/BookTag2.ts
+++ b/tests/entities-sql/BookTag2.ts
@@ -17,7 +17,7 @@ export class BookTag2 {
   booksUnordered!: Collection<Book2>;
 
   constructor(name: string) {
-    const props = wrap(this).__meta.properties;
+    const props = wrap(this, true).__meta.properties;
 
     Object.keys(props).forEach(prop => {
       if ([ReferenceType.ONE_TO_MANY, ReferenceType.MANY_TO_MANY].includes(props[prop].reference)) {

--- a/tests/entities/Author.ts
+++ b/tests/entities/Author.ts
@@ -1,6 +1,6 @@
 import {
   AfterCreate, AfterDelete, AfterUpdate, BeforeCreate, BeforeDelete, BeforeUpdate, DateType, Collection,
-  Cascade, Entity, EntityAssigner, ManyToMany, ManyToOne, OneToMany, Property, wrap, Index, Unique,
+  Cascade, Entity, ManyToMany, ManyToOne, OneToMany, Property, Index, Unique, EntityAssigner,
 } from '@mikro-orm/core';
 
 import { Book } from './Book';
@@ -9,7 +9,7 @@ import { BaseEntity } from './BaseEntity';
 
 @Entity({ customRepository: () => AuthorRepository })
 @Index({ name: 'custom_idx_1', properties: ['name', 'email'] })
-export class Author extends BaseEntity {
+export class Author extends BaseEntity<Author> {
 
   static beforeDestroyCalled = 0;
   static afterDestroyCalled = 0;
@@ -113,7 +113,7 @@ export class Author extends BaseEntity {
   }
 
   toJSON(strict = true, strip = ['id', 'email'], ...args: any[]): { [p: string]: any } {
-    const o = wrap(this).toObject(...args);
+    const o = this.toObject(...args);
     o.fooBar = 123;
 
     if (strict) {

--- a/tests/entities/BaseEntity.ts
+++ b/tests/entities/BaseEntity.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from 'bson';
-import { BeforeCreate, PrimaryKey, Property, SerializedPrimaryKey } from '@mikro-orm/core';
+import { BeforeCreate, PrimaryKey, Property, SerializedPrimaryKey, BaseEntity as MikroBaseEntity } from '@mikro-orm/core';
 
-export abstract class BaseEntity {
+export abstract class BaseEntity<T extends BaseEntity<T>> extends MikroBaseEntity<T, 'id' | '_id'> {
 
   @PrimaryKey()
   _id!: ObjectId;

--- a/tests/entities/BaseEntity3.ts
+++ b/tests/entities/BaseEntity3.ts
@@ -1,7 +1,7 @@
-import { ObjectId } from 'bson';
-import { PrimaryKey, SerializedPrimaryKey } from '@mikro-orm/core';
+import { ObjectId } from '@mikro-orm/mongodb';
+import { BaseEntity, PrimaryKey, SerializedPrimaryKey } from '@mikro-orm/core';
 
-export abstract class BaseEntity3 {
+export abstract class BaseEntity3 extends BaseEntity<BaseEntity3, 'id' | '_id'>{
 
   @PrimaryKey()
   _id!: ObjectId;

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -38,7 +38,7 @@ export class Book extends BaseEntity3 {
   constructor(title: string, author?: Author) {
     super();
     this.title = title;
-    this.author = author as Author;
+    this.author = author!;
   }
 
   toJSON(strict = true, strip = ['metaObject', 'metaArray', 'metaArrayOfStrings'], ...args: any[]): { [p: string]: any } {


### PR DESCRIPTION
Previously all the methods and properties of `WrappedEntity` interface were
added to the entity prototype during discovery. In v4 there is only one property
added: `__helper: WrappedEntity`. `WrappedEntity` has been converted to actual class.

`wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is
being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...),
if you want to access internal properties like `__meta` or `__em`, you need to explicitly
ask for the helper via `wrap(entity, true)`.

Instead of interface merging with `WrappedEntity`, one can now use classic inheritance,
by extending `BaseEntity` exported from `@mikro-orm/core`. If you do so, `wrap(entity)`
will return your entity.

BREAKING CHANGE:
Instead of interface merging with WrappedEntity interface, it is now needed to extend BaseEntity.
If you want to access internal prefixed properties from `wrap(e)`, you need to use `wrap(e, true)`.

Closes #506
Closes #528