### PR TITLE
feat(core): allow passing arrays in `orderBy` parameter

### DIFF
--- a/docs/docs/upgrading-v4-to-v5.md
+++ b/docs/docs/upgrading-v4-to-v5.md
@@ -40,13 +40,28 @@ This also applies to the methods on `IDatabaseDriver` interface.
 
 ## Type-safe populate parameter with dot notation
 
-`FindOptions.populate` parameter is now strictly typed and supports only array of strings or a boolean.
+`FindOptions.populate` parameter is now strictly typed and supports only array of 
+strings or a boolean.
 Object way is no longer supported. To set loading strategy, use `FindOptions.strategy`.
 The return type of all such methods now returns properly typed `Loaded` response. 
 
 ## Type-safe fields parameter
 
 `FindOptions.fields` parameter is now strictly typed also for the dot notation.
+
+## Type-safe orderBy parameter
+
+`FindOptions.orderBy` parameter is now strictly typed. It also allows passing an 
+array of objects instead of just a single object.
+
+```ts
+const books = await em.find(Book, {}, {
+  orderBy: [
+    { title: 1 },
+    { author: { name: -1 } },
+  ],
+});
+```
 
 ## Removed `@Repository()` decorator
 

--- a/packages/core/src/decorators/ManyToMany.ts
+++ b/packages/core/src/decorators/ManyToMany.ts
@@ -2,7 +2,7 @@ import type { ReferenceOptions } from './Property';
 import { MetadataStorage, MetadataValidator } from '../metadata';
 import { Utils } from '../utils';
 import type { EntityName, EntityProperty, AnyEntity } from '../typings';
-import type { QueryOrder } from '../enums';
+import type { QueryOrderMap } from '../enums';
 import { ReferenceType } from '../enums';
 
 export function ManyToMany<T, O>(
@@ -25,7 +25,7 @@ export interface ManyToManyOptions<T, O> extends ReferenceOptions<T, O> {
   owner?: boolean;
   inversedBy?: (string & keyof T) | ((e: T) => any);
   mappedBy?: (string & keyof T) | ((e: T) => any);
-  orderBy?: { [field: string]: QueryOrder };
+  orderBy?: QueryOrderMap<T> | QueryOrderMap<T>[];
   fixedOrder?: boolean;
   fixedOrderColumn?: string;
   pivotTable?: string;

--- a/packages/core/src/decorators/OneToMany.ts
+++ b/packages/core/src/decorators/OneToMany.ts
@@ -1,7 +1,7 @@
 import type { ReferenceOptions } from './Property';
 import { MetadataStorage, MetadataValidator } from '../metadata';
 import { Utils } from '../utils';
-import type { QueryOrder } from '../enums';
+import type { QueryOrderMap } from '../enums';
 import { ReferenceType } from '../enums';
 import type { EntityName, EntityProperty, AnyEntity } from '../typings';
 
@@ -41,7 +41,7 @@ export function OneToMany<T, O>(
 export type OneToManyOptions<T, O> = ReferenceOptions<T, O> & {
   entity?: string | (() => EntityName<T>);
   orphanRemoval?: boolean;
-  orderBy?: { [field: string]: QueryOrder };
+  orderBy?: QueryOrderMap<T> | QueryOrderMap<T>[];
   joinColumn?: string;
   joinColumns?: string[];
   inverseJoinColumn?: string;

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -53,7 +53,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     throw new Error(`Aggregations are not supported by ${this.constructor.name} driver`);
   }
 
-  async loadFromPivotTable<T, O>(prop: EntityProperty, owners: Primary<O>[][], where?: FilterQuery<T>, orderBy?: QueryOrderMap, ctx?: Transaction, options?: FindOptions<T>): Promise<Dictionary<T[]>> {
+  async loadFromPivotTable<T, O>(prop: EntityProperty, owners: Primary<O>[][], where?: FilterQuery<T>, orderBy?: QueryOrderMap<T>[], ctx?: Transaction, options?: FindOptions<T>): Promise<Dictionary<T[]>> {
     throw new Error(`${this.constructor.name} does not use pivot tables`);
   }
 
@@ -189,20 +189,20 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     });
   }
 
-  protected getPivotOrderBy(prop: EntityProperty, orderBy?: QueryOrderMap): QueryOrderMap {
-    if (orderBy) {
-      return orderBy;
+  protected getPivotOrderBy<T>(prop: EntityProperty<T>, orderBy?: QueryOrderMap<T>[]): QueryOrderMap<T>[] {
+    if (!Utils.isEmpty(orderBy)) {
+      return orderBy!;
     }
 
-    if (prop.orderBy) {
-      return prop.orderBy;
+    if (!Utils.isEmpty(prop.orderBy)) {
+      return Utils.asArray(prop.orderBy);
     }
 
     if (prop.fixedOrder) {
-      return { [`${prop.pivotTable}.${prop.fixedOrderColumn}`]: QueryOrder.ASC };
+      return [{ [`${prop.pivotTable}.${prop.fixedOrderColumn}`]: QueryOrder.ASC } as QueryOrderMap<T>];
     }
 
-    return {};
+    return [];
   }
 
   protected getPrimaryKeyFields(entityName: string): string[] {

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -59,7 +59,7 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   /**
    * When driver uses pivot tables for M:N, this method will load identifiers for given collections from them
    */
-  loadFromPivotTable<T extends AnyEntity<T>, O extends AnyEntity<O>>(prop: EntityProperty, owners: Primary<O>[][], where?: FilterQuery<T>, orderBy?: QueryOrderMap, ctx?: Transaction, options?: FindOptions<T>): Promise<Dictionary<T[]>>;
+  loadFromPivotTable<T extends AnyEntity<T>, O extends AnyEntity<O>>(prop: EntityProperty, owners: Primary<O>[][], where?: FilterQuery<T>, orderBy?: QueryOrderMap<T>[], ctx?: Transaction, options?: FindOptions<T>): Promise<Dictionary<T[]>>;
 
   getPlatform(): Platform;
 
@@ -87,7 +87,7 @@ export type EntityField<T, P extends string = never> = keyof T | AutoPath<T, P> 
 
 export interface FindOptions<T, P extends string = never> {
   populate?: readonly AutoPath<T, P>[] | boolean;
-  orderBy?: QueryOrderMap;
+  orderBy?: QueryOrderMap<T> | QueryOrderMap<T>[];
   cache?: boolean | number | [string, number];
   limit?: number;
   offset?: number;

--- a/packages/core/src/enums.ts
+++ b/packages/core/src/enums.ts
@@ -1,3 +1,5 @@
+import type { ExpandProperty } from './typings';
+
 export enum GroupOperator {
   $and = 'and',
   $or = 'or',
@@ -44,11 +46,11 @@ export enum QueryOrderNumeric {
 }
 
 export type QueryOrderKeysFlat = QueryOrder | QueryOrderNumeric | keyof typeof QueryOrder;
-export type QueryOrderKeys = QueryOrderKeysFlat | QueryOrderMap;
+export type QueryOrderKeys<T> = QueryOrderKeysFlat | QueryOrderMap<T>;
 
-export interface QueryOrderMap {
-  [x: string]: QueryOrderKeys;
-}
+export type QueryOrderMap<T> = {
+  [K in keyof T]?: QueryOrderKeys<ExpandProperty<T[K]>>;
+};
 
 export interface FlatQueryOrderMap {
   [x: string]: QueryOrderKeysFlat;

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1,4 +1,4 @@
-import type { Cascade, EventType, LoadStrategy, LockMode, QueryOrder } from './enums';
+import type { Cascade, EventType, LoadStrategy, LockMode, QueryOrderMap } from './enums';
 import { ReferenceType } from './enums';
 import type { AssignOptions, Collection, EntityFactory, EntityIdentifier, EntityRepository, IdentifiedReference, Reference, SerializationContext } from './entity';
 import type { EntitySchema, MetadataStorage } from './metadata';
@@ -229,7 +229,7 @@ export interface EntityProperty<T extends AnyEntity<T> = any> {
   owner: boolean;
   inversedBy: string;
   mappedBy: string;
-  orderBy?: { [field: string]: QueryOrder };
+  orderBy?: QueryOrderMap<T> | QueryOrderMap<T>[];
   fixedOrder?: boolean;
   fixedOrderColumn?: string;
   pivotTable: string;

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -454,7 +454,18 @@ export class QueryBuilderHelper {
     }
   }
 
-  getQueryOrder(type: QueryType, orderBy: FlatQueryOrderMap, populate: Dictionary<string>): string {
+  getQueryOrder(type: QueryType, orderBy: FlatQueryOrderMap | FlatQueryOrderMap[], populate: Dictionary<string>): string {
+    if (Array.isArray(orderBy)) {
+      return orderBy
+        .map(o => this.getQueryOrder(type, o, populate))
+        .filter(o => o)
+        .join(', ');
+    }
+
+    return this.getQueryOrderFromObject(type, orderBy, populate);
+  }
+
+  getQueryOrderFromObject(type: QueryType, orderBy: FlatQueryOrderMap, populate: Dictionary<string>): string {
     const ret: string[] = [];
     Object.keys(orderBy).forEach(k => {
       const direction = orderBy[k];

--- a/packages/knex/src/typings.ts
+++ b/packages/knex/src/typings.ts
@@ -122,7 +122,7 @@ export interface IQueryBuilder<T> {
   andWhere(cond: string, params?: any[]): this;
   orWhere(cond: QBFilterQuery<T>): this;
   orWhere(cond: string, params?: any[]): this;
-  orderBy(orderBy: QueryOrderMap): this;
+  orderBy(orderBy: QueryOrderMap<T>): this;
   groupBy(fields: (string | keyof T) | (string | keyof T)[]): this;
   having(cond?: QBFilterQuery | string, params?: any[]): this;
   getAliasForJoinPath(path: string): string | undefined;

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -1016,7 +1016,7 @@ describe('EntityManagerMySql', () => {
 
     const a2 = await orm.em.findOneOrFail(Author2, author, {
       populate: ['books'],
-      orderBy: { books: { title: QueryOrder.DESC } },
+      orderBy: [{ books: { title: QueryOrder.DESC } }],
     });
     expect(a2.books.getItems().map(b => b.title)).toEqual(['b5', 'b4', 'b3', 'b2', 'b1']);
     orm.em.clear();
@@ -1026,6 +1026,16 @@ describe('EntityManagerMySql', () => {
       orderBy: { books: { tags: { name: QueryOrder.DESC }, title: QueryOrder.ASC } },
     });
     expect(a3.books.getItems().map(b => b.title)).toEqual(['b4', 'b1', 'b2']); // first strange tag (desc), then silly by name (asc)
+    orm.em.clear();
+
+    const a4 = await orm.em.findOneOrFail(Author2, { books: { tags: { name: { $in: ['silly', 'strange'] } } } }, {
+      populate: ['books.tags'],
+      orderBy: [
+        { books: { tags: { name: QueryOrder.DESC } } },
+        { books: { title: QueryOrder.ASC } },
+      ],
+    });
+    expect(a4.books.getItems().map(b => b.title)).toEqual(['b4', 'b1', 'b2']); // first strange tag (desc), then silly by name (asc)
   });
 
   test('many to many relation', async () => {

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -450,18 +450,18 @@ describe('EntityManagerPostgre', () => {
     await orm.em.nativeDelete(Author2, {});
     await orm.em.nativeInsert(Author2, { name: 'n', email: 'e', id: 1 });
     await orm.em.getDriver().nativeInsertMany(Book2.name, [
-      { uuid: '123e4567-e89b-12d3-a456-426614174001', title: 't1', author: 1, meta: { foo: 3, bar: { str: 'c', num: 3 } } },
-      { uuid: '123e4567-e89b-12d3-a456-426614174002', title: 't2', author: 1, meta: { foo: 2, bar: { str: 'b', num: 1 } } },
-      { uuid: '123e4567-e89b-12d3-a456-426614174003', title: 't3', author: 1, meta: { foo: 1, bar: { str: 'a', num: 2 } } },
+      { uuid: '123e4567-e89b-12d3-a456-426614174001', title: 't1', author: 1, meta: { nested: { foo: 3, deep: { str: 'c', baz: 3 } } } },
+      { uuid: '123e4567-e89b-12d3-a456-426614174002', title: 't2', author: 1, meta: { nested: { foo: 2, deep: { str: 'b', baz: 1 } } } },
+      { uuid: '123e4567-e89b-12d3-a456-426614174003', title: 't3', author: 1, meta: { nested: { foo: 1, deep: { str: 'a', baz: 2 } } } },
     ]);
 
-    const res14 = await orm.em.fork().find(Book2, {}, { orderBy: { meta: { foo: 'asc' } } });
+    const res14 = await orm.em.fork().find(Book2, {}, { orderBy: { meta: { nested: { foo: 'asc' } } } });
     expect(res14.map(r => r.title)).toEqual(['t3', 't2', 't1']);
 
-    const res15 = await orm.em.fork().find(Book2, {}, { orderBy: { meta: { bar: { str: 'asc' } } } });
+    const res15 = await orm.em.fork().find(Book2, {}, { orderBy: { meta: { nested: { deep: { str: 'asc' } } } } });
     expect(res15.map(r => r.title)).toEqual(['t3', 't2', 't1']);
 
-    const res16 = await orm.em.fork().find(Book2, {}, { orderBy: { meta: { bar: { num: QueryOrder.DESC } } } });
+    const res16 = await orm.em.fork().find(Book2, {}, { orderBy: { meta: { nested: { deep: { baz: QueryOrder.DESC } } } } });
     expect(res16.map(r => r.title)).toEqual(['t1', 't3', 't2']);
   });
 

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -67,6 +67,21 @@ describe('QueryBuilder', () => {
     qb2.select('*').where({ name: 'test 123' }).orderBy({ name: 'desc', type: -1 }).limit(2, 1);
     expect(qb2.getQuery()).toEqual('select `e0`.* from `publisher2` as `e0` where `e0`.`name` = ? order by `e0`.`name` desc, `e0`.`type` desc limit ? offset ?');
     expect(qb2.getParams()).toEqual(['test 123', 2, 1]);
+
+    const qb3 = orm.em.createQueryBuilder(Publisher2);
+    qb3.select('*').where({ name: 'test 123' }).orderBy([{ name: 'desc' }, { type: -1 }]).limit(2, 1);
+    expect(qb3.getQuery()).toEqual('select `e0`.* from `publisher2` as `e0` where `e0`.`name` = ? order by `e0`.`name` desc, `e0`.`type` desc limit ? offset ?');
+    expect(qb3.getParams()).toEqual(['test 123', 2, 1]);
+
+    const qb4 = orm.em.createQueryBuilder(Publisher2);
+    qb4.select('*').where({ name: 'test 123' }).orderBy([{ name: 'desc', type: -1 }]).limit(2, 1);
+    expect(qb4.getQuery()).toEqual('select `e0`.* from `publisher2` as `e0` where `e0`.`name` = ? order by `e0`.`name` desc, `e0`.`type` desc limit ? offset ?');
+    expect(qb4.getParams()).toEqual(['test 123', 2, 1]);
+
+    const qb5 = orm.em.createQueryBuilder(Publisher2);
+    qb5.select('*').where({ name: 'test 123' }).orderBy([{ name: 'desc' }, { type: -1 }, { name: 'asc' }]).limit(2, 1);
+    expect(qb5.getQuery()).toEqual('select `e0`.* from `publisher2` as `e0` where `e0`.`name` = ? order by `e0`.`name` desc, `e0`.`type` desc, `e0`.`name` asc limit ? offset ?');
+    expect(qb5.getParams()).toEqual(['test 123', 2, 1]);
   });
 
   test('select constant expression', async () => {

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -66,5 +66,10 @@ export interface Book2Meta {
   category: string;
   items: number;
   valid?: boolean;
-  nested?: { foo: string; bar?: number; deep?: { baz: number; qux: boolean } };
+  nested?: {
+    foo: string;
+    bar?: number;
+    num?: number;
+    deep?: { baz: number; qux: boolean; str?: string };
+  };
 }

--- a/tests/features/embeddables/entities-in-embeddables.mongo.test.ts
+++ b/tests/features/embeddables/entities-in-embeddables.mongo.test.ts
@@ -403,12 +403,12 @@ describe('embedded entities in mongo', () => {
       orderBy: { name: 'desc' },
     });
 
-    expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('user').find({}, { session: undefined }).sort({ name: -1 }).toArray();`);
-    expect(mock.mock.calls[1][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000004'), ObjectId('600000000000000000000012') ] } }, { session: undefined }).sort({ _id: 1 }).toArray();`);
-    expect(mock.mock.calls[2][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000003'), ObjectId('600000000000000000000013') ] } }, { session: undefined }).sort({ _id: 1 }).toArray();`);
-    expect(mock.mock.calls[3][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000002') ] } }, { session: undefined }).sort({ _id: 1 }).toArray();`);
-    expect(mock.mock.calls[4][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000014'), ObjectId('600000000000000000000015') ] } }, { session: undefined }).sort({ _id: 1 }).toArray();`);
-    expect(mock.mock.calls[5][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000016'), ObjectId('600000000000000000000017'), ObjectId('600000000000000000000018'), ObjectId('600000000000000000000019'), ObjectId('60000000000000000000001a'), ObjectId('60000000000000000000001b') ] } }, { session: undefined }).sort({ _id: 1 }).toArray();`);
+    expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('user').find({}, { session: undefined }).sort([ [ 'name', -1 ] ]).toArray();`);
+    expect(mock.mock.calls[1][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000004'), ObjectId('600000000000000000000012') ] } }, { session: undefined }).sort([ [ '_id', 1 ] ]).toArray();`);
+    expect(mock.mock.calls[2][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000003'), ObjectId('600000000000000000000013') ] } }, { session: undefined }).sort([ [ '_id', 1 ] ]).toArray();`);
+    expect(mock.mock.calls[3][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000002') ] } }, { session: undefined }).sort([ [ '_id', 1 ] ]).toArray();`);
+    expect(mock.mock.calls[4][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000014'), ObjectId('600000000000000000000015') ] } }, { session: undefined }).sort([ [ '_id', 1 ] ]).toArray();`);
+    expect(mock.mock.calls[5][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000016'), ObjectId('600000000000000000000017'), ObjectId('600000000000000000000018'), ObjectId('600000000000000000000019'), ObjectId('60000000000000000000001a'), ObjectId('60000000000000000000001b') ] } }, { session: undefined }).sort([ [ '_id', 1 ] ]).toArray();`);
     expect(wrap(users[0].profile1.source).isInitialized()).toBe(true);
     expect(users[0].profile1.source!.name).toBe('s1');
     expect(wrap(users[1].profile1.identity.links[1].source).isInitialized()).toBe(true);

--- a/tests/features/partial-loading/partial-loading.mongo.test.ts
+++ b/tests/features/partial-loading/partial-loading.mongo.test.ts
@@ -48,7 +48,7 @@ describe('partial loading (mongo)', () => {
     expect(r1[0].books[0].tenant).toBeUndefined();
     expect(r1[0].books[0].author).toBeDefined();
     expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: ObjectId\('.*'\) }, { session: undefined, projection: { _id: 1 } }\)\.toArray\(\);/);
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ author: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, author: 1, title: 1 } }\)\.sort\({ author: 1 }\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ author: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, author: 1, title: 1 } }\)\.sort\(\[ \[ 'author', 1 ] ]\)\.toArray\(\);/);
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -61,7 +61,7 @@ describe('partial loading (mongo)', () => {
     expect(r2[0].books[0].tenant).toBeUndefined();
     expect(r2[0].books[0].author).toBeDefined();
     expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: ObjectId\('.*'\) }, { session: undefined, projection: { _id: 1 } }\)\.toArray\(\);/);
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ author: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, author: 1, title: 1 } }\)\.sort\({ author: 1 }\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ author: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, author: 1, title: 1 } }\)\.sort\(\[ \[ 'author', 1 ] ]\)\.toArray\(\);/);
   });
 
   test('partial nested loading (m:1)', async () => {
@@ -89,7 +89,7 @@ describe('partial loading (mongo)', () => {
     expect(r1[0].author.name).toBeUndefined();
     expect(r1[0].author.email).toBeDefined();
     expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ _id: ObjectId\('.*'\) }, { session: undefined, projection: { _id: 1, title: 1, author: 1 } }\)\.toArray\(\);/);
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, email: 1 } }\)\.sort\({ _id: 1 }\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, email: 1 } }\)\.sort\(\[ \[ '_id', 1 ] ]\)\.toArray\(\);/);
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -103,7 +103,7 @@ describe('partial loading (mongo)', () => {
     expect(r2[0].author.name).toBeUndefined();
     expect(r2[0].author.email).toBeDefined();
     expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ _id: ObjectId\('.*'\) }, { session: undefined, projection: { _id: 1, title: 1, author: 1 } }\)\.toArray\(\);/);
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, email: 1 } }\)\.sort\({ _id: 1 }\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, email: 1 } }\)\.sort\(\[ \[ '_id', 1 ] ]\)\.toArray\(\);/);
   });
 
   test('partial nested loading (m:n)', async () => {
@@ -132,7 +132,7 @@ describe('partial loading (mongo)', () => {
     expect(r1[0].books[0].tenant).toBeUndefined();
     expect(r1[0].books[0].author).toBeUndefined();
     expect(mock.mock.calls[0][0]).toMatch('db.getCollection(\'book-tag\').find({}, { session: undefined, projection: { _id: 1, name: 1 } }).toArray();');
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, title: 1, tags: 1 } }\)\.sort\({ tags: 1 }\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, title: 1, tags: 1 } }\)\.sort\(\[ \[ 'tags', 1 ] ]\)\.toArray\(\);/);
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -143,7 +143,7 @@ describe('partial loading (mongo)', () => {
     expect(r2[0].books[0].tenant).toBeUndefined();
     expect(r2[0].books[0].author).toBeUndefined();
     expect(mock.mock.calls[0][0]).toMatch('db.getCollection(\'book-tag\').find({ name: \'t1\' }, { session: undefined, projection: { _id: 1, name: 1 } }).toArray();');
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, title: 1, tags: 1 } }\)\.sort\({ tags: 1 }\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, title: 1, tags: 1 } }\)\.sort\(\[ \[ 'tags', 1 ] ]\)\.toArray\(\);/);
   });
 
   test('partial nested loading (mixed)', async () => {
@@ -174,8 +174,8 @@ describe('partial loading (mongo)', () => {
     expect(r1[0].books[0].author.name).toBeUndefined();
     expect(r1[0].books[0].author.email).toBe(god.email);
     expect(mock.mock.calls[0][0]).toMatch('db.getCollection(\'book-tag\').find({}, { session: undefined, projection: { _id: 1, name: 1 } }).toArray();');
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, title: 1, tags: 1, author: 1 } }\)\.sort\({ tags: 1 }\)\.toArray\(\);/);
-    expect(mock.mock.calls[2][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, email: 1 } }\)\.sort\({ _id: 1 }\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, title: 1, tags: 1, author: 1 } }\)\.sort\(\[ \[ 'tags', 1 ] ]\)\.toArray\(\);/);
+    expect(mock.mock.calls[2][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, email: 1 } }\)\.sort\(\[ \[ '_id', 1 ] ]\)\.toArray\(\);/);
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -189,8 +189,8 @@ describe('partial loading (mongo)', () => {
     expect(r2[0].books[0].author.name).toBeUndefined();
     expect(r2[0].books[0].author.email).toBe(god.email);
     expect(mock.mock.calls[0][0]).toMatch('db.getCollection(\'book-tag\').find({}, { session: undefined, projection: { _id: 1, name: 1 } }).toArray();');
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, title: 1, tags: 1, author: 1 } }\)\.sort\({ tags: 1 }\)\.toArray\(\);/);
-    expect(mock.mock.calls[2][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, email: 1 } }\)\.sort\({ _id: 1 }\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, title: 1, tags: 1, author: 1 } }\)\.sort\(\[ \[ 'tags', 1 ] ]\)\.toArray\(\);/);
+    expect(mock.mock.calls[2][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { session: undefined, projection: { _id: 1, email: 1 } }\)\.sort\(\[ \[ '_id', 1 ] ]\)\.toArray\(\);/);
   });
 
 });


### PR DESCRIPTION
`FindOptions.orderBy` parameter is now strictly typed. It also allows passing an
array of objects instead of just a single object.

```ts
const books = await em.find(Book, {}, {
  orderBy: [
    { title: 1 },
    { author: { name: -1 } },
  ],
});
```

BREAKING CHANGE:
`FindOptions.orderBy` parameter is now strictly typed.

Closes #2010