### PR TITLE
feat(core): support globs in `entities`

### DIFF
--- a/docs/docs/upgrading-v3-to-v4.md
+++ b/docs/docs/upgrading-v3-to-v4.md
@@ -37,6 +37,23 @@ Previously the name was constructed from 2 entity names as `entity_a_to_entity_b
 ignoring the actual property name. In v4 the name will be `entity_a_coll_name` in 
 case of the collection property on the owning side being named `collName`. 
 
+## Changes in folder-based discovery (`entitiesDirs` removed)
+
+`entitiesDirs` and `entitiesDirsTs` were removed in favour of `entities` and `entitiesTs`,
+`entities` will be used as a default for `entitiesTs` (that is used when we detect `ts-node`).
+
+`entities` can now contain mixture of paths to directories, globs pointing to entities,
+or references to the entities or instances of `EntitySchema`. 
+
+This basically means that all you need to change is renaming `entitiesDirs` to `entities`.
+
+```typescript
+MikroORM.init({
+  entities: ['dist/**/entities', 'dist/**/*.entity.js', FooBar, FooBaz],
+  entitiesTs: ['src/**/entities', 'src/**/*.entity.ts', FooBar, FooBaz],
+});
+```
+
 ## Changes in `wrap()` helper, `WrappedEntity` interface and `Reference` wrapper
 
 Previously all the methods and properties of `WrappedEntity` interface were

--- a/packages/core/src/metadata/MetadataValidator.ts
+++ b/packages/core/src/metadata/MetadataValidator.ts
@@ -86,7 +86,7 @@ export class MetadataValidator {
     }
 
     // has correct `inversedBy` reference type
-    if (inverse.type !== meta.name) {
+    if (inverse.type !== meta.className) {
       throw MetadataError.fromWrongReference(meta, prop, 'inversedBy', inverse);
     }
 
@@ -103,7 +103,7 @@ export class MetadataValidator {
     }
 
     // has correct `mappedBy` reference type
-    if (owner.type !== meta.name) {
+    if (owner.type !== meta.className) {
       throw MetadataError.fromWrongReference(meta, prop, 'mappedBy', owner);
     }
 

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -18,8 +18,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
   static readonly DEFAULTS = {
     pool: {},
     entities: [],
-    entitiesDirs: [],
-    entitiesDirsTs: [],
+    entitiesTs: [],
     subscribers: [],
     discovery: {
       warnWhenNoEntities: true,
@@ -206,10 +205,6 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
       this.options.dbName = this.get('dbName', url[1]);
     }
 
-    if (this.options.entitiesDirsTs.length === 0) {
-      this.options.entitiesDirsTs = this.options.entitiesDirs;
-    }
-
     if (!this.options.charset) {
       this.options.charset = this.platform.getDefaultCharset();
     }
@@ -227,14 +222,8 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
       throw new Error('No database specified, please fill in `dbName` or `clientUrl` option');
     }
 
-    if (this.options.entities.length === 0 && this.options.entitiesDirs.length === 0 && this.options.discovery.warnWhenNoEntities) {
-      throw new Error('No entities found, please use `entities` or `entitiesDirs` option');
-    }
-
-    const notDirectory = this.options.entitiesDirs.find(dir => dir.match(/\.[jt]s$/));
-
-    if (notDirectory) {
-      throw new Error(`Please provide path to directory in \`entitiesDirs\`, found: '${notDirectory}'`);
+    if (this.options.entities.length === 0 && this.options.discovery.warnWhenNoEntities) {
+      throw new Error('No entities found, please use `entities` option');
     }
   }
 
@@ -310,9 +299,8 @@ export interface PoolConfig {
 }
 
 export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> extends ConnectionOptions {
-  entities: (EntityClass<AnyEntity> | EntityClassGroup<AnyEntity> | EntitySchema<any>)[]; // `any` required here for some TS weirdness
-  entitiesDirs: string[];
-  entitiesDirsTs: string[];
+  entities: (string | EntityClass<AnyEntity> | EntityClassGroup<AnyEntity> | EntitySchema<any>)[]; // `any` required here for some TS weirdness
+  entitiesTs: (string | EntityClass<AnyEntity> | EntityClassGroup<AnyEntity> | EntitySchema<any>)[]; // `any` required here for some TS weirdness
   subscribers: EventSubscriber[];
   discovery: {
     warnWhenNoEntities?: boolean;

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -522,7 +522,7 @@ export class Utils {
     let path = parts.join('/').replace(/\\/g, '/').replace(/\/$/, '');
     path = normalize(path).replace(/\\/g, '/');
 
-    return path.match(/^[/.]|[a-zA-Z]:/) ? path : './' + path;
+    return (path.match(/^[/.]|[a-zA-Z]:/) || path.startsWith('!')) ? path : './' + path;
   }
 
   static relativePath(path: string, relativeTo: string): string {

--- a/packages/reflection/src/TsMorphMetadataProvider.ts
+++ b/packages/reflection/src/TsMorphMetadataProvider.ts
@@ -1,4 +1,3 @@
-import globby from 'globby';
 import { Project, PropertyDeclaration, SourceFile } from 'ts-morph';
 import { EntityMetadata, EntityProperty, MetadataProvider, MetadataStorage, Utils } from '@mikro-orm/core';
 
@@ -19,14 +18,14 @@ export class TsMorphMetadataProvider extends MetadataProvider {
     await this.initProperties(meta);
   }
 
-  async getExistingSourceFile(meta: EntityMetadata, ext?: string, validate = true): Promise<SourceFile> {
+  async getExistingSourceFile(path: string, ext?: string, validate = true): Promise<SourceFile> {
     if (!ext) {
-      return await this.getExistingSourceFile(meta, '.d.ts', false) || await this.getExistingSourceFile(meta, '.ts');
+      return await this.getExistingSourceFile(path, '.d.ts', false) || await this.getExistingSourceFile(path, '.ts');
     }
 
-    const path = meta.path.match(/\/[^/]+$/)![0].replace(/\.js$/, ext);
+    const tsPath = path.match(/\/[^/]+$/)![0].replace(/\.js$/, ext);
 
-    return (await this.getSourceFile(path, validate))!;
+    return (await this.getSourceFile(tsPath, path, validate))!;
   }
 
   protected async initProperties(meta: EntityMetadata): Promise<void> {
@@ -67,7 +66,7 @@ export class TsMorphMetadataProvider extends MetadataProvider {
   }
 
   private async readTypeFromSource(meta: EntityMetadata, prop: EntityProperty): Promise<{ type: string; optional?: boolean }> {
-    const source = await this.getExistingSourceFile(meta);
+    const source = await this.getExistingSourceFile(meta.path);
     const cls = source.getClass(meta.className);
 
     /* istanbul ignore next */
@@ -89,15 +88,15 @@ export class TsMorphMetadataProvider extends MetadataProvider {
     return { type, optional };
   }
 
-  private async getSourceFile(file: string, validate: boolean): Promise<SourceFile | undefined> {
+  private async getSourceFile(tsPath: string, file: string, validate: boolean): Promise<SourceFile | undefined> {
     if (!this.sources) {
       await this.initSourceFiles();
     }
 
-    const source = this.sources.find(s => s.getFilePath().endsWith(file));
+    const source = this.sources.find(s => s.getFilePath().endsWith(tsPath));
 
     if (!source && validate) {
-      throw new Error(`Source file for entity ${file} not found, check your 'entitiesDirsTs' option. If you are using webpack, see https://bit.ly/35pPDNn`);
+      throw new Error(`Source file for entity '${file}' not found, check your 'entitiesTs' option. If you are using webpack, see https://bit.ly/35pPDNn`);
     }
 
     return source;
@@ -118,32 +117,12 @@ export class TsMorphMetadataProvider extends MetadataProvider {
   }
 
   private async initSourceFiles(): Promise<void> {
-    const tsDirs = this.config.get('entitiesDirsTs');
-
-    if (tsDirs.length > 0) {
-      const dirs = await this.validateDirectories(tsDirs);
-      this.sources = this.project.addSourceFilesAtPaths(dirs);
-    } else {
-      const dirs = Object.values(MetadataStorage.getMetadata()).map(m => m.path.replace(/\.js$/, '.d.ts'));
-      this.sources = this.project.addSourceFilesAtPaths(dirs);
-    }
-  }
-
-  private async validateDirectories(dirs: string[]): Promise<string[]> {
-    const ret: string[] = [];
-
-    for (const dir of dirs) {
-      const path = Utils.normalizePath(this.config.get('baseDir'), dir);
-      const files = await globby(`${path}/*`);
-
-      if (files.length === 0) {
-        throw new Error(`Path ${path} does not exist`);
-      }
-
-      ret.push(Utils.normalizePath(path, '**', '*.ts'));
-    }
-
-    return ret;
+    // All entity files are first required during the discovery, before we reach here, so it is safe to get the parts from the global
+    // metadata storage. We know the path thanks the the decorators being executed. In case we are running via ts-node, the extension
+    // will be already `.ts`, so no change needed. `.js` files will get renamed to `.d.ts` files as they will be used as a source for
+    // the ts-morph reflection.
+    const paths = Object.values(MetadataStorage.getMetadata()).map(m => m.path.replace(/\.js$/, '.d.ts'));
+    this.sources = this.project.addSourceFilesAtPaths(paths);
   }
 
 }

--- a/tests/SchemaGenerator.test.ts
+++ b/tests/SchemaGenerator.test.ts
@@ -404,12 +404,15 @@ describe('SchemaGenerator', () => {
 
     const dropDump = await generator.getDropSchemaSQL();
     expect(dropDump).toMatchSnapshot('postgres-drop-schema-dump');
+    await generator.dropSchema();
 
     const createDump = await generator.getCreateSchemaSQL();
     expect(createDump).toMatchSnapshot('postgres-create-schema-dump');
+    await generator.createSchema();
 
     const updateDump = await generator.getUpdateSchemaSQL();
     expect(updateDump).toMatchSnapshot('postgres-update-schema-dump');
+    await generator.updateSchema();
 
     await orm.close(true);
   });

--- a/tests/Webpack.test.ts
+++ b/tests/Webpack.test.ts
@@ -38,7 +38,7 @@ describe('Webpack', () => {
     const options = {
       dbName: `mikro_orm_test`,
       type: 'mysql',
-      entitiesDirs: ['not/existing'],
+      entities: ['not/existing'],
       discovery: { disableDynamicFileAccess: true },
     } as Options;
     const err = `[requireEntitiesArray] Explicit list of entities is required, please use the 'entities' option.`;

--- a/tests/__snapshots__/SchemaGenerator.test.ts.snap
+++ b/tests/__snapshots__/SchemaGenerator.test.ts.snap
@@ -6,11 +6,20 @@ set foreign_key_checks = 0;
 
 create table \`sandwich\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`price\` int(11) not null) default character set utf8mb4 engine = InnoDB;
 
-create table \`base_user2\` (\`id\` int unsigned not null auto_increment primary key, \`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`type\` enum('employee', 'manager', 'owner') not null, \`employee_prop\` int(11) null, \`manager_prop\` varchar(255) null, \`owner_prop\` varchar(255) null, \`favourite_employee_id\` int(11) unsigned null, \`favourite_manager_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
-alter table \`base_user2\` add index \`base_user2_type_index\`(\`type\`);
-alter table \`base_user2\` add index \`base_user2_favourite_employee_id_index\`(\`favourite_employee_id\`);
-alter table \`base_user2\` add index \`base_user2_favourite_manager_id_index\`(\`favourite_manager_id\`);
-alter table \`base_user2\` add unique \`base_user2_favourite_manager_id_unique\`(\`favourite_manager_id\`);
+create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` enum('local', 'global') not null, \`type2\` enum('LOCAL', 'GLOBAL') not null, \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null) default character set utf8mb4 engine = InnoDB;
+
+create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
+
+create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`array\` text null, \`object\` json null) default character set utf8mb4 engine = InnoDB;
+alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
+alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
+alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
+alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
+
+create table \`foo_param2\` (\`bar_id\` int(11) unsigned not null, \`baz_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);
+alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);
+alter table \`foo_param2\` add primary key \`foo_param2_pkey\`(\`bar_id\`, \`baz_id\`);
 
 create table \`car2\` (\`name\` varchar(100) not null, \`year\` int(11) unsigned not null, \`price\` int(11) not null) default character set utf8mb4 engine = InnoDB;
 alter table \`car2\` add index \`car2_name_index\`(\`name\`);
@@ -38,22 +47,13 @@ alter table \`user2_cars\` add primary key \`user2_cars_pkey\`(\`user2_first_nam
 alter table \`user2_cars\` add index \`user2_cars_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);
 alter table \`user2_cars\` add index \`user2_cars_car2_name_car2_year_index\`(\`car2_name\`, \`car2_year\`);
 
-create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
-
-create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`array\` text null, \`object\` json null) default character set utf8mb4 engine = InnoDB;
-alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
-alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
-alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
-alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
-
-create table \`foo_param2\` (\`bar_id\` int(11) unsigned not null, \`baz_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
-alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);
-alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);
-alter table \`foo_param2\` add primary key \`foo_param2_pkey\`(\`bar_id\`, \`baz_id\`);
-
-create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` enum('local', 'global') not null, \`type2\` enum('LOCAL', 'GLOBAL') not null, \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null) default character set utf8mb4 engine = InnoDB;
-
 create table \`book_tag2\` (\`id\` bigint unsigned not null auto_increment primary key, \`name\` varchar(50) not null) default character set utf8mb4 engine = InnoDB;
+
+create table \`base_user2\` (\`id\` int unsigned not null auto_increment primary key, \`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`type\` enum('employee', 'manager', 'owner') not null, \`owner_prop\` varchar(255) null, \`favourite_employee_id\` int(11) unsigned null, \`favourite_manager_id\` int(11) unsigned null, \`employee_prop\` int(11) null, \`manager_prop\` varchar(255) null) default character set utf8mb4 engine = InnoDB;
+alter table \`base_user2\` add index \`base_user2_type_index\`(\`type\`);
+alter table \`base_user2\` add index \`base_user2_favourite_employee_id_index\`(\`favourite_employee_id\`);
+alter table \`base_user2\` add index \`base_user2_favourite_manager_id_index\`(\`favourite_manager_id\`);
+alter table \`base_user2\` add unique \`base_user2_favourite_manager_id_unique\`(\`favourite_manager_id\`);
 
 create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table \`author2\` add index \`custom_email_index_name\`(\`email\`);
@@ -66,11 +66,6 @@ alter table \`author2\` add index \`author2_favourite_author_id_index\`(\`favour
 alter table \`author2\` add index \`custom_idx_name_123\`(\`name\`);
 alter table \`author2\` add index \`author2_name_age_index\`(\`name\`, \`age\`);
 alter table \`author2\` add unique \`author2_name_email_unique\`(\`name\`, \`email\`);
-
-create table \`address2\` (\`author_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
-alter table \`address2\` add primary key \`address2_pkey\`(\`author_id\`);
-alter table \`address2\` add index \`address2_author_id_index\`(\`author_id\`);
-alter table \`address2\` add unique \`address2_author_id_unique\`(\`author_id\`);
 
 create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`title\` varchar(255) null default '', \`perex\` text null, \`price\` float null, \`double\` double null, \`meta\` json null, \`author_id\` int(11) unsigned not null, \`publisher_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table \`book2\` add primary key \`book2_pkey\`(\`uuid_pk\`);
@@ -109,8 +104,16 @@ alter table \`author2_following\` add index \`author2_following_author2_1_id_ind
 alter table \`author2_following\` add index \`author2_following_author2_2_id_index\`(\`author2_2_id\`);
 alter table \`author2_following\` add primary key \`author2_following_pkey\`(\`author2_1_id\`, \`author2_2_id\`);
 
-alter table \`base_user2\` add constraint \`base_user2_favourite_employee_id_foreign\` foreign key (\`favourite_employee_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
-alter table \`base_user2\` add constraint \`base_user2_favourite_manager_id_foreign\` foreign key (\`favourite_manager_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
+create table \`address2\` (\`author_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+alter table \`address2\` add primary key \`address2_pkey\`(\`author_id\`);
+alter table \`address2\` add index \`address2_author_id_index\`(\`author_id\`);
+alter table \`address2\` add unique \`address2_author_id_unique\`(\`author_id\`);
+
+alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;
+alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;
+
+alter table \`foo_param2\` add constraint \`foo_param2_bar_id_foreign\` foreign key (\`bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade;
+alter table \`foo_param2\` add constraint \`foo_param2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade;
 
 alter table \`car_owner2\` add constraint \`car_owner2_car_name_car_year_foreign\` foreign key (\`car_name\`, \`car_year\`) references \`car2\` (\`name\`, \`year\`) on update cascade;
 
@@ -122,16 +125,11 @@ alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_sandwich_id_f
 alter table \`user2_cars\` add constraint \`user2_cars_user2_first_name_user2_last_name_foreign\` foreign key (\`user2_first_name\`, \`user2_last_name\`) references \`user2\` (\`first_name\`, \`last_name\`) on update cascade on delete cascade;
 alter table \`user2_cars\` add constraint \`user2_cars_car2_name_car2_year_foreign\` foreign key (\`car2_name\`, \`car2_year\`) references \`car2\` (\`name\`, \`year\`) on update cascade on delete cascade;
 
-alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;
-alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;
-
-alter table \`foo_param2\` add constraint \`foo_param2_bar_id_foreign\` foreign key (\`bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade;
-alter table \`foo_param2\` add constraint \`foo_param2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade;
+alter table \`base_user2\` add constraint \`base_user2_favourite_employee_id_foreign\` foreign key (\`favourite_employee_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
+alter table \`base_user2\` add constraint \`base_user2_favourite_manager_id_foreign\` foreign key (\`favourite_manager_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
 
 alter table \`author2\` add constraint \`author2_favourite_book_uuid_pk_foreign\` foreign key (\`favourite_book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update no action on delete cascade;
 alter table \`author2\` add constraint \`author2_favourite_author_id_foreign\` foreign key (\`favourite_author_id\`) references \`author2\` (\`id\`) on update cascade on delete set null;
-
-alter table \`address2\` add constraint \`address2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 
 alter table \`book2\` add constraint \`book2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`);
 alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key (\`publisher_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
@@ -155,6 +153,8 @@ alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_
 alter table \`author2_following\` add constraint \`author2_following_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 alter table \`author2_following\` add constraint \`author2_following_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 
+alter table \`address2\` add constraint \`address2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+
 set foreign_key_checks = 1;
 "
 `;
@@ -163,6 +163,7 @@ exports[`SchemaGenerator generate schema from metadata [mysql]: mysql-drop-schem
 "set names utf8mb4;
 set foreign_key_checks = 0;
 
+drop table if exists \`address2\`;
 drop table if exists \`author2_following\`;
 drop table if exists \`author_to_friend\`;
 drop table if exists \`book_to_tag_unordered\`;
@@ -171,19 +172,18 @@ drop table if exists \`publisher2_tests\`;
 drop table if exists \`configuration2\`;
 drop table if exists \`test2\`;
 drop table if exists \`book2\`;
-drop table if exists \`address2\`;
 drop table if exists \`author2\`;
+drop table if exists \`base_user2\`;
 drop table if exists \`book_tag2\`;
-drop table if exists \`publisher2\`;
-drop table if exists \`foo_param2\`;
-drop table if exists \`foo_bar2\`;
-drop table if exists \`foo_baz2\`;
 drop table if exists \`user2_cars\`;
 drop table if exists \`user2_sandwiches\`;
 drop table if exists \`user2\`;
 drop table if exists \`car_owner2\`;
 drop table if exists \`car2\`;
-drop table if exists \`base_user2\`;
+drop table if exists \`foo_param2\`;
+drop table if exists \`foo_bar2\`;
+drop table if exists \`foo_baz2\`;
+drop table if exists \`publisher2\`;
 drop table if exists \`sandwich\`;
 
 set foreign_key_checks = 1;
@@ -194,6 +194,7 @@ exports[`SchemaGenerator generate schema from metadata [mysql]: mysql-schema-dum
 "set names utf8mb4;
 set foreign_key_checks = 0;
 
+drop table if exists \`address2\`;
 drop table if exists \`author2_following\`;
 drop table if exists \`author_to_friend\`;
 drop table if exists \`book_to_tag_unordered\`;
@@ -202,28 +203,36 @@ drop table if exists \`publisher2_tests\`;
 drop table if exists \`configuration2\`;
 drop table if exists \`test2\`;
 drop table if exists \`book2\`;
-drop table if exists \`address2\`;
 drop table if exists \`author2\`;
+drop table if exists \`base_user2\`;
 drop table if exists \`book_tag2\`;
-drop table if exists \`publisher2\`;
-drop table if exists \`foo_param2\`;
-drop table if exists \`foo_bar2\`;
-drop table if exists \`foo_baz2\`;
 drop table if exists \`user2_cars\`;
 drop table if exists \`user2_sandwiches\`;
 drop table if exists \`user2\`;
 drop table if exists \`car_owner2\`;
 drop table if exists \`car2\`;
-drop table if exists \`base_user2\`;
+drop table if exists \`foo_param2\`;
+drop table if exists \`foo_bar2\`;
+drop table if exists \`foo_baz2\`;
+drop table if exists \`publisher2\`;
 drop table if exists \`sandwich\`;
 
 create table \`sandwich\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`price\` int(11) not null) default character set utf8mb4 engine = InnoDB;
 
-create table \`base_user2\` (\`id\` int unsigned not null auto_increment primary key, \`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`type\` enum('employee', 'manager', 'owner') not null, \`employee_prop\` int(11) null, \`manager_prop\` varchar(255) null, \`owner_prop\` varchar(255) null, \`favourite_employee_id\` int(11) unsigned null, \`favourite_manager_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
-alter table \`base_user2\` add index \`base_user2_type_index\`(\`type\`);
-alter table \`base_user2\` add index \`base_user2_favourite_employee_id_index\`(\`favourite_employee_id\`);
-alter table \`base_user2\` add index \`base_user2_favourite_manager_id_index\`(\`favourite_manager_id\`);
-alter table \`base_user2\` add unique \`base_user2_favourite_manager_id_unique\`(\`favourite_manager_id\`);
+create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` enum('local', 'global') not null, \`type2\` enum('LOCAL', 'GLOBAL') not null, \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null) default character set utf8mb4 engine = InnoDB;
+
+create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
+
+create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`array\` text null, \`object\` json null) default character set utf8mb4 engine = InnoDB;
+alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
+alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
+alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
+alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
+
+create table \`foo_param2\` (\`bar_id\` int(11) unsigned not null, \`baz_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);
+alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);
+alter table \`foo_param2\` add primary key \`foo_param2_pkey\`(\`bar_id\`, \`baz_id\`);
 
 create table \`car2\` (\`name\` varchar(100) not null, \`year\` int(11) unsigned not null, \`price\` int(11) not null) default character set utf8mb4 engine = InnoDB;
 alter table \`car2\` add index \`car2_name_index\`(\`name\`);
@@ -251,22 +260,13 @@ alter table \`user2_cars\` add primary key \`user2_cars_pkey\`(\`user2_first_nam
 alter table \`user2_cars\` add index \`user2_cars_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);
 alter table \`user2_cars\` add index \`user2_cars_car2_name_car2_year_index\`(\`car2_name\`, \`car2_year\`);
 
-create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
-
-create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`array\` text null, \`object\` json null) default character set utf8mb4 engine = InnoDB;
-alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
-alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
-alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
-alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
-
-create table \`foo_param2\` (\`bar_id\` int(11) unsigned not null, \`baz_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
-alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);
-alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);
-alter table \`foo_param2\` add primary key \`foo_param2_pkey\`(\`bar_id\`, \`baz_id\`);
-
-create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` enum('local', 'global') not null, \`type2\` enum('LOCAL', 'GLOBAL') not null, \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null) default character set utf8mb4 engine = InnoDB;
-
 create table \`book_tag2\` (\`id\` bigint unsigned not null auto_increment primary key, \`name\` varchar(50) not null) default character set utf8mb4 engine = InnoDB;
+
+create table \`base_user2\` (\`id\` int unsigned not null auto_increment primary key, \`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`type\` enum('employee', 'manager', 'owner') not null, \`owner_prop\` varchar(255) null, \`favourite_employee_id\` int(11) unsigned null, \`favourite_manager_id\` int(11) unsigned null, \`employee_prop\` int(11) null, \`manager_prop\` varchar(255) null) default character set utf8mb4 engine = InnoDB;
+alter table \`base_user2\` add index \`base_user2_type_index\`(\`type\`);
+alter table \`base_user2\` add index \`base_user2_favourite_employee_id_index\`(\`favourite_employee_id\`);
+alter table \`base_user2\` add index \`base_user2_favourite_manager_id_index\`(\`favourite_manager_id\`);
+alter table \`base_user2\` add unique \`base_user2_favourite_manager_id_unique\`(\`favourite_manager_id\`);
 
 create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table \`author2\` add index \`custom_email_index_name\`(\`email\`);
@@ -279,11 +279,6 @@ alter table \`author2\` add index \`author2_favourite_author_id_index\`(\`favour
 alter table \`author2\` add index \`custom_idx_name_123\`(\`name\`);
 alter table \`author2\` add index \`author2_name_age_index\`(\`name\`, \`age\`);
 alter table \`author2\` add unique \`author2_name_email_unique\`(\`name\`, \`email\`);
-
-create table \`address2\` (\`author_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
-alter table \`address2\` add primary key \`address2_pkey\`(\`author_id\`);
-alter table \`address2\` add index \`address2_author_id_index\`(\`author_id\`);
-alter table \`address2\` add unique \`address2_author_id_unique\`(\`author_id\`);
 
 create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`title\` varchar(255) null default '', \`perex\` text null, \`price\` float null, \`double\` double null, \`meta\` json null, \`author_id\` int(11) unsigned not null, \`publisher_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table \`book2\` add primary key \`book2_pkey\`(\`uuid_pk\`);
@@ -322,8 +317,16 @@ alter table \`author2_following\` add index \`author2_following_author2_1_id_ind
 alter table \`author2_following\` add index \`author2_following_author2_2_id_index\`(\`author2_2_id\`);
 alter table \`author2_following\` add primary key \`author2_following_pkey\`(\`author2_1_id\`, \`author2_2_id\`);
 
-alter table \`base_user2\` add constraint \`base_user2_favourite_employee_id_foreign\` foreign key (\`favourite_employee_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
-alter table \`base_user2\` add constraint \`base_user2_favourite_manager_id_foreign\` foreign key (\`favourite_manager_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
+create table \`address2\` (\`author_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+alter table \`address2\` add primary key \`address2_pkey\`(\`author_id\`);
+alter table \`address2\` add index \`address2_author_id_index\`(\`author_id\`);
+alter table \`address2\` add unique \`address2_author_id_unique\`(\`author_id\`);
+
+alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;
+alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;
+
+alter table \`foo_param2\` add constraint \`foo_param2_bar_id_foreign\` foreign key (\`bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade;
+alter table \`foo_param2\` add constraint \`foo_param2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade;
 
 alter table \`car_owner2\` add constraint \`car_owner2_car_name_car_year_foreign\` foreign key (\`car_name\`, \`car_year\`) references \`car2\` (\`name\`, \`year\`) on update cascade;
 
@@ -335,16 +338,11 @@ alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_sandwich_id_f
 alter table \`user2_cars\` add constraint \`user2_cars_user2_first_name_user2_last_name_foreign\` foreign key (\`user2_first_name\`, \`user2_last_name\`) references \`user2\` (\`first_name\`, \`last_name\`) on update cascade on delete cascade;
 alter table \`user2_cars\` add constraint \`user2_cars_car2_name_car2_year_foreign\` foreign key (\`car2_name\`, \`car2_year\`) references \`car2\` (\`name\`, \`year\`) on update cascade on delete cascade;
 
-alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;
-alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;
-
-alter table \`foo_param2\` add constraint \`foo_param2_bar_id_foreign\` foreign key (\`bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade;
-alter table \`foo_param2\` add constraint \`foo_param2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade;
+alter table \`base_user2\` add constraint \`base_user2_favourite_employee_id_foreign\` foreign key (\`favourite_employee_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
+alter table \`base_user2\` add constraint \`base_user2_favourite_manager_id_foreign\` foreign key (\`favourite_manager_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
 
 alter table \`author2\` add constraint \`author2_favourite_book_uuid_pk_foreign\` foreign key (\`favourite_book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update no action on delete cascade;
 alter table \`author2\` add constraint \`author2_favourite_author_id_foreign\` foreign key (\`favourite_author_id\`) references \`author2\` (\`id\`) on update cascade on delete set null;
-
-alter table \`address2\` add constraint \`address2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 
 alter table \`book2\` add constraint \`book2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`);
 alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key (\`publisher_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
@@ -367,6 +365,8 @@ alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_
 
 alter table \`author2_following\` add constraint \`author2_following_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 alter table \`author2_following\` add constraint \`author2_following_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`address2\` add constraint \`address2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 
 set foreign_key_checks = 1;
 "
@@ -627,10 +627,6 @@ set session_replication_role = 'origin';
 exports[`SchemaGenerator generate schema from metadata [postgres]: postgres-update-schema-dump 1`] = `
 "set names 'utf8';
 set session_replication_role = 'replica';
-
-alter table \\"book2\\" drop column \\"foo\\";
-
-alter table \\"test2\\" drop column \\"path\\";
 
 set session_replication_role = 'origin';
 "
@@ -903,11 +899,20 @@ set foreign_key_checks = 0;
 
 create table \`sandwich\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`price\` int(11) not null) default character set utf8mb4 engine = InnoDB;
 
-create table \`base_user2\` (\`id\` int unsigned not null auto_increment primary key, \`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`type\` enum('employee', 'manager', 'owner') not null, \`employee_prop\` int(11) null, \`manager_prop\` varchar(255) null, \`owner_prop\` varchar(255) null, \`favourite_employee_id\` int(11) unsigned null, \`favourite_manager_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
-alter table \`base_user2\` add index \`base_user2_type_index\`(\`type\`);
-alter table \`base_user2\` add index \`base_user2_favourite_employee_id_index\`(\`favourite_employee_id\`);
-alter table \`base_user2\` add index \`base_user2_favourite_manager_id_index\`(\`favourite_manager_id\`);
-alter table \`base_user2\` add unique \`base_user2_favourite_manager_id_unique\`(\`favourite_manager_id\`);
+create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` enum('local', 'global') not null, \`type2\` enum('LOCAL', 'GLOBAL') not null, \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null) default character set utf8mb4 engine = InnoDB;
+
+create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
+
+create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`array\` text null, \`object\` json null) default character set utf8mb4 engine = InnoDB;
+alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
+alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
+alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
+alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
+
+create table \`foo_param2\` (\`bar_id\` int(11) unsigned not null, \`baz_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);
+alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);
+alter table \`foo_param2\` add primary key \`foo_param2_pkey\`(\`bar_id\`, \`baz_id\`);
 
 create table \`car2\` (\`name\` varchar(100) not null, \`year\` int(11) unsigned not null, \`price\` int(11) not null) default character set utf8mb4 engine = InnoDB;
 alter table \`car2\` add index \`car2_name_index\`(\`name\`);
@@ -935,22 +940,13 @@ alter table \`user2_cars\` add primary key \`user2_cars_pkey\`(\`user2_first_nam
 alter table \`user2_cars\` add index \`user2_cars_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);
 alter table \`user2_cars\` add index \`user2_cars_car2_name_car2_year_index\`(\`car2_name\`, \`car2_year\`);
 
-create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
-
-create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`array\` text null, \`object\` json null) default character set utf8mb4 engine = InnoDB;
-alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
-alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
-alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
-alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
-
-create table \`foo_param2\` (\`bar_id\` int(11) unsigned not null, \`baz_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
-alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);
-alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);
-alter table \`foo_param2\` add primary key \`foo_param2_pkey\`(\`bar_id\`, \`baz_id\`);
-
-create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` enum('local', 'global') not null, \`type2\` enum('LOCAL', 'GLOBAL') not null, \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null) default character set utf8mb4 engine = InnoDB;
-
 create table \`book_tag2\` (\`id\` bigint unsigned not null auto_increment primary key, \`name\` varchar(50) not null) default character set utf8mb4 engine = InnoDB;
+
+create table \`base_user2\` (\`id\` int unsigned not null auto_increment primary key, \`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`type\` enum('employee', 'manager', 'owner') not null, \`owner_prop\` varchar(255) null, \`favourite_employee_id\` int(11) unsigned null, \`favourite_manager_id\` int(11) unsigned null, \`employee_prop\` int(11) null, \`manager_prop\` varchar(255) null) default character set utf8mb4 engine = InnoDB;
+alter table \`base_user2\` add index \`base_user2_type_index\`(\`type\`);
+alter table \`base_user2\` add index \`base_user2_favourite_employee_id_index\`(\`favourite_employee_id\`);
+alter table \`base_user2\` add index \`base_user2_favourite_manager_id_index\`(\`favourite_manager_id\`);
+alter table \`base_user2\` add unique \`base_user2_favourite_manager_id_unique\`(\`favourite_manager_id\`);
 
 create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table \`author2\` add index \`custom_email_index_name\`(\`email\`);
@@ -963,11 +959,6 @@ alter table \`author2\` add index \`author2_favourite_author_id_index\`(\`favour
 alter table \`author2\` add index \`custom_idx_name_123\`(\`name\`);
 alter table \`author2\` add index \`author2_name_age_index\`(\`name\`, \`age\`);
 alter table \`author2\` add unique \`author2_name_email_unique\`(\`name\`, \`email\`);
-
-create table \`address2\` (\`author_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
-alter table \`address2\` add primary key \`address2_pkey\`(\`author_id\`);
-alter table \`address2\` add index \`address2_author_id_index\`(\`author_id\`);
-alter table \`address2\` add unique \`address2_author_id_unique\`(\`author_id\`);
 
 create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`title\` varchar(255) null default '', \`perex\` text null, \`price\` float null, \`double\` double null, \`meta\` json null, \`author_id\` int(11) unsigned not null, \`publisher_id\` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table \`book2\` add primary key \`book2_pkey\`(\`uuid_pk\`);
@@ -1006,8 +997,16 @@ alter table \`author2_following\` add index \`author2_following_author2_1_id_ind
 alter table \`author2_following\` add index \`author2_following_author2_2_id_index\`(\`author2_2_id\`);
 alter table \`author2_following\` add primary key \`author2_following_pkey\`(\`author2_1_id\`, \`author2_2_id\`);
 
-alter table \`base_user2\` add constraint \`base_user2_favourite_employee_id_foreign\` foreign key (\`favourite_employee_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
-alter table \`base_user2\` add constraint \`base_user2_favourite_manager_id_foreign\` foreign key (\`favourite_manager_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
+create table \`address2\` (\`author_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+alter table \`address2\` add primary key \`address2_pkey\`(\`author_id\`);
+alter table \`address2\` add index \`address2_author_id_index\`(\`author_id\`);
+alter table \`address2\` add unique \`address2_author_id_unique\`(\`author_id\`);
+
+alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;
+alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;
+
+alter table \`foo_param2\` add constraint \`foo_param2_bar_id_foreign\` foreign key (\`bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade;
+alter table \`foo_param2\` add constraint \`foo_param2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade;
 
 alter table \`car_owner2\` add constraint \`car_owner2_car_name_car_year_foreign\` foreign key (\`car_name\`, \`car_year\`) references \`car2\` (\`name\`, \`year\`) on update cascade;
 
@@ -1019,16 +1018,11 @@ alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_sandwich_id_f
 alter table \`user2_cars\` add constraint \`user2_cars_user2_first_name_user2_last_name_foreign\` foreign key (\`user2_first_name\`, \`user2_last_name\`) references \`user2\` (\`first_name\`, \`last_name\`) on update cascade on delete cascade;
 alter table \`user2_cars\` add constraint \`user2_cars_car2_name_car2_year_foreign\` foreign key (\`car2_name\`, \`car2_year\`) references \`car2\` (\`name\`, \`year\`) on update cascade on delete cascade;
 
-alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;
-alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;
-
-alter table \`foo_param2\` add constraint \`foo_param2_bar_id_foreign\` foreign key (\`bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade;
-alter table \`foo_param2\` add constraint \`foo_param2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade;
+alter table \`base_user2\` add constraint \`base_user2_favourite_employee_id_foreign\` foreign key (\`favourite_employee_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
+alter table \`base_user2\` add constraint \`base_user2_favourite_manager_id_foreign\` foreign key (\`favourite_manager_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;
 
 alter table \`author2\` add constraint \`author2_favourite_book_uuid_pk_foreign\` foreign key (\`favourite_book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update no action on delete cascade;
 alter table \`author2\` add constraint \`author2_favourite_author_id_foreign\` foreign key (\`favourite_author_id\`) references \`author2\` (\`id\`) on update cascade on delete set null;
-
-alter table \`address2\` add constraint \`address2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 
 alter table \`book2\` add constraint \`book2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`);
 alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key (\`publisher_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
@@ -1051,6 +1045,8 @@ alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_
 
 alter table \`author2_following\` add constraint \`author2_following_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 alter table \`author2_following\` add constraint \`author2_following_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`address2\` add constraint \`address2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
 
 set foreign_key_checks = 1;
 "
@@ -1375,20 +1371,6 @@ exports[`SchemaGenerator update schema enums [postgres]: postgres-update-schema-
 alter table \\"book2\\" drop column \\"foo\\";
 
 alter table \\"test2\\" drop column \\"path\\";
-
-drop table if exists \\"base_user2\\" cascade;
-
-drop table if exists \\"car2\\" cascade;
-
-drop table if exists \\"car_owner2\\" cascade;
-
-drop table if exists \\"sandwich\\" cascade;
-
-drop table if exists \\"user2\\" cascade;
-
-drop table if exists \\"user2_cars\\" cascade;
-
-drop table if exists \\"user2_sandwiches\\" cascade;
 
 "
 `;

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -10,7 +10,7 @@ import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 import { Author, Book, BookTag, Publisher, Test } from './entities';
 import {
   Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, Test2, Label2, Configuration2, Address2, FooParam2,
-  Car2, CarOwner2, User2, BaseUser2, Employee2, Manager2, CompanyOwner2, Sandwich,
+  Car2, CarOwner2, User2, BaseUser2,
 } from './entities-sql';
 import { BaseEntity2 } from './entities-sql/BaseEntity2';
 import { BaseEntity22 } from './entities-sql/BaseEntity22';
@@ -34,7 +34,7 @@ export const TEMP_DIR = process.cwd() + '/temp';
 
 export async function initORMMongo() {
   const orm = await MikroORM.init<MongoDriver>({
-    entitiesDirs: ['entities'],
+    entities: ['entities'],
     tsNode: false,
     clientUrl: 'mongodb://localhost:27017,localhost:27018,localhost:27019/mikro-orm-test?replicaSet=rs0',
     baseDir: BASE_DIR,
@@ -55,10 +55,8 @@ export async function initORMMongo() {
 
 export async function initORMMySql<D extends MySqlDriver | MariaDbDriver = MySqlDriver>(type: 'mysql' | 'mariadb' = 'mysql') {
   let orm = await MikroORM.init<AbstractSqlDriver>({
-    entities: [
-      Author2, Address2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, FooParam2, Configuration2, BaseEntity2, BaseEntity22,
-      Car2, CarOwner2, User2, BaseUser2, Employee2, Manager2, CompanyOwner2, Sandwich,
-    ],
+    entities: ['entities-sql/**/*.js', '!**/Label2.js'],
+    entitiesTs: ['entities-sql/**/*.ts', '!**/Label2.ts'],
     clientUrl: `mysql://root@127.0.0.1:3306/mikro_orm_test`,
     port: type === 'mysql' ? 3307 : 3309,
     baseDir: BASE_DIR,

--- a/tests/cli/CLIHelper.test.ts
+++ b/tests/cli/CLIHelper.test.ts
@@ -1,7 +1,7 @@
 (global as any).process.env.FORCE_COLOR = 0;
 
-jest.mock('../../tests/mikro-orm.config.js', () => ({ type: 'mongo', dbName: 'foo_bar', entitiesDirs: ['.'] }), { virtual: true });
-jest.mock('../../tests/mikro-orm.config.ts', () => ({ type: 'mongo', dbName: 'foo_bar', entitiesDirs: ['.'] }), { virtual: true });
+jest.mock('../../tests/mikro-orm.config.js', () => ({ type: 'mongo', dbName: 'foo_bar', entities: ['.'] }), { virtual: true });
+jest.mock('../../tests/mikro-orm.config.ts', () => ({ type: 'mongo', dbName: 'foo_bar', entities: ['.'] }), { virtual: true });
 const pkg = { 'mikro-orm': {} } as any;
 jest.mock('../../tests/package.json', () => pkg, { virtual: true });
 const tsc = { compilerOptions: {} } as any;
@@ -93,7 +93,7 @@ describe('CLIHelper', () => {
     const conf = await CLIHelper.getConfiguration();
     expect(conf).toBeInstanceOf(Configuration);
     expect(conf.get('dbName')).toBe('foo_bar');
-    expect(conf.get('entitiesDirs')).toEqual(['.']);
+    expect(conf.get('entities')).toEqual(['.']);
     pathExistsMock.mockRestore();
   });
 
@@ -104,7 +104,7 @@ describe('CLIHelper', () => {
     const conf = await CLIHelper.getConfiguration();
     expect(conf).toBeInstanceOf(Configuration);
     expect(conf.get('dbName')).toBe('foo_bar');
-    expect(conf.get('entitiesDirs')).toEqual(['.']);
+    expect(conf.get('entities')).toEqual(['.']);
     pathExistsMock.mockRestore();
   });
 

--- a/tests/cli/DebugCommand.test.ts
+++ b/tests/cli/DebugCommand.test.ts
@@ -26,7 +26,7 @@ describe('DebugCommand', () => {
     getSettings.mockResolvedValue({});
     getConfiguration.mockResolvedValue(new Configuration({ type: 'mongo' } as any, false));
     getConfigPaths.mockResolvedValue(['./path/orm-config.ts']);
-    await expect(cmd.handler({} as any)).resolves.toBeUndefined();
+    await expect(cmd.handler()).resolves.toBeUndefined();
     expect(dumpDependencies).toBeCalledTimes(1);
     expect(dump.mock.calls).toEqual([
       ['Current MikroORM CLI configuration'],
@@ -37,9 +37,9 @@ describe('DebugCommand', () => {
 
     getSettings.mockResolvedValue({ useTsNode: true });
     globbyMock.mockImplementation(async (path: string) => path.endsWith('entities-1') || path.endsWith('orm-config.ts'));
-    getConfiguration.mockResolvedValue(new Configuration({ type: 'mongo', entitiesDirs: ['./entities-1', './entities-2'] } as any, false));
+    getConfiguration.mockResolvedValue(new Configuration({ type: 'mongo', entities: ['./entities-1', './entities-2'] } as any, false));
     dump.mock.calls.length = 0;
-    await expect(cmd.handler({} as any)).resolves.toBeUndefined();
+    await expect(cmd.handler()).resolves.toBeUndefined();
     expect(dumpDependencies).toBeCalledTimes(2);
     expect(dump.mock.calls).toEqual([
       ['Current MikroORM CLI configuration'],
@@ -47,14 +47,14 @@ describe('DebugCommand', () => {
       [' - searched config paths:'],
       [`   - ${Utils.normalizePath(process.cwd() + '/path/orm-config.ts') } (found)`],
       [' - configuration found'],
-      [' - will use `entitiesDirs` paths:'],
+      [' - will use `entities` array (contains 0 references and 2 paths)'],
       [`   - ${Utils.normalizePath(process.cwd() + '/entities-1') } (found)`],
       [`   - ${Utils.normalizePath(process.cwd() + '/entities-2') } (not found)`],
     ]);
 
     getConfiguration.mockResolvedValue(new Configuration({ type: 'mongo', entities: [FooBar, FooBaz] } as any, false));
     dump.mock.calls.length = 0;
-    await expect(cmd.handler({} as any)).resolves.toBeUndefined();
+    await expect(cmd.handler()).resolves.toBeUndefined();
     expect(dumpDependencies).toBeCalledTimes(3);
     expect(dump.mock.calls).toEqual([
       ['Current MikroORM CLI configuration'],
@@ -62,12 +62,12 @@ describe('DebugCommand', () => {
       [' - searched config paths:'],
       [`   - ${Utils.normalizePath(process.cwd() + '/path/orm-config.ts') } (found)`],
       [' - configuration found'],
-      [' - will use `entities` array (contains 2 items)'],
+      [' - will use `entities` array (contains 2 references and 0 paths)'],
     ]);
 
     getConfiguration.mockRejectedValueOnce(new Error('test error message'));
     dump.mock.calls.length = 0;
-    await expect(cmd.handler({} as any)).resolves.toBeUndefined();
+    await expect(cmd.handler()).resolves.toBeUndefined();
     expect(dumpDependencies).toBeCalledTimes(4);
     expect(dump.mock.calls).toEqual([
       ['Current MikroORM CLI configuration'],
@@ -79,7 +79,7 @@ describe('DebugCommand', () => {
 
     globbyMock.mockResolvedValue(false);
     dump.mock.calls.length = 0;
-    await expect(cmd.handler({} as any)).resolves.toBeUndefined();
+    await expect(cmd.handler()).resolves.toBeUndefined();
     expect(dumpDependencies).toBeCalledTimes(5);
     expect(dump.mock.calls).toEqual([
       ['Current MikroORM CLI configuration'],
@@ -87,7 +87,7 @@ describe('DebugCommand', () => {
       [' - searched config paths:'],
       [`   - ${Utils.normalizePath(process.cwd() + '/path/orm-config.ts') } (not found)`],
       [' - configuration found'],
-      [' - will use `entities` array (contains 2 items)'],
+      [' - will use `entities` array (contains 2 references and 0 paths)'],
     ]);
     globbyMock.mockRestore();
   });

--- a/tests/reflection/TsMorphMetadataProvider.test.ts
+++ b/tests/reflection/TsMorphMetadataProvider.test.ts
@@ -28,7 +28,7 @@ describe('TsMorphMetadataProvider', () => {
 
   test('should load entities based on .d.ts files', async () => {
     const orm = await MikroORM.init({
-      entitiesDirs: ['./entities-compiled'],
+      entities: ['./entities-compiled'],
       tsNode: false,
       baseDir: __dirname,
       clientUrl: 'mongodb://localhost:27017,localhost:27018,localhost:27019/mikro-orm-test?replicaSet=rs0',
@@ -44,7 +44,7 @@ describe('TsMorphMetadataProvider', () => {
 
   test('should load entities', async () => {
     const orm = await MikroORM.init<MongoDriver>({
-      entitiesDirs: ['entities'],
+      entities: ['entities'],
       baseDir: __dirname,
       clientUrl: 'mongodb://localhost:27017,localhost:27018,localhost:27019/mikro-orm-test?replicaSet=rs0',
       type: 'mongo',
@@ -75,6 +75,12 @@ describe('TsMorphMetadataProvider', () => {
     expect(initProperties).toBeCalledTimes(0);
     await provider.loadEntityMetadata({} as any, 'name');
     expect(initProperties).toBeCalledTimes(0);
+  });
+
+  test('should throw when source file not found', async () => {
+    const provider = new TsMorphMetadataProvider({} as any);
+    const error = 'Source file for entity \'./path/to/entity.js\' not found, check your \'entitiesTs\' option. If you are using webpack, see https://bit.ly/35pPDNn';
+    await expect(provider.getExistingSourceFile('./path/to/entity.js')).rejects.toThrowError(error);
   });
 
 });

--- a/tests/single-table-inheritance.mysql.test.ts
+++ b/tests/single-table-inheritance.mysql.test.ts
@@ -33,6 +33,7 @@ describe('single table inheritance in mysql', () => {
   }
 
   test('check metadata', async () => {
+    expect(orm.getMetadata().get('CompanyOwner2').collection).toBe('base_user2');
     expect(orm.getMetadata().get('BaseUser2').hooks).toEqual({
       afterCreate: ['afterCreate1'],
       afterUpdate: ['afterUpdate1'],
@@ -131,6 +132,7 @@ describe('single table inheritance in mysql', () => {
     class B {}
     class C {}
     orm.config.set('entities', [A, B, C]);
+    orm.config.set('entitiesTs', [A, B, C]);
     const discovery = new MetadataDiscovery(storage, orm.em.getDriver().getPlatform(), orm.config);
     const discovered = await discovery.discover();
     expect(discovered.get('A').discriminatorMap).toEqual({ a: 'A', b: 'B', c: 'C' });


### PR DESCRIPTION
`entitiesDirs` and `entitiesDirsTs` were removed in favour of `entities` and `entitiesTs`,
`entities` will be used as a default for `entitiesTs` (that is used when we detect `ts-node`).

`entities` can now contain mixture of paths to directories, globs pointing to entities,
or references to the entities or instances of `EntitySchema`. Negative globs are also
supported.

This basically means that all you need to change is renaming `entitiesDirs` to `entities`.

```typescript
MikroORM.init({
  entities: ['dist/**/entities', 'dist/**/*.entity.js', FooBar, FooBaz],
  entitiesTs: ['src/**/entities', 'src/**/*.entity.ts', FooBar, FooBaz],
});
```

**BREAKING CHANGE:**
`entitiesDirs` and `entitiesDirsTs` are removed in favour of `entities` and `entitiesTs`.

Closes #605