### PR TITLE
feat(core): implement transaction lifecycle hooks

### DIFF
--- a/packages/core/src/connections/Connection.ts
+++ b/packages/core/src/connections/Connection.ts
@@ -5,6 +5,7 @@ import { Configuration, ConnectionOptions, Utils } from '../utils';
 import { MetadataStorage } from '../metadata';
 import { Dictionary } from '../typings';
 import { Platform } from '../platforms/Platform';
+import { TransactionEventBroadcaster } from '../events/TransactionEventBroadcaster';
 
 export abstract class Connection {
 
@@ -41,19 +42,19 @@ export abstract class Connection {
    */
   abstract getDefaultClientUrl(): string;
 
-  async transactional<T>(cb: (trx: Transaction) => Promise<T>, ctx?: Transaction): Promise<T> {
+  async transactional<T>(cb: (trx: Transaction) => Promise<T>, ctx?: Transaction, eventBroadcaster?: TransactionEventBroadcaster): Promise<T> {
     throw new Error(`Transactions are not supported by current driver`);
   }
 
-  async begin(ctx?: Transaction): Promise<unknown> {
+  async begin(ctx?: Transaction, eventBroadcaster?: TransactionEventBroadcaster): Promise<unknown> {
     throw new Error(`Transactions are not supported by current driver`);
   }
 
-  async commit(ctx: Transaction): Promise<void> {
+  async commit(ctx: Transaction, eventBroadcaster?: TransactionEventBroadcaster): Promise<void> {
     throw new Error(`Transactions are not supported by current driver`);
   }
 
-  async rollback(ctx: Transaction): Promise<void> {
+  async rollback(ctx: Transaction, eventBroadcaster?: TransactionEventBroadcaster): Promise<void> {
     throw new Error(`Transactions are not supported by current driver`);
   }
 
@@ -138,3 +139,9 @@ export interface ConnectionConfig {
 }
 
 export type Transaction<T = any> = T;
+
+export const parentTransactionSymbol = Symbol('parentTransaction');
+
+export function isRootTransaction<T>(trx: Transaction<T>) {
+  return !Object.getOwnPropertySymbols(trx).includes(parentTransactionSymbol);
+}

--- a/packages/core/src/connections/Connection.ts
+++ b/packages/core/src/connections/Connection.ts
@@ -139,9 +139,3 @@ export interface ConnectionConfig {
 }
 
 export type Transaction<T = any> = T;
-
-export const parentTransactionSymbol = Symbol('parentTransaction');
-
-export function isRootTransaction<T>(trx: Transaction<T>) {
-  return !Object.getOwnPropertySymbols(trx).includes(parentTransactionSymbol);
-}

--- a/packages/core/src/enums.ts
+++ b/packages/core/src/enums.ts
@@ -103,4 +103,12 @@ export enum EventType {
   beforeFlush = 'beforeFlush',
   onFlush = 'onFlush',
   afterFlush = 'afterFlush',
+  beforeTransactionStart = 'beforeTransactionStart',
+  afterTransactionStart = 'afterTransactionStart',
+  beforeTransactionCommit = 'beforeTransactionCommit',
+  afterTransactionCommit = 'afterTransactionCommit',
+  beforeTransactionRollback = 'beforeTransactionRollback',
+  afterTransactionRollback = 'afterTransactionRollback',
 }
+
+export type TransactionEventType = EventType.beforeTransactionStart | EventType.afterTransactionStart | EventType.beforeTransactionCommit | EventType.afterTransactionCommit | EventType.beforeTransactionRollback | EventType.afterTransactionRollback;

--- a/packages/core/src/events/EventSubscriber.ts
+++ b/packages/core/src/events/EventSubscriber.ts
@@ -1,6 +1,7 @@
 import { EntityName } from '../typings';
 import { EntityManager } from '../EntityManager';
 import { ChangeSet, UnitOfWork } from '../unit-of-work';
+import { Transaction } from '../connections';
 
 export interface EventArgs<T> {
   entity: T;
@@ -10,6 +11,10 @@ export interface EventArgs<T> {
 
 export interface FlushEventArgs extends Omit<EventArgs<unknown>, 'entity'> {
   uow: UnitOfWork;
+}
+
+export interface TransactionEventArgs extends Omit<EventArgs<unknown>, 'entity' | 'changeSet'> {
+  transaction?: Transaction;
 }
 
 export interface EventSubscriber<T = any> {
@@ -24,4 +29,11 @@ export interface EventSubscriber<T = any> {
   beforeFlush?(args: FlushEventArgs): Promise<void>;
   onFlush?(args: FlushEventArgs): Promise<void>;
   afterFlush?(args: FlushEventArgs): Promise<void>;
+
+  beforeTransactionStart?(args: TransactionEventArgs): Promise<void>;
+  afterTransactionStart?(args: TransactionEventArgs): Promise<void>;
+  beforeTransactionCommit?(args: TransactionEventArgs): Promise<void>;
+  afterTransactionCommit?(args: TransactionEventArgs): Promise<void>;
+  beforeTransactionRollback?(args: TransactionEventArgs): Promise<void>;
+  afterTransactionRollback?(args: TransactionEventArgs): Promise<void>;
 }

--- a/packages/core/src/events/EventSubscriber.ts
+++ b/packages/core/src/events/EventSubscriber.ts
@@ -15,6 +15,7 @@ export interface FlushEventArgs extends Omit<EventArgs<unknown>, 'entity'> {
 
 export interface TransactionEventArgs extends Omit<EventArgs<unknown>, 'entity' | 'changeSet'> {
   transaction?: Transaction;
+  uow?: UnitOfWork;
 }
 
 export interface EventSubscriber<T = any> {

--- a/packages/core/src/events/TransactionEventBroadcaster.ts
+++ b/packages/core/src/events/TransactionEventBroadcaster.ts
@@ -1,15 +1,17 @@
 import { Transaction } from '../connections';
 import { EntityManager } from '../EntityManager';
 import { TransactionEventType } from '../enums';
+import { UnitOfWork } from '../unit-of-work';
 
 export class TransactionEventBroadcaster {
 
   constructor(
-    private entityManager: EntityManager
+    private entityManager: EntityManager,
+    private uow?: UnitOfWork
   ) {}
 
   async dispatchEvent(event: TransactionEventType, transaction?: Transaction) {
-    await this.entityManager.getEventManager().dispatchEvent(event, { em: this.entityManager, transaction });
+    await this.entityManager.getEventManager().dispatchEvent(event, { em: this.entityManager, transaction, uow: this.uow });
   }
 
 }

--- a/packages/core/src/events/TransactionEventBroadcaster.ts
+++ b/packages/core/src/events/TransactionEventBroadcaster.ts
@@ -1,0 +1,15 @@
+import { Transaction } from '../connections';
+import { EntityManager } from '../EntityManager';
+import { TransactionEventType } from '../enums';
+
+export class TransactionEventBroadcaster {
+
+  constructor(
+    private entityManager: EntityManager
+  ) {}
+
+  async dispatchEvent(event: TransactionEventType, transaction?: Transaction) {
+    await this.entityManager.getEventManager().dispatchEvent(event, { em: this.entityManager, transaction });
+  }
+
+}

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -1,2 +1,3 @@
 export * from './EventSubscriber';
 export * from './EventManager';
+export * from './TransactionEventBroadcaster';

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -224,7 +224,7 @@ export class UnitOfWork {
       const runInTransaction = !this.em.isInTransaction() && platform.supportsTransactions() && this.em.config.get('implicitTransactions');
 
       if (runInTransaction) {
-        await this.em.getConnection('write').transactional(trx => this.persistToDatabase(groups, trx), undefined, new TransactionEventBroadcaster(this.em));
+        await this.em.getConnection('write').transactional(trx => this.persistToDatabase(groups, trx), undefined, new TransactionEventBroadcaster(this.em, this));
       } else {
         await this.persistToDatabase(groups, this.em.getTransactionContext());
       }

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -9,6 +9,7 @@ import { EntityManager } from '../EntityManager';
 import { Cascade, EventType, LockMode, ReferenceType } from '../enums';
 import { OptimisticLockError, ValidationError } from '../errors';
 import { Transaction } from '../connections';
+import { TransactionEventBroadcaster } from '../events';
 import { IdentityMap } from './IdentityMap';
 
 export class UnitOfWork {
@@ -223,7 +224,7 @@ export class UnitOfWork {
       const runInTransaction = !this.em.isInTransaction() && platform.supportsTransactions() && this.em.config.get('implicitTransactions');
 
       if (runInTransaction) {
-        await this.em.getConnection('write').transactional(trx => this.persistToDatabase(groups, trx));
+        await this.em.getConnection('write').transactional(trx => this.persistToDatabase(groups, trx), undefined, new TransactionEventBroadcaster(this.em));
       } else {
         await this.persistToDatabase(groups, this.em.getTransactionContext());
       }

--- a/packages/knex/src/AbstractSqlConnection.ts
+++ b/packages/knex/src/AbstractSqlConnection.ts
@@ -1,7 +1,16 @@
 import Knex, { Config, QueryBuilder, Raw, Client, Transaction as KnexTransaction } from 'knex';
 import { readFile } from 'fs-extra';
-import { AnyEntity, Configuration, Connection, ConnectionOptions, EntityData, EventType, isRootTransaction, parentTransactionSymbol, QueryResult, Transaction, TransactionEventBroadcaster, Utils } from '@mikro-orm/core';
+import {
+  AnyEntity, Configuration, Connection, ConnectionOptions, EntityData, EventType, QueryResult,
+  Transaction, TransactionEventBroadcaster, Utils,
+} from '@mikro-orm/core';
 import { AbstractSqlPlatform } from './AbstractSqlPlatform';
+
+const parentTransactionSymbol = Symbol('parentTransaction');
+
+function isRootTransaction<T>(trx: Transaction<T>) {
+  return !Object.getOwnPropertySymbols(trx).includes(parentTransactionSymbol);
+}
 
 export abstract class AbstractSqlConnection extends Connection {
 

--- a/packages/knex/src/AbstractSqlConnection.ts
+++ b/packages/knex/src/AbstractSqlConnection.ts
@@ -1,6 +1,6 @@
 import Knex, { Config, QueryBuilder, Raw, Client, Transaction as KnexTransaction } from 'knex';
 import { readFile } from 'fs-extra';
-import { AnyEntity, Configuration, Connection, ConnectionOptions, EntityData, QueryResult, Transaction, Utils } from '@mikro-orm/core';
+import { AnyEntity, Configuration, Connection, ConnectionOptions, EntityData, EventType, isRootTransaction, parentTransactionSymbol, QueryResult, Transaction, TransactionEventBroadcaster, Utils } from '@mikro-orm/core';
 import { AbstractSqlPlatform } from './AbstractSqlPlatform';
 
 export abstract class AbstractSqlConnection extends Connection {
@@ -30,21 +30,52 @@ export abstract class AbstractSqlConnection extends Connection {
     }
   }
 
-  async transactional<T>(cb: (trx: Transaction<KnexTransaction>) => Promise<T>, ctx?: Transaction<KnexTransaction>): Promise<T> {
-    return (ctx || this.client).transaction(cb);
+  async transactional<T>(cb: (trx: Transaction<KnexTransaction>) => Promise<T>, ctx?: Transaction<KnexTransaction>, eventBroadcaster?: TransactionEventBroadcaster): Promise<T> {
+    const trx = await this.begin(ctx, eventBroadcaster);
+    try {
+      const ret = await cb(trx);
+      await this.commit(trx, eventBroadcaster);
+      return ret;
+    } catch (error) {
+      await this.rollback(trx, eventBroadcaster);
+      throw error;
+    }
   }
 
-  async begin(ctx?: KnexTransaction): Promise<KnexTransaction> {
-    return (ctx || this.client).transaction();
+  async begin(ctx?: KnexTransaction, eventBroadcaster?: TransactionEventBroadcaster): Promise<KnexTransaction> {
+    if (!ctx) {
+      await eventBroadcaster?.dispatchEvent(EventType.beforeTransactionStart);
+    }
+    const trx = await (ctx || this.client).transaction();
+    if (!ctx) {
+      await eventBroadcaster?.dispatchEvent(EventType.afterTransactionStart, trx);
+    } else {
+      trx[parentTransactionSymbol] = ctx;
+    }
+    return trx;
   }
 
-  async commit(ctx: KnexTransaction): Promise<void> {
+  async commit(ctx: KnexTransaction, eventBroadcaster?: TransactionEventBroadcaster): Promise<void> {
+    const runTrxHooks = isRootTransaction(ctx);
+    if (runTrxHooks) {
+      await eventBroadcaster?.dispatchEvent(EventType.beforeTransactionCommit, ctx);
+    }
     ctx.commit();
-    return ctx.executionPromise; // https://github.com/knex/knex/issues/3847#issuecomment-626330453
+    await ctx.executionPromise; // https://github.com/knex/knex/issues/3847#issuecomment-626330453
+    if (runTrxHooks) {
+      await eventBroadcaster?.dispatchEvent(EventType.afterTransactionCommit, ctx);
+    }
   }
 
-  async rollback(ctx: KnexTransaction): Promise<void> {
-    return ctx.rollback();
+  async rollback(ctx: KnexTransaction, eventBroadcaster?: TransactionEventBroadcaster): Promise<void> {
+    const runTrxHooks = isRootTransaction(ctx);
+    if (runTrxHooks) {
+      await eventBroadcaster?.dispatchEvent(EventType.beforeTransactionRollback, ctx);
+    }
+    await ctx.rollback();
+    if (runTrxHooks) {
+      await eventBroadcaster?.dispatchEvent(EventType.afterTransactionRollback, ctx);
+    }
   }
 
   async execute<T extends QueryResult | EntityData<AnyEntity> | EntityData<AnyEntity>[] = EntityData<AnyEntity>[]>(queryOrKnex: string | QueryBuilder | Raw, params: any[] = [], method: 'all' | 'get' | 'run' = 'all', ctx?: Transaction): Promise<T> {

--- a/packages/mongodb/src/MongoConnection.ts
+++ b/packages/mongodb/src/MongoConnection.ts
@@ -163,25 +163,34 @@ export class MongoConnection extends Connection {
   }
 
   async begin(ctx?: ClientSession, eventBroadcaster?: TransactionEventBroadcaster): Promise<ClientSession> {
+    if (!ctx) {
+      /* istanbul ignore next */
+      await eventBroadcaster?.dispatchEvent(EventType.beforeTransactionStart);
+    }
     const session = ctx || this.client.startSession();
     session.startTransaction();
     this.logQuery('db.begin();');
+    /* istanbul ignore next */
     await eventBroadcaster?.dispatchEvent(EventType.afterTransactionStart, session);
 
     return session;
   }
 
   async commit(ctx: ClientSession, eventBroadcaster?: TransactionEventBroadcaster): Promise<void> {
+    /* istanbul ignore next */
     await eventBroadcaster?.dispatchEvent(EventType.beforeTransactionCommit, ctx);
     await ctx.commitTransaction();
     this.logQuery('db.commit();');
+    /* istanbul ignore next */
     await eventBroadcaster?.dispatchEvent(EventType.afterTransactionCommit, ctx);
   }
 
   async rollback(ctx: ClientSession, eventBroadcaster?: TransactionEventBroadcaster): Promise<void> {
+    /* istanbul ignore next */
     await eventBroadcaster?.dispatchEvent(EventType.beforeTransactionRollback, ctx);
     await ctx.abortTransaction();
     this.logQuery('db.rollback();');
+    /* istanbul ignore next */
     await eventBroadcaster?.dispatchEvent(EventType.afterTransactionRollback, ctx);
   }
 

--- a/packages/mongodb/src/MongoConnection.ts
+++ b/packages/mongodb/src/MongoConnection.ts
@@ -5,7 +5,7 @@ import {
 import { inspect } from 'util';
 import {
   Connection, ConnectionConfig, QueryResult, Transaction, Utils, QueryOrder, QueryOrderMap,
-  FilterQuery, AnyEntity, EntityName, Dictionary, EntityData,
+  FilterQuery, AnyEntity, EntityName, Dictionary, EntityData, TransactionEventBroadcaster, EventType,
 } from '@mikro-orm/core';
 
 export class MongoConnection extends Connection {
@@ -148,39 +148,41 @@ export class MongoConnection extends Connection {
     return this.runQuery<T, number>('countDocuments', collection, undefined, where, ctx);
   }
 
-  async transactional<T>(cb: (trx: Transaction<ClientSession>) => Promise<T>, ctx?: Transaction<ClientSession>): Promise<T> {
-    const session = ctx || this.client.startSession();
-    let ret: T = null as unknown as T;
-
+  async transactional<T>(cb: (trx: Transaction<ClientSession>) => Promise<T>, ctx?: Transaction<ClientSession>, eventBroadcaster?: TransactionEventBroadcaster): Promise<T> {
+    const session = await this.begin(ctx, eventBroadcaster);
     try {
-      this.logQuery('db.begin();');
-      await session.withTransaction(async () => ret = await cb(session));
+      const ret = await cb(session);
+      await this.commit(session, eventBroadcaster);
+      return ret;
+    } catch (error) {
+      await this.rollback(session, eventBroadcaster);
+      throw error;
+    } finally {
       session.endSession();
-      this.logQuery('db.commit();');
-    } catch (e) {
-      this.logQuery('db.rollback();');
-      throw e;
     }
-
-    return ret;
   }
 
-  async begin(ctx?: ClientSession): Promise<ClientSession> {
+  async begin(ctx?: ClientSession, eventBroadcaster?: TransactionEventBroadcaster): Promise<ClientSession> {
     const session = ctx || this.client.startSession();
     session.startTransaction();
     this.logQuery('db.begin();');
+    await eventBroadcaster?.dispatchEvent(EventType.afterTransactionStart, session);
 
     return session;
   }
 
-  async commit(ctx: ClientSession): Promise<void> {
+  async commit(ctx: ClientSession, eventBroadcaster?: TransactionEventBroadcaster): Promise<void> {
+    await eventBroadcaster?.dispatchEvent(EventType.beforeTransactionCommit, ctx);
     await ctx.commitTransaction();
     this.logQuery('db.commit();');
+    await eventBroadcaster?.dispatchEvent(EventType.afterTransactionCommit, ctx);
   }
 
-  async rollback(ctx: ClientSession): Promise<void> {
+  async rollback(ctx: ClientSession, eventBroadcaster?: TransactionEventBroadcaster): Promise<void> {
+    await eventBroadcaster?.dispatchEvent(EventType.beforeTransactionRollback, ctx);
     await ctx.abortTransaction();
     this.logQuery('db.rollback();');
+    await eventBroadcaster?.dispatchEvent(EventType.afterTransactionRollback, ctx);
   }
 
   protected logQuery(query: string, took?: number): void {

--- a/tests/issues/GH1175.test.ts
+++ b/tests/issues/GH1175.test.ts
@@ -8,31 +8,16 @@ import {
   EventArgs,
   TransactionEventArgs,
   Transaction,
+  UnitOfWork,
+  Unique,
 } from '@mikro-orm/core';
-import { PostgreSqlDriver, SqlEntityManager } from '@mikro-orm/postgresql';
+import { MongoDriver, ObjectId } from '@mikro-orm/mongodb';
+import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 import { v4 as uuid } from 'uuid';
 
-@Entity({ tableName: 'users' })
-class User {
-
-  @PrimaryKey()
-  id!: number;
-
-  @Property()
-  readonly username: string;
-
-  constructor(username: string) {
-    this.username = username;
-  }
-
-}
-
-class UserSubscriber implements EventSubscriber<User> {
+class UserSubscriber implements EventSubscriber {
 
   pendingActions = new Map<Transaction, (() => void | Promise<void>)[]>();
-  getSubscribedEntities() {
-    return [User];
-  }
 
   async beforeTransactionStart(args: TransactionEventArgs) {
     //
@@ -59,32 +44,20 @@ class UserSubscriber implements EventSubscriber<User> {
     this.pendingActions.delete(em);
   }
 
-  async afterCreate(args: EventArgs<User>) {
+  async afterCreate(args: EventArgs<any>) {
     const { em } = args;
     this.pendingActions.get(em)?.push(() => {
       this.afterCommitCreate(args);
     });
   }
 
-  async afterCommitCreate(args: EventArgs<User>) {
+  async afterCommitCreate(args: EventArgs<any>) {
     //
   }
 
 }
 
-async function getOrmInstance(subscriber?: EventSubscriber): Promise<MikroORM<PostgreSqlDriver>> {
-  const orm = await MikroORM.init({
-    entities: [User],
-    dbName: 'mikro_orm_test_gh_1175',
-    type: 'postgresql',
-    subscribers: subscriber ? [subscriber] : [],
-  });
-
-  return orm as MikroORM<PostgreSqlDriver>;
-}
-
 describe('GH issue 1175', () => {
-  let orm: MikroORM<PostgreSqlDriver>;
   let em: EntityManager;
   const testSubscriber = new UserSubscriber();
   const afterCreate = jest.spyOn(testSubscriber, 'afterCreate');
@@ -93,20 +66,6 @@ describe('GH issue 1175', () => {
   const afterTransactionCommit = jest.spyOn(testSubscriber, 'afterTransactionCommit');
   const afterTransactionRollback = jest.spyOn(testSubscriber, 'afterTransactionRollback');
   const afterCommitCreate = jest.spyOn(testSubscriber, 'afterCommitCreate');
-
-  beforeAll(async () => {
-    orm = await getOrmInstance(testSubscriber);
-    await orm.getSchemaGenerator().dropDatabase('mikro_orm_test_gh_1175');
-    await orm.getSchemaGenerator().createDatabase('mikro_orm_test_gh_1175');
-  });
-
-  afterAll(async () => {
-    await orm.close();
-  });
-
-  beforeEach(() => {
-    em = orm.em.fork();
-  });
 
   afterEach(() => {
     beforeTransactionStart.mockClear();
@@ -117,40 +76,564 @@ describe('GH issue 1175', () => {
     afterTransactionRollback.mockClear();
   });
 
-  describe('immediate constraints (failures on insert)', () => {
+  describe('sql', () => {
+    @Entity({ tableName: 'users' })
+    class User {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      readonly username: string;
+
+      constructor(username: string) {
+        this.username = username;
+      }
+
+    }
+
+    async function getOrmInstance(subscriber?: EventSubscriber): Promise<MikroORM<PostgreSqlDriver>> {
+      const orm = await MikroORM.init({
+        entities: [User],
+        dbName: 'mikro_orm_test_gh_1175',
+        type: 'postgresql',
+        subscribers: subscriber ? [subscriber] : [],
+      });
+
+      return orm as MikroORM<PostgreSqlDriver>;
+    }
+
+    let orm: MikroORM<PostgreSqlDriver>;
+
     beforeAll(async () => {
-      const orm = await getOrmInstance();
-      await orm.em.getConnection().execute(
-        `
+      orm = await getOrmInstance(testSubscriber);
+      await orm.getSchemaGenerator().dropDatabase('mikro_orm_test_gh_1175');
+      await orm.getSchemaGenerator().createDatabase('mikro_orm_test_gh_1175');
+    });
+
+    afterAll(async () => {
+      await orm.close();
+    });
+
+    beforeEach(() => {
+      em = orm.em.fork();
+    });
+
+    describe('immediate constraints (failures on insert)', () => {
+      beforeAll(async () => {
+        const orm = await getOrmInstance();
+        await orm.em.getConnection().execute(
+          `
+            drop table if exists users;
+            create table users (
+              id serial primary key,
+              username varchar(50) not null unique deferrable initially immediate
+            );
+            `
+        );
+        await orm.close();
+      });
+      describe('implicit transactions', () => {
+        let username: string;
+        it('afterCommitCreate called when transaction succeeds', async () => {
+          username = uuid();
+          const user = new User(username);
+          em.persist(user);
+
+          await expect(em.flush()).resolves.toBeUndefined();
+          expect(afterCreate).toHaveBeenCalledTimes(1);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
+          expect(afterTransactionCommit).toHaveBeenCalledWith(expect.objectContaining({ em, uow: expect.any(UnitOfWork) }));
+          expect(afterCommitCreate).toHaveBeenCalledTimes(1);
+          expect(afterCommitCreate).toHaveBeenCalledWith(expect.objectContaining({ entity: expect.objectContaining({ username }) }));
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
+        });
+        it('afterCommitCreate not called when transaction fails', async () => {
+          const user = new User(username);
+          em.persist(user);
+
+          await expect(em.flush()).rejects.toThrowError(
+            /^insert.+duplicate key value/
+          );
+          expect(afterCreate).toHaveBeenCalledTimes(0);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+          expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      describe('explicit transactions with "transactional()"', () => {
+        let username: string;
+        it('afterCommitCreate called when transaction succeeds', async () => {
+          const work = em.transactional(async em => {
+            username = uuid();
+            const user = new User(username);
+            em.persist(user);
+          });
+
+          await expect(work).resolves.toBeUndefined();
+          expect(afterCreate).toHaveBeenCalledTimes(1);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
+          expect(afterCommitCreate).toHaveBeenCalledTimes(1);
+          expect(afterCommitCreate).toHaveBeenCalledWith(expect.objectContaining({ entity: expect.objectContaining({ username }) }));
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
+        });
+        it('afterCommitCreate not called when transaction fails', async () => {
+          const work = em.transactional(async em => {
+            const user = new User(username);
+            em.persist(user);
+          });
+
+          await expect(work).rejects.toThrowError(/^insert.+duplicate key value/);
+          expect(afterCreate).toHaveBeenCalledTimes(0);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+          expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+        });
+        describe('nested transactions', () => {
+          it('inner and outer afterCommitCreate called', async () => {
+            let em1: EntityManager;
+            let trx1: Transaction;
+            const work = async () => {
+              await em.transactional(async em => {
+                em1 = em;
+                trx1 = em.getTransactionContext();
+                username = 'nested1';
+                const user = new User(username);
+                em.persist(user);
+                await em.transactional(async em => {
+                  username = 'nested2';
+                  const user = new User(username);
+                  em.persist(user);
+                });
+              });
+            };
+            await expect(work()).resolves.toBeUndefined();
+            expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
+            expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
+            expect(afterTransactionStart).toHaveBeenCalledTimes(1);
+            expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+            expect(afterCreate).toHaveBeenCalledTimes(2);
+            expect(afterCreate).toHaveBeenNthCalledWith(1, expect.objectContaining({ em: em1!, entity: expect.objectContaining({ username: 'nested1' }) }));
+            expect(afterCreate).toHaveBeenNthCalledWith(2, expect.objectContaining({ em: em1!, entity: expect.objectContaining({ username: 'nested2' }) }));
+            expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
+            expect(afterTransactionCommit).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+            expect(afterCommitCreate).toHaveBeenCalledTimes(2);
+            expect(afterCommitCreate).toHaveBeenNthCalledWith(1, expect.objectContaining({ em: em1!, entity: expect.objectContaining({ username: 'nested1' }) }));
+            expect(afterCommitCreate).toHaveBeenNthCalledWith(2, expect.objectContaining({ em: em1!, entity: expect.objectContaining({ username: 'nested2' }) }));
+            expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
+          });
+          it('no afterCommitCreate called if inner transaction fails', async () => {
+            const username = uuid();
+            let em1: EntityManager;
+            let trx1: Transaction;
+            const work = async () => {
+              await em.transactional(async em => {
+                em1 = em;
+                trx1 = em.getTransactionContext();
+                const user = new User(username);
+                em.persist(user);
+                await em.transactional(async em => {
+                  const user = new User(username);
+                  em.persist(user);
+                });
+              });
+            };
+            await expect(work()).rejects.toThrowError(/^insert.+duplicate key value/);
+            expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
+            expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
+            expect(afterTransactionStart).toHaveBeenCalledTimes(1);
+            expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+            expect(afterCreate).toHaveBeenCalledTimes(0);
+            expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+            expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+            expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+            expect(afterTransactionRollback).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+          });
+          it('no afterCommitCreate called if outer transaction fails before running inner transaction', async () => {
+            let em1: EntityManager;
+            let trx1: Transaction;
+            const work = async () => {
+              await em.transactional(async em => {
+                em1 = em;
+                trx1 = em.getTransactionContext();
+                const user = new User(username);
+                em.persist(user);
+                await em.flush();
+                await em.transactional(async em => {
+                  const user = new User(username);
+                  em.persist(user);
+                });
+              });
+            };
+            await expect(work()).rejects.toThrowError(/^insert.+duplicate key value/);
+            expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
+            expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
+            expect(afterTransactionStart).toHaveBeenCalledTimes(1);
+            expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+            expect(afterCreate).toHaveBeenCalledTimes(0);
+            expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+            expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+            expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+            expect(afterTransactionRollback).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+          });
+          it('no afterCommitCreate called if outer transaction fails after running inner transaction', async () => {
+            const username = uuid();
+            let em1: EntityManager;
+            let trx1: Transaction;
+            const work = async () => {
+              await em.transactional(async em => {
+                em1 = em;
+                trx1 = em.getTransactionContext();
+                await em.transactional(async em => {
+                  const user = new User(username);
+                  em.persist(user);
+                });
+                const user = new User(username);
+                em.persist(user);
+              });
+            };
+            await expect(work()).rejects.toThrowError(/^insert.+duplicate key value/);
+            expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
+            expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
+            expect(afterTransactionStart).toHaveBeenCalledTimes(1);
+            expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+            expect(afterCreate).toHaveBeenCalledTimes(1);
+            expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+            expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+            expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+            expect(afterTransactionRollback).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+          });
+        });
+      });
+
+      describe('explicit transactions with explicit begin/commit method calls', () => {
+        let username: string;
+        it('creating a new user succeeds', async () => {
+          await em.begin();
+          username = uuid();
+          const user = new User(username);
+          em.persist(user);
+
+          await expect(em.commit()).resolves.toBeUndefined();
+          expect(afterCreate).toHaveBeenCalledTimes(1);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
+          expect(afterCommitCreate).toHaveBeenCalledTimes(1);
+          expect(afterCommitCreate).toHaveBeenCalledWith(expect.objectContaining({ entity: expect.objectContaining({ username }) }));
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
+        });
+        it('afterCreate hook is called when commit() fails', async () => {
+          await em.begin();
+          const work = async () => {
+            try {
+              const user = new User(username);
+              em.persist(user);
+              await em.commit();
+            } catch (error) {
+              await em.rollback();
+              throw error;
+            }
+          };
+
+          await expect(work).rejects.toThrowError(/^insert.+duplicate key value/);
+          expect(afterCreate).toHaveBeenCalledTimes(0);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+          expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+
+    describe('deferred constraints (failures on commit)', () => {
+      beforeAll(async () => {
+        const orm = await getOrmInstance();
+        await orm.em.getConnection().execute(
+          `
           drop table if exists users;
           create table users (
             id serial primary key,
-            username varchar(50) not null unique deferrable initially immediate
+            username varchar(50) not null unique deferrable initially deferred
           );
-          `
-      );
+            `
+        );
+        await orm.close();
+      });
+
+      describe('implicit transactions', () => {
+        let username: string;
+        it('creating a new user succeeds', async () => {
+          username = uuid();
+          const user = new User(username);
+          em.persist(user);
+
+          await expect(em.flush()).resolves.toBeUndefined();
+          expect(afterCreate).toHaveBeenCalledTimes(1);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
+          expect(afterTransactionCommit).toHaveBeenCalledWith(expect.objectContaining({ em, uow: expect.any(UnitOfWork) }));
+          expect(afterCommitCreate).toHaveBeenCalledTimes(1);
+          expect(afterCommitCreate).toHaveBeenCalledWith(expect.objectContaining({ entity: expect.objectContaining({ username }) }));
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
+        });
+        it('afterCreate hook is called when flush fails', async () => {
+          const user = new User(username);
+          em.persist(user);
+
+          await expect(em.flush()).rejects.toThrowError(
+            /^COMMIT.+duplicate key value/
+          );
+          expect(afterCreate).toHaveBeenCalledTimes(1);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+          expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      describe('explicit transactions with "transactional()"', () => {
+        let username: string;
+        it('creating a new user succeeds', async () => {
+          const work = em.transactional(async em => {
+            username = uuid();
+            const user = new User(username);
+            em.persist(user);
+          });
+
+          await expect(work).resolves.toBeUndefined();
+          expect(afterCreate).toHaveBeenCalledTimes(1);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
+          expect(afterCommitCreate).toHaveBeenCalledTimes(1);
+          expect(afterCommitCreate).toHaveBeenCalledWith(expect.objectContaining({ entity: expect.objectContaining({ username }) }));
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
+        });
+        it('afterCreate hook is called when transactional() fails', async () => {
+          const work = async () => {
+            await em.transactional(async em => {
+              const user = new User(username);
+              em.persist(user);
+            });
+          };
+
+          await expect(work).rejects.toThrowError(/^COMMIT.+duplicate key value/);
+          expect(afterCreate).toHaveBeenCalledTimes(1);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+          expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+        });
+        describe('nested transactions', () => {
+          it('inner and outer afterCommitCreate called', async () => {
+            let em1: EntityManager;
+            let trx1: Transaction;
+            const work = async () => {
+              await em.transactional(async em => {
+                em1 = em;
+                trx1 = em.getTransactionContext();
+                username = 'dnested1';
+                const user = new User(username);
+                em.persist(user);
+                await em.transactional(async em => {
+                  username = 'dnested2';
+                  const user = new User(username);
+                  em.persist(user);
+                });
+              });
+            };
+            await expect(work()).resolves.toBeUndefined();
+            expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
+            expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
+            expect(afterTransactionStart).toHaveBeenCalledTimes(1);
+            expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+            expect(afterCreate).toHaveBeenCalledTimes(2);
+            expect(afterCreate).toHaveBeenNthCalledWith(1, expect.objectContaining({ em: em1!, entity: expect.objectContaining({ username: 'dnested1' }) }));
+            expect(afterCreate).toHaveBeenNthCalledWith(2, expect.objectContaining({ em: em1!, entity: expect.objectContaining({ username: 'dnested2' }) }));
+            expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
+            expect(afterTransactionCommit).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+            expect(afterCommitCreate).toHaveBeenCalledTimes(2);
+            expect(afterCommitCreate).toHaveBeenNthCalledWith(1, expect.objectContaining({ em: em1!, entity: expect.objectContaining({ username: 'dnested1' }) }));
+            expect(afterCommitCreate).toHaveBeenNthCalledWith(2, expect.objectContaining({ em: em1!, entity: expect.objectContaining({ username: 'dnested2' }) }));
+            expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
+          });
+          it('no afterCommitCreate called if inner transaction fails', async () => {
+            const username = uuid();
+            let em1: EntityManager;
+            let trx1: Transaction;
+            const work = async () => {
+              await em.transactional(async em => {
+                em1 = em;
+                trx1 = em.getTransactionContext();
+                const user = new User(username);
+                em.persist(user);
+                await em.transactional(async em => {
+                  const user = new User(username);
+                  em.persist(user);
+                });
+              });
+            };
+            await expect(work()).rejects.toThrowError(/^COMMIT.+duplicate key value/);
+            expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
+            expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
+            expect(afterTransactionStart).toHaveBeenCalledTimes(1);
+            expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+            expect(afterCreate).toHaveBeenCalledTimes(2);
+            expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+            expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+            expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+            expect(afterTransactionRollback).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+          });
+          it('no afterCommitCreate called if outer transaction fails before running inner transaction', async () => {
+            let em1: EntityManager;
+            let trx1: Transaction;
+            const work = async () => {
+              await em.transactional(async em => {
+                em1 = em;
+                trx1 = em.getTransactionContext();
+                const user = new User(username);
+                em.persist(user);
+                await em.flush();
+                await em.transactional(async em => {
+                  const user = new User(username);
+                  em.persist(user);
+                });
+              });
+            };
+            await expect(work()).rejects.toThrowError(/^COMMIT.+duplicate key value/);
+            expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
+            expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
+            expect(afterTransactionStart).toHaveBeenCalledTimes(1);
+            expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+            expect(afterCreate).toHaveBeenCalledTimes(2);
+            expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+            expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+            expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+            expect(afterTransactionRollback).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+          });
+          it('no afterCommitCreate called if outer transaction fails after running inner transaction', async () => {
+            const username = uuid();
+            let em1: EntityManager;
+            let trx1: Transaction;
+            const work = async () => {
+              await em.transactional(async em => {
+                em1 = em;
+                trx1 = em.getTransactionContext();
+                await em.transactional(async em => {
+                  const user = new User(username);
+                  em.persist(user);
+                });
+                const user = new User(username);
+                em.persist(user);
+              });
+            };
+            await expect(work()).rejects.toThrowError(/^COMMIT.+duplicate key value/);
+            expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
+            expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
+            expect(afterTransactionStart).toHaveBeenCalledTimes(1);
+            expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+            expect(afterCreate).toHaveBeenCalledTimes(2);
+            expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+            expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+            expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+            expect(afterTransactionRollback).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+          });
+        });
+      });
+
+      describe('explicit transactions with explicit begin/commit/rollback method calls', () => {
+        let username: string;
+        it('creating a new user succeeds', async () => {
+          await em.begin();
+          username = uuid();
+          const user = new User(username);
+          em.persist(user);
+
+          await expect(em.commit()).resolves.toBeUndefined();
+          expect(afterCreate).toHaveBeenCalledTimes(1);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
+          expect(afterCommitCreate).toHaveBeenCalledTimes(1);
+          expect(afterCommitCreate).toHaveBeenCalledWith(expect.objectContaining({ entity: expect.objectContaining({ username }) }));
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
+        });
+        it('afterCreate hook is called when commit() fails', async () => {
+          await em.begin();
+          const work = async () => {
+            try {
+              const user = new User(username);
+              em.persist(user);
+              await em.commit();
+            } catch (error) {
+              await em.rollback();
+              throw error;
+            }
+          };
+
+          await expect(work).rejects.toThrowError(/^COMMIT.+duplicate key value/);
+          expect(afterCreate).toHaveBeenCalledTimes(1);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+          expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+  });
+
+  describe('mongo', () => {
+    @Entity()
+    class Entity1175 {
+
+      @PrimaryKey()
+      _id!: ObjectId;
+
+      @Unique()
+      @Property()
+      readonly username: string;
+
+      constructor(username: string) {
+        this.username = username;
+      }
+
+    }
+
+    let orm: MikroORM<MongoDriver>;
+
+    beforeAll(async () => {
+      orm = await MikroORM.init({
+        entities: [Entity1175],
+        clientUrl: 'mongodb://localhost:27017,localhost:27018,localhost:27019/mikro-orm-test?replicaSet=rs0',
+        type: 'mongo',
+        implicitTransactions: true,
+        subscribers: [testSubscriber],
+      });
+      await orm.em.nativeDelete(Entity1175, {});
+      await orm.em.nativeInsert(Entity1175, { username: 'test1' });
+      await orm.em.getDriver().ensureIndexes();
+    });
+
+    afterAll(async () => {
       await orm.close();
     });
+
+    beforeEach(() => {
+      em = orm.em.fork();
+    });
+
     describe('implicit transactions', () => {
       let username: string;
       it('afterCommitCreate called when transaction succeeds', async () => {
         username = uuid();
-        const user = new User(username);
+        const user = new Entity1175(username);
         em.persist(user);
 
         await expect(em.flush()).resolves.toBeUndefined();
         expect(afterCreate).toHaveBeenCalledTimes(1);
         expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
+        expect(afterTransactionCommit).toHaveBeenCalledWith(expect.objectContaining({ em, uow: expect.any(UnitOfWork) }));
         expect(afterCommitCreate).toHaveBeenCalledTimes(1);
         expect(afterCommitCreate).toHaveBeenCalledWith(expect.objectContaining({ entity: expect.objectContaining({ username }) }));
         expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
       });
       it('afterCommitCreate not called when transaction fails', async () => {
-        const user = new User(username);
+        const user = new Entity1175(username);
         em.persist(user);
 
         await expect(em.flush()).rejects.toThrowError(
-          /^insert.+duplicate key value/
+          /^E11000 duplicate key error/
         );
         expect(afterCreate).toHaveBeenCalledTimes(0);
         expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
@@ -164,7 +647,7 @@ describe('GH issue 1175', () => {
       it('afterCommitCreate called when transaction succeeds', async () => {
         const work = em.transactional(async em => {
           username = uuid();
-          const user = new User(username);
+          const user = new Entity1175(username);
           em.persist(user);
         });
 
@@ -177,127 +660,36 @@ describe('GH issue 1175', () => {
       });
       it('afterCommitCreate not called when transaction fails', async () => {
         const work = em.transactional(async em => {
-          const user = new User(username);
+          const user = new Entity1175(username);
           em.persist(user);
         });
 
-        await expect(work).rejects.toThrowError(/^insert.+duplicate key value/);
+        await expect(work).rejects.toThrowError(/^E11000 duplicate key error/);
         expect(afterCreate).toHaveBeenCalledTimes(0);
         expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
         expect(afterCommitCreate).toHaveBeenCalledTimes(0);
         expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
       });
       describe('nested transactions', () => {
-        it('inner and outer afterCommitCreate called', async () => {
-          let em1: EntityManager;
-          let trx1: Transaction;
+        it('not allowed', async () => {
           const work = async () => {
             await em.transactional(async em => {
-              em1 = em;
-              trx1 = em.getTransactionContext();
               username = 'nested1';
-              const user = new User(username);
+              const user = new Entity1175(username);
               em.persist(user);
               await em.transactional(async em => {
                 username = 'nested2';
-                const user = new User(username);
+                const user = new Entity1175(username);
                 em.persist(user);
               });
             });
           };
-          await expect(work()).resolves.toBeUndefined();
+          await expect(work()).rejects.toThrowError(/Transaction already in progress/);
           expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
-          expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
-          expect(afterTransactionStart).toHaveBeenCalledTimes(1);
-          expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
-          expect(afterCreate).toHaveBeenCalledTimes(2);
-          expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
-          expect(afterTransactionCommit).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
-          expect(afterCommitCreate).toHaveBeenCalledTimes(2);
-          expect(afterCommitCreate).toHaveBeenNthCalledWith(1, expect.objectContaining({ entity: expect.objectContaining({ username: 'nested1' }) }));
-          expect(afterCommitCreate).toHaveBeenNthCalledWith(2, expect.objectContaining({ entity: expect.objectContaining({ username: 'nested2' }) }));
-          expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
-        });
-        it('no afterCommitCreate called if inner transaction fails', async () => {
-          const username = uuid();
-          let em1: EntityManager;
-          let trx1: Transaction;
-          const work = async () => {
-            await em.transactional(async em => {
-              em1 = em;
-              trx1 = em.getTransactionContext();
-              const user = new User(username);
-              em.persist(user);
-              await em.transactional(async em => {
-                const user = new User(username);
-                em.persist(user);
-              });
-            });
-          };
-          await expect(work()).rejects.toThrowError(/^insert.+duplicate key value/);
-          expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
-          expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
-          expect(afterTransactionStart).toHaveBeenCalledTimes(1);
-          expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
           expect(afterCreate).toHaveBeenCalledTimes(0);
           expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
           expect(afterCommitCreate).toHaveBeenCalledTimes(0);
           expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
-          expect(afterTransactionRollback).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
-        });
-        it('no afterCommitCreate called if outer transaction fails before running inner transaction', async () => {
-          let em1: EntityManager;
-          let trx1: Transaction;
-          const work = async () => {
-            await em.transactional(async em => {
-              em1 = em;
-              trx1 = em.getTransactionContext();
-              const user = new User(username);
-              em.persist(user);
-              await em.flush();
-              await em.transactional(async em => {
-                const user = new User(username);
-                em.persist(user);
-              });
-            });
-          };
-          await expect(work()).rejects.toThrowError(/^insert.+duplicate key value/);
-          expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
-          expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
-          expect(afterTransactionStart).toHaveBeenCalledTimes(1);
-          expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
-          expect(afterCreate).toHaveBeenCalledTimes(0);
-          expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
-          expect(afterCommitCreate).toHaveBeenCalledTimes(0);
-          expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
-          expect(afterTransactionRollback).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
-        });
-        it('no afterCommitCreate called if outer transaction fails after running inner transaction', async () => {
-          const username = uuid();
-          let em1: EntityManager;
-          let trx1: Transaction;
-          const work = async () => {
-            await em.transactional(async em => {
-              em1 = em;
-              trx1 = em.getTransactionContext();
-              await em.transactional(async em => {
-                const user = new User(username);
-                em.persist(user);
-              });
-              const user = new User(username);
-              em.persist(user);
-            });
-          };
-          await expect(work()).rejects.toThrowError(/^insert.+duplicate key value/);
-          expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
-          expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
-          expect(afterTransactionStart).toHaveBeenCalledTimes(1);
-          expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
-          expect(afterCreate).toHaveBeenCalledTimes(1);
-          expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
-          expect(afterCommitCreate).toHaveBeenCalledTimes(0);
-          expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
-          expect(afterTransactionRollback).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
         });
       });
     });
@@ -307,7 +699,7 @@ describe('GH issue 1175', () => {
       it('creating a new user succeeds', async () => {
         await em.begin();
         username = uuid();
-        const user = new User(username);
+        const user = new Entity1175(username);
         em.persist(user);
 
         await expect(em.commit()).resolves.toBeUndefined();
@@ -321,7 +713,7 @@ describe('GH issue 1175', () => {
         await em.begin();
         const work = async () => {
           try {
-            const user = new User(username);
+            const user = new Entity1175(username);
             em.persist(user);
             await em.commit();
           } catch (error) {
@@ -330,233 +722,8 @@ describe('GH issue 1175', () => {
           }
         };
 
-        await expect(work).rejects.toThrowError(/^insert.+duplicate key value/);
+        await expect(work).rejects.toThrowError(/^E11000 duplicate key error/);
         expect(afterCreate).toHaveBeenCalledTimes(0);
-        expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
-        expect(afterCommitCreate).toHaveBeenCalledTimes(0);
-        expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
-      });
-    });
-  });
-
-  describe('deferred constraints (failures on commit)', () => {
-    beforeAll(async () => {
-      const orm = await getOrmInstance();
-      await orm.em.getConnection().execute(
-        `
-        drop table if exists users;
-        create table users (
-          id serial primary key,
-          username varchar(50) not null unique deferrable initially deferred
-        );
-          `
-      );
-      await orm.close();
-    });
-
-    describe('implicit transactions', () => {
-      let username: string;
-      it('creating a new user succeeds', async () => {
-        username = uuid();
-        const user = new User(username);
-        em.persist(user);
-
-        await expect(em.flush()).resolves.toBeUndefined();
-        expect(afterCreate).toHaveBeenCalledTimes(1);
-        expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
-        expect(afterCommitCreate).toHaveBeenCalledTimes(1);
-        expect(afterCommitCreate).toHaveBeenCalledWith(expect.objectContaining({ entity: expect.objectContaining({ username }) }));
-        expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
-      });
-      it('afterCreate hook is called when flush fails', async () => {
-        const user = new User(username);
-        em.persist(user);
-
-        await expect(em.flush()).rejects.toThrowError(
-          /^COMMIT.+duplicate key value/
-        );
-        expect(afterCreate).toHaveBeenCalledTimes(1);
-        expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
-        expect(afterCommitCreate).toHaveBeenCalledTimes(0);
-        expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    describe('explicit transactions with "transactional()"', () => {
-      let username: string;
-      it('creating a new user succeeds', async () => {
-        const work = em.transactional(async em => {
-          username = uuid();
-          const user = new User(username);
-          em.persist(user);
-        });
-
-        await expect(work).resolves.toBeUndefined();
-        expect(afterCreate).toHaveBeenCalledTimes(1);
-        expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
-        expect(afterCommitCreate).toHaveBeenCalledTimes(1);
-        expect(afterCommitCreate).toHaveBeenCalledWith(expect.objectContaining({ entity: expect.objectContaining({ username }) }));
-        expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
-      });
-      it('afterCreate hook is called when transactional() fails', async () => {
-        const work = async () => {
-          await em.transactional(async em => {
-            const user = new User(username);
-            em.persist(user);
-          });
-        };
-
-        await expect(work).rejects.toThrowError(/^COMMIT.+duplicate key value/);
-        expect(afterCreate).toHaveBeenCalledTimes(1);
-        expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
-        expect(afterCommitCreate).toHaveBeenCalledTimes(0);
-        expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
-      });
-      describe('nested transactions', () => {
-        it('inner and outer afterCommitCreate called', async () => {
-          let em1: EntityManager;
-          let trx1: Transaction;
-          const work = async () => {
-            await em.transactional(async em => {
-              em1 = em;
-              trx1 = em.getTransactionContext();
-              username = 'dnested1';
-              const user = new User(username);
-              em.persist(user);
-              await em.transactional(async em => {
-                username = 'dnested2';
-                const user = new User(username);
-                em.persist(user);
-              });
-            });
-          };
-          await expect(work()).resolves.toBeUndefined();
-          expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
-          expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
-          expect(afterTransactionStart).toHaveBeenCalledTimes(1);
-          expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
-          expect(afterCreate).toHaveBeenCalledTimes(2);
-          expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
-          expect(afterTransactionCommit).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
-          expect(afterCommitCreate).toHaveBeenCalledTimes(2);
-          expect(afterCommitCreate).toHaveBeenNthCalledWith(1, expect.objectContaining({ entity: expect.objectContaining({ username: 'dnested1' }) }));
-          expect(afterCommitCreate).toHaveBeenNthCalledWith(2, expect.objectContaining({ entity: expect.objectContaining({ username: 'dnested2' }) }));
-          expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
-        });
-        it('no afterCommitCreate called if inner transaction fails', async () => {
-          const username = uuid();
-          let em1: EntityManager;
-          let trx1: Transaction;
-          const work = async () => {
-            await em.transactional(async em => {
-              em1 = em;
-              trx1 = em.getTransactionContext();
-              const user = new User(username);
-              em.persist(user);
-              await em.transactional(async em => {
-                const user = new User(username);
-                em.persist(user);
-              });
-            });
-          };
-          await expect(work()).rejects.toThrowError(/^COMMIT.+duplicate key value/);
-          expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
-          expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
-          expect(afterTransactionStart).toHaveBeenCalledTimes(1);
-          expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
-          expect(afterCreate).toHaveBeenCalledTimes(2);
-          expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
-          expect(afterCommitCreate).toHaveBeenCalledTimes(0);
-          expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
-          expect(afterTransactionRollback).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
-        });
-        it('no afterCommitCreate called if outer transaction fails before running inner transaction', async () => {
-          let em1: EntityManager;
-          let trx1: Transaction;
-          const work = async () => {
-            await em.transactional(async em => {
-              em1 = em;
-              trx1 = em.getTransactionContext();
-              const user = new User(username);
-              em.persist(user);
-              await em.flush();
-              await em.transactional(async em => {
-                const user = new User(username);
-                em.persist(user);
-              });
-            });
-          };
-          await expect(work()).rejects.toThrowError(/^COMMIT.+duplicate key value/);
-          expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
-          expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
-          expect(afterTransactionStart).toHaveBeenCalledTimes(1);
-          expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
-          expect(afterCreate).toHaveBeenCalledTimes(2);
-          expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
-          expect(afterCommitCreate).toHaveBeenCalledTimes(0);
-          expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
-          expect(afterTransactionRollback).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
-        });
-        it('no afterCommitCreate called if outer transaction fails after running inner transaction', async () => {
-          const username = uuid();
-          let em1: EntityManager;
-          let trx1: Transaction;
-          const work = async () => {
-            await em.transactional(async em => {
-              em1 = em;
-              trx1 = em.getTransactionContext();
-              await em.transactional(async em => {
-                const user = new User(username);
-                em.persist(user);
-              });
-              const user = new User(username);
-              em.persist(user);
-            });
-          };
-          await expect(work()).rejects.toThrowError(/^COMMIT.+duplicate key value/);
-          expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
-          expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
-          expect(afterTransactionStart).toHaveBeenCalledTimes(1);
-          expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
-          expect(afterCreate).toHaveBeenCalledTimes(2);
-          expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
-          expect(afterCommitCreate).toHaveBeenCalledTimes(0);
-          expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
-          expect(afterTransactionRollback).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
-        });
-      });
-    });
-
-    describe('explicit transactions with explicit begin/commit/rollback method calls', () => {
-      let username: string;
-      it('creating a new user succeeds', async () => {
-        await em.begin();
-        username = uuid();
-        const user = new User(username);
-        em.persist(user);
-
-        await expect(em.commit()).resolves.toBeUndefined();
-        expect(afterCreate).toHaveBeenCalledTimes(1);
-        expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
-        expect(afterCommitCreate).toHaveBeenCalledTimes(1);
-        expect(afterCommitCreate).toHaveBeenCalledWith(expect.objectContaining({ entity: expect.objectContaining({ username }) }));
-        expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
-      });
-      it('afterCreate hook is called when commit() fails', async () => {
-        await em.begin();
-        const work = async () => {
-          try {
-            const user = new User(username);
-            em.persist(user);
-            await em.commit();
-          } catch (error) {
-            await em.rollback();
-            throw error;
-          }
-        };
-
-        await expect(work).rejects.toThrowError(/^COMMIT.+duplicate key value/);
-        expect(afterCreate).toHaveBeenCalledTimes(1);
         expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
         expect(afterCommitCreate).toHaveBeenCalledTimes(0);
         expect(afterTransactionRollback).toHaveBeenCalledTimes(1);

--- a/tests/issues/GH1175.test.ts
+++ b/tests/issues/GH1175.test.ts
@@ -1,0 +1,566 @@
+import {
+  EntityManager,
+  Entity,
+  MikroORM,
+  PrimaryKey,
+  Property,
+  EventSubscriber,
+  EventArgs,
+  TransactionEventArgs,
+  Transaction,
+} from '@mikro-orm/core';
+import { PostgreSqlDriver, SqlEntityManager } from '@mikro-orm/postgresql';
+import { v4 as uuid } from 'uuid';
+
+@Entity({ tableName: 'users' })
+class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  readonly username: string;
+
+  constructor(username: string) {
+    this.username = username;
+  }
+
+}
+
+class UserSubscriber implements EventSubscriber<User> {
+
+  pendingActions = new Map<Transaction, (() => void | Promise<void>)[]>();
+  getSubscribedEntities() {
+    return [User];
+  }
+
+  async beforeTransactionStart(args: TransactionEventArgs) {
+    //
+  }
+
+  async afterTransactionStart(args: TransactionEventArgs) {
+    const { em } = args;
+    this.pendingActions.set(em, []);
+  }
+
+  async afterTransactionCommit(args: TransactionEventArgs) {
+    const { em } = args;
+    const actions = this.pendingActions.get(em);
+    if (actions) {
+      for (const action of actions) {
+        await action();
+      }
+    }
+    this.pendingActions.delete(em);
+  }
+
+  async afterTransactionRollback(args: TransactionEventArgs) {
+    const { em } = args;
+    this.pendingActions.delete(em);
+  }
+
+  async afterCreate(args: EventArgs<User>) {
+    const { em } = args;
+    this.pendingActions.get(em)?.push(() => {
+      this.afterCommitCreate(args);
+    });
+  }
+
+  async afterCommitCreate(args: EventArgs<User>) {
+    //
+  }
+
+}
+
+async function getOrmInstance(subscriber?: EventSubscriber): Promise<MikroORM<PostgreSqlDriver>> {
+  const orm = await MikroORM.init({
+    entities: [User],
+    dbName: 'mikro_orm_test_gh_1175',
+    type: 'postgresql',
+    subscribers: subscriber ? [subscriber] : [],
+  });
+
+  return orm as MikroORM<PostgreSqlDriver>;
+}
+
+describe('GH issue 1175', () => {
+  let orm: MikroORM<PostgreSqlDriver>;
+  let em: EntityManager;
+  const testSubscriber = new UserSubscriber();
+  const afterCreate = jest.spyOn(testSubscriber, 'afterCreate');
+  const beforeTransactionStart = jest.spyOn(testSubscriber, 'beforeTransactionStart');
+  const afterTransactionStart = jest.spyOn(testSubscriber, 'afterTransactionStart');
+  const afterTransactionCommit = jest.spyOn(testSubscriber, 'afterTransactionCommit');
+  const afterTransactionRollback = jest.spyOn(testSubscriber, 'afterTransactionRollback');
+  const afterCommitCreate = jest.spyOn(testSubscriber, 'afterCommitCreate');
+
+  beforeAll(async () => {
+    orm = await getOrmInstance(testSubscriber);
+    await orm.getSchemaGenerator().dropDatabase('mikro_orm_test_gh_1175');
+    await orm.getSchemaGenerator().createDatabase('mikro_orm_test_gh_1175');
+  });
+
+  afterAll(async () => {
+    await orm.close();
+  });
+
+  beforeEach(() => {
+    em = orm.em.fork();
+  });
+
+  afterEach(() => {
+    beforeTransactionStart.mockClear();
+    afterTransactionStart.mockClear();
+    afterCreate.mockClear();
+    afterTransactionCommit.mockClear();
+    afterCommitCreate.mockClear();
+    afterTransactionRollback.mockClear();
+  });
+
+  describe('immediate constraints (failures on insert)', () => {
+    beforeAll(async () => {
+      const orm = await getOrmInstance();
+      await orm.em.getConnection().execute(
+        `
+          drop table if exists users;
+          create table users (
+            id serial primary key,
+            username varchar(50) not null unique deferrable initially immediate
+          );
+          `
+      );
+      await orm.close();
+    });
+    describe('implicit transactions', () => {
+      let username: string;
+      it('afterCommitCreate called when transaction succeeds', async () => {
+        username = uuid();
+        const user = new User(username);
+        em.persist(user);
+
+        await expect(em.flush()).resolves.toBeUndefined();
+        expect(afterCreate).toHaveBeenCalledTimes(1);
+        expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
+        expect(afterCommitCreate).toHaveBeenCalledTimes(1);
+        expect(afterCommitCreate).toHaveBeenCalledWith(expect.objectContaining({ entity: expect.objectContaining({ username }) }));
+        expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
+      });
+      it('afterCommitCreate not called when transaction fails', async () => {
+        const user = new User(username);
+        em.persist(user);
+
+        await expect(em.flush()).rejects.toThrowError(
+          /^insert.+duplicate key value/
+        );
+        expect(afterCreate).toHaveBeenCalledTimes(0);
+        expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+        expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+        expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('explicit transactions with "transactional()"', () => {
+      let username: string;
+      it('afterCommitCreate called when transaction succeeds', async () => {
+        const work = em.transactional(async em => {
+          username = uuid();
+          const user = new User(username);
+          em.persist(user);
+        });
+
+        await expect(work).resolves.toBeUndefined();
+        expect(afterCreate).toHaveBeenCalledTimes(1);
+        expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
+        expect(afterCommitCreate).toHaveBeenCalledTimes(1);
+        expect(afterCommitCreate).toHaveBeenCalledWith(expect.objectContaining({ entity: expect.objectContaining({ username }) }));
+        expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
+      });
+      it('afterCommitCreate not called when transaction fails', async () => {
+        const work = em.transactional(async em => {
+          const user = new User(username);
+          em.persist(user);
+        });
+
+        await expect(work).rejects.toThrowError(/^insert.+duplicate key value/);
+        expect(afterCreate).toHaveBeenCalledTimes(0);
+        expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+        expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+        expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+      });
+      describe('nested transactions', () => {
+        it('inner and outer afterCommitCreate called', async () => {
+          let em1: EntityManager;
+          let trx1: Transaction;
+          const work = async () => {
+            await em.transactional(async em => {
+              em1 = em;
+              trx1 = em.getTransactionContext();
+              username = 'nested1';
+              const user = new User(username);
+              em.persist(user);
+              await em.transactional(async em => {
+                username = 'nested2';
+                const user = new User(username);
+                em.persist(user);
+              });
+            });
+          };
+          await expect(work()).resolves.toBeUndefined();
+          expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
+          expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
+          expect(afterTransactionStart).toHaveBeenCalledTimes(1);
+          expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+          expect(afterCreate).toHaveBeenCalledTimes(2);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
+          expect(afterTransactionCommit).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+          expect(afterCommitCreate).toHaveBeenCalledTimes(2);
+          expect(afterCommitCreate).toHaveBeenNthCalledWith(1, expect.objectContaining({ entity: expect.objectContaining({ username: 'nested1' }) }));
+          expect(afterCommitCreate).toHaveBeenNthCalledWith(2, expect.objectContaining({ entity: expect.objectContaining({ username: 'nested2' }) }));
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
+        });
+        it('no afterCommitCreate called if inner transaction fails', async () => {
+          const username = uuid();
+          let em1: EntityManager;
+          let trx1: Transaction;
+          const work = async () => {
+            await em.transactional(async em => {
+              em1 = em;
+              trx1 = em.getTransactionContext();
+              const user = new User(username);
+              em.persist(user);
+              await em.transactional(async em => {
+                const user = new User(username);
+                em.persist(user);
+              });
+            });
+          };
+          await expect(work()).rejects.toThrowError(/^insert.+duplicate key value/);
+          expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
+          expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
+          expect(afterTransactionStart).toHaveBeenCalledTimes(1);
+          expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+          expect(afterCreate).toHaveBeenCalledTimes(0);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+          expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+          expect(afterTransactionRollback).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+        });
+        it('no afterCommitCreate called if outer transaction fails before running inner transaction', async () => {
+          let em1: EntityManager;
+          let trx1: Transaction;
+          const work = async () => {
+            await em.transactional(async em => {
+              em1 = em;
+              trx1 = em.getTransactionContext();
+              const user = new User(username);
+              em.persist(user);
+              await em.flush();
+              await em.transactional(async em => {
+                const user = new User(username);
+                em.persist(user);
+              });
+            });
+          };
+          await expect(work()).rejects.toThrowError(/^insert.+duplicate key value/);
+          expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
+          expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
+          expect(afterTransactionStart).toHaveBeenCalledTimes(1);
+          expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+          expect(afterCreate).toHaveBeenCalledTimes(0);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+          expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+          expect(afterTransactionRollback).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+        });
+        it('no afterCommitCreate called if outer transaction fails after running inner transaction', async () => {
+          const username = uuid();
+          let em1: EntityManager;
+          let trx1: Transaction;
+          const work = async () => {
+            await em.transactional(async em => {
+              em1 = em;
+              trx1 = em.getTransactionContext();
+              await em.transactional(async em => {
+                const user = new User(username);
+                em.persist(user);
+              });
+              const user = new User(username);
+              em.persist(user);
+            });
+          };
+          await expect(work()).rejects.toThrowError(/^insert.+duplicate key value/);
+          expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
+          expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
+          expect(afterTransactionStart).toHaveBeenCalledTimes(1);
+          expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+          expect(afterCreate).toHaveBeenCalledTimes(1);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+          expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+          expect(afterTransactionRollback).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+        });
+      });
+    });
+
+    describe('explicit transactions with explicit begin/commit method calls', () => {
+      let username: string;
+      it('creating a new user succeeds', async () => {
+        await em.begin();
+        username = uuid();
+        const user = new User(username);
+        em.persist(user);
+
+        await expect(em.commit()).resolves.toBeUndefined();
+        expect(afterCreate).toHaveBeenCalledTimes(1);
+        expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
+        expect(afterCommitCreate).toHaveBeenCalledTimes(1);
+        expect(afterCommitCreate).toHaveBeenCalledWith(expect.objectContaining({ entity: expect.objectContaining({ username }) }));
+        expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
+      });
+      it('afterCreate hook is called when commit() fails', async () => {
+        await em.begin();
+        const work = async () => {
+          try {
+            const user = new User(username);
+            em.persist(user);
+            await em.commit();
+          } catch (error) {
+            await em.rollback();
+            throw error;
+          }
+        };
+
+        await expect(work).rejects.toThrowError(/^insert.+duplicate key value/);
+        expect(afterCreate).toHaveBeenCalledTimes(0);
+        expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+        expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+        expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('deferred constraints (failures on commit)', () => {
+    beforeAll(async () => {
+      const orm = await getOrmInstance();
+      await orm.em.getConnection().execute(
+        `
+        drop table if exists users;
+        create table users (
+          id serial primary key,
+          username varchar(50) not null unique deferrable initially deferred
+        );
+          `
+      );
+      await orm.close();
+    });
+
+    describe('implicit transactions', () => {
+      let username: string;
+      it('creating a new user succeeds', async () => {
+        username = uuid();
+        const user = new User(username);
+        em.persist(user);
+
+        await expect(em.flush()).resolves.toBeUndefined();
+        expect(afterCreate).toHaveBeenCalledTimes(1);
+        expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
+        expect(afterCommitCreate).toHaveBeenCalledTimes(1);
+        expect(afterCommitCreate).toHaveBeenCalledWith(expect.objectContaining({ entity: expect.objectContaining({ username }) }));
+        expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
+      });
+      it('afterCreate hook is called when flush fails', async () => {
+        const user = new User(username);
+        em.persist(user);
+
+        await expect(em.flush()).rejects.toThrowError(
+          /^COMMIT.+duplicate key value/
+        );
+        expect(afterCreate).toHaveBeenCalledTimes(1);
+        expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+        expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+        expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('explicit transactions with "transactional()"', () => {
+      let username: string;
+      it('creating a new user succeeds', async () => {
+        const work = em.transactional(async em => {
+          username = uuid();
+          const user = new User(username);
+          em.persist(user);
+        });
+
+        await expect(work).resolves.toBeUndefined();
+        expect(afterCreate).toHaveBeenCalledTimes(1);
+        expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
+        expect(afterCommitCreate).toHaveBeenCalledTimes(1);
+        expect(afterCommitCreate).toHaveBeenCalledWith(expect.objectContaining({ entity: expect.objectContaining({ username }) }));
+        expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
+      });
+      it('afterCreate hook is called when transactional() fails', async () => {
+        const work = async () => {
+          await em.transactional(async em => {
+            const user = new User(username);
+            em.persist(user);
+          });
+        };
+
+        await expect(work).rejects.toThrowError(/^COMMIT.+duplicate key value/);
+        expect(afterCreate).toHaveBeenCalledTimes(1);
+        expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+        expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+        expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+      });
+      describe('nested transactions', () => {
+        it('inner and outer afterCommitCreate called', async () => {
+          let em1: EntityManager;
+          let trx1: Transaction;
+          const work = async () => {
+            await em.transactional(async em => {
+              em1 = em;
+              trx1 = em.getTransactionContext();
+              username = 'dnested1';
+              const user = new User(username);
+              em.persist(user);
+              await em.transactional(async em => {
+                username = 'dnested2';
+                const user = new User(username);
+                em.persist(user);
+              });
+            });
+          };
+          await expect(work()).resolves.toBeUndefined();
+          expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
+          expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
+          expect(afterTransactionStart).toHaveBeenCalledTimes(1);
+          expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+          expect(afterCreate).toHaveBeenCalledTimes(2);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
+          expect(afterTransactionCommit).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+          expect(afterCommitCreate).toHaveBeenCalledTimes(2);
+          expect(afterCommitCreate).toHaveBeenNthCalledWith(1, expect.objectContaining({ entity: expect.objectContaining({ username: 'dnested1' }) }));
+          expect(afterCommitCreate).toHaveBeenNthCalledWith(2, expect.objectContaining({ entity: expect.objectContaining({ username: 'dnested2' }) }));
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
+        });
+        it('no afterCommitCreate called if inner transaction fails', async () => {
+          const username = uuid();
+          let em1: EntityManager;
+          let trx1: Transaction;
+          const work = async () => {
+            await em.transactional(async em => {
+              em1 = em;
+              trx1 = em.getTransactionContext();
+              const user = new User(username);
+              em.persist(user);
+              await em.transactional(async em => {
+                const user = new User(username);
+                em.persist(user);
+              });
+            });
+          };
+          await expect(work()).rejects.toThrowError(/^COMMIT.+duplicate key value/);
+          expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
+          expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
+          expect(afterTransactionStart).toHaveBeenCalledTimes(1);
+          expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+          expect(afterCreate).toHaveBeenCalledTimes(2);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+          expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+          expect(afterTransactionRollback).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+        });
+        it('no afterCommitCreate called if outer transaction fails before running inner transaction', async () => {
+          let em1: EntityManager;
+          let trx1: Transaction;
+          const work = async () => {
+            await em.transactional(async em => {
+              em1 = em;
+              trx1 = em.getTransactionContext();
+              const user = new User(username);
+              em.persist(user);
+              await em.flush();
+              await em.transactional(async em => {
+                const user = new User(username);
+                em.persist(user);
+              });
+            });
+          };
+          await expect(work()).rejects.toThrowError(/^COMMIT.+duplicate key value/);
+          expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
+          expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
+          expect(afterTransactionStart).toHaveBeenCalledTimes(1);
+          expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+          expect(afterCreate).toHaveBeenCalledTimes(2);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+          expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+          expect(afterTransactionRollback).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+        });
+        it('no afterCommitCreate called if outer transaction fails after running inner transaction', async () => {
+          const username = uuid();
+          let em1: EntityManager;
+          let trx1: Transaction;
+          const work = async () => {
+            await em.transactional(async em => {
+              em1 = em;
+              trx1 = em.getTransactionContext();
+              await em.transactional(async em => {
+                const user = new User(username);
+                em.persist(user);
+              });
+              const user = new User(username);
+              em.persist(user);
+            });
+          };
+          await expect(work()).rejects.toThrowError(/^COMMIT.+duplicate key value/);
+          expect(beforeTransactionStart).toHaveBeenCalledTimes(1);
+          expect(beforeTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: undefined }));
+          expect(afterTransactionStart).toHaveBeenCalledTimes(1);
+          expect(afterTransactionStart).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+          expect(afterCreate).toHaveBeenCalledTimes(2);
+          expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+          expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+          expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+          expect(afterTransactionRollback).toHaveBeenCalledWith(expect.objectContaining({ em: em1!, transaction: trx1 }));
+        });
+      });
+    });
+
+    describe('explicit transactions with explicit begin/commit/rollback method calls', () => {
+      let username: string;
+      it('creating a new user succeeds', async () => {
+        await em.begin();
+        username = uuid();
+        const user = new User(username);
+        em.persist(user);
+
+        await expect(em.commit()).resolves.toBeUndefined();
+        expect(afterCreate).toHaveBeenCalledTimes(1);
+        expect(afterTransactionCommit).toHaveBeenCalledTimes(1);
+        expect(afterCommitCreate).toHaveBeenCalledTimes(1);
+        expect(afterCommitCreate).toHaveBeenCalledWith(expect.objectContaining({ entity: expect.objectContaining({ username }) }));
+        expect(afterTransactionRollback).toHaveBeenCalledTimes(0);
+      });
+      it('afterCreate hook is called when commit() fails', async () => {
+        await em.begin();
+        const work = async () => {
+          try {
+            const user = new User(username);
+            em.persist(user);
+            await em.commit();
+          } catch (error) {
+            await em.rollback();
+            throw error;
+          }
+        };
+
+        await expect(work).rejects.toThrowError(/^COMMIT.+duplicate key value/);
+        expect(afterCreate).toHaveBeenCalledTimes(1);
+        expect(afterTransactionCommit).toHaveBeenCalledTimes(0);
+        expect(afterCommitCreate).toHaveBeenCalledTimes(0);
+        expect(afterTransactionRollback).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/tests/issues/GH1176.test.ts
+++ b/tests/issues/GH1176.test.ts
@@ -51,7 +51,7 @@ describe('GH issue 1176', () => {
     em = orm.em.fork();
   });
 
-  describe('immediate constraint (failures on insert)', () => {
+  describe('immediate constraints (failures on insert)', () => {
     beforeAll(async () => {
       const orm = await getOrmInstance();
       await orm.em.getConnection().execute(
@@ -157,7 +157,7 @@ describe('GH issue 1176', () => {
 
         await expect(em.flush()).resolves.toBeUndefined();
       });
-      it('flush throws when a database constraint ffails', async () => {
+      it('flush throws when a database constraint fails', async () => {
         const user = new User(username);
         em.persist(user);
 


### PR DESCRIPTION
Current lifecycle hooks cover entity and unit of work events, but
transaction-related ones are missing. Add beforeTransactionStart,
afterTransactionStart, beforeTransactionCommit, afterTransactionCommit,
beforeTransactionRollback, and afterTransactionRollback

Closes #1175

---
Although #1175 mentions implementing "after" entity hooks post commit, they are not included in this PR as they are not needed. Refer to the `UserSubscriber` example class in test file `GH1175.test.ts` to see how to implement an ad-hoc `afterCommitCreate` hook using a combination of `afterTransactionStart`, `afterCreate`, and `afterTransactionCommit`.

Currently, all this PR is missing right now is documentation. Please let me know if you need me to do that as well, but I was thinking maybe @B4nan could lend a hand with that as he might have a better idea regarding form, style, and content.