### PR TITLE
Feature: Add $fulltext operator

### DIFF
--- a/docs/docs/entity-manager.md
+++ b/docs/docs/entity-manager.md
@@ -150,7 +150,7 @@ const user1 = await orm.em.findOne(User, 1);
 ```
 
 As you can see in the fifth example, one can also use operators like `$and`, `$or`, `$gte`, 
-`$gt`, `$lte`, `$lt`, `$in`, `$nin`, `$eq`, `$ne`, `$like`, `$re`. More about that can be found in 
+`$gt`, `$lte`, `$lt`, `$in`, `$nin`, `$eq`, `$ne`, `$like`, `$fulltext`, `$re`. More about that can be found in 
 [Query Conditions](query-conditions.md) section. 
 
 #### Mitigating `Type instantiation is excessively deep and possibly infinite.ts(2589)` error

--- a/docs/docs/query-conditions.md
+++ b/docs/docs/query-conditions.md
@@ -80,18 +80,20 @@ const res = await orm.em.find(Author, [1, 2, 7]);
 
 ### Comparison
 
-| operator | name               | description |
-|----------|--------------------|-------------|
-| `$eq`	   | equals             | Matches values that are equal to a specified value. |
-| `$gt`	   | greater            | Matches values that are greater than a specified value. |
-| `$gte`   | greater or equal   | Matches values that are greater than or equal to a specified value. |
-| `$in`	   | contains           | Matches any of the values specified in an array. |
-| `$lt`	   | lower              | Matches values that are less than a specified value. |
-| `$lte`   | lower or equal     | Matches values that are less than or equal to a specified value. |
-| `$ne`	   | not equal          | Matches all values that are not equal to a specified value. |
-| `$nin`   | not contains       | Matches none of the values specified in an array. |
-| `$like`  | like               | Uses LIKE operator |
-| `$re`    | regexp             | Uses REGEXP operator |
+| operator    | name             | description                                                         |
+|-------------|------------------|---------------------------------------------------------------------|
+| `$eq`       | equals           | Matches values that are equal to a specified value.                 |
+| `$gt`       | greater          | Matches values that are greater than a specified value.             |
+| `$gte`      | greater or equal | Matches values that are greater than or equal to a specified value. |
+| `$in`       | contains         | Matches any of the values specified in an array.                    |
+| `$lt`       | lower            | Matches values that are less than a specified value.                |
+| `$lte`      | lower or equal   | Matches values that are less than or equal to a specified value.    |
+| `$ne`       | not equal        | Matches all values that are not equal to a specified value.         |
+| `$nin`      | not contains     | Matches none of the values specified in an array.                   |
+| `$like`     | like             | Uses LIKE operator.                                                 |
+| `$fulltext` | full text        | A driver specific full text search function.                        |
+| `$re`       | regexp           | Uses REGEXP operator.                                               |
+
 
 ### Logical
 

--- a/lib/platforms/MongoPlatform.ts
+++ b/lib/platforms/MongoPlatform.ts
@@ -36,4 +36,8 @@ export class MongoPlatform extends Platform {
     return false;
   }
 
+  getFullTextWhereClause(): string {
+    throw new Error('Full text search is not yet supported on Mongo');
+  }
+
 }

--- a/lib/platforms/MySqlPlatform.ts
+++ b/lib/platforms/MySqlPlatform.ts
@@ -10,7 +10,7 @@ export class MySqlPlatform extends Platform {
   }
 
   getFullTextWhereClause(): string {
-    return `match(?) against ('?' in natural language mode)`;
+    return `match(:column:) against (:query)`;
   }
 
 }

--- a/lib/platforms/MySqlPlatform.ts
+++ b/lib/platforms/MySqlPlatform.ts
@@ -9,4 +9,8 @@ export class MySqlPlatform extends Platform {
     return 'utf8mb4';
   }
 
+  getFullTextWhereClause(): string {
+    return `match(?) against ('?' in natural language mode)`;
+  }
+
 }

--- a/lib/platforms/Platform.ts
+++ b/lib/platforms/Platform.ts
@@ -1,6 +1,7 @@
 import { NamingStrategy, UnderscoreNamingStrategy } from '../naming-strategy';
 import { EntityProperty, IPrimaryKey, Primary } from '../typings';
 import { SchemaHelper } from '../schema';
+import Knex from 'knex';
 
 export abstract class Platform {
 
@@ -83,8 +84,10 @@ export abstract class Platform {
   }
 
   getFullTextWhereClause(): string {
-    return `? match '?'`;
+    return `:column: match :query`;
   }
+
+  addFullTextIndex(table: Knex.CreateTableBuilder, index: { name?: string | boolean; properties: string | string[]; type?: string }) {}
 
   isBigIntProperty(prop: EntityProperty): boolean {
     return prop.columnTypes && prop.columnTypes[0] === 'bigint';

--- a/lib/platforms/Platform.ts
+++ b/lib/platforms/Platform.ts
@@ -82,6 +82,10 @@ export abstract class Platform {
     return 'regexp';
   }
 
+  getFullTextWhereClause(): string {
+    return `? match '?'`;
+  }
+
   isBigIntProperty(prop: EntityProperty): boolean {
     return prop.columnTypes && prop.columnTypes[0] === 'bigint';
   }

--- a/lib/platforms/PostgreSqlPlatform.ts
+++ b/lib/platforms/PostgreSqlPlatform.ts
@@ -26,6 +26,10 @@ export class PostgreSqlPlatform extends Platform {
     return '~';
   }
 
+  getFullTextWhereClause(): string {
+    return `? @@ '?'`;
+  }
+
   isBigIntProperty(prop: EntityProperty): boolean {
     return super.isBigIntProperty(prop) || (prop.columnTypes && prop.columnTypes[0] === 'bigserial');
   }

--- a/lib/platforms/PostgreSqlPlatform.ts
+++ b/lib/platforms/PostgreSqlPlatform.ts
@@ -27,7 +27,7 @@ export class PostgreSqlPlatform extends Platform {
   }
 
   getFullTextWhereClause(): string {
-    return `? @@ '?'`;
+    return `:column: @@ :query`;
   }
 
   isBigIntProperty(prop: EntityProperty): boolean {

--- a/lib/platforms/SqlitePlatform.ts
+++ b/lib/platforms/SqlitePlatform.ts
@@ -17,4 +17,8 @@ export class SqlitePlatform extends Platform {
     return super.getCurrentTimestampSQL(0);
   }
 
+  getFullTextWhereClause(): string {
+    return `? match '?'`;
+  }
+
 }

--- a/lib/platforms/SqlitePlatform.ts
+++ b/lib/platforms/SqlitePlatform.ts
@@ -18,7 +18,7 @@ export class SqlitePlatform extends Platform {
   }
 
   getFullTextWhereClause(): string {
-    return `? match '?'`;
+    return `:table: match :column:::query`;
   }
 
 }

--- a/lib/query/QueryBuilderHelper.ts
+++ b/lib/query/QueryBuilderHelper.ts
@@ -324,7 +324,11 @@ export class QueryBuilderHelper {
     // Full text queries aren't usually a simple operator, they can look like
     // SELECT column::tsvector @@ 'something'::tsquery;
     if (op === '$fulltext') {
-      qb[m](this.knex.raw(this.platform.getFullTextWhereClause(), [key, value[op]]));
+      qb[m](this.knex.raw(this.platform.getFullTextWhereClause(), {
+        table: this.metadata.get(this.entityName).tableName,
+        column: key,
+        query: value[op]
+      }));
     } else {
       qb[m](this.mapper(key, type), replacement, value[op]);
     }

--- a/lib/query/QueryBuilderHelper.ts
+++ b/lib/query/QueryBuilderHelper.ts
@@ -28,6 +28,7 @@ export class QueryBuilderHelper {
     $ne: '!=',
     $not: 'not',
     $like: 'like',
+    $fulltext: 'fulltext',
     $re: 'regexp',
   };
 
@@ -320,7 +321,13 @@ export class QueryBuilderHelper {
       value[op] = this.knex.raw(`(${fields.map(() => '?').join(', ')})`, value[op]);
     }
 
-    qb[m](this.mapper(key, type), replacement, value[op]);
+    // Full text queries aren't usually a simple operator, they can look like
+    // SELECT column::tsvector @@ 'something'::tsquery;
+    if (op === '$fulltext') {
+      qb[m](this.knex.raw(this.platform.getFullTextWhereClause(), [key, value[op]]));
+    } else {
+      qb[m](this.mapper(key, type), replacement, value[op]);
+    }
   }
 
   private getOperatorReplacement(op: string, value: Dictionary): string {

--- a/lib/schema/SchemaGenerator.ts
+++ b/lib/schema/SchemaGenerator.ts
@@ -191,6 +191,9 @@ export class SchemaGenerator {
 
         if (unique) {
           table.unique(properties, name);
+        } else if (index.type === 'fulltext') {
+          // Full text indexes are platform specific.
+          this.platform.addFullTextIndex(table, index);
         } else {
           table.index(properties, name, index.type);
         }

--- a/lib/typings.ts
+++ b/lib/typings.ts
@@ -50,6 +50,7 @@ export type OperatorMap<T> = {
   $lt?: Query<T>;
   $lte?: Query<T>;
   $like?: string;
+  $fulltext?: string;
   $re?: string;
 };
 export type StringProp<T> = T extends string ? string | RegExp : never;

--- a/tests/EntityManager.mariadb.test.ts
+++ b/tests/EntityManager.mariadb.test.ts
@@ -111,6 +111,10 @@ describe('EntityManagerMariaDb', () => {
     const authors = await authorRepository.findAll(['books', 'favouriteBook']);
     expect(await authorRepository.findOne({ email: 'not existing' })).toBeNull();
 
+    // full text search test
+    const fullTextBooks = (await booksRepository.find({ title: { $fulltext: 'on the Wa' }}))!;
+    expect(fullTextBooks.length).toBe(3);
+
     // count test
     const count = await authorRepository.count();
     expect(count).toBe(authors.length);

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -69,6 +69,10 @@ describe('EntityManagerMongo', () => {
     const authors = await authorRepository.findAll(['books', 'favouriteBook']);
     expect(await authorRepository.findOne({ email: 'not existing' })).toBeNull();
 
+    // full text search test
+    const fullTextBooks = (await booksRepository.find({ title: { $fulltext: 'on the Wa' }}))!;
+    expect(fullTextBooks.length).toBe(3);
+    
     // count test
     const count = await authorRepository.count();
     expect(count).toBe(authors.length);

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -379,6 +379,10 @@ describe('EntityManagerMySql', () => {
     expect(await authorRepository.findOne({ email: 'not existing' })).toBeNull();
     await expect(orm.em.populate([], ['books', 'favouriteBook'])).resolves.toEqual([]);
 
+    // full text search test
+    const fullTextBooks = (await booksRepository.find({ title: { $fulltext: 'on the Wa' }}))!;
+    expect(fullTextBooks.length).toBe(3);
+    
     // count test
     const count = await authorRepository.count();
     expect(count).toBe(authors.length);

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -248,6 +248,10 @@ describe('EntityManagerPostgre', () => {
     const jon = (await authorRepository.findOne({ name: 'Jon Snow' }, ['books', 'favouriteBook']))!;
     const authors = await authorRepository.findAll(['books', 'favouriteBook']);
     await expect(authorRepository.findOne({ email: 'not existing' })).resolves.toBeNull();
+ 
+    // full text search test
+    const fullTextBooks = (await booksRepository.find({ title: { $fulltext: 'on the Wa' }}))!;
+    expect(fullTextBooks.length).toBe(3);
 
     // count test
     const count = await authorRepository.count();

--- a/tests/EntityManager.sqlite.test.ts
+++ b/tests/EntityManager.sqlite.test.ts
@@ -217,6 +217,10 @@ describe('EntityManagerSqlite', () => {
     const authors = await authorRepository.findAll(['books', 'favouriteBook']);
     expect(await authorRepository.findOne({ email: 'not existing' })).toBeNull();
 
+    // full text search test
+    const fullTextBooks = (await booksRepository.find({ title: { $fulltext: 'on the Wa' }}))!;
+    expect(fullTextBooks.length).toBe(3);
+    
     // count test
     const count = await authorRepository.count();
     expect(count).toBe(authors.length);

--- a/tests/EntityManager.sqlite2.test.ts
+++ b/tests/EntityManager.sqlite2.test.ts
@@ -176,6 +176,10 @@ describe('EntityManagerSqlite2', () => {
     const authors = await authorRepository.findAll(['books', 'favouriteBook']);
     expect(await authorRepository.findOne({ email: 'not existing' })).toBeNull();
 
+    // full text search test
+    const fullTextBooks = (await booksRepository.find({ title: { $fulltext: 'on the Wa' }}))!;
+    expect(fullTextBooks.length).toBe(3);
+
     // count test
     const count = await authorRepository.count();
     expect(count).toBe(authors.length);

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -1213,7 +1213,7 @@ describe('QueryBuilder', () => {
   test('select via fulltext search', async () => {
     const qb1 = orm.em.createQueryBuilder(Author2, 'a');
     qb1.select('*').where({ name: { $fulltext: 'test' }  });
-    expect(qb1.getQuery()).toEqual('select `a`.* from `author2` as `a` where match(?) against (\'?\' in natural language mode)');
+    expect(qb1.getQuery()).toEqual('select `a`.* from `author2` as `a` where match(?) against (? in natural language mode)');
   });
 
   test('select via multiple where clauses with fulltext search', async () => {
@@ -1223,7 +1223,7 @@ describe('QueryBuilder', () => {
       name: { $fulltext: 'test' },
       email: { $fulltext: 'test'}
     });
-    expect(qb1.getQuery()).toEqual('select `a`.* from `author2` as `a` where `a`.`terms_accepted` = ? and match(?) against (\'?\' in natural language mode) and match(?) against (\'?\' in natural language mode)');
+    expect(qb1.getQuery()).toEqual('select `a`.* from `author2` as `a` where `a`.`terms_accepted` = ? and match(?) against (? in natural language mode) and match(?) against (? in natural language mode)');
   });
 
   afterAll(async () => orm.close(true));

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -1210,6 +1210,21 @@ describe('QueryBuilder', () => {
     expect(() => em.createQueryBuilder(Author2, 'a')).toThrowError('Not supported by given driver');
   });
 
-  afterAll(async () => orm.close(true));
+  test('select via fulltext search', async () => {
+    const qb1 = orm.em.createQueryBuilder(Author2, 'a');
+    qb1.select('*').where({ name: { $fulltext: 'test' }  });
+    expect(qb1.getQuery()).toEqual('select `a`.* from `author2` as `a` where match(?) against (\'?\' in natural language mode)');
+  });
 
+  test('select via multiple where clauses with fulltext search', async () => {
+    const qb1 = orm.em.createQueryBuilder(Author2, 'a');
+    qb1.select('*').where({
+      termsAccepted: true,
+      name: { $fulltext: 'test' },
+      email: { $fulltext: 'test'}
+    });
+    expect(qb1.getQuery()).toEqual('select `a`.* from `author2` as `a` where `a`.`terms_accepted` = ? and match(?) against (\'?\' in natural language mode) and match(?) against (\'?\' in natural language mode)');
+  });
+
+  afterAll(async () => orm.close(true));
 });

--- a/tests/__snapshots__/SchemaGenerator.test.ts.snap
+++ b/tests/__snapshots__/SchemaGenerator.test.ts.snap
@@ -987,6 +987,14 @@ set foreign_key_checks = 1;
 "
 `;
 
+exports[`SchemaGenerator update empty schema from metadata [mysql]: postgres-update-schema-drop-table 1`] = `
+"drop table if exists \\"author2\\" cascade;
+
+drop table if exists \\"new_table\\" cascade;
+
+"
+`;
+
 exports[`SchemaGenerator update empty schema from metadata [postgres]: postgres-update-empty-schema-dump 1`] = `
 "set names 'utf8';
 set session_replication_role = 'replica';

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -1,5 +1,5 @@
 import { v4 } from 'uuid';
-import { Cascade, Collection, Entity, IdentifiedReference, ManyToMany, ManyToOne, OneToOne, PrimaryKey, Property, QueryOrder } from '../../lib';
+import { Cascade, Collection, Entity, IdentifiedReference, ManyToMany, ManyToOne, OneToOne, PrimaryKey, Property, QueryOrder, Index } from '../../lib';
 import { Publisher2 } from './Publisher2';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
@@ -14,6 +14,7 @@ export class Book2 {
   @Property({ default: 'current_timestamp(3)', length: 3 })
   createdAt: Date = new Date();
 
+  @Index({ type: 'fulltext'})
   @Property({ nullable: true, default: '' })
   title?: string;
 


### PR DESCRIPTION
Add a $fulltext operator that can be used in queries on SQL databases. The syntax used varies per database and is not supported on MongoDB.

Closes: #620