### PR TITLE
feat(core): refactor merging to allow querying by custom type

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "run-rs": "^0.6.2",
     "ts-jest": "^26.1.3",
     "ts-node": "^9.0.0",
-    "typescript": "4.0.2"
+    "typescript": "4.0.2",
+    "uuid": "^8.3.0"
   }
 }

--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -166,7 +166,7 @@ export class Collection<T extends AnyEntity<T>, O extends AnyEntity<O> = AnyEnti
 
     if (!this.initialized && this.property.reference === ReferenceType.MANY_TO_MANY && em.getDriver().getPlatform().usesPivotTable()) {
       const map = await em.getDriver().loadFromPivotTable<T, O>(this.property, [this.owner.__helper!.__primaryKeys], options.where, options.orderBy);
-      this.hydrate(map[this.owner.__helper!.__serializedPrimaryKey].map(item => em.merge<T>(this.property.type, item)));
+      this.hydrate(map[this.owner.__helper!.__serializedPrimaryKey].map(item => em.merge<T>(this.property.type, item, false, true)));
       this._lazyInitialized = true;
 
       return this;

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -220,7 +220,7 @@ export class EntityLoader {
     const children: AnyEntity[] = [];
 
     for (const entity of filtered) {
-      const items = map[entity.__helper!.__serializedPrimaryKey as string].map(item => this.em.merge(prop.type, item, refresh));
+      const items = map[entity.__helper!.__serializedPrimaryKey as string].map(item => this.em.merge(prop.type, item, refresh, true));
       (entity[field] as unknown as Collection<AnyEntity>).hydrate(items);
       children.push(...items);
     }

--- a/packages/core/src/hydration/Hydrator.ts
+++ b/packages/core/src/hydration/Hydrator.ts
@@ -7,7 +7,30 @@ export abstract class Hydrator {
   constructor(protected readonly factory: EntityFactory,
               protected readonly em: EntityManager) { }
 
-  hydrate<T extends AnyEntity<T>>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, newEntity: boolean): void {
+  /**
+   * Hydrates the whole entity. This process handles custom type conversions, creating missing Collection instances,
+   * mapping FKs to entity instances, as well as merging those entities.
+   */
+  hydrate<T extends AnyEntity<T>>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, newEntity?: boolean, convertCustomTypes?: boolean): void {
+    const props = this.getProperties(meta, entity);
+
+    for (const prop of props) {
+      this.hydrateProperty(entity, prop, data, newEntity, convertCustomTypes);
+    }
+  }
+
+  /**
+   * Hydrates primary keys only
+   */
+  hydrateReference<T extends AnyEntity<T>>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, convertCustomTypes?: boolean): void {
+    const props = this.getProperties(meta, entity).filter(prop => prop.primary);
+
+    for (const prop of props) {
+      this.hydrateProperty<T>(entity, prop, data, false, convertCustomTypes);
+    }
+  }
+
+  private getProperties<T extends AnyEntity<T>>(meta: EntityMetadata<T>, entity: T): EntityProperty<T>[] {
     const metadata = this.em.getMetadata();
     const root = Utils.getRootEntity(metadata, meta);
 
@@ -15,15 +38,11 @@ export abstract class Hydrator {
       meta = metadata.find(entity.constructor.name)!;
     }
 
-    const props = Object.values<EntityProperty>(meta.properties).filter(prop => {
+    return Object.values<EntityProperty>(meta.properties).filter(prop => {
       return !prop.inherited && root.discriminatorColumn !== prop.name && !prop.embedded;
     });
-
-    for (const prop of props) {
-      this.hydrateProperty(entity, prop, data, newEntity);
-    }
   }
 
-  protected abstract hydrateProperty<T extends AnyEntity<T>>(entity: T, prop: EntityProperty, value: EntityData<T>, newEntity: boolean): void;
+  protected abstract hydrateProperty<T extends AnyEntity<T>>(entity: T, prop: EntityProperty, value: EntityData<T>, newEntity?: boolean, convertCustomTypes?: boolean): void;
 
 }

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -650,7 +650,6 @@ export class MetadataDiscovery {
 
     if (prop.type as unknown instanceof Type) {
       prop.customType = prop.type as unknown as Type<any>;
-      prop.type = prop.customType.constructor.name;
     }
 
     if (Object.getPrototypeOf(prop.type) === Type && !prop.customType) {
@@ -658,8 +657,11 @@ export class MetadataDiscovery {
     }
 
     if (prop.customType) {
-      prop.type = prop.customType.constructor.name;
       prop.columnTypes = prop.columnTypes ?? [prop.customType.getColumnType(prop, this.platform)];
+    }
+
+    if (prop.customType as unknown instanceof Type && prop.reference === ReferenceType.SCALAR) {
+      prop.type = prop.customType.constructor.name;
     }
   }
 
@@ -686,6 +688,7 @@ export class MetadataDiscovery {
 
       if (pk.customType) {
         prop.columnTypes.push(pk.customType.getColumnType(pk, this.platform));
+        prop.customType = pk.customType;
         return;
       }
 

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -143,7 +143,7 @@ export class ChangeSetPersister {
 
         return data;
       }, {} as Dictionary);
-      this.hydrator.hydrate<T>(entity, meta, data as EntityData<T>, false);
+      this.hydrator.hydrate<T>(entity, meta, data as EntityData<T>, false, true);
     }
   }
 

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -283,7 +283,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return this.rethrow(this.updateCollectionDiff<T, O>(meta, coll.property, pks, deleteDiff, insertDiff, ctx));
   }
 
-  async loadFromPivotTable<T extends AnyEntity<T>, O extends AnyEntity<O>>(prop: EntityProperty, owners: Primary<O>[][], where?: FilterQuery<T>, orderBy?: QueryOrderMap, ctx?: Transaction): Promise<Dictionary<T[]>> {
+  async loadFromPivotTable<T extends AnyEntity<T>, O extends AnyEntity<O>>(prop: EntityProperty, owners: Primary<O>[][], where: FilterQuery<T> = {}, orderBy?: QueryOrderMap, ctx?: Transaction): Promise<Dictionary<T[]>> {
     const pivotProp2 = this.getPivotInverseProperty(prop);
     const ownerMeta = this.metadata.find(pivotProp2.type)!;
     const targetMeta = this.metadata.find(prop.type)!;

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -108,7 +108,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
       cond = { [`(${cond})`]: Utils.asArray(params) };
       operator = operator || '$and';
     } else {
-      cond = QueryHelper.processWhere(cond, this.entityName, this.metadata)!;
+      cond = QueryHelper.processWhere(cond, this.entityName, this.metadata, this.platform)!;
     }
 
     const op = operator || params as keyof typeof GroupOperator;
@@ -146,7 +146,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
   }
 
   orderBy(orderBy: QueryOrderMap): this {
-    orderBy = QueryHelper.processWhere(orderBy as Dictionary, this.entityName, this.metadata) as QueryOrderMap;
+    QueryHelper.inlinePrimaryKeyObjects(orderBy, this.metadata.find(this.entityName)!, this.metadata);
     this._orderBy = CriteriaNode.create(this.metadata, this.entityName, orderBy).process(this);
     return this;
   }
@@ -341,7 +341,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     const entityName = this._aliasMap[fromAlias];
     const prop = this.metadata.get(entityName).properties[fromField];
     this._aliasMap[alias] = prop.type;
-    cond = QueryHelper.processWhere(cond, this.entityName, this.metadata)!;
+    cond = QueryHelper.processWhere(cond, this.entityName, this.metadata, this.platform)!;
     const aliasedName = `${fromAlias}.${prop.name}`;
 
     if (prop.reference === ReferenceType.ONE_TO_MANY) {

--- a/tests/EntityAssigner.mongo.test.ts
+++ b/tests/EntityAssigner.mongo.test.ts
@@ -1,0 +1,89 @@
+import { assign, EntityData, MikroORM, wrap } from '@mikro-orm/core';
+import { MongoDriver, ObjectId } from '@mikro-orm/mongodb';
+import { Author, Book, BookTag } from './entities';
+import { initORMMongo, wipeDatabase } from './bootstrap';
+
+describe('EntityAssignerMongo', () => {
+
+  let orm: MikroORM<MongoDriver>;
+
+  beforeAll(async () => orm = await initORMMongo());
+  beforeEach(async () => wipeDatabase(orm.em));
+
+  test('#assign() should update entity values', async () => {
+    const god = new Author('God', 'hello@heaven.god');
+    const jon = new Author('Jon Snow', 'snow@wall.st');
+    const book = new Book('Book2', jon);
+    await orm.em.persistAndFlush(book);
+    expect(book.title).toBe('Book2');
+    expect(book.author).toBe(jon);
+    book.assign({ title: 'Better Book2 1', author: god, notExisting: true });
+    expect(book.author).toBe(god);
+    expect((book as any).notExisting).toBe(true);
+    await orm.em.persistAndFlush(god);
+    wrap(book, true).assign({ title: 'Better Book2 2', author: god.id });
+    expect(book.author).toBe(god);
+    book.assign({ title: 'Better Book2 3', author: jon._id });
+    expect(book.title).toBe('Better Book2 3');
+    expect(book.author).toBe(jon);
+  });
+
+  test('#assign() should update entity collection', async () => {
+    const other = new BookTag('other');
+    await orm.em.persistAndFlush(other);
+    const jon = new Author('Jon Snow', 'snow@wall.st');
+    const book = new Book('Book2', jon);
+    const tag1 = new BookTag('tag 1');
+    const tag2 = new BookTag('tag 2');
+    const tag3 = new BookTag('tag 3');
+    book.tags.add(tag1);
+    book.tags.add(tag2);
+    book.tags.add(tag3);
+    await orm.em.persistAndFlush(book);
+    assign(book, { tags: [other._id] });
+    expect(book.tags.getIdentifiers('_id')).toMatchObject([other._id]);
+    assign(book, { tags: [] });
+    expect(book.tags.getIdentifiers()).toMatchObject([]);
+    assign(book, { tags: [tag1.id, tag3.id] });
+    expect(book.tags.getIdentifiers('id')).toMatchObject([tag1.id, tag3.id]);
+    assign(book, { tags: [tag2] });
+    expect(book.tags.getIdentifiers('_id')).toMatchObject([tag2._id]);
+    assign(book, { tags: [wrap(tag2).toObject()] });
+    expect(book.tags.getIdentifiers('_id')).toMatchObject([tag2._id]);
+    expect(book.tags.isDirty()).toBe(true);
+    expect(() => assign(book, { tags: [false] } as any)).toThrowError(`Invalid collection values provided for 'Book.tags' in Book.assign(): [ false ]`);
+    expect(() => assign(book, { publisher: [{ foo: 'bar' }] } as EntityData<Book>)).toThrowError(`Invalid reference value provided for 'Book.publisher' in Book.assign(): [{"foo":"bar"}]`);
+  });
+
+  test('#assign() should ignore undefined properties', async () => {
+    const jon = new Author('Jon Snow', 'snow@wall.st');
+    assign(jon, { name: 'test', unknown: 123 }, { onlyProperties: true });
+    expect((jon as any).unknown).toBeUndefined();
+  });
+
+  test('#assign() should merge references', async () => {
+    const jon = new Author('Jon Snow', 'snow@wall.st');
+    orm.em.assign(jon, { favouriteBook: { _id: ObjectId.createFromTime(1), title: 'b1' } }, { merge: false });
+    expect(wrap(jon.favouriteBook, true).__em).toBeUndefined();
+    orm.em.assign(jon, { favouriteBook: { _id: ObjectId.createFromTime(1), title: 'b1' } }, { merge: true });
+    expect(wrap(jon.favouriteBook, true).__em).not.toBeUndefined();
+  });
+
+  test('#assign() should merge collection items', async () => {
+    const jon = new Author('Jon Snow', 'snow@wall.st');
+    orm.em.assign(jon, { books: [{ _id: ObjectId.createFromTime(1), title: 'b1' }] }, { merge: false });
+    expect(wrap(jon.books[0], true).__em).toBeUndefined();
+    orm.em.assign(jon, { books: [{ _id: ObjectId.createFromTime(2), title: 'b2' }] }, { merge: true });
+    expect(wrap(jon.books[0], true).__em).not.toBeUndefined();
+  });
+
+  test('#assign() ignores virtual props with only getters', async () => {
+    const jon = new Author('n', 'e');
+    assign(jon, { code: '123' });
+    expect(jon.getCode()).toBe(`e - n`);
+    expect((jon as any).code).toBeUndefined();
+  });
+
+  afterAll(async () => orm.close(true));
+
+});

--- a/tests/EntityFactory.test.ts
+++ b/tests/EntityFactory.test.ts
@@ -157,13 +157,15 @@ describe('EntityFactory', () => {
     expect(book.author).toBe(author);
   });
 
-  test('create should flag collections as dirty', async () => {
+  test('create should flag collections as dirty for new entities', async () => {
     const a = new Author('n', 'e');
     const t1 = new BookTag('t1');
     const t2 = new BookTag('t2');
     const t3 = new BookTag('t3');
-    const b = factory.create(Book, { title: 'b', author: a, tags: [t1, t2, t3] });
-    expect(b.tags.isDirty()).toBe(true);
+    const b1 = factory.create(Book, { title: 'b1', author: a, tags: [t1, t2, t3] }, { newEntity: false });
+    expect(b1.tags.isDirty()).toBe(false);
+    const b2 = factory.create(Book, { title: 'b2', author: a, tags: [t1, t2, t3] }, { newEntity: true });
+    expect(b2.tags.isDirty()).toBe(true);
   });
 
   test('create entity from nested object', async () => {

--- a/tests/EntityHelper.mongo.test.ts
+++ b/tests/EntityHelper.mongo.test.ts
@@ -1,14 +1,14 @@
 import { ObjectId } from 'mongodb';
 import { inspect } from 'util';
 
-import { EntityAssigner, EntityData, EntityHelper, MikroORM, Reference, Utils, wrap } from '@mikro-orm/core';
+import { EntityHelper, MikroORM, Reference, Utils, wrap } from '@mikro-orm/core';
 import { MongoDriver } from '@mikro-orm/mongodb';
-import { Author, Book, BookTag, Publisher, Test } from './entities';
+import { Author, Book, Publisher, Test } from './entities';
 import { initORMMongo, wipeDatabase } from './bootstrap';
 import FooBar from './entities/FooBar';
 import { FooBaz } from './entities/FooBaz';
 
-describe('EntityAssignerMongo', () => {
+describe('EntityHelperMongo', () => {
 
   let orm: MikroORM<MongoDriver>;
 
@@ -106,51 +106,6 @@ describe('EntityAssignerMongo', () => {
     expect(jon!.name).toBe('Jon Snow');
     await EntityHelper.init(jon!);
     expect(jon!.name).toBe('Changed!');
-  });
-
-  test('#assign() should update entity values', async () => {
-    const god = new Author('God', 'hello@heaven.god');
-    const jon = new Author('Jon Snow', 'snow@wall.st');
-    const book = new Book('Book2', jon);
-    await orm.em.persistAndFlush(book);
-    expect(book.title).toBe('Book2');
-    expect(book.author).toBe(jon);
-    book.assign({ title: 'Better Book2 1', author: god, notExisting: true });
-    expect(book.author).toBe(god);
-    expect((book as any).notExisting).toBe(true);
-    await orm.em.persistAndFlush(god);
-    wrap(book, true).assign({ title: 'Better Book2 2', author: god.id });
-    expect(book.author).toBe(god);
-    book.assign({ title: 'Better Book2 3', author: jon._id });
-    expect(book.title).toBe('Better Book2 3');
-    expect(book.author).toBe(jon);
-  });
-
-  test('#assign() should update entity collection', async () => {
-    const other = new BookTag('other');
-    await orm.em.persistAndFlush(other);
-    const jon = new Author('Jon Snow', 'snow@wall.st');
-    const book = new Book('Book2', jon);
-    const tag1 = new BookTag('tag 1');
-    const tag2 = new BookTag('tag 2');
-    const tag3 = new BookTag('tag 3');
-    book.tags.add(tag1);
-    book.tags.add(tag2);
-    book.tags.add(tag3);
-    await orm.em.persistAndFlush(book);
-    EntityAssigner.assign(book, { tags: [other._id] });
-    expect(book.tags.getIdentifiers('_id')).toMatchObject([other._id]);
-    EntityAssigner.assign(book, { tags: [] });
-    expect(book.tags.getIdentifiers()).toMatchObject([]);
-    EntityAssigner.assign(book, { tags: [tag1.id, tag3.id] });
-    expect(book.tags.getIdentifiers('id')).toMatchObject([tag1.id, tag3.id]);
-    EntityAssigner.assign(book, { tags: [tag2] });
-    expect(book.tags.getIdentifiers('_id')).toMatchObject([tag2._id]);
-    EntityAssigner.assign(book, { tags: [wrap(tag2).toObject()] });
-    expect(book.tags.getIdentifiers('_id')).toMatchObject([tag2._id]);
-    expect(book.tags.isDirty()).toBe(true);
-    expect(() => EntityAssigner.assign(book, { tags: [false] } as any)).toThrowError(`Invalid collection values provided for 'Book.tags' in Book.assign(): [ false ]`);
-    expect(() => EntityAssigner.assign(book, { publisher: [{ foo: 'bar' }] } as EntityData<Book>)).toThrowError(`Invalid reference value provided for 'Book.publisher' in Book.assign(): [{"foo":"bar"}]`);
   });
 
   test('should have string id getter and setter', async () => {

--- a/tests/EntityRepository.test.ts
+++ b/tests/EntityRepository.test.ts
@@ -21,6 +21,7 @@ const methods = {
   populate: jest.fn(),
   count: jest.fn(),
   create: jest.fn(),
+  assign: jest.fn(),
   nativeInsert: jest.fn(),
   nativeUpdate: jest.fn(),
   nativeDelete: jest.fn(),
@@ -66,6 +67,8 @@ describe('EntityRepository', () => {
     expect(methods.removeLater.mock.calls[0]).toEqual([entity]);
     await repo.create({ name: 'bar' });
     expect(methods.create.mock.calls[0]).toEqual([Publisher, { name: 'bar' }]);
+    await repo.assign(e, { name: 'bar' });
+    expect(methods.assign.mock.calls[0]).toEqual([e, { name: 'bar' }]);
     await repo.populate([], 'bar');
     expect(methods.populate.mock.calls[0]).toEqual([[], 'bar', {}, {}, false, true]);
 

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -1358,7 +1358,7 @@ describe('QueryBuilder', () => {
       'from `book2` as `b` ' +
       'left join `book2_tags` as `e1` on `b`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
       'where (`e1`.`book_tag2_id` is null or `e1`.`book_tag2_id` != ?)');
-    expect(qb2.getParams()).toEqual([1]);
+    expect(qb2.getParams()).toEqual(['1']);
 
     const qb3 = await orm.em.createQueryBuilder(Author2, 'a').select('a.*').where({ friends: null }).orderBy({ friends: { name: QueryOrder.ASC } });
     expect(qb3.getQuery()).toMatch('select `a`.* ' +
@@ -1384,7 +1384,7 @@ describe('QueryBuilder', () => {
       'from `book2` as `b` ' +
       'left join `book2_tags` as `e1` on `b`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
       'where `e1`.`book_tag2_id` = ?');
-    expect(qb1.getParams()).toEqual([1]);
+    expect(qb1.getParams()).toEqual(['1']);
 
     const qb11 = await orm.em.createQueryBuilder(User2, 'u').select('u.*').where({ cars: { name: 'n', year: 1 } });
     expect(qb11.getQuery()).toMatch('select `u`.* ' +
@@ -1405,7 +1405,7 @@ describe('QueryBuilder', () => {
       'from `book2` as `b` ' +
       'left join `book2_tags` as `e1` on `b`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
       'where (`e1`.`book_tag2_id` is null or `e1`.`book_tag2_id` != ?)');
-    expect(qb2.getParams()).toEqual([1]);
+    expect(qb2.getParams()).toEqual(['1']);
 
     const qb4 = await orm.em.createQueryBuilder(Author2, 'a').select('a.*').where({ friends: 1 }).orderBy({ friends: { id: QueryOrder.ASC } });
     expect(qb4.getQuery()).toMatch('select `a`.* ' +

--- a/tests/SmartQueryHelper.test.ts
+++ b/tests/SmartQueryHelper.test.ts
@@ -18,7 +18,7 @@ describe('QueryHelper', () => {
       'key4<=': 123,
       'key5!=': 123,
       'key6!': 123,
-    }, 'id', orm.getMetadata())).toEqual({
+    }, 'id', orm.getMetadata(), orm.em.getDriver().getPlatform())).toEqual({
       key1: { $gt: 123 },
       key2: { $lt: 123 },
       key3: { $gte: 123 },
@@ -33,7 +33,7 @@ describe('QueryHelper', () => {
       'key4 <=': 123,
       'key5 !=': 123,
       'key6 !': 123,
-    }, 'id', orm.getMetadata())).toEqual({
+    }, 'id', orm.getMetadata(), orm.em.getDriver().getPlatform())).toEqual({
       key1: { $gt: 123 },
       key2: { $lt: 123 },
       key3: { $gte: 123 },
@@ -53,7 +53,7 @@ describe('QueryHelper', () => {
       'key6:not': 123,
       'key7:in': [123],
       'key8:nin': [123],
-    }, 'id', orm.getMetadata())).toEqual({
+    }, 'id', orm.getMetadata(), orm.em.getDriver().getPlatform())).toEqual({
       key1: { $gt: 123 },
       key2: { $lt: 123 },
       key3: { $gte: 123 },
@@ -66,7 +66,7 @@ describe('QueryHelper', () => {
   });
 
   test('processWhere returns empty object for undefined condition', async () => {
-    expect(QueryHelper.processWhere(undefined as any, 'id', orm.getMetadata())).toEqual({});
+    expect(QueryHelper.processWhere(undefined as any, 'id', orm.getMetadata(), orm.em.getDriver().getPlatform())).toEqual({});
   });
 
   test('test entity conversion to PK', async () => {
@@ -102,10 +102,10 @@ describe('QueryHelper', () => {
     const book1 = new Book2('b1', author);
     const book2 = new Book2('b2', author);
     const book3 = new Book2('b3', author);
-    expect(QueryHelper.processWhere<Author2>([1, 2, 3], 'uuid', orm.getMetadata())).toEqual({ uuid: { $in: [1, 2, 3] } });
-    expect(QueryHelper.processWhere<Book2>([book1, book2, book3], 'uuid', orm.getMetadata())).toEqual({ uuid: { $in: [book1.uuid, book2.uuid, book3.uuid] } });
-    expect(QueryHelper.processWhere<Author2>({ favouriteBook: ['1', '2', '3'] }, 'id', orm.getMetadata())).toEqual({ favouriteBook: { $in: ['1', '2', '3'] } });
-    expect(QueryHelper.processWhere<Book2>({ $or: [{ author: [1, 2, 3] }, { author: [7, 8, 9] }] }, 'id', orm.getMetadata())).toEqual({
+    expect(QueryHelper.processWhere<Author2>([1, 2, 3], 'uuid', orm.getMetadata(), orm.em.getDriver().getPlatform())).toEqual({ uuid: { $in: [1, 2, 3] } });
+    expect(QueryHelper.processWhere<Book2>([book1, book2, book3], 'uuid', orm.getMetadata(), orm.em.getDriver().getPlatform())).toEqual({ uuid: { $in: [book1.uuid, book2.uuid, book3.uuid] } });
+    expect(QueryHelper.processWhere<Author2>({ favouriteBook: ['1', '2', '3'] }, 'id', orm.getMetadata(), orm.em.getDriver().getPlatform())).toEqual({ favouriteBook: { $in: ['1', '2', '3'] } });
+    expect(QueryHelper.processWhere<Book2>({ $or: [{ author: [1, 2, 3] }, { author: [7, 8, 9] }] }, 'id', orm.getMetadata(), orm.em.getDriver().getPlatform())).toEqual({
       $or: [{ author: { $in: [1, 2, 3] } }, { author: { $in: [7, 8, 9] } }],
     });
   });

--- a/tests/composite-keys.mysql.test.ts
+++ b/tests/composite-keys.mysql.test.ts
@@ -165,10 +165,12 @@ describe('composite keys in mysql', () => {
     orm.em.clear();
 
     const u1 = await orm.em.findOneOrFail(User2, user1, { populate: { cars: LoadStrategy.JOINED } });
+    expect(u1.cars.isDirty()).toBe(false);
     expect(u1.cars.getItems()).toMatchObject([
       { name: 'Audi A8', price: 100_000, year: 2011 },
       { name: 'Audi A8', price: 200_000, year: 2013 },
     ]);
+    expect(u1.cars[0].users.isDirty()).toBe(false);
     expect(wrap(u1).toJSON()).toEqual({
       firstName: 'John',
       lastName: 'Doe 1',
@@ -261,14 +263,13 @@ describe('composite keys in mysql', () => {
   test('composite key in em.create()', async () => {
     await orm.em.nativeInsert(Car2, { name: 'n4', year: 2000, price: 456 });
 
-    const factory = orm.em.getEntityFactory();
     const c1 = new Car2('n1', 2000, 1);
     const c2 = { name: 'n3', year: 2000, price: 123 };
     const c3 = ['n4', 2000]; // composite PK
 
     // managed entity have an internal __em reference, so that is what we are testing here
     expect(wrap(c1, true).__em).toBeUndefined();
-    const u1 = factory.create(User2, { firstName: 'f', lastName: 'l', cars: [c1, c2, c3] });
+    const u1 = orm.em.create(User2, { firstName: 'f', lastName: 'l', cars: [c1, c2, c3] });
     expect(wrap(u1, true).__em).toBeUndefined();
     expect(wrap(u1.cars[0], true).__em).toBeUndefined();
     expect(wrap(u1.cars[1], true).__em).toBeUndefined();

--- a/tests/embedded-entities.mongo.test.ts
+++ b/tests/embedded-entities.mongo.test.ts
@@ -1,4 +1,4 @@
-import { Embeddable, Embedded, Entity, Logger, MikroORM, PrimaryKey, Property, ReferenceType, SerializedPrimaryKey } from '@mikro-orm/core';
+import { assign, Embeddable, Embedded, Entity, Logger, MikroORM, PrimaryKey, Property, ReferenceType, SerializedPrimaryKey } from '@mikro-orm/core';
 import { ObjectId, MongoDriver } from '@mikro-orm/mongodb';
 
 @Embeddable()
@@ -184,6 +184,12 @@ describe('embedded entities in mongo', () => {
     expect(u3).toBe(u1);
     const err = `Using operators inside embeddables is not allowed, move the operator above. (property: User.address1, payload: { address1: { '$or': [ [Object], [Object] ] } })`;
     await expect(orm.em.findOneOrFail(User, { address1: { $or: [{ city: 'London 1' }, { city: 'Berlin' }] } })).rejects.toThrowError(err);
+  });
+
+  test('#assign() works with embeddables', async () => {
+    const jon = new User();
+    assign(jon, { address1: { city: '1', country: '2', postalCode: '3', street: '4' } });
+    expect(jon.address1).toMatchObject({ city: '1', country: '2', postalCode: '3', street: '4' });
   });
 
 });

--- a/tests/issues/GH446.test.ts
+++ b/tests/issues/GH446.test.ts
@@ -1,13 +1,31 @@
-import { v4 } from 'uuid';
-import { Entity, MikroORM, OneToOne, PrimaryKey, PrimaryKeyType, wrap } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
-import { SchemaGenerator } from '@mikro-orm/knex';
+import { v4, parse, stringify } from 'uuid';
+import { Entity, ManyToOne, MikroORM, OneToOne, PrimaryKey, PrimaryKeyType, Property, Type, wrap } from '@mikro-orm/core';
+import { MySqlDriver, SchemaGenerator } from '@mikro-orm/mysql';
+
+export class UuidBinaryType extends Type<string, Buffer> {
+
+  convertToDatabaseValue(value: string): Buffer {
+    return Buffer.from(parse(value));
+  }
+
+  convertToJSValue(value: Buffer): string {
+    return stringify(value);
+  }
+
+  getColumnType(): string {
+    return 'binary(16)';
+  }
+
+}
 
 @Entity()
 class A {
 
-  @PrimaryKey({ columnType: 'uuid' })
+  @PrimaryKey({ type: UuidBinaryType })
   id: string = v4();
+
+  @Property({ nullable: true })
+  name?: string;
 
 }
 
@@ -25,19 +43,31 @@ class C {
   @OneToOne({ primary: true })
   b!: B;
 
-  [PrimaryKeyType]: B | string;
+  [PrimaryKeyType]: B | A | string;
+
+}
+
+@Entity()
+class D {
+
+  @PrimaryKey({ type: UuidBinaryType })
+  id: string = v4();
+
+  @ManyToOne()
+  a!: A;
 
 }
 
 describe('GH issue 446', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM<MySqlDriver>;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      entities: [A, B, C],
+      entities: [A, B, C, D],
       dbName: `mikro_orm_test_gh_446`,
-      type: 'postgresql',
+      type: 'mysql',
+      port: 3307,
     });
     await new SchemaGenerator(orm.em).ensureDatabase();
     await new SchemaGenerator(orm.em).dropSchema();
@@ -54,16 +84,44 @@ describe('GH issue 446', () => {
     b.a = a;
     const c = new C();
     c.b = b;
-    await orm.em.persistAndFlush(c);
+    const d = new D();
+    d.a = a;
+    await orm.em.persistAndFlush([c, d]);
     orm.em.clear();
 
-    const c1 = await orm.em.findOneOrFail(C, c.b, ['b.a']);
+    const c1 = await orm.em.findOneOrFail(C, c.b.a.id, ['b.a']);
     expect(c1).toBeInstanceOf(C);
     expect(c1.b).toBeInstanceOf(B);
     expect(wrap(c1.b).isInitialized()).toBe(true);
     expect(c1.b.a).toBeInstanceOf(A);
     expect(wrap(c1.b.a).isInitialized()).toBe(true);
     expect(c1.b.a.id).toBe(a.id);
+  });
+
+  test(`assign with custom types`, async () => {
+    const d = new D();
+    orm.em.assign(d, { id: Buffer.from(parse(v4())) as any, a: Buffer.from(parse(v4())) }, { convertCustomTypes: true });
+    expect(typeof d.id).toBe('string');
+    expect(typeof d.a.id).toBe('string');
+    orm.em.assign(d, { id: v4(), a: v4() });
+    expect(typeof d.id).toBe('string');
+    expect(typeof d.a.id).toBe('string');
+    orm.em.assign(d, { id: v4(), a: { id: v4(), name: 'abc' } });
+    expect(typeof d.id).toBe('string');
+    expect(typeof d.a.id).toBe('string');
+    expect(d.a.name).toBe('abc');
+  });
+
+  test('merging cached entity', async () => {
+    const a1 = new A();
+    a1.name = 'test';
+    expect(typeof a1.id).toBe('string');
+    // simulate caching by converting to JSON and back to POJO
+    const cache = JSON.parse(JSON.stringify(wrap(a1).toObject()));
+    expect(typeof cache.id).toBe('string');
+    const a2 = orm.em.merge(A, cache);
+    expect(typeof a2.id).toBe('string');
+    expect(a2.name).toBe('test');
   });
 
 });


### PR DESCRIPTION
This changes internal mechanism of `em.merge()`. Originally it was using
`EntityAssigner` inside `em.merge()` together with `UoW.merge()`, which
was called twice. Because of this, the custom types were processed multiple
times, and the value passed to conversion method was often already converted.

Now we use only the `Hydrator` for this. As a sideproduct of those changes,
we can now query by custom types.

```typescript
class UuidBinaryType extends Type<string, Buffer> {

  convertToDatabaseValue(value: string): Buffer {
    return Buffer.from(parse(value));
  }

  convertToJSValue(value: Buffer): string {
    return stringify(value);
  }

  getColumnType(): string {
    return 'binary(16)';
  }

}

@Entity()
class A {

  @PrimaryKey({ type: UuidBinaryType })
  id: string = v4();

}

const a = await em.find(A, { id: '...' });
```

Closes #739