### PR TITLE
feat(core): allow using SQL expressions with custom types

### DIFF
--- a/docs/docs/custom-types.md
+++ b/docs/docs/custom-types.md
@@ -2,7 +2,7 @@
 title: Custom Types
 ---
 
-You can define custom types by extending `Type` abstract class. It has 4 optional methods:
+You can define custom types by extending `Type` abstract class. It has several optional methods:
 
 - `convertToDatabaseValue(value: any, platform: Platform): any`
 
@@ -18,11 +18,21 @@ You can define custom types by extending `Type` abstract class. It has 4 optiona
 
   Converts a value from its JS representation to its serialized JSON form of this type.
   By default uses the runtime value.
-  
+
 - `getColumnType(prop: EntityProperty, platform: Platform): string`
 
   Gets the SQL declaration snippet for a field of this type.
   By default returns `columnType` of given property.
+
+- `convertToDatabaseValueSQL(key: string, platform: Platform): string`
+
+  Converts a value from its JS representation to its database representation of this type.
+  _(added in v4.4.2)_
+
+- `convertToJSValueSQL?(key: string, platform: Platform): string`
+
+  Modifies the SQL expression (identifier, parameter) to convert to a JS value.
+  _(added in v4.4.2)_
 
 ```typescript
 import { Type, Platform, EntityProperty, ValidationError } from '@mikro-orm/core';
@@ -80,6 +90,130 @@ export class FooBar {
 }
 ```
 
+## Advanced example - PointType and WKT
+
+In this example we will combine mapping values via database as well as during runtime.
+
+> The Point type is part of the Spatial extension of MySQL and enables you to store
+> a single location in a coordinate space by using x and y coordinates. You can use
+> the Point type to store a longitude/latitude pair to represent a geographic location.
+
+First let's define the `Point` class that will be used to represent the value during runtime:
+
+```ts
+export class Point {
+
+  constructor(public latitude: number,
+              public longitude: number) { }
+
+}
+```
+
+Then the mapping type:
+
+```ts
+export class PointType extends Type<Point | undefined, string | undefined> {
+
+  convertToDatabaseValue(value: Point | undefined): string | undefined {
+    if (!value) {
+      return value;
+    }
+
+    return `point(${value.latitude} ${value.longitude})`;
+  }
+
+  convertToJSValue(value: string | undefined): Point | undefined {
+    const m = value?.match(/point\((\d+(\.\d+)?) (\d+(\.\d+)?)\)/i);
+
+    if (!m) {
+      return undefined;
+    }
+
+    return new Point(+m[1], +m[3]);
+  }
+
+  convertToJSValueSQL(key: string) {
+    return `ST_AsText(${key})`;
+  }
+
+  convertToDatabaseValueSQL(key: string) {
+    return `ST_PointFromText(${key})`;
+  }
+
+  getColumnType(): string {
+    return 'point';
+  }
+
+}
+```
+
+Now let's define an entity:
+
+```ts
+@Entity()
+export class Location {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: PointType })
+  point?: Point;
+
+}
+```
+
+...and use it:
+
+```ts
+const loc = new Location();
+loc.point = new Point(1.23, 4.56);
+await em.persist(loc).flush();
+em.clear();
+
+const loc1 = await em.findOneOrFail(Location, loc.id);
+
+// update it
+loc1.point = new Point(2.34, 9.87);
+await em.flush();
+```
+
+This will result in following queries:
+
+```sql
+begin
+insert into `location` (`point`) values (ST_PointFromText('point(1.23 4.56)'))
+commit
+
+select `e0`.*, ST_AsText(`e0`.point) as point from `location` as `e0` where `e0`.`id` = ? limit ?
+
+begin
+update `location` set `point` = ST_PointFromText('point(2.34 9.87)') where `id` = ?
+commit
+```
+
+We do a 2-step conversion here. In the first step, we convert the Point object into
+a string representation before saving to the database (in the convertToDatabaseValue
+method) and back into an object after fetching the value from the database (in the
+convertToJSValue method).
+
+The format of the string representation format is called Well-known text (WKT). The
+advantage of this format is, that it is both human readable and parsable by MySQL.
+
+Internally, MySQL stores geometry values in a binary format that is not identical to
+the WKT format. So, we need to let MySQL transform the WKT representation into its
+internal format.
+
+This is where the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods come
+into play.
+
+This methods wrap a sql expression (the WKT representation of the Point) into MySQL
+functions ST_PointFromText and ST_AsText which convert WKT strings to and from the
+internal format of MySQL.
+
+> When using DQL queries, the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods
+> only apply to identification variables and path expressions in SELECT clauses. Expressions
+> in WHERE clauses are not wrapped!
+
 ## Types provided by MikroORM
 
 There are few types provided by MikroORM. All of them aim to provide similar
@@ -88,18 +222,18 @@ out of box by the driver.
 
 ### ArrayType
 
-In PostgreSQL and MongoDB, it uses native arrays, otherwise it concatenates the 
+In PostgreSQL and MongoDB, it uses native arrays, otherwise it concatenates the
 values into string separated by commas. This means that you can't use values that
 contain comma with the `ArrayType` (but you can create custom array type that will
 handle this case, e.g. by using different separator).
 
-By default array of strings is returned from the type. You can also have arrays 
-of numbers or other data types - to do so, you will need to implement custom 
+By default array of strings is returned from the type. You can also have arrays
+of numbers or other data types - to do so, you will need to implement custom
 `hydrate` method that is used for converting the array values to the right type.
 
 > `ArrayType` will be used automatically if `type` is set to `array` (default behaviour
 > of reflect-metadata) or `string[]` or `number[]` (either manually or via ts-morph).
-> In case of `number[]` it will automatically handle the conversion to numbers. 
+> In case of `number[]` it will automatically handle the conversion to numbers.
 > This means that the following examples would both have the `ArrayType` used
 > automatically (but with reflect-metadata we would have a string array for both
 > unless we specify the type manually as `type: 'number[]')
@@ -114,8 +248,8 @@ numericArray?: number[];
 
 ### BigIntType
 
-You can use `BigIntType` to support `bigint`s. By default, it will represent the 
-value as a `string`. 
+You can use `BigIntType` to support `bigint`s. By default, it will represent the
+value as a `string`.
 
 ```typescript
 @PrimaryKey({ type: BigIntType })
@@ -124,10 +258,10 @@ id: string;
 
 ### BlobType
 
-Blob type can be used to store binary data in the database. 
+Blob type can be used to store binary data in the database.
 
-> `BlobType` will be used automatically if you specify the type hint as `Buffer`. 
-> This means that the following example should work even without the explicit 
+> `BlobType` will be used automatically if you specify the type hint as `Buffer`.
+> This means that the following example should work even without the explicit
 > `type: BlobType` option (with both reflect-metadata and ts-morph providers).
 
 ```typescript
@@ -137,7 +271,7 @@ blob?: Buffer;
 
 ### JsonType
 
-To store objects we can use `JsonType`. As some drivers are handling objects 
+To store objects we can use `JsonType`. As some drivers are handling objects
 automatically and some don't, this type will handle the serialization in a driver
 independent way (calling `parse` and `stringify` only when needed).
 
@@ -149,7 +283,7 @@ object?: { foo: string; bar: number };
 ### DateType
 
 To store dates without time information, we can use `DateType`. It does use `date`
-column type and maps it to the `Date` object. 
+column type and maps it to the `Date` object.
 
 ```typescript
 @Property({ type: DateType, nullable: true })
@@ -159,7 +293,7 @@ born?: Date;
 ### TimeType
 
 As opposed to the `DateType`, to store only the time information, we can use
-`TimeType`. It will use the `time` column type, the runtime type is string. 
+`TimeType`. It will use the `time` column type, the runtime type is string.
 
 ```typescript
 @Property({ type: TimeType, nullable: true })

--- a/docs/versioned_docs/version-4.4/custom-types.md
+++ b/docs/versioned_docs/version-4.4/custom-types.md
@@ -2,7 +2,7 @@
 title: Custom Types
 ---
 
-You can define custom types by extending `Type` abstract class. It has 4 optional methods:
+You can define custom types by extending `Type` abstract class. It has several optional methods:
 
 - `convertToDatabaseValue(value: any, platform: Platform): any`
 
@@ -18,11 +18,21 @@ You can define custom types by extending `Type` abstract class. It has 4 optiona
 
   Converts a value from its JS representation to its serialized JSON form of this type.
   By default uses the runtime value.
-  
+
 - `getColumnType(prop: EntityProperty, platform: Platform): string`
 
   Gets the SQL declaration snippet for a field of this type.
   By default returns `columnType` of given property.
+
+- `convertToDatabaseValueSQL(key: string, platform: Platform): string`
+
+  Converts a value from its JS representation to its database representation of this type.
+  _(added in v4.4.2)_
+
+- `convertToJSValueSQL?(key: string, platform: Platform): string`
+
+  Modifies the SQL expression (identifier, parameter) to convert to a JS value. 
+  _(added in v4.4.2)_
 
 ```typescript
 import { Type, Platform, EntityProperty, ValidationError } from '@mikro-orm/core';
@@ -80,6 +90,130 @@ export class FooBar {
 }
 ```
 
+## Advanced example - PointType and WKT
+
+In this example we will combine mapping values via database as well as during runtime.
+
+> The Point type is part of the Spatial extension of MySQL and enables you to store
+> a single location in a coordinate space by using x and y coordinates. You can use
+> the Point type to store a longitude/latitude pair to represent a geographic location.
+
+First let's define the `Point` class that will be used to represent the value during runtime:
+
+```ts
+export class Point {
+
+  constructor(public latitude: number,
+              public longitude: number) { }
+
+}
+```
+
+Then the mapping type:
+
+```ts
+export class PointType extends Type<Point | undefined, string | undefined> {
+
+  convertToDatabaseValue(value: Point | undefined): string | undefined {
+    if (!value) {
+      return value;
+    }
+
+    return `point(${value.latitude} ${value.longitude})`;
+  }
+
+  convertToJSValue(value: string | undefined): Point | undefined {
+    const m = value?.match(/point\((\d+(\.\d+)?) (\d+(\.\d+)?)\)/i);
+
+    if (!m) {
+      return undefined;
+    }
+
+    return new Point(+m[1], +m[3]);
+  }
+
+  convertToJSValueSQL(key: string) {
+    return `ST_AsText(${key})`;
+  }
+
+  convertToDatabaseValueSQL(key: string) {
+    return `ST_PointFromText(${key})`;
+  }
+
+  getColumnType(): string {
+    return 'point';
+  }
+
+}
+```
+
+Now let's define an entity:
+
+```ts
+@Entity()
+export class Location {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: PointType })
+  point?: Point;
+
+}
+```
+
+...and use it:
+
+```ts
+const loc = new Location();
+loc.point = new Point(1.23, 4.56);
+await em.persist(loc).flush();
+em.clear();
+
+const loc1 = await em.findOneOrFail(Location, loc.id);
+
+// update it
+loc1.point = new Point(2.34, 9.87);
+await em.flush();
+```
+
+This will result in following queries:
+
+```sql
+begin
+insert into `location` (`point`) values (ST_PointFromText('point(1.23 4.56)'))
+commit
+
+select `e0`.*, ST_AsText(`e0`.point) as point from `location` as `e0` where `e0`.`id` = ? limit ?
+
+begin
+update `location` set `point` = ST_PointFromText('point(2.34 9.87)') where `id` = ?
+commit
+```
+
+We do a 2-step conversion here. In the first step, we convert the Point object into
+a string representation before saving to the database (in the convertToDatabaseValue
+method) and back into an object after fetching the value from the database (in the
+convertToJSValue method).
+
+The format of the string representation format is called Well-known text (WKT). The
+advantage of this format is, that it is both human readable and parsable by MySQL.
+
+Internally, MySQL stores geometry values in a binary format that is not identical to
+the WKT format. So, we need to let MySQL transform the WKT representation into its
+internal format.
+
+This is where the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods come
+into play.
+
+This methods wrap a sql expression (the WKT representation of the Point) into MySQL
+functions ST_PointFromText and ST_AsText which convert WKT strings to and from the
+internal format of MySQL.
+
+> When using DQL queries, the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods
+> only apply to identification variables and path expressions in SELECT clauses. Expressions
+> in WHERE clauses are not wrapped!
+
 ## Types provided by MikroORM
 
 There are few types provided by MikroORM. All of them aim to provide similar
@@ -88,18 +222,18 @@ out of box by the driver.
 
 ### ArrayType
 
-In PostgreSQL and MongoDB, it uses native arrays, otherwise it concatenates the 
+In PostgreSQL and MongoDB, it uses native arrays, otherwise it concatenates the
 values into string separated by commas. This means that you can't use values that
 contain comma with the `ArrayType` (but you can create custom array type that will
 handle this case, e.g. by using different separator).
 
-By default array of strings is returned from the type. You can also have arrays 
-of numbers or other data types - to do so, you will need to implement custom 
+By default array of strings is returned from the type. You can also have arrays
+of numbers or other data types - to do so, you will need to implement custom
 `hydrate` method that is used for converting the array values to the right type.
 
 > `ArrayType` will be used automatically if `type` is set to `array` (default behaviour
 > of reflect-metadata) or `string[]` or `number[]` (either manually or via ts-morph).
-> In case of `number[]` it will automatically handle the conversion to numbers. 
+> In case of `number[]` it will automatically handle the conversion to numbers.
 > This means that the following examples would both have the `ArrayType` used
 > automatically (but with reflect-metadata we would have a string array for both
 > unless we specify the type manually as `type: 'number[]')
@@ -114,8 +248,8 @@ numericArray?: number[];
 
 ### BigIntType
 
-You can use `BigIntType` to support `bigint`s. By default, it will represent the 
-value as a `string`. 
+You can use `BigIntType` to support `bigint`s. By default, it will represent the
+value as a `string`.
 
 ```typescript
 @PrimaryKey({ type: BigIntType })
@@ -124,10 +258,10 @@ id: string;
 
 ### BlobType
 
-Blob type can be used to store binary data in the database. 
+Blob type can be used to store binary data in the database.
 
-> `BlobType` will be used automatically if you specify the type hint as `Buffer`. 
-> This means that the following example should work even without the explicit 
+> `BlobType` will be used automatically if you specify the type hint as `Buffer`.
+> This means that the following example should work even without the explicit
 > `type: BlobType` option (with both reflect-metadata and ts-morph providers).
 
 ```typescript
@@ -137,7 +271,7 @@ blob?: Buffer;
 
 ### JsonType
 
-To store objects we can use `JsonType`. As some drivers are handling objects 
+To store objects we can use `JsonType`. As some drivers are handling objects
 automatically and some don't, this type will handle the serialization in a driver
 independent way (calling `parse` and `stringify` only when needed).
 
@@ -149,7 +283,7 @@ object?: { foo: string; bar: number };
 ### DateType
 
 To store dates without time information, we can use `DateType`. It does use `date`
-column type and maps it to the `Date` object. 
+column type and maps it to the `Date` object.
 
 ```typescript
 @Property({ type: DateType, nullable: true })
@@ -159,7 +293,7 @@ born?: Date;
 ### TimeType
 
 As opposed to the `DateType`, to store only the time information, we can use
-`TimeType`. It will use the `time` column type, the runtime type is string. 
+`TimeType`. It will use the `time` column type, the runtime type is string.
 
 ```typescript
 @Property({ type: TimeType, nullable: true })

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -197,6 +197,10 @@ export abstract class Platform {
     return `${quote}${id.replace('.', `${quote}.${quote}`)}${quote}`;
   }
 
+  quoteValue(value: any): string {
+    return value;
+  }
+
   setConfig(config: Configuration): void {
     this.config = config;
 

--- a/packages/core/src/types/Type.ts
+++ b/packages/core/src/types/Type.ts
@@ -20,6 +20,16 @@ export abstract class Type<JSType = string, DBType = JSType> {
   }
 
   /**
+   * Converts a value from its JS representation to its database representation of this type.
+   */
+  convertToDatabaseValueSQL?(key: string, platform: Platform): string;
+
+  /**
+   * Modifies the SQL expression (identifier, parameter) to convert to a JS value.
+   */
+  convertToJSValueSQL?(key: string, platform: Platform): string;
+
+  /**
    * How should the raw database values be compared? Used in `EntityComparator`.
    * Possible values: string | number | boolean | date | any | buffer | array
    */

--- a/tests/DatabaseDriver.test.ts
+++ b/tests/DatabaseDriver.test.ts
@@ -63,6 +63,7 @@ describe('DatabaseDriver', () => {
     const driver = new Driver(config, []);
     expect(driver.createEntityManager()).toBeInstanceOf(EntityManager);
     expect(driver.getPlatform().getRepositoryClass()).toBe(EntityRepository);
+    expect(driver.getPlatform().quoteValue('a')).toBe('a');
     await expect(driver.aggregate('', [])).rejects.toThrowError('Aggregations are not supported by Driver driver');
     await expect(driver.nativeUpdateMany('', [], [])).rejects.toThrowError('Batch updates are not supported by Driver driver');
     await expect(driver.lockPessimistic({}, LockMode.NONE)).rejects.toThrowError('Pessimistic locks are not supported by Driver driver');

--- a/tests/custom-types.test.ts
+++ b/tests/custom-types.test.ts
@@ -1,0 +1,103 @@
+import { Entity, Logger, MikroORM, PrimaryKey, Property, Type } from '@mikro-orm/core';
+import { MySqlDriver } from '@mikro-orm/mysql';
+
+export class Point {
+
+  constructor(public latitude: number, public longitude: number) { }
+
+}
+
+export class PointType extends Type<Point | undefined, string | undefined> {
+
+  convertToDatabaseValue(value: Point | undefined): string | undefined {
+    if (!value) {
+      return value;
+    }
+
+    return `point(${value.latitude} ${value.longitude})`;
+  }
+
+  convertToJSValue(value: string | undefined): Point | undefined {
+    const m = value?.match(/point\((\d+(\.\d+)?) (\d+(\.\d+)?)\)/i);
+
+    if (!m) {
+      return undefined;
+    }
+
+    return new Point(+m[1], +m[3]);
+  }
+
+  convertToJSValueSQL(key: string) {
+    return `ST_AsText(${key})`;
+  }
+
+  convertToDatabaseValueSQL(key: string) {
+    return `ST_PointFromText(${key})`;
+  }
+
+  getColumnType(): string {
+    return 'point';
+  }
+
+}
+
+@Entity()
+export class Location {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: PointType })
+  point?: Point;
+
+}
+
+describe('custom types [mysql]', () => {
+
+  let orm: MikroORM<MySqlDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init<MySqlDriver>({
+      entities: [Location],
+      dbName: `mikro_orm_test_custom_types`,
+      type: 'mysql',
+      port: 3307,
+    });
+
+    await orm.getSchemaGenerator().ensureDatabase();
+    await orm.getSchemaGenerator().dropSchema();
+    await orm.getSchemaGenerator().createSchema();
+  });
+  beforeEach(async () => {
+    await orm.em.nativeDelete(Location, {});
+  });
+  afterAll(async () => orm.close(true));
+
+  test('advanced custom types', async () => {
+    const mock = jest.fn();
+    const logger = new Logger(mock, ['query']);
+    Object.assign(orm.config, { logger });
+
+    const loc = new Location();
+    loc.point = new Point(1.23, 4.56);
+    await orm.em.persistAndFlush(loc);
+    orm.em.clear();
+
+    const l1 = await orm.em.findOneOrFail(Location, loc);
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch('insert into `location` (`point`) values (ST_PointFromText(\'point(1.23 4.56)\'))');
+    expect(mock.mock.calls[2][0]).toMatch('commit');
+    expect(mock.mock.calls[3][0]).toMatch('select `e0`.*, ST_AsText(`e0`.point) as point from `location` as `e0` where `e0`.`id` = ? limit ?');
+    expect(mock.mock.calls).toHaveLength(4);
+    await orm.em.flush(); // ensure we do not fire queries when nothing changed
+    expect(mock.mock.calls).toHaveLength(4);
+
+    l1.point = new Point(2.34, 9.87);
+    await orm.em.flush();
+    expect(mock.mock.calls).toHaveLength(7);
+    expect(mock.mock.calls[4][0]).toMatch('begin');
+    expect(mock.mock.calls[5][0]).toMatch('update `location` set `point` = ST_PointFromText(\'point(2.34 9.87)\') where `id` = ?');
+    expect(mock.mock.calls[6][0]).toMatch('commit');
+  });
+
+});


### PR DESCRIPTION
Adds two methods to the custom type interface that allows to adjust the SQL fragment
used to select or update the value.

Example usage:

```ts
export class PointType extends Type<Point, string> {

  convertToDatabaseValue(value: Point): string {
    return `point(${value.latitude} ${value.longitude})`;
  }

  convertToJSValue(value: string): Point {
    const m = value.match(/point\((\d+(\.\d+)?) (\d+(\.\d+)?)\)/i);
    return new Point(+m[1], +m[3]);
  }

  convertToJSValueSQL(key: string) {
    return `ST_AsText(${key})`;
  }

  convertToDatabaseValueSQL(key: string) {
    return `ST_PointFromText(${key})`;
  }

  getColumnType(): string {
    return 'point';
  }

}
```

Closes #735