### PR TITLE
fix(core): update filter typing to allow async condition

### DIFF
--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -249,7 +249,7 @@ export interface MigrationObject {
 
 export type FilterDef<T extends AnyEntity<T>> = {
   name: string;
-  cond: FilterQuery<T> | ((args: Dictionary, type: 'read' | 'update' | 'delete') => FilterQuery<T>);
+  cond: FilterQuery<T> | ((args: Dictionary, type: 'read' | 'update' | 'delete') => FilterQuery<T> | Promise<FilterQuery<T>>);
   default?: boolean;
   entity?: string[];
 };


### PR DESCRIPTION
**What's the problem this PR addresses?**

Using a filter with an async condition shows a type error that the return type is invalid

**How did you fix it?**

Update the type definition for `FilterDef.cond` to allow returning a `Promise<FilterQuery<T>>`