### PR TITLE
fix(validation): throw when trying to call `em.flush()` from hooks

### DIFF
--- a/docs/docs/lifecycle-hooks.md
+++ b/docs/docs/lifecycle-hooks.md
@@ -23,3 +23,14 @@ removing entity or entity reference, not when deleting records by query.
 the identity map.
 
 > `@OnInit` is not fired when you create the entity manually via its constructor (`new MyEntity()`)
+
+## Limitations of lifecycle hooks
+
+Hooks are executed inside the commit action of unit of work, after all change 
+sets are computed. This means that it is not possible to create new entities as
+usual from inside the hook. Calling `em.flush()` from hooks will result in 
+validation error. Calling `em.persist()` can result in undefined behaviour like
+locking errors. 
+
+> The **internal** instance of `EntityManager` accessible under `wrap(this).__em` is 
+> not meant for public usage. 

--- a/docs/versioned_docs/version-3.6/lifecycle-hooks.md
+++ b/docs/versioned_docs/version-3.6/lifecycle-hooks.md
@@ -23,3 +23,14 @@ removing entity or entity reference, not when deleting records by query.
 the identity map.
 
 > `@OnInit` is not fired when you create the entity manually via its constructor (`new MyEntity()`)
+
+## Limitations of lifecycle hooks
+
+Hooks are executed inside the commit action of unit of work, after all change 
+sets are computed. This means that it is not possible to create new entities as
+usual from inside the hook. Calling `em.flush()` from hooks will result in 
+validation error. Calling `em.persist()` can result in undefined behaviour like
+locking errors. 
+
+> The **internal** instance of `EntityManager` accessible under `wrap(this).__em` is 
+> not meant for public usage. 

--- a/lib/utils/ValidationError.ts
+++ b/lib/utils/ValidationError.ts
@@ -167,6 +167,10 @@ export class ValidationError<T extends AnyEntity = AnyEntity> extends Error {
     return new ValidationError(`Composite key required for entity ${meta.className}.`);
   }
 
+  static cannotCommit(): ValidationError {
+    return new ValidationError('You cannot call em.flush() from inside lifecycle hook handlers');
+  }
+
   private static fromMessage(meta: EntityMetadata, prop: EntityProperty, message: string): ValidationError {
     return new ValidationError(`${meta.className}.${prop.name} ${message}`);
   }

--- a/tests/issues/GH493.test.ts
+++ b/tests/issues/GH493.test.ts
@@ -1,0 +1,57 @@
+import { unlinkSync } from 'fs';
+import { BeforeDelete, BeforeUpdate, Entity, MikroORM, PrimaryKey, Property, ReflectMetadataProvider, wrap } from '../../lib';
+import { PostgreSqlDriver } from '../../lib/drivers/PostgreSqlDriver';
+import { BASE_DIR } from '../bootstrap';
+
+@Entity()
+export class A {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+  @BeforeUpdate()
+  async beforeUpdate() {
+    await wrap(this).__em!.flush();
+  }
+
+  @BeforeDelete()
+  async beforeDelete() {
+    await wrap(this).__em!.flush();
+  }
+
+}
+
+describe('GH issue 493', () => {
+
+  let orm: MikroORM<PostgreSqlDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [A],
+      dbName: BASE_DIR + '/../temp/mikro_orm_test_gh493.db',
+      type: 'sqlite',
+      metadataProvider: ReflectMetadataProvider,
+      cache: { enabled: false },
+      highlight: false,
+    });
+    await orm.getSchemaGenerator().dropSchema();
+    await orm.getSchemaGenerator().createSchema();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+    unlinkSync(orm.config.get('dbName')!);
+  });
+
+  test(`GH issue 493`, async () => {
+    const a = new A();
+    await orm.em.persistAndFlush(a);
+    a.name = 'test';
+    await expect(orm.em.flush()).rejects.toThrowError('You cannot call em.flush() from inside lifecycle hook handlers');
+    orm.em.removeEntity(a);
+    await expect(orm.em.flush()).rejects.toThrowError('You cannot call em.flush() from inside lifecycle hook handlers');
+  });
+});


### PR DESCRIPTION
Hooks are executed inside the commit action of unit of work, after all change
sets are computed. This means that it is not possible to create new entities as
usual from inside the hook. Calling `em.flush()` from hooks will result in
validation error. Calling `em.persist()` can result in undefined behaviour like
locking errors.

> The **internal** instance of `EntityManager` accessible under `wrap(this).__em` is
> not meant for public usage.

Closes #493