### PR TITLE
Bug: populating m:n relation where only one side hase composite PK causes Error: Expected 1 bindings, saw 2 

### DIFF
--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -10,7 +10,7 @@ import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 import { Author, Book, BookTag, Publisher, Test } from './entities';
 import {
   Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, Test2, Label2, Configuration2, Address2, FooParam2,
-  Car2, CarOwner2, User2, BaseUser2, Employee2, Manager2, CompanyOwner2,
+  Car2, CarOwner2, User2, BaseUser2, Employee2, Manager2, CompanyOwner2, Sandwich,
 } from './entities-sql';
 import { BaseEntity2 } from './entities-sql/BaseEntity2';
 import { BaseEntity22 } from './entities-sql/BaseEntity22';
@@ -55,7 +55,7 @@ export async function initORMMySql<D extends MySqlDriver | MariaDbDriver = MySql
   let orm = await MikroORM.init<AbstractSqlDriver>({
     entities: [
       Author2, Address2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, FooParam2, Configuration2, BaseEntity2, BaseEntity22,
-      Car2, CarOwner2, User2, BaseUser2, Employee2, Manager2, CompanyOwner2,
+      Car2, CarOwner2, User2, BaseUser2, Employee2, Manager2, CompanyOwner2, Sandwich,
     ],
     discovery: { tsConfigPath: BASE_DIR + '/tsconfig.test.json' },
     clientUrl: `mysql://root@127.0.0.1:3306/mikro_orm_test`,

--- a/tests/entities-sql/User2.ts
+++ b/tests/entities-sql/User2.ts
@@ -1,5 +1,6 @@
 import { Collection, Entity, ManyToMany, PrimaryKey, Property } from '@mikro-orm/core';
 import { Car2 } from './Car2';
+import { Sandwich } from './sandwich';
 
 @Entity()
 export class User2 {
@@ -15,6 +16,9 @@ export class User2 {
 
   @ManyToMany(() => Car2)
   cars = new Collection<Car2>(this);
+
+  @ManyToMany(() => Sandwich)
+  sandwiches = new Collection<Sandwich>(this);
 
   constructor(firstName: string, lastName: string) {
     this.firstName = firstName;

--- a/tests/entities-sql/index.ts
+++ b/tests/entities-sql/index.ts
@@ -16,3 +16,4 @@ export * from './BaseUser2';
 export * from './Employee2';
 export * from './Manager2';
 export * from './CompanyOwner2';
+export * from './sandwich';

--- a/tests/entities-sql/sandwich.ts
+++ b/tests/entities-sql/sandwich.ts
@@ -1,0 +1,24 @@
+import { Collection, Entity, ManyToMany, PrimaryKey, Property } from '@mikro-orm/core';
+import { User2 } from './User2';
+
+@Entity()
+export class Sandwich {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 255 })
+  name: string;
+
+  @Property()
+  price: number;
+
+  @ManyToMany(() => User2, u => u.sandwiches)
+  users: Collection<User2> = new Collection<User2>(this);
+
+  constructor(name: string, price: number) {
+    this.name = name;
+    this.price = price;
+  }
+
+}

--- a/tests/mysql-schema.sql
+++ b/tests/mysql-schema.sql
@@ -27,6 +27,8 @@ drop table if exists `author2_to_author2`;
 drop table if exists `book2_to_book_tag2`;
 drop table if exists `publisher2_to_test2`;
 drop table if exists `user2_to_car2`;
+drop table if exists `sandwich`;
+drop table if exists `user2_sandwiches`;
 
 create table `author2` (`id` int unsigned not null auto_increment primary key, `created_at` datetime(3) not null default current_timestamp(3), `updated_at` datetime(3) not null default current_timestamp(3), `name` varchar(255) not null, `email` varchar(255) not null, `age` int(11) null default null, `terms_accepted` tinyint(1) not null default false, `optional` tinyint(1) null, `identities` text null, `born` date null, `born_time` time null, `favourite_book_uuid_pk` varchar(36) null, `favourite_author_id` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table `author2` add index `custom_email_index_name`(`email`);
@@ -169,5 +171,16 @@ alter table `user2_cars` add constraint `user2_cars_user2_first_name_foreign` fo
 alter table `user2_cars` add constraint `user2_cars_user2_last_name_foreign` foreign key (`user2_last_name`) references `user2` (`last_name`) on update cascade on delete cascade;
 alter table `user2_cars` add constraint `user2_cars_car2_name_foreign` foreign key (`car2_name`) references `car2` (`name`) on update cascade on delete cascade;
 alter table `user2_cars` add constraint `user2_cars_car2_year_foreign` foreign key (`car2_year`) references `car2` (`year`) on update cascade on delete cascade;
+
+create table `sandwich` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) not null, `price` int(11) not null) default character set utf8mb4 engine = InnoDB;
+
+create table `user2_sandwiches` (`user2_first_name` varchar(100) not null, `user2_last_name` varchar(100) not null, `sandwich_id` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table `user2_sandwiches` add index `user2_sandwiches_sandwich_id_index`(`sandwich_id`);
+alter table `user2_sandwiches` add primary key `user2_sandwiches_pkey`(`user2_first_name`, `user2_last_name`, `sandwich_id`);
+alter table `user2_sandwiches` add index `user2_sandwiches_user2_first_name_user2_last_name_index`(`user2_first_name`, `user2_last_name`);
+
+alter table `user2_sandwiches` add constraint `user2_sandwiches_user2_first_name_foreign` foreign key (`user2_first_name`) references `user2` (`first_name`) on update cascade on delete cascade;
+alter table `user2_sandwiches` add constraint `user2_sandwiches_user2_last_name_foreign` foreign key (`user2_last_name`) references `user2` (`last_name`) on update cascade on delete cascade;
+alter table `user2_sandwiches` add constraint `user2_sandwiches_sandwich_id_foreign` foreign key (`sandwich_id`) references `sandwich` (`id`) on update cascade on delete cascade;
 
 set foreign_key_checks = 1;


### PR DESCRIPTION
when populating m:n relation in some cases was error, where wrong metadata used to check is there composite PK involved in query, which caused some cryptic errors