### PR TITLE
fix(core): quote custom type aliases

### DIFF
--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -38,7 +38,7 @@ export class QueryBuilderHelper {
     if (prop?.customType && 'convertToJSValueSQL' in prop.customType) {
       const prefixed = this.prefix(field, true);
       /* istanbul ignore next */
-      return this.knex.raw(prop.customType.convertToJSValueSQL!(prefixed, this.platform) + ' as ' + (alias ?? prop.name));
+      return this.knex.raw(prop.customType.convertToJSValueSQL!(prefixed, this.platform) + ' as ' + this.platform.quoteIdentifier(alias ?? prop.name));
     }
 
     // do not wrap custom expressions

--- a/tests/custom-types.test.ts
+++ b/tests/custom-types.test.ts
@@ -87,7 +87,7 @@ describe('custom types [mysql]', () => {
     expect(mock.mock.calls[0][0]).toMatch('begin');
     expect(mock.mock.calls[1][0]).toMatch('insert into `location` (`point`) values (ST_PointFromText(\'point(1.23 4.56)\'))');
     expect(mock.mock.calls[2][0]).toMatch('commit');
-    expect(mock.mock.calls[3][0]).toMatch('select `e0`.*, ST_AsText(`e0`.point) as point from `location` as `e0` where `e0`.`id` = ? limit ?');
+    expect(mock.mock.calls[3][0]).toMatch('select `e0`.*, ST_AsText(`e0`.point) as `point` from `location` as `e0` where `e0`.`id` = ? limit ?');
     expect(mock.mock.calls).toHaveLength(4);
     await orm.em.flush(); // ensure we do not fire queries when nothing changed
     expect(mock.mock.calls).toHaveLength(4);


### PR DESCRIPTION
My custom properties are not getting mapped well because in Postgres casing is ignored for identifiers unless quoted.
The mapper uses the alias to map the results back to the entity and the results are getting lost because it's all lower case.

In other words, the compiled mapping function fails:

    if ('my_custom_prop' in result) { ret.myCustomProp = result.my_custom_prop; mapped.my_custom_prop = true; 

Because `result.mycustomprop` is not matched against the rule, and the generic treatment at the end of the mapping function also fails because it mappes the value into a property that doesn't exist:

    for (let k in result) { if (result.hasOwnProperty(k) && !mapped[k]) ret[k] = result[k]; }

I added the plaform quotes for the custom type alias.