### PR TITLE
feat(core): allow storing embeddables as objects

### DIFF
--- a/docs/docs/embeddables.md
+++ b/docs/docs/embeddables.md
@@ -99,5 +99,24 @@ export class User {
 }
 ```
 
+## Storing embeddables as objects
+
+From MikroORM v4.2 we can also store the embeddable as an object instead of
+inlining its properties to the owing entity.
+
+```ts
+@Entity()
+export class User {
+
+  @Embedded({ entity: () => Address, object: true })
+  address!: Address;
+
+}
+```
+
+In SQL drivers, this will use a JSON column to store the value. 
+
+> Only MySQL and PostgreSQL drivers support searching by JSON properties currently.
+
 > This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/embeddables.html)
 > as the behaviour here is pretty much the same.

--- a/packages/core/src/decorators/Embedded.ts
+++ b/packages/core/src/decorators/Embedded.ts
@@ -21,4 +21,5 @@ export type EmbeddedOptions = {
   type?: string;
   prefix?: string | boolean;
   nullable?: boolean;
+  object?: boolean;
 };

--- a/packages/core/src/hydration/ObjectHydrator.ts
+++ b/packages/core/src/hydration/ObjectHydrator.ts
@@ -101,11 +101,12 @@ export class ObjectHydrator extends Hydrator {
         lines.push(`  }`);
       } else if (prop.reference === ReferenceType.EMBEDDED) {
         context.set(`prototype_${prop.name}`, prop.embeddable.prototype);
+        const mapProp = <T>(childProp: EntityProperty<T>) => prop.object ? `data.${prop.name}.${childProp.embedded![1]}` : `data.${childProp.name}`;
 
         lines.push(`  entity.${prop.name} = Object.create(prototype_${prop.name});`);
         meta.props
           .filter(p => p.embedded?.[0] === prop.name)
-          .forEach(childProp => lines.push(`  entity.${prop.name}.${childProp.embedded![1]} = data.${childProp.name};`));
+          .forEach(childProp => lines.push(`  entity.${prop.name}.${childProp.embedded![1]} = ${mapProp(childProp)};`));
       } else { // ReferenceType.SCALAR
         if (prop.type.toLowerCase() === 'date') {
           lines.push(`  if (data.${prop.name}) entity.${prop.name} = new Date(data.${prop.name});`);

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -27,7 +27,7 @@ type Metadata<T, U> =
 
 export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntity<U> | undefined = undefined> {
 
-  private readonly _meta: EntityMetadata<T> = {} as EntityMetadata<T>;
+  private readonly _meta: EntityMetadata<T> = new EntityMetadata<T>();
   private internal = false;
   private initialized = false;
 
@@ -39,7 +39,7 @@ export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntit
       meta.tableName = meta.collection;
     }
 
-    Object.assign(this._meta, { className: meta.name, properties: {}, hooks: {}, filters: {}, primaryKeys: [], indexes: [], uniques: [] }, meta);
+    Object.assign(this._meta, { className: meta.name }, meta);
   }
 
   static fromMetadata<T extends AnyEntity<T> = AnyEntity, U extends AnyEntity<U> | undefined = undefined>(meta: EntityMetadata<T> | DeepPartial<EntityMetadata<T>>): EntitySchema<T, U> {
@@ -233,6 +233,7 @@ export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntit
     this.initProperties();
     this.initPrimaryKeys();
     this._meta.props = Object.values(this._meta.properties);
+    this._meta.relations = this._meta.props.filter(prop => prop.reference !== ReferenceType.SCALAR && prop.reference !== ReferenceType.EMBEDDED);
     this.initialized = true;
 
     return this;

--- a/packages/core/src/metadata/MetadataStorage.ts
+++ b/packages/core/src/metadata/MetadataStorage.ts
@@ -21,7 +21,7 @@ export class MetadataStorage {
     const key = entity && path ? entity + '-' + Utils.hash(path) : null;
 
     if (key && !MetadataStorage.metadata[key]) {
-      MetadataStorage.metadata[key] = { className: entity, path, properties: {}, hooks: {}, filters: {}, indexes: [] as any[], uniques: [] as any[] } as EntityMetadata;
+      MetadataStorage.metadata[key] = new EntityMetadata({ className: entity, path });
     }
 
     if (key) {
@@ -61,7 +61,7 @@ export class MetadataStorage {
     }
 
     if (init && !this.has(entity)) {
-      this.metadata[entity] = { properties: {}, hooks: {}, indexes: [] as any[], uniques: [] as any[] } as EntityMetadata;
+      this.metadata[entity] = new EntityMetadata();
     }
 
     return this.metadata[entity];

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -145,6 +145,10 @@ export abstract class Platform {
     return 'json';
   }
 
+  getSearchJsonPropertySQL(path: string): string {
+    return path;
+  }
+
   convertsJsonAutomatically(marshall = false): boolean {
     return !marshall;
   }
@@ -167,6 +171,10 @@ export abstract class Platform {
 
   processDateProperty(value: unknown): string | number | Date {
     return value as string;
+  }
+
+  quoteIdentifier(id: string, quote = '`'): string {
+    return `${quote}${id.replace('.', `${quote}.${quote}`)}${quote}`;
   }
 
   setConfig(config: Configuration): void {

--- a/packages/core/src/types/EnumArrayType.ts
+++ b/packages/core/src/types/EnumArrayType.ts
@@ -1,6 +1,6 @@
 import { inspect } from 'util';
 import { ArrayType } from './ArrayType';
-import { Platform } from '../platforms/Platform';
+import { Platform } from '../platforms';
 import { ValidationError } from '../errors';
 
 function mapHydrator<T>(items: T[] | undefined, hydrate: (i: string) => T): (i: string) => T {

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -229,6 +229,10 @@ export class EntityComparator {
     }
 
     if (prop.reference === ReferenceType.EMBEDDED) {
+      if (prop.object) {
+        return ret + `    ret.${prop.name} = clone({ ...entity.${prop.name} });\n  }\n`;
+      }
+
       return ret + meta.props.filter(p => p.embedded?.[0] === prop.name).map(childProp => {
         return `    ret.${childProp.name} = clone(entity.${prop.name}.${childProp.embedded![1]});`;
       }).join('\n') + '\n  }\n';

--- a/packages/knex/src/AbstractSqlPlatform.ts
+++ b/packages/knex/src/AbstractSqlPlatform.ts
@@ -23,10 +23,6 @@ export abstract class AbstractSqlPlatform extends Platform {
     return new SchemaGenerator(em as any); // cast as `any` to get around circular dependencies
   }
 
-  quoteIdentifier(id: string, quote = '`'): string {
-    return `${quote}${id.replace('.', `${quote}.${quote}`)}${quote}`;
-  }
-
   quoteValue(value: any): string {
     /* istanbul ignore if */
     if (Utils.isPlainObject(value) || Array.isArray(value)) {

--- a/packages/knex/src/schema/SchemaHelper.ts
+++ b/packages/knex/src/schema/SchemaHelper.ts
@@ -235,7 +235,7 @@ export abstract class SchemaHelper {
   }
 
   private hasSameIndex(prop: EntityProperty, column: Column): boolean {
-    if (prop.reference === ReferenceType.SCALAR) {
+    if ([ReferenceType.SCALAR, ReferenceType.EMBEDDED].includes(prop.reference)) {
       return true;
     }
 

--- a/packages/mysql-base/src/MySqlPlatform.ts
+++ b/packages/mysql-base/src/MySqlPlatform.ts
@@ -11,4 +11,9 @@ export class MySqlPlatform extends AbstractSqlPlatform {
     return 'utf8mb4';
   }
 
+  getSearchJsonPropertySQL(path: string): string {
+    const [a, b] = path.split('->', 2);
+    return `${this.quoteIdentifier(a)}->'$.${b}'`;
+  }
+
 }

--- a/tests/SchemaGenerator.test.ts
+++ b/tests/SchemaGenerator.test.ts
@@ -162,15 +162,15 @@ describe('SchemaGenerator', () => {
 
     const idProp = newTableMeta.properties.id;
     const updatedAtProp = newTableMeta.properties.updatedAt;
-    delete newTableMeta.properties.id;
-    delete newTableMeta.properties.updatedAt;
-    delete authorMeta.properties.favouriteBook;
+    newTableMeta.removeProperty('id');
+    newTableMeta.removeProperty('updatedAt');
+    authorMeta.removeProperty('favouriteBook');
     await expect(generator.getUpdateSchemaSQL(false)).resolves.toMatchSnapshot('mysql-update-schema-drop-column');
     await generator.updateSchema();
 
-    newTableMeta.properties.id = idProp;
-    newTableMeta.properties.updatedAt = updatedAtProp;
-    authorMeta.properties.favouriteBook = favouriteBookProp;
+    newTableMeta.addProperty(idProp);
+    newTableMeta.addProperty(updatedAtProp);
+    authorMeta.addProperty(favouriteBookProp);
     await expect(generator.getUpdateSchemaSQL(false)).resolves.toMatchSnapshot('mysql-update-schema-add-column');
     await generator.updateSchema();
 
@@ -184,8 +184,8 @@ describe('SchemaGenerator', () => {
     // remove 1:1 relation
     const fooBarMeta = meta.get('FooBar2');
     const fooBazMeta = meta.get('FooBaz2');
-    delete fooBarMeta.properties.baz;
-    delete fooBazMeta.properties.bar;
+    fooBarMeta.removeProperty('baz');
+    fooBazMeta.removeProperty('bar');
     await expect(generator.getUpdateSchemaSQL(false)).resolves.toMatchSnapshot('mysql-update-schema-drop-1:1');
     await generator.updateSchema();
 
@@ -203,14 +203,14 @@ describe('SchemaGenerator', () => {
     ageProp.fieldNames = ['age_in_years'];
     const index = authorMeta.indexes.find(i => Utils.asArray(i.properties).join() === 'name,age')!;
     index.properties = ['name', 'ageInYears'];
-    delete authorMeta.properties.age;
-    authorMeta.properties.ageInYears = ageProp;
+    authorMeta.removeProperty('age');
+    authorMeta.addProperty(ageProp);
     const favouriteAuthorProp = authorMeta.properties.favouriteAuthor;
     favouriteAuthorProp.name = 'favouriteWriter';
     favouriteAuthorProp.fieldNames = ['favourite_writer_id'];
     favouriteAuthorProp.joinColumns = ['favourite_writer_id'];
-    delete authorMeta.properties.favouriteAuthor;
-    authorMeta.properties.favouriteWriter = favouriteAuthorProp;
+    authorMeta.removeProperty('favouriteAuthor');
+    authorMeta.addProperty(favouriteAuthorProp);
     await (generator.getUpdateSchemaSQL(false));
     await expect(generator.getUpdateSchemaSQL(false)).resolves.toMatchSnapshot('mysql-update-schema-rename-column');
     await generator.updateSchema();
@@ -503,9 +503,9 @@ describe('SchemaGenerator', () => {
     authorMeta.properties.name.nullable = false;
     const idProp = newTableMeta.properties.id;
     const updatedAtProp = newTableMeta.properties.updatedAt;
-    delete newTableMeta.properties.id;
-    delete newTableMeta.properties.updatedAt;
-    delete authorMeta.properties.favouriteBook;
+    newTableMeta.removeProperty('id');
+    newTableMeta.removeProperty('updatedAt');
+    authorMeta.removeProperty('favouriteBook');
     await expect(generator.getUpdateSchemaSQL(false)).resolves.toMatchSnapshot('postgres-update-schema-drop-column');
     await generator.updateSchema();
 
@@ -516,14 +516,14 @@ describe('SchemaGenerator', () => {
     favouriteAuthorProp.name = 'favouriteWriter';
     favouriteAuthorProp.fieldNames = ['favourite_writer_id'];
     favouriteAuthorProp.joinColumns = ['favourite_writer_id'];
-    delete authorMeta.properties.favouriteAuthor;
-    authorMeta.properties.favouriteWriter = favouriteAuthorProp;
+    authorMeta.removeProperty('favouriteAuthor');
+    authorMeta.addProperty(favouriteAuthorProp);
     await expect(generator.getUpdateSchemaSQL(false)).resolves.toMatchSnapshot('postgres-update-schema-rename-column');
     await generator.updateSchema();
 
-    newTableMeta.properties.id = idProp;
-    newTableMeta.properties.updatedAt = updatedAtProp;
-    authorMeta.properties.favouriteBook = favouriteBookProp;
+    newTableMeta.addProperty(idProp);
+    newTableMeta.addProperty(updatedAtProp);
+    authorMeta.addProperty(favouriteBookProp);
     await expect(generator.getUpdateSchemaSQL(false)).resolves.toMatchSnapshot('postgres-update-schema-add-column');
     await generator.updateSchema();
     await expect(generator.getUpdateSchemaSQL(false)).resolves.toBe('');
@@ -531,8 +531,8 @@ describe('SchemaGenerator', () => {
     // remove 1:1 relation
     const fooBarMeta = meta.get('FooBar2');
     const fooBazMeta = meta.get('FooBaz2');
-    delete fooBarMeta.properties.baz;
-    delete fooBazMeta.properties.bar;
+    fooBarMeta.removeProperty('baz');
+    fooBazMeta.removeProperty('bar');
     await expect(generator.getUpdateSchemaSQL(false)).resolves.toMatchSnapshot('postgres-update-schema-drop-1:1');
     await generator.updateSchema();
 

--- a/tests/__snapshots__/embedded-entities.mysql.test.ts.snap
+++ b/tests/__snapshots__/embedded-entities.mysql.test.ts.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`embedded entities in mysql schema: embeddables 1 1`] = `
-"create table \`user\` (\`id\` int unsigned not null auto_increment primary key, \`address1_street\` varchar(255) not null, \`address1_postal_code\` varchar(255) not null, \`address1_city\` varchar(255) not null, \`address1_country\` varchar(255) not null, \`addr_street\` varchar(255) null, \`addr_postal_code\` varchar(255) null, \`addr_city\` varchar(255) null, \`addr_country\` varchar(255) null, \`street\` varchar(255) not null, \`postal_code\` varchar(255) not null, \`city\` varchar(255) not null, \`country\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+"create table \`user\` (\`id\` int unsigned not null auto_increment primary key, \`address1_street\` varchar(255) not null, \`address1_postal_code\` varchar(255) not null, \`address1_city\` varchar(255) not null, \`address1_country\` varchar(255) not null, \`addr_street\` varchar(255) null, \`addr_postal_code\` varchar(255) null, \`addr_city\` varchar(255) null, \`addr_country\` varchar(255) null, \`street\` varchar(255) not null, \`postal_code\` varchar(255) not null, \`city\` varchar(255) not null, \`country\` varchar(255) not null, \`address4\` json not null, \`after\` int(11) null) default character set utf8mb4 engine = InnoDB;
 
 "
 `;
 
 exports[`embedded entities in mysql schema: embeddables 2 1`] = `""`;
 
-exports[`embedded entities in mysql schema: embeddables 2 2`] = `
+exports[`embedded entities in mysql schema: embeddables 3 1`] = `
 "drop table if exists \`user\`;
 
 "


### PR DESCRIPTION
```ts
@Entity()
export class User {

  @Embedded({ entity: () => Address, object: true })
  address!: Address;

}
```

In SQL drivers, this will use a JSON column to store the value.

> Only MySQL and PostgreSQL drivers support searching by JSON properties currently.

Closes #906