### PR TITLE
fix: use lazy registered EventSubscribers

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -23,7 +23,6 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   private readonly entityLoader: EntityLoader = new EntityLoader(this);
   private readonly unitOfWork = new UnitOfWork(this);
   private readonly entityFactory = new EntityFactory(this.unitOfWork, this);
-  private readonly eventManager = new EventManager(this.config.get('subscribers'));
   private filters: Dictionary<FilterDef<any>> = {};
   private filterParams: Dictionary<Dictionary> = {};
   private transactionContext?: Transaction;
@@ -31,7 +30,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   constructor(readonly config: Configuration,
               private readonly driver: D,
               private readonly metadata: MetadataStorage,
-              private readonly useContext = true) { }
+              private readonly useContext = true,
+              private readonly eventManager = new EventManager(config.get('subscribers'))) { }
 
   /**
    * Gets the Driver instance used by this EntityManager
@@ -608,7 +608,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * @param useContext use request context? should be used only for top level request scope EM, defaults to false
    */
   fork(clear = true, useContext = false): D[typeof EntityManagerType] {
-    const em = new (this.constructor as typeof EntityManager)(this.config, this.driver, this.metadata, useContext);
+    const em = new (this.constructor as typeof EntityManager)(this.config, this.driver, this.metadata, useContext, this.eventManager);
     em.filters = { ...this.filters };
     em.filterParams = Utils.copy(this.filterParams);
 


### PR DESCRIPTION
Before for every new context an EM was created with a new EventManager.
This EventManager would only use EventSubscribers that were annotated or explicitly defined in the
config.
Now the EventManager from the global EM is reused in every context specific EM.
Thereby lazy registeren EventSubscribers are also listening to events.

I did take a slight different approach then was suggested here https://github.com/mikro-orm/mikro-orm/issues/711#issuecomment-671087399. This I did to preserve the readonly property and keep the code cleaner (in my perspective). Hope you agree and otherwise we'll make changes.