### PR TITLE
feat(core): add support for alternative loading strategies

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -3,7 +3,7 @@ import { v4 as uuid } from 'uuid';
 import { Configuration, RequestContext, Utils, ValidationError, SmartQueryHelper } from './utils';
 import { EntityAssigner, EntityFactory, EntityLoader, EntityRepository, EntityValidator, IdentifiedReference, Reference, ReferenceType, wrap } from './entity';
 import { LockMode, UnitOfWork } from './unit-of-work';
-import { IDatabaseDriver, FindOneOptions, FindOptions, EntityManagerType, PopulateOptions, Populate } from './drivers';
+import { IDatabaseDriver, FindOneOptions, FindOptions, EntityManagerType, Populate, PopulateOptions } from './drivers';
 import { EntityData, EntityMetadata, EntityName, AnyEntity, IPrimaryKey, FilterQuery, Primary, Dictionary } from './typings';
 import { QueryOrderMap } from './enums';
 import { MetadataStorage } from './metadata';

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -505,6 +505,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     if (entitiesArray.length === 0) {
       return entities;
     }
+    populate = typeof populate === 'string' ? Utils.asArray(populate) : populate;
 
     const entityName = entitiesArray[0].constructor.name;
     const preparedPopulate = this.preparePopulate(entityName, populate);
@@ -592,34 +593,25 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     return entity;
   }
 
-  private preparePopulate(entityName: string, populate?: string | Populate): PopulateOptions[] {
+  private preparePopulate(entityName: string, populate?: Populate): PopulateOptions[] {
+    if (!populate) {
+      return [];
+    }
+
     if (populate === true) {
       return [{ field: '*', all: true }];
     }
 
     const meta = this.metadata.get(entityName);
 
-    if (Array.isArray(populate)) {
-      return populate.map(field => {
-        if (Utils.isString(field)) {
-          const strategy = meta.properties[field]?.strategy;
-          return { field, strategy };
-        }
+    return populate.map(field => {
+      if (Utils.isString(field)) {
+        const strategy = meta.properties[field]?.strategy;
+        return { field, strategy };
+      }
 
-        return field;
-      });
-    }
-
-    if (Utils.isString(populate)) {
-      const relation = meta.properties[populate];
-
-      return [{
-        field: populate,
-        strategy: relation.strategy,
-      }];
-    }
-
-    return [];
+      return field;
+    });
   }
 
 }

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -593,6 +593,10 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   }
 
   private preparePopulate(entityName: string, populate?: string | Populate): PopulateOptions[] {
+    if (populate === true) {
+      return [{ field: '*', all: true }];
+    }
+
     const meta = this.metadata.get(entityName);
 
     if (Array.isArray(populate)) {

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -598,20 +598,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     if (Array.isArray(populate)) {
       return populate.map(field => {
         if (Utils.isString(field)) {
-          const relation = meta.properties[field];
-
-          // If no relation is found, we assume that the relation is invalid and don't attempt to get the strategy.
-          // By returning a field/relation that doesn't exist, validation code will handle that error upstream.
-          if (!relation) {
-            return {
-              field,
-            };
-          }
-
-          return {
-            field,
-            strategy: relation.strategy,
-          };
+          const strategy = meta.properties[field]?.strategy;
+          return { field, strategy };
         }
 
         return field;

--- a/packages/core/src/decorators/Property.ts
+++ b/packages/core/src/decorators/Property.ts
@@ -1,6 +1,6 @@
 import { MetadataStorage } from '../metadata';
 import { Utils } from '../utils';
-import { Cascade, EntityValidator, ReferenceType } from '../entity';
+import { Cascade, EntityValidator, ReferenceType, LoadStrategy } from '../entity';
 import { EntityName, EntityProperty, AnyEntity, Constructor } from '../typings';
 import { Type } from '../types';
 
@@ -60,4 +60,5 @@ export interface ReferenceOptions<T extends AnyEntity<T>, O extends AnyEntity<O>
   entity?: string | (() => EntityName<T>);
   cascade?: Cascade[];
   eager?: boolean;
+  strategy?: LoadStrategy;
 }

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -1,4 +1,4 @@
-import { EntityManagerType, FindOneOptions, FindOptions, IDatabaseDriver } from './IDatabaseDriver';
+import { EntityManagerType, FindOneOptions, FindOptions, IDatabaseDriver, PopulateOptions } from './IDatabaseDriver';
 import { EntityData, EntityMetadata, EntityProperty, FilterQuery, AnyEntity, Dictionary, Primary } from '../typings';
 import { MetadataStorage } from '../metadata';
 import { Connection, QueryResult, Transaction } from '../connections';
@@ -51,7 +51,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     await this.nativeUpdate<T>(coll.owner.constructor.name, wrap(coll.owner, true).__primaryKey, data, ctx);
   }
 
-  mapResult<T extends AnyEntity<T>>(result: EntityData<T>, meta: EntityMetadata): T | null {
+  mapResult<T extends AnyEntity<T>>(result: EntityData<T>, meta: EntityMetadata, populate: PopulateOptions[] = []): T | null {
     if (!result || !meta) {
       return null;
     }

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -105,4 +105,5 @@ export type Populate = (string | PopulateOptions)[] | boolean;
 export type PopulateOptions = {
   field: string;
   strategy?: LoadStrategy;
+  all?: boolean;
 };

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -4,7 +4,7 @@ import { QueryOrderMap, QueryFlag } from '../enums';
 import { Platform } from '../platforms';
 import { MetadataStorage } from '../metadata';
 import { LockMode } from '../unit-of-work';
-import { Collection } from '../entity';
+import { Collection, LoadStrategy } from '../entity';
 import { EntityManager } from '../index';
 import { DriverException } from '../exceptions';
 
@@ -46,7 +46,7 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
 
   aggregate(entityName: string, pipeline: any[]): Promise<any[]>;
 
-  mapResult<T extends AnyEntity<T>>(result: EntityData<T>, meta: EntityMetadata): T | null;
+  mapResult<T extends AnyEntity<T>>(result: EntityData<T>, meta: EntityMetadata, populate?: PopulateOptions[]): T | null;
 
   /**
    * When driver uses pivot tables for M:N, this method will load identifiers for given collections from them
@@ -75,7 +75,7 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
 }
 
 export interface FindOptions<T> {
-  populate?: string[] | boolean;
+  populate?: Populate;
   orderBy?: QueryOrderMap;
   limit?: number;
   offset?: number;
@@ -88,7 +88,7 @@ export interface FindOptions<T> {
 }
 
 export interface FindOneOptions<T> {
-  populate?: string[] | boolean;
+  populate?: Populate;
   orderBy?: QueryOrderMap;
   groupBy?: string | string[];
   having?: QBFilterQuery<T>;
@@ -99,3 +99,10 @@ export interface FindOneOptions<T> {
   schema?: string;
   flags?: QueryFlag[];
 }
+
+export type Populate = (string | PopulateOptions)[] | boolean;
+
+export type PopulateOptions = {
+  field: string;
+  strategy?: LoadStrategy;
+};

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -1,5 +1,5 @@
 import { AnyEntity, EntityProperty, FilterQuery } from '../typings';
-import { EntityManager, Populate } from '../index';
+import { EntityManager } from '../index';
 import { ReferenceType, LoadStrategy } from './enums';
 import { Utils, ValidationError } from '../utils';
 import { Collection } from './Collection';

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -34,7 +34,7 @@ export class EntityLoader {
   }
 
   private normalizePopulate(entityName: string, populate: PopulateOptions[] | true, lookup: boolean): PopulateOptions[] {
-    if (populate === true) {
+    if (populate === true || populate.some(p => p.all)) {
       populate = this.lookupAllRelationships(entityName);
     } else {
       populate = Utils.asArray(populate);

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -16,7 +16,7 @@ export class EntityLoader {
   constructor(private readonly em: EntityManager) { }
 
   async populate<T extends AnyEntity<T>>(entityName: string, entities: T[], populate: PopulateOptions[] | boolean, where: FilterQuery<T> = {}, orderBy: QueryOrderMap = {}, refresh = false, validate = true, lookup = true): Promise<void> {
-    if (entities.length === 0 || populate === false || (Array.isArray(populate) && populate.length > 0)) {
+    if (entities.length === 0 || populate === false) {
       return;
     }
 

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -1,7 +1,7 @@
 import { EntityManager, FindOneOrFailOptions } from '../EntityManager';
 import { EntityData, EntityName, AnyEntity, Primary } from '../typings';
 import { QueryOrderMap } from '../enums';
-import { FilterQuery, FindOneOptions, FindOptions, IdentifiedReference, Reference } from '..';
+import { FilterQuery, FindOneOptions, FindOptions, IdentifiedReference, Reference, Utils } from '..';
 
 export class EntityRepository<T extends AnyEntity<T>> {
 

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -1,7 +1,7 @@
 import { EntityManager, FindOneOrFailOptions } from '../EntityManager';
 import { EntityData, EntityName, AnyEntity, Primary } from '../typings';
 import { QueryOrderMap } from '../enums';
-import { FilterQuery, FindOneOptions, FindOptions, IdentifiedReference, Reference, Utils } from '..';
+import { FilterQuery, FindOneOptions, FindOptions, IdentifiedReference, Reference } from '..';
 
 export class EntityRepository<T extends AnyEntity<T>> {
 

--- a/packages/core/src/entity/enums.ts
+++ b/packages/core/src/entity/enums.ts
@@ -13,3 +13,8 @@ export enum Cascade {
   REMOVE = 'remove',
   ALL = 'all',
 }
+
+export enum LoadStrategy {
+  SELECT_IN = 'select-in',
+  JOINED = 'joined'
+}

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -113,10 +113,7 @@ export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntit
   }
 
   addManyToOne<K = object>(name: string & keyof T, type: TypeType, options: ManyToOneOptions<K, T>): void {
-    const prop = {
-      ...this.defaultRelationshipConfig(ReferenceType.MANY_TO_ONE),
-      ...options,
-    };
+    const prop = this.createProperty(ReferenceType.MANY_TO_ONE, options);
     Utils.defaultValue(prop, 'nullable', prop.cascade.includes(Cascade.REMOVE) || prop.cascade.includes(Cascade.ALL));
     this.addProperty(name, type, prop);
   }
@@ -132,26 +129,17 @@ export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntit
       Utils.renameKey(options, 'mappedBy', 'inversedBy');
     }
 
-    const prop = {
-      ...this.defaultRelationshipConfig(ReferenceType.MANY_TO_MANY),
-      ...options,
-    };
+    const prop = this.createProperty(ReferenceType.MANY_TO_MANY, options);
     this.addProperty(name, type, prop);
   }
 
   addOneToMany<K = object>(name: string & keyof T, type: TypeType, options: OneToManyOptions<K, T>): void {
-    const prop = {
-      ...this.defaultRelationshipConfig(ReferenceType.ONE_TO_MANY),
-      ...options,
-    };
+    const prop = this.createProperty<T>(ReferenceType.ONE_TO_MANY, options);
     this.addProperty(name, type, prop);
   }
 
   addOneToOne<K = object>(name: string & keyof T, type: TypeType, options: OneToOneOptions<K, T>): void {
-    const prop = {
-      ...this.defaultRelationshipConfig(ReferenceType.ONE_TO_ONE),
-      ...options,
-    };
+    const prop = this.createProperty(ReferenceType.ONE_TO_ONE, options) as EntityProperty;
     Utils.defaultValue(prop, 'nullable', prop.cascade.includes(Cascade.REMOVE) || prop.cascade.includes(Cascade.ALL));
     Utils.defaultValue(prop, 'owner', !!prop.inversedBy || !prop.mappedBy);
     Utils.defaultValue(prop, 'unique', prop.owner);
@@ -300,11 +288,12 @@ export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntit
     return type;
   }
 
-  private defaultRelationshipConfig(reference: ReferenceType) {
+  private createProperty<T>(reference: ReferenceType, options: PropertyOptions<T> | EntityProperty = {}) {
     return {
       reference,
       cascade: [Cascade.PERSIST, Cascade.MERGE],
       strategy: LoadStrategy.SELECT_IN,
+      ...options,
     };
   }
 

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -3,7 +3,7 @@ import {
   EmbeddedOptions, EnumOptions, IndexOptions, ManyToManyOptions, ManyToOneOptions, OneToManyOptions, OneToOneOptions, PrimaryKeyOptions, PropertyOptions,
   SerializedPrimaryKeyOptions, UniqueOptions,
 } from '../decorators';
-import { BaseEntity, Cascade, Collection, EntityRepository, ReferenceType } from '../entity';
+import { BaseEntity, Cascade, Collection, EntityRepository, ReferenceType, LoadStrategy } from '../entity';
 import { Type } from '../types';
 import { Utils } from '../utils';
 
@@ -113,7 +113,10 @@ export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntit
   }
 
   addManyToOne<K = object>(name: string & keyof T, type: TypeType, options: ManyToOneOptions<K, T>): void {
-    const prop = { reference: ReferenceType.MANY_TO_ONE, cascade: [Cascade.PERSIST, Cascade.MERGE], ...options } as unknown as EntityProperty<T>;
+    const prop = {
+      ...this.defaultRelationshipConfig(ReferenceType.MANY_TO_ONE),
+      ...options,
+    };
     Utils.defaultValue(prop, 'nullable', prop.cascade.includes(Cascade.REMOVE) || prop.cascade.includes(Cascade.ALL));
     this.addProperty(name, type, prop);
   }
@@ -129,17 +132,26 @@ export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntit
       Utils.renameKey(options, 'mappedBy', 'inversedBy');
     }
 
-    const prop = { reference: ReferenceType.MANY_TO_MANY, cascade: [Cascade.PERSIST, Cascade.MERGE], ...options } as PropertyOptions<T>;
+    const prop = {
+      ...this.defaultRelationshipConfig(ReferenceType.MANY_TO_MANY),
+      ...options,
+    };
     this.addProperty(name, type, prop);
   }
 
   addOneToMany<K = object>(name: string & keyof T, type: TypeType, options: OneToManyOptions<K, T>): void {
-    const prop = { reference: ReferenceType.ONE_TO_MANY, cascade: [Cascade.PERSIST, Cascade.MERGE], ...options } as PropertyOptions<T>;
+    const prop = {
+      ...this.defaultRelationshipConfig(ReferenceType.ONE_TO_MANY),
+      ...options,
+    };
     this.addProperty(name, type, prop);
   }
 
   addOneToOne<K = object>(name: string & keyof T, type: TypeType, options: OneToOneOptions<K, T>): void {
-    const prop = { reference: ReferenceType.ONE_TO_ONE, cascade: [Cascade.PERSIST, Cascade.MERGE], ...options } as unknown as EntityProperty<T>;
+    const prop = {
+      ...this.defaultRelationshipConfig(ReferenceType.ONE_TO_ONE),
+      ...options,
+    };
     Utils.defaultValue(prop, 'nullable', prop.cascade.includes(Cascade.REMOVE) || prop.cascade.includes(Cascade.ALL));
     Utils.defaultValue(prop, 'owner', !!prop.inversedBy || !prop.mappedBy);
     Utils.defaultValue(prop, 'unique', prop.owner);
@@ -286,6 +298,14 @@ export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntit
     }
 
     return type;
+  }
+
+  private defaultRelationshipConfig(reference: ReferenceType) {
+    return {
+      reference,
+      cascade: [Cascade.PERSIST, Cascade.MERGE],
+      strategy: LoadStrategy.SELECT_IN,
+    };
   }
 
 }

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -288,7 +288,7 @@ export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntit
     return type;
   }
 
-  private createProperty<T>(reference: ReferenceType, options: PropertyOptions<T> | EntityProperty = {}) {
+  private createProperty<T>(reference: ReferenceType, options: PropertyOptions<T> | EntityProperty) {
     return {
       reference,
       cascade: [Cascade.PERSIST, Cascade.MERGE],

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1,5 +1,5 @@
 import { QueryOrder } from './enums';
-import { AssignOptions, Cascade, Collection, EntityRepository, EntityValidator, IdentifiedReference, Reference, ReferenceType } from './entity';
+import { AssignOptions, Cascade, Collection, EntityRepository, EntityValidator, IdentifiedReference, Reference, ReferenceType, LoadStrategy } from './entity';
 import { EntityManager } from './EntityManager';
 import { LockMode } from './unit-of-work';
 import { Platform } from './platforms';
@@ -135,6 +135,7 @@ export interface EntityProperty<T extends AnyEntity<T> = any> {
   onUpdate?: (entity: T) => any;
   onDelete?: 'cascade' | 'no action' | 'set null' | 'set default' | string;
   onUpdateIntegrity?: 'cascade' | 'no action' | 'set null' | 'set default' | string;
+  strategy?: LoadStrategy;
   owner: boolean;
   inversedBy: string;
   mappedBy: string;

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -75,7 +75,11 @@ export class ChangeSetPersister {
     }
 
     if (meta.versionProperty && [ChangeSetType.CREATE, ChangeSetType.UPDATE].includes(changeSet.type)) {
-      const e = await this.driver.findOne<T>(meta.name, wrap(changeSet.entity, true).__primaryKey, { populate: [meta.versionProperty] }, ctx);
+      const e = await this.driver.findOne<T>(meta.name, wrap(changeSet.entity, true).__primaryKey, {
+        populate: [{
+          field: meta.versionProperty,
+        }],
+      }, ctx);
       (changeSet.entity as T)[meta.versionProperty] = e![meta.versionProperty];
     }
   }

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -33,8 +33,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     const meta = this.metadata.get(entityName);
     options = { populate: [], orderBy: {}, ...(options || {}) };
 
-    const populate = options.populate as PopulateOptions[];
-    options.populate = this.autoJoinOneToOneOwner(meta, populate);
+    const populate = this.autoJoinOneToOneOwner(meta, options.populate as PopulateOptions[]);
 
     if (options.fields) {
       options.fields.unshift(...meta.primaryKeys.filter(pk => !options!.fields!.includes(pk)));
@@ -62,9 +61,8 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     options = { populate: [], orderBy: {}, ...(options || {}) };
 
     const meta = this.metadata.get(entityName);
-    const populate = options.populate as PopulateOptions[];
 
-    options.populate = this.autoJoinOneToOneOwner(meta, populate);
+    const populate = this.autoJoinOneToOneOwner(meta, options.populate as PopulateOptions[]);
     const pk = meta.primaryKeys[0];
 
     if (Utils.isPrimaryKey(where)) {
@@ -89,16 +87,18 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
 
     const method = joinedLoads.length > 0 ? 'all' : 'get';
 
-    const result = await qb
-      .select(selects)
+    qb.select(selects)
       .populate(populate)
       .where(where as Dictionary)
       .orderBy(options.orderBy!)
       .groupBy(options.groupBy!)
       .having(options.having!)
       .setLockMode(options.lockMode)
-      .withSchema(options.schema)
-      .execute(method);
+      .withSchema(options.schema);
+
+    Utils.asArray(options.flags).forEach(flag => qb.setFlag(flag));
+
+    const result = await this.rethrow(qb.execute('all'));
 
     if (Array.isArray(result)) {
       return this.processJoinedLoads(result, joinedLoads) as unknown as T;
@@ -123,7 +123,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
       const relationPojo = {};
 
       Object.values(properties)
-        .filter(({ reference }) => reference === 'scalar')
+        .filter(({ reference }) => reference === ReferenceType.SCALAR)
         .forEach(prop => {
           const aliasedProp = this.getAliasedField(prop.fieldNames[0], relationName, index).as;
 
@@ -282,15 +282,9 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
   }
 
   protected joinedLoads(meta: EntityMetadata, populate: PopulateOptions[]): string[] {
-    return populate.filter(({ field }) => {
-      const relation = meta.properties[field];
-
-      if (!relation) {
-        return false;
-      }
-
-      return relation.strategy === LoadStrategy.JOINED;
-    }).map(({ field }) => field);
+    return populate
+      .filter(({ field }) => meta.properties[field]?.strategy === LoadStrategy.JOINED)
+      .map(({ field }) => field);
   }
 
   protected processJoinedLoads<T extends AnyEntity<T>>(results: object[], joinedLoads: string[]): T {
@@ -321,6 +315,10 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     };
   }
 
+  getRefForField(field: string, schema: string, alias: string) {
+    return this.connection.getKnex().ref(field).withSchema(schema).as(alias);
+  }
+
   protected getSelectForJoinedLoad(queryBuilder: QueryBuilder, meta: EntityMetadata, joinedLoads: string[]): Field[] {
     const selects: Field[] = [];
 
@@ -340,7 +338,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
         .filter(prop => prop.reference === ReferenceType.SCALAR && prop.persist !== false)
         .forEach(prop => {
           const { field, schema, as } = this.getAliasedField(prop.fieldNames[0], relationName, index);
-          selects.push(queryBuilder.getRefForField(field, schema, as));
+          selects.push(this.getRefForField(field, schema, as));
           queryBuilder.join(relationName, relationName);
         });
     });

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -98,7 +98,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
 
     Utils.asArray(options.flags).forEach(flag => qb.setFlag(flag));
 
-    const result = await this.rethrow(qb.execute('all'));
+    const result = await this.rethrow(qb.execute(method));
 
     if (Array.isArray(result)) {
       return this.processJoinedLoads(result, joinedLoads) as unknown as T;
@@ -287,8 +287,12 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
       .map(({ field }) => field);
   }
 
-  protected processJoinedLoads<T extends AnyEntity<T>>(results: object[], joinedLoads: string[]): T {
-    return results.reduce((accumulator, value) => {
+  protected processJoinedLoads<T extends AnyEntity<T>>(result: object[], joinedLoads: string[]): T | null {
+    if (result.length === 0) {
+      return null;
+    }
+
+    return result.reduce((accumulator, value) => {
       joinedLoads.forEach(relationName => {
         if (relationName in value) {
           const relation = value[relationName];

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -1,9 +1,9 @@
 import { QueryBuilder as KnexQueryBuilder, Raw, Transaction as KnexTransaction, Value } from 'knex';
 import {
   AnyEntity, Collection, Configuration, Constructor, DatabaseDriver, Dictionary, EntityData, EntityManager, EntityManagerType, EntityMetadata, EntityProperty,
-  FilterQuery, FindOneOptions, FindOptions, IDatabaseDriver, LockMode, Primary, QueryOrderMap, QueryResult, ReferenceType, Transaction, Utils, wrap,
+  FilterQuery, FindOneOptions, FindOptions, IDatabaseDriver, LockMode, Primary, QueryOrderMap, QueryResult, ReferenceType, Transaction, Utils, wrap, PopulateOptions, LoadStrategy,
 } from '@mikro-orm/core';
-import { AbstractSqlConnection, AbstractSqlPlatform, QueryBuilder } from './index';
+import { AbstractSqlConnection, AbstractSqlPlatform, QueryBuilder, Field } from './index';
 import { SqlEntityManager } from './SqlEntityManager';
 
 export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = AbstractSqlConnection> extends DatabaseDriver<C> {
@@ -32,7 +32,9 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
   async find<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, options?: FindOptions<T>, ctx?: Transaction<KnexTransaction>): Promise<T[]> {
     const meta = this.metadata.get(entityName);
     options = { populate: [], orderBy: {}, ...(options || {}) };
-    options.populate = this.autoJoinOneToOneOwner(meta, options.populate as string[]);
+
+    const populate = options.populate as PopulateOptions[];
+    options.populate = this.autoJoinOneToOneOwner(meta, populate);
 
     if (options.fields) {
       options.fields.unshift(...meta.primaryKeys.filter(pk => !options!.fields!.includes(pk)));
@@ -40,7 +42,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
 
     const qb = this.createQueryBuilder(entityName, ctx, !!ctx);
     qb.select(options.fields || '*')
-      .populate(options.populate)
+      .populate(populate)
       .where(where as Dictionary)
       .orderBy(options.orderBy!)
       .groupBy(options.groupBy!)
@@ -58,8 +60,11 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
 
   async findOne<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T>, ctx?: Transaction<KnexTransaction>): Promise<T | null> {
     options = { populate: [], orderBy: {}, ...(options || {}) };
+
     const meta = this.metadata.get(entityName);
-    options.populate = this.autoJoinOneToOneOwner(meta, options.populate as string[]);
+    const populate = options.populate as PopulateOptions[];
+
+    options.populate = this.autoJoinOneToOneOwner(meta, populate);
     const pk = meta.primaryKeys[0];
 
     if (Utils.isPrimaryKey(where)) {
@@ -70,20 +75,68 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
       options.fields.unshift(pk);
     }
 
-    const qb = this.createQueryBuilder(entityName, ctx, !!ctx)
-      .select(options.fields || '*')
-      .populate(options.populate)
+    const joinedLoads = this.joinedLoads(meta, populate);
+    const qb = this.createQueryBuilder(entityName, ctx, !!ctx);
+    const selects: Field[] = [];
+
+    if (joinedLoads.length > 0) {
+      selects.push(...this.getSelectForJoinedLoad(qb, meta, joinedLoads));
+    } else {
+      const defaultSelect = options.fields || ['*'];
+      selects.push(...defaultSelect);
+      qb.limit(1);
+    }
+
+    const method = joinedLoads.length > 0 ? 'all' : 'get';
+
+    const result = await qb
+      .select(selects)
+      .populate(populate)
       .where(where as Dictionary)
       .orderBy(options.orderBy!)
       .groupBy(options.groupBy!)
       .having(options.having!)
-      .limit(1)
       .setLockMode(options.lockMode)
-      .withSchema(options.schema);
+      .withSchema(options.schema)
+      .execute(method);
 
-    Utils.asArray(options.flags).forEach(flag => qb.setFlag(flag));
+    if (Array.isArray(result)) {
+      return this.processJoinedLoads(result, joinedLoads) as unknown as T;
+    }
 
-    return this.rethrow(qb.execute('get'));
+    return result;
+  }
+
+  mapResult<T extends AnyEntity<T>>(result: EntityData<T>, meta: EntityMetadata, populate: PopulateOptions[] = []): T | null {
+    const ret = super.mapResult(result, meta, populate);
+
+    if (!ret) {
+      return null;
+    }
+    const joinedLoads = this.joinedLoads(meta, populate);
+
+    joinedLoads.forEach((relationName, index) => {
+      const prop = meta.properties[relationName];
+      const properties = this.metadata.get(prop.type).properties;
+
+      ret[relationName] = ret[relationName] || [];
+      const relationPojo = {};
+
+      Object.values(properties)
+        .filter(({ reference }) => reference === 'scalar')
+        .forEach(prop => {
+          const aliasedProp = this.getAliasedField(prop.fieldNames[0], relationName, index).as;
+
+          if (aliasedProp in ret) {
+            relationPojo[prop.name] = ret[aliasedProp];
+            delete ret[aliasedProp];
+          }
+        });
+
+      ret[relationName].push(relationPojo);
+    });
+
+    return ret as T;
   }
 
   async count(entityName: string, where: any, ctx?: Transaction<KnexTransaction>): Promise<number> {
@@ -187,7 +240,9 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
 
     orderBy = this.getPivotOrderBy(prop, orderBy);
     const qb = this.createQueryBuilder(prop.type, ctx, !!ctx);
-    const populate = this.autoJoinOneToOneOwner(meta, [prop.pivotTable]);
+    const populate = this.autoJoinOneToOneOwner(meta, [{
+      field: prop.pivotTable,
+    }]);
     qb.select('*').populate(populate).where(where as Dictionary).orderBy(orderBy!);
     const items = owners.length ? await this.rethrow(qb.execute('all')) : [];
 
@@ -210,16 +265,87 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
   /**
    * 1:1 owner side needs to be marked for population so QB auto-joins the owner id
    */
-  protected autoJoinOneToOneOwner(meta: EntityMetadata, populate: string[]): string[] {
+  protected autoJoinOneToOneOwner(meta: EntityMetadata, populate: PopulateOptions[]): PopulateOptions[] {
     if (!this.config.get('autoJoinOneToOneOwner')) {
       return populate;
     }
 
-    const toPopulate = Object.values(meta.properties)
-      .filter(prop => prop.reference === ReferenceType.ONE_TO_ONE && !prop.owner && !populate.includes(prop.name))
-      .map(prop => prop.name);
+    const relationToPopulate = populate.map(({ field }) => field);
+
+    const toPopulate: PopulateOptions[] = Object.values(meta.properties)
+      .filter(prop => {
+        return prop.reference === ReferenceType.ONE_TO_ONE && !prop.owner && !relationToPopulate.includes(prop.name);
+      })
+      .map(prop => ({ field: prop.name, strategy: prop.strategy }));
 
     return [...populate, ...toPopulate];
+  }
+
+  protected joinedLoads(meta: EntityMetadata, populate: PopulateOptions[]): string[] {
+    return populate.filter(({ field }) => {
+      const relation = meta.properties[field];
+
+      if (!relation) {
+        return false;
+      }
+
+      return relation.strategy === LoadStrategy.JOINED;
+    }).map(({ field }) => field);
+  }
+
+  protected processJoinedLoads<T extends AnyEntity<T>>(results: object[], joinedLoads: string[]): T {
+    return results.reduce((accumulator, value) => {
+      joinedLoads.forEach(relationName => {
+        if (relationName in value) {
+          const relation = value[relationName];
+
+          if (Array.isArray(relation)) {
+            const existing = accumulator[relationName] || [];
+            accumulator[relationName] = [...existing, ...relation];
+          }
+        }
+      });
+
+      return { ...value, ...accumulator };
+    }, {}) as unknown as T;
+  }
+
+  protected getAliasedField(field: string, schema: string, index = 0){
+    const tableAlias = schema.charAt(0);
+    const as = `${tableAlias}${index}_${field}`;
+
+    return {
+      field,
+      schema,
+      as,
+    };
+  }
+
+  protected getSelectForJoinedLoad(queryBuilder: QueryBuilder, meta: EntityMetadata, joinedLoads: string[]): Field[] {
+    const selects: Field[] = [];
+
+    // alias all fields in the primary table
+    Object.values(meta.properties)
+      .filter((prop) => prop.reference === ReferenceType.SCALAR && prop.persist !== false)
+      .forEach((prop) => {
+        selects.push(prop.fieldNames[0]);
+        queryBuilder.addSelect(prop.fieldNames[0]);
+      });
+
+    joinedLoads.forEach((relationName, index) => {
+      const prop = meta.properties[relationName];
+      const properties = this.metadata.get(prop.type).properties;
+
+      Object.values(properties)
+        .filter(prop => prop.reference === ReferenceType.SCALAR && prop.persist !== false)
+        .forEach(prop => {
+          const { field, schema, as } = this.getAliasedField(prop.fieldNames[0], relationName, index);
+          selects.push(queryBuilder.getRefForField(field, schema, as));
+          queryBuilder.join(relationName, relationName);
+        });
+    });
+
+    return selects;
   }
 
   protected createQueryBuilder<T extends AnyEntity<T>>(entityName: string, ctx?: Transaction<KnexTransaction>, write?: boolean): QueryBuilder<T> {

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -308,11 +308,9 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return rawResults.reduce((result, value) => {
       joinedLoads.forEach(relationName => {
         const relation = value[relationName];
+        const existing = result[relationName] || [];
 
-        if (Array.isArray(relation)) {
-          const existing = result[relationName] || [];
-          result[relationName] = [...existing, ...relation];
-        }
+        result[relationName] = [...existing, ...relation];
       });
 
       return { ...value, ...result };

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -119,13 +119,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     joinedLoads.forEach((relationName) => {
       const relation = meta.properties[relationName];
       const properties = this.metadata.get(relation.type).properties;
-      const found = Object.entries(aliasMap).find(([,r]) => r === relation.type);
-
-      if (!found) {
-        // TODO: Should an error be thrown? If so, what error?
-        throw new Error(`no alias found for relation ${relationName}`);
-      }
-
+      const found = Object.entries(aliasMap).find(([,r]) => r === relation.type)!;
       const relationAlias = found[0];
 
       ret[relationName] = ret[relationName] || [];
@@ -303,13 +297,11 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
 
     return rawResults.reduce((result, value) => {
       joinedLoads.forEach(relationName => {
-        if (relationName in value) {
-          const relation = value[relationName];
+        const relation = value[relationName];
 
-          if (Array.isArray(relation)) {
-            const existing = result[relationName] || [];
-            result[relationName] = [...existing, ...relation];
-          }
+        if (Array.isArray(relation)) {
+          const existing = result[relationName] || [];
+          result[relationName] = [...existing, ...relation];
         }
       });
 

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -324,10 +324,6 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     return qb;
   }
 
-  getRefForField(field: string, schema: string, as: string) {
-    return this.knex.ref(field).withSchema(schema).as(as);
-  }
-
   private joinReference(field: string, alias: string, cond: Dictionary, type: 'leftJoin' | 'innerJoin' | 'pivotJoin', path?: string): string[] {
     const [fromAlias, fromField] = this.helper.splitField(field);
     const entityName = this._aliasMap[fromAlias];

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -1,7 +1,7 @@
-import { QueryBuilder as KnexQueryBuilder, Raw, Transaction, Value } from 'knex';
+import Knex, { QueryBuilder as KnexQueryBuilder, Raw, Transaction, Value, Ref } from 'knex';
 import {
   AnyEntity, Dictionary, EntityMetadata, EntityProperty, FlatQueryOrderMap, GroupOperator, LockMode, MetadataStorage, QBFilterQuery, QueryFlag,
-  QueryOrderMap, ReferenceType, SmartQueryHelper, Utils, ValidationError,
+  QueryOrderMap, ReferenceType, SmartQueryHelper, Utils, ValidationError, PopulateOptions,
 } from '@mikro-orm/core';
 import { QueryType } from './enums';
 import { AbstractSqlDriver, QueryBuilderHelper } from '../index';
@@ -14,8 +14,8 @@ import { SqlEntityManager } from '../SqlEntityManager';
 export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
 
   type!: QueryType;
-  _fields?: (string | KnexQueryBuilder)[];
-  _populate: string[] = [];
+  _fields?: Field[];
+  _populate: PopulateOptions[] = [];
   _populateMap: Dictionary<string> = {};
 
   private aliasCounter = 1;
@@ -47,7 +47,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     this.select('*');
   }
 
-  select(fields: string | KnexQueryBuilder | (string | KnexQueryBuilder)[], distinct = false): this {
+  select(fields: Field | Field[], distinct = false): this {
     this._fields = Utils.asArray(fields);
 
     if (distinct) {
@@ -169,8 +169,9 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
   /**
    * @internal
    */
-  populate(populate: string[]): this {
+  populate(populate: PopulateOptions[]): this {
     this._populate = populate;
+
     return this;
   }
 
@@ -267,10 +268,10 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     }
 
     if (method === 'all' && Array.isArray(res)) {
-      return res.map(r => this.driver.mapResult(r, meta)) as unknown as U;
+      return res.map(r => this.driver.mapResult(r, meta, this._populate)) as unknown as U;
     }
 
-    return this.driver.mapResult(res, meta) as unknown as U;
+    return this.driver.mapResult(res, meta, this._populate) as unknown as U;
   }
 
   async getResult(): Promise<T[]> {
@@ -323,6 +324,10 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     return qb;
   }
 
+  getRefForField(field: string, schema: string, as: string) {
+    return this.knex.ref(field).withSchema(schema).as(as);
+  }
+
   private joinReference(field: string, alias: string, cond: Dictionary, type: 'leftJoin' | 'innerJoin' | 'pivotJoin', path?: string): string[] {
     const [fromAlias, fromField] = this.helper.splitField(field);
     const entityName = this._aliasMap[fromAlias];
@@ -351,8 +356,8 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     return ret;
   }
 
-  private prepareFields<T extends string | Raw = string | Raw>(fields: (string | KnexQueryBuilder)[], type: 'where' | 'groupBy' | 'sub-query' = 'where'): T[] {
-    const ret: (string | KnexQueryBuilder)[] = [];
+  private prepareFields<T extends string | Raw = string | Raw>(fields: Field[], type: 'where' | 'groupBy' | 'sub-query' = 'where'): T[] {
+    const ret: Field[] = [];
 
     fields.forEach(f => {
       if (!Utils.isString(f)) {
@@ -447,7 +452,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     }
 
     const meta = this.metadata.get(this.entityName, false, false);
-    this._populate.forEach(field => {
+    this._populate.forEach(({ field }) => {
       const [fromAlias, fromField] = this.helper.splitField(field);
       const aliasedField = `${fromAlias}.${fromField}`;
 
@@ -536,6 +541,12 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
   }
 
 }
+
+type KnexStringRef = Ref<string, {
+  [alias: string]: string;
+}>;
+
+export type Field = string | KnexStringRef | KnexQueryBuilder;
 
 export interface JoinOptions {
   table: string;

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -1,4 +1,4 @@
-import Knex, { QueryBuilder as KnexQueryBuilder, Raw, Transaction, Value, Ref } from 'knex';
+import { QueryBuilder as KnexQueryBuilder, Raw, Transaction, Value, Ref } from 'knex';
 import {
   AnyEntity, Dictionary, EntityMetadata, EntityProperty, FlatQueryOrderMap, GroupOperator, LockMode, MetadataStorage, QBFilterQuery, QueryFlag,
   QueryOrderMap, ReferenceType, SmartQueryHelper, Utils, ValidationError, PopulateOptions,

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -254,8 +254,9 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     return found ? found[0] : undefined;
   }
 
-  getNextAlias(): string {
-    return `e${this.aliasCounter++}`;
+  getNextAlias(prefix = 'e', increment = true): string {
+    // Take only the first letter of the prefix to keep character counts down since some engines have character limits
+    return `${prefix.charAt(0)}${increment ? this.aliasCounter++ : this.aliasCounter}`;
   }
 
   async execute<U = any>(method: 'all' | 'get' | 'run' = 'all', mapResults = true): Promise<U> {
@@ -268,10 +269,10 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     }
 
     if (method === 'all' && Array.isArray(res)) {
-      return res.map(r => this.driver.mapResult(r, meta, this._populate)) as unknown as U;
+      return res.map(r => this.driver.mapResult(r, meta, this._populate, this._aliasMap)) as unknown as U;
     }
 
-    return this.driver.mapResult(res, meta, this._populate) as unknown as U;
+    return this.driver.mapResult(res, meta, this._populate, this._aliasMap) as unknown as U;
   }
 
   async getResult(): Promise<T[]> {

--- a/tests/JoinedLoads.test.ts
+++ b/tests/JoinedLoads.test.ts
@@ -3,7 +3,7 @@ import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 import { initORMPostgreSql, wipeDatabasePostgreSql } from './bootstrap';
 import { Author2, Book2 } from './entities-sql';
 
-describe('Joined loading', () => {
+describe.skip('Joined loading', () => {
 
   let orm: MikroORM<PostgreSqlDriver>;
 

--- a/tests/JoinedLoads.test.ts
+++ b/tests/JoinedLoads.test.ts
@@ -49,6 +49,22 @@ describe('Joined loading', () => {
     expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."created_at", "e0"."updated_at", "e0"."name", "e0"."email", "e0"."age", "e0"."terms_accepted", "e0"."optional", "e0"."identities", "e0"."born", "e0"."born_time", "b1"."uuid_pk" as "b1_uuid_pk", "b1"."created_at" as "b1_created_at", "b1"."title" as "b1_title", "b1"."perex" as "b1_perex", "b1"."price" as "b1_price", "b1"."double" as "b1_double", "b1"."meta" as "b1_meta" from "author2" as "e0" inner join "book2" as "b1" on "e0"."id" = "b1"."author_id" where "e0"."id" = $1');
   });
 
+  test('can populate all related entities', async () => {
+    const author2 = new Author2('Albert Camus', 'albert.camus@email.com');
+    const stranger = new Book2('The Stranger', author2);
+    const fall = new Book2('The Fall', author2);
+
+    author2.books2.add(stranger, fall);
+
+    await orm.em.persistAndFlush(author2);
+    orm.em.clear();
+
+    const a2 = await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: true });
+
+    expect(a2.books2).toHaveLength(2);
+    expect(a2.books).toHaveLength(2);
+  });
+
   test.todo('populate OneToOne with joined strategy');
   test.todo('populate ManyToMany with joined strategy');
   test.todo('handles nested joinedLoads that map to the same entity, eg book.author.favouriteAuthor');

--- a/tests/JoinedLoads.test.ts
+++ b/tests/JoinedLoads.test.ts
@@ -46,7 +46,7 @@ describe('Joined loading', () => {
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books2'] });
 
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."created_at", "e0"."updated_at", "e0"."name", "e0"."email", "e0"."age", "e0"."terms_accepted", "e0"."optional", "e0"."identities", "e0"."born", "e0"."born_time", "b1"."uuid_pk" as "b1_uuid_pk", "b1"."created_at" as "b1_created_at", "b1"."title" as "b1_title", "b1"."perex" as "b1_perex", "b1"."price" as "b1_price", "b1"."double" as "b1_double", "b1"."meta" as "b1_meta" from "author2" as "e0" inner join "book2" as "b1" on "e0"."id" = "b1"."author_id" where "e0"."id" = $1');
+    expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."created_at", "e0"."updated_at", "e0"."name", "e0"."email", "e0"."age", "e0"."terms_accepted", "e0"."optional", "e0"."identities", "e0"."born", "e0"."born_time", "b1"."uuid_pk" as "b1_uuid_pk", "b1"."created_at" as "b1_created_at", "b1"."title" as "b1_title", "b1"."perex" as "b1_perex", "b1"."price" as "b1_price", "b1"."double" as "b1_double", "b1"."meta" as "b1_meta" from "author2" as "e0" left join "book2" as "b1" on "e0"."id" = "b1"."author_id" where "e0"."id" = $1');
   });
 
   test('can populate all related entities', async () => {
@@ -63,6 +63,24 @@ describe('Joined loading', () => {
 
     expect(a2.books2).toHaveLength(2);
     expect(a2.books).toHaveLength(2);
+  });
+
+  test('when related records exist it still returns the root entity', async () => {
+    const author2 = new Author2('Albert Camus', 'albert.camus@email.com');
+
+    await orm.em.persistAndFlush(author2);
+    orm.em.clear();
+
+    const a2 = await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books2'] });
+
+    expect(a2).toHaveProperty('id');
+    expect(a2.books2).toHaveLength(0);
+  });
+
+  test('when the root entity does not exist', async () => {
+    const a2 = await orm.em.findOne(Author2, { id: 1 }, { populate: ['books2'] });
+
+    expect(a2).toBeNull();
   });
 
   test.todo('populate OneToOne with joined strategy');

--- a/tests/JoinedLoads.test.ts
+++ b/tests/JoinedLoads.test.ts
@@ -48,4 +48,8 @@ describe('Joined loading', () => {
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."created_at", "e0"."updated_at", "e0"."name", "e0"."email", "e0"."age", "e0"."terms_accepted", "e0"."optional", "e0"."identities", "e0"."born", "e0"."born_time", "b1"."uuid_pk" as "b1_uuid_pk", "b1"."created_at" as "b1_created_at", "b1"."title" as "b1_title", "b1"."perex" as "b1_perex", "b1"."price" as "b1_price", "b1"."double" as "b1_double", "b1"."meta" as "b1_meta" from "author2" as "e0" inner join "book2" as "b1" on "e0"."id" = "b1"."author_id" where "e0"."id" = $1');
   });
+
+  test.todo('populate OneToOne with joined strategy');
+  test.todo('populate ManyToMany with joined strategy');
+  test.todo('handles nested joinedLoads that map to the same entity, eg book.author.favouriteAuthor');
 });

--- a/tests/JoinedLoads.test.ts
+++ b/tests/JoinedLoads.test.ts
@@ -1,0 +1,59 @@
+import { MikroORM, Logger } from '@mikro-orm/core';
+import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { initORMPostgreSql, wipeDatabasePostgreSql } from './bootstrap';
+import { Author2, Book2 } from './entities-sql';
+
+describe('Joined loading', () => {
+
+  let orm: MikroORM<PostgreSqlDriver>;
+
+  beforeAll(async () => orm = await initORMPostgreSql());
+  beforeEach(async () => wipeDatabasePostgreSql(orm.em));
+
+  afterAll(async () => orm.close(true));
+
+  test('populate OneToMany with joined strategy', async () => {
+    const author2 = new Author2('Albert Camus', 'albert.camus@email.com');
+    const stranger = new Book2('The Stranger', author2);
+    const fall = new Book2('The Fall', author2);
+
+    author2.books.add(stranger, fall);
+
+    await orm.em.persistAndFlush(author2);
+    orm.em.clear();
+
+    const a2 = await orm.em.findOneOrFail(Author2, {
+      id: author2.id,
+    }, {
+      populate: ['books', 'following'],
+    });
+
+    expect(a2.books).toHaveLength(2);
+    expect(a2.books[0].title).toEqual('The Stranger');
+    expect(a2.books[1].title).toEqual('The Fall');
+  });
+
+  test('should only fire one query', async () => {
+    const author2 = new Author2('Albert Camus', 'albert.camus@email.com');
+    const stranger = new Book2('The Stranger', author2);
+    const fall = new Book2('The Fall', author2);
+
+    author2.books.add(stranger, fall);
+
+    await orm.em.persistAndFlush(author2);
+    orm.em.clear();
+
+    const mock = jest.fn();
+    const logger = new Logger(mock, true);
+    Object.assign(orm.em.config, { logger });
+
+    await orm.em.findOneOrFail(Author2, {
+      id: author2.id,
+    }, {
+      populate: ['books'],
+    });
+
+    expect(mock.mock.calls.length).toBe(1);
+    expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."created_at", "e0"."updated_at", "e0"."name", "e0"."email", "e0"."age", "e0"."terms_accepted", "e0"."optional", "e0"."identities", "e0"."born", "e0"."born_time", "books"."uuid_pk" as "b0_uuid_pk", "books"."created_at" as "b0_created_at", "books"."title" as "b0_title", "books"."perex" as "b0_perex", "books"."price" as "b0_price", "books"."double" as "b0_double", "books"."meta" as "b0_meta" from "author2" as "e0" inner join "book2" as "books" on "e0"."id" = "books"."author_id" where "e0"."id" = $1');
+  });
+});

--- a/tests/JoinedLoads.test.ts
+++ b/tests/JoinedLoads.test.ts
@@ -1,9 +1,9 @@
-import { MikroORM, Logger } from '@mikro-orm/core';
+import { MikroORM, Logger, LoadStrategy } from '@mikro-orm/core';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 import { initORMPostgreSql, wipeDatabasePostgreSql } from './bootstrap';
 import { Author2, Book2 } from './entities-sql';
 
-describe.skip('Joined loading', () => {
+describe('Joined loading', () => {
 
   let orm: MikroORM<PostgreSqlDriver>;
 
@@ -17,20 +17,16 @@ describe.skip('Joined loading', () => {
     const stranger = new Book2('The Stranger', author2);
     const fall = new Book2('The Fall', author2);
 
-    author2.books.add(stranger, fall);
+    author2.books2.add(stranger, fall);
 
     await orm.em.persistAndFlush(author2);
     orm.em.clear();
 
-    const a2 = await orm.em.findOneOrFail(Author2, {
-      id: author2.id,
-    }, {
-      populate: ['books', 'following'],
-    });
+    const a2 = await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books2', 'following'] });
 
-    expect(a2.books).toHaveLength(2);
-    expect(a2.books[0].title).toEqual('The Stranger');
-    expect(a2.books[1].title).toEqual('The Fall');
+    expect(a2.books2).toHaveLength(2);
+    expect(a2.books2[0].title).toEqual('The Stranger');
+    expect(a2.books2[1].title).toEqual('The Fall');
   });
 
   test('should only fire one query', async () => {
@@ -38,7 +34,7 @@ describe.skip('Joined loading', () => {
     const stranger = new Book2('The Stranger', author2);
     const fall = new Book2('The Fall', author2);
 
-    author2.books.add(stranger, fall);
+    author2.books2.add(stranger, fall);
 
     await orm.em.persistAndFlush(author2);
     orm.em.clear();
@@ -50,10 +46,10 @@ describe.skip('Joined loading', () => {
     await orm.em.findOneOrFail(Author2, {
       id: author2.id,
     }, {
-      populate: ['books'],
+      populate: ['books2'],
     });
 
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."created_at", "e0"."updated_at", "e0"."name", "e0"."email", "e0"."age", "e0"."terms_accepted", "e0"."optional", "e0"."identities", "e0"."born", "e0"."born_time", "books"."uuid_pk" as "b0_uuid_pk", "books"."created_at" as "b0_created_at", "books"."title" as "b0_title", "books"."perex" as "b0_perex", "books"."price" as "b0_price", "books"."double" as "b0_double", "books"."meta" as "b0_meta" from "author2" as "e0" inner join "book2" as "books" on "e0"."id" = "books"."author_id" where "e0"."id" = $1');
+    expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."created_at", "e0"."updated_at", "e0"."name", "e0"."email", "e0"."age", "e0"."terms_accepted", "e0"."optional", "e0"."identities", "e0"."born", "e0"."born_time", "b0"."uuid_pk" as "b0_uuid_pk", "b0"."created_at" as "b0_created_at", "b0"."title" as "b0_title", "b0"."perex" as "b0_perex", "b0"."price" as "b0_price", "b0"."double" as "b0_double", "b0"."meta" as "b0_meta" from "author2" as "e0" inner join "book2" as "b0" on "e0"."id" = "b0"."author_id" where "e0"."id" = $1');
   });
 });

--- a/tests/JoinedLoads.test.ts
+++ b/tests/JoinedLoads.test.ts
@@ -43,13 +43,9 @@ describe('Joined loading', () => {
     const logger = new Logger(mock, true);
     Object.assign(orm.em.config, { logger });
 
-    await orm.em.findOneOrFail(Author2, {
-      id: author2.id,
-    }, {
-      populate: ['books2'],
-    });
+    await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books2'] });
 
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."created_at", "e0"."updated_at", "e0"."name", "e0"."email", "e0"."age", "e0"."terms_accepted", "e0"."optional", "e0"."identities", "e0"."born", "e0"."born_time", "b0"."uuid_pk" as "b0_uuid_pk", "b0"."created_at" as "b0_created_at", "b0"."title" as "b0_title", "b0"."perex" as "b0_perex", "b0"."price" as "b0_price", "b0"."double" as "b0_double", "b0"."meta" as "b0_meta" from "author2" as "e0" inner join "book2" as "b0" on "e0"."id" = "b0"."author_id" where "e0"."id" = $1');
+    expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."created_at", "e0"."updated_at", "e0"."name", "e0"."email", "e0"."age", "e0"."terms_accepted", "e0"."optional", "e0"."identities", "e0"."born", "e0"."born_time", "b1"."uuid_pk" as "b1_uuid_pk", "b1"."created_at" as "b1_created_at", "b1"."title" as "b1_title", "b1"."perex" as "b1_perex", "b1"."price" as "b1_price", "b1"."double" as "b1_double", "b1"."meta" as "b1_meta" from "author2" as "e0" inner join "book2" as "b1" on "e0"."id" = "b1"."author_id" where "e0"."id" = $1');
   });
 });

--- a/tests/JoinedLoads.test.ts
+++ b/tests/JoinedLoads.test.ts
@@ -83,6 +83,22 @@ describe('Joined loading', () => {
     expect(a2).toBeNull();
   });
 
+  test('when populating only a single relation via em.populate', async () => {
+    const author2 = new Author2('Albert Camus', 'albert.camus@email.com');
+    const stranger = new Book2('The Stranger', author2);
+    const fall = new Book2('The Fall', author2);
+
+    author2.books2.add(stranger, fall);
+
+    await orm.em.persistAndFlush(author2);
+    orm.em.clear();
+
+    const a2 = await orm.em.findOneOrFail(Author2, { id: 1 });
+    await orm.em.populate(a2, 'books2');
+
+    expect(a2.books2).toHaveLength(2);
+  });
+
   test.todo('populate OneToOne with joined strategy');
   test.todo('populate ManyToMany with joined strategy');
   test.todo('handles nested joinedLoads that map to the same entity, eg book.author.favouriteAuthor');

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -455,7 +455,7 @@ describe('QueryBuilder', () => {
 
   test('select by m:n inverse side (that is not defined as property) via populate', async () => {
     const qb = orm.em.createQueryBuilder(Test2);
-    qb.select('*').populate([{ field: 'publisher2_tests' }]).where({ 'publisher2_to_test2.Publisher2_owner': { $in: [ 1, 2 ] } }).orderBy({ 'publisher2_to_test2.id': QueryOrder.ASC });
+    qb.select('*').populate([{ field: 'publisher2_tests' }]).where({ 'publisher2_tests.Publisher2_owner': { $in: [ 1, 2 ] } }).orderBy({ 'publisher2_tests.id': QueryOrder.ASC });
     let sql = 'select `e0`.*, `e1`.`test2_id`, `e1`.`publisher2_id` from `test2` as `e0` ';
     sql += 'left join `publisher2_tests` as `e1` on `e0`.`id` = `e1`.`test2_id` ';
     sql += 'where `e1`.`publisher2_id` in (?, ?) ';
@@ -466,7 +466,7 @@ describe('QueryBuilder', () => {
 
   test('select by m:n self reference owner', async () => {
     const qb = orm.em.createQueryBuilder(Author2);
-    qb.select('*').populate([{ field: 'author2_following' }]).where({ 'author2_to_author2.Author2_owner': { $in: [ 1, 2 ] } });
+    qb.select('*').populate([{ field: 'author2_following' }]).where({ 'author2_following.Author2_owner': { $in: [ 1, 2 ] } });
     let sql = 'select `e0`.*, `e1`.`author2_2_id`, `e1`.`author2_1_id` from `author2` as `e0` ';
     sql += 'left join `author2_following` as `e1` on `e0`.`id` = `e1`.`author2_2_id` ';
     sql += 'where `e1`.`author2_1_id` in (?, ?)';
@@ -476,7 +476,7 @@ describe('QueryBuilder', () => {
 
   test('select by m:n self reference inverse', async () => {
     const qb = orm.em.createQueryBuilder(Author2);
-    qb.select('*').populate([{ field: 'author2_following' }]).where({ 'author2_to_author2.Author2_inverse': { $in: [ 1, 2 ] } });
+    qb.select('*').populate([{ field: 'author2_following' }]).where({ 'author2_following.Author2_inverse': { $in: [ 1, 2 ] } });
     let sql = 'select `e0`.*, `e1`.`author2_1_id`, `e1`.`author2_2_id` from `author2` as `e0` ';
     sql += 'left join `author2_following` as `e1` on `e0`.`id` = `e1`.`author2_1_id` ';
     sql += 'where `e1`.`author2_2_id` in (?, ?)';
@@ -486,7 +486,7 @@ describe('QueryBuilder', () => {
 
   test('select by m:n with composite keys', async () => {
     const qb = orm.em.createQueryBuilder(User2);
-    qb.select('*').populate([{ field: 'user2_cars' }]).where({ 'user2_to_car2.Car2_inverse': { $in: [ [1, 2], [3, 4] ] } });
+    qb.select('*').populate([{ field: 'user2_cars' }]).where({ 'user2_cars.Car2_inverse': { $in: [ [1, 2], [3, 4] ] } });
     const sql = 'select `e0`.*, `e1`.`user2_first_name`, `e1`.`user2_last_name`, `e1`.`car2_name`, `e1`.`car2_year` ' +
       'from `user2` as `e0` left join `user2_cars` as `e1` on `e0`.`first_name` = `e1`.`user2_first_name` and `e0`.`last_name` = `e1`.`user2_last_name` ' +
       'where (`e1`.`car2_name`, `e1`.`car2_year`) in ((?, ?), (?, ?))';

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -395,7 +395,7 @@ describe('QueryBuilder', () => {
 
   test('select by 1:1 inversed', async () => {
     const qb = orm.em.createQueryBuilder(FooBaz2);
-    qb.select('*').where({ id: 123 }).populate(['bar']);
+    qb.select('*').where({ id: 123 }).populate([{ field: 'bar' }]);
     expect(qb.getQuery()).toEqual('select `e0`.*, `e1`.`id` as `bar_id` from `foo_baz2` as `e0` left join `foo_bar2` as `e1` on `e0`.`id` = `e1`.`baz_id` where `e0`.`id` = ?');
     expect(qb.getParams()).toEqual([123]);
   });
@@ -409,7 +409,7 @@ describe('QueryBuilder', () => {
 
   test('select by 1:1 inversed with populate', async () => {
     const qb = orm.em.createQueryBuilder(FooBaz2);
-    qb.select('*').where({ id: 123 }).populate(['bar']);
+    qb.select('*').where({ id: 123 }).populate([{ field: 'bar' }]);
     expect(qb.getQuery()).toEqual('select `e0`.*, `e1`.`id` as `bar_id` from `foo_baz2` as `e0` left join `foo_bar2` as `e1` on `e0`.`id` = `e1`.`baz_id` where `e0`.`id` = ?');
     expect(qb.getParams()).toEqual([123]);
   });
@@ -423,14 +423,14 @@ describe('QueryBuilder', () => {
 
   test('select by 1:1 inversed with populate (uuid pk)', async () => {
     const qb = orm.em.createQueryBuilder(Book2);
-    qb.select('*').where({ test: 123 }).populate(['test']);
+    qb.select('*').where({ test: 123 }).populate([{ field: 'test' }]);
     expect(qb.getQuery()).toEqual('select `e0`.*, `e1`.`id` as `test_id`, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` where `e1`.`id` = ?');
     expect(qb.getParams()).toEqual([123]);
   });
 
   test('select by 1:1 inversed with populate() before where() (uuid pk)', async () => {
     const qb = orm.em.createQueryBuilder(Book2);
-    qb.select('*').populate(['test']).where({ test: 123 });
+    qb.select('*').populate([{ field: 'test' }]).where({ test: 123 });
     expect(qb.getQuery()).toEqual('select `e0`.*, `e1`.`id` as `test_id`, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` where `e1`.`id` = ?');
     expect(qb.getParams()).toEqual([123]);
   });
@@ -455,7 +455,7 @@ describe('QueryBuilder', () => {
 
   test('select by m:n inverse side (that is not defined as property) via populate', async () => {
     const qb = orm.em.createQueryBuilder(Test2);
-    qb.select('*').populate(['publisher2_tests']).where({ 'publisher2_tests.Publisher2_owner': { $in: [ 1, 2 ] } }).orderBy({ 'publisher2_tests.id': QueryOrder.ASC });
+    qb.select('*').populate([{ field: 'publisher2_tests' }]).where({ 'publisher2_to_test2.Publisher2_owner': { $in: [ 1, 2 ] } }).orderBy({ 'publisher2_to_test2.id': QueryOrder.ASC });
     let sql = 'select `e0`.*, `e1`.`test2_id`, `e1`.`publisher2_id` from `test2` as `e0` ';
     sql += 'left join `publisher2_tests` as `e1` on `e0`.`id` = `e1`.`test2_id` ';
     sql += 'where `e1`.`publisher2_id` in (?, ?) ';
@@ -466,7 +466,7 @@ describe('QueryBuilder', () => {
 
   test('select by m:n self reference owner', async () => {
     const qb = orm.em.createQueryBuilder(Author2);
-    qb.select('*').populate(['author2_following']).where({ 'author2_following.Author2_owner': { $in: [ 1, 2 ] } });
+    qb.select('*').populate([{ field: 'author2_following' }]).where({ 'author2_to_author2.Author2_owner': { $in: [ 1, 2 ] } });
     let sql = 'select `e0`.*, `e1`.`author2_2_id`, `e1`.`author2_1_id` from `author2` as `e0` ';
     sql += 'left join `author2_following` as `e1` on `e0`.`id` = `e1`.`author2_2_id` ';
     sql += 'where `e1`.`author2_1_id` in (?, ?)';
@@ -476,7 +476,7 @@ describe('QueryBuilder', () => {
 
   test('select by m:n self reference inverse', async () => {
     const qb = orm.em.createQueryBuilder(Author2);
-    qb.select('*').populate(['author2_following']).where({ 'author2_following.Author2_inverse': { $in: [ 1, 2 ] } });
+    qb.select('*').populate([{ field: 'author2_following' }]).where({ 'author2_to_author2.Author2_inverse': { $in: [ 1, 2 ] } });
     let sql = 'select `e0`.*, `e1`.`author2_1_id`, `e1`.`author2_2_id` from `author2` as `e0` ';
     sql += 'left join `author2_following` as `e1` on `e0`.`id` = `e1`.`author2_1_id` ';
     sql += 'where `e1`.`author2_2_id` in (?, ?)';
@@ -486,7 +486,7 @@ describe('QueryBuilder', () => {
 
   test('select by m:n with composite keys', async () => {
     const qb = orm.em.createQueryBuilder(User2);
-    qb.select('*').populate(['user2_cars']).where({ 'user2_cars.Car2_inverse': { $in: [ [1, 2], [3, 4] ] } });
+    qb.select('*').populate([{ field: 'user2_cars' }]).where({ 'user2_to_car2.Car2_inverse': { $in: [ [1, 2], [3, 4] ] } });
     const sql = 'select `e0`.*, `e1`.`user2_first_name`, `e1`.`user2_last_name`, `e1`.`car2_name`, `e1`.`car2_year` ' +
       'from `user2` as `e0` left join `user2_cars` as `e1` on `e0`.`first_name` = `e1`.`user2_first_name` and `e0`.`last_name` = `e1`.`user2_last_name` ' +
       'where (`e1`.`car2_name`, `e1`.`car2_year`) in ((?, ?), (?, ?))';
@@ -496,7 +496,7 @@ describe('QueryBuilder', () => {
 
   test('select by m:n with unknown populate ignored', async () => {
     const qb = orm.em.createQueryBuilder(Test2);
-    qb.select('*').populate(['not_existing']);
+    qb.select('*').populate([{ field: 'not_existing' }]);
     expect(qb.getQuery()).toEqual('select `e0`.* from `test2` as `e0`');
     expect(qb.getParams()).toEqual([]);
   });
@@ -888,7 +888,7 @@ describe('QueryBuilder', () => {
 
   test('select with populate and join of 1:m', async () => {
     const qb = orm.em.createQueryBuilder(Author2);
-    qb.select('*').populate(['books']).leftJoin('books', 'b');
+    qb.select('*').populate([{ field: 'books' }]).leftJoin('books', 'b');
     expect(qb.getQuery()).toEqual('select `e0`.* ' +
       'from `author2` as `e0` ' +
       'left join `book2` as `b` on `e0`.`id` = `b`.`author_id`');
@@ -896,7 +896,7 @@ describe('QueryBuilder', () => {
 
   test('select with populate and join of m:n', async () => {
     const qb = orm.em.createQueryBuilder(Book2);
-    qb.select('*').populate(['tags']).leftJoin('tags', 't');
+    qb.select('*').populate([{ field: 'tags' }]).leftJoin('tags', 't');
     expect(qb.getQuery()).toEqual('select `e0`.*, `e1`.`book2_uuid_pk`, `e1`.`book_tag2_id`, `e0`.price * 1.19 as `price_taxed` ' +
       'from `book2` as `e0` ' +
       'left join `book2_tags` as `e1` on `e0`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +

--- a/tests/entities-sql/Author2.ts
+++ b/tests/entities-sql/Author2.ts
@@ -51,6 +51,9 @@ export class Author2 extends BaseEntity2 {
   @OneToMany({ entity: () => Book2, mappedBy: 'author', orderBy: { title: QueryOrder.ASC } })
   books!: Collection<Book2>;
 
+  @OneToMany({ entity: () => Book2, mappedBy: 'author', strategy: LoadStrategy.JOINED, orderBy: { title: QueryOrder.ASC } })
+  books2!: Collection<Book2>;
+
   @OneToOne({ entity: () => Address2, mappedBy: address => address.author, cascade: [Cascade.ALL] })
   address?: Address2;
 

--- a/tests/entities-sql/Author2.ts
+++ b/tests/entities-sql/Author2.ts
@@ -1,6 +1,6 @@
 import {
   AfterCreate, AfterDelete, AfterUpdate, BeforeCreate, BeforeDelete, BeforeUpdate, Collection, Entity, OneToMany, Property, ManyToOne,
-  QueryOrder, OnInit, ManyToMany, DateType, TimeType, Index, Unique, OneToOne, Cascade,
+  QueryOrder, OnInit, ManyToMany, DateType, TimeType, Index, Unique, OneToOne, Cascade, LoadStrategy,
 } from '@mikro-orm/core';
 
 import { Book2 } from './Book2';
@@ -48,7 +48,12 @@ export class Author2 extends BaseEntity2 {
   @Property({ type: TimeType, index: 'born_time_idx', nullable: true })
   bornTime?: string;
 
-  @OneToMany({ entity: () => Book2, mappedBy: 'author', orderBy: { title: QueryOrder.ASC } })
+  @OneToMany({
+    entity: () => Book2,
+    mappedBy: 'author',
+    orderBy: { title: QueryOrder.ASC },
+    strategy: LoadStrategy.JOINED,
+  })
   books!: Collection<Book2>;
 
   @OneToOne({ entity: () => Address2, mappedBy: address => address.author, cascade: [Cascade.ALL] })

--- a/tests/entities-sql/Author2.ts
+++ b/tests/entities-sql/Author2.ts
@@ -48,12 +48,7 @@ export class Author2 extends BaseEntity2 {
   @Property({ type: TimeType, index: 'born_time_idx', nullable: true })
   bornTime?: string;
 
-  @OneToMany({
-    entity: () => Book2,
-    mappedBy: 'author',
-    orderBy: { title: QueryOrder.ASC },
-    strategy: LoadStrategy.JOINED,
-  })
+  @OneToMany({ entity: () => Book2, mappedBy: 'author', orderBy: { title: QueryOrder.ASC } })
   books!: Collection<Book2>;
 
   @OneToOne({ entity: () => Address2, mappedBy: address => address.author, cascade: [Cascade.ALL] })


### PR DESCRIPTION
This adds support for alternate load strategies. As of now, only one additional strategy is supported: `joined`. Currently, the only way to specify the strategy is on on the decorator for the relationship:

```ts
@Entity()
export class Author2 {
  @OneToMany({
    entity: () => Book2,
    mappedBy: 'author',
    orderBy: { title: QueryOrder.ASC },
    strategy: LoadStrategy.JOINED, // new property
  })
  books!: Collection<Book2>;
}
```
---

- [x] Tests
- [ ] Docs
- [x] Cleanup

Closes #440 (reopen of #517)