### PR TITLE
Added custom type reproduction case.

### DIFF
--- a/docs/docs/query-conditions.md
+++ b/docs/docs/query-conditions.md
@@ -82,22 +82,23 @@ const res = await orm.em.find(Author, [1, 2, 7]);
 
 ### Comparison
 
-| operator | name               | description |
-|----------|--------------------|-------------|
-| `$eq`	   | equals             | Matches values that are equal to a specified value. |
-| `$gt`	   | greater            | Matches values that are greater than a specified value. |
-| `$gte`   | greater or equal   | Matches values that are greater than or equal to a specified value. |
-| `$in`	   | contains           | Matches any of the values specified in an array. |
-| `$lt`	   | lower              | Matches values that are less than a specified value. |
-| `$lte`   | lower or equal     | Matches values that are less than or equal to a specified value. |
-| `$ne`	   | not equal          | Matches all values that are not equal to a specified value. |
-| `$nin`   | not contains       | Matches none of the values specified in an array. |
-| `$like`  | like               | Uses LIKE operator |
-| `$re`    | regexp             | Uses REGEXP operator |
-| `$ilike` | ilike              | (postgres only) |
-| `$overlap` | &&               | (postgres only) |
-| `$contains` | @>              | (postgres only) |
-| `$contained` | <@             | (postgres only) |
+| operator     | name             | description                                                         |
+|--------------|------------------|---------------------------------------------------------------------|
+| `$eq`        | equals           | Matches values that are equal to a specified value.                 |
+| `$gt`        | greater          | Matches values that are greater than a specified value.             |
+| `$gte`       | greater or equal | Matches values that are greater than or equal to a specified value. |
+| `$in`        | contains         | Matches any of the values specified in an array.                    |
+| `$lt`        | lower            | Matches values that are less than a specified value.                |
+| `$lte`       | lower or equal   | Matches values that are less than or equal to a specified value.    |
+| `$ne`        | not equal        | Matches all values that are not equal to a specified value.         |
+| `$nin`       | not contains     | Matches none of the values specified in an array.                   |
+| `$like`      | like             | Uses LIKE operator                                                  |
+| `$re`        | regexp           | Uses REGEXP operator                                                |
+| `$ilike`     | ilike            | (postgres only)                                                     |
+| `$overlap`   | &&               | (postgres only)                                                     |
+| `$contains`  | @>               | (postgres only)                                                     |
+| `$contained` | <@               | (postgres only)                                                     |
+| `$sameAs`    | ~=               | (postgres only)                                                     |
 
 ### Logical
 

--- a/docs/versioned_docs/version-4.4/query-conditions.md
+++ b/docs/versioned_docs/version-4.4/query-conditions.md
@@ -82,22 +82,23 @@ const res = await orm.em.find(Author, [1, 2, 7]);
 
 ### Comparison
 
-| operator | name               | description |
-|----------|--------------------|-------------|
-| `$eq`	   | equals             | Matches values that are equal to a specified value. |
-| `$gt`	   | greater            | Matches values that are greater than a specified value. |
-| `$gte`   | greater or equal   | Matches values that are greater than or equal to a specified value. |
-| `$in`	   | contains           | Matches any of the values specified in an array. |
-| `$lt`	   | lower              | Matches values that are less than a specified value. |
-| `$lte`   | lower or equal     | Matches values that are less than or equal to a specified value. |
-| `$ne`	   | not equal          | Matches all values that are not equal to a specified value. |
-| `$nin`   | not contains       | Matches none of the values specified in an array. |
-| `$like`  | like               | Uses LIKE operator |
-| `$re`    | regexp             | Uses REGEXP operator |
-| `$ilike` | ilike              | (postgres only) |
-| `$overlap` | &&               | (postgres only) |
-| `$contains` | @>              | (postgres only) |
-| `$contained` | <@             | (postgres only) |
+| operator     | name             | description                                                         |
+|--------------|------------------|---------------------------------------------------------------------|
+| `$eq`        | equals           | Matches values that are equal to a specified value.                 |
+| `$gt`        | greater          | Matches values that are greater than a specified value.             |
+| `$gte`       | greater or equal | Matches values that are greater than or equal to a specified value. |
+| `$in`        | contains         | Matches any of the values specified in an array.                    |
+| `$lt`        | lower            | Matches values that are less than a specified value.                |
+| `$lte`       | lower or equal   | Matches values that are less than or equal to a specified value.    |
+| `$ne`        | not equal        | Matches all values that are not equal to a specified value.         |
+| `$nin`       | not contains     | Matches none of the values specified in an array.                   |
+| `$like`      | like             | Uses LIKE operator                                                  |
+| `$re`        | regexp           | Uses REGEXP operator                                                |
+| `$ilike`     | ilike            | (postgres only)                                                     |
+| `$overlap`   | &&               | (postgres only)                                                     |
+| `$contains`  | @>               | (postgres only)                                                     |
+| `$contained` | <@               | (postgres only)                                                     |
+| `$sameAs`    | ~=               | (postgres only)                                                     |
 
 ### Logical
 

--- a/packages/core/src/enums.ts
+++ b/packages/core/src/enums.ts
@@ -19,6 +19,7 @@ export enum QueryOperator {
   $overlap = '&&', // postgres only
   $contains = '@>', // postgres only
   $contained = '<@', // postgres only
+  $sameAs = '~=', // postgres only
 }
 
 export const ARRAY_OPERATORS = ['$overlap', '$contains', '$contained'];

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -62,6 +62,7 @@ export type OperatorMap<T> = {
   $overlap?: string[];
   $contains?: string[];
   $contained?: string[];
+  $sameAs?: ExpandScalar<T>;
 };
 
 export type FilterValue2<T> = T | ExpandScalar<T> | Primary<T>;

--- a/tests/issues/GH1263.test.ts
+++ b/tests/issues/GH1263.test.ts
@@ -1,0 +1,97 @@
+(global as any).process.env.FORCE_COLOR = 0;
+
+import Knex, { Raw } from 'knex';
+import { SchemaGenerator } from '@mikro-orm/knex';
+import {
+  Entity,
+  Logger,
+  MikroORM,
+  PrimaryKey,
+  Property,
+  Type,
+  ValidationError,
+} from '@mikro-orm/core';
+import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+
+type Point = { x: number; y: number };
+
+class PointType extends Type<Point, Raw> {
+
+  convertToDatabaseValue(value: any): Raw {
+    if (!value) { return value; }
+    if (typeof value.x === 'number' && typeof value.y === 'number') {
+      return Knex({ client: 'pg' }).raw(`point(?,?)`, [value.x, value.y]);
+    }
+
+    throw ValidationError.invalidType(PointType, value, 'database');
+  }
+
+  convertToJSValue(value: any): Point {
+    if (typeof value === 'object') {
+      return value; // pg connector is automatically converting point to { x, y }
+    }
+
+    value = value.match(/(\(\d+,\d+\))/);
+    return { x: value[0], y: value[1] };
+  }
+
+  getColumnType() {
+    return 'point';
+  }
+
+}
+
+@Entity()
+class A {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: PointType })
+  prop!: Point;
+
+}
+
+describe('GH issue 1263', () => {
+  let orm: MikroORM<PostgreSqlDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [A],
+      dbName: `mikro_orm_test_gh_1263`,
+      type: 'postgresql',
+    });
+    await new SchemaGenerator(orm.em).ensureDatabase();
+    await new SchemaGenerator(orm.em).dropSchema();
+    await new SchemaGenerator(orm.em).createSchema();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test(`queries are able to match on point values`, async () => {
+    const mock = jest.fn();
+    const logger = new Logger(mock, ['query']);
+    Object.assign(orm.config, { logger });
+
+    const a1 = new A();
+    a1.prop = { x: 5, y: 9 };
+
+    await orm.em.persistAndFlush(a1);
+    orm.em.clear();
+
+	const [result] = await orm.em.find(A, { prop: { $sameAs: { x: 5, y: 9 } } });
+    expect(result?.prop.x).toBe(5);
+    expect(result?.prop.y).toBe(9);
+
+	const result2 = await orm.em.findOne(A, { prop: { $sameAs: { x: 5, y: 9 } } });
+    expect(result2?.prop.x).toBe(5);
+    expect(result2?.prop.y).toBe(9);
+
+	const result3 = await orm.em.findOneOrFail(A, { prop: { $sameAs: { x: 5, y: 9 } } });
+    expect(result3.prop.x).toBe(5);
+    expect(result3.prop.y).toBe(9);
+
+  });
+});


### PR DESCRIPTION
test(custom types): added custom type reproduction case

When a custom type uses object values, we used to incorrectly assume
these were nested where parameters when they could actually be an
instance of a custom type. Also added support for the $sameAs operator.