### PR TITLE
Fix: Read replicas connection settings replaced by master settings (continuation)

### DIFF
--- a/packages/core/src/connections/Connection.ts
+++ b/packages/core/src/connections/Connection.ts
@@ -64,11 +64,11 @@ export abstract class Connection {
   getConnectionOptions(): ConnectionConfig {
     const ret: ConnectionConfig = {};
     const url = new URL(this.options!.clientUrl || this.config.getClientUrl());
-    this.options!.host = ret.host = (this.options!.host || this.config.get('host', url.hostname));
-    this.options!.port = ret.port = (this.options!.port || this.config.get('port', +url.port));
-    this.options!.user = ret.user = (this.options!.user || this.config.get('user', url.username));
-    this.options!.password = ret.password = (this.options!.password || this.config.get('password', url.password));
-    this.options!.dbName = ret.database = (this.options!.dbName || this.config.get('dbName', url.pathname.replace(/^\//, '')));
+    this.options!.host = ret.host = (this.options!.host ?? this.config.get('host', url.hostname));
+    this.options!.port = ret.port = (this.options!.port ?? this.config.get('port', +url.port));
+    this.options!.user = ret.user = (this.options!.user ?? this.config.get('user', url.username));
+    this.options!.password = ret.password = (this.options!.password ?? this.config.get('password', url.password));
+    this.options!.dbName = ret.database = (this.options!.dbName ?? this.config.get('dbName', url.pathname.replace(/^\//, '')));
 
     return ret;
   }

--- a/packages/core/src/connections/Connection.ts
+++ b/packages/core/src/connections/Connection.ts
@@ -64,11 +64,11 @@ export abstract class Connection {
   getConnectionOptions(): ConnectionConfig {
     const ret: ConnectionConfig = {};
     const url = new URL(this.options!.clientUrl || this.config.getClientUrl());
-    this.options!.host = ret.host = this.config.get('host', url.hostname);
-    this.options!.port = ret.port = this.config.get('port', +url.port);
-    this.options!.user = ret.user = this.config.get('user', url.username);
-    this.options!.password = ret.password = this.config.get('password', url.password);
-    this.options!.dbName = ret.database = this.config.get('dbName', url.pathname.replace(/^\//, ''));
+    this.options!.host = ret.host = (this.options!.host || this.config.get('host', url.hostname));
+    this.options!.port = ret.port = (this.options!.port || this.config.get('port', +url.port));
+    this.options!.user = ret.user = (this.options!.user || this.config.get('user', url.username));
+    this.options!.password = ret.password = (this.options!.password || this.config.get('password', url.password));
+    this.options!.dbName = ret.database = (this.options!.dbName || this.config.get('dbName', url.pathname.replace(/^\//, '')));
 
     return ret;
   }

--- a/tests/EntityManager.mariadb.test.ts
+++ b/tests/EntityManager.mariadb.test.ts
@@ -43,6 +43,33 @@ describe('EntityManagerMariaDb', () => {
     });
   });
 
+  test('getConnection() with replicas', async () => {
+    const config = new Configuration({
+      type: 'mysql',
+      clientUrl: 'mysql://root@127.0.0.1:3308/db_name',
+      host: '127.0.0.10',
+      password: 'secret',
+      user: 'user',
+      logger: jest.fn(),
+      forceUtcTimezone: true,
+      replicas: [
+        { name: 'read-1', host: 'read_host_1', user: 'read_user' },
+      ],
+    } as any, false);
+    const driver = new MariaDbDriver(config);
+    expect(driver.getConnection('read').getConnectionOptions()).toEqual({
+      database: 'db_name',
+      host: 'read_host_1',
+      password: 'secret',
+      port: 3308,
+      user: 'read_user',
+      timezone: 'Z',
+      supportBigNumbers: true,
+      bigNumberStrings: true,
+      dateStrings: ['DATE'],
+    });
+  });
+
   test('should return mariadb driver', async () => {
     const driver = orm.em.getDriver();
     expect(driver).toBeInstanceOf(MariaDbDriver);

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -62,6 +62,32 @@ describe('EntityManagerMySql', () => {
     });
   });
 
+  test('getConnection() with replicas', async () => {
+    const config = new Configuration({
+      type: 'mysql',
+      clientUrl: 'mysql://root@127.0.0.1:3308/db_name',
+      host: '127.0.0.10',
+      password: 'secret',
+      user: 'user',
+      logger: jest.fn(),
+      forceUtcTimezone: true,
+      replicas: [
+        { name: 'read-1', host: 'read_host_1', user: 'read_user' },
+      ],
+    } as any, false);
+    const driver = new MySqlDriver(config);
+    expect(driver.getConnection('read').getConnectionOptions()).toEqual({
+      database: 'db_name',
+      host: 'read_host_1',
+      password: 'secret',
+      port: 3308,
+      user: 'read_user',
+      timezone: 'Z',
+      dateStrings: ['DATE'],
+      supportBigNumbers: true,
+    });
+  });
+
   test('raw query with array param', async () => {
     const q1 = await orm.em.getPlatform().formatQuery(`select * from author2 where id in (?) limit ?`, [[1, 2, 3], 3]);
     expect(q1).toBe('select * from author2 where id in (1, 2, 3) limit 3');

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -65,6 +65,29 @@ describe('EntityManagerPostgre', () => {
     });
   });
 
+  test('getConnection() with replicas', async () => {
+    const config = new Configuration({
+      type: 'postgresql',
+      clientUrl: 'postgre://root@127.0.0.1:1234/db_name',
+      host: '127.0.0.10',
+      password: 'secret',
+      user: 'user',
+      logger: jest.fn(),
+      forceUtcTimezone: true,
+      replicas: [
+        { name: 'read-1', host: 'read_host_1', user: 'read_user' },
+      ],
+    } as any, false);
+    const driver = new PostgreSqlDriver(config);
+    expect(driver.getConnection('read').getConnectionOptions()).toEqual({
+      database: 'db_name',
+      host: 'read_host_1',
+      password: 'secret',
+      port: 1234,
+      user: 'read_user',
+    });
+  });
+
   test('raw query with array param', async () => {
     const q1 = await orm.em.getPlatform().formatQuery(`select * from author2 where id in (?) limit ?`, [[1, 2, 3], 3]);
     expect(q1).toBe('select * from author2 where id in (1, 2, 3) limit 3');


### PR DESCRIPTION
Based on the [previous pull request](https://github.com/mikro-orm/mikro-orm/pull/1964) for fixing #1963

This PR adds the unit test to check if MikroORM is initialized with replicas, when getting the connection with the params of `read`, it should return the configuration with the replicas db configuration.
