### PR TITLE
docs: extra flags on Terser/Webpack configuration

### DIFF
--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -197,6 +197,14 @@ module.exports = {
           // https://terser.org/docs/api-reference.html#mangle-options) but the safest default
           // config is that we simply disable mangling altogether but allow minification to proceed.
           mangle: false,
+          // Similarly, Terser's compression may at its own discretion change function and class names.
+          // While it only rarely does so, it's safest to also disable changing their names here.
+          // This can be controlled in a more granular way if needed (see 
+          // https://terser.org/docs/api-reference.html#compress-options).
+          compress: {
+            keep_classnames: true,
+            keep_fnames: true,
+          },
         }
       })
     ]


### PR DESCRIPTION
I've found that Terser, in some cases, also changes function and class names during its compression phase, even though mangling is disabled. This can cause trouble in some relations and table naming.

This is apparently also documented over at https://terser.org/docs/api-reference.html#mangle-options.

This PR is a minuscule addition to the docs that provides the proper options to Terser to avoid any issues occurring in production.