### PR TITLE
feat(sql): add support for schemas (multi tenancy)

### DIFF
--- a/packages/core/src/connections/Connection.ts
+++ b/packages/core/src/connections/Connection.ts
@@ -22,6 +22,10 @@ export abstract class Connection {
     }
   }
 
+  getSchema(): string|undefined {
+    return undefined;
+  }
+
   /**
    * Establishes connection to database
    */

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -287,6 +287,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
 
 export interface ConnectionOptions {
   dbName?: string;
+  schema?: string;
   name?: string;
   clientUrl?: string;
   host?: string;

--- a/packages/knex/src/AbstractSqlConnection.ts
+++ b/packages/knex/src/AbstractSqlConnection.ts
@@ -16,7 +16,6 @@ export abstract class AbstractSqlConnection extends Connection {
 
   protected platform!: AbstractSqlPlatform;
   protected client!: Knex;
-  knexSchemaGetter: (() => any) | undefined;
 
   constructor(config: Configuration, options?: ConnectionOptions, type?: 'read' | 'write') {
     super(config, options, type);

--- a/packages/knex/src/AbstractSqlConnection.ts
+++ b/packages/knex/src/AbstractSqlConnection.ts
@@ -22,9 +22,6 @@ export abstract class AbstractSqlConnection extends Connection {
     this.patchKnexClient();
   }
 
-  /**
-  * this is required to support schemas for migrations
-  */
   getKnex(): Knex {
     return this.client;
   }

--- a/packages/knex/src/SqlEntityManager.ts
+++ b/packages/knex/src/SqlEntityManager.ts
@@ -14,7 +14,7 @@ export class SqlEntityManager<D extends AbstractSqlDriver = AbstractSqlDriver> e
    */
   createQueryBuilder<T>(entityName: EntityName<T>, alias?: string, type?: 'read' | 'write'): QueryBuilder<T> {
     entityName = Utils.className(entityName);
-    return new QueryBuilder<T>(entityName, this.getMetadata(), this.getDriver(), this.getTransactionContext(), alias, type, this);
+    return new QueryBuilder<T>(entityName, this.getMetadata(), this.getDriver(), this.getTransactionContext(), alias, type, this).withSchema(this.config.get('schema'));
   }
 
   /**

--- a/packages/migrations/src/MigrationGenerator.ts
+++ b/packages/migrations/src/MigrationGenerator.ts
@@ -30,6 +30,12 @@ export class MigrationGenerator {
   createStatement(sql: string, padLeft: number): string {
     if (sql) {
       const padding = ' '.repeat(padLeft);
+      const schema = this.driver.getConnection().getSchema();
+      if (schema) {
+        const regex = new RegExp(`"${schema}"`, 'g');
+        return `${padding}this.addSql(\`${sql.replace(/['\\]/g, '\\\'')
+          .replace(regex, '"${schema}"')}\`);\n`;
+      }
       return `${padding}this.addSql('${sql.replace(/['\\]/g, '\\\'')}');\n`;
     }
 
@@ -42,6 +48,10 @@ export class MigrationGenerator {
     ret += `const Migration = require('@mikro-orm/migrations').Migration;\n\n`;
     ret += `class ${className} extends Migration {\n\n`;
     ret += `  async up() {\n`;
+    const schema = this.driver.getConnection().getSchema();
+    if (schema) {
+      ret += `    const schema = this.config.get('schema');\n`;
+    }
     diff.forEach(sql => ret += this.createStatement(sql, 4));
     ret += `  }\n\n`;
     ret += `}\n`;
@@ -54,6 +64,10 @@ export class MigrationGenerator {
     let ret = `import { Migration } from '@mikro-orm/migrations';\n\n`;
     ret += `export class ${className} extends Migration {\n\n`;
     ret += `  async up(): Promise<void> {\n`;
+    const schema = this.driver.getConnection().getSchema();
+    if (schema) {
+      ret += `    const schema = this.config.get('schema' as any);\n`;
+    }
     diff.forEach(sql => ret += this.createStatement(sql, 4));
     ret += `  }\n\n`;
     ret += `}\n`;

--- a/packages/migrations/src/MigrationStorage.ts
+++ b/packages/migrations/src/MigrationStorage.ts
@@ -42,7 +42,7 @@ export class MigrationStorage {
       return;
     }
 
-    await this.knex.schema.createTable(this.options.tableName!, table => {
+    await this.knex.schema.withSchema(this.connection.getSchema()).createTable(this.options.tableName!, table => {
       table.increments();
       table.string('name');
       table.dateTime('executed_at').defaultTo(this.knex.fn.now());

--- a/packages/migrations/src/MigrationStorage.ts
+++ b/packages/migrations/src/MigrationStorage.ts
@@ -38,11 +38,12 @@ export class MigrationStorage {
   async ensureTable(): Promise<void> {
     const tables = await this.connection.execute<Table[]>(this.helper.getListTablesSQL(), [], 'all', this.masterTransaction);
 
-    if (tables.find(t => t.table_name === this.options.tableName!)) {
+    if (tables.find(t => t.table_name === this.options.tableName! && t.schema_name === this.connection.getSchema())) {
       return;
     }
 
-    await this.knex.schema.withSchema(this.connection.getSchema()).createTable(this.options.tableName!, table => {
+    await this.knex.schema.createSchemaIfNotExists(this.connection.getSchema())
+      .withSchema(this.connection.getSchema()).createTable(this.options.tableName!, table => {
       table.increments();
       table.string('name');
       table.dateTime('executed_at').defaultTo(this.knex.fn.now());

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -7,8 +7,6 @@ import { MigrationRunner } from './MigrationRunner';
 import { MigrationGenerator } from './MigrationGenerator';
 import { MigrationStorage } from './MigrationStorage';
 import { MigrateOptions, MigrationResult, MigrationRow, UmzugMigration } from './typings';
-import fspath from 'path';
-import fs from 'fs';
 
 export class Migrator {
 
@@ -54,39 +52,12 @@ export class Migrator {
 
 
     const migration = await this.generator.generate(diff, path);
-    const result = {
+
+    return {
       fileName: migration[1],
       code: migration[0],
       diff,
     };
-
-    const dir = this.config.get('migrations').path;
-    if (!result.fileName) {
-      return result;
-    }
-
-    const schema = this.config.getDriver().getConnection().getSchema();
-
-    if (!schema) {
-      return result;
-    }
-
-    const file = fspath.join(dir!, result.fileName);
-    let content = fs.readFileSync(file).toString();
-    const regex = new RegExp(`"${schema}"`, 'g');
-
-    content = content
-      .replace(/addSql\('/g, 'addSql(`')
-      .replace(/'\);/g, '`);')
-      .replace(regex, '"${schema}"');
-    content = content.replace(
-      'async up(): Promise<void> {',
-      'async up(): Promise<void> {\n    const schema = this.config.get(\'schema\' as any);\n'
-    );
-    fs.writeFileSync(file, content);
-
-    result.code = content;
-    return result;
   }
 
   async createInitialMigration(path?: string): Promise<MigrationResult> {
@@ -99,38 +70,11 @@ export class Migrator {
       await this.storage.logMigration(migration[1]);
     }
 
-    const result = {
+    return {
       fileName: migration[1],
       code: migration[0],
       diff,
     };
-    const dir = this.config.get('migrations').path;
-    if (!result.fileName) {
-      return result;
-    }
-
-    const schema = this.config.getDriver().getConnection().getSchema();
-    if (!schema) {
-      return result;
-    }
-
-    const file = fspath.join(dir!, result.fileName);
-
-    let content = fs.readFileSync(file).toString();
-    const regex = new RegExp(`"${schema}"`, 'g');
-
-    content = content
-      .replace(/addSql\('/g, 'addSql(`')
-      .replace(/'\);/g, '`);')
-      .replace(regex, '"${schema}"');
-    content = content.replace(
-      'async up(): Promise<void> {',
-      'async up(): Promise<void> {\n    const schema = this.config.get(\'schema\' as any);\n'
-    );
-    fs.writeFileSync(file, content);
-
-    result.code = content;
-    return result;
   }
 
   /**

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -8,6 +8,7 @@ import { PostgreSqlDriver, PostgreSqlConnection } from '@mikro-orm/postgresql';
 import { Address2, Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, PublisherType, PublisherType2, Test2, Label2 } from './entities-sql';
 import { initORMPostgreSql, wipeDatabasePostgreSql } from './bootstrap';
 import { performance } from 'perf_hooks';
+import * as fs from 'fs';
 
 describe('EntityManagerPostgre', () => {
 
@@ -1705,5 +1706,46 @@ describe('EntityManagerPostgre', () => {
   });
 
   afterAll(async () => orm.close(true));
+
+});
+
+
+describe('EntityManagerPostgre schemas', () => {
+  let orm1: MikroORM<PostgreSqlDriver>, orm2: MikroORM<PostgreSqlDriver>;
+  beforeAll(async () => {
+    orm1 = await initORMPostgreSql(undefined, 'test_1');
+    orm2 = await initORMPostgreSql(undefined, 'test_2');
+  });
+
+
+  afterEach(async () => {
+    await wipeDatabasePostgreSql(orm1.em);
+    await wipeDatabasePostgreSql(orm2.em);
+  });
+
+  it('migrate correctly', async () => {
+    fs.mkdirSync('tests/migrations', { recursive: true });
+    const migrator1 = orm1.getMigrator();
+    await migrator1.createMigration();
+    await migrator1.up();
+
+    const migrator2 = orm2.getMigrator();
+    await migrator2.createMigration();
+    await migrator2.up();
+
+    const d = await orm1.connect();
+    const res = await d.execute('select nspname from pg_catalog.pg_namespace;');
+    expect(res.map(x => x.nspname)).toContain('test_1');
+    expect(res.map(x => x.nspname)).toContain('test_2');
+  });
+
+  it('migrate correctly', async () => {
+    orm1.em.create(Author2, {
+      email: 'author@mikro',
+      name: 'mikro',
+      address: 'none',
+    });
+    await orm1.em.flush();
+  });
 
 });

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -1721,6 +1721,8 @@ describe('EntityManagerPostgre multiple schemas', () => {
   afterAll(async () => {
     await orm1.em.getConnection().execute(`drop schema ${orm1.em.getConnection().getSchema()} cascade`);
     await orm2.em.getConnection().execute(`drop schema ${orm2.em.getConnection().getSchema()} cascade`);
+    await orm1.close();
+    await orm2.close();
   });
 
   it('migrate correctly', async () => {

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -1721,8 +1721,8 @@ describe('EntityManagerPostgre multiple schemas', () => {
   afterAll(async () => {
     await orm1.em.getConnection().execute(`drop schema ${orm1.em.getConnection().getSchema()} cascade`);
     await orm2.em.getConnection().execute(`drop schema ${orm2.em.getConnection().getSchema()} cascade`);
-    await orm1.close();
-    await orm2.close();
+    await orm1.close(true);
+    await orm2.close(true);
   });
 
   it('migrate correctly', async () => {

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -110,7 +110,6 @@ export async function initORMPostgreSql(loadStrategy = LoadStrategy.SELECT_IN, s
   }
   const schemaGenerator = new SchemaGenerator(orm.em);
   await schemaGenerator.ensureDatabase();
-  await schemaGenerator.createSchema();
   const connection = orm.em.getConnection();
   await connection.loadFile(__dirname + '/postgre-schema.sql');
   Author2Subscriber.log.length = 0;

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -89,7 +89,7 @@ export async function initORMMySql<D extends MySqlDriver | MariaDbDriver = MySql
   return orm as MikroORM<D>;
 }
 
-export async function initORMPostgreSql(loadStrategy = LoadStrategy.SELECT_IN, schema?: string) {
+export async function initORMPostgreSql(loadStrategy = LoadStrategy.SELECT_IN, schema?: string, skipInit=false) {
   const orm = await MikroORM.init<PostgreSqlDriver>({
     entities: [Author2, Address2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, FooParam2, Label2, Configuration2],
     dbName: `mikro_orm_test`,
@@ -105,10 +105,9 @@ export async function initORMPostgreSql(loadStrategy = LoadStrategy.SELECT_IN, s
     loadStrategy,
   });
 
-  try {
-    await orm.em.getConnection().execute(`drop schema ${orm.em.getConnection().getSchema()} cascade`);
-  } catch (e) {}
-
+  if (skipInit) {
+    return orm;
+  }
   const schemaGenerator = new SchemaGenerator(orm.em);
   await schemaGenerator.ensureDatabase();
   await schemaGenerator.createSchema();


### PR DESCRIPTION
this is to support schemas in e.g . postgres/mysql (multi tenancy)
This should also work for creating migrations.
Each ORM instance can have another schema assigned to work with multiple schemas. (schema passed to MikroORM.init options)

the initial migration files will also support dynamic schema by passing in the schema variable.
e.g.
```
async up(): Promise<void> {
    const schema = this.config.get('schema' as any);

    this.addSql(`create index "${schema}"."BOOKS_KEY_index" on "${schema}"."BOOKS" ("KEY");`);
  }
  ```