### PR TITLE
feat(core): allow updating nested 1:1 and m:1 references with EntityAssigner

### DIFF
--- a/docs/docs/entity-helper.md
+++ b/docs/docs/entity-helper.md
@@ -44,7 +44,7 @@ wrap(book).assign({
 ```
 
 By default, `entity.assign(data)` behaves same way as `Object.assign(entity, data)`, 
-e.g. it does not merge things recursively. To enable deep merging of object properties, 
+e.g. it does not merge things recursively. To enable deep merging of object properties (not referenced entities), 
 use second parameter to enable `mergeObjects` flag:
 
 ```typescript
@@ -57,6 +57,24 @@ console.log(book.meta); // { foo: 3, bar: 2 }
 
 wrap(book).assign({ meta: { foo: 4 } });
 console.log(book.meta); // { foo: 4 }
+```
+
+To get the same behavior as `mergeObjects` flag for m:1 and 1:1 references, enable the `updateNestedEntities` flag.
+
+```typescript
+import { wrap } from '@mikro-orm/core';
+
+const authorEntity = new Author('Jon2 Snow', 'snow3@wall.st');
+book.author = authorEntity;
+
+wrap(book).assign({ author: { name: 'Jon Snow2' } }, { updateNestedEntities: true });
+console.log(book.author); // { ... name: 'Jon Snow2' ... }
+console.log(book.author === authorEntity) // true
+
+//this will have no influence as author is an entity
+wrap(book).assign({ author: { name: 'Jon Snow2' } }, { mergeObjects: true });
+console.log(book.author); // { ... name: 'Jon Snow2' ... }
+console.log(book.author === authorEntity) // false
 ```
 
 ## `WrappedEntity` and `wrap()` helper

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -43,7 +43,7 @@ export class EntityAssigner {
       }
 
       if ([ReferenceType.MANY_TO_ONE, ReferenceType.ONE_TO_ONE].includes(props[prop]?.reference) && Utils.isDefined(value, true) && EntityAssigner.validateEM(em)) {
-          return EntityAssigner.assignReference<T>(entity, value, props[prop], em!, options);
+        return EntityAssigner.assignReference<T>(entity, value, props[prop], em!, options);
       }
 
       if (props[prop]?.reference === ReferenceType.SCALAR && SCALAR_TYPES.includes(props[prop].type) && (props[prop].setter || !props[prop].getter)) {

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -47,7 +47,7 @@ export class EntityAssigner {
 
         // eslint-disable-next-line no-prototype-builtins
         if (options.updateNestedEntities && entity.hasOwnProperty(prop) && (Utils.isEntity(entity[prop]) || Reference.isReference(entity[prop])) && Utils.isPlainObject(value)) {
-          const unwrappedEntity = Reference.isReference(entity[prop]) ? entity[prop].unwrap() : entity[prop];
+          const unwrappedEntity = Reference.unwrapReference(entity[prop]);
 
           if (wrap(unwrappedEntity).isInitialized()) {
             return EntityAssigner.assign(unwrappedEntity, value, options);

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -6,6 +6,7 @@ import { Utils } from '../utils/Utils';
 import { Reference } from './Reference';
 import { ReferenceType, SCALAR_TYPES } from '../enums';
 import { EntityValidator } from './EntityValidator';
+import { wrap } from './wrap';
 
 const validator = new EntityValidator(false);
 
@@ -43,7 +44,8 @@ export class EntityAssigner {
       }
 
       if ([ReferenceType.MANY_TO_ONE, ReferenceType.ONE_TO_ONE].includes(props[prop]?.reference) && Utils.isDefined(value, true) && EntityAssigner.validateEM(em)) {
-        if (options.updateNestedEntities && Utils.isEntity(entity[prop], false) && Utils.isPlainObject(value)) {
+        // eslint-disable-next-line no-prototype-builtins
+        if (options.updateNestedEntities && entity.hasOwnProperty(prop) && Utils.isEntity(entity[prop]) && wrap(entity[prop]).isInitialized() && Utils.isPlainObject(value)) {
           return EntityAssigner.assign(entity[prop], value, options);
         }
 
@@ -60,8 +62,7 @@ export class EntityAssigner {
 
       if (options.mergeObjects && Utils.isPlainObject(value)) {
         Utils.merge(entity[prop as keyof T], value);
-      // eslint-disable-next-line no-prototype-builtins
-      } else if (entity.hasOwnProperty(prop) && (!props[prop] || props[prop].setter || !props[prop].getter)) {
+      } else if (!props[prop] || props[prop].setter || !props[prop].getter) {
         entity[prop as keyof T] = value;
       }
     });

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -44,9 +44,14 @@ export class EntityAssigner {
       }
 
       if ([ReferenceType.MANY_TO_ONE, ReferenceType.ONE_TO_ONE].includes(props[prop]?.reference) && Utils.isDefined(value, true) && EntityAssigner.validateEM(em)) {
+
         // eslint-disable-next-line no-prototype-builtins
-        if (options.updateNestedEntities && entity.hasOwnProperty(prop) && Utils.isEntity(entity[prop]) && wrap(entity[prop]).isInitialized() && Utils.isPlainObject(value)) {
-          return EntityAssigner.assign(entity[prop], value, options);
+        if (options.updateNestedEntities && entity.hasOwnProperty(prop) && (Utils.isEntity(entity[prop]) || Reference.isReference(entity[prop])) && Utils.isPlainObject(value)) {
+          const unwrappedEntity = Reference.isReference(entity[prop]) ? entity[prop].unwrap() : entity[prop];
+
+          if (wrap(unwrappedEntity).isInitialized()) {
+            return EntityAssigner.assign(unwrappedEntity, value, options);
+          }
         }
 
         return EntityAssigner.assignReference<T>(entity, value, props[prop], em!, options);

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -60,7 +60,8 @@ export class EntityAssigner {
 
       if (options.mergeObjects && Utils.isPlainObject(value)) {
         Utils.merge(entity[prop as keyof T], value);
-      } else if (!props[prop] || props[prop].setter || !props[prop].getter) {
+      // eslint-disable-next-line no-prototype-builtins
+      } else if (entity.hasOwnProperty(prop) && (!props[prop] || props[prop].setter || !props[prop].getter)) {
         entity[prop as keyof T] = value;
       }
     });

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -43,7 +43,11 @@ export class EntityAssigner {
       }
 
       if ([ReferenceType.MANY_TO_ONE, ReferenceType.ONE_TO_ONE].includes(props[prop]?.reference) && Utils.isDefined(value, true) && EntityAssigner.validateEM(em)) {
-        return EntityAssigner.assignReference<T>(entity, value, props[prop], em!, options);
+        if (options.updateNestedEntities && Utils.isEntity(entity[prop], false) && Utils.isPlainObject(value)) {
+          return EntityAssigner.assign(entity[prop], value, options);
+        }
+          return EntityAssigner.assignReference<T>(entity, value, props[prop], em!, options);
+
       }
 
       if (props[prop]?.reference === ReferenceType.SCALAR && SCALAR_TYPES.includes(props[prop].type) && (props[prop].setter || !props[prop].getter)) {
@@ -96,24 +100,20 @@ export class EntityAssigner {
   }
 
   private static assignReference<T extends AnyEntity<T>>(entity: T, value: any, prop: EntityProperty, em: EntityManager, options: AssignOptions): void {
-    if (options.updateNestedEntities && Utils.isEntity(entity[prop.name], false) && Utils.isPlainObject(value)) {
-      EntityAssigner.assign(entity[prop.name], value, options);
+    if (Utils.isEntity(value, true)) {
+      entity[prop.name] = value;
+    } else if (Utils.isPrimaryKey(value, true)) {
+      entity[prop.name] = Reference.wrapReference(em.getReference<T>(prop.type, value, false, options.convertCustomTypes), prop);
+    } else if (Utils.isPlainObject(value) && options.merge) {
+      entity[prop.name] = Reference.wrapReference(em.merge(prop.type, value), prop);
+    } else if (Utils.isPlainObject(value)) {
+      entity[prop.name] = Reference.wrapReference(em.create(prop.type, value), prop);
     } else {
-      if (Utils.isEntity(value, true)) {
-        entity[prop.name] = value;
-      } else if (Utils.isPrimaryKey(value, true)) {
-        entity[prop.name] = Reference.wrapReference(em.getReference<T>(prop.type, value, false, options.convertCustomTypes), prop);
-      } else if (Utils.isPlainObject(value) && options.merge) {
-        entity[prop.name] = Reference.wrapReference(em.merge(prop.type, value), prop);
-      } else if (Utils.isPlainObject(value)) {
-        entity[prop.name] = Reference.wrapReference(em.create(prop.type, value), prop);
-      } else {
-        const name = entity.constructor.name;
-        throw new Error(`Invalid reference value provided for '${name}.${prop.name}' in ${name}.assign(): ${JSON.stringify(value)}`);
-      }
-
-      EntityAssigner.autoWireOneToOne(prop, entity);
+      const name = entity.constructor.name;
+      throw new Error(`Invalid reference value provided for '${name}.${prop.name}' in ${name}.assign(): ${JSON.stringify(value)}`);
     }
+
+    EntityAssigner.autoWireOneToOne(prop, entity);
   }
 
   private static assignCollection<T extends AnyEntity<T>, U extends AnyEntity<U> = AnyEntity>(entity: T, collection: Collection<U>, value: any[], prop: EntityProperty, em: EntityManager, options: AssignOptions): void {

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -46,8 +46,8 @@ export class EntityAssigner {
         if (options.updateNestedEntities && Utils.isEntity(entity[prop], false) && Utils.isPlainObject(value)) {
           return EntityAssigner.assign(entity[prop], value, options);
         }
-          return EntityAssigner.assignReference<T>(entity, value, props[prop], em!, options);
 
+        return EntityAssigner.assignReference<T>(entity, value, props[prop], em!, options);
       }
 
       if (props[prop]?.reference === ReferenceType.SCALAR && SCALAR_TYPES.includes(props[prop].type) && (props[prop].setter || !props[prop].getter)) {

--- a/tests/EntityAssigner.mysql.test.ts
+++ b/tests/EntityAssigner.mysql.test.ts
@@ -76,6 +76,24 @@ describe('EntityAssignerMySql', () => {
     expect(book2.tags.getIdentifiers()).toMatchObject([tag2.id]);
   });
 
+  test('assign() should update m:1 or 1:1 nested entities [mysql]', async () => {
+    const jon = new Author2('Jon Snow', 'snow@wall.st');
+    const book1 = new Book2('Book2', jon);
+    const jon2 = new Author2('Jon2 Snow', 'snow3@wall.st');
+    const book2 = new Book2('Book2', jon2);
+    await orm.em.persistAndFlush(book1);
+    await orm.em.persistAndFlush(book2);
+    wrap(book1).assign({ author: { name: 'Jon Snow2' } });
+    expect(book1.author.name).toEqual('Jon Snow2');
+    expect(book1.author.email).toBeUndefined();
+    expect(book1.author).not.toEqual(jon);
+
+    wrap(book2).assign({ author: { name: 'Jon Snow2' } }, { updateNestedEntities: true });
+    expect(book2.author.name).toEqual('Jon Snow2');
+    expect(book2.author.email).toEqual('snow3@wall.st');
+    expect(book2.author).toEqual(jon2);
+  });
+
   test('assign() should update not initialized collection [mysql]', async () => {
     const other = new BookTag2('other');
     await orm.em.persistAndFlush(other);

--- a/tests/EntityAssigner.mysql.test.ts
+++ b/tests/EntityAssigner.mysql.test.ts
@@ -116,7 +116,6 @@ describe('EntityAssignerMySql', () => {
     expect(Reference.isReference(book2.publisher)).toEqual(true);
 
     wrap(book2).assign({ author: { name: 'Jon Snow2' }, publisher: { name: 'Better Books LLC' } }, { updateNestedEntities: true });
-    wrap(originalAuthorRef).populated(true);
 
     // this means that the original object has been replaced, something updateNestedEntities does not do
     expect(book2.author).not.toEqual(originalAuthorRef);

--- a/tests/EntityAssigner.mysql.test.ts
+++ b/tests/EntityAssigner.mysql.test.ts
@@ -1,4 +1,4 @@
-import { MikroORM, NotNullConstraintViolationException, wrap } from '@mikro-orm/core';
+import { MikroORM, wrap } from '@mikro-orm/core';
 import { MySqlDriver } from '@mikro-orm/mysql';
 import { initORMMySql, wipeDatabaseMySql } from './bootstrap';
 import { Author2, Book2, BookTag2, FooBar2 } from './entities-sql';


### PR DESCRIPTION
Currently, when you do the following:
```
const authorEntity = new Author('Jon2 Snow', 'snow3@wall.st');
book.author = authorEntity;

wrap(book).assign({ author: { name: 'Jon Snow2' } }, { mergeObjects: true });
console.log(book.author); // { ... name: 'Jon Snow2' ... }
console.log(book.author === authorEntity) // false
```
... it will try to create a new author entity with the name Jon Snow2 altough it can assign these values to the existing m:1 reference. Was doubting to fix the functionality for the mergeObjects flag, however that may be a breaking change.

Right now, it will only update loaded references; should I also implement initializing the enitity and then asssign the new values?
