### PR TITLE
perf(core): use batch inserts in UoW (postgres & mongodb)

### DIFF
--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -44,6 +44,14 @@ export abstract class Platform {
     return true;
   }
 
+  returningMultiInsert(): boolean {
+    return false;
+  }
+
+  usesDefaultKeyword(): boolean {
+    return true;
+  }
+
   /**
    * Normalizes primary key wrapper to scalar value (e.g. mongodb's ObjectId to string)
    */

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -49,6 +49,8 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     populateAfterFlush: false,
     forceUtcTimezone: false,
     ensureIndexes: false,
+    useBatchInserts: true,
+    batchSize: 1000,
     debug: false,
     verbose: false,
     driverOptions: {},
@@ -328,6 +330,8 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
   forceUtcTimezone: boolean;
   timezone?: string;
   ensureIndexes: boolean;
+  useBatchInserts: boolean;
+  batchSize: number;
   hydrator: { new (factory: EntityFactory, em: EntityManager): Hydrator };
   loadStrategy: LoadStrategy;
   entityRepository?: Constructor<EntityRepository<any>>;

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -51,9 +51,9 @@ export class QueryBuilderHelper {
     return this.alias + '.' + ret;
   }
 
-  processData(data: Dictionary): any {
+  processData(data: Dictionary, multi = false): any {
     if (Array.isArray(data)) {
-      return data.map(d => this.processData(d));
+      return data.map(d => this.processData(d, true));
     }
 
     data = Object.assign({}, data); // copy first
@@ -82,6 +82,10 @@ export class QueryBuilderHelper {
         Utils.renameKey(data, k, prop.fieldNames[0]);
       }
     });
+
+    if (Object.keys(data).length === 0 && meta && multi) {
+      data[meta.primaryKeys[0]] = this.platform.usesDefaultKeyword() ? this.knex.raw('default') : undefined;
+    }
 
     return data;
   }

--- a/packages/knex/src/query/ScalarCriteriaNode.ts
+++ b/packages/knex/src/query/ScalarCriteriaNode.ts
@@ -10,12 +10,8 @@ export class ScalarCriteriaNode extends CriteriaNode {
       const parentPath = this.parent!.getPath(); // the parent is always there, otherwise `shouldJoin` would return `false`
       const nestedAlias = qb.getAliasForJoinPath(path) || qb.getNextAlias();
       const field = `${alias}.${this.prop!.name}`;
-
-      if (this.prop!.reference === ReferenceType.MANY_TO_MANY) {
-        qb.join(field, nestedAlias, undefined, 'pivotJoin', path);
-      } else {
-        qb.join(field, nestedAlias, undefined, 'leftJoin', path);
-      }
+      const type = this.prop!.reference === ReferenceType.MANY_TO_MANY ? 'pivotJoin' : 'leftJoin';
+      qb.join(field, nestedAlias, undefined, type, path);
 
       // select the owner as virtual property when joining from 1:1 inverse side, but only if the parent is root entity
       if (this.prop!.reference === ReferenceType.ONE_TO_ONE && !parentPath.includes('.')) {

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -35,6 +35,10 @@ export class MongoPlatform extends Platform {
     return false;
   }
 
+  returningMultiInsert(): boolean {
+    return true;
+  }
+
   convertsJsonAutomatically(marshall = false): boolean {
     return true;
   }

--- a/packages/postgresql/src/PostgreSqlPlatform.ts
+++ b/packages/postgresql/src/PostgreSqlPlatform.ts
@@ -16,6 +16,10 @@ export class PostgreSqlPlatform extends AbstractSqlPlatform {
     return true;
   }
 
+  returningMultiInsert(): boolean {
+    return true;
+  }
+
   getCurrentTimestampSQL(length: number): string {
     return `current_timestamp(${length})`;
   }

--- a/packages/sqlite/src/SqlitePlatform.ts
+++ b/packages/sqlite/src/SqlitePlatform.ts
@@ -15,6 +15,10 @@ export class SqlitePlatform extends AbstractSqlPlatform {
     return false;
   }
 
+  usesDefaultKeyword(): boolean {
+    return false;
+  }
+
   getCurrentTimestampSQL(length: number): string {
     return super.getCurrentTimestampSQL(0);
   }

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -994,7 +994,7 @@ describe('EntityManagerMySql', () => {
     // test collection CRUD
     // remove
     expect(book.tags.count()).toBe(2);
-    book.tags.remove(tag1);
+    book.tags.remove(tagRepository.getReference(tag1.id));
     await orm.em.persistAndFlush(book);
     orm.em.clear();
     book = (await orm.em.findOne(Book2, book.uuid, ['tags']))!;
@@ -1009,11 +1009,11 @@ describe('EntityManagerMySql', () => {
     expect(book.tags.count()).toBe(3);
 
     // contains
-    expect(book.tags.contains(tag1)).toBe(true);
-    expect(book.tags.contains(tag2)).toBe(false);
-    expect(book.tags.contains(tag3)).toBe(true);
-    expect(book.tags.contains(tag4)).toBe(false);
-    expect(book.tags.contains(tag5)).toBe(false);
+    expect(book.tags.contains(tagRepository.getReference(tag1.id))).toBe(true);
+    expect(book.tags.contains(tagRepository.getReference(tag2.id))).toBe(false);
+    expect(book.tags.contains(tagRepository.getReference(tag3.id))).toBe(true);
+    expect(book.tags.contains(tagRepository.getReference(tag4.id))).toBe(false);
+    expect(book.tags.contains(tagRepository.getReference(tag5.id))).toBe(false);
 
     // removeAll
     book.tags.removeAll();

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -778,7 +778,7 @@ describe('EntityManagerPostgre', () => {
     // test collection CRUD
     // remove
     expect(book.tags.count()).toBe(2);
-    book.tags.remove(tag1);
+    book.tags.remove(orm.em.getReference(BookTag2, tag1.id)); // we need to get reference as tag1 is detached from current EM
     await orm.em.persistAndFlush(book);
     orm.em.clear();
     book = (await orm.em.findOne(Book2, book.uuid, ['tags']))!;
@@ -793,11 +793,11 @@ describe('EntityManagerPostgre', () => {
     expect(book.tags.count()).toBe(3);
 
     // contains
-    expect(book.tags.contains(tag1)).toBe(true);
-    expect(book.tags.contains(tag2)).toBe(false);
-    expect(book.tags.contains(tag3)).toBe(true);
-    expect(book.tags.contains(tag4)).toBe(false);
-    expect(book.tags.contains(tag5)).toBe(false);
+    expect(book.tags.contains(tagRepository.getReference(tag1.id))).toBe(true);
+    expect(book.tags.contains(tagRepository.getReference(tag2.id))).toBe(false);
+    expect(book.tags.contains(tagRepository.getReference(tag3.id))).toBe(true);
+    expect(book.tags.contains(tagRepository.getReference(tag4.id))).toBe(false);
+    expect(book.tags.contains(tagRepository.getReference(tag5.id))).toBe(false);
 
     // removeAll
     book.tags.removeAll();
@@ -1110,15 +1110,13 @@ describe('EntityManagerPostgre', () => {
     expect(wrap(a1).toJSON()).toMatchObject({ favouriteAuthor: a1.id });
 
     // check fired queries
-    expect(mock.mock.calls.length).toBe(8);
+    expect(mock.mock.calls.length).toBe(6);
     expect(mock.mock.calls[0][0]).toMatch('begin');
     expect(mock.mock.calls[1][0]).toMatch('insert into "author2" ("created_at", "email", "name", "terms_accepted", "updated_at") values ($1, $2, $3, $4, $5)');
-    expect(mock.mock.calls[2][0]).toMatch('insert into "book2" ("author_id", "created_at", "title", "uuid_pk") values ($1, $2, $3, $4)');
-    expect(mock.mock.calls[2][0]).toMatch('insert into "book2" ("author_id", "created_at", "title", "uuid_pk") values ($1, $2, $3, $4)');
-    expect(mock.mock.calls[2][0]).toMatch('insert into "book2" ("author_id", "created_at", "title", "uuid_pk") values ($1, $2, $3, $4)');
-    expect(mock.mock.calls[5][0]).toMatch('update "author2" set "favourite_author_id" = $1, "updated_at" = $2 where "id" = $3');
-    expect(mock.mock.calls[6][0]).toMatch('commit');
-    expect(mock.mock.calls[7][0]).toMatch('select "e0".* from "author2" as "e0" where "e0"."id" = $1');
+    expect(mock.mock.calls[2][0]).toMatch('insert into "book2" ("author_id", "created_at", "title", "uuid_pk") values ($1, $2, $3, $4), ($5, $6, $7, $8), ($9, $10, $11, $12)');
+    expect(mock.mock.calls[3][0]).toMatch('update "author2" set "favourite_author_id" = $1, "updated_at" = $2 where "id" = $3');
+    expect(mock.mock.calls[4][0]).toMatch('commit');
+    expect(mock.mock.calls[5][0]).toMatch('select "e0".* from "author2" as "e0" where "e0"."id" = $1');
   });
 
   test('EM supports smart search conditions', async () => {
@@ -1428,6 +1426,20 @@ describe('EntityManagerPostgre', () => {
     if (took > 300) {
       process.stdout.write(`delete test took ${took}\n`);
     }
+  });
+
+  // this should run in ~600ms (when running single test locally)
+  test('perf: one to many', async () => {
+    const author = new Author2('Jon Snow', 'snow@wall.st');
+    await orm.em.persistAndFlush(author);
+
+    for (let i = 1; i <= 1000; i++) {
+      const b = new Book2('My Life on The Wall, part ' + i, author);
+      author.books.add(b);
+    }
+
+    await orm.em.flush();
+    expect(author.books.getItems().every(b => b.uuid)).toBe(true);
   });
 
   afterAll(async () => orm.close(true));

--- a/tests/EntityManager.sqlite.test.ts
+++ b/tests/EntityManager.sqlite.test.ts
@@ -78,6 +78,14 @@ describe('EntityManagerSqlite', () => {
       { id: 3, name: 'test 3', type: 'GLOBAL' },
     ]);
 
+    // multi inserts with no values
+    await driver.nativeInsertMany(Test3.name, [{}, {}]);
+    const res3 = await driver.find(Test3.name, {});
+    expect(res3).toEqual([
+      { id: 2, name: null, version: 1 },
+      { id: 3, name: null, version: 1 },
+    ]);
+
     const now = new Date();
     expect(driver.getPlatform().processDateProperty(now)).toBe(+now);
     expect(driver.getPlatform().processDateProperty(1)).toBe(1);
@@ -644,7 +652,7 @@ describe('EntityManagerSqlite', () => {
     // test collection CRUD
     // remove
     expect(book.tags.count()).toBe(2);
-    book.tags.remove(tag1);
+    book.tags.remove(tagRepository.getReference(tag1.id));
     await orm.em.persist(book).flush();
     orm.em.clear();
     book = (await orm.em.findOne(Book3, book.id, ['tags']))!;
@@ -658,11 +666,11 @@ describe('EntityManagerSqlite', () => {
     expect(book.tags.count()).toBe(2);
 
     // contains
-    expect(book.tags.contains(tag1)).toBe(true);
-    expect(book.tags.contains(tag2)).toBe(false);
-    expect(book.tags.contains(tag3)).toBe(true);
-    expect(book.tags.contains(tag4)).toBe(false);
-    expect(book.tags.contains(tag5)).toBe(false);
+    expect(book.tags.contains(tagRepository.getReference(tag1.id))).toBe(true);
+    expect(book.tags.contains(tagRepository.getReference(tag2.id))).toBe(false);
+    expect(book.tags.contains(tagRepository.getReference(tag3.id))).toBe(true);
+    expect(book.tags.contains(tagRepository.getReference(tag4.id))).toBe(false);
+    expect(book.tags.contains(tagRepository.getReference(tag5.id))).toBe(false);
 
     // removeAll
     book.tags.removeAll();

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -1055,6 +1055,11 @@ describe('QueryBuilder', () => {
   });
 
   test('insert query', async () => {
+    const qb0 = orm.em.createQueryBuilder(Publisher2);
+    qb0.insert([{}, {}]);
+    expect(qb0.getQuery()).toEqual('insert into `publisher2` (`id`) values (default), (default)');
+    expect(qb0.getParams()).toEqual([]);
+
     const qb1 = orm.em.createQueryBuilder(Publisher2);
     qb1.insert({ name: 'test 123', type: PublisherType.GLOBAL });
     expect(qb1.getQuery()).toEqual('insert into `publisher2` (`name`, `type`) values (?, ?)');


### PR DESCRIPTION
UoW will now batch all inserts statements if the driver supports returning all of their
PKs back (so postgres and mongodb currently).

This also changes how `Collection.contains()` was implemented - it did a linear check
on all values, comparing by the PK for persisted entities. This took extreme amount of
time with huge collections, just to add to a collection 1000 times, it was as slow as
1s for this, without persisting anything.

Now the collection items are stored as `Set`, and `contains` method does a simple identity
lookup (`set.has(entity)`). Another issue that slowed it down was the array like index support,
where we are able to use `coll[0]` to access the first item in the collection. This was
implemented as a re-assigning of all items to the collection object, which was extremely slow
for large collections. Now when we add to a collection, we only append the last index instead
of reassigning everything.

Closes #732