### PR TITLE
perf(core): do not use `em.merge()` internally

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -245,7 +245,11 @@ MikroORM.init({
 
 Read more about this in [Repositories](repositories.md) section.
 
-## Strict Mode
+## Strict Mode and property validation
+
+> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`.
+> It has performance implications and usually should not be needed, as long as
+> you don't modify your entities via `Object.assign()`.
 
 `MirkoORM` will validate your properties before actual persisting happens. It will try to fix wrong 
 data types for you automatically. If automatic conversion fails, it will throw an error. You can 
@@ -254,6 +258,7 @@ when persisting the entity.
 
 ```typescript
 MikroORM.init({
+  validate: true,
   strict: true,
 });
 ```

--- a/docs/docs/property-validation.md
+++ b/docs/docs/property-validation.md
@@ -2,6 +2,10 @@
 title: Property Validation
 ---
 
+> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`.
+> It has performance implications and usually should not be needed, as long as
+> you don't modify your entities via `Object.assign()`.
+
 `MirkoORM` will validate your properties before actual persisting happens. It will try to fix wrong 
 data types for you automatically. If automatic conversion fails, it will throw an error. You can 
 enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered 

--- a/docs/versioned_docs/version-4.0/configuration.md
+++ b/docs/versioned_docs/version-4.0/configuration.md
@@ -245,7 +245,11 @@ MikroORM.init({
 
 Read more about this in [Repositories](repositories.md) section.
 
-## Strict Mode
+## Strict Mode and property validation
+
+> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`.
+> It has performance implications and usually should not be needed, as long as
+> you don't modify your entities via `Object.assign()`.
 
 `MirkoORM` will validate your properties before actual persisting happens. It will try to fix wrong 
 data types for you automatically. If automatic conversion fails, it will throw an error. You can 
@@ -254,6 +258,7 @@ when persisting the entity.
 
 ```typescript
 MikroORM.init({
+  validate: true,
   strict: true,
 });
 ```

--- a/docs/versioned_docs/version-4.0/property-validation.md
+++ b/docs/versioned_docs/version-4.0/property-validation.md
@@ -2,6 +2,10 @@
 title: Property Validation
 ---
 
+> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`.
+> It has performance implications and usually should not be needed, as long as
+> you don't modify your entities via `Object.assign()`.
+
 `MirkoORM` will validate your properties before actual persisting happens. It will try to fix wrong 
 data types for you automatically. If automatic conversion fails, it will throw an error. You can 
 enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered 

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -102,7 +102,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     const ret: T[] = [];
 
     for (const data of results) {
-      const entity = this.merge<T>(entityName, data, options.refresh, true);
+      const entity = this.getEntityFactory().create(entityName, data as EntityData<T>, { merge: true, convertCustomTypes: true }) as T;
+      this.getUnitOfWork().registerManaged(entity, data, options.refresh);
       ret.push(entity);
     }
 
@@ -233,7 +234,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       return null;
     }
 
-    entity = this.merge(entityName, data as EntityData<T>, options.refresh, true) as T;
+    entity = this.getEntityFactory().create<T>(entityName, data as EntityData<T>, { refresh: options.refresh, merge: true, convertCustomTypes: true });
+    this.getUnitOfWork().registerManaged(entity, data, options.refresh);
     await this.lockAndPopulate(entityName, entity, where, options);
 
     return entity as Loaded<T, P>;

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -222,7 +222,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     let entity = this.getUnitOfWork().tryGetById<T>(entityName, where);
     const isOptimisticLocking = !Utils.isDefined(options.lockMode) || options.lockMode === LockMode.OPTIMISTIC;
 
-    if (entity && entity.__helper!.isInitialized() && !options.refresh && isOptimisticLocking) {
+    if (entity && entity.__helper!.__initialized && !options.refresh && isOptimisticLocking) {
       return this.lockAndPopulate<T, P>(entityName, entity, where, options);
     }
 
@@ -419,7 +419,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     this.validator.validatePrimaryKey(data as EntityData<T>, this.metadata.get(entityName));
     let entity = this.getUnitOfWork().tryGetById<T>(entityName, data as FilterQuery<T>, false);
 
-    if (entity && entity.__helper!.isInitialized() && !refresh) {
+    if (entity && entity.__helper!.__initialized && !refresh) {
       return entity;
     }
 

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -23,9 +23,9 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   private readonly validator = new EntityValidator(this.config.get('strict'));
   private readonly repositoryMap: Dictionary<EntityRepository<AnyEntity>> = {};
   private readonly entityLoader: EntityLoader = new EntityLoader(this);
+  private readonly comparator = new EntityComparator(this.metadata, this.driver.getPlatform());
   private readonly unitOfWork = new UnitOfWork(this);
   private readonly entityFactory = new EntityFactory(this.unitOfWork, this);
-  private readonly comparator = new EntityComparator(this.metadata, this.driver.getPlatform());
   private filters: Dictionary<FilterDef<any>> = {};
   private filterParams: Dictionary<Dictionary> = {};
   private transactionContext?: Transaction;

--- a/packages/core/src/entity/ArrayCollection.ts
+++ b/packages/core/src/entity/ArrayCollection.ts
@@ -114,7 +114,7 @@ export class ArrayCollection<T, O> {
 
   isInitialized(fully = false): boolean {
     if (fully) {
-      return this.initialized && this.items.every((item: AnyEntity<T>) => item.__helper!.isInitialized());
+      return this.initialized && this.items.every((item: AnyEntity<T>) => item.__helper!.__initialized);
     }
 
     return this.initialized;

--- a/packages/core/src/entity/ArrayCollection.ts
+++ b/packages/core/src/entity/ArrayCollection.ts
@@ -102,7 +102,7 @@ export class ArrayCollection<T, O> {
 
     return !!this.items.find((i: AnyEntity<T>) => {
       const objectIdentity = i === entity;
-      const primaryKeyIdentity = i.__helper!.__primaryKey && entity.__helper!.__primaryKey && i.__helper!.__serializedPrimaryKey === entity.__helper!.__serializedPrimaryKey;
+      const primaryKeyIdentity = i.__helper!.hasPrimaryKey() && entity.__helper!.hasPrimaryKey() && i.__helper!.__serializedPrimaryKey === entity.__helper!.__serializedPrimaryKey;
 
       return objectIdentity || primaryKeyIdentity;
     });

--- a/packages/core/src/entity/BaseEntity.ts
+++ b/packages/core/src/entity/BaseEntity.ts
@@ -9,7 +9,7 @@ export abstract class BaseEntity<T extends AnyEntity<T>, PK extends keyof T> imp
   }
 
   isInitialized(): boolean {
-    return (this as unknown as T).__helper!.isInitialized();
+    return (this as unknown as T).__helper!.__initialized;
   }
 
   populated(populated = true): void {

--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -230,7 +230,7 @@ export class Collection<T, O = unknown> extends ArrayCollection<T, O> {
   }
 
   private createManyToManyCondition(cond: Dictionary) {
-    if (this.property.owner || this.owner.__helper!.__internal.platform.usesPivotTable()) {
+    if (this.property.owner || this.property.pivotTable) {
       const pk = (this.items[0] as AnyEntity<T>).__helper!.__meta.primaryKeys[0]; // we know there is at least one item as it was checked in load method
       cond[pk] = { $in: this.items.map((item: AnyEntity<T>) => item.__helper!.__primaryKey) };
     } else {
@@ -283,12 +283,12 @@ export class Collection<T, O = unknown> extends ArrayCollection<T, O> {
 
   private validateModification(items: T[]): void {
     // currently we allow persisting to inverse sides only in SQL drivers
-    if (this.owner.__helper!.__internal.platform.usesPivotTable() || !this.property.mappedBy) {
+    if (this.property.pivotTable || !this.property.mappedBy) {
       return;
     }
 
     const check = (item: T & AnyEntity<T>) => {
-      if (item.__helper!.isInitialized()) {
+      if (item.__helper!.__initialized) {
         return false;
       }
 

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -15,8 +15,8 @@ export class EntityAssigner {
     const wrapped = entity.__helper!;
     const em = options.em || wrapped.__em;
     const meta = wrapped.__meta;
-    const validator = wrapped.__internal.validator;
-    const platform = wrapped.__internal.platform;
+    const validator = wrapped.__internal.getValidator();
+    const platform = wrapped.__internal.getDriver().getPlatform();
     const props = meta.properties;
 
     Object.keys(data).forEach(prop => {

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -37,7 +37,7 @@ export class EntityFactory {
     const meta2 = this.processDiscriminatorColumn<T>(meta, data);
     const exists = this.findEntity<T>(data, meta2, options.convertCustomTypes);
 
-    if (exists && exists.__helper!.isInitialized() && !options.refresh) {
+    if (exists && exists.__helper!.__initialized && !options.refresh) {
       return exists as New<T, P>;
     }
 
@@ -87,7 +87,7 @@ export class EntityFactory {
       // creates new instance via constructor as this is the new entity
       const entity = new Entity(...params);
       // perf: create the helper instance early to bypass the double getter defined on the prototype in EntityHelper
-      Object.defineProperty(entity, '__helper', { value: new WrappedEntity(entity as T, this.em) });
+      Object.defineProperty(entity, '__helper', { value: new WrappedEntity(entity as T, this.em, meta) });
 
       return entity;
     }
@@ -95,7 +95,7 @@ export class EntityFactory {
     // creates new entity instance, bypassing constructor call as its already persisted entity
     const entity = Object.create(meta.class.prototype) as T & AnyEntity<T>;
     // perf: create the helper instance early to bypass the double getter defined on the prototype in EntityHelper
-    Object.defineProperty(entity, '__helper', { value: new WrappedEntity(entity as T, this.em) });
+    Object.defineProperty(entity, '__helper', { value: new WrappedEntity(entity as T, this.em, meta) });
     entity.__helper!.__managed = true;
     this.hydrator.hydrateReference(entity, meta, data, options.convertCustomTypes);
 

--- a/packages/core/src/entity/EntityHelper.ts
+++ b/packages/core/src/entity/EntityHelper.ts
@@ -53,11 +53,12 @@ export class EntityHelper {
   private static defineBaseProperties<T extends AnyEntity<T>>(meta: EntityMetadata<T>, prototype: T, em: EntityManager) {
     Object.defineProperties(prototype, {
       __entity: { value: true },
+      __meta: { value: meta },
       __helper: {
         get(): string {
           if (!this.___helper) {
-            const helper = new WrappedEntity(this, meta, em);
-            Object.defineProperty(this, '___helper', { value: helper });
+            const helper = new WrappedEntity(this, em);
+            Object.defineProperty(this, '___helper', { value: helper, writable: true });
           }
 
           return this.___helper;

--- a/packages/core/src/entity/EntityHelper.ts
+++ b/packages/core/src/entity/EntityHelper.ts
@@ -53,11 +53,10 @@ export class EntityHelper {
   private static defineBaseProperties<T extends AnyEntity<T>>(meta: EntityMetadata<T>, prototype: T, em: EntityManager) {
     Object.defineProperties(prototype, {
       __entity: { value: true },
-      __meta: { value: meta },
       __helper: {
         get(): string {
           if (!this.___helper) {
-            const helper = new WrappedEntity(this, em);
+            const helper = new WrappedEntity(this, em, meta);
             Object.defineProperty(this, '___helper', { value: helper, writable: true });
           }
 
@@ -94,7 +93,7 @@ export class EntityHelper {
       let name = meta.name;
 
       // distinguish not initialized entities
-      if (!this.__helper!.isInitialized()) {
+      if (!this.__helper!.__initialized) {
         name = `Ref<${name}>`;
       }
 
@@ -125,7 +124,7 @@ export class EntityHelper {
       inverse.add(owner);
     }
 
-    if (prop.reference === ReferenceType.ONE_TO_ONE && entity && entity.__helper!.isInitialized() && Reference.unwrapReference(inverse) !== owner) {
+    if (prop.reference === ReferenceType.ONE_TO_ONE && entity && entity.__helper!.__initialized && Reference.unwrapReference(inverse) !== owner) {
       EntityHelper.propagateOneToOne(entity, owner, prop);
     }
   }

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -230,7 +230,10 @@ export class EntityLoader {
     const children: AnyEntity[] = [];
 
     for (const entity of filtered) {
-      const items = map[entity.__helper!.__serializedPrimaryKey as string].map(item => this.em.merge(prop.type, item, refresh, true));
+      const items = map[entity.__helper!.__serializedPrimaryKey as string].map(item => {
+        const entity = this.em.getEntityFactory().create<T>(prop.type, item, { refresh, merge: true, convertCustomTypes: true });
+        return this.em.getUnitOfWork().registerManaged(entity, item, refresh);
+      });
       (entity[field] as unknown as Collection<AnyEntity>).hydrate(items);
       children.push(...items);
     }

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -273,7 +273,7 @@ export class EntityLoader {
       return children.map(e => Reference.unwrapReference(e[field]));
     }
 
-    return children.filter(e => !(e[field] as AnyEntity).__helper!.isInitialized()).map(e => Reference.unwrapReference(e[field]));
+    return children.filter(e => !(e[field] as AnyEntity).__helper!.__initialized).map(e => Reference.unwrapReference(e[field]));
   }
 
   private lookupAllRelationships<T>(entityName: string, prefix = '', visited: string[] = []): PopulateOptions<T>[] {

--- a/packages/core/src/entity/EntityTransformer.ts
+++ b/packages/core/src/entity/EntityTransformer.ts
@@ -31,7 +31,7 @@ export class EntityTransformer {
       })
       .forEach(([pk, value]) => ret[this.propertyName(meta, pk, platform)] = value as unknown as T[keyof T]);
 
-    if ((!wrapped.isInitialized() && Utils.isDefined(wrapped.__primaryKey, true)) || visited.has(entity)) {
+    if ((!wrapped.isInitialized() && wrapped.hasPrimaryKey()) || visited.has(entity)) {
       return ret;
     }
 

--- a/packages/core/src/entity/EntityTransformer.ts
+++ b/packages/core/src/entity/EntityTransformer.ts
@@ -31,11 +31,11 @@ export class EntityTransformer {
       })
       .forEach(([pk, value]) => ret[this.propertyName(meta, pk, platform)] = value as unknown as T[keyof T]);
 
-    if ((!wrapped.isInitialized() && Utils.isDefined(wrapped.__primaryKey, true)) || visited.has(entity.__helper!)) {
+    if ((!wrapped.isInitialized() && Utils.isDefined(wrapped.__primaryKey, true)) || visited.has(entity)) {
       return ret;
     }
 
-    visited.add(entity.__helper!);
+    visited.add(entity);
 
     // normal properties
     Object.keys(entity)

--- a/packages/core/src/entity/EntityTransformer.ts
+++ b/packages/core/src/entity/EntityTransformer.ts
@@ -10,7 +10,7 @@ export class EntityTransformer {
 
   static toObject<T extends AnyEntity<T>>(entity: T, ignoreFields: string[] = [], visited = new WeakSet<AnyEntity>()): EntityData<T> {
     const wrapped = entity.__helper!;
-    const platform = wrapped.__internal.platform;
+    const platform = wrapped.__internal.getDriver().getPlatform();
     const meta = wrapped.__meta;
     const ret = {} as EntityData<T>;
 
@@ -77,7 +77,7 @@ export class EntityTransformer {
   private static processProperty<T extends AnyEntity<T>>(prop: keyof T & string, entity: T, ignoreFields: string[], visited: WeakSet<AnyEntity>): T[keyof T] | undefined {
     const wrapped = entity.__helper!;
     const property = wrapped.__meta.properties[prop];
-    const platform = wrapped.__internal.platform;
+    const platform = wrapped.__internal.getDriver().getPlatform();
 
     /* istanbul ignore next */
     const serializer = property?.serializer;
@@ -113,7 +113,7 @@ export class EntityTransformer {
       return wrap(child).toJSON(...args) as T[keyof T];
     }
 
-    return wrapped.__internal.platform.normalizePrimaryKey(wrapped.__primaryKey as unknown as IPrimaryKey) as unknown as T[keyof T];
+    return wrapped.__internal.getDriver().getPlatform().normalizePrimaryKey(wrapped.__primaryKey as unknown as IPrimaryKey) as unknown as T[keyof T];
   }
 
   private static processCollection<T extends AnyEntity<T>>(prop: keyof T, entity: T): T[keyof T] | undefined {

--- a/packages/core/src/entity/EntityValidator.ts
+++ b/packages/core/src/entity/EntityValidator.ts
@@ -85,7 +85,7 @@ export class EntityValidator {
   }
 
   private validateCollection<T extends AnyEntity<T>>(entity: T, prop: EntityProperty): void {
-    if (entity.__helper!.isInitialized() && !entity[prop.name as keyof T]) {
+    if (entity.__helper!.__initialized && !entity[prop.name as keyof T]) {
       throw ValidationError.fromCollectionNotInitialized(entity, prop);
     }
   }

--- a/packages/core/src/entity/EntityValidator.ts
+++ b/packages/core/src/entity/EntityValidator.ts
@@ -12,20 +12,23 @@ export class EntityValidator {
       if ([ReferenceType.ONE_TO_MANY, ReferenceType.MANY_TO_MANY].includes(prop.reference)) {
         this.validateCollection(entity, prop);
       }
-    });
 
-    Object.keys(payload).forEach(prop => {
-      const property = meta.properties[prop];
       const SCALAR_TYPES = ['string', 'number', 'boolean', 'Date'];
 
-      if (!property || property.reference !== ReferenceType.SCALAR || !SCALAR_TYPES.includes(property.type)) {
+      if (prop.reference !== ReferenceType.SCALAR || !SCALAR_TYPES.includes(prop.type)) {
         return;
       }
 
-      payload[prop] = this.validateProperty(property, payload[prop], entity);
+      const newValue = this.validateProperty(prop, payload[prop.name], entity);
 
-      if (entity[prop]) {
-        entity[prop] = payload[prop];
+      if (payload[prop.name] === newValue) {
+        return;
+      }
+
+      payload[prop.name] = newValue;
+
+      if (entity[prop.name]) {
+        entity[prop.name] = payload[prop.name];
       }
     });
   }

--- a/packages/core/src/entity/Reference.ts
+++ b/packages/core/src/entity/Reference.ts
@@ -102,7 +102,7 @@ export class Reference<T extends AnyEntity<T>> {
   }
 
   isInitialized(): boolean {
-    return this.entity.__helper!.isInitialized();
+    return this.entity.__helper!.__initialized;
   }
 
   populated(populated?: boolean): void {

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -12,6 +12,7 @@ import { ValidationError } from '../errors';
 
 export class WrappedEntity<T extends AnyEntity<T>, PK extends keyof T> {
 
+  readonly __meta: EntityMetadata<T>;
   __initialized = true;
   __populated = false;
   __lazyInitialized = false;
@@ -30,9 +31,8 @@ export class WrappedEntity<T extends AnyEntity<T>, PK extends keyof T> {
     validator: EntityValidator;
   };
 
-  constructor(private readonly entity: T,
-              readonly __meta: EntityMetadata<T>,
-              em: EntityManager) {
+  constructor(private readonly entity: T, em: EntityManager) {
+    this.__meta = (entity as Dictionary).__meta;
     this.__internal = {
       platform: em.getDriver().getPlatform(),
       metadata: em.getMetadata(),

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -1,4 +1,3 @@
-import { v4 as uuid } from 'uuid';
 import { EntityManager } from '../EntityManager';
 import { Platform } from '../platforms';
 import { MetadataStorage } from '../metadata';
@@ -25,7 +24,6 @@ export class WrappedEntity<T extends AnyEntity<T>, PK extends keyof T> {
   /** holds wrapped primary key so we can compute change set without eager commit */
   __identifier?: EntityData<T>;
 
-  readonly __uuid = uuid();
   readonly __internal: {
     platform: Platform;
     metadata: MetadataStorage;

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -1,7 +1,4 @@
 import { EntityManager } from '../EntityManager';
-import { Platform } from '../platforms';
-import { MetadataStorage } from '../metadata';
-import { EntityValidator } from './EntityValidator';
 import { AnyEntity, Dictionary, EntityData, EntityMetadata, Populate, Primary } from '../typings';
 import { IdentifiedReference, Reference } from './Reference';
 import { EntityTransformer } from './EntityTransformer';
@@ -12,11 +9,10 @@ import { ValidationError } from '../errors';
 
 export class WrappedEntity<T extends AnyEntity<T>, PK extends keyof T> {
 
-  readonly __meta: EntityMetadata<T>;
   __initialized = true;
-  __populated = false;
-  __lazyInitialized = false;
-  __managed = false;
+  __populated?: boolean;
+  __lazyInitialized?: boolean;
+  __managed?: boolean;
   __em?: EntityManager;
 
   /** holds last entity data snapshot so we can compute changes when persisting managed entities */
@@ -25,20 +21,9 @@ export class WrappedEntity<T extends AnyEntity<T>, PK extends keyof T> {
   /** holds wrapped primary key so we can compute change set without eager commit */
   __identifier?: EntityData<T>;
 
-  readonly __internal: {
-    platform: Platform;
-    metadata: MetadataStorage;
-    validator: EntityValidator;
-  };
-
-  constructor(private readonly entity: T, em: EntityManager) {
-    this.__meta = (entity as Dictionary).__meta;
-    this.__internal = {
-      platform: em.getDriver().getPlatform(),
-      metadata: em.getMetadata(),
-      validator: em.getValidator(),
-    };
-  }
+  constructor(private readonly entity: T,
+              readonly __internal: EntityManager,
+              readonly __meta: EntityMetadata<T>) { }
 
   isInitialized(): boolean {
     return this.__initialized;

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -19,6 +19,9 @@ export class WrappedEntity<T extends AnyEntity<T>, PK extends keyof T> {
   __managed = false;
   __em?: EntityManager;
 
+  /** holds last entity data snapshot so we can compute changes when persisting managed entities */
+  __originalEntityData?: EntityData<T>;
+
   readonly __uuid = uuid();
   readonly __internal: {
     platform: Platform;

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -22,6 +22,9 @@ export class WrappedEntity<T extends AnyEntity<T>, PK extends keyof T> {
   /** holds last entity data snapshot so we can compute changes when persisting managed entities */
   __originalEntityData?: EntityData<T>;
 
+  /** holds wrapped primary key so we can compute change set without eager commit */
+  __identifier?: EntityData<T>;
+
   readonly __uuid = uuid();
   readonly __internal: {
     platform: Platform;

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -70,6 +70,13 @@ export class WrappedEntity<T extends AnyEntity<T>, PK extends keyof T> {
     return this.entity;
   }
 
+  hasPrimaryKey(): boolean {
+    return this.__meta.primaryKeys.every(pk => {
+      const val = Utils.extractPK(this.entity[pk]);
+      return val !== undefined && val !== null;
+    });
+  }
+
   get __primaryKey(): Primary<T> {
     return Utils.getPrimaryKeyValue(this.entity, this.__meta.primaryKeys);
   }

--- a/packages/core/src/hydration/ObjectHydrator.ts
+++ b/packages/core/src/hydration/ObjectHydrator.ts
@@ -29,7 +29,11 @@ export class ObjectHydrator extends Hydrator {
       value = prop.customType.convertToJSValue(value, this.em.getDriver().getPlatform());
     }
 
-    entity[prop.name] = value;
+    if (value && prop.type.toLowerCase() === 'date') {
+      entity[prop.name] = new Date(value);
+    } else {
+      entity[prop.name] = value;
+    }
   }
 
   private hydrateEmbeddable<T extends AnyEntity<T>>(entity: T, prop: EntityProperty, data: EntityData<T>): void {
@@ -78,7 +82,7 @@ export class ObjectHydrator extends Hydrator {
 
     if (Utils.isPrimaryKey(value, meta.compositePK)) {
       const ref = this.factory.createReference<T>(prop.type, value, { merge: true });
-      this.em.merge(ref);
+      this.em.getUnitOfWork().registerManaged(ref, value);
 
       return ref;
     }
@@ -87,7 +91,7 @@ export class ObjectHydrator extends Hydrator {
       return value;
     }
 
-    return this.factory.create(prop.type, value as EntityData<T>, { newEntity });
+    return this.factory.create(prop.type, value as EntityData<T>, { newEntity, merge: true });
   }
 
 }

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -282,7 +282,7 @@ export class MetadataDiscovery {
     const meta2 = this.metadata.get(prop.type);
     Utils.defaultValue(prop, 'fixedOrder', !!prop.fixedOrderColumn);
 
-    if (!prop.pivotTable && prop.owner) {
+    if (!prop.pivotTable && prop.owner && this.platform.usesPivotTable()) {
       prop.pivotTable = this.namingStrategy.joinTableName(meta.collection, meta2.collection, prop.name);
     }
 

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -1,6 +1,6 @@
 import { EntityRepository } from '../entity';
 import { NamingStrategy, UnderscoreNamingStrategy } from '../naming-strategy';
-import { Constructor, Dictionary, EntityProperty, EntityMetadata, IPrimaryKey, Primary, ISchemaGenerator } from '../typings';
+import { Constructor, Dictionary, EntityProperty, IPrimaryKey, Primary, ISchemaGenerator } from '../typings';
 import { ExceptionConverter } from './ExceptionConverter';
 import { EntityManager } from '../EntityManager';
 
@@ -130,10 +130,6 @@ export abstract class Platform {
 
   getSchemaGenerator(em: EntityManager): ISchemaGenerator {
     throw new Error(`${this.constructor.name} does not use a schema generator`);
-  }
-
-  processVersionProperty<T>(meta: EntityMetadata<T>, entity: T): string | number | Date {
-    return entity[meta.versionProperty] as unknown as string;
   }
 
   processDateProperty(value: unknown): string | number | Date {

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -1,6 +1,6 @@
 import { EntityRepository } from '../entity';
 import { NamingStrategy, UnderscoreNamingStrategy } from '../naming-strategy';
-import { Constructor, Dictionary, EntityProperty, IPrimaryKey, Primary, ISchemaGenerator } from '../typings';
+import { Constructor, Dictionary, EntityProperty, EntityMetadata, IPrimaryKey, Primary, ISchemaGenerator } from '../typings';
 import { ExceptionConverter } from './ExceptionConverter';
 import { EntityManager } from '../EntityManager';
 
@@ -130,6 +130,10 @@ export abstract class Platform {
 
   getSchemaGenerator(em: EntityManager): ISchemaGenerator {
     throw new Error(`${this.constructor.name} does not use a schema generator`);
+  }
+
+  processVersionProperty<T>(meta: EntityMetadata<T>, entity: T): string | number | Date {
+    return entity[meta.versionProperty] as unknown as string;
   }
 
 }

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -136,4 +136,8 @@ export abstract class Platform {
     return entity[meta.versionProperty] as unknown as string;
   }
 
+  processDateProperty(value: unknown): string | number | Date {
+    return value as string;
+  }
+
 }

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -71,7 +71,6 @@ export interface IWrappedEntity<T extends AnyEntity<T>, PK extends keyof T, P = 
 }
 
 export interface IWrappedEntityInternal<T extends AnyEntity<T>, PK extends keyof T, P = keyof T> extends IWrappedEntity<T, PK, P> {
-  __uuid: string;
   __meta: EntityMetadata<T>;
   __internal: { platform: Platform; metadata: IMetadataStorage; validator: EntityValidator };
   __data: Dictionary;

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1,5 +1,5 @@
 import { Cascade, EventType, LoadStrategy, QueryOrder, ReferenceType, LockMode } from './enums';
-import { AssignOptions, Collection, EntityRepository, EntityValidator, IdentifiedReference, Reference } from './entity';
+import { AssignOptions, Collection, EntityRepository, EntityValidator, EntityIdentifier, IdentifiedReference, Reference } from './entity';
 import { Platform } from './platforms';
 import { EntitySchema } from './metadata';
 import { Type } from './types';
@@ -78,6 +78,7 @@ export interface IWrappedEntityInternal<T extends AnyEntity<T>, PK extends keyof
   __em?: any; // we cannot have `EntityManager` here as that causes a cycle
   __initialized?: boolean;
   __originalEntityData?: EntityData<T>;
+  __identifier?: EntityIdentifier;
   __managed: boolean;
   __populated: boolean;
   __lazyInitialized: boolean;

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1,6 +1,5 @@
 import { Cascade, EventType, LoadStrategy, QueryOrder, ReferenceType, LockMode } from './enums';
-import { AssignOptions, Collection, EntityRepository, EntityValidator, EntityIdentifier, IdentifiedReference, Reference } from './entity';
-import { Platform } from './platforms';
+import { AssignOptions, Collection, EntityRepository, EntityIdentifier, IdentifiedReference, Reference } from './entity';
 import { EntitySchema } from './metadata';
 import { Type } from './types';
 
@@ -72,10 +71,10 @@ export interface IWrappedEntity<T extends AnyEntity<T>, PK extends keyof T, P = 
 
 export interface IWrappedEntityInternal<T extends AnyEntity<T>, PK extends keyof T, P = keyof T> extends IWrappedEntity<T, PK, P> {
   __meta: EntityMetadata<T>;
-  __internal: { platform: Platform; metadata: IMetadataStorage; validator: EntityValidator };
   __data: Dictionary;
   __em?: any; // we cannot have `EntityManager` here as that causes a cycle
-  __initialized?: boolean;
+  __internal: any; // we cannot have `EntityManager` here as that causes a cycle
+  __initialized: boolean;
   __originalEntityData?: EntityData<T>;
   __identifier?: EntityIdentifier;
   __managed: boolean;

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -70,6 +70,7 @@ export interface IWrappedEntity<T extends AnyEntity<T>, PK extends keyof T, P = 
 }
 
 export interface IWrappedEntityInternal<T extends AnyEntity<T>, PK extends keyof T, P = keyof T> extends IWrappedEntity<T, PK, P> {
+  hasPrimaryKey(): boolean;
   __meta: EntityMetadata<T>;
   __data: Dictionary;
   __em?: any; // we cannot have `EntityManager` here as that causes a cycle

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -77,6 +77,7 @@ export interface IWrappedEntityInternal<T extends AnyEntity<T>, PK extends keyof
   __data: Dictionary;
   __em?: any; // we cannot have `EntityManager` here as that causes a cycle
   __initialized?: boolean;
+  __originalEntityData?: EntityData<T>;
   __managed: boolean;
   __populated: boolean;
   __lazyInitialized: boolean;

--- a/packages/core/src/unit-of-work/ChangeSetComputer.ts
+++ b/packages/core/src/unit-of-work/ChangeSetComputer.ts
@@ -98,7 +98,7 @@ export class ChangeSetComputer {
       return;
     }
 
-    if (prop.owner || target.getItems(false).filter(item => !item.__helper!.isInitialized()).length > 0) {
+    if (prop.owner || target.getItems(false).filter(item => !item.__helper!.__initialized).length > 0) {
       this.collectionUpdates.push(target);
     } else {
       target.setDirty(false); // inverse side with only populated items, nothing to persist

--- a/packages/core/src/unit-of-work/ChangeSetComputer.ts
+++ b/packages/core/src/unit-of-work/ChangeSetComputer.ts
@@ -2,7 +2,7 @@ import { Configuration, Utils } from '../utils';
 import { MetadataStorage } from '../metadata';
 import { AnyEntity, EntityData, EntityProperty, Primary } from '../typings';
 import { ChangeSet, ChangeSetType } from './ChangeSet';
-import { Collection, EntityIdentifier, EntityValidator } from '../entity';
+import { Collection, EntityValidator } from '../entity';
 import { Platform } from '../platforms';
 import { ReferenceType } from '../enums';
 import { EntityComparator } from '../utils/EntityComparator';
@@ -12,7 +12,6 @@ export class ChangeSetComputer {
   private readonly comparator = new EntityComparator(this.metadata, this.platform);
 
   constructor(private readonly validator: EntityValidator,
-              private readonly identifierMap: Map<string, EntityIdentifier>,
               private readonly collectionUpdates: Collection<AnyEntity>[],
               private readonly removeStack: Set<AnyEntity>,
               private readonly metadata: MetadataStorage,
@@ -88,7 +87,7 @@ export class ChangeSetComputer {
     const isToOneOwner = prop.reference === ReferenceType.MANY_TO_ONE || (prop.reference === ReferenceType.ONE_TO_ONE && prop.owner);
 
     if (isToOneOwner && pks.length === 1 && !Utils.isDefined(entity[pks[0]], true)) {
-      changeSet.payload[prop.name] = this.identifierMap.get(entity.__helper!.__uuid);
+      changeSet.payload[prop.name] = entity.__helper!.__identifier;
     }
   }
 

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -64,9 +64,8 @@ export class ChangeSetPersister {
     const meta = this.metadata.find(changeSet.name)!;
     const wrapped = changeSet.entity.__helper!;
     const res = await this.driver.nativeInsert(changeSet.name, changeSet.payload, ctx);
-    const hasPrimaryKey = Utils.isDefined(wrapped.__primaryKey, true);
 
-    if (!hasPrimaryKey) {
+    if (!wrapped.hasPrimaryKey()) {
       this.mapPrimaryKey(meta, res.insertId, changeSet);
     }
 
@@ -90,7 +89,11 @@ export class ChangeSetPersister {
     const prop = meta.properties[meta.primaryKeys[0]];
     const insertId = prop.customType ? prop.customType.convertToJSValue(value, this.driver.getPlatform()) : value;
     const wrapped = changeSet.entity.__helper!;
-    wrapped.__primaryKey = Utils.isDefined(wrapped.__primaryKey, true) ? wrapped.__primaryKey : insertId;
+
+    if (!wrapped.hasPrimaryKey()) {
+      wrapped.__primaryKey = insertId;
+    }
+
     changeSet.payload[wrapped.__meta.primaryKeys[0]] = value;
     wrapped.__identifier!.setValue(changeSet.entity[prop.name] as unknown as IPrimaryKey);
   }

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -1,5 +1,13 @@
 import { MetadataStorage } from '../metadata';
-import { AnyEntity, Dictionary, EntityData, EntityMetadata, EntityProperty, FilterQuery, IPrimaryKey } from '../typings';
+import {
+  AnyEntity,
+  Dictionary,
+  EntityData,
+  EntityMetadata,
+  EntityProperty,
+  FilterQuery,
+  IPrimaryKey,
+} from '../typings';
 import { EntityIdentifier } from '../entity';
 import { ChangeSet, ChangeSetType } from './ChangeSet';
 import { QueryResult, Transaction } from '../connections';
@@ -139,6 +147,8 @@ export class ChangeSetPersister {
     } else {
       changeSet.entity[meta.versionProperty] = e![meta.versionProperty];
     }
+
+    changeSet.payload![meta.versionProperty] = e![meta.versionProperty];
   }
 
   private processProperty<T extends AnyEntity<T>>(changeSet: ChangeSet<T>, prop: EntityProperty<T>): void {
@@ -158,6 +168,10 @@ export class ChangeSetPersister {
 
     if (prop.onUpdate && changeSet.type === ChangeSetType.UPDATE) {
       changeSet.entity[prop.name] = changeSet.payload[prop.name] = prop.onUpdate(changeSet.entity);
+    }
+
+    if (changeSet.payload[prop.name] as unknown instanceof Date) {
+      changeSet.payload[prop.name] = this.driver.getPlatform().processDateProperty(changeSet.payload[prop.name]);
     }
   }
 

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -11,7 +11,6 @@ import { OptimisticLockError } from '../errors';
 export class ChangeSetPersister {
 
   constructor(private readonly driver: IDatabaseDriver,
-              private readonly identifierMap: Map<string, EntityIdentifier>,
               private readonly metadata: MetadataStorage,
               private readonly hydrator: Hydrator,
               private readonly config: Configuration) { }
@@ -85,7 +84,7 @@ export class ChangeSetPersister {
     const wrapped = changeSet.entity.__helper!;
     wrapped.__primaryKey = Utils.isDefined(wrapped.__primaryKey, true) ? wrapped.__primaryKey : insertId;
     changeSet.payload[wrapped.__meta.primaryKeys[0]] = value;
-    this.identifierMap.get(wrapped.__uuid)!.setValue(changeSet.entity[prop.name] as unknown as IPrimaryKey);
+    wrapped.__identifier!.setValue(changeSet.entity[prop.name] as unknown as IPrimaryKey);
   }
 
   /**

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -122,7 +122,7 @@ export class ChangeSetPersister {
 
     const cond = {
       ...Utils.getPrimaryKeyCond<T>(changeSet.entity, meta.primaryKeys),
-      [meta.versionProperty]: this.driver.getPlatform().processVersionProperty(meta, changeSet.entity),
+      [meta.versionProperty]: changeSet.entity[meta.versionProperty],
     } as FilterQuery<T>;
 
     return this.driver.nativeUpdate(changeSet.name, cond, changeSet.payload, ctx);

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -101,9 +101,9 @@ export class UnitOfWork {
   }
 
   /**
-   * @deprecated, use `uow.getOriginalEntityData(entity)`
+   * @deprecated use `uow.getOriginalEntityData(entity)`
    */
-  getOriginalEntityData<T extends AnyEntity<T>>(): Map<string, AnyEntity>;
+  getOriginalEntityData<T extends AnyEntity<T>>(): AnyEntity[];
 
   /**
    * Returns stored snapshot of entity state that is used for change set computation.
@@ -113,14 +113,11 @@ export class UnitOfWork {
   /**
    * Returns stored snapshot of entity state that is used for change set computation.
    */
-  getOriginalEntityData<T extends AnyEntity<T>>(entity?: T): Map<string, AnyEntity> | EntityData<T> | undefined {
+  getOriginalEntityData<T extends AnyEntity<T>>(entity?: T): EntityData<T>[] | EntityData<T> | undefined {
     if (!entity) {
-      const map = new Map();
-      this.identityMap.forEach(e => {
-        map.set(e.__helper!.__uuid, e.__helper!.__originalEntityData);
+      return [...this.identityMap.values()].map(e => {
+        return e.__helper!.__originalEntityData;
       });
-
-      return map;
     }
 
     return entity.__helper!.__originalEntityData;

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -117,9 +117,7 @@ export class UnitOfWork {
     if (!entity) {
       const map = new Map();
       this.identityMap.forEach(e => {
-        if (e.__helper!.__originalEntityData) {
-          map.set(e.__helper!.__uuid, e.__helper!.__originalEntityData);
-        }
+        map.set(e.__helper!.__uuid, e.__helper!.__originalEntityData);
       });
 
       return map;

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -301,7 +301,7 @@ export class UnitOfWork {
     visited.add(entity);
     const wrapped = entity.__helper!;
 
-    if (!wrapped.isInitialized() || this.removeStack.has(entity) || this.orphanRemoveStack.has(entity)) {
+    if (!wrapped.__initialized || this.removeStack.has(entity) || this.orphanRemoveStack.has(entity)) {
       return;
     }
 
@@ -427,7 +427,7 @@ export class UnitOfWork {
     if ([ReferenceType.ONE_TO_MANY, ReferenceType.MANY_TO_MANY].includes(prop.reference) && collection) {
       collection
         .getItems(false)
-        .filter(item => !requireFullyInitialized || item.__helper!.isInitialized())
+        .filter(item => !requireFullyInitialized || item.__helper!.__initialized)
         .forEach(item => this.cascade(item, type, visited, options));
     }
   }
@@ -464,7 +464,7 @@ export class UnitOfWork {
 
     const wrapped = entity.__helper!;
 
-    if (!wrapped.isInitialized()) {
+    if (!wrapped.__initialized) {
       await wrapped.init();
     }
 

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -34,6 +34,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
       disableDynamicFileAccess: false,
     },
     strict: false,
+    validate: false,
     // eslint-disable-next-line no-console
     logger: console.log.bind(console),
     findOneOrFailHandler: (entityName: string, where: Dictionary | IPrimaryKey) => NotFoundError.findOneFailed(entityName, where),
@@ -327,6 +328,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
   entityRepository?: Constructor<EntityRepository<any>>;
   replicas?: Partial<ConnectionOptions>[];
   strict: boolean;
+  validate: boolean;
   logger: (message: string) => void;
   findOneOrFailHandler: (entityName: string, where: Dictionary | IPrimaryKey) => Error;
   debug: boolean | LoggerNamespace[];

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -81,7 +81,7 @@ export class EntityComparator {
 
     const value = entity[prop.name];
     const collection = Utils.isCollection(value);
-    const noPkRef = Utils.isEntity<T>(value, true) && !value.__helper!.__primaryKeys.every(pk => Utils.isDefined(pk, true));
+    const noPkRef = Utils.isEntity<T>(value, true) && !value.__helper!.hasPrimaryKey();
     const noPkProp = prop.primary && !Utils.isDefined(value, true);
     const inverse = prop.reference === ReferenceType.ONE_TO_ONE && !prop.owner;
     const discriminator = prop.name === root.discriminatorColumn;

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -58,6 +58,10 @@ export class EntityComparator {
         return ret[prop.name] = Utils.copy(prop.customType.convertToDatabaseValue(entity[prop.name], this.platform));
       }
 
+      if (prop.type.toLowerCase() === 'date') {
+        return ret[prop.name] = Utils.copy(this.platform.processDateProperty(entity[prop.name]));
+      }
+
       if (Array.isArray(entity[prop.name]) || Utils.isObject(entity[prop.name])) {
         return ret[prop.name] = Utils.copy(entity[prop.name]);
       }
@@ -86,7 +90,7 @@ export class EntityComparator {
     const isSetter = [ReferenceType.ONE_TO_ONE, ReferenceType.MANY_TO_ONE].includes(prop.reference) && (prop.inversedBy || prop.mappedBy);
     const emptyRef = isSetter && value === undefined;
 
-    return collection || noPkProp || noPkRef || inverse || discriminator || emptyRef;
+    return collection || noPkProp || noPkRef || inverse || discriminator || emptyRef || prop.version;
   }
 
 }

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -289,15 +289,24 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     return this.driver.mapResult(res as unknown as T, meta, this._populate, this) as unknown as U;
   }
 
+  /**
+   * Alias for `qb.getResultList()`
+   */
   async getResult(): Promise<T[]> {
     return this.getResultList();
   }
 
+  /**
+   * Executes the query, returning array of results
+   */
   async getResultList(): Promise<T[]> {
     const res = await this.execute<T[]>('all', true);
     return res.map(r => this.em!.map<T>(this.entityName, r));
   }
 
+  /**
+   * Executes the query, returning the first result or null
+   */
   async getSingleResult(): Promise<T | null> {
     const res = await this.getResult();
     return res[0] || null;

--- a/packages/mysql-base/src/MySqlConnection.ts
+++ b/packages/mysql-base/src/MySqlConnection.ts
@@ -26,6 +26,7 @@ export class MySqlConnection extends AbstractSqlConnection {
     }
 
     ret.supportBigNumbers = true;
+    ret.dateStrings = ['DATE'] as any;
 
     return ret;
   }

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@mikro-orm/mysql-base": "^4.0.2",
-    "mysql2": "^2.1.0"
+    "mysql2": "sidorares/node-mysql2#master"
   },
   "devDependencies": {
     "@mikro-orm/core": "^4.0.2"

--- a/packages/sqlite/src/SqlitePlatform.ts
+++ b/packages/sqlite/src/SqlitePlatform.ts
@@ -34,13 +34,27 @@ export class SqlitePlatform extends AbstractSqlPlatform {
    * This might be narrowed via custom DateTimeType that would be automatically used in v5.
    */
   processVersionProperty<T>(meta: EntityMetadata<T>, entity: T): string | number | Date {
-    const value = entity[meta.versionProperty] as unknown as string;
+    const value = entity[meta.versionProperty] as unknown;
 
-    if (meta.properties[meta.versionProperty].type.toLowerCase() === 'date') {
-      return new Date().toISOString().substr(0, 19).replace('T', ' ');
+    if (value instanceof Date) {
+      return value.toISOString().substr(0, 19).replace('T', ' ');
     }
 
-    return value ;
+    return value as string;
+  }
+
+  /**
+   * This is used to narrow the value of Date properties as they will be stored as timestamps in sqlite.
+   * We use this method to convert Dates to timestamps when computing the changeset, so we have the right
+   * data type in the payload as well as in original entity data. Without that, we would end up with diffs
+   * including all Date properties, as we would be comparing Date object with timestamp.
+   */
+  processDateProperty(value: unknown): string | number | Date {
+    if (value instanceof Date) {
+      return +value;
+    }
+
+    return value as number;
   }
 
 }

--- a/packages/sqlite/src/SqlitePlatform.ts
+++ b/packages/sqlite/src/SqlitePlatform.ts
@@ -1,7 +1,6 @@
 import { AbstractSqlPlatform } from '@mikro-orm/knex';
 import { SqliteSchemaHelper } from './SqliteSchemaHelper';
 import { SqliteExceptionConverter } from './SqliteExceptionConverter';
-import { EntityMetadata } from '@mikro-orm/core';
 
 export class SqlitePlatform extends AbstractSqlPlatform {
 
@@ -22,25 +21,6 @@ export class SqlitePlatform extends AbstractSqlPlatform {
 
   convertsJsonAutomatically(): boolean {
     return false;
-  }
-
-  /**
-   * This is used to get around a bug in sqlite dates. They are stored as timestamps by sqlite3,
-   * but `current_timestamp` from the db will give us a string date.
-   * This method is here to allow narrowing the date version property value to string, as otherwise
-   * sqlite3 would not understand the comparison with native Date and string.
-   *
-   * Ideally we should store all the dates in the same way, which would be huge BC break for sqlite.
-   * This might be narrowed via custom DateTimeType that would be automatically used in v5.
-   */
-  processVersionProperty<T>(meta: EntityMetadata<T>, entity: T): string | number | Date {
-    const value = entity[meta.versionProperty] as unknown;
-
-    if (value instanceof Date) {
-      return value.toISOString().substr(0, 19).replace('T', ' ');
-    }
-
-    return value as string;
   }
 
   /**

--- a/packages/sqlite/src/SqlitePlatform.ts
+++ b/packages/sqlite/src/SqlitePlatform.ts
@@ -1,6 +1,7 @@
 import { AbstractSqlPlatform } from '@mikro-orm/knex';
 import { SqliteSchemaHelper } from './SqliteSchemaHelper';
 import { SqliteExceptionConverter } from './SqliteExceptionConverter';
+import { EntityMetadata } from '@mikro-orm/core';
 
 export class SqlitePlatform extends AbstractSqlPlatform {
 
@@ -21,6 +22,25 @@ export class SqlitePlatform extends AbstractSqlPlatform {
 
   convertsJsonAutomatically(): boolean {
     return false;
+  }
+
+  /**
+   * This is used to get around a bug in sqlite dates. They are stored as timestamps by sqlite3,
+   * but `current_timestamp` from the db will give us a string date.
+   * This method is here to allow narrowing the date version property value to string, as otherwise
+   * sqlite3 would not understand the comparison with native Date and string.
+   *
+   * Ideally we should store all the dates in the same way, which would be huge BC break for sqlite.
+   * This might be narrowed via custom DateTimeType that would be automatically used in v5.
+   */
+  processVersionProperty<T>(meta: EntityMetadata<T>, entity: T): string | number | Date {
+    const value = entity[meta.versionProperty] as unknown as string;
+
+    if (meta.properties[meta.versionProperty].type.toLowerCase() === 'date') {
+      return new Date().toISOString().substr(0, 19).replace('T', ' ');
+    }
+
+    return value ;
   }
 
 }

--- a/tests/EntityHelper.mongo.test.ts
+++ b/tests/EntityHelper.mongo.test.ts
@@ -76,7 +76,7 @@ describe('EntityHelperMongo', () => {
 
   test('BaseEntity methods', async () => {
     const god = new Author('God', 'hello@heaven.god');
-    expect(wrap(god, true).__populated).toBe(false);
+    expect(wrap(god, true).__populated).toBeUndefined();
     god.populated();
     expect(wrap(god, true).__populated).toBe(true);
 

--- a/tests/EntityHelper.mysql.test.ts
+++ b/tests/EntityHelper.mysql.test.ts
@@ -1,4 +1,4 @@
-import { MetadataDiscovery, MikroORM, wrap } from '@mikro-orm/core';
+import { MikroORM, wrap } from '@mikro-orm/core';
 import { MySqlDriver } from '@mikro-orm/mysql';
 import { initORMMySql, wipeDatabaseMySql } from './bootstrap';
 import { Author2, Book2, BookTag2, FooBar2, FooBaz2 } from './entities-sql';
@@ -7,10 +7,7 @@ describe('EntityHelperMySql', () => {
 
   let orm: MikroORM<MySqlDriver>;
 
-  beforeAll(async () => {
-    orm = await initORMMySql();
-    await new MetadataDiscovery(orm.getMetadata(), orm.em.getDriver().getPlatform(), orm.config).discover();
-  });
+  beforeAll(async () => orm = await initORMMySql());
   beforeEach(async () => wipeDatabaseMySql(orm.em));
 
   test('assign() should update entity values [mysql]', async () => {

--- a/tests/EntityManager.mariadb.test.ts
+++ b/tests/EntityManager.mariadb.test.ts
@@ -39,6 +39,7 @@ describe('EntityManagerMariaDb', () => {
       timezone: 'Z',
       supportBigNumbers: true,
       bigNumberStrings: true,
+      dateStrings: ['DATE'],
     });
   });
 

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -1557,12 +1557,12 @@ describe('EntityManagerMongo', () => {
     const baz2 = FooBaz.create('fz2');
     bar.baz = baz1;
     await orm.em.persistAndFlush(bar);
-    expect(orm.em.getUnitOfWork().getOriginalEntityData().get(wrap(bar, true).__uuid)!.baz).toEqual(baz1._id);
+    expect(orm.em.getUnitOfWork().getOriginalEntityData(bar)!.baz).toEqual(baz1._id);
 
     // replacing reference with value will trigger orphan removal
     bar.baz = baz2;
     await orm.em.persistAndFlush(bar);
-    expect(orm.em.getUnitOfWork().getOriginalEntityData().get(wrap(bar, true).__uuid)!.baz).toEqual(baz2._id);
+    expect(orm.em.getUnitOfWork().getOriginalEntityData(bar)!.baz).toEqual(baz2._id);
     await expect(orm.em.findOne(FooBaz, baz1)).resolves.toBeNull();
     await expect(orm.em.findOne(FooBaz, baz2)).resolves.not.toBeNull();
 

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -541,7 +541,7 @@ describe('EntityManagerMongo', () => {
   });
 
   test('ensure indexes', async () => {
-    await orm.em.getDriver().ensureIndexes();
+    // await orm.em.getDriver().ensureIndexes(); // executed in the init method
     const conn = orm.em.getDriver().getConnection('write');
 
     const authorInfo = await conn.getCollection('author').indexInformation({ full: true, session: undefined as any });

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -504,6 +504,7 @@ describe('EntityManagerMongo', () => {
     const driver = orm.em.getDriver();
     expect(driver).toBeInstanceOf(MongoDriver);
     expect(driver.getDependencies()).toEqual(['mongodb']);
+    expect(orm.config.getNamingStrategy().joinTableName('a', 'b', 'c')).toEqual('');
     expect(await driver.find(BookTag.name, { foo: 'bar', books: 123 }, { orderBy: {} })).toEqual([]);
     expect(await driver.findOne(BookTag.name, { foo: 'bar', books: 123 })).toBeNull();
     expect(await driver.findOne(BookTag.name, { foo: 'bar', books: 123 }, { orderBy: {} })).toBeNull();

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -50,6 +50,7 @@ describe('EntityManagerMySql', () => {
       port: 3308,
       user: 'user',
       timezone: 'Z',
+      dateStrings: ['DATE'],
       supportBigNumbers: true,
     });
   });
@@ -899,7 +900,6 @@ describe('EntityManagerMySql', () => {
     b4.tags.add(tag2, tag4, tag5);
     b5.tags.add(tag5);
 
-    author.books.add(b1, b2, b3, b4, b5);
     await orm.em.persistAndFlush(author);
     orm.em.clear();
 

--- a/tests/EntityManager.sqlite.test.ts
+++ b/tests/EntityManager.sqlite.test.ts
@@ -77,6 +77,10 @@ describe('EntityManagerSqlite', () => {
       { id: 2, name: 'test 2', type: 'LOCAL' },
       { id: 3, name: 'test 3', type: 'GLOBAL' },
     ]);
+
+    const now = new Date();
+    expect(driver.getPlatform().processDateProperty(now)).toBe(+now);
+    expect(driver.getPlatform().processDateProperty(1)).toBe(1);
   });
 
   test('driver appends errored query', async () => {

--- a/tests/EntityManager.sqlite.test.ts
+++ b/tests/EntityManager.sqlite.test.ts
@@ -1,4 +1,3 @@
-import { unlinkSync } from 'fs';
 import {
   Collection, EntityManager, EntityMetadata, JavaScriptMetadataProvider, LockMode, MikroORM, QueryOrder, Logger, ValidationError, wrap,
   UniqueConstraintViolationException, TableNotFoundException, NotNullConstraintViolationException, TableExistsException, SyntaxErrorException,
@@ -331,6 +330,7 @@ describe('EntityManagerSqlite', () => {
     expect(authors[0].name).toBe('Author 1');
     expect(authors[1].name).toBe('Author 2');
     expect(authors[2].name).toBe('Author 3');
+    expect(authors[0].createdAt).toBeInstanceOf(Date);
   });
 
   test('findOne supports optimistic locking [testMultipleFlushesDoIncrementalUpdates]', async () => {
@@ -870,6 +870,9 @@ describe('EntityManagerSqlite', () => {
     expect(res[0].created_at).toBe(+author.createdAt);
     const a = await orm.em.findOneOrFail<any>(Author3, author.id);
     expect(+a.createdAt!).toBe(+author.createdAt);
+    const a1 = await orm.em.findOneOrFail<any>(Author3, { createdAt: { $eq: a.createdAt } });
+    expect(+a1.createdAt!).toBe(+author.createdAt);
+    expect(orm.em.merge(a1)).toBe(a1);
   });
 
   test('exceptions', async () => {
@@ -886,7 +889,6 @@ describe('EntityManagerSqlite', () => {
 
   afterAll(async () => {
     await orm.close(true);
-    unlinkSync(orm.config.get('dbName')!);
   });
 
 });

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -1603,6 +1603,8 @@ describe('QueryBuilder', () => {
     qb4.select('*').where({ name: { $ilike: 'test' } });
     expect(qb4.getQuery()).toEqual('select "e0".* from "publisher2" as "e0" where "e0"."name" ilike $1');
     expect(qb4.getParams()).toEqual(['test']);
+
+    await pg.close(true);
   });
 
   test('perf: insert', async () => {

--- a/tests/UnitOfWork.test.ts
+++ b/tests/UnitOfWork.test.ts
@@ -123,9 +123,9 @@ describe('UnitOfWork', () => {
     uow.persist(author);
     expect([...uow.getPersistStack()]).toEqual([author]);
     expect([...uow.getRemoveStack()]).toEqual([]);
-    expect(uow.getOriginalEntityData()).toEqual(new Map());
+    expect(uow.getOriginalEntityData()).toEqual([]);
     uow.merge(author);
-    expect(uow.getOriginalEntityData().get(wrap(author, true).__uuid)).toMatchObject({ name: 'test', email: 'test' });
+    expect(uow.getOriginalEntityData()).toEqual([{ _id: author._id, name: 'test', email: 'test' }]);
     uow.remove(author);
     expect([...uow.getRemoveStack()]).toEqual([author]);
     expect(() => uow.recomputeSingleChangeSet(author)).not.toThrow();

--- a/tests/UnitOfWork.test.ts
+++ b/tests/UnitOfWork.test.ts
@@ -68,6 +68,7 @@ describe('UnitOfWork', () => {
     expect(() => computer.computeChangeSet(author)).toThrowError(/Trying to set Author\.age of type 'number' to '.*' of type 'date'/);
     Object.assign(author, { age: false });
     expect(() => computer.computeChangeSet(author)).toThrowError(`Trying to set Author.age of type 'number' to 'false' of type 'boolean'`);
+    author.age = 21;
 
     // missing collection instance in m:n and 1:m relations
     // @ts-ignore

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -370,6 +370,10 @@ describe('Utils', () => {
     expect(name).toEqual('mikro-orm-root');
   });
 
+  test('getPrimaryKeyCond', () => {
+    expect(Utils.getPrimaryKeyCond({ a: null }, ['a'])).toBe(null);
+  });
+
   afterAll(async () => orm.close(true));
 
 });

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -40,6 +40,7 @@ export async function initORMMongo() {
     ensureIndexes,
     implicitTransactions: true,
     populateAfterFlush: true,
+    validate: true,
     filters: { allowedFooBars: { cond: args => ({ id: { $in: args.allowed } }), entity: ['FooBar'], default: false } },
   });
 

--- a/tests/issues/GH349.test.ts
+++ b/tests/issues/GH349.test.ts
@@ -71,7 +71,7 @@ describe('GH issue 349', () => {
     });
   });
 
-  afterEach(async () => {
+  beforeEach(async () => {
     await orm.em.nativeDelete(A, {});
     await orm.em.nativeDelete(B, {});
     await orm.em.nativeDelete(C, {});

--- a/tests/issues/GH811.test.ts
+++ b/tests/issues/GH811.test.ts
@@ -86,13 +86,13 @@ describe('GH issue 811', () => {
     contact.address = address;
 
     // Find my previously created employee
-    expect([...orm.em.getUnitOfWork().getOriginalEntityData().values()]).toEqual([
+    expect(orm.em.getUnitOfWork().getOriginalEntityData()).toEqual([
       { id: contact.id, name: 'My Contact', address: null },
     ]);
     const employee = await orm.em.findOneOrFail(Employee, employeeCreate.id);
 
     // previously the `Employee.contact.address` was accidentally cascade merged
-    expect([...orm.em.getUnitOfWork().getOriginalEntityData().values()]).toEqual([
+    expect(orm.em.getUnitOfWork().getOriginalEntityData()).toEqual([
       { id: contact.id, name: 'My Contact', address: null },
       { id: employee.id, contact: contact.id, name: 'My Employee' },
     ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2056,11 +2056,6 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
 
-ansicolors@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.3.2.tgz#665597de86a9ffe3aa9bfbe6cae5c6ea426b4979"
-  integrity sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=
-
 any-promise@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
@@ -2585,14 +2580,6 @@ capture-exit@^2.0.0:
   integrity sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==
   dependencies:
     rsvp "^4.8.4"
-
-cardinal@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/cardinal/-/cardinal-2.1.1.tgz#7cc1055d822d212954d07b085dea251cc7bc5505"
-  integrity sha1-fMEFXYItISlU0HsIXeolHMe8VQU=
-  dependencies:
-    ansicolors "~0.3.2"
-    redeyed "~2.1.0"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -3622,7 +3609,7 @@ espree@^7.3.0:
     acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.3.0"
 
-esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
+esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -6359,12 +6346,10 @@ mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-mysql2@^2.1.0:
+mysql2@sidorares/node-mysql2#master:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mysql2/-/mysql2-2.1.0.tgz#55ecfd4353114c148cc4c253192dbbfd000e6642"
-  integrity sha512-9kGVyi930rG2KaHrz3sHwtc6K+GY9d8wWk1XRSYxQiunvGcn4DwuZxOwmK11ftuhhwrYDwGx9Ta4VBwznJn36A==
+  resolved "https://codeload.github.com/sidorares/node-mysql2/tar.gz/3133dc12e969c650f2e6a586e17af26f268599f0"
   dependencies:
-    cardinal "^2.1.1"
     denque "^1.4.1"
     generate-function "^2.3.1"
     iconv-lite "^0.5.0"
@@ -6372,7 +6357,7 @@ mysql2@^2.1.0:
     lru-cache "^5.1.1"
     named-placeholders "^1.1.2"
     seq-queue "^0.0.5"
-    sqlstring "^2.3.1"
+    sqlstring "^2.3.2"
 
 mz@^2.5.0:
   version "2.7.0"
@@ -7572,13 +7557,6 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-redeyed@~2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-2.1.1.tgz#8984b5815d99cb220469c99eeeffe38913e6cc0b"
-  integrity sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=
-  dependencies:
-    esprima "~4.0.0"
-
 reflect-metadata@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
@@ -8216,7 +8194,7 @@ sqlite3@^4.2.0:
     nan "^2.12.1"
     node-pre-gyp "^0.11.0"
 
-sqlstring@^2.3.1:
+sqlstring@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.2.tgz#cdae7169389a1375b18e885f2e60b3e460809514"
   integrity sha512-vF4ZbYdKS8OnoJAWBmMxCQDkiEBkGQYU7UZPtL8flbDRSNkhaXvRJ279ZtI6M+zDaQovVU4tuRgzK5fVhvFAhg==


### PR DESCRIPTION
Every managed entity did pass thru `em.merge()` originally. While it was a good invariant
for managed entities, it turns out the method was overcomplicated and had a serious performance
impact on the persistence.

With this change, UoW won't use `em.merge()` during flush operation. Instead, entity factory is
used directly to create new instance and new method - `uow.registerManaged()` is used to add it
to the identity map.

The method `em.merge()` is still present and used is some parts of the ORM like in `assign` helper,
it is also still a valid goto method for loading entities from cache.

Related: #732 