### PR TITLE
fix: correct type for getAliasForJoinPath argument

### DIFF
--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -332,7 +332,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     return this.platform.formatQuery(query.sql, query.bindings);
   }
 
-  getAliasForJoinPath(path: string): string | undefined {
+  getAliasForJoinPath(path?: string): string | undefined {
     if (!path || path === this.entityName) {
       return this.alias;
     }


### PR DESCRIPTION
As evidenced by the first line of the method, `path` can be falsy. This PR updates the parameter type accordingly.