### PR TITLE
fix: Avoid mutation of Property options object

### DIFF
--- a/packages/core/src/decorators/Property.ts
+++ b/packages/core/src/decorators/Property.ts
@@ -11,14 +11,17 @@ export function Property<T>(options: PropertyOptions<T> = {}) {
     MetadataValidator.validateSingleDecorator(meta, propertyName, ReferenceType.SCALAR);
     const name = options.name || propertyName;
 
-    if (propertyName !== name && !(desc.value instanceof Function)) {
-      Utils.renameKey(options, 'name', 'fieldName');
-    }
+    const prop = {
+      reference: ReferenceType.SCALAR,
+      ...options,
+      name: propertyName,
+      getter: !!desc.get,
+      setter: !!desc.set,
+    } as EntityProperty
 
-    options.name = propertyName;
-    const prop = Object.assign({ reference: ReferenceType.SCALAR }, options) as EntityProperty;
-    prop.getter = !!desc.get;
-    prop.setter = !!desc.set;
+     if (propertyName !== name && !(desc.value instanceof Function)) {
+      (prop as any).fieldName = options.name;
+    }
 
     if (desc.value instanceof Function) {
       prop.getter = true;


### PR DESCRIPTION
I have a number of properties that I pass the same options to so I made a single object that I import and pass to fields to reduce some boilerplate, but this caused bugs.

The previous implementation mutated the passed in object so I've updated it to avoid that.