### PR TITLE
fix(core): fix querying embeddables over cast fields

### DIFF
--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -20,12 +20,12 @@ import { JoinOptions } from '../typings';
 export class QueryBuilderHelper {
 
   constructor(private readonly entityName: string,
-              private readonly alias: string,
-              private readonly aliasMap: Dictionary<string>,
-              private readonly subQueries: Dictionary<string>,
-              private readonly metadata: MetadataStorage,
-              private readonly knex: Knex,
-              private readonly platform: Platform) { }
+    private readonly alias: string,
+    private readonly aliasMap: Dictionary<string>,
+    private readonly subQueries: Dictionary<string>,
+    private readonly metadata: MetadataStorage,
+    private readonly knex: Knex,
+    private readonly platform: Platform) { }
 
   mapper(field: string, type?: QueryType): string;
   mapper(field: string, type?: QueryType, value?: any, alias?: string | null): string;
@@ -516,7 +516,12 @@ export class QueryBuilderHelper {
 
     if (!this.isPrefixed(field)) {
       const alias = always ? (quote ? this.alias : this.platform.quoteIdentifier(this.alias)) + '.' : '';
-      ret = alias + this.fieldName(field, this.alias);
+      const fieldName = this.fieldName(field, this.alias);
+      if (fieldName.startsWith('(')) {
+        ret = '(' + alias + fieldName.slice(1);
+      } else {
+        ret = alias + fieldName;
+      }
     } else {
       const [a, f] = field.split('.');
       ret = a + '.' + this.fieldName(f, a);

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -20,12 +20,12 @@ import { JoinOptions } from '../typings';
 export class QueryBuilderHelper {
 
   constructor(private readonly entityName: string,
-    private readonly alias: string,
-    private readonly aliasMap: Dictionary<string>,
-    private readonly subQueries: Dictionary<string>,
-    private readonly metadata: MetadataStorage,
-    private readonly knex: Knex,
-    private readonly platform: Platform) { }
+              private readonly alias: string,
+              private readonly aliasMap: Dictionary<string>,
+              private readonly subQueries: Dictionary<string>,
+              private readonly metadata: MetadataStorage,
+              private readonly knex: Knex,
+              private readonly platform: Platform) { }
 
   mapper(field: string, type?: QueryType): string;
   mapper(field: string, type?: QueryType, value?: any, alias?: string | null): string;

--- a/tests/features/embeddables/__snapshots__/embedded-entities.postgres.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/embedded-entities.postgres.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`embedded entities in postgresql schema: embeddables 1 1`] = `
-"create table \\"user\\" (\\"id\\" serial primary key, \\"address1_street\\" varchar(255) not null, \\"address1_postal_code\\" varchar(255) not null, \\"address1_city\\" varchar(255) not null, \\"address1_country\\" varchar(255) not null, \\"addr_street\\" varchar(255) null, \\"addr_postal_code\\" varchar(255) null, \\"addr_city\\" varchar(255) null, \\"addr_country\\" varchar(255) null, \\"street\\" varchar(255) not null, \\"postal_code\\" varchar(255) not null, \\"city\\" varchar(255) not null, \\"country\\" varchar(255) not null, \\"address4\\" jsonb not null, \\"addresses\\" jsonb not null, \\"after\\" int4 null);
+"create table \\"user\\" (\\"id\\" serial primary key, \\"address1_street\\" varchar(255) not null, \\"address1_number\\" int4 not null, \\"address1_postal_code\\" varchar(255) not null, \\"address1_city\\" varchar(255) not null, \\"address1_country\\" varchar(255) not null, \\"addr_street\\" varchar(255) null, \\"addr_postal_code\\" varchar(255) null, \\"addr_city\\" varchar(255) null, \\"addr_country\\" varchar(255) null, \\"street\\" varchar(255) not null, \\"number\\" int4 not null, \\"postal_code\\" varchar(255) not null, \\"city\\" varchar(255) not null, \\"country\\" varchar(255) not null, \\"address4\\" jsonb not null, \\"addresses\\" jsonb not null, \\"after\\" int4 null);
 
 "
 `;


### PR DESCRIPTION
When within an embedded entity a numeric query is performed on a numeric field, the query is malformed:

`SyntaxErrorException: select "e0".* from "user" as "e0" where "e0".("address4"->>'number')::float8 > 2 limit 1 - syntax error at or near "("`

in this change the query builder prefix function detects if the field name has parenthesis, to add the alias inside

