### PR TITLE
fix(cli): add missing peer dependencies

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,5 +60,29 @@
     "tsconfig-paths": "3.9.0",
     "yargonaut": "1.1.4",
     "yargs": "15.4.1"
+  },
+  "peerDependencies": {
+    "@mikro-orm/mariadb": "^4.0.0",
+    "@mikro-orm/mongodb": "^4.0.0",
+    "@mikro-orm/mysql": "^4.0.0",
+    "@mikro-orm/postgresql": "^4.0.0",
+    "@mikro-orm/sqlite": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@mikro-orm/mariadb": {
+      "optional": true
+    },
+    "@mikro-orm/mongodb": {
+      "optional": true
+    },
+    "@mikro-orm/mysql": {
+      "optional": true
+    },
+    "@mikro-orm/postgresql": {
+      "optional": true
+    },
+    "@mikro-orm/sqlite": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@mikro-orm/cli` has a direct dependency on `@mikro-orm/core` which makes it inherit its peer dependencies but they're not declared as such.

**How did you fix it?**

Explicitly declare the missing optional peer dependencies