### PR TITLE
fix: allow trailing comma in tsconfig file

### DIFF
--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -82,7 +82,7 @@ export class ConfigurationLoader {
 
   static async getTsConfig(tsConfigPath: string): Promise<Dictionary> {
     const json = await readFile(tsConfigPath);
-    return JSON.parse(stripJsonComments(json.toString()));
+    return JSON.parse(stripJsonComments(JSON.stringify(json)));
   }
 
 }

--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -82,7 +82,7 @@ export class ConfigurationLoader {
 
   static async getTsConfig(tsConfigPath: string): Promise<Dictionary> {
     const json = await readFile(tsConfigPath);
-    return JSON.parse(stripJsonComments(JSON.stringify(json)));
+    return JSON.parse(stripJsonComments(JSON.stringify(json.toString())));
   }
 
 }


### PR DESCRIPTION
Given the following `tsconfig.json`:

```json
{
  "compilerOptions": {
    "module": "commonjs",
    "target": "es2018",
    "experimentalDecorators": true,
    "emitDecoratorMetadata": true,
    "sourceMap": true,
    "declaration": true,
    "strictNullChecks": true,
    "noUnusedLocals": false,
    "allowUnusedLabels": false,
    "noUnusedParameters": false,
    "pretty": true,
    "skipLibCheck": true,
    "lib": ["es2018", "esnext.asynciterable"],
    "noImplicitAny": false,
    "resolveJsonModule": true,
  },
  "sourceMap": true,
  "outDir": ".build",
  "moduleResolution": "node",
  "rootDir": "./src",
}
```

As you can see ` "resolveJsonModule": true,` and `"rootDir": "./src",` have an extra comma at the end of their line. Now If we run  migration `mikro-orm migration:create` we will get the following error:

```js
(node:7982) UnhandledPromiseRejectionWarning: SyntaxError: Unexpected token } in JSON at position 472
    at JSON.parse (<anonymous>)
    at Function.getTsConfig (/Users/myuser/Documents/Projects/myproject/node_modules/@mikro-orm/core/utils/ConfigurationLoader.js:71:21)
    at Function.registerTsNode (/Users/myuser/Documents/Projects/myproject/node_modules/@mikro-orm/core/utils/ConfigurationLoader.js:58:30)
    at Function.configure (/Users/myuser/Documents/Projects/myproject/node_modules/@mikro-orm/cli/CLIConfigurator.js:20:13)
    at /Users/myuser/Documents/Projects/myproject/node_modules/@mikro-orm/cli/cli.js:16:19
(node:7982) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:7982) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
✨  Done in 1.23s.
```

The problem is that `JSON.parse()` doesn’t support trailing commas. I added `JSON.stringify` to ignore the trailing comma.