### PR TITLE
docs: update Debugging section with query-params namespace

### DIFF
--- a/docs/docs/debugging.md
+++ b/docs/docs/debugging.md
@@ -53,4 +53,6 @@ return MikroORM.init({
 });
 ```
 
-Currently there are 3 namespaces – `query`, `discovery` and `info`.
+Currently there are 4 namespaces – `query`, `query-params` `discovery` and `info`.
+
+If you provide `query-params` then you must also provide `query` in order for it to take effect.

--- a/docs/docs/debugging.md
+++ b/docs/docs/debugging.md
@@ -53,6 +53,6 @@ return MikroORM.init({
 });
 ```
 
-Currently there are 4 namespaces – `query`, `query-params` `discovery` and `info`.
+Currently there are 4 namespaces – `query`, `query-params`, `discovery` and `info`.
 
 If you provide `query-params` then you must also provide `query` in order for it to take effect.

--- a/docs/versioned_docs/version-3.3/debugging.md
+++ b/docs/versioned_docs/version-3.3/debugging.md
@@ -53,4 +53,6 @@ return MikroORM.init({
 });
 ```
 
-Currently there are 3 namespaces – `query`, `discovery` and `info`.
+Currently there are 4 namespaces – `query`, `query-params` `discovery` and `info`.
+
+If you provide `query-params` then you must also provide `query` in order for it to take effect.

--- a/docs/versioned_docs/version-3.3/debugging.md
+++ b/docs/versioned_docs/version-3.3/debugging.md
@@ -53,6 +53,6 @@ return MikroORM.init({
 });
 ```
 
-Currently there are 4 namespaces – `query`, `query-params` `discovery` and `info`.
+Currently there are 4 namespaces – `query`, `query-params`, `discovery` and `info`.
 
 If you provide `query-params` then you must also provide `query` in order for it to take effect.

--- a/docs/versioned_docs/version-3.4/debugging.md
+++ b/docs/versioned_docs/version-3.4/debugging.md
@@ -53,4 +53,6 @@ return MikroORM.init({
 });
 ```
 
-Currently there are 3 namespaces – `query`, `discovery` and `info`.
+Currently there are 4 namespaces – `query`, `query-params` `discovery` and `info`.
+
+If you provide `query-params` then you must also provide `query` in order for it to take effect.

--- a/docs/versioned_docs/version-3.4/debugging.md
+++ b/docs/versioned_docs/version-3.4/debugging.md
@@ -53,6 +53,6 @@ return MikroORM.init({
 });
 ```
 
-Currently there are 4 namespaces – `query`, `query-params` `discovery` and `info`.
+Currently there are 4 namespaces – `query`, `query-params`, `discovery` and `info`.
 
 If you provide `query-params` then you must also provide `query` in order for it to take effect.

--- a/docs/versioned_docs/version-3.5/debugging.md
+++ b/docs/versioned_docs/version-3.5/debugging.md
@@ -53,4 +53,6 @@ return MikroORM.init({
 });
 ```
 
-Currently there are 3 namespaces – `query`, `discovery` and `info`.
+Currently there are 4 namespaces – `query`, `query-params` `discovery` and `info`.
+
+If you provide `query-params` then you must also provide `query` in order for it to take effect.

--- a/docs/versioned_docs/version-3.5/debugging.md
+++ b/docs/versioned_docs/version-3.5/debugging.md
@@ -53,6 +53,6 @@ return MikroORM.init({
 });
 ```
 
-Currently there are 4 namespaces – `query`, `query-params` `discovery` and `info`.
+Currently there are 4 namespaces – `query`, `query-params`, `discovery` and `info`.
 
 If you provide `query-params` then you must also provide `query` in order for it to take effect.

--- a/docs/versioned_docs/version-3.6/debugging.md
+++ b/docs/versioned_docs/version-3.6/debugging.md
@@ -53,4 +53,6 @@ return MikroORM.init({
 });
 ```
 
-Currently there are 3 namespaces – `query`, `discovery` and `info`.
+Currently there are 4 namespaces – `query`, `query-params` `discovery` and `info`.
+
+If you provide `query-params` then you must also provide `query` in order for it to take effect.

--- a/docs/versioned_docs/version-3.6/debugging.md
+++ b/docs/versioned_docs/version-3.6/debugging.md
@@ -53,6 +53,6 @@ return MikroORM.init({
 });
 ```
 
-Currently there are 4 namespaces – `query`, `query-params` `discovery` and `info`.
+Currently there are 4 namespaces – `query`, `query-params`, `discovery` and `info`.
 
 If you provide `query-params` then you must also provide `query` in order for it to take effect.


### PR DESCRIPTION
As the title says, "query-params'" logger namespace is not present in the "Debugging" section(only mentioned in "Advanced configuration"). Great ORM btw!