### PR TITLE
fix(core): fix aliasing of embeddables in update query

### DIFF
--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -482,7 +482,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
   }
 
   getKnex(): KnexQueryBuilder {
-    const tableName = this.helper.getTableName(this.entityName) + (this.finalized && [QueryType.SELECT, QueryType.COUNT].includes(this.type) ? ` as ${this.alias}` : '');
+    const tableName = this.helper.getTableName(this.entityName) + (this.finalized && this.helper.isTableNameAliasRequired(this.type) ? ` as ${this.alias}` : '');
     const qb = this.knex(tableName);
 
     if (this.context) {
@@ -575,7 +575,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     this.type = type;
     this._aliasMap[this.alias] = this.entityName;
 
-    if (![QueryType.SELECT, QueryType.COUNT].includes(type)) {
+    if (!this.helper.isTableNameAliasRequired(type)) {
       delete this._fields;
     }
 

--- a/tests/features/embeddables/embedded-entities.postgres.test.ts
+++ b/tests/features/embeddables/embedded-entities.postgres.test.ts
@@ -260,6 +260,65 @@ describe('embedded entities in postgresql', () => {
     });
   });
 
+
+  test('native update entity', async () => {
+    const user = new User();
+    wrap(user).assign({
+      address1: { street: 'Downing street 10', number: 3, postalCode: '123', city: 'London 1', country: 'UK 1' },
+      address2: { street: 'Downing street 11', number: 3, city: 'London 2', country: 'UK 2' },
+      address3: { street: 'Downing street 12', number: 3, postalCode: '789', city: 'London 3', country: 'UK 3' },
+      address4: { street: 'Downing street 10', number: 3, postalCode: '123', city: 'London 1', country: 'UK 1' },
+    }, { em: orm.em });
+
+    await orm.em.persistAndFlush(user);
+
+    await orm.em.nativeUpdate(User, {
+      address4: {
+        number: {
+          $gt: 2,
+        },
+      },
+    }, {
+      after: 2,
+    });
+    orm.em.clear();
+
+    const userAfterUpdate = await orm.em.findOne(User, user.id);
+    expect(userAfterUpdate?.after).toBe(2);
+  });
+
+  test('assign', async () => {
+    const user = new User();
+    wrap(user).assign({
+      address1: { street: 'Downing street 10', postalCode: '123', city: 'London 1', country: 'UK 1' },
+      address2: { street: 'Downing street 11', city: 'London 2', country: 'UK 2' },
+      address3: { street: 'Downing street 12', postalCode: '789', city: 'London 3', country: 'UK 3' },
+    }, { em: orm.em });
+    assign(user, { address4: { city: '41', country: '42', postalCode: '43', street: '44' } });
+    expect(user.address4).toMatchObject({ city: '41', country: '42', postalCode: '43', street: '44' });
+
+    expect(user.address1).toBeInstanceOf(Address1);
+    expect(user.address1).toEqual({
+      street: 'Downing street 10',
+      postalCode: '123',
+      city: 'London 1',
+      country: 'UK 1',
+    });
+    expect(user.address2).toBeInstanceOf(Address2);
+    expect(user.address2).toEqual({
+      street: 'Downing street 11',
+      city: 'London 2',
+      country: 'UK 2',
+    });
+    expect(user.address3).toBeInstanceOf(Address1);
+    expect(user.address3).toEqual({
+      street: 'Downing street 12',
+      postalCode: '789',
+      city: 'London 3',
+      country: 'UK 3',
+    });
+  });
+
   test('query by complex custom expressions with JSON operator and casting (GH issue 1261)', async () => {
     const user = new User();
     user.address1 = new Address1('Test', 10, '12000', 'Prague', 'CZ');

--- a/tests/features/embeddables/embedded-entities.postgres.test.ts
+++ b/tests/features/embeddables/embedded-entities.postgres.test.ts
@@ -287,38 +287,6 @@ describe('embedded entities in postgresql', () => {
     expect(userAfterUpdate?.after).toBe(2);
   });
 
-  test('assign', async () => {
-    const user = new User();
-    wrap(user).assign({
-      address1: { street: 'Downing street 10', postalCode: '123', city: 'London 1', country: 'UK 1' },
-      address2: { street: 'Downing street 11', city: 'London 2', country: 'UK 2' },
-      address3: { street: 'Downing street 12', postalCode: '789', city: 'London 3', country: 'UK 3' },
-    }, { em: orm.em });
-    assign(user, { address4: { city: '41', country: '42', postalCode: '43', street: '44' } });
-    expect(user.address4).toMatchObject({ city: '41', country: '42', postalCode: '43', street: '44' });
-
-    expect(user.address1).toBeInstanceOf(Address1);
-    expect(user.address1).toEqual({
-      street: 'Downing street 10',
-      postalCode: '123',
-      city: 'London 1',
-      country: 'UK 1',
-    });
-    expect(user.address2).toBeInstanceOf(Address2);
-    expect(user.address2).toEqual({
-      street: 'Downing street 11',
-      city: 'London 2',
-      country: 'UK 2',
-    });
-    expect(user.address3).toBeInstanceOf(Address1);
-    expect(user.address3).toEqual({
-      street: 'Downing street 12',
-      postalCode: '789',
-      city: 'London 3',
-      country: 'UK 3',
-    });
-  });
-
   test('query by complex custom expressions with JSON operator and casting (GH issue 1261)', async () => {
     const user = new User();
     user.address1 = new Address1('Test', 10, '12000', 'Prague', 'CZ');


### PR DESCRIPTION
…query over embedded field

When I perform a nativeUpdate as
```typescript
await orm.em.nativeUpdate(User, {
      address4: {
        number: {
          $gt: 2,
        },
      },
    }, {
      after: 2,
    });
```
the result is:
```
TableNotFoundException: update "user" set "after" = 2 where ("e0"."address4"->>'number')::float8 > 2 - missing FROM-clause entry for table "e0"
```

this pr refactors some checks on whether it is necessary to include a prefix based on the type of operation and it puts the decision in a single method.


Thank you for your excellent work!
