### PR TITLE
feat(seeder): add seeder package

### DIFF
--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -78,6 +78,7 @@ npx mikro-orm migration:up       # Migrate up to the latest version
 npx mikro-orm migration:down     # Migrate one step down
 npx mikro-orm migration:list     # List all executed migrations
 npx mikro-orm migration:pending  # List all pending migrations
+npx mikro-orm migration:fresh    # Drop the database and migrate up to the latest version
 ```
 
 For `migration:up` and `migration:down` commands you can specify `--from` (`-f`), `--to` (`-t`) 
@@ -86,11 +87,18 @@ and `--only` (`-o`) options to run only a subset of migrations:
 ```sh
 npx mikro-orm migration:up --from 2019101911 --to 2019102117  # the same as above
 npx mikro-orm migration:up --only 2019101923                  # apply a single migration
-npx mikro-orm migration:down --to 0                           # migratee down all migrations
+npx mikro-orm migration:down --to 0                           # migrate down all migrations
 ```
 
-> To run TS migration files, you will need to [enable `useTsNode` flag](installation.md) 
+> To run TS migration files, you will need to [enable `useTsNode` flag](installation.md)
 > in your `package.json`.
+
+For the `migration:fresh` command you can specify `--seed` to seed the database after migrating.
+```shell
+npx mikro-orm migration:fresh --seed              # seed the database with the default database seeder
+npx mikro-orm migration:fresh --seed=UsersSeeder  # seed the database with the UsersSeeder
+```
+> You can specify the default database seeder in the orm config with the key `config.seeder.defaultSeeder`
 
 ## Using the Migrator programmatically
 

--- a/docs/docs/schema-generator.md
+++ b/docs/docs/schema-generator.md
@@ -20,7 +20,7 @@ You can use it via CLI:
 ```sh
 npx mikro-orm schema:create --dump   # Dumps create schema SQL
 npx mikro-orm schema:update --dump   # Dumps update schema SQL
-npx mikro-orm schema:drop --dump     # Dumps drop schema SQL
+npx mikro-orm schema:drop --dump     # Dumps drop schema SQL 
 ```
 
 > You can also use `--run` flag to fire all queries, but be careful as it might break your
@@ -35,6 +35,16 @@ well as column dropping.
 
 `schema:drop` will by default drop all database tables. You can use `--drop-db` flag to drop
 the whole database instead. 
+
+```shell
+npx mikro-orm schema:fresh --run     # !WARNING! Drops the database schema and recreates it
+```
+This command can be run with the `--seed` option to seed the database after it has been created again.
+```shell
+npx mikro-orm schema:fresh --run --seed              # seed the database with the default database seeder
+npx mikro-orm schema:fresh --run --seed=UsersSeeder  # seed the database with the UsersSeeder
+```
+> You can specify the default database seeder in the orm config with the key `config.seeder.defaultSeeder`
 
 ## Using SchemaGenerator programmatically
 

--- a/docs/docs/seeding.md
+++ b/docs/docs/seeding.md
@@ -1,0 +1,194 @@
+---
+title: Seeding
+---
+
+When initializing your application or testing it can be exhausting to create sample data for your database. The solution is to use seeding. Create factories for your entities and use them in the seed script or combine multiple seed scripts.
+
+## Seeders
+A seeder class contains one method `run`. This method is called when you use the command `npx mikro-orm seeder:run`. In the `run` method you define how and what data you want to insert into the database. You can create entities using the [EntityManager](http://mikro-orm.io/docs/entity-manager) or you can use [Factories](#using-entity-factories).
+
+You can create your own seeder classes using the following CLI command:
+```shell
+npx mikro-orm seeder:create DatabaseSeeder
+```
+This creates a new seeder class. By default it will be generated in the `./database/seeder/` directory. You can configure the directory in the config with the key `seeder.path`.
+
+As an example we will look at a very basic seeder.
+```typescript
+// ./database/seeder/database.seeder.ts
+
+import { EntityManager } from '@mikro-orm/core';
+import { Seeder } from '@mikro-orm/seeder';
+import { Author } from './author'
+
+export class DatabaseSeeder extends Seeder {
+
+  async run(em: EntityManager): Promise<void> {
+    const author = em.create(Author, {
+      name: 'John Snow',
+      email: 'snow@wall.st'
+    });
+  }
+}
+```
+> Running a seeder from the command line or programmatically will automatically call `flush` and `clear` after the `run` method has completed.
+
+### Using entity factories
+Instead of specifying all the attributes for every entity, you can also use [entity factories](#entity-factories). These can be used to generate large amounts of database records. Please read the [documentation on how to define factories](#entity-factories) to learn how to define your factories. 
+
+As an example we will generate 10 authors.
+```typescript
+import { EntityManager } from '@mikro-orm/core';
+import { Seeder } from '@mikro-orm/seeder';
+import { AuthorFactory } from '../factories/author.factory'
+
+export class DatabaseSeeder extends Seeder {
+
+  async run(em: EntityManager): Promise<void> {
+    new AuthorFactory(em).count(10).make()
+  }
+}
+```
+
+### Calling additional seeders
+Inside the `run` method you can specify other seeder classes. You can use the `call` method to breakup the database seeder into multiple files to prevent a seeder file from becoming too large. The `call` method accepts an array of seeder classes.
+```typescript
+import { EntityManager } from '@mikro-orm/core';
+import { Seeder } from '@mikro-orm/seeder';
+import { AuthorSeeder, BookSeeder } from '../seeders'
+
+export class DatabaseSeeder extends Seeder {
+
+  run(em: EntityManager): Promise<void> {
+    return this.call(em, [
+      AuthorSeeder,
+      BookSeeder
+    ]);
+  }
+}
+```
+
+## Entity factories
+When testing you may insert entities in the database before starting a test. Instead of specifying every attribute of every entity by hand, you could also use a `Factory` to define a set of default attributes for an entity using entity factories.
+
+Lets have a look at an example factory for an [Author entity](http://mikro-orm.io/docs/defining-entities).
+```typescript
+import { Factory } from '@mikro-orm/seeder';
+import Faker from 'faker';
+import { Author } from './entities/author.entity';
+
+export class AuthorFactory extends Factory<Author> {
+  model = Author;
+
+  definition(faker: typeof Faker): Partial<Author> {
+    return {
+      name: faker.person.findName(),
+      email: faker.internet.email(),
+      age: faker.random.number(18, 99)
+    };
+  }
+}
+``` 
+Basically you extend the base `Factory` class, define a `model` property and a `definition` method. The `model` defines for which entity the factory generates entity instances. The `definition` method returns the default set of attribute values that should be applied when creating an entity using the factory.
+
+Via the faker property, factories have access to the [Faker library](https://github.com/marak/Faker.js/), which allows you to conveniently generate various kinds of random data for testing.
+
+### Creating entities using factories
+Once you defined your factories you can use them to generate entities. Simply import the factory, instantiate it and call the `makeOne` method.
+```typescript
+const author: Author = new AuthorFactory(orm.em).makeOne();
+```
+
+#### Generate multiple entities
+Generate multiple entities by calling the `make` method. The parameter of the `make` method is the number of entities you generate.
+```typescript
+// Generate 5 authors
+const authors: Author[] = new AuthorFactory(orm.em).make(5);
+``` 
+
+#### Overriding attributes
+If you would like to override some of the default values of your factories, you may pass an object to the make method. Only the specified attributes will be replaced while the rest of the attributes remain set to their default values as specified by the factory.
+```typescript
+const author: Author = new AuthorFactory(orm.em).make({
+    name: 'John Snow'
+});
+``` 
+
+### Persisting entities
+The `create` method instantiates entities and persists them to the database using the `persistAndFlush` method of the EntityManager.
+```typescript
+// Make and persist a single author
+const author: Author = await new AuthorFactory(orm.em).createOne();
+
+// Make and persist 5 authors
+const authors: Author[] = await new AuthorFactory(orm.em).create(5);
+```
+You can override the default values of your factories by passing an object to the `create` method.
+```typescript
+// Make and persist a single author
+const author: Author = await new AuthorFactory(orm.em).createOne({
+    name: 'John Snow'
+});
+
+// Make and persist a 5 authors
+const authors: Author[] = await new AuthorFactory(orm.em).create(5, {
+    name: 'John Snow'
+});
+```
+### Factory relationships
+It is nice to create large quantities of data for one entity, but most of the time we want to create data for multiple entities and also have relations between these. For this we can use the `each` method which can be chained on a factory. The `each` method can be called with a function that transforms output entity from the factory before returning it. Lets look at some examples for the different relations.
+
+#### ManyToOne and OneToOne relations
+```typescript
+const books: Book[] = new BookFactory(orm.em).each(book => {
+    book.author = new AuthorFactory(orm.em).makeOne();
+}).make(5);
+``` 
+
+#### OneToMany and ManyToMany
+```typescript
+const books: Book[] = new BookFactory(orm.em).each(book => {
+    book.owners.set(new OwnerFactory(orm.em).make(5));
+}).make(5);
+``` 
+
+## Use with CLI
+You may execute the `seeder:run` MikroORM CLI command to seed your database. By default, the `seeder:run` command runs the DatabaseSeeder class, which may in turn invoke other seed classes. However, you may use the `--class` option to specify a specific seeder class to run individually:
+```shell script
+npx mikro-orm seeder:run
+
+npx mikro-orm seeder:run --class=BookSeeder
+```
+
+You may also seed your database using the [`migrate:fresh`](migrations.md#using-via-cli) or [`schema:fresh`](schema-generator.md) command in combination with the `--seed` option, which will drop all tables and re-run all of your migrations or generate the database based on the current entities. This command is useful for completely re-building your database:
+```shell script
+npx mikro-orm migration:fresh --seed
+
+npx mikro-orm schema:fresh --seed
+```
+
+
+## Use in tests
+Now we know how to create seeders and factories, but how can we effectively use them in tests. We will show an example how it can be used.
+
+```typescript
+beforeAll(async () => {
+    // Get seeder from MikroORM
+    const seeder = orm.getSeeder();
+    
+    // Refresh the database to start clean
+    await seeder.refreshDatabase();
+    
+    // Seed using a seeder defined by you
+    await seeder.seed(DatabaseSeeder);
+})
+
+test(() => {
+    // Do tests
+});
+
+afterAll(async () => {
+    // Close connection
+    await orm.close();
+})
+```

--- a/packages/cli/src/CLIConfigurator.ts
+++ b/packages/cli/src/CLIConfigurator.ts
@@ -2,12 +2,14 @@ import yargs, { Argv } from 'yargs';
 
 import { ConfigurationLoader, Utils } from '@mikro-orm/core';
 import { ClearCacheCommand } from './commands/ClearCacheCommand';
-import { GenerateEntitiesCommand } from './commands/GenerateEntitiesCommand';
-import { SchemaCommandFactory } from './commands/SchemaCommandFactory';
-import { MigrationCommandFactory } from './commands/MigrationCommandFactory';
+import { DatabaseSeedCommand } from './commands/DatabaseSeedCommand';
 import { DebugCommand } from './commands/DebugCommand';
 import { GenerateCacheCommand } from './commands/GenerateCacheCommand';
+import { GenerateEntitiesCommand } from './commands/GenerateEntitiesCommand';
 import { ImportCommand } from './commands/ImportCommand';
+import { MigrationCommandFactory } from './commands/MigrationCommandFactory';
+import { SchemaCommandFactory } from './commands/SchemaCommandFactory';
+import { CreateSeederCommand } from './commands/CreateSeederCommand';
 import { CreateDatabaseCommand } from './commands/CreateDatabaseCommand';
 
 /**
@@ -35,14 +37,18 @@ export class CLIConfigurator {
       .command(new GenerateEntitiesCommand())
       .command(new CreateDatabaseCommand())
       .command(new ImportCommand())
+      .command(new DatabaseSeedCommand())
+      .command(new CreateSeederCommand())
       .command(SchemaCommandFactory.create('create'))
       .command(SchemaCommandFactory.create('drop'))
       .command(SchemaCommandFactory.create('update'))
+      .command(SchemaCommandFactory.create('fresh'))
       .command(MigrationCommandFactory.create('create'))
       .command(MigrationCommandFactory.create('up'))
       .command(MigrationCommandFactory.create('down'))
       .command(MigrationCommandFactory.create('list'))
       .command(MigrationCommandFactory.create('pending'))
+      .command(MigrationCommandFactory.create('fresh'))
       .command(new DebugCommand())
       .recommendCommands()
       .strict();

--- a/packages/cli/src/commands/CreateSeederCommand.ts
+++ b/packages/cli/src/commands/CreateSeederCommand.ts
@@ -1,0 +1,30 @@
+import c from 'ansi-colors';
+import { Arguments, Argv, CommandModule } from 'yargs';
+import { CLIHelper } from '../CLIHelper';
+import { MikroORM } from '@mikro-orm/core';
+import { AbstractSqlDriver } from '@mikro-orm/knex';
+
+export class CreateSeederCommand<T> implements CommandModule<T, { seeder: string }> {
+
+  command = 'seeder:create <seeder>';
+  describe = 'Create a new seeder class';
+  builder = (args: Argv) => {
+    args.positional('seeder', {
+      describe: 'Seeder class to create (use PascalCase and end with `Seeder` e.g. DatabaseSeeder)',
+    });
+    args.demandOption('seeder');
+    return args as Argv<{ seeder: string }>;
+  };
+
+  /**
+   * @inheritdoc
+   */
+  async handler(args: Arguments<{ seeder: string }>) {
+    const orm = await CLIHelper.getORM(undefined) as MikroORM<AbstractSqlDriver>;
+    const seeder = orm.getSeeder();
+    const path = await seeder.createSeeder(args.seeder);
+    CLIHelper.dump(c.green(`Seeder ${args.seeder} successfully created at ${path}`));
+    await orm.close(true);
+  }
+
+}

--- a/packages/cli/src/commands/DatabaseSeedCommand.ts
+++ b/packages/cli/src/commands/DatabaseSeedCommand.ts
@@ -1,0 +1,33 @@
+import c from 'ansi-colors';
+import { Arguments, Argv, CommandModule } from 'yargs';
+import { CLIHelper } from '../CLIHelper';
+import { MikroORM } from '@mikro-orm/core';
+import { AbstractSqlDriver } from '@mikro-orm/knex';
+
+export class DatabaseSeedCommand<T> implements CommandModule<T, { class: string }> {
+
+  command = 'seeder:run';
+  describe = 'Seed the database using the seeder class';
+  builder = (args: Argv) => {
+    args.option('c', {
+      alias: 'class',
+      type: 'string',
+      desc: 'Seeder class to run',
+      default: '',
+    });
+    return args as Argv<{ class: string }>;
+  };
+
+  /**
+   * @inheritdoc
+   */
+  async handler(args: Arguments<{ class?: string }>) {
+    const orm = await CLIHelper.getORM(undefined) as MikroORM<AbstractSqlDriver>;
+    const seeder = orm.getSeeder();
+    const seederClass = args.class || orm.config.get('seeder').defaultSeeder;
+    await seeder.seedString(seederClass);
+    CLIHelper.dump(c.green(`Seeder ${seederClass} successfully seeded`));
+    await orm.close(true);
+  }
+
+}

--- a/packages/cli/src/commands/ImportCommand.ts
+++ b/packages/cli/src/commands/ImportCommand.ts
@@ -1,7 +1,7 @@
-import { Arguments, CommandModule } from 'yargs';
-import c from 'ansi-colors';
 import { MikroORM } from '@mikro-orm/core';
 import { AbstractSqlDriver } from '@mikro-orm/knex';
+import c from 'ansi-colors';
+import { Arguments, CommandModule } from 'yargs';
 import { CLIHelper } from '../CLIHelper';
 
 export class ImportCommand implements CommandModule {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,6 +71,7 @@
     "@mikro-orm/mongodb": "^4.0.0",
     "@mikro-orm/mysql": "^4.0.0",
     "@mikro-orm/postgresql": "^4.0.0",
+    "@mikro-orm/seeder": "^4.0.0",
     "@mikro-orm/sqlite": "^4.0.0"
   },
   "peerDependenciesMeta": {
@@ -90,6 +91,9 @@
       "optional": true
     },
     "@mikro-orm/postgresql": {
+      "optional": true
+    },
+    "@mikro-orm/seeder": {
       "optional": true
     },
     "@mikro-orm/sqlite": {

--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -5,7 +5,7 @@ import { MetadataDiscovery, MetadataStorage, MetadataValidator, ReflectMetadataP
 import { Configuration, ConfigurationLoader, Logger, Options, Utils } from './utils';
 import { NullCacheAdapter } from './cache';
 import { EntityManager } from './EntityManager';
-import { AnyEntity, Constructor, IEntityGenerator, IMigrator, ISchemaGenerator } from './typings';
+import { AnyEntity, Constructor, IEntityGenerator, IMigrator, ISchemaGenerator, ISeedManager } from './typings';
 
 /**
  * Helper class for bootstrapping the MikroORM.
@@ -141,6 +141,12 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
    */
   getMigrator<T extends IMigrator = IMigrator>(): T {
     return this.driver.getPlatform().getMigrator(this.em) as T;
+  }
+
+  getSeeder<T extends ISeedManager = ISeedManager>(): T {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { SeedManager } = require('@mikro-orm/seeder');
+    return new SeedManager(this);
   }
 
 }

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -4,6 +4,7 @@ import { EntitySchema, MetadataStorage } from './metadata';
 import { Type } from './types';
 import { Platform } from './platforms';
 import { Configuration, EntityComparator, Utils } from './utils';
+import { EntityManager } from './EntityManager';
 
 export type Constructor<T = unknown> = new (...args: any[]) => T;
 export type Dictionary<T = any> = { [k: string]: T };
@@ -501,4 +502,15 @@ export interface IHydrator {
 
 export interface HydratorConstructor {
   new (metadata: MetadataStorage, platform: Platform, config: Configuration): IHydrator;
+}
+
+export interface ISeedManager {
+  refreshDatabase(): Promise<void>;
+  seed(...seederClasses: { new(): Seeder }[]): Promise<void>;
+  seedString(...seederClasses: string[]): Promise<void>;
+  createSeeder(seederClass: string): Promise<void>;
+}
+
+export interface Seeder {
+  run(em: EntityManager): Promise<void>;
 }

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -81,6 +81,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     },
     metadataProvider: ReflectMetadataProvider,
     highlighter: new NullHighlighter(),
+    seeder: { path: './database/seeder', defaultSeeder: 'DatabaseSeeder' },
   };
 
   static readonly PLATFORMS = {
@@ -350,9 +351,9 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
     disableDynamicFileAccess?: boolean;
   };
   type?: keyof typeof Configuration.PLATFORMS;
-  driver?: { new (config: Configuration): D };
+  driver?: { new(config: Configuration): D };
   driverOptions: Dictionary;
-  namingStrategy?: { new (): NamingStrategy };
+  namingStrategy?: { new(): NamingStrategy };
   implicitTransactions?: boolean;
   autoJoinOneToOneOwner: boolean;
   propagateToOneOwner: boolean;
@@ -383,15 +384,18 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
   cache: {
     enabled?: boolean;
     pretty?: boolean;
-    adapter?: { new (...params: any[]): CacheAdapter };
+    adapter?: { new(...params: any[]): CacheAdapter };
     options?: Dictionary;
   };
   resultCache: {
     expiration?: number;
-    adapter?: { new (...params: any[]): CacheAdapter };
+    adapter?: { new(...params: any[]): CacheAdapter };
     options?: Dictionary;
   };
-  metadataProvider: { new (config: Configuration): MetadataProvider };
+  metadataProvider: { new(config: Configuration): MetadataProvider };
+  seeder: { path: string; defaultSeeder: string };
 }
 
-export type Options<D extends IDatabaseDriver = IDatabaseDriver> = Pick<MikroORMOptions<D>, Exclude<keyof MikroORMOptions<D>, keyof typeof Configuration.DEFAULTS>> & Partial<MikroORMOptions<D>>;
+export type Options<D extends IDatabaseDriver = IDatabaseDriver> =
+  Pick<MikroORMOptions<D>, Exclude<keyof MikroORMOptions<D>, keyof typeof Configuration.DEFAULTS>>
+  & Partial<MikroORMOptions<D>>;

--- a/packages/seeder/package.json
+++ b/packages/seeder/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@mikro-orm/seeder",
+  "version": "4.4.4",
+  "description": "Seeder package for MikroORM.",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/mikro-orm/mikro-orm.git"
+  },
+  "keywords": [
+    "orm",
+    "mongo",
+    "mongodb",
+    "mysql",
+    "mariadb",
+    "postgresql",
+    "sqlite",
+    "sqlite3",
+    "ts",
+    "typescript",
+    "js",
+    "javascript",
+    "entity",
+    "ddd",
+    "mikro-orm",
+    "unit-of-work",
+    "data-mapper",
+    "identity-map",
+    "seeder"
+  ],
+  "author": "Wybren Kortstra",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/mikro-orm/mikro-orm/issues"
+  },
+  "homepage": "https://mikro-orm.io",
+  "engines": {
+    "node": ">= 10.13.0"
+  },
+  "scripts": {
+    "build": "yarn clean && yarn compile && yarn copy",
+    "clean": "rimraf ./dist",
+    "compile": "tsc -p tsconfig.build.json",
+    "copy": "ts-node -T ../../scripts/copy.ts"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "faker": "5.4.0"
+  },
+  "peerDependencies": {
+    "@mikro-orm/core": "^4.4.4"
+  },
+  "devDependencies": {
+    "@mikro-orm/core": "^4.4.4",
+    "@types/faker": "^5.1.6"
+  }
+}

--- a/packages/seeder/src/factory.ts
+++ b/packages/seeder/src/factory.ts
@@ -1,0 +1,68 @@
+import Faker from 'faker';
+import { EntityManager } from '@mikro-orm/core';
+
+export abstract class Factory<C> {
+
+  abstract readonly model: { new(): C };
+  private eachFunction?: (entity: C) => void;
+
+  constructor(private readonly em: EntityManager) {
+  }
+
+  protected abstract definition(faker: typeof Faker): Partial<C>;
+
+  /**
+   * Make a single entity
+   * @param overrideParameters Object specifying what default attributes of the entity factory should be overridden
+   */
+  makeOne(overrideParameters?: Partial<C>): C {
+    const entity = this.em.create(this.model, Object.assign({}, this.definition(Faker), overrideParameters));
+    if (this.eachFunction) {
+      this.eachFunction(entity);
+    }
+    return entity;
+  }
+
+  /**
+   * Make multiple entities
+   * @param amount Number of entities that should be generated
+   * @param overrideParameters Object specifying what default attributes of the entity factory should be overridden
+   */
+  make(amount: number, overrideParameters?: Partial<C>): C[] {
+    return [...Array(amount)].map(() => {
+      return this.makeOne(overrideParameters);
+    });
+  }
+
+  /**
+   * Create (and persist) a single entity
+   * @param overrideParameters Object specifying what default attributes of the entity factory should be overridden
+   */
+  async createOne(overrideParameters?: Partial<C>): Promise<C> {
+    const entity = this.makeOne(overrideParameters);
+    await this.em.persistAndFlush(entity);
+    return entity;
+  }
+
+  /**
+   * Create (and persist) multiple entities
+   * @param amount Number of entities that should be generated
+   * @param overrideParameters Object specifying what default attributes of the entity factory should be overridden
+   */
+  async create(amount: number, overrideParameters?: Partial<C>): Promise<C[]> {
+    const entities = this.make(amount, overrideParameters);
+    await this.em.persistAndFlush(entities);
+    return entities;
+  }
+
+  /**
+   * Set a function that is applied to each entity before it is returned
+   * In case of `createOne` or `create` it is applied before the entity is persisted
+   * @param eachFunction The function that is applied on every entity
+   */
+  each(eachFunction: (entity: C) => void) {
+    this.eachFunction = eachFunction;
+    return this;
+  }
+
+}

--- a/packages/seeder/src/index.ts
+++ b/packages/seeder/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @packageDocumentation
+ * @module seeder
+ */
+export * from './seeder';
+export * from './factory';
+export * from './seed-manager';

--- a/packages/seeder/src/seed-manager.ts
+++ b/packages/seeder/src/seed-manager.ts
@@ -1,0 +1,71 @@
+import { MikroORM, Utils } from '@mikro-orm/core';
+import { Seeder } from './seeder';
+import { ensureDir, writeFile } from 'fs-extra';
+
+export class SeedManager {
+
+  constructor(private orm: MikroORM) {
+  }
+
+  async refreshDatabase(): Promise<void> {
+    const generator = this.orm.getSchemaGenerator();
+    await generator.dropSchema();
+    await generator.createSchema();
+  }
+
+  async seed(...seederClasses: { new(): Seeder }[]): Promise<void> {
+    for (const seederClass of seederClasses) {
+      const seeder = new seederClass();
+      await seeder.run(this.orm.em);
+      await this.orm.em.flush();
+      this.orm.em.clear();
+    }
+  }
+
+  async seedString(...seederClasses: string[]): Promise<void> {
+    for (const seederClass of seederClasses) {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const seeder = require(`${process.cwd()}/${this.orm.config.get('seeder').path}/${this.getFileName(seederClass)}`);
+      await this.seed(seeder);
+    }
+  }
+
+  async createSeeder(seederClass: string): Promise<string> {
+    await this.ensureMigrationsDirExists();
+    return this.generate(seederClass);
+  }
+
+  private getFileName(seederClass: string): string {
+    const split = seederClass.split(/(?=[A-Z])/);
+    const parts = split.reduce((previousValue: string[], currentValue: string, index: number) => {
+      if (index === split.length - 1) {
+        return previousValue;
+      }
+      previousValue.push(currentValue.toLowerCase());
+      return previousValue;
+    }, []);
+    return `${parts.join('-')}.seeder.ts`;
+  }
+
+  private async ensureMigrationsDirExists() {
+    await ensureDir(Utils.normalizePath(this.orm.config.get('seeder').path));
+  }
+
+  private async generate(seeder: string): Promise<string> {
+    const path = Utils.normalizePath(this.orm.config.get('seeder').path);
+    const fileName = this.getFileName(seeder);
+    const ret = `import { EntityManager } from '@mikro-orm/core';
+import { Seeder } from '@mikro-orm/seeder';
+class DatabaseSeeder extends Seeder {
+
+  run(em: EntityManager): Promise<void> {
+  }
+
+}`;
+
+    await writeFile(path + '/' + fileName, ret);
+
+    return path + '/' + fileName;
+  }
+
+}

--- a/packages/seeder/src/seeder.ts
+++ b/packages/seeder/src/seeder.ts
@@ -1,0 +1,16 @@
+import { EntityManager } from '@mikro-orm/core';
+
+export abstract class Seeder {
+
+  abstract run(em: EntityManager): Promise<void>;
+
+  protected call(em: EntityManager, seeders: { new(): Seeder }[]): Promise<void> {
+    return new Promise((resolve, reject) => {
+      Promise.all(seeders.map(s => {
+        return (new s()).run(em.fork());
+      })).then(() => resolve()).catch(reject);
+    });
+  }
+
+}
+

--- a/packages/seeder/tsconfig.build.json
+++ b/packages/seeder/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/seeder/tsconfig.json
+++ b/packages/seeder/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"]
+}

--- a/tests/cli/CreateSeederCommand.test.ts
+++ b/tests/cli/CreateSeederCommand.test.ts
@@ -1,0 +1,47 @@
+import { SeedManager } from '@mikro-orm/seeder';
+
+(global as any).process.env.FORCE_COLOR = 0;
+
+import { Migrator } from '@mikro-orm/migrations';
+import { MikroORM } from '@mikro-orm/core';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+import { CLIHelper } from '@mikro-orm/cli';
+// noinspection ES6PreferShortImport
+import { initORMSqlite } from '../bootstrap';
+import { CreateSeederCommand } from '../../packages/cli/src/commands/CreateSeederCommand';
+
+const close = jest.fn();
+jest.spyOn(MikroORM.prototype, 'close').mockImplementation(close);
+jest.spyOn(require('yargs'), 'showHelp').mockReturnValue('');
+const createSeederMock = jest.spyOn(SeedManager.prototype, 'createSeeder');
+createSeederMock.mockResolvedValue('database/seeders/database.seeder.ts');
+
+describe('CreateSeederCommand', () => {
+
+  let orm: MikroORM<SqliteDriver>;
+
+  beforeAll(async () => {
+    orm = await initORMSqlite();
+    const getORMMock = jest.spyOn(CLIHelper, 'getORM');
+    getORMMock.mockResolvedValue(orm);
+  });
+
+  afterAll(async () => await orm.close(true));
+
+  test('handler', async () => {
+    const cmd = new CreateSeederCommand();
+    const mockPositional = jest.fn();
+    const mockDemand = jest.fn();
+    const args = { positional: mockPositional, demandOption: mockDemand };
+    cmd.builder(args as any);
+    expect(mockPositional).toBeCalledWith('seeder', {
+      describe: 'Seeder class to create (use PascalCase and end with `Seeder` e.g. DatabaseSeeder)',
+    });
+    expect(mockDemand).toBeCalledWith('seeder');
+
+    await expect(cmd.handler({ seeder: 'DatabaseSeeder' } as any)).resolves.toBeUndefined();
+    expect(createSeederMock).toBeCalledTimes(1);
+    expect(close).toBeCalledTimes(1);
+  });
+
+});

--- a/tests/cli/DatabaseSeedCommand.test.ts
+++ b/tests/cli/DatabaseSeedCommand.test.ts
@@ -1,0 +1,60 @@
+import { SeedManager } from '@mikro-orm/seeder';
+import { Configuration, CLIHelper, MikroORM } from '../../packages/mikro-orm/src';
+
+const config = new Configuration({ type: 'mongo' } as any, false);
+const connection = { loadFile: jest.fn() };
+const em = { getConnection: () => connection };
+const showHelpMock = jest.spyOn(require('yargs'), 'showHelp');
+showHelpMock.mockReturnValue('');
+const close = jest.fn();
+jest.spyOn(MikroORM.prototype, 'close').mockImplementation(close);
+const getConfigMock = jest.spyOn(CLIHelper, 'getConfiguration');
+getConfigMock.mockResolvedValue(config as any);
+const dumpMock = jest.spyOn(CLIHelper, 'dump');
+dumpMock.mockImplementation(() => void 0);
+const seed = jest.spyOn(SeedManager.prototype, 'seedString');
+seed.mockImplementation(async () => void 0);
+
+(global as any).console.log = jest.fn();
+
+// noinspection ES6PreferShortImport
+import { DatabaseSeedCommand } from '../../packages/cli/src/commands/DatabaseSeedCommand';
+import { initORMSqlite } from '../bootstrap';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+
+describe('DatabaseSeedCommand', () => {
+
+  let orm: MikroORM<SqliteDriver>;
+
+  beforeAll(async () => {
+    orm = await initORMSqlite();
+    const getORMMock = jest.spyOn(CLIHelper, 'getORM');
+    getORMMock.mockResolvedValue(orm);
+  });
+
+  afterAll(async () => await orm.close(true));
+
+  test('handler', async () => {
+    const cmd = new DatabaseSeedCommand();
+
+    const mockOption = jest.fn();
+    const args = { option: mockOption };
+    cmd.builder(args as any);
+    expect(mockOption).toBeCalledWith('c', {
+      alias: 'class',
+      type: 'string',
+      desc: 'Seeder class to run',
+      default: '',
+    });
+    await expect(cmd.handler({} as any)).resolves.toBeUndefined();
+    expect(seed).toBeCalledTimes(1);
+    expect(seed).toBeCalledWith((orm.config.get('seeder').defaultSeeder));
+    expect(close).toBeCalledTimes(1);
+
+    await expect(cmd.handler({ class: 'TestSeeder' } as any)).resolves.toBeUndefined();
+    expect(seed).toBeCalledTimes(2);
+    expect(seed).toBeCalledWith(('TestSeeder'));
+    expect(close).toBeCalledTimes(2);
+  });
+
+});

--- a/tests/cli/FreshSchemaCommand.test.ts
+++ b/tests/cli/FreshSchemaCommand.test.ts
@@ -1,12 +1,12 @@
-import { SeedManager } from '@mikro-orm/seeder';
-
 (global as any).process.env.FORCE_COLOR = 0;
 
 import { MikroORM } from '@mikro-orm/core';
+import { SeedManager } from '@mikro-orm/seeder';
 import { SchemaGenerator, SqliteDriver } from '@mikro-orm/sqlite';
 import { CLIHelper } from '@mikro-orm/cli';
-import { SchemaCommandFactory } from '../../../packages/cli/src/commands/SchemaCommandFactory';
-import { initORMSqlite } from '../../bootstrap';
+// noinspection ES6PreferShortImport
+import { SchemaCommandFactory } from '../../packages/cli/src/commands/SchemaCommandFactory';
+import { initORMSqlite } from '../bootstrap';
 
 const close = jest.fn();
 jest.spyOn(MikroORM.prototype, 'close').mockImplementation(close);
@@ -14,14 +14,16 @@ const showHelpMock = jest.spyOn(require('yargs'), 'showHelp');
 showHelpMock.mockReturnValue('');
 const createSchema = jest.spyOn(SchemaGenerator.prototype, 'createSchema');
 createSchema.mockImplementation(async () => void 0);
-const getCreateSchemaSQL = jest.spyOn(SchemaGenerator.prototype, 'getCreateSchemaSQL');
-getCreateSchemaSQL.mockImplementation(async () => '');
+const dropSchema = jest.spyOn(SchemaGenerator.prototype, 'dropSchema');
+dropSchema.mockImplementation(async () => void 0);
 const seed = jest.spyOn(SeedManager.prototype, 'seedString');
 seed.mockImplementation(async () => void 0);
+const getDropSchemaSQL = jest.spyOn(SchemaGenerator.prototype, 'getDropSchemaSQL');
+getDropSchemaSQL.mockImplementation(async () => '');
 const dumpMock = jest.spyOn(CLIHelper, 'dump');
 dumpMock.mockImplementation(() => void 0);
 
-describe('CreateSchemaCommand', () => {
+describe('FreshSchemaCommand', () => {
 
   let orm: MikroORM<SqliteDriver>;
 
@@ -33,42 +35,39 @@ describe('CreateSchemaCommand', () => {
 
   afterAll(async () => await orm.close(true));
 
-  test('builder', async () => {
-    const cmd = SchemaCommandFactory.create('create');
-    const args = { option: jest.fn() };
-    cmd.builder(args as any);
-  });
-
   test('handler', async () => {
-    const cmd = SchemaCommandFactory.create('create');
+    const cmd = SchemaCommandFactory.create('fresh');
 
     expect(showHelpMock.mock.calls.length).toBe(0);
     await expect(cmd.handler({} as any)).resolves.toBeUndefined();
     expect(showHelpMock.mock.calls.length).toBe(1);
 
+    expect(dropSchema.mock.calls.length).toBe(0);
     expect(createSchema.mock.calls.length).toBe(0);
+    expect(dropSchema.mock.calls.length).toBe(0);
+    expect(createSchema.mock.calls.length).toBe(0);
+    expect(seed.mock.calls.length).toBe(0);
     expect(close.mock.calls.length).toBe(0);
+
     await expect(cmd.handler({ run: true } as any)).resolves.toBeUndefined();
+    expect(dropSchema.mock.calls.length).toBe(1);
     expect(createSchema.mock.calls.length).toBe(1);
+    expect(seed.mock.calls.length).toBe(0);
     expect(close.mock.calls.length).toBe(1);
 
-    expect(getCreateSchemaSQL.mock.calls.length).toBe(0);
-    await expect(cmd.handler({ dump: true } as any)).resolves.toBeUndefined();
-    expect(getCreateSchemaSQL.mock.calls.length).toBe(1);
-    expect(close.mock.calls.length).toBe(2);
-
-    expect(seed.mock.calls.length).toBe(0);
     await expect(cmd.handler({ run: true, seed: '' } as any)).resolves.toBeUndefined();
+    expect(dropSchema.mock.calls.length).toBe(2);
     expect(createSchema.mock.calls.length).toBe(2);
     expect(seed.mock.calls.length).toBe(1);
     expect(seed).toBeCalledWith(orm.config.get('seeder').defaultSeeder);
-    expect(close.mock.calls.length).toBe(3);
+    expect(close.mock.calls.length).toBe(2);
 
     await expect(cmd.handler({ run: true, seed: 'UsersSeeder' } as any)).resolves.toBeUndefined();
+    expect(dropSchema.mock.calls.length).toBe(3);
     expect(createSchema.mock.calls.length).toBe(3);
     expect(seed.mock.calls.length).toBe(2);
     expect(seed).toBeCalledWith('UsersSeeder');
-    expect(close.mock.calls.length).toBe(4);
+    expect(close.mock.calls.length).toBe(3);
   });
 
 });

--- a/tests/cli/MigrateFreshCommand.test.ts
+++ b/tests/cli/MigrateFreshCommand.test.ts
@@ -1,0 +1,67 @@
+(global as any).process.env.FORCE_COLOR = 0;
+
+import { Migrator } from '@mikro-orm/migrations';
+import { MikroORM } from '@mikro-orm/core';
+import { SeedManager } from '@mikro-orm/seeder';
+import { SchemaGenerator, SqliteDriver } from '@mikro-orm/sqlite';
+import { CLIHelper } from '@mikro-orm/cli';
+// noinspection ES6PreferShortImport
+import { MigrationCommandFactory } from '../../packages/cli/src/commands/MigrationCommandFactory';
+import { initORMSqlite } from '../bootstrap';
+
+const close = jest.fn();
+jest.spyOn(MikroORM.prototype, 'close').mockImplementation(close);
+jest.spyOn(require('yargs'), 'showHelp').mockReturnValue('');
+const up = jest.spyOn(Migrator.prototype, 'up');
+up.mockResolvedValue([]);
+const dumpMock = jest.spyOn(CLIHelper, 'dump');
+dumpMock.mockImplementation(() => void 0);
+const dropSchema = jest.spyOn(SchemaGenerator.prototype, 'dropSchema');
+dropSchema.mockImplementation(async () => void 0);
+const seed = jest.spyOn(SeedManager.prototype, 'seedString');
+seed.mockImplementation(async () => void 0);
+jest.spyOn(CLIHelper, 'dumpTable').mockImplementation(() => void 0);
+
+describe('MigrateUpCommand', () => {
+
+  let orm: MikroORM<SqliteDriver>;
+
+  beforeAll(async () => {
+    orm = await initORMSqlite();
+    const getORMMock = jest.spyOn(CLIHelper, 'getORM');
+    getORMMock.mockResolvedValue(orm);
+  });
+
+  afterAll(async () => await orm.close(true));
+
+  test('builder', async () => {
+    const cmd = MigrationCommandFactory.create('fresh');
+    const args = { option: jest.fn() };
+    cmd.builder(args as any);
+  });
+
+  test('handler', async () => {
+    const cmd = MigrationCommandFactory.create('fresh');
+
+    await expect(cmd.handler({} as any)).resolves.toBeUndefined();
+    expect(dropSchema).toBeCalledTimes(1);
+    expect(up).toBeCalledTimes(1);
+    expect(seed).toBeCalledTimes(0);
+    expect(close).toBeCalledTimes(1);
+
+    await expect(cmd.handler({ seed: '' } as any)).resolves.toBeUndefined();
+    expect(dropSchema).toBeCalledTimes(2);
+    expect(up).toBeCalledTimes(2);
+    expect(seed).toBeCalledTimes(1);
+    expect(seed).toBeCalledWith(orm.config.get('seeder').defaultSeeder);
+    expect(close).toBeCalledTimes(2);
+
+    await expect(cmd.handler({ seed: 'UsersSeeder' } as any)).resolves.toBeUndefined();
+    expect(dropSchema).toBeCalledTimes(3);
+    expect(up).toBeCalledTimes(3);
+    expect(seed).toBeCalledTimes(2);
+    expect(seed).toBeCalledWith('UsersSeeder');
+    expect(close).toBeCalledTimes(3);
+  });
+
+});

--- a/tests/database/seeder/book3.seeder.ts
+++ b/tests/database/seeder/book3.seeder.ts
@@ -1,0 +1,10 @@
+import { EntityManager } from '@mikro-orm/core';
+import { Seeder } from '@mikro-orm/seeder';
+
+export class Book3Seeder extends Seeder {
+
+  run(em: EntityManager): Promise<void> {
+    return Promise.resolve(undefined);
+  }
+
+}

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -28,14 +28,18 @@ describe('CLIHelper', () => {
       'generate-entities',
       'database:create',
       'database:import',
+      'seeder:run',
+      'seeder:create',
       'schema:create',
       'schema:drop',
       'schema:update',
+      'schema:fresh',
       'migration:create',
       'migration:up',
       'migration:down',
       'migration:list',
       'migration:pending',
+      'migration:fresh',
       'debug',
     ]);
   });
@@ -206,6 +210,16 @@ describe('CLIHelper', () => {
     expect(args.option.mock.calls[3][1]).toMatchObject({ type: 'boolean' });
     expect(args.option.mock.calls[4][0]).toBe('drop-tables');
     expect(args.option.mock.calls[4][1]).toMatchObject({ type: 'boolean' });
+  });
+
+  test('builder (schema fresh)', async () => {
+    const args = { option: jest.fn() };
+    SchemaCommandFactory.configureSchemaCommand(args as any, 'fresh');
+    expect(args.option.mock.calls.length).toBe(2);
+    expect(args.option.mock.calls[0][0]).toBe('r');
+    expect(args.option.mock.calls[0][1]).toMatchObject({ alias: 'run', type: 'boolean' });
+    expect(args.option.mock.calls[1][0]).toBe('seed');
+    expect(args.option.mock.calls[1][1]).toMatchObject({ type: 'string' });
   });
 
   test('dump', async () => {

--- a/tests/seeder/entities/house.entity.ts
+++ b/tests/seeder/entities/house.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Project } from './project.entity';
+
+@Entity()
+export class House {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  address!: string;
+
+  @Property()
+  bought = false;
+
+  @ManyToOne(() => Project)
+  project!: Project;
+
+  @Property()
+  createdAt: Date = new Date();
+
+}

--- a/tests/seeder/entities/project.entity.ts
+++ b/tests/seeder/entities/project.entity.ts
@@ -1,0 +1,25 @@
+import { Collection, Entity, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
+import { House } from './house.entity';
+
+@Entity()
+export class Project {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property()
+  owner!: string;
+
+  @Property()
+  worth!: number;
+
+  @OneToMany(() => House, house => house.project)
+  houses = new Collection<House>(this);
+
+  @Property()
+  createdAt: Date = new Date();
+
+}

--- a/tests/seeder/entities/user.entity.ts
+++ b/tests/seeder/entities/user.entity.ts
@@ -1,0 +1,21 @@
+import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity()
+export class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property()
+  email!: string;
+
+  @Property()
+  password!: string;
+
+  @Property()
+  createdAt: Date = new Date();
+
+}

--- a/tests/seeder/factory.test.ts
+++ b/tests/seeder/factory.test.ts
@@ -1,0 +1,119 @@
+import { MikroORM } from '@mikro-orm/core';
+import { Factory } from '@mikro-orm/seeder';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+import * as Faker from 'faker';
+import { House } from './entities/house.entity';
+import { Project } from './entities/project.entity';
+
+export class ProjectFactory extends Factory<Project> {
+
+  model = Project;
+
+  definition(faker: typeof Faker): Partial<Project> {
+    return {
+      name: 'Money vault',
+      owner: faker.name.findName(),
+      worth: 120000,
+    };
+  }
+
+}
+
+export class HouseFactory extends Factory<House> {
+
+  model = House;
+
+  definition(faker: typeof Faker): Partial<House> {
+    return {
+      address: faker.address.city(),
+    };
+  }
+
+}
+
+describe('Factory', () => {
+
+  let orm: MikroORM<SqliteDriver>;
+  let projectCountBefore: number;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Project, House],
+      type: 'sqlite',
+      dbName: ':memory:',
+    });
+    await orm.getSchemaGenerator().createSchema();
+  });
+
+  afterAll(() => orm.close(true));
+
+  beforeEach(async () => {
+    projectCountBefore = (await orm.em.findAndCount(Project, {}))[1];
+    orm.em.clear();
+  });
+
+  test('that a factory can make a single instance of an entity without saving it in the database', async () => {
+    const project = new ProjectFactory(orm.em).makeOne();
+    expect(project).toBeInstanceOf(Project);
+    expect(project.id).toBeUndefined();
+
+    const projectCountAfter = (await orm.em.findAndCount(Project, {}))[1];
+    expect(projectCountAfter).toEqual(projectCountBefore);
+  });
+
+  test('that a factory can create a single instance of an entity and save it in the database', async () => {
+    const projectSaved = await new ProjectFactory(orm.em).createOne();
+    expect(projectSaved).toBeInstanceOf(Project);
+    expect(projectSaved.id).toBeDefined();
+    const projectCountAfter = (await orm.em.findAndCount(Project, {}))[1];
+    expect(projectCountAfter).toEqual(projectCountBefore + 1);
+  });
+
+  test('that a factory can make multiple instances of an entity without saving them in the database', async () => {
+    const projects = new ProjectFactory(orm.em).make(5);
+    expect(projects).toBeInstanceOf(Array);
+    expect(projects.length).toBe(5);
+    const projectCountAfter = (await orm.em.findAndCount(Project, {}))[1];
+    expect(projectCountAfter).toEqual(projectCountBefore);
+  });
+
+  test('that a factory can create multiple instances of an entity and save them in the database', async () => {
+    const projectSaved = await new ProjectFactory(orm.em).create(5);
+    expect(projectSaved).toBeInstanceOf(Array);
+    expect(projectSaved.length).toBe(5);
+    const projectCountAfter = (await orm.em.findAndCount(Project, {}))[1];
+    expect(projectCountAfter).toEqual(projectCountBefore + 5);
+  });
+
+  test('that properties of the factory can be overwritten', async () => {
+    const projectDefault = new ProjectFactory(orm.em).makeOne();
+
+    expect(projectDefault.worth).toBe(120000);
+
+    const project = new ProjectFactory(orm.em)
+      .makeOne({
+        worth: 36,
+      }) as Project;
+    expect(project.worth).toBe(36);
+  });
+
+  test('that relations can be populated on an entity', async () => {
+    const project = new ProjectFactory(orm.em)
+      .each((p: Project) => {
+        p.houses.set(new HouseFactory(orm.em).make(2));
+      })
+      .makeOne();
+    expect(project.houses.count()).toBe(2);
+  });
+
+  test('that relations can be populated on an entity and saved at once', async () => {
+    const project = await new ProjectFactory(orm.em)
+      .each((p: Project) => {
+        p.houses.set(new HouseFactory(orm.em).make(2));
+      })
+      .createOne();
+    expect(project.houses.count()).toBe(2);
+    expect(project.id).toBeDefined();
+    expect(project.houses.getItems()[0].id).toBeDefined();
+  });
+});

--- a/tests/seeder/run-seeders.test.ts
+++ b/tests/seeder/run-seeders.test.ts
@@ -1,0 +1,74 @@
+import { EntityManager, MikroORM } from '@mikro-orm/core';
+import { Seeder } from '@mikro-orm/seeder';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+import { House } from './entities/house.entity';
+import { Project } from './entities/project.entity';
+import { User } from './entities/user.entity';
+
+class ProjectSeeder extends Seeder {
+
+  async run(em: EntityManager): Promise<void> {
+    const project = em.create(Project, {
+      name: 'Construction',
+      owner: 'Donald Duck',
+      worth: 313,
+    });
+    await em.persistAndFlush(project);
+    em.clear();
+  }
+
+}
+
+class UserSeeder extends Seeder {
+
+  async run(em: EntityManager): Promise<void> {
+    const user = em.create(User, {
+      name: 'Scrooge McDuck',
+      email: 'scrooge@money.dc',
+      password: 'MoneyIsForSwimming',
+    });
+    await em.persistAndFlush(user);
+    em.clear();
+  }
+
+}
+
+class DatabaseSeeder extends Seeder {
+
+  run(em: EntityManager): Promise<void> {
+    return this.call(em, [
+      ProjectSeeder,
+      UserSeeder,
+    ]);
+  }
+
+}
+
+
+describe('Run seeders', () => {
+
+  let orm: MikroORM<SqliteDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Project, User, House],
+      type: 'sqlite',
+      dbName: ':memory:',
+    });
+    await orm.getSchemaGenerator().createSchema();
+  });
+
+  afterAll(() => orm.close(true));
+
+  test('that by calling DatabaseSeeder both ProjectSeeder and UserSeeder have been called', async () => {
+
+    const seeder = new DatabaseSeeder();
+    await seeder.run(orm.em);
+
+    const projects = await orm.em.findAndCount(Project, {});
+    expect(projects[1]).toBe(1);
+
+    const users = await orm.em.findAndCount(User, {});
+    expect(users[1]).toBe(1);
+  });
+});

--- a/tests/seeder/seed-manager.test.ts
+++ b/tests/seeder/seed-manager.test.ts
@@ -1,0 +1,90 @@
+import SpyInstance = jest.SpyInstance;
+
+(global as any).process.env.FORCE_COLOR = 0;
+const { Author3, Book3 } = require('../entities-js/index');
+
+import { Configuration, EntityManager, MikroORM } from '@mikro-orm/core';
+import { SeedManager, Seeder } from '@mikro-orm/seeder';
+import { SchemaGenerator, SqliteDriver } from '@mikro-orm/sqlite';
+// noinspection ES6PreferShortImport
+import { initORMSqlite } from '../bootstrap';
+import { Book3Seeder } from '../database/seeder/book3.seeder';
+import { remove } from 'fs-extra';
+
+const configuration = new Configuration({ type: 'mongo', dbName: 'test', entities: ['entities'], clientUrl: 'test' });
+const close = jest.fn();
+jest.spyOn(MikroORM.prototype, 'close').mockImplementation(close);
+const createSchema = jest.spyOn(SchemaGenerator.prototype, 'createSchema');
+createSchema.mockImplementation(async () => void 0);
+const dropSchema = jest.spyOn(SchemaGenerator.prototype, 'dropSchema');
+dropSchema.mockImplementation(async () => void 0);
+
+class Author3Seeder extends Seeder {
+
+  run(em: EntityManager): Promise<void> {
+    return Promise.resolve(undefined);
+  }
+
+}
+
+describe('MikroOrmSeeder', () => {
+
+  let orm: MikroORM<SqliteDriver>;
+  let getORMMock: SpyInstance;
+
+  beforeAll(async () => {
+    orm = await initORMSqlite();
+    getORMMock = jest.spyOn(MikroORM, 'init');
+    getORMMock.mockResolvedValue(orm);
+  });
+
+  afterAll(async () => await orm.close(true));
+
+  test('refreshDatabase', async () => {
+    const seeder = orm.getSeeder();
+    await seeder.refreshDatabase();
+    expect(dropSchema).toHaveBeenCalledTimes(1);
+    expect(createSchema).toHaveBeenCalledTimes(1);
+  });
+
+  test('seed', async () => {
+    const seeder = orm.getSeeder();
+    const bookRunMock = jest.spyOn(Book3Seeder.prototype, 'run');
+    bookRunMock.mockImplementation(async () => void 0);
+    const authorRunMock = jest.spyOn(Author3Seeder.prototype, 'run');
+    authorRunMock.mockImplementation(async () => void 0);
+
+    await seeder.seed(Book3Seeder);
+    expect(bookRunMock).toHaveBeenCalledTimes(1);
+    await seeder.seed(Book3Seeder, Author3Seeder);
+    expect(bookRunMock).toHaveBeenCalledTimes(2);
+    expect(authorRunMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('seedString', async () => {
+    orm.config.set('seeder', { path: 'database/seeder', defaultSeeder: 'DatabaseSeeder' });
+    const seeder = orm.getSeeder();
+    const seedMock = jest.spyOn(SeedManager.prototype, 'seed');
+    seedMock.mockImplementation(async () => void 0);
+    jest.mock(`${process.cwd()}/database/seeder/book3.seeder.ts`, () => {
+      return Book3Seeder;
+    }, { virtual: true });
+    jest.mock(`${process.cwd()}/database/seeder/author3.seeder.ts`, () => {
+      return Book3Seeder;
+    }, { virtual: true });
+
+    await seeder.seedString('Book3Seeder');
+    expect(seedMock).toHaveBeenCalledTimes(1);
+    await seeder.seedString('Book3Seeder', 'Author3Seeder');
+    expect(seedMock).toHaveBeenCalledTimes(3);
+  });
+
+  test('createSeeder', async () => {
+    orm.config.set('seeder', { path: './database/seeder', defaultSeeder: 'DatabaseSeeder' });
+    const seeder = orm.getSeeder();
+
+    const seederFile = await seeder.createSeeder('Book3Seeder');
+    expect(seederFile).toBe(`./database/seeder/book3.seeder.ts`);
+    await remove('./database');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1611,6 +1611,11 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
+"@types/faker@^5.1.6":
+  version "5.5.5"
+  resolved "https://registry.yarnpkg.com/@types/faker/-/faker-5.5.5.tgz#b2e60fd1c3e2e5911791425b37b936faf4adc1af"
+  integrity sha512-TNR5SjCg8sSfU4bdXsPJlpLXOH4YGBCVggvdZnttD2SMiONSxfJm231Nxn1VaQWWF2Twl4Wr2KC1hYaNd4M5Zw==
+
 "@types/fs-extra@9.0.11":
   version "9.0.11"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.11.tgz#8cc99e103499eab9f347dbc6ca4e99fb8d2c2b87"
@@ -3616,6 +3621,11 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
+
+faker@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-5.4.0.tgz#f18e55993c6887918182b003d163df14daeb3011"
+  integrity sha512-Y9n/Ky/xZx/Bj8DePvXspUYRtHl/rGQytoIT5LaxmNwSe3wWyOeOXb3lT6Dpipq240PVpeFaGKzScz/5fvff2g==
 
 fast-deep-equal@^3.1.1:
   version "3.1.3"


### PR DESCRIPTION
Currently this is still a WIP, but I am opening the PR already to gather some feedback. Nothing from this code has been tested yet and I am not even sure it will transpile or pass eslint and/or prettier.

todo:
- [x] Add documentation for the other CLI commands
- [x] Add configurable seeder class for `--seed` option for migration and schema fresh commands
- [x] Add configurable default seed class for fresh commands
- [x] Add documentation on the config option for the path for seed files
- [x] Refactor seed commands to `seed:action`
- [x] Add `seed:create` command for creating a seeder class

Closes #251 