### PR TITLE
feat(core): add support for flush events

### DIFF
--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -150,7 +150,7 @@ export class EntityFactory {
       hooks.forEach(hook => (entity[hook] as unknown as () => void)());
     }
 
-    this.em.getEventManager().dispatchEvent(EventType.onInit, entity, { em: this.em });
+    this.em.getEventManager().dispatchEvent(EventType.onInit, { entity, em: this.em });
   }
 
 }

--- a/packages/core/src/events/EventSubscriber.ts
+++ b/packages/core/src/events/EventSubscriber.ts
@@ -1,11 +1,15 @@
 import { AnyEntity, EntityName } from '../typings';
 import { EntityManager } from '../EntityManager';
-import { ChangeSet } from '../unit-of-work';
+import { ChangeSet, UnitOfWork } from '../unit-of-work';
 
 export interface EventArgs<T> {
   entity: T;
   em: EntityManager;
   changeSet?: ChangeSet<T>;
+}
+
+export interface FlushEventArgs extends Omit<EventArgs<unknown>, 'entity'> {
+  uow: UnitOfWork;
 }
 
 export interface EventSubscriber<T = AnyEntity> {
@@ -17,4 +21,7 @@ export interface EventSubscriber<T = AnyEntity> {
   afterUpdate?(args: EventArgs<T>): Promise<void>;
   beforeDelete?(args: EventArgs<T>): Promise<void>;
   afterDelete?(args: EventArgs<T>): Promise<void>;
+  beforeFlush?(args: FlushEventArgs): Promise<void>;
+  onFlush?(args: FlushEventArgs): Promise<void>;
+  afterFlush?(args: FlushEventArgs): Promise<void>;
 }

--- a/packages/core/src/events/EventType.ts
+++ b/packages/core/src/events/EventType.ts
@@ -6,4 +6,7 @@ export enum EventType {
   afterUpdate = 'afterUpdate',
   beforeDelete = 'beforeDelete',
   afterDelete = 'afterDelete',
+  beforeFlush = 'beforeFlush',
+  onFlush = 'onFlush',
+  afterFlush = 'afterFlush',
 }

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -26,6 +26,7 @@ import { schema as FooBaz4 } from './entities-schema/FooBaz4';
 import { schema as BaseEntity5 } from './entities-schema/BaseEntity5';
 import { Author2Subscriber } from './subscribers/Author2Subscriber';
 import { EverythingSubscriber } from './subscribers/EverythingSubscriber';
+import { FlushSubscriber } from './subscribers/FlushSubscriber';
 
 const { BaseEntity4, Author3, Book3, BookTag3, Publisher3, Test3 } = require('./entities-js/index');
 
@@ -86,6 +87,7 @@ export async function initORMMySql<D extends MySqlDriver | MariaDbDriver = MySql
   orm = await MikroORM.init(orm.config);
   Author2Subscriber.log.length = 0;
   EverythingSubscriber.log.length = 0;
+  FlushSubscriber.log.length = 0;
 
   return orm as MikroORM<D>;
 }
@@ -110,6 +112,7 @@ export async function initORMPostgreSql() {
   await connection.loadFile(__dirname + '/postgre-schema.sql');
   Author2Subscriber.log.length = 0;
   EverythingSubscriber.log.length = 0;
+  FlushSubscriber.log.length = 0;
 
   return orm;
 }
@@ -188,6 +191,7 @@ export async function wipeDatabaseMySql(em: SqlEntityManager) {
   em.clear();
   Author2Subscriber.log.length = 0;
   EverythingSubscriber.log.length = 0;
+  FlushSubscriber.log.length = 0;
 }
 
 export async function wipeDatabasePostgreSql(em: SqlEntityManager) {
@@ -207,6 +211,7 @@ export async function wipeDatabasePostgreSql(em: SqlEntityManager) {
   em.clear();
   Author2Subscriber.log.length = 0;
   EverythingSubscriber.log.length = 0;
+  FlushSubscriber.log.length = 0;
 }
 
 export async function wipeDatabaseSqlite(em: SqlEntityManager) {

--- a/tests/entities-sql/Author2.ts
+++ b/tests/entities-sql/Author2.ts
@@ -113,7 +113,6 @@ export class Author2 extends BaseEntity2 {
   @BeforeUpdate()
   beforeUpdate(args: EventArgs<this>) {
     this.version += 1;
-    console.log(this);
     this.hookParams.push(args);
   }
 

--- a/tests/subscribers/FlushSubscriber.ts
+++ b/tests/subscribers/FlushSubscriber.ts
@@ -1,0 +1,20 @@
+import { EventSubscriber, FlushEventArgs, Subscriber } from '@mikro-orm/core';
+
+@Subscriber()
+export class FlushSubscriber implements EventSubscriber {
+
+  static readonly log: [string, FlushEventArgs][] = [];
+
+  async beforeFlush(args: FlushEventArgs): Promise<void> {
+    FlushSubscriber.log.push(['beforeFlush', args]);
+  }
+
+  async onFlush(args: FlushEventArgs): Promise<void> {
+    FlushSubscriber.log.push(['onFlush', args]);
+  }
+
+  async afterFlush(args: FlushEventArgs): Promise<void> {
+    FlushSubscriber.log.push(['afterFlush', args]);
+  }
+
+}


### PR DESCRIPTION
There is a special kind of events executed during the commit phase (flush operation).
They are executed before, during and after the flush, and they are not bound to any
entity in particular.

- `beforeFlush` is executed before change sets are computed, this is the only
  event where it is safe to persist new entities.
- `onFlush` is executed after the change sets are computed.
- `afterFlush` is executed as the last step just before the `flush` call resolves.
  it will be executed even if there are no changes to be flushed.

Flush event args will not contain any entity instance, as they are entity agnostic.
They do contain additional reference to the `UnitOfWork` instance.

Closes #637