### PR TITLE
feat(core): add custom types for array, blob and json

### DIFF
--- a/docs/docs/custom-types.md
+++ b/docs/docs/custom-types.md
@@ -24,8 +24,6 @@ You can define custom types by extending `Type` abstract class. It has 4 optiona
   Gets the SQL declaration snippet for a field of this type.
   By default returns `columnType` of given property.
 
-> `DateType` and `TimeType` types are already implemented in the ORM.
-
 ```typescript
 import { Type, Platform, EntityProperty, ValidationError } from 'mikro-orm';
 
@@ -80,4 +78,90 @@ export class FooBar {
   born?: Date;
 
 }
+```
+
+## Types provided by MikroORM
+
+There are few types provided by MikroORM. All of them aim to provide similar
+experience among all the drivers, even if the particular feature is not supported
+out of box by the driver.
+
+### ArrayType
+
+In PostgreSQL and MongoDB, it uses native arrays, otherwise it concatenates the 
+values into string separated by commas. This means that you can't use values that
+contain comma with the `ArrayType` (but you can create custom array type that will
+handle this case, e.g. by using different separator).
+
+By default array of strings is returned from the type. You can also have arrays 
+of numbers or other data types - to do so, you will need to implement custom 
+`hydrate` method that is used for converting the array values to the right type.
+
+> `ArrayType` will be used automatically if `type` is set to `array` (default behaviour
+> of reflect-metadata) or `string[]` or `number[]` (either manually or via ts-morph).
+> In case of `number[]` it will automatically handle the conversion to numbers. 
+> This means that the following examples would both have the `ArrayType` used
+> automatically (but with reflect-metadata we would have a string array for both
+> unless we specify the type manually as `type: 'number[]')
+
+```typescript
+@Property({ type: ArrayType, nullable: true })
+stringArray?: string[];
+
+@Property({ type: new ArrayType(i => +i), nullable: true })
+numericArray?: number[];
+```
+
+### BigIntType
+
+You can use `BigIntType` to support `bigint`s. By default, it will represent the 
+value as a `string`. 
+
+```typescript
+@PrimaryKey({ type: BigIntType })
+id: string;
+```
+
+### BlobType
+
+Blob type can be used to store binary data in the database. 
+
+> `BlobType` will be used automatically if you specify the type hint as `Buffer`. 
+> This means that the following example should work even without the explicit 
+> `type: BlobType` option (with both reflect-metadata and ts-morph providers).
+
+```typescript
+@Property({ type: BlobType, nullable: true })
+blob?: Buffer;
+```
+
+### JsonType
+
+To store objects we can use `JsonType`. As some drivers are handling objects 
+automatically and some don't, this type will handle the serialization in a driver
+independent way (calling `parse` and `stringify` only when needed).
+
+```typescript
+@Property({ type: JsonType, nullable: true })
+object?: { foo: string; bar: number };
+```
+
+### DateType
+
+To store dates without time information, we can use `DateType`. It does use `date`
+column type and maps it to the `Date` object. 
+
+```typescript
+@Property({ type: DateType, nullable: true })
+born?: Date;
+```
+
+### TimeType
+
+As opposed to the `DateType`, to store only the time information, we can use
+`TimeType`. It will use the `time` column type, the runtime type is string. 
+
+```typescript
+@Property({ type: TimeType, nullable: true })
+bornTime?: string;
 ```

--- a/packages/core/src/decorators/Property.ts
+++ b/packages/core/src/decorators/Property.ts
@@ -38,7 +38,7 @@ export type PropertyOptions = {
   fieldNames?: string[];
   customType?: Type<any>;
   columnType?: string;
-  type?: 'string' | 'number' | 'boolean' | 'bigint' | 'ObjectId' | string | object | bigint | Date | Constructor<Type>;
+  type?: 'string' | 'number' | 'boolean' | 'bigint' | 'ObjectId' | string | object | bigint | Date | Constructor<Type<any>> | Type<any>;
   length?: any;
   onCreate?: () => any;
   onUpdate?: () => any;

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -91,6 +91,30 @@ export abstract class Platform {
     return 'bigint';
   }
 
+  getArrayDeclarationSQL(): string {
+    return 'text';
+  }
+
+  marshallArray(values: string[]): string {
+    return values.join(',');
+  }
+
+  unmarshallArray(value: string): string[] {
+    return value.split(',') as string[];
+  }
+
+  getBlobDeclarationSQL(): string {
+    return 'blob';
+  }
+
+  getJsonDeclarationSQL(): string {
+    return 'json';
+  }
+
+  convertsJsonAutomatically(marshall = false): boolean {
+    return !marshall;
+  }
+
   getRepositoryClass<T>(): Constructor<EntityRepository<T>> {
     return EntityRepository;
   }

--- a/packages/core/src/types/ArrayType.ts
+++ b/packages/core/src/types/ArrayType.ts
@@ -1,0 +1,44 @@
+import { Type } from './Type';
+import { Utils, ValidationError } from '../utils';
+import { EntityProperty } from '../typings';
+import { Platform } from '../platforms';
+
+export class ArrayType<T extends string | number = string> extends Type<T[] | null, string | null> {
+
+  constructor(private readonly hydrate: (i: string) => T = i => i as T) {
+    super();
+  }
+
+  convertToDatabaseValue(value: T[] | null, platform: Platform): string | null {
+    if (!value) {
+      return value as null;
+    }
+
+    if (Array.isArray(value)) {
+      return platform.marshallArray(value as string[]);
+    }
+
+    throw ValidationError.invalidType(ArrayType, value, 'JS');
+  }
+
+  convertToJSValue(value: T[] | string | null, platform: Platform): T[] | null {
+    if (!value) {
+      return value as null;
+    }
+
+    if (Utils.isString(value)) {
+      value = platform.unmarshallArray(value) as T[];
+    }
+
+    return value.map(i => this.hydrate(i as string));
+  }
+
+  toJSON(value: T[]): T[] {
+    return value;
+  }
+
+  getColumnType(prop: EntityProperty, platform: Platform): string {
+    return platform.getArrayDeclarationSQL();
+  }
+
+}

--- a/packages/core/src/types/BlobType.ts
+++ b/packages/core/src/types/BlobType.ts
@@ -1,0 +1,27 @@
+import { Type } from './Type';
+import { Platform } from '../platforms';
+import { EntityProperty } from '../typings';
+
+export class BlobType extends Type<Buffer | null> {
+
+  convertToDatabaseValue(value: Buffer, platform: Platform): Buffer {
+    return value;
+  }
+
+  convertToJSValue(value: Buffer, platform: Platform): Buffer | null {
+    if (!value) {
+      return value;
+    }
+
+    if (value.buffer instanceof Buffer) {
+      return value.buffer;
+    }
+
+    return Buffer.from(value);
+  }
+
+  getColumnType(prop: EntityProperty, platform: Platform): string {
+    return platform.getBlobDeclarationSQL();
+  }
+
+}

--- a/packages/core/src/types/JsonType.ts
+++ b/packages/core/src/types/JsonType.ts
@@ -1,0 +1,28 @@
+import { Type } from './Type';
+import { Platform } from '../platforms';
+import { EntityProperty } from '../typings';
+import { Utils } from '../utils';
+
+export class JsonType extends Type<object, string | null> {
+
+  convertToDatabaseValue(value: object, platform: Platform): string | null {
+    if (platform.convertsJsonAutomatically(true) || value === null) {
+      return value as unknown as string;
+    }
+
+    return JSON.stringify(value);
+  }
+
+  convertToJSValue(value: string | object, platform: Platform): object {
+    if (!platform.convertsJsonAutomatically() && Utils.isString(value)) {
+      return JSON.parse(value);
+    }
+
+    return value as object;
+  }
+
+  getColumnType(prop: EntityProperty, platform: Platform): string {
+    return platform.getJsonDeclarationSQL();
+  }
+
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -2,3 +2,6 @@ export * from './Type';
 export * from './DateType';
 export * from './TimeType';
 export * from './BigIntType';
+export * from './BlobType';
+export * from './ArrayType';
+export * from './JsonType';

--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -140,7 +140,13 @@ export class DatabaseTable {
       return namingStrategy.getClassName(column.fk.referencedTableName, '_');
     }
 
-    return schemaHelper.getTypeFromDefinition(column.type, defaultType);
+    const type = schemaHelper.getTypeFromDefinition(column.type, defaultType);
+
+    if (column.type.endsWith('[]')) {
+      return type + '[]';
+    }
+
+    return type;
   }
 
   private getPropertyDefaultValue(schemaHelper: SchemaHelper, column: Column, propType: string, raw = false): any {

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -30,4 +30,12 @@ export class MongoPlatform extends Platform {
     return false;
   }
 
+  convertsJsonAutomatically(marshall = false): boolean {
+    return true;
+  }
+
+  marshallArray(values: string[]): string {
+    return values as unknown as string;
+  }
+
 }

--- a/packages/postgresql/src/PostgreSqlPlatform.ts
+++ b/packages/postgresql/src/PostgreSqlPlatform.ts
@@ -32,4 +32,20 @@ export class PostgreSqlPlatform extends AbstractSqlPlatform {
     return super.isBigIntProperty(prop) || (prop.columnTypes && prop.columnTypes[0] === 'bigserial');
   }
 
+  getArrayDeclarationSQL(): string {
+    return 'text[]';
+  }
+
+  marshallArray(values: string[]): string {
+    return `{${values.join(',')}}`;
+  }
+
+  getBlobDeclarationSQL(): string {
+    return 'bytea';
+  }
+
+  getJsonDeclarationSQL(): string {
+    return 'jsonb';
+  }
+
 }

--- a/packages/sqlite/src/SqlitePlatform.ts
+++ b/packages/sqlite/src/SqlitePlatform.ts
@@ -19,4 +19,8 @@ export class SqlitePlatform extends AbstractSqlPlatform {
     return super.getCurrentTimestampSQL(0);
   }
 
+  convertsJsonAutomatically(): boolean {
+    return false;
+  }
+
 }

--- a/tests/EntityHelper.mysql.test.ts
+++ b/tests/EntityHelper.mysql.test.ts
@@ -116,6 +116,9 @@ describe('EntityHelperMySql', () => {
       name: 'fb',
       random: 123,
       version: a.version,
+      array: null,
+      object: null,
+      blob: null,
     });
   });
 

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -2054,6 +2054,48 @@ describe('EntityManagerMySql', () => {
       'where `e1`.`name` = ? limit ?');
   });
 
+  test('custom types', async () => {
+    const bar = FooBar2.create('b1');
+    bar.blob = Buffer.from([1, 2, 3, 4, 5]);
+    bar.array = [1, 2, 3, 4, 5];
+    bar.object = { foo: 'bar', bar: 3 };
+    await orm.em.persistAndFlush(bar);
+    orm.em.clear();
+
+    const b1 = await orm.em.findOneOrFail(FooBar2, bar.id);
+    expect(b1.blob).toEqual(Buffer.from([1, 2, 3, 4, 5]));
+    expect(b1.blob).toBeInstanceOf(Buffer);
+    expect(b1.array).toEqual([1, 2, 3, 4, 5]);
+    expect(b1.array![2]).toBe(3);
+    expect(b1.array).toBeInstanceOf(Array);
+    expect(b1.object).toEqual({ foo: 'bar', bar: 3 });
+    expect(b1.object).toBeInstanceOf(Object);
+    expect(b1.object!.bar).toBe(3);
+
+    b1.object = 'foo';
+    await orm.em.flush();
+    orm.em.clear();
+
+    const b2 = await orm.em.findOneOrFail(FooBar2, bar.id);
+    expect(b2.object).toBe('foo');
+
+    b2.object = [1, 2, '3'];
+    await orm.em.flush();
+    orm.em.clear();
+
+    const b3 = await orm.em.findOneOrFail(FooBar2, bar.id);
+    expect(b3.object[0]).toBe(1);
+    expect(b3.object[1]).toBe(2);
+    expect(b3.object[2]).toBe('3');
+
+    b3.object = 123;
+    await orm.em.flush();
+    orm.em.clear();
+
+    const b4 = await orm.em.findOneOrFail(FooBar2, bar.id);
+    expect(b4.object).toBe(123);
+  });
+
   test('exceptions', async () => {
     await orm.em.nativeInsert(Author2, { name: 'author', email: 'email' });
     await expect(orm.em.nativeInsert(Author2, { name: 'author', email: 'email' })).rejects.toThrow(UniqueConstraintViolationException);

--- a/tests/__snapshots__/EntityGenerator.test.ts.snap
+++ b/tests/__snapshots__/EntityGenerator.test.ts.snap
@@ -52,8 +52,8 @@ export class Author2 {
   @Property({ nullable: true })
   optional?: boolean;
 
-  @Property({ nullable: true })
-  identities?: object;
+  @Property({ columnType: 'text', length: 65535, nullable: true })
+  identities?: string;
 
   @Index({ name: 'author2_born_index' })
   @Property({ columnType: 'date', nullable: true })
@@ -225,7 +225,7 @@ export class BookToTagUnordered {
 export class Car2 {
 
   @Index({ name: 'car2_name_index' })
-  @PrimaryKey({ length: 255 })
+  @PrimaryKey({ length: 100 })
   name!: string;
 
   @Index({ name: 'car2_year_index' })
@@ -249,7 +249,7 @@ export class CarOwner2 {
   @Property({ length: 255 })
   name!: string;
 
-  @ManyToOne({ entity: () => Car2, index: 'car_owner2_car_name_car_year_idx' })
+  @ManyToOne({ entity: () => Car2, index: 'car_owner2_car_name_car_year_index' })
   car!: Car2;
 
 }
@@ -292,6 +292,15 @@ export class FooBar2 {
 
   @Property({ default: \`CURRENT_TIMESTAMP\` })
   version!: Date;
+
+  @Property({ length: 65535, columnType: 'blob', nullable: true })
+  blob?: string;
+
+  @Property({ columnType: 'text', length: 65535, nullable: true })
+  array?: string;
+
+  @Property({ nullable: true })
+  object?: object;
 
 }
 ",
@@ -493,8 +502,8 @@ export class Author2 {
   @Property({ nullable: true })
   optional?: boolean;
 
-  @Property({ nullable: true })
-  identities?: object;
+  @Property({ columnType: 'text[]', nullable: true })
+  identities?: string[];
 
   @Index({ name: 'author2_born_index' })
   @Property({ columnType: 'date', nullable: true })
@@ -663,6 +672,15 @@ export class FooBar2 {
 
   @Property({ default: \`current_timestamp(0)\` })
   version!: Date;
+
+  @Property({ nullable: true })
+  blob?: Buffer;
+
+  @Property({ columnType: 'text[]', nullable: true })
+  array?: string[];
+
+  @Property({ nullable: true })
+  object?: object;
 
 }
 ",

--- a/tests/__snapshots__/SchemaGenerator.test.ts.snap
+++ b/tests/__snapshots__/SchemaGenerator.test.ts.snap
@@ -4,7 +4,7 @@ exports[`SchemaGenerator generate schema from metadata [mysql]: mysql-create-sch
 "set names utf8mb4;
 set foreign_key_checks = 0;
 
-create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` json null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
+create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table \`author2\` add index \`custom_email_index_name\`(\`email\`);
 alter table \`author2\` add unique \`custom_email_unique_name\`(\`email\`);
 alter table \`author2\` add index \`author2_terms_accepted_index\`(\`terms_accepted\`);
@@ -34,7 +34,7 @@ create table \`test2\` (\`id\` int unsigned not null auto_increment primary key,
 alter table \`test2\` add index \`test2_book_uuid_pk_index\`(\`book_uuid_pk\`);
 alter table \`test2\` add unique \`test2_book_uuid_pk_unique\`(\`book_uuid_pk\`);
 
-create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp) default character set utf8mb4 engine = InnoDB;
+create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`array\` text null, \`object\` json null) default character set utf8mb4 engine = InnoDB;
 alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
 alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
 alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
@@ -201,7 +201,7 @@ drop table if exists \`book_to_tag_unordered\`;
 drop table if exists \`publisher2_tests\`;
 drop table if exists \`user2_cars\`;
 
-create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` json null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
+create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table \`author2\` add index \`custom_email_index_name\`(\`email\`);
 alter table \`author2\` add unique \`custom_email_unique_name\`(\`email\`);
 alter table \`author2\` add index \`author2_terms_accepted_index\`(\`terms_accepted\`);
@@ -231,7 +231,7 @@ create table \`test2\` (\`id\` int unsigned not null auto_increment primary key,
 alter table \`test2\` add index \`test2_book_uuid_pk_index\`(\`book_uuid_pk\`);
 alter table \`test2\` add unique \`test2_book_uuid_pk_unique\`(\`book_uuid_pk\`);
 
-create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp) default character set utf8mb4 engine = InnoDB;
+create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`array\` text null, \`object\` json null) default character set utf8mb4 engine = InnoDB;
 alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
 alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
 alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
@@ -364,7 +364,7 @@ exports[`SchemaGenerator generate schema from metadata [postgres]: postgres-crea
 "set names 'utf8';
 set session_replication_role = 'replica';
 
-create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"updated_at\\" timestamptz(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int4 null default null, \\"terms_accepted\\" bool not null default false, \\"optional\\" bool null, \\"identities\\" jsonb null, \\"born\\" date null, \\"born_time\\" time(0) null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int4 null);
+create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"updated_at\\" timestamptz(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int4 null default null, \\"terms_accepted\\" bool not null default false, \\"optional\\" bool null, \\"identities\\" text[] null, \\"born\\" date null, \\"born_time\\" time(0) null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int4 null);
 create index \\"custom_email_index_name\\" on \\"author2\\" (\\"email\\");
 alter table \\"author2\\" add constraint \\"custom_email_unique_name\\" unique (\\"email\\");
 create index \\"author2_terms_accepted_index\\" on \\"author2\\" (\\"terms_accepted\\");
@@ -388,7 +388,7 @@ create table \\"publisher2\\" (\\"id\\" serial primary key, \\"name\\" varchar(2
 create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"version\\" int4 not null default 1);
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_unique\\" unique (\\"book_uuid_pk\\");
 
-create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int4 null, \\"foo_bar_id\\" int4 null, \\"version\\" timestamptz(0) not null default current_timestamp(0));
+create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int4 null, \\"foo_bar_id\\" int4 null, \\"version\\" timestamptz(0) not null default current_timestamp(0), \\"blob\\" bytea null, \\"array\\" text[] null, \\"object\\" jsonb null);
 alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_unique\\" unique (\\"baz_id\\");
 alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_unique\\" unique (\\"foo_bar_id\\");
 
@@ -503,7 +503,7 @@ drop table if exists \\"book2_tags\\" cascade;
 drop table if exists \\"book_to_tag_unordered\\" cascade;
 drop table if exists \\"publisher2_tests\\" cascade;
 
-create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"updated_at\\" timestamptz(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int4 null default null, \\"terms_accepted\\" bool not null default false, \\"optional\\" bool null, \\"identities\\" jsonb null, \\"born\\" date null, \\"born_time\\" time(0) null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int4 null);
+create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"updated_at\\" timestamptz(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int4 null default null, \\"terms_accepted\\" bool not null default false, \\"optional\\" bool null, \\"identities\\" text[] null, \\"born\\" date null, \\"born_time\\" time(0) null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int4 null);
 create index \\"custom_email_index_name\\" on \\"author2\\" (\\"email\\");
 alter table \\"author2\\" add constraint \\"custom_email_unique_name\\" unique (\\"email\\");
 create index \\"author2_terms_accepted_index\\" on \\"author2\\" (\\"terms_accepted\\");
@@ -527,7 +527,7 @@ create table \\"publisher2\\" (\\"id\\" serial primary key, \\"name\\" varchar(2
 create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"version\\" int4 not null default 1);
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_unique\\" unique (\\"book_uuid_pk\\");
 
-create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int4 null, \\"foo_bar_id\\" int4 null, \\"version\\" timestamptz(0) not null default current_timestamp(0));
+create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int4 null, \\"foo_bar_id\\" int4 null, \\"version\\" timestamptz(0) not null default current_timestamp(0), \\"blob\\" bytea null, \\"array\\" text[] null, \\"object\\" jsonb null);
 alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_unique\\" unique (\\"baz_id\\");
 alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_unique\\" unique (\\"foo_bar_id\\");
 
@@ -611,7 +611,7 @@ set session_replication_role = 'origin';
 exports[`SchemaGenerator generate schema from metadata [sqlite]: sqlite-create-schema-dump 1`] = `
 "pragma foreign_keys = off;
 
-create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` varchar null, \`born\` date(3) null, \`born_time\` time(3) null);
+create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` date(3) null, \`born_time\` time(3) null);
 create unique index \`author3_email_unique\` on \`author3\` (\`email\`);
 
 create table \`book3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`title\` varchar not null default '');
@@ -681,7 +681,7 @@ drop table if exists \`test3\`;
 drop table if exists \`book3_tags\`;
 drop table if exists \`publisher3_tests\`;
 
-create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` varchar null, \`born\` date(3) null, \`born_time\` time(3) null);
+create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` date(3) null, \`born_time\` time(3) null);
 create unique index \`author3_email_unique\` on \`author3\` (\`email\`);
 
 create table \`book3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`title\` varchar not null default '');
@@ -722,7 +722,7 @@ pragma foreign_keys = on;
 exports[`SchemaGenerator generate schema from metadata [sqlite2]: sqlite2-create-schema-dump 1`] = `
 "pragma foreign_keys = off;
 
-create table \`author4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` varchar null, \`born\` date(3) null, \`born_time\` time(3) null);
+create table \`author4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` date(3) null, \`born_time\` time(3) null);
 create unique index \`author4_email_unique\` on \`author4\` (\`email\`);
 
 create table \`book4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`title\` varchar not null);
@@ -733,7 +733,7 @@ create table \`publisher4\` (\`id\` integer not null primary key autoincrement, 
 
 create table \`test4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar null, \`version\` integer not null default 1);
 
-create table \`foo_bar4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default 'asd', \`version\` datetime not null default current_timestamp);
+create table \`foo_bar4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default 'asd', \`version\` integer not null default 1, \`blob\` blob null, \`array\` text null, \`object\` json null);
 
 create table \`foo_baz4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
 
@@ -816,7 +816,7 @@ drop table if exists \`tags_ordered\`;
 drop table if exists \`tags_unordered\`;
 drop table if exists \`publisher4_tests\`;
 
-create table \`author4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` varchar null, \`born\` date(3) null, \`born_time\` time(3) null);
+create table \`author4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` date(3) null, \`born_time\` time(3) null);
 create unique index \`author4_email_unique\` on \`author4\` (\`email\`);
 
 create table \`book4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`title\` varchar not null);
@@ -827,7 +827,7 @@ create table \`publisher4\` (\`id\` integer not null primary key autoincrement, 
 
 create table \`test4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar null, \`version\` integer not null default 1);
 
-create table \`foo_bar4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default 'asd', \`version\` datetime not null default current_timestamp);
+create table \`foo_bar4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default 'asd', \`version\` integer not null default 1, \`blob\` blob null, \`array\` text null, \`object\` json null);
 
 create table \`foo_baz4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
 
@@ -873,7 +873,7 @@ exports[`SchemaGenerator update empty schema from metadata [mysql]: mysql-update
 "set names utf8mb4;
 set foreign_key_checks = 0;
 
-create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` json null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
+create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table \`author2\` add index \`custom_email_index_name\`(\`email\`);
 alter table \`author2\` add unique \`custom_email_unique_name\`(\`email\`);
 alter table \`author2\` add index \`author2_terms_accepted_index\`(\`terms_accepted\`);
@@ -903,7 +903,7 @@ create table \`test2\` (\`id\` int unsigned not null auto_increment primary key,
 alter table \`test2\` add index \`test2_book_uuid_pk_index\`(\`book_uuid_pk\`);
 alter table \`test2\` add unique \`test2_book_uuid_pk_unique\`(\`book_uuid_pk\`);
 
-create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp) default character set utf8mb4 engine = InnoDB;
+create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`array\` text null, \`object\` json null) default character set utf8mb4 engine = InnoDB;
 alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
 alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
 alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
@@ -1020,7 +1020,7 @@ exports[`SchemaGenerator update empty schema from metadata [postgres]: postgres-
 "set names 'utf8';
 set session_replication_role = 'replica';
 
-create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"updated_at\\" timestamptz(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int4 null default null, \\"terms_accepted\\" bool not null default false, \\"optional\\" bool null, \\"identities\\" jsonb null, \\"born\\" date null, \\"born_time\\" time(0) null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int4 null);
+create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"updated_at\\" timestamptz(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int4 null default null, \\"terms_accepted\\" bool not null default false, \\"optional\\" bool null, \\"identities\\" text[] null, \\"born\\" date null, \\"born_time\\" time(0) null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int4 null);
 create index \\"custom_email_index_name\\" on \\"author2\\" (\\"email\\");
 alter table \\"author2\\" add constraint \\"custom_email_unique_name\\" unique (\\"email\\");
 create index \\"author2_terms_accepted_index\\" on \\"author2\\" (\\"terms_accepted\\");
@@ -1044,7 +1044,7 @@ create table \\"publisher2\\" (\\"id\\" serial primary key, \\"name\\" varchar(2
 create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"version\\" int4 not null default 1);
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_unique\\" unique (\\"book_uuid_pk\\");
 
-create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int4 null, \\"foo_bar_id\\" int4 null, \\"version\\" timestamptz(0) not null default current_timestamp(0));
+create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int4 null, \\"foo_bar_id\\" int4 null, \\"version\\" timestamptz(0) not null default current_timestamp(0), \\"blob\\" bytea null, \\"array\\" text[] null, \\"object\\" jsonb null);
 alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_unique\\" unique (\\"baz_id\\");
 alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_unique\\" unique (\\"foo_bar_id\\");
 
@@ -1116,7 +1116,7 @@ set session_replication_role = 'origin';
 exports[`SchemaGenerator update empty schema from metadata [sqlite]: sqlite-update-empty-schema-dump 1`] = `
 "pragma foreign_keys = off;
 
-create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` varchar null, \`born\` date(3) null, \`born_time\` time(3) null);
+create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` date(3) null, \`born_time\` time(3) null);
 create unique index \`author3_email_unique\` on \`author3\` (\`email\`);
 
 create table \`book3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`title\` varchar not null default '');

--- a/tests/entities-schema/FooBar4.ts
+++ b/tests/entities-schema/FooBar4.ts
@@ -1,11 +1,14 @@
-import { EntitySchema } from '@mikro-orm/core';
+import { ArrayType, BlobType, EntitySchema, JsonType, Property } from '@mikro-orm/core';
 import { FooBaz4, BaseEntity5 } from './index';
 
 export interface FooBar4 extends BaseEntity5 {
   name: string;
   baz?: FooBaz4;
   fooBar?: FooBar4;
-  version: Date;
+  version: number;
+  blob?: Buffer;
+  array?: number[];
+  object?: { foo: string; bar: number } | any;
 }
 
 export const schema = new EntitySchema<FooBar4, BaseEntity5>({
@@ -15,6 +18,9 @@ export const schema = new EntitySchema<FooBar4, BaseEntity5>({
     name: { type: 'string', default: 'asd' },
     baz: { reference: '1:1', entity: 'FooBaz4', orphanRemoval: true, nullable: true },
     fooBar: { reference: '1:1', entity: 'FooBar4', nullable: true },
-    version: { type: 'Date', version: true, length: 0 },
+    version: { type: 'number', version: true },
+    blob: { type: BlobType, nullable: true },
+    array: { customType: new ArrayType(i => +i), nullable: true },
+    object: { type: JsonType, nullable: true },
   },
 });

--- a/tests/entities-sql/FooBar2.ts
+++ b/tests/entities-sql/FooBar2.ts
@@ -1,4 +1,4 @@
-import { Entity, Formula, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { ArrayType, BlobType, Entity, Formula, JsonType, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseEntity22 } from './BaseEntity22';
 import { FooBaz2 } from './FooBaz2';
 
@@ -19,6 +19,15 @@ export class FooBar2 extends BaseEntity22 {
 
   @Property({ version: true, length: 0 })
   version!: Date;
+
+  @Property({ nullable: true })
+  blob?: Buffer;
+
+  @Property({ type: 'number[]', nullable: true })
+  array?: number[];
+
+  @Property({ type: JsonType, nullable: true })
+  object?: { foo: string; bar: number } | any;
 
   @Formula(`(select 123)`)
   random?: number;

--- a/tests/entities/FooBar.ts
+++ b/tests/entities/FooBar.ts
@@ -1,5 +1,5 @@
 import { ObjectId } from 'mongodb';
-import { Entity, OneToOne, PrimaryKey, Property, SerializedPrimaryKey } from '@mikro-orm/core';
+import { ArrayType, BlobType, Entity, JsonType, OneToOne, PrimaryKey, Property, SerializedPrimaryKey } from '@mikro-orm/core';
 import { FooBaz } from './FooBaz';
 
 @Entity()
@@ -19,6 +19,15 @@ export default class FooBar {
 
   @OneToOne(() => FooBar)
   fooBar!: FooBar;
+
+  @Property({ nullable: true })
+  blob?: Buffer;
+
+  @Property({ type: new ArrayType(i => +i), nullable: true })
+  array?: number[];
+
+  @Property({ type: JsonType, nullable: true })
+  object?: { foo: string; bar: number } | any;
 
   static create(name: string) {
     const bar = new FooBar();

--- a/tests/mysql-schema.sql
+++ b/tests/mysql-schema.sql
@@ -28,14 +28,14 @@ drop table if exists `book2_to_book_tag2`;
 drop table if exists `publisher2_to_test2`;
 drop table if exists `user2_to_car2`;
 
-create table `author2` (`id` int unsigned not null auto_increment primary key, `created_at` datetime(3) not null default current_timestamp(3), `updated_at` datetime(3) not null default current_timestamp(3), `name` varchar(255) not null, `email` varchar(255) not null, `age` int(11) null default null, `terms_accepted` tinyint(1) not null default false, `optional` tinyint(1) null, `identities` json null, `born` date null, `born_time` time null, `favourite_book_uuid_pk` varchar(36) null, `favourite_author_id` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
+create table `author2` (`id` int unsigned not null auto_increment primary key, `created_at` datetime(3) not null default current_timestamp(3), `updated_at` datetime(3) not null default current_timestamp(3), `name` varchar(255) not null, `email` varchar(255) not null, `age` int(11) null default null, `terms_accepted` tinyint(1) not null default false, `optional` tinyint(1) null, `identities` text null, `born` date null, `born_time` time null, `favourite_book_uuid_pk` varchar(36) null, `favourite_author_id` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
+alter table `author2` add index `custom_email_index_name`(`email`);
 alter table `author2` add unique `custom_email_unique_name`(`email`);
+alter table `author2` add index `author2_terms_accepted_index`(`terms_accepted`);
 alter table `author2` add index `author2_born_index`(`born`);
 alter table `author2` add index `born_time_idx`(`born_time`);
 alter table `author2` add index `author2_favourite_book_uuid_pk_index`(`favourite_book_uuid_pk`);
 alter table `author2` add index `author2_favourite_author_id_index`(`favourite_author_id`);
-alter table `author2` add index `custom_email_index_name`(`email`);
-alter table `author2` add index `author2_terms_accepted_index`(`terms_accepted`);
 alter table `author2` add index `custom_idx_name_123`(`name`);
 alter table `author2` add index `author2_name_age_index`(`name`, `age`);
 alter table `author2` add unique `author2_name_email_unique`(`name`, `email`);
@@ -60,7 +60,7 @@ alter table `test2` add unique `test2_book_uuid_pk_unique`(`book_uuid_pk`);
 alter table `test2` add index `test2_foo___bar_index`(`foo___bar`);
 alter table `test2` add unique `test2_foo___bar_unique`(`foo___bar`);
 
-create table `foo_bar2` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) not null, `baz_id` int(11) unsigned null, `foo_bar_id` int(11) unsigned null, `version` datetime not null default current_timestamp) default character set utf8mb4 engine = InnoDB;
+create table `foo_bar2` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) not null, `baz_id` int(11) unsigned null, `foo_bar_id` int(11) unsigned null, `version` datetime not null default current_timestamp, `blob` blob null, `array` text null, `object` json null) default character set utf8mb4 engine = InnoDB;
 alter table `foo_bar2` add index `foo_bar2_baz_id_index`(`baz_id`);
 alter table `foo_bar2` add unique `foo_bar2_baz_id_unique`(`baz_id`);
 alter table `foo_bar2` add index `foo_bar2_foo_bar_id_index`(`foo_bar_id`);
@@ -78,19 +78,18 @@ alter table `configuration2` add index `configuration2_property_index`(`property
 alter table `configuration2` add index `configuration2_test_id_index`(`test_id`);
 alter table `configuration2` add primary key `configuration2_pkey`(`property`, `test_id`);
 
-create table `car2` (`name` varchar(255) not null, `year` int(11) unsigned not null, `price` int(11) not null) default character set utf8mb4 engine = InnoDB;
+create table `car2` (`name` varchar(100) not null, `year` int(11) unsigned not null, `price` int(11) not null) default character set utf8mb4 engine = InnoDB;
 alter table `car2` add index `car2_name_index`(`name`);
 alter table `car2` add index `car2_year_index`(`year`);
 alter table `car2` add primary key `car2_pkey`(`name`, `year`);
 
-create table `car_owner2` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) not null, `car_name` varchar(255) not null, `car_year` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table `car_owner2` add index `car_owner2_car_name_car_year_idx`(`car_name`, `car_year`);
+create table `car_owner2` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) not null, `car_name` varchar(100) not null, `car_year` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table `car_owner2` add index `car_owner2_car_name_car_year_index`(`car_name`, `car_year`);
 
 create table `user2` (`first_name` varchar(100) not null, `last_name` varchar(100) not null, `foo` int(11) null) default character set utf8mb4 engine = InnoDB;
 alter table `user2` add index `user2_first_name_index`(`first_name`);
 alter table `user2` add index `user2_last_name_index`(`last_name`);
 alter table `user2` add primary key `user2_pkey`(`first_name`, `last_name`);
-
 
 create table `base_user2` (`id` int unsigned not null auto_increment primary key, `first_name` varchar(100) not null, `last_name` varchar(100) not null, `type` enum('employee', 'manager', 'owner') not null, `employee_prop` int(11) null, `manager_prop` varchar(255) null, `owner_prop` varchar(255) null, `favourite_employee_id` int(11) unsigned null, `favourite_manager_id` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table `base_user2` add index `base_user2_type_index`(`type`);

--- a/tests/postgre-schema.sql
+++ b/tests/postgre-schema.sql
@@ -24,17 +24,17 @@ drop table if exists "author2_to_author2" cascade;
 drop table if exists "book2_to_book_tag2" cascade;
 drop table if exists "publisher2_to_test2" cascade;
 
-create table "author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), "updated_at" timestamptz(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int4 null default null, "terms_accepted" bool not null default false, "optional" bool null, "identities" jsonb null, "born" date null, "born_time" time(0) null, "favourite_book_uuid_pk" varchar(36) null, "favourite_author_id" int4 null);
+create table "author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), "updated_at" timestamptz(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int4 null default null, "terms_accepted" bool not null default false, "optional" bool null, "identities" text[] null, "born" date null, "born_time" time(0) null, "favourite_book_uuid_pk" varchar(36) null, "favourite_author_id" int4 null);
+create index "custom_email_index_name" on "author2" ("email");
 alter table "author2" add constraint "custom_email_unique_name" unique ("email");
+create index "author2_terms_accepted_index" on "author2" ("terms_accepted");
 create index "author2_born_index" on "author2" ("born");
 create index "born_time_idx" on "author2" ("born_time");
-create index "custom_email_index_name" on "author2" ("email");
-create index "author2_terms_accepted_index" on "author2" ("terms_accepted");
 create index "custom_idx_name_123" on "author2" ("name");
 create index "author2_name_age_index" on "author2" ("name", "age");
 alter table "author2" add constraint "author2_name_email_unique" unique ("name", "email");
 
-create table "address2" ("author_id" int4 not null check ("author_id" > 0), "value" varchar(255) not null);
+create table "address2" ("author_id" int4 not null, "value" varchar(255) not null);
 alter table "address2" add constraint "address2_pkey" primary key ("author_id");
 alter table "address2" add constraint "address2_author_id_unique" unique ("author_id");
 
@@ -48,7 +48,7 @@ create table "publisher2" ("id" serial primary key, "name" varchar(255) not null
 create table "test2" ("id" serial primary key, "name" varchar(255) null, "book_uuid_pk" varchar(36) null, "version" int4 not null default 1, "path" polygon null);
 alter table "test2" add constraint "test2_book_uuid_pk_unique" unique ("book_uuid_pk");
 
-create table "foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "baz_id" int4 null, "foo_bar_id" int4 null, "version" timestamptz(0) not null default current_timestamp(0));
+create table "foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "baz_id" int4 null, "foo_bar_id" int4 null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "array" text[] null, "object" jsonb null);
 alter table "foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");
 alter table "foo_bar2" add constraint "foo_bar2_foo_bar_id_unique" unique ("foo_bar_id");
 
@@ -112,3 +112,5 @@ alter table "book_to_tag_unordered" add constraint "book_to_tag_unordered_book_t
 
 alter table "publisher2_tests" add constraint "publisher2_tests_publisher2_id_foreign" foreign key ("publisher2_id") references "publisher2" ("id") on update cascade on delete cascade;
 alter table "publisher2_tests" add constraint "publisher2_tests_test2_id_foreign" foreign key ("test2_id") references "test2" ("id") on update cascade on delete cascade;
+
+set session_replication_role = 'origin';

--- a/tests/types/ArrayType.test.ts
+++ b/tests/types/ArrayType.test.ts
@@ -1,0 +1,18 @@
+import { ArrayType } from '@mikro-orm/core';
+import { MongoPlatform } from '@mikro-orm/mongodb';
+
+describe('ArrayType', () => {
+
+  const type = new ArrayType();
+  const platform = new MongoPlatform();
+
+  test('convertToDatabaseValue', () => {
+    expect(type.convertToDatabaseValue(['a'], platform)).toStrictEqual(['a']);
+    expect(type.convertToDatabaseValue(null, platform)).toStrictEqual(null);
+    expect(type.convertToDatabaseValue(undefined as any, platform)).toBe(undefined);
+    expect(() => type.convertToDatabaseValue(1 as any, platform)).toThrowError(`Could not convert JS value '1' of type 'number' to type ArrayType`);
+    // expect(() => type.convertToDatabaseValue('2000-01-01', platform)).toThrowError(`Could not convert JS value '2000-01-01' of type 'string' to type ArrayType`);
+    // expect(() => type.convertToDatabaseValue(new Date('2000-01-01'), platform)).toThrowError(`Could not convert JS value '2000-01-01T00:00:00.000Z' of type 'date' to type ArrayType`);
+  });
+
+});


### PR DESCRIPTION
### ArrayType

In PostgreSQL and MongoDB, it uses native arrays, otherwise it concatenates the 
values into string separated by commas. This means that you can't use values that
contain comma with the `ArrayType` (but you can create custom array type that will
handle this case, e.g. by using different separator).

By default array of strings is returned from the type. You can also have arrays 
of numbers or other data types - to do so, you will need to implement custom 
`hydrate` method that is used for converting the array values to the right type.

```typescript
@Property({ type: new ArrayType(i => +i), nullable: true })
array?: number[];
```

### BlobType

Blob type can be used to store binary data in the database. 

```typescript
@Property({ type: BlobType, nullable: true })
blob?: Buffer;
```

### JsonType

To store objects we can use `JsonType`. As some drivers are handling objects 
automatically and some don't, this type will handle the serialization in a driver
independent way (calling `parse` and `stringify` only when needed).

```typescript
@Property({ type: JsonType, nullable: true })
object?: { foo: string; bar: number };
```

Related: #476