### PR TITLE
fix(sql): sort fetch-joined properties on their orderBy

### DIFF
--- a/tests/issues/GH1331.test.ts
+++ b/tests/issues/GH1331.test.ts
@@ -1,0 +1,133 @@
+import {
+  Collection,
+  Entity,
+  IdentifiedReference,
+  LoadStrategy,
+  ManyToOne,
+  MikroORM,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  QueryOrder,
+} from '@mikro-orm/core';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+
+@Entity()
+export class RadioOption {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  order!: number;
+
+  @ManyToOne({
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    entity: () => Radio,
+    wrappedReference: true,
+  })
+  radio!: IdentifiedReference<Radio>;
+
+}
+
+@Entity()
+export class Radio {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  order!: number;
+
+  @ManyToOne({
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    entity: () => Project,
+    wrappedReference: true,
+  })
+  project!: IdentifiedReference<Project>;
+
+  @OneToMany(
+    () => RadioOption,
+    option => option.radio,
+    {
+      eager: true,
+      orderBy: { order: QueryOrder.ASC, id: QueryOrder.ASC },
+    },
+  )
+  options = new Collection<RadioOption>(this);
+
+}
+
+@Entity()
+export class Project {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(
+    () => Radio,
+    radio => radio.project,
+    {
+      eager: true,
+      orderBy: { order: QueryOrder.ASC, id: QueryOrder.ASC },
+    },
+  )
+  radios = new Collection<Radio>(this);
+
+}
+
+describe('GH issue 1331', () => {
+
+  let orm: MikroORM<SqliteDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      type: 'sqlite',
+      dbName: ':memory:',
+      entities: [Project, Radio, RadioOption],
+      loadStrategy: LoadStrategy.JOINED,
+    });
+    await orm.getSchemaGenerator().createSchema();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test(`relations' orderBy should be respectend when using LoadStrategy.JOINED`, async () => {
+    const project = orm.em.create(Project, { name: 'project name' });
+    const radio1 = orm.em.create(Radio, { order: 0 });
+    const radio2 = orm.em.create(Radio, { order: 2 });
+    const radio3 = orm.em.create(Radio, { order: 1 });
+
+    radio1.options.add(orm.em.create(RadioOption, { order: 3 }));
+    radio1.options.add(orm.em.create(RadioOption, { order: 2 }));
+    radio1.options.add(orm.em.create(RadioOption, { order: 4 }));
+    radio1.options.add(orm.em.create(RadioOption, { order: 1 }));
+
+    radio2.options.add(orm.em.create(RadioOption, { order: 5 }));
+    radio2.options.add(orm.em.create(RadioOption, { order: 2 }));
+    radio2.options.add(orm.em.create(RadioOption, { order: 11 }));
+    radio2.options.add(orm.em.create(RadioOption, { order: 12 }));
+
+    radio3.options.add(orm.em.create(RadioOption, { order: 0 }));
+    radio3.options.add(orm.em.create(RadioOption, { order: 2 }));
+    radio3.options.add(orm.em.create(RadioOption, { order: 4 }));
+    radio3.options.add(orm.em.create(RadioOption, { order: 1 }));
+
+    project.radios.add(radio1, radio2, radio3);
+
+    await orm.em.persistAndFlush(project);
+    orm.em.clear();
+
+    const loadedProject = await orm.em.findOneOrFail(Project, project.id);
+    expect(loadedProject.radios.getItems().map(r => r.order)).toStrictEqual([0, 1, 2]);
+    expect(loadedProject.radios[0].options.getIdentifiers('order')).toEqual([1, 2, 3, 4]);
+    expect(loadedProject.radios[2].options.getIdentifiers('order')).toEqual([2, 5, 11, 12]);
+    expect(loadedProject.radios[1].options.getIdentifiers('order')).toEqual([0, 1, 2, 4]);
+  });
+
+});

--- a/tests/joined-strategy.postgre.test.ts
+++ b/tests/joined-strategy.postgre.test.ts
@@ -22,10 +22,10 @@ describe('Joined loading strategy', () => {
 
     const a2 = await orm.em.findOneOrFail(Author2, author, { populate: ['books2', 'following'] });
     expect(a2.books2).toHaveLength(2);
-    expect(a2.books2[0].title).toBe('The Stranger');
-    expect(a2.books2[0].priceTaxed).toBe(119);
-    expect(a2.books2[1].title).toBe('The Fall');
-    expect(a2.books2[1].priceTaxed).toBe(238);
+    expect(a2.books2[0].title).toBe('The Fall');
+    expect(a2.books2[0].priceTaxed).toBe(238);
+    expect(a2.books2[1].title).toBe('The Stranger');
+    expect(a2.books2[1].priceTaxed).toBe(119);
   });
 
   test('populate OneToMany with joined strategy [find()]', async () => {
@@ -41,20 +41,20 @@ describe('Joined loading strategy', () => {
     const ret = await orm.em.find(Author2, {}, { populate: ['books2', 'following'], orderBy: { email: 'asc' } });
     expect(ret).toHaveLength(3);
     expect(ret[0].books2).toHaveLength(2);
-    expect(ret[0].books2[0].title).toEqual('The Stranger 1');
-    expect(ret[0].books2[0].priceTaxed).toBe(119);
-    expect(ret[0].books2[1].title).toEqual('The Fall 1');
-    expect(ret[0].books2[1].priceTaxed).toBe(238);
+    expect(ret[0].books2[0].title).toEqual('The Fall 1');
+    expect(ret[0].books2[0].priceTaxed).toBe(238);
+    expect(ret[0].books2[1].title).toEqual('The Stranger 1');
+    expect(ret[0].books2[1].priceTaxed).toBe(119);
     expect(ret[1].books2).toHaveLength(2);
-    expect(ret[1].books2[0].title).toEqual('The Stranger 2');
-    expect(ret[1].books2[0].priceTaxed).toBe(357);
-    expect(ret[1].books2[1].title).toEqual('The Fall 2');
-    expect(ret[1].books2[1].priceTaxed).toBe(476);
+    expect(ret[1].books2[0].title).toEqual('The Fall 2');
+    expect(ret[1].books2[0].priceTaxed).toBe(476);
+    expect(ret[1].books2[1].title).toEqual('The Stranger 2');
+    expect(ret[1].books2[1].priceTaxed).toBe(357);
     expect(ret[2].books2).toHaveLength(2);
-    expect(ret[2].books2[0].title).toEqual('The Stranger 3');
-    expect(ret[2].books2[0].priceTaxed).toBe(595);
-    expect(ret[2].books2[1].title).toEqual('The Fall 3');
-    expect(ret[2].books2[1].priceTaxed).toBe(714);
+    expect(ret[2].books2[0].title).toEqual('The Fall 3');
+    expect(ret[2].books2[0].priceTaxed).toBe(714);
+    expect(ret[2].books2[1].title).toEqual('The Stranger 3');
+    expect(ret[2].books2[1].priceTaxed).toBe(595);
   });
 
   test('populate ManyToOne with joined strategy [findOne()]', async () => {


### PR DESCRIPTION
Merges a joined relation's orderBy with the parent's, keeping tableAliases in mind. Fixes #1331 