### PR TITLE
feat(core): allow mapping m:1/1:1 relations to PK

### DIFF
--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -250,6 +250,24 @@ export const enum UserStatus {
 // export { OutsideEnum } from './OutsideEnum.ts';
 ``` 
 
+### Mapping directly to primary keys
+
+Sometimes we might want to work only with the primary key of a relation. 
+To do that, we can use `mapToPk` option on M:1 and 1:1 relations:
+
+```ts
+@ManyToOne(() => User, { mapToPk: true })
+user: number;
+```
+
+For composite keys, this will give us ordered tuple representing the raw PKs,
+which is the internal format of composite PK:
+
+```ts
+@ManyToOne(() => User, { mapToPk: true })
+user: [string, string]; // [first_name, last_name]
+```
+
 ### Formulas
 
 `@Formula()` decorator can be used to map some SQL snippet to your entity. 

--- a/packages/core/src/decorators/ManyToOne.ts
+++ b/packages/core/src/decorators/ManyToOne.ts
@@ -23,6 +23,7 @@ export interface ManyToOneOptions<T, O> extends ReferenceOptions<T, O> {
   inversedBy?: (string & keyof T) | ((e: T) => any);
   wrappedReference?: boolean;
   primary?: boolean;
+  mapToPk?: boolean;
   joinColumn?: string;
   joinColumns?: string[];
   onDelete?: 'cascade' | 'no action' | 'set null' | 'set default' | string;

--- a/packages/core/src/decorators/OneToOne.ts
+++ b/packages/core/src/decorators/OneToOne.ts
@@ -15,6 +15,7 @@ export interface OneToOneOptions<T, O> extends Partial<Omit<OneToManyOptions<T, 
   inversedBy?: (string & keyof T) | ((e: T) => any);
   wrappedReference?: boolean;
   primary?: boolean;
+  mapToPk?: boolean;
   onDelete?: 'cascade' | 'no action' | 'set null' | 'set default' | string;
   onUpdateIntegrity?: 'cascade' | 'no action' | 'set null' | 'set default' | string;
 }

--- a/packages/core/src/hydration/ObjectHydrator.ts
+++ b/packages/core/src/hydration/ObjectHydrator.ts
@@ -55,7 +55,9 @@ export class ObjectHydrator extends Hydrator {
         lines.push(`  } else if (typeof data.${prop.name} !== 'undefined') {`);
         lines.push(`    if (isPrimaryKey(data.${prop.name}, true)) {`);
 
-        if (prop.wrappedReference) {
+        if (prop.mapToPk) {
+          lines.push(`      entity.${prop.name} = data.${prop.name};`);
+        } else if (prop.wrappedReference) {
           lines.push(`      entity.${prop.name} = new Reference(factory.createReference('${prop.type}', data.${prop.name}, { merge: true }));`);
         } else {
           lines.push(`      entity.${prop.name} = factory.createReference('${prop.type}', data.${prop.name}, { merge: true });`);
@@ -63,7 +65,9 @@ export class ObjectHydrator extends Hydrator {
 
         lines.push(`    } else if (data.${prop.name} && typeof data.${prop.name} === 'object') {`);
 
-        if (prop.wrappedReference) {
+        if (prop.mapToPk) {
+          lines.push(`      entity.${prop.name} = data.${prop.name};`);
+        } else if (prop.wrappedReference) {
           lines.push(`      entity.${prop.name} = new Reference(factory.create('${prop.type}', data.${prop.name}, { initialized: true, merge: true }));`);
         } else {
           lines.push(`      entity.${prop.name} = factory.create('${prop.type}', data.${prop.name}, { initialized: true, merge: true });`);

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -136,6 +136,7 @@ export interface EntityProperty<T extends AnyEntity<T> = any> {
   nullable?: boolean;
   inherited?: boolean;
   unsigned: boolean;
+  mapToPk?: boolean;
   persist?: boolean;
   hidden?: boolean;
   enum?: boolean;

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -1424,6 +1424,26 @@ describe('EntityManagerPostgre', () => {
     expect(e2.name).toBe(`?baz? uh ? wut?`);
   });
 
+  test('mapping to raw PKs instead of entities', async () => {
+    const t1 = new Test2({ name: 't1' });
+    const t2 = new Test2({ name: 't2' });
+    const t3 = new Test2({ name: 't3' });
+    await orm.em.persistAndFlush([t1, t2, t3]);
+    t1.parent = t2.id;
+    await orm.em.flush();
+    orm.em.clear();
+
+    const tt1 = await orm.em.findOneOrFail(Test2, t1.id);
+    expect(tt1.parent).toBe(t2.id);
+
+    tt1.parent = t3.id;
+    await orm.em.flush();
+    orm.em.clear();
+
+    const ttt1 = await orm.em.findOneOrFail(Test2, t1.id);
+    expect(ttt1.parent).toBe(t3.id);
+  });
+
   test('perf: delete', async () => {
     const start = performance.now();
     for (let i = 1; i <= 5_000; i++) {

--- a/tests/__snapshots__/EntityGenerator.test.ts.snap
+++ b/tests/__snapshots__/EntityGenerator.test.ts.snap
@@ -415,7 +415,7 @@ export class Sandwich {
 
 }
 ",
-  "import { Cascade, Entity, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Cascade, Entity, ManyToOne, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
@@ -430,6 +430,9 @@ export class Test2 {
 
   @OneToOne({ entity: () => Book2, cascade: [Cascade.MERGE], nullable: true, index: 'test2_book_uuid_pk_index', unique: 'test2_book_uuid_pk_unique' })
   book?: Book2;
+
+  @ManyToOne({ entity: () => Test2, nullable: true, index: 'test2_parent_id_index' })
+  parent?: Test2;
 
   @Property()
   version: number = 1;
@@ -842,7 +845,7 @@ export class Publisher2Tests {
 
 }
 ",
-  "import { Cascade, Entity, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Cascade, Entity, ManyToOne, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -856,6 +859,9 @@ export class Test2 {
 
   @OneToOne({ entity: () => Book2, cascade: [Cascade.MERGE], nullable: true, unique: 'test2_book_uuid_pk_unique' })
   book?: Book2;
+
+  @ManyToOne({ entity: () => Test2, nullable: true })
+  parent?: Test2;
 
   @Property()
   version: number = 1;

--- a/tests/__snapshots__/SchemaGenerator.test.ts.snap
+++ b/tests/__snapshots__/SchemaGenerator.test.ts.snap
@@ -62,9 +62,10 @@ alter table \`book2\` add primary key \`book2_pkey\`(\`uuid_pk\`);
 alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);
 alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);
 
-create table \`test2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) null, \`book_uuid_pk\` varchar(36) null, \`version\` int(11) not null default 1) default character set utf8mb4 engine = InnoDB;
+create table \`test2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) null, \`book_uuid_pk\` varchar(36) null, \`parent_id\` int(11) unsigned null, \`version\` int(11) not null default 1) default character set utf8mb4 engine = InnoDB;
 alter table \`test2\` add index \`test2_book_uuid_pk_index\`(\`book_uuid_pk\`);
 alter table \`test2\` add unique \`test2_book_uuid_pk_unique\`(\`book_uuid_pk\`);
+alter table \`test2\` add index \`test2_parent_id_index\`(\`parent_id\`);
 
 create table \`configuration2\` (\`property\` varchar(255) not null, \`test_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
 alter table \`configuration2\` add index \`configuration2_test_id_index\`(\`test_id\`);
@@ -129,6 +130,7 @@ alter table \`book2\` add constraint \`book2_author_id_foreign\` foreign key (\`
 alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key (\`publisher_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
 
 alter table \`test2\` add constraint \`test2_book_uuid_pk_foreign\` foreign key (\`book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on delete set null;
+alter table \`test2\` add constraint \`test2_parent_id_foreign\` foreign key (\`parent_id\`) references \`test2\` (\`id\`) on update cascade on delete set null;
 
 alter table \`configuration2\` add constraint \`configuration2_test_id_foreign\` foreign key (\`test_id\`) references \`test2\` (\`id\`) on update cascade;
 
@@ -290,9 +292,10 @@ alter table \`book2\` add primary key \`book2_pkey\`(\`uuid_pk\`);
 alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);
 alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);
 
-create table \`test2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) null, \`book_uuid_pk\` varchar(36) null, \`version\` int(11) not null default 1) default character set utf8mb4 engine = InnoDB;
+create table \`test2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) null, \`book_uuid_pk\` varchar(36) null, \`parent_id\` int(11) unsigned null, \`version\` int(11) not null default 1) default character set utf8mb4 engine = InnoDB;
 alter table \`test2\` add index \`test2_book_uuid_pk_index\`(\`book_uuid_pk\`);
 alter table \`test2\` add unique \`test2_book_uuid_pk_unique\`(\`book_uuid_pk\`);
+alter table \`test2\` add index \`test2_parent_id_index\`(\`parent_id\`);
 
 create table \`configuration2\` (\`property\` varchar(255) not null, \`test_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
 alter table \`configuration2\` add index \`configuration2_test_id_index\`(\`test_id\`);
@@ -357,6 +360,7 @@ alter table \`book2\` add constraint \`book2_author_id_foreign\` foreign key (\`
 alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key (\`publisher_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
 
 alter table \`test2\` add constraint \`test2_book_uuid_pk_foreign\` foreign key (\`book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on delete set null;
+alter table \`test2\` add constraint \`test2_parent_id_foreign\` foreign key (\`parent_id\`) references \`test2\` (\`id\`) on update cascade on delete set null;
 
 alter table \`configuration2\` add constraint \`configuration2_test_id_foreign\` foreign key (\`test_id\`) references \`test2\` (\`id\`) on update cascade;
 
@@ -450,7 +454,7 @@ alter table \\"address2\\" add constraint \\"address2_author_id_unique\\" unique
 create table \\"book2\\" (\\"uuid_pk\\" varchar(36) not null, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"title\\" varchar(255) null default '', \\"perex\\" text null, \\"price\\" float null, \\"double\\" double precision null, \\"meta\\" jsonb null, \\"author_id\\" int4 not null, \\"publisher_id\\" int4 null);
 alter table \\"book2\\" add constraint \\"book2_pkey\\" primary key (\\"uuid_pk\\");
 
-create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"version\\" int4 not null default 1);
+create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"parent_id\\" int4 null, \\"version\\" int4 not null default 1);
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_unique\\" unique (\\"book_uuid_pk\\");
 
 create table \\"configuration2\\" (\\"property\\" varchar(255) not null, \\"test_id\\" int4 not null, \\"value\\" varchar(255) not null);
@@ -487,6 +491,7 @@ alter table \\"book2\\" add constraint \\"book2_author_id_foreign\\" foreign key
 alter table \\"book2\\" add constraint \\"book2_publisher_id_foreign\\" foreign key (\\"publisher_id\\") references \\"publisher2\\" (\\"id\\") on update cascade on delete cascade;
 
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_foreign\\" foreign key (\\"book_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on delete set null;
+alter table \\"test2\\" add constraint \\"test2_parent_id_foreign\\" foreign key (\\"parent_id\\") references \\"test2\\" (\\"id\\") on update cascade on delete set null;
 
 alter table \\"configuration2\\" add constraint \\"configuration2_test_id_foreign\\" foreign key (\\"test_id\\") references \\"test2\\" (\\"id\\") on update cascade;
 
@@ -596,7 +601,7 @@ alter table \\"address2\\" add constraint \\"address2_author_id_unique\\" unique
 create table \\"book2\\" (\\"uuid_pk\\" varchar(36) not null, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"title\\" varchar(255) null default '', \\"perex\\" text null, \\"price\\" float null, \\"double\\" double precision null, \\"meta\\" jsonb null, \\"author_id\\" int4 not null, \\"publisher_id\\" int4 null);
 alter table \\"book2\\" add constraint \\"book2_pkey\\" primary key (\\"uuid_pk\\");
 
-create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"version\\" int4 not null default 1);
+create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"parent_id\\" int4 null, \\"version\\" int4 not null default 1);
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_unique\\" unique (\\"book_uuid_pk\\");
 
 create table \\"configuration2\\" (\\"property\\" varchar(255) not null, \\"test_id\\" int4 not null, \\"value\\" varchar(255) not null);
@@ -633,6 +638,7 @@ alter table \\"book2\\" add constraint \\"book2_author_id_foreign\\" foreign key
 alter table \\"book2\\" add constraint \\"book2_publisher_id_foreign\\" foreign key (\\"publisher_id\\") references \\"publisher2\\" (\\"id\\") on update cascade on delete cascade;
 
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_foreign\\" foreign key (\\"book_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on delete set null;
+alter table \\"test2\\" add constraint \\"test2_parent_id_foreign\\" foreign key (\\"parent_id\\") references \\"test2\\" (\\"id\\") on update cascade on delete set null;
 
 alter table \\"configuration2\\" add constraint \\"configuration2_test_id_foreign\\" foreign key (\\"test_id\\") references \\"test2\\" (\\"id\\") on update cascade;
 
@@ -1019,9 +1025,10 @@ alter table \`book2\` add primary key \`book2_pkey\`(\`uuid_pk\`);
 alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);
 alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);
 
-create table \`test2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) null, \`book_uuid_pk\` varchar(36) null, \`version\` int(11) not null default 1) default character set utf8mb4 engine = InnoDB;
+create table \`test2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) null, \`book_uuid_pk\` varchar(36) null, \`parent_id\` int(11) unsigned null, \`version\` int(11) not null default 1) default character set utf8mb4 engine = InnoDB;
 alter table \`test2\` add index \`test2_book_uuid_pk_index\`(\`book_uuid_pk\`);
 alter table \`test2\` add unique \`test2_book_uuid_pk_unique\`(\`book_uuid_pk\`);
+alter table \`test2\` add index \`test2_parent_id_index\`(\`parent_id\`);
 
 create table \`configuration2\` (\`property\` varchar(255) not null, \`test_id\` int(11) unsigned not null, \`value\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
 alter table \`configuration2\` add index \`configuration2_test_id_index\`(\`test_id\`);
@@ -1086,6 +1093,7 @@ alter table \`book2\` add constraint \`book2_author_id_foreign\` foreign key (\`
 alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key (\`publisher_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
 
 alter table \`test2\` add constraint \`test2_book_uuid_pk_foreign\` foreign key (\`book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on delete set null;
+alter table \`test2\` add constraint \`test2_parent_id_foreign\` foreign key (\`parent_id\`) references \`test2\` (\`id\`) on update cascade on delete set null;
 
 alter table \`configuration2\` add constraint \`configuration2_test_id_foreign\` foreign key (\`test_id\`) references \`test2\` (\`id\`) on update cascade;
 
@@ -1163,7 +1171,7 @@ alter table \\"address2\\" add constraint \\"address2_author_id_unique\\" unique
 create table \\"book2\\" (\\"uuid_pk\\" varchar(36) not null, \\"created_at\\" timestamptz(3) not null default current_timestamp(3), \\"title\\" varchar(255) null default '', \\"perex\\" text null, \\"price\\" float null, \\"double\\" double precision null, \\"meta\\" jsonb null, \\"author_id\\" int4 not null, \\"publisher_id\\" int4 null);
 alter table \\"book2\\" add constraint \\"book2_pkey\\" primary key (\\"uuid_pk\\");
 
-create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"version\\" int4 not null default 1);
+create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"parent_id\\" int4 null, \\"version\\" int4 not null default 1);
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_unique\\" unique (\\"book_uuid_pk\\");
 
 create table \\"configuration2\\" (\\"property\\" varchar(255) not null, \\"test_id\\" int4 not null, \\"value\\" varchar(255) not null);
@@ -1200,6 +1208,7 @@ alter table \\"book2\\" add constraint \\"book2_author_id_foreign\\" foreign key
 alter table \\"book2\\" add constraint \\"book2_publisher_id_foreign\\" foreign key (\\"publisher_id\\") references \\"publisher2\\" (\\"id\\") on update cascade on delete cascade;
 
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_foreign\\" foreign key (\\"book_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on delete set null;
+alter table \\"test2\\" add constraint \\"test2_parent_id_foreign\\" foreign key (\\"parent_id\\") references \\"test2\\" (\\"id\\") on update cascade on delete set null;
 
 alter table \\"configuration2\\" add constraint \\"configuration2_test_id_foreign\\" foreign key (\\"test_id\\") references \\"test2\\" (\\"id\\") on update cascade;
 

--- a/tests/entities-sql/Test2.ts
+++ b/tests/entities-sql/Test2.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, ManyToMany, OneToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Collection, Entity, ManyToMany, ManyToOne, OneToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
@@ -14,6 +14,9 @@ export class Test2 {
 
   @OneToOne({ entity: () => Book2, cascade: [], nullable: true })
   book?: Book2;
+
+  @ManyToOne({ entity: () => Test2, mapToPk: true, nullable: true })
+  parent?: number;
 
   @OneToMany(() => Configuration2, config => config.test)
   config = new Collection<Configuration2>(this);

--- a/tests/mysql-schema.sql
+++ b/tests/mysql-schema.sql
@@ -102,11 +102,12 @@ alter table `book2` add primary key `book2_pkey`(`uuid_pk`);
 alter table `book2` add index `book2_author_id_index`(`author_id`);
 alter table `book2` add index `book2_publisher_id_index`(`publisher_id`);
 
-create table `test2` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) null, `book_uuid_pk` varchar(36) null, `version` int(11) not null default 1, `foo___bar` int(11) unsigned null, `foo___baz` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
+create table `test2` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) null, `book_uuid_pk` varchar(36) null, `parent_id` int(11) unsigned null, `version` int(11) not null default 1, `foo___bar` int(11) unsigned null, `foo___baz` int(11) unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table `test2` add index `test2_book_uuid_pk_index`(`book_uuid_pk`);
 alter table `test2` add unique `test2_book_uuid_pk_unique`(`book_uuid_pk`);
 alter table `test2` add index `test2_foo___bar_index`(`foo___bar`);
 alter table `test2` add unique `test2_foo___bar_unique`(`foo___bar`);
+alter table `test2` add index `test2_parent_id_index`(`parent_id`);
 
 create table `configuration2` (`property` varchar(255) not null, `test_id` int(11) unsigned not null, `value` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
 alter table `configuration2` add index `configuration2_test_id_index`(`test_id`);
@@ -172,6 +173,7 @@ alter table `book2` add constraint `book2_publisher_id_foreign` foreign key (`pu
 
 alter table `test2` add constraint `test2_book_uuid_pk_foreign` foreign key (`book_uuid_pk`) references `book2` (`uuid_pk`) on delete set null;
 alter table `test2` add constraint `test2_foo___bar_foreign` foreign key (`foo___bar`) references `foo_bar2` (`id`) on update cascade on delete set null;
+alter table `test2` add constraint `test2_parent_id_foreign` foreign key (`parent_id`) references `test2` (`id`) on update cascade on delete set null;
 
 alter table `configuration2` add constraint `configuration2_test_id_foreign` foreign key (`test_id`) references `test2` (`id`) on update cascade;
 

--- a/tests/postgre-schema.sql
+++ b/tests/postgre-schema.sql
@@ -59,7 +59,7 @@ alter table "address2" add constraint "address2_author_id_unique" unique ("autho
 create table "book2" ("uuid_pk" varchar(36) not null, "created_at" timestamptz(3) not null default current_timestamp(3), "title" varchar(255) null default '', "perex" text null, "price" float null, "double" numeric null, "meta" jsonb null, "author_id" int4 not null, "publisher_id" int4 null, "foo" varchar(255) null default 'lol');
 alter table "book2" add constraint "book2_pkey" primary key ("uuid_pk");
 
-create table "test2" ("id" serial primary key, "name" varchar(255) null, "book_uuid_pk" varchar(36) null, "version" int4 not null default 1, "path" polygon null);
+create table "test2" ("id" serial primary key, "name" varchar(255) null, "book_uuid_pk" varchar(36) null, "parent_id" int4 null, "version" int4 not null default 1, "path" polygon null);
 alter table "test2" add constraint "test2_book_uuid_pk_unique" unique ("book_uuid_pk");
 
 create table "configuration2" ("property" varchar(255) not null, "test_id" int4 not null, "value" varchar(255) not null);
@@ -96,6 +96,7 @@ alter table "book2" add constraint "book2_author_id_foreign" foreign key ("autho
 alter table "book2" add constraint "book2_publisher_id_foreign" foreign key ("publisher_id") references "publisher2" ("id") on update cascade on delete cascade;
 
 alter table "test2" add constraint "test2_book_uuid_pk_foreign" foreign key ("book_uuid_pk") references "book2" ("uuid_pk") on delete set null;
+alter table "test2" add constraint "test2_parent_id_foreign" foreign key ("parent_id") references "test2" ("id") on update cascade on delete set null;
 
 alter table "configuration2" add constraint "configuration2_test_id_foreign" foreign key ("test_id") references "test2" ("id") on update cascade;
 


### PR DESCRIPTION
Sometimes we might want to work only with the primary key of a relation.
To do that, we can use `mapToPk` option on M:1 and 1:1 relations:

```ts
@ManyToOne(() => User, { mapToPk: true })
user: number;
```

For composite keys, this will give us ordered tuple representing the raw PKs,
which is the internal format of composite PK:

```ts
@ManyToOne(() => User, { mapToPk: true })
user: [string, string]; // [first_name, last_name]
```

Closes #750