### PR TITLE
docs: add note about multiple m:n between same entities

### DIFF
--- a/docs/versioned_docs/version-3.3/relationships.md
+++ b/docs/versioned_docs/version-3.3/relationships.md
@@ -170,3 +170,18 @@ export class BookTag implements IdEntity<BookTag> {
 ```
 
 Again, more information about how collections work can be found on [collections page](collections.md). 
+
+> Note: if you are using multiple M:N relations between the same entities, you will need to manually specify the pivot table's name just on the **owning** sides. Here is an example:
+
+```typescript
+@Entity()
+export class Publisher {
+  // just on owning side (no mapped by provided)
+  @ManyToMany({ entity: () => Customer, pivotTable: "customer_publisher" })
+  costumers = new Collection<Customer>(this);
+
+  // just on owning side (no mapped by provided)
+  @ManyToMany({ entity: () => Author, pivotTable: "publisher_author" })
+  authors = new Collection<Author>(this);
+}
+```

--- a/docs/versioned_docs/version-3.4/relationships.md
+++ b/docs/versioned_docs/version-3.4/relationships.md
@@ -170,3 +170,18 @@ export class BookTag {
 ```
 
 Again, more information about how collections work can be found on [collections page](collections.md). 
+
+> Note: if you are using multiple M:N relations between the same entities, you will need to manually specify the pivot table's name just on the **owning** sides. Here is an example:
+
+```typescript
+@Entity()
+export class Publisher {
+  // just on owning side (no mapped by provided)
+  @ManyToMany({ entity: () => Customer, pivotTable: "customer_publisher" })
+  costumers = new Collection<Customer>(this);
+
+  // just on owning side (no mapped by provided)
+  @ManyToMany({ entity: () => Author, pivotTable: "publisher_author" })
+  authors = new Collection<Author>(this);
+}
+```

--- a/docs/versioned_docs/version-3.5/relationships.md
+++ b/docs/versioned_docs/version-3.5/relationships.md
@@ -170,3 +170,18 @@ export class BookTag {
 ```
 
 Again, more information about how collections work can be found on [collections page](collections.md). 
+
+> Note: if you are using multiple M:N relations between the same entities, you will need to manually specify the pivot table's name just on the **owning** sides. Here is an example:
+
+```typescript
+@Entity()
+export class Publisher {
+  // just on owning side (no mapped by provided)
+  @ManyToMany({ entity: () => Customer, pivotTable: "customer_publisher" })
+  costumers = new Collection<Customer>(this);
+
+  // just on owning side (no mapped by provided)
+  @ManyToMany({ entity: () => Author, pivotTable: "publisher_author" })
+  authors = new Collection<Author>(this);
+}
+```

--- a/docs/versioned_docs/version-3.6/relationships.md
+++ b/docs/versioned_docs/version-3.6/relationships.md
@@ -170,3 +170,18 @@ export class BookTag {
 ```
 
 Again, more information about how collections work can be found on [collections page](collections.md). 
+
+> Note: if you are using multiple M:N relations between the same entities, you will need to manually specify the pivot table's name just on the **owning** sides. Here is an example:
+
+```typescript
+@Entity()
+export class Publisher {
+  // just on owning side (no mapped by provided)
+  @ManyToMany({ entity: () => Customer, pivotTable: "customer_publisher" })
+  costumers = new Collection<Customer>(this);
+
+  // just on owning side (no mapped by provided)
+  @ManyToMany({ entity: () => Author, pivotTable: "publisher_author" })
+  authors = new Collection<Author>(this);
+}
+```


### PR DESCRIPTION
Hello, 

This PR improves the docs about multiple M:N Relationships on the same entity via manual naming of the pivot table on all V3 docs as mentioned [here](https://github.com/mikro-orm/mikro-orm/issues/555#issuecomment-625854857). 

This PR references [this issue](https://github.com/mikro-orm/mikro-orm/issues/555). 

I have also added an example to demonstrate how it is done but let me know if this is extra and I can remove it. 

Many thanks for this great project,
Ali
