### PR TITLE
feat: support multitenancy insert/update/delete on native & from uow with flush options

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -658,8 +658,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * Persists your entity immediately, flushing all not yet persisted changes to the database too.
    * Equivalent to `em.persist(e).flush()`.
    */
-  async persistAndFlush(entity: AnyEntity | Reference<AnyEntity> | (AnyEntity | Reference<AnyEntity>)[]): Promise<void> {
-    await this.persist(entity).flush();
+  async persistAndFlush(entity: AnyEntity | Reference<AnyEntity> | (AnyEntity | Reference<AnyEntity>)[], options?: FlushOptions): Promise<void> {
+    await this.persist(entity).flush(options);
   }
 
   /**
@@ -696,8 +696,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * Removes an entity instance immediately, flushing all not yet persisted changes to the database too.
    * Equivalent to `em.remove(e).flush()`
    */
-  async removeAndFlush(entity: AnyEntity | Reference<AnyEntity>): Promise<void> {
-    await this.remove(entity).flush();
+  async removeAndFlush(entity: AnyEntity | Reference<AnyEntity>, options?: FlushOptions): Promise<void> {
+    await this.remove(entity).flush(options);
   }
 
   /**
@@ -715,7 +715,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * This effectively synchronizes the in-memory state of managed objects with the database.
    */
   async flush(options?: FlushOptions): Promise<void> {
-    await this.getUnitOfWork().commit();
+    await this.getUnitOfWork().commit(options);
   }
 
   /**

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -1,4 +1,4 @@
-import { CountOptions, EntityManagerType, FindOneOptions, FindOptions, IDatabaseDriver } from './IDatabaseDriver';
+import { CountOptions, EntityManagerType, FindOneOptions, FindOptions, IDatabaseDriver, InsertOptions } from './IDatabaseDriver';
 import { AnyEntity, Dictionary, EntityData, EntityDictionary, EntityMetadata, EntityProperty, FilterQuery, PopulateOptions, Primary } from '../typings';
 import { MetadataStorage } from '../metadata';
 import { Connection, QueryResult, Transaction } from '../connections';
@@ -9,6 +9,7 @@ import { Collection } from '../entity';
 import { EntityManager } from '../EntityManager';
 import { ValidationError } from '../errors';
 import { DriverException } from '../exceptions';
+import { DeleteOptions, UpdateOptions } from '.';
 
 export abstract class DatabaseDriver<C extends Connection> implements IDatabaseDriver<C> {
 
@@ -28,17 +29,17 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
 
   abstract findOne<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T>, ctx?: Transaction): Promise<EntityData<T> | null>;
 
-  abstract nativeInsert<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>, ctx?: Transaction, convertCustomTypes?: boolean): Promise<QueryResult>;
+  abstract nativeInsert<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>, ctx?: Transaction, convertCustomTypes?: boolean, options?: InsertOptions<T>): Promise<QueryResult>;
 
-  abstract nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>[], ctx?: Transaction, processCollections?: boolean, convertCustomTypes?: boolean): Promise<QueryResult>;
+  abstract nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>[], ctx?: Transaction, processCollections?: boolean, convertCustomTypes?: boolean, options?: InsertOptions<T>): Promise<QueryResult>;
 
-  abstract nativeUpdate<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, data: EntityDictionary<T>, ctx?: Transaction, convertCustomTypes?: boolean): Promise<QueryResult>;
+  abstract nativeUpdate<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, data: EntityDictionary<T>, ctx?: Transaction, convertCustomTypes?: boolean, options?: UpdateOptions<T>): Promise<QueryResult>;
 
-  async nativeUpdateMany<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>[], data: EntityDictionary<T>[], ctx?: Transaction, processCollections?: boolean, convertCustomTypes?: boolean): Promise<QueryResult> {
+  async nativeUpdateMany<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>[], data: EntityDictionary<T>[], ctx?: Transaction, processCollections?: boolean, convertCustomTypes?: boolean, options?: UpdateOptions<T>): Promise<QueryResult> {
     throw new Error(`Batch updates are not supported by ${this.constructor.name} driver`);
   }
 
-  abstract nativeDelete<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, ctx?: Transaction): Promise<QueryResult>;
+  abstract nativeDelete<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, ctx?: Transaction, options?: DeleteOptions<T>): Promise<QueryResult>;
 
   abstract count<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, options?: CountOptions<T>, ctx?: Transaction): Promise<number>;
 

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -33,15 +33,15 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
    */
   findOne<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T>, ctx?: Transaction): Promise<EntityData<T> | null>;
 
-  nativeInsert<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>, ctx?: Transaction, convertCustomTypes?: boolean): Promise<QueryResult>;
+  nativeInsert<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>, ctx?: Transaction, convertCustomTypes?: boolean, options?: InsertOptions<T>): Promise<QueryResult>;
 
-  nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>[], ctx?: Transaction, processCollections?: boolean, convertCustomTypes?: boolean): Promise<QueryResult>;
+  nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>[], ctx?: Transaction, processCollections?: boolean, convertCustomTypes?: boolean, options?: InsertOptions<T>): Promise<QueryResult>;
 
-  nativeUpdate<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, data: EntityDictionary<T>, ctx?: Transaction, convertCustomTypes?: boolean): Promise<QueryResult>;
+  nativeUpdate<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, data: EntityDictionary<T>, ctx?: Transaction, convertCustomTypes?: boolean, options?: UpdateOptions<T>): Promise<QueryResult>;
 
-  nativeUpdateMany<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>[], data: EntityDictionary<T>[], ctx?: Transaction, processCollections?: boolean, convertCustomTypes?: boolean): Promise<QueryResult>;
+  nativeUpdateMany<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>[], data: EntityDictionary<T>[], ctx?: Transaction, processCollections?: boolean, convertCustomTypes?: boolean, options?: UpdateOptions<T>): Promise<QueryResult>;
 
-  nativeDelete<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, ctx?: Transaction): Promise<QueryResult>;
+  nativeDelete<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, ctx?: Transaction, options?: DeleteOptions<T>): Promise<QueryResult>;
 
   syncCollection<T, O>(collection: Collection<T, O>, ctx?: Transaction): Promise<void>;
 
@@ -119,10 +119,16 @@ export interface CountOptions<T>  {
   populate?: Populate<T>;
 }
 
+export interface InsertOptions<T> {
+  schema?: string;
+}
+
 export interface UpdateOptions<T>  {
   filters?: Dictionary<boolean | Dictionary> | string[] | boolean;
+  schema?: string;
 }
 
 export interface DeleteOptions<T>  {
   filters?: Dictionary<boolean | Dictionary> | string[] | boolean;
+  schema?: string;
 }

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -1,7 +1,7 @@
 import { EntityManager } from '../EntityManager';
 import { EntityData, EntityName, AnyEntity, Primary, Populate, Loaded, New, FilterQuery, EntityDictionary } from '../typings';
 import { QueryOrderMap } from '../enums';
-import { CountOptions, DeleteOptions, FindOneOptions, FindOneOrFailOptions, FindOptions, UpdateOptions } from '../drivers/IDatabaseDriver';
+import { CountOptions, DeleteOptions, FindOneOptions, FindOneOrFailOptions, FindOptions, InsertOptions, UpdateOptions } from '../drivers/IDatabaseDriver';
 import { IdentifiedReference, Reference } from './Reference';
 import { EntityLoaderOptions } from './EntityLoader';
 
@@ -171,8 +171,8 @@ export class EntityRepository<T extends AnyEntity<T>> {
   /**
    * Fires native insert query. Calling this has no side effects on the context (identity map).
    */
-  async nativeInsert(data: EntityData<T>): Promise<Primary<T>> {
-    return this.em.nativeInsert<T>(this.entityName, data);
+  async nativeInsert(data: EntityData<T>, options?: InsertOptions<T>): Promise<Primary<T>> {
+    return this.em.nativeInsert<T>(this.entityName, data, options);
   }
 
   /**

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -314,7 +314,9 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
   }
 
   withSchema(schema?: string): this {
-    this._schema = schema;
+    if (schema) {
+      this._schema = schema;
+    }
 
     return this;
   }

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -8,6 +8,7 @@ import { PostgreSqlDriver, PostgreSqlConnection } from '@mikro-orm/postgresql';
 import { Address2, Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, PublisherType, PublisherType2, Test2, Label2 } from './entities-sql';
 import { initORMPostgreSql, wipeDatabasePostgreSql } from './bootstrap';
 import { performance } from 'perf_hooks';
+import { Team2 } from './entities-sql/Team2';
 
 describe('EntityManagerPostgre', () => {
 
@@ -1275,9 +1276,16 @@ describe('EntityManagerPostgre', () => {
 
     const mock = jest.fn();
     const logger = new Logger(mock, ['query', 'query-params']);
+
     Object.assign(orm.config, { logger });
     await orm.em.nativeInsert(Author2, { name: 'native name 1', email: 'native1@email.com' });
     expect(mock.mock.calls[0][0]).toMatch('insert into "author2" ("email", "name") values (\'native1@email.com\', \'native name 1\') returning "id", "created_at", "updated_at"');
+
+    const res6 = await orm.em.nativeInsert(Team2, { name: 'native name 3' }, { schema: 'test123' });
+    expect(res6).toBe(1);
+
+    // expect(mock.mock.calls[1][0]).toMatch('insert into "test123"."team2" ("name") values (\'native name 3\') returning "id"');
+
     orm.config.set('debug', ['query']);
   });
 

--- a/tests/EntityRepository.test.ts
+++ b/tests/EntityRepository.test.ts
@@ -75,7 +75,7 @@ describe('EntityRepository', () => {
     expect(methods.populate.mock.calls[0]).toEqual([[], 'bar', undefined]);
 
     await repo.nativeInsert({ name: 'bar' });
-    expect(methods.nativeInsert.mock.calls[0]).toEqual([Publisher, { name: 'bar' }]);
+    expect(methods.nativeInsert.mock.calls[0]).toEqual([Publisher, { name: 'bar' }, undefined]);
     await repo.nativeUpdate({ name: 'bar' }, { name: 'baz' });
     expect(methods.nativeUpdate.mock.calls[0]).toEqual([Publisher, { name: 'bar' }, { name: 'baz' }, undefined]);
     await repo.nativeDelete({ name: 'bar' });

--- a/tests/EntityRepository.test.ts
+++ b/tests/EntityRepository.test.ts
@@ -82,6 +82,13 @@ describe('EntityRepository', () => {
     expect(methods.nativeDelete.mock.calls[0]).toEqual([Publisher, { name: 'bar' }, undefined]);
     await repoMongo.aggregate([{ name: 'bar' }]);
     expect(methods.aggregate.mock.calls[0]).toEqual([Publisher, [{ name: 'bar' }]]);
+
+    await repo.nativeInsert({ name: 'bar' }, { schema: 'test123' });
+    expect(methods.nativeInsert.mock.calls[1]).toEqual([Publisher, { name: 'bar' }, { schema: 'test123' }]);
+    await repo.nativeUpdate({ name: 'bar' }, { name: 'baz' }, { schema: 'test123' });
+    expect(methods.nativeUpdate.mock.calls[1]).toEqual([Publisher, { name: 'bar' }, { name: 'baz' }, { schema: 'test123' }]);
+    await repo.nativeDelete({ name: 'bar' }, { schema: 'test123' });
+    expect(methods.nativeDelete.mock.calls[1]).toEqual([Publisher, { name: 'bar' }, { schema: 'test123' }]);
   });
 
   test('find() supports calling with config object', async () => {

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -1268,6 +1268,11 @@ describe('QueryBuilder', () => {
     expect(qb1.getParams()).toEqual(['test 1', PublisherType.GLOBAL, 'test 2', PublisherType.LOCAL, 'test 3', PublisherType.GLOBAL]);
   });
 
+  test('insert with schema', async () => {
+    const sql = orm.em.createQueryBuilder(Publisher2).insert({ name: 'test 123', type: PublisherType.GLOBAL }).withSchema('test123').getQuery();
+    expect(sql).toEqual('insert into `test123`.`publisher2` (`name`, `type`) values (?, ?)');
+  });
+
   test('update query', async () => {
     const qb = orm.em.createQueryBuilder(Publisher2);
     qb.update({ name: 'test 123', type: PublisherType.GLOBAL }).where({ id: 123, type: PublisherType.LOCAL });

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -19,6 +19,7 @@ import { Author2Subscriber } from './subscribers/Author2Subscriber';
 import { Test2Subscriber } from './subscribers/Test2Subscriber';
 import { EverythingSubscriber } from './subscribers/EverythingSubscriber';
 import { FlushSubscriber } from './subscribers/FlushSubscriber';
+import { Team2 } from './entities-sql/Team2';
 
 const { BaseEntity4, Author3, Book3, BookTag3, Publisher3, Test3 } = require('./entities-js/index');
 
@@ -93,7 +94,7 @@ export async function initORMMySql<D extends MySqlDriver | MariaDbDriver = MySql
 
 export async function initORMPostgreSql(loadStrategy = LoadStrategy.SELECT_IN) {
   const orm = await MikroORM.init<PostgreSqlDriver>({
-    entities: [Author2, Address2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, FooParam2, Label2, Configuration2],
+    entities: [Author2, Address2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, FooParam2, Label2, Configuration2, Team2],
     dbName: `mikro_orm_test`,
     baseDir: BASE_DIR,
     type: 'postgresql',

--- a/tests/entities-sql/Team2.ts
+++ b/tests/entities-sql/Team2.ts
@@ -1,0 +1,15 @@
+import { Entity, Property } from '@mikro-orm/core';
+import { BaseEntity2 } from './BaseEntity2';
+
+@Entity({ tableName: `test123.team` })
+export class Team2 extends BaseEntity2 {
+
+  @Property()
+  name: string;
+
+  constructor(name: string) {
+    super();
+    this.name = name;
+  }
+
+}

--- a/tests/postgre-schema.sql
+++ b/tests/postgre-schema.sql
@@ -5,8 +5,8 @@ drop table if exists "author2_following" cascade;
 drop table if exists "author_to_friend" cascade;
 drop table if exists "book_to_tag_unordered" cascade;
 drop table if exists "book2_tags" cascade;
-drop table if exists "test2_bars" cascade;
 drop table if exists "publisher2_tests" cascade;
+drop table if exists "test2_bars" cascade;
 drop table if exists "configuration2" cascade;
 drop table if exists "test2" cascade;
 drop table if exists "book2" cascade;
@@ -18,7 +18,12 @@ drop table if exists "foo_param2" cascade;
 drop table if exists "foo_bar2" cascade;
 drop table if exists "foo_baz2" cascade;
 drop table if exists "label2" cascade;
-drop table if exists "team" cascade;
+drop table if exists "new_table" cascade;
+drop table if exists "test123"."team" cascade;
+
+drop table if exists "author2_to_author2" cascade;
+drop table if exists "book2_to_book_tag2" cascade;
+drop table if exists "publisher2_to_test2" cascade;
 
 create schema if not exists "test123";
 
@@ -29,21 +34,18 @@ alter table "label2" add constraint "label2_pkey" primary key ("uuid");
 
 create table "foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
 
-create table "foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int null, "foo_bar_id" int null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "array" text[] null, "object_property" jsonb null);
+create table "foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int4 null, "foo_bar_id" int4 null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "array" text[] null, "object_property" jsonb null);
 alter table "foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");
 alter table "foo_bar2" add constraint "foo_bar2_foo_bar_id_unique" unique ("foo_bar_id");
 
-create table "foo_param2" ("bar_id" int not null, "baz_id" int not null, "value" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
+create table "foo_param2" ("bar_id" int4 not null, "baz_id" int4 not null, "value" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
 alter table "foo_param2" add constraint "foo_param2_pkey" primary key ("bar_id", "baz_id");
 
-create table "publisher2" ("id" serial primary key, "name" varchar(255) not null, "type" text check ("type" in ('local', 'global')) not null, "type2" text check ("type2" in ('LOCAL', 'GLOBAL')) not null, "enum1" smallint null, "enum2" smallint null, "enum3" smallint null, "enum4" text check ("enum4" in ('a', 'b', 'c')) null, "enum5" text check ("enum5" in ('a')) null);
+create table "publisher2" ("id" serial primary key, "name" varchar(255) not null, "type" text check ("type" in ('local', 'global')) not null, "type2" text check ("type2" in ('LOCAL', 'GLOBAL')) not null, "enum1" int2 null, "enum2" int2 null, "enum3" int2 null, "enum4" text check ("enum4" in ('a', 'b', 'c')) null, "enum5" text check ("enum5" in ('a')) null);
 
 create table "book_tag2" ("id" bigserial primary key, "name" varchar(50) not null);
 
-create table "author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), 
-"updated_at" timestamptz(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not 
-null, "age" int null default null, "terms_accepted" boolean not null default false, "optional" boolean null, "identities" 
-text[] null, "born" date null, "born_time" time(0) null, "favourite_book_uuid_pk" uuid null, "favourite_author_id" int null);
+create table "author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), "updated_at" timestamp(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int4 null default null, "terms_accepted" bool not null default false, "optional" bool null, "identities" text[] null, "born" date null, "born_time" time(0) null, "favourite_book_uuid_pk" uuid null, "favourite_author_id" int4 null);
 create index "custom_email_index_name" on "author2" ("email");
 alter table "author2" add constraint "custom_email_unique_name" unique ("email");
 create index "author2_terms_accepted_index" on "author2" ("terms_accepted");
@@ -53,23 +55,23 @@ create index "custom_idx_name_123" on "author2" ("name");
 create index "author2_name_age_index" on "author2" ("name", "age");
 alter table "author2" add constraint "author2_name_email_unique" unique ("name", "email");
 
-create table "address2" ("author_id" int not null, "value" varchar(255) not null);
+create table "address2" ("author_id" int4 not null, "value" varchar(255) not null);
 comment on table "address2" is 'This is address table';
 comment on column "address2"."value" is 'This is address property';
 alter table "address2" add constraint "address2_pkey" primary key ("author_id");
 
-create table "book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "title" varchar(255) null default '', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null);
+create table "book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "title" varchar(255) null default '', "perex" text null, "price" numeric(8, 2) null, "double" numeric null, "meta" jsonb null, "author_id" int4 not null, "publisher_id" int4 null, "foo" varchar(255) null default 'lol');
 alter table "book2" add constraint "book2_pkey" primary key ("uuid_pk");
 
-create table "test2" ("id" serial primary key, "name" varchar(255) null, "book_uuid_pk" uuid null, "parent_id" int null, "version" int not null default 1);
+create table "test2" ("id" serial primary key, "name" varchar(255) null, "book_uuid_pk" uuid null, "parent_id" int4 null, "version" int4 not null default 1, "path" polygon null);
 alter table "test2" add constraint "test2_book_uuid_pk_unique" unique ("book_uuid_pk");
 
-create table "configuration2" ("property" varchar(255) not null, "test_id" int not null, "value" varchar(255) not null);
+create table "configuration2" ("property" varchar(255) not null, "test_id" int4 not null, "value" varchar(255) not null);
 alter table "configuration2" add constraint "configuration2_pkey" primary key ("property", "test_id");
 
-create table "publisher2_tests" ("id" serial primary key, "publisher2_id" int not null, "test2_id" int not null);
+create table "publisher2_tests" ("id" serial primary key, "publisher2_id" int4 not null, "test2_id" int4 not null);
 
-create table "test2_bars" ("test2_id" int not null, "foo_bar2_id" int not null);
+create table "test2_bars" ("test2_id" int4 not null, "foo_bar2_id" int4 not null);
 alter table "test2_bars" add constraint "test2_bars_pkey" primary key ("test2_id", "foo_bar2_id");
 
 create table "book2_tags" ("order" serial primary key, "book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null);
@@ -77,10 +79,10 @@ create table "book2_tags" ("order" serial primary key, "book2_uuid_pk" uuid not 
 create table "book_to_tag_unordered" ("book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null);
 alter table "book_to_tag_unordered" add constraint "book_to_tag_unordered_pkey" primary key ("book2_uuid_pk", "book_tag2_id");
 
-create table "author_to_friend" ("author2_1_id" int not null, "author2_2_id" int not null);
+create table "author_to_friend" ("author2_1_id" int4 not null, "author2_2_id" int4 not null);
 alter table "author_to_friend" add constraint "author_to_friend_pkey" primary key ("author2_1_id", "author2_2_id");
 
-create table "author2_following" ("author2_1_id" int not null, "author2_2_id" int not null);
+create table "author2_following" ("author2_1_id" int4 not null, "author2_2_id" int4 not null);
 alter table "author2_following" add constraint "author2_following_pkey" primary key ("author2_1_id", "author2_2_id");
 
 alter table "foo_bar2" add constraint "foo_bar2_baz_id_foreign" foreign key ("baz_id") references "foo_baz2" ("id") on update cascade on delete set null;

--- a/tests/postgre-schema.sql
+++ b/tests/postgre-schema.sql
@@ -5,8 +5,8 @@ drop table if exists "author2_following" cascade;
 drop table if exists "author_to_friend" cascade;
 drop table if exists "book_to_tag_unordered" cascade;
 drop table if exists "book2_tags" cascade;
-drop table if exists "publisher2_tests" cascade;
 drop table if exists "test2_bars" cascade;
+drop table if exists "publisher2_tests" cascade;
 drop table if exists "configuration2" cascade;
 drop table if exists "test2" cascade;
 drop table if exists "book2" cascade;
@@ -18,29 +18,32 @@ drop table if exists "foo_param2" cascade;
 drop table if exists "foo_bar2" cascade;
 drop table if exists "foo_baz2" cascade;
 drop table if exists "label2" cascade;
-drop table if exists "new_table" cascade;
+drop table if exists "team" cascade;
 
-drop table if exists "author2_to_author2" cascade;
-drop table if exists "book2_to_book_tag2" cascade;
-drop table if exists "publisher2_to_test2" cascade;
+create schema if not exists "test123";
+
+create table "test123"."team" ("id" serial primary key, "name" varchar(255) not null);
 
 create table "label2" ("uuid" uuid not null, "name" varchar(255) not null);
 alter table "label2" add constraint "label2_pkey" primary key ("uuid");
 
 create table "foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
 
-create table "foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int4 null, "foo_bar_id" int4 null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "array" text[] null, "object_property" jsonb null);
+create table "foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int null, "foo_bar_id" int null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "array" text[] null, "object_property" jsonb null);
 alter table "foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");
 alter table "foo_bar2" add constraint "foo_bar2_foo_bar_id_unique" unique ("foo_bar_id");
 
-create table "foo_param2" ("bar_id" int4 not null, "baz_id" int4 not null, "value" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
+create table "foo_param2" ("bar_id" int not null, "baz_id" int not null, "value" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
 alter table "foo_param2" add constraint "foo_param2_pkey" primary key ("bar_id", "baz_id");
 
-create table "publisher2" ("id" serial primary key, "name" varchar(255) not null, "type" text check ("type" in ('local', 'global')) not null, "type2" text check ("type2" in ('LOCAL', 'GLOBAL')) not null, "enum1" int2 null, "enum2" int2 null, "enum3" int2 null, "enum4" text check ("enum4" in ('a', 'b', 'c')) null, "enum5" text check ("enum5" in ('a')) null);
+create table "publisher2" ("id" serial primary key, "name" varchar(255) not null, "type" text check ("type" in ('local', 'global')) not null, "type2" text check ("type2" in ('LOCAL', 'GLOBAL')) not null, "enum1" smallint null, "enum2" smallint null, "enum3" smallint null, "enum4" text check ("enum4" in ('a', 'b', 'c')) null, "enum5" text check ("enum5" in ('a')) null);
 
 create table "book_tag2" ("id" bigserial primary key, "name" varchar(50) not null);
 
-create table "author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), "updated_at" timestamp(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int4 null default null, "terms_accepted" bool not null default false, "optional" bool null, "identities" text[] null, "born" date null, "born_time" time(0) null, "favourite_book_uuid_pk" uuid null, "favourite_author_id" int4 null);
+create table "author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), 
+"updated_at" timestamptz(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not 
+null, "age" int null default null, "terms_accepted" boolean not null default false, "optional" boolean null, "identities" 
+text[] null, "born" date null, "born_time" time(0) null, "favourite_book_uuid_pk" uuid null, "favourite_author_id" int null);
 create index "custom_email_index_name" on "author2" ("email");
 alter table "author2" add constraint "custom_email_unique_name" unique ("email");
 create index "author2_terms_accepted_index" on "author2" ("terms_accepted");
@@ -50,23 +53,23 @@ create index "custom_idx_name_123" on "author2" ("name");
 create index "author2_name_age_index" on "author2" ("name", "age");
 alter table "author2" add constraint "author2_name_email_unique" unique ("name", "email");
 
-create table "address2" ("author_id" int4 not null, "value" varchar(255) not null);
+create table "address2" ("author_id" int not null, "value" varchar(255) not null);
 comment on table "address2" is 'This is address table';
 comment on column "address2"."value" is 'This is address property';
 alter table "address2" add constraint "address2_pkey" primary key ("author_id");
 
-create table "book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "title" varchar(255) null default '', "perex" text null, "price" numeric(8, 2) null, "double" numeric null, "meta" jsonb null, "author_id" int4 not null, "publisher_id" int4 null, "foo" varchar(255) null default 'lol');
+create table "book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "title" varchar(255) null default '', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null);
 alter table "book2" add constraint "book2_pkey" primary key ("uuid_pk");
 
-create table "test2" ("id" serial primary key, "name" varchar(255) null, "book_uuid_pk" uuid null, "parent_id" int4 null, "version" int4 not null default 1, "path" polygon null);
+create table "test2" ("id" serial primary key, "name" varchar(255) null, "book_uuid_pk" uuid null, "parent_id" int null, "version" int not null default 1);
 alter table "test2" add constraint "test2_book_uuid_pk_unique" unique ("book_uuid_pk");
 
-create table "configuration2" ("property" varchar(255) not null, "test_id" int4 not null, "value" varchar(255) not null);
+create table "configuration2" ("property" varchar(255) not null, "test_id" int not null, "value" varchar(255) not null);
 alter table "configuration2" add constraint "configuration2_pkey" primary key ("property", "test_id");
 
-create table "publisher2_tests" ("id" serial primary key, "publisher2_id" int4 not null, "test2_id" int4 not null);
+create table "publisher2_tests" ("id" serial primary key, "publisher2_id" int not null, "test2_id" int not null);
 
-create table "test2_bars" ("test2_id" int4 not null, "foo_bar2_id" int4 not null);
+create table "test2_bars" ("test2_id" int not null, "foo_bar2_id" int not null);
 alter table "test2_bars" add constraint "test2_bars_pkey" primary key ("test2_id", "foo_bar2_id");
 
 create table "book2_tags" ("order" serial primary key, "book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null);
@@ -74,10 +77,10 @@ create table "book2_tags" ("order" serial primary key, "book2_uuid_pk" uuid not 
 create table "book_to_tag_unordered" ("book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null);
 alter table "book_to_tag_unordered" add constraint "book_to_tag_unordered_pkey" primary key ("book2_uuid_pk", "book_tag2_id");
 
-create table "author_to_friend" ("author2_1_id" int4 not null, "author2_2_id" int4 not null);
+create table "author_to_friend" ("author2_1_id" int not null, "author2_2_id" int not null);
 alter table "author_to_friend" add constraint "author_to_friend_pkey" primary key ("author2_1_id", "author2_2_id");
 
-create table "author2_following" ("author2_1_id" int4 not null, "author2_2_id" int4 not null);
+create table "author2_following" ("author2_1_id" int not null, "author2_2_id" int not null);
 alter table "author2_following" add constraint "author2_following_pkey" primary key ("author2_1_id", "author2_2_id");
 
 alter table "foo_bar2" add constraint "foo_bar2_baz_id_foreign" foreign key ("baz_id") references "foo_baz2" ("id") on update cascade on delete set null;


### PR DESCRIPTION
Hello,

as discussed here #2074 I propose you a very basic PR for the moment (I'm really struggling with the tests on migrations in particular). I also know that other people have worked on PRs or that there are topics on multitenancy (I tried to read the whole thing before deciding to write an issue and a PR).

The idea behind what I did is to be able to specify at the time of a `nativeInsert/nativeUpdate` or via the EM on a `flush`, the schema on which the modifications will apply. This avoids having several open connections or several instances of mikro-orm. This allows, in the context of a multi-tenancy API, to be able to specify upstream or at the last moment on which schema the modifications will be applied. I tried to respect the logic of `FindOptions`.

With this PR, a single Mikro-ORM instance, we would be able to search in several schemas. I saw that anothers PRs #1001 #1424 were proposed, especially on the migration part which I didn't deal with at all, should I integrate it here?

I think there are some shortcomings in what I did, because I don't master Mikro-ORM at all, and I could see the huge work you did on this lib :clap:

Don't validate this PR, but could you help me and guide me on what I could do to reach a level where multitenancy would be a feature of Mikro-ORM? Sorry for the very raw nature of my questions and my way of doing things... but I need to move forward on these topics on my side. In any case, thank you very much for your time and energy on reading this PR and for your work on this lib.

Xavier (Uminily).