### PR TITLE
feat(typings): make `em.create()` and other methods strict

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -4,7 +4,7 @@ import { Configuration, QueryHelper, TransactionContext, Utils } from './utils';
 import { AssignOptions, EntityAssigner, EntityFactory, EntityLoader, EntityRepository, EntityValidator, IdentifiedReference, Reference } from './entity';
 import { UnitOfWork } from './unit-of-work';
 import { CountOptions, DeleteOptions, EntityManagerType, FindOneOptions, FindOneOrFailOptions, FindOptions, IDatabaseDriver, UpdateOptions } from './drivers';
-import { AnyEntity, Dictionary, EntityData, EntityMetadata, EntityName, FilterDef, FilterQuery, GetRepository, Loaded, New, Populate, PopulateMap, PopulateOptions, Primary } from './typings';
+import { AnyEntity, Dictionary, EntityData, EntityDictionary, EntityMetadata, EntityName, FilterDef, FilterQuery, GetRepository, Loaded, New, Populate, PopulateMap, PopulateOptions, Primary } from './typings';
 import { LoadStrategy, LockMode, QueryOrderMap, ReferenceType, SCALAR_TYPES } from './enums';
 import { MetadataStorage } from './metadata';
 import { Transaction } from './connections';
@@ -484,7 +484,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Maps raw database result to an entity and merges it to this EntityManager.
    */
-  map<T extends AnyEntity<T>>(entityName: EntityName<T>, result: EntityData<T>): T {
+  map<T extends AnyEntity<T>>(entityName: EntityName<T>, result: EntityDictionary<T>): T {
     entityName = Utils.className(entityName);
     const meta = this.metadata.get(entityName);
     const data = this.driver.mapResult(result, meta) as Dictionary;
@@ -518,7 +518,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    */
   merge<T extends AnyEntity<T>>(entityName: EntityName<T> | T, data?: EntityData<T> | boolean, refresh?: boolean, convertCustomTypes?: boolean): T {
     if (Utils.isEntity(entityName)) {
-      return this.merge(entityName.constructor.name, entityName as EntityData<T>, data as boolean);
+      return this.merge(entityName.constructor.name, entityName as unknown as EntityData<T>, data as boolean);
     }
 
     entityName = Utils.className(entityName as string);

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -1,5 +1,5 @@
 import { CountOptions, EntityManagerType, FindOneOptions, FindOptions, IDatabaseDriver } from './IDatabaseDriver';
-import { AnyEntity, Dictionary, EntityData, EntityMetadata, EntityProperty, FilterQuery, PopulateOptions, Primary } from '../typings';
+import { AnyEntity, Dictionary, EntityData, EntityDictionary, EntityMetadata, EntityProperty, FilterQuery, PopulateOptions, Primary } from '../typings';
 import { MetadataStorage } from '../metadata';
 import { Connection, QueryResult, Transaction } from '../connections';
 import { Configuration, ConnectionOptions, EntityComparator, Utils } from '../utils';
@@ -28,13 +28,13 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
 
   abstract findOne<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T>, ctx?: Transaction): Promise<EntityData<T> | null>;
 
-  abstract nativeInsert<T extends AnyEntity<T>>(entityName: string, data: EntityData<T>, ctx?: Transaction, convertCustomTypes?: boolean): Promise<QueryResult>;
+  abstract nativeInsert<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>, ctx?: Transaction, convertCustomTypes?: boolean): Promise<QueryResult>;
 
-  abstract nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityData<T>[], ctx?: Transaction, processCollections?: boolean, convertCustomTypes?: boolean): Promise<QueryResult>;
+  abstract nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>[], ctx?: Transaction, processCollections?: boolean, convertCustomTypes?: boolean): Promise<QueryResult>;
 
-  abstract nativeUpdate<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, data: EntityData<T>, ctx?: Transaction, convertCustomTypes?: boolean): Promise<QueryResult>;
+  abstract nativeUpdate<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, data: EntityDictionary<T>, ctx?: Transaction, convertCustomTypes?: boolean): Promise<QueryResult>;
 
-  async nativeUpdateMany<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>[], data: EntityData<T>[], ctx?: Transaction, processCollections?: boolean, convertCustomTypes?: boolean): Promise<QueryResult> {
+  async nativeUpdateMany<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>[], data: EntityDictionary<T>[], ctx?: Transaction, processCollections?: boolean, convertCustomTypes?: boolean): Promise<QueryResult> {
     throw new Error(`Batch updates are not supported by ${this.constructor.name} driver`);
   }
 
@@ -60,7 +60,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     await this.nativeUpdate<T>(coll.owner.constructor.name, coll.owner.__helper!.getPrimaryKey() as FilterQuery<T>, data, ctx);
   }
 
-  mapResult<T extends AnyEntity<T>>(result: EntityData<T>, meta: EntityMetadata<T>, populate: PopulateOptions<T>[] = []): EntityData<T> | null {
+  mapResult<T extends AnyEntity<T>>(result: EntityDictionary<T>, meta: EntityMetadata<T>, populate: PopulateOptions<T>[] = []): EntityData<T> | null {
     if (!result || !meta) {
       return null;
     }

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -1,4 +1,4 @@
-import { EntityData, EntityMetadata, EntityProperty, AnyEntity, FilterQuery, Primary, Dictionary, QBFilterQuery, IPrimaryKey, Populate, PopulateOptions } from '../typings';
+import { EntityData, EntityMetadata, EntityProperty, AnyEntity, FilterQuery, Primary, Dictionary, QBFilterQuery, IPrimaryKey, Populate, PopulateOptions, EntityDictionary } from '../typings';
 import { Connection, QueryResult, Transaction } from '../connections';
 import { LockMode, QueryOrderMap, QueryFlag, LoadStrategy } from '../enums';
 import { Platform } from '../platforms';
@@ -33,13 +33,13 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
    */
   findOne<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T>, ctx?: Transaction): Promise<EntityData<T> | null>;
 
-  nativeInsert<T extends AnyEntity<T>>(entityName: string, data: EntityData<T>, ctx?: Transaction, convertCustomTypes?: boolean): Promise<QueryResult>;
+  nativeInsert<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>, ctx?: Transaction, convertCustomTypes?: boolean): Promise<QueryResult>;
 
-  nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityData<T>[], ctx?: Transaction, processCollections?: boolean, convertCustomTypes?: boolean): Promise<QueryResult>;
+  nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>[], ctx?: Transaction, processCollections?: boolean, convertCustomTypes?: boolean): Promise<QueryResult>;
 
-  nativeUpdate<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, data: EntityData<T>, ctx?: Transaction, convertCustomTypes?: boolean): Promise<QueryResult>;
+  nativeUpdate<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, data: EntityDictionary<T>, ctx?: Transaction, convertCustomTypes?: boolean): Promise<QueryResult>;
 
-  nativeUpdateMany<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>[], data: EntityData<T>[], ctx?: Transaction, processCollections?: boolean, convertCustomTypes?: boolean): Promise<QueryResult>;
+  nativeUpdateMany<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>[], data: EntityDictionary<T>[], ctx?: Transaction, processCollections?: boolean, convertCustomTypes?: boolean): Promise<QueryResult>;
 
   nativeDelete<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, ctx?: Transaction): Promise<QueryResult>;
 
@@ -49,7 +49,7 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
 
   aggregate(entityName: string, pipeline: any[]): Promise<any[]>;
 
-  mapResult<T extends AnyEntity<T>>(result: EntityData<T>, meta: EntityMetadata, populate?: PopulateOptions<T>[]): EntityData<T> | null;
+  mapResult<T extends AnyEntity<T>>(result: EntityDictionary<T>, meta: EntityMetadata, populate?: PopulateOptions<T>[]): EntityData<T> | null;
 
   /**
    * When driver uses pivot tables for M:N, this method will load identifiers for given collections from them

--- a/packages/core/src/entity/BaseEntity.ts
+++ b/packages/core/src/entity/BaseEntity.ts
@@ -2,18 +2,18 @@ import { Reference } from './Reference';
 import { AnyEntity, Dictionary, EntityData, IWrappedEntity, Populate } from '../typings';
 import { AssignOptions, EntityAssigner } from './EntityAssigner';
 
-export abstract class BaseEntity<T extends AnyEntity<T>, PK extends keyof T, P extends Populate<T> | unknown = unknown> implements IWrappedEntity<T, PK, P> {
+export abstract class BaseEntity<T, PK extends keyof T, P extends Populate<T> | unknown = unknown> implements IWrappedEntity<T, PK, P> {
 
   constructor() {
     Object.defineProperty(this, '__baseEntity', { value: true });
   }
 
   isInitialized(): boolean {
-    return (this as unknown as T).__helper!.__initialized;
+    return (this as unknown as AnyEntity<T>).__helper!.__initialized;
   }
 
   populated(populated = true): void {
-    (this as unknown as T).__helper!.populated(populated);
+    (this as unknown as AnyEntity<T>).__helper!.populated(populated);
   }
 
   toReference() {
@@ -21,7 +21,7 @@ export abstract class BaseEntity<T extends AnyEntity<T>, PK extends keyof T, P e
   }
 
   toObject(ignoreFields: string[] = []): Dictionary {
-    return (this as unknown as T).__helper!.toObject(ignoreFields) as EntityData<T>;
+    return (this as unknown as AnyEntity<T>).__helper!.toObject(ignoreFields) as EntityData<T>;
   }
 
   toJSON(...args: any[]): Dictionary {
@@ -29,7 +29,7 @@ export abstract class BaseEntity<T extends AnyEntity<T>, PK extends keyof T, P e
   }
 
   toPOJO(): EntityData<T> {
-    return (this as unknown as T).__helper!.toPOJO();
+    return (this as unknown as AnyEntity<T>).__helper!.toPOJO();
   }
 
   assign(data: EntityData<T>, options?: AssignOptions): T {
@@ -37,7 +37,7 @@ export abstract class BaseEntity<T extends AnyEntity<T>, PK extends keyof T, P e
   }
 
   init(populated = true): Promise<T> {
-    return (this as unknown as T).__helper!.init(populated);
+    return (this as unknown as AnyEntity<T>).__helper!.init(populated);
   }
 
 }

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -68,7 +68,7 @@ export class EntityAssigner {
       if (options.mergeObjects && Utils.isPlainObject(value)) {
         Utils.merge(entity[prop as keyof T], value);
       } else if (!props[prop] || props[prop].setter || !props[prop].getter) {
-        entity[prop as keyof T] = value;
+        entity[prop as keyof T] = value as T[keyof T];
       }
     });
 

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -27,7 +27,7 @@ export class EntityFactory {
   create<T extends AnyEntity<T>, P extends Populate<T> = any>(entityName: EntityName<T>, data: EntityData<T>, options: FactoryOptions = {}): New<T, P> {
     options.initialized = options.initialized ?? true;
 
-    if (data.__entity) {
+    if ((data as Dictionary).__entity) {
       return data as New<T, P>;
     }
 
@@ -117,7 +117,7 @@ export class EntityFactory {
 
   private findEntity<T>(data: EntityData<T>, meta: EntityMetadata<T>, convertCustomTypes?: boolean): T | undefined {
     if (!meta.compositePK && !meta.properties[meta.primaryKeys[0]].customType) {
-      return this.unitOfWork.getById<T>(meta.name!, data[meta.primaryKeys[0]]);
+      return this.unitOfWork.getById<T>(meta.name!, data[meta.primaryKeys[0]] as Primary<T>);
     }
 
     if (meta.primaryKeys.some(pk => !Utils.isDefined(data[pk as keyof T], true))) {

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -1,5 +1,5 @@
 import { EntityManager } from '../EntityManager';
-import { EntityData, EntityName, AnyEntity, Primary, Populate, Loaded, New, FilterQuery } from '../typings';
+import { EntityData, EntityName, AnyEntity, Primary, Populate, Loaded, New, FilterQuery, EntityDictionary } from '../typings';
 import { QueryOrderMap } from '../enums';
 import { CountOptions, DeleteOptions, FindOneOptions, FindOneOrFailOptions, FindOptions, UpdateOptions } from '../drivers/IDatabaseDriver';
 import { IdentifiedReference, Reference } from './Reference';
@@ -191,7 +191,7 @@ export class EntityRepository<T extends AnyEntity<T>> {
   /**
    * Maps raw database result to an entity and merges it to this EntityManager.
    */
-  map(result: EntityData<T>): T {
+  map(result: EntityDictionary<T>): T {
     return this.em.map(this.entityName, result);
   }
 

--- a/packages/core/src/entity/EntityTransformer.ts
+++ b/packages/core/src/entity/EntityTransformer.ts
@@ -122,7 +122,7 @@ export class EntityTransformer {
         return [prop, val];
       })
       .filter(([, value]) => typeof value !== 'undefined')
-      .forEach(([prop, value]) => ret[this.propertyName(meta, prop as keyof T & string, entity.__platform)] = value as T[keyof T]);
+      .forEach(([prop, value]) => ret[this.propertyName(meta, prop as keyof T & string, entity.__platform)] = value as T[keyof T & string]);
 
     if (!wrapped.isInitialized() && wrapped.hasPrimaryKey()) {
       return ret;
@@ -136,7 +136,7 @@ export class EntityTransformer {
     // decorated get methods
     meta.props
       .filter(prop => prop.getterName && !prop.hidden && entity[prop.getterName] as unknown instanceof Function)
-      .forEach(prop => ret[this.propertyName(meta, prop.name, entity.__platform)] = (entity[prop.getterName!] as unknown as () => void)());
+      .forEach(prop => ret[this.propertyName(meta, prop.name, entity.__platform)] = (entity[prop.getterName!] as unknown as () => T[keyof T & string])());
 
     if (contextCreated) {
       delete wrapped.__serializationContext.root;

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -1,6 +1,6 @@
 import { inspect } from 'util';
 import { EntityManager } from '../EntityManager';
-import { AnyEntity, Dictionary, EntityData, EntityMetadata, Populate, PopulateOptions, Primary } from '../typings';
+import { AnyEntity, Dictionary, EntityData, EntityDictionary, EntityMetadata, Populate, PopulateOptions, Primary } from '../typings';
 import { IdentifiedReference, Reference } from './Reference';
 import { EntityTransformer, SerializationContext } from './EntityTransformer';
 import { AssignOptions, EntityAssigner } from './EntityAssigner';
@@ -49,7 +49,7 @@ export class WrappedEntity<T extends AnyEntity<T>, PK extends keyof T> {
     return EntityTransformer.toObject(this.entity, [], true);
   }
 
-  toJSON(...args: any[]): EntityData<T> & Dictionary {
+  toJSON(...args: any[]): EntityDictionary<T> {
     // toJSON methods is added to thee prototype during discovery to support automatic serialization via JSON.stringify()
     return (this.entity as Dictionary).toJSON(...args);
   }

--- a/packages/core/src/hydration/ObjectHydrator.ts
+++ b/packages/core/src/hydration/ObjectHydrator.ts
@@ -160,6 +160,10 @@ export class ObjectHydrator extends Hydrator {
       const ret: string[] = [];
 
       ret.push(...this.createCollectionItemMapper(prop));
+      ret.push(`  if (data.${prop.name} && !Array.isArray(data.${prop.name}) && typeof data.${prop.name} === 'object') {`);
+      ret.push(`    console.log('${prop.name}', data.${prop.name});`);
+      ret.push(`    data.${prop.name} = [data.${prop.name}];`);
+      ret.push(`  }`);
       ret.push(`  if (Array.isArray(data.${prop.name})) {`);
       ret.push(`     const items = data.${prop.name}.map(value => createCollectionItem_${prop.name}(value));`);
       ret.push(`     const coll = Collection.create(entity, '${prop.name}', items, newEntity);`);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,7 @@
 export {
   Constructor, Dictionary, PrimaryKeyType, PrimaryKeyProp, Primary, IPrimaryKey, FilterQuery, IWrappedEntity, EntityName, EntityData, Highlighter,
   AnyEntity, EntityProperty, EntityMetadata, QBFilterQuery, PopulateOptions, Populate, Loaded, New, LoadedReference, LoadedCollection,
-  GetRepository, EntityRepositoryType, MigrationObject, DeepPartial, PrimaryProperty, Cast, IsUnknown,
+  GetRepository, EntityRepositoryType, MigrationObject, DeepPartial, PrimaryProperty, Cast, IsUnknown, EntityDictionary,
 } from './typings';
 export * from './enums';
 export * from './errors';

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -1,4 +1,4 @@
-import { AnyEntity, Constructor, DeepPartial, Dictionary, EntityMetadata, EntityName, EntityProperty, ExpandProperty, NonFunctionPropertyNames } from '../typings';
+import { AnyEntity, Constructor, DeepPartial, Dictionary, EntityMetadata, EntityName, EntityProperty, ExcludeFunctions, ExpandProperty } from '../typings';
 import {
   EmbeddedOptions, EnumOptions, IndexOptions, ManyToManyOptions, ManyToOneOptions, OneToManyOptions, OneToOneOptions, PrimaryKeyOptions, PropertyOptions,
   SerializedPrimaryKeyOptions, UniqueOptions,
@@ -19,11 +19,10 @@ type Property<T, O> =
   | ({ reference: ReferenceType.EMBEDDED | 'embedded' } & TypeDef<T> & EmbeddedOptions & PropertyOptions<O>)
   | ({ enum: true } & EnumOptions<O>)
   | (TypeDef<T> & PropertyOptions<O>);
-type PropertyKey<T, U> = NonFunctionPropertyNames<Omit<T, keyof U>>;
 type Metadata<T, U> =
   & Omit<Partial<EntityMetadata<T>>, 'name' | 'properties'>
   & ({ name: string } | { class: Constructor<T>; name?: string })
-  & { properties?: { [K in PropertyKey<T, U> & string]-?: Property<ExpandProperty<NonNullable<T[K]>>, T> } };
+  & { properties?: { [K in keyof Omit<T, keyof U> as ExcludeFunctions<Omit<T, keyof U>, K>]-?: Property<ExpandProperty<NonNullable<T[K]>>, T> } };
 
 export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntity<U> | undefined = undefined> {
 
@@ -44,7 +43,7 @@ export class EntitySchema<T extends AnyEntity<T> = AnyEntity, U extends AnyEntit
   }
 
   static fromMetadata<T extends AnyEntity<T> = AnyEntity, U extends AnyEntity<U> | undefined = undefined>(meta: EntityMetadata<T> | DeepPartial<EntityMetadata<T>>): EntitySchema<T, U> {
-    const schema = new EntitySchema<T, U>(meta as Metadata<T, U>);
+    const schema = new EntitySchema<T, U>(meta as unknown as Metadata<T, U>);
     schema.internal = true;
 
     return schema;

--- a/packages/core/src/unit-of-work/ChangeSet.ts
+++ b/packages/core/src/unit-of-work/ChangeSet.ts
@@ -1,10 +1,10 @@
-import { EntityData, AnyEntity, EntityMetadata } from '../typings';
+import { EntityData, AnyEntity, EntityMetadata, EntityDictionary } from '../typings';
 
 export class ChangeSet<T extends AnyEntity<T>> {
 
   constructor(public entity: T,
               public type: ChangeSetType,
-              public payload: EntityData<T>,
+              public payload: EntityDictionary<T>,
               meta: EntityMetadata<T>) {
     this.name = meta.className;
     this.rootName = meta.root.className;
@@ -19,7 +19,7 @@ export interface ChangeSet<T extends AnyEntity<T>> {
   collection: string;
   type: ChangeSetType;
   entity: T;
-  payload: EntityData<T>;
+  payload: EntityDictionary<T>;
   persisted: boolean;
   originalEntity?: EntityData<T>;
 }

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -222,11 +222,11 @@ export class ChangeSetPersister {
 
     const pk = Utils.getPrimaryKeyHash(meta.primaryKeys);
     const pks = changeSets.map(cs => cs.entity.__helper!.__primaryKeyCond);
-    const data = await this.driver.find(meta.name!, { [pk]: { $in: pks } }, {
+    const data = await this.driver.find<T>(meta.name!, { [pk]: { $in: pks } }, {
       fields: [meta.versionProperty],
     }, ctx);
     const map = new Map<string, Date>();
-    data.forEach(e => map.set(Utils.getCompositeKeyHash<T>(e as T, meta), e[meta.versionProperty]));
+    data.forEach(e => map.set(Utils.getCompositeKeyHash<T>(e as T, meta), e[meta.versionProperty] as Date));
 
     for (const changeSet of changeSets) {
       const version = map.get(changeSet.entity.__helper!.getSerializedPrimaryKey());

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -1,4 +1,4 @@
-import { AnyEntity, EntityData, EntityMetadata, EntityProperty, FilterQuery, Primary } from '../typings';
+import { AnyEntity, EntityData, EntityMetadata, EntityProperty, FilterQuery, IPrimaryKeyValue, Primary } from '../typings';
 import { Collection, EntityIdentifier, Reference } from '../entity';
 import { ChangeSet, ChangeSetType } from './ChangeSet';
 import { ChangeSetComputer } from './ChangeSetComputer';
@@ -443,7 +443,7 @@ export class UnitOfWork {
     const wrapped = changeSet.entity.__helper!;
 
     if (wrapped.__identifier && diff[wrapped.__meta.primaryKeys[0]]) {
-      wrapped.__identifier.setValue(diff[wrapped.__meta.primaryKeys[0]]);
+      wrapped.__identifier.setValue(diff[wrapped.__meta.primaryKeys[0]] as IPrimaryKeyValue);
     }
   }
 

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -1,5 +1,5 @@
 import clone from 'clone';
-import { AnyEntity, EntityData, EntityMetadata, EntityProperty, IMetadataStorage, Primary } from '../typings';
+import { AnyEntity, EntityData, EntityDictionary, EntityMetadata, EntityProperty, IMetadataStorage, Primary } from '../typings';
 import { ReferenceType } from '../enums';
 import { Platform } from '../platforms';
 import { compareArrays, compareBuffers, compareObjects, equals, Utils } from './Utils';
@@ -42,7 +42,7 @@ export class EntityComparator {
   /**
    * Maps database columns to properties.
    */
-  mapResult<T extends AnyEntity<T>>(entityName: string, result: EntityData<T>): EntityData<T> | null {
+  mapResult<T extends AnyEntity<T>>(entityName: string, result: EntityDictionary<T>): EntityData<T> | null {
     const mapper = this.getResultMapper<T>(entityName);
     return Utils.callCompiledFunction(mapper, result);
   }
@@ -223,7 +223,7 @@ export class EntityComparator {
     return ret;
   }
 
-  private getEmbeddedArrayPropertySnapshot<T>(meta: EntityMetadata<T>, prop: EntityProperty<T>, context: Map<string, any>, level: number, path: string[] = [prop.name], dataKey?: string, object?: boolean, serialize?: boolean): string {
+  private getEmbeddedArrayPropertySnapshot<T>(meta: EntityMetadata<T>, prop: EntityProperty<T>, context: Map<string, any>, level: number, path: string[] = [prop.name], dataKey?: string): string {
     const entityKey = path.join('.');
     dataKey = dataKey ?? entityKey;
     const ret: string[] = [];
@@ -309,7 +309,7 @@ export class EntityComparator {
 
     if (prop.reference === ReferenceType.EMBEDDED) {
       if (prop.array) {
-        return this.getEmbeddedArrayPropertySnapshot(meta, prop, context, level, path, dataKey, true) + '\n';
+        return this.getEmbeddedArrayPropertySnapshot(meta, prop, context, level, path, dataKey) + '\n';
       }
 
       return this.getEmbeddedPropertySnapshot(meta, prop, context, level, path, dataKey, object) + '\n';

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -110,7 +110,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     return this.select([...Utils.asArray(this._fields), ...Utils.asArray(fields)]);
   }
 
-  insert(data: EntityData<T>): this {
+  insert(data: EntityData<T> | EntityData<T>[]): this {
     return this.init(QueryType.INSERT, data);
   }
 
@@ -282,11 +282,11 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     return this.knex.ref(field);
   }
 
-  raw(sql: string, bindings: Knex.RawBinding[] | Knex.ValueDict = []): Knex.Raw {
+  raw<R = Knex.Raw>(sql: string, bindings: Knex.RawBinding[] | Knex.ValueDict = []): R {
     const raw = this.knex.raw(sql, bindings);
     (raw as Dictionary).__raw = true; // tag it as there is now way to check via `instanceof`
 
-    return raw;
+    return raw as unknown as R;
   }
 
   limit(limit?: number, offset = 0): this {

--- a/packages/mariadb/src/MariaDbDriver.ts
+++ b/packages/mariadb/src/MariaDbDriver.ts
@@ -1,4 +1,4 @@
-import { AnyEntity, Configuration, EntityData, QueryResult, Transaction } from '@mikro-orm/core';
+import { AnyEntity, Configuration, EntityDictionary, QueryResult, Transaction } from '@mikro-orm/core';
 import { AbstractSqlDriver, MySqlPlatform, Knex } from '@mikro-orm/mysql-base';
 import { MariaDbConnection } from './MariaDbConnection';
 
@@ -8,7 +8,7 @@ export class MariaDbDriver extends AbstractSqlDriver<MariaDbConnection> {
     super(config, new MySqlPlatform(), MariaDbConnection, ['knex', 'mariadb']);
   }
 
-  async nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityData<T>[], ctx?: Transaction<Knex.Transaction>, processCollections = true): Promise<QueryResult> {
+  async nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>[], ctx?: Transaction<Knex.Transaction>, processCollections = true): Promise<QueryResult> {
     const res = await super.nativeInsertMany(entityName, data, ctx, processCollections);
     const pks = this.getPrimaryKeyFields(entityName);
     data.forEach((item, idx) => res.rows![idx] = { [pks[0]]: item[pks[0]] ?? res.insertId + idx });

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -1,7 +1,7 @@
 import { ClientSession, ObjectId } from 'mongodb';
 import {
   DatabaseDriver, EntityData, AnyEntity, FilterQuery, EntityMetadata, EntityProperty, Configuration, Utils, ReferenceType, FindOneOptions, FindOptions,
-  QueryResult, Transaction, IDatabaseDriver, EntityManager, EntityManagerType, Dictionary, PopulateOptions, CountOptions, FieldsMap,
+  QueryResult, Transaction, IDatabaseDriver, EntityManager, EntityManagerType, Dictionary, PopulateOptions, CountOptions, FieldsMap, EntityDictionary,
 } from '@mikro-orm/core';
 import { MongoConnection } from './MongoConnection';
 import { MongoPlatform } from './MongoPlatform';
@@ -47,17 +47,17 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     return this.rethrow(this.getConnection('read').countDocuments(entityName, where, ctx));
   }
 
-  async nativeInsert<T extends AnyEntity<T>>(entityName: string, data: EntityData<T>, ctx?: Transaction<ClientSession>): Promise<QueryResult> {
+  async nativeInsert<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>, ctx?: Transaction<ClientSession>): Promise<QueryResult> {
     data = this.renameFields(entityName, data);
     return this.rethrow(this.getConnection('write').insertOne(entityName, data as { _id: any }, ctx));
   }
 
-  async nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityData<T>[], ctx?: Transaction<ClientSession>, processCollections = true): Promise<QueryResult> {
+  async nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>[], ctx?: Transaction<ClientSession>, processCollections = true): Promise<QueryResult> {
     data = data.map(d => this.renameFields(entityName, d));
     return this.rethrow(this.getConnection('write').insertMany(entityName, data as any[], ctx));
   }
 
-  async nativeUpdate<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, data: EntityData<T>, ctx?: Transaction<ClientSession>): Promise<QueryResult> {
+  async nativeUpdate<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, data: EntityDictionary<T>, ctx?: Transaction<ClientSession>): Promise<QueryResult> {
     if (Utils.isPrimaryKey(where)) {
       where = this.buildFilterById(entityName, where as string);
     }
@@ -68,7 +68,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     return this.rethrow(this.getConnection('write').updateMany(entityName, where as FilterQuery<T>, data as { _id: any }, ctx));
   }
 
-  async nativeUpdateMany<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>[], data: EntityData<T>[], ctx?: Transaction<ClientSession>, processCollections?: boolean): Promise<QueryResult> {
+  async nativeUpdateMany<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>[], data: EntityDictionary<T>[], ctx?: Transaction<ClientSession>, processCollections?: boolean): Promise<QueryResult> {
     data = data.map(row => this.renameFields(entityName, row));
     return this.rethrow(this.getConnection('write').bulkUpdateMany(entityName, where, data as { _id: any }[], ctx));
   }

--- a/packages/mysql-base/src/MySqlDriver.ts
+++ b/packages/mysql-base/src/MySqlDriver.ts
@@ -1,4 +1,4 @@
-import { AnyEntity, Configuration, EntityData, QueryResult, Transaction } from '@mikro-orm/core';
+import { AnyEntity, Configuration, EntityDictionary, QueryResult, Transaction } from '@mikro-orm/core';
 import { AbstractSqlDriver, Knex } from '@mikro-orm/knex';
 import { MySqlConnection } from './MySqlConnection';
 import { MySqlPlatform } from './MySqlPlatform';
@@ -9,7 +9,7 @@ export class MySqlDriver extends AbstractSqlDriver<MySqlConnection> {
     super(config, new MySqlPlatform(), MySqlConnection, ['knex', 'mysql2']);
   }
 
-  async nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityData<T>[], ctx?: Transaction<Knex.Transaction>, processCollections = true): Promise<QueryResult> {
+  async nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>[], ctx?: Transaction<Knex.Transaction>, processCollections = true): Promise<QueryResult> {
     const res = await super.nativeInsertMany(entityName, data, ctx, processCollections);
     const pks = this.getPrimaryKeyFields(entityName);
     data.forEach((item, idx) => res.rows![idx] = { [pks[0]]: item[pks[0]] ?? res.insertId + idx });

--- a/packages/sqlite/src/SqliteDriver.ts
+++ b/packages/sqlite/src/SqliteDriver.ts
@@ -1,4 +1,4 @@
-import { AnyEntity, Configuration, EntityData, QueryResult, Transaction } from '@mikro-orm/core';
+import { AnyEntity, Configuration, EntityDictionary, QueryResult, Transaction } from '@mikro-orm/core';
 import { AbstractSqlDriver, Knex } from '@mikro-orm/knex';
 import { SqliteConnection } from './SqliteConnection';
 import { SqlitePlatform } from './SqlitePlatform';
@@ -9,7 +9,7 @@ export class SqliteDriver extends AbstractSqlDriver<SqliteConnection> {
     super(config, new SqlitePlatform(), SqliteConnection, ['knex', 'sqlite3']);
   }
 
-  async nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityData<T>[], ctx?: Transaction<Knex.Transaction>, processCollections = true): Promise<QueryResult> {
+  async nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>[], ctx?: Transaction<Knex.Transaction>, processCollections = true): Promise<QueryResult> {
     const res = await super.nativeInsertMany(entityName, data, ctx, processCollections);
     const pks = this.getPrimaryKeyFields(entityName);
     const first = res.insertId - data.length + 1;

--- a/tests/DatabaseDriver.test.ts
+++ b/tests/DatabaseDriver.test.ts
@@ -30,11 +30,11 @@ class Driver extends DatabaseDriver<Connection> {
     return Promise.resolve(0);
   }
 
-  async find<T>(entityName: string, where: FilterQuery<T>, options: FindOptions<T> | undefined, ctx: Transaction | undefined): Promise<T[]> {
+  async find<T>(entityName: string, where: FilterQuery<T>, options: FindOptions<T> | undefined, ctx: Transaction | undefined): Promise<EntityData<T>[]> {
     return Promise.resolve([]);
   }
 
-  async findOne<T>(entityName: string, where: FilterQuery<T>, options: FindOneOptions<T> | undefined, ctx: Transaction | undefined): Promise<T | null> {
+  async findOne<T>(entityName: string, where: FilterQuery<T>, options: FindOneOptions<T> | undefined, ctx: Transaction | undefined): Promise<EntityData<T> | null> {
     return null;
   }
 

--- a/tests/EntityAssigner.mongo.test.ts
+++ b/tests/EntityAssigner.mongo.test.ts
@@ -1,4 +1,4 @@
-import { assign, EntityData, MikroORM, wrap } from '@mikro-orm/core';
+import { assign, EntityData, expr, MikroORM, wrap } from '@mikro-orm/core';
 import { MongoDriver, ObjectId } from '@mikro-orm/mongodb';
 import { Author, Book, BookTag } from './entities';
 import { initORMMongo, wipeDatabase } from './bootstrap';
@@ -17,7 +17,7 @@ describe('EntityAssignerMongo', () => {
     await orm.em.persistAndFlush(book);
     expect(book.title).toBe('Book2');
     expect(book.author).toBe(jon);
-    book.assign({ title: 'Better Book2 1', author: god, notExisting: true });
+    book.assign({ title: 'Better Book2 1', author: god, [expr('notExisting')]: true });
     expect(book.author).toBe(god);
     expect((book as any).notExisting).toBe(true);
     await orm.em.persistAndFlush(god);
@@ -57,7 +57,7 @@ describe('EntityAssignerMongo', () => {
 
   test('#assign() should ignore undefined properties', async () => {
     const jon = new Author('Jon Snow', 'snow@wall.st');
-    assign(jon, { name: 'test', unknown: 123 }, { onlyProperties: true });
+    assign<any>(jon, { name: 'test', unknown: 123 }, { onlyProperties: true });
     expect((jon as any).unknown).toBeUndefined();
   });
 
@@ -79,7 +79,7 @@ describe('EntityAssignerMongo', () => {
 
   test('#assign() ignores virtual props with only getters', async () => {
     const jon = new Author('n', 'e');
-    assign(jon, { code: '123' });
+    assign<any>(jon, { code: '123' });
     expect(jon.getCode()).toBe(`e - n`);
     expect((jon as any).code).toBeUndefined();
   });

--- a/tests/EntityComparator.test.ts
+++ b/tests/EntityComparator.test.ts
@@ -71,7 +71,7 @@ export class ObjectHydratorOld {
   }
 
   private hydrateScalar<T>(entity: T, prop: EntityProperty<T>, data: EntityData<T>, convertCustomTypes: boolean): void {
-    let value = data[prop.name];
+    let value = data[prop.name as any];
 
     if (typeof value === 'undefined') {
       return;
@@ -79,13 +79,13 @@ export class ObjectHydratorOld {
 
     if (prop.customType && convertCustomTypes) {
       value = prop.customType.convertToJSValue(value, this.platform);
-      data[prop.name] = prop.customType.convertToDatabaseValue(value, this.platform); // make sure the value is comparable
+      data[prop.name as any] = prop.customType.convertToDatabaseValue(value, this.platform); // make sure the value is comparable
     }
 
     if (value && prop.type.toLowerCase() === 'date') {
-      entity[prop.name] = new Date(value) as unknown as T[keyof T & string];
+      entity[prop.name] = new Date(value as string) as unknown as T[keyof T & string];
     } else {
-      entity[prop.name] = value;
+      entity[prop.name] = value as any;
     }
   }
 
@@ -93,7 +93,7 @@ export class ObjectHydratorOld {
     const value: Dictionary = {};
 
     entity.__meta!.props.filter(p => p.embedded?.[0] === prop.name).forEach(childProp => {
-      value[childProp.embedded![1]] = data[childProp.name];
+      value[childProp.embedded![1]] = data[childProp.name as any];
     });
 
     entity[prop.name] = Object.create(prop.embeddable.prototype);
@@ -153,7 +153,7 @@ export class EntityComparatorOld {
     const ret = {} as EntityData<T>;
 
     if (meta.discriminatorValue) {
-      ret[meta.root.discriminatorColumn as keyof T] = meta.discriminatorValue as unknown as EntityData<T>[keyof T];
+      ret[meta.root.discriminatorColumn as any] = meta.discriminatorValue as any;
     }
 
     // copy all comparable props, ignore collections and references, process custom types
@@ -164,29 +164,29 @@ export class EntityComparatorOld {
 
       if (prop.reference === ReferenceType.EMBEDDED) {
         return meta.props.filter(p => p.embedded?.[0] === prop.name).forEach(childProp => {
-          ret[childProp.name as keyof T] = Utils.copy(entity[prop.name][childProp.embedded![1]]);
+          ret[childProp.name as any] = Utils.copy(entity[prop.name][childProp.embedded![1]]);
         });
       }
 
       if (Utils.isEntity(entity[prop.name], true)) {
-        ret[prop.name] = Utils.getPrimaryKeyValues(entity[prop.name], metadata.find(prop.type)!.primaryKeys, true);
+        ret[prop.name as any] = Utils.getPrimaryKeyValues(entity[prop.name], metadata.find(prop.type)!.primaryKeys, true);
 
         if (prop.customType) {
-          return ret[prop.name] = Utils.copy(prop.customType.convertToDatabaseValue(ret[prop.name], platform));
+          return ret[prop.name as any] = Utils.copy(prop.customType.convertToDatabaseValue(ret[prop.name as any], platform));
         }
 
         return;
       }
 
       if (prop.customType) {
-        return ret[prop.name] = Utils.copy(prop.customType.convertToDatabaseValue(entity[prop.name], platform));
+        return ret[prop.name as any] = Utils.copy(prop.customType.convertToDatabaseValue(entity[prop.name], platform));
       }
 
       if (prop.type.toLowerCase() === 'date') {
-        return ret[prop.name] = Utils.copy(platform.processDateProperty(entity[prop.name]));
+        return ret[prop.name as any] = Utils.copy(platform.processDateProperty(entity[prop.name])) as any;
       }
 
-      ret[prop.name] = Utils.copy(entity[prop.name]);
+      ret[prop.name as any] = Utils.copy(entity[prop.name]);
     });
 
     return ret;

--- a/tests/EntityFactory.test.ts
+++ b/tests/EntityFactory.test.ts
@@ -47,11 +47,14 @@ describe('EntityFactory', () => {
   });
 
   test('should return entity', async () => {
-    const entity = factory.create(Author, { id: '5b0d19b28b21c648c2c8a600', name: 'test', email: 'mail@test.com' });
+    const entity = factory.create(Author, { id: '5b0d19b28b21c648c2c8a600', name: 'test', email: 'mail@test.com', books: { title: 'asd' } });
     expect(entity).toBeInstanceOf(Author);
     expect(entity.id).toBe('5b0d19b28b21c648c2c8a600');
     expect(entity.name).toBe('test');
     expect(entity.email).toBe('mail@test.com');
+    expect(entity.books.isInitialized()).toBe(true);
+    expect(entity.books).toHaveLength(1);
+    expect(entity.books[0].title).toBe('asd');
   });
 
   test('entity ctor can have different params than props', async () => {

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -1411,10 +1411,10 @@ describe('EntityManagerMongo', () => {
     const res6 = await orm.em.nativeUpdate(Author, { name: 'native name 2' }, { name: 'new native name', updatedAt: new Date('2018-10-28') });
     expect(res6).toBe(1);
 
-    const res7 = await orm.em.nativeInsert('test', { name: 'native name 1', test: 'abc' });
+    const res7 = await orm.em.nativeInsert<any>('test', { name: 'native name 1', test: 'abc' });
     expect(res7).toBeInstanceOf(ObjectId);
 
-    const res8 = await orm.em.nativeUpdate('test', { name: 'native name 1' }, { $unset: { test: 1 } });
+    const res8 = await orm.em.nativeUpdate<any>('test', { name: 'native name 1' }, { $unset: { test: 1 } });
     expect(res8).toBe(1);
 
     const res9 = await orm.em.nativeDelete('test', { name: 'native name 1' });

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -2346,7 +2346,7 @@ describe('EntityManagerMySql', () => {
   test('exceptions', async () => {
     await orm.em.nativeInsert(Author2, { name: 'author', email: 'email' });
     await expect(orm.em.nativeInsert(Author2, { name: 'author', email: 'email' })).rejects.toThrow(UniqueConstraintViolationException);
-    await expect(orm.em.nativeInsert('not_existing', { foo: 'bar' })).rejects.toThrow(TableNotFoundException);
+    await expect(orm.em.nativeInsert<any>('not_existing', { foo: 'bar' })).rejects.toThrow(TableNotFoundException);
     await expect(orm.em.execute('create table author2 (foo text not null)')).rejects.toThrow(TableExistsException);
     await expect(orm.em.execute('foo bar 123')).rejects.toThrow(SyntaxErrorException);
     await expect(orm.em.execute('select id from author2, foo_bar2')).rejects.toThrow(NonUniqueFieldNameException);

--- a/tests/EntityManager.sqlite.test.ts
+++ b/tests/EntityManager.sqlite.test.ts
@@ -370,7 +370,7 @@ describe('EntityManagerSqlite', () => {
     orm.em.clear();
 
     const test2 = await orm.em.findOne<any>(Test3, test.id);
-    await orm.em.nativeUpdate(Test3, { id: test.id }, { name: 'Changed!' }); // simulate concurrent update
+    await orm.em.nativeUpdate<any>(Test3, { id: test.id }, { name: 'Changed!' }); // simulate concurrent update
     test2!.name = 'WHATT???';
 
     try {
@@ -825,19 +825,19 @@ describe('EntityManagerSqlite', () => {
 
   test('EM supports native insert/update/delete', async () => {
     orm.config.getLogger().setDebugMode(false);
-    const res1 = await orm.em.nativeInsert(Author3, { name: 'native name 1', email: 'native1@email.com' });
+    const res1 = await orm.em.nativeInsert<any>(Author3, { name: 'native name 1', email: 'native1@email.com' });
     expect(typeof res1).toBe('number');
 
-    const res2 = await orm.em.nativeUpdate(Author3, { name: 'native name 1' }, { name: 'new native name' });
+    const res2 = await orm.em.nativeUpdate<any>(Author3, { name: 'native name 1' }, { name: 'new native name' });
     expect(res2).toBe(1);
 
-    const res3 = await orm.em.nativeDelete(Author3, { name: 'new native name' });
+    const res3 = await orm.em.nativeDelete<any>(Author3, { name: 'new native name' });
     expect(res3).toBe(1);
 
-    const res4 = await orm.em.nativeInsert(Author3, { createdAt: new Date('1989-11-17'), updatedAt: new Date('2018-10-28'), name: 'native name 2', email: 'native2@email.com' });
+    const res4 = await orm.em.nativeInsert<any>(Author3, { createdAt: new Date('1989-11-17'), updatedAt: new Date('2018-10-28'), name: 'native name 2', email: 'native2@email.com' });
     expect(typeof res4).toBe('number');
 
-    const res5 = await orm.em.nativeUpdate(Author3, { name: 'native name 2' }, { name: 'new native name', updatedAt: new Date('2018-10-28') });
+    const res5 = await orm.em.nativeUpdate<any>(Author3, { name: 'native name 2' }, { name: 'new native name', updatedAt: new Date('2018-10-28') });
     expect(res5).toBe(1);
   });
 

--- a/tests/EntityManager.sqlite2.test.ts
+++ b/tests/EntityManager.sqlite2.test.ts
@@ -1,7 +1,7 @@
 import { ArrayCollection, Collection, EntityManager, LockMode, Logger, MikroORM, QueryOrder, ValidationError, wrap } from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 import { initORMSqlite2, wipeDatabaseSqlite2 } from './bootstrap';
-import { Author4, Book4, BookTag4, FooBar4, IAuthor4, IPublisher4, Publisher4, PublisherType, Test4 } from './entities-schema';
+import { Author4, Book4, BookTag4, FooBar4, IAuthor4, IPublisher4, ITest4, Publisher4, PublisherType, Test4 } from './entities-schema';
 
 describe('EntityManagerSqlite2', () => {
 
@@ -331,7 +331,7 @@ describe('EntityManagerSqlite2', () => {
     orm.em.clear();
 
     const test2 = await orm.em.findOne(Test4, test.id);
-    await orm.em.nativeUpdate('Test4', { id: test.id }, { name: 'Changed!' }); // simulate concurrent update
+    await orm.em.nativeUpdate<ITest4>('Test4', { id: test.id }, { name: 'Changed!' }); // simulate concurrent update
     test2!.name = 'WHATT???';
 
     try {
@@ -862,19 +862,19 @@ describe('EntityManagerSqlite2', () => {
 
   test('EM supports native insert/update/delete', async () => {
     orm.config.getLogger().setDebugMode(false);
-    const res1 = await orm.em.nativeInsert('Author4', { name: 'native name 1', email: 'native1@email.com' });
+    const res1 = await orm.em.nativeInsert<IAuthor4>('Author4', { name: 'native name 1', email: 'native1@email.com' });
     expect(typeof res1).toBe('number');
 
-    const res2 = await orm.em.nativeUpdate('Author4', { name: 'native name 1' }, { name: 'new native name' });
+    const res2 = await orm.em.nativeUpdate(Author4, { name: 'native name 1' }, { name: 'new native name' });
     expect(res2).toBe(1);
 
-    const res3 = await orm.em.nativeDelete('Author4', { name: 'new native name' });
+    const res3 = await orm.em.nativeDelete(Author4, { name: 'new native name' });
     expect(res3).toBe(1);
 
-    const res4 = await orm.em.nativeInsert('Author4', { createdAt: new Date('1989-11-17'), updatedAt: new Date('2018-10-28'), name: 'native name 2', email: 'native2@email.com' });
+    const res4 = await orm.em.nativeInsert(Author4, { createdAt: new Date('1989-11-17'), updatedAt: new Date('2018-10-28'), name: 'native name 2', email: 'native2@email.com' });
     expect(typeof res4).toBe('number');
 
-    const res5 = await orm.em.nativeUpdate('Author4', { name: 'native name 2' }, { name: 'new native name', updatedAt: new Date('2018-10-28') });
+    const res5 = await orm.em.nativeUpdate(Author4, { name: 'native name 2' }, { name: 'new native name', updatedAt: new Date('2018-10-28') });
     expect(res5).toBe(1);
   });
 

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -1170,11 +1170,11 @@ describe('QueryBuilder', () => {
     expect(qb1.getParams()).toEqual(['test 123', PublisherType.GLOBAL]);
 
     const qb2 = orm.em.createQueryBuilder(Author2);
-    qb2.insert({ name: 'test 123', favouriteBook: 2359, termsAccepted: true });
+    qb2.insert({ name: 'test 123', favouriteBook: '2359', termsAccepted: true });
     expect(qb2.getQuery()).toEqual('insert into `author2` (`favourite_book_uuid_pk`, `name`, `terms_accepted`) values (?, ?, ?)');
-    expect(qb2.getParams()).toEqual([2359, 'test 123', true]);
+    expect(qb2.getParams()).toEqual(['2359', 'test 123', true]);
 
-    const qb3 = orm.em.createQueryBuilder(BookTag2);
+    const qb3 = orm.em.createQueryBuilder<any>(BookTag2);
     qb3.insert({ books: 123 }).withSchema('test123');
     expect(qb3.getQuery()).toEqual('insert into `test123`.`book_tag2` (`books`) values (?)');
     expect(qb3.getParams()).toEqual([123]);
@@ -1186,7 +1186,7 @@ describe('QueryBuilder', () => {
     expect(qb0.getQuery()).toEqual('insert ignore into `author2` (`email`, `name`) values (?, ?)');
     expect(qb0.getParams()).toEqual(['ignore@example.com', 'John Doe']);
 
-    const timestamp = Date.now();
+    const timestamp = new Date();
     const qb1 = orm.em.createQueryBuilder(Author2)
       .insert({
         createdAt: timestamp,
@@ -1231,14 +1231,14 @@ describe('QueryBuilder', () => {
 
   test('update query with JSON type and raw value', async () => {
     const qb = orm.em.createQueryBuilder(Book2);
-    const raw = qb.raw(`jsonb_set(payload, '$.{consumed}', ?)`, [123]);
+    const raw = qb.raw<any>(`jsonb_set(payload, '$.{consumed}', ?)`, [123]);
     qb.update({ meta: raw }).where({ uuid: '456' });
     expect(qb.getFormattedQuery()).toEqual('update `book2` set `meta` = jsonb_set(payload, \'$.{consumed}\', 123) where `uuid_pk` = \'456\'');
   });
 
   test('qb.raw() with named bindings', async () => {
     const qb = orm.em.createQueryBuilder(Book2);
-    const raw = qb.raw(`jsonb_set(payload, '$.{consumed}', :val)`, { val: 123 });
+    const raw = qb.raw<any>(`jsonb_set(payload, '$.{consumed}', :val)`, { val: 123 });
     qb.update({ meta: raw }).where({ uuid: '456' });
     expect(qb.getFormattedQuery()).toEqual('update `book2` set `meta` = jsonb_set(payload, \'$.{consumed}\', 123) where `uuid_pk` = \'456\'');
   });
@@ -1301,7 +1301,7 @@ describe('QueryBuilder', () => {
   });
 
   test('update query with entity in data', async () => {
-    const qb = orm.em.createQueryBuilder(Publisher2);
+    const qb = orm.em.createQueryBuilder<any>(Publisher2);
     qb.withSchema('test123');
     const test = Test2.create('test');
     test.id = 321;
@@ -1800,7 +1800,7 @@ describe('QueryBuilder', () => {
     expect(qb9.getQuery()).toEqual('insert into "author2" ("email", "name") values ($1, $2) on conflict ("email") do nothing returning "id", "created_at", "updated_at", "age", "terms_accepted"');
     expect(qb9.getParams()).toEqual(['ignore@example.com', 'John Doe']);
 
-    const timestamp = Date.now();
+    const timestamp = new Date();
     const qb10 = pg.em.createQueryBuilder(Author2)
       .insert({
         createdAt: timestamp,

--- a/tests/UnitOfWork.test.ts
+++ b/tests/UnitOfWork.test.ts
@@ -1,5 +1,5 @@
 import { Author } from './entities';
-import { ChangeSet, ChangeSetComputer, ChangeSetType, EntityValidator, EventSubscriber, FlushEventArgs, IdentityMap, Logger, MikroORM, UnitOfWork, wrap } from '@mikro-orm/core';
+import { ChangeSet, ChangeSetComputer, ChangeSetType, EntityValidator, EventSubscriber, FlushEventArgs, IdentityMap, Logger, MikroORM, UnitOfWork } from '@mikro-orm/core';
 import { initORMMongo, wipeDatabase } from './bootstrap';
 import FooBar from './entities/FooBar';
 import { FooBaz } from './entities/FooBaz';

--- a/tests/entities-sql/User2.ts
+++ b/tests/entities-sql/User2.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyType, Property } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './sandwich';
 
@@ -22,6 +22,8 @@ export class User2 {
 
   @OneToOne({ entity: () => Car2, nullable: true })
   favouriteCar?: Car2;
+
+  [PrimaryKeyType]: [string, string];
 
   constructor(firstName: string, lastName: string) {
     this.firstName = firstName;

--- a/tests/entities/BaseEntity3.ts
+++ b/tests/entities/BaseEntity3.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from '@mikro-orm/mongodb';
 import { BaseEntity, PrimaryKey, SerializedPrimaryKey } from '@mikro-orm/core';
 
-export abstract class BaseEntity3 extends BaseEntity<BaseEntity3, 'id' | '_id'>{
+export abstract class BaseEntity3<T> extends BaseEntity<T & BaseEntity3<T>, 'id' | '_id'> {
 
   @PrimaryKey()
   _id!: ObjectId;

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -10,7 +10,7 @@ import { BaseEntity3 } from './BaseEntity3';
 @Index({ properties: 'title', type: 'text' })
 @Index({ options: { point: '2dsphere', title: -1 } })
 @Filter({ name: 'writtenBy', cond: args => ({ author: args.author }) })
-export class Book extends BaseEntity3 {
+export class Book extends BaseEntity3<Book> {
 
   @PrimaryKey()
   _id!: ObjectId;

--- a/tests/features/composite-keys/composite-keys.mysql.test.ts
+++ b/tests/features/composite-keys/composite-keys.mysql.test.ts
@@ -285,7 +285,7 @@ describe('composite keys in mysql', () => {
 
     const c1 = new Car2('n1', 2000, 1);
     const c2 = { name: 'n3', year: 2000, price: 123 };
-    const c3 = ['n4', 2000]; // composite PK
+    const c3 = ['n4', 2000] as const; // composite PK
 
     // managed entity have an internal __em reference, so that is what we are testing here
     expect(wrap(c1, true).__em).toBeUndefined();

--- a/tests/features/composite-keys/composite-keys.sqlite.test.ts
+++ b/tests/features/composite-keys/composite-keys.sqlite.test.ts
@@ -184,6 +184,8 @@ export class User2 {
   @OneToOne({ entity: () => Car2, nullable: true })
   favouriteCar?: Car2;
 
+  [PrimaryKeyType]: [string, string];
+
   constructor(firstName: string, lastName: string) {
     this.firstName = firstName;
     this.lastName = lastName;
@@ -536,7 +538,7 @@ describe('composite keys in sqlite', () => {
 
     const c1 = new Car2('n1', 2000, 1);
     const c2 = { name: 'n3', year: 2000, price: 123 };
-    const c3 = ['n4', 2000]; // composite PK
+    const c3 = ['n4', 2000] as const; // composite PK
 
     // managed entity have an internal __em reference, so that is what we are testing here
     expect(wrap(c1, true).__em).toBeUndefined();

--- a/tests/issues/GH222.test.ts
+++ b/tests/issues/GH222.test.ts
@@ -102,7 +102,7 @@ describe('GH issue 222', () => {
     expect(cc.bCollection.count()).toBe(1);
     expect(cc.a.prop).toEqual(cc.bCollection[0].a.prop);
     const ccJson = wrap(cc).toJSON();
-    expect(ccJson.a.prop).toEqual(ccJson.bCollection[0].a.prop);
+    expect(ccJson.a!.prop).toEqual(ccJson.bCollection[0].a.prop);
   });
 
 });

--- a/tests/issues/GH446.test.ts
+++ b/tests/issues/GH446.test.ts
@@ -109,7 +109,7 @@ describe('GH issue 446', () => {
 
   test(`assign with custom types`, async () => {
     const d = new D();
-    orm.em.assign(d, { id: Buffer.from(parse(v4()) as number[]) as any, a: Buffer.from(parse(v4()) as number[]) }, { convertCustomTypes: true });
+    orm.em.assign<any>(d, { id: Buffer.from(parse(v4()) as number[]) as any, a: Buffer.from(parse(v4()) as number[]) }, { convertCustomTypes: true });
     expect(typeof d.id).toBe('string');
     expect(typeof d.a.id).toBe('string');
     orm.em.assign(d, { id: v4(), a: v4() });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,7 +1,7 @@
 import { assert, Has, IsExact } from 'conditional-type-checks';
 import { ObjectId } from 'mongodb';
-import { FilterQuery, FilterValue, OperatorMap, Primary, PrimaryKeyType, Query } from '../packages/core/src/typings';
-import { Author2, Book2, BookTag2, FooBar2, FooParam2 } from './entities-sql';
+import { EntityData, FilterQuery, FilterValue, OperatorMap, Primary, PrimaryKeyType, Query } from '../packages/core/src/typings';
+import { Author2, Book2, BookTag2, Car2, FooBar2, FooParam2, Publisher2, User2 } from './entities-sql';
 import { Author, Book } from './entities';
 import { Collection, IdentifiedReference, Reference, wrap } from '@mikro-orm/core';
 
@@ -29,6 +29,48 @@ describe('check typings', () => {
     // bigint support
     assert<IsExact<Primary<BookTag2>, string>>(true);
     assert<IsExact<Primary<BookTag2>, number>>(false);
+  });
+
+  test('EntityData', async () => {
+    let b: EntityData<Book2>;
+    b = {};
+    b = {} as Author2;
+    b = { author: { name: 'a' } };
+    b = { author: { name: 'a', books: [] } };
+    b = { author: { name: 'a', books: [{ title: 'b', tags: { name: 't' } }] } };
+    b = { publisher: null };
+    b = { publisher: { name: 'p' } };
+    b = { publisher: {} as Publisher2 };
+    b = { publisher: {} as IdentifiedReference<Publisher2> };
+
+    // @ts-expect-error
+    b = { name: 'a' };
+    // @ts-expect-error
+    b = { author: { title: 'a' } };
+    // @ts-expect-error
+    b = { author: { name: 'a', books: [{ name: 'b' }] } };
+    // @ts-expect-error
+    b = { author: { name: 'a', books: [{ title: 'b', tags: { title: 't' } }] } };
+
+    let c: EntityData<Car2>;
+    c = {};
+    c = {} as Car2;
+    c = { name: 'n', price: 123, year: 2021 };
+    c = { name: 'n', price: 123, year: 2021, users: { firstName: 'f', lastName: 'l' } };
+    c = { name: 'n', price: 123, year: 2021, users: [{ firstName: 'f', lastName: 'l' }] };
+    c = { name: 'n', price: 123, year: 2021, users: [{} as User2] };
+    c = { name: 'n', price: 123, year: 2021, users: [['f', 'l']] };
+
+    // @ts-expect-error
+    c = { name: 'n', price: 123, year: '2021' };
+    // @ts-expect-error
+    c = { name: 'n', price: 123, year: 2021, users: { firstName: 321, lastName: 'l' } };
+    // @ts-expect-error
+    c = { name: 'n', price: 123, year: 2021, users: [{ firstName: 'f', lastName: 123 }] };
+    // @ts-expect-error
+    c = { name: 'n', price: 123, year: 2021, users: [{} as Car2] };
+    // @ts-expect-error
+    c = { name: 'n', price: 123, year: 2021, users: [['f', 1]] };
   });
 
   test('FilterValue', async () => {


### PR DESCRIPTION
`EntityData` interface is now strictly typed. This means that the following methods (and probably more) 
are now strict:

- `em.create()`
- `em.assign()`
- `em.nativeInsert()`
- `em.nativeUpdate()`
- `qb.insert()`
- `qb.update()`

The property keys and their types are recursively checked. The type makes all properties optional
to allow better DX. While it would be nice to also require non-nullable properties, it would cause
problems with properties with property initializer (e.g. `createdAt: Date = new Date()`) or PKs
in general (auto increment). Same applies to all properties with native DB defaults. If the type
would be strict about nullability, we would have to define all such properties as optional and force
non-null assertions (`!` operator), which would be quite tedious.

BREAKING CHANGE:
Some methods are now strictly typed, so previously fine usages might be restricted on TS level.
To get around those, we might either cast as `any`, provide the generic `T` type as `any`, or
use `expr` helper.

```ts
em.create(User, { someNotDefinedProp: 123 }); // throws if someNotDefinedProp not on the User
em.create(User, { [expr('someNotDefinedProp')]: 123 }); // works, using expr
em.create<any>(User, { someNotDefinedProp: 123 }); // works, using type cast
em.create(User, { someNotDefinedProp: 123 } as any); // works, using type cast
```

Closes #1456 