### PR TITLE
Fix documentation for orderBy

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ const books = await booksRepository.find({ author: '...' }, {
   populate: ['author'],
   limit: 1,
   offset: 2,
-  sort: { title: QueryOrder.DESC },
+  orderBy: { title: QueryOrder.DESC },
 });
 
 console.log(books); // Book[]

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -182,7 +182,7 @@ const books = await booksRepository.find({ author: '...' }, {
   populate: ['author'],
   limit: 1,
   offset: 2,
-  sort: { title: QueryOrder.DESC },
+  orderBy: { title: QueryOrder.DESC },
 });
 
 console.log(books); // Book[]

--- a/docs/docs/repositories.md
+++ b/docs/docs/repositories.md
@@ -19,7 +19,7 @@ const books = await booksRepository.find({ author: '...' }, {
   populate: ['author'],
   limit: 1,
   offset: 2,
-  sort: { title: QueryOrder.DESC },
+  orderBy: { title: QueryOrder.DESC },
 });
 
 console.log(books); // Book[]


### PR DESCRIPTION
I found it was documented as `sort:` but the only way I managed to compile it is with `orderBy:`.
I'm not sure if it ever was `sort:` in the past so older versions of the docs may be wrong as well.