### PR TITLE
fix(knex): find entity by advanced custom types

### DIFF
--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -54,6 +54,7 @@ export class QueryBuilderHelper {
         return this.knex.raw(valueSQL);
       }
 
+      /* istanbul ignore next */
       return this.knex.raw(valueSQL + ' as ' + this.platform.quoteIdentifier(alias ?? prop.fieldNames[0]));
     }
 

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -28,8 +28,8 @@ export class QueryBuilderHelper {
               private readonly platform: Platform) { }
 
   mapper(field: string, type?: QueryType): string;
-  mapper(field: string, type?: QueryType, value?: any, alias?: string): string;
-  mapper(field: string, type = QueryType.SELECT, value?: any, alias?: string): string | Raw {
+  mapper(field: string, type?: QueryType, value?: any, alias?: string | null): string;
+  mapper(field: string, type = QueryType.SELECT, value?: any, alias?: string | null): string | Raw {
     const fields = Utils.splitPrimaryKeys(field);
 
     if (fields.length > 1) {
@@ -48,8 +48,13 @@ export class QueryBuilderHelper {
 
     if (prop?.customType?.convertToJSValueSQL) {
       const prefixed = this.prefix(field, true, true);
-      /* istanbul ignore next */
-      return this.knex.raw(prop.customType.convertToJSValueSQL!(prefixed, this.platform) + ' as ' + this.platform.quoteIdentifier(alias ?? prop.fieldNames[0]));
+      const valueSQL = prop.customType.convertToJSValueSQL!(prefixed, this.platform);
+
+      if (alias === null) {
+        return this.knex.raw(valueSQL);
+      }
+
+      return this.knex.raw(valueSQL + ' as ' + this.platform.quoteIdentifier(alias ?? prop.fieldNames[0]));
     }
 
     // do not wrap custom expressions
@@ -300,7 +305,7 @@ export class QueryBuilderHelper {
       return void qb[m](this.knex.raw(`(${this.subQueries[key]})`), op, cond[key]);
     }
 
-    qb[m](this.mapper(key, type, cond[key]), op, cond[key]);
+    qb[m](this.mapper(key, type, cond[key], null), op, cond[key]);
   }
 
   private processCustomExpression<T extends any[] = any[]>(clause: any, m: string, key: string, cond: any, type = QueryType.SELECT): void {

--- a/tests/features/custom-types.test.ts
+++ b/tests/features/custom-types.test.ts
@@ -183,4 +183,25 @@ describe('custom types [mysql]', () => {
     expect(mock.mock.calls).toHaveLength(6);
   });
 
+  test('find entity by custom types (gh issue 1630)', async () => {
+    const mock = jest.fn();
+    const logger = new Logger(mock, ['query', 'query-params']);
+
+    const location = new Location();
+    location.point = new Point(1, 1);
+    await orm.em.persistAndFlush(location);
+    orm.em.clear();
+
+    Object.assign(orm.config, { logger });
+
+    const foundLocation = await orm.em.findOne(Location, {
+      point: new Point(1, 1),
+      extendedPoint: null,
+    });
+
+    expect(mock.mock.calls[0][0]).toMatch('select `e0`.*, ST_AsText(`e0`.`point`) as `point`, ST_AsText(`e0`.`extended_point`) as `extended_point` from `location` as `e0` where ST_AsText(`e0`.`point`) = \'point(1 1)\' and ST_AsText(`e0`.`extended_point`) is null limit 1');
+    expect(mock.mock.calls).toHaveLength(1);
+
+    expect(foundLocation).toBeInstanceOf(Location);
+  });
 });


### PR DESCRIPTION
Fixes SQL queries using custom types as find conditions.

Field `mapper` was adding unnecessary aliases in where clause creating invalid SQL syntax:
```
... where T_AsText(`e0`.`point`) as point = 'point(1 1)' 
```
and now it's
```
... where T_AsText(`e0`.`point`) = 'point(1 1)' 
```