### PR TITLE
feat(core): use custom exceptions for driver related errors

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -17,7 +17,7 @@ checks:
     config:
       threshold: 7
 
-engines:
+plugins:
   duplication:
     enabled: true
     config:
@@ -26,3 +26,12 @@ engines:
         typescript:
           # make it higher so it does not report bullshit like similarity of abstract method and its implementation
           mass_threshold: 80
+
+exclude_patterns:
+  - '**/*ExceptionConverter.ts'
+  - 'docs/'
+  - 'temp/'
+  - '**/dist/'
+  - '**/node_modules/'
+  - '**/tests/'
+  - '**/*.d.ts'

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,6 +28,7 @@ discuss specifics.
 - [x] Support subqueries in QB
 - [x] Nested conditions in `qb.update()` queries via subqueries (#319)
 - [x] Nested conditions in `em.remove()` via subqueries (#492)
+- [x] Use custom errors for specific cases (unique constraint violation, db not accessible, ...)
 - [ ] Association scopes/filters ([hibernate docs](https://docs.jboss.org/hibernate/orm/3.6/reference/en-US/html/filters.html))
 - [ ] Support external hooks when using EntitySchema (hooks outside of entity)
 - [ ] Cache metadata only with ts-morph provider
@@ -35,7 +36,6 @@ discuss specifics.
 - [ ] Support computed properties
 - [ ] Add `groupBy` and `distinct` to `FindOptions` and `FindOneOptions`
 - [ ] Paginator helper or something similar ([doctrine docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/pagination.html))
-- [ ] Use custom errors for specific cases (unique constraint violation, db not accessible, ...)
 - [ ] Add custom types for blob, array, json
 - [ ] Lazy scalar properties (allow having props that won't be loaded by default, but can be populated)
 - [ ] Seeds (#251)

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -6,7 +6,7 @@ import { Configuration, ConnectionOptions, Utils } from '../utils';
 import { QueryOrder, QueryOrderMap } from '../enums';
 import { Platform } from '../platforms';
 import { Collection, wrap } from '../entity';
-import { EntityManager, LockMode } from '../index';
+import { DriverException, EntityManager, LockMode } from '../index';
 
 export abstract class DatabaseDriver<C extends Connection> implements IDatabaseDriver<C> {
 
@@ -174,6 +174,19 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
 
   async lockPessimistic<T extends AnyEntity<T>>(entity: T, mode: LockMode, ctx?: Transaction): Promise<void> {
     throw new Error(`Pessimistic locks are not supported by ${this.constructor.name} driver`);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  convertException(exception: Error): DriverException {
+    return this.platform.getExceptionConverter().convertException(exception);
+  }
+
+  protected rethrow<T>(promise: Promise<T>): Promise<T> {
+    return promise.catch(e => {
+      throw this.convertException(e);
+    });
   }
 
 }

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -6,6 +6,7 @@ import { MetadataStorage } from '../metadata';
 import { LockMode } from '../unit-of-work';
 import { Collection } from '../entity';
 import { EntityManager } from '../index';
+import { DriverException } from '../exceptions';
 
 export const EntityManagerType = Symbol('EntityManagerType');
 
@@ -65,6 +66,11 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   getDependencies(): string[];
 
   lockPessimistic<T extends AnyEntity<T>>(entity: T, mode: LockMode, ctx?: Transaction): Promise<void>;
+
+  /**
+   * Converts native db errors to standardized driver exceptions
+   */
+  convertException(exception: Error): DriverException;
 
 }
 

--- a/packages/core/src/exceptions.ts
+++ b/packages/core/src/exceptions.ts
@@ -1,0 +1,107 @@
+/**
+ * Base class for all errors detected in the driver.
+ */
+export class DriverException extends Error {
+
+  code?: string;
+  errno?: number;
+  sqlState?: string;
+  sqlMessage?: string;
+  errmsg?: string;
+
+  constructor(previous: Error) {
+    super(previous.message);
+    Object.assign(this, previous);
+    this.name = this.constructor.name;
+    this.stack = (new Error()).stack!.split('\n').join('\n');
+  }
+
+}
+
+/**
+ * Base class for all connection related errors detected in the driver.
+ */
+export class ConnectionException extends DriverException { }
+
+/**
+ * Base class for all server related errors detected in the driver.
+ */
+export class ServerException extends DriverException { }
+
+/**
+ * Base class for all constraint violation related errors detected in the driver.
+ */
+export class ConstraintViolationException extends ServerException { }
+
+/**
+ * Base class for all already existing database object related errors detected in the driver.
+ *
+ * A database object is considered any asset that can be created in a database
+ * such as schemas, tables, views, sequences, triggers,  constraints, indexes,
+ * functions, stored procedures etc.
+ */
+export class DatabaseObjectExistsException extends ServerException { }
+
+/**
+ * Base class for all unknown database object related errors detected in the driver.
+ *
+ * A database object is considered any asset that can be created in a database
+ * such as schemas, tables, views, sequences, triggers,  constraints, indexes,
+ * functions, stored procedures etc.
+ */
+export class DatabaseObjectNotFoundException extends ServerException { }
+
+/**
+ * Exception for a deadlock error of a transaction detected in the driver.
+ */
+export class DeadlockException extends ServerException { }
+
+/**
+ * Exception for a foreign key constraint violation detected in the driver.
+ */
+export class ForeignKeyConstraintViolationException extends ConstraintViolationException { }
+
+/**
+ * Exception for an invalid specified field name in a statement detected in the driver.
+ */
+export class InvalidFieldNameException extends ServerException { }
+
+/**
+ * Exception for a lock wait timeout error of a transaction detected in the driver.
+ */
+export class LockWaitTimeoutException extends ServerException { }
+
+/**
+ * Exception for a non-unique/ambiguous specified field name in a statement detected in the driver.
+ */
+export class NonUniqueFieldNameException extends ServerException { }
+
+/**
+ * Exception for a NOT NULL constraint violation detected in the driver.
+ */
+export class NotNullConstraintViolationException extends ConstraintViolationException { }
+
+/**
+ * Exception for a write operation attempt on a read-only database element detected in the driver.
+ */
+export class ReadOnlyException extends ServerException { }
+
+/**
+ * Exception for a syntax error in a statement detected in the driver.
+ */
+export class SyntaxErrorException extends ServerException { }
+
+/**
+ * Exception for an already existing table referenced in a statement detected in the driver.
+ */
+export class TableExistsException extends DatabaseObjectExistsException { }
+
+/**
+ * Exception for an unknown table referenced in a statement detected in the driver.
+ */
+export class TableNotFoundException extends DatabaseObjectNotFoundException { }
+
+/**
+ * Exception for a unique constraint violation detected in the driver.
+ */
+export class UniqueConstraintViolationException extends ConstraintViolationException { }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export {
   AnyEntity, EntityProperty, EntityMetadata, QBFilterQuery,
 } from './typings';
 export * from './enums';
+export * from './exceptions';
 export * from './MikroORM';
 export * from './entity';
 export * from './EntityManager';

--- a/packages/core/src/platforms/ExceptionConverter.ts
+++ b/packages/core/src/platforms/ExceptionConverter.ts
@@ -1,0 +1,11 @@
+import { Dictionary } from '../typings';
+import { DriverException } from '../exceptions';
+
+export class ExceptionConverter {
+
+  /* istanbul ignore next */
+  convertException(exception: Error & Dictionary): DriverException {
+    return new DriverException(exception);
+  }
+
+}

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -1,8 +1,11 @@
 import { EntityRepository } from '../entity';
 import { NamingStrategy, UnderscoreNamingStrategy } from '../naming-strategy';
 import { Constructor, Dictionary, EntityProperty, IPrimaryKey, Primary } from '../typings';
+import { ExceptionConverter } from './ExceptionConverter';
 
 export abstract class Platform {
+
+  protected readonly exceptionConverter = new ExceptionConverter();
 
   usesPivotTable(): boolean {
     return false;
@@ -94,6 +97,10 @@ export abstract class Platform {
 
   getDefaultCharset(): string {
     return 'utf8';
+  }
+
+  getExceptionConverter(): ExceptionConverter {
+    return this.exceptionConverter;
   }
 
 }

--- a/packages/core/src/platforms/index.ts
+++ b/packages/core/src/platforms/index.ts
@@ -1,1 +1,2 @@
 export * from './Platform';
+export * from './ExceptionConverter';

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -1,4 +1,4 @@
-import { Transaction as KnexTransaction, Value } from 'knex';
+import { Raw, Transaction as KnexTransaction, QueryBuilder as KnexQueryBuilder, Value } from 'knex';
 import {
   AnyEntity, Constructor, Dictionary, EntityData, EntityMetadata, EntityProperty, FilterQuery, Primary, QueryOrderMap,
   Configuration, Utils, Collection, FindOneOptions, FindOptions, ReferenceType, wrap, DatabaseDriver, QueryResult,
@@ -46,7 +46,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
       qb.limit(options.limit, options.offset);
     }
 
-    return qb.execute('all');
+    return this.rethrow(qb.execute('all'));
   }
 
   async findOne<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions, ctx?: Transaction<KnexTransaction>): Promise<T | null> {
@@ -63,21 +63,24 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
       options.fields.unshift(pk);
     }
 
-    return this.createQueryBuilder(entityName, ctx, !!ctx)
+    const qb = this.createQueryBuilder(entityName, ctx, !!ctx)
       .select(options.fields || '*')
       .populate(options.populate)
       .where(where as Dictionary)
       .orderBy(options.orderBy!)
       .limit(1)
       .setLockMode(options.lockMode)
-      .withSchema(options.schema)
-      .execute('get');
+      .withSchema(options.schema);
+
+    return this.rethrow(qb.execute('get'));
   }
 
   async count(entityName: string, where: any, ctx?: Transaction<KnexTransaction>): Promise<number> {
-    const qb = this.createQueryBuilder(entityName, ctx, !!ctx);
     const pks = this.metadata.get(entityName).primaryKeys;
-    const res = await qb.count(pks, true).where(where).execute('get', false);
+    const qb = this.createQueryBuilder(entityName, ctx, !!ctx)
+      .count(pks, true)
+      .where(where);
+    const res = await this.rethrow(qb.execute('get', false));
 
     return +res.count;
   }
@@ -87,7 +90,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     const collections = this.extractManyToMany(entityName, data);
     const pks = this.getPrimaryKeyFields(entityName);
     const qb = this.createQueryBuilder(entityName, ctx, true);
-    const res = await qb.insert(data).execute('run', false);
+    const res = await this.rethrow(qb.insert(data).execute('run', false));
     res.row = res.row || {};
     let pk: any;
 
@@ -114,8 +117,11 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     }
 
     if (Object.keys(data).length > 0) {
-      const qb = this.createQueryBuilder(entityName, ctx, true);
-      res = await qb.update(data).where(where as Dictionary).execute('run', false);
+      const qb = this.createQueryBuilder(entityName, ctx, true)
+        .update(data)
+        .where(where as Dictionary);
+
+      res = await this.rethrow(qb.execute('run', false));
     }
 
     const pk = pks.map(pk => Utils.extractPK<T>(data[pk] || where, meta)) as Primary<T>[];
@@ -131,7 +137,9 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
       where = { [pks[0]]: where };
     }
 
-    return this.createQueryBuilder(entityName, ctx, true).delete(where).execute('run', false);
+    const qb = this.createQueryBuilder(entityName, ctx, true).delete(where);
+
+    return this.rethrow(qb.execute('run', false));
   }
 
   async syncCollection<T extends AnyEntity<T>, O extends AnyEntity<O>>(coll: Collection<T, O>, ctx?: Transaction): Promise<void> {
@@ -152,7 +160,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
       insertDiff.push(...current);
     }
 
-    await this.updateCollectionDiff<T, O>(meta, coll.property, pks, deleteDiff, insertDiff, ctx);
+    await this.rethrow(this.updateCollectionDiff<T, O>(meta, coll.property, pks, deleteDiff, insertDiff, ctx));
   }
 
   async loadFromPivotTable<T extends AnyEntity<T>, O extends AnyEntity<O>>(prop: EntityProperty, owners: Primary<O>[][], where?: FilterQuery<T>, orderBy?: QueryOrderMap, ctx?: Transaction): Promise<Dictionary<T[]>> {
@@ -170,7 +178,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     const qb = this.createQueryBuilder(prop.type, ctx, !!ctx);
     const populate = this.autoJoinOneToOneOwner(meta, [prop.pivotTable]);
     qb.select('*').populate(populate).where(where as Dictionary).orderBy(orderBy!);
-    const items = owners.length ? await qb.execute('all') : [];
+    const items = owners.length ? await this.rethrow(qb.execute('all')) : [];
 
     const map: Dictionary<T[]> = {};
     owners.forEach(owner => map['' + Utils.getPrimaryKeyHash(owner as string[])] = []);
@@ -182,6 +190,10 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     });
 
     return map;
+  }
+
+  async execute<T extends QueryResult | EntityData<AnyEntity> | EntityData<AnyEntity>[] = EntityData<AnyEntity>[]>(queryOrKnex: string | KnexQueryBuilder | Raw, params: any[] = [], method: 'all' | 'get' | 'run' = 'all', ctx?: Transaction): Promise<T> {
+    return this.rethrow(this.connection.execute(queryOrKnex, params, method, ctx));
   }
 
   /**
@@ -231,7 +243,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     const props = meta.properties;
 
     for (const k of Object.keys(collections)) {
-      await this.updateCollectionDiff(meta, props[k], pks, clear, collections[k], ctx);
+      await this.rethrow(this.updateCollectionDiff(meta, props[k], pks, clear, collections[k], ctx));
     }
   }
 
@@ -251,7 +263,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
       }
 
       meta2.primaryKeys.forEach((pk, idx) => knex.andWhere(prop.joinColumns[idx], pks[idx] as Value[][]));
-      await this.connection.execute(knex.delete());
+      await this.execute(knex.delete());
     }
 
     const items = insertDiff.map(item => {
@@ -264,7 +276,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
 
     if (this.platform.allowsMultiInsert()) {
       const qb2 = this.createQueryBuilder(prop.pivotTable, ctx, true);
-      await this.connection.execute(qb2.getKnex().insert(items));
+      await this.execute(qb2.getKnex().insert(items));
     } else {
       await Utils.runSerial(items, item => this.createQueryBuilder(prop.pivotTable, ctx, true).insert(item).execute('run', false));
     }
@@ -274,7 +286,8 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     const qb = this.createQueryBuilder(entity.constructor.name, ctx);
     const meta = wrap(entity, true).__meta;
     const cond = Utils.getPrimaryKeyCond(entity, meta.primaryKeys);
-    await qb.select('1').where(cond!).setLockMode(mode).execute();
+    qb.select('1').where(cond!).setLockMode(mode);
+    await this.rethrow(qb.execute());
   }
 
 }

--- a/packages/knex/src/schema/SchemaGenerator.ts
+++ b/packages/knex/src/schema/SchemaGenerator.ts
@@ -116,7 +116,7 @@ export class SchemaGenerator {
    * creates new database and connects to it
    */
   async createDatabase(name: string): Promise<void> {
-    await this.connection.execute(this.helper.getCreateDatabaseSQL('' + this.knex.ref(name)));
+    await this.driver.execute(this.helper.getCreateDatabaseSQL('' + this.knex.ref(name)));
     this.config.set('dbName', name);
     await this.driver.reconnect();
   }
@@ -124,14 +124,14 @@ export class SchemaGenerator {
   async dropDatabase(name: string): Promise<void> {
     this.config.set('dbName', this.helper.getManagementDbName());
     await this.driver.reconnect();
-    await this.connection.execute(this.helper.getDropDatabaseSQL('' + this.knex.ref(name)));
+    await this.driver.execute(this.helper.getDropDatabaseSQL('' + this.knex.ref(name)));
   }
 
   async execute(sql: string) {
     const lines = sql.split('\n').filter(i => i.trim());
 
     for (const line of lines) {
-      await this.connection.execute(line);
+      await this.driver.execute(line);
     }
   }
 

--- a/packages/migrations/src/MigrationRunner.ts
+++ b/packages/migrations/src/MigrationRunner.ts
@@ -26,12 +26,12 @@ export class MigrationRunner {
     queries = queries.filter(sql => sql.trim().length > 0);
 
     if (!this.options.transactional || !migration.isTransactional()) {
-      await Utils.runSerial(queries, sql => this.connection.execute(sql));
+      await Utils.runSerial(queries, sql => this.driver.execute(sql));
       return;
     }
 
     await this.connection.transactional(async tx => {
-      await Utils.runSerial(queries, sql => this.connection.execute(tx.raw(sql)));
+      await Utils.runSerial(queries, sql => this.driver.execute(tx.raw(sql)));
     }, this.masterTransaction);
   }
 

--- a/packages/mongodb/src/MongoExceptionConverter.ts
+++ b/packages/mongodb/src/MongoExceptionConverter.ts
@@ -1,0 +1,18 @@
+import { Dictionary, DriverException, UniqueConstraintViolationException, ExceptionConverter } from '@mikro-orm/core';
+
+export class MongoExceptionConverter extends ExceptionConverter {
+
+  /* istanbul ignore next */
+  /**
+   * @link http://www.postgresql.org/docs/9.4/static/errcodes-appendix.html
+   */
+  convertException(exception: Error & Dictionary): DriverException {
+    switch (exception.code) {
+      case 11000:
+        return new UniqueConstraintViolationException(exception);
+    }
+
+    return super.convertException(exception);
+  }
+
+}

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -1,7 +1,10 @@
 import { ObjectId } from 'mongodb';
 import { IPrimaryKey, Primary, Platform, MongoNamingStrategy, NamingStrategy } from '@mikro-orm/core';
+import { MongoExceptionConverter } from './MongoExceptionConverter';
 
 export class MongoPlatform extends Platform {
+
+  protected readonly exceptionConverter = new MongoExceptionConverter();
 
   getNamingStrategy(): { new(): NamingStrategy} {
     return MongoNamingStrategy;

--- a/packages/mysql-base/src/MySqlExceptionConverter.ts
+++ b/packages/mysql-base/src/MySqlExceptionConverter.ts
@@ -1,0 +1,85 @@
+import {
+  Dictionary, DeadlockException, LockWaitTimeoutException, TableExistsException, TableNotFoundException,
+  ForeignKeyConstraintViolationException, UniqueConstraintViolationException, InvalidFieldNameException, NonUniqueFieldNameException,
+  SyntaxErrorException, ConnectionException, NotNullConstraintViolationException, DriverException, ExceptionConverter,
+} from '@mikro-orm/core';
+
+export class MySqlExceptionConverter extends ExceptionConverter {
+
+  /* istanbul ignore next */
+  /**
+   * @link http://dev.mysql.com/doc/refman/5.7/en/error-messages-client.html
+   * @link http://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html
+   * @link https://github.com/doctrine/dbal/blob/master/src/Driver/AbstractMySQLDriver.php
+   */
+  convertException(exception: Error & Dictionary): DriverException {
+    switch (exception.errno) {
+      case 1213:
+        return new DeadlockException(exception);
+      case 1205:
+        return new LockWaitTimeoutException(exception);
+      case 1050:
+        return new TableExistsException(exception);
+      case 1051:
+      case 1146:
+        return new TableNotFoundException(exception);
+      case 1216:
+      case 1217:
+      case 1451:
+      case 1452:
+      case 1701:
+        return new ForeignKeyConstraintViolationException(exception);
+      case 1062:
+      case 1557:
+      case 1569:
+      case 1586:
+        return new UniqueConstraintViolationException(exception);
+      case 1054:
+      case 1166:
+      case 1611:
+        return new InvalidFieldNameException(exception);
+      case 1052:
+      case 1060:
+      case 1110:
+        return new NonUniqueFieldNameException(exception);
+      case 1064:
+      case 1149:
+      case 1287:
+      case 1341:
+      case 1342:
+      case 1343:
+      case 1344:
+      case 1382:
+      case 1479:
+      case 1541:
+      case 1554:
+      case 1626:
+        return new SyntaxErrorException(exception);
+      case 1044:
+      case 1045:
+      case 1046:
+      case 1049:
+      case 1095:
+      case 1142:
+      case 1143:
+      case 1227:
+      case 1370:
+      case 1429:
+      case 2002:
+      case 2005:
+        return new ConnectionException(exception);
+      case 1048:
+      case 1121:
+      case 1138:
+      case 1171:
+      case 1252:
+      case 1263:
+      case 1364:
+      case 1566:
+        return new NotNullConstraintViolationException(exception);
+    }
+
+    return super.convertException(exception);
+  }
+
+}

--- a/packages/mysql-base/src/MySqlPlatform.ts
+++ b/packages/mysql-base/src/MySqlPlatform.ts
@@ -1,9 +1,11 @@
-import { MySqlSchemaHelper } from './MySqlSchemaHelper';
 import { AbstractSqlPlatform } from '@mikro-orm/knex';
+import { MySqlSchemaHelper } from './MySqlSchemaHelper';
+import { MySqlExceptionConverter } from './MySqlExceptionConverter';
 
 export class MySqlPlatform extends AbstractSqlPlatform {
 
   protected readonly schemaHelper = new MySqlSchemaHelper();
+  protected readonly exceptionConverter = new MySqlExceptionConverter();
 
   getDefaultCharset(): string {
     return 'utf8mb4';

--- a/packages/mysql-base/src/index.ts
+++ b/packages/mysql-base/src/index.ts
@@ -3,3 +3,4 @@ export * from './MySqlConnection';
 export * from './MySqlDriver';
 export * from './MySqlPlatform';
 export * from './MySqlSchemaHelper';
+export * from './MySqlExceptionConverter';

--- a/packages/postgresql/src/PostgreSqlExceptionConverter.ts
+++ b/packages/postgresql/src/PostgreSqlExceptionConverter.ts
@@ -1,0 +1,48 @@
+import {
+  DeadlockException, Dictionary, DriverException, ExceptionConverter, ForeignKeyConstraintViolationException, InvalidFieldNameException,
+  NonUniqueFieldNameException, NotNullConstraintViolationException, SyntaxErrorException, TableExistsException,
+  TableNotFoundException, UniqueConstraintViolationException,
+} from '@mikro-orm/core';
+
+export class PostgreSqlExceptionConverter extends ExceptionConverter {
+
+  /* istanbul ignore next */
+  /**
+   * @link http://www.postgresql.org/docs/9.4/static/errcodes-appendix.html
+   * @link https://github.com/doctrine/dbal/blob/master/src/Driver/AbstractPostgreSQLDriver.php
+   */
+  convertException(exception: Error & Dictionary): DriverException {
+    switch (exception.code) {
+      case '40001':
+      case '40P01':
+        return new DeadlockException(exception);
+      case '0A000':
+        // Foreign key constraint violations during a TRUNCATE operation
+        // are considered "feature not supported" in PostgreSQL.
+        if (exception.message.includes('truncate')) {
+          return new ForeignKeyConstraintViolationException(exception);
+        }
+
+        break;
+      case '23502':
+        return new NotNullConstraintViolationException(exception);
+      case '23503':
+        return new ForeignKeyConstraintViolationException(exception);
+      case '23505':
+        return new UniqueConstraintViolationException(exception);
+      case '42601':
+        return new SyntaxErrorException(exception);
+      case '42702':
+        return new NonUniqueFieldNameException(exception);
+      case '42703':
+        return new InvalidFieldNameException(exception);
+      case '42P01':
+        return new TableNotFoundException(exception);
+      case '42P07':
+        return new TableExistsException(exception);
+    }
+
+    return super.convertException(exception);
+  }
+
+}

--- a/packages/postgresql/src/PostgreSqlPlatform.ts
+++ b/packages/postgresql/src/PostgreSqlPlatform.ts
@@ -1,10 +1,12 @@
 import { EntityProperty } from '@mikro-orm/core';
 import { AbstractSqlPlatform } from '@mikro-orm/knex';
 import { PostgreSqlSchemaHelper } from './PostgreSqlSchemaHelper';
+import { PostgreSqlExceptionConverter } from './PostgreSqlExceptionConverter';
 
 export class PostgreSqlPlatform extends AbstractSqlPlatform {
 
   protected readonly schemaHelper = new PostgreSqlSchemaHelper();
+  protected readonly exceptionConverter = new PostgreSqlExceptionConverter();
 
   usesReturningStatement(): boolean {
     return true;

--- a/packages/postgresql/src/index.ts
+++ b/packages/postgresql/src/index.ts
@@ -3,3 +3,4 @@ export * from './PostgreSqlConnection';
 export * from './PostgreSqlDriver';
 export * from './PostgreSqlPlatform';
 export * from './PostgreSqlSchemaHelper';
+export * from './PostgreSqlExceptionConverter';

--- a/packages/sqlite/src/SqliteDriver.ts
+++ b/packages/sqlite/src/SqliteDriver.ts
@@ -1,6 +1,5 @@
 import { Configuration } from '@mikro-orm/core';
 import { AbstractSqlDriver } from '@mikro-orm/knex';
-
 import { SqliteConnection } from './SqliteConnection';
 import { SqlitePlatform } from './SqlitePlatform';
 

--- a/packages/sqlite/src/SqliteExceptionConverter.ts
+++ b/packages/sqlite/src/SqliteExceptionConverter.ts
@@ -1,0 +1,63 @@
+import {
+  ConnectionException, Dictionary, DriverException, ExceptionConverter, InvalidFieldNameException, LockWaitTimeoutException, NonUniqueFieldNameException,
+  NotNullConstraintViolationException, ReadOnlyException, SyntaxErrorException, TableExistsException, TableNotFoundException, UniqueConstraintViolationException,
+} from '@mikro-orm/core';
+
+export class SqliteExceptionConverter extends ExceptionConverter {
+
+  /* istanbul ignore next */
+  /**
+   * @inheritDoc
+   * @link http://www.sqlite.org/c3ref/c_abort.html
+   * @link https://github.com/doctrine/dbal/blob/master/src/Driver/AbstractSQLiteDriver.php
+   */
+  convertException(exception: Error & Dictionary): DriverException {
+    if (exception.message.includes('database is locked')) {
+      return new LockWaitTimeoutException(exception);
+    }
+
+    if (
+      exception.message.includes('must be unique') ||
+      exception.message.includes('is not unique') ||
+      exception.message.includes('are not unique') ||
+      exception.message.includes('UNIQUE constraint failed')
+    ) {
+      return new UniqueConstraintViolationException(exception);
+    }
+
+    if (exception.message.includes('may not be NULL') || exception.message.includes('NOT NULL constraint failed')) {
+      return new NotNullConstraintViolationException(exception);
+    }
+
+    if (exception.message.includes('no such table:')) {
+      return new TableNotFoundException(exception);
+    }
+
+    if (exception.message.includes('already exists')) {
+      return new TableExistsException(exception);
+    }
+
+    if (exception.message.includes('no such column:')) {
+      return new InvalidFieldNameException(exception);
+    }
+
+    if (exception.message.includes('ambiguous column name')) {
+      return new NonUniqueFieldNameException(exception);
+    }
+
+    if (exception.message.includes('syntax error')) {
+      return new SyntaxErrorException(exception);
+    }
+
+    if (exception.message.includes('attempt to write a readonly database')) {
+      return new ReadOnlyException(exception);
+    }
+
+    if (exception.message.includes('unable to open database file')) {
+      return new ConnectionException(exception);
+    }
+
+    return super.convertException(exception);
+  }
+
+}

--- a/packages/sqlite/src/SqlitePlatform.ts
+++ b/packages/sqlite/src/SqlitePlatform.ts
@@ -1,9 +1,11 @@
 import { AbstractSqlPlatform } from '@mikro-orm/knex';
 import { SqliteSchemaHelper } from './SqliteSchemaHelper';
+import { SqliteExceptionConverter } from './SqliteExceptionConverter';
 
 export class SqlitePlatform extends AbstractSqlPlatform {
 
   protected readonly schemaHelper = new SqliteSchemaHelper();
+  protected readonly exceptionConverter = new SqliteExceptionConverter();
 
   requiresNullableForAlteringColumn() {
     return true;

--- a/packages/sqlite/src/index.ts
+++ b/packages/sqlite/src/index.ts
@@ -3,3 +3,4 @@ export * from './SqliteConnection';
 export * from './SqliteDriver';
 export * from './SqlitePlatform';
 export * from './SqliteSchemaHelper';
+export * from './SqliteExceptionConverter';

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -1,8 +1,8 @@
 import { ObjectId } from 'mongodb';
 import chalk from 'chalk';
-
-import { Collection, Configuration, EntityProperty, MikroORM, QueryOrder, Reference, wrap, Logger } from '@mikro-orm/core';
+import { Collection, Configuration, EntityProperty, MikroORM, QueryOrder, Reference, wrap, Logger, UniqueConstraintViolationException } from '@mikro-orm/core';
 import { EntityManager, MongoConnection, MongoDriver } from '@mikro-orm/mongodb';
+
 import { Author, Book, BookTag, Publisher, PublisherType, Test } from './entities';
 import { AuthorRepository } from './repositories/AuthorRepository';
 import { initORMMongo, wipeDatabase } from './bootstrap';
@@ -1899,6 +1899,12 @@ describe('EntityManagerMongo', () => {
 
     await orm.em.flush();
     expect(author.books.getItems().every(b => b.id)).toBe(true);
+  });
+
+  test('exceptions', async () => {
+    const driver = orm.em.getDriver();
+    await driver.nativeInsert(Author.name, { name: 'author', email: 'email' });
+    await expect(driver.nativeInsert(Author.name, { name: 'author', email: 'email' })).rejects.toThrow(UniqueConstraintViolationException);
   });
 
   afterAll(async () => orm.close(true));

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -1,5 +1,8 @@
 import { v4 } from 'uuid';
-import { Collection, Configuration, EntityManager, LockMode, MikroORM, QueryOrder, Reference, Utils, Logger, ValidationError, wrap } from '@mikro-orm/core';
+import {
+  Collection, Configuration, EntityManager, LockMode, MikroORM, QueryOrder, Reference, Utils, Logger, ValidationError, wrap, UniqueConstraintViolationException,
+  TableNotFoundException, NotNullConstraintViolationException, TableExistsException, SyntaxErrorException, NonUniqueFieldNameException, InvalidFieldNameException,
+} from '@mikro-orm/core';
 import { PostgreSqlDriver, PostgreSqlConnection } from '@mikro-orm/postgresql';
 import { Address2, Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, PublisherType, Test2 } from './entities-sql';
 import { initORMPostgreSql, wipeDatabasePostgreSql } from './bootstrap';
@@ -1203,6 +1206,18 @@ describe('EntityManagerPostgre', () => {
     expect(a3).toBeNull();
     const address2 = await orm.em.findOne(Address2, author.id as any);
     expect(address2).toBeNull();
+  });
+
+  test('exceptions', async () => {
+    const driver = orm.em.getDriver();
+    await driver.nativeInsert(Author2.name, { name: 'author', email: 'email' });
+    await expect(driver.nativeInsert(Author2.name, { name: 'author', email: 'email' })).rejects.toThrow(UniqueConstraintViolationException);
+    await expect(driver.nativeInsert(Author2.name, {})).rejects.toThrow(NotNullConstraintViolationException);
+    await expect(driver.nativeInsert('not_existing', { foo: 'bar' })).rejects.toThrow(TableNotFoundException);
+    await expect(driver.execute('create table author2 (foo text not null)')).rejects.toThrow(TableExistsException);
+    await expect(driver.execute('foo bar 123')).rejects.toThrow(SyntaxErrorException);
+    await expect(driver.execute('select id from author2, foo_bar2')).rejects.toThrow(NonUniqueFieldNameException);
+    await expect(driver.execute('select uuid from author2')).rejects.toThrow(InvalidFieldNameException);
   });
 
   afterAll(async () => orm.close(true));


### PR DESCRIPTION
Custom exceptions are now thrown from the driver for common problems like:

- `NotNullConstraintViolationException`
- `UniqueConstraintViolationException`
- `SyntaxErrorException`

Mongo driver currently supports only `UniqueConstraintViolationException`.

```typescript
const driver = orm.em.getDriver();
await driver.nativeInsert(Author3.name, { name: 'author', email: 'email' });
await expect(driver.nativeInsert(Author3.name, { name: 'author', email: 'email' })).rejects.toThrow(UniqueConstraintViolationException);
await expect(driver.nativeInsert(Author3.name, {})).rejects.toThrow(NotNullConstraintViolationException);
await expect(driver.nativeInsert('not_existing', { foo: 'bar' })).rejects.toThrow(TableNotFoundException);
await expect(driver.execute('create table author3 (foo text not null)')).rejects.toThrow(TableExistsException);
await expect(driver.execute('foo bar 123')).rejects.toThrow(SyntaxErrorException);
await expect(driver.execute('select id from author3, book_tag3')).rejects.toThrow(NonUniqueFieldNameException);
await expect(driver.execute('select uuid from author3')).rejects.toThrow(InvalidFieldNameException);
```
