### PR TITLE
refactor(core): remove flush parameter from persist and remove

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -149,24 +149,6 @@ MikroORM.init({
 
 Read more about this in [Installation](installation.md) and [Read Connections](read-connections.md) sections.
 
-## Auto-flush
-
-Since MikroORM v3, default value for `autoFlush` is `false`. That means you need to call 
-`em.flush()` yourself to persist changes into database. You can still change this via ORM's 
-options to ease the transition but generally it is not recommended as it can cause unwanted 
-small transactions being created around each `persist`. 
-
-```typescript
-MikroORM.init({
-  autoFlush: true,
-});
-
-await orm.em.persist(new Entity()); // flushed
-orm.em.persist(new Entity(), false); // you can still use second parameter to disable auto-flushing
-```
-
-Read more about this in [Entity Manager](entity-manager.md#auto-flushing) docs.
-
 ## Naming Strategy
 
 When mapping your entities to database tables and columns, their names will be defined by naming 

--- a/docs/docs/entity-manager.md
+++ b/docs/docs/entity-manager.md
@@ -8,10 +8,9 @@ sidebar_label: Entity Manager
 There are 2 methods we should first describe to understand how persisting works in MikroORM: 
 `em.persist()` and `em.flush()`.
 
-`em.persist(entity, flush?: boolean)` is used to mark new entities for future persisting. 
+`em.persist(entity)` is used to mark new entities for future persisting. 
 It will make the entity managed by given `EntityManager` and once `flush` will be called, it 
-will be written to the database. Second boolean parameter can be used to invoke `flush` 
-immediately. Its default value is configurable via `autoFlush` option.
+will be written to the database. 
 
 To understand `flush`, lets first define what managed entity is: An entity is managed if 
 it’s fetched from the database (via `em.find()`, `em.findOne()` or via other managed entity) 
@@ -58,19 +57,6 @@ orm.em.persistLater(book1);
 orm.em.persistLater(book2);
 orm.em.persistLater(book3); 
 await orm.em.flush(); // flush everything to database at once
-```
-
-### Auto-flushing
-
-Since MikroORM v3, default value for `autoFlush` is `false`. That means you need to call 
-`em.flush()` yourself to persist changes into database. You can still change this via ORM's
-options to ease the transition but generally it is not recommended as it can cause unwanted
-small transactions being created around each `persist`. 
-
-```typescript
-orm.em.persist(new Entity()); // no auto-flushing by default
-await orm.em.flush();
-await orm.em.persist(new Entity(), true); // you can still use second parameter to auto-flush
 ```
 
 ## Fetching Entities with EntityManager
@@ -353,18 +339,17 @@ Gets count of entities matching the `where` condition.
 
 ---
 
-#### `persist(entity: AnyEntity | AnyEntity[], flush?: boolean): void | Promise<void>`
+#### `persist(entity: AnyEntity | AnyEntity[]): EntityManager`
 
 Tells the EntityManager to make an instance managed and persistent. The entity will be 
 entered into the database at or before transaction commit or as a result of the flush 
-operation. You can control immediate flushing via `flush` parameter and via `autoFlush`
-configuration option. 
+operation.
 
 ---
 
 #### `persistAndFlush(entity: AnyEntity | AnyEntity[]): Promise<void>`
 
-Shortcut for `persist` & `flush`.
+Shortcut for `persist` & `flush`. Same as `em.persist(entity).flush()`.
 
 ---
 
@@ -380,20 +365,10 @@ Flushes all changes to objects that have been queued up to now to the database.
 
 ---
 
-#### `remove(entityName: string | EntityClass<T>, where: AnyEntity | FilterQuery<T> | IPrimaryKey, flush?: boolean): Promise<number>`
-
-When provided entity instance as `where` value, then it calls `removeEntity(entity, flush)`, 
-otherwise it fires delete query with given `where` condition. 
-
-This method fires `beforeDelete` and `afterDelete` hooks only if you provide entity instance.  
-
----
-
-#### `removeEntity(entity: AnyEntity, flush?: boolean): Promise<number>`
+#### `remove(entity: AnyEntity): EntityManager`
 
 Removes an entity instance. A removed entity will be removed from the database at or before 
-transaction commit or as a result of the flush operation. You can control immediate flushing 
-via `flush` parameter and via `autoFlush` configuration option.
+transaction commit or as a result of the flush operation. 
 
 This method fires `beforeDelete` and `afterDelete` hooks.  
 
@@ -401,13 +376,13 @@ This method fires `beforeDelete` and `afterDelete` hooks.
 
 #### `removeAndFlush(entity: AnyEntity): Promise<void>`
 
-Shortcut for `removeEntity` & `flush`.
+Shortcut for `remove` & `flush`. Same as `em.remove(entity).flush()`.
 
 ---
 
 #### `removeLater(entity: AnyEntity): void`
 
-Shortcut for `removeEntity` without flushing. 
+Shortcut for `remove` without flushing. 
 
 ---
 

--- a/docs/docs/repositories.md
+++ b/docs/docs/repositories.md
@@ -143,12 +143,11 @@ Gets count of entities matching the `where` condition.
 
 ---
 
-#### `persist(entity: AnyEntity | AnyEntity[], flush?: boolean): Promise<void>`
+#### `persist(entity: AnyEntity | AnyEntity[]): Promise<void>`
 
 Tells the EntityManager to make an instance managed and persistent. The entity will be 
 entered into the database at or before transaction commit or as a result of the flush 
-operation. You can control immediate flushing via `flush` parameter and via `autoFlush`
-configuration option. 
+operation. 
 
 ---
 
@@ -160,7 +159,7 @@ Shortcut for `persist` & `flush`.
 
 #### `persistLater(entity: AnyEntity | AnyEntity[]): void`
 
-Shortcut for just `persist`, without flushing. 
+Shortcut for just `persist`, without flushing. Deprecated, use `em.persist()`.
 
 ---
 
@@ -170,7 +169,7 @@ Flushes all changes to objects that have been queued up to now to the database.
 
 ---
 
-#### `remove(where: AnyEntity | FilterQuery<T>, flush?: boolean): Promise<number>`
+#### `remove(where: AnyEntity | Reference<AnyEntity> | (AnyEntity | Reference<AnyEntity>)[]): Promise<void>`
 
 When provided entity instance as `where` value, then it calls `removeEntity(entity, flush)`, 
 otherwise it fires delete query with given `where` condition. 
@@ -181,7 +180,7 @@ This method fires `beforeDelete` and `afterDelete` hooks only if you provide ent
 
 #### `removeAndFlush(entity: AnyEntity): Promise<void>`
 
-Shortcut for `removeEntity` & `flush`.
+Shortcut for `remove` & `flush`.
 
 This method fires `beforeDelete` and `afterDelete` hooks. 
 
@@ -189,7 +188,7 @@ This method fires `beforeDelete` and `afterDelete` hooks.
 
 #### `removeLater(entity: AnyEntity): void`
 
-Shortcut for `removeEntity` without flushing. 
+Shortcut for `remove` without flushing. Deprecated, use `em.remove()`.
 
 This method fires `beforeDelete` and `afterDelete` hooks. 
 

--- a/docs/docs/unit-of-work.md
+++ b/docs/docs/unit-of-work.md
@@ -100,29 +100,5 @@ await em.persistAndFlush(user);
 You can find more information about transactions in [Transactions and concurrency](transactions.md) 
 page.
 
-### Beware: Auto-flushing and Transactions
-
-> Since MikroORM v3, default value for `autoFlush` is `false`. That means you need to call 
-> `em.flush()` yourself to persist changes into database. You can still change this via ORM's
-> options to ease the transition but generally it is not recommended. 
-
-Originally there was only `em.persist(entity, flush = true)` method, that was
-automatically flushing changes to database, if not given second `false` parameter. This 
-behaviour can be now changed via `autoFlush` option when initializing the ORM:
-
-```typescript
-const orm = await MikroORM.init({
-  autoFlush: false, // defaults to false in v3, was true in v2
-  // ...
-});
-orm.em.persist(new Entity()); // no auto-flushing now
-await orm.em.flush();
-await orm.em.persist(new Entity(), true); // you can still use second parameter to auto-flush
-```
-
-When using driver that supports transactions (all SQL drivers), you should either keep auto-flushing 
-disabled, or use `persistLater()` method instead, as otherwise each `persist()` call will immediately 
-create new transaction to run the query.
-
 > This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/unitofwork.html)
 > as the behaviour here is pretty much the same.

--- a/docs/docs/upgrading-v3-to-v4.md
+++ b/docs/docs/upgrading-v3-to-v4.md
@@ -72,6 +72,41 @@ Instead of interface merging with `WrappedEntity`, one can now use classic inher
 by extending `BaseEntity` exported from `@mikro-orm/core`. If you do so, `wrap(entity)` 
 will return your entity. 
 
+## Removed `flush` parameter from `persist()` and `remove()` methods
+
+`persist()` and `remove()` are now sync methods that only mark the entity for 
+persistence or removal. They now return the `EntityManager` to allow fluid flushing:
+
+```typescript
+// before
+await em.persist(jon, true);
+await em.remove(Author, jon, true);
+
+// after
+await em.persist(jon).flush();
+await em.remove(jon).flush();
+```
+
+## `remove()` method requires entity instances
+
+The `em.remove()` method originally allowed to pass either entity instance, or 
+a condition. When one passed a condition, it was firing a native delete query, 
+without handling transactions or hooks. 
+
+In v4, the method is now simplified and works only with entity instances. Use 
+`em.nativeDelete()` explicitly if you want to fire a delete query instead of 
+letting the `UnitOfWork` doing its job.
+
+```typescript
+// before
+await em.remove(Author, 1); // fires query directly
+
+// after 
+await em.nativeDelete(Author, 1);
+```
+
+> `em.removeEntity()` has been removed in favour of `em.remove()` (that now has almost the same signature).
+
 ## Custom types are now type safe
 
 Generic `Type` class has now two type arguments - the input and output types. 

--- a/docs/docs/usage-with-nestjs.md
+++ b/docs/docs/usage-with-nestjs.md
@@ -36,7 +36,6 @@ create the request context for you automatically.
       entitiesDirsTs: ['src/entities'],
       dbName: 'my-db-name.sqlite3',
       type: 'sqlite',
-      autoFlush: false, // read more here: https://mikro-orm.io/unit-of-work/
     }),
     // ... your feature modules
   ],

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -8,10 +8,8 @@ export class EntityRepository<T> {
   constructor(protected readonly em: EntityManager,
               protected readonly entityName: EntityName<T>) { }
 
-  persist(entity: AnyEntity | AnyEntity[], flush?: false): void;
-  persist(entity: AnyEntity | AnyEntity[], flush: true): Promise<void>;
-  persist(entity: AnyEntity | AnyEntity[], flush = false): void | Promise<void> {
-    return this.em.persist(entity, flush as true);
+  persist(entity: AnyEntity | AnyEntity[]): EntityManager {
+    return this.em.persist(entity);
   }
 
   async persistAndFlush(entity: AnyEntity | AnyEntity[]): Promise<void> {
@@ -55,10 +53,8 @@ export class EntityRepository<T> {
     return this.em.find<T>(this.entityName, {}, populate as string[], orderBy, limit, offset);
   }
 
-  remove(where: T | FilterQuery<T>, flush?: false): void;
-  remove(where: T | FilterQuery<T>, flush: true): Promise<number>;
-  remove(where: T | FilterQuery<T>, flush = false): void | Promise<number> {
-    return this.em.remove(this.entityName, where, flush as true);
+  remove(entity: AnyEntity): EntityManager {
+    return this.em.remove(entity);
   }
 
   async removeAndFlush(entity: AnyEntity): Promise<void> {

--- a/packages/core/src/entity/EntityValidator.ts
+++ b/packages/core/src/entity/EntityValidator.ts
@@ -81,12 +81,6 @@ export class EntityValidator {
     }
   }
 
-  validateRemoveEmptyWhere<T extends AnyEntity<T>>(className: string, where: FilterQuery<T>): void {
-    if (!Utils.isDefined(where, true)) {
-      throw new Error(`You cannot call 'EntityManager.remove()' with empty 'where' parameter. If you want to remove all entities, use 'em.remove(${className}, {})'.`);
-    }
-  }
-
   private validateCollection<T extends AnyEntity<T>>(entity: T, prop: EntityProperty): void {
     if (wrap(entity).isInitialized() && !entity[prop.name as keyof T]) {
       throw ValidationError.fromCollectionNotInitialized(entity, prop);

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -204,8 +204,8 @@ export class Utils {
   /**
    * Normalize the argument to always be an array.
    */
-  static asArray<T>(data?: T | T[]): T[] {
-    if (typeof data === 'undefined') {
+  static asArray<T>(data?: T | T[], strict = false): T[] {
+    if (typeof data === 'undefined' && !strict) {
       return [];
     }
 

--- a/tests/EntityManager.mariadb.test.ts
+++ b/tests/EntityManager.mariadb.test.ts
@@ -198,7 +198,7 @@ describe('EntityManagerMariaDb', () => {
     expect(lastBook[0].title).toBe('My Life on The Wall, part 1');
     expect(lastBook[0].author).toBeInstanceOf(Author2);
     expect(wrap(lastBook[0].author).isInitialized()).toBe(true);
-    await orm.em.getRepository(Book2).remove(lastBook[0].uuid);
+    await orm.em.getRepository(Book2).remove(lastBook[0]).flush();
   });
 
   afterAll(async () => orm.close(true));

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -457,7 +457,7 @@ describe('EntityManagerMySql', () => {
     expect(lastBook[0].title).toBe('My Life on The Wall, part 1');
     expect(lastBook[0].author).toBeInstanceOf(Author2);
     expect(wrap(lastBook[0].author).isInitialized()).toBe(true);
-    await orm.em.getRepository(Book2).remove(lastBook[0].uuid);
+    await orm.em.getRepository(Book2).remove(lastBook[0]).flush();
   });
 
   test('json properties', async () => {
@@ -1220,9 +1220,9 @@ describe('EntityManagerMySql', () => {
     bible2.title = '123';
     await orm.em.flush();
 
-    orm.em.removeEntity(bible);
-    orm.em.removeEntity(bible2);
-    orm.em.removeEntity(god);
+    orm.em.remove(bible);
+    orm.em.remove(bible2);
+    orm.em.remove(god);
     await orm.em.flush();
 
     expect(Author2Subscriber.log.map(l => [l[0], l[1].entity.constructor.name])).toEqual([
@@ -1984,7 +1984,7 @@ describe('EntityManagerMySql', () => {
     orm.em.clear();
 
     const a = await orm.em.findOneOrFail(FooBar2, bar.id, ['baz']);
-    orm.em.removeEntity(a.baz!);
+    orm.em.remove(a.baz!);
 
     const mock = jest.fn();
     const logger = new Logger(mock, true);
@@ -1996,8 +1996,10 @@ describe('EntityManagerMySql', () => {
   });
 
   test('em.remove() with null or undefined in where parameter throws', async () => {
-    expect(() => orm.em.remove(Book2, undefined as any)).toThrowError(`You cannot call 'EntityManager.remove()' with empty 'where' parameter. If you want to remove all entities, use 'em.remove(Book2, {})'.`);
-    expect(() => orm.em.remove(Book2, null)).toThrowError(`You cannot call 'EntityManager.remove()' with empty 'where' parameter. If you want to remove all entities, use 'em.remove(Book2, {})'.`);
+    expect(() => orm.em.remove(undefined as any)).toThrowError(`You need to pass entity instance or reference to 'em.remove()'. To remove entities by condition, use 'em.nativeDelete()'.`);
+    expect(() => orm.em.remove(null as any)).toThrowError(`You need to pass entity instance or reference to 'em.remove()'. To remove entities by condition, use 'em.nativeDelete()'.`);
+    expect(() => orm.em.remove({} as any)).toThrowError(`You need to pass entity instance or reference to 'em.remove()'. To remove entities by condition, use 'em.nativeDelete()'.`);
+    expect(() => orm.em.remove({ foo: 1 } as any)).toThrowError(`You need to pass entity instance or reference to 'em.remove()'. To remove entities by condition, use 'em.nativeDelete()'.`);
   });
 
   test('adding items to not initialized collection', async () => {
@@ -2048,11 +2050,6 @@ describe('EntityManagerMySql', () => {
     tag.books.add(book);
     await orm.em.flush();
     orm.em.clear();
-  });
-
-  test('em.remove() with null or undefined in where parameter throws', async () => {
-    expect(() => orm.em.remove(Book2, undefined as any)).toThrowError(`You cannot call 'EntityManager.remove()' with empty 'where' parameter. If you want to remove all entities, use 'em.remove(Book2, {})'.`);
-    expect(() => orm.em.remove(Book2, null)).toThrowError(`You cannot call 'EntityManager.remove()' with empty 'where' parameter. If you want to remove all entities, use 'em.remove(Book2, {})'.`);
   });
 
   test('adding items to not initialized collection', async () => {

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -318,7 +318,7 @@ describe('EntityManagerPostgre', () => {
     expect(lastBook[0].title).toBe('My Life on The Wall, part 1');
     expect(lastBook[0].author).toBeInstanceOf(Author2);
     expect(wrap(lastBook[0].author).isInitialized()).toBe(true);
-    await orm.em.getRepository(Book2).remove(lastBook[0].uuid);
+    await orm.em.getRepository(Book2).remove(lastBook[0]).flush();
   });
 
   test('json properties', async () => {
@@ -1219,7 +1219,7 @@ describe('EntityManagerPostgre', () => {
     expect(address.author).toBe(a2);
     expect(address.author.address).toBe(address);
 
-    await orm.em.removeEntity(a2, true);
+    await orm.em.remove(a2).flush();
     const a3 = await orm.em.findOne(Author2, author.id);
     expect(a3).toBeNull();
     const address2 = await orm.em.findOne(Address2, author.id as any);

--- a/tests/EntityManager.sqlite.test.ts
+++ b/tests/EntityManager.sqlite.test.ts
@@ -177,7 +177,7 @@ describe('EntityManagerSqlite', () => {
 
     const god = new Author3('God', 'hello@heaven.god');
     const bible = new Book3('Bible', god);
-    await orm.em.persist(bible, true);
+    await orm.em.persist(bible).flush();
 
     const author = new Author3('Jon Snow', 'snow@wall.st');
     author.born = new Date('1990-03-23');
@@ -284,13 +284,13 @@ describe('EntityManagerSqlite', () => {
     expect(lastBook[0].title).toBe('My Life on The Wall, part 1');
     expect(lastBook[0].author).toBeInstanceOf(Author3);
     expect(lastBook[0].author.isInitialized()).toBe(true);
-    await orm.em.getRepository(Book3).remove(lastBook[0].id);
+    await orm.em.getRepository(Book3).remove(lastBook[0]).flush();
   });
 
   test('findOne should initialize entity that is already in IM', async () => {
     const god = new Author3('God', 'hello@heaven.god');
     const bible = new Book3('Bible', god);
-    await orm.em.persist(bible, true);
+    await orm.em.persist(bible).flush();
     orm.em.clear();
 
     const ref = orm.em.getReference<any>(Author3, god.id);
@@ -304,7 +304,7 @@ describe('EntityManagerSqlite', () => {
     const author1 = new Author3('Author 1', 'a1@example.com');
     const author2 = new Author3('Author 2', 'a2@example.com');
     const author3 = new Author3('Author 3', 'a3@example.com');
-    await orm.em.persist([author1, author2, author3], true);
+    await orm.em.persist([author1, author2, author3]).flush();
     orm.em.clear();
 
     const authors = await orm.em.find<any>(Author3, { email: /exa.*le\.c.m$/ });
@@ -464,7 +464,7 @@ describe('EntityManagerSqlite', () => {
     const bible = new Book3('Bible', god);
     const bible2 = new Book3('Bible pt. 2', god);
     const bible3 = new Book3('Bible pt. 3', new Author3('Lol', 'lol@lol.lol'));
-    await orm.em.persist([bible, bible2, bible3], true);
+    await orm.em.persist([bible, bible2, bible3]).flush();
     orm.em.clear();
 
     const newGod = (await orm.em.findOne<any>(Author3, god.id))!;
@@ -480,7 +480,7 @@ describe('EntityManagerSqlite', () => {
 
   test('stable results of serialization (collection)', async () => {
     const pub = new Publisher3('Publisher3');
-    await orm.em.persist(pub, true);
+    await orm.em.persist(pub).flush();
     const god = new Author3('God', 'hello@heaven.god');
     const bible = new Book3('Bible', god);
     bible.publisher = pub;
@@ -488,7 +488,7 @@ describe('EntityManagerSqlite', () => {
     bible2.publisher = pub;
     const bible3 = new Book3('Bible pt. 3', new Author3('Lol', 'lol@lol.lol'));
     bible3.publisher = pub;
-    await orm.em.persist([bible, bible2, bible3], true);
+    await orm.em.persist([bible, bible2, bible3]).flush();
     orm.em.clear();
 
     const newGod = orm.em.getReference<any>(Author3, god.id);
@@ -524,12 +524,12 @@ describe('EntityManagerSqlite', () => {
     const authorRepository = orm.em.getRepository(Author3);
     const god = new Author3('God', 'hello@heaven.god');
     const bible = new Book3('Bible', god);
-    await orm.em.persist(bible, true);
+    await orm.em.persist(bible).flush();
 
     let jon = new Author3('Jon Snow', 'snow@wall.st');
     jon.born = new Date('1990-03-23');
     jon.favouriteBook = bible;
-    await orm.em.persist(jon, true);
+    await orm.em.persist(jon).flush();
     orm.em.clear();
 
     jon = (await authorRepository.findOne(jon.id))!;
@@ -560,7 +560,7 @@ describe('EntityManagerSqlite', () => {
 
     await orm.em.persist(book1);
     await orm.em.persist(book2);
-    await orm.em.persist(book3, true);
+    await orm.em.persist(book3).flush();
 
     expect(tag1.id).toBeDefined();
     expect(tag2.id).toBeDefined();
@@ -622,14 +622,14 @@ describe('EntityManagerSqlite', () => {
     // remove
     expect(book.tags.count()).toBe(2);
     book.tags.remove(tag1);
-    await orm.em.persist(book, true);
+    await orm.em.persist(book).flush();
     orm.em.clear();
     book = (await orm.em.findOne(Book3, book.id, ['tags']))!;
     expect(book.tags.count()).toBe(1);
 
     // add
     book.tags.add(tagRepository.getReference(tag1.id)); // we need to get reference as tag1 is detached from current EM
-    await orm.em.persist(book, true);
+    await orm.em.persist(book).flush();
     orm.em.clear();
     book = (await orm.em.findOne(Book3, book.id, ['tags']))!;
     expect(book.tags.count()).toBe(2);
@@ -643,7 +643,7 @@ describe('EntityManagerSqlite', () => {
 
     // removeAll
     book.tags.removeAll();
-    await orm.em.persist(book, true);
+    await orm.em.persist(book).flush();
     orm.em.clear();
     book = (await orm.em.findOne(Book3, book.id, ['tags']))!;
     expect(book.tags.count()).toBe(0);
@@ -657,7 +657,7 @@ describe('EntityManagerSqlite', () => {
     expect(p1.tests.count()).toBe(0);
     const p2 = new Publisher3('bar');
     p2.tests.add(new Test3(), new Test3());
-    await orm.em.persist([p1, p2], true);
+    await orm.em.persist([p1, p2]).flush();
     const repo = orm.em.getRepository<any>(Publisher3);
 
     orm.em.clear();
@@ -686,7 +686,7 @@ describe('EntityManagerSqlite', () => {
     book1.tags.add(tag1, tag3);
     book2.tags.add(tag1, tag2, tag5);
     book3.tags.add(tag2, tag4, tag5);
-    await orm.em.persist([book1, book2, book3], true);
+    await orm.em.persist([book1, book2, book3]).flush();
     const repo = orm.em.getRepository<any>(BookTag3);
 
     orm.em.clear();
@@ -722,13 +722,13 @@ describe('EntityManagerSqlite', () => {
 
     expect(Author3.beforeDestroyCalled).toBe(0);
     expect(Author3.afterDestroyCalled).toBe(0);
-    await repo.remove(author, true);
+    await repo.remove(author).flush();
     expect(Author3.beforeDestroyCalled).toBe(1);
     expect(Author3.afterDestroyCalled).toBe(1);
 
     const author2 = new Author3('Johny Cash', 'johny@cash.com');
     await repo.persistAndFlush(author2);
-    await repo.remove(author2, true);
+    await repo.remove(author2).flush();
     expect(Author3.beforeDestroyCalled).toBe(2);
     expect(Author3.afterDestroyCalled).toBe(2);
   });
@@ -749,7 +749,7 @@ describe('EntityManagerSqlite', () => {
     const t1 = Test3.create('t1');
     const t2 = Test3.create('t2');
     const t3 = Test3.create('t3');
-    await orm.em.persist([t1, t2, t3], true);
+    await orm.em.persist([t1, t2, t3]).flush();
     publisher.tests.add(t2, t1, t3);
     await repo.persistAndFlush(publisher);
     orm.em.clear();
@@ -811,7 +811,7 @@ describe('EntityManagerSqlite', () => {
     const author2 = new Author3('Name 2', 'e-mail2');
     author2.favouriteBook = book;
     author2.version = 123;
-    await orm.em.persist([author1, author2, book], true);
+    await orm.em.persist([author1, author2, book]).flush();
     const diff = Utils.diffEntities(author1, author2, orm.getMetadata(), orm.em.getDriver().getPlatform());
     expect(diff).toMatchObject({ name: 'Name 2', favouriteBook: book.id });
     expect(typeof diff.favouriteBook).toBe('number');
@@ -822,7 +822,7 @@ describe('EntityManagerSqlite', () => {
     const b1 = new Book3('b1', author);
     const b2 = new Book3('b2', author);
     const b3 = new Book3('b3', author);
-    await orm.em.persist([b1, b2, b3], true);
+    await orm.em.persist([b1, b2, b3]).flush();
     orm.em.clear();
 
     const a1 = (await orm.em.findOne<any>(Author3, { 'id:ne': 10 }))!;

--- a/tests/EntityManager.sqlite2.test.ts
+++ b/tests/EntityManager.sqlite2.test.ts
@@ -239,13 +239,13 @@ describe('EntityManagerSqlite2', () => {
     expect(lastBook[0].title).toBe('My Life on The Wall, part 1');
     expect(lastBook[0].author.constructor.name).toBe('Author4');
     expect(wrap(lastBook[0].author).isInitialized()).toBe(true);
-    await orm.em.getRepository<Book4>('Book4').remove(lastBook[0].id);
+    await orm.em.getRepository<Book4>('Book4').remove(lastBook[0]).flush();
   });
 
   test('findOne should initialize entity that is already in IM', async () => {
     const god = orm.em.create<Author4>('Author4', { name: 'God', email: 'hello@heaven.god' });
     const bible = orm.em.create<Book4>('Book4', { title: 'Bible', author: god });
-    await orm.em.persist(bible, true);
+    await orm.em.persist(bible).flush();
     orm.em.clear();
 
     const ref = orm.em.getReference<Author4>('Author4', god.id);
@@ -259,7 +259,7 @@ describe('EntityManagerSqlite2', () => {
     const author1 = orm.em.create<Author4>('Author4', { name: 'Author 1', email: 'a1@example.com' });
     const author2 = orm.em.create<Author4>('Author4', { name: 'Author 2', email: 'a2@example.com' });
     const author4 = orm.em.create<Author4>('Author4', { name: 'Author 3', email: 'a3@example.com' });
-    await orm.em.persist([author1, author2, author4], true);
+    await orm.em.persist([author1, author2, author4]).flush();
     orm.em.clear();
 
     const authors = await orm.em.find<Author4>('Author4', { email: /exa.*le\.c.m$/ });
@@ -419,7 +419,7 @@ describe('EntityManagerSqlite2', () => {
     const bible = orm.em.create<Book4>('Book4', { title: 'Bible', author: god });
     const bible2 = orm.em.create<Book4>('Book4', { title: 'Bible pt. 2', author: god });
     const bible3 = orm.em.create<Book4>('Book4', { title: 'Bible pt. 3', author: orm.em.create<Author4>('Author4', { name: 'Lol', email: 'lol@lol.lol' }) });
-    await orm.em.persist([bible, bible2, bible3], true);
+    await orm.em.persist([bible, bible2, bible3]).flush();
     orm.em.clear();
 
     const newGod = (await orm.em.findOne<Author4>('Author4', god.id))!;
@@ -435,7 +435,7 @@ describe('EntityManagerSqlite2', () => {
 
   test('stable results of serialization (collection)', async () => {
     const pub = orm.em.create<Publisher4>('Publisher4', { name: 'Publisher4' });
-    await orm.em.persist(pub, true);
+    await orm.em.persist(pub).flush();
     const god = orm.em.create<Author4>('Author4', { name: 'God', email: 'hello@heaven.god' });
     const bible = orm.em.create<Book4>('Book4', { title: 'Bible', author: god });
     bible.publisher = pub;
@@ -443,7 +443,7 @@ describe('EntityManagerSqlite2', () => {
     bible2.publisher = pub;
     const bible3 = orm.em.create<Book4>('Book4', { title: 'Bible pt. 3', author: orm.em.create<Author4>('Author4', { name: 'Lol', email: 'lol@lol.lol' }) });
     bible3.publisher = pub;
-    await orm.em.persist([bible, bible2, bible3], true);
+    await orm.em.persist([bible, bible2, bible3]).flush();
     orm.em.clear();
 
     const newGod = orm.em.getReference<Author4>('Author4', god.id);
@@ -479,12 +479,12 @@ describe('EntityManagerSqlite2', () => {
     const authorRepository = orm.em.getRepository<Author4>('Author4');
     const god = orm.em.create<Author4>('Author4', { name: 'God', email: 'hello@heaven.god' });
     const bible = orm.em.create<Book4>('Book4', { title: 'Bible', god });
-    await orm.em.persist(bible, true);
+    await orm.em.persist(bible).flush();
 
     let jon = orm.em.create<Author4>('Author4', { name: 'Jon Snow', email: 'snow@wall.st' });
     jon.born = new Date('1990-03-23');
     jon.favouriteBook = bible;
-    await orm.em.persist(jon, true);
+    await orm.em.persist(jon).flush();
     orm.em.clear();
 
     jon = (await authorRepository.findOne(jon.id))!;
@@ -515,7 +515,7 @@ describe('EntityManagerSqlite2', () => {
 
     await orm.em.persist(book1);
     await orm.em.persist(book2);
-    await orm.em.persist(book3, true);
+    await orm.em.persist(book3).flush();
 
     expect(tag1.id).toBeDefined();
     expect(tag2.id).toBeDefined();
@@ -577,14 +577,14 @@ describe('EntityManagerSqlite2', () => {
     // remove
     expect(book.tags.count()).toBe(2);
     book.tags.remove(tag1);
-    await orm.em.persist(book, true);
+    await orm.em.persist(book).flush();
     orm.em.clear();
     book = (await orm.em.findOne<Book4>('Book4', book.id, ['tags']))!;
     expect(book.tags.count()).toBe(1);
 
     // add
     book.tags.add(tagRepository.getReference(tag1.id)); // we need to get reference as tag1 is detached from current EM
-    await orm.em.persist(book, true);
+    await orm.em.persist(book).flush();
     orm.em.clear();
     book = (await orm.em.findOne<Book4>('Book4', book.id, ['tags']))!;
     expect(book.tags.count()).toBe(2);
@@ -598,7 +598,7 @@ describe('EntityManagerSqlite2', () => {
 
     // removeAll
     book.tags.removeAll();
-    await orm.em.persist(book, true);
+    await orm.em.persist(book).flush();
     orm.em.clear();
     book = (await orm.em.findOne<Book4>('Book4', book.id, ['tags']))!;
     expect(book.tags.count()).toBe(0);
@@ -612,7 +612,7 @@ describe('EntityManagerSqlite2', () => {
     expect(p1.tests.count()).toBe(0);
     const p2 = orm.em.create<Publisher4>('Publisher4', { name: 'bar' });
     p2.tests.add(orm.em.create<Test4>('Test4', {}), orm.em.create<Test4>('Test4', {}));
-    await orm.em.persist([p1, p2], true);
+    await orm.em.persist([p1, p2]).flush();
     const repo = orm.em.getRepository<Publisher4>('Publisher4');
 
     orm.em.clear();
@@ -641,7 +641,7 @@ describe('EntityManagerSqlite2', () => {
     book1.tags.add(tag1, tag3);
     book2.tags.add(tag1, tag2, tag5);
     book3.tags.add(tag2, tag4, tag5);
-    await orm.em.persist([book1, book2, book3], true);
+    await orm.em.persist([book1, book2, book3]).flush();
     const repo = orm.em.getRepository<BookTag4>('BookTag4');
 
     orm.em.clear();
@@ -672,7 +672,7 @@ describe('EntityManagerSqlite2', () => {
     const t1 = orm.em.create<Test4>('Test4', { name: 't1' });
     const t2 = orm.em.create<Test4>('Test4', { name: 't2' });
     const t3 = orm.em.create<Test4>('Test4', { name: 't3' });
-    await orm.em.persist([t1, t2, t3], true);
+    await orm.em.persist([t1, t2, t3]).flush();
     publisher.tests.add(t2, t1, t3);
     await repo.persistAndFlush(publisher);
     orm.em.clear();
@@ -734,7 +734,7 @@ describe('EntityManagerSqlite2', () => {
     const author2 = orm.em.create<Author4>('Author4', { name: 'Name 2', email: 'e-mail2' });
     author2.favouriteBook = book;
     author2.version = 123;
-    await orm.em.persist([author1, author2, book], true);
+    await orm.em.persist([author1, author2, book]).flush();
     const diff = Utils.diffEntities(author1, author2, orm.getMetadata(), orm.em.getDriver().getPlatform());
     expect(diff).toMatchObject({ name: 'Name 2', favouriteBook: book.id });
     expect(typeof diff.favouriteBook).toBe('number');
@@ -745,7 +745,7 @@ describe('EntityManagerSqlite2', () => {
     const b1 = orm.em.create<Book4>('Book4', { title: 'b1', author });
     const b2 = orm.em.create<Book4>('Book4', { title: 'b2', author });
     const b3 = orm.em.create<Book4>('Book4', { title: 'b3', author });
-    await orm.em.persist([b1, b2, b3], true);
+    await orm.em.persist([b1, b2, b3]).flush();
     orm.em.clear();
 
     const a1 = (await orm.em.findOne<Author4>('Author4', { 'id:ne': 10 } as any))!;

--- a/tests/EntityRepository.test.ts
+++ b/tests/EntityRepository.test.ts
@@ -41,8 +41,8 @@ describe('EntityRepository', () => {
     repo.getReference('bar');
     expect(methods.getReference.mock.calls[0]).toEqual([Publisher, 'bar', false]);
     const e = Object.create(Publisher.prototype);
-    await repo.persist(e);
-    expect(methods.persist.mock.calls[0]).toEqual([e, false]);
+    repo.persist(e);
+    expect(methods.persist.mock.calls[0]).toEqual([e]);
     await repo.persistAndFlush(e);
     expect(methods.persistAndFlush.mock.calls[0]).toEqual([e]);
     repo.persistLater(e);
@@ -57,8 +57,8 @@ describe('EntityRepository', () => {
     expect(methods.findOneOrFail.mock.calls[0]).toEqual([Publisher, 'bar', [], undefined]);
     await repo.createQueryBuilder();
     expect(methods.createQueryBuilder.mock.calls[0]).toEqual([Publisher, undefined]);
-    await repo.remove('bar', true);
-    expect(methods.remove.mock.calls[0]).toEqual([Publisher, 'bar', true]);
+    repo.remove(e);
+    expect(methods.remove.mock.calls[0]).toEqual([e]);
     const entity = {} as AnyEntity;
     await repo.removeAndFlush(entity);
     expect(methods.removeAndFlush.mock.calls[0]).toEqual([entity]);

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -157,13 +157,13 @@ export async function initORMSqlite2() {
 }
 
 export async function wipeDatabase(em: EntityManager) {
-  await em.getRepository(Author).remove({});
-  await em.getRepository(Book).remove({});
-  await em.getRepository(BookTag).remove({});
-  await em.getRepository(Publisher).remove({});
-  await em.getRepository(Test).remove({});
-  await em.getRepository(FooBar).remove({});
-  await em.getRepository(FooBaz).remove({});
+  await em.getRepository(Author).nativeDelete({});
+  await em.getRepository(Book).nativeDelete({});
+  await em.getRepository(BookTag).nativeDelete({});
+  await em.getRepository(Publisher).nativeDelete({});
+  await em.getRepository(Test).nativeDelete({});
+  await em.getRepository(FooBar).nativeDelete({});
+  await em.getRepository(FooBaz).nativeDelete({});
   em.clear();
 }
 
@@ -216,23 +216,23 @@ export async function wipeDatabasePostgreSql(em: SqlEntityManager) {
 
 export async function wipeDatabaseSqlite(em: SqlEntityManager) {
   await em.createQueryBuilder('Author3').delete().execute();
-  await em.remove('Book3', {});
-  await em.remove('BookTag3', {});
-  await em.remove('Publisher3', {});
-  await em.remove('Test3', {});
-  await em.remove('book3_tags', {});
-  await em.remove('publisher3_tests', {});
+  await em.nativeDelete('Book3', {});
+  await em.nativeDelete('BookTag3', {});
+  await em.nativeDelete('Publisher3', {});
+  await em.nativeDelete('Test3', {});
+  await em.nativeDelete('book3_tags', {});
+  await em.nativeDelete('publisher3_tests', {});
   em.clear();
 }
 
 export async function wipeDatabaseSqlite2(em: SqlEntityManager) {
-  await em.remove('Author4', {});
-  await em.remove('Book4', {});
-  await em.remove('BookTag4', {});
-  await em.remove('Publisher4', {});
-  await em.remove('Test4', {});
-  await em.remove('tags_ordered', {});
-  await em.remove('tags_unordered', {});
-  await em.remove('publisher4_tests', {});
+  await em.nativeDelete('Author4', {});
+  await em.nativeDelete('Book4', {});
+  await em.nativeDelete('BookTag4', {});
+  await em.nativeDelete('Publisher4', {});
+  await em.nativeDelete('Test4', {});
+  await em.nativeDelete('tags_ordered', {});
+  await em.nativeDelete('tags_unordered', {});
+  await em.nativeDelete('publisher4_tests', {});
   em.clear();
 }

--- a/tests/composite-keys.mysql.test.ts
+++ b/tests/composite-keys.mysql.test.ts
@@ -53,7 +53,7 @@ describe('composite keys in mysql', () => {
     const p3 = await orm.em.findOneOrFail(FooParam2, { bar: param.bar.id, baz: param.baz.id });
     expect(p3).toBe(p2);
 
-    await orm.em.removeEntity(p3, true);
+    await orm.em.remove(p3).flush();
     const p4 = await orm.em.findOne(FooParam2, { bar: param.bar.id, baz: param.baz.id });
     expect(p4).toBeNull();
   });
@@ -81,7 +81,7 @@ describe('composite keys in mysql', () => {
     expect(address.author).toBe(a2);
     expect(address.author.address).toBe(address);
 
-    await orm.em.removeEntity(a2, true);
+    await orm.em.remove(a2).flush();
     const a3 = await orm.em.findOne(Author2, author.id);
     expect(a3).toBeNull();
     const address2 = await orm.em.findOne(Address2, author.id as any);
@@ -125,12 +125,12 @@ describe('composite keys in mysql', () => {
     const c1 = await orm.em.findOneOrFail(Car2, { name: car.name, year: car.year });
     expect(c1).toBe(o2.car);
 
-    await orm.em.removeEntity(o2, true);
+    await orm.em.remove(o2).flush();
     const o3 = await orm.em.findOne(CarOwner2, owner.id);
     expect(o3).toBeNull();
     const c2 = await orm.em.findOneOrFail(Car2, car);
     expect(c2).toBe(o2.car);
-    await orm.em.removeEntity(c2, true);
+    await orm.em.remove(c2).flush();
     const c3 = await orm.em.findOne(Car2, car);
     expect(c3).toBeNull();
     const user1 = new User2('f', 'l');
@@ -187,12 +187,12 @@ describe('composite keys in mysql', () => {
     const c1 = await orm.em.findOneOrFail(Car2, { name: car1.name, year: car1.year });
     expect(c1).toBe(u2.cars[0]);
 
-    await orm.em.removeEntity(u2, true);
+    await orm.em.remove(u2).flush();
     const o3 = await orm.em.findOne(User2, u1);
     expect(o3).toBeNull();
     const c2 = await orm.em.findOneOrFail(Car2, car1);
     expect(c2).toBe(u2.cars[0]);
-    await orm.em.removeEntity(c2, true);
+    await orm.em.remove(c2).flush();
     const c3 = await orm.em.findOne(Car2, car1);
     expect(c3).toBeNull();
   });
@@ -236,12 +236,12 @@ describe('composite keys in mysql', () => {
     const c1 = await orm.em.findOneOrFail(Sandwich, { id: sandwich1.id });
     expect(c1).toBe(u2.sandwiches[0]);
 
-    await orm.em.removeEntity(u2, true);
+    await orm.em.remove(u2).flush();
     const o3 = await orm.em.findOne(User2, u1);
     expect(o3).toBeNull();
     const c2 = await orm.em.findOneOrFail(Sandwich, sandwich1, ['users']);
     expect(c2).toBe(u2.sandwiches[0]);
-    await orm.em.removeEntity(c2, true);
+    await orm.em.remove(c2).flush();
     const c3 = await orm.em.findOne(Sandwich, sandwich1);
     expect(c3).toBeNull();
   });

--- a/tests/issues/GH349.test.ts
+++ b/tests/issues/GH349.test.ts
@@ -79,9 +79,9 @@ describe('GH issue 349', () => {
   });
 
   afterEach(async () => {
-    await orm.em.remove(A, {});
-    await orm.em.remove(B, {});
-    await orm.em.remove(C, {});
+    await orm.em.nativeDelete(A, {});
+    await orm.em.nativeDelete(B, {});
+    await orm.em.nativeDelete(C, {});
   });
 
   afterAll(async () => {

--- a/tests/issues/GH401.test.ts
+++ b/tests/issues/GH401.test.ts
@@ -30,7 +30,7 @@ describe('GH issue 401', () => {
       clientUrl: 'mongodb://localhost:27017,localhost:27018,localhost:27019/mikro-orm-test?replicaSet=rs0',
       type: 'mongo',
     });
-    await orm.em.remove(Entity401, {});
+    await orm.em.nativeDelete(Entity401, {});
   });
 
   afterAll(() => orm.close(true));

--- a/tests/issues/GH493.test.ts
+++ b/tests/issues/GH493.test.ts
@@ -51,7 +51,7 @@ describe('GH issue 493', () => {
     await orm.em.persistAndFlush(a);
     a.name = 'test';
     await expect(orm.em.flush()).rejects.toThrowError('You cannot call em.flush() from inside lifecycle hook handlers');
-    orm.em.removeEntity(a);
+    orm.em.remove(a);
     await expect(orm.em.flush()).rejects.toThrowError('You cannot call em.flush() from inside lifecycle hook handlers');
   });
 });


### PR DESCRIPTION
`persist()` and `remove()` are now sync methods that only mark the entity for
persistence or removal. They now return the `EntityManager` to allow fluid flushing:

```typescript
// before
await em.persist(jon, true);
await em.remove(Author, jon, true);

// after
await em.persist(jon).flush();
await em.remove(jon).flush();
```

Additionally `remove()` method now requires entity instances.
The `em.remove()` method originally allowed to pass either entity instance, or
a condition. When one passed a condition, it was firing a native delete query,
without handling transactions or hooks.

In v4, the method is now simplified and works only with entity instances. Use
`em.nativeDelete()` explicitly if you want to fire a delete query instead of
letting the `UnitOfWork` doing its job.

```typescript
// before
await em.remove(Author, 1); // fires query directly

// after
await em.nativeDelete(Author, 1);
```

> `em.removeEntity()` has been removed in favour of `em.remove()` (that now has
almost the same signature).

**Motivation**:
`em.remove()` was quite confusing, as it was behaving like `em.removeEntity()` when given entity instance (so using UoW, requiring flush to make changes), as well as `em.nativeDelete()`, that fires the query directly. 

**BREAKING CHANGE:**
`flush` param is removed, both `persist` and `remove` methods are synchronous and
require explicit flushing, possibly via fluent interface call.