### PR TITLE
docs: improve primary key decorator section

### DIFF
--- a/docs/docs/decorators.md
+++ b/docs/docs/decorators.md
@@ -70,7 +70,9 @@ registered = false;
 > `@PrimaryKey()` decorator extend the `@Property()` decorator, so you can use all 
 > its parameters.
 
-> Every entity needs to have exactly one primary key.
+> Every entity needs to have at least one primary key (see composite primary keys).
+
+> Note that if only one PrimaryKey is set and it's type is number it will be set to auto incremented automatically in all SQL drivers. 
 
 ```typescript
 @PrimaryKey()

--- a/docs/versioned_docs/version-3.5/decorators.md
+++ b/docs/versioned_docs/version-3.5/decorators.md
@@ -70,7 +70,9 @@ registered = false;
 > `@PrimaryKey()` decorator extend the `@Property()` decorator, so you can use all 
 > its parameters.
 
-> Every entity needs to have exactly one primary key.
+> Every entity needs to have at least one primary key (see composite primary keys).
+
+> Note that if only one PrimaryKey is set and it's type is number it will be set to auto incremented automatically in all SQL drivers. 
 
 ```typescript
 @PrimaryKey()

--- a/docs/versioned_docs/version-3.6/decorators.md
+++ b/docs/versioned_docs/version-3.6/decorators.md
@@ -72,7 +72,7 @@ registered = false;
 
 > Every entity needs to have at least one primary key (see composite primary keys).
 
-> Note that if only one PrimaryKey is set and it's type is number it will be set to auto incremented automatically in MySQL. 
+> Note that if only one PrimaryKey is set and it's type is number it will be set to auto incremented automatically in all SQL drivers. 
 
 ```typescript
 @PrimaryKey()

--- a/docs/versioned_docs/version-3.6/decorators.md
+++ b/docs/versioned_docs/version-3.6/decorators.md
@@ -70,7 +70,9 @@ registered = false;
 > `@PrimaryKey()` decorator extend the `@Property()` decorator, so you can use all 
 > its parameters.
 
-> Every entity needs to have exactly one primary key.
+> Every entity needs to have at least one primary key (see composite primary keys).
+
+> Note that if only one PrimaryKey is set and it's type is number it will be set to auto incremented automatically in MySQL. 
 
 ```typescript
 @PrimaryKey()


### PR DESCRIPTION
Since mikro-orm has now composite PK support it's not true that every entity must have exactly one PK. 

Also I clarified a little bit about 'auto_increment' prop in MySQL (maybe all SQL drivers tho, I haven't checked that) since I assume it's not 100% clear, when it's set to 'auto_increment' and when it's not.