### PR TITLE
feat(core): add `Collection.matching()` method to allow pagination

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -122,7 +122,7 @@ module.exports = {
     'comma-dangle': ['error', 'always-multiline'],
     'dot-notation': 'error',
     'eol-last': 'error',
-    'eqeqeq': ['error', 'always'],
+    'eqeqeq': ['error', 'always', {"null": "ignore"}],
     'jsdoc/no-types': 'error',
     'no-console': 'error',
     'no-duplicate-imports': 'error',

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -85,6 +85,10 @@ export class ValidationError<T extends AnyEntity = AnyEntity> extends Error {
     return new ValidationError(error, owner);
   }
 
+  static cannotModifyReadonlyCollection(owner: AnyEntity, property: EntityProperty): ValidationError {
+    return new ValidationError(`You cannot modify collection ${owner.constructor.name}.${property.name} as it is marked as readonly.`, owner);
+  }
+
   static invalidCompositeIdentifier(meta: EntityMetadata): ValidationError {
     return new ValidationError(`Composite key required for entity ${meta.className}.`);
   }

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -396,6 +396,11 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     const populate = this.autoJoinOneToOneOwner(targetMeta, [{ field: prop.pivotTable }]);
     const fields = this.buildFields(targetMeta, (options?.populate ?? []) as PopulateOptions<T>[], [], qb, options?.fields as Field<T>[]);
     qb.select(fields).populate(populate).where(where).orderBy(orderBy!);
+
+    if (owners.length === 1 && (options?.offset != null || options?.limit != null)) {
+      qb.limit(options.limit, options.offset);
+    }
+
     const items = owners.length ? await this.rethrow(qb.execute('all')) : [];
 
     const map: Dictionary<T[]> = {};


### PR DESCRIPTION
Collections now have a `matching` method that allows to slice parts of data from a collection.
By default, it will return the list of entities based on the query. We can use the `store`
boolean parameter to save this list into the collection items - this will mark the
collection as `readonly`, methods like `add` or `remove` will throw.

```ts
const a = await em.findOneOrFail(Author, 1);

// only loading the list of items
const books = await a.books.matching({ limit: 3, offset: 10, orderBy: { title: 'asc' } });
console.log(books); // [Book, Book, Book]
console.log(a.books.isInitialized()); // false

// storing the items in collection
const tags = await books[0].tags.matching({
  limit: 3,
  offset: 5,
  orderBy: { name: 'asc' },
  store: true,
});
console.log(tags); // [BookTag, BookTag, BookTag]
console.log(books[0].tags.isInitialized()); // true
console.log(books[0].tags.getItems()); // [BookTag, BookTag, BookTag]
```

Closes #334