### PR TITLE
refactor: add undeclared optional peer dependencies

### DIFF
--- a/packages/knex/package.json
+++ b/packages/knex/package.json
@@ -54,6 +54,28 @@
     "@mikro-orm/core": "^4.0.0-alpha.6"
   },
   "peerDependencies": {
-    "@mikro-orm/core": "^4.0.0-alpha.6"
+    "@mikro-orm/core": "^4.0.0-alpha.6",
+    "mssql": "^6.2.0",
+    "mysql": "^2.18.1",
+    "mysql2": "^2.1.0",
+    "pg": "^8.0.3",
+    "sqlite3": "^4.1.1"
+  },
+  "peerDependenciesMeta": {
+    "mssql": {
+      "optional": true
+    },
+    "mysql": {
+      "optional": true
+    },
+    "mysql2": {
+      "optional": true
+    },
+    "pg": {
+      "optional": true
+    },
+    "sqlite3": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@mikro-orm/knex` doesn't declare the optional peer dependencies declared by `knex` (https://cdn.jsdelivr.net/npm/knex@0.21.2/package.json), continues https://github.com/mikro-orm/mikro-orm/pull/645.

Didn't notice this in the first round as `@yarnpkg/doctor` doesn't report missing optional peer dependencies (https://github.com/yarnpkg/berry/blob/c7da64d2261e4565cffac3100a98218a7c67e3ef/packages/yarnpkg-doctor/sources/cli.ts#L276-L283) and I had already fixed it locally using packageExtensions(https://yarnpkg.com/configuration/yarnrc#packageExtensions) and thus forgot it add it to the PR.

**How did you fix it?**

Add the optional peer dependencies specified by `knex`