### PR TITLE
docs(inheritance-mapping): change extended class name

### DIFF
--- a/docs/docs/inheritance-mapping.md
+++ b/docs/docs/inheritance-mapping.md
@@ -166,7 +166,7 @@ export abstract class BasePerson {
 }
 
 @Entity()
-export class Person extends Base {
+export class Person extends BasePerson {
   // ...
 }
 
@@ -192,7 +192,7 @@ export abstract class BasePerson {
 }
 
 @Entity({ discriminatorValue: 'person' })
-export class Person extends Base {
+export class Person extends BasePerson {
   // ...
 }
 

--- a/docs/versioned_docs/version-4.0/inheritance-mapping.md
+++ b/docs/versioned_docs/version-4.0/inheritance-mapping.md
@@ -165,7 +165,7 @@ export abstract class BasePerson {
 }
 
 @Entity()
-export class Person extends Base {
+export class Person extends BasePerson {
   // ...
 }
 

--- a/docs/versioned_docs/version-4.1/inheritance-mapping.md
+++ b/docs/versioned_docs/version-4.1/inheritance-mapping.md
@@ -165,7 +165,7 @@ export abstract class BasePerson {
 }
 
 @Entity()
-export class Person extends Base {
+export class Person extends BasePerson {
   // ...
 }
 

--- a/docs/versioned_docs/version-4.2/inheritance-mapping.md
+++ b/docs/versioned_docs/version-4.2/inheritance-mapping.md
@@ -166,7 +166,7 @@ export abstract class BasePerson {
 }
 
 @Entity()
-export class Person extends Base {
+export class Person extends BasePerson {
   // ...
 }
 
@@ -192,7 +192,7 @@ export abstract class BasePerson {
 }
 
 @Entity({ discriminatorValue: 'person' })
-export class Person extends Base {
+export class Person extends BasePerson {
   // ...
 }
 


### PR DESCRIPTION
Changed the extended class name from `Base` to `BasePerson`
### Before
```ts
@Entity()
export class Person extends Base {
  // ...
}
```
### After
```ts
@Entity()
export class Person extends BasePerson {
  // ...
}
```