### PR TITLE
fix(core): do not override child class properties

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -511,11 +511,11 @@ export class MetadataDiscovery {
     }
 
     let order = this.defineBaseEntityProperties(base);
-    const old = Object.values(meta.properties);
+    const old = Object.values(meta.properties).map(x => x.name);
     meta.properties = { ...base.properties, ...meta.properties };
 
     if (!meta.discriminatorValue) {
-      Object.values(base.properties).filter(prop => !old.includes(prop)).forEach(prop => {
+      Object.values(base.properties).filter(prop => !old.includes(prop.name)).forEach(prop => {
         meta.properties[prop.name] = { ...prop };
         meta.propertyOrder.set(prop.name, (order += 0.01));
       });


### PR DESCRIPTION
when the base class has properties that are also defined in the child class with different options (e.g. nullable or not nullable). the base class property would just override the child properties.
with this change the properties will be filtered out by name and allow the child class to keep its own property definitions while inheriting others from the parent