### PR TITLE
feat(core): maintain transaction context automatically

### DIFF
--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -6,7 +6,7 @@ import { IdentifiedReference, Reference } from './Reference';
 
 export class EntityRepository<T extends AnyEntity<T>> {
 
-  constructor(protected readonly em: EntityManager,
+  constructor(protected readonly _em: EntityManager,
               protected readonly entityName: EntityName<T>) { }
 
   /**
@@ -51,7 +51,6 @@ export class EntityRepository<T extends AnyEntity<T>> {
   async findOne<P extends Populate<T> = any>(where: FilterQuery<T>, populate?: P | FindOneOptions<T, P>, orderBy?: QueryOrderMap): Promise<Loaded<T, P> | null> {
     return this.em.findOne<T, P>(this.entityName, where, populate as P, orderBy);
   }
-
 
   /**
    * Finds first entity matching your `where` query. If nothing found, it will throw an error.
@@ -274,6 +273,10 @@ export class EntityRepository<T extends AnyEntity<T>> {
    */
   async count(where: FilterQuery<T> = {}, options: CountOptions<T> = {}): Promise<number> {
     return this.em.count<T>(this.entityName, where, options);
+  }
+
+  protected get em(): EntityManager {
+    return this._em.getContext();
   }
 
 }

--- a/packages/core/src/utils/TransactionContext.ts
+++ b/packages/core/src/utils/TransactionContext.ts
@@ -1,0 +1,43 @@
+import domain, { Domain } from 'domain';
+import { EntityManager } from '../EntityManager';
+import { Dictionary } from '../typings';
+
+export type TXDomain = Domain & { __mikro_orm_tx_context?: TransactionContext };
+
+export class TransactionContext {
+
+  readonly id = this.em.id;
+
+  constructor(readonly em: EntityManager) { }
+
+  /**
+   * Creates new TransactionContext instance and runs the code inside its domain.
+   * Async variant, when the `next` handler needs to be awaited (like in Koa).
+   */
+  static async createAsync<T>(em: EntityManager, next: (...args: any[]) => Promise<T>): Promise<T> {
+    const context = new TransactionContext(em);
+    const d = domain.create() as TXDomain;
+    d.__mikro_orm_tx_context = context;
+
+    return new Promise((resolve, reject) => {
+      d.run(() => next().then(resolve).catch(reject));
+    });
+  }
+
+  /**
+   * Returns current TransactionContext (if available).
+   */
+  static currentTransactionContext(): TransactionContext | undefined {
+    const active = (domain as Dictionary).active as TXDomain;
+    return active ? active.__mikro_orm_tx_context : undefined;
+  }
+
+  /**
+   * Returns current EntityManager (if available).
+   */
+  static getEntityManager(): EntityManager | undefined {
+    const context = TransactionContext.currentTransactionContext();
+    return context ? context.em : undefined;
+  }
+
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -3,6 +3,7 @@ export * from './ConfigurationLoader';
 export * from './Logger';
 export * from './Utils';
 export * from './RequestContext';
+export * from './TransactionContext';
 export * from './QueryHelper';
 export * from './NullHighlighter';
 export * from './EntityComparator';

--- a/packages/knex/src/SqlEntityRepository.ts
+++ b/packages/knex/src/SqlEntityRepository.ts
@@ -5,9 +5,9 @@ import { QueryBuilder } from './query';
 
 export class SqlEntityRepository<T> extends EntityRepository<T> {
 
-  constructor(protected readonly em: SqlEntityManager,
+  constructor(protected readonly _em: SqlEntityManager,
               protected readonly entityName: EntityName<T>) {
-    super(em, entityName);
+    super(_em, entityName);
   }
 
   /**
@@ -22,6 +22,10 @@ export class SqlEntityRepository<T> extends EntityRepository<T> {
    */
   getKnex(type?: 'read' | 'write'): Knex {
     return this.em.getConnection(type).getKnex();
+  }
+
+  protected get em(): SqlEntityManager {
+    return this._em.getContext() as SqlEntityManager;
   }
 
 }

--- a/packages/mongodb/src/MongoEntityRepository.ts
+++ b/packages/mongodb/src/MongoEntityRepository.ts
@@ -3,9 +3,9 @@ import { MongoEntityManager } from './MongoEntityManager';
 
 export class MongoEntityRepository<T> extends EntityRepository<T> {
 
-  constructor(protected readonly em: MongoEntityManager,
+  constructor(protected readonly _em: MongoEntityManager,
               protected readonly entityName: EntityName<T>) {
-    super(em, entityName);
+    super(_em, entityName);
   }
 
   /**
@@ -13,6 +13,10 @@ export class MongoEntityRepository<T> extends EntityRepository<T> {
    */
   async aggregate(pipeline: any[]): Promise<any[]> {
     return this.em.aggregate(this.entityName, pipeline);
+  }
+
+  protected get em(): MongoEntityManager {
+    return this._em.getContext() as MongoEntityManager;
   }
 
 }

--- a/tests/EntityRepository.test.ts
+++ b/tests/EntityRepository.test.ts
@@ -27,9 +27,11 @@ const methods = {
   nativeDelete: jest.fn(),
   aggregate: jest.fn(),
   config: new Configuration({ type: 'mongo' } as any, false),
+  getContext: () => undefined as any,
 };
 const Mock = jest.fn<EntityManager, any>(() => methods as any);
 const em = new Mock();
+methods.getContext = () => em;
 const repo = new EntityRepository(em, Publisher);
 
 const MongoMock = jest.fn<MongoEntityManager, any>(() => methods as any);


### PR DESCRIPTION
Domain API is now used behind the scenes to automatically bare the tx context. This means
we can now use any EM, repository or a service (from DI), regardless of what EM instance
they were created from.

```ts
// this repo is based on `orm.em`, but thanks `TransactionContext` helper,
// it will use the right EM behind the scenes when used inside `em.transactional()`
const repo = orm.em.getRepository(Author4);

await orm.em.transactional(async () => {
  const a = await repo.findOneOrFail(god1);
  a.name = 'abc';
});
```