### PR TITLE
docs: improvements for body parser & request context for nest

### DIFF
--- a/docs/docs/usage-with-nestjs.md
+++ b/docs/docs/usage-with-nestjs.md
@@ -238,16 +238,16 @@ export class MyService {
 
 ## Request scoping when using GraphQL
 
- The GraphQL module in NestJS uses `apollo-server-express` which enables `bodyparser` by default. ([source](https://github.com/mikro-orm/mikro-orm/issues/696#issuecomment-669846919)) As mentioned in "[RequestContext helper for DI containers](https://mikro-orm.io/docs/identity-map/#requestcontext-helper-for-di-containers)" this causes issues as the Middleware the NestJS MikroORM module installs needs to be loaded after `bodyparser`. 
+The GraphQL module in NestJS uses `apollo-server-express` which enables `bodyparser` by default. ([source](https://github.com/mikro-orm/mikro-orm/issues/696#issuecomment-669846919)) As mentioned in "[RequestContext helper for DI containers](https://mikro-orm.io/docs/identity-map/#requestcontext-helper-for-di-containers)" this causes issues as the Middleware the NestJS MikroORM module installs needs to be loaded after `bodyparser`. At the same time make sure to disable body-parser in NestJs itself as well.
 
  This can be done by adding bodyparser to your main.ts file
 
  ```ts
  import { NestFactory } from '@nestjs/core';
- import bodyParser from 'body-parser';
+ import express from 'express';
  async function bootstrap() {
-   const app = await NestFactory.create(LaunchpadModule);
-   app.use(bodyParser.json());
+   const app = await NestFactory.create(AppModule,{ bodyParser: false });
+   app.use(express.json());
    await app.listen(5555);
  }
  ```

--- a/docs/versioned_docs/version-4.5/usage-with-nestjs.md
+++ b/docs/versioned_docs/version-4.5/usage-with-nestjs.md
@@ -238,17 +238,17 @@ export class MyService {
 
 ## Request scoping when using GraphQL
 
-The GraphQL module in NestJS uses `apollo-server-express` which enables `bodyparser` by default. ([source](https://github.com/mikro-orm/mikro-orm/issues/696#issuecomment-669846919)) As mentioned in "[RequestContext helper for DI containers](https://mikro-orm.io/docs/identity-map/#requestcontext-helper-for-di-containers)" this causes issues as the Middleware the NestJS MikroORM module installs needs to be loaded after `bodyparser`. 
+The GraphQL module in NestJS uses `apollo-server-express` which enables `bodyparser` by default. ([source](https://github.com/mikro-orm/mikro-orm/issues/696#issuecomment-669846919)) As mentioned in "[RequestContext helper for DI containers](https://mikro-orm.io/docs/identity-map/#requestcontext-helper-for-di-containers)" this causes issues as the Middleware the NestJS MikroORM module installs needs to be loaded after `bodyparser`. At the same time make sure to disable body-parser in NestJs itself as well.
 
 This can be done by adding bodyparser to your main.ts file
 
 ```ts
 import { NestFactory } from '@nestjs/core';
-import bodyParser from 'body-parser';
+import express from 'express';
 
 async function bootstrap() {
-  const app = await NestFactory.create(LaunchpadModule);
-  app.use(bodyParser.json());
+  const app = await NestFactory.create(AppModule,{ bodyParser: false });
+  app.use(express.json());
   await app.listen(5555);
 }
 ```


### PR DESCRIPTION
- bodyParser is deprecated, you need to use it via express or have an annoying deprecated warning
- forgot to disable bodyparser in nest itself 
- switched our internal module name for a more generic one