### PR TITLE
feat(query-builder): allow mapping of complex joined results

### DIFF
--- a/docs/docs/query-builder.md
+++ b/docs/docs/query-builder.md
@@ -177,6 +177,21 @@ console.log(qb.getQuery());
 // limit ? offset ?
 ```
 
+## Mapping joined results
+
+To select multiple entities and map them from `QueryBuilder`, we can use
+`joinAndSelect` or `leftJoinAndSelect` method:
+
+```ts
+// `res` will contain array of authors, with books and their tags populated
+const res = await orm.em.createQueryBuilder(Author, 'a')
+  .select('*')
+  .leftJoinAndSelect('a.books', 'b')
+  .leftJoinAndSelect('b.tags', 't')
+  .where({ 't.name': ['sick', 'sexy'] })
+  .getResultList();
+```
+
 ## Complex Where Conditions
 
 There are multiple ways to construct complex query conditions. You can either write parts of SQL

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -204,7 +204,10 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     throw new Error(`Pessimistic locks are not supported by ${this.constructor.name} driver`);
   }
 
-  protected shouldHaveColumn<T extends AnyEntity<T>>(prop: EntityProperty<T>, populate: PopulateOptions<T>[], includeFormulas = true): boolean {
+  /**
+   * @internal
+   */
+  shouldHaveColumn<T extends AnyEntity<T>>(prop: EntityProperty<T>, populate: PopulateOptions<T>[], includeFormulas = true): boolean {
     if (prop.formula) {
       return includeFormulas;
     }

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -434,7 +434,10 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     });
   }
 
-  protected mergeJoinedResult<T extends AnyEntity<T>>(rawResults: Dictionary[], meta: EntityMetadata<T>): EntityData<T>[] {
+  /**
+   * @internal
+   */
+  mergeJoinedResult<T extends AnyEntity<T>>(rawResults: Dictionary[], meta: EntityMetadata<T>): EntityData<T>[] {
     // group by the root entity primary key first
     const res = rawResults.reduce((result, item) => {
       const pk = Utils.getCompositeKeyHash<T>(item as T, meta);
@@ -469,7 +472,10 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return fields;
   }
 
-  protected mapPropToFieldNames<T extends AnyEntity<T>>(qb: QueryBuilder<T>, prop: EntityProperty<T>, tableAlias?: string): Field<T>[] {
+  /**
+   * @internal
+   */
+  mapPropToFieldNames<T extends AnyEntity<T>>(qb: QueryBuilder<T>, prop: EntityProperty<T>, tableAlias?: string): Field<T>[] {
     if (prop.formula) {
       const alias = qb.ref(tableAlias ?? qb.alias).toString();
       const aliased = qb.ref(tableAlias ? `${tableAlias}_${prop.fieldNames[0]}` : prop.fieldNames[0]).toString();

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -117,7 +117,7 @@ export class QueryBuilderHelper {
     };
   }
 
-  joinManyToManyReference(prop: EntityProperty, ownerAlias: string, alias: string, pivotAlias: string, type: 'leftJoin' | 'innerJoin' | 'pivotJoin', cond: Dictionary, path?: string): Dictionary<JoinOptions> {
+  joinManyToManyReference(prop: EntityProperty, ownerAlias: string, alias: string, pivotAlias: string, type: 'leftJoin' | 'innerJoin' | 'pivotJoin', cond: Dictionary, path: string): Dictionary<JoinOptions> {
     const ret = {
       [`${ownerAlias}.${prop.name}`]: {
         prop, type, cond, ownerAlias,
@@ -127,12 +127,10 @@ export class QueryBuilderHelper {
         inverseJoinColumns: prop.inverseJoinColumns,
         primaryKeys: prop.referencedColumnNames,
         table: prop.pivotTable,
+        path: path.endsWith('[pivot]') ? path : `${path}[pivot]`,
       } as JoinOptions,
     };
 
-    if (path) {
-      ret[`${ownerAlias}.${prop.name}`].path = path.endsWith('[pivot]') ? path : `${path}[pivot]`;
-    }
 
     if (type === 'pivotJoin') {
       return ret;
@@ -140,10 +138,7 @@ export class QueryBuilderHelper {
 
     const prop2 = this.metadata.find(prop.pivotTable)!.properties[prop.type + (prop.owner ? '_inverse' : '_owner')];
     ret[`${pivotAlias}.${prop2.name}`] = this.joinManyToOneReference(prop2, pivotAlias, alias, type);
-
-    if (path) {
-      ret[`${pivotAlias}.${prop2.name}`].path = path;
-    }
+    ret[`${pivotAlias}.${prop2.name}`].path = path;
 
     return ret;
   }

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -280,7 +280,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     return fields;
   }
 
-  protected shouldHaveColumn<T>(prop: EntityProperty<T>, populate: PopulateOptions<T>[]): boolean {
+  shouldHaveColumn<T>(prop: EntityProperty<T>, populate: PopulateOptions<T>[]): boolean {
     if (super.shouldHaveColumn(prop, populate)) {
       return true;
     }

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -755,7 +755,7 @@ describe('EntityManagerMySql', () => {
     const qb2 = orm.em.createQueryBuilder(Book2);
     const res2 = await qb2.select('*').where({ title: 'not exists' }).getSingleResult();
     expect(res2).toBeNull();
-    const res3 = await qb1.select('*').getResultList();
+    const res3 = await qb1.select('*').getResult();
     expect(res3).toHaveLength(1);
   });
 

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -181,6 +181,28 @@ describe('QueryBuilder', () => {
     expect(qb.getParams()).toEqual(['test 123', 2, 1]);
   });
 
+  test('complex select with mapping of joined results', async () => {
+    const qb = orm.em.createQueryBuilder(FooBar2, 'fb1');
+    qb.select('*').leftJoinAndSelect('fb1.baz', 'fz');
+
+    const err = `Trying to join fz.fooBar, but fooBar is not a defined relation on FooBaz2`;
+    expect(() => qb.leftJoinAndSelect('fz.fooBar', 'fb2')).toThrowError(err);
+
+    qb.leftJoinAndSelect('fz.bar', 'fb2')
+      .where({ 'fz.name': 'baz' })
+      .limit(1);
+    const sql = 'select `fb1`.*, ' +
+      '`fz`.`id` as `fz_id`, `fz`.`name` as `fz_name`, `fz`.`version` as `fz_version`, ' +
+      '`fb2`.`id` as `fb2_id`, `fb2`.`name` as `fb2_name`, `fb2`.`baz_id` as `fb2_baz_id`, `fb2`.`foo_bar_id` as `fb2_foo_bar_id`, `fb2`.`version` as `fb2_version`, `fb2`.`blob` as `fb2_blob`, `fb2`.`array` as `fb2_array`, `fb2`.`object` as `fb2_object`, (select 123) as `fb2_random`, ' +
+      '(select 123) as `random` from `foo_bar2` as `fb1` ' +
+      'left join `foo_baz2` as `fz` on `fb1`.`baz_id` = `fz`.`id` ' +
+      'left join `foo_bar2` as `fb2` on `fz`.`id` = `fb2`.`baz_id` ' +
+      'where `fz`.`name` = ? ' +
+      'limit ?';
+    expect(qb.getQuery()).toEqual(sql);
+    expect(qb.getParams()).toEqual(['baz', 1]);
+  });
+
   test('select leftJoin 1:1 inverse', async () => {
     const qb = orm.em.createQueryBuilder(FooBaz2, 'fz');
     qb.select(['fb.*', 'fz.*'])


### PR DESCRIPTION
To select multiple entities and map them from `QueryBuilder`, we can use
`joinAndSelect` or `leftJoinAndSelect` method:

```ts
// `res` will contain array of authors, with books and their tags populated
const res = await orm.em.createQueryBuilder(Author, 'a')
  .select('*')
  .leftJoinAndSelect('a.books', 'b')
  .leftJoinAndSelect('b.tags', 't')
  .where({ 't.name': ['sick', 'sexy'] })
  .getResultList();
```

Closes #932