### PR TITLE
fix(schema): fix diffing FKs in MySQL 8

### DIFF
--- a/packages/mysql-base/src/MySqlSchemaHelper.ts
+++ b/packages/mysql-base/src/MySqlSchemaHelper.ts
@@ -62,7 +62,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
   }
 
   getForeignKeysSQL(tableName: string, schemaName?: string): string {
-    return `select distinct k.constraint_name, k.column_name, k.referenced_table_name, k.referenced_column_name, c.update_rule, c.delete_rule `
+    return `select distinct k.constraint_name as constraint_name, k.column_name as column_name, k.referenced_table_name as referenced_table_name, k.referenced_column_name as referenced_column_name, c.update_rule as update_rule, c.delete_rule as delete_rule `
       + `from information_schema.key_column_usage k `
       + `inner join information_schema.referential_constraints c on c.constraint_name = k.constraint_name and c.table_name = '${tableName}' `
       + `where k.table_name = '${tableName}' and k.table_schema = database() and c.constraint_schema = database() and k.referenced_column_name is not null`;


### PR DESCRIPTION
It is exactly the same issue as #398 with exactly the same solution. This caused https://github.com/mikro-orm/mikro-orm/blob/master/packages/knex/src/schema/SchemaHelper.ts#L112 to return

```
{
  "undefined": {
    "columnName": undefined,
    "constraintName": undefined,
    "referencedTableName": undefined,
    "referencedColumnName":  undefined,
    "updateRule": undefined,
    "deleteRule": undefined
  }
}
``` 

for all found foreign keys causing all foreign keys to be dropped and re-added.