### PR TITLE
Use mysql2 instead of mysql for MonkeyPatcher

### DIFF
--- a/packages/knex/src/MonkeyPatchable.ts
+++ b/packages/knex/src/MonkeyPatchable.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import MySqlDialect from 'knex/lib/dialects/mysql';
+import MySqlDialect from 'knex/lib/dialects/mysql2';
 // @ts-ignore
 import PostgresDialectTableCompiler from 'knex/lib/dialects/postgres/schema/tablecompiler';
 // @ts-ignore


### PR DESCRIPTION
This might be incorrect but why is the monkeypatcher using the `mysql` instead of the `mysql2` reference?