### PR TITLE
fix(migrations): fix generation of empty migrations

### DIFF
--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -175,12 +175,12 @@ export class Migrator {
       lines.push(...dump.split('\n'));
     }
 
-    for (let i = lines.length - 1; i > 0; i--) {
+    for (let i = lines.length - 1; i >= 0; i--) {
       if (lines[i]) {
         break;
       }
 
-      delete lines[i];
+      lines.splice(i, 1);
     }
 
     return lines;

--- a/tests/Migrator.test.ts
+++ b/tests/Migrator.test.ts
@@ -2,7 +2,7 @@
 import umzug from 'umzug';
 import { Logger, MetadataStorage, MikroORM } from '@mikro-orm/core';
 import { Migration, MigrationStorage, Migrator } from '@mikro-orm/migrations';
-import { DatabaseSchema, DatabaseTable, MySqlDriver } from '@mikro-orm/mysql';
+import { DatabaseSchema, DatabaseTable, MySqlDriver, SchemaGenerator } from '@mikro-orm/mysql';
 import { remove } from 'fs-extra';
 import { initORMMySql } from './bootstrap';
 
@@ -133,8 +133,8 @@ describe('Migrator', () => {
 
   test('migration is skipped when no diff', async () => {
     const migrator = new Migrator(orm.em);
-    const getSchemaDiffMock = jest.spyOn<any, any>(Migrator.prototype, 'getSchemaDiff');
-    getSchemaDiffMock.mockResolvedValueOnce([]);
+    const schemaGeneratorMock = jest.spyOn<any, any>(SchemaGenerator.prototype, 'getUpdateSchemaSQL');
+    schemaGeneratorMock.mockResolvedValue('');
     const migration = await migrator.createMigration();
     expect(migration).toEqual({ fileName: '', code: '', diff: [] });
   });

--- a/tests/__snapshots__/Migrator.postgres.test.ts.snap
+++ b/tests/__snapshots__/Migrator.postgres.test.ts.snap
@@ -198,8 +198,6 @@ export class Migration20191013214813 extends Migration {
     "create index \\"custom_idx_name_123\\" on \\"author2\\" (\\"name\\");",
     "create index \\"author2_name_age_index\\" on \\"author2\\" (\\"name\\", \\"age\\");",
     "alter table \\"author2\\" add constraint \\"author2_name_email_unique\\" unique (\\"name\\", \\"email\\");",
-    undefined,
-    undefined,
   ],
   "fileName": "Migration20191013214813.ts",
 }
@@ -403,8 +401,6 @@ export class Migration20191013214813 extends Migration {
     "create index \\"custom_idx_name_123\\" on \\"author2\\" (\\"name\\");",
     "create index \\"author2_name_age_index\\" on \\"author2\\" (\\"name\\", \\"age\\");",
     "alter table \\"author2\\" add constraint \\"author2_name_email_unique\\" unique (\\"name\\", \\"email\\");",
-    undefined,
-    undefined,
   ],
   "fileName": "Migration20191013214813.ts",
 }
@@ -431,8 +427,6 @@ exports.Migration20191013214813 = Migration20191013214813;
     "alter table \\"book2\\" drop column \\"foo\\";",
     "",
     "alter table \\"test2\\" drop column \\"path\\";",
-    undefined,
-    undefined,
   ],
   "fileName": "Migration20191013214813.js",
 }
@@ -456,8 +450,6 @@ export class Migration20191013214813 extends Migration {
     "alter table \\"book2\\" drop column \\"foo\\";",
     "",
     "alter table \\"test2\\" drop column \\"path\\";",
-    undefined,
-    undefined,
   ],
   "fileName": "migration-20191013214813.ts",
 }
@@ -481,8 +473,6 @@ export class Migration20191013214813 extends Migration {
     "alter table \\"book2\\" drop column \\"foo\\";",
     "",
     "alter table \\"test2\\" drop column \\"path\\";",
-    undefined,
-    undefined,
   ],
   "fileName": "Migration20191013214813.ts",
 }

--- a/tests/__snapshots__/Migrator.test.ts.snap
+++ b/tests/__snapshots__/Migrator.test.ts.snap
@@ -353,8 +353,6 @@ export class Migration20191013214813 extends Migration {
     "alter table \`author2\` add index \`custom_idx_name_123\`(\`name\`);",
     "alter table \`author2\` add index \`author2_name_age_index\`(\`name\`, \`age\`);",
     "alter table \`author2\` add unique \`author2_name_email_unique\`(\`name\`, \`email\`);",
-    undefined,
-    undefined,
   ],
   "fileName": "Migration20191013214813.ts",
 }
@@ -696,8 +694,6 @@ export class Migration20191013214813 extends Migration {
     "alter table \`author2\` add index \`custom_idx_name_123\`(\`name\`);",
     "alter table \`author2\` add index \`author2_name_age_index\`(\`name\`, \`age\`);",
     "alter table \`author2\` add unique \`author2_name_email_unique\`(\`name\`, \`email\`);",
-    undefined,
-    undefined,
   ],
   "fileName": "Migration20191013214813.ts",
 }
@@ -732,8 +728,6 @@ exports.Migration20191013214813 = Migration20191013214813;
     "alter table \`test2\` drop index \`test2_foo___bar_index\`;",
     "alter table \`test2\` drop \`foo___bar\`;",
     "alter table \`test2\` drop \`foo___baz\`;",
-    undefined,
-    undefined,
   ],
   "fileName": "Migration20191013214813.js",
 }
@@ -765,8 +759,6 @@ export class Migration20191013214813 extends Migration {
     "alter table \`test2\` drop index \`test2_foo___bar_index\`;",
     "alter table \`test2\` drop \`foo___bar\`;",
     "alter table \`test2\` drop \`foo___baz\`;",
-    undefined,
-    undefined,
   ],
   "fileName": "migration-20191013214813.ts",
 }
@@ -798,8 +790,6 @@ export class Migration20191013214813 extends Migration {
     "alter table \`test2\` drop index \`test2_foo___bar_index\`;",
     "alter table \`test2\` drop \`foo___bar\`;",
     "alter table \`test2\` drop \`foo___baz\`;",
-    undefined,
-    undefined,
   ],
   "fileName": "Migration20191013214813.ts",
 }


### PR DESCRIPTION
Migrations are still being created with `migrator.createMigration()` even if there is no schema diff. The current implementation of getSchemaDiff returns an Array with an empty string inside for an empty string as schema diff.