### PR TITLE
Added reproduction for issue 1326.

### DIFF
--- a/tests/issues/GH1326.test.ts
+++ b/tests/issues/GH1326.test.ts
@@ -1,0 +1,88 @@
+import { Collection, Entity, Logger, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, Property, Reference, wrap } from '@mikro-orm/core';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+
+@Entity()
+export class Driver {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToMany('License', 'driver')
+  licenses = new Collection<License>(this);
+
+}
+
+@Entity()
+export class License {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  expiresAt!: Date;
+
+  @ManyToOne(() => Driver, { inversedBy: 'licenses', wrappedReference: true })
+  driver!: Reference<Driver>;
+
+  @ManyToOne('LicenseType', { inversedBy: 'licenses', wrappedReference: true })
+  licenseType!: Reference<LicenseType>;
+
+}
+
+@Entity()
+export class LicenseType {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToMany('License', 'licenseType')
+  licenses = new Collection<License>(this);
+
+}
+
+
+describe('GH issue 1326', () => {
+
+  let orm: MikroORM<SqliteDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      type: 'mysql',
+      dbName: `mikro_orm_test_gh_1326`,
+      port: 3307,
+      entities: [Driver, License, LicenseType],
+    });
+    await orm.getSchemaGenerator().createSchema();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test(`GH issue 1326`, async () => {
+    const mock = jest.fn();
+    const logger = new Logger(mock, ['query']);
+    Object.assign(orm.config, { logger });
+
+    const newDriver = new Driver();
+
+    wrap(newDriver).assign({
+      name: 'Martin Adámek',
+      licenses: [{
+        expiresAt: new Date(2050, 0, 1),
+        licenseType: {
+          name: 'Standard Driver License',
+        },
+      }],
+    }, { em: orm.em });
+
+    await orm.em.persistAndFlush(newDriver);
+  });
+
+});

--- a/tests/issues/GH1326.test.ts
+++ b/tests/issues/GH1326.test.ts
@@ -1,5 +1,5 @@
-import { Collection, Entity, Logger, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, Property, Reference, wrap } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, Logger, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, Reference } from '@mikro-orm/core';
+import { MySqlDriver } from '@mikro-orm/mysql/src';
 
 @Entity()
 export class Driver {
@@ -49,7 +49,7 @@ export class LicenseType {
 
 describe('GH issue 1326', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM<MySqlDriver>;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
@@ -70,9 +70,7 @@ describe('GH issue 1326', () => {
     const logger = new Logger(mock, ['query']);
     Object.assign(orm.config, { logger });
 
-    const newDriver = new Driver();
-
-    wrap(newDriver).assign({
+    const newDriver = orm.em.create(Driver, {
       name: 'Martin Adámek',
       licenses: [{
         expiresAt: new Date(2050, 0, 1),
@@ -80,7 +78,7 @@ describe('GH issue 1326', () => {
           name: 'Standard Driver License',
         },
       }],
-    }, { em: orm.em });
+    });
 
     await orm.em.persistAndFlush(newDriver);
   });


### PR DESCRIPTION
This test outputs:

```
❯ yarn test GH1326
yarn run v1.22.5
$ jest --runInBand GH1326
 FAIL  tests/issues/GH1326.test.ts (17.983 s)
  GH issue 1326
    ✕ GH issue 1326 (102 ms)

  ● GH issue 1326 › GH issue 1326

    NotNullConstraintViolationException: insert into `license` (`driver_id`, `expires_at`, `license_type_id`) values (1, '2050-01-01 00:00:00.000', NULL) - Column 'license_type_id' cannot be null

      77 |       case 1364:
      78 |       case 1566:
    > 79 |         return new NotNullConstraintViolationException(exception);
         |                ^
      80 |     }
      81 | 
      82 |     return super.convertException(exception);

      at MySqlExceptionConverter.convertException (packages/mysql-base/src/MySqlExceptionConverter.ts:79:16)
      at MySqlDriver.convertException (packages/core/src/drivers/DatabaseDriver.ts:249:50)
      at packages/core/src/drivers/DatabaseDriver.ts:254:18
      at MySqlDriver.nativeInsert (packages/knex/src/AbstractSqlDriver.ts:189:17)
      at ChangeSetPersister.persistNewEntity (packages/core/src/unit-of-work/ChangeSetPersister.ts:68:17)
      at ChangeSetPersister.executeInserts (packages/core/src/unit-of-work/ChangeSetPersister.ts:29:7)
      at UnitOfWork.commitCreateChangeSets (packages/core/src/unit-of-work/UnitOfWork.ts:606:5)
      at UnitOfWork.persistToDatabase (packages/core/src/unit-of-work/UnitOfWork.ts:557:7)
      at MySqlConnection.transactional (packages/knex/src/AbstractSqlConnection.ts:46:19)
      at UnitOfWork.commit (packages/core/src/unit-of-work/UnitOfWork.ts:227:9)
      at SqlEntityManager.flush (packages/core/src/EntityManager.ts:685:5)
      at SqlEntityManager.persistAndFlush (packages/core/src/EntityManager.ts:629:5)
      at Object.<anonymous> (tests/issues/GH1326.test.ts:85:5)
      previous Error: insert into `license` (`driver_id`, `expires_at`, `license_type_id`) values (1, '2050-01-01 00:00:00.000', NULL) - Column 'license_type_id' cannot be null
      at Packet.asError (node_modules/mysql2/lib/packets/packet.js:712:17)
      at Query.execute (node_modules/mysql2/lib/commands/command.js:28:26)
      at Connection.handlePacket (node_modules/mysql2/lib/connection.js:425:32)
      at PacketParser.onPacket (node_modules/mysql2/lib/connection.js:75:12)
      at PacketParser.executeStart (node_modules/mysql2/lib/packet_parser.js:75:16)
      at Socket.<anonymous> (node_modules/mysql2/lib/connection.js:82:25)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        19.627 s
Ran all test suites matching /GH1326/i.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```