### PR TITLE
refactor: fixes issue where create schema command triggers seeder by default

### DIFF
--- a/packages/cli/src/commands/SchemaCommandFactory.ts
+++ b/packages/cli/src/commands/SchemaCommandFactory.ts
@@ -53,7 +53,6 @@ export class SchemaCommandFactory {
       args.option('seed', {
         type: 'string',
         desc: 'Allows to seed the database on create or drop and recreate',
-        default: '',
       });
     }
 

--- a/tests/features/cli/CreateSchemaCommand.test.ts
+++ b/tests/features/cli/CreateSchemaCommand.test.ts
@@ -49,12 +49,14 @@ describe('CreateSchemaCommand', () => {
     expect(createSchema.mock.calls.length).toBe(0);
     expect(close.mock.calls.length).toBe(0);
     await expect(cmd.handler({ run: true } as any)).resolves.toBeUndefined();
+    expect(seed.mock.calls.length).toBe(0);
     expect(createSchema.mock.calls.length).toBe(1);
     expect(close.mock.calls.length).toBe(1);
 
     expect(getCreateSchemaSQL.mock.calls.length).toBe(0);
     await expect(cmd.handler({ dump: true } as any)).resolves.toBeUndefined();
     expect(getCreateSchemaSQL.mock.calls.length).toBe(1);
+    expect(seed.mock.calls.length).toBe(0);
     expect(close.mock.calls.length).toBe(2);
 
     expect(seed.mock.calls.length).toBe(0);


### PR DESCRIPTION
This is a follow up for #1843, as of `5.0.0-dev.159` `schema:create --run` still triggers default seeder without explicit `--seed` argument.