### PR TITLE
fix(knex): find by custom types with object subconditions

### DIFF
--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -356,7 +356,7 @@ export class QueryBuilderHelper {
       return void qb[m](this.knex.raw(`(${this.subQueries[key]})`), replacement, value[op]);
     }
 
-    qb[m](this.mapper(key, type), replacement, value[op]);
+    qb[m](this.mapper(key, type, undefined, null), replacement, value[op]);
   }
 
   private getOperatorReplacement(op: string, value: Dictionary): string {


### PR DESCRIPTION
When using queries with conditions in custom types an alias gets appended in the `where` expression for the type.

```
    const foundLocation = await orm.em.findOne(Location, {
      point: new Point(1, 1),
      extendedPoint: { $ne: null },
    });
```
