### PR TITLE
docs: update defining-entities section

### DIFF
--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -1536,7 +1536,7 @@ and other methods that are otherwise available via the `wrap()` helper.
 import { BaseEntity } from '@mikro-orm/core';
 
 @Entity()
-export class Book extends BaseEntity {
+export class Book extends BaseEntity<Book, 'id'> {
 
   @PrimaryKey()
   id!: number;

--- a/docs/versioned_docs/version-4.4/defining-entities.md
+++ b/docs/versioned_docs/version-4.4/defining-entities.md
@@ -1536,7 +1536,7 @@ and other methods that are otherwise available via the `wrap()` helper.
 import { BaseEntity } from '@mikro-orm/core';
 
 @Entity()
-export class Book extends BaseEntity {
+export class Book extends BaseEntity<Book, 'id'> {
 
   @PrimaryKey()
   id!: number;


### PR DESCRIPTION
Hi,

I think this should be `export class Book extends BaseEntity<Book, 'id'> { ... }`. There's a `Book` declaration at the bottom of [entity-helper.md](https://github.com/mikro-orm/mikro-orm/blob/master/docs/versioned_docs/version-4.4/entity-helper.md) that has the correct code.