### PR TITLE
refactor(dev-experience): turn on curly eslint rule to match preferred project styling

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -68,6 +68,7 @@ module.exports = {
     'prefer-rest-params': 'error',
     'prefer-spread': 'error',
     'constructor-super': 'error',
+    'curly': 'error',
     'for-direction': 'error',
     'getter-return': 'error',
     'no-async-promise-executor': 'error',


### PR DESCRIPTION
Turn on the curly eslint rule so that the linter matches the project's preferred style.