### PR TITLE
perf(core): implement bulk deletes

### DIFF
--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -30,9 +30,7 @@ export class ChangeSetPersister {
     let res: QueryResult | undefined;
     const wrapped = changeSet.entity.__helper!;
 
-    if (changeSet.type === ChangeSetType.DELETE) {
-      await this.driver.nativeDelete(changeSet.name, wrapped.__primaryKey as Dictionary, ctx);
-    } else if (changeSet.type === ChangeSetType.UPDATE) {
+    if (changeSet.type === ChangeSetType.UPDATE) {
       res = await this.updateEntity(meta, changeSet, ctx);
       this.mapReturnedValues(changeSet.entity, res, meta);
     } else if (Utils.isDefined(wrapped.__primaryKey, true)) { // ChangeSetType.CREATE with primary key

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -1282,8 +1282,8 @@ describe('EntityManagerMySql', () => {
       ['beforeUpdate', 'Book2'],
       ['afterUpdate', 'Book2'],
       ['beforeDelete', 'Book2'],
-      ['afterDelete', 'Book2'],
       ['beforeDelete', 'Book2'],
+      ['afterDelete', 'Book2'],
       ['afterDelete', 'Book2'],
       ['beforeDelete', 'Author2'],
       ['afterDelete', 'Author2'],
@@ -2119,7 +2119,7 @@ describe('EntityManagerMySql', () => {
     Object.assign(orm.config, { logger });
     await orm.em.flush();
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('delete from `foo_baz2` where `id` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('delete from `foo_baz2` where `id` in (?)');
     expect(mock.mock.calls[2][0]).toMatch('commit');
   });
 

--- a/tests/UnitOfWork.test.ts
+++ b/tests/UnitOfWork.test.ts
@@ -172,8 +172,8 @@ describe('UnitOfWork', () => {
     expect(mock.mock.calls[3][0]).toMatch('db.commit()');
 
     expect(changeSets.map(cs => [cs.type, cs.name])).toEqual([
-      [ChangeSetType.CREATE, 'FooBaz'],
       [ChangeSetType.CREATE, 'FooBar'],
+      [ChangeSetType.CREATE, 'FooBaz'],
     ]);
   });
 

--- a/tests/issues/GH369.test.ts
+++ b/tests/issues/GH369.test.ts
@@ -59,7 +59,7 @@ describe('GH issue 369', () => {
     expect(mock.mock.calls[2][0]).toMatch('insert into `b` (`a_id`, `foo`) values (?, ?)');
     expect(mock.mock.calls[3][0]).toMatch('commit');
     expect(mock.mock.calls[4][0]).toMatch('begin');
-    expect(mock.mock.calls[5][0]).toMatch('delete from `b` where `id` = ?');
+    expect(mock.mock.calls[5][0]).toMatch('delete from `b` where `id` in (?)');
     expect(mock.mock.calls[6][0]).toMatch('commit');
     expect(mock.mock.calls).toHaveLength(7);
   });

--- a/tests/issues/GH482.test.ts
+++ b/tests/issues/GH482.test.ts
@@ -66,9 +66,8 @@ describe('GH issue 482', () => {
     orm.config.set('debug', ['query', 'query-params']);
     await orm.em.flush();
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch(`delete from "level" where "type" = 'A' and "job_id" = '1'`);
-    expect(mock.mock.calls[2][0]).toMatch(`delete from "level" where "type" = 'B' and "job_id" = '1'`);
-    expect(mock.mock.calls[3][0]).toMatch('commit');
+    expect(mock.mock.calls[1][0]).toMatch(`delete from "level" where ("type", "job_id") in (('A', '1'), ('B', '1'))`);
+    expect(mock.mock.calls[2][0]).toMatch('commit');
     mock.mock.calls.length = 0;
   });
 


### PR DESCRIPTION
UoW will now group change sets based on the type and entity. Instead of ordering
all the change sets based on the type and entity, we can now travers those groups
based on the commit order.

Related: #732