### PR TITLE
refactor: move monkey patchable portions of Knex to Knex package

### DIFF
--- a/packages/knex/src/MonkeyPatchable.ts
+++ b/packages/knex/src/MonkeyPatchable.ts
@@ -1,0 +1,19 @@
+// @ts-ignore
+import MySqlDialect from 'knex/lib/dialects/mysql';
+// @ts-ignore
+import PostgresDialectTableCompiler from 'knex/lib/dialects/postgres/schema/tablecompiler';
+// @ts-ignore
+import Sqlite3Dialect from 'knex/lib/dialects/sqlite3';
+// @ts-ignore
+import TableCompiler from 'knex/lib/schema/tablecompiler';
+
+// These specific portions of knex are overridden by the different
+// database packages. We need to be sure the knex files they get to
+// monkey patch are the same version as our overall knex instance
+// which is why we need to import them in this package.
+export const MonkeyPatchable = {
+  MySqlDialect,
+  PostgresDialectTableCompiler,
+  Sqlite3Dialect,
+  TableCompiler,
+};

--- a/packages/knex/src/index.ts
+++ b/packages/knex/src/index.ts
@@ -2,6 +2,7 @@
 export * from './AbstractSqlConnection';
 export * from './AbstractSqlDriver';
 export * from './AbstractSqlPlatform';
+export * from './MonkeyPatchable';
 export * from './SqlEntityManager';
 export * from './SqlEntityRepository';
 export * from './query';

--- a/packages/mariadb/src/MariaDbConnection.ts
+++ b/packages/mariadb/src/MariaDbConnection.ts
@@ -1,11 +1,5 @@
 import { Connection } from 'mariadb';
-import { MySqlConnection, Knex } from '@mikro-orm/mysql-base';
-import { Utils } from '@mikro-orm/core';
-
-const Dialect = Utils.requireFrom(
-  'knex/lib/dialects/mysql/index.js',
-  require.resolve('@mikro-orm/knex', { paths: [require.resolve('@mikro-orm/mysql-base')] })
-);
+import { MySqlConnection, Knex, MonkeyPatchable } from '@mikro-orm/mysql-base';
 
 export class MariaDbConnection extends MySqlConnection {
 
@@ -21,11 +15,12 @@ export class MariaDbConnection extends MySqlConnection {
   }
 
   private getPatchedDialect() {
-    Dialect.prototype.driverName = 'mariadb';
-    Dialect.prototype._driver = () => require('mariadb/callback');
-    Dialect.prototype.validateConnection = (connection: Connection) => connection.isValid();
+    const { MySqlDialect } = MonkeyPatchable;
+    MySqlDialect.prototype.driverName = 'mariadb';
+    MySqlDialect.prototype._driver = () => require('mariadb/callback');
+    MySqlDialect.prototype.validateConnection = (connection: Connection) => connection.isValid();
 
-    return Dialect;
+    return MySqlDialect;
   }
 
 }

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -1,7 +1,8 @@
+import path from 'path';
 import { ObjectId } from 'mongodb';
 import { Collection, EntityMetadata, MikroORM, Utils } from '@mikro-orm/core';
 import { Author, Book } from './entities';
-import { initORMMongo, wipeDatabase } from './bootstrap';
+import { initORMMongo, wipeDatabase, BASE_DIR } from './bootstrap';
 import FooBar from './entities/FooBar';
 
 class Test {}
@@ -329,6 +330,11 @@ describe('Utils', () => {
       '    at Function.Module._load (internal/modules/cjs/loader.js:703:12)',
     ];
     expect(Utils.lookupPathFromDecorator(stack1)).toBe('C:/www/my-project/src/entities/Customer.ts');
+  });
+
+  test('requireFrom can require a package.json file', () => {
+    const { name } = Utils.requireFrom('', path.join(BASE_DIR, '..', 'package.json'));
+    expect(name).toEqual('mikro-orm-root');
   });
 
   afterAll(async () => orm.close(true));


### PR DESCRIPTION
Moves the portions of Knex that are being monkey patched from dynamic requires to hard requires so webpack can trace them. They're optional, but each driver insists that they're received.