### PR TITLE
test(joined-strategy): added failing test case

### DIFF
--- a/tests/issues/GH1352.test.ts
+++ b/tests/issues/GH1352.test.ts
@@ -1,0 +1,151 @@
+import {
+  Collection,
+  Entity,
+  IdentifiedReference,
+  LoadStrategy,
+  ManyToOne,
+  MikroORM,
+  OneToMany,
+  PrimaryKey,
+  Property,
+} from '@mikro-orm/core';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+
+@Entity()
+export class Manager {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @ManyToOne('Project', { wrappedReference: true })
+  project!: IdentifiedReference<Project>;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+}
+
+@Entity()
+export class Owner {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @ManyToOne('Risk', { wrappedReference: true })
+  risk!: IdentifiedReference<Risk>;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+}
+
+@Entity()
+export class Risk {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  value!: string;
+
+  @OneToMany(() => Owner, owner => owner.risk)
+  owners = new Collection<Owner>(this);
+
+  @ManyToOne('Project', { wrappedReference: true })
+  project!: IdentifiedReference<Project>;
+
+  constructor(value: string) {
+    this.value = value;
+  }
+
+}
+
+@Entity()
+export class Project {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name: string;
+
+  @OneToMany(
+    () => Risk,
+    risk => risk.project,
+    {
+      eager: true,
+    },
+  )
+  risks = new Collection<Risk>(this);
+
+  @OneToMany(
+    () => Manager,
+    manager => manager.project,
+    {
+      eager: true,
+    },
+  )
+  managers = new Collection<Manager>(this);
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+}
+
+describe('GH issue 1352', () => {
+
+  let orm: MikroORM<SqliteDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      type: 'sqlite',
+      dbName: ':memory:',
+      entities: [Project, Owner, Risk, Manager],
+      loadStrategy: LoadStrategy.JOINED,
+    });
+    await orm.getSchemaGenerator().createSchema();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test(`GH issue 1352`, async () => {
+    const project = new Project('Apartment construction');
+
+    const manager1 = new Manager('John');
+    const manager2 = new Manager('John');
+    const manager3 = new Manager('John');
+
+    project.managers.add(
+      manager1,
+      manager2,
+      manager3,
+    );
+
+    const risk1 = new Risk('Wild animals');
+    const risk2 = new Risk('Oil pipe');
+    const risk3 = new Risk('Earth quake');
+
+    risk1.owners.add(new Owner('Some name'));
+    risk2.owners.add(new Owner('Some name'));
+    risk3.owners.add(new Owner('Some name'));
+    project.risks.add(risk1, risk2, risk3);
+    await orm.em.persistAndFlush(project);
+    orm.em.clear();
+
+    const queriedProject = await orm.em.findOneOrFail(Manager, { id: manager1.id }, ['project']);
+    expect(queriedProject.project.unwrap().managers.isInitialized()).toBeTruthy();
+    expect(queriedProject.project.unwrap().risks.isInitialized()).toBeTruthy();
+  });
+
+});


### PR DESCRIPTION
Added a test case to show that the JOINED strategy gives different results than the SELECT_IN strategy. This is the case when entity A has a ManyToOne relation with entity B. This entity B has OneToMany relations that are eager loaded with C and D. 

When loading this entity A and then populating relation B using the SELECT_IN strategy it does eager load C and D. When using the JOINED strategy the relations C and D are not eager loaded. 