### PR TITLE
docs: replace old removeEntity references

### DIFF
--- a/docs/docs/cascading.md
+++ b/docs/docs/cascading.md
@@ -81,7 +81,7 @@ as cascade removed entity can stay referenced in another entities that were not 
 const publisher = new Publisher(...);
 // all books with same publisher
 book1.publisher = book2.publisher = book3.publisher = publisher;
-await orm.em.remove(book1); // this will remove book1 and its publisher
+await orm.em.remove(book1).flush(); // this will remove book1 and its publisher
 
 // but we still have reference to removed publisher here
 console.log(book2.publisher, book3.publisher);

--- a/docs/docs/cascading.md
+++ b/docs/docs/cascading.md
@@ -71,7 +71,7 @@ example assumes that `Book.publisher` is set to `Cascade.REMOVE`:
 > for each entity in collection.
 
 ```typescript
-await orm.em.removeEntity(book); // this will also remove book.publisher
+await orm.em.remove(book); // this will also remove book.publisher
 ```
 
 Keep in mind that cascade remove **can be dangerous** when used on `@ManyToOne` fields, 
@@ -81,7 +81,7 @@ as cascade removed entity can stay referenced in another entities that were not 
 const publisher = new Publisher(...);
 // all books with same publisher
 book1.publisher = book2.publisher = book3.publisher = publisher;
-await orm.em.removeEntity(book1); // this will remove book1 and its publisher
+await orm.em.remove(book1); // this will remove book1 and its publisher
 
 // but we still have reference to removed publisher here
 console.log(book2.publisher, book3.publisher);

--- a/docs/docs/cascading.md
+++ b/docs/docs/cascading.md
@@ -71,7 +71,7 @@ example assumes that `Book.publisher` is set to `Cascade.REMOVE`:
 > for each entity in collection.
 
 ```typescript
-await orm.em.remove(book); // this will also remove book.publisher
+await orm.em.remove(book).flush(); // this will also remove book.publisher
 ```
 
 Keep in mind that cascade remove **can be dangerous** when used on `@ManyToOne` fields, 

--- a/docs/docs/repositories-api.md
+++ b/docs/docs/repositories-api.md
@@ -108,10 +108,9 @@ Flushes all changes to objects that have been queued up to now to the database.
 
 #### `remove(where: AnyEntity | Reference<AnyEntity> | (AnyEntity | Reference<AnyEntity>)[]): Promise<void>`
 
-When provided entity instance as `where` value, then it calls `removeEntity(entity, flush)`, 
-otherwise it fires delete query with given `where` condition. 
+It queues entity for removal when flush or commit is called.
 
-This method fires `beforeDelete` and `afterDelete` hooks only if you provide entity instance.  
+This method fires `beforeDelete` and `afterDelete` hooks.
 
 ---
 

--- a/docs/versioned_docs/version-4.4/cascading.md
+++ b/docs/versioned_docs/version-4.4/cascading.md
@@ -71,7 +71,7 @@ example assumes that `Book.publisher` is set to `Cascade.REMOVE`:
 > for each entity in collection.
 
 ```typescript
-await orm.em.removeEntity(book); // this will also remove book.publisher
+await orm.em.remove(book).flush(); // this will also remove book.publisher
 ```
 
 Keep in mind that cascade remove **can be dangerous** when used on `@ManyToOne` fields, 
@@ -81,7 +81,7 @@ as cascade removed entity can stay referenced in another entities that were not 
 const publisher = new Publisher(...);
 // all books with same publisher
 book1.publisher = book2.publisher = book3.publisher = publisher;
-await orm.em.removeEntity(book1); // this will remove book1 and its publisher
+await orm.em.remove(book1).flush(); // this will remove book1 and its publisher
 
 // but we still have reference to removed publisher here
 console.log(book2.publisher, book3.publisher);

--- a/docs/versioned_docs/version-4.4/repositories-api.md
+++ b/docs/versioned_docs/version-4.4/repositories-api.md
@@ -108,10 +108,9 @@ Flushes all changes to objects that have been queued up to now to the database.
 
 #### `remove(where: AnyEntity | Reference<AnyEntity> | (AnyEntity | Reference<AnyEntity>)[]): Promise<void>`
 
-When provided entity instance as `where` value, then it calls `removeEntity(entity, flush)`, 
-otherwise it fires delete query with given `where` condition. 
+It queues entity for removal when flush or commit is called.
 
-This method fires `beforeDelete` and `afterDelete` hooks only if you provide entity instance.  
+This method fires `beforeDelete` and `afterDelete` hooks.
 
 ---
 


### PR DESCRIPTION
Replace references to old `removeEntity` method with the current `remove` method.