### PR TITLE
feat(core): add support for nested embedddables

### DIFF
--- a/docs/docs/embeddables.md
+++ b/docs/docs/embeddables.md
@@ -120,3 +120,51 @@ In SQL drivers, this will use a JSON column to store the value.
 
 > This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/embeddables.html)
 > as the behaviour here is pretty much the same.
+
+## Nested embeddables
+
+Starting with v4.4, we can also nest embeddables, both in inline mode and object mode:
+
+```ts
+@Entity()
+class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Embedded(() => Profile, { object: true, nullable: true })
+  profile?: Profile;
+
+}
+
+@Embeddable()
+class Profile {
+
+  @Property()
+  username: string;
+
+  @Embedded(() => Identity)
+  identity: Identity;
+
+  constructor(username: string, identity: Identity) {
+    this.username = username;
+    this.identity = identity;
+  }
+
+}
+
+@Embeddable()
+class Identity {
+
+  @Property()
+  email: string;
+
+  constructor(email: string) {
+    this.email = email;
+  }
+
+}
+```

--- a/packages/core/src/decorators/Embedded.ts
+++ b/packages/core/src/decorators/Embedded.ts
@@ -3,11 +3,11 @@ import { MetadataStorage, MetadataValidator } from '../metadata';
 import { Utils } from '../utils';
 import { ReferenceType } from '../enums';
 
-export function Embedded(options: EmbeddedOptions | (() => AnyEntity) = {}) {
+export function Embedded(type: EmbeddedOptions | (() => AnyEntity) = {}, options: EmbeddedOptions = {}) {
   return function (target: AnyEntity, propertyName: string) {
     const meta = MetadataStorage.getMetadataFromDecorator(target.constructor);
     MetadataValidator.validateSingleDecorator(meta, propertyName, ReferenceType.EMBEDDED);
-    options = options instanceof Function ? { entity: options } : options;
+    options = type instanceof Function ? { entity: type, ...options } : { ...type, ...options };
     Utils.defaultValue(options, 'prefix', true);
     const property = { name: propertyName, reference: ReferenceType.EMBEDDED } as EntityProperty;
     meta.properties[propertyName] = Object.assign(property, options);

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -97,6 +97,10 @@ export class ValidationError<T extends AnyEntity = AnyEntity> extends Error {
     return new ValidationError(`Using operators inside embeddables is not allowed, move the operator above. (property: ${className}.${propName}, payload: ${inspect(payload)})`);
   }
 
+  static invalidEmbeddableQuery(className: string, propName: string, embeddableType: string): ValidationError {
+    return new ValidationError(`Invalid query for entity '${className}', property '${propName}' does not exist in embeddable '${embeddableType}'`);
+  }
+
 }
 
 export class OptimisticLockError<T extends AnyEntity = AnyEntity> extends ValidationError<T> {
@@ -190,6 +194,10 @@ export class MetadataError<T extends AnyEntity = AnyEntity> extends ValidationEr
 
   static missingMetadata(entity: string): MetadataError {
     return new MetadataError(`Metadata for entity ${entity} not found`);
+  }
+
+  static conflictingPropertyName(className: string, name: string, embeddedName: string): MetadataError {
+    return new MetadataError(`Property ${className}:${name} is being overwritten by its child property ${embeddedName}:${name}. Consider using a prefix to overcome this issue.`);
   }
 
   private static fromMessage(meta: EntityMetadata, prop: EntityProperty, message: string): MetadataError {

--- a/packages/knex/src/query/CriteriaNodeFactory.ts
+++ b/packages/knex/src/query/CriteriaNodeFactory.ts
@@ -67,6 +67,10 @@ export class CriteriaNodeFactory {
     }
 
     const map = Object.keys(payload[item]).reduce((oo, k) => {
+      if (!prop.embeddedProps[k]) {
+        throw ValidationError.invalidEmbeddableQuery(entityName, k, prop.type);
+      }
+
       oo[prop.embeddedProps[k].name] = payload[item][k];
       return oo;
     }, {});

--- a/packages/knex/src/schema/SchemaGenerator.ts
+++ b/packages/knex/src/schema/SchemaGenerator.ts
@@ -345,7 +345,7 @@ export class SchemaGenerator {
   }
 
   private shouldHaveColumn(meta: EntityMetadata, prop: EntityProperty, update = false): boolean {
-    if (prop.persist === false) {
+    if (prop.persist === false || !prop.fieldNames) {
       return false;
     }
 
@@ -355,6 +355,13 @@ export class SchemaGenerator {
 
     if (prop.reference !== ReferenceType.SCALAR && !prop.primary && !this.helper.supportsSchemaConstraints() && !update) {
       return false;
+    }
+
+    const getRootProperty: (prop: EntityProperty) => EntityProperty = (prop: EntityProperty) => prop.embedded ? getRootProperty(meta.properties[prop.embedded[0]]) : prop;
+    const rootProp = getRootProperty(prop);
+
+    if (rootProp.reference === ReferenceType.EMBEDDED) {
+      return prop === rootProp || !rootProp.object;
     }
 
     return [ReferenceType.SCALAR, ReferenceType.MANY_TO_ONE].includes(prop.reference) || (prop.reference === ReferenceType.ONE_TO_ONE && prop.owner);

--- a/packages/mysql-base/src/MySqlPlatform.ts
+++ b/packages/mysql-base/src/MySqlPlatform.ts
@@ -12,7 +12,7 @@ export class MySqlPlatform extends AbstractSqlPlatform {
   }
 
   getSearchJsonPropertySQL(path: string): string {
-    const [a, b] = path.split('->', 2);
+    const [a, b] = path.split('->', 2); // TODO
     return `${this.quoteIdentifier(a)}->'$.${b}'`;
   }
 

--- a/packages/postgresql/src/PostgreSqlPlatform.ts
+++ b/packages/postgresql/src/PostgreSqlPlatform.ts
@@ -59,8 +59,16 @@ export class PostgreSqlPlatform extends AbstractSqlPlatform {
   }
 
   getSearchJsonPropertySQL(path: string): string {
-    const [a, b] = path.split('->', 2);
-    return `${this.quoteIdentifier(a)}->>'${b}'`;
+    const parts = path.split('->');
+    const first = parts.shift();
+    const last = parts.pop();
+    const root = this.quoteIdentifier(first!);
+
+    if (parts.length === 0) {
+      return `${root}->>'${last}'`;
+    }
+
+    return `${root}->${parts.map(a => this.quoteValue(a)).join('->')}->>'${last}'`;
   }
 
   quoteIdentifier(id: string, quote = '"'): string {

--- a/tests/__snapshots__/nested-embeddables.mongo.test.ts.snap
+++ b/tests/__snapshots__/nested-embeddables.mongo.test.ts.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`embedded entities in mongo diffing 1`] = `
+"function(entity) {
+  const ret = {};
+  if ('_id' in entity && entity._id != null) {
+    ret._id = clone(entity._id);
+  }
+
+  if ('name' in entity) {
+    ret.name = entity.name;
+  }
+
+  if (entity.profile1 != null) {
+    ret.profile1_username = clone(entity.profile1.username);
+
+    if (entity.profile1.identity != null) {
+      ret.profile1_identity_email = clone(entity.profile1.identity.email);
+
+      if (entity.profile1.identity.meta != null) {
+        ret.profile1_identity_meta_foo = clone(entity.profile1.identity.meta.foo);
+        ret.profile1_identity_meta_bar = clone(entity.profile1.identity.meta.bar);
+      }
+    }
+  }
+
+  if ('profile2' in entity) {
+    ret.profile2 = cloneEmbeddable({ ...entity.profile2 });
+  }
+
+  return ret;
+}"
+`;

--- a/tests/__snapshots__/nested-embeddables.postgres.test.ts.snap
+++ b/tests/__snapshots__/nested-embeddables.postgres.test.ts.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`embedded entities in postgres diffing 1`] = `
+"function(entity) {
+  const ret = {};
+  if ('id' in entity && entity.id != null) {
+    ret.id = entity.id;
+  }
+
+  if ('name' in entity) {
+    ret.name = entity.name;
+  }
+
+  if (entity.profile1 != null) {
+    ret.profile1_username = clone(entity.profile1.username);
+
+    if (entity.profile1.identity != null) {
+      ret.profile1_identity_email = clone(entity.profile1.identity.email);
+
+      if (entity.profile1.identity.meta != null) {
+        ret.profile1_identity_meta_foo = clone(entity.profile1.identity.meta.foo);
+        ret.profile1_identity_meta_bar = clone(entity.profile1.identity.meta.bar);
+      }
+    }
+  }
+
+  if ('profile2' in entity) {
+    ret.profile2 = cloneEmbeddable({ ...entity.profile2 });
+  }
+
+  return ret;
+}"
+`;
+
+exports[`embedded entities in postgres schema: nested embeddables 1 1`] = `
+"create table \\"user\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"profile1_username\\" varchar(255) not null, \\"profile1_identity_email\\" varchar(255) not null, \\"profile1_identity_meta_foo\\" varchar(255) null, \\"profile1_identity_meta_bar\\" varchar(255) null, \\"profile2\\" jsonb not null);
+
+"
+`;
+
+exports[`embedded entities in postgres schema: nested embeddables 2 1`] = `""`;
+
+exports[`embedded entities in postgres schema: nested embeddables 3 1`] = `
+"drop table if exists \\"user\\" cascade;
+
+"
+`;

--- a/tests/nested-embeddables.mongo.test.ts
+++ b/tests/nested-embeddables.mongo.test.ts
@@ -1,0 +1,232 @@
+import { assign, Embeddable, Embedded, Entity, Logger, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
+import { ObjectId, MongoDriver, MongoConnection } from '@mikro-orm/mongodb';
+
+@Embeddable()
+class IdentityMeta {
+
+  @Property()
+  foo?: string;
+
+  @Property()
+  bar?: string;
+
+  constructor(foo?: string, bar?: string) {
+    this.foo = foo;
+    this.bar = bar;
+  }
+
+}
+
+@Embeddable()
+class Identity {
+
+  @Property()
+  email: string;
+
+  @Embedded(() => IdentityMeta, { nullable: true })
+  meta?: IdentityMeta;
+
+  constructor(email: string, meta?: IdentityMeta) {
+    this.email = email;
+    this.meta = meta;
+  }
+
+}
+
+@Embeddable()
+class Profile {
+
+  @Property()
+  username: string;
+
+  @Embedded(() => Identity)
+  identity: Identity;
+
+  constructor(username: string, identity: Identity) {
+    this.username = username;
+    this.identity = identity;
+  }
+
+}
+
+@Entity()
+class User {
+
+  @PrimaryKey()
+  _id!: ObjectId;
+
+  @Property()
+  name!: string;
+
+  @Embedded(() => Profile)
+  profile1!: Profile;
+
+  @Embedded(() => Profile, { object: true })
+  profile2!: Profile;
+
+}
+
+describe('embedded entities in mongo', () => {
+
+  let orm: MikroORM<MongoDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [User, Profile, Identity, IdentityMeta],
+      clientUrl: 'mongodb://localhost:27017,localhost:27018,localhost:27019/mikro-orm-test-nested-embeddables?replicaSet=rs0',
+      type: 'mongo',
+    });
+  });
+
+  afterAll(async () => {
+    await orm.em.getDriver().dropCollections();
+    await orm.close(true);
+  });
+
+  test('create collections', async () => {
+    const createCollection = jest.spyOn(MongoConnection.prototype, 'createCollection');
+    createCollection.mockResolvedValue({} as any);
+    await orm.em.getDriver().createCollections();
+    expect(createCollection.mock.calls.map(c => c[0])).toEqual(['user']);
+    createCollection.mockRestore();
+  });
+
+  test('diffing', async () => {
+    expect(orm.em.getComparator().getSnapshotGenerator('User').toString()).toMatchSnapshot();
+  });
+
+  test('persist and load', async () => {
+    const user1 = new User();
+    user1.name = 'Uwe';
+    user1.profile1 = new Profile('u1', new Identity('e1', new IdentityMeta('f1', 'b1')));
+    user1.profile2 = new Profile('u2', new Identity('e2', new IdentityMeta('f2', 'b2')));
+
+    const user2 = new User();
+    user2.name = 'Uschi';
+    user2.profile1 = new Profile('u3', new Identity('e3'));
+    user2.profile2 = new Profile('u4', new Identity('e4', new IdentityMeta('f4')));
+
+    const mock = jest.fn();
+    const logger = new Logger(mock, true);
+    Object.assign(orm.config, { logger });
+    await orm.em.persistAndFlush([user1, user2]);
+    orm.em.clear();
+    expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('user').insertMany([ { name: 'Uwe', profile1_username: 'u1', profile1_identity_email: 'e1', profile1_identity_meta_foo: 'f1', profile1_identity_meta_bar: 'b1', profile2: { username: 'u2', identity: { email: 'e2', meta: { foo: 'f2', bar: 'b2' } } } }, { name: 'Uschi', profile1_username: 'u3', profile1_identity_email: 'e3', profile2: { username: 'u4', identity: { email: 'e4', meta: { foo: 'f4' } } } } ], { session: undefined });`);
+
+    const u1 = await orm.em.findOneOrFail(User, user1._id);
+    const u2 = await orm.em.findOneOrFail(User, user2._id);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('user'\)\.find\({ _id: .* }, { session: undefined }\)\.limit\(1\).toArray\(\);/);
+    expect(u1.profile1).toBeInstanceOf(Profile);
+    expect(u1.profile1).toEqual({
+      username: 'u1',
+      identity: {
+        email: 'e1',
+        meta: {
+          bar: 'b1',
+          foo: 'f1',
+        },
+      },
+    });
+    expect(u1.profile2).toBeInstanceOf(Profile);
+    expect(u1.profile2).toEqual({
+      username: 'u2',
+      identity: {
+        email: 'e2',
+        meta: {
+          bar: 'b2',
+          foo: 'f2',
+        },
+      },
+    });
+    expect(u2.profile1).toBeInstanceOf(Profile);
+    expect(u2.profile1).toEqual({
+      username: 'u3',
+      identity: {
+        email: 'e3',
+      },
+    });
+    expect(u2.profile2).toBeInstanceOf(Profile);
+    expect(u2.profile2).toEqual({
+      username: 'u4',
+      identity: {
+        email: 'e4',
+        meta: {
+          foo: 'f4',
+        },
+      },
+    });
+
+    expect(mock.mock.calls.length).toBe(3);
+    await orm.em.flush();
+    expect(mock.mock.calls.length).toBe(3);
+
+    u1.profile1!.identity.email = 'e123';
+    u1.profile1!.identity.meta!.foo = 'foooooooo';
+    u1.profile2!.identity.meta!.bar = 'bababar';
+    await orm.em.flush();
+    expect(mock.mock.calls[3][0]).toMatch(/db\.getCollection\('user'\)\.updateMany\({ _id: .* }, { '\$set': { profile1_identity_email: 'e123', profile1_identity_meta_foo: 'foooooooo', profile2: { username: 'u2', identity: { email: 'e2', meta: { foo: 'f2', bar: 'bababar' } } } } }, { session: undefined }\);/);
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const u3 = await orm.em.findOneOrFail(User, {
+      profile1: { identity: { email: 'e123', meta: { foo: 'foooooooo' } } },
+      profile2: { identity: { email: 'e2', meta: { foo: 'f2', bar: 'bababar' } } },
+    });
+    expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('user'\)\.find\({ profile1_identity_email: 'e123', profile1_identity_meta_foo: 'foooooooo', 'profile2\.identity\.email': 'e2', 'profile2\.identity\.meta\.foo': 'f2', 'profile2\.identity\.meta\.bar': 'bababar' }, { session: undefined }\)\.limit\(1\).toArray\(\);/);
+    expect(u3._id).toEqual(u1._id);
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const u4 = await orm.em.findOneOrFail(User, {
+      profile1: { identity: { email: 'e123', meta: { foo: /fo+/ } } },
+      profile2: { identity: { email: 'e2', meta: { foo: 'f2', bar: /(ba)+r/ } } },
+    });
+    expect(u4._id).toEqual(u1._id);
+    expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('user'\)\.find\({ profile1_identity_email: 'e123', profile1_identity_meta_foo: \/fo\+\/, 'profile2\.identity\.email': 'e2', 'profile2\.identity\.meta\.foo': 'f2', 'profile2\.identity\.meta\.bar': \/\(ba\)\+r\/ }, { session: undefined }\)\.limit\(1\).toArray\(\);/);
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const u5 = await orm.em.findOneOrFail(User, { $or: [{ profile1: { identity: { meta: { foo: 'foooooooo' } } } }, { profile2: { identity: { meta: { bar: 'bababar' } } } }] });
+    expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('user'\)\.find\({ '\$or': \[ { profile1_identity_meta_foo: 'foooooooo' }, { 'profile2\.identity\.meta\.bar': 'bababar' } ] }, { session: undefined }\)\.limit\(1\).toArray\(\);/);
+    expect(u5._id).toEqual(u1._id);
+
+    const err1 = `Invalid query for entity 'User', property 'city' does not exist in embeddable 'Identity'`;
+    await expect(orm.em.findOneOrFail(User, { profile1: { identity: { city: 'London 1' } as any } })).rejects.toThrowError(err1);
+
+    const err2 = `Invalid query for entity 'User', property 'city' does not exist in embeddable 'Identity'`;
+    await expect(orm.em.findOneOrFail(User, { profile2: { identity: { city: 'London 1' } as any } })).rejects.toThrowError(err2);
+  });
+
+  test('#assign() works with nested embeddables', async () => {
+    const jon = new User();
+
+    assign(jon, {
+      profile1: { username: 'u1', identity: { email: 'e1', meta: { bar: 'b1', foo: 'f1' } } },
+      profile2: { username: 'u2', identity: { email: 'e2', meta: { bar: 'b2', foo: 'f2' } } },
+    });
+    expect(jon.profile1).toMatchObject({ username: 'u1', identity: { email: 'e1', meta: { bar: 'b1', foo: 'f1' } } });
+    expect(jon.profile1).toBeInstanceOf(Profile);
+    expect(jon.profile1.identity).toBeInstanceOf(Identity);
+    expect(jon.profile1.identity.meta).toBeInstanceOf(IdentityMeta);
+    expect(jon.profile2).toMatchObject({ username: 'u2', identity: { email: 'e2', meta: { bar: 'b2', foo: 'f2' } } });
+    expect(jon.profile2).toBeInstanceOf(Profile);
+    expect(jon.profile2.identity).toBeInstanceOf(Identity);
+    expect(jon.profile2.identity.meta).toBeInstanceOf(IdentityMeta);
+
+    assign(jon, { profile1: { identity: { email: 'e3' } } }, { mergeObjects: true });
+    expect(jon.profile1.username).toBe('u1');
+    expect(jon.profile1.identity.email).toBe('e3');
+    expect(jon.profile1.identity.meta).not.toBeUndefined();
+    delete jon.profile1.identity.meta;
+
+    assign(jon, { profile1: { identity: { meta: { foo: 'f' } } } }, { mergeObjects: true });
+    expect(jon.profile1.identity.meta!.foo).toBe('f');
+    expect(jon.profile1.identity.meta).toBeInstanceOf(IdentityMeta);
+
+    assign(jon, { profile1: { identity: { email: 'e4' } } });
+    expect(jon.profile1.username).toBeUndefined();
+    expect(jon.profile1.identity.email).toBe('e4');
+    expect(jon.profile1.identity.meta).toBeUndefined();
+  });
+
+});

--- a/tests/nested-embeddables.postgres.test.ts
+++ b/tests/nested-embeddables.postgres.test.ts
@@ -1,0 +1,234 @@
+import { assign, Embeddable, Embedded, Entity, Logger, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
+import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+
+@Embeddable()
+class IdentityMeta {
+
+  @Property()
+  foo?: string;
+
+  @Property()
+  bar?: string;
+
+  constructor(foo?: string, bar?: string) {
+    this.foo = foo;
+    this.bar = bar;
+  }
+
+}
+
+@Embeddable()
+class Identity {
+
+  @Property()
+  email: string;
+
+  @Embedded(() => IdentityMeta, { nullable: true })
+  meta?: IdentityMeta;
+
+  constructor(email: string, meta?: IdentityMeta) {
+    this.email = email;
+    this.meta = meta;
+  }
+
+}
+
+@Embeddable()
+class Profile {
+
+  @Property()
+  username: string;
+
+  @Embedded(() => Identity)
+  identity: Identity;
+
+  constructor(username: string, identity: Identity) {
+    this.username = username;
+    this.identity = identity;
+  }
+
+}
+
+@Entity()
+class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Embedded(() => Profile)
+  profile1!: Profile;
+
+  @Embedded(() => Profile, { object: true })
+  profile2!: Profile;
+
+}
+
+describe('embedded entities in postgres', () => {
+
+  let orm: MikroORM<PostgreSqlDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [User, Profile, Identity, IdentityMeta],
+      type: 'postgresql',
+      dbName: `mikro_orm_test_nested_embedddables`,
+    });
+    await orm.getSchemaGenerator().ensureDatabase();
+    await orm.getSchemaGenerator().dropSchema();
+    await orm.getSchemaGenerator().createSchema();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('schema', async () => {
+    await expect(orm.getSchemaGenerator().getCreateSchemaSQL(false)).resolves.toMatchSnapshot('nested embeddables 1');
+    await expect(orm.getSchemaGenerator().getUpdateSchemaSQL(false)).resolves.toMatchSnapshot('nested embeddables 2');
+    await expect(orm.getSchemaGenerator().getDropSchemaSQL(false)).resolves.toMatchSnapshot('nested embeddables 3');
+  });
+
+  test('diffing', async () => {
+    expect(orm.em.getComparator().getSnapshotGenerator('User').toString()).toMatchSnapshot();
+  });
+
+  test('persist and load', async () => {
+    const user1 = new User();
+    user1.name = 'Uwe';
+    user1.profile1 = new Profile('u1', new Identity('e1', new IdentityMeta('f1', 'b1')));
+    user1.profile2 = new Profile('u2', new Identity('e2', new IdentityMeta('f2', 'b2')));
+
+    const user2 = new User();
+    user2.name = 'Uschi';
+    user2.profile1 = new Profile('u3', new Identity('e3'));
+    user2.profile2 = new Profile('u4', new Identity('e4', new IdentityMeta('f4')));
+
+    const mock = jest.fn();
+    const logger = new Logger(mock, true);
+    Object.assign(orm.config, { logger });
+    await orm.em.persistAndFlush([user1, user2]);
+    orm.em.clear();
+    expect(mock.mock.calls[0][0]).toMatch(`begin`);
+    expect(mock.mock.calls[1][0]).toMatch(`insert into "user" ("name", "profile1_username", "profile1_identity_email", "profile1_identity_meta_foo", "profile1_identity_meta_bar", "profile2") values ('Uwe', 'u1', 'e1', 'f1', 'b1', '{"username":"u2","identity":{"email":"e2","meta":{"foo":"f2","bar":"b2"}}}'), ('Uschi', 'u3', 'e3', NULL, NULL, '{"username":"u4","identity":{"email":"e4","meta":{"foo":"f4"}}}') returning "id"`);
+    expect(mock.mock.calls[2][0]).toMatch(`commit`);
+
+    const u1 = await orm.em.findOneOrFail(User, user1.id);
+    const u2 = await orm.em.findOneOrFail(User, user2.id);
+    expect(mock.mock.calls[3][0]).toMatch(`select "e0".* from "user" as "e0" where "e0"."id" = 1 limit 1`);
+    expect(u1.profile1).toBeInstanceOf(Profile);
+    expect(u1.profile1).toEqual({
+      username: 'u1',
+      identity: {
+        email: 'e1',
+        meta: {
+          bar: 'b1',
+          foo: 'f1',
+        },
+      },
+    });
+    expect(u1.profile2).toBeInstanceOf(Profile);
+    expect(u1.profile2).toEqual({
+      username: 'u2',
+      identity: {
+        email: 'e2',
+        meta: {
+          bar: 'b2',
+          foo: 'f2',
+        },
+      },
+    });
+    expect(u2.profile1).toBeInstanceOf(Profile);
+    expect(u2.profile1).toEqual({
+      username: 'u3',
+      identity: {
+        email: 'e3',
+      },
+    });
+    expect(u2.profile2).toBeInstanceOf(Profile);
+    expect(u2.profile2).toEqual({
+      username: 'u4',
+      identity: {
+        email: 'e4',
+        meta: {
+          foo: 'f4',
+        },
+      },
+    });
+
+    expect(mock.mock.calls.length).toBe(5);
+    await orm.em.flush();
+    expect(mock.mock.calls.length).toBe(5);
+
+    u1.profile1!.identity.email = 'e123';
+    u1.profile1!.identity.meta!.foo = 'foooooooo';
+    u1.profile2!.identity.meta!.bar = 'bababar';
+    await orm.em.flush();
+    expect(mock.mock.calls[3][0]).toMatch(`select "e0".* from "user" as "e0" where "e0"."id" = 1 limit 1`);
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const u3 = await orm.em.findOneOrFail(User, {
+      profile1: { identity: { email: 'e123', meta: { foo: 'foooooooo' } } },
+      profile2: { identity: { email: 'e2', meta: { foo: 'f2', bar: 'bababar' } } },
+    });
+    expect(mock.mock.calls[0][0]).toMatch(`select "e0".* from "user" as "e0" where "e0"."profile1_identity_email" = 'e123' and "e0"."profile1_identity_meta_foo" = 'foooooooo' and "e0"."profile2"->'identity'->>'email' = 'e2' and "e0"."profile2"->'identity'->'meta'->>'foo' = 'f2' and "e0"."profile2"->'identity'->'meta'->>'bar' = 'bababar' limit 1`);
+    expect(u3.id).toEqual(u1.id);
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const u4 = await orm.em.findOneOrFail(User, {
+      profile1: { identity: { email: 'e123', meta: { foo: { $re: 'fo+' } } } },
+      profile2: { identity: { email: 'e2', meta: { foo: 'f2', bar: { $re: '(ba)+r' } } } },
+    });
+    expect(u4.id).toEqual(u1.id);
+    expect(mock.mock.calls[0][0]).toMatch(`select "e0".* from "user" as "e0" where "e0"."profile1_identity_email" = 'e123' and "e0"."profile1_identity_meta_foo" ~ 'fo+' and "e0"."profile2"->'identity'->>'email' = 'e2' and "e0"."profile2"->'identity'->'meta'->>'foo' = 'f2' and "e0"."profile2"->'identity'->'meta'->>'bar' ~ '(ba)+r' limit 1`);
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const u5 = await orm.em.findOneOrFail(User, { $or: [{ profile1: { identity: { meta: { foo: 'foooooooo' } } } }, { profile2: { identity: { meta: { bar: 'bababar' } } } }] });
+    expect(mock.mock.calls[0][0]).toMatch(`select "e0".* from "user" as "e0" where ("e0"."profile1_identity_meta_foo" = 'foooooooo' or "e0"."profile2"->'identity'->'meta'->>'bar' = 'bababar') limit 1`);
+    expect(u5.id).toEqual(u1.id);
+
+    const err1 = `Invalid query for entity 'User', property 'city' does not exist in embeddable 'Identity'`;
+    await expect(orm.em.findOneOrFail(User, { profile1: { identity: { city: 'London 1' } as any } })).rejects.toThrowError(err1);
+
+    const err2 = `Invalid query for entity 'User', property 'city' does not exist in embeddable 'Identity'`;
+    await expect(orm.em.findOneOrFail(User, { profile2: { identity: { city: 'London 1' } as any } })).rejects.toThrowError(err2);
+  });
+
+  test('#assign() works with nested embeddables', async () => {
+    const jon = new User();
+
+    assign(jon, {
+      profile1: { username: 'u1', identity: { email: 'e1', meta: { bar: 'b1', foo: 'f1' } } },
+      profile2: { username: 'u2', identity: { email: 'e2', meta: { bar: 'b2', foo: 'f2' } } },
+    });
+    expect(jon.profile1).toMatchObject({ username: 'u1', identity: { email: 'e1', meta: { bar: 'b1', foo: 'f1' } } });
+    expect(jon.profile1).toBeInstanceOf(Profile);
+    expect(jon.profile1.identity).toBeInstanceOf(Identity);
+    expect(jon.profile1.identity.meta).toBeInstanceOf(IdentityMeta);
+    expect(jon.profile2).toMatchObject({ username: 'u2', identity: { email: 'e2', meta: { bar: 'b2', foo: 'f2' } } });
+    expect(jon.profile2).toBeInstanceOf(Profile);
+    expect(jon.profile2.identity).toBeInstanceOf(Identity);
+    expect(jon.profile2.identity.meta).toBeInstanceOf(IdentityMeta);
+
+    assign(jon, { profile1: { identity: { email: 'e3' } } }, { mergeObjects: true });
+    expect(jon.profile1.username).toBe('u1');
+    expect(jon.profile1.identity.email).toBe('e3');
+    expect(jon.profile1.identity.meta).not.toBeUndefined();
+    delete jon.profile1.identity.meta;
+
+    assign(jon, { profile1: { identity: { meta: { foo: 'f' } } } }, { mergeObjects: true });
+    expect(jon.profile1.identity.meta!.foo).toBe('f');
+    expect(jon.profile1.identity.meta).toBeInstanceOf(IdentityMeta);
+
+    assign(jon, { profile1: { identity: { email: 'e4' } } });
+    expect(jon.profile1.username).toBeUndefined();
+    expect(jon.profile1.identity.email).toBe('e4');
+    expect(jon.profile1.identity.meta).toBeUndefined();
+  });
+
+});


### PR DESCRIPTION
Embeddables can now be nested, both in object and inlined mode. The mode of the root
embedded property is always propagated, e.g. there is no way to nest object embeddable
inside inlined one and vice versa.

`assign` helper now also allows using `mergeObjects` with embeddadble properties.

Closes #1017