### PR TITLE
feat(core): add support for nested partial loading

### DIFF
--- a/docs/docs/entity-manager.md
+++ b/docs/docs/entity-manager.md
@@ -186,14 +186,47 @@ console.log(author.books[0].tags[0].isInitialized()); // true, because it was po
 
 ### Fetching Partial Entities
 
+> This feature is supported only for `SELECT_IN` loading strategy.
+
 When fetching single entity, you can choose to select only parts of an entity via `options.fields`:
 
-```typescript
+```ts
 const author = await orm.em.findOne(Author, '...', { fields: ['name', 'born'] });
 console.log(author.id); // PK is always selected
 console.log(author.name); // Jon Snow
 console.log(author.email); // undefined
 ```
+
+From v4.4 it is also possible to specify fields for nested relations:
+
+```ts
+const author = await orm.em.findOne(Author, '...', { fields: ['name', 'books.title', 'books.author', 'books.price'] });
+```
+
+Or with an alternative object syntax:
+
+```ts
+const author = await orm.em.findOne(Author, '...', { fields: ['name', { books: ['title', 'author', 'price'] }] });
+```
+
+It is also possible to use multiple levels:
+
+```ts
+const author = await orm.em.findOne(Author, '...', { fields: ['name', { books: ['title', 'price', 'author', { author: ['email'] }] }] });
+```
+
+Primary keys are always selected even if you omit them. On the other hand, you are responsible 
+for selecting the FKs - if you omit such property, the relation might not be loaded properly.
+In the following example the books would not be linked the author, because we did not specify 
+the `books.author` field to be loaded.
+
+```ts
+// this will load both author and book entities, but they won't be connected due to the missing FK in select
+const author = await orm.em.findOne(Author, '...', { fields: ['name', { books: ['title', 'price'] });
+```
+
+> Same problem can occur in mongo with M:N collections - those are stored as array property 
+> on the owning entity, so you need to make sure to mark such properties too.
 
 ### Fetching Paginated Results
 

--- a/docs/versioned_docs/version-4.3/entity-manager.md
+++ b/docs/versioned_docs/version-4.3/entity-manager.md
@@ -186,6 +186,8 @@ console.log(author.books[0].tags[0].isInitialized()); // true, because it was po
 
 ### Fetching Partial Entities
 
+> This feature is supported only for `SELECT_IN` loading strategy.
+
 When fetching single entity, you can choose to select only parts of an entity via `options.fields`:
 
 ```typescript

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -50,7 +50,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     throw new Error(`Aggregations are not supported by ${this.constructor.name} driver`);
   }
 
-  async loadFromPivotTable<T extends AnyEntity<T>, O extends AnyEntity<O>>(prop: EntityProperty, owners: Primary<O>[][], where?: FilterQuery<T>, orderBy?: QueryOrderMap, ctx?: Transaction): Promise<Dictionary<T[]>> {
+  async loadFromPivotTable<T extends AnyEntity<T>, O extends AnyEntity<O>>(prop: EntityProperty, owners: Primary<O>[][], where?: FilterQuery<T>, orderBy?: QueryOrderMap, ctx?: Transaction, options?: FindOptions<T>): Promise<Dictionary<T[]>> {
     throw new Error(`${this.constructor.name} does not use pivot tables`);
   }
 

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -54,7 +54,7 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   /**
    * When driver uses pivot tables for M:N, this method will load identifiers for given collections from them
    */
-  loadFromPivotTable<T extends AnyEntity<T>, O extends AnyEntity<O>>(prop: EntityProperty, owners: Primary<O>[][], where?: FilterQuery<T>, orderBy?: QueryOrderMap, ctx?: Transaction): Promise<Dictionary<T[]>>;
+  loadFromPivotTable<T extends AnyEntity<T>, O extends AnyEntity<O>>(prop: EntityProperty, owners: Primary<O>[][], where?: FilterQuery<T>, orderBy?: QueryOrderMap, ctx?: Transaction, options?: FindOptions<T>): Promise<Dictionary<T[]>>;
 
   getPlatform(): Platform;
 
@@ -77,6 +77,8 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
 
 }
 
+export type FieldsMap = { [K: string]: (string | FieldsMap)[] };
+
 export interface FindOptions<T, P extends Populate<T> = Populate<T>> {
   populate?: P;
   orderBy?: QueryOrderMap;
@@ -85,7 +87,7 @@ export interface FindOptions<T, P extends Populate<T> = Populate<T>> {
   offset?: number;
   refresh?: boolean;
   convertCustomTypes?: boolean;
-  fields?: string[];
+  fields?: (string | FieldsMap)[];
   schema?: string;
   flags?: QueryFlag[];
   groupBy?: string | string[];

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -1657,18 +1657,6 @@ describe('EntityManagerMongo', () => {
     expect(b2.title).toBe('test 2');
   });
 
-  test('partial selects', async () => {
-    const author = new Author('Jon Snow', 'snow@wall.st');
-    author.born = new Date();
-    await orm.em.persistAndFlush(author);
-    orm.em.clear();
-
-    const a = (await orm.em.findOne(Author, author, { fields: ['name'] }))!;
-    expect(a.name).toBe('Jon Snow');
-    expect(a.email).toBeUndefined();
-    expect(a.born).toBeUndefined();
-  });
-
   test(`populating inverse side of 1:1 also back-links inverse side's owner (both eager)`, async () => {
     const bar = FooBar.create('fb');
     bar.baz = FooBaz.create('fz');
@@ -1898,6 +1886,8 @@ describe('EntityManagerMongo', () => {
     await orm.em.flush();
     orm.em.clear();
 
+    const tags = await orm.em.find(BookTag, {}, ['books']);
+    console.log(tags);
     let tag = await orm.em.findOneOrFail(BookTag, tag1.id, ['books']);
     const err = 'You cannot modify inverse side of M:N collection BookTag.books when the owning side is not initialized. Consider working with the owning side instead (Book.tags).';
     expect(() => tag.books.add(orm.em.getReference(Book, book4.id))).toThrowError(err);

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -1461,8 +1461,11 @@ describe('EntityManagerMySql', () => {
   test('many to many with composite pk', async () => {
     const author = new Author2('Jon Snow', 'snow@wall.st');
     const book1 = new Book2('My Life on The Wall, part 1', author);
+    book1.perex = 'asd 1';
     const book2 = new Book2('My Life on The Wall, part 2', author);
+    book2.perex = 'asd 2';
     const book3 = new Book2('My Life on The Wall, part 3', author);
+    book3.perex = 'asd 3';
     const tag1 = new BookTag2('silly');
     const tag2 = new BookTag2('funny');
     const tag3 = new BookTag2('sick');
@@ -1951,18 +1954,6 @@ describe('EntityManagerMySql', () => {
       'left join `author2` as `e3` on `e2`.`author_id` = `e3`.`id` ' +
       'left join `test2` as `e4` on `e0`.`uuid_pk` = `e4`.`book_uuid_pk` ' +
       'where `e0`.`author_id` is not null and `e3`.`name` = ?');
-  });
-
-  test('partial selects', async () => {
-    const author = new Author2('Jon Snow', 'snow@wall.st');
-    author.born = new Date('1990-03-23');
-    await orm.em.persistAndFlush(author);
-    orm.em.clear();
-
-    const a = (await orm.em.findOne(Author2, author, { fields: ['name'] }))!;
-    expect(a.name).toBe('Jon Snow');
-    expect(a.email).toBeUndefined();
-    expect(a.born).toBeUndefined();
   });
 
   test('question marks and parameter interpolation (GH issue #920)', async () => {

--- a/tests/partial-loading.mongo.test.ts
+++ b/tests/partial-loading.mongo.test.ts
@@ -1,0 +1,195 @@
+import { MikroORM, Logger } from '@mikro-orm/core';
+import { MongoDriver } from '@mikro-orm/mongodb';
+import { Author, Book, BookTag } from './entities';
+import { initORMMongo, wipeDatabase } from './bootstrap';
+
+describe('partial loading (mongo)', () => {
+
+  let orm: MikroORM<MongoDriver>;
+
+  beforeAll(async () => orm = await initORMMongo());
+  beforeEach(async () => wipeDatabase(orm.em));
+  afterAll(async () => orm.close(true));
+
+  test('partial selects', async () => {
+    const author = new Author('Jon Snow', 'snow@wall.st');
+    author.born = new Date('1990-03-23');
+    await orm.em.persistAndFlush(author);
+    orm.em.clear();
+
+    const a = (await orm.em.findOne(Author, author, { fields: ['name'] }))!;
+    expect(a.name).toBe('Jon Snow');
+    expect(a.email).toBeUndefined();
+    expect(a.born).toBeUndefined();
+  });
+
+  test('partial nested loading (1:m)', async () => {
+    const god = new Author(`God `, `hello@heaven.god`);
+    const b1 = new Book(`Bible 1`, god);
+    b1.tenant = 123;
+    const b2 = new Book(`Bible 2`, god);
+    b2.tenant = 456;
+    const b3 = new Book(`Bible 3`, god);
+    b3.tenant = 789;
+    await orm.em.persistAndFlush(god);
+    orm.em.clear();
+
+    const mock = jest.fn();
+    const logger = new Logger(mock, ['query']);
+    Object.assign(orm.config, { logger });
+
+    const r1 = await orm.em.find(Author, god, { fields: ['id', 'books.author', 'books.title'], populate: ['books'] });
+    expect(r1).toHaveLength(1);
+    expect(r1[0].id).toBe(god.id);
+    expect(r1[0].name).toBeUndefined();
+    expect(r1[0].books[0].id).toBe(b1.id);
+    expect(r1[0].books[0].title).toBe('Bible 1');
+    expect(r1[0].books[0].tenant).toBeUndefined();
+    expect(r1[0].books[0].author).toBeDefined();
+    expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: ObjectId\('.*'\) }, { session: undefined, projection: { _id: 1 } }\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ author: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, author: 1, title: 1 } }\)\.sort\({ author: 1 }\)\.toArray\(\);/);
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const r2 = await orm.em.find(Author, god, { fields: ['id', { books: ['id', 'author', 'title'] }], populate: ['books'] });
+    expect(r2).toHaveLength(1);
+    expect(r2[0].id).toBe(god.id);
+    expect(r2[0].name).toBeUndefined();
+    expect(r2[0].books[0].id).toBe(b1.id);
+    expect(r2[0].books[0].title).toBe('Bible 1');
+    expect(r2[0].books[0].tenant).toBeUndefined();
+    expect(r2[0].books[0].author).toBeDefined();
+    expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: ObjectId\('.*'\) }, { session: undefined, projection: { _id: 1 } }\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ author: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, author: 1, title: 1 } }\)\.sort\({ author: 1 }\)\.toArray\(\);/);
+  });
+
+  test('partial nested loading (m:1)', async () => {
+    const god = new Author(`God `, `hello@heaven.god`);
+    const b1 = new Book(`Bible 1`, god);
+    b1.tenant = 123;
+    const b2 = new Book(`Bible 2`, god);
+    b2.tenant = 456;
+    const b3 = new Book(`Bible 3`, god);
+    b3.tenant = 789;
+    await orm.em.persistAndFlush(god);
+    orm.em.clear();
+
+    const mock = jest.fn();
+    const logger = new Logger(mock, ['query']);
+    Object.assign(orm.config, { logger });
+
+    const r1 = await orm.em.find(Book, b1, { fields: ['id', 'title', 'author', 'author.email'], populate: ['author'], filters: false });
+    expect(r1).toHaveLength(1);
+    expect(r1[0].id).toBe(b1.id);
+    expect(r1[0].title).toBe('Bible 1');
+    expect(r1[0].tenant).toBeUndefined();
+    expect(r1[0].author).toBeDefined();
+    expect(r1[0].author.id).toBe(god.id);
+    expect(r1[0].author.name).toBeUndefined();
+    expect(r1[0].author.email).toBeDefined();
+    expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ _id: ObjectId\('.*'\) }, { session: undefined, projection: { _id: 1, title: 1, author: 1 } }\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, email: 1 } }\)\.sort\({ _id: 1 }\)\.toArray\(\);/);
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const r2 = await orm.em.find(Book, b1, { fields: ['id', 'title', 'author', { author: ['email'] }], populate: ['author'], filters: false });
+    expect(r2).toHaveLength(1);
+    expect(r2[0].id).toBe(b1.id);
+    expect(r2[0].title).toBe('Bible 1');
+    expect(r2[0].tenant).toBeUndefined();
+    expect(r2[0].author).toBeDefined();
+    expect(r2[0].author.id).toBe(god.id);
+    expect(r2[0].author.name).toBeUndefined();
+    expect(r2[0].author.email).toBeDefined();
+    expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ _id: ObjectId\('.*'\) }, { session: undefined, projection: { _id: 1, title: 1, author: 1 } }\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, email: 1 } }\)\.sort\({ _id: 1 }\)\.toArray\(\);/);
+  });
+
+  test('partial nested loading (m:n)', async () => {
+    const god = new Author(`God `, `hello@heaven.god`);
+    const b1 = new Book(`Bible 1`, god);
+    b1.tenant = 123;
+    const t1 = new BookTag('t1');
+    b1.tags.add(t1, new BookTag('t2'));
+    const b2 = new Book(`Bible 2`, god);
+    b2.tenant = 456;
+    b2.tags.add(new BookTag('t3'), new BookTag('t4'), t1);
+    const b3 = new Book(`Bible 3`, god);
+    b3.tenant = 789;
+    b3.tags.add(new BookTag('t5'), new BookTag('t6'), t1);
+    await orm.em.persistAndFlush(god);
+    orm.em.clear();
+
+    const mock = jest.fn();
+    const logger = new Logger(mock, ['query']);
+    Object.assign(orm.config, { logger });
+
+    const r1 = await orm.em.find(BookTag, {}, { fields: ['name', 'books.title', 'books.tags'], populate: ['books'], filters: false, refresh: true });
+    expect(r1).toHaveLength(6);
+    expect(r1[0].name).toBe('t1');
+    expect(r1[0].books[0].title).toBe('Bible 1');
+    expect(r1[0].books[0].tenant).toBeUndefined();
+    expect(r1[0].books[0].author).toBeUndefined();
+    expect(mock.mock.calls[0][0]).toMatch('db.getCollection(\'book-tag\').find({}, { session: undefined, projection: { _id: 1, name: 1 } }).toArray();');
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, title: 1, tags: 1 } }\)\.sort\({ tags: 1 }\)\.toArray\(\);/);
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const r2 = await orm.em.find(BookTag, { name: 't1' }, { fields: ['name', { books: ['title', 'tags'] }], populate: ['books'], filters: false });
+    expect(r2).toHaveLength(1);
+    expect(r2[0].name).toBe('t1');
+    expect(r2[0].books[0].title).toBe('Bible 1');
+    expect(r2[0].books[0].tenant).toBeUndefined();
+    expect(r2[0].books[0].author).toBeUndefined();
+    expect(mock.mock.calls[0][0]).toMatch('db.getCollection(\'book-tag\').find({ name: \'t1\' }, { session: undefined, projection: { _id: 1, name: 1 } }).toArray();');
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, title: 1, tags: 1 } }\)\.sort\({ tags: 1 }\)\.toArray\(\);/);
+  });
+
+  test('partial nested loading (mixed)', async () => {
+    const god = new Author(`God `, `hello@heaven.god`);
+    const b1 = new Book(`Bible 1`, god);
+    b1.tenant = 123;
+    b1.tags.add(new BookTag('t1'), new BookTag('t2'));
+    const b2 = new Book(`Bible 2`, god);
+    b2.tenant = 456;
+    b2.tags.add(new BookTag('t3'), new BookTag('t4'));
+    const b3 = new Book(`Bible 3`, god);
+    b3.tenant = 789;
+    b3.tags.add(new BookTag('t5'), new BookTag('t6'));
+    await orm.em.persistAndFlush(god);
+    orm.em.clear();
+
+    const mock = jest.fn();
+    const logger = new Logger(mock, ['query']);
+    Object.assign(orm.config, { logger });
+
+    const r1 = await orm.em.find(BookTag, {}, { fields: ['name', 'books.title', 'books.tags', 'books.author', 'books.author.email'], populate: ['books.author'], filters: false });
+    expect(r1).toHaveLength(6);
+    expect(r1[0].name).toBe('t1');
+    expect(r1[0].books[0].title).toBe('Bible 1');
+    expect(r1[0].books[0].tenant).toBeUndefined();
+    expect(r1[0].books[0].author).toBeDefined();
+    expect(r1[0].books[0].author.id).toBeDefined();
+    expect(r1[0].books[0].author.name).toBeUndefined();
+    expect(r1[0].books[0].author.email).toBe(god.email);
+    expect(mock.mock.calls[0][0]).toMatch('db.getCollection(\'book-tag\').find({}, { session: undefined, projection: { _id: 1, name: 1 } }).toArray();');
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, title: 1, tags: 1, author: 1 } }\)\.sort\({ tags: 1 }\)\.toArray\(\);/);
+    expect(mock.mock.calls[2][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, email: 1 } }\)\.sort\({ _id: 1 }\)\.toArray\(\);/);
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const r2 = await orm.em.find(BookTag, {}, { fields: ['name', { books: ['title', 'tags', 'author', { author: ['email'] }] } ], populate: ['books.author'], filters: false });
+    expect(r2).toHaveLength(6);
+    expect(r2[0].name).toBe('t1');
+    expect(r2[0].books[0].title).toBe('Bible 1');
+    expect(r2[0].books[0].tenant).toBeUndefined();
+    expect(r2[0].books[0].author).toBeDefined();
+    expect(r2[0].books[0].author.id).toBeDefined();
+    expect(r2[0].books[0].author.name).toBeUndefined();
+    expect(r2[0].books[0].author.email).toBe(god.email);
+    expect(mock.mock.calls[0][0]).toMatch('db.getCollection(\'book-tag\').find({}, { session: undefined, projection: { _id: 1, name: 1 } }).toArray();');
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, title: 1, tags: 1, author: 1 } }\)\.sort\({ tags: 1 }\)\.toArray\(\);/);
+    expect(mock.mock.calls[2][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, email: 1 } }\)\.sort\({ _id: 1 }\)\.toArray\(\);/);
+  });
+
+});

--- a/tests/partial-loading.mysql.test.ts
+++ b/tests/partial-loading.mysql.test.ts
@@ -1,0 +1,194 @@
+import { MikroORM, Logger } from '@mikro-orm/core';
+import { MySqlDriver } from '@mikro-orm/mysql';
+import { Author2, Book2, BookTag2 } from './entities-sql';
+import { initORMMySql, wipeDatabaseMySql } from './bootstrap';
+
+describe('partial loading (mysql)', () => {
+
+  let orm: MikroORM<MySqlDriver>;
+
+  beforeAll(async () => orm = await initORMMySql('mysql', {}, true));
+  beforeEach(async () => wipeDatabaseMySql(orm.em));
+  afterAll(async () => orm.close(true));
+
+  test('partial selects', async () => {
+    const author = new Author2('Jon Snow', 'snow@wall.st');
+    author.born = new Date('1990-03-23');
+    await orm.em.persistAndFlush(author);
+    orm.em.clear();
+
+    const a = (await orm.em.findOne(Author2, author, { fields: ['name'] }))!;
+    expect(a.name).toBe('Jon Snow');
+    expect(a.email).toBeUndefined();
+    expect(a.born).toBeUndefined();
+  });
+
+  test('partial nested loading (1:m)', async () => {
+    const god = new Author2(`God `, `hello@heaven.god`);
+    const b1 = new Book2(`Bible 1`, god);
+    b1.price = 123;
+    const b2 = new Book2(`Bible 2`, god);
+    b2.price = 456;
+    const b3 = new Book2(`Bible 3`, god);
+    b3.price = 789;
+    await orm.em.persistAndFlush(god);
+    orm.em.clear();
+
+    const mock = jest.fn();
+    const logger = new Logger(mock, ['query']);
+    Object.assign(orm.config, { logger });
+
+    const r1 = await orm.em.find(Author2, god, { fields: ['id', 'books.author', 'books.title'], populate: ['books'] });
+    expect(r1).toHaveLength(1);
+    expect(r1[0].id).toBe(god.id);
+    expect(r1[0].name).toBeUndefined();
+    expect(r1[0].books[0].uuid).toBe(b1.uuid);
+    expect(r1[0].books[0].title).toBe('Bible 1');
+    expect(r1[0].books[0].price).toBeUndefined();
+    expect(r1[0].books[0].author).toBeDefined();
+    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`id` from `author2` as `e0` where `e0`.`id` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`author_id`, `e0`.`title` from `book2` as `e0` where `e0`.`author_id` is not null and `e0`.`author_id` in (?) order by `e0`.`title` asc');
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const r2 = await orm.em.find(Author2, god, { fields: ['id', { books: ['uuid', 'author', 'title'] }], populate: ['books'] });
+    expect(r2).toHaveLength(1);
+    expect(r2[0].id).toBe(god.id);
+    expect(r2[0].name).toBeUndefined();
+    expect(r2[0].books[0].uuid).toBe(b1.uuid);
+    expect(r2[0].books[0].title).toBe('Bible 1');
+    expect(r2[0].books[0].price).toBeUndefined();
+    expect(r2[0].books[0].author).toBeDefined();
+    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`id` from `author2` as `e0` where `e0`.`id` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`author_id`, `e0`.`title` from `book2` as `e0` where `e0`.`author_id` is not null and `e0`.`author_id` in (?) order by `e0`.`title` asc');
+  });
+
+  test('partial nested loading (m:1)', async () => {
+    const god = new Author2(`God `, `hello@heaven.god`);
+    const b1 = new Book2(`Bible 1`, god);
+    b1.price = 123;
+    const b2 = new Book2(`Bible 2`, god);
+    b2.price = 456;
+    const b3 = new Book2(`Bible 3`, god);
+    b3.price = 789;
+    await orm.em.persistAndFlush(god);
+    orm.em.clear();
+
+    const mock = jest.fn();
+    const logger = new Logger(mock, ['query']);
+    Object.assign(orm.config, { logger });
+
+    const r1 = await orm.em.find(Book2, b1, { fields: ['uuid', 'title', 'author', 'author.email'], populate: ['author'], filters: false });
+    expect(r1).toHaveLength(1);
+    expect(r1[0].uuid).toBe(b1.uuid);
+    expect(r1[0].title).toBe('Bible 1');
+    expect(r1[0].price).toBeUndefined();
+    expect(r1[0].author).toBeDefined();
+    expect(r1[0].author.id).toBe(god.id);
+    expect(r1[0].author.name).toBeUndefined();
+    expect(r1[0].author.email).toBeDefined();
+    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`title`, `e0`.`author_id` from `book2` as `e0` where `e0`.`uuid_pk` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select `e0`.`id`, `e0`.`email` from `author2` as `e0` where `e0`.`id` in (?) order by `e0`.`id` asc');
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const r2 = await orm.em.find(Book2, b1, { fields: ['uuid', 'title', 'author', { author: ['email'] }], populate: ['author'], filters: false });
+    expect(r2).toHaveLength(1);
+    expect(r2[0].uuid).toBe(b1.uuid);
+    expect(r2[0].title).toBe('Bible 1');
+    expect(r2[0].price).toBeUndefined();
+    expect(r2[0].author).toBeDefined();
+    expect(r2[0].author.id).toBe(god.id);
+    expect(r2[0].author.name).toBeUndefined();
+    expect(r2[0].author.email).toBeDefined();
+    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`title`, `e0`.`author_id` from `book2` as `e0` where `e0`.`uuid_pk` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select `e0`.`id`, `e0`.`email` from `author2` as `e0` where `e0`.`id` in (?) order by `e0`.`id` asc');
+  });
+
+  test('partial nested loading (m:n)', async () => {
+    const god = new Author2(`God `, `hello@heaven.god`);
+    const b1 = new Book2(`Bible 1`, god);
+    b1.price = 123;
+    b1.tags.add(new BookTag2('t1'), new BookTag2('t2'));
+    const b2 = new Book2(`Bible 2`, god);
+    b2.price = 456;
+    b2.tags.add(new BookTag2('t3'), new BookTag2('t4'));
+    const b3 = new Book2(`Bible 3`, god);
+    b3.price = 789;
+    b3.tags.add(new BookTag2('t5'), new BookTag2('t6'));
+    await orm.em.persistAndFlush(god);
+    orm.em.clear();
+
+    const mock = jest.fn();
+    const logger = new Logger(mock, ['query']);
+    Object.assign(orm.config, { logger });
+
+    const r1 = await orm.em.find(BookTag2, {}, { fields: ['name', 'books.title'], populate: ['books'], filters: false });
+    expect(r1).toHaveLength(6);
+    expect(r1[0].name).toBe('t1');
+    expect(r1[0].books[0].title).toBe('Bible 1');
+    expect(r1[0].books[0].price).toBeUndefined();
+    expect(r1[0].books[0].author).toBeUndefined();
+    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`id`, `e0`.`name` from `book_tag2` as `e0`');
+    expect(mock.mock.calls[1][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`title`, `e1`.`book2_uuid_pk`, `e1`.`book_tag2_id`, `e2`.`id` as `test_id` from `book2` as `e0` left join `book2_tags` as `e1` on `e0`.`uuid_pk` = `e1`.`book2_uuid_pk` left join `test2` as `e2` on `e0`.`uuid_pk` = `e2`.`book_uuid_pk` where `e1`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) order by `e1`.`order` asc');
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const r2 = await orm.em.find(BookTag2, { name: 't1' }, { fields: ['name', { books: ['title'] }], populate: ['books'], filters: false });
+    expect(r2).toHaveLength(1);
+    expect(r2[0].name).toBe('t1');
+    expect(r2[0].books[0].title).toBe('Bible 1');
+    expect(r2[0].books[0].price).toBeUndefined();
+    expect(r2[0].books[0].author).toBeUndefined();
+    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`id`, `e0`.`name` from `book_tag2` as `e0` where `e0`.`name` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`title`, `e1`.`book2_uuid_pk`, `e1`.`book_tag2_id`, `e2`.`id` as `test_id` from `book2` as `e0` left join `book2_tags` as `e1` on `e0`.`uuid_pk` = `e1`.`book2_uuid_pk` left join `test2` as `e2` on `e0`.`uuid_pk` = `e2`.`book_uuid_pk` where `e1`.`book_tag2_id` in (?) order by `e1`.`order` asc');
+  });
+
+  test('partial nested loading (mixed)', async () => {
+    const god = new Author2(`God `, `hello@heaven.god`);
+    const b1 = new Book2(`Bible 1`, god);
+    b1.price = 123;
+    b1.tags.add(new BookTag2('t1'), new BookTag2('t2'));
+    const b2 = new Book2(`Bible 2`, god);
+    b2.price = 456;
+    b2.tags.add(new BookTag2('t3'), new BookTag2('t4'));
+    const b3 = new Book2(`Bible 3`, god);
+    b3.price = 789;
+    b3.tags.add(new BookTag2('t5'), new BookTag2('t6'));
+    await orm.em.persistAndFlush(god);
+    orm.em.clear();
+
+    const mock = jest.fn();
+    const logger = new Logger(mock, ['query']);
+    Object.assign(orm.config, { logger });
+
+    const r1 = await orm.em.find(BookTag2, {}, { fields: ['name', 'books.title', 'books.author', 'books.author.email'], populate: ['books.author'], filters: false });
+    expect(r1).toHaveLength(6);
+    expect(r1[0].name).toBe('t1');
+    expect(r1[0].books[0].title).toBe('Bible 1');
+    expect(r1[0].books[0].price).toBeUndefined();
+    expect(r1[0].books[0].author).toBeDefined();
+    expect(r1[0].books[0].author.id).toBeDefined();
+    expect(r1[0].books[0].author.name).toBeUndefined();
+    expect(r1[0].books[0].author.email).toBe(god.email);
+    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`id`, `e0`.`name` from `book_tag2` as `e0`');
+    expect(mock.mock.calls[1][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`title`, `e0`.`author_id`, `e1`.`book2_uuid_pk`, `e1`.`book_tag2_id`, `e2`.`id` as `test_id` from `book2` as `e0` left join `book2_tags` as `e1` on `e0`.`uuid_pk` = `e1`.`book2_uuid_pk` left join `test2` as `e2` on `e0`.`uuid_pk` = `e2`.`book_uuid_pk` where `e1`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) order by `e1`.`order` asc');
+    expect(mock.mock.calls[2][0]).toMatch('select `e0`.`id`, `e0`.`email` from `author2` as `e0` where `e0`.`id` in (?) order by `e0`.`id` asc');
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const r2 = await orm.em.find(BookTag2, {}, { fields: ['name', { books: ['title', 'author', { author: ['email'] }] } ], populate: ['books.author'], filters: false });
+    expect(r2).toHaveLength(6);
+    expect(r2[0].name).toBe('t1');
+    expect(r2[0].books[0].title).toBe('Bible 1');
+    expect(r2[0].books[0].price).toBeUndefined();
+    expect(r2[0].books[0].author).toBeDefined();
+    expect(r2[0].books[0].author.id).toBeDefined();
+    expect(r2[0].books[0].author.name).toBeUndefined();
+    expect(r2[0].books[0].author.email).toBe(god.email);
+    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`id`, `e0`.`name` from `book_tag2` as `e0`');
+    expect(mock.mock.calls[1][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`title`, `e0`.`author_id`, `e1`.`book2_uuid_pk`, `e1`.`book_tag2_id`, `e2`.`id` as `test_id` from `book2` as `e0` left join `book2_tags` as `e1` on `e0`.`uuid_pk` = `e1`.`book2_uuid_pk` left join `test2` as `e2` on `e0`.`uuid_pk` = `e2`.`book_uuid_pk` where `e1`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) order by `e1`.`order` asc');
+    expect(mock.mock.calls[2][0]).toMatch('select `e0`.`id`, `e0`.`email` from `author2` as `e0` where `e0`.`id` in (?) order by `e0`.`id` asc');
+  });
+
+});


### PR DESCRIPTION
Adds support for nested partial loading:

```ts
const author = await orm.em.findOne(Author, '...', { fields: ['name', 'books.title', 'books.author', 'books.price'] });
```

Or with alternative object syntax:

```ts
const author = await orm.em.findOne(Author, '...', { fields: ['name', { books: ['title', 'author', 'price'] }] });
```

It is also possible to use multiple levels:

```ts
const author = await orm.em.findOne(Author, '...', { fields: ['name', { books: ['title', 'price', 'author', { author: ['email'] }] }] });
```

Primary keys are always selected even if you omit them. On the other hand, you are responsible 
for selecting the FKs - if you omit such property, the relation might not be loaded properly.
In the following example the books would not be linked the author, because we did not specify 
the `books.author` field to be loaded.

```ts
// this will load both author and book entities, but they won't be connected due to the missing FK in select
const author = await orm.em.findOne(Author, '...', { fields: ['name', { books: ['title', 'price'] });
```

> Same problem can occur in mongo with M:N collections - those are stored as array property 
> on the owning entity, so you need to make sure to mark such properties too.

Closes #221