### PR TITLE
PostgreSQL time column type should be a string

### DIFF
--- a/packages/postgresql/src/PostgreSqlConnection.ts
+++ b/packages/postgresql/src/PostgreSqlConnection.ts
@@ -17,7 +17,7 @@ export class PostgreSqlConnection extends AbstractSqlConnection {
     const ret: Knex.PgConnectionConfig = super.getConnectionOptions();
 
     if (this.config.get('forceUtcTimezone')) {
-      [1082, 1083, 1114].forEach(oid => types.setTypeParser(oid, str => new Date(str + 'Z'))); // date, time, timestamp types
+      [1082, 1114].forEach(oid => types.setTypeParser(oid, str => new Date(str + 'Z'))); // date, timestamp types
       (defaults as any).parseInputDatesAsUTC = true;
     }
 


### PR DESCRIPTION
The **time** column type from PostgreSQL is only [time of day (no date)](https://www.postgresql.org/docs/12/datatype-datetime.html). Trying to create a `new Date()` with that value (ie 18:00:00) causes an Invalid Date error.