### PR TITLE
Add custom type mapping for find method

### DIFF
--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -38,7 +38,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     const meta = this.metadata.find<T>(entityName)!;
     const populate = this.autoJoinOneToOneOwner(meta, options.populate as PopulateOptions<T>[], options.fields);
     const joinedProps = this.joinedProps(meta, populate);
-    const qb = this.createQueryBuilder<T>(entityName, ctx, !!ctx, false);
+    const qb = this.createQueryBuilder<T>(entityName, ctx, !!ctx, true);
     const fields = this.buildFields(meta, populate, joinedProps, qb, options.fields as Field<T>[]);
     const joinedPropsOrderBy = this.buildJoinedPropsOrderBy(entityName, qb, meta, joinedProps);
 


### PR DESCRIPTION
I'm not sure if this is right or not, but my custom types are failing to load when using `findOne` or `find` methods.

Debugging I realized the `find` method in `AbstractSqlDriver` creates a `QueryBuilder` with the `convertCustomTypes` flag set to `false`. 

I changed it to `true` and now I get the results as expected.

Am I missing something? 

Shouldn't the `find` methods return the mapped custom types as I defined them in the entities?