### PR TITLE
refactor(mysql-base): add missing optional peer dependency

### DIFF
--- a/packages/mysql-base/package.json
+++ b/packages/mysql-base/package.json
@@ -54,14 +54,10 @@
   },
   "peerDependencies": {
     "@mikro-orm/core": "^4.0.0-alpha.6",
-    "mysql2": "^2.1.0",
-    "mariadb": "^2.4.0"
+    "mysql2": "^2.1.0"
   },
   "peerDependenciesMeta": {
     "mysql2": {
-      "optional": true
-    },
-    "mariadb": {
       "optional": true
     }
   }

--- a/packages/mysql-base/package.json
+++ b/packages/mysql-base/package.json
@@ -54,10 +54,14 @@
   },
   "peerDependencies": {
     "@mikro-orm/core": "^4.0.0-alpha.6",
-    "mysql2": "^2.1.0"
+    "mysql2": "^2.1.0",
+    "mariadb": "^2.4.0"
   },
   "peerDependenciesMeta": {
     "mysql2": {
+      "optional": true
+    },
+    "mariadb": {
       "optional": true
     }
   }

--- a/packages/mysql-base/package.json
+++ b/packages/mysql-base/package.json
@@ -53,6 +53,12 @@
     "@mikro-orm/core": "^4.0.0-alpha.6"
   },
   "peerDependencies": {
-    "@mikro-orm/core": "^4.0.0-alpha.6"
+    "@mikro-orm/core": "^4.0.0-alpha.6",
+    "mysql2": "^2.1.0"
+  },
+  "peerDependenciesMeta": {
+    "mysql2": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@mikro-orm/mysql-base` is missing a optional peer dependency on `mysql2` which it inherits from `@mikro-orm/knex` (added in https://github.com/mikro-orm/mikro-orm/pull/673)

Continues https://github.com/mikro-orm/mikro-orm/pull/645 and https://github.com/mikro-orm/mikro-orm/pull/673

**How did you fix it?**

Add undeclared optional peer dependency `mysql2` to `