### PR TITLE
feat(core): add `driver.nativeInsertMany()` method

### DIFF
--- a/packages/core/src/connections/Connection.ts
+++ b/packages/core/src/connections/Connection.ts
@@ -112,6 +112,7 @@ export interface QueryResult {
   affectedRows: number;
   insertId: number;
   row?: Dictionary;
+  rows?: Dictionary[];
 }
 
 export interface ConnectionConfig {

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -27,6 +27,8 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
 
   abstract async nativeInsert<T extends AnyEntity<T>>(entityName: string, data: EntityData<T>, ctx?: Transaction): Promise<QueryResult>;
 
+  abstract async nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityData<T>[], ctx?: Transaction): Promise<QueryResult>;
+
   abstract async nativeUpdate<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, data: EntityData<T>, ctx?: Transaction): Promise<QueryResult>;
 
   abstract async nativeDelete<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, ctx?: Transaction): Promise<QueryResult>;

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -36,6 +36,8 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
 
   nativeInsert<T>(entityName: string, data: EntityData<T>, ctx?: Transaction): Promise<QueryResult>;
 
+  nativeInsertMany<T>(entityName: string, data: EntityData<T>[], ctx?: Transaction): Promise<QueryResult>;
+
   nativeUpdate<T>(entityName: string, where: FilterQuery<T>, data: EntityData<T>, ctx?: Transaction): Promise<QueryResult>;
 
   nativeDelete<T>(entityName: string, where: FilterQuery<T>, ctx?: Transaction): Promise<QueryResult>;

--- a/packages/knex/src/AbstractSqlConnection.ts
+++ b/packages/knex/src/AbstractSqlConnection.ts
@@ -113,7 +113,7 @@ export abstract class AbstractSqlConnection extends Connection {
     const affectedRows = typeof res === 'number' ? res : 0;
     const insertId = typeof res[0] === 'number' ? res[0] : 0;
 
-    return { insertId, affectedRows, row: res[0] };
+    return { insertId, affectedRows, row: res[0], rows: res };
   }
 
   protected abstract transformRawResult<T>(res: any, method: 'all' | 'get' | 'run'): T;

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -52,6 +52,10 @@ export class QueryBuilderHelper {
   }
 
   processData(data: Dictionary): any {
+    if (Array.isArray(data)) {
+      return data.map(d => this.processData(d));
+    }
+
     data = Object.assign({}, data); // copy first
     const meta = this.metadata.find(this.entityName);
 

--- a/tests/DatabaseDriver.test.ts
+++ b/tests/DatabaseDriver.test.ts
@@ -27,6 +27,10 @@ class Driver extends DatabaseDriver<Connection> {
     return { affectedRows: 0, insertId: 0 };
   }
 
+  async nativeInsertMany<T>(entityName: string, data: EntityData<T>[], ctx: Transaction | undefined): Promise<QueryResult> {
+    return { affectedRows: 0, insertId: 0 };
+  }
+
   async nativeUpdate<T>(entityName: string, where: FilterQuery<T>, data: EntityData<T>, ctx: Transaction | undefined): Promise<QueryResult> {
     return { affectedRows: 0, insertId: 0 };
   }

--- a/tests/EntityManager.mariadb.test.ts
+++ b/tests/EntityManager.mariadb.test.ts
@@ -70,6 +70,22 @@ describe('EntityManagerMariaDb', () => {
     expect(driver.getPlatform().denormalizePrimaryKey(1)).toBe(1);
     expect(driver.getPlatform().denormalizePrimaryKey('1')).toBe('1');
     await expect(driver.find(BookTag2.name, { books: { $in: [1] } })).resolves.not.toBeNull();
+
+    // multi inserts
+    const res = await driver.nativeInsertMany(Publisher2.name, [
+      { name: 'test 1', type: PublisherType.GLOBAL },
+      { name: 'test 2', type: PublisherType.LOCAL },
+      { name: 'test 3', type: PublisherType.GLOBAL },
+    ]);
+
+    // mysql returns the first inserted id
+    expect(res).toMatchObject({ insertId: 1, affectedRows: 0, row: 1, rows: [ 1 ] });
+    const res2 = await driver.find(Publisher2.name, {});
+    expect(res2).toMatchObject([
+      { id: 1, name: 'test 1', type: PublisherType.GLOBAL },
+      { id: 2, name: 'test 2', type: PublisherType.LOCAL },
+      { id: 3, name: 'test 3', type: PublisherType.GLOBAL },
+    ]);
   });
 
   test('driver appends errored query', async () => {

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -87,6 +87,22 @@ describe('EntityManagerMySql', () => {
       await conn.execute(orm.em.getKnex().raw('select 1'), [], 'all', tx);
       await conn.execute(orm.em.getRepository(Author2).getKnex().raw('select 1'), [], 'all', tx);
     });
+
+    // multi inserts
+    const res = await driver.nativeInsertMany(Publisher2.name, [
+      { name: 'test 1', type: PublisherType.GLOBAL },
+      { name: 'test 2', type: PublisherType.LOCAL },
+      { name: 'test 3', type: PublisherType.GLOBAL },
+    ]);
+
+    // mysql returns the first inserted id
+    expect(res).toMatchObject({ insertId: 1, affectedRows: 0, row: 1, rows: [ 1 ] });
+    const res2 = await driver.find(Publisher2.name, {});
+    expect(res2).toMatchObject([
+      { id: 1, name: 'test 1', type: PublisherType.GLOBAL },
+      { id: 2, name: 'test 2', type: PublisherType.LOCAL },
+      { id: 3, name: 'test 3', type: PublisherType.GLOBAL },
+    ]);
   });
 
   test('driver appends errored query', async () => {

--- a/tests/EntityManager.sqlite.test.ts
+++ b/tests/EntityManager.sqlite.test.ts
@@ -59,6 +59,22 @@ describe('EntityManagerSqlite', () => {
       insertId: 1,
     });
     expect(await driver.find(BookTag3.name, { books: [1] })).not.toBeNull();
+
+    // multi inserts
+    const res = await driver.nativeInsertMany(Publisher3.name, [
+      { name: 'test 1', type: 'GLOBAL' },
+      { name: 'test 2', type: 'LOCAL' },
+      { name: 'test 3', type: 'GLOBAL' },
+    ]);
+
+    // sqlite returns the last inserted id
+    expect(res).toMatchObject({ insertId: 3, affectedRows: 0, row: 3, rows: [ 3 ] });
+    const res2 = await driver.find(Publisher3.name, {});
+    expect(res2).toEqual([
+      { id: 1, name: 'test 1', type: 'GLOBAL' },
+      { id: 2, name: 'test 2', type: 'LOCAL' },
+      { id: 3, name: 'test 3', type: 'GLOBAL' },
+    ]);
   });
 
   test('driver appends errored query', async () => {

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -1069,6 +1069,17 @@ describe('QueryBuilder', () => {
     expect(qb3.getParams()).toEqual([123]);
   });
 
+  test('insert many query', async () => {
+    const qb1 = orm.em.createQueryBuilder(Publisher2);
+    qb1.insert([
+      { name: 'test 1', type: PublisherType.GLOBAL },
+      { name: 'test 2', type: PublisherType.LOCAL },
+      { name: 'test 3', type: PublisherType.GLOBAL },
+    ]);
+    expect(qb1.getQuery()).toEqual('insert into `publisher2` (`name`, `type`) values (?, ?), (?, ?), (?, ?)');
+    expect(qb1.getParams()).toEqual(['test 1', PublisherType.GLOBAL, 'test 2', PublisherType.LOCAL, 'test 3', PublisherType.GLOBAL]);
+  });
+
   test('update query', async () => {
     const qb = orm.em.createQueryBuilder(Publisher2);
     qb.update({ name: 'test 123', type: PublisherType.GLOBAL }).where({ id: 123, type: PublisherType.LOCAL });


### PR DESCRIPTION
This method can be used for bulk inserts. It works in all existing drivers,
but has some limitations in SQLite and MySQL/MariaDB. Those drivers do not
return all the just created PKs.

MySQL/MariaDB will return PK of the first entity in the batch. If we have
`innodb_autoinc_lock_mode` set to 0/1 it is possible to compute the following
PKs simply by incrementing the first PK value.
(see https://stackoverflow.com/a/16592867/3665878)

SQLite on the other hand will return only the last PK.

Postgres and MongoDB both return all the PKs in the `res.rows` array.

Related: #442