### PR TITLE
fix(core): allow assigning null to embeddable property

### DIFF
--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -27,7 +27,7 @@ export class EntityAssigner {
 
       let value = data[prop as keyof EntityData<T>];
 
-      if (!props[prop].nullable && (value === undefined || value === null)) {
+      if (props[prop] && !props[prop]?.nullable && (value === undefined || value === null)) {
         throw new Error(`You must pass a non-${value} value to the property ${prop} of entity ${entity.constructor.name}.`);
       }
 

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -27,6 +27,10 @@ export class EntityAssigner {
 
       let value = data[prop as keyof EntityData<T>];
 
+      if (!props[prop].nullable && (value === undefined || value === null)) {
+        throw new Error(`You must pass a non-${value} value to the property ${prop} of entity ${entity.constructor.name}.`);
+      }
+
       if (props[prop] && Utils.isCollection(entity[prop as keyof T], props[prop]) && Array.isArray(value) && EntityAssigner.validateEM(em)) {
         return EntityAssigner.assignCollection<T>(entity, entity[prop as keyof T] as unknown as Collection<AnyEntity>, value, props[prop], em!, options);
       }
@@ -124,19 +128,21 @@ export class EntityAssigner {
     const Embeddable = prop.embeddable;
     const propName = prop.embedded ? prop.embedded[1] : prop.name;
     entity[propName] = options.mergeObjects ? entity[propName] || Object.create(Embeddable.prototype) : Object.create(Embeddable.prototype);
-    if (prop.nullable && value === null) {
-      entity[propName] = null;
-    } else if (typeof value === 'object') {
-      Object.keys(value).forEach(key => {
-        const childProp = prop.embeddedProps[key];
 
-        if (childProp && childProp.reference === ReferenceType.EMBEDDED) {
-          return EntityAssigner.assignEmbeddable(entity[propName], value[key], childProp, em, options);
-        }
-
-        entity[propName][key] = value[key];
-      });
+    if (!value) {
+      entity[propName] = value;
+      return;
     }
+
+    Object.keys(value).forEach(key => {
+      const childProp = prop.embeddedProps[key];
+
+      if (childProp && childProp.reference === ReferenceType.EMBEDDED) {
+        return EntityAssigner.assignEmbeddable(entity[propName], value[key], childProp, em, options);
+      }
+
+      entity[propName][key] = value[key];
+    });
   }
 
   private static createCollectionItem<T extends AnyEntity<T>>(item: any, em: EntityManager, prop: EntityProperty, invalid: any[], options: AssignOptions): T {

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -27,7 +27,7 @@ export class EntityAssigner {
 
       let value = data[prop as keyof EntityData<T>];
 
-      if (props[prop] && !props[prop]?.nullable && (value === undefined || value === null)) {
+      if (props[prop] && !props[prop].nullable && (value === undefined || value === null)) {
         throw new Error(`You must pass a non-${value} value to the property ${prop} of entity ${entity.constructor.name}.`);
       }
 

--- a/tests/embedded-entities.mysql.test.ts
+++ b/tests/embedded-entities.mysql.test.ts
@@ -252,6 +252,9 @@ describe('embedded entities in mysql', () => {
     assign(user, { address4: { city: '41', country: '42', postalCode: '43', street: '44' } });
     expect(user.address4).toMatchObject({ city: '41', country: '42', postalCode: '43', street: '44' });
 
+    assign(user, { address5: { city: '51', country: '52', postalCode: '53', street: '54' } });
+    expect(user.address5).toMatchObject({ city: '51', country: '52', postalCode: '53', street: '54' });
+
     expect(user.address1).toBeInstanceOf(Address1);
     expect(user.address1).toEqual({
       street: 'Downing street 10',
@@ -273,8 +276,26 @@ describe('embedded entities in mysql', () => {
       country: 'UK 3',
     });
 
+    assign(user, { address2: undefined });
+    expect(user.address2).toBe(undefined);
+
     assign(user, { address2: null });
     expect(user.address2).toBe(null);
+
+    expect(() => {
+      assign(user, { address4: undefined });
+    }).toThrow('You must pass a non-undefined value to the property address4 of entity User.');
+
+    expect(() => {
+      assign(user, { address4: null });
+    }).toThrow('You must pass a non-null value to the property address4 of entity User.');
+
+
+    assign(user, { address5: undefined });
+    expect(user.address5).toBe(undefined);
+
+    assign(user, { address5: null });
+    expect(user.address5).toBe(null);
   });
 
   test('should throw error with object&prefix false', async () => {

--- a/tests/embedded-entities.mysql.test.ts
+++ b/tests/embedded-entities.mysql.test.ts
@@ -272,6 +272,9 @@ describe('embedded entities in mysql', () => {
       city: 'London 3',
       country: 'UK 3',
     });
+
+    assign(user, { address2: null });
+    expect(user.address2).toBe(null);
   });
 
   test('should throw error with object&prefix false', async () => {


### PR DESCRIPTION
When you have entity like this:

```
@Entity()
class Document extends BaseEntity<Document> {
...
  @Embedded({
    entity: () => Summary,
    nullable: true,
  })
  summary!: Summary;
...
}
```

and do this:

```
document.assign({summary: null}, { mergeObjects: true });
```

it explode with:
```
Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at Function.assignEmbeddable (***/node_modules/@mikro-orm/core/entity/EntityAssigner.js:108:16)
```

thank you very much for your great work!