### PR TITLE
Sync MigrateOptions type with packages/migrations/src/typings.ts

### DIFF
--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -392,7 +392,7 @@ export interface IEntityGenerator {
 }
 
 type UmzugMigration = { path?: string; file: string };
-type MigrateOptions = { from?: string | number; to?: string | number; migrations?: string[] };
+type MigrateOptions = { from?: string | number; to?: string | number; migrations?: string[]; transaction?: Transaction };
 type MigrationResult = { fileName: string; code: string; diff: MigrationDiff };
 type MigrationRow = { name: string; executed_at: Date };
 


### PR DESCRIPTION
The code example in the docs for using a custom transaction for running migrations doesn't work due to a small typing error.
https://mikro-orm.io/docs/migrations/#providing-transaction-context

code to reproduce the issue:
```
            await em.transactional(async em => {
                await migrator.up({ transaction: em.getTransactionContext() });
              });
```

Typescript error I get:
```
Argument of type '{ transaction: any; }' is not assignable to parameter of type 'string | string[] | MigrateOptions | undefined'.
  Object literal may only specify known properties, and 'transaction' does not exist in type 'string[] | MigrateOptions'.ts(2345)
```