### PR TITLE
refactor(seeder): seed manager generate and seedString

### DIFF
--- a/packages/cli/src/commands/DatabaseSeedCommand.ts
+++ b/packages/cli/src/commands/DatabaseSeedCommand.ts
@@ -13,7 +13,6 @@ export class DatabaseSeedCommand<T> implements CommandModule<T, { class: string 
       alias: 'class',
       type: 'string',
       desc: 'Seeder class to run',
-      default: '',
     });
     return args as Argv<{ class: string }>;
   };

--- a/packages/seeder/src/seed-manager.ts
+++ b/packages/seeder/src/seed-manager.ts
@@ -24,9 +24,8 @@ export class SeedManager {
 
   async seedString(...seederClasses: string[]): Promise<void> {
     for (const seederClass of seederClasses) {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const seeder = require(`${process.cwd()}/${this.orm.config.get('seeder').path}/${this.getFileName(seederClass)}`);
-      await this.seed(seeder);
+      const seeder = await import(`${process.cwd()}/${this.orm.config.get('seeder').path}/${this.getFileName(seederClass)}`);
+      await this.seed(seeder[seederClass]);
     }
   }
 
@@ -51,12 +50,12 @@ export class SeedManager {
     await ensureDir(Utils.normalizePath(this.orm.config.get('seeder').path));
   }
 
-  private async generate(seeder: string): Promise<string> {
+  private async generate(seederClass: string): Promise<string> {
     const path = Utils.normalizePath(this.orm.config.get('seeder').path);
-    const fileName = this.getFileName(seeder);
+    const fileName = this.getFileName(seederClass);
     const ret = `import { EntityManager } from '@mikro-orm/core';
 import { Seeder } from '@mikro-orm/seeder';
-class DatabaseSeeder extends Seeder {
+export class ${seederClass} extends Seeder {
 
   run(em: EntityManager): Promise<void> {
   }

--- a/tests/database/seeder/author3.seeder.ts
+++ b/tests/database/seeder/author3.seeder.ts
@@ -1,0 +1,10 @@
+import { Seeder } from '@mikro-orm/seeder';
+import { EntityManager } from '@mikro-orm/core';
+
+export class Author3Seeder extends Seeder {
+
+  run(em: EntityManager): Promise<void> {
+    return Promise.resolve(undefined);
+  }
+
+}

--- a/tests/database/seeder/database.seeder.ts
+++ b/tests/database/seeder/database.seeder.ts
@@ -1,0 +1,15 @@
+import { Seeder } from '@mikro-orm/seeder';
+import { EntityManager } from '@mikro-orm/core';
+import { ProjectSeeder } from './project.seeder';
+import { UserSeeder } from './user.seeder';
+
+export class DatabaseSeeder extends Seeder {
+
+  run(em: EntityManager): Promise<void> {
+    return this.call(em, [
+      ProjectSeeder,
+      UserSeeder,
+    ]);
+  }
+
+}

--- a/tests/database/seeder/project.seeder.ts
+++ b/tests/database/seeder/project.seeder.ts
@@ -1,0 +1,17 @@
+import { Seeder } from '@mikro-orm/seeder';
+import { EntityManager } from '@mikro-orm/core';
+import { Project } from '../../features/seeder/entities/project.entity';
+
+export class ProjectSeeder extends Seeder {
+
+  async run(em: EntityManager): Promise<void> {
+    const project = em.create(Project, {
+      name: 'Construction',
+      owner: 'Donald Duck',
+      worth: 313,
+    });
+    await em.persistAndFlush(project);
+    em.clear();
+  }
+
+}

--- a/tests/database/seeder/user.seeder.ts
+++ b/tests/database/seeder/user.seeder.ts
@@ -1,0 +1,17 @@
+import { Seeder } from '@mikro-orm/seeder';
+import { EntityManager } from '@mikro-orm/core';
+import { User } from '../../features/seeder/entities/user.entity';
+
+export class UserSeeder extends Seeder {
+
+  async run(em: EntityManager): Promise<void> {
+    const user = em.create(User, {
+      name: 'Scrooge McDuck',
+      email: 'scrooge@money.dc',
+      password: 'MoneyIsForSwimming',
+    });
+    await em.persistAndFlush(user);
+    em.clear();
+  }
+
+}

--- a/tests/features/cli/DatabaseSeedCommand.test.ts
+++ b/tests/features/cli/DatabaseSeedCommand.test.ts
@@ -41,7 +41,6 @@ describe('DatabaseSeedCommand', () => {
       alias: 'class',
       type: 'string',
       desc: 'Seeder class to run',
-      default: '',
     });
     await expect(cmd.handler({} as any)).resolves.toBeUndefined();
     expect(seed).toBeCalledTimes(1);

--- a/tests/features/seeder/run-seeders.test.ts
+++ b/tests/features/seeder/run-seeders.test.ts
@@ -1,49 +1,9 @@
-import { EntityManager, MikroORM } from '@mikro-orm/core';
-import { Seeder } from '@mikro-orm/seeder';
+import { MikroORM } from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 import { House } from './entities/house.entity';
 import { Project } from './entities/project.entity';
 import { User } from './entities/user.entity';
-
-class ProjectSeeder extends Seeder {
-
-  async run(em: EntityManager): Promise<void> {
-    const project = em.create(Project, {
-      name: 'Construction',
-      owner: 'Donald Duck',
-      worth: 313,
-    });
-    await em.persistAndFlush(project);
-    em.clear();
-  }
-
-}
-
-class UserSeeder extends Seeder {
-
-  async run(em: EntityManager): Promise<void> {
-    const user = em.create(User, {
-      name: 'Scrooge McDuck',
-      email: 'scrooge@money.dc',
-      password: 'MoneyIsForSwimming',
-    });
-    await em.persistAndFlush(user);
-    em.clear();
-  }
-
-}
-
-class DatabaseSeeder extends Seeder {
-
-  run(em: EntityManager): Promise<void> {
-    return this.call(em, [
-      ProjectSeeder,
-      UserSeeder,
-    ]);
-  }
-
-}
-
+import { DatabaseSeeder } from '../../database/seeder/database.seeder';
 
 describe('Run seeders', () => {
 


### PR DESCRIPTION
Seeder manager now generates seed files with `export class` and the
correct seeder name (e.g. BookSeeder) instead of the default. Also when
seeding using string it executes the exported member of default instead
of the file.

Fixes #1843