### PR TITLE
feat(sql): allow update queries with auto-joining via sub-queries

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,6 +26,8 @@ discuss specifics.
 - [x] Embedded entities (allow in-lining child entity into parent one with prefixed keys)
 - [x] Use `jsonb` as default for object columns in postgres
 - [x] Support subqueries in QB
+- [x] Nested conditions in `qb.update()` queries via subqueries (#319)
+- [ ] Nested conditions in `em.remove()` via subqueries (#492)
 - [ ] Association scopes/filters ([hibernate docs](https://docs.jboss.org/hibernate/orm/3.6/reference/en-US/html/filters.html))
 - [ ] Support external hooks when using EntitySchema (hooks outside of entity)
 - [ ] Cache metadata only with ts-morph provider
@@ -36,6 +38,10 @@ discuss specifics.
 - [ ] Use custom errors for specific cases (unique constraint violation, db not accessible, ...)
 - [ ] Add custom types for blob, array, json
 - [ ] Lazy scalar properties (allow having props that won't be loaded by default, but can be populated)
+- [ ] Seeds (#251)
+- [ ] Static checking of population (#214)
+- [ ] Nested object validation (#466)
+- [ ] Migrations Support for MongoDB (#295)
 
 ## Planned breaking changes for v4
 

--- a/packages/knex/src/query/ArrayCriteriaNode.ts
+++ b/packages/knex/src/query/ArrayCriteriaNode.ts
@@ -16,6 +16,12 @@ export class ArrayCriteriaNode extends CriteriaNode {
     });
   }
 
+  willAutoJoin(qb: QueryBuilder, alias?: string) {
+    return this.payload.some((node: CriteriaNode) => {
+      return node.willAutoJoin(qb, alias);
+    });
+  }
+
   getPath(): string {
     if (this.parent && this.parent.parent) {
       return this.parent.parent.getPath();

--- a/packages/knex/src/query/CriteriaNode.ts
+++ b/packages/knex/src/query/CriteriaNode.ts
@@ -53,6 +53,10 @@ export class CriteriaNode {
     return false;
   }
 
+  willAutoJoin(qb: QueryBuilder, alias?: string) {
+    return false;
+  }
+
   shouldRename(payload: any): boolean {
     const type = this.prop ? this.prop.reference : null;
     const composite = this.prop && this.prop.joinColumns ? this.prop.joinColumns.length > 1 : false;

--- a/packages/knex/src/query/ObjectCriteriaNode.ts
+++ b/packages/knex/src/query/ObjectCriteriaNode.ts
@@ -64,6 +64,24 @@ export class ObjectCriteriaNode extends CriteriaNode {
     }, {});
   }
 
+  willAutoJoin(qb: QueryBuilder, alias?: string): boolean {
+    const nestedAlias = qb.getAliasForEntity(this.entityName, this);
+    const ownerAlias = alias || qb.alias;
+
+    if (nestedAlias) {
+      alias = nestedAlias;
+    }
+
+    if (this.shouldAutoJoin(nestedAlias)) {
+      return true;
+    }
+
+    return Object.keys(this.payload).some(field => {
+      const childNode = this.payload[field] as CriteriaNode;
+      return childNode.willAutoJoin(qb, this.prop ? alias : ownerAlias);
+    });
+  }
+
   shouldInline(payload: any): boolean {
     const customExpression = QueryBuilderHelper.isCustomExpression(this.key!);
     const scalar = Utils.isPrimaryKey(payload) || payload instanceof RegExp || payload instanceof Date || customExpression;

--- a/packages/knex/src/query/enums.ts
+++ b/packages/knex/src/query/enums.ts
@@ -9,4 +9,5 @@ export enum QueryType {
 
 export enum QueryFlag {
   DISTINCT = 'DISTINCT',
+  UPDATE_SUB_QUERY = 'UPDATE_SUB_QUERY',
 }


### PR DESCRIPTION
```typescript
qb.update({ name: 'test 123', type: PublisherType.GLOBAL }).where({ books: { author: 123 } });`
```

will result in following query:

```sql
update `publisher2` set `name` = ?, `type` = ? where `id` in (select `e0`.`id` from (
  select distinct `e0`.`id` from `publisher2` as `e0` left join `book2` as `e1` on `e0`.`id` = `e1`.`publisher_id` where `e1`.`author_id` = ?
) as `e0`)
```

Closes #319