### PR TITLE
feat(sql): ensure correct table order in schema generator

### DIFF
--- a/tests/__snapshots__/SchemaGenerator.test.ts.snap
+++ b/tests/__snapshots__/SchemaGenerator.test.ts.snap
@@ -4,6 +4,57 @@ exports[`SchemaGenerator generate schema from metadata [mysql]: mysql-create-sch
 "set names utf8mb4;
 set foreign_key_checks = 0;
 
+create table \`sandwich\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`price\` int(11) not null) default character set utf8mb4 engine = InnoDB;
+
+create table \`base_user2\` (\`id\` int unsigned not null auto_increment primary key, \`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`type\` enum('employee', 'manager', 'owner') not null, \`employee_prop\` int(11) null, \`manager_prop\` varchar(255) null, \`owner_prop\` varchar(255) null, \`favourite_employee_id\` int(11) unsigned null, \`favourite_manager_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
+alter table \`base_user2\` add index \`base_user2_type_index\`(\`type\`);
+alter table \`base_user2\` add index \`base_user2_favourite_employee_id_index\`(\`favourite_employee_id\`);
+alter table \`base_user2\` add index \`base_user2_favourite_manager_id_index\`(\`favourite_manager_id\`);
+alter table \`base_user2\` add unique \`base_user2_favourite_manager_id_unique\`(\`favourite_manager_id\`);
+
+create table \`car2\` (\`name\` varchar(100) not null, \`year\` int(11) unsigned not null, \`price\` int(11) not null) default character set utf8mb4 engine = InnoDB;
+alter table \`car2\` add index \`car2_name_index\`(\`name\`);
+alter table \`car2\` add index \`car2_year_index\`(\`year\`);
+alter table \`car2\` add primary key \`car2_pkey\`(\`name\`, \`year\`);
+
+create table \`car_owner2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`car_name\` varchar(100) not null, \`car_year\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`car_owner2\` add index \`car_owner2_car_name_car_year_index\`(\`car_name\`, \`car_year\`);
+
+create table \`user2\` (\`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`foo\` int(11) null, \`favourite_car_name\` varchar(100) null, \`favourite_car_year\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
+alter table \`user2\` add index \`user2_first_name_index\`(\`first_name\`);
+alter table \`user2\` add index \`user2_last_name_index\`(\`last_name\`);
+alter table \`user2\` add unique \`user2_favourite_car_name_unique\`(\`favourite_car_name\`);
+alter table \`user2\` add unique \`user2_favourite_car_year_unique\`(\`favourite_car_year\`);
+alter table \`user2\` add primary key \`user2_pkey\`(\`first_name\`, \`last_name\`);
+alter table \`user2\` add index \`user2_favourite_car_name_favourite_car_year_index\`(\`favourite_car_name\`, \`favourite_car_year\`);
+
+create table \`user2_sandwiches\` (\`user2_first_name\` varchar(100) not null, \`user2_last_name\` varchar(100) not null, \`sandwich_id\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`user2_sandwiches\` add index \`user2_sandwiches_sandwich_id_index\`(\`sandwich_id\`);
+alter table \`user2_sandwiches\` add primary key \`user2_sandwiches_pkey\`(\`user2_first_name\`, \`user2_last_name\`, \`sandwich_id\`);
+alter table \`user2_sandwiches\` add index \`user2_sandwiches_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);
+
+create table \`user2_cars\` (\`user2_first_name\` varchar(100) not null, \`user2_last_name\` varchar(100) not null, \`car2_name\` varchar(100) not null, \`car2_year\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`user2_cars\` add primary key \`user2_cars_pkey\`(\`user2_first_name\`, \`user2_last_name\`, \`car2_name\`, \`car2_year\`);
+alter table \`user2_cars\` add index \`user2_cars_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);
+alter table \`user2_cars\` add index \`user2_cars_car2_name_car2_year_index\`(\`car2_name\`, \`car2_year\`);
+
+create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
+
+create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`array\` text null, \`object\` json null) default character set utf8mb4 engine = InnoDB;
+alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
+alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
+alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
+alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
+
+create table \`foo_param2\` (\`bar_id\` int(11) unsigned not null, \`baz_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);
+alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);
+alter table \`foo_param2\` add primary key \`foo_param2_pkey\`(\`bar_id\`, \`baz_id\`);
+
+create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` enum('local', 'global') not null, \`type2\` enum('LOCAL', 'GLOBAL') not null, \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null) default character set utf8mb4 engine = InnoDB;
+
+create table \`book_tag2\` (\`id\` bigint unsigned not null auto_increment primary key, \`name\` varchar(50) not null) default character set utf8mb4 engine = InnoDB;
+
 create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table \`author2\` add index \`custom_email_index_name\`(\`email\`);
 alter table \`author2\` add unique \`custom_email_unique_name\`(\`email\`);
@@ -26,55 +77,27 @@ alter table \`book2\` add primary key \`book2_pkey\`(\`uuid_pk\`);
 alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);
 alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);
 
-create table \`book_tag2\` (\`id\` bigint unsigned not null auto_increment primary key, \`name\` varchar(50) not null) default character set utf8mb4 engine = InnoDB;
-
-create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` enum('local', 'global') not null, \`type2\` enum('LOCAL', 'GLOBAL') not null, \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null) default character set utf8mb4 engine = InnoDB;
-
 create table \`test2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) null, \`book_uuid_pk\` varchar(36) null, \`version\` int(11) not null default 1) default character set utf8mb4 engine = InnoDB;
 alter table \`test2\` add index \`test2_book_uuid_pk_index\`(\`book_uuid_pk\`);
 alter table \`test2\` add unique \`test2_book_uuid_pk_unique\`(\`book_uuid_pk\`);
-
-create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`array\` text null, \`object\` json null) default character set utf8mb4 engine = InnoDB;
-alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
-alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
-alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
-alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
-
-create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
-
-create table \`foo_param2\` (\`bar_id\` int(11) unsigned not null, \`baz_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
-alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);
-alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);
-alter table \`foo_param2\` add primary key \`foo_param2_pkey\`(\`bar_id\`, \`baz_id\`);
 
 create table \`configuration2\` (\`property\` varchar(255) not null, \`test_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
 alter table \`configuration2\` add index \`configuration2_property_index\`(\`property\`);
 alter table \`configuration2\` add index \`configuration2_test_id_index\`(\`test_id\`);
 alter table \`configuration2\` add primary key \`configuration2_pkey\`(\`property\`, \`test_id\`);
 
-create table \`car2\` (\`name\` varchar(100) not null, \`year\` int(11) unsigned not null, \`price\` int(11) not null) default character set utf8mb4 engine = InnoDB;
-alter table \`car2\` add index \`car2_name_index\`(\`name\`);
-alter table \`car2\` add index \`car2_year_index\`(\`year\`);
-alter table \`car2\` add primary key \`car2_pkey\`(\`name\`, \`year\`);
+create table \`publisher2_tests\` (\`id\` int unsigned not null auto_increment primary key, \`publisher2_id\` int(11) unsigned not null, \`test2_id\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`publisher2_tests\` add index \`publisher2_tests_publisher2_id_index\`(\`publisher2_id\`);
+alter table \`publisher2_tests\` add index \`publisher2_tests_test2_id_index\`(\`test2_id\`);
 
-create table \`car_owner2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`car_name\` varchar(100) not null, \`car_year\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table \`car_owner2\` add index \`car_owner2_car_name_car_year_index\`(\`car_name\`, \`car_year\`);
+create table \`book2_tags\` (\`order\` int unsigned not null auto_increment primary key, \`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`book2_tags\` add index \`book2_tags_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
+alter table \`book2_tags\` add index \`book2_tags_book_tag2_id_index\`(\`book_tag2_id\`);
 
-create table \`user2\` (\`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`foo\` int(11) null, \`favourite_car_name\` varchar(100) null, \`favourite_car_year\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
-alter table \`user2\` add index \`user2_first_name_index\`(\`first_name\`);
-alter table \`user2\` add index \`user2_last_name_index\`(\`last_name\`);
-alter table \`user2\` add unique \`user2_favourite_car_name_unique\`(\`favourite_car_name\`);
-alter table \`user2\` add unique \`user2_favourite_car_year_unique\`(\`favourite_car_year\`);
-alter table \`user2\` add primary key \`user2_pkey\`(\`first_name\`, \`last_name\`);
-alter table \`user2\` add index \`user2_favourite_car_name_favourite_car_year_index\`(\`favourite_car_name\`, \`favourite_car_year\`);
-
-create table \`base_user2\` (\`id\` int unsigned not null auto_increment primary key, \`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`type\` enum('employee', 'manager', 'owner') not null, \`employee_prop\` int(11) null, \`manager_prop\` varchar(255) null, \`owner_prop\` varchar(255) null, \`favourite_employee_id\` int(11) unsigned null, \`favourite_manager_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
-alter table \`base_user2\` add index \`base_user2_type_index\`(\`type\`);
-alter table \`base_user2\` add index \`base_user2_favourite_employee_id_index\`(\`favourite_employee_id\`);
-alter table \`base_user2\` add index \`base_user2_favourite_manager_id_index\`(\`favourite_manager_id\`);
-alter table \`base_user2\` add unique \`base_user2_favourite_manager_id_unique\`(\`favourite_manager_id\`);
-
-create table \`sandwich\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`price\` int(11) not null) default character set utf8mb4 engine = InnoDB;
+create table \`book_to_tag_unordered\` (\`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
+alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book_tag2_id_index\`(\`book_tag2_id\`);
+alter table \`book_to_tag_unordered\` add primary key \`book_to_tag_unordered_pkey\`(\`book2_uuid_pk\`, \`book_tag2_id\`);
 
 create table \`author_to_friend\` (\`author2_1_id\` int(11) unsigned not null, \`author2_2_id\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
 alter table \`author_to_friend\` add index \`author_to_friend_author2_1_id_index\`(\`author2_1_id\`);
@@ -86,28 +109,29 @@ alter table \`author2_following\` add index \`author2_following_author2_1_id_ind
 alter table \`author2_following\` add index \`author2_following_author2_2_id_index\`(\`author2_2_id\`);
 alter table \`author2_following\` add primary key \`author2_following_pkey\`(\`author2_1_id\`, \`author2_2_id\`);
 
-create table \`book2_tags\` (\`order\` int unsigned not null auto_increment primary key, \`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table \`book2_tags\` add index \`book2_tags_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
-alter table \`book2_tags\` add index \`book2_tags_book_tag2_id_index\`(\`book_tag2_id\`);
+alter table \`base_user2\` add constraint \`base_user2_favourite_employee_id_foreign\` foreign key (\`favourite_employee_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
+alter table \`base_user2\` add constraint \`base_user2_favourite_manager_id_foreign\` foreign key (\`favourite_manager_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
 
-create table \`book_to_tag_unordered\` (\`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
-alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book_tag2_id_index\`(\`book_tag2_id\`);
-alter table \`book_to_tag_unordered\` add primary key \`book_to_tag_unordered_pkey\`(\`book2_uuid_pk\`, \`book_tag2_id\`);
+alter table \`car_owner2\` add constraint \`car_owner2_car_name_foreign\` foreign key (\`car_name\`) references \`car2\` (\`name\`) on update cascade;
+alter table \`car_owner2\` add constraint \`car_owner2_car_year_foreign\` foreign key (\`car_year\`) references \`car2\` (\`year\`) on update cascade;
 
-create table \`publisher2_tests\` (\`id\` int unsigned not null auto_increment primary key, \`publisher2_id\` int(11) unsigned not null, \`test2_id\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table \`publisher2_tests\` add index \`publisher2_tests_publisher2_id_index\`(\`publisher2_id\`);
-alter table \`publisher2_tests\` add index \`publisher2_tests_test2_id_index\`(\`test2_id\`);
+alter table \`user2\` add constraint \`user2_favourite_car_name_foreign\` foreign key (\`favourite_car_name\`) references \`car2\` (\`name\`) on update cascade on delete set null;
+alter table \`user2\` add constraint \`user2_favourite_car_year_foreign\` foreign key (\`favourite_car_year\`) references \`car2\` (\`year\`) on update cascade on delete set null;
 
-create table \`user2_cars\` (\`user2_first_name\` varchar(100) not null, \`user2_last_name\` varchar(100) not null, \`car2_name\` varchar(100) not null, \`car2_year\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table \`user2_cars\` add primary key \`user2_cars_pkey\`(\`user2_first_name\`, \`user2_last_name\`, \`car2_name\`, \`car2_year\`);
-alter table \`user2_cars\` add index \`user2_cars_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);
-alter table \`user2_cars\` add index \`user2_cars_car2_name_car2_year_index\`(\`car2_name\`, \`car2_year\`);
+alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_user2_first_name_foreign\` foreign key (\`user2_first_name\`) references \`user2\` (\`first_name\`) on update cascade on delete cascade;
+alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_user2_last_name_foreign\` foreign key (\`user2_last_name\`) references \`user2\` (\`last_name\`) on update cascade on delete cascade;
+alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_sandwich_id_foreign\` foreign key (\`sandwich_id\`) references \`sandwich\` (\`id\`) on update cascade on delete cascade;
 
-create table \`user2_sandwiches\` (\`user2_first_name\` varchar(100) not null, \`user2_last_name\` varchar(100) not null, \`sandwich_id\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table \`user2_sandwiches\` add index \`user2_sandwiches_sandwich_id_index\`(\`sandwich_id\`);
-alter table \`user2_sandwiches\` add primary key \`user2_sandwiches_pkey\`(\`user2_first_name\`, \`user2_last_name\`, \`sandwich_id\`);
-alter table \`user2_sandwiches\` add index \`user2_sandwiches_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);
+alter table \`user2_cars\` add constraint \`user2_cars_user2_first_name_foreign\` foreign key (\`user2_first_name\`) references \`user2\` (\`first_name\`) on update cascade on delete cascade;
+alter table \`user2_cars\` add constraint \`user2_cars_user2_last_name_foreign\` foreign key (\`user2_last_name\`) references \`user2\` (\`last_name\`) on update cascade on delete cascade;
+alter table \`user2_cars\` add constraint \`user2_cars_car2_name_foreign\` foreign key (\`car2_name\`) references \`car2\` (\`name\`) on update cascade on delete cascade;
+alter table \`user2_cars\` add constraint \`user2_cars_car2_year_foreign\` foreign key (\`car2_year\`) references \`car2\` (\`year\`) on update cascade on delete cascade;
+
+alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;
+alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;
+
+alter table \`foo_param2\` add constraint \`foo_param2_bar_id_foreign\` foreign key (\`bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade;
+alter table \`foo_param2\` add constraint \`foo_param2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade;
 
 alter table \`author2\` add constraint \`author2_favourite_book_uuid_pk_foreign\` foreign key (\`favourite_book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update no action on delete cascade;
 alter table \`author2\` add constraint \`author2_favourite_author_id_foreign\` foreign key (\`favourite_author_id\`) references \`author2\` (\`id\`) on update cascade on delete set null;
@@ -119,28 +143,10 @@ alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key 
 
 alter table \`test2\` add constraint \`test2_book_uuid_pk_foreign\` foreign key (\`book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on delete set null;
 
-alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;
-alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;
-
-alter table \`foo_param2\` add constraint \`foo_param2_bar_id_foreign\` foreign key (\`bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade;
-alter table \`foo_param2\` add constraint \`foo_param2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade;
-
 alter table \`configuration2\` add constraint \`configuration2_test_id_foreign\` foreign key (\`test_id\`) references \`test2\` (\`id\`) on update cascade;
 
-alter table \`car_owner2\` add constraint \`car_owner2_car_name_foreign\` foreign key (\`car_name\`) references \`car2\` (\`name\`) on update cascade;
-alter table \`car_owner2\` add constraint \`car_owner2_car_year_foreign\` foreign key (\`car_year\`) references \`car2\` (\`year\`) on update cascade;
-
-alter table \`user2\` add constraint \`user2_favourite_car_name_foreign\` foreign key (\`favourite_car_name\`) references \`car2\` (\`name\`) on update cascade on delete set null;
-alter table \`user2\` add constraint \`user2_favourite_car_year_foreign\` foreign key (\`favourite_car_year\`) references \`car2\` (\`year\`) on update cascade on delete set null;
-
-alter table \`base_user2\` add constraint \`base_user2_favourite_employee_id_foreign\` foreign key (\`favourite_employee_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
-alter table \`base_user2\` add constraint \`base_user2_favourite_manager_id_foreign\` foreign key (\`favourite_manager_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
-
-alter table \`author_to_friend\` add constraint \`author_to_friend_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
-alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
-
-alter table \`author2_following\` add constraint \`author2_following_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
-alter table \`author2_following\` add constraint \`author2_following_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+alter table \`publisher2_tests\` add constraint \`publisher2_tests_publisher2_id_foreign\` foreign key (\`publisher2_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
+alter table \`publisher2_tests\` add constraint \`publisher2_tests_test2_id_foreign\` foreign key (\`test2_id\`) references \`test2\` (\`id\`) on update cascade on delete cascade;
 
 alter table \`book2_tags\` add constraint \`book2_tags_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;
 alter table \`book2_tags\` add constraint \`book2_tags_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;
@@ -148,17 +154,11 @@ alter table \`book2_tags\` add constraint \`book2_tags_book_tag2_id_foreign\` fo
 alter table \`book_to_tag_unordered\` add constraint \`book_to_tag_unordered_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;
 alter table \`book_to_tag_unordered\` add constraint \`book_to_tag_unordered_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;
 
-alter table \`publisher2_tests\` add constraint \`publisher2_tests_publisher2_id_foreign\` foreign key (\`publisher2_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
-alter table \`publisher2_tests\` add constraint \`publisher2_tests_test2_id_foreign\` foreign key (\`test2_id\`) references \`test2\` (\`id\`) on update cascade on delete cascade;
+alter table \`author_to_friend\` add constraint \`author_to_friend_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 
-alter table \`user2_cars\` add constraint \`user2_cars_user2_first_name_foreign\` foreign key (\`user2_first_name\`) references \`user2\` (\`first_name\`) on update cascade on delete cascade;
-alter table \`user2_cars\` add constraint \`user2_cars_user2_last_name_foreign\` foreign key (\`user2_last_name\`) references \`user2\` (\`last_name\`) on update cascade on delete cascade;
-alter table \`user2_cars\` add constraint \`user2_cars_car2_name_foreign\` foreign key (\`car2_name\`) references \`car2\` (\`name\`) on update cascade on delete cascade;
-alter table \`user2_cars\` add constraint \`user2_cars_car2_year_foreign\` foreign key (\`car2_year\`) references \`car2\` (\`year\`) on update cascade on delete cascade;
-
-alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_user2_first_name_foreign\` foreign key (\`user2_first_name\`) references \`user2\` (\`first_name\`) on update cascade on delete cascade;
-alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_user2_last_name_foreign\` foreign key (\`user2_last_name\`) references \`user2\` (\`last_name\`) on update cascade on delete cascade;
-alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_sandwich_id_foreign\` foreign key (\`sandwich_id\`) references \`sandwich\` (\`id\`) on update cascade on delete cascade;
+alter table \`author2_following\` add constraint \`author2_following_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+alter table \`author2_following\` add constraint \`author2_following_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 
 set foreign_key_checks = 1;
 "
@@ -168,28 +168,28 @@ exports[`SchemaGenerator generate schema from metadata [mysql]: mysql-drop-schem
 "set names utf8mb4;
 set foreign_key_checks = 0;
 
-drop table if exists \`author2\`;
-drop table if exists \`address2\`;
+drop table if exists \`author2_following\`;
+drop table if exists \`author_to_friend\`;
+drop table if exists \`book_to_tag_unordered\`;
+drop table if exists \`book2_tags\`;
+drop table if exists \`publisher2_tests\`;
+drop table if exists \`configuration2\`;
+drop table if exists \`test2\`;
 drop table if exists \`book2\`;
+drop table if exists \`address2\`;
+drop table if exists \`author2\`;
 drop table if exists \`book_tag2\`;
 drop table if exists \`publisher2\`;
-drop table if exists \`test2\`;
+drop table if exists \`foo_param2\`;
 drop table if exists \`foo_bar2\`;
 drop table if exists \`foo_baz2\`;
-drop table if exists \`foo_param2\`;
-drop table if exists \`configuration2\`;
-drop table if exists \`car2\`;
-drop table if exists \`car_owner2\`;
-drop table if exists \`user2\`;
-drop table if exists \`base_user2\`;
-drop table if exists \`sandwich\`;
-drop table if exists \`author_to_friend\`;
-drop table if exists \`author2_following\`;
-drop table if exists \`book2_tags\`;
-drop table if exists \`book_to_tag_unordered\`;
-drop table if exists \`publisher2_tests\`;
 drop table if exists \`user2_cars\`;
 drop table if exists \`user2_sandwiches\`;
+drop table if exists \`user2\`;
+drop table if exists \`car_owner2\`;
+drop table if exists \`car2\`;
+drop table if exists \`base_user2\`;
+drop table if exists \`sandwich\`;
 
 set foreign_key_checks = 1;
 "
@@ -199,28 +199,79 @@ exports[`SchemaGenerator generate schema from metadata [mysql]: mysql-schema-dum
 "set names utf8mb4;
 set foreign_key_checks = 0;
 
-drop table if exists \`author2\`;
-drop table if exists \`address2\`;
+drop table if exists \`author2_following\`;
+drop table if exists \`author_to_friend\`;
+drop table if exists \`book_to_tag_unordered\`;
+drop table if exists \`book2_tags\`;
+drop table if exists \`publisher2_tests\`;
+drop table if exists \`configuration2\`;
+drop table if exists \`test2\`;
 drop table if exists \`book2\`;
+drop table if exists \`address2\`;
+drop table if exists \`author2\`;
 drop table if exists \`book_tag2\`;
 drop table if exists \`publisher2\`;
-drop table if exists \`test2\`;
+drop table if exists \`foo_param2\`;
 drop table if exists \`foo_bar2\`;
 drop table if exists \`foo_baz2\`;
-drop table if exists \`foo_param2\`;
-drop table if exists \`configuration2\`;
-drop table if exists \`car2\`;
-drop table if exists \`car_owner2\`;
-drop table if exists \`user2\`;
-drop table if exists \`base_user2\`;
-drop table if exists \`sandwich\`;
-drop table if exists \`author_to_friend\`;
-drop table if exists \`author2_following\`;
-drop table if exists \`book2_tags\`;
-drop table if exists \`book_to_tag_unordered\`;
-drop table if exists \`publisher2_tests\`;
 drop table if exists \`user2_cars\`;
 drop table if exists \`user2_sandwiches\`;
+drop table if exists \`user2\`;
+drop table if exists \`car_owner2\`;
+drop table if exists \`car2\`;
+drop table if exists \`base_user2\`;
+drop table if exists \`sandwich\`;
+
+create table \`sandwich\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`price\` int(11) not null) default character set utf8mb4 engine = InnoDB;
+
+create table \`base_user2\` (\`id\` int unsigned not null auto_increment primary key, \`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`type\` enum('employee', 'manager', 'owner') not null, \`employee_prop\` int(11) null, \`manager_prop\` varchar(255) null, \`owner_prop\` varchar(255) null, \`favourite_employee_id\` int(11) unsigned null, \`favourite_manager_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
+alter table \`base_user2\` add index \`base_user2_type_index\`(\`type\`);
+alter table \`base_user2\` add index \`base_user2_favourite_employee_id_index\`(\`favourite_employee_id\`);
+alter table \`base_user2\` add index \`base_user2_favourite_manager_id_index\`(\`favourite_manager_id\`);
+alter table \`base_user2\` add unique \`base_user2_favourite_manager_id_unique\`(\`favourite_manager_id\`);
+
+create table \`car2\` (\`name\` varchar(100) not null, \`year\` int(11) unsigned not null, \`price\` int(11) not null) default character set utf8mb4 engine = InnoDB;
+alter table \`car2\` add index \`car2_name_index\`(\`name\`);
+alter table \`car2\` add index \`car2_year_index\`(\`year\`);
+alter table \`car2\` add primary key \`car2_pkey\`(\`name\`, \`year\`);
+
+create table \`car_owner2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`car_name\` varchar(100) not null, \`car_year\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`car_owner2\` add index \`car_owner2_car_name_car_year_index\`(\`car_name\`, \`car_year\`);
+
+create table \`user2\` (\`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`foo\` int(11) null, \`favourite_car_name\` varchar(100) null, \`favourite_car_year\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
+alter table \`user2\` add index \`user2_first_name_index\`(\`first_name\`);
+alter table \`user2\` add index \`user2_last_name_index\`(\`last_name\`);
+alter table \`user2\` add unique \`user2_favourite_car_name_unique\`(\`favourite_car_name\`);
+alter table \`user2\` add unique \`user2_favourite_car_year_unique\`(\`favourite_car_year\`);
+alter table \`user2\` add primary key \`user2_pkey\`(\`first_name\`, \`last_name\`);
+alter table \`user2\` add index \`user2_favourite_car_name_favourite_car_year_index\`(\`favourite_car_name\`, \`favourite_car_year\`);
+
+create table \`user2_sandwiches\` (\`user2_first_name\` varchar(100) not null, \`user2_last_name\` varchar(100) not null, \`sandwich_id\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`user2_sandwiches\` add index \`user2_sandwiches_sandwich_id_index\`(\`sandwich_id\`);
+alter table \`user2_sandwiches\` add primary key \`user2_sandwiches_pkey\`(\`user2_first_name\`, \`user2_last_name\`, \`sandwich_id\`);
+alter table \`user2_sandwiches\` add index \`user2_sandwiches_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);
+
+create table \`user2_cars\` (\`user2_first_name\` varchar(100) not null, \`user2_last_name\` varchar(100) not null, \`car2_name\` varchar(100) not null, \`car2_year\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`user2_cars\` add primary key \`user2_cars_pkey\`(\`user2_first_name\`, \`user2_last_name\`, \`car2_name\`, \`car2_year\`);
+alter table \`user2_cars\` add index \`user2_cars_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);
+alter table \`user2_cars\` add index \`user2_cars_car2_name_car2_year_index\`(\`car2_name\`, \`car2_year\`);
+
+create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
+
+create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`array\` text null, \`object\` json null) default character set utf8mb4 engine = InnoDB;
+alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
+alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
+alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
+alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
+
+create table \`foo_param2\` (\`bar_id\` int(11) unsigned not null, \`baz_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);
+alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);
+alter table \`foo_param2\` add primary key \`foo_param2_pkey\`(\`bar_id\`, \`baz_id\`);
+
+create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` enum('local', 'global') not null, \`type2\` enum('LOCAL', 'GLOBAL') not null, \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null) default character set utf8mb4 engine = InnoDB;
+
+create table \`book_tag2\` (\`id\` bigint unsigned not null auto_increment primary key, \`name\` varchar(50) not null) default character set utf8mb4 engine = InnoDB;
 
 create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table \`author2\` add index \`custom_email_index_name\`(\`email\`);
@@ -244,55 +295,27 @@ alter table \`book2\` add primary key \`book2_pkey\`(\`uuid_pk\`);
 alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);
 alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);
 
-create table \`book_tag2\` (\`id\` bigint unsigned not null auto_increment primary key, \`name\` varchar(50) not null) default character set utf8mb4 engine = InnoDB;
-
-create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` enum('local', 'global') not null, \`type2\` enum('LOCAL', 'GLOBAL') not null, \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null) default character set utf8mb4 engine = InnoDB;
-
 create table \`test2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) null, \`book_uuid_pk\` varchar(36) null, \`version\` int(11) not null default 1) default character set utf8mb4 engine = InnoDB;
 alter table \`test2\` add index \`test2_book_uuid_pk_index\`(\`book_uuid_pk\`);
 alter table \`test2\` add unique \`test2_book_uuid_pk_unique\`(\`book_uuid_pk\`);
-
-create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`array\` text null, \`object\` json null) default character set utf8mb4 engine = InnoDB;
-alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
-alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
-alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
-alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
-
-create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
-
-create table \`foo_param2\` (\`bar_id\` int(11) unsigned not null, \`baz_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
-alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);
-alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);
-alter table \`foo_param2\` add primary key \`foo_param2_pkey\`(\`bar_id\`, \`baz_id\`);
 
 create table \`configuration2\` (\`property\` varchar(255) not null, \`test_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
 alter table \`configuration2\` add index \`configuration2_property_index\`(\`property\`);
 alter table \`configuration2\` add index \`configuration2_test_id_index\`(\`test_id\`);
 alter table \`configuration2\` add primary key \`configuration2_pkey\`(\`property\`, \`test_id\`);
 
-create table \`car2\` (\`name\` varchar(100) not null, \`year\` int(11) unsigned not null, \`price\` int(11) not null) default character set utf8mb4 engine = InnoDB;
-alter table \`car2\` add index \`car2_name_index\`(\`name\`);
-alter table \`car2\` add index \`car2_year_index\`(\`year\`);
-alter table \`car2\` add primary key \`car2_pkey\`(\`name\`, \`year\`);
+create table \`publisher2_tests\` (\`id\` int unsigned not null auto_increment primary key, \`publisher2_id\` int(11) unsigned not null, \`test2_id\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`publisher2_tests\` add index \`publisher2_tests_publisher2_id_index\`(\`publisher2_id\`);
+alter table \`publisher2_tests\` add index \`publisher2_tests_test2_id_index\`(\`test2_id\`);
 
-create table \`car_owner2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`car_name\` varchar(100) not null, \`car_year\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table \`car_owner2\` add index \`car_owner2_car_name_car_year_index\`(\`car_name\`, \`car_year\`);
+create table \`book2_tags\` (\`order\` int unsigned not null auto_increment primary key, \`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`book2_tags\` add index \`book2_tags_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
+alter table \`book2_tags\` add index \`book2_tags_book_tag2_id_index\`(\`book_tag2_id\`);
 
-create table \`user2\` (\`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`foo\` int(11) null, \`favourite_car_name\` varchar(100) null, \`favourite_car_year\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
-alter table \`user2\` add index \`user2_first_name_index\`(\`first_name\`);
-alter table \`user2\` add index \`user2_last_name_index\`(\`last_name\`);
-alter table \`user2\` add unique \`user2_favourite_car_name_unique\`(\`favourite_car_name\`);
-alter table \`user2\` add unique \`user2_favourite_car_year_unique\`(\`favourite_car_year\`);
-alter table \`user2\` add primary key \`user2_pkey\`(\`first_name\`, \`last_name\`);
-alter table \`user2\` add index \`user2_favourite_car_name_favourite_car_year_index\`(\`favourite_car_name\`, \`favourite_car_year\`);
-
-create table \`base_user2\` (\`id\` int unsigned not null auto_increment primary key, \`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`type\` enum('employee', 'manager', 'owner') not null, \`employee_prop\` int(11) null, \`manager_prop\` varchar(255) null, \`owner_prop\` varchar(255) null, \`favourite_employee_id\` int(11) unsigned null, \`favourite_manager_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
-alter table \`base_user2\` add index \`base_user2_type_index\`(\`type\`);
-alter table \`base_user2\` add index \`base_user2_favourite_employee_id_index\`(\`favourite_employee_id\`);
-alter table \`base_user2\` add index \`base_user2_favourite_manager_id_index\`(\`favourite_manager_id\`);
-alter table \`base_user2\` add unique \`base_user2_favourite_manager_id_unique\`(\`favourite_manager_id\`);
-
-create table \`sandwich\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`price\` int(11) not null) default character set utf8mb4 engine = InnoDB;
+create table \`book_to_tag_unordered\` (\`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
+alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book_tag2_id_index\`(\`book_tag2_id\`);
+alter table \`book_to_tag_unordered\` add primary key \`book_to_tag_unordered_pkey\`(\`book2_uuid_pk\`, \`book_tag2_id\`);
 
 create table \`author_to_friend\` (\`author2_1_id\` int(11) unsigned not null, \`author2_2_id\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
 alter table \`author_to_friend\` add index \`author_to_friend_author2_1_id_index\`(\`author2_1_id\`);
@@ -304,28 +327,29 @@ alter table \`author2_following\` add index \`author2_following_author2_1_id_ind
 alter table \`author2_following\` add index \`author2_following_author2_2_id_index\`(\`author2_2_id\`);
 alter table \`author2_following\` add primary key \`author2_following_pkey\`(\`author2_1_id\`, \`author2_2_id\`);
 
-create table \`book2_tags\` (\`order\` int unsigned not null auto_increment primary key, \`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table \`book2_tags\` add index \`book2_tags_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
-alter table \`book2_tags\` add index \`book2_tags_book_tag2_id_index\`(\`book_tag2_id\`);
+alter table \`base_user2\` add constraint \`base_user2_favourite_employee_id_foreign\` foreign key (\`favourite_employee_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
+alter table \`base_user2\` add constraint \`base_user2_favourite_manager_id_foreign\` foreign key (\`favourite_manager_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
 
-create table \`book_to_tag_unordered\` (\`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
-alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book_tag2_id_index\`(\`book_tag2_id\`);
-alter table \`book_to_tag_unordered\` add primary key \`book_to_tag_unordered_pkey\`(\`book2_uuid_pk\`, \`book_tag2_id\`);
+alter table \`car_owner2\` add constraint \`car_owner2_car_name_foreign\` foreign key (\`car_name\`) references \`car2\` (\`name\`) on update cascade;
+alter table \`car_owner2\` add constraint \`car_owner2_car_year_foreign\` foreign key (\`car_year\`) references \`car2\` (\`year\`) on update cascade;
 
-create table \`publisher2_tests\` (\`id\` int unsigned not null auto_increment primary key, \`publisher2_id\` int(11) unsigned not null, \`test2_id\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table \`publisher2_tests\` add index \`publisher2_tests_publisher2_id_index\`(\`publisher2_id\`);
-alter table \`publisher2_tests\` add index \`publisher2_tests_test2_id_index\`(\`test2_id\`);
+alter table \`user2\` add constraint \`user2_favourite_car_name_foreign\` foreign key (\`favourite_car_name\`) references \`car2\` (\`name\`) on update cascade on delete set null;
+alter table \`user2\` add constraint \`user2_favourite_car_year_foreign\` foreign key (\`favourite_car_year\`) references \`car2\` (\`year\`) on update cascade on delete set null;
 
-create table \`user2_cars\` (\`user2_first_name\` varchar(100) not null, \`user2_last_name\` varchar(100) not null, \`car2_name\` varchar(100) not null, \`car2_year\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table \`user2_cars\` add primary key \`user2_cars_pkey\`(\`user2_first_name\`, \`user2_last_name\`, \`car2_name\`, \`car2_year\`);
-alter table \`user2_cars\` add index \`user2_cars_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);
-alter table \`user2_cars\` add index \`user2_cars_car2_name_car2_year_index\`(\`car2_name\`, \`car2_year\`);
+alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_user2_first_name_foreign\` foreign key (\`user2_first_name\`) references \`user2\` (\`first_name\`) on update cascade on delete cascade;
+alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_user2_last_name_foreign\` foreign key (\`user2_last_name\`) references \`user2\` (\`last_name\`) on update cascade on delete cascade;
+alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_sandwich_id_foreign\` foreign key (\`sandwich_id\`) references \`sandwich\` (\`id\`) on update cascade on delete cascade;
 
-create table \`user2_sandwiches\` (\`user2_first_name\` varchar(100) not null, \`user2_last_name\` varchar(100) not null, \`sandwich_id\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table \`user2_sandwiches\` add index \`user2_sandwiches_sandwich_id_index\`(\`sandwich_id\`);
-alter table \`user2_sandwiches\` add primary key \`user2_sandwiches_pkey\`(\`user2_first_name\`, \`user2_last_name\`, \`sandwich_id\`);
-alter table \`user2_sandwiches\` add index \`user2_sandwiches_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);
+alter table \`user2_cars\` add constraint \`user2_cars_user2_first_name_foreign\` foreign key (\`user2_first_name\`) references \`user2\` (\`first_name\`) on update cascade on delete cascade;
+alter table \`user2_cars\` add constraint \`user2_cars_user2_last_name_foreign\` foreign key (\`user2_last_name\`) references \`user2\` (\`last_name\`) on update cascade on delete cascade;
+alter table \`user2_cars\` add constraint \`user2_cars_car2_name_foreign\` foreign key (\`car2_name\`) references \`car2\` (\`name\`) on update cascade on delete cascade;
+alter table \`user2_cars\` add constraint \`user2_cars_car2_year_foreign\` foreign key (\`car2_year\`) references \`car2\` (\`year\`) on update cascade on delete cascade;
+
+alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;
+alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;
+
+alter table \`foo_param2\` add constraint \`foo_param2_bar_id_foreign\` foreign key (\`bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade;
+alter table \`foo_param2\` add constraint \`foo_param2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade;
 
 alter table \`author2\` add constraint \`author2_favourite_book_uuid_pk_foreign\` foreign key (\`favourite_book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update no action on delete cascade;
 alter table \`author2\` add constraint \`author2_favourite_author_id_foreign\` foreign key (\`favourite_author_id\`) references \`author2\` (\`id\`) on update cascade on delete set null;
@@ -337,28 +361,10 @@ alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key 
 
 alter table \`test2\` add constraint \`test2_book_uuid_pk_foreign\` foreign key (\`book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on delete set null;
 
-alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;
-alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;
-
-alter table \`foo_param2\` add constraint \`foo_param2_bar_id_foreign\` foreign key (\`bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade;
-alter table \`foo_param2\` add constraint \`foo_param2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade;
-
 alter table \`configuration2\` add constraint \`configuration2_test_id_foreign\` foreign key (\`test_id\`) references \`test2\` (\`id\`) on update cascade;
 
-alter table \`car_owner2\` add constraint \`car_owner2_car_name_foreign\` foreign key (\`car_name\`) references \`car2\` (\`name\`) on update cascade;
-alter table \`car_owner2\` add constraint \`car_owner2_car_year_foreign\` foreign key (\`car_year\`) references \`car2\` (\`year\`) on update cascade;
-
-alter table \`user2\` add constraint \`user2_favourite_car_name_foreign\` foreign key (\`favourite_car_name\`) references \`car2\` (\`name\`) on update cascade on delete set null;
-alter table \`user2\` add constraint \`user2_favourite_car_year_foreign\` foreign key (\`favourite_car_year\`) references \`car2\` (\`year\`) on update cascade on delete set null;
-
-alter table \`base_user2\` add constraint \`base_user2_favourite_employee_id_foreign\` foreign key (\`favourite_employee_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
-alter table \`base_user2\` add constraint \`base_user2_favourite_manager_id_foreign\` foreign key (\`favourite_manager_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
-
-alter table \`author_to_friend\` add constraint \`author_to_friend_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
-alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
-
-alter table \`author2_following\` add constraint \`author2_following_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
-alter table \`author2_following\` add constraint \`author2_following_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+alter table \`publisher2_tests\` add constraint \`publisher2_tests_publisher2_id_foreign\` foreign key (\`publisher2_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
+alter table \`publisher2_tests\` add constraint \`publisher2_tests_test2_id_foreign\` foreign key (\`test2_id\`) references \`test2\` (\`id\`) on update cascade on delete cascade;
 
 alter table \`book2_tags\` add constraint \`book2_tags_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;
 alter table \`book2_tags\` add constraint \`book2_tags_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;
@@ -366,17 +372,11 @@ alter table \`book2_tags\` add constraint \`book2_tags_book_tag2_id_foreign\` fo
 alter table \`book_to_tag_unordered\` add constraint \`book_to_tag_unordered_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;
 alter table \`book_to_tag_unordered\` add constraint \`book_to_tag_unordered_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;
 
-alter table \`publisher2_tests\` add constraint \`publisher2_tests_publisher2_id_foreign\` foreign key (\`publisher2_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
-alter table \`publisher2_tests\` add constraint \`publisher2_tests_test2_id_foreign\` foreign key (\`test2_id\`) references \`test2\` (\`id\`) on update cascade on delete cascade;
+alter table \`author_to_friend\` add constraint \`author_to_friend_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 
-alter table \`user2_cars\` add constraint \`user2_cars_user2_first_name_foreign\` foreign key (\`user2_first_name\`) references \`user2\` (\`first_name\`) on update cascade on delete cascade;
-alter table \`user2_cars\` add constraint \`user2_cars_user2_last_name_foreign\` foreign key (\`user2_last_name\`) references \`user2\` (\`last_name\`) on update cascade on delete cascade;
-alter table \`user2_cars\` add constraint \`user2_cars_car2_name_foreign\` foreign key (\`car2_name\`) references \`car2\` (\`name\`) on update cascade on delete cascade;
-alter table \`user2_cars\` add constraint \`user2_cars_car2_year_foreign\` foreign key (\`car2_year\`) references \`car2\` (\`year\`) on update cascade on delete cascade;
-
-alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_user2_first_name_foreign\` foreign key (\`user2_first_name\`) references \`user2\` (\`first_name\`) on update cascade on delete cascade;
-alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_user2_last_name_foreign\` foreign key (\`user2_last_name\`) references \`user2\` (\`last_name\`) on update cascade on delete cascade;
-alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_sandwich_id_foreign\` foreign key (\`sandwich_id\`) references \`sandwich\` (\`id\`) on update cascade on delete cascade;
+alter table \`author2_following\` add constraint \`author2_following_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+alter table \`author2_following\` add constraint \`author2_following_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 
 set foreign_key_checks = 1;
 "
@@ -402,6 +402,24 @@ exports[`SchemaGenerator generate schema from metadata [postgres]: postgres-crea
 "set names 'utf8';
 set session_replication_role = 'replica';
 
+create table \\"label2\\" (\\"uuid\\" uuid not null, \\"name\\" varchar(255) not null);
+alter table \\"label2\\" add constraint \\"label2_pkey\\" primary key (\\"uuid\\");
+
+create table \\"foo_baz2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"version\\" timestamptz(3) not null default current_timestamp(3));
+
+create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int4 null, \\"foo_bar_id\\" int4 null, \\"version\\" timestamptz(0) not null default current_timestamp(0), \\"blob\\" bytea null, \\"array\\" text[] null, \\"object\\" jsonb null);
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_unique\\" unique (\\"baz_id\\");
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_unique\\" unique (\\"foo_bar_id\\");
+
+create table \\"foo_param2\\" (\\"bar_id\\" int4 not null, \\"baz_id\\" int4 not null, \\"value\\" varchar(255) not null);
+create index \\"foo_param2_bar_id_index\\" on \\"foo_param2\\" (\\"bar_id\\");
+create index \\"foo_param2_baz_id_index\\" on \\"foo_param2\\" (\\"baz_id\\");
+alter table \\"foo_param2\\" add constraint \\"foo_param2_pkey\\" primary key (\\"bar_id\\", \\"baz_id\\");
+
+create table \\"publisher2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"type\\" text check (\\"type\\" in ('local', 'global')) not null, \\"type2\\" text check (\\"type2\\" in ('LOCAL', 'GLOBAL')) not null, \\"enum1\\" int2 null, \\"enum2\\" int2 null, \\"enum3\\" int2 null, \\"enum4\\" text check (\\"enum4\\" in ('a', 'b', 'c')) null);
+
+create table \\"book_tag2\\" (\\"id\\" bigserial primary key, \\"name\\" varchar(50) not null);
+
 create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"updated_at\\" timestamptz(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int4 null default null, \\"terms_accepted\\" bool not null default false, \\"optional\\" bool null, \\"identities\\" text[] null, \\"born\\" date null, \\"born_time\\" time(0) null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int4 null);
 create index \\"custom_email_index_name\\" on \\"author2\\" (\\"email\\");
 alter table \\"author2\\" add constraint \\"custom_email_unique_name\\" unique (\\"email\\");
@@ -419,31 +437,20 @@ alter table \\"address2\\" add constraint \\"address2_author_id_unique\\" unique
 create table \\"book2\\" (\\"uuid_pk\\" varchar(36) not null, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"title\\" varchar(255) null default '', \\"perex\\" text null, \\"price\\" float null, \\"double\\" double precision null, \\"meta\\" jsonb null, \\"author_id\\" int4 not null, \\"publisher_id\\" int4 null);
 alter table \\"book2\\" add constraint \\"book2_pkey\\" primary key (\\"uuid_pk\\");
 
-create table \\"book_tag2\\" (\\"id\\" bigserial primary key, \\"name\\" varchar(50) not null);
-
-create table \\"publisher2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"type\\" text check (\\"type\\" in ('local', 'global')) not null, \\"type2\\" text check (\\"type2\\" in ('LOCAL', 'GLOBAL')) not null, \\"enum1\\" int2 null, \\"enum2\\" int2 null, \\"enum3\\" int2 null, \\"enum4\\" text check (\\"enum4\\" in ('a', 'b', 'c')) null);
-
 create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"version\\" int4 not null default 1);
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_unique\\" unique (\\"book_uuid_pk\\");
-
-create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int4 null, \\"foo_bar_id\\" int4 null, \\"version\\" timestamptz(0) not null default current_timestamp(0), \\"blob\\" bytea null, \\"array\\" text[] null, \\"object\\" jsonb null);
-alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_unique\\" unique (\\"baz_id\\");
-alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_unique\\" unique (\\"foo_bar_id\\");
-
-create table \\"foo_baz2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"version\\" timestamptz(3) not null default current_timestamp(3));
-
-create table \\"foo_param2\\" (\\"bar_id\\" int4 not null, \\"baz_id\\" int4 not null, \\"value\\" varchar(255) not null);
-create index \\"foo_param2_bar_id_index\\" on \\"foo_param2\\" (\\"bar_id\\");
-create index \\"foo_param2_baz_id_index\\" on \\"foo_param2\\" (\\"baz_id\\");
-alter table \\"foo_param2\\" add constraint \\"foo_param2_pkey\\" primary key (\\"bar_id\\", \\"baz_id\\");
-
-create table \\"label2\\" (\\"uuid\\" uuid not null, \\"name\\" varchar(255) not null);
-alter table \\"label2\\" add constraint \\"label2_pkey\\" primary key (\\"uuid\\");
 
 create table \\"configuration2\\" (\\"property\\" varchar(255) not null, \\"test_id\\" int4 not null, \\"value\\" varchar(255) not null);
 create index \\"configuration2_property_index\\" on \\"configuration2\\" (\\"property\\");
 create index \\"configuration2_test_id_index\\" on \\"configuration2\\" (\\"test_id\\");
 alter table \\"configuration2\\" add constraint \\"configuration2_pkey\\" primary key (\\"property\\", \\"test_id\\");
+
+create table \\"publisher2_tests\\" (\\"id\\" serial primary key, \\"publisher2_id\\" int4 not null, \\"test2_id\\" int4 not null);
+
+create table \\"book2_tags\\" (\\"order\\" serial primary key, \\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" bigint not null);
+
+create table \\"book_to_tag_unordered\\" (\\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" bigint not null);
+alter table \\"book_to_tag_unordered\\" add constraint \\"book_to_tag_unordered_pkey\\" primary key (\\"book2_uuid_pk\\", \\"book_tag2_id\\");
 
 create table \\"author_to_friend\\" (\\"author2_1_id\\" int4 not null, \\"author2_2_id\\" int4 not null);
 alter table \\"author_to_friend\\" add constraint \\"author_to_friend_pkey\\" primary key (\\"author2_1_id\\", \\"author2_2_id\\");
@@ -451,12 +458,11 @@ alter table \\"author_to_friend\\" add constraint \\"author_to_friend_pkey\\" pr
 create table \\"author2_following\\" (\\"author2_1_id\\" int4 not null, \\"author2_2_id\\" int4 not null);
 alter table \\"author2_following\\" add constraint \\"author2_following_pkey\\" primary key (\\"author2_1_id\\", \\"author2_2_id\\");
 
-create table \\"book2_tags\\" (\\"order\\" serial primary key, \\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" bigint not null);
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_foreign\\" foreign key (\\"baz_id\\") references \\"foo_baz2\\" (\\"id\\") on update cascade on delete set null;
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_foreign\\" foreign key (\\"foo_bar_id\\") references \\"foo_bar2\\" (\\"id\\") on update cascade on delete set null;
 
-create table \\"book_to_tag_unordered\\" (\\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" bigint not null);
-alter table \\"book_to_tag_unordered\\" add constraint \\"book_to_tag_unordered_pkey\\" primary key (\\"book2_uuid_pk\\", \\"book_tag2_id\\");
-
-create table \\"publisher2_tests\\" (\\"id\\" serial primary key, \\"publisher2_id\\" int4 not null, \\"test2_id\\" int4 not null);
+alter table \\"foo_param2\\" add constraint \\"foo_param2_bar_id_foreign\\" foreign key (\\"bar_id\\") references \\"foo_bar2\\" (\\"id\\") on update cascade;
+alter table \\"foo_param2\\" add constraint \\"foo_param2_baz_id_foreign\\" foreign key (\\"baz_id\\") references \\"foo_baz2\\" (\\"id\\") on update cascade;
 
 alter table \\"author2\\" add constraint \\"author2_favourite_book_uuid_pk_foreign\\" foreign key (\\"favourite_book_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update no action on delete cascade;
 alter table \\"author2\\" add constraint \\"author2_favourite_author_id_foreign\\" foreign key (\\"favourite_author_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete set null;
@@ -468,19 +474,10 @@ alter table \\"book2\\" add constraint \\"book2_publisher_id_foreign\\" foreign 
 
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_foreign\\" foreign key (\\"book_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on delete set null;
 
-alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_foreign\\" foreign key (\\"baz_id\\") references \\"foo_baz2\\" (\\"id\\") on update cascade on delete set null;
-alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_foreign\\" foreign key (\\"foo_bar_id\\") references \\"foo_bar2\\" (\\"id\\") on update cascade on delete set null;
-
-alter table \\"foo_param2\\" add constraint \\"foo_param2_bar_id_foreign\\" foreign key (\\"bar_id\\") references \\"foo_bar2\\" (\\"id\\") on update cascade;
-alter table \\"foo_param2\\" add constraint \\"foo_param2_baz_id_foreign\\" foreign key (\\"baz_id\\") references \\"foo_baz2\\" (\\"id\\") on update cascade;
-
 alter table \\"configuration2\\" add constraint \\"configuration2_test_id_foreign\\" foreign key (\\"test_id\\") references \\"test2\\" (\\"id\\") on update cascade;
 
-alter table \\"author_to_friend\\" add constraint \\"author_to_friend_author2_1_id_foreign\\" foreign key (\\"author2_1_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
-alter table \\"author_to_friend\\" add constraint \\"author_to_friend_author2_2_id_foreign\\" foreign key (\\"author2_2_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
-
-alter table \\"author2_following\\" add constraint \\"author2_following_author2_1_id_foreign\\" foreign key (\\"author2_1_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
-alter table \\"author2_following\\" add constraint \\"author2_following_author2_2_id_foreign\\" foreign key (\\"author2_2_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
+alter table \\"publisher2_tests\\" add constraint \\"publisher2_tests_publisher2_id_foreign\\" foreign key (\\"publisher2_id\\") references \\"publisher2\\" (\\"id\\") on update cascade on delete cascade;
+alter table \\"publisher2_tests\\" add constraint \\"publisher2_tests_test2_id_foreign\\" foreign key (\\"test2_id\\") references \\"test2\\" (\\"id\\") on update cascade on delete cascade;
 
 alter table \\"book2_tags\\" add constraint \\"book2_tags_book2_uuid_pk_foreign\\" foreign key (\\"book2_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update cascade on delete cascade;
 alter table \\"book2_tags\\" add constraint \\"book2_tags_book_tag2_id_foreign\\" foreign key (\\"book_tag2_id\\") references \\"book_tag2\\" (\\"id\\") on update cascade on delete cascade;
@@ -488,8 +485,11 @@ alter table \\"book2_tags\\" add constraint \\"book2_tags_book_tag2_id_foreign\\
 alter table \\"book_to_tag_unordered\\" add constraint \\"book_to_tag_unordered_book2_uuid_pk_foreign\\" foreign key (\\"book2_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update cascade on delete cascade;
 alter table \\"book_to_tag_unordered\\" add constraint \\"book_to_tag_unordered_book_tag2_id_foreign\\" foreign key (\\"book_tag2_id\\") references \\"book_tag2\\" (\\"id\\") on update cascade on delete cascade;
 
-alter table \\"publisher2_tests\\" add constraint \\"publisher2_tests_publisher2_id_foreign\\" foreign key (\\"publisher2_id\\") references \\"publisher2\\" (\\"id\\") on update cascade on delete cascade;
-alter table \\"publisher2_tests\\" add constraint \\"publisher2_tests_test2_id_foreign\\" foreign key (\\"test2_id\\") references \\"test2\\" (\\"id\\") on update cascade on delete cascade;
+alter table \\"author_to_friend\\" add constraint \\"author_to_friend_author2_1_id_foreign\\" foreign key (\\"author2_1_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
+alter table \\"author_to_friend\\" add constraint \\"author_to_friend_author2_2_id_foreign\\" foreign key (\\"author2_2_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
+
+alter table \\"author2_following\\" add constraint \\"author2_following_author2_1_id_foreign\\" foreign key (\\"author2_1_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
+alter table \\"author2_following\\" add constraint \\"author2_following_author2_2_id_foreign\\" foreign key (\\"author2_2_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
 
 set session_replication_role = 'origin';
 "
@@ -499,22 +499,22 @@ exports[`SchemaGenerator generate schema from metadata [postgres]: postgres-drop
 "set names 'utf8';
 set session_replication_role = 'replica';
 
-drop table if exists \\"author2\\" cascade;
-drop table if exists \\"address2\\" cascade;
+drop table if exists \\"author2_following\\" cascade;
+drop table if exists \\"author_to_friend\\" cascade;
+drop table if exists \\"book_to_tag_unordered\\" cascade;
+drop table if exists \\"book2_tags\\" cascade;
+drop table if exists \\"publisher2_tests\\" cascade;
+drop table if exists \\"configuration2\\" cascade;
+drop table if exists \\"test2\\" cascade;
 drop table if exists \\"book2\\" cascade;
+drop table if exists \\"address2\\" cascade;
+drop table if exists \\"author2\\" cascade;
 drop table if exists \\"book_tag2\\" cascade;
 drop table if exists \\"publisher2\\" cascade;
-drop table if exists \\"test2\\" cascade;
+drop table if exists \\"foo_param2\\" cascade;
 drop table if exists \\"foo_bar2\\" cascade;
 drop table if exists \\"foo_baz2\\" cascade;
-drop table if exists \\"foo_param2\\" cascade;
 drop table if exists \\"label2\\" cascade;
-drop table if exists \\"configuration2\\" cascade;
-drop table if exists \\"author_to_friend\\" cascade;
-drop table if exists \\"author2_following\\" cascade;
-drop table if exists \\"book2_tags\\" cascade;
-drop table if exists \\"book_to_tag_unordered\\" cascade;
-drop table if exists \\"publisher2_tests\\" cascade;
 
 set session_replication_role = 'origin';
 "
@@ -524,22 +524,40 @@ exports[`SchemaGenerator generate schema from metadata [postgres]: postgres-sche
 "set names 'utf8';
 set session_replication_role = 'replica';
 
-drop table if exists \\"author2\\" cascade;
-drop table if exists \\"address2\\" cascade;
+drop table if exists \\"author2_following\\" cascade;
+drop table if exists \\"author_to_friend\\" cascade;
+drop table if exists \\"book_to_tag_unordered\\" cascade;
+drop table if exists \\"book2_tags\\" cascade;
+drop table if exists \\"publisher2_tests\\" cascade;
+drop table if exists \\"configuration2\\" cascade;
+drop table if exists \\"test2\\" cascade;
 drop table if exists \\"book2\\" cascade;
+drop table if exists \\"address2\\" cascade;
+drop table if exists \\"author2\\" cascade;
 drop table if exists \\"book_tag2\\" cascade;
 drop table if exists \\"publisher2\\" cascade;
-drop table if exists \\"test2\\" cascade;
+drop table if exists \\"foo_param2\\" cascade;
 drop table if exists \\"foo_bar2\\" cascade;
 drop table if exists \\"foo_baz2\\" cascade;
-drop table if exists \\"foo_param2\\" cascade;
 drop table if exists \\"label2\\" cascade;
-drop table if exists \\"configuration2\\" cascade;
-drop table if exists \\"author_to_friend\\" cascade;
-drop table if exists \\"author2_following\\" cascade;
-drop table if exists \\"book2_tags\\" cascade;
-drop table if exists \\"book_to_tag_unordered\\" cascade;
-drop table if exists \\"publisher2_tests\\" cascade;
+
+create table \\"label2\\" (\\"uuid\\" uuid not null, \\"name\\" varchar(255) not null);
+alter table \\"label2\\" add constraint \\"label2_pkey\\" primary key (\\"uuid\\");
+
+create table \\"foo_baz2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"version\\" timestamptz(3) not null default current_timestamp(3));
+
+create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int4 null, \\"foo_bar_id\\" int4 null, \\"version\\" timestamptz(0) not null default current_timestamp(0), \\"blob\\" bytea null, \\"array\\" text[] null, \\"object\\" jsonb null);
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_unique\\" unique (\\"baz_id\\");
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_unique\\" unique (\\"foo_bar_id\\");
+
+create table \\"foo_param2\\" (\\"bar_id\\" int4 not null, \\"baz_id\\" int4 not null, \\"value\\" varchar(255) not null);
+create index \\"foo_param2_bar_id_index\\" on \\"foo_param2\\" (\\"bar_id\\");
+create index \\"foo_param2_baz_id_index\\" on \\"foo_param2\\" (\\"baz_id\\");
+alter table \\"foo_param2\\" add constraint \\"foo_param2_pkey\\" primary key (\\"bar_id\\", \\"baz_id\\");
+
+create table \\"publisher2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"type\\" text check (\\"type\\" in ('local', 'global')) not null, \\"type2\\" text check (\\"type2\\" in ('LOCAL', 'GLOBAL')) not null, \\"enum1\\" int2 null, \\"enum2\\" int2 null, \\"enum3\\" int2 null, \\"enum4\\" text check (\\"enum4\\" in ('a', 'b', 'c')) null);
+
+create table \\"book_tag2\\" (\\"id\\" bigserial primary key, \\"name\\" varchar(50) not null);
 
 create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"updated_at\\" timestamptz(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int4 null default null, \\"terms_accepted\\" bool not null default false, \\"optional\\" bool null, \\"identities\\" text[] null, \\"born\\" date null, \\"born_time\\" time(0) null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int4 null);
 create index \\"custom_email_index_name\\" on \\"author2\\" (\\"email\\");
@@ -558,31 +576,20 @@ alter table \\"address2\\" add constraint \\"address2_author_id_unique\\" unique
 create table \\"book2\\" (\\"uuid_pk\\" varchar(36) not null, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"title\\" varchar(255) null default '', \\"perex\\" text null, \\"price\\" float null, \\"double\\" double precision null, \\"meta\\" jsonb null, \\"author_id\\" int4 not null, \\"publisher_id\\" int4 null);
 alter table \\"book2\\" add constraint \\"book2_pkey\\" primary key (\\"uuid_pk\\");
 
-create table \\"book_tag2\\" (\\"id\\" bigserial primary key, \\"name\\" varchar(50) not null);
-
-create table \\"publisher2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"type\\" text check (\\"type\\" in ('local', 'global')) not null, \\"type2\\" text check (\\"type2\\" in ('LOCAL', 'GLOBAL')) not null, \\"enum1\\" int2 null, \\"enum2\\" int2 null, \\"enum3\\" int2 null, \\"enum4\\" text check (\\"enum4\\" in ('a', 'b', 'c')) null);
-
 create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"version\\" int4 not null default 1);
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_unique\\" unique (\\"book_uuid_pk\\");
-
-create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int4 null, \\"foo_bar_id\\" int4 null, \\"version\\" timestamptz(0) not null default current_timestamp(0), \\"blob\\" bytea null, \\"array\\" text[] null, \\"object\\" jsonb null);
-alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_unique\\" unique (\\"baz_id\\");
-alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_unique\\" unique (\\"foo_bar_id\\");
-
-create table \\"foo_baz2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"version\\" timestamptz(3) not null default current_timestamp(3));
-
-create table \\"foo_param2\\" (\\"bar_id\\" int4 not null, \\"baz_id\\" int4 not null, \\"value\\" varchar(255) not null);
-create index \\"foo_param2_bar_id_index\\" on \\"foo_param2\\" (\\"bar_id\\");
-create index \\"foo_param2_baz_id_index\\" on \\"foo_param2\\" (\\"baz_id\\");
-alter table \\"foo_param2\\" add constraint \\"foo_param2_pkey\\" primary key (\\"bar_id\\", \\"baz_id\\");
-
-create table \\"label2\\" (\\"uuid\\" uuid not null, \\"name\\" varchar(255) not null);
-alter table \\"label2\\" add constraint \\"label2_pkey\\" primary key (\\"uuid\\");
 
 create table \\"configuration2\\" (\\"property\\" varchar(255) not null, \\"test_id\\" int4 not null, \\"value\\" varchar(255) not null);
 create index \\"configuration2_property_index\\" on \\"configuration2\\" (\\"property\\");
 create index \\"configuration2_test_id_index\\" on \\"configuration2\\" (\\"test_id\\");
 alter table \\"configuration2\\" add constraint \\"configuration2_pkey\\" primary key (\\"property\\", \\"test_id\\");
+
+create table \\"publisher2_tests\\" (\\"id\\" serial primary key, \\"publisher2_id\\" int4 not null, \\"test2_id\\" int4 not null);
+
+create table \\"book2_tags\\" (\\"order\\" serial primary key, \\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" bigint not null);
+
+create table \\"book_to_tag_unordered\\" (\\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" bigint not null);
+alter table \\"book_to_tag_unordered\\" add constraint \\"book_to_tag_unordered_pkey\\" primary key (\\"book2_uuid_pk\\", \\"book_tag2_id\\");
 
 create table \\"author_to_friend\\" (\\"author2_1_id\\" int4 not null, \\"author2_2_id\\" int4 not null);
 alter table \\"author_to_friend\\" add constraint \\"author_to_friend_pkey\\" primary key (\\"author2_1_id\\", \\"author2_2_id\\");
@@ -590,12 +597,11 @@ alter table \\"author_to_friend\\" add constraint \\"author_to_friend_pkey\\" pr
 create table \\"author2_following\\" (\\"author2_1_id\\" int4 not null, \\"author2_2_id\\" int4 not null);
 alter table \\"author2_following\\" add constraint \\"author2_following_pkey\\" primary key (\\"author2_1_id\\", \\"author2_2_id\\");
 
-create table \\"book2_tags\\" (\\"order\\" serial primary key, \\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" bigint not null);
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_foreign\\" foreign key (\\"baz_id\\") references \\"foo_baz2\\" (\\"id\\") on update cascade on delete set null;
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_foreign\\" foreign key (\\"foo_bar_id\\") references \\"foo_bar2\\" (\\"id\\") on update cascade on delete set null;
 
-create table \\"book_to_tag_unordered\\" (\\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" bigint not null);
-alter table \\"book_to_tag_unordered\\" add constraint \\"book_to_tag_unordered_pkey\\" primary key (\\"book2_uuid_pk\\", \\"book_tag2_id\\");
-
-create table \\"publisher2_tests\\" (\\"id\\" serial primary key, \\"publisher2_id\\" int4 not null, \\"test2_id\\" int4 not null);
+alter table \\"foo_param2\\" add constraint \\"foo_param2_bar_id_foreign\\" foreign key (\\"bar_id\\") references \\"foo_bar2\\" (\\"id\\") on update cascade;
+alter table \\"foo_param2\\" add constraint \\"foo_param2_baz_id_foreign\\" foreign key (\\"baz_id\\") references \\"foo_baz2\\" (\\"id\\") on update cascade;
 
 alter table \\"author2\\" add constraint \\"author2_favourite_book_uuid_pk_foreign\\" foreign key (\\"favourite_book_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update no action on delete cascade;
 alter table \\"author2\\" add constraint \\"author2_favourite_author_id_foreign\\" foreign key (\\"favourite_author_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete set null;
@@ -607,19 +613,10 @@ alter table \\"book2\\" add constraint \\"book2_publisher_id_foreign\\" foreign 
 
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_foreign\\" foreign key (\\"book_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on delete set null;
 
-alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_foreign\\" foreign key (\\"baz_id\\") references \\"foo_baz2\\" (\\"id\\") on update cascade on delete set null;
-alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_foreign\\" foreign key (\\"foo_bar_id\\") references \\"foo_bar2\\" (\\"id\\") on update cascade on delete set null;
-
-alter table \\"foo_param2\\" add constraint \\"foo_param2_bar_id_foreign\\" foreign key (\\"bar_id\\") references \\"foo_bar2\\" (\\"id\\") on update cascade;
-alter table \\"foo_param2\\" add constraint \\"foo_param2_baz_id_foreign\\" foreign key (\\"baz_id\\") references \\"foo_baz2\\" (\\"id\\") on update cascade;
-
 alter table \\"configuration2\\" add constraint \\"configuration2_test_id_foreign\\" foreign key (\\"test_id\\") references \\"test2\\" (\\"id\\") on update cascade;
 
-alter table \\"author_to_friend\\" add constraint \\"author_to_friend_author2_1_id_foreign\\" foreign key (\\"author2_1_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
-alter table \\"author_to_friend\\" add constraint \\"author_to_friend_author2_2_id_foreign\\" foreign key (\\"author2_2_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
-
-alter table \\"author2_following\\" add constraint \\"author2_following_author2_1_id_foreign\\" foreign key (\\"author2_1_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
-alter table \\"author2_following\\" add constraint \\"author2_following_author2_2_id_foreign\\" foreign key (\\"author2_2_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
+alter table \\"publisher2_tests\\" add constraint \\"publisher2_tests_publisher2_id_foreign\\" foreign key (\\"publisher2_id\\") references \\"publisher2\\" (\\"id\\") on update cascade on delete cascade;
+alter table \\"publisher2_tests\\" add constraint \\"publisher2_tests_test2_id_foreign\\" foreign key (\\"test2_id\\") references \\"test2\\" (\\"id\\") on update cascade on delete cascade;
 
 alter table \\"book2_tags\\" add constraint \\"book2_tags_book2_uuid_pk_foreign\\" foreign key (\\"book2_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update cascade on delete cascade;
 alter table \\"book2_tags\\" add constraint \\"book2_tags_book_tag2_id_foreign\\" foreign key (\\"book_tag2_id\\") references \\"book_tag2\\" (\\"id\\") on update cascade on delete cascade;
@@ -627,8 +624,11 @@ alter table \\"book2_tags\\" add constraint \\"book2_tags_book_tag2_id_foreign\\
 alter table \\"book_to_tag_unordered\\" add constraint \\"book_to_tag_unordered_book2_uuid_pk_foreign\\" foreign key (\\"book2_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update cascade on delete cascade;
 alter table \\"book_to_tag_unordered\\" add constraint \\"book_to_tag_unordered_book_tag2_id_foreign\\" foreign key (\\"book_tag2_id\\") references \\"book_tag2\\" (\\"id\\") on update cascade on delete cascade;
 
-alter table \\"publisher2_tests\\" add constraint \\"publisher2_tests_publisher2_id_foreign\\" foreign key (\\"publisher2_id\\") references \\"publisher2\\" (\\"id\\") on update cascade on delete cascade;
-alter table \\"publisher2_tests\\" add constraint \\"publisher2_tests_test2_id_foreign\\" foreign key (\\"test2_id\\") references \\"test2\\" (\\"id\\") on update cascade on delete cascade;
+alter table \\"author_to_friend\\" add constraint \\"author_to_friend_author2_1_id_foreign\\" foreign key (\\"author2_1_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
+alter table \\"author_to_friend\\" add constraint \\"author_to_friend_author2_2_id_foreign\\" foreign key (\\"author2_2_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
+
+alter table \\"author2_following\\" add constraint \\"author2_following_author2_1_id_foreign\\" foreign key (\\"author2_1_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
+alter table \\"author2_following\\" add constraint \\"author2_following_author2_2_id_foreign\\" foreign key (\\"author2_2_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
 
 set session_replication_role = 'origin';
 "
@@ -649,24 +649,24 @@ set session_replication_role = 'origin';
 exports[`SchemaGenerator generate schema from metadata [sqlite]: sqlite-create-schema-dump 1`] = `
 "pragma foreign_keys = off;
 
+create table \`test3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar null, \`version\` integer not null default 1);
+
+create table \`publisher3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar not null, \`type\` varchar not null);
+
+create table \`publisher3_tests\` (\`id\` integer not null primary key autoincrement, \`publisher3_id\` integer not null, \`test3_id\` integer not null);
+create index \`publisher3_tests_publisher3_id_index\` on \`publisher3_tests\` (\`publisher3_id\`);
+create index \`publisher3_tests_test3_id_index\` on \`publisher3_tests\` (\`test3_id\`);
+
+create table \`book_tag3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
+
 create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` date(3) null, \`born_time\` time(3) null);
 create unique index \`author3_email_unique\` on \`author3\` (\`email\`);
 
 create table \`book3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`title\` varchar not null default '');
 
-create table \`book_tag3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
-
-create table \`publisher3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar not null, \`type\` varchar not null);
-
-create table \`test3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar null, \`version\` integer not null default 1);
-
 create table \`book3_tags\` (\`id\` integer not null primary key autoincrement, \`book3_id\` integer not null, \`book_tag3_id\` integer not null);
 create index \`book3_tags_book3_id_index\` on \`book3_tags\` (\`book3_id\`);
 create index \`book3_tags_book_tag3_id_index\` on \`book3_tags\` (\`book_tag3_id\`);
-
-create table \`publisher3_tests\` (\`id\` integer not null primary key autoincrement, \`publisher3_id\` integer not null, \`test3_id\` integer not null);
-create index \`publisher3_tests_publisher3_id_index\` on \`publisher3_tests\` (\`publisher3_id\`);
-create index \`publisher3_tests_test3_id_index\` on \`publisher3_tests\` (\`test3_id\`);
 
 alter table \`author3\` add column \`favourite_book_id\` integer null;
 create index \`author3_favourite_book_id_index\` on \`author3\` (\`favourite_book_id\`);
@@ -681,13 +681,13 @@ pragma foreign_keys = on;
 `;
 
 exports[`SchemaGenerator generate schema from metadata [sqlite]: sqlite-drop-schema-dump-1 1`] = `
-"drop table if exists \`author3\`;
+"drop table if exists \`book3_tags\`;
 drop table if exists \`book3\`;
+drop table if exists \`author3\`;
 drop table if exists \`book_tag3\`;
+drop table if exists \`publisher3_tests\`;
 drop table if exists \`publisher3\`;
 drop table if exists \`test3\`;
-drop table if exists \`book3_tags\`;
-drop table if exists \`publisher3_tests\`;
 drop table if exists \`mikro_orm_migrations\`;
 
 "
@@ -696,13 +696,13 @@ drop table if exists \`mikro_orm_migrations\`;
 exports[`SchemaGenerator generate schema from metadata [sqlite]: sqlite-drop-schema-dump-2 1`] = `
 "pragma foreign_keys = off;
 
-drop table if exists \`author3\`;
+drop table if exists \`book3_tags\`;
 drop table if exists \`book3\`;
+drop table if exists \`author3\`;
 drop table if exists \`book_tag3\`;
+drop table if exists \`publisher3_tests\`;
 drop table if exists \`publisher3\`;
 drop table if exists \`test3\`;
-drop table if exists \`book3_tags\`;
-drop table if exists \`publisher3_tests\`;
 
 pragma foreign_keys = on;
 "
@@ -711,32 +711,32 @@ pragma foreign_keys = on;
 exports[`SchemaGenerator generate schema from metadata [sqlite]: sqlite-schema-dump 1`] = `
 "pragma foreign_keys = off;
 
-drop table if exists \`author3\`;
+drop table if exists \`book3_tags\`;
 drop table if exists \`book3\`;
+drop table if exists \`author3\`;
 drop table if exists \`book_tag3\`;
+drop table if exists \`publisher3_tests\`;
 drop table if exists \`publisher3\`;
 drop table if exists \`test3\`;
-drop table if exists \`book3_tags\`;
-drop table if exists \`publisher3_tests\`;
+
+create table \`test3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar null, \`version\` integer not null default 1);
+
+create table \`publisher3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar not null, \`type\` varchar not null);
+
+create table \`publisher3_tests\` (\`id\` integer not null primary key autoincrement, \`publisher3_id\` integer not null, \`test3_id\` integer not null);
+create index \`publisher3_tests_publisher3_id_index\` on \`publisher3_tests\` (\`publisher3_id\`);
+create index \`publisher3_tests_test3_id_index\` on \`publisher3_tests\` (\`test3_id\`);
+
+create table \`book_tag3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
 
 create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` date(3) null, \`born_time\` time(3) null);
 create unique index \`author3_email_unique\` on \`author3\` (\`email\`);
 
 create table \`book3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`title\` varchar not null default '');
 
-create table \`book_tag3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
-
-create table \`publisher3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar not null, \`type\` varchar not null);
-
-create table \`test3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar null, \`version\` integer not null default 1);
-
 create table \`book3_tags\` (\`id\` integer not null primary key autoincrement, \`book3_id\` integer not null, \`book_tag3_id\` integer not null);
 create index \`book3_tags_book3_id_index\` on \`book3_tags\` (\`book3_id\`);
 create index \`book3_tags_book_tag3_id_index\` on \`book3_tags\` (\`book_tag3_id\`);
-
-create table \`publisher3_tests\` (\`id\` integer not null primary key autoincrement, \`publisher3_id\` integer not null, \`test3_id\` integer not null);
-create index \`publisher3_tests_publisher3_id_index\` on \`publisher3_tests\` (\`publisher3_id\`);
-create index \`publisher3_tests_test3_id_index\` on \`publisher3_tests\` (\`test3_id\`);
 
 alter table \`author3\` add column \`favourite_book_id\` integer null;
 create index \`author3_favourite_book_id_index\` on \`author3\` (\`favourite_book_id\`);
@@ -760,20 +760,24 @@ pragma foreign_keys = on;
 exports[`SchemaGenerator generate schema from metadata [sqlite2]: sqlite2-create-schema-dump 1`] = `
 "pragma foreign_keys = off;
 
+create table \`foo_baz4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
+
+create table \`foo_bar4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default 'asd', \`version\` integer not null default 1, \`blob\` blob null, \`array\` text null, \`object\` json null);
+
+create table \`test4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar null, \`version\` integer not null default 1);
+
+create table \`publisher4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default 'asd', \`type\` text check (\`type\` in ('local', 'global')) not null default 'local');
+
+create table \`publisher4_tests\` (\`id\` integer not null primary key autoincrement, \`publisher4_id\` integer not null, \`test4_id\` integer not null);
+create index \`publisher4_tests_publisher4_id_index\` on \`publisher4_tests\` (\`publisher4_id\`);
+create index \`publisher4_tests_test4_id_index\` on \`publisher4_tests\` (\`test4_id\`);
+
+create table \`book_tag4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
+
 create table \`author4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` date(3) null, \`born_time\` time(3) null);
 create unique index \`author4_email_unique\` on \`author4\` (\`email\`);
 
 create table \`book4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`title\` varchar not null);
-
-create table \`book_tag4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
-
-create table \`publisher4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default 'asd', \`type\` text check (\`type\` in ('local', 'global')) not null default 'local');
-
-create table \`test4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar null, \`version\` integer not null default 1);
-
-create table \`foo_bar4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default 'asd', \`version\` integer not null default 1, \`blob\` blob null, \`array\` text null, \`object\` json null);
-
-create table \`foo_baz4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
 
 create table \`tags_ordered\` (\`id\` integer not null primary key autoincrement, \`book4_id\` integer not null, \`book_tag4_id\` integer not null);
 create index \`tags_ordered_book4_id_index\` on \`tags_ordered\` (\`book4_id\`);
@@ -783,9 +787,12 @@ create table \`tags_unordered\` (\`book4_id\` integer not null, \`book_tag4_id\`
 create index \`tags_unordered_book4_id_index\` on \`tags_unordered\` (\`book4_id\`);
 create index \`tags_unordered_book_tag4_id_index\` on \`tags_unordered\` (\`book_tag4_id\`);
 
-create table \`publisher4_tests\` (\`id\` integer not null primary key autoincrement, \`publisher4_id\` integer not null, \`test4_id\` integer not null);
-create index \`publisher4_tests_publisher4_id_index\` on \`publisher4_tests\` (\`publisher4_id\`);
-create index \`publisher4_tests_test4_id_index\` on \`publisher4_tests\` (\`test4_id\`);
+alter table \`foo_bar4\` add column \`baz_id\` integer null;
+alter table \`foo_bar4\` add column \`foo_bar_id\` integer null;
+create index \`foo_bar4_baz_id_index\` on \`foo_bar4\` (\`baz_id\`);
+create unique index \`foo_bar4_baz_id_unique\` on \`foo_bar4\` (\`baz_id\`);
+create index \`foo_bar4_foo_bar_id_index\` on \`foo_bar4\` (\`foo_bar_id\`);
+create unique index \`foo_bar4_foo_bar_id_unique\` on \`foo_bar4\` (\`foo_bar_id\`);
 
 alter table \`author4\` add column \`favourite_book_id\` integer null;
 create index \`author4_favourite_book_id_index\` on \`author4\` (\`favourite_book_id\`);
@@ -795,28 +802,21 @@ alter table \`book4\` add column \`publisher_id\` integer null;
 create index \`book4_author_id_index\` on \`book4\` (\`author_id\`);
 create index \`book4_publisher_id_index\` on \`book4\` (\`publisher_id\`);
 
-alter table \`foo_bar4\` add column \`baz_id\` integer null;
-alter table \`foo_bar4\` add column \`foo_bar_id\` integer null;
-create index \`foo_bar4_baz_id_index\` on \`foo_bar4\` (\`baz_id\`);
-create unique index \`foo_bar4_baz_id_unique\` on \`foo_bar4\` (\`baz_id\`);
-create index \`foo_bar4_foo_bar_id_index\` on \`foo_bar4\` (\`foo_bar_id\`);
-create unique index \`foo_bar4_foo_bar_id_unique\` on \`foo_bar4\` (\`foo_bar_id\`);
-
 pragma foreign_keys = on;
 "
 `;
 
 exports[`SchemaGenerator generate schema from metadata [sqlite2]: sqlite2-drop-schema-dump-1 1`] = `
-"drop table if exists \`author4\`;
+"drop table if exists \`tags_unordered\`;
+drop table if exists \`tags_ordered\`;
 drop table if exists \`book4\`;
+drop table if exists \`author4\`;
 drop table if exists \`book_tag4\`;
+drop table if exists \`publisher4_tests\`;
 drop table if exists \`publisher4\`;
 drop table if exists \`test4\`;
 drop table if exists \`foo_bar4\`;
 drop table if exists \`foo_baz4\`;
-drop table if exists \`tags_ordered\`;
-drop table if exists \`tags_unordered\`;
-drop table if exists \`publisher4_tests\`;
 drop table if exists \`mikro_orm_migrations\`;
 
 "
@@ -825,16 +825,16 @@ drop table if exists \`mikro_orm_migrations\`;
 exports[`SchemaGenerator generate schema from metadata [sqlite2]: sqlite2-drop-schema-dump-2 1`] = `
 "pragma foreign_keys = off;
 
-drop table if exists \`author4\`;
+drop table if exists \`tags_unordered\`;
+drop table if exists \`tags_ordered\`;
 drop table if exists \`book4\`;
+drop table if exists \`author4\`;
 drop table if exists \`book_tag4\`;
+drop table if exists \`publisher4_tests\`;
 drop table if exists \`publisher4\`;
 drop table if exists \`test4\`;
 drop table if exists \`foo_bar4\`;
 drop table if exists \`foo_baz4\`;
-drop table if exists \`tags_ordered\`;
-drop table if exists \`tags_unordered\`;
-drop table if exists \`publisher4_tests\`;
 
 pragma foreign_keys = on;
 "
@@ -843,31 +843,35 @@ pragma foreign_keys = on;
 exports[`SchemaGenerator generate schema from metadata [sqlite2]: sqlite2-schema-dump 1`] = `
 "pragma foreign_keys = off;
 
-drop table if exists \`author4\`;
+drop table if exists \`tags_unordered\`;
+drop table if exists \`tags_ordered\`;
 drop table if exists \`book4\`;
+drop table if exists \`author4\`;
 drop table if exists \`book_tag4\`;
+drop table if exists \`publisher4_tests\`;
 drop table if exists \`publisher4\`;
 drop table if exists \`test4\`;
 drop table if exists \`foo_bar4\`;
 drop table if exists \`foo_baz4\`;
-drop table if exists \`tags_ordered\`;
-drop table if exists \`tags_unordered\`;
-drop table if exists \`publisher4_tests\`;
+
+create table \`foo_baz4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
+
+create table \`foo_bar4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default 'asd', \`version\` integer not null default 1, \`blob\` blob null, \`array\` text null, \`object\` json null);
+
+create table \`test4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar null, \`version\` integer not null default 1);
+
+create table \`publisher4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default 'asd', \`type\` text check (\`type\` in ('local', 'global')) not null default 'local');
+
+create table \`publisher4_tests\` (\`id\` integer not null primary key autoincrement, \`publisher4_id\` integer not null, \`test4_id\` integer not null);
+create index \`publisher4_tests_publisher4_id_index\` on \`publisher4_tests\` (\`publisher4_id\`);
+create index \`publisher4_tests_test4_id_index\` on \`publisher4_tests\` (\`test4_id\`);
+
+create table \`book_tag4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
 
 create table \`author4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` date(3) null, \`born_time\` time(3) null);
 create unique index \`author4_email_unique\` on \`author4\` (\`email\`);
 
 create table \`book4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`title\` varchar not null);
-
-create table \`book_tag4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
-
-create table \`publisher4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default 'asd', \`type\` text check (\`type\` in ('local', 'global')) not null default 'local');
-
-create table \`test4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar null, \`version\` integer not null default 1);
-
-create table \`foo_bar4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null default 'asd', \`version\` integer not null default 1, \`blob\` blob null, \`array\` text null, \`object\` json null);
-
-create table \`foo_baz4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
 
 create table \`tags_ordered\` (\`id\` integer not null primary key autoincrement, \`book4_id\` integer not null, \`book_tag4_id\` integer not null);
 create index \`tags_ordered_book4_id_index\` on \`tags_ordered\` (\`book4_id\`);
@@ -877,9 +881,12 @@ create table \`tags_unordered\` (\`book4_id\` integer not null, \`book_tag4_id\`
 create index \`tags_unordered_book4_id_index\` on \`tags_unordered\` (\`book4_id\`);
 create index \`tags_unordered_book_tag4_id_index\` on \`tags_unordered\` (\`book_tag4_id\`);
 
-create table \`publisher4_tests\` (\`id\` integer not null primary key autoincrement, \`publisher4_id\` integer not null, \`test4_id\` integer not null);
-create index \`publisher4_tests_publisher4_id_index\` on \`publisher4_tests\` (\`publisher4_id\`);
-create index \`publisher4_tests_test4_id_index\` on \`publisher4_tests\` (\`test4_id\`);
+alter table \`foo_bar4\` add column \`baz_id\` integer null;
+alter table \`foo_bar4\` add column \`foo_bar_id\` integer null;
+create index \`foo_bar4_baz_id_index\` on \`foo_bar4\` (\`baz_id\`);
+create unique index \`foo_bar4_baz_id_unique\` on \`foo_bar4\` (\`baz_id\`);
+create index \`foo_bar4_foo_bar_id_index\` on \`foo_bar4\` (\`foo_bar_id\`);
+create unique index \`foo_bar4_foo_bar_id_unique\` on \`foo_bar4\` (\`foo_bar_id\`);
 
 alter table \`author4\` add column \`favourite_book_id\` integer null;
 create index \`author4_favourite_book_id_index\` on \`author4\` (\`favourite_book_id\`);
@@ -888,13 +895,6 @@ alter table \`book4\` add column \`author_id\` integer null;
 alter table \`book4\` add column \`publisher_id\` integer null;
 create index \`book4_author_id_index\` on \`book4\` (\`author_id\`);
 create index \`book4_publisher_id_index\` on \`book4\` (\`publisher_id\`);
-
-alter table \`foo_bar4\` add column \`baz_id\` integer null;
-alter table \`foo_bar4\` add column \`foo_bar_id\` integer null;
-create index \`foo_bar4_baz_id_index\` on \`foo_bar4\` (\`baz_id\`);
-create unique index \`foo_bar4_baz_id_unique\` on \`foo_bar4\` (\`baz_id\`);
-create index \`foo_bar4_foo_bar_id_index\` on \`foo_bar4\` (\`foo_bar_id\`);
-create unique index \`foo_bar4_foo_bar_id_unique\` on \`foo_bar4\` (\`foo_bar_id\`);
 
 pragma foreign_keys = on;
 "
@@ -910,6 +910,57 @@ pragma foreign_keys = on;
 exports[`SchemaGenerator update empty schema from metadata [mysql]: mysql-update-empty-schema-dump 1`] = `
 "set names utf8mb4;
 set foreign_key_checks = 0;
+
+create table \`sandwich\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`price\` int(11) not null) default character set utf8mb4 engine = InnoDB;
+
+create table \`base_user2\` (\`id\` int unsigned not null auto_increment primary key, \`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`type\` enum('employee', 'manager', 'owner') not null, \`employee_prop\` int(11) null, \`manager_prop\` varchar(255) null, \`owner_prop\` varchar(255) null, \`favourite_employee_id\` int(11) unsigned null, \`favourite_manager_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
+alter table \`base_user2\` add index \`base_user2_type_index\`(\`type\`);
+alter table \`base_user2\` add index \`base_user2_favourite_employee_id_index\`(\`favourite_employee_id\`);
+alter table \`base_user2\` add index \`base_user2_favourite_manager_id_index\`(\`favourite_manager_id\`);
+alter table \`base_user2\` add unique \`base_user2_favourite_manager_id_unique\`(\`favourite_manager_id\`);
+
+create table \`car2\` (\`name\` varchar(100) not null, \`year\` int(11) unsigned not null, \`price\` int(11) not null) default character set utf8mb4 engine = InnoDB;
+alter table \`car2\` add index \`car2_name_index\`(\`name\`);
+alter table \`car2\` add index \`car2_year_index\`(\`year\`);
+alter table \`car2\` add primary key \`car2_pkey\`(\`name\`, \`year\`);
+
+create table \`car_owner2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`car_name\` varchar(100) not null, \`car_year\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`car_owner2\` add index \`car_owner2_car_name_car_year_index\`(\`car_name\`, \`car_year\`);
+
+create table \`user2\` (\`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`foo\` int(11) null, \`favourite_car_name\` varchar(100) null, \`favourite_car_year\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
+alter table \`user2\` add index \`user2_first_name_index\`(\`first_name\`);
+alter table \`user2\` add index \`user2_last_name_index\`(\`last_name\`);
+alter table \`user2\` add unique \`user2_favourite_car_name_unique\`(\`favourite_car_name\`);
+alter table \`user2\` add unique \`user2_favourite_car_year_unique\`(\`favourite_car_year\`);
+alter table \`user2\` add primary key \`user2_pkey\`(\`first_name\`, \`last_name\`);
+alter table \`user2\` add index \`user2_favourite_car_name_favourite_car_year_index\`(\`favourite_car_name\`, \`favourite_car_year\`);
+
+create table \`user2_sandwiches\` (\`user2_first_name\` varchar(100) not null, \`user2_last_name\` varchar(100) not null, \`sandwich_id\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`user2_sandwiches\` add index \`user2_sandwiches_sandwich_id_index\`(\`sandwich_id\`);
+alter table \`user2_sandwiches\` add primary key \`user2_sandwiches_pkey\`(\`user2_first_name\`, \`user2_last_name\`, \`sandwich_id\`);
+alter table \`user2_sandwiches\` add index \`user2_sandwiches_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);
+
+create table \`user2_cars\` (\`user2_first_name\` varchar(100) not null, \`user2_last_name\` varchar(100) not null, \`car2_name\` varchar(100) not null, \`car2_year\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`user2_cars\` add primary key \`user2_cars_pkey\`(\`user2_first_name\`, \`user2_last_name\`, \`car2_name\`, \`car2_year\`);
+alter table \`user2_cars\` add index \`user2_cars_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);
+alter table \`user2_cars\` add index \`user2_cars_car2_name_car2_year_index\`(\`car2_name\`, \`car2_year\`);
+
+create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
+
+create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`array\` text null, \`object\` json null) default character set utf8mb4 engine = InnoDB;
+alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
+alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
+alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
+alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
+
+create table \`foo_param2\` (\`bar_id\` int(11) unsigned not null, \`baz_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);
+alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);
+alter table \`foo_param2\` add primary key \`foo_param2_pkey\`(\`bar_id\`, \`baz_id\`);
+
+create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` enum('local', 'global') not null, \`type2\` enum('LOCAL', 'GLOBAL') not null, \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null) default character set utf8mb4 engine = InnoDB;
+
+create table \`book_tag2\` (\`id\` bigint unsigned not null auto_increment primary key, \`name\` varchar(50) not null) default character set utf8mb4 engine = InnoDB;
 
 create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table \`author2\` add index \`custom_email_index_name\`(\`email\`);
@@ -933,55 +984,27 @@ alter table \`book2\` add primary key \`book2_pkey\`(\`uuid_pk\`);
 alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);
 alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);
 
-create table \`book_tag2\` (\`id\` bigint unsigned not null auto_increment primary key, \`name\` varchar(50) not null) default character set utf8mb4 engine = InnoDB;
-
-create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` enum('local', 'global') not null, \`type2\` enum('LOCAL', 'GLOBAL') not null, \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null) default character set utf8mb4 engine = InnoDB;
-
 create table \`test2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) null, \`book_uuid_pk\` varchar(36) null, \`version\` int(11) not null default 1) default character set utf8mb4 engine = InnoDB;
 alter table \`test2\` add index \`test2_book_uuid_pk_index\`(\`book_uuid_pk\`);
 alter table \`test2\` add unique \`test2_book_uuid_pk_unique\`(\`book_uuid_pk\`);
-
-create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`array\` text null, \`object\` json null) default character set utf8mb4 engine = InnoDB;
-alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
-alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
-alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
-alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
-
-create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
-
-create table \`foo_param2\` (\`bar_id\` int(11) unsigned not null, \`baz_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
-alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);
-alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);
-alter table \`foo_param2\` add primary key \`foo_param2_pkey\`(\`bar_id\`, \`baz_id\`);
 
 create table \`configuration2\` (\`property\` varchar(255) not null, \`test_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
 alter table \`configuration2\` add index \`configuration2_property_index\`(\`property\`);
 alter table \`configuration2\` add index \`configuration2_test_id_index\`(\`test_id\`);
 alter table \`configuration2\` add primary key \`configuration2_pkey\`(\`property\`, \`test_id\`);
 
-create table \`car2\` (\`name\` varchar(100) not null, \`year\` int(11) unsigned not null, \`price\` int(11) not null) default character set utf8mb4 engine = InnoDB;
-alter table \`car2\` add index \`car2_name_index\`(\`name\`);
-alter table \`car2\` add index \`car2_year_index\`(\`year\`);
-alter table \`car2\` add primary key \`car2_pkey\`(\`name\`, \`year\`);
+create table \`publisher2_tests\` (\`id\` int unsigned not null auto_increment primary key, \`publisher2_id\` int(11) unsigned not null, \`test2_id\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`publisher2_tests\` add index \`publisher2_tests_publisher2_id_index\`(\`publisher2_id\`);
+alter table \`publisher2_tests\` add index \`publisher2_tests_test2_id_index\`(\`test2_id\`);
 
-create table \`car_owner2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`car_name\` varchar(100) not null, \`car_year\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table \`car_owner2\` add index \`car_owner2_car_name_car_year_index\`(\`car_name\`, \`car_year\`);
+create table \`book2_tags\` (\`order\` int unsigned not null auto_increment primary key, \`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`book2_tags\` add index \`book2_tags_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
+alter table \`book2_tags\` add index \`book2_tags_book_tag2_id_index\`(\`book_tag2_id\`);
 
-create table \`user2\` (\`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`foo\` int(11) null, \`favourite_car_name\` varchar(100) null, \`favourite_car_year\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
-alter table \`user2\` add index \`user2_first_name_index\`(\`first_name\`);
-alter table \`user2\` add index \`user2_last_name_index\`(\`last_name\`);
-alter table \`user2\` add unique \`user2_favourite_car_name_unique\`(\`favourite_car_name\`);
-alter table \`user2\` add unique \`user2_favourite_car_year_unique\`(\`favourite_car_year\`);
-alter table \`user2\` add primary key \`user2_pkey\`(\`first_name\`, \`last_name\`);
-alter table \`user2\` add index \`user2_favourite_car_name_favourite_car_year_index\`(\`favourite_car_name\`, \`favourite_car_year\`);
-
-create table \`base_user2\` (\`id\` int unsigned not null auto_increment primary key, \`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`type\` enum('employee', 'manager', 'owner') not null, \`employee_prop\` int(11) null, \`manager_prop\` varchar(255) null, \`owner_prop\` varchar(255) null, \`favourite_employee_id\` int(11) unsigned null, \`favourite_manager_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
-alter table \`base_user2\` add index \`base_user2_type_index\`(\`type\`);
-alter table \`base_user2\` add index \`base_user2_favourite_employee_id_index\`(\`favourite_employee_id\`);
-alter table \`base_user2\` add index \`base_user2_favourite_manager_id_index\`(\`favourite_manager_id\`);
-alter table \`base_user2\` add unique \`base_user2_favourite_manager_id_unique\`(\`favourite_manager_id\`);
-
-create table \`sandwich\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`price\` int(11) not null) default character set utf8mb4 engine = InnoDB;
+create table \`book_to_tag_unordered\` (\`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
+alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book_tag2_id_index\`(\`book_tag2_id\`);
+alter table \`book_to_tag_unordered\` add primary key \`book_to_tag_unordered_pkey\`(\`book2_uuid_pk\`, \`book_tag2_id\`);
 
 create table \`author_to_friend\` (\`author2_1_id\` int(11) unsigned not null, \`author2_2_id\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
 alter table \`author_to_friend\` add index \`author_to_friend_author2_1_id_index\`(\`author2_1_id\`);
@@ -993,28 +1016,29 @@ alter table \`author2_following\` add index \`author2_following_author2_1_id_ind
 alter table \`author2_following\` add index \`author2_following_author2_2_id_index\`(\`author2_2_id\`);
 alter table \`author2_following\` add primary key \`author2_following_pkey\`(\`author2_1_id\`, \`author2_2_id\`);
 
-create table \`book2_tags\` (\`order\` int unsigned not null auto_increment primary key, \`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table \`book2_tags\` add index \`book2_tags_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
-alter table \`book2_tags\` add index \`book2_tags_book_tag2_id_index\`(\`book_tag2_id\`);
+alter table \`base_user2\` add constraint \`base_user2_favourite_employee_id_foreign\` foreign key (\`favourite_employee_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
+alter table \`base_user2\` add constraint \`base_user2_favourite_manager_id_foreign\` foreign key (\`favourite_manager_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
 
-create table \`book_to_tag_unordered\` (\`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
-alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book_tag2_id_index\`(\`book_tag2_id\`);
-alter table \`book_to_tag_unordered\` add primary key \`book_to_tag_unordered_pkey\`(\`book2_uuid_pk\`, \`book_tag2_id\`);
+alter table \`car_owner2\` add constraint \`car_owner2_car_name_foreign\` foreign key (\`car_name\`) references \`car2\` (\`name\`) on update cascade;
+alter table \`car_owner2\` add constraint \`car_owner2_car_year_foreign\` foreign key (\`car_year\`) references \`car2\` (\`year\`) on update cascade;
 
-create table \`publisher2_tests\` (\`id\` int unsigned not null auto_increment primary key, \`publisher2_id\` int(11) unsigned not null, \`test2_id\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table \`publisher2_tests\` add index \`publisher2_tests_publisher2_id_index\`(\`publisher2_id\`);
-alter table \`publisher2_tests\` add index \`publisher2_tests_test2_id_index\`(\`test2_id\`);
+alter table \`user2\` add constraint \`user2_favourite_car_name_foreign\` foreign key (\`favourite_car_name\`) references \`car2\` (\`name\`) on update cascade on delete set null;
+alter table \`user2\` add constraint \`user2_favourite_car_year_foreign\` foreign key (\`favourite_car_year\`) references \`car2\` (\`year\`) on update cascade on delete set null;
 
-create table \`user2_cars\` (\`user2_first_name\` varchar(100) not null, \`user2_last_name\` varchar(100) not null, \`car2_name\` varchar(100) not null, \`car2_year\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table \`user2_cars\` add primary key \`user2_cars_pkey\`(\`user2_first_name\`, \`user2_last_name\`, \`car2_name\`, \`car2_year\`);
-alter table \`user2_cars\` add index \`user2_cars_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);
-alter table \`user2_cars\` add index \`user2_cars_car2_name_car2_year_index\`(\`car2_name\`, \`car2_year\`);
+alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_user2_first_name_foreign\` foreign key (\`user2_first_name\`) references \`user2\` (\`first_name\`) on update cascade on delete cascade;
+alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_user2_last_name_foreign\` foreign key (\`user2_last_name\`) references \`user2\` (\`last_name\`) on update cascade on delete cascade;
+alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_sandwich_id_foreign\` foreign key (\`sandwich_id\`) references \`sandwich\` (\`id\`) on update cascade on delete cascade;
 
-create table \`user2_sandwiches\` (\`user2_first_name\` varchar(100) not null, \`user2_last_name\` varchar(100) not null, \`sandwich_id\` int(11) unsigned not null) default character set utf8mb4 engine = InnoDB;
-alter table \`user2_sandwiches\` add index \`user2_sandwiches_sandwich_id_index\`(\`sandwich_id\`);
-alter table \`user2_sandwiches\` add primary key \`user2_sandwiches_pkey\`(\`user2_first_name\`, \`user2_last_name\`, \`sandwich_id\`);
-alter table \`user2_sandwiches\` add index \`user2_sandwiches_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);
+alter table \`user2_cars\` add constraint \`user2_cars_user2_first_name_foreign\` foreign key (\`user2_first_name\`) references \`user2\` (\`first_name\`) on update cascade on delete cascade;
+alter table \`user2_cars\` add constraint \`user2_cars_user2_last_name_foreign\` foreign key (\`user2_last_name\`) references \`user2\` (\`last_name\`) on update cascade on delete cascade;
+alter table \`user2_cars\` add constraint \`user2_cars_car2_name_foreign\` foreign key (\`car2_name\`) references \`car2\` (\`name\`) on update cascade on delete cascade;
+alter table \`user2_cars\` add constraint \`user2_cars_car2_year_foreign\` foreign key (\`car2_year\`) references \`car2\` (\`year\`) on update cascade on delete cascade;
+
+alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;
+alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;
+
+alter table \`foo_param2\` add constraint \`foo_param2_bar_id_foreign\` foreign key (\`bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade;
+alter table \`foo_param2\` add constraint \`foo_param2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade;
 
 alter table \`author2\` add constraint \`author2_favourite_book_uuid_pk_foreign\` foreign key (\`favourite_book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update no action on delete cascade;
 alter table \`author2\` add constraint \`author2_favourite_author_id_foreign\` foreign key (\`favourite_author_id\`) references \`author2\` (\`id\`) on update cascade on delete set null;
@@ -1026,28 +1050,10 @@ alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key 
 
 alter table \`test2\` add constraint \`test2_book_uuid_pk_foreign\` foreign key (\`book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on delete set null;
 
-alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;
-alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;
-
-alter table \`foo_param2\` add constraint \`foo_param2_bar_id_foreign\` foreign key (\`bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade;
-alter table \`foo_param2\` add constraint \`foo_param2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade;
-
 alter table \`configuration2\` add constraint \`configuration2_test_id_foreign\` foreign key (\`test_id\`) references \`test2\` (\`id\`) on update cascade;
 
-alter table \`car_owner2\` add constraint \`car_owner2_car_name_foreign\` foreign key (\`car_name\`) references \`car2\` (\`name\`) on update cascade;
-alter table \`car_owner2\` add constraint \`car_owner2_car_year_foreign\` foreign key (\`car_year\`) references \`car2\` (\`year\`) on update cascade;
-
-alter table \`user2\` add constraint \`user2_favourite_car_name_foreign\` foreign key (\`favourite_car_name\`) references \`car2\` (\`name\`) on update cascade on delete set null;
-alter table \`user2\` add constraint \`user2_favourite_car_year_foreign\` foreign key (\`favourite_car_year\`) references \`car2\` (\`year\`) on update cascade on delete set null;
-
-alter table \`base_user2\` add constraint \`base_user2_favourite_employee_id_foreign\` foreign key (\`favourite_employee_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
-alter table \`base_user2\` add constraint \`base_user2_favourite_manager_id_foreign\` foreign key (\`favourite_manager_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
-
-alter table \`author_to_friend\` add constraint \`author_to_friend_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
-alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
-
-alter table \`author2_following\` add constraint \`author2_following_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
-alter table \`author2_following\` add constraint \`author2_following_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+alter table \`publisher2_tests\` add constraint \`publisher2_tests_publisher2_id_foreign\` foreign key (\`publisher2_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
+alter table \`publisher2_tests\` add constraint \`publisher2_tests_test2_id_foreign\` foreign key (\`test2_id\`) references \`test2\` (\`id\`) on update cascade on delete cascade;
 
 alter table \`book2_tags\` add constraint \`book2_tags_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;
 alter table \`book2_tags\` add constraint \`book2_tags_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;
@@ -1055,17 +1061,11 @@ alter table \`book2_tags\` add constraint \`book2_tags_book_tag2_id_foreign\` fo
 alter table \`book_to_tag_unordered\` add constraint \`book_to_tag_unordered_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;
 alter table \`book_to_tag_unordered\` add constraint \`book_to_tag_unordered_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;
 
-alter table \`publisher2_tests\` add constraint \`publisher2_tests_publisher2_id_foreign\` foreign key (\`publisher2_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
-alter table \`publisher2_tests\` add constraint \`publisher2_tests_test2_id_foreign\` foreign key (\`test2_id\`) references \`test2\` (\`id\`) on update cascade on delete cascade;
+alter table \`author_to_friend\` add constraint \`author_to_friend_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 
-alter table \`user2_cars\` add constraint \`user2_cars_user2_first_name_foreign\` foreign key (\`user2_first_name\`) references \`user2\` (\`first_name\`) on update cascade on delete cascade;
-alter table \`user2_cars\` add constraint \`user2_cars_user2_last_name_foreign\` foreign key (\`user2_last_name\`) references \`user2\` (\`last_name\`) on update cascade on delete cascade;
-alter table \`user2_cars\` add constraint \`user2_cars_car2_name_foreign\` foreign key (\`car2_name\`) references \`car2\` (\`name\`) on update cascade on delete cascade;
-alter table \`user2_cars\` add constraint \`user2_cars_car2_year_foreign\` foreign key (\`car2_year\`) references \`car2\` (\`year\`) on update cascade on delete cascade;
-
-alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_user2_first_name_foreign\` foreign key (\`user2_first_name\`) references \`user2\` (\`first_name\`) on update cascade on delete cascade;
-alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_user2_last_name_foreign\` foreign key (\`user2_last_name\`) references \`user2\` (\`last_name\`) on update cascade on delete cascade;
-alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_sandwich_id_foreign\` foreign key (\`sandwich_id\`) references \`sandwich\` (\`id\`) on update cascade on delete cascade;
+alter table \`author2_following\` add constraint \`author2_following_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+alter table \`author2_following\` add constraint \`author2_following_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 
 set foreign_key_checks = 1;
 "
@@ -1074,6 +1074,24 @@ set foreign_key_checks = 1;
 exports[`SchemaGenerator update empty schema from metadata [postgres]: postgres-update-empty-schema-dump 1`] = `
 "set names 'utf8';
 set session_replication_role = 'replica';
+
+create table \\"label2\\" (\\"uuid\\" uuid not null, \\"name\\" varchar(255) not null);
+alter table \\"label2\\" add constraint \\"label2_pkey\\" primary key (\\"uuid\\");
+
+create table \\"foo_baz2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"version\\" timestamptz(3) not null default current_timestamp(3));
+
+create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int4 null, \\"foo_bar_id\\" int4 null, \\"version\\" timestamptz(0) not null default current_timestamp(0), \\"blob\\" bytea null, \\"array\\" text[] null, \\"object\\" jsonb null);
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_unique\\" unique (\\"baz_id\\");
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_unique\\" unique (\\"foo_bar_id\\");
+
+create table \\"foo_param2\\" (\\"bar_id\\" int4 not null, \\"baz_id\\" int4 not null, \\"value\\" varchar(255) not null);
+create index \\"foo_param2_bar_id_index\\" on \\"foo_param2\\" (\\"bar_id\\");
+create index \\"foo_param2_baz_id_index\\" on \\"foo_param2\\" (\\"baz_id\\");
+alter table \\"foo_param2\\" add constraint \\"foo_param2_pkey\\" primary key (\\"bar_id\\", \\"baz_id\\");
+
+create table \\"publisher2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"type\\" text check (\\"type\\" in ('local', 'global')) not null, \\"type2\\" text check (\\"type2\\" in ('LOCAL', 'GLOBAL')) not null, \\"enum1\\" int2 null, \\"enum2\\" int2 null, \\"enum3\\" int2 null, \\"enum4\\" text check (\\"enum4\\" in ('a', 'b', 'c')) null);
+
+create table \\"book_tag2\\" (\\"id\\" bigserial primary key, \\"name\\" varchar(50) not null);
 
 create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"updated_at\\" timestamptz(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int4 null default null, \\"terms_accepted\\" bool not null default false, \\"optional\\" bool null, \\"identities\\" text[] null, \\"born\\" date null, \\"born_time\\" time(0) null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int4 null);
 create index \\"custom_email_index_name\\" on \\"author2\\" (\\"email\\");
@@ -1092,31 +1110,20 @@ alter table \\"address2\\" add constraint \\"address2_author_id_unique\\" unique
 create table \\"book2\\" (\\"uuid_pk\\" varchar(36) not null, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"title\\" varchar(255) null default '', \\"perex\\" text null, \\"price\\" float null, \\"double\\" double precision null, \\"meta\\" jsonb null, \\"author_id\\" int4 not null, \\"publisher_id\\" int4 null);
 alter table \\"book2\\" add constraint \\"book2_pkey\\" primary key (\\"uuid_pk\\");
 
-create table \\"book_tag2\\" (\\"id\\" bigserial primary key, \\"name\\" varchar(50) not null);
-
-create table \\"publisher2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"type\\" text check (\\"type\\" in ('local', 'global')) not null, \\"type2\\" text check (\\"type2\\" in ('LOCAL', 'GLOBAL')) not null, \\"enum1\\" int2 null, \\"enum2\\" int2 null, \\"enum3\\" int2 null, \\"enum4\\" text check (\\"enum4\\" in ('a', 'b', 'c')) null);
-
 create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"version\\" int4 not null default 1);
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_unique\\" unique (\\"book_uuid_pk\\");
-
-create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int4 null, \\"foo_bar_id\\" int4 null, \\"version\\" timestamptz(0) not null default current_timestamp(0), \\"blob\\" bytea null, \\"array\\" text[] null, \\"object\\" jsonb null);
-alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_unique\\" unique (\\"baz_id\\");
-alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_unique\\" unique (\\"foo_bar_id\\");
-
-create table \\"foo_baz2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"version\\" timestamptz(3) not null default current_timestamp(3));
-
-create table \\"foo_param2\\" (\\"bar_id\\" int4 not null, \\"baz_id\\" int4 not null, \\"value\\" varchar(255) not null);
-create index \\"foo_param2_bar_id_index\\" on \\"foo_param2\\" (\\"bar_id\\");
-create index \\"foo_param2_baz_id_index\\" on \\"foo_param2\\" (\\"baz_id\\");
-alter table \\"foo_param2\\" add constraint \\"foo_param2_pkey\\" primary key (\\"bar_id\\", \\"baz_id\\");
-
-create table \\"label2\\" (\\"uuid\\" uuid not null, \\"name\\" varchar(255) not null);
-alter table \\"label2\\" add constraint \\"label2_pkey\\" primary key (\\"uuid\\");
 
 create table \\"configuration2\\" (\\"property\\" varchar(255) not null, \\"test_id\\" int4 not null, \\"value\\" varchar(255) not null);
 create index \\"configuration2_property_index\\" on \\"configuration2\\" (\\"property\\");
 create index \\"configuration2_test_id_index\\" on \\"configuration2\\" (\\"test_id\\");
 alter table \\"configuration2\\" add constraint \\"configuration2_pkey\\" primary key (\\"property\\", \\"test_id\\");
+
+create table \\"publisher2_tests\\" (\\"id\\" serial primary key, \\"publisher2_id\\" int4 not null, \\"test2_id\\" int4 not null);
+
+create table \\"book2_tags\\" (\\"order\\" serial primary key, \\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" bigint not null);
+
+create table \\"book_to_tag_unordered\\" (\\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" bigint not null);
+alter table \\"book_to_tag_unordered\\" add constraint \\"book_to_tag_unordered_pkey\\" primary key (\\"book2_uuid_pk\\", \\"book_tag2_id\\");
 
 create table \\"author_to_friend\\" (\\"author2_1_id\\" int4 not null, \\"author2_2_id\\" int4 not null);
 alter table \\"author_to_friend\\" add constraint \\"author_to_friend_pkey\\" primary key (\\"author2_1_id\\", \\"author2_2_id\\");
@@ -1124,12 +1131,11 @@ alter table \\"author_to_friend\\" add constraint \\"author_to_friend_pkey\\" pr
 create table \\"author2_following\\" (\\"author2_1_id\\" int4 not null, \\"author2_2_id\\" int4 not null);
 alter table \\"author2_following\\" add constraint \\"author2_following_pkey\\" primary key (\\"author2_1_id\\", \\"author2_2_id\\");
 
-create table \\"book2_tags\\" (\\"order\\" serial primary key, \\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" bigint not null);
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_foreign\\" foreign key (\\"baz_id\\") references \\"foo_baz2\\" (\\"id\\") on update cascade on delete set null;
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_foreign\\" foreign key (\\"foo_bar_id\\") references \\"foo_bar2\\" (\\"id\\") on update cascade on delete set null;
 
-create table \\"book_to_tag_unordered\\" (\\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" bigint not null);
-alter table \\"book_to_tag_unordered\\" add constraint \\"book_to_tag_unordered_pkey\\" primary key (\\"book2_uuid_pk\\", \\"book_tag2_id\\");
-
-create table \\"publisher2_tests\\" (\\"id\\" serial primary key, \\"publisher2_id\\" int4 not null, \\"test2_id\\" int4 not null);
+alter table \\"foo_param2\\" add constraint \\"foo_param2_bar_id_foreign\\" foreign key (\\"bar_id\\") references \\"foo_bar2\\" (\\"id\\") on update cascade;
+alter table \\"foo_param2\\" add constraint \\"foo_param2_baz_id_foreign\\" foreign key (\\"baz_id\\") references \\"foo_baz2\\" (\\"id\\") on update cascade;
 
 alter table \\"author2\\" add constraint \\"author2_favourite_book_uuid_pk_foreign\\" foreign key (\\"favourite_book_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update no action on delete cascade;
 alter table \\"author2\\" add constraint \\"author2_favourite_author_id_foreign\\" foreign key (\\"favourite_author_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete set null;
@@ -1141,19 +1147,10 @@ alter table \\"book2\\" add constraint \\"book2_publisher_id_foreign\\" foreign 
 
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_foreign\\" foreign key (\\"book_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on delete set null;
 
-alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_foreign\\" foreign key (\\"baz_id\\") references \\"foo_baz2\\" (\\"id\\") on update cascade on delete set null;
-alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_foreign\\" foreign key (\\"foo_bar_id\\") references \\"foo_bar2\\" (\\"id\\") on update cascade on delete set null;
-
-alter table \\"foo_param2\\" add constraint \\"foo_param2_bar_id_foreign\\" foreign key (\\"bar_id\\") references \\"foo_bar2\\" (\\"id\\") on update cascade;
-alter table \\"foo_param2\\" add constraint \\"foo_param2_baz_id_foreign\\" foreign key (\\"baz_id\\") references \\"foo_baz2\\" (\\"id\\") on update cascade;
-
 alter table \\"configuration2\\" add constraint \\"configuration2_test_id_foreign\\" foreign key (\\"test_id\\") references \\"test2\\" (\\"id\\") on update cascade;
 
-alter table \\"author_to_friend\\" add constraint \\"author_to_friend_author2_1_id_foreign\\" foreign key (\\"author2_1_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
-alter table \\"author_to_friend\\" add constraint \\"author_to_friend_author2_2_id_foreign\\" foreign key (\\"author2_2_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
-
-alter table \\"author2_following\\" add constraint \\"author2_following_author2_1_id_foreign\\" foreign key (\\"author2_1_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
-alter table \\"author2_following\\" add constraint \\"author2_following_author2_2_id_foreign\\" foreign key (\\"author2_2_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
+alter table \\"publisher2_tests\\" add constraint \\"publisher2_tests_publisher2_id_foreign\\" foreign key (\\"publisher2_id\\") references \\"publisher2\\" (\\"id\\") on update cascade on delete cascade;
+alter table \\"publisher2_tests\\" add constraint \\"publisher2_tests_test2_id_foreign\\" foreign key (\\"test2_id\\") references \\"test2\\" (\\"id\\") on update cascade on delete cascade;
 
 alter table \\"book2_tags\\" add constraint \\"book2_tags_book2_uuid_pk_foreign\\" foreign key (\\"book2_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update cascade on delete cascade;
 alter table \\"book2_tags\\" add constraint \\"book2_tags_book_tag2_id_foreign\\" foreign key (\\"book_tag2_id\\") references \\"book_tag2\\" (\\"id\\") on update cascade on delete cascade;
@@ -1161,8 +1158,11 @@ alter table \\"book2_tags\\" add constraint \\"book2_tags_book_tag2_id_foreign\\
 alter table \\"book_to_tag_unordered\\" add constraint \\"book_to_tag_unordered_book2_uuid_pk_foreign\\" foreign key (\\"book2_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update cascade on delete cascade;
 alter table \\"book_to_tag_unordered\\" add constraint \\"book_to_tag_unordered_book_tag2_id_foreign\\" foreign key (\\"book_tag2_id\\") references \\"book_tag2\\" (\\"id\\") on update cascade on delete cascade;
 
-alter table \\"publisher2_tests\\" add constraint \\"publisher2_tests_publisher2_id_foreign\\" foreign key (\\"publisher2_id\\") references \\"publisher2\\" (\\"id\\") on update cascade on delete cascade;
-alter table \\"publisher2_tests\\" add constraint \\"publisher2_tests_test2_id_foreign\\" foreign key (\\"test2_id\\") references \\"test2\\" (\\"id\\") on update cascade on delete cascade;
+alter table \\"author_to_friend\\" add constraint \\"author_to_friend_author2_1_id_foreign\\" foreign key (\\"author2_1_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
+alter table \\"author_to_friend\\" add constraint \\"author_to_friend_author2_2_id_foreign\\" foreign key (\\"author2_2_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
+
+alter table \\"author2_following\\" add constraint \\"author2_following_author2_1_id_foreign\\" foreign key (\\"author2_1_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
+alter table \\"author2_following\\" add constraint \\"author2_following_author2_2_id_foreign\\" foreign key (\\"author2_2_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete cascade;
 
 set session_replication_role = 'origin';
 "
@@ -1171,24 +1171,24 @@ set session_replication_role = 'origin';
 exports[`SchemaGenerator update empty schema from metadata [sqlite]: sqlite-update-empty-schema-dump 1`] = `
 "pragma foreign_keys = off;
 
+create table \`test3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar null, \`version\` integer not null default 1);
+
+create table \`publisher3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar not null, \`type\` varchar not null);
+
+create table \`publisher3_tests\` (\`id\` integer not null primary key autoincrement, \`publisher3_id\` integer not null, \`test3_id\` integer not null);
+create index \`publisher3_tests_publisher3_id_index\` on \`publisher3_tests\` (\`publisher3_id\`);
+create index \`publisher3_tests_test3_id_index\` on \`publisher3_tests\` (\`test3_id\`);
+
+create table \`book_tag3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
+
 create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` date(3) null, \`born_time\` time(3) null);
 create unique index \`author3_email_unique\` on \`author3\` (\`email\`);
 
 create table \`book3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`title\` varchar not null default '');
 
-create table \`book_tag3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
-
-create table \`publisher3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar not null, \`type\` varchar not null);
-
-create table \`test3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar null, \`version\` integer not null default 1);
-
 create table \`book3_tags\` (\`id\` integer not null primary key autoincrement, \`book3_id\` integer not null, \`book_tag3_id\` integer not null);
 create index \`book3_tags_book3_id_index\` on \`book3_tags\` (\`book3_id\`);
 create index \`book3_tags_book_tag3_id_index\` on \`book3_tags\` (\`book_tag3_id\`);
-
-create table \`publisher3_tests\` (\`id\` integer not null primary key autoincrement, \`publisher3_id\` integer not null, \`test3_id\` integer not null);
-create index \`publisher3_tests_publisher3_id_index\` on \`publisher3_tests\` (\`publisher3_id\`);
-create index \`publisher3_tests_test3_id_index\` on \`publisher3_tests\` (\`test3_id\`);
 
 alter table \`author3\` add column \`favourite_book_id\` integer null;
 create index \`author3_favourite_book_id_index\` on \`author3\` (\`favourite_book_id\`);
@@ -1203,10 +1203,10 @@ pragma foreign_keys = on;
 `;
 
 exports[`SchemaGenerator update schema [mysql]: mysql-update-schema-add-column 1`] = `
-"alter table \`author2\` add \`favourite_book_uuid_pk\` varchar(36) null;
-alter table \`author2\` add index \`author2_favourite_book_uuid_pk_index\`(\`favourite_book_uuid_pk\`);
+"alter table \`new_table\` add \`id\` int unsigned not null auto_increment primary key, add \`updated_at\` datetime(3) not null default current_timestamp(3);
 
-alter table \`new_table\` add \`id\` int unsigned not null auto_increment primary key, add \`updated_at\` datetime(3) not null default current_timestamp(3);
+alter table \`author2\` add \`favourite_book_uuid_pk\` varchar(36) null;
+alter table \`author2\` add index \`author2_favourite_book_uuid_pk_index\`(\`favourite_book_uuid_pk\`);
 
 alter table \`author2\` add constraint \`author2_favourite_book_uuid_pk_foreign\` foreign key (\`favourite_book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update no action on delete cascade;
 
@@ -1223,15 +1223,15 @@ alter table \`author2\` add constraint \`author2_favourite_author_id_foreign\` f
 `;
 
 exports[`SchemaGenerator update schema [mysql]: mysql-update-schema-create-table 1`] = `
-"alter table \`book2\` drop \`foo\`;
+"create table \`new_table\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+
+alter table \`book2\` drop \`foo\`;
 
 alter table \`test2\` drop foreign key \`test2_foo___bar_foreign\`;
 alter table \`test2\` drop index \`test2_foo___bar_unique\`;
 alter table \`test2\` drop index \`test2_foo___bar_index\`;
 alter table \`test2\` drop \`foo___bar\`;
 alter table \`test2\` drop \`foo___baz\`;
-
-create table \`new_table\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
 
 "
 `;
@@ -1246,12 +1246,12 @@ alter table \`foo_bar2\` drop \`baz_id\`;
 `;
 
 exports[`SchemaGenerator update schema [mysql]: mysql-update-schema-drop-column 1`] = `
-"alter table \`author2\` drop foreign key \`author2_favourite_book_uuid_pk_foreign\`;
+"alter table \`new_table\` drop \`id\`;
+alter table \`new_table\` drop \`updated_at\`;
+
+alter table \`author2\` drop foreign key \`author2_favourite_book_uuid_pk_foreign\`;
 alter table \`author2\` drop index \`author2_favourite_book_uuid_pk_index\`;
 alter table \`author2\` drop \`favourite_book_uuid_pk\`;
-
-alter table \`new_table\` drop \`id\`;
-alter table \`new_table\` drop \`updated_at\`;
 
 "
 `;
@@ -1279,9 +1279,9 @@ alter table \`author2\` change \`favourite_author_id\` \`favourite_writer_id\` i
 `;
 
 exports[`SchemaGenerator update schema [postgres]: postgres-update-schema-add-column 1`] = `
-"alter table \\"author2\\" add column \\"favourite_book_uuid_pk\\" varchar(36) null;
+"alter table \\"new_table\\" add column \\"id\\" serial primary key, add column \\"updated_at\\" timestamp(3) not null default current_timestamp(3);
 
-alter table \\"new_table\\" add column \\"id\\" serial primary key, add column \\"updated_at\\" timestamp(3) not null default current_timestamp(3);
+alter table \\"author2\\" add column \\"favourite_book_uuid_pk\\" varchar(36) null;
 
 alter table \\"author2\\" add constraint \\"author2_favourite_book_uuid_pk_foreign\\" foreign key (\\"favourite_book_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update no action on delete cascade;
 
@@ -1303,11 +1303,11 @@ alter table \\"author2\\" add constraint \\"author2_favourite_author_id_foreign\
 `;
 
 exports[`SchemaGenerator update schema [postgres]: postgres-update-schema-create-table 1`] = `
-"alter table \\"book2\\" drop column \\"foo\\";
+"create table \\"new_table\\" (\\"id\\" serial primary key, \\"created_at\\" timestamp(3) not null default current_timestamp(3), \\"updated_at\\" timestamp(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null);
+
+alter table \\"book2\\" drop column \\"foo\\";
 
 alter table \\"test2\\" drop column \\"path\\";
-
-create table \\"new_table\\" (\\"id\\" serial primary key, \\"created_at\\" timestamp(3) not null default current_timestamp(3), \\"updated_at\\" timestamp(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null);
 
 "
 `;
@@ -1321,15 +1321,15 @@ alter table \\"foo_bar2\\" drop column \\"baz_id\\";
 `;
 
 exports[`SchemaGenerator update schema [postgres]: postgres-update-schema-drop-column 1`] = `
-"alter table \\"author2\\" drop constraint if exists \\"author2_name_check\\";
+"alter table \\"new_table\\" drop column \\"id\\";
+alter table \\"new_table\\" drop column \\"updated_at\\";
+
+alter table \\"author2\\" drop constraint if exists \\"author2_name_check\\";
 alter table \\"author2\\" alter column \\"name\\" type int4 using (\\"name\\"::int4);
 alter table \\"author2\\" alter column \\"name\\" drop default;
 alter table \\"author2\\" alter column \\"name\\" set not null;
 alter table \\"author2\\" drop constraint \\"author2_favourite_book_uuid_pk_foreign\\";
 alter table \\"author2\\" drop column \\"favourite_book_uuid_pk\\";
-
-alter table \\"new_table\\" drop column \\"id\\";
-alter table \\"new_table\\" drop column \\"updated_at\\";
 
 "
 `;
@@ -1353,15 +1353,15 @@ alter table \\"author2\\" rename column \\"favourite_author_id\\" to \\"favourit
 `;
 
 exports[`SchemaGenerator update schema enums [mysql]: mysql-update-schema-enums-1 1`] = `
-"alter table \`book2\` drop \`foo\`;
+"create table \`new_table\` (\`id\` int unsigned not null auto_increment primary key, \`enum_test\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+
+alter table \`book2\` drop \`foo\`;
 
 alter table \`test2\` drop foreign key \`test2_foo___bar_foreign\`;
 alter table \`test2\` drop index \`test2_foo___bar_unique\`;
 alter table \`test2\` drop index \`test2_foo___bar_index\`;
 alter table \`test2\` drop \`foo___bar\`;
 alter table \`test2\` drop \`foo___baz\`;
-
-create table \`new_table\` (\`id\` int unsigned not null auto_increment primary key, \`enum_test\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
 
 "
 `;
@@ -1385,11 +1385,11 @@ exports[`SchemaGenerator update schema enums [mysql]: mysql-update-schema-enums-
 `;
 
 exports[`SchemaGenerator update schema enums [postgres]: postgres-update-schema-enums-1 1`] = `
-"alter table \\"book2\\" drop column \\"foo\\";
+"create table \\"new_table\\" (\\"id\\" serial primary key, \\"enum_test\\" varchar(255) not null);
+
+alter table \\"book2\\" drop column \\"foo\\";
 
 alter table \\"test2\\" drop column \\"path\\";
-
-create table \\"new_table\\" (\\"id\\" serial primary key, \\"enum_test\\" varchar(255) not null);
 
 "
 `;


### PR DESCRIPTION
Use `CommitOrderCalculator` to calculate correct order for defining tables.