### PR TITLE
fix(reflection): relative paths not stripped completely

### DIFF
--- a/packages/reflection/src/TsMorphMetadataProvider.ts
+++ b/packages/reflection/src/TsMorphMetadataProvider.ts
@@ -139,7 +139,7 @@ export class TsMorphMetadataProvider extends MetadataProvider {
       await this.initSourceFiles();
     }
 
-    const source = this.sources.find(s => s.getFilePath().endsWith(tsPath.replace(/^\./, '')));
+    const source = this.sources.find(s => s.getFilePath().endsWith(tsPath.replace(/^\.+/, '')));
 
     if (!source && validate) {
       throw new MetadataError(`Source file '${tsPath}' not found. Check your 'entitiesTs' option and verify you have 'compilerOptions.declaration' enabled in your 'tsconfig.json'. If you are using webpack, see https://bit.ly/35pPDNn`);


### PR DESCRIPTION
The intention seems to be to strip leading `.` to get to the significant
part of the path. Previously only a single `.` was stripped, now all of
them are stripped.

Fixes #2163
