### PR TITLE
MariaDB: wrong Date value during select

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,8 @@ jobs:
         yarn run-rs-in-background
         yarn coverage > COVERAGE_RESULT
         echo "$(cat COVERAGE_RESULT)"
+      env:
+        TZ: Europe/Prague # use different timezone than UTC, because we need to validate that time zone shifting works
 
     - name: Release dev version for testing
       if: github.ref == 'refs/heads/master' && matrix.node-version == '15.x' && steps.changed_packages.outputs.changed_packages != '0'


### PR DESCRIPTION
Hi,

I'm facing a strange bug with MariaDB driver. When I'm trying to load `date` property, the value is not shifted. It's still in UTC. Saving works correctly. The mysql driver contains a test for this scenario, but the MariaDB driver not. So I copy&pasted them and It's really failing just for MariaDB.

So here is PR with a failing code. Any idea, how to fix it?