### PR TITLE
feat(configuration): validating platform before driver init #1543

### DIFF
--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -263,7 +263,11 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
 
   private initDriver(): D {
     if (!this.options.driver) {
-      const { className, module } = Configuration.PLATFORMS[this.options.type!];
+      const platform = Configuration.PLATFORMS[this.options.type!];
+      if (!platform) {
+        throw new Error(`Invalid specified platform \`${this.options.type}\`, please fill in a valid \`type\`. Available platforms types: ${inspect(Object.keys(Configuration.PLATFORMS))}`);
+      }
+      const { className, module } = platform;
       this.options.driver = module()[className];
     }
 


### PR DESCRIPTION
This PR improves error logging when the ORM is initialized with an invalid driver mentioned in this issue #1543.

This is an example of the error before changes:
```bash
TypeError: Cannot destructure property 'className' of 'Configuration.PLATFORMS[this.options.type]' as it is undefined.
|     at Configuration.initDriver (/home/app/node_modules/@mikro-orm/core/utils/Configuration.js:151:21)
|     at new Configuration (/home/app/node_modules/@mikro-orm/core/utils/Configuration.js:25:28)
|     at new MikroORM (/home/app/node_modules/@mikro-orm/core/MikroORM.js:20:27)
|     at Function.init (/home/app/node_modules/@mikro-orm/core/MikroORM.js:38:21)
|     at InstanceWrapper.useFactory [as metatype] (/home/app/node_modules/@mikro-orm/nestjs/mikro-orm.providers.js:21:32)
|     at Injector.instantiateClass (/home/app/node_modules/@nestjs/core/injector/injector.js:289:55)
|     at callback (/home/app/node_modules/@nestjs/core/injector/injector.js:42:41)
|     at async Injector.resolveConstructorParams (/home/app/node_modules/@nestjs/core/injector/injector.js:114:24)
|     at async Injector.loadInstance (/home/app/node_modules/@nestjs/core/injector/injector.js:46:9)
|     at async Injector.loadProvider (/home/app/node_modules/@nestjs/core/injector/injector.js:68:9)
```