### PR TITLE
feat(typings): make `toObject()` and similar strict

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -4,7 +4,7 @@ import { Configuration, QueryHelper, TransactionContext, Utils } from './utils';
 import { AssignOptions, EntityAssigner, EntityFactory, EntityLoader, EntityRepository, EntityValidator, IdentifiedReference, Reference } from './entity';
 import { UnitOfWork } from './unit-of-work';
 import { CountOptions, DeleteOptions, EntityManagerType, FindOneOptions, FindOneOrFailOptions, FindOptions, IDatabaseDriver, UpdateOptions } from './drivers';
-import { AnyEntity, Dictionary, EntityData, EntityDictionary, EntityMetadata, EntityName, FilterDef, FilterQuery, GetRepository, Loaded, New, Populate, PopulateMap, PopulateOptions, Primary } from './typings';
+import { AnyEntity, Dictionary, EntityData, EntityDictionary, EntityDTO, EntityMetadata, EntityName, FilterDef, FilterQuery, GetRepository, Loaded, New, Populate, PopulateMap, PopulateOptions, Primary } from './typings';
 import { LoadStrategy, LockMode, QueryOrderMap, ReferenceType, SCALAR_TYPES } from './enums';
 import { MetadataStorage } from './metadata';
 import { Transaction } from './connections';
@@ -510,13 +510,13 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * Merges given entity to this EntityManager so it becomes managed. You can force refreshing of existing entities
    * via second parameter. By default it will return already loaded entities without modifying them.
    */
-  merge<T extends AnyEntity<T>>(entityName: EntityName<T>, data: EntityData<T>, refresh?: boolean, convertCustomTypes?: boolean): T;
+  merge<T extends AnyEntity<T>>(entityName: EntityName<T>, data: EntityData<T> | EntityDTO<T>, refresh?: boolean, convertCustomTypes?: boolean): T;
 
   /**
    * Merges given entity to this EntityManager so it becomes managed. You can force refreshing of existing entities
    * via second parameter. By default it will return already loaded entities without modifying them.
    */
-  merge<T extends AnyEntity<T>>(entityName: EntityName<T> | T, data?: EntityData<T> | boolean, refresh?: boolean, convertCustomTypes?: boolean): T {
+  merge<T extends AnyEntity<T>>(entityName: EntityName<T> | T, data?: EntityData<T> | EntityDTO<T> | boolean, refresh?: boolean, convertCustomTypes?: boolean): T {
     if (Utils.isEntity(entityName)) {
       return this.merge(entityName.constructor.name, entityName as unknown as EntityData<T>, data as boolean);
     }

--- a/packages/core/src/entity/BaseEntity.ts
+++ b/packages/core/src/entity/BaseEntity.ts
@@ -1,5 +1,5 @@
 import { Reference } from './Reference';
-import { AnyEntity, Dictionary, EntityData, IWrappedEntity, Populate } from '../typings';
+import { AnyEntity, EntityData, EntityDTO, IWrappedEntity, Populate } from '../typings';
 import { AssignOptions, EntityAssigner } from './EntityAssigner';
 
 export abstract class BaseEntity<T, PK extends keyof T, P extends Populate<T> | unknown = unknown> implements IWrappedEntity<T, PK, P> {
@@ -20,15 +20,15 @@ export abstract class BaseEntity<T, PK extends keyof T, P extends Populate<T> | 
     return Reference.create(this) as any; // maintain the type from IWrappedEntity
   }
 
-  toObject(ignoreFields: string[] = []): Dictionary {
-    return (this as unknown as AnyEntity<T>).__helper!.toObject(ignoreFields) as EntityData<T>;
+  toObject(ignoreFields: string[] = []): EntityDTO<T> {
+    return (this as unknown as AnyEntity<T>).__helper!.toObject(ignoreFields);
   }
 
-  toJSON(...args: any[]): Dictionary {
+  toJSON(...args: any[]): EntityDTO<T> {
     return this.toObject(...args);
   }
 
-  toPOJO(): EntityData<T> {
+  toPOJO(): EntityDTO<T> {
     return (this as unknown as AnyEntity<T>).__helper!.toPOJO();
   }
 

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -1,7 +1,7 @@
 import { inspect } from 'util';
 import { Collection } from './Collection';
 import { EntityManager } from '../EntityManager';
-import { AnyEntity, EntityData, EntityMetadata, EntityProperty } from '../typings';
+import { AnyEntity, EntityData, EntityDTO, EntityMetadata, EntityProperty } from '../typings';
 import { Utils } from '../utils/Utils';
 import { Reference } from './Reference';
 import { ReferenceType, SCALAR_TYPES } from '../enums';
@@ -12,9 +12,9 @@ const validator = new EntityValidator(false);
 
 export class EntityAssigner {
 
-  static assign<T extends AnyEntity<T>>(entity: T, data: EntityData<T>, options?: AssignOptions): T;
-  static assign<T extends AnyEntity<T>>(entity: T, data: EntityData<T>, onlyProperties?: boolean): T;
-  static assign<T extends AnyEntity<T>>(entity: T, data: EntityData<T>, onlyProperties: AssignOptions | boolean = false): T {
+  static assign<T extends AnyEntity<T>>(entity: T, data: EntityData<T> | Partial<EntityDTO<T>>, options?: AssignOptions): T;
+  static assign<T extends AnyEntity<T>>(entity: T, data: EntityData<T> | Partial<EntityDTO<T>>, onlyProperties?: boolean): T;
+  static assign<T extends AnyEntity<T>>(entity: T, data: EntityData<T> | Partial<EntityDTO<T>>, onlyProperties: AssignOptions | boolean = false): T {
     const options = (typeof onlyProperties === 'boolean' ? { onlyProperties } : onlyProperties);
     const wrapped = entity.__helper!;
     const meta = entity.__meta!;
@@ -26,7 +26,7 @@ export class EntityAssigner {
         return;
       }
 
-      let value = data[prop as keyof EntityData<T>];
+      let value = data[prop as keyof typeof data];
 
       if (props[prop] && !props[prop].nullable && (value === undefined || value === null)) {
         throw new Error(`You must pass a non-${value} value to the property ${prop} of entity ${entity.constructor.name}.`);

--- a/packages/core/src/entity/EntityTransformer.ts
+++ b/packages/core/src/entity/EntityTransformer.ts
@@ -198,7 +198,7 @@ export class EntityTransformer {
     const wrapped = (child as T).__helper!;
 
     if (raw && wrapped.isInitialized() && child !== entity) {
-      return wrapped.toPOJO() as T[keyof T];
+      return wrapped.toPOJO() as unknown as T[keyof T];
     }
 
     if (wrapped.isInitialized() && wrapped.__populated && child !== entity && !wrapped.__lazyInitialized) {

--- a/packages/core/src/entity/wrap.ts
+++ b/packages/core/src/entity/wrap.ts
@@ -1,20 +1,20 @@
-import { AnyEntity, Dictionary, IWrappedEntity, IWrappedEntityInternal } from '../typings';
+import { AnyEntity, Dictionary, IWrappedEntity, IWrappedEntityInternal, PrimaryProperty } from '../typings';
 
 /**
  * returns WrappedEntity instance associated with this entity. This includes all the internal properties like `__meta` or `__em`.
  */
-export function wrap<T, PK extends keyof T>(entity: T, preferHelper: true): IWrappedEntityInternal<T, PK>;
+export function wrap<T, PK extends keyof T | unknown = PrimaryProperty<T>>(entity: T, preferHelper: true): IWrappedEntityInternal<T, PK>;
 
 /**
  * wraps entity type with WrappedEntity internal properties and helpers like init/isInitialized/populated/toJSON
  */
-export function wrap<T, PK extends keyof T>(entity: T, preferHelper?: false): IWrappedEntity<T, PK>;
+export function wrap<T, PK extends keyof T | unknown = PrimaryProperty<T>>(entity: T, preferHelper?: false): IWrappedEntity<T, PK>;
 
 /**
  * wraps entity type with WrappedEntity internal properties and helpers like init/isInitialized/populated/toJSON
  * use `preferHelper = true` to have access to the internal `__` properties like `__meta` or `__em`
  */
-export function wrap<T extends AnyEntity<T>, PK extends keyof T>(entity: T & Dictionary, preferHelper = false): IWrappedEntity<T, PK> | IWrappedEntityInternal<T, PK> {
+export function wrap<T extends AnyEntity<T>, PK extends keyof T | unknown = PrimaryProperty<T>>(entity: T & Dictionary, preferHelper = false): IWrappedEntity<T, PK> | IWrappedEntityInternal<T, PK> {
   if (entity?.__baseEntity && !preferHelper) {
     return entity as unknown as IWrappedEntity<T, PK>;
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,7 @@
 export {
   Constructor, Dictionary, PrimaryKeyType, PrimaryKeyProp, Primary, IPrimaryKey, FilterQuery, IWrappedEntity, EntityName, EntityData, Highlighter,
   AnyEntity, EntityProperty, EntityMetadata, QBFilterQuery, PopulateOptions, Populate, Loaded, New, LoadedReference, LoadedCollection,
-  GetRepository, EntityRepositoryType, MigrationObject, DeepPartial, PrimaryProperty, Cast, IsUnknown, EntityDictionary,
+  GetRepository, EntityRepositoryType, MigrationObject, DeepPartial, PrimaryProperty, Cast, IsUnknown, EntityDictionary, EntityDTO,
 } from './typings';
 export * from './enums';
 export * from './errors';

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -197,7 +197,7 @@ describe('EntityManagerMongo', () => {
     await orm.em.persistAndFlush(bar);
     orm.em.clear();
 
-    const a = await orm.em.findOne(FooBar, bar.id, ['baz']);
+    const a = await orm.em.findOneOrFail(FooBar, bar.id, ['baz']);
     expect(wrap(a).toJSON()).toMatchObject({
       name: 'fb',
       fooBaz: 'FooBaz id: ' + bar.baz.id,
@@ -496,7 +496,7 @@ describe('EntityManagerMongo', () => {
     const json = wrap(publisher).toJSON().books;
 
     for (const book of publisher.books) {
-      expect(json.find((b: Book) => b.id === book.id)).toMatchObject({
+      expect(json.find(b => b.id === book.id)).toMatchObject({
         author: book.author.id,
       });
     }
@@ -870,7 +870,7 @@ describe('EntityManagerMongo', () => {
     orm.em.clear();
 
     // cache author with favouriteBook and its tags
-    const jon = await orm.em.findOne(Author, author.id, ['favouriteBook.tags']);
+    const jon = await orm.em.findOneOrFail(Author, author.id, ['favouriteBook.tags']);
     const cache = wrap(jon).toObject();
 
     // merge cached author with his references

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -834,7 +834,7 @@ describe('EntityManagerMySql', () => {
     const json = wrap(publisher).toJSON().books;
 
     for (const book of publisher.books) {
-      expect(json.find((b: Book2) => b.uuid === book.uuid)).toMatchObject({
+      expect(json.find(b => b.uuid === book.uuid)).toMatchObject({
         author: book.author.id,
       });
     }

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -678,7 +678,7 @@ describe('EntityManagerPostgre', () => {
     const json = wrap(publisher).toJSON().books;
 
     for (const book of publisher.books) {
-      expect(json.find((b: Book2) => b.uuid === book.uuid)).toMatchObject({
+      expect(json.find(b => b.uuid === book.uuid)).toMatchObject({
         author: book.author.id,
       });
     }

--- a/tests/entities-sql/Test2.ts
+++ b/tests/entities-sql/Test2.ts
@@ -2,6 +2,7 @@ import { Collection, Entity, ManyToMany, ManyToOne, OneToMany, OneToOne, Primary
 import { Book2 } from './Book2';
 import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
+import { Publisher2 } from './Publisher2';
 
 @Entity()
 export class Test2 {

--- a/tests/entities/Author.ts
+++ b/tests/entities/Author.ts
@@ -1,6 +1,6 @@
 import {
-  AfterCreate, AfterDelete, AfterUpdate, BeforeCreate, BeforeDelete, BeforeUpdate, DateType, Collection, Filter,
-  Cascade, Entity, ManyToMany, ManyToOne, OneToMany, Property, Index, Unique, EntityAssigner, EntityRepositoryType,
+  AfterCreate, AfterDelete, AfterUpdate, BeforeCreate, BeforeDelete, BeforeUpdate, DateType, Collection, Filter, EntityDTO,
+  Cascade, Entity, ManyToMany, ManyToOne, OneToMany, Property, Index, Unique, EntityAssigner, EntityRepositoryType, Dictionary,
 } from '@mikro-orm/core';
 
 import { Book } from './Book';
@@ -126,9 +126,9 @@ export class Author extends BaseEntity<Author> {
     return EntityAssigner.assign<Author>(this, data);
   }
 
-  toJSON(strict = true, strip = ['id', 'email'], ...args: any[]): { [p: string]: any } {
+  toJSON(strict = true, strip = ['id', 'email'], ...args: any[]): EntityDTO<Author> {
     const o = this.toObject(...args);
-    o.fooBar = 123;
+    (o as Dictionary).fooBar = 123;
 
     if (strict) {
       strip.forEach(k => delete o[k]);

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -1,5 +1,5 @@
 import { ObjectId } from 'mongodb';
-import { Collection, IdentifiedReference, Cascade, Entity, Index, ManyToMany, ManyToOne, PrimaryKey, Property, Unique, wrap, Filter, Dictionary } from '@mikro-orm/core';
+import { Collection, IdentifiedReference, Cascade, Entity, Index, ManyToMany, ManyToOne, PrimaryKey, Property, Unique, wrap, Filter, Dictionary, EntityDTO } from '@mikro-orm/core';
 import { Publisher } from './Publisher';
 import { Author } from './Author';
 import { BookTag } from './book-tag';
@@ -56,8 +56,8 @@ export class Book extends BaseEntity3<Book> {
     this.author = author!;
   }
 
-  toJSON(strict = true, strip = ['metaObject', 'metaArray', 'metaArrayOfStrings'], ...args: any[]): { [p: string]: any } {
-    const o = wrap(this).toObject(...args);
+  toJSON(strict = true, strip = ['metaObject', 'metaArray', 'metaArrayOfStrings'], ...args: any[]): EntityDTO<Book> {
+    const o = wrap(this as Book).toObject(...args);
 
     if (strict) {
       strip.forEach(k => delete o[k]);

--- a/tests/issues/GH222.test.ts
+++ b/tests/issues/GH222.test.ts
@@ -102,7 +102,7 @@ describe('GH issue 222', () => {
     expect(cc.bCollection.count()).toBe(1);
     expect(cc.a.prop).toEqual(cc.bCollection[0].a.prop);
     const ccJson = wrap(cc).toJSON();
-    expect(ccJson.a!.prop).toEqual(ccJson.bCollection[0].a.prop);
+    expect(ccJson.a.prop).toEqual(ccJson.bCollection[0].a.prop);
   });
 
 });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,6 +1,6 @@
 import { assert, Has, IsExact } from 'conditional-type-checks';
 import { ObjectId } from 'mongodb';
-import { EntityData, FilterQuery, FilterValue, OperatorMap, Primary, PrimaryKeyType, Query } from '../packages/core/src/typings';
+import { EntityData, EntityDTO, FilterQuery, FilterValue, Loaded, OperatorMap, Primary, PrimaryKeyType, Query } from '../packages/core/src/typings';
 import { Author2, Book2, BookTag2, Car2, FooBar2, FooParam2, Publisher2, User2 } from './entities-sql';
 import { Author, Book } from './entities';
 import { Collection, IdentifiedReference, Reference, wrap } from '@mikro-orm/core';
@@ -71,6 +71,43 @@ describe('check typings', () => {
     c = { name: 'n', price: 123, year: 2021, users: [{} as Car2] };
     // @ts-expect-error
     c = { name: 'n', price: 123, year: 2021, users: [['f', 1]] };
+  });
+
+  test('EntityDTO', async () => {
+    const b = { author: { books: [{}] } } as EntityDTO<Book2>;
+    const b1 = b.author.name;
+    const b2 = b.test?.name;
+    const b3 = b.test?.book?.author.books2;
+    const b4 = b.author.books[0].tags;
+    const b5 = b.publisher?.name;
+    const b6 = b.publisher?.tests;
+    const b7 = b.author.favouriteBook?.tags[0].name;
+
+    // @ts-expect-error
+    b.author.afterDelete?.();
+    // @ts-expect-error
+    b.author.title;
+    // @ts-expect-error
+    b.author.favouriteBook?.tags[0].title;
+    // @ts-expect-error
+    b.test?.getConfiguration?.();
+
+    const a = { books: [{ tags: [{}] }] } as EntityDTO<Loaded<Author2, { books: { tags: true; publisher: true } }>>;
+    const a11 = a.books;
+    const a12 = a.books[0];
+    const a1 = a.books[0].tags;
+    const a2 = a.books[0].publisher?.type;
+    const a3 = a.books;
+    const a4 = a.books.map(b => b.title);
+    const a5 = a.books[0].tags.map(t => t.name);
+    const a6 = a.books[0].tags[0].name;
+
+    // @ts-expect-error
+    a.books.map(b => b.name);
+    // @ts-expect-error
+    a.books[0].publisher?.title;
+    // @ts-expect-error
+    a.books[0].tags.map(t => t.title);
   });
 
   test('FilterValue', async () => {


### PR DESCRIPTION
`toObject()`, `toJSON()` and `toPOJO()` now all return `EntityDTO` type, that is strict,
so it allows (deep) key autosuggestions.

The implementation is a best effort, as the serialized form of an entity can be very unpredictable.
There are many variables that define how things will be serialized, e.g. loaded entity vs reference, 
property serializers, custom entity serializer/toJSON method, eager loading, recursion checks, ...

Currently all relations are concidered as loaded on the type level, this is mainly done to allow better
DX, as if we had all relations typed as `Primary<T> | EntityDTO<T>` (e.g. `number | EntityDTO<Book>`), it 
would be impossible to benefit from intellisense/autosuggestions. Imagine this scenario:

```ts
const book = {} as Book;
const dto = wrap(book).toObject(); // EntityDTO<Book>

// this is now possible, but with the PK union type, we would need to type cast all the time
const name = dto.author.name;
```

BREAKING CHANGE:
Some methods are now strictly typed, so previously fine usages might be restricted on TS level.