### PR TITLE
feat(core): allow persisting 1:m collections

### DIFF
--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -287,7 +287,7 @@ export class UnitOfWork {
       return this.processToOneReference(reference, visited);
     }
 
-    if (Utils.isCollection(reference, prop, ReferenceType.MANY_TO_MANY) && reference.isDirty()) {
+    if (Utils.isCollection<any>(reference, prop, ReferenceType.MANY_TO_MANY) && reference.isDirty()) {
       this.processToManyReference(reference, visited, parent, prop);
     }
   }

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -494,7 +494,7 @@ export class Utils {
     return ret;
   }
 
-  static isCollection(item: any, prop?: EntityProperty, type?: ReferenceType): item is Collection<AnyEntity> {
+  static isCollection<T extends AnyEntity<T>, O extends AnyEntity<O> = AnyEntity>(item: any, prop?: EntityProperty<T>, type?: ReferenceType): item is Collection<T, O> {
     if (!(item instanceof Collection)) {
       return false;
     }

--- a/tests/EntityFactory.test.ts
+++ b/tests/EntityFactory.test.ts
@@ -175,7 +175,7 @@ describe('EntityFactory', () => {
     expect(a1.name).toBe('Jon');
     expect(a1.email).toBe('jon@snow.com');
     expect(a1.books.isInitialized()).toBe(true);
-    expect(a1.books.isDirty()).toBe(false); // inverse side
+    expect(a1.books.isDirty()).toBe(true);
     expect(a1.books[0].title).toBe('B1');
     expect(a1.books[0].author).toBe(a1); // propagation to owning side
     expect(a1.books[0].publisher.id).toBe('5b0d19b28b21c648c2c8a600');
@@ -211,7 +211,7 @@ describe('EntityFactory', () => {
     expect(a2.name).toBe('Jon');
     expect(a2.email).toBe('jon2@snow.com');
     expect(a2.books.isInitialized()).toBe(true);
-    expect(a2.books.isDirty()).toBe(false); // inverse side
+    expect(a2.books.isDirty()).toBe(true);
     expect(a2.books[0].title).toBe('B1');
     expect(a2.books[0].author).toBe(a2); // propagation to owning side
     expect(a2.books[0].publisher.id).toBe('5b0d19b28b21c648c2c8a600');

--- a/tests/EntityHelper.mongo.test.ts
+++ b/tests/EntityHelper.mongo.test.ts
@@ -240,7 +240,7 @@ describe('EntityAssignerMongo', () => {
         '      publisher: [Reference]\n' +
         '    },\n' +
         '    initialized: true,\n' +
-        '    dirty: false\n' +
+        '    dirty: true\n' +
         '  },\n' +
         '  friends: Collection { initialized: true, dirty: false },\n' +
         "  name: 'God',\n" +
@@ -249,7 +249,7 @@ describe('EntityAssignerMongo', () => {
         '  favouriteAuthor: Author {\n' +
         '    hookTest: false,\n' +
         '    termsAccepted: false,\n' +
-        "    books: Collection { '0': [Book], initialized: true, dirty: false },\n" +
+        "    books: Collection { '0': [Book], initialized: true, dirty: true },\n" +
         '    friends: Collection { initialized: true, dirty: false },\n' +
         "    name: 'God',\n" +
         "    email: 'hello@heaven.god',\n" +

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -1022,8 +1022,12 @@ describe('EntityManagerMySql', () => {
     orm.em.clear();
 
     let tag = await orm.em.findOneOrFail(BookTag2, tag1.id, ['books']);
-    const err = 'You cannot modify inverse side of M:N collection BookTag2.books when the owning side is not initialized. Consider working with the owning side instead (Book2.tags).';
-    expect(() => tag.books.add(orm.em.getReference(Book2, book4.uuid))).toThrowError(err);
+    expect(tag.books.count()).toBe(2);
+    tag.books.add(orm.em.getReference(Book2, book4.uuid));
+    await orm.em.flush();
+    orm.em.clear();
+    tag = await orm.em.findOneOrFail(BookTag2, tag1.id, ['books']);
+    expect(tag.books.count()).toBe(3);
     orm.em.clear();
 
     tag = await orm.em.findOneOrFail(BookTag2, tag1.id, ['books']);

--- a/tests/issues/GH467.test.ts
+++ b/tests/issues/GH467.test.ts
@@ -1,0 +1,99 @@
+import { unlinkSync } from 'fs';
+import { Collection, Entity, PrimaryKey, ManyToOne, OneToMany, MikroORM, IdentifiedReference } from '@mikro-orm/core';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+
+@Entity()
+class A {
+
+  @PrimaryKey()
+  id!: string;
+
+  @ManyToOne({ entity: 'B', wrappedReference: true, nullable: true })
+  b?: IdentifiedReference<B>;
+
+}
+
+@Entity()
+class B {
+
+  @PrimaryKey()
+  id!: string;
+
+  @OneToMany(() => A, a => a.b)
+  as = new Collection<A>(this);
+
+}
+
+describe('GH issue 467', () => {
+
+  let orm: MikroORM<SqliteDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [A, B],
+      dbName: __dirname + '/../../temp/mikro_orm_test_gh467.db',
+      debug: false,
+      highlight: false,
+      type: 'sqlite',
+    });
+    await orm.getSchemaGenerator().dropSchema();
+    await orm.getSchemaGenerator().createSchema();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+    unlinkSync(orm.config.get('dbName')!);
+  });
+
+  test(`wrap().assign to collections is persisted`, async () => {
+    const a = new A();
+    a.id = 'a1';
+    await orm.em.persistAndFlush(a);
+
+    const b = new B();
+    orm.em.assign(b, {
+      id: 'b1',
+      as: ['a1'],
+    });
+    await orm.em.persistAndFlush(b);
+    orm.em.clear();
+
+    const b1 = await orm.em.findOneOrFail(B, 'b1', ['as']);
+    expect(b1.as.getIdentifiers()).toEqual(['a1']);
+  });
+
+  test(`assigning to new collection from inverse side is persisted`, async () => {
+    const a = new A();
+    a.id = 'a2';
+    await orm.em.persistAndFlush(a);
+
+    const b = new B();
+    b.id = 'b2';
+    b.as.set([orm.em.getReference(A, 'a2')]);
+    await orm.em.persistAndFlush(b);
+    orm.em.clear();
+
+    const b1 = await orm.em.findOneOrFail(B, 'b2', ['as']);
+    expect(b1.as.getIdentifiers()).toEqual(['a2']);
+  });
+
+  test(`assigning to loaded collection from inverse side is persisted`, async () => {
+    const a = new A();
+    a.id = 'a3';
+    await orm.em.persistAndFlush(a);
+
+    const b = new B();
+    b.id = 'b3';
+    await orm.em.persistAndFlush(b);
+    orm.em.clear();
+
+    const b1 = await orm.em.findOneOrFail(B, 'b3', ['as']);
+    b1.as.set([orm.em.getReference(A, 'a3')]);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const b2 = await orm.em.findOneOrFail(B, 'b3', ['as']);
+    expect(b2.as.getIdentifiers()).toEqual(['a3']);
+  });
+
+});


### PR DESCRIPTION
Previously only initialized items were allowed to be persisted when adding to
1:m collection, due to how propagation works. With this change we now allow
having inverse side collections dirty as well, firing single update query
for those if we see the items are now initialized.

Closes #467