### PR TITLE
feat(core): support handling `Set` as array-like input

### DIFF
--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -274,6 +274,10 @@ export class Utils {
       return [];
     }
 
+    if (data instanceof Set) {
+      return Array.from(data);
+    }
+
     return Array.isArray(data!) ? data : [data!];
   }
 

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -350,6 +350,12 @@ describe('Utils', () => {
     expect(Utils.getPrimaryKeyCond({ a: null }, ['a'])).toBe(null);
   });
 
+  test('asArray', () => {
+    expect(Utils.asArray('a')).toEqual(['a']);
+    expect(Utils.asArray(['a'])).toEqual(['a']);
+    expect(Utils.asArray(new Set(['a']))).toEqual(['a']);
+  });
+
   afterAll(async () => orm.close(true));
 
 });


### PR DESCRIPTION
When passing a `Set<Foo>` into `em.persist()` for example, the TS check would accept it as an argument, but a `Set` is no actually expected.

This change allows for `Set`s to be treated like `Array`s wherever `Utils.asArray` is utilized to inspect inputs.