### PR TITLE
feat(sql): allow delete queries with auto-joining via sub-queries

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ discuss specifics.
 - [x] Use `jsonb` as default for object columns in postgres
 - [x] Support subqueries in QB
 - [x] Nested conditions in `qb.update()` queries via subqueries (#319)
-- [ ] Nested conditions in `em.remove()` via subqueries (#492)
+- [x] Nested conditions in `em.remove()` via subqueries (#492)
 - [ ] Association scopes/filters ([hibernate docs](https://docs.jboss.org/hibernate/orm/3.6/reference/en-US/html/filters.html))
 - [ ] Support external hooks when using EntitySchema (hooks outside of entity)
 - [ ] Cache metadata only with ts-morph provider

--- a/packages/knex/src/query/enums.ts
+++ b/packages/knex/src/query/enums.ts
@@ -10,4 +10,5 @@ export enum QueryType {
 export enum QueryFlag {
   DISTINCT = 'DISTINCT',
   UPDATE_SUB_QUERY = 'UPDATE_SUB_QUERY',
+  DELETE_SUB_QUERY = 'DELETE_SUB_QUERY',
 }


### PR DESCRIPTION
```typescript
qb.delete({ books: { author: 123 } });`
```

will result in following query:

```sql
delete from `publisher2` where `id` in (select `e0`.`id` from (
  select distinct `e0`.`id` from `publisher2` as `e0` left join `book2` as `e1` on `e0`.`id` = `e1`.`publisher_id` where `e1`.`author_id` = ?
) as `e0`)
```

Closes #492