### PR TITLE
feat(core): execute hooks via `EventManager`

### DIFF
--- a/docs/docs/lifecycle-hooks.md
+++ b/docs/docs/lifecycle-hooks.md
@@ -9,6 +9,10 @@ There are two ways to hook to the lifecycle of an entity:
 - **EventSubscriber**s are classes that can be used to hook to multiple entities
   or when you do not want to have the method present on the entity prototype.
 
+> Hooks are internally executed the same way as subscribers.
+
+> Hooks are executed before subscribers.
+
 ## Hooks
 
 You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of
@@ -100,5 +104,19 @@ export class EverythingSubscriber implements EventSubscriber {
   async beforeUpdate<T>(args: EventArgs<T>): Promise<void> { ... }
   onInit<T>(args: EventArgs<T>): void { ... }
 
+}
+```
+
+## EventArgs
+
+As a parameter to the hook method we get `EventArgs` instance. It will always contain
+reference to the current `EntityManager` and the particular entity. Events fired
+from `UnitOfWork` during flush operation also contain the `ChangeSet` object.
+
+```typescript
+interface EventArgs<T> {
+  entity: T;
+  em: EntityManager;
+  changeSet?: ChangeSet<T>;
 }
 ```

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -150,7 +150,7 @@ export class EntityFactory {
       hooks.forEach(hook => (entity[hook] as unknown as () => void)());
     }
 
-    this.em.getEventManager().dispatchEvent(EventType.onInit, entity, this.em);
+    this.em.getEventManager().dispatchEvent(EventType.onInit, entity, { em: this.em });
   }
 
 }

--- a/packages/core/src/events/EventManager.ts
+++ b/packages/core/src/events/EventManager.ts
@@ -1,8 +1,8 @@
 import { AnyEntity } from '../typings';
-import { EntityManager } from '../EntityManager';
-import { EventSubscriber } from './EventSubscriber';
+import { EventArgs, EventSubscriber } from './EventSubscriber';
 import { Utils } from '../utils';
 import { EventType } from './EventType';
+import { wrap } from '../entity/wrap';
 
 export class EventManager {
 
@@ -23,24 +23,28 @@ export class EventManager {
       });
   }
 
-  dispatchEvent(event: EventType.onInit, entity: AnyEntity, em: EntityManager): unknown;
-  dispatchEvent(event: EventType, entity: AnyEntity, em: EntityManager): Promise<unknown>;
-  dispatchEvent(event: EventType, entity: AnyEntity, em: EntityManager): Promise<unknown> | unknown {
-    const listeners: EventSubscriber[] = [];
+  dispatchEvent<T extends AnyEntity<T>>(event: EventType.onInit, entity: T, args: Partial<EventArgs<T>>): unknown;
+  dispatchEvent<T extends AnyEntity<T>>(event: EventType, entity: T, args: Partial<EventArgs<T>>): Promise<unknown>;
+  dispatchEvent<T extends AnyEntity<T>>(event: EventType, entity: T, args: Partial<EventArgs<T>>): Promise<unknown> | unknown {
+    const listeners: [EventType, EventSubscriber<T>][] = [];
+
+    // execute lifecycle hooks first
+    const hooks = wrap(entity, true).__meta.hooks[event] || [];
+    listeners.push(...hooks.map(hook => [hook, entity] as [EventType, EventSubscriber<T>]));
 
     for (const listener of this.listeners[event] || []) {
       const entities = this.entities.get(listener)!;
 
       if (entities.length === 0 || entities.includes(entity.constructor.name)) {
-        listeners.push(listener);
+        listeners.push([event, listener]);
       }
     }
 
     if (event === EventType.onInit) {
-      return listeners.forEach(listener => listener[event]!({ em, entity }));
+      return listeners.forEach(listener => listener[1][listener[0]]!({ ...args, entity } as EventArgs<T>));
     }
 
-    return Utils.runSerial(listeners, listener => listener[event]!({ em, entity }));
+    return Utils.runSerial(listeners, listener => listener[1][listener[0]]!({ ...args, entity } as EventArgs<T>) as Promise<void>);
   }
 
   private getSubscribedEntities(listener: EventSubscriber): string[] {

--- a/packages/core/src/events/EventSubscriber.ts
+++ b/packages/core/src/events/EventSubscriber.ts
@@ -1,9 +1,11 @@
 import { AnyEntity, EntityName } from '../typings';
 import { EntityManager } from '../EntityManager';
+import { ChangeSet } from '../unit-of-work';
 
 export interface EventArgs<T> {
   entity: T;
   em: EntityManager;
+  changeSet?: ChangeSet<T>;
 }
 
 export interface EventSubscriber<T = AnyEntity> {

--- a/packages/core/src/unit-of-work/ChangeSet.ts
+++ b/packages/core/src/unit-of-work/ChangeSet.ts
@@ -7,6 +7,7 @@ export interface ChangeSet<T extends AnyEntity<T>> {
   entity: T;
   payload: EntityData<T>;
   persisted: boolean;
+  originalEntity?: EntityData<T>;
 }
 
 export enum ChangeSetType {

--- a/packages/core/src/unit-of-work/ChangeSetComputer.ts
+++ b/packages/core/src/unit-of-work/ChangeSetComputer.ts
@@ -24,6 +24,10 @@ export class ChangeSetComputer {
     changeSet.collection = meta.collection;
     changeSet.payload = this.computePayload(entity);
 
+    if (changeSet.type === ChangeSetType.UPDATE) {
+      changeSet.originalEntity = this.originalEntityData[wrap(entity, true).__uuid];
+    }
+
     this.validator.validate<T>(changeSet.entity, changeSet.payload, meta);
 
     for (const prop of Object.values(meta.properties)) {

--- a/tests/entities-sql/Author2.ts
+++ b/tests/entities-sql/Author2.ts
@@ -1,6 +1,6 @@
 import {
   AfterCreate, AfterDelete, AfterUpdate, BeforeCreate, BeforeDelete, BeforeUpdate, Collection, Entity, OneToMany, Property, ManyToOne,
-  QueryOrder, OnInit, ManyToMany, DateType, TimeType, Index, Unique, OneToOne, Cascade, LoadStrategy,
+  QueryOrder, OnInit, ManyToMany, DateType, TimeType, Index, Unique, OneToOne, Cascade, LoadStrategy, EventArgs,
 } from '@mikro-orm/core';
 
 import { Book2 } from './Book2';
@@ -84,6 +84,8 @@ export class Author2 extends BaseEntity2 {
   @Property({ persist: false })
   booksTotal!: number;
 
+  hookParams: any[] = [];
+
   constructor(name: string, email: string) {
     super();
     this.name = name;
@@ -93,26 +95,32 @@ export class Author2 extends BaseEntity2 {
   @OnInit()
   onInit() {
     this.code = `${this.email} - ${this.name}`;
+    this.hookParams = [];
   }
 
   @BeforeCreate()
-  beforeCreate() {
+  beforeCreate(args: EventArgs<this>) {
     this.version = 1;
+    this.hookParams.push(args);
   }
 
   @AfterCreate()
-  afterCreate() {
+  afterCreate(args: EventArgs<this>) {
     this.versionAsString = 'v' + this.version;
+    this.hookParams.push(args);
   }
 
   @BeforeUpdate()
-  beforeUpdate() {
+  beforeUpdate(args: EventArgs<this>) {
     this.version += 1;
+    console.log(this);
+    this.hookParams.push(args);
   }
 
   @AfterUpdate()
-  afterUpdate() {
+  afterUpdate(args: EventArgs<this>) {
     this.versionAsString = 'v' + this.version;
+    this.hookParams.push(args);
   }
 
   @BeforeDelete()


### PR DESCRIPTION
Lifecycle hooks are now executed the same way as `EntitySubscriber`s, this means that they
will also get the `EventArgs` in the parameters.

`EventArgs` now also optionally contain the `ChangeSet` object, so it is possible to get
the information about what fields actually changed or access the original entity data.

Closes #622