### PR TITLE
fix: bigint as primary key

### DIFF
--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -355,7 +355,7 @@ export class Utils {
       return true;
     }
 
-    return Utils.isString(key) || typeof key === 'number' || Utils.isObjectID(key) || key instanceof Date || key instanceof Buffer;
+    return Utils.isString(key) || typeof key === 'number' || typeof key === 'bigint' || Utils.isObjectID(key) || key instanceof Date || key instanceof Buffer;
   }
 
   /**

--- a/tests/issues/GH1626.test.ts
+++ b/tests/issues/GH1626.test.ts
@@ -1,0 +1,111 @@
+import {
+  BigIntType,
+  Entity,
+  Logger,
+  MikroORM,
+  PrimaryKey,
+  Property,
+} from '@mikro-orm/core';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+export class NativeBigIntType extends BigIntType {
+
+  convertToJSValue(value: any): any {
+    if (!value) {
+      return value;
+    }
+
+    /* eslint-env es2020 */
+    return BigInt(value);
+  }
+
+}
+
+@Entity()
+export class Author {
+
+  @PrimaryKey({ type: NativeBigIntType, comment: 'PK' })
+  id!: bigint;
+
+  @Property({ nullable: true })
+  name?: string;
+
+}
+
+describe('GH issue 1626', () => {
+  let orm: MikroORM<SqliteDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Author],
+      dbName: ':memory:',
+      type: 'sqlite',
+    });
+    await orm.getSchemaGenerator().createSchema();
+  });
+
+  afterAll(() => orm.close(true));
+
+  test(`queries with custom type PK (native bigint)`, async () => {
+    const mock = jest.fn();
+    const logger = new Logger(mock, ['query']);
+    Object.assign(orm.config, { logger });
+
+    const author = new Author();
+    await orm.em.persistAndFlush(author);
+
+    author.name = 'A';
+    await orm.em.flush();
+
+    await orm.em.removeAndFlush(author);
+
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch(
+      'insert into `author` default values',
+    );
+    expect(mock.mock.calls[2][0]).toMatch('commit');
+    expect(mock.mock.calls[3][0]).toMatch('begin');
+    expect(mock.mock.calls[4][0]).toMatch(
+      'update `author` set `name` = ? where `id` = ?',
+    );
+    expect(mock.mock.calls[5][0]).toMatch('commit');
+    expect(mock.mock.calls[6][0]).toMatch('begin');
+    expect(mock.mock.calls[7][0]).toMatch(
+      'delete from `author` where `id` in (?)',
+    );
+    expect(mock.mock.calls[8][0]).toMatch('commit');
+    expect(mock.mock.calls.length).toBe(9);
+  });
+
+  test(`queries for multiple entities with custom type PK (native bigint)`, async () => {
+    const mock = jest.fn();
+    const logger = new Logger(mock, ['query']);
+    Object.assign(orm.config, { logger });
+
+    const authors = [new Author(), new Author()];
+    authors[0].name = 'A';
+    await orm.em.persistAndFlush(authors);
+
+    authors[0].name = 'B';
+    authors[1].name = 'C';
+    await orm.em.flush();
+
+    await orm.em.removeAndFlush(authors);
+
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch(
+      'insert into `author` (`name`) values (?), (?)',
+    );
+    expect(mock.mock.calls[2][0]).toMatch('commit');
+    expect(mock.mock.calls[3][0]).toMatch('begin');
+    expect(mock.mock.calls[4][0]).toMatch(
+      'update `author` set `name` = case when (`id` = ?) then ? when (`id` = ?) then ? else `name` end where `id` in (?, ?)',
+    );
+    expect(mock.mock.calls[5][0]).toMatch('commit');
+    expect(mock.mock.calls[6][0]).toMatch('begin');
+    expect(mock.mock.calls[7][0]).toMatch(
+      'delete from `author` where `id` in (?, ?)',
+    );
+    expect(mock.mock.calls[8][0]).toMatch('commit');
+    expect(mock.mock.calls.length).toBe(9);
+  });
+});


### PR DESCRIPTION
This PR adds bigint as acceptable type of `isPrimaryKey`.

I was following https://mikro-orm.io/docs/using-bigint-pks recipe, but saw that `update` queries were missing `where` clause when using bigint as PK.

I've pinpointed issue to those lines that doesn't prepare correct `where` object for knex when `where` is of bigint type.
https://github.com/mikro-orm/mikro-orm/blob/c0c658eb125695bd1aed760aa95f2eadc1da8d43/packages/knex/src/AbstractSqlDriver.ts#L270-L272

