### PR TITLE
docs: update deployment webpack config due to v4 release

### DIFF
--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -177,7 +177,7 @@ for (const devDependency of Object.keys(devDependencies)) {
 const optionalModules = new Set([
   ...Object.keys(require('knex/package.json').browser),
   ...Object.keys(require('@mikro-orm/core/package.json').peerDependencies),
-  ...Object.keys(require('@mikro-orm/core/package.json').devDependencies)
+  ...Object.keys(require('@mikro-orm/core/package.json').devDependencies || {})
 ]);
 
 module.exports = {
@@ -239,7 +239,7 @@ module.exports = {
     new EnvironmentPlugin({ WEBPACK: true }),
     new IgnorePlugin({
       checkResource: resource => {
-        const [baseResource] = resource.split('/');
+        const baseResource = resource.split('/', resource[0] === '@' ? 2 : 1).join('/');
 
         if (optionalModules.has(baseResource)) {
           try {

--- a/docs/versioned_docs/version-4.2/deployment.md
+++ b/docs/versioned_docs/version-4.2/deployment.md
@@ -177,7 +177,7 @@ for (const devDependency of Object.keys(devDependencies)) {
 const optionalModules = new Set([
   ...Object.keys(require('knex/package.json').browser),
   ...Object.keys(require('@mikro-orm/core/package.json').peerDependencies),
-  ...Object.keys(require('@mikro-orm/core/package.json').devDependencies)
+  ...Object.keys(require('@mikro-orm/core/package.json').devDependencies || {})
 ]);
 
 module.exports = {
@@ -239,7 +239,7 @@ module.exports = {
     new EnvironmentPlugin({ WEBPACK: true }),
     new IgnorePlugin({
       checkResource: resource => {
-        const [baseResource] = resource.split('/');
+        const [baseResource] = resource.split("/", resource[0] === "@" ? 2 : 1).join("/");
 
         if (optionalModules.has(baseResource)) {
           try {

--- a/docs/versioned_docs/version-4.2/deployment.md
+++ b/docs/versioned_docs/version-4.2/deployment.md
@@ -239,7 +239,7 @@ module.exports = {
     new EnvironmentPlugin({ WEBPACK: true }),
     new IgnorePlugin({
       checkResource: resource => {
-        const [baseResource] = resource.split("/", resource[0] === "@" ? 2 : 1).join("/");
+        const baseResource = resource.split("/", resource[0] === "@" ? 2 : 1).join("/");
 
         if (optionalModules.has(baseResource)) {
           try {


### PR DESCRIPTION
- devDependencies defaults to empty object - @mikro-orm/core doesn't have devDependecies in its package.json so webpack throws error
- check is optional package is not like @mikro-orm/... - like all database adapters dependencies - if so than check extended name  (@mikro-orm/mssql) in optional dependencies