### PR TITLE
fix(core): assign embedded properties from class objects

### DIFF
--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -49,7 +49,7 @@ export class EntityAssigner {
       if (props[prop]?.reference === ReferenceType.EMBEDDED) {
         const Embeddable = props[prop].embeddable;
         entity[props[prop].name] = Object.create(Embeddable.prototype);
-        Utils.merge(entity[prop as keyof T], value);
+        Utils.merge(entity[prop as keyof T], Utils.isPlainObject(value) ? value : { ...value });
         return;
       }
 


### PR DESCRIPTION
This fixes entity assign not merging embedded properties when the source has a prototype.

Closes #1083