### PR TITLE
feat(core): allow disabling identity map and change set tracking

### DIFF
--- a/docs/docs/entity-manager.md
+++ b/docs/docs/entity-manager.md
@@ -291,6 +291,28 @@ where lower(email) = 'foo@bar.baz'
 order by (point(loc_latitude, loclongitude) <@> point(0, 0)) asc
 ```
 
+## Disabling identity map and change set tracking
+
+Sometimes we might want to disable identity map and change set tracking for some query.
+This is possible via `disableIdentityMap` option. Behind the scenes, it will create new 
+context, load the entities inside that, and clear it afterwards, so the main identity map
+will stay clean.
+
+> As opposed to _managed_ entities, such entities are called _detached_. 
+> To be able to work with them, you first need to merge them via `em.registerManaged()`. 
+
+```ts
+const users = await orm.em.find(User, { email: 'foo@bar.baz' }, {
+  disableIdentityMap: true,
+  populate: { cars: { brand: true } },
+});
+users[0].name = 'changed';
+await orm.em.flush(); // calling flush have no effect, as the entity is not managed  
+```
+
+> Keep in mind that this can also have 
+> [negative effect on the performance](https://stackoverflow.com/questions/9259480/entity-framework-mergeoption-notracking-bad-performance).
+
 ## Type of Fetched Entities
 
 Both `em.find` and `em.findOne()` methods have generic return types.

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -87,6 +87,7 @@ export interface FindOptions<T, P extends Populate<T> = Populate<T>> {
   offset?: number;
   refresh?: boolean;
   convertCustomTypes?: boolean;
+  disableIdentityMap?: boolean;
   fields?: (string | FieldsMap)[];
   schema?: string;
   flags?: QueryFlag[];

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -1886,8 +1886,6 @@ describe('EntityManagerMongo', () => {
     await orm.em.flush();
     orm.em.clear();
 
-    const tags = await orm.em.find(BookTag, {}, ['books']);
-    console.log(tags);
     let tag = await orm.em.findOneOrFail(BookTag, tag1.id, ['books']);
     const err = 'You cannot modify inverse side of M:N collection BookTag.books when the owning side is not initialized. Consider working with the owning side instead (Book.tags).';
     expect(() => tag.books.add(orm.em.getReference(Book, book4.id))).toThrowError(err);


### PR DESCRIPTION
Sometimes we might want to disable identity map and change set tracking for some query.
This is possible via `disableIdentityMap` option. Behind the scenes, it will create new
context, load the entities inside that, and clear it afterwards, so the main identity map
will stay clean.

```ts
const users = await orm.em.find(User, { email: 'foo@bar.baz' }, {
  disableIdentityMap: true,
  populate: { cars: { brand: true } },
});
users[0].name = 'changed';
await orm.em.flush(); // calling flush have no effect, as the entity is not managed
```

> Keep in mind that this can also have
> [negative effect on the performance](https://stackoverflow.com/questions/9259480/entity-framework-mergeoption-notracking-bad-performance).

Closes #1267