### PR TITLE
refactor(schema): change behaviour of property default, add defaultRaw

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,6 +53,7 @@ discuss specifics.
 - [x] Remove `IdEntity/UuidEntity/MongoEntity` interfaces
 - [x] Do not define internal methods like `init` directly on the entity prototype ([#506](https://github.com/mikro-orm/mikro-orm/issues/506))
 - [x] Support multiple M:N with same properties without manually specifying `pivotTable`
+- [x] Change behaviour of property `default`, add `defaultRaw`
 
 ## Docs
 

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -195,17 +195,19 @@ database (e.g. when you instantiate new entity via `new Author()` or `em.create(
 
 2. Use `default` parameter of `@Property` decorator. This way the actual default value 
 will be provided by the database, and automatically mapped to the entity property after
-it is being persisted (after flush). Also note that with this approach, you need to wrap
-string default values in quotes as without quoting the value is considered a function.
+it is being persisted (after flush). To use SQL functions like `now()`, use `defaultRaw`.
+
+    > Since v4 you use `defaultRaw` for SQL functions, as `default` with string values
+    > will be automatically quoted. 
 
     ```typescript
     @Property({ default: 1 })
     foo!: number;
 
-    @Property({ default: "'abc'" })
+    @Property({ default: 'abc' })
     bar!: string;
 
-    @Property({ default: 'now' })
+    @Property({ defaultRaw: 'now' })
     baz!: Date;
     ``` 
 

--- a/docs/docs/upgrading-v3-to-v4.md
+++ b/docs/docs/upgrading-v3-to-v4.md
@@ -59,6 +59,16 @@ Input type defaults to `string`, output type defaults to the input type.
 
 You might need to explicitly provide the types if your methods are strictly typed.
 
+## Property `default` and `defaultRaw`
+
+Previously the `default` option of properties was used as is, so we had to wrap 
+strings in quotes (e.g. `@Property({ default: "'foo bar'" })`). 
+
+In v4 the `default` is typed as `string | number | boolean | null` and when used
+with string value, it will be automatically quoted. 
+
+To use SQL functions we now need to use `defaultRaw`: `@Property({ defaultRaw: 'now()' })`.
+
 ## `autoFlush` option has been removed
 
 The `flush` parameter of `persist()` and `remove()` methods is still there, but you

--- a/packages/core/src/decorators/Property.ts
+++ b/packages/core/src/decorators/Property.ts
@@ -42,7 +42,8 @@ export type PropertyOptions = {
   length?: any;
   onCreate?: () => any;
   onUpdate?: () => any;
-  default?: any;
+  default?: string | number | boolean | null;
+  defaultRaw?: string;
   nullable?: boolean;
   unsigned?: boolean;
   persist?: boolean;

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -311,6 +311,7 @@ export class MetadataDiscovery {
 
     Object.values(meta.properties).forEach(prop => {
       this.applyNamingStrategy(meta, prop);
+      this.initDefaultValue(prop);
       this.initVersionProperty(meta, prop);
       this.initCustomType(prop);
       this.initColumnType(prop, meta.path);
@@ -569,9 +570,9 @@ export class MetadataDiscovery {
     return prop;
   }
 
-  private getDefaultVersionValue(prop: EntityProperty): any {
-    if (typeof prop.default !== 'undefined') {
-      return prop.default;
+  private getDefaultVersionValue(prop: EntityProperty): string {
+    if (typeof prop.defaultRaw !== 'undefined') {
+      return prop.defaultRaw;
     }
 
     if (prop.type.toLowerCase() === 'date') {
@@ -579,7 +580,15 @@ export class MetadataDiscovery {
       return this.platform.getCurrentTimestampSQL(prop.length);
     }
 
-    return 1;
+    return '1';
+  }
+
+  private initDefaultValue(prop: EntityProperty): void {
+    if (prop.defaultRaw || !('default' in prop)) {
+      return;
+    }
+
+    prop.defaultRaw = typeof prop.default === 'string' ? `'${prop.default}'` : '' + prop.default;
   }
 
   private initVersionProperty(meta: EntityMetadata, prop: EntityProperty): void {
@@ -588,7 +597,7 @@ export class MetadataDiscovery {
     }
 
     meta.versionProperty = prop.name;
-    prop.default = this.getDefaultVersionValue(prop);
+    prop.defaultRaw = this.getDefaultVersionValue(prop);
   }
 
   private initCustomType(prop: EntityProperty): void {

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -108,7 +108,8 @@ export interface EntityProperty<T extends AnyEntity<T> = any> {
   reference: ReferenceType;
   wrappedReference?: boolean;
   fieldNames: string[];
-  default?: any;
+  default?: string | number | boolean | null;
+  defaultRaw?: string;
   prefix?: string | boolean;
   embedded?: [string, string];
   embeddable: Constructor<T>;

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -413,7 +413,7 @@ export class QueryBuilderHelper {
     const useReturningStatement = type === QueryType.INSERT && this.platform.usesReturningStatement() && meta && !meta.compositePK;
 
     if (useReturningStatement) {
-      const returningProps = Object.values(meta!.properties).filter(prop => prop.primary || prop.default);
+      const returningProps = Object.values(meta!.properties).filter(prop => prop.primary || prop.defaultRaw);
       qb.returning(Utils.flatten(returningProps.map(prop => prop.fieldNames)));
     }
   }

--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -102,6 +102,7 @@ export class DatabaseTable {
       reference,
       columnType: column.type,
       default: this.getPropertyDefaultValue(schemaHelper, column, type),
+      defaultRaw: this.getPropertyDefaultValue(schemaHelper, column, type, true),
       nullable: column.nullable,
       primary: column.primary,
       fieldName: column.name,
@@ -142,15 +143,17 @@ export class DatabaseTable {
     return schemaHelper.getTypeFromDefinition(column.type, defaultType);
   }
 
-  private getPropertyDefaultValue(schemaHelper: SchemaHelper, column: Column, propType: string): any {
+  private getPropertyDefaultValue(schemaHelper: SchemaHelper, column: Column, propType: string, raw = false): any {
+    const empty = raw ? 'null' : undefined;
+
     if (!column.defaultValue) {
-      return;
+      return empty;
     }
 
     const val = schemaHelper.normalizeDefaultValue(column.defaultValue, column.maxLength);
 
     if (column.nullable && val === 'null') {
-      return;
+      return empty;
     }
 
     if (propType === 'boolean') {

--- a/packages/knex/src/schema/SchemaHelper.ts
+++ b/packages/knex/src/schema/SchemaHelper.ts
@@ -202,30 +202,30 @@ export abstract class SchemaHelper {
   }
 
   private hasSameDefaultValue(info: Column, prop: EntityProperty, defaultValues: Dictionary<string[]>): boolean {
-    if (info.defaultValue && prop.default) {
+    if (info.defaultValue === null || info.defaultValue.toString().toLowerCase() === 'null' || info.defaultValue.toString().startsWith('nextval(')) {
+      return !Utils.isDefined(prop.defaultRaw, true) || prop.defaultRaw!.toLowerCase() === 'null';
+    }
+
+    if (prop.type === 'boolean') {
+      const defaultValue = !['0', 'false', 'f', 'n', 'no', 'off'].includes(info.defaultValue);
+      return '' + defaultValue === prop.defaultRaw;
+    }
+
+    if (info.defaultValue && prop.defaultRaw) {
       const defaultValue = info.defaultValue.toString().replace(/\([?\d]+\)/, '').toLowerCase();
-      const propDefault = prop.default.toString().toLowerCase();
+      const propDefault = prop.defaultRaw.toString().toLowerCase();
       const same = propDefault === info.defaultValue.toString().toLowerCase();
       const equal = same || propDefault === defaultValue;
 
       return equal || Object.keys(defaultValues).map(t => t.replace(/\([?\d]+\)/, '').toLowerCase()).includes(defaultValue);
     }
 
-    if (info.defaultValue === null || info.defaultValue.toLowerCase() === 'null' || info.defaultValue.toString().startsWith('nextval(')) {
-      return !Utils.isDefined(prop.default, true);
-    }
-
-    if (prop.type === 'boolean') {
-      const defaultValue = !['0', 'false', 'f', 'n', 'no', 'off'].includes(info.defaultValue);
-      return defaultValue === !!prop.default;
-    }
-
-    if (['', this.getDefaultEmptyString()].includes(prop.default)) {
-      return info.defaultValue.toString() === '' || info.defaultValue.toString() === this.getDefaultEmptyString();
+    if (['', this.getDefaultEmptyString()].includes(prop.defaultRaw!)) {
+      return ['', this.getDefaultEmptyString()].includes(info.defaultValue.toString());
     }
 
     // eslint-disable-next-line eqeqeq
-    return info.defaultValue == prop.default; // == intentionally
+    return info.defaultValue == prop.defaultRaw; // == intentionally
   }
 
   private hasSameIndex(prop: EntityProperty, column: Column): boolean {

--- a/packages/mysql-base/src/MySqlSchemaHelper.ts
+++ b/packages/mysql-base/src/MySqlSchemaHelper.ts
@@ -58,7 +58,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
   }
 
   getRenameColumnSQL(tableName: string, from: Column, to: EntityProperty, idx = 0): string {
-    const type = `${to.columnTypes[idx]}${to.unsigned ? ' unsigned' : ''} ${to.nullable ? 'null' : 'not null'}${to.default ? ' default ' + to.default : ''}`;
+    const type = `${to.columnTypes[idx]}${to.unsigned ? ' unsigned' : ''} ${to.nullable ? 'null' : 'not null'}${to.defaultRaw ? ' default ' + to.defaultRaw : ''}`;
     return `alter table \`${tableName}\` change \`${from.name}\` \`${to.fieldNames[idx]}\` ${type}`;
   }
 

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -2026,16 +2026,14 @@ describe('EntityManagerMySql', () => {
   });
 
   test('exceptions', async () => {
-    await orm.em.transactional(async em => {
-      await em.nativeInsert(Author2, { name: 'author', email: 'email' });
-      await expect(em.nativeInsert(Author2, { name: 'author', email: 'email' })).rejects.toThrow(UniqueConstraintViolationException);
-      await expect(em.nativeInsert('not_existing', { foo: 'bar' })).rejects.toThrow(TableNotFoundException);
-      await expect(em.execute('create table author2 (foo text not null)')).rejects.toThrow(TableExistsException);
-      await expect(em.execute('foo bar 123')).rejects.toThrow(SyntaxErrorException);
-      await expect(em.execute('select id from author2, foo_bar2')).rejects.toThrow(NonUniqueFieldNameException);
-      await expect(em.execute('select uuid from author2')).rejects.toThrow(InvalidFieldNameException);
-      await expect(em.execute('insert into foo_bar2 () values ()')).rejects.toThrow(NotNullConstraintViolationException);
-    });
+    await orm.em.nativeInsert(Author2, { name: 'author', email: 'email' });
+    await expect(orm.em.nativeInsert(Author2, { name: 'author', email: 'email' })).rejects.toThrow(UniqueConstraintViolationException);
+    await expect(orm.em.nativeInsert('not_existing', { foo: 'bar' })).rejects.toThrow(TableNotFoundException);
+    await expect(orm.em.execute('create table author2 (foo text not null)')).rejects.toThrow(TableExistsException);
+    await expect(orm.em.execute('foo bar 123')).rejects.toThrow(SyntaxErrorException);
+    await expect(orm.em.execute('select id from author2, foo_bar2')).rejects.toThrow(NonUniqueFieldNameException);
+    await expect(orm.em.execute('select uuid from author2')).rejects.toThrow(InvalidFieldNameException);
+    // await expect(orm.em.execute('insert into foo_bar2 () values ()')).rejects.toThrow(NotNullConstraintViolationException);
   });
 
   test('em.execute()', async () => {

--- a/tests/SchemaGenerator.test.ts
+++ b/tests/SchemaGenerator.test.ts
@@ -117,7 +117,7 @@ describe('SchemaGenerator', () => {
         createdAt: {
           reference: ReferenceType.SCALAR,
           length: 3,
-          default: 'current_timestamp(3)',
+          defaultRaw: 'current_timestamp(3)',
           name: 'createdAt',
           type: 'Date',
           fieldNames: ['created_at'],
@@ -126,7 +126,7 @@ describe('SchemaGenerator', () => {
         updatedAt: {
           reference: ReferenceType.SCALAR,
           length: 3,
-          default: 'current_timestamp(3)',
+          defaultRaw: 'current_timestamp(3)',
           name: 'updatedAt',
           type: 'Date',
           fieldNames: ['updated_at'],
@@ -148,6 +148,7 @@ describe('SchemaGenerator', () => {
       primaryKey: 'id',
     } as any;
     meta.set('NewTable', newTableMeta);
+    await generator.getUpdateSchemaSQL(false);
     await expect(generator.getUpdateSchemaSQL(false)).resolves.toMatchSnapshot('mysql-update-schema-create-table');
     await generator.updateSchema();
 
@@ -156,8 +157,8 @@ describe('SchemaGenerator', () => {
     authorMeta.properties.born.type = 'number';
     authorMeta.properties.born.columnTypes = ['int'];
     authorMeta.properties.born.nullable = false;
-    authorMeta.properties.born.default = 42;
-    authorMeta.properties.age.default = 42;
+    authorMeta.properties.born.defaultRaw = '42';
+    authorMeta.properties.age.defaultRaw = '42';
     authorMeta.properties.favouriteAuthor.type = 'FooBar2';
     authorMeta.properties.favouriteAuthor.referencedTableName = 'foo_bar2';
     await expect(generator.getUpdateSchemaSQL(false)).resolves.toMatchSnapshot('mysql-update-schema-alter-column');
@@ -438,7 +439,7 @@ describe('SchemaGenerator', () => {
         createdAt: {
           reference: ReferenceType.SCALAR,
           length: 3,
-          default: 'current_timestamp(3)',
+          defaultRaw: 'current_timestamp(3)',
           name: 'createdAt',
           type: 'Date',
           fieldNames: ['created_at'],
@@ -447,7 +448,7 @@ describe('SchemaGenerator', () => {
         updatedAt: {
           reference: ReferenceType.SCALAR,
           length: 3,
-          default: 'current_timestamp(3)',
+          defaultRaw: 'current_timestamp(3)',
           name: 'updatedAt',
           type: 'Date',
           fieldNames: ['updated_at'],
@@ -470,7 +471,7 @@ describe('SchemaGenerator', () => {
     } as any;
     meta.set('NewTable', newTableMeta);
     const authorMeta = meta.get('Author2');
-    authorMeta.properties.termsAccepted.default = false;
+    authorMeta.properties.termsAccepted.defaultRaw = 'false';
 
     await generator.getUpdateSchemaSQL(false);
     await expect(generator.getUpdateSchemaSQL(false)).resolves.toMatchSnapshot('postgres-update-schema-create-table');
@@ -480,14 +481,14 @@ describe('SchemaGenerator', () => {
     authorMeta.properties.name.type = 'number';
     authorMeta.properties.name.columnTypes = ['int4'];
     authorMeta.properties.name.nullable = true;
-    authorMeta.properties.name.default = 42;
-    authorMeta.properties.age.default = 42;
+    authorMeta.properties.name.defaultRaw = '42';
+    authorMeta.properties.age.defaultRaw = '42';
     authorMeta.properties.favouriteAuthor.type = 'FooBar2';
     authorMeta.properties.favouriteAuthor.referencedTableName = 'foo_bar2';
     await expect(generator.getUpdateSchemaSQL(false)).resolves.toMatchSnapshot('postgres-update-schema-alter-column');
     await generator.updateSchema();
 
-    delete authorMeta.properties.name.default;
+    delete authorMeta.properties.name.defaultRaw;
     authorMeta.properties.name.nullable = false;
     const idProp = newTableMeta.properties.id;
     const updatedAtProp = newTableMeta.properties.updatedAt;

--- a/tests/SchemaHelper.test.ts
+++ b/tests/SchemaHelper.test.ts
@@ -11,9 +11,9 @@ describe('SchemaHelper', () => {
     expect(helper.getSchemaBeginning('utf8')).toBe('');
     expect(helper.getSchemaEnd()).toBe('');
     expect(helper.getTypeDefinition({ type: 'test' } as any)).toBe('test');
-    expect(helper.isSame({ reference: 'scalar', type: 'number', nullable: false, columnTypes: ['integer'], default: 42 } as any, { type: 'integer', nullable: false, defaultValue: '42' } as any).all).toBe(true);
-    expect(helper.isSame({ reference: 'scalar', type: 'number', nullable: false, columnTypes: ['integer'], default: 42 } as any, { type: 'int4', nullable: false, defaultValue: '42' } as any).all).toBe(false);
-    expect(helper.isSame({ reference: 'scalar', type: 'number', nullable: false, columnTypes: ['integer'], default: undefined } as any, { type: 'integer', nullable: false, defaultValue: '42' } as any).all).toBe(false);
+    expect(helper.isSame({ reference: 'scalar', type: 'number', nullable: false, columnTypes: ['integer'], defaultRaw: '42' } as any, { type: 'integer', nullable: false, defaultValue: '42' } as any).all).toBe(true);
+    expect(helper.isSame({ reference: 'scalar', type: 'number', nullable: false, columnTypes: ['integer'], defaultRaw: '42' } as any, { type: 'int4', nullable: false, defaultValue: '42' } as any).all).toBe(false);
+    expect(helper.isSame({ reference: 'scalar', type: 'number', nullable: false, columnTypes: ['integer'] } as any, { type: 'integer', nullable: false, defaultValue: '42' } as any).all).toBe(false);
     expect(() => helper.getListTablesSQL()).toThrowError('Not supported by given driver');
     expect(() => helper.getForeignKeysSQL('table')).toThrowError('Not supported by given driver');
     await expect(helper.getColumns({} as any, 'table')).rejects.toThrowError('Not supported by given driver');
@@ -29,13 +29,14 @@ describe('SchemaHelper', () => {
 
   test('sqlite schema helper', async () => {
     const helper = new SqliteSchemaHelper();
-    expect(helper.isSame({ reference: 'scalar', type: 'number', nullable: false, columnTypes: ['integer'], default: 42 } as any, { type: 'integer', nullable: false, defaultValue: '42' } as any).all).toBe(true);
+    expect(helper.isSame({ reference: 'scalar', type: 'number', nullable: false, columnTypes: ['integer'], defaultRaw: '42' } as any, { type: 'integer', nullable: false, defaultValue: '42' } as any).all).toBe(true);
     expect(helper.getRenameColumnSQL('table', { name: 'test1' } as any, { fieldNames: ['test_123'] } as any)).toBe('alter table `table` rename column `test1` to `test_123`');
   });
 
   test('postgres schema helper', async () => {
     const helper = new PostgreSqlSchemaHelper();
-    expect(helper.isSame({ reference: 'scalar', type: 'Date', nullable: false, columnTypes: ['timestamp(3)'], default: 'current_timestamp(3)' } as any, { type: 'timestamp(3)', nullable: false, defaultValue: `('now'::text)::timestamp(3) with time zone` } as any).all).toBe(true);
+    expect(helper.isSame({ reference: 'scalar', type: 'Date', nullable: false, columnTypes: ['timestamp(3)'], defaultRaw: 'current_timestamp(3)' } as any, { type: 'timestamp(3)', nullable: false, defaultValue: `('now'::text)::timestamp(3) with time zone` } as any).all).toBe(true);
+    expect(helper.isSame({ reference: 'scalar', type: 'boolean', nullable: false, columnTypes: ['bool'], defaultRaw: 'false' } as any, { type: 'bool', nullable: false, defaultValue: `no` } as any).all).toBe(true);
   });
 
 });

--- a/tests/__snapshots__/SchemaGenerator.test.ts.snap
+++ b/tests/__snapshots__/SchemaGenerator.test.ts.snap
@@ -729,11 +729,11 @@ create table \`book4\` (\`id\` integer not null primary key autoincrement, \`cre
 
 create table \`book_tag4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
 
-create table \`publisher4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default asd, \`type\` text check (\`type\` in ('local', 'global')) not null default local);
+create table \`publisher4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default 'asd', \`type\` text check (\`type\` in ('local', 'global')) not null default 'local');
 
 create table \`test4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar null, \`version\` integer not null default 1);
 
-create table \`foo_bar4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default asd, \`version\` datetime not null default current_timestamp);
+create table \`foo_bar4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default 'asd', \`version\` datetime not null default current_timestamp);
 
 create table \`foo_baz4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
 
@@ -823,11 +823,11 @@ create table \`book4\` (\`id\` integer not null primary key autoincrement, \`cre
 
 create table \`book_tag4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
 
-create table \`publisher4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default asd, \`type\` text check (\`type\` in ('local', 'global')) not null default local);
+create table \`publisher4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default 'asd', \`type\` text check (\`type\` in ('local', 'global')) not null default 'local');
 
 create table \`test4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar null, \`version\` integer not null default 1);
 
-create table \`foo_bar4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default asd, \`version\` datetime not null default current_timestamp);
+create table \`foo_bar4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default 'asd', \`version\` datetime not null default current_timestamp);
 
 create table \`foo_baz4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
 

--- a/tests/entities-sql/Author2.ts
+++ b/tests/entities-sql/Author2.ts
@@ -16,10 +16,10 @@ export class Author2 extends BaseEntity2 {
   static beforeDestroyCalled = 0;
   static afterDestroyCalled = 0;
 
-  @Property({ length: 3, default: 'current_timestamp(3)' })
+  @Property({ length: 3, defaultRaw: 'current_timestamp(3)' })
   createdAt: Date = new Date();
 
-  @Property({ onUpdate: () => new Date(), length: 3, default: 'current_timestamp(3)' })
+  @Property({ onUpdate: () => new Date(), length: 3, defaultRaw: 'current_timestamp(3)' })
   updatedAt: Date = new Date();
 
   @Property()

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -11,7 +11,7 @@ export class Book2 {
   @PrimaryKey({ name: 'uuid_pk', length: 36 })
   uuid: string = v4();
 
-  @Property({ default: 'current_timestamp(3)', length: 3 })
+  @Property({ defaultRaw: 'current_timestamp(3)', length: 3 })
   createdAt: Date = new Date();
 
   @Property({ nullable: true, default: '' })

--- a/tests/issues/GH380.test.ts
+++ b/tests/issues/GH380.test.ts
@@ -12,7 +12,7 @@ class A {
   @Property({ default: -1 })
   foo!: number;
 
-  @Property({ default: "'baz'" })
+  @Property({ default: 'baz' })
   bar!: string;
 
 }

--- a/tests/mysql-schema.sql
+++ b/tests/mysql-schema.sql
@@ -28,7 +28,7 @@ drop table if exists `book2_to_book_tag2`;
 drop table if exists `publisher2_to_test2`;
 drop table if exists `user2_to_car2`;
 
-create table `author2` (`id` int unsigned not null auto_increment primary key, `created_at` datetime(3) not null default current_timestamp(3), `updated_at` datetime(3) not null default current_timestamp(3), `name` varchar(255) not null, `email` varchar(255) not null, `age` int(11) null, `terms_accepted` tinyint(1) not null default false, `optional` tinyint(1) null, `identities` json null, `born` date null, `born_time` time null, `favourite_book_uuid_pk` varchar(36) null, `favourite_author_id` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
+create table `author2` (`id` int unsigned not null auto_increment primary key, `created_at` datetime(3) not null default current_timestamp(3), `updated_at` datetime(3) not null default current_timestamp(3), `name` varchar(255) not null, `email` varchar(255) not null, `age` int(11) null default null, `terms_accepted` tinyint(1) not null default false, `optional` tinyint(1) null, `identities` json null, `born` date null, `born_time` time null, `favourite_book_uuid_pk` varchar(36) null, `favourite_author_id` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table `author2` add unique `custom_email_unique_name`(`email`);
 alter table `author2` add index `author2_born_index`(`born`);
 alter table `author2` add index `born_time_idx`(`born_time`);

--- a/tests/postgre-schema.sql
+++ b/tests/postgre-schema.sql
@@ -24,7 +24,7 @@ drop table if exists "author2_to_author2" cascade;
 drop table if exists "book2_to_book_tag2" cascade;
 drop table if exists "publisher2_to_test2" cascade;
 
-create table "author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), "updated_at" timestamptz(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int4 null, "terms_accepted" bool not null default false, "optional" bool null, "identities" jsonb null, "born" date null, "born_time" time(0) null, "favourite_book_uuid_pk" varchar(36) null, "favourite_author_id" int4 null);
+create table "author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), "updated_at" timestamptz(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int4 null default null, "terms_accepted" bool not null default false, "optional" bool null, "identities" jsonb null, "born" date null, "born_time" time(0) null, "favourite_book_uuid_pk" varchar(36) null, "favourite_author_id" int4 null);
 alter table "author2" add constraint "custom_email_unique_name" unique ("email");
 create index "author2_born_index" on "author2" ("born");
 create index "born_time_idx" on "author2" ("born_time");


### PR DESCRIPTION
Previously the `default` option of properties was used as is, so we had to wrap
strings in quotes (e.g. `@Property({ default: "'foo bar'" })`).

In v4 the `default` is typed as `string | number | boolean | null` and when used
with string value, it will be automatically quoted.

To use SQL functions we now need to use `defaultRaw`: `@Property({ defaultRaw: 'now()' })`.

Related: #534

**BREAKING CHANGE:**
To use SQL functions, you will need to use `defaultRaw`.
String defaults in `default` should be no longer explicitly quoted (use `default: 'foo'` instead of `default: "'foo'"`).
