### PR TITLE
feat(core): add support for filters/scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ There is also auto-generated [CHANGELOG.md](CHANGELOG.md) file based on commit m
 - [Transactions](https://mikro-orm.io/transactions/)
 - [Cascading persist and remove](https://mikro-orm.io/cascading/)
 - [Composite and Foreign Keys as Primary Key](https://mikro-orm.io/composite-keys/)
+- [Filters](https://mikro-orm.io/filters/)
 - [Using `QueryBuilder`](https://mikro-orm.io/query-builder/)
 - [Preloading Deeply Nested Structures via populate](https://mikro-orm.io/nested-populate/)
 - [Property Validation](https://mikro-orm.io/property-validation/)

--- a/docs/docs/filters.md
+++ b/docs/docs/filters.md
@@ -1,0 +1,144 @@
+---
+title: Filters
+---
+
+MikroORM has the ability to pre-define filter criteria and attach those filters 
+to given entities. The application can then decide at runtime whether certain 
+filters should be enabled and what their parameter values should be. Filters 
+can be used like database views, but they are parameterized inside the application.
+
+> Filter can be defined at the entity level, dynamically via EM (global filters) 
+> or in the ORM configuration.
+
+Filters are applied to those methods of `EntityManager`: `find()`, `findOne()`, 
+`findAndCount()`, `findOneOrFail()`, `count()`, `nativeUpdate()` and `nativeDelete()`. 
+
+> The `cond` parameter can be a callback, possibly asynchronous.
+
+```typescript
+@Entity()
+@Filter({ name: 'expensive', cond: { price: { $gt: 1000 } } })
+@Filter({ name: 'long', cond: { 'length(text)': { $gt: 10000 } } })
+@Filter({ name: 'hasAuthor', cond: { author: { $ne: null } }, default: true })
+@Filter({ name: 'writtenBy', cond: args => ({ author: { name: args.name } }) })
+export class Book {
+  ...
+}
+
+const books1 = await orm.em.find(Book, {}, {
+  filters: ['long', 'expensive'],
+});
+const books2 = await orm.em.find(Book, {}, {
+  filters: { hasAuthor: false, long: true, writtenBy: { name: 'God' } },
+});
+```
+
+## Parameters
+
+You can define the `cond` dynamically as a callback. This callback can be also 
+asynchronous. It will get two arguments:
+
+- `args` - dictionary of parameters provided by user
+- `type` - type of operation that is being filtered, one of `'read'`, `'update'`, `'delete'`
+
+```typescript
+@Entity()
+@Filter({ name: 'writtenBy', cond: async (args, type) => {
+  if (type === 'update') {
+    return {}; // do not apply when updating
+  }
+
+  return { author: { name: args.name } };
+} })
+export class Book {
+  ...
+}
+
+const books = await orm.em.find(Book, {}, {
+  filters: { writtenBy: { name: 'God' } },
+});
+```
+
+## Global filters
+
+We can also register filters dynamically via `EntityManager` API. We call such filters 
+global. They are enabled by default (unless disabled via last parameter in `addFilter()`
+method), and applied to all entities. You can limit the global filter to only specified
+entities. 
+
+> Filters as well as filter params set on the EM will be copied to all its forks.
+
+```typescript
+// bound to entity, enabled by default
+em.addFilter('writtenBy', args => ({ author: args.id }), Book);
+
+// global, enabled by default, for all entities
+em.addFilter('tenant', args => { ... });
+
+// global, enabled by default, for only specified entities
+em.addFilter('tenant', args => { ... }, [Author, Book]);
+...
+
+// set params (probably in some middleware)
+em.setFilterParams('tenant', { tenantId: 123 });
+em.setFilterParams('writtenBy', { id: 321 });
+```
+
+Global filters can be also registered via ORM configuration:
+
+```typescript
+MikroORM.init({
+  filters: { tenant: { cond: args => ({ tenant: args.tenant }), entity: ['Author', 'User'] } },
+  ...
+})
+```
+
+## Using filters
+
+We can control what filters will be applied via `filter` parameter in `FindOptions`.
+We can either provide an array of names of filters you want to enable, or options 
+object, where we can also disable a filter (that was enabled by default), or pass some
+parameters to those that are expecting them.
+
+> By passing `filters: false` we can also disable all the filters for given call. 
+
+```typescript
+em.find(Book, {}); // same as `{ tenantId: 123 }`
+em.find(Book, {}, { filters: ['writtenBy'] }); // same as `{ author: 321, tenantId: 123 }`
+em.find(Book, {}, { filters: { tenant: false } }); // disabled tenant filter, so truly `{}`
+em.find(Book, {}, { filters: false }); // disabled all filters, so truly `{}`
+```
+
+## Filters and populating of relationships
+
+When populating relationships, filters will be applied only to the root entity of 
+given query, but not to those that are auto-joined. On the other hand, this means that
+when you use the default loading strategy - `LoadStrategy.SELECT_IN` - filters will
+be applied to every entity populated this way, as the child entities will become
+root entities in their respective load calls.
+
+## Naming of filters
+
+When toggling filters via `FindOptions`, we do not care about the entity name. This
+means that when you have multiple filters defined on different entities, but with 
+the same name, they will be controlled via single toggle in the `FindOptions`. 
+
+```typescript
+@Entity()
+@Filter({ name: 'tenant', cond: args => ({ tenant: args.tenant }) })
+export class Author {
+  ...
+}
+
+@Entity()
+@Filter({ name: 'tenant', cond: args => ({ tenant: args.tenant }) })
+export class Book {
+  ...
+}
+
+// this will apply the tenant filter to both Author and Book entities (with SELECT_IN loading strategy)
+const authors = await orm.em.find(Author, {}, {
+  populate: ['books'],
+  filters: { tenant: 123 },
+});
+```

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -20,6 +20,7 @@ hide_title: true
   - [Unit of Work](unit-of-work.md)
   - [Transactions](transactions.md)
   - [Cascading persist and remove](cascading.md)
+  - [Filters](filters.md)
   - [Deployment](deployment.md)
 - Advanced Features
   - [Smart Nested Populate](nested-populate.md)

--- a/docs/docs/query-builder.md
+++ b/docs/docs/query-builder.md
@@ -154,7 +154,7 @@ console.log(qb.getQuery());
 ```
 
 This is currently available only for filtering (`where`) and sorting (`orderBy`), only 
-the root entity will be selected. To populate its relationships, you can use [EntityLoader](nested-populate.md).
+the root entity will be selected. To populate its relationships, you can use [`em.populate()`](nested-populate.md).
 
 ## Explicit Joining
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -16,6 +16,7 @@ module.exports = {
       'transactions',
       'cascading',
       'composite-keys',
+      'filters',
       'deployment',
       'decorators',
     ],

--- a/packages/core/src/decorators/Filter.ts
+++ b/packages/core/src/decorators/Filter.ts
@@ -1,0 +1,11 @@
+import { MetadataStorage } from '../metadata';
+import { Dictionary, FilterDef } from '../typings';
+
+export function Filter<T>(options: FilterDef<T>) {
+  return function <U>(target: U & Dictionary) {
+    const meta = MetadataStorage.getMetadataFromDecorator(target);
+    meta.filters[options.name] = options as unknown as FilterDef<U>;
+
+    return target;
+  };
+}

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -11,5 +11,6 @@ export * from './Indexed';
 export * from './Repository';
 export * from './Embeddable';
 export * from './Embedded';
+export * from './Filter';
 export * from './Subscriber';
 export * from './hooks';

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -86,6 +86,7 @@ export interface FindOptions<T> {
   groupBy?: string | string[];
   having?: QBFilterQuery<T>;
   strategy?: LoadStrategy;
+  filters?: Dictionary<boolean | Dictionary> | string[] | boolean;
 }
 
 export interface FindOneOptions<T> extends Omit<FindOptions<T>, 'limit' | 'offset'> {

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -94,6 +94,18 @@ export interface FindOneOptions<T> extends Omit<FindOptions<T>, 'limit' | 'offse
   lockVersion?: number | Date;
 }
 
+export interface CountOptions<T>  {
+  filters?: Dictionary<boolean | Dictionary> | string[] | boolean;
+}
+
+export interface UpdateOptions<T>  {
+  filters?: Dictionary<boolean | Dictionary> | string[] | boolean;
+}
+
+export interface DeleteOptions<T>  {
+  filters?: Dictionary<boolean | Dictionary> | string[] | boolean;
+}
+
 export type PopulateChildren<T> = { [K in keyof T]?: PopulateMap<ReferencedEntity<T[K]> | CollectionItem<T[K]>> };
 export type PopulateMap<T> = boolean | LoadStrategy | PopulateChildren<T> | [LoadStrategy, PopulateChildren<T>];
 export type Populate<T> = (string | PopulateOptions<T>)[] | boolean | PopulateMap<T>;

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -8,6 +8,15 @@ import { Reference } from './Reference';
 import { wrap } from './wrap';
 import { PopulateOptions } from '../drivers';
 
+type Options<T extends AnyEntity<T>> = {
+  where?: FilterQuery<T>;
+  orderBy?: QueryOrderMap;
+  refresh?: boolean;
+  validate?: boolean;
+  lookup?: boolean;
+  filters?: Dictionary<boolean | Dictionary> | string[] | boolean;
+};
+
 export class EntityLoader {
 
   private readonly metadata = this.em.getMetadata();
@@ -15,20 +24,26 @@ export class EntityLoader {
 
   constructor(private readonly em: EntityManager) { }
 
-  async populate<T extends AnyEntity<T>>(entityName: string, entities: T[], populate: PopulateOptions<T>[] | boolean, where: FilterQuery<T> = {}, orderBy: QueryOrderMap = {}, refresh = false, validate = true, lookup = true): Promise<void> {
+  async populate<T extends AnyEntity<T>>(entityName: string, entities: T[], populate: PopulateOptions<T>[] | boolean, options: Options<T>): Promise<void> {
     if (entities.length === 0 || populate === false) {
       return;
     }
 
-    populate = this.normalizePopulate<T>(entityName, populate, lookup);
+    options.where = options.where ?? {};
+    options.orderBy = options.orderBy ?? {};
+    options.filters = options.filters ?? {};
+    options.lookup = options.lookup ?? true;
+    options.validate = options.validate ?? true;
+    options.refresh = options.refresh ?? false;
+    populate = this.normalizePopulate<T>(entityName, populate, options.lookup);
     const invalid = populate.find(({ field }) => !this.em.canPopulate(entityName, field));
 
-    if (validate && invalid) {
+    if (options.validate && invalid) {
       throw ValidationError.invalidPropertyName(entityName, invalid.field);
     }
 
     for (const pop of populate) {
-      await this.populateField<T>(entityName, entities, pop, where, orderBy, refresh);
+      await this.populateField<T>(entityName, entities, pop, options as Required<Options<T>>);
     }
   }
 
@@ -77,7 +92,7 @@ export class EntityLoader {
   /**
    * preload everything in one call (this will update already existing references in IM)
    */
-  private async populateMany<T extends AnyEntity<T>>(entityName: string, entities: T[], populate: PopulateOptions<T>, where: FilterQuery<T>, orderBy: QueryOrderMap, refresh: boolean): Promise<AnyEntity[]> {
+  private async populateMany<T extends AnyEntity<T>>(entityName: string, entities: T[], populate: PopulateOptions<T>, options: Required<Options<T>>): Promise<AnyEntity[]> {
     const field = populate.field as keyof T;
     const meta = this.metadata.get<T>(entityName);
     const prop = meta.properties[field as string];
@@ -93,14 +108,14 @@ export class EntityLoader {
       }
     });
 
-    const filtered = this.filterCollections<T>(entities, field, refresh);
-    const innerOrderBy = Utils.isObject(orderBy[prop.name]) ? orderBy[prop.name] : undefined;
+    const filtered = this.filterCollections<T>(entities, field, options.refresh);
+    const innerOrderBy = Utils.isObject(options.orderBy[prop.name]) ? options.orderBy[prop.name] as QueryOrderMap : undefined;
 
     if (prop.reference === ReferenceType.MANY_TO_MANY && this.driver.getPlatform().usesPivotTable()) {
-      return this.findChildrenFromPivotTable<T>(filtered, prop, field, refresh, where[prop.name], innerOrderBy as QueryOrderMap);
+      return this.findChildrenFromPivotTable<T>(filtered, prop, field, options.refresh, options.where[prop.name], innerOrderBy as QueryOrderMap);
     }
 
-    let subCond = Utils.isPlainObject(where[prop.name]) ? where[prop.name] : {};
+    let subCond = Utils.isPlainObject(options.where[prop.name]) ? options.where[prop.name] : {};
     const op = Object.keys(subCond).find(key => Utils.isOperator(key, false));
     const meta2 = this.metadata.get(prop.type);
 
@@ -108,7 +123,7 @@ export class EntityLoader {
       subCond = { [Utils.getPrimaryKeyHash(meta2.primaryKeys)]: subCond };
     }
 
-    const data = await this.findChildren<T>(entities, prop, refresh, subCond, populate, innerOrderBy as QueryOrderMap);
+    const data = await this.findChildren<T>(entities, prop, populate, { ...options, where: subCond, orderBy: innerOrderBy! });
     this.initializeCollections<T>(filtered, prop, field, data);
 
     return data;
@@ -138,8 +153,8 @@ export class EntityLoader {
     }
   }
 
-  private async findChildren<T extends AnyEntity<T>>(entities: T[], prop: EntityProperty, refresh: boolean, where: FilterQuery<T>, populate: PopulateOptions<T>, orderBy?: QueryOrderMap): Promise<AnyEntity[]> {
-    const children = this.getChildReferences<T>(entities, prop, refresh);
+  private async findChildren<T extends AnyEntity<T>>(entities: T[], prop: EntityProperty, populate: PopulateOptions<T>, options: Required<Options<T>>): Promise<AnyEntity[]> {
+    const children = this.getChildReferences<T>(entities, prop, options.refresh);
     const meta = this.metadata.get(prop.type);
     let fk = Utils.getPrimaryKeyHash(meta.primaryKeys);
 
@@ -158,18 +173,22 @@ export class EntityLoader {
     }
 
     const ids = Utils.unique(children.map(e => Utils.getPrimaryKeyValues(e, wrap(e, true).__meta.primaryKeys, true)));
-    where = { [fk]: { $in: ids }, ...(where as Dictionary) };
-    orderBy = orderBy || prop.orderBy || { [fk]: QueryOrder.ASC };
+    const where = { [fk]: { $in: ids }, ...(options.where as Dictionary) };
 
-    return this.em.find<T>(prop.type, where, { orderBy, refresh, populate: populate.children });
+    return this.em.find<T>(prop.type, where, {
+      orderBy: options.orderBy || prop.orderBy || { [fk]: QueryOrder.ASC },
+      refresh: options.refresh,
+      filters: options.filters,
+      populate: populate.children,
+    });
   }
 
-  private async populateField<T extends AnyEntity<T>>(entityName: string, entities: T[], populate: PopulateOptions<T>, where: FilterQuery<T>, orderBy: QueryOrderMap, refresh: boolean): Promise<void> {
+  private async populateField<T extends AnyEntity<T>>(entityName: string, entities: T[], populate: PopulateOptions<T>, options: Required<Options<T>>): Promise<void> {
     if (!populate.children) {
-      return void await this.populateMany<T>(entityName, entities, populate, where, orderBy, refresh);
+      return void await this.populateMany<T>(entityName, entities, populate, options);
     }
 
-    await this.populateMany<T>(entityName, entities, populate, where, orderBy, refresh);
+    await this.populateMany<T>(entityName, entities, populate, options);
     const children: T[] = [];
 
     for (const entity of entities) {
@@ -184,7 +203,14 @@ export class EntityLoader {
 
     const filtered = Utils.unique(children);
     const prop = this.metadata.get(entityName).properties[populate.field];
-    await this.populate<T>(prop.type, filtered, populate.children, where[prop.name], orderBy[prop.name] as QueryOrderMap, refresh, false, false);
+    await this.populate<T>(prop.type, filtered, populate.children, {
+      where: options.where[prop.name],
+      orderBy: options.orderBy[prop.name] as QueryOrderMap,
+      refresh: options.refresh,
+      filters: options.filters,
+      validate: false,
+      lookup: false,
+    });
   }
 
   private async findChildrenFromPivotTable<T extends AnyEntity<T>>(filtered: T[], prop: EntityProperty, field: keyof T, refresh: boolean, where?: FilterQuery<T>, orderBy?: QueryOrderMap): Promise<AnyEntity[]> {

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -38,7 +38,7 @@ export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntit
       meta.tableName = meta.collection;
     }
 
-    Object.assign(this._meta, { className: meta.name, properties: {}, hooks: {}, primaryKeys: [], indexes: [], uniques: [] }, meta);
+    Object.assign(this._meta, { className: meta.name, properties: {}, hooks: {}, filters: {}, primaryKeys: [], indexes: [], uniques: [] }, meta);
   }
 
   static fromMetadata<T extends AnyEntity<T> = AnyEntity, U extends AnyEntity<U> | undefined = undefined>(meta: EntityMetadata<T>): EntitySchema<T, U> {

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -386,6 +386,7 @@ export class MetadataDiscovery {
       pivotTable: true,
       properties: {} as Record<string, EntityProperty>,
       hooks: {},
+      filters: {},
       indexes: [] as any[],
       uniques: [] as any[],
     } as EntityMetadata;

--- a/packages/core/src/metadata/MetadataStorage.ts
+++ b/packages/core/src/metadata/MetadataStorage.ts
@@ -20,7 +20,7 @@ export class MetadataStorage {
     const key = entity && path ? entity + '-' + Utils.hash(path) : null;
 
     if (key && !MetadataStorage.metadata[key]) {
-      MetadataStorage.metadata[key] = { className: entity, path, properties: {}, hooks: {}, indexes: [] as any[], uniques: [] as any[] } as EntityMetadata;
+      MetadataStorage.metadata[key] = { className: entity, path, properties: {}, hooks: {}, filters: {}, indexes: [] as any[], uniques: [] as any[] } as EntityMetadata;
     }
 
     if (key) {

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -181,6 +181,7 @@ export interface EntityMetadata<T extends AnyEntity<T> = any> {
   class: Constructor<T>;
   abstract: boolean;
   useCache: boolean;
+  filters: Dictionary<FilterDef<T>>;
   comment?: string;
 }
 
@@ -214,3 +215,10 @@ export interface IMigrator {
   up(options?: string | string[] | MigrateOptions): Promise<UmzugMigration[]>;
   down(options?: string | string[] | MigrateOptions): Promise<UmzugMigration[]>;
 }
+
+export type FilterDef<T extends AnyEntity<T>> = {
+  name: string;
+  cond: FilterQuery<T> | ((args: Dictionary) => FilterQuery<T>);
+  default?: boolean;
+  entity?: string[];
+};

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -218,7 +218,7 @@ export interface IMigrator {
 
 export type FilterDef<T extends AnyEntity<T>> = {
   name: string;
-  cond: FilterQuery<T> | ((args: Dictionary) => FilterQuery<T>);
+  cond: FilterQuery<T> | ((args: Dictionary, type: 'read' | 'update' | 'delete') => FilterQuery<T>);
   default?: boolean;
   entity?: string[];
 };

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -4,7 +4,7 @@ import { inspect } from 'util';
 import { NamingStrategy } from '../naming-strategy';
 import { CacheAdapter, FileCacheAdapter, NullCacheAdapter } from '../cache';
 import { EntityFactory, EntityRepository } from '../entity';
-import { AnyEntity, Constructor, Dictionary, EntityClass, EntityClassGroup, IPrimaryKey } from '../typings';
+import { AnyEntity, Constructor, Dictionary, EntityClass, EntityClassGroup, FilterDef, IPrimaryKey } from '../typings';
 import { Hydrator, ObjectHydrator } from '../hydration';
 import { Logger, LoggerNamespace, NotFoundError, Utils } from '../utils';
 import { EntityManager } from '../EntityManager';
@@ -20,6 +20,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     entities: [],
     entitiesTs: [],
     subscribers: [],
+    filters: [],
     discovery: {
       warnWhenNoEntities: true,
       requireEntitiesArray: false,
@@ -301,6 +302,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
   entities: (string | EntityClass<AnyEntity> | EntityClassGroup<AnyEntity> | EntitySchema<any>)[]; // `any` required here for some TS weirdness
   entitiesTs: (string | EntityClass<AnyEntity> | EntityClassGroup<AnyEntity> | EntitySchema<any>)[]; // `any` required here for some TS weirdness
   subscribers: EventSubscriber[];
+  filters: Dictionary<FilterDef<AnyEntity>>;
   discovery: {
     warnWhenNoEntities?: boolean;
     requireEntitiesArray?: boolean;

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -20,7 +20,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     entities: [],
     entitiesTs: [],
     subscribers: [],
-    filters: [],
+    filters: {},
     discovery: {
       warnWhenNoEntities: true,
       requireEntitiesArray: false,
@@ -302,7 +302,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
   entities: (string | EntityClass<AnyEntity> | EntityClassGroup<AnyEntity> | EntitySchema<any>)[]; // `any` required here for some TS weirdness
   entitiesTs: (string | EntityClass<AnyEntity> | EntityClassGroup<AnyEntity> | EntitySchema<any>)[]; // `any` required here for some TS weirdness
   subscribers: EventSubscriber[];
-  filters: Dictionary<FilterDef<AnyEntity>>;
+  filters: Dictionary<{ name?: string } & Omit<FilterDef<AnyEntity>, 'name'>>;
   discovery: {
     warnWhenNoEntities?: boolean;
     requireEntitiesArray?: boolean;

--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -72,7 +72,7 @@ export class QueryHelper {
 
     where = QueryHelper.processParams(where, true) || {};
 
-    if (Array.isArray(where)) {
+    if (Array.isArray(where) && where.length > 0) {
       const rootPrimaryKey = meta ? Utils.getPrimaryKeyHash(meta.primaryKeys) : entityName;
       return { [rootPrimaryKey]: { $in: (where as FilterQuery<T>[]).map(sub => QueryHelper.processWhere(sub, entityName, metadata)) } } as FilterQuery<T>;
     }

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -71,9 +71,9 @@ export class Utils {
 
     const source = sources.shift();
 
-    if (Utils.isObject(target) && Utils.isObject(source)) {
+    if (Utils.isObject(target) && Utils.isPlainObject(source)) {
       Object.entries(source).forEach(([key, value]) => {
-        if (Utils.isObject(value, [Date, RegExp, Buffer])) {
+        if (Utils.isPlainObject(value)) {
           if (!(key in target)) {
             Object.assign(target, { [key]: {} });
           }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -3,5 +3,5 @@ export * from './ConfigurationLoader';
 export * from './Logger';
 export * from './Utils';
 export * from './RequestContext';
-export * from './SmartQueryHelper';
+export * from './QueryHelper';
 export * from './errors';

--- a/packages/knex/src/query/ObjectCriteriaNode.ts
+++ b/packages/knex/src/query/ObjectCriteriaNode.ts
@@ -51,6 +51,12 @@ export class ObjectCriteriaNode extends CriteriaNode {
       const customExpression = QueryBuilderHelper.isCustomExpression(field);
 
       if (childNode.shouldInline(payload)) {
+        const operators = Object.keys(payload).filter(k => Utils.isOperator(k, false));
+        operators.forEach(op => {
+          const tmp = payload[op];
+          delete payload[op];
+          payload[`${alias}.${field}`] = { [op]: tmp, ...(payload[`${alias}.${field}`] || {}) };
+        });
         Object.assign(o, payload);
       } else if (childNode.shouldRename(payload)) {
         o[childNode.renameFieldToPK(qb)] = payload;

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -1,7 +1,7 @@
 import { QueryBuilder as KnexQueryBuilder, Raw, Transaction, Value, Ref } from 'knex';
 import {
   AnyEntity, Dictionary, EntityMetadata, EntityProperty, FlatQueryOrderMap, GroupOperator, LockMode, MetadataStorage, QBFilterQuery, QueryFlag,
-  QueryOrderMap, ReferenceType, SmartQueryHelper, Utils, ValidationError, PopulateOptions,
+  QueryOrderMap, ReferenceType, QueryHelper, Utils, ValidationError, PopulateOptions,
 } from '@mikro-orm/core';
 import { QueryType } from './enums';
 import { AbstractSqlDriver, QueryBuilderHelper } from '../index';
@@ -104,7 +104,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
   where(cond: QBFilterQuery<T>, operator?: keyof typeof GroupOperator): this;
   where(cond: string, params?: any[], operator?: keyof typeof GroupOperator): this;
   where(cond: QBFilterQuery<T> | string, params?: keyof typeof GroupOperator | any[], operator?: keyof typeof GroupOperator): this {
-    cond = SmartQueryHelper.processWhere(cond as Dictionary, this.entityName, this.metadata)!;
+    cond = QueryHelper.processWhere(cond as Dictionary, this.entityName, this.metadata)!;
 
     if (Utils.isString(cond)) {
       cond = { [`(${cond})`]: Utils.asArray(params) };
@@ -146,7 +146,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
   }
 
   orderBy(orderBy: QueryOrderMap): this {
-    orderBy = SmartQueryHelper.processWhere(orderBy as Dictionary, this.entityName, this.metadata) as QueryOrderMap;
+    orderBy = QueryHelper.processWhere(orderBy as Dictionary, this.entityName, this.metadata) as QueryOrderMap;
     this._orderBy = CriteriaNode.create(this.metadata, this.entityName, orderBy).process(this);
     return this;
   }
@@ -337,7 +337,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     const entityName = this._aliasMap[fromAlias];
     const prop = this.metadata.get(entityName).properties[fromField];
     this._aliasMap[alias] = prop.type;
-    cond = SmartQueryHelper.processWhere(cond, this.entityName, this.metadata)!;
+    cond = QueryHelper.processWhere(cond, this.entityName, this.metadata)!;
     const aliasedName = `${fromAlias}.${prop.name}`;
 
     if (prop.reference === ReferenceType.ONE_TO_MANY) {
@@ -485,7 +485,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
         });
     }
 
-    SmartQueryHelper.processParams([this._data, this._cond, this._having]);
+    QueryHelper.processParams([this._data, this._cond, this._having]);
     this.finalized = true;
 
     if (this.flags.has(QueryFlag.PAGINATE) && this._limit! > 0) {

--- a/tests/EntityHelper.mongo.test.ts
+++ b/tests/EntityHelper.mongo.test.ts
@@ -176,6 +176,7 @@ describe('EntityAssignerMongo', () => {
     const b = await orm.em.findOneOrFail(Book, book.id);
     expect(Utils.prepareEntity(b, orm.getMetadata(), orm.em.getDriver().getPlatform())).toEqual({
       _id: b._id,
+      createdAt: b.createdAt,
       title: b.title,
       author: b.author._id,
     });
@@ -218,6 +219,7 @@ describe('EntityAssignerMongo', () => {
 
     const god = new Author('God', 'hello@heaven.god');
     const bible = new Book('Bible', god);
+    bible.createdAt = new Date('2020-07-18T17:31:08.535Z');
     god.favouriteAuthor = god;
     delete god.createdAt;
     delete god.updatedAt;
@@ -231,6 +233,7 @@ describe('EntityAssignerMongo', () => {
         '  termsAccepted: false,\n' +
         '  books: Collection {\n' +
         "    '0': Book {\n" +
+        '      createdAt: ISODate(\'2020-07-18T17:31:08.535Z\'),\n' +
         '      tags: [Collection],\n' +
         "      title: 'Bible',\n" +
         '      author: [Author],\n' +

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -1400,7 +1400,7 @@ describe('EntityManagerMySql', () => {
       'left join `book_to_tag_unordered` as `e2` on `e0`.`uuid_pk` = `e2`.`book2_uuid_pk` ' +
       'left join `book_tag2` as `e1` on `e2`.`book_tag2_id` = `e1`.`id` ' +
       'left join `test2` as `e3` on `e0`.`uuid_pk` = `e3`.`book_uuid_pk` ' +
-      'where `e1`.`name` != ? ' +
+      'where `e1`.`name` != ? and `e0`.`author_id` is not null ' +
       'order by `e0`.`title` desc');
     await expect(books.length).toBe(3);
     await expect(books[0].title).toBe('My Life on The Wall, part 3');
@@ -1492,6 +1492,7 @@ describe('EntityManagerMySql', () => {
       'from `book2` as `e0` ' +
       'left join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` ' +
       'left join `test2` as `e2` on `e0`.`uuid_pk` = `e2`.`book_uuid_pk` where `e1`.`name` = \'Jon\' and length(perex) > 10000 limit 1');
+    orm.config.set('debug', false);
   });
 
   test('self referencing M:N (unidirectional)', async () => {
@@ -2263,7 +2264,7 @@ describe('EntityManagerMySql', () => {
       'from `book2` as `e0` ' +
       'left join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` ' +
       'left join `test2` as `e2` on `e0`.`uuid_pk` = `e2`.`book_uuid_pk` ' +
-      'where `e1`.`name` = ? limit ?');
+      'where `e1`.`name` = ? and `e0`.`author_id` is not null limit ?');
   });
 
   test('custom types', async () => {
@@ -2351,7 +2352,7 @@ describe('EntityManagerMySql', () => {
     expect(mock.mock.calls[1][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`created_at`, `e0`.`title`, `e0`.`price`, `e0`.`double`, `e0`.`meta`, `e0`.`author_id`, `e0`.`publisher_id`, `e0`.price * 1.19 as `price_taxed`, `e1`.`id` as `test_id` ' +
       'from `book2` as `e0` ' +
       'left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` ' +
-      'where `e0`.`author_id` in (?) ' +
+      'where `e0`.`author_id` is not null and `e0`.`author_id` in (?) ' +
       'order by `e0`.`title` asc');
 
     orm.em.clear();
@@ -2363,7 +2364,7 @@ describe('EntityManagerMySql', () => {
     expect(mock.mock.calls[1][0]).toMatch('select `e0`.*, `e0`.price * 1.19 as `price_taxed`, `e1`.`id` as `test_id` ' +
       'from `book2` as `e0` ' +
       'left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` ' +
-      'where `e0`.`author_id` in (?) ' +
+      'where `e0`.`author_id` is not null and `e0`.`author_id` in (?) ' +
       'order by `e0`.`title` asc');
 
     orm.em.clear();
@@ -2375,7 +2376,7 @@ describe('EntityManagerMySql', () => {
     expect(mock.mock.calls[1][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`created_at`, `e0`.`title`, `e0`.`price`, `e0`.`double`, `e0`.`meta`, `e0`.`author_id`, `e0`.`publisher_id`, `e0`.price * 1.19 as `price_taxed`, `e1`.`id` as `test_id` ' +
       'from `book2` as `e0` ' +
       'left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` ' +
-      'where `e0`.`author_id` in (?) ' +
+      'where `e0`.`author_id` is not null and `e0`.`author_id` in (?) ' +
       'order by `e0`.`title` asc');
 
     orm.em.clear();
@@ -2387,7 +2388,7 @@ describe('EntityManagerMySql', () => {
     expect(mock.mock.calls[1][0]).toMatch('select `e0`.*, `e0`.price * 1.19 as `price_taxed`, `e1`.`id` as `test_id` ' +
       'from `book2` as `e0` ' +
       'left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` ' +
-      'where `e0`.`author_id` in (?) ' +
+      'where `e0`.`author_id` is not null and `e0`.`author_id` in (?) ' +
       'order by `e0`.`title` asc');
   });
 

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -1467,7 +1467,7 @@ describe('EntityManagerMySql', () => {
     expect(mock.mock.calls[2][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`created_at`, `e0`.`title`, `e0`.`price`, `e0`.`double`, `e0`.`meta`, `e0`.`author_id`, `e0`.`publisher_id`, `e0`.price * 1.19 as `price_taxed`, `e1`.`id` as `test_id` ' +
       'from `book2` as `e0` ' +
       'left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` ' +
-      'where `e0`.`title` = \'123\' and `e0`.`author_id` is not null');
+      'where `e0`.`title` = \'123\'');
 
     const books4 = await orm.em.find(Book2, { title: '123' }, {
       filters: true,
@@ -1492,7 +1492,6 @@ describe('EntityManagerMySql', () => {
       'from `book2` as `e0` ' +
       'left join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` ' +
       'left join `test2` as `e2` on `e0`.`uuid_pk` = `e2`.`book_uuid_pk` where `e1`.`name` = \'Jon\' and length(perex) > 10000 limit 1');
-    orm.config.set('debug', false);
   });
 
   test('self referencing M:N (unidirectional)', async () => {

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -943,7 +943,7 @@ describe('EntityManagerPostgre', () => {
     expect(res).toHaveLength(1);
     expect(res[0].books.length).toBe(2);
     expect(mock.mock.calls[0][0]).toMatch('select "e0".* from "author2" as "e0" left join "book2" as "e1" on "e0"."id" = "e1"."author_id" where "e1"."title" in ($1, $2)');
-    expect(mock.mock.calls[1][0]).toMatch('select "e0".*, "e0".price * 1.19 as "price_taxed" from "book2" as "e0" where "e0"."author_id" in ($1) and "e0"."title" in ($2, $3) order by "e0"."title" asc');
+    expect(mock.mock.calls[1][0]).toMatch('select "e0".*, "e0".price * 1.19 as "price_taxed" from "book2" as "e0" where "e0"."author_id" is not null and "e0"."author_id" in ($1) and "e0"."title" in ($2, $3) order by "e0"."title" asc');
   });
 
   test('trying to populate non-existing or non-reference property will throw', async () => {

--- a/tests/Migrator.test.ts
+++ b/tests/Migrator.test.ts
@@ -3,7 +3,7 @@ import umzug from 'umzug';
 import { Logger, MikroORM } from '@mikro-orm/core';
 import { Migration, Migrator } from '@mikro-orm/migrations';
 import { MySqlDriver } from '@mikro-orm/mysql';
-import { unlink, writeFile } from 'fs-extra';
+import { remove, writeFile } from 'fs-extra';
 import { initORMMySql } from './bootstrap';
 
 class MigrationTest1 extends Migration {
@@ -30,11 +30,15 @@ describe('Migrator', () => {
 
   let orm: MikroORM<MySqlDriver>;
 
-  beforeAll(async () => orm = await initORMMySql());
+  beforeAll(async () => {
+    orm = await initORMMySql();
+    await remove(process.cwd() + '/temp/migrations/Migration20191013214813.js');
+    await remove(process.cwd() + '/temp/migrations/Migration20191013214813.ts');
+    await remove(process.cwd() + '/temp/migrations/migration-20191013214813.ts');
+  });
   afterAll(async () => orm.close(true));
 
   test('generate js schema migration', async () => {
-    await unlink(process.cwd() + '/temp/migrations/Migration20191013214813.ts');
     const dateMock = jest.spyOn(Date.prototype, 'toISOString');
     dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
     const migrationsSettings = orm.config.get('migrations');
@@ -43,11 +47,10 @@ describe('Migrator', () => {
     const migration = await migrator.createMigration();
     expect(migration).toMatchSnapshot('migration-js-dump');
     orm.config.set('migrations', migrationsSettings); // Revert migration config changes
-    await unlink(process.cwd() + '/temp/migrations/Migration20191013214813.ts');
+    await remove(process.cwd() + '/temp/migrations/' + migration.fileName);
   });
 
   test('generate migration with custom name', async () => {
-    await unlink(process.cwd() + '/temp/migrations/Migration20191013214813.ts');
     const dateMock = jest.spyOn(Date.prototype, 'toISOString');
     dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
     const migrationsSettings = orm.config.get('migrations');
@@ -56,17 +59,16 @@ describe('Migrator', () => {
     const migration = await migrator.createMigration();
     expect(migration).toMatchSnapshot('migration-dump');
     orm.config.set('migrations', migrationsSettings); // Revert migration config changes
-    await unlink(process.cwd() + '/temp/migrations/Migration20191013214813.ts');
+    await remove(process.cwd() + '/temp/migrations/' + migration.fileName);
   });
 
   test('generate schema migration', async () => {
-    await unlink(process.cwd() + '/temp/migrations/Migration20191013214813.ts');
     const dateMock = jest.spyOn(Date.prototype, 'toISOString');
     dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
     const migrator = new Migrator(orm.em);
     const migration = await migrator.createMigration();
     expect(migration).toMatchSnapshot('migration-dump');
-    await unlink(process.cwd() + '/temp/migrations/Migration20191013214813.ts');
+    await remove(process.cwd() + '/temp/migrations/' + migration.fileName);
   });
 
   test('migration is skipped when no diff', async () => {
@@ -173,7 +175,7 @@ describe('Migrator', () => {
     await migrator.up({ from: migration.fileName } as any);
     await migrator.down();
 
-    await unlink(path + '/' + migration.fileName);
+    await remove(path + '/' + migration.fileName);
     const calls = mock.mock.calls.map(call => {
       return call[0]
         .replace(/ \[took \d+ ms]/, '')
@@ -209,7 +211,7 @@ describe('Migrator', () => {
     await migrator.up({ from: migration.fileName } as any);
     await migrator.down();
 
-    await unlink(path + '/' + migration.fileName);
+    await remove(path + '/' + migration.fileName);
     const calls = mock.mock.calls.map(call => {
       return call[0]
         .replace(/ \[took \d+ ms]/, '')

--- a/tests/Migrator.test.ts
+++ b/tests/Migrator.test.ts
@@ -34,6 +34,7 @@ describe('Migrator', () => {
   afterAll(async () => orm.close(true));
 
   test('generate js schema migration', async () => {
+    await unlink(process.cwd() + '/temp/migrations/Migration20191013214813.ts');
     const dateMock = jest.spyOn(Date.prototype, 'toISOString');
     dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
     const migrationsSettings = orm.config.get('migrations');
@@ -42,10 +43,11 @@ describe('Migrator', () => {
     const migration = await migrator.createMigration();
     expect(migration).toMatchSnapshot('migration-js-dump');
     orm.config.set('migrations', migrationsSettings); // Revert migration config changes
-    await unlink(process.cwd() + '/temp/migrations/' + migration.fileName);
+    await unlink(process.cwd() + '/temp/migrations/Migration20191013214813.ts');
   });
 
   test('generate migration with custom name', async () => {
+    await unlink(process.cwd() + '/temp/migrations/Migration20191013214813.ts');
     const dateMock = jest.spyOn(Date.prototype, 'toISOString');
     dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
     const migrationsSettings = orm.config.get('migrations');
@@ -54,16 +56,17 @@ describe('Migrator', () => {
     const migration = await migrator.createMigration();
     expect(migration).toMatchSnapshot('migration-dump');
     orm.config.set('migrations', migrationsSettings); // Revert migration config changes
-    await unlink(process.cwd() + '/temp/migrations/' + migration.fileName);
+    await unlink(process.cwd() + '/temp/migrations/Migration20191013214813.ts');
   });
 
   test('generate schema migration', async () => {
+    await unlink(process.cwd() + '/temp/migrations/Migration20191013214813.ts');
     const dateMock = jest.spyOn(Date.prototype, 'toISOString');
     dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
     const migrator = new Migrator(orm.em);
     const migration = await migrator.createMigration();
     expect(migration).toMatchSnapshot('migration-dump');
-    await unlink(process.cwd() + '/temp/migrations/' + migration.fileName);
+    await unlink(process.cwd() + '/temp/migrations/Migration20191013214813.ts');
   });
 
   test('migration is skipped when no diff', async () => {

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -91,6 +91,18 @@ describe('QueryBuilder', () => {
     expect(qb3.getParams()).toEqual(['Audi A8', 2010]);
   });
 
+  test('select query with auto-joined query with operator and scalar', async () => {
+    const qb1 = orm.em.createQueryBuilder(Book2);
+    qb1.select('*').where({ author: { $ne: null } });
+    expect(qb1.getQuery()).toEqual('select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` where `e0`.`author_id` is not null');
+    expect(qb1.getParams()).toEqual([]);
+
+    const qb2 = orm.em.createQueryBuilder(Book2);
+    qb2.select('*').where({ author: { $ne: null, name: 'Jon Snow' } });
+    expect(qb2.getQuery()).toEqual('select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` left join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` where `e1`.`name` = ? and `e0`.`author_id` is not null');
+    expect(qb2.getParams()).toEqual(['Jon Snow']);
+  });
+
   test('select andWhere/orWhere', async () => {
     const qb = orm.em.createQueryBuilder(Publisher2);
     qb.select('*')

--- a/tests/SmartQueryHelper.test.ts
+++ b/tests/SmartQueryHelper.test.ts
@@ -1,9 +1,9 @@
-import { MikroORM, Reference, SmartQueryHelper } from '@mikro-orm/core';
+import { MikroORM, Reference, QueryHelper } from '@mikro-orm/core';
 import { initORMMySql } from './bootstrap';
 import { Author2, Book2, FooBar2, FooBaz2, Test2 } from './entities-sql';
 import { FooParam2 } from './entities-sql/FooParam2';
 
-describe('SmartQueryHelper', () => {
+describe('QueryHelper', () => {
 
   let orm: MikroORM;
 
@@ -11,7 +11,7 @@ describe('SmartQueryHelper', () => {
   afterAll(async () => orm.close(true));
 
   test('test operators `>, <, >=, <=, !`', async () => {
-    expect(SmartQueryHelper.processWhere({
+    expect(QueryHelper.processWhere({
       'key1>': 123,
       'key2<': 123,
       'key3>=': 123,
@@ -26,7 +26,7 @@ describe('SmartQueryHelper', () => {
       key5: { $ne: 123 },
       key6: { $not: 123 },
     });
-    expect(SmartQueryHelper.processWhere({
+    expect(QueryHelper.processWhere({
       'key1 >': 123,
       'key2 <': 123,
       'key3 >=': 123,
@@ -44,7 +44,7 @@ describe('SmartQueryHelper', () => {
   });
 
   test('test operators `:in, :nin, :gt(e), :lt(e), :ne, :not`', async () => {
-    expect(SmartQueryHelper.processWhere({
+    expect(QueryHelper.processWhere({
       'key1:gt': 123,
       'key2:lt': 123,
       'key3:gte': 123,
@@ -66,22 +66,22 @@ describe('SmartQueryHelper', () => {
   });
 
   test('processWhere returns empty object for undefined condition', async () => {
-    expect(SmartQueryHelper.processWhere(undefined as any, 'id', orm.getMetadata())).toEqual({});
+    expect(QueryHelper.processWhere(undefined as any, 'id', orm.getMetadata())).toEqual({});
   });
 
   test('test entity conversion to PK', async () => {
     const test = Test2.create('t123');
     test.id = 123;
-    expect(SmartQueryHelper.processParams({ test })).toEqual({ test: test.id });
-    expect(SmartQueryHelper.processParams(test)).toEqual({ id: test.id });
+    expect(QueryHelper.processParams({ test })).toEqual({ test: test.id });
+    expect(QueryHelper.processParams(test)).toEqual({ id: test.id });
     const author = new Author2('name', 'mail');
     let book = new Book2('test', author);
-    expect(SmartQueryHelper.processParams(book)).toEqual({ uuid: book.uuid });
+    expect(QueryHelper.processParams(book)).toEqual({ uuid: book.uuid });
     book = Reference.create(book);
-    expect(SmartQueryHelper.processParams(book)).toEqual({ uuid: book.uuid });
-    expect(SmartQueryHelper.processParams({ book })).toEqual({ book: book.uuid });
+    expect(QueryHelper.processParams(book)).toEqual({ uuid: book.uuid });
+    expect(QueryHelper.processParams({ book })).toEqual({ book: book.uuid });
     const field = undefined;
-    expect(SmartQueryHelper.processParams({ field })).toEqual({ field: null });
+    expect(QueryHelper.processParams({ field })).toEqual({ field: null });
   });
 
   test('test entity conversion to composite PK', async () => {
@@ -89,7 +89,7 @@ describe('SmartQueryHelper', () => {
     bar.id = 3;
     const baz = new FooBaz2('baz');
     baz.id = 7;
-    expect(SmartQueryHelper.processParams({ field: new FooParam2(bar, baz, 'val') })).toEqual({
+    expect(QueryHelper.processParams({ field: new FooParam2(bar, baz, 'val') })).toEqual({
       field: {
         bar: 3,
         baz: 7,
@@ -102,10 +102,10 @@ describe('SmartQueryHelper', () => {
     const book1 = new Book2('b1', author);
     const book2 = new Book2('b2', author);
     const book3 = new Book2('b3', author);
-    expect(SmartQueryHelper.processWhere<Author2>([1, 2, 3], 'uuid', orm.getMetadata())).toEqual({ uuid: { $in: [1, 2, 3] } });
-    expect(SmartQueryHelper.processWhere<Book2>([book1, book2, book3], 'uuid', orm.getMetadata())).toEqual({ uuid: { $in: [book1.uuid, book2.uuid, book3.uuid] } });
-    expect(SmartQueryHelper.processWhere<Author2>({ favouriteBook: ['1', '2', '3'] }, 'id', orm.getMetadata())).toEqual({ favouriteBook: { $in: ['1', '2', '3'] } });
-    expect(SmartQueryHelper.processWhere<Book2>({ $or: [{ author: [1, 2, 3] }, { author: [7, 8, 9] }] }, 'id', orm.getMetadata())).toEqual({
+    expect(QueryHelper.processWhere<Author2>([1, 2, 3], 'uuid', orm.getMetadata())).toEqual({ uuid: { $in: [1, 2, 3] } });
+    expect(QueryHelper.processWhere<Book2>([book1, book2, book3], 'uuid', orm.getMetadata())).toEqual({ uuid: { $in: [book1.uuid, book2.uuid, book3.uuid] } });
+    expect(QueryHelper.processWhere<Author2>({ favouriteBook: ['1', '2', '3'] }, 'id', orm.getMetadata())).toEqual({ favouriteBook: { $in: ['1', '2', '3'] } });
+    expect(QueryHelper.processWhere<Book2>({ $or: [{ author: [1, 2, 3] }, { author: [7, 8, 9] }] }, 'id', orm.getMetadata())).toEqual({
       $or: [{ author: { $in: [1, 2, 3] } }, { author: { $in: [7, 8, 9] } }],
     });
   });

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -38,6 +38,7 @@ describe('Utils', () => {
     expect(Utils.isObject({})).toBe(true);
     expect(Utils.isObject(new Test())).toBe(true);
     expect(Utils.isObject(new Date())).toBe(true);
+    expect(Utils.isObject(new Date(), [Date])).toBe(false);
     expect(Utils.isObject(Test)).toBe(false);
   });
 

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -45,6 +45,7 @@ export async function initORMMongo() {
     type: 'mongo',
     ensureIndexes: true,
     implicitTransactions: true,
+    filters: { allowedFooBars: { cond: args => ({ id: { $in: args.allowed } }), entity: ['FooBar'], default: false } },
   });
 
   // create collections first so we can use transactions
@@ -189,6 +190,7 @@ export async function wipeDatabaseMySql(em: SqlEntityManager) {
   await em.createQueryBuilder('publisher2_tests').truncate().execute();
   await em.getConnection().execute('set foreign_key_checks = 1');
   em.clear();
+  em.config.set('debug', false);
   Author2Subscriber.log.length = 0;
   EverythingSubscriber.log.length = 0;
   FlushSubscriber.log.length = 0;

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -1,11 +1,15 @@
 import { v4 } from 'uuid';
-import { Cascade, Collection, Entity, Formula, IdentifiedReference, ManyToMany, ManyToOne, OneToOne, PrimaryKey, Property, QueryOrder } from '@mikro-orm/core';
+import { Cascade, Collection, Entity, Filter, Formula, IdentifiedReference, ManyToMany, ManyToOne, OneToOne, PrimaryKey, Property, QueryOrder } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Test2 } from './Test2';
 
 @Entity()
+@Filter({ name: 'expensive', cond: { price: { $gt: 1000 } } })
+@Filter({ name: 'long', cond: { 'length(perex)': { $gt: 10000 } } })
+@Filter({ name: 'hasAuthor', cond: { author: { $ne: null } }, default: true })
+@Filter({ name: 'writtenBy', cond: args => ({ author: { name: args.name } }) })
 export class Book2 {
 
   @PrimaryKey({ name: 'uuid_pk', length: 36 })

--- a/tests/entities/Author.ts
+++ b/tests/entities/Author.ts
@@ -56,6 +56,9 @@ export class Author extends BaseEntity<Author> {
   @Property({ persist: false })
   versionAsString!: string;
 
+  @Property()
+  tenant?: number;
+
   constructor(name: string, email: string) {
     super();
     this.name = name;

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -1,5 +1,5 @@
 import { ObjectId } from 'mongodb';
-import { Collection, IdentifiedReference, Cascade, Entity, Index, ManyToMany, ManyToOne, PrimaryKey, Property, Unique, wrap } from '@mikro-orm/core';
+import { Collection, IdentifiedReference, Cascade, Entity, Index, ManyToMany, ManyToOne, PrimaryKey, Property, Unique, wrap, Filter, Dictionary } from '@mikro-orm/core';
 import { Publisher } from './Publisher';
 import { Author } from './Author';
 import { BookTag } from './book-tag';
@@ -9,10 +9,14 @@ import { BaseEntity3 } from './BaseEntity3';
 @Unique({ properties: ['title', 'author'] })
 @Index({ properties: 'title', type: 'text' })
 @Index({ options: { point: '2dsphere', title: -1 } })
+@Filter({ name: 'writtenBy', cond: args => ({ author: args.author }) })
 export class Book extends BaseEntity3 {
 
   @PrimaryKey()
   _id!: ObjectId;
+
+  @Property()
+  createdAt: Date = new Date();
 
   @Property()
   title: string;
@@ -31,7 +35,7 @@ export class Book extends BaseEntity3 {
   tags: Collection<BookTag> = new Collection<BookTag>(this);
 
   @Property()
-  metaObject?: object;
+  metaObject?: Dictionary<unknown>;
 
   @Property()
   metaArray?: any[];
@@ -42,6 +46,9 @@ export class Book extends BaseEntity3 {
   @Property()
   @Index({ type: '2dsphere' })
   point?: [number, number];
+
+  @Property()
+  tenant?: number;
 
   constructor(title: string, author?: Author) {
     super();

--- a/tests/issues/GH603.test.ts
+++ b/tests/issues/GH603.test.ts
@@ -102,7 +102,7 @@ describe('GH issue 603', () => {
   // composite pk for versioning purposes. Id stays the same, but version can be changed
   test(`GH issue 603, update entity`, async () => {
     const project = await orm.em.findOneOrFail(ProjectProps, projectId);
-    const task = await orm.em.findOneOrFail(TaskProps, taskId);
+    const task = await orm.em.findOneOrFail(TaskProps, { id: taskId });
     const newVersion = orm.em.create(TaskProps, { id: task.id });
     newVersion.projects.add(project);
     await expect(orm.em.flush()).resolves.not.toThrow();

--- a/tests/joined-strategy.postgre.test.ts
+++ b/tests/joined-strategy.postgre.test.ts
@@ -225,6 +225,7 @@ describe('Joined loading strategy', () => {
       'from "book2" as "e0" ' +
       'left join "book2_tags" as "e2" on "e0"."uuid_pk" = "e2"."book2_uuid_pk" ' +
       'left join "book_tag2" as "t1" on "e2"."book_tag2_id" = "t1"."id" ' +
+      'where "e0"."author_id" is not null ' +
       'order by "t1"."name" desc');
 
     expect(books.map(b => b.title)).toEqual(['b4', 'b2', 'b1', 'b5', 'b3']);


### PR DESCRIPTION
Allows to define filters that will be automatically applied to the conditions.
Filter can be defined at the entity level, dynamically via EM or in the ORM
Configuration.

```typescript
@Entity()
@Filter({ name: 'expensive', cond: { price: { $gt: 1000 } } })
@Filter({ name: 'long', cond: { 'length(text)': { $gt: 10000 } } })
@Filter({ name: 'hasAuthor', cond: { author: { $ne: null } }, default: true })
@Filter({ name: 'writtenBy', cond: args => ({ author: { name: args.name } }) })
export class Book {
  ...
}

const books1 = await orm.em.find(Book, {}, {
  filters: ['long', 'expensive'],
});
const books2 = await orm.em.find(Book, {}, {
  filters: { hasAuthor: false, long: true, writtenBy: { name: 'God' } },
});
```

EM filter API:

```typescript
// bound to entity, enabled by default
em.addFilter('writtenBy', args => ({ author: args.id }), Book);

// global, enabled by default, for all entities
em.addFilter('tenant', args => { ... });

// global, enabled by default, for only specified entities
em.addFilter('tenant', args => { ... }, [Author, Book]);
...

// set params (probably in some middleware)
em.setFilterParams('tenant', { tenantId: 123 });
em.setFilterParams('writtenBy', { id: 321 });

...

// usage
em.find(Book, {}); // same as `{ tenantId: 123 }`
em.find(Book, {}, { filters: ['writtenBy'] }); // same as `{ author: 321, tenantId: 123 }`
em.find(Book, {}, { filters: { tenant: false } }); // disabled tenant filter, so truly `{}`
em.find(Book, {}, { filters: false }); // disabled all filters, so truly `{}`
```

Closes #385