### PR TITLE
perf: move reference to metadata to entity prototype + more improvements

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -504,6 +504,11 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * The entity will be entered into the database at or before transaction commit or as a result of the flush operation.
    */
   persist(entity: AnyEntity | Reference<AnyEntity> | (AnyEntity | Reference<AnyEntity>)[]): this {
+    if (Utils.isEntity(entity)) {
+      this.getUnitOfWork().persist(entity);
+      return this;
+    }
+
     const entities = Utils.asArray(entity);
 
     for (const ent of entities) {

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -62,7 +62,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
 
     const ret = Object.assign({}, result) as any;
 
-    Object.values(meta.properties).forEach(prop => {
+    meta.props.forEach(prop => {
       if (prop.fieldNames && prop.fieldNames.length > 1 && prop.fieldNames.every(joinColumn => Utils.isDefined(ret[joinColumn], true))) {
         const temp: any[] = [];
         prop.fieldNames.forEach(joinColumn => {
@@ -134,7 +134,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       }
     });
 
-    Object.values<EntityProperty>(meta.properties).forEach(prop => {
+    meta.props.forEach(prop => {
       if (prop.reference === ReferenceType.EMBEDDED && Utils.isObject(data[prop.name])) {
         const props = prop.embeddedProps;
 

--- a/packages/core/src/entity/ArrayCollection.ts
+++ b/packages/core/src/entity/ArrayCollection.ts
@@ -29,7 +29,7 @@ export class ArrayCollection<T, O> {
 
   toArray(): Dictionary[] {
     return this.getItems().map((item: AnyEntity<T>) => {
-      const meta = item.__helper!.__meta;
+      const meta = item.__meta!;
       const args = [...meta.toJsonParams.map(() => undefined), [this.property.name]];
 
       return wrap(item).toJSON(...args);
@@ -47,7 +47,7 @@ export class ArrayCollection<T, O> {
       return [];
     }
 
-    field = field || (this.items[0] as AnyEntity<T>).__helper!.__meta.serializedPrimaryKey;
+    field = field || (this.items[0] as AnyEntity<T>).__meta!.serializedPrimaryKey;
 
     return this.getItems().map(i => i[field as keyof T]) as unknown as U[];
   }
@@ -135,7 +135,7 @@ export class ArrayCollection<T, O> {
    */
   get property(): EntityProperty<T> {
     if (!this._property) {
-      const meta = this.owner.__helper!.__meta;
+      const meta = this.owner.__meta!;
       const field = Object.keys(meta.properties).find(k => this.owner[k] === this);
       this._property = meta.properties[field!];
     }

--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -231,7 +231,7 @@ export class Collection<T, O = unknown> extends ArrayCollection<T, O> {
 
   private createManyToManyCondition(cond: Dictionary) {
     if (this.property.owner || this.property.pivotTable) {
-      const pk = (this.items[0] as AnyEntity<T>).__helper!.__meta.primaryKeys[0]; // we know there is at least one item as it was checked in load method
+      const pk = (this.items[0] as AnyEntity<T>).__meta!.primaryKeys[0]; // we know there is at least one item as it was checked in load method
       cond[pk] = { $in: this.items.map((item: AnyEntity<T>) => item.__helper!.__primaryKey) };
     } else {
       cond[this.property.mappedBy] = this.owner.__helper!.__primaryKey;

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -5,6 +5,9 @@ import { AnyEntity, EntityData, EntityMetadata, EntityProperty } from '../typing
 import { Utils } from '../utils/Utils';
 import { Reference } from './Reference';
 import { ReferenceType, SCALAR_TYPES } from '../enums';
+import { EntityValidator } from './EntityValidator';
+
+const validator = new EntityValidator(false);
 
 export class EntityAssigner {
 
@@ -13,10 +16,8 @@ export class EntityAssigner {
   static assign<T extends AnyEntity<T>>(entity: T, data: EntityData<T>, onlyProperties: AssignOptions | boolean = false): T {
     const options = (typeof onlyProperties === 'boolean' ? { onlyProperties } : onlyProperties);
     const wrapped = entity.__helper!;
+    const meta = entity.__meta!;
     const em = options.em || wrapped.__em;
-    const meta = wrapped.__meta;
-    const validator = wrapped.__internal.getValidator();
-    const platform = wrapped.__internal.getDriver().getPlatform();
     const props = meta.properties;
 
     Object.keys(data).forEach(prop => {
@@ -29,7 +30,7 @@ export class EntityAssigner {
       let value = data[prop as keyof EntityData<T>];
 
       if (options.convertCustomTypes && customType && props[prop].reference === ReferenceType.SCALAR && !Utils.isEntity(data)) {
-        value = props[prop].customType.convertToJSValue(value, platform);
+        value = props[prop].customType.convertToJSValue(value, entity.__platform);
       }
 
       if ([ReferenceType.MANY_TO_ONE, ReferenceType.ONE_TO_ONE].includes(props[prop]?.reference) && Utils.isDefined(value, true) && EntityAssigner.validateEM(em)) {
@@ -71,7 +72,7 @@ export class EntityAssigner {
       return;
     }
 
-    const meta2 = entity[prop.name].__helper!.__meta as EntityMetadata;
+    const meta2 = entity[prop.name].__meta! as EntityMetadata;
     const prop2 = meta2.properties[prop.inversedBy || prop.mappedBy];
 
     if (prop2 && !entity[prop.name][prop2.name]) {

--- a/packages/core/src/entity/EntityHelper.ts
+++ b/packages/core/src/entity/EntityHelper.ts
@@ -22,7 +22,7 @@ export class EntityHelper {
       EntityHelper.defineIdProperty(meta, em.getDriver().getPlatform());
     }
 
-    EntityHelper.defineBaseProperties(meta, meta.prototype, em);
+    EntityHelper.defineBaseProperties(meta, meta.prototype, em.getDriver().getPlatform());
     const prototype = meta.prototype as Dictionary;
 
     if (em.config.get('propagateToOneOwner')) {
@@ -50,17 +50,17 @@ export class EntityHelper {
     });
   }
 
-  private static defineBaseProperties<T extends AnyEntity<T>>(meta: EntityMetadata<T>, prototype: T, em: EntityManager) {
+  private static defineBaseProperties<T extends AnyEntity<T>>(meta: EntityMetadata<T>, prototype: T, platform: Platform) {
     Object.defineProperties(prototype, {
       __entity: { value: true },
+      __meta: { value: meta },
+      __platform: { value: platform },
       __helper: {
-        get(): string {
-          if (!this.___helper) {
-            const helper = new WrappedEntity(this, em, meta);
-            Object.defineProperty(this, '___helper', { value: helper, writable: true });
-          }
+        get(): WrappedEntity<T, keyof T> {
+          const helper = new WrappedEntity(this);
+          Object.defineProperty(this, '__helper', { value: helper, writable: true });
 
-          return this.___helper;
+          return helper;
         },
       },
     });

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -177,7 +177,7 @@ export class EntityLoader {
       return [];
     }
 
-    const ids = Utils.unique(children.map(e => Utils.getPrimaryKeyValues(e, e.__helper!.__meta.primaryKeys, true)));
+    const ids = Utils.unique(children.map(e => Utils.getPrimaryKeyValues(e, e.__meta!.primaryKeys, true)));
     const where = { ...QueryHelper.processWhere({ [fk]: { $in: ids } }, meta.name!, this.metadata, this.driver.getPlatform()), ...(options.where as Dictionary) } as FilterQuery<T>;
 
     return this.em.find<T>(prop.type, where, {
@@ -285,8 +285,7 @@ export class EntityLoader {
     const ret: PopulateOptions<T>[] = [];
     const meta = this.metadata.find(entityName)!;
 
-    Object.values(meta.properties)
-      .filter(prop => prop.reference !== ReferenceType.SCALAR)
+    meta.relations
       .forEach(prop => {
         const prefixed = prefix ? `${prefix}.${prop.name}` : prop.name;
         const nested = this.lookupAllRelationships(prop.type, prefixed, visited);
@@ -312,7 +311,7 @@ export class EntityLoader {
     visited.push(entityName);
     const meta = this.metadata.find(entityName)!;
 
-    Object.values(meta.properties)
+    meta.relations
       .filter(prop => prop.eager)
       .forEach(prop => {
         const prefixed = prefix ? `${prefix}.${prop.name}` : prop.name;

--- a/packages/core/src/entity/EntityTransformer.ts
+++ b/packages/core/src/entity/EntityTransformer.ts
@@ -1,6 +1,6 @@
 import { ArrayCollection } from './ArrayCollection';
 import { Collection } from './Collection';
-import { AnyEntity, EntityData, EntityMetadata, EntityProperty, IPrimaryKey } from '../typings';
+import { AnyEntity, EntityData, EntityMetadata, IPrimaryKey } from '../typings';
 import { Reference } from './Reference';
 import { wrap } from './wrap';
 import { Platform } from '../platforms';
@@ -10,8 +10,7 @@ export class EntityTransformer {
 
   static toObject<T extends AnyEntity<T>>(entity: T, ignoreFields: string[] = [], visited = new WeakSet<AnyEntity>()): EntityData<T> {
     const wrapped = entity.__helper!;
-    const platform = wrapped.__internal.getDriver().getPlatform();
-    const meta = wrapped.__meta;
+    const meta = entity.__meta!;
     const ret = {} as EntityData<T>;
 
     meta.primaryKeys
@@ -22,14 +21,14 @@ export class EntityTransformer {
         if (meta.properties[pk].serializer) {
           value = meta.properties[pk].serializer!(entity[pk]);
         } else if (Utils.isEntity(entity[pk], true)) {
-          value = EntityTransformer.processEntity(pk, entity, ignoreFields, visited);
+          value = EntityTransformer.processEntity(pk, entity, ignoreFields, entity.__platform!, visited);
         } else {
-          value = platform.normalizePrimaryKey(Utils.getPrimaryKeyValue<T>(entity, [pk]));
+          value = entity.__platform!.normalizePrimaryKey(Utils.getPrimaryKeyValue<T>(entity, [pk]));
         }
 
         return [pk, value] as [string & keyof T, string];
       })
-      .forEach(([pk, value]) => ret[this.propertyName(meta, pk, platform)] = value as unknown as T[keyof T]);
+      .forEach(([pk, value]) => ret[this.propertyName(meta, pk, entity.__platform!)] = value as unknown as T[keyof T]);
 
     if ((!wrapped.isInitialized() && wrapped.hasPrimaryKey()) || visited.has(entity)) {
       return ret;
@@ -45,12 +44,12 @@ export class EntityTransformer {
       .forEach(([prop, value]) => ret[this.propertyName(meta, prop as keyof T & string)] = value as T[keyof T]);
 
     // decorated getters
-    Object.values<EntityProperty<T>>(meta.properties)
+    meta.props
       .filter(prop => prop.getter && !prop.hidden && typeof entity[prop.name] !== 'undefined')
       .forEach(prop => ret[this.propertyName(meta, prop.name)] = entity[prop.name]);
 
     // decorated get methods
-    Object.values<EntityProperty<T>>(meta.properties)
+    meta.props
       .filter(prop => prop.getterName && !prop.hidden && entity[prop.getterName] as unknown instanceof Function)
       .forEach(prop => ret[this.propertyName(meta, prop.name)] = (entity[prop.getterName!] as unknown as () => void)());
 
@@ -77,7 +76,6 @@ export class EntityTransformer {
   private static processProperty<T extends AnyEntity<T>>(prop: keyof T & string, entity: T, ignoreFields: string[], visited: WeakSet<AnyEntity>): T[keyof T] | undefined {
     const wrapped = entity.__helper!;
     const property = wrapped.__meta.properties[prop];
-    const platform = wrapped.__internal.getDriver().getPlatform();
 
     /* istanbul ignore next */
     const serializer = property?.serializer;
@@ -90,7 +88,7 @@ export class EntityTransformer {
     const customType = property?.customType;
 
     if (customType) {
-      return customType.toJSON(entity[prop], platform);
+      return customType.toJSON(entity[prop], entity.__platform!);
     }
 
     if (entity[prop] as unknown instanceof ArrayCollection) {
@@ -98,13 +96,13 @@ export class EntityTransformer {
     }
 
     if (Utils.isEntity(entity[prop], true)) {
-      return EntityTransformer.processEntity(prop, entity, ignoreFields, visited);
+      return EntityTransformer.processEntity(prop, entity, ignoreFields, entity.__platform!, visited);
     }
 
     return entity[prop];
   }
 
-  private static processEntity<T extends AnyEntity<T>>(prop: keyof T, entity: T, ignoreFields: string[], visited: WeakSet<AnyEntity>): T[keyof T] | undefined {
+  private static processEntity<T extends AnyEntity<T>>(prop: keyof T, entity: T, ignoreFields: string[], platform: Platform, visited: WeakSet<AnyEntity>): T[keyof T] | undefined {
     const child = entity[prop] as unknown as T | Reference<T>;
     const wrapped = (child as T).__helper!;
 
@@ -113,7 +111,7 @@ export class EntityTransformer {
       return wrap(child).toJSON(...args) as T[keyof T];
     }
 
-    return wrapped.__internal.getDriver().getPlatform().normalizePrimaryKey(wrapped.__primaryKey as unknown as IPrimaryKey) as unknown as T[keyof T];
+    return platform.normalizePrimaryKey(wrapped.__primaryKey as unknown as IPrimaryKey) as unknown as T[keyof T];
   }
 
   private static processCollection<T extends AnyEntity<T>>(prop: keyof T, entity: T): T[keyof T] | undefined {

--- a/packages/core/src/entity/EntityValidator.ts
+++ b/packages/core/src/entity/EntityValidator.ts
@@ -1,6 +1,6 @@
 import { EntityData, EntityMetadata, EntityProperty, FilterQuery, AnyEntity } from '../typings';
 import { ReferenceType } from '../enums';
-import { Utils } from '../utils';
+import { Utils } from '../utils/Utils';
 import { ValidationError } from '../errors';
 
 export class EntityValidator {
@@ -8,7 +8,7 @@ export class EntityValidator {
   constructor(private strict: boolean) { }
 
   validate<T extends AnyEntity<T>>(entity: T, payload: any, meta: EntityMetadata): void {
-    Object.values(meta.properties).forEach(prop => {
+    meta.props.forEach(prop => {
       if ([ReferenceType.ONE_TO_MANY, ReferenceType.MANY_TO_MANY].includes(prop.reference)) {
         this.validateCollection(entity, prop);
       }

--- a/packages/core/src/entity/Reference.ts
+++ b/packages/core/src/entity/Reference.ts
@@ -7,10 +7,10 @@ export class Reference<T extends AnyEntity<T>> {
 
   constructor(private entity: T) {
     this.set(entity);
-    const wrapped = this.entity.__helper!;
+    const meta = this.entity.__meta!;
     Object.defineProperty(this, '__reference', { value: true });
 
-    wrapped.__meta.primaryKeys.forEach(primaryKey => {
+    meta.primaryKeys.forEach(primaryKey => {
       Object.defineProperty(this, primaryKey, {
         get() {
           return this.entity[primaryKey];
@@ -18,8 +18,8 @@ export class Reference<T extends AnyEntity<T>> {
       });
     });
 
-    if (wrapped.__meta.serializedPrimaryKey && wrapped.__meta.primaryKeys[0] !== wrapped.__meta.serializedPrimaryKey) {
-      Object.defineProperty(this, wrapped.__meta.serializedPrimaryKey, {
+    if (meta.serializedPrimaryKey && meta.primaryKeys[0] !== meta.serializedPrimaryKey) {
+      Object.defineProperty(this, meta.serializedPrimaryKey, {
         get() {
           return this.entity.__helper!.__serializedPrimaryKey;
         },
@@ -80,6 +80,8 @@ export class Reference<T extends AnyEntity<T>> {
     }
 
     this.entity = entity;
+    Object.defineProperty(this, '__meta', { value: this.entity.__meta!, writable: true });
+    Object.defineProperty(this, '__platform', { value: this.entity.__platform!, writable: true });
     Object.defineProperty(this, '__helper', { value: this.entity.__helper!, writable: true });
     Object.defineProperty(this, '$', { value: this.entity, writable: true });
     Object.defineProperty(this, 'get', { value: () => this.entity, writable: true });
@@ -91,7 +93,7 @@ export class Reference<T extends AnyEntity<T>> {
 
   getEntity(): T {
     if (!this.isInitialized()) {
-      throw new Error(`Reference<${this.entity.__helper!.__meta.name}> ${(this.entity.__helper!.__primaryKey as Primary<T>)} not initialized`);
+      throw new Error(`Reference<${this.entity.__meta!.name}> ${(this.entity.__helper!.__primaryKey as Primary<T>)} not initialized`);
     }
 
     return this.entity;

--- a/packages/core/src/events/EventManager.ts
+++ b/packages/core/src/events/EventManager.ts
@@ -29,7 +29,7 @@ export class EventManager {
     const entity: T = (args as EventArgs<T>).entity;
 
     // execute lifecycle hooks first
-    const hooks = (entity && entity.__helper!.__meta.hooks[event]) || [];
+    const hooks = (entity && entity.__meta!.hooks[event]) || [];
     listeners.push(...hooks.map(hook => [hook, entity] as [EventType, EventSubscriber<T>]));
 
     for (const listener of this.listeners[event] || []) {
@@ -49,7 +49,7 @@ export class EventManager {
 
   hasListeners<T extends AnyEntity<T>>(event: EventType, entity?: T): boolean {
     /* istanbul ignore next */
-    const hasHooks = entity?.__helper!.__meta.hooks[event]?.length;
+    const hasHooks = entity?.__meta!.hooks[event]?.length;
 
     if (hasHooks) {
       return true;

--- a/packages/core/src/hydration/Hydrator.ts
+++ b/packages/core/src/hydration/Hydrator.ts
@@ -1,5 +1,4 @@
 import { EntityManager } from '../EntityManager';
-import { Utils } from '../utils/Utils';
 import { AnyEntity, EntityData, EntityMetadata, EntityProperty } from '../typings';
 import { EntityFactory } from '../entity';
 
@@ -33,15 +32,14 @@ export abstract class Hydrator {
 
   private getProperties<T extends AnyEntity<T>>(meta: EntityMetadata<T>, entity: T): EntityProperty<T>[] {
     const metadata = this.em.getMetadata();
-    const root = Utils.getRootEntity(metadata, meta);
 
-    if (root.discriminatorColumn) {
+    if (meta.root.discriminatorColumn) {
       meta = metadata.find(entity.constructor.name)!;
     }
 
-    return Object.values<EntityProperty>(meta.properties).filter(prop => {
+    return meta.props.filter(prop => {
       // `prop.userDefined` is either `undefined` or `false`
-      const discriminator = root.discriminatorColumn === prop.name && prop.userDefined === false;
+      const discriminator = meta.root.discriminatorColumn === prop.name && prop.userDefined === false;
       return !prop.inherited && !discriminator && !prop.embedded;
     });
   }

--- a/packages/core/src/hydration/ObjectHydrator.ts
+++ b/packages/core/src/hydration/ObjectHydrator.ts
@@ -39,7 +39,7 @@ export class ObjectHydrator extends Hydrator {
   private hydrateEmbeddable<T extends AnyEntity<T>>(entity: T, prop: EntityProperty, data: EntityData<T>): void {
     const value: Dictionary = {};
 
-    Object.values<EntityProperty>(entity.__helper!.__meta.properties).filter(p => p.embedded?.[0] === prop.name).forEach(childProp => {
+    entity.__meta!.props.filter(p => p.embedded?.[0] === prop.name).forEach(childProp => {
       value[childProp.embedded![1]] = data[childProp.name];
     });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,7 @@
 export {
   Constructor, Dictionary, PrimaryKeyType, Primary, IPrimaryKey, FilterQuery, IWrappedEntity, EntityName, EntityData, Highlighter,
   AnyEntity, EntityProperty, EntityMetadata, QBFilterQuery, PopulateOptions, Populate, Loaded, New, LoadedReference, LoadedCollection,
-  GetRepository, EntityRepositoryType, MigrationObject,
+  GetRepository, EntityRepositoryType, MigrationObject, DeepPartial,
 } from './typings';
 export * from './enums';
 export * from './errors';

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -1,10 +1,10 @@
-import { AnyEntity, Constructor, Dictionary, EntityMetadata, EntityName, EntityProperty, ExpandProperty, NonFunctionPropertyNames } from '../typings';
+import { AnyEntity, Constructor, DeepPartial, Dictionary, EntityMetadata, EntityName, EntityProperty, ExpandProperty, NonFunctionPropertyNames } from '../typings';
 import {
   EmbeddedOptions, EnumOptions, IndexOptions, ManyToManyOptions, ManyToOneOptions, OneToManyOptions, OneToOneOptions, PrimaryKeyOptions, PropertyOptions,
   SerializedPrimaryKeyOptions, UniqueOptions,
 } from '../decorators';
 import { BaseEntity, EntityRepository } from '../entity';
-import { Cascade, ReferenceType, LoadStrategy } from '../enums';
+import { Cascade, LoadStrategy, ReferenceType } from '../enums';
 import { Type } from '../types';
 import { Utils } from '../utils';
 
@@ -41,7 +41,7 @@ export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntit
     Object.assign(this._meta, { className: meta.name, properties: {}, hooks: {}, filters: {}, primaryKeys: [], indexes: [], uniques: [] }, meta);
   }
 
-  static fromMetadata<T extends AnyEntity<T> = AnyEntity, U extends AnyEntity<U> | undefined = undefined>(meta: EntityMetadata<T>): EntitySchema<T, U> {
+  static fromMetadata<T extends AnyEntity<T> = AnyEntity, U extends AnyEntity<U> | undefined = undefined>(meta: EntityMetadata<T> | DeepPartial<EntityMetadata<T>>): EntitySchema<T, U> {
     const schema = new EntitySchema<T, U>(meta as Metadata<T, U>);
     schema.internal = true;
 
@@ -225,6 +225,7 @@ export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntit
 
     this.initProperties();
     this.initPrimaryKeys();
+    this._meta.props = Object.values(this._meta.properties);
     this.initialized = true;
 
     return this;

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -2,11 +2,20 @@ import { Cascade, EventType, LoadStrategy, QueryOrder, ReferenceType, LockMode }
 import { AssignOptions, Collection, EntityRepository, EntityIdentifier, IdentifiedReference, Reference } from './entity';
 import { EntitySchema } from './metadata';
 import { Type } from './types';
+import { Platform } from './platforms';
 
 export type Constructor<T> = new (...args: any[]) => T;
 export type Dictionary<T = any> = { [k: string]: T };
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type NonFunctionPropertyNames<T> = NonNullable<{ [K in keyof T]: T[K] extends Function ? never : K }[keyof T]>;
+
+export type DeepPartial<T> = T & {
+  [P in keyof T]?: T[P] extends (infer U)[]
+    ? DeepPartial<U>[]
+    : T[P] extends Readonly<infer U>[]
+      ? Readonly<DeepPartial<U>>[]
+      : DeepPartial<T[P]>
+};
 
 export const EntityRepositoryType = Symbol('EntityRepositoryType');
 export const PrimaryKeyType = Symbol('PrimaryKeyType');
@@ -74,7 +83,7 @@ export interface IWrappedEntityInternal<T extends AnyEntity<T>, PK extends keyof
   __meta: EntityMetadata<T>;
   __data: Dictionary;
   __em?: any; // we cannot have `EntityManager` here as that causes a cycle
-  __internal: any; // we cannot have `EntityManager` here as that causes a cycle
+  __platform: Platform;
   __initialized: boolean;
   __originalEntityData?: EntityData<T>;
   __identifier?: EntityIdentifier;
@@ -86,7 +95,14 @@ export interface IWrappedEntityInternal<T extends AnyEntity<T>, PK extends keyof
   __serializedPrimaryKey: string & keyof T;
 }
 
-export type AnyEntity<T = any> = { [K in keyof T]?: T[K] } & { [PrimaryKeyType]?: unknown; [EntityRepositoryType]?: unknown; __helper?: IWrappedEntityInternal<T, keyof T> };
+export type AnyEntity<T = any> = { [K in keyof T]?: T[K] } & {
+  [PrimaryKeyType]?: unknown;
+  [EntityRepositoryType]?: unknown;
+  __helper?: IWrappedEntityInternal<T, keyof T>;
+  __meta?: EntityMetadata<T>;
+  __platform?: Platform;
+};
+
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type EntityClass<T extends AnyEntity<T>> = Function & { prototype: T };
 export type EntityClassGroup<T extends AnyEntity<T>> = { entity: EntityClass<T>; schema: EntityMetadata<T> | EntitySchema<T> };
@@ -173,6 +189,9 @@ export interface EntityMetadata<T extends AnyEntity<T> = any> {
   versionProperty: keyof T & string;
   serializedPrimaryKey: keyof T & string;
   properties: { [K in keyof T & string]: EntityProperty<T> };
+  props: EntityProperty<T>[];
+  relations: EntityProperty<T>[];
+  comparableProps: EntityProperty<T>[]; // for EntityComparator
   indexes: { properties: string | string[]; name?: string; type?: string; options?: Dictionary }[];
   uniques: { properties: string | string[]; name?: string; options?: Dictionary }[];
   customRepository: () => Constructor<EntityRepository<T>>;
@@ -184,6 +203,7 @@ export interface EntityMetadata<T extends AnyEntity<T> = any> {
   filters: Dictionary<FilterDef<T>>;
   comment?: string;
   readonly?: boolean;
+  root: EntityMetadata<T>;
 }
 
 export interface ISchemaGenerator {

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -25,21 +25,20 @@ export class EntityComparator {
     }
 
     const meta = this.metadata.get<T>(entity.constructor.name);
-    const root = Utils.getRootEntity(this.metadata, meta);
     const ret = {} as EntityData<T>;
 
     if (meta.discriminatorValue) {
-      ret[root.discriminatorColumn as keyof T] = meta.discriminatorValue as unknown as T[keyof T];
+      ret[meta.root.discriminatorColumn as keyof T] = meta.discriminatorValue as unknown as T[keyof T];
     }
 
-    // copy all props, ignore collections and references, process custom types
-    Object.values<EntityProperty<T>>(meta.properties).forEach(prop => {
-      if (this.shouldIgnoreProperty(entity, prop, root)) {
+    // copy all comparable props, ignore collections and references, process custom types
+    meta.comparableProps.forEach(prop => {
+      if (this.shouldIgnoreProperty(entity, prop)) {
         return;
       }
 
       if (prop.reference === ReferenceType.EMBEDDED) {
-        return Object.values<EntityProperty>(meta.properties).filter(p => p.embedded?.[0] === prop.name).forEach(childProp => {
+        return meta.props.filter(p => p.embedded?.[0] === prop.name).forEach(childProp => {
           ret[childProp.name as keyof T] = Utils.copy(entity[prop.name][childProp.embedded![1]]);
         });
       }
@@ -74,23 +73,35 @@ export class EntityComparator {
     return ret;
   }
 
-  private shouldIgnoreProperty<T extends AnyEntity<T>>(entity: T, prop: EntityProperty<T>, root: EntityMetadata) {
-    if (!(prop.name in entity) || prop.persist === false) {
+  /**
+   * should be used only for `meta.comparableProps` that are defined based on the static `isComparable` helper
+   */
+  private shouldIgnoreProperty<T extends AnyEntity<T>>(entity: T, prop: EntityProperty<T>) {
+    if (!(prop.name in entity)) {
       return true;
     }
 
     const value = entity[prop.name];
-    const collection = Utils.isCollection(value);
     const noPkRef = Utils.isEntity<T>(value, true) && !value.__helper!.hasPrimaryKey();
     const noPkProp = prop.primary && !Utils.isDefined(value, true);
-    const inverse = prop.reference === ReferenceType.ONE_TO_ONE && !prop.owner;
-    const discriminator = prop.name === root.discriminatorColumn;
 
     // bidirectional 1:1 and m:1 fields are defined as setters, we need to check for `undefined` explicitly
     const isSetter = [ReferenceType.ONE_TO_ONE, ReferenceType.MANY_TO_ONE].includes(prop.reference) && (prop.inversedBy || prop.mappedBy);
     const emptyRef = isSetter && value === undefined;
 
-    return collection || noPkProp || noPkRef || inverse || discriminator || emptyRef || prop.version;
+    return noPkProp || noPkRef || emptyRef || prop.version;
+  }
+
+  /**
+   * perf: used to generate list of comparable properties during discovery, so we speed up the runtime comparison
+   */
+  static isComparable<T extends AnyEntity<T>>(prop: EntityProperty<T>, root: EntityMetadata) {
+    const virtual = prop.persist === false;
+    const inverse = prop.reference === ReferenceType.ONE_TO_ONE && !prop.owner;
+    const discriminator = prop.name === root.discriminatorColumn;
+    const collection = prop.reference === ReferenceType.ONE_TO_MANY || prop.reference === ReferenceType.MANY_TO_MANY;
+
+    return !virtual && !collection && !inverse && !discriminator && !prop.version;
   }
 
 }

--- a/packages/knex/src/query/CriteriaNode.ts
+++ b/packages/knex/src/query/CriteriaNode.ts
@@ -20,7 +20,7 @@ export class CriteriaNode {
 
     if (meta && key) {
       Utils.splitPrimaryKeys(key).forEach(k => {
-        this.prop = Object.values(meta.properties).find(prop => prop.name === k || (prop.fieldNames || []).includes(k));
+        this.prop = meta.props.find(prop => prop.name === k || (prop.fieldNames || []).includes(k));
 
         if (validate && !this.prop && !k.includes('.') && !Utils.isOperator(k) && !CriteriaNode.isCustomExpression(k)) {
           throw new Error(`Trying to query by not existing property ${entityName}.${k}`);

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -500,7 +500,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     });
 
     if (meta && (this._fields?.includes('*') || this._fields?.includes(`${this.alias}.*`))) {
-      Object.values(meta.properties)
+      meta.props
         .filter(prop => prop.formula)
         .forEach(prop => {
           const alias = this.knex.ref(this.alias).toString();
@@ -559,8 +559,8 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
 
   private autoJoinPivotTable(field: string): void {
     const pivotMeta = this.metadata.find(field)!;
-    const owner = Object.values(pivotMeta.properties).find(prop => prop.reference === ReferenceType.MANY_TO_ONE && prop.owner)!;
-    const inverse = Object.values(pivotMeta.properties).find(prop => prop.reference === ReferenceType.MANY_TO_ONE && !prop.owner)!;
+    const owner = pivotMeta.props.find(prop => prop.reference === ReferenceType.MANY_TO_ONE && prop.owner)!;
+    const inverse = pivotMeta.props.find(prop => prop.reference === ReferenceType.MANY_TO_ONE && !prop.owner)!;
     const prop = this._cond[pivotMeta.name + '.' + owner.name] || this._orderBy[pivotMeta.name + '.' + owner.name] ? inverse : owner;
     const pivotAlias = this.getNextAlias();
 

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -413,7 +413,7 @@ export class QueryBuilderHelper {
     const useReturningStatement = type === QueryType.INSERT && this.platform.usesReturningStatement() && meta && !meta.compositePK;
 
     if (useReturningStatement) {
-      const returningProps = Object.values(meta!.properties).filter(prop => prop.primary || prop.defaultRaw);
+      const returningProps = meta!.props.filter(prop => prop.primary || prop.defaultRaw);
       qb.returning(Utils.flatten(returningProps.map(prop => prop.fieldNames)));
     }
   }

--- a/tests/EntityFactory.test.ts
+++ b/tests/EntityFactory.test.ts
@@ -1,5 +1,5 @@
 import { ObjectId } from 'mongodb';
-import { MikroORM, Collection, EntityFactory, MetadataDiscovery, ReferenceType, wrap, Logger } from '@mikro-orm/core';
+import { MikroORM, Collection, EntityFactory, ReferenceType, wrap, Logger } from '@mikro-orm/core';
 import { Book, Author, Publisher, Test, BookTag } from './entities';
 import { initORMMongo, wipeDatabase } from './bootstrap';
 import { AuthorRepository } from './repositories/AuthorRepository';
@@ -12,8 +12,7 @@ describe('EntityFactory', () => {
 
   beforeAll(async () => {
     orm = await initORMMongo();
-    await new MetadataDiscovery(orm.getMetadata(), orm.em.getDriver().getPlatform(), orm.config).discover();
-    factory = new EntityFactory(orm.em.getUnitOfWork(), orm.em);
+    factory = orm.em.getEntityFactory();
     expect(orm.config.getNamingStrategy().referenceColumnName()).toBe('_id');
   });
   beforeEach(async () => wipeDatabase(orm.em));

--- a/tests/EntityHelper.mongo.test.ts
+++ b/tests/EntityHelper.mongo.test.ts
@@ -79,6 +79,7 @@ describe('EntityHelperMongo', () => {
     expect(wrap(god, true).__populated).toBeUndefined();
     god.populated();
     expect(wrap(god, true).__populated).toBe(true);
+    expect(wrap(god, true).__platform).toBe(orm.em.getDriver().getPlatform());
 
     const ref = god.toReference();
     expect(ref).toBeInstanceOf(Reference);

--- a/tests/SchemaGenerator.test.ts
+++ b/tests/SchemaGenerator.test.ts
@@ -100,7 +100,7 @@ describe('SchemaGenerator', () => {
     const meta = orm.getMetadata();
     const generator = new SchemaGenerator(orm.em);
 
-    const newTableMeta = {
+    const newTableMeta = EntitySchema.fromMetadata({
       properties: {
         id: {
           reference: ReferenceType.SCALAR,
@@ -142,7 +142,7 @@ describe('SchemaGenerator', () => {
       uniques: [],
       collection: 'new_table',
       primaryKey: 'id',
-    } as any;
+    } as any).init().meta;
     meta.set('NewTable', newTableMeta);
     await generator.getUpdateSchemaSQL(false);
     await expect(generator.getUpdateSchemaSQL(false)).resolves.toMatchSnapshot('mysql-update-schema-create-table');
@@ -423,7 +423,7 @@ describe('SchemaGenerator', () => {
     const meta = orm.getMetadata();
     const generator = new SchemaGenerator(orm.em as EntityManager);
 
-    const newTableMeta = {
+    const newTableMeta = EntitySchema.fromMetadata({
       properties: {
         id: {
           reference: ReferenceType.SCALAR,
@@ -465,7 +465,7 @@ describe('SchemaGenerator', () => {
       hooks: {},
       indexes: [],
       uniques: [],
-    } as any;
+    } as any).init().meta;
     meta.set('NewTable', newTableMeta);
     const authorMeta = meta.get('Author2');
     authorMeta.properties.termsAccepted.defaultRaw = 'false';


### PR DESCRIPTION
Various small performance improvements:
- adding meta.root to get rid of excessive usage of `Utils.getRootEntity()`
- store lists of properties on metadata instead of using `Object.values()` all the time
- use Set instead of array for change sets and extra updates
- improve lookup of extra updates
- simplify entity diffing via precomputed `prop.comparable`
- add hot path for `em.persist()` when its called with single entity

Related: #732