### PR TITLE
feat(migrations): use snapshots for generating diffs in new migrations

### DIFF
--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -49,6 +49,17 @@ npx mikro-orm migration:create --initial
 This will create the initial migration, containing the schema dump from 
 `schema:create` command. The migration will be automatically marked as executed. 
 
+## Snapshots
+
+Creating new migration will automatically save the target schema snapshot into 
+migrations folder. This snapshot will be then used if you try to create new migration,
+instead of using current database schema. This means that if we try to create new 
+migration before we run the pending ones, we still get the right schema diff.
+
+> Snapshots should be versioned just like the regular migration files.
+
+Snapshotting can be disabled via `migrations.snapshot: false` in the ORM config.
+
 ## Configuration
 
 ```typescript
@@ -63,6 +74,7 @@ await MikroORM.init({
     allOrNothing: true, // wrap all migrations in master transaction
     dropTables: true, // allow to disable table dropping
     safe: false, // allow to disable table and column dropping
+    snapshot: true, // save snapshot when creating new migrations
     emit: 'ts', // migration generation mode
   },
 })

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -66,6 +66,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
       allOrNothing: true,
       dropTables: true,
       safe: false,
+      snapshot: true,
       emit: 'ts',
       fileName: (timestamp: string) => `Migration${timestamp}`,
     },
@@ -310,6 +311,7 @@ export type MigrationsOptions = {
   allOrNothing?: boolean;
   dropTables?: boolean;
   safe?: boolean;
+  snapshot?: boolean;
   emit?: 'js' | 'ts';
   fileName?: (timestamp: string) => string;
   migrationsList?: MigrationObject[];

--- a/packages/knex/src/schema/DatabaseSchema.ts
+++ b/packages/knex/src/schema/DatabaseSchema.ts
@@ -1,4 +1,4 @@
-import { Configuration, EntityMetadata, EntityProperty, ReferenceType } from '@mikro-orm/core';
+import { Configuration, Dictionary, EntityMetadata, EntityProperty, ReferenceType } from '@mikro-orm/core';
 import { DatabaseTable } from './DatabaseTable';
 import { AbstractSqlConnection } from '../AbstractSqlConnection';
 import { Table } from '../typings';
@@ -15,9 +15,9 @@ export class DatabaseSchema {
   constructor(private readonly platform: AbstractSqlPlatform,
               readonly name: string) { }
 
-  addTable(name: string, schema: string | undefined | null, meta?: EntityMetadata): DatabaseTable {
+  addTable(name: string, schema: string | undefined | null): DatabaseTable {
     const namespaceName = schema ?? undefined;
-    const table = new DatabaseTable(this.platform, name, namespaceName, meta);
+    const table = new DatabaseTable(this.platform, name, namespaceName);
     this.tables.push(table);
 
     if (namespaceName != null && !table.isInDefaultNamespace(this.name) && !this.hasNamespace(namespaceName)) {
@@ -74,7 +74,7 @@ export class DatabaseSchema {
     const schema = new DatabaseSchema(platform, config.get('schema'));
 
     for (const meta of metadata) {
-      const table = schema.addTable(meta.collection, meta.schema ?? config.get('schema'), meta);
+      const table = schema.addTable(meta.collection, meta.schema ?? config.get('schema'));
       table.comment = meta.comment;
       meta.props
         .filter(prop => this.shouldHaveColumn(meta, prop))
@@ -104,6 +104,11 @@ export class DatabaseSchema {
     }
 
     return [ReferenceType.SCALAR, ReferenceType.MANY_TO_ONE].includes(prop.reference) || (prop.reference === ReferenceType.ONE_TO_ONE && prop.owner);
+  }
+
+  toJSON(): Dictionary {
+    const { platform, ...rest } = this;
+    return rest;
   }
 
 }

--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -1,4 +1,4 @@
-import { Cascade, DecimalType, Dictionary, EntityMetadata, EntityProperty, EntitySchema, NamingStrategy, ReferenceType, Utils } from '@mikro-orm/core';
+import { Cascade, DecimalType, Dictionary, EntityMetadata, EntityProperty, EntitySchema, NamingStrategy, ReferenceType, t, Utils } from '@mikro-orm/core';
 import { SchemaHelper } from './SchemaHelper';
 import { Column, ForeignKey, Index } from '../typings';
 import { AbstractSqlPlatform } from '../AbstractSqlPlatform';
@@ -15,8 +15,7 @@ export class DatabaseTable {
 
   constructor(private readonly platform: AbstractSqlPlatform,
               readonly name: string,
-              readonly schema?: string,
-              readonly meta?: EntityMetadata) { }
+              readonly schema?: string) { }
 
   getColumns(): Column[] {
     return Object.values(this.columns);
@@ -46,6 +45,10 @@ export class DatabaseTable {
 
       return o;
     }, {} as Dictionary<Column>);
+  }
+
+  addColumn(column: Column) {
+    this.columns[column.name] = column;
   }
 
   addColumnFromProperty(prop: EntityProperty, meta: EntityMetadata) {
@@ -321,6 +324,19 @@ export class DatabaseTable {
 
   isInDefaultNamespace(defaultNamespaceName: string) {
     return this.schema === defaultNamespaceName || this.schema == null;
+  }
+
+  toJSON(): Dictionary {
+    const { platform, columns, ...rest } = this;
+    const columnsMapped = Object.keys(columns).reduce((o, col) => {
+      const { mappedType, ...restCol } = columns[col];
+      o[col] = restCol;
+      o[col].mappedType = Object.keys(t).find(k => t[k] === mappedType.constructor);
+
+      return o;
+    }, {} as Dictionary);
+
+    return { columns: columnsMapped, ...rest };
   }
 
 }

--- a/packages/knex/src/schema/SchemaComparator.ts
+++ b/packages/knex/src/schema/SchemaComparator.ts
@@ -420,8 +420,8 @@ export class SchemaComparator {
   }
 
   hasSameDefaultValue(from: Column, to: Column): boolean {
-    if (from.default === null || from.default?.toString().toLowerCase() === 'null' || from.default?.toString().startsWith('nextval(')) {
-      return !Utils.isDefined(to.default, true) || to.default!.toLowerCase() === 'null';
+    if (from.default == null || from.default.toString().toLowerCase() === 'null' || from.default.toString().startsWith('nextval(')) {
+      return to.default == null || to.default!.toLowerCase() === 'null';
     }
 
     if (to.mappedType instanceof BooleanType) {

--- a/packages/knex/src/schema/SchemaGenerator.ts
+++ b/packages/knex/src/schema/SchemaGenerator.ts
@@ -97,17 +97,17 @@ export class SchemaGenerator {
     return this.wrapSchema(ret + '\n', { wrap });
   }
 
-  async updateSchema(options: { wrap?: boolean; safe?: boolean; dropTables?: boolean } = {}): Promise<void> {
+  async updateSchema(options: { wrap?: boolean; safe?: boolean; dropTables?: boolean; fromSchema?: DatabaseSchema } = {}): Promise<void> {
     const sql = await this.getUpdateSchemaSQL(options);
     await this.execute(sql);
   }
 
-  async getUpdateSchemaSQL(options: { wrap?: boolean; safe?: boolean; dropTables?: boolean } = {}): Promise<string> {
+  async getUpdateSchemaSQL(options: { wrap?: boolean; safe?: boolean; dropTables?: boolean; fromSchema?: DatabaseSchema } = {}): Promise<string> {
     const wrap = options.wrap ?? true;
     options.safe = options.safe ?? false;
     options.dropTables = options.dropTables ?? true;
     const toSchema = this.getTargetSchema();
-    const fromSchema = await DatabaseSchema.create(this.connection, this.platform, this.config);
+    const fromSchema = options.fromSchema ?? await DatabaseSchema.create(this.connection, this.platform, this.config);
     const comparator = new SchemaComparator(this.platform);
     const schemaDiff = comparator.compare(fromSchema, toSchema);
     let ret = '';

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -62,7 +62,7 @@ export async function initORMMySql<D extends MySqlDriver | MariaDbDriver = MySql
     entityRepository: SqlEntityRepository,
     type,
     replicas: [{ name: 'read-1' }, { name: 'read-2' }], // create two read replicas with same configuration, just for testing purposes
-    migrations: { path: BASE_DIR + '/../temp/migrations' },
+    migrations: { path: BASE_DIR + '/../temp/migrations', snapshot: false },
   }, additionalOptions));
 
   const schemaGenerator = new SchemaGenerator(orm.em);
@@ -100,7 +100,7 @@ export async function initORMPostgreSql(loadStrategy = LoadStrategy.SELECT_IN) {
     autoJoinOneToOneOwner: false,
     logger: i => i,
     cache: { enabled: true },
-    migrations: { path: BASE_DIR + '/../temp/migrations' },
+    migrations: { path: BASE_DIR + '/../temp/migrations', snapshot: false },
     loadStrategy,
   });
 

--- a/tests/features/migrations/__snapshots__/Migrator.postgres.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.postgres.test.ts.snap
@@ -459,6 +459,41 @@ export class Migration20191013214813 extends Migration {
 }
 `;
 
+exports[`Migrator (postgres) generate migration with snapshot: migration-snapshot-dump-1 1`] = `
+Object {
+  "code": "import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20191013214813 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql('alter table \\"book2\\" drop constraint if exists \\"book2_double_check\\";');
+    this.addSql('alter table \\"book2\\" alter column \\"double\\" type double precision using (\\"double\\"::double precision);');
+    this.addSql('alter table \\"book2\\" drop column \\"foo\\";');
+
+    this.addSql('alter table \\"test2\\" drop column \\"path\\";');
+  }
+
+}
+",
+  "diff": Array [
+    "alter table \\"book2\\" drop constraint if exists \\"book2_double_check\\";",
+    "alter table \\"book2\\" alter column \\"double\\" type double precision using (\\"double\\"::double precision);",
+    "alter table \\"book2\\" drop column \\"foo\\";",
+    "",
+    "alter table \\"test2\\" drop column \\"path\\";",
+  ],
+  "fileName": "Migration20191013214813.ts",
+}
+`;
+
+exports[`Migrator (postgres) generate migration with snapshot: migration-snapshot-dump-2 1`] = `
+Object {
+  "code": "",
+  "diff": Array [],
+  "fileName": "",
+}
+`;
+
 exports[`Migrator (postgres) generate schema migration: migration-dump 1`] = `
 Object {
   "code": "import { Migration } from '@mikro-orm/migrations';


### PR DESCRIPTION
Creating new migration will automatically save the target schema snapshot into
migrations folder. This snapshot will be then used if you try to create new migration,
instead of using current database schema. This means that if we try to create new
migration before we run the pending ones, we still get the right schema diff.

> Snapshots should be versioned just like the regular migration files.

Snapshotting can be disabled via `migrations.snapshot: false` in the ORM config.