### PR TITLE
fix(core): fix `em.create()` with deeply nested data

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -387,6 +387,13 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   }
 
   /**
+   * Shortcut for `wrap(entity).assign(data, { em })`
+   */
+  assign<T>(entity: T, data: EntityData<T>): T {
+    return EntityAssigner.assign(entity, data, { em: this });
+  }
+
+  /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
   getReference<T, PK extends keyof T>(entityName: EntityName<T>, id: Primary<T>, wrapped: true): IdentifiedReference<T, PK>;

--- a/packages/core/src/entity/ArrayCollection.ts
+++ b/packages/core/src/entity/ArrayCollection.ts
@@ -70,8 +70,7 @@ export class ArrayCollection<T extends AnyEntity<T>, O extends AnyEntity<O>> {
    */
   hydrate(items: T[]): void {
     this.items.length = 0;
-    this.items.push(...items);
-    Object.assign(this, this.items);
+    this.add(...items);
   }
 
   remove(...items: (T | Reference<T>)[]): void {
@@ -158,7 +157,7 @@ export class ArrayCollection<T extends AnyEntity<T>, O extends AnyEntity<O>> {
   }
 
   protected shouldPropagateToCollection(collection: Collection<O, T>, method: 'add' | 'remove'): boolean {
-    if (!collection) {
+    if (!collection || !collection.isInitialized()) {
       return false;
     }
 

--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -21,6 +21,20 @@ export class Collection<T extends AnyEntity<T>, O extends AnyEntity<O> = AnyEnti
   }
 
   /**
+   * Creates new Collection instance, assigns it to the owning entity and sets the items to it (propagating them to their inverse sides)
+   */
+  static create<T extends AnyEntity<T>, O extends AnyEntity<O> = AnyEntity>(owner: O, prop: keyof O, items: undefined | T[], initialized: boolean): Collection<T, O> {
+    const coll = new Collection<T, O>(owner, items, initialized);
+    owner[prop] = coll as unknown as O[keyof O];
+
+    if (items) {
+      coll.set(items);
+    }
+
+    return coll;
+  }
+
+  /**
    * Initializes the collection and returns the items
    */
   async loadItems(): Promise<T[]> {
@@ -67,8 +81,10 @@ export class Collection<T extends AnyEntity<T>, O extends AnyEntity<O> = AnyEnti
     }
 
     const wasInitialized = this.initialized;
+    const wasDirty = this.dirty;
     this.initialized = true;
     super.hydrate(items);
+    this.dirty = wasDirty;
 
     if (!wasInitialized) {
       this.snapshot = undefined;

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -115,6 +115,13 @@ export class EntityRepository<T> {
     return this.em.create<T>(this.entityName, data);
   }
 
+  /**
+   * Shortcut for `wrap(entity).assign(data, { em })`
+   */
+  assign(entity: T, data: EntityData<T>): T {
+    return this.em.assign(entity, data);
+  }
+
   async count(where: FilterQuery<T> = {}): Promise<number> {
     return this.em.count<T>(this.entityName, where);
   }

--- a/packages/core/src/entity/Reference.ts
+++ b/packages/core/src/entity/Reference.ts
@@ -1,11 +1,9 @@
-import { AnyEntity, Dictionary, EntityProperty, IWrappedEntityInternal, Primary } from '../typings';
+import { AnyEntity, Dictionary, EntityProperty, Primary } from '../typings';
 import { wrap } from './wrap';
 
 export type IdentifiedReference<T, PK extends keyof T = 'id' & keyof T> = { [K in PK]: T[K] } & Reference<T>;
 
 export class Reference<T> {
-
-  private __helper?: IWrappedEntityInternal<T, keyof T>;
 
   constructor(private entity: T) {
     this.set(entity);
@@ -81,7 +79,7 @@ export class Reference<T> {
     }
 
     this.entity = entity;
-    this.__helper = wrap(this.entity, true);
+    Object.defineProperty(this, '__helper', { value: wrap(this.entity, true), writable: true });
   }
 
   unwrap(): T {


### PR DESCRIPTION
Previously `em.create()` did not handle collection updates correctly, basically ignoring all the
values if the property was not M:N owning side.

With this fix, both `em.create()` and `wrap(e).assign()` properly handled collection updates,
including propagation to the owning sides.

Closes #678