### PR TITLE
feat(cli): allow mikro-orm config to return Promise

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -188,7 +188,12 @@ $ yarn mikro-orm
 ```
 
 For CLI to be able to access your database, you will need to create `mikro-orm.config.js` file that 
-exports your ORM configuration. TypeScript is also supported, just enable `useTsNode` flag in your
+exports your ORM configuration. 
+
+> Your ORM configuration file can export the Promise, like:
+> `export default Promise.resolve({...});`.
+
+TypeScript is also supported, just enable `useTsNode` flag in your
 `package.json` file. There you can also set up array of possible paths to `mikro-orm.config` file,
 as well as use different file name:
 

--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -18,7 +18,7 @@ export class ConfigurationLoader {
       if (await pathExists(path)) {
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const config = require(path);
-        return new Configuration({ ...(config.default || config), ...options }, validate);
+        return new Configuration({ ...(await (config.default || config)), ...options }, validate);
       }
     }
 


### PR DESCRIPTION
The use case is - when I need to get my connection information from a remote system (Secret Store, Microservice etc.)