### PR TITLE
fix(cli): custom tsconfig gets wrong path

### DIFF
--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -1,4 +1,5 @@
 import { pathExists } from 'fs-extra';
+import path from 'path';
 import { IDatabaseDriver } from '../drivers';
 import { Configuration } from './Configuration';
 import { Utils } from './Utils';
@@ -56,7 +57,9 @@ export class ConfigurationLoader {
     return paths;
   }
 
-  static async registerTsNode(tsConfigPath = process.cwd() + '/tsconfig.json') {
+  static async registerTsNode(configPath = 'tsconfig.json') {
+    const tsConfigPath = path.join(process.cwd(), configPath);
+
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     require('ts-node').register({ project: tsConfigPath });
 


### PR DESCRIPTION
When using a custom tsconfig it fails on the ` require(tsConfigPath);` because the path is wrong:
`(node:34784) UnhandledPromiseRejectionWarning: Error: Cannot find module 'tsconfig.server.json'`

Before this fix only the default parameter had the correct path.