### PR TITLE
feat(core): allow querying by JSON properties

### DIFF
--- a/docs/docs/json-properties.md
+++ b/docs/docs/json-properties.md
@@ -1,0 +1,57 @@
+---
+title: Using JSON properties
+---
+
+## Defining JSON properties
+
+Each database driver behaves a bit differently when it comes to JSON properties.
+MikroORM tries to unify the experience via [JsonType](custom-types.md#jsontype).
+This type will be also used if you specify `type: 'json'`.
+
+```ts
+@Entity()
+export class Book {
+
+  @Property({ type: 'json', nullable: true })
+  meta?: { foo: string; bar: number };
+
+}
+```
+
+## Querying by JSON object properties
+
+> Support for querying by JSON object properties was added in v4.4.2
+
+We can query by JSON object properties easily:
+
+```ts
+const b = await em.findOne(Book, {
+  meta: {
+    valid: true,
+    nested: { 
+      foo: '123', 
+      bar: 321, 
+      deep: { 
+        baz: 59,
+        qux: false,
+      },
+    },
+  },
+});
+```
+
+Will produce following query (in postgres):
+
+```sql
+select "e0".* 
+from "book" as "e0" 
+where ("meta"->>'valid')::bool = true 
+  and "meta"->'nested'->>'foo' = '123' 
+  and ("meta"->'nested'->>'bar')::float8 = 321 
+  and ("meta"->'nested'->'deep'->>'baz')::float8 = 59 
+  and ("meta"->'nested'->'deep'->>'qux')::bool = false 
+limit 1
+```
+
+> All drivers are currently supported (including sqlite and mongo). In postgres we
+> also try to cast the value if we detect number or boolean on the right-hand side.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -33,6 +33,7 @@ module.exports = {
       'custom-types',
       'embeddables',
       'entity-schema',
+      'json-properties',
       'metadata-providers',
       'metadata-cache',
       'schema-generator',

--- a/docs/versioned_docs/version-4.4/json-properties.md
+++ b/docs/versioned_docs/version-4.4/json-properties.md
@@ -1,0 +1,57 @@
+---
+title: Using JSON properties
+---
+
+## Defining JSON properties
+
+Each database driver behaves a bit differently when it comes to JSON properties. 
+MikroORM tries to unify the experience via [JsonType](custom-types.md#jsontype). 
+This type will be also used if you specify `type: 'json'`. 
+
+```ts
+@Entity()
+export class Book {
+  
+  @Property({ type: 'json', nullable: true })
+  meta?: { foo: string; bar: number };
+
+}
+```
+
+## Querying by JSON object properties
+
+> Support for querying by JSON object properties was added in v4.4.2
+
+We can query by JSON object properties easily:
+
+```ts
+const b = await em.findOne(Book, {
+  meta: {
+    valid: true,
+    nested: { 
+      foo: '123', 
+      bar: 321, 
+      deep: { 
+        baz: 59,
+        qux: false,
+      },
+    },
+  },
+});
+```
+
+Will produce following query (in postgres):
+
+```sql
+select "e0".* 
+from "book" as "e0" 
+where ("meta"->>'valid')::bool = true 
+  and "meta"->'nested'->>'foo' = '123' 
+  and ("meta"->'nested'->>'bar')::float8 = 321 
+  and ("meta"->'nested'->'deep'->>'baz')::float8 = 59 
+  and ("meta"->'nested'->'deep'->>'qux')::bool = false 
+limit 1
+```
+
+> All drivers are currently supported (including sqlite and mongo). In postgres we
+> also try to cast the value if we detect number or boolean on the right-hand side.

--- a/docs/versioned_sidebars/version-4.4-sidebars.json
+++ b/docs/versioned_sidebars/version-4.4-sidebars.json
@@ -133,6 +133,10 @@
         },
         {
           "type": "doc",
+          "id": "version-4.4/json-properties"
+        },
+        {
+          "type": "doc",
           "id": "version-4.4/metadata-providers"
         },
         {

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -602,7 +602,7 @@ export class MetadataDiscovery {
         path.unshift(this.namingStrategy.propertyToColumnName(rootProperty.name));
         path.push(prop.name);
 
-        meta.properties[name].fieldNameRaw = this.platform.getSearchJsonPropertySQL(path.join('->')); // for querying in SQL drivers
+        meta.properties[name].fieldNameRaw = this.platform.getSearchJsonPropertySQL(path.join('->'), prop.type); // for querying in SQL drivers
         meta.properties[name].persist = false; // only virtual as we store the whole object
       }
 

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -161,8 +161,12 @@ export abstract class Platform {
     return 'json';
   }
 
-  getSearchJsonPropertySQL(path: string): string {
+  getSearchJsonPropertySQL(path: string, type: string): string {
     return path;
+  }
+
+  getSearchJsonPropertyKey(path: string[], type: string): string {
+    return path.join('.');
   }
 
   convertsJsonAutomatically(marshall = false): boolean {

--- a/packages/knex/src/AbstractSqlPlatform.ts
+++ b/packages/knex/src/AbstractSqlPlatform.ts
@@ -66,4 +66,8 @@ export abstract class AbstractSqlPlatform extends Platform {
     return ret;
   }
 
+  getSearchJsonPropertySQL(path: string, type: string): string {
+    return this.getSearchJsonPropertyKey(path.split('->'), type);
+  }
+
 }

--- a/packages/mysql-base/src/MySqlPlatform.ts
+++ b/packages/mysql-base/src/MySqlPlatform.ts
@@ -11,9 +11,9 @@ export class MySqlPlatform extends AbstractSqlPlatform {
     return 'utf8mb4';
   }
 
-  getSearchJsonPropertySQL(path: string): string {
-    const [a, b] = path.split('->', 2); // TODO
-    return `${this.quoteIdentifier(a)}->'$.${b}'`;
+  getSearchJsonPropertyKey(path: string[], type: string): string {
+    const [a, ...b] = path;
+    return `${this.quoteIdentifier(a)}->'$.${b.join('.')}'`;
   }
 
 }

--- a/packages/postgresql/src/PostgreSqlPlatform.ts
+++ b/packages/postgresql/src/PostgreSqlPlatform.ts
@@ -58,17 +58,21 @@ export class PostgreSqlPlatform extends AbstractSqlPlatform {
     return 'jsonb';
   }
 
-  getSearchJsonPropertySQL(path: string): string {
-    const parts = path.split('->');
-    const first = parts.shift();
-    const last = parts.pop();
+  getSearchJsonPropertyKey(path: string[], type: string): string {
+    const first = path.shift();
+    const last = path.pop();
     const root = this.quoteIdentifier(first!);
+    const types = {
+      number: 'float8',
+      boolean: 'bool',
+    };
+    const cast = (key: string) => type in types ? `(${key})::${types[type]}` : key;
 
-    if (parts.length === 0) {
-      return `${root}->>'${last}'`;
+    if (path.length === 0) {
+      return cast(`${root}->>'${last}'`);
     }
 
-    return `${root}->${parts.map(a => this.quoteValue(a)).join('->')}->>'${last}'`;
+    return cast(`${root}->${path.map(a => this.quoteValue(a)).join('->')}->>'${last}'`);
   }
 
   quoteIdentifier(id: string, quote = '"'): string {

--- a/packages/sqlite/src/SqlitePlatform.ts
+++ b/packages/sqlite/src/SqlitePlatform.ts
@@ -69,4 +69,9 @@ export class SqlitePlatform extends AbstractSqlPlatform {
     return escape(value, true, this.timezone);
   }
 
+  getSearchJsonPropertyKey(path: string[], type: string): string {
+    const [a, ...b] = path;
+    return `json_extract(${this.quoteIdentifier(a)}, '$.${b.join('.')}')`;
+  }
+
 }

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -525,15 +525,30 @@ describe('EntityManagerMySql', () => {
     const god = new Author2('God', 'hello@heaven.god');
     god.identities = ['fb-123', 'pw-231', 'tw-321'];
     const bible = new Book2('Bible', god);
-    bible.meta = { category: 'god like', items: 3 };
+    bible.meta = { category: 'god like', items: 3, valid: true, nested: { foo: '123', bar: 321, deep: { baz: 59, qux: false } } };
     await orm.em.persistAndFlush(bible);
     orm.em.clear();
 
-    const g = (await orm.em.findOne(Author2, god.id, ['books']))!;
+    const g = await orm.em.findOneOrFail(Author2, god.id, ['books']);
     expect(Array.isArray(g.identities)).toBe(true);
     expect(g.identities).toEqual(['fb-123', 'pw-231', 'tw-321']);
     expect(typeof g.books[0].meta).toBe('object');
-    expect(g.books[0].meta).toEqual({ category: 'god like', items: 3 });
+    expect(g.books[0].meta).toEqual({ category: 'god like', items: 3, valid: true, nested: { foo: '123', bar: 321, deep: { baz: 59, qux: false } } });
+    orm.em.clear();
+
+    const b1 = await orm.em.findOneOrFail(Book2, { meta: { category: 'god like' } });
+    const b2 = await orm.em.findOneOrFail(Book2, { meta: { category: 'god like', items: 3 } });
+    const b3 = await orm.em.findOneOrFail(Book2, { meta: { nested: { bar: 321 } } });
+    const b4 = await orm.em.findOneOrFail(Book2, { meta: { nested: { foo: '123', bar: 321 } } });
+    const b5 = await orm.em.findOneOrFail(Book2, { meta: { valid: true, nested: { foo: '123', bar: 321 } } });
+    const b6 = await orm.em.findOneOrFail(Book2, { meta: { valid: true, nested: { foo: '123', bar: 321, deep: { baz: 59 } } } });
+    const b7 = await orm.em.findOneOrFail(Book2, { meta: { valid: true, nested: { foo: '123', bar: 321, deep: { baz: 59, qux: false } } } });
+    expect(b1).toBe(b2);
+    expect(b1).toBe(b3);
+    expect(b1).toBe(b4);
+    expect(b1).toBe(b5);
+    expect(b1).toBe(b6);
+    expect(b1).toBe(b7);
   });
 
   test('findOne should initialize entity that is already in IM', async () => {

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -393,15 +393,30 @@ describe('EntityManagerPostgre', () => {
     const god = new Author2('God', 'hello@heaven.god');
     god.identities = ['fb-123', 'pw-231', 'tw-321'];
     const bible = new Book2('Bible', god);
-    bible.meta = { category: 'god like', items: 3 };
+    bible.meta = { category: 'god like', items: 3, valid: true, nested: { foo: '123', bar: 321, deep: { baz: 59, qux: false } } };
     await orm.em.persistAndFlush(bible);
     orm.em.clear();
 
-    const g = (await orm.em.findOne(Author2, god.id, ['books']))!;
+    const g = await orm.em.findOneOrFail(Author2, god.id, ['books']);
     expect(Array.isArray(g.identities)).toBe(true);
     expect(g.identities).toEqual(['fb-123', 'pw-231', 'tw-321']);
     expect(typeof g.books[0].meta).toBe('object');
-    expect(g.books[0].meta).toEqual({ category: 'god like', items: 3 });
+    expect(g.books[0].meta).toEqual({ category: 'god like', items: 3, valid: true, nested: { foo: '123', bar: 321, deep: { baz: 59, qux: false } } });
+    orm.em.clear();
+
+    const b1 = await orm.em.findOneOrFail(Book2, { meta: { category: 'god like' } });
+    const b2 = await orm.em.findOneOrFail(Book2, { meta: { category: 'god like', items: 3 } });
+    const b3 = await orm.em.findOneOrFail(Book2, { meta: { nested: { bar: 321 } } });
+    const b4 = await orm.em.findOneOrFail(Book2, { meta: { nested: { foo: '123', bar: 321 } } });
+    const b5 = await orm.em.findOneOrFail(Book2, { meta: { valid: true, nested: { foo: '123', bar: 321 } } });
+    const b6 = await orm.em.findOneOrFail(Book2, { meta: { valid: true, nested: { foo: '123', bar: 321, deep: { baz: 59 } } } });
+    const b7 = await orm.em.findOneOrFail(Book2, { meta: { valid: true, nested: { foo: '123', bar: 321, deep: { baz: 59, qux: false } } } });
+    expect(b1).toBe(b2);
+    expect(b1).toBe(b3);
+    expect(b1).toBe(b4);
+    expect(b1).toBe(b5);
+    expect(b1).toBe(b6);
+    expect(b1).toBe(b7);
   });
 
   test('findOne should initialize entity that is already in IM', async () => {

--- a/tests/entities-schema/Book4.ts
+++ b/tests/entities-schema/Book4.ts
@@ -4,13 +4,20 @@ import { IAuthor4 } from './Author4';
 import { IPublisher4 } from './Publisher4';
 import { IBookTag4 } from './BookTag4';
 
+export interface Book4Meta {
+  category: string;
+  items: number;
+  valid?: boolean;
+  nested?: { foo: string; bar?: number; deep?: { baz: number; qux: boolean } };
+}
+
 export interface IBook4 extends IBaseEntity5 {
   title: string;
   author: IAuthor4;
   publisher?: Reference<IPublisher4>;
   tags: Collection<IBookTag4>;
   tagsUnordered: Collection<IBookTag4>;
-  meta: { category: string; items: number };
+  meta: Book4Meta;
 }
 
 export const Book4 = new EntitySchema<IBook4, IBaseEntity5>({

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -65,4 +65,6 @@ export class Book2 {
 export interface Book2Meta {
   category: string;
   items: number;
+  valid?: boolean;
+  nested?: { foo: string; bar?: number; deep?: { baz: number; qux: boolean } };
 }

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -34,7 +34,7 @@ export class Book extends BaseEntity3 {
   @ManyToMany(() => BookTag)
   tags = new Collection<BookTag>(this);
 
-  @Property()
+  @Property({ type: 'json' })
   metaObject?: Dictionary<unknown>;
 
   @Property()


### PR DESCRIPTION
We can query by JSON object properties easily:

```ts
const b = await em.findOne(Book, {
  meta: {
    valid: true,
    nested: {
      foo: '123',
      bar: 321,
      deep: {
        baz: 59,
        qux: false,
      },
    },
  },
});
```

Will produce following query (in postgres):

```sql
select "e0".*
from "book" as "e0"
where ("meta"->>'valid')::bool = true
  and "meta"->'nested'->>'foo' = '123'
  and ("meta"->'nested'->>'bar')::float8 = 321
  and ("meta"->'nested'->'deep'->>'baz')::float8 = 59
  and ("meta"->'nested'->'deep'->>'qux')::bool = false
limit 1
```

> All drivers are currently supported (including sqlite and mongo). In postgres we
> also try to cast the value if we detect number or boolean on the right-hand side.

Closes #1359
Related: #1261