### PR TITLE
feat(core): rework deep assigning of entities and enable it by default

### DIFF
--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -87,7 +87,7 @@ export interface IWrappedEntity<T extends AnyEntity<T>, PK extends keyof T | unk
   toObject(ignoreFields?: string[]): EntityDTO<T>;
   toJSON(...args: any[]): EntityDTO<T>;
   toPOJO(): EntityDTO<T>;
-  assign(data: any, options?: AssignOptions | boolean): T;
+  assign(data: EntityData<T> | Partial<EntityDTO<T>>, options?: AssignOptions | boolean): T;
 }
 
 export interface IWrappedEntityInternal<T, PK extends keyof T | unknown = PrimaryProperty<T>, P = keyof T> extends IWrappedEntity<T, PK, P> {
@@ -136,7 +136,9 @@ export type EntityDataProp<T> = T extends Scalar
     ? EntityDataNested<U>
     : T extends Collection<infer U>
         ? U | U[] | EntityDataNested<U> | EntityDataNested<U>[]
-        : EntityDataNested<T>;
+        : T extends readonly (infer U)[]
+            ? U | U[] | EntityDataNested<U> | EntityDataNested<U>[]
+            : EntityDataNested<T>;
 
 export type EntityDataNested<T> = T extends undefined
   ? never

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { EntityManager, JavaScriptMetadataProvider, LoadStrategy, MikroORM, Options, Utils } from '@mikro-orm/core';
+import { EntityManager, JavaScriptMetadataProvider, LoadStrategy, Logger, LoggerNamespace, MikroORM, Options, Utils } from '@mikro-orm/core';
 import { AbstractSqlDriver, SchemaGenerator, SqlEntityManager, SqlEntityRepository } from '@mikro-orm/knex';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 import { MongoDriver } from '@mikro-orm/mongodb';
@@ -242,4 +242,12 @@ export async function wipeDatabaseSqlite2(em: SqlEntityManager) {
   await em.nativeDelete('publisher4_tests', {});
   await em.execute('pragma foreign_keys = on');
   em.clear();
+}
+
+export function mockLogger(orm: MikroORM, debugMode: LoggerNamespace[] = ['query', 'query-params']) {
+  const mock = jest.fn();
+  const logger = new Logger(mock, debugMode);
+  Object.assign(orm.config, { logger });
+
+  return mock;
 }

--- a/tests/features/embeddables/embedded-entities.postgres.test.ts
+++ b/tests/features/embeddables/embedded-entities.postgres.test.ts
@@ -298,7 +298,7 @@ describe('embedded entities in postgresql', () => {
     const user = new User();
     wrap(user).assign({
       address1: { street: 'Downing street 10', number: 3, postalCode: '123', city: 'London 1', country: 'UK 1' },
-      address2: { street: 'Downing street 11', number: 3, city: 'London 2', country: 'UK 2' },
+      address2: { street: 'Downing street 11', city: 'London 2', country: 'UK 2' },
       address3: { street: 'Downing street 12', number: 3, postalCode: '789', city: 'London 3', country: 'UK 3' },
       address4: { street: 'Downing street 10', number: 3, postalCode: '123', city: 'London 1', country: 'UK 1' },
     }, { em: orm.em });

--- a/tests/features/entity-assigner/EntityAssigner.mongo.test.ts
+++ b/tests/features/entity-assigner/EntityAssigner.mongo.test.ts
@@ -1,7 +1,7 @@
 import { assign, EntityData, expr, MikroORM, wrap } from '@mikro-orm/core';
 import { MongoDriver, ObjectId } from '@mikro-orm/mongodb';
-import { Author, Book, BookTag } from './entities';
-import { initORMMongo, wipeDatabase } from './bootstrap';
+import { Author, Book, BookTag } from '../../entities';
+import { initORMMongo, wipeDatabase } from '../../bootstrap';
 
 describe('EntityAssignerMongo', () => {
 
@@ -71,9 +71,9 @@ describe('EntityAssignerMongo', () => {
 
   test('#assign() should merge collection items', async () => {
     const jon = new Author('Jon Snow', 'snow@wall.st');
-    orm.em.assign(jon, { books: [{ _id: ObjectId.createFromTime(1), title: 'b1' }] }, { merge: false });
+    orm.em.assign(jon, { books: [{ _id: ObjectId.createFromTime(1), title: 'b1' }] }, { merge: false, updateNestedEntities: false });
     expect(wrap(jon.books[0], true).__em).toBeUndefined();
-    orm.em.assign(jon, { books: [{ _id: ObjectId.createFromTime(2), title: 'b2' }] }, { merge: true });
+    orm.em.assign(jon, { books: [{ _id: ObjectId.createFromTime(2), title: 'b2' }] }, { merge: true, updateNestedEntities: false });
     expect(wrap(jon.books[0], true).__em).not.toBeUndefined();
   });
 

--- a/tests/features/entity-assigner/EntityAssigner.mysql.test.ts
+++ b/tests/features/entity-assigner/EntityAssigner.mysql.test.ts
@@ -1,7 +1,7 @@
-import { EntityData, MikroORM, Reference, wrap } from '@mikro-orm/core';
+import { MikroORM, Reference, wrap } from '@mikro-orm/core';
 import { MySqlDriver } from '@mikro-orm/mysql';
-import { initORMMySql, wipeDatabaseMySql } from './bootstrap';
-import { Author2, Book2, BookTag2, FooBar2, Publisher2, PublisherType } from './entities-sql';
+import { initORMMySql, wipeDatabaseMySql } from '../../bootstrap';
+import { Author2, Book2, BookTag2, FooBar2, Publisher2, PublisherType } from '../../entities-sql';
 
 describe('EntityAssignerMySql', () => {
 
@@ -17,6 +17,7 @@ describe('EntityAssignerMySql', () => {
     await orm.em.persistAndFlush(book);
     expect(book.title).toBe('Book2');
     expect(book.author).toBe(jon);
+    // @ts-expect-error
     wrap(book).assign({ title: 'Better Book2 1', author: god, notExisting: true });
     expect(book.author).toBe(god);
     expect((book as any).notExisting).toBe(true);
@@ -30,22 +31,27 @@ describe('EntityAssignerMySql', () => {
 
   test('assign() should fix property types [mysql]', async () => {
     const god = new Author2('God', 'hello@heaven.god');
+    // @ts-expect-error
     wrap(god).assign({ createdAt: '2018-01-01', termsAccepted: 1 });
     expect(god.createdAt).toEqual(new Date('2018-01-01'));
     expect(god.termsAccepted).toBe(true);
 
     const d1 = +new Date('2018-01-01');
+    // @ts-expect-error
     wrap(god).assign({ createdAt: '' + d1, termsAccepted: 0 });
     expect(god.createdAt).toEqual(new Date('2018-01-01'));
     expect(god.termsAccepted).toBe(false);
 
+    // @ts-expect-error
     wrap(god).assign({ createdAt: d1, termsAccepted: 0 });
     expect(god.createdAt).toEqual(new Date('2018-01-01'));
 
     const d2 = +new Date('2018-01-01 00:00:00.123');
+    // @ts-expect-error
     wrap(god).assign({ createdAt: '' + d2 });
     expect(god.createdAt).toEqual(new Date('2018-01-01 00:00:00.123'));
 
+    // @ts-expect-error
     wrap(god).assign({ createdAt: d2 });
     expect(god.createdAt).toEqual(new Date('2018-01-01 00:00:00.123'));
   });
@@ -88,7 +94,7 @@ describe('EntityAssignerMySql', () => {
     expect(book1.author.email).toBeUndefined();
     expect(book1.author).not.toEqual(jon);
 
-    wrap(book2).assign({ author: { name: 'Jon Snow2' } }, { updateNestedEntities: true });
+    wrap(book2).assign({ author: { name: 'Jon Snow2' } }, { updateByPrimaryKey: false });
     expect(book2.author.name).toEqual('Jon Snow2');
     expect(book2.author.email).toEqual('snow3@wall.st');
     expect(book2.author).toEqual(jon2);
@@ -147,7 +153,7 @@ describe('EntityAssignerMySql', () => {
     const originalRef = book2.publisher!;
     expect(originalValue.name).toEqual('Good Books LLC');
 
-    wrap(book2).assign({ author: { name: 'Jon Snow2' }, publisher: { name: 'Better Books LLC' } }, { updateNestedEntities: true });
+    wrap(book2).assign({ author: { name: 'Jon Snow2' }, publisher: { name: 'Better Books LLC' } }, { updateByPrimaryKey: false });
 
     // this means that the original object has been replaced, something updateNestedEntities does not do
     expect(book2.publisher).toEqual(originalRef);

--- a/tests/features/entity-assigner/GH1811.test.ts
+++ b/tests/features/entity-assigner/GH1811.test.ts
@@ -1,0 +1,204 @@
+import { Collection, Entity, ManyToMany, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, t, wrap } from '@mikro-orm/core';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+import { v4 } from 'uuid';
+import { mockLogger } from '../../bootstrap';
+
+@Entity()
+export class Recipe {
+
+  @PrimaryKey({ type: t.uuid })
+  id: string = v4();
+
+  @Property()
+  name!: string;
+
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  @OneToMany({ entity: () => Ingredient, mappedBy: 'recipe', orphanRemoval: true })
+  ingredients = new Collection<Ingredient>(this);
+
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  @ManyToMany({ entity: () => User })
+  authors = new Collection<User>(this);
+
+}
+
+@Entity()
+export class Ingredient {
+
+  @PrimaryKey({ type: t.uuid })
+  id: string = v4();
+
+  @ManyToOne({ entity: () => Recipe })
+  recipe!: Recipe;
+
+  @Property()
+  name!: string;
+
+}
+
+@Entity()
+export class User {
+
+  @PrimaryKey({ type: t.uuid })
+  id: string = v4();
+
+  @Property()
+  name!: string;
+
+}
+
+describe('GH issue 1811', () => {
+
+  let orm: MikroORM<SqliteDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Ingredient, Recipe, User],
+      dbName: ':memory:',
+      type: 'sqlite',
+    });
+    await orm.getSchemaGenerator().createSchema();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    await orm.em.createQueryBuilder(Ingredient).truncate().execute();
+    await orm.em.createQueryBuilder(User).truncate().execute();
+    await orm.em.createQueryBuilder(Recipe).truncate().execute();
+    orm.em.clear();
+  });
+
+  async function createRecipe() {
+    const recipe = orm.em.create(Recipe, {
+      id: '3ea3e69c-c221-41b1-a14e-135ef3141ea3',
+      name: 'Salad',
+      ingredients: [
+        { id: '16e443a7-b527-493f-ab8a-63012514b719', name: 'Spinach' },
+        { id: '1d4876ce-01de-4ba8-9d17-3c1c0d56fe73', name: 'Carrot' },
+      ],
+      authors: [
+        { id: '22222222-0000-493f-ab8a-03012514b719', name: 'Alice' },
+        { id: '33333333-0000-4ba8-9d17-1c1c0d56fe73', name: 'Bob' },
+      ],
+    });
+    await orm.em.persistAndFlush(recipe);
+    orm.em.clear();
+
+    return recipe;
+  }
+
+  test('assigning to 1:m with nested entities', async () => {
+    const r = await createRecipe();
+    const recipe = await orm.em.findOneOrFail(Recipe, r, ['ingredients']);
+
+    wrap(recipe).assign({
+      ingredients: [
+        { id: '16e443a7-b527-493f-ab8a-63012514b719', name: 'Spinach' }, // existing
+        { name: 'Onion' }, // new, should be created
+        // carrot should be dropped, id: '1d4876ce-01de-4ba8-9d17-3c1c0d56fe73',
+      ],
+    });
+    expect(recipe.ingredients.toArray()).toEqual([
+      { id: '16e443a7-b527-493f-ab8a-63012514b719', name: 'Spinach', recipe: recipe.id },
+      { id: expect.stringMatching(/[\w-]{36}/), name: 'Onion', recipe: recipe.id },
+    ]);
+
+    const mock = mockLogger(orm, ['query']);
+    await orm.em.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch('insert into `ingredient` (`id`, `name`, `recipe_id`) values (?, ?, ?)');
+    expect(mock.mock.calls[2][0]).toMatch('delete from `ingredient` where `id` in (?)');
+    expect(mock.mock.calls[3][0]).toMatch('commit');
+
+    const r1 = await orm.em.fork().findOneOrFail(Recipe, recipe, { populate: ['ingredients'] });
+    expect(r1.ingredients.toArray()).toEqual([
+      { id: '16e443a7-b527-493f-ab8a-63012514b719', name: 'Spinach', recipe: recipe.id },
+      { id: expect.stringMatching(/[\w-]{36}/), name: 'Onion', recipe: recipe.id },
+    ]);
+  });
+
+  test('assigning to m:1 with nested entities', async () => {
+    const r = await createRecipe();
+    const recipe = await orm.em.findOneOrFail(Recipe, r, ['ingredients']);
+    const onion = wrap(recipe.ingredients[1]).assign({
+      name: 'Onion',
+      recipe: { name: 'Scrambled eggs' }, // should create new recipe entity
+    });
+    const mock = mockLogger(orm, ['query']);
+    await orm.em.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch('insert into `recipe` (`id`, `name`) values (?, ?)');
+    expect(mock.mock.calls[2][0]).toMatch('update `ingredient` set `recipe_id` = ?, `name` = ? where `id` = ?');
+    expect(mock.mock.calls[3][0]).toMatch('commit');
+
+    const r2 = await orm.em.fork().find(Recipe, {}, { populate: ['ingredients'] });
+    expect(r2.map(r => r.name)).toEqual(['Salad', 'Scrambled eggs']);
+    expect(r2[0].ingredients.toArray()).toEqual([
+      { id: '16e443a7-b527-493f-ab8a-63012514b719', name: 'Spinach', recipe: recipe.id },
+    ]);
+    expect(r2[1].ingredients.toArray()).toEqual([
+      { id: onion.id, name: 'Onion', recipe: r2[1].id },
+    ]);
+
+    wrap(onion).assign({
+      name: 'Spring Onion',
+      recipe: { id: onion.recipe.id, name: 'Poached eggs' }, // should update existing recipe entity
+    });
+
+    mock.mock.calls.length = 0;
+    await orm.em.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch('update `recipe` set `name` = ? where `id` = ?');
+    expect(mock.mock.calls[2][0]).toMatch('update `ingredient` set `name` = ? where `id` = ?');
+    expect(mock.mock.calls[3][0]).toMatch('commit');
+
+    const r3 = await orm.em.fork().find(Recipe, {}, { populate: ['ingredients'] });
+    expect(r3.map(r => r.name)).toEqual(['Salad', 'Poached eggs']);
+    expect(r3[0].ingredients.toArray()).toEqual([
+      { id: '16e443a7-b527-493f-ab8a-63012514b719', name: 'Spinach', recipe: recipe.id },
+    ]);
+    expect(r3[1].ingredients.toArray()).toEqual([
+      { id: onion.id, name: 'Spring Onion', recipe: r3[1].id },
+    ]);
+  });
+
+  test('assigning to m:m with nested entities', async () => {
+    const r = await createRecipe();
+    const recipe = await orm.em.findOneOrFail(Recipe, r, ['authors']);
+
+    wrap(recipe).assign({
+      authors: [
+        { id: '22222222-0000-493f-ab8a-03012514b719', name: 'Malice' }, // existing
+        { name: 'Tom' }, // new, should be created
+        // Bob should be dropped
+      ],
+    });
+    expect(recipe.authors.toArray()).toEqual([
+      { id: '22222222-0000-493f-ab8a-03012514b719', name: 'Malice' },
+      { id: expect.stringMatching(/[\w-]{36}/), name: 'Tom' },
+    ]);
+
+    const mock = mockLogger(orm, ['query']);
+    await orm.em.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch('insert into `user` (`id`, `name`) values (?, ?)');
+    expect(mock.mock.calls[2][0]).toMatch('update `user` set `name` = ? where `id` = ?');
+    expect(mock.mock.calls[3][0]).toMatch('delete from `recipe_authors` where (`user_id`) in ( values (?)) and `recipe_id` = ?');
+    expect(mock.mock.calls[4][0]).toMatch('insert into `recipe_authors` (`recipe_id`, `user_id`) values (?, ?)');
+    expect(mock.mock.calls[5][0]).toMatch('commit');
+
+    const r1 = await orm.em.fork().findOneOrFail(Recipe, recipe, { populate: ['authors'], orderBy: { authors: { name: 'asc' } } });
+    expect(r1.authors.toArray()).toEqual([
+      { id: '22222222-0000-493f-ab8a-03012514b719', name: 'Malice' },
+      { id: expect.stringMatching(/[\w-]{36}/), name: 'Tom' },
+    ]);
+  });
+
+});


### PR DESCRIPTION
BREAKING CHANGE:
Deep assigning of child entities now works by default based on the presence of PKs in the payload.
This behaviour can be disable via `updateByPrimaryKey: false` in the `assign` options.

Closes #1811