### PR TITLE
docs: fix references loading with key name

### DIFF
--- a/docs/docs/entity-references.md
+++ b/docs/docs/entity-references.md
@@ -56,7 +56,7 @@ defining `load(): Promise<T>` method that will first lazy load the association i
 available. You can also use `unwrap(): T` method to access the underlying entity without loading
 it.
 
-You can also use `get<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
 for you, making sure the entity is initialized first, then returning the value of given property 
 directly. 
 

--- a/docs/docs/entity-references.md
+++ b/docs/docs/entity-references.md
@@ -56,9 +56,8 @@ defining `load(): Promise<T>` method that will first lazy load the association i
 available. You can also use `unwrap(): T` method to access the underlying entity without loading
 it.
 
-You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
-for you, making sure the entity is initialized first, then returning the value of given property 
-directly. 
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>`, which works like `load()`
+but returns the specified property.
 
 <Tabs
 groupId="entity-def"

--- a/docs/versioned_docs/version-3.6/entity-references.md
+++ b/docs/versioned_docs/version-3.6/entity-references.md
@@ -53,7 +53,7 @@ defining `load(): Promise<T>` method that will first lazy load the association i
 available. You can also use `unwrap(): T` method to access the underlying entity without loading
 it.
 
-You can also use `get<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
 for you, making sure the entity is initialized first, then returning the value of given property 
 directly. 
 

--- a/docs/versioned_docs/version-3.6/entity-references.md
+++ b/docs/versioned_docs/version-3.6/entity-references.md
@@ -53,9 +53,8 @@ defining `load(): Promise<T>` method that will first lazy load the association i
 available. You can also use `unwrap(): T` method to access the underlying entity without loading
 it.
 
-You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
-for you, making sure the entity is initialized first, then returning the value of given property 
-directly. 
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>`, which works like `load()`
+but returns the specified property.
 
 ```typescript
 import { Entity, IdentifiedReference, ManyToOne, PrimaryKey, Reference } from 'mikro-orm';

--- a/docs/versioned_docs/version-4.0/entity-references.md
+++ b/docs/versioned_docs/version-4.0/entity-references.md
@@ -53,9 +53,8 @@ defining `load(): Promise<T>` method that will first lazy load the association i
 available. You can also use `unwrap(): T` method to access the underlying entity without loading
 it.
 
-You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
-for you, making sure the entity is initialized first, then returning the value of given property 
-directly. 
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>`, which works like `load()`
+but returns the specified property.
 
 ```typescript
 import { Entity, IdentifiedReference, ManyToOne, PrimaryKey, Reference } from '@mikro-orm/core';

--- a/docs/versioned_docs/version-4.0/entity-references.md
+++ b/docs/versioned_docs/version-4.0/entity-references.md
@@ -53,7 +53,7 @@ defining `load(): Promise<T>` method that will first lazy load the association i
 available. You can also use `unwrap(): T` method to access the underlying entity without loading
 it.
 
-You can also use `get<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
 for you, making sure the entity is initialized first, then returning the value of given property 
 directly. 
 

--- a/docs/versioned_docs/version-4.1/entity-references.md
+++ b/docs/versioned_docs/version-4.1/entity-references.md
@@ -53,9 +53,8 @@ defining `load(): Promise<T>` method that will first lazy load the association i
 available. You can also use `unwrap(): T` method to access the underlying entity without loading
 it.
 
-You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
-for you, making sure the entity is initialized first, then returning the value of given property 
-directly. 
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>`, which works like `load()`
+but returns the specified property.
 
 ```typescript
 import { Entity, IdentifiedReference, ManyToOne, PrimaryKey, Reference } from '@mikro-orm/core';

--- a/docs/versioned_docs/version-4.1/entity-references.md
+++ b/docs/versioned_docs/version-4.1/entity-references.md
@@ -53,7 +53,7 @@ defining `load(): Promise<T>` method that will first lazy load the association i
 available. You can also use `unwrap(): T` method to access the underlying entity without loading
 it.
 
-You can also use `get<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
 for you, making sure the entity is initialized first, then returning the value of given property 
 directly. 
 

--- a/docs/versioned_docs/version-4.2/entity-references.md
+++ b/docs/versioned_docs/version-4.2/entity-references.md
@@ -53,9 +53,8 @@ defining `load(): Promise<T>` method that will first lazy load the association i
 available. You can also use `unwrap(): T` method to access the underlying entity without loading
 it.
 
-You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
-for you, making sure the entity is initialized first, then returning the value of given property 
-directly. 
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>`, which works like `load()`
+but returns the specified property.
 
 ```typescript
 import { Entity, IdentifiedReference, ManyToOne, PrimaryKey, Reference } from '@mikro-orm/core';

--- a/docs/versioned_docs/version-4.2/entity-references.md
+++ b/docs/versioned_docs/version-4.2/entity-references.md
@@ -53,7 +53,7 @@ defining `load(): Promise<T>` method that will first lazy load the association i
 available. You can also use `unwrap(): T` method to access the underlying entity without loading
 it.
 
-You can also use `get<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
 for you, making sure the entity is initialized first, then returning the value of given property 
 directly. 
 

--- a/docs/versioned_docs/version-4.3/entity-references.md
+++ b/docs/versioned_docs/version-4.3/entity-references.md
@@ -53,9 +53,8 @@ defining `load(): Promise<T>` method that will first lazy load the association i
 available. You can also use `unwrap(): T` method to access the underlying entity without loading
 it.
 
-You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
-for you, making sure the entity is initialized first, then returning the value of given property 
-directly. 
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>`, which works like `load()`
+but returns the specified property.
 
 ```typescript
 import { Entity, IdentifiedReference, ManyToOne, PrimaryKey, Reference } from '@mikro-orm/core';

--- a/docs/versioned_docs/version-4.3/entity-references.md
+++ b/docs/versioned_docs/version-4.3/entity-references.md
@@ -53,7 +53,7 @@ defining `load(): Promise<T>` method that will first lazy load the association i
 available. You can also use `unwrap(): T` method to access the underlying entity without loading
 it.
 
-You can also use `get<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
 for you, making sure the entity is initialized first, then returning the value of given property 
 directly. 
 

--- a/docs/versioned_docs/version-4.4/entity-references.md
+++ b/docs/versioned_docs/version-4.4/entity-references.md
@@ -56,9 +56,8 @@ defining `load(): Promise<T>` method that will first lazy load the association i
 available. You can also use `unwrap(): T` method to access the underlying entity without loading
 it.
 
-You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()`
-for you, making sure the entity is initialized first, then returning the value of given property
-directly.
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>`, which works like `load()`
+but returns the specified property.
 
 <Tabs
 groupId="entity-def"

--- a/docs/versioned_docs/version-4.4/entity-references.md
+++ b/docs/versioned_docs/version-4.4/entity-references.md
@@ -56,7 +56,7 @@ defining `load(): Promise<T>` method that will first lazy load the association i
 available. You can also use `unwrap(): T` method to access the underlying entity without loading
 it.
 
-You can also use `get<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()`
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()`
 for you, making sure the entity is initialized first, then returning the value of given property
 directly.
 

--- a/docs/versioned_docs/version-4.5/entity-references.md
+++ b/docs/versioned_docs/version-4.5/entity-references.md
@@ -56,7 +56,7 @@ defining `load(): Promise<T>` method that will first lazy load the association i
 available. You can also use `unwrap(): T` method to access the underlying entity without loading
 it.
 
-You can also use `get<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
 for you, making sure the entity is initialized first, then returning the value of given property 
 directly. 
 

--- a/docs/versioned_docs/version-4.5/entity-references.md
+++ b/docs/versioned_docs/version-4.5/entity-references.md
@@ -56,9 +56,8 @@ defining `load(): Promise<T>` method that will first lazy load the association i
 available. You can also use `unwrap(): T` method to access the underlying entity without loading
 it.
 
-You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>` helper, that will call `load()` 
-for you, making sure the entity is initialized first, then returning the value of given property 
-directly. 
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>`, which works like `load()`
+but returns the specified property.
 
 <Tabs
 groupId="entity-def"


### PR DESCRIPTION
The docs are wrong.