### PR TITLE
docs: update request context docs

### DIFF
--- a/docs/docs/usage-with-nestjs.md
+++ b/docs/docs/usage-with-nestjs.md
@@ -222,6 +222,8 @@ We can use the `@UseRequestContext()` decorator. It requires you to first inject
 for you. Under the hood, the decorator will register new request context for your 
 method and execute it inside the context. 
 
+Keep in mind, that all handlers that are decorated with @UseRequestContext(), should return void.
+
 ```ts
 @Injectable()
 export class MyService {
@@ -235,6 +237,32 @@ export class MyService {
 
 }
 ```
+
+Another thing to look out is how you combine them with other decorators.
+
+For example if you use it in combination with NestJS's "[BullJS queues module](https://docs.nestjs.com/techniques/queues)", a safe bet is to extract the part of the code that needs a clean [docs](identity-map.md),
+either in a new method or inject a separate service.
+
+```ts
+@Processor({
+  name: 'example-queue',
+})
+export class MyConsumber {
+  constructor(private readonly orm: MikroORM) { }
+
+  @Process()
+  async doSomething(job: Job<any>) {
+    await this.doSomethingWithMikro();
+  }
+
+  @UseRequestContext()
+  async doSomethingWithMikro() {
+    // this will be executed in a separate context
+  }
+}
+```
+
+As in this case, the `@Process()` decorator expects to receive a executable function, but if we wrap add `@UseRequestContext()` as well, if `@UseRequestContext()` is executed before `@Process()`, the later will receive `void`.
 
 ## Request scoping when using GraphQL
 

--- a/docs/docs/usage-with-nestjs.md
+++ b/docs/docs/usage-with-nestjs.md
@@ -262,7 +262,7 @@ export class MyConsumber {
 }
 ```
 
-As in this case, the `@Process()` decorator expects to receive a executable function, but if we wrap add `@UseRequestContext()` as well, if `@UseRequestContext()` is executed before `@Process()`, the later will receive `void`.
+As in this case, the `@Process()` decorator expects to receive an executable function, but if we add `@UseRequestContext()` to the handler as well, if `@UseRequestContext()` is executed before `@Process()`, the later will receive `void`.
 
 ## Request scoping when using GraphQL
 

--- a/docs/docs/usage-with-nestjs.md
+++ b/docs/docs/usage-with-nestjs.md
@@ -222,7 +222,7 @@ We can use the `@UseRequestContext()` decorator. It requires you to first inject
 for you. Under the hood, the decorator will register new request context for your 
 method and execute it inside the context. 
 
-Keep in mind, that all handlers that are decorated with @UseRequestContext(), should return void.
+Keep in mind, that all handlers that are decorated with @UseRequestContext(), should NOT return anything.
 
 ```ts
 @Injectable()
@@ -238,8 +238,7 @@ export class MyService {
 }
 ```
 
-Another thing to look out is how you combine them with other decorators.
-
+Another thing to look out for how you combine them with other decorators.
 For example if you use it in combination with NestJS's "[BullJS queues module](https://docs.nestjs.com/techniques/queues)", a safe bet is to extract the part of the code that needs a clean [docs](identity-map.md),
 either in a new method or inject a separate service.
 
@@ -247,7 +246,7 @@ either in a new method or inject a separate service.
 @Processor({
   name: 'example-queue',
 })
-export class MyConsumber {
+export class MyConsumer {
   constructor(private readonly orm: MikroORM) { }
 
   @Process()

--- a/docs/versioned_docs/version-4.5/usage-with-nestjs.md
+++ b/docs/versioned_docs/version-4.5/usage-with-nestjs.md
@@ -265,6 +265,32 @@ And at the same time disabling the bodyparser in the GraphQL Module
 })
 ```
 
+Another thing to look out is how you combine them with other decorators.
+
+For example if you use it in combination with NestJS's "[BullJS queues module](https://docs.nestjs.com/techniques/queues)", a safe bet is to extract the part of the code that needs a clean [docs](identity-map.md),
+either in a new method or inject a separate service.
+
+```ts
+@Processor({
+  name: 'example-queue',
+})
+export class MyConsumber {
+  constructor(private readonly orm: MikroORM) { }
+
+  @Process()
+  async doSomething(job: Job<any>) {
+    await this.doSomethingWithMikro();
+  }
+
+  @UseRequestContext()
+  async doSomethingWithMikro() {
+    // this will be executed in a separate context
+  }
+}
+```
+
+As in this case, the `@Process()` decorator expects to receive a executable function, but if we wrap add `@UseRequestContext()` as well, if `@UseRequestContext()` is executed before `@Process()`, the later will receive `void`.
+
 ## Using `AsyncLocalStorage` for request context
 
 By default, the `domain` api is used in the `RequestContext` helper. Since `@mikro-orm/core@4.0.3`,

--- a/docs/versioned_docs/version-4.5/usage-with-nestjs.md
+++ b/docs/versioned_docs/version-4.5/usage-with-nestjs.md
@@ -222,6 +222,8 @@ We can use the `@UseRequestContext()` decorator. It requires you to first inject
 for you. Under the hood, the decorator will register new request context for your 
 method and execute it inside the context. 
 
+Keep in mind, that all handlers that are decorated with @UseRequestContext(), should return void.
+
 ```ts
 @Injectable()
 export class MyService {

--- a/docs/versioned_docs/version-4.5/usage-with-nestjs.md
+++ b/docs/versioned_docs/version-4.5/usage-with-nestjs.md
@@ -238,6 +238,33 @@ export class MyService {
 }
 ```
 
+Another thing to look out is how you combine them with other decorators.
+
+For example if you use it in combination with NestJS's "[BullJS queues module](https://docs.nestjs.com/techniques/queues)", a safe bet is to extract the part of the code that needs a clean [docs](identity-map.md),
+either in a new method or inject a separate service.
+
+```ts
+@Processor({
+  name: 'example-queue',
+})
+export class MyConsumber {
+  constructor(private readonly orm: MikroORM) { }
+
+  @Process()
+  async doSomething(job: Job<any>) {
+    await this.doSomethingWithMikro();
+  }
+
+  @UseRequestContext()
+  async doSomethingWithMikro() {
+    // this will be executed in a separate context
+  }
+}
+```
+
+As in this case, the `@Process()` decorator expects to receive an executable function, but if we add `@UseRequestContext()` to the handler as well, if `@UseRequestContext()` is executed before `@Process()`, the later will receive `void`.
+
+
 ## Request scoping when using GraphQL
 
 The GraphQL module in NestJS uses `apollo-server-express` which enables `bodyparser` by default. ([source](https://github.com/mikro-orm/mikro-orm/issues/696#issuecomment-669846919)) As mentioned in "[RequestContext helper for DI containers](https://mikro-orm.io/docs/identity-map/#requestcontext-helper-for-di-containers)" this causes issues as the Middleware the NestJS MikroORM module installs needs to be loaded after `bodyparser`. 
@@ -266,32 +293,6 @@ And at the same time disabling the bodyparser in the GraphQL Module
   ],
 })
 ```
-
-Another thing to look out is how you combine them with other decorators.
-
-For example if you use it in combination with NestJS's "[BullJS queues module](https://docs.nestjs.com/techniques/queues)", a safe bet is to extract the part of the code that needs a clean [docs](identity-map.md),
-either in a new method or inject a separate service.
-
-```ts
-@Processor({
-  name: 'example-queue',
-})
-export class MyConsumber {
-  constructor(private readonly orm: MikroORM) { }
-
-  @Process()
-  async doSomething(job: Job<any>) {
-    await this.doSomethingWithMikro();
-  }
-
-  @UseRequestContext()
-  async doSomethingWithMikro() {
-    // this will be executed in a separate context
-  }
-}
-```
-
-As in this case, the `@Process()` decorator expects to receive a executable function, but if we wrap add `@UseRequestContext()` as well, if `@UseRequestContext()` is executed before `@Process()`, the later will receive `void`.
 
 ## Using `AsyncLocalStorage` for request context
 

--- a/docs/versioned_docs/version-4.5/usage-with-nestjs.md
+++ b/docs/versioned_docs/version-4.5/usage-with-nestjs.md
@@ -222,7 +222,7 @@ We can use the `@UseRequestContext()` decorator. It requires you to first inject
 for you. Under the hood, the decorator will register new request context for your 
 method and execute it inside the context. 
 
-Keep in mind, that all handlers that are decorated with @UseRequestContext(), should return void.
+Keep in mind, that all handlers that are decorated with @UseRequestContext(), should NOT return anything.
 
 ```ts
 @Injectable()
@@ -238,8 +238,7 @@ export class MyService {
 }
 ```
 
-Another thing to look out is how you combine them with other decorators.
-
+Another thing to look out for how you combine them with other decorators.
 For example if you use it in combination with NestJS's "[BullJS queues module](https://docs.nestjs.com/techniques/queues)", a safe bet is to extract the part of the code that needs a clean [docs](identity-map.md),
 either in a new method or inject a separate service.
 
@@ -247,7 +246,7 @@ either in a new method or inject a separate service.
 @Processor({
   name: 'example-queue',
 })
-export class MyConsumber {
+export class MyConsumer {
   constructor(private readonly orm: MikroORM) { }
 
   @Process()


### PR DESCRIPTION
Add more information on working with @UseRequestContext in NestJS in combination with other decorators.

There is an issue when the `UseRequestContext` is used with other decorators, in this case, the `Processor` decorator used by @nest-js/bull, where based on the order of execution, the consumers stop working. 