### PR TITLE
Added reproduction for transactional() with pool of 1 timeout.

### DIFF
--- a/tests/issues/GH947.test.ts
+++ b/tests/issues/GH947.test.ts
@@ -1,0 +1,35 @@
+import { Entity, PrimaryKey, MikroORM } from '@mikro-orm/core';
+
+@Entity()
+class A {
+
+  @PrimaryKey()
+  id!: number;
+
+}
+
+describe('GH issue 947', () => {
+
+  test(`transactional works with a single postgres connection`, async () => {
+    const orm = await MikroORM.init({
+      entities: [A],
+      dbName: `mikro_orm_test_gh_947`,
+      type: 'postgresql',
+      pool: {
+        min: 1,
+        max: 1,
+      },
+    });
+    await orm.getSchemaGenerator().ensureDatabase();
+    await orm.getSchemaGenerator().dropSchema();
+    await orm.getSchemaGenerator().createSchema();
+
+    await orm.em.transactional(async () => {
+      await orm.em.find(A, {});
+    });
+
+    await orm.close();
+
+  });
+
+});

--- a/tests/issues/GH947.test.ts
+++ b/tests/issues/GH947.test.ts
@@ -27,7 +27,8 @@ describe('GH issue 947', () => {
 
     await orm.em.transactional(async transactionalEm => {
       // Comment this line out and the test will pass.
-      await transactionalEm.getConnection().execute(`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`);
+      const ctx = transactionalEm.getTransactionContext();
+      await transactionalEm.getConnection().execute(`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`, ctx);
       await transactionalEm.persistAndFlush(new A());
     });
 

--- a/tests/issues/GH947.test.ts
+++ b/tests/issues/GH947.test.ts
@@ -8,6 +8,7 @@ class A {
 
 }
 
+
 describe('GH issue 947', () => {
 
   test(`transactional works with a single postgres connection`, async () => {
@@ -25,7 +26,9 @@ describe('GH issue 947', () => {
     await orm.getSchemaGenerator().createSchema();
 
     await orm.em.transactional(async transactionalEm => {
-      await transactionalEm.find(A, {});
+      // Comment this line out and the test will pass.
+      await transactionalEm.getConnection().execute(`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`);
+      await transactionalEm.persistAndFlush(new A());
     });
 
     await orm.close();

--- a/tests/issues/GH947.test.ts
+++ b/tests/issues/GH947.test.ts
@@ -28,7 +28,7 @@ describe('GH issue 947', () => {
     await orm.em.transactional(async transactionalEm => {
       // Comment this line out and the test will pass.
       const ctx = transactionalEm.getTransactionContext();
-      await transactionalEm.getConnection().execute(`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`, ctx);
+      await transactionalEm.getConnection().execute(`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`, undefined, undefined, ctx);
       await transactionalEm.persistAndFlush(new A());
     });
 

--- a/tests/issues/GH947.test.ts
+++ b/tests/issues/GH947.test.ts
@@ -24,8 +24,8 @@ describe('GH issue 947', () => {
     await orm.getSchemaGenerator().dropSchema();
     await orm.getSchemaGenerator().createSchema();
 
-    await orm.em.transactional(async () => {
-      await orm.em.find(A, {});
+    await orm.em.transactional(async transactionalEm => {
+      await transactionalEm.find(A, {});
     });
 
     await orm.close();


### PR DESCRIPTION
This replicates #947.