### PR TITLE
refactor: make seed option optional

### DIFF
--- a/packages/cli/src/commands/MigrationCommandFactory.ts
+++ b/packages/cli/src/commands/MigrationCommandFactory.ts
@@ -112,7 +112,6 @@ export class MigrationCommandFactory {
     args.option('seed', {
       type: 'string',
       desc: 'Allows to seed the database after dropping it and rerunning all migrations',
-      default: '',
     });
   }
 


### PR DESCRIPTION
Seed option when executing migration:fresh defaulted to empty string
and so it always tried to seed after migrating.