### PR TITLE
feat(cli): allow the use of TS path mapping

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,6 +53,7 @@
     "cli-highlight": "^2.1.4",
     "cli-table3": "^0.6.0",
     "fs-extra": "^9.0.0",
+    "tsconfig-paths": "^3.9.0",
     "yargonaut": "^1.1.4",
     "yargs": "^15.3.1"
   }

--- a/packages/cli/src/CLIHelper.ts
+++ b/packages/cli/src/CLIHelper.ts
@@ -39,9 +39,7 @@ export class CLIHelper {
     const settings = await ConfigurationLoader.getSettings();
 
     if (settings.useTsNode) {
-      require('ts-node').register({
-        project: settings.tsConfigPath,
-      });
+      await ConfigurationLoader.registerTsNode(settings.tsConfigPath);
     }
 
     // noinspection HtmlDeprecatedTag

--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -56,6 +56,27 @@ export class ConfigurationLoader {
     return paths;
   }
 
+  static async registerTsNode(tsConfigPath = process.cwd() + '/tsconfig.json') {
+    require('ts-node').register({
+      project: tsConfigPath,
+    });
+
+    if (await pathExists(tsConfigPath)) {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const tsConfig = require(tsConfigPath);
+
+      /* istanbul ignore next */
+      const paths = tsConfig?.compilerOptions?.paths;
+
+      if (paths) {
+        require('tsconfig-paths').register({
+          baseUrl: tsConfig.compilerOptions.baseUrl,
+          paths: tsConfig.compilerOptions.paths,
+        });
+      }
+    }
+  }
+
 }
 
 export interface Settings {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1791,6 +1791,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
 "@types/lodash@*":
   version "4.14.150"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.150.tgz#649fe44684c3f1fcb6164d943c5a61977e8cf0bd"
@@ -6153,6 +6158,13 @@ json5@2.x, json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+  dependencies:
+    minimist "^1.2.0"
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -10222,6 +10234,16 @@ ts-node@^8.8.2:
     make-error "^1.1.1"
     source-map-support "^0.5.17"
     yn "3.1.1"
+
+tsconfig-paths@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
+  integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
 
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"


### PR DESCRIPTION
This enables the use of path aliases in the config file.

Example `tsconfig.json`

```json
{
	"compilerOptions": {
		"paths": {
			"@foo": ["src/foo/index.ts"]
		}
	},
}
```

Example `mikro-orm.config.ts`

```ts
import * as foo from '@foo';

const config = foo.myFancyFunctionThatReturnsAFancyConfig();

export default config;
```