### PR TITLE
feat(core): implement auto-refreshing of loaded entities

### DIFF
--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -20,6 +20,7 @@ export class EntityFactory {
   private readonly metadata = this.em.getMetadata();
   private readonly hydrator = this.config.getHydrator(this.metadata);
   private readonly eventManager = this.em.getEventManager();
+  private readonly comparator = this.em.getComparator();
 
   constructor(private readonly unitOfWork: UnitOfWork,
               private readonly em: EntityManager) { }
@@ -42,6 +43,9 @@ export class EntityFactory {
     const exists = this.findEntity<T>(data, meta2, options.convertCustomTypes);
 
     if (exists && exists.__helper!.__initialized && !options.refresh) {
+      exists.__helper!.__initialized = options.initialized;
+      this.mergeData(meta2, exists, data, options);
+
       return exists as New<T, P>;
     }
 
@@ -59,6 +63,54 @@ export class EntityFactory {
     }
 
     return entity as New<T, P>;
+  }
+
+  mergeData<T extends AnyEntity<T>>(meta: EntityMetadata<T>, entity: T, data: EntityData<T>, options: FactoryOptions): void {
+    // merge unchanged properties automatically
+    data = { ...data };
+    const existsData = this.comparator.prepareEntity(entity);
+    const originalEntityData = entity.__helper!.__originalEntityData ?? {} as EntityData<T>;
+    const diff = this.comparator.diffEntities(meta.className, originalEntityData, existsData);
+
+    // version properties are not part of entity snapshots
+    if (meta.versionProperty && data[meta.versionProperty] && data[meta.versionProperty] !== originalEntityData[meta.versionProperty]) {
+      diff[meta.versionProperty] = data[meta.versionProperty];
+    }
+
+    const diff2 = this.comparator.diffEntities(meta.className, existsData, data);
+
+    // do not override values changed by user
+    Object.keys(diff).forEach(key => delete diff2[key]);
+    this.hydrate<T>(entity, meta, diff2, options);
+
+    // we need to update the entity data only with keys that were not present before
+    Object.keys(diff2).forEach(key => {
+      const prop = meta.properties[key];
+
+      if ([ReferenceType.MANY_TO_ONE, ReferenceType.ONE_TO_ONE].includes(prop.reference) && Utils.isPlainObject(data[prop.name])) {
+        diff2[key] = (entity[prop.name] as AnyEntity).__helper!.getPrimaryKey(options.convertCustomTypes);
+      }
+
+      originalEntityData[key] = diff2[key];
+      entity.__helper!.__loadedProperties.add(key);
+    });
+
+    // in case of joined loading strategy, we need to cascade the merging to possibly loaded relations manually
+    meta.relations.forEach(prop => {
+      if ([ReferenceType.MANY_TO_MANY, ReferenceType.ONE_TO_MANY].includes(prop.reference) && Array.isArray(data[prop.name])) {
+        // instead of trying to match the collection items (which could easily fail if the collection was loaded with different ordering),
+        // we just create the entity from scratch, which will automatically pick the right one from the identity map and call `mergeData` on it
+        (data[prop.name] as EntityData<T>[])
+          .filter(child => Utils.isPlainObject(child)) // objects with prototype can be PKs (e.g. `ObjectId`)
+          .forEach(child => this.create(prop.type, child, options)); // we can ignore the value, we just care about the `mergeData` call
+
+        return;
+      }
+
+      if ([ReferenceType.MANY_TO_ONE, ReferenceType.ONE_TO_ONE].includes(prop.reference) && Utils.isPlainObject(data[prop.name]) && entity[prop.name] && (entity[prop.name] as AnyEntity).__helper!.__initialized) {
+        this.create(prop.type, data[prop.name] as EntityData<T>, options); // we can ignore the value, we just care about the `mergeData` call
+      }
+    });
   }
 
   createReference<T>(entityName: EntityName<T>, id: Primary<T> | Primary<T>[] | Record<string, Primary<T>>, options: Pick<FactoryOptions, 'merge' | 'convertCustomTypes'> = {}): T {
@@ -107,12 +159,13 @@ export class EntityFactory {
     return entity;
   }
 
-  private hydrate<T>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, options: FactoryOptions): void {
+  private hydrate<T extends AnyEntity<T>>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, options: FactoryOptions): void {
     if (options.initialized) {
       this.hydrator.hydrate(entity, meta, data, this, 'full', options.newEntity, options.convertCustomTypes);
     } else {
       this.hydrator.hydrateReference(entity, meta, data, this, options.convertCustomTypes);
     }
+    Object.keys(data).forEach(key => entity.__helper!.__loadedProperties.add(key));
   }
 
   private findEntity<T>(data: EntityData<T>, meta: EntityMetadata<T>, convertCustomTypes?: boolean): T | undefined {

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -20,6 +20,7 @@ export class WrappedEntity<T extends AnyEntity<T>, PK extends keyof T> {
   __managed?: boolean;
   __em?: EntityManager;
   __serializationContext: { root?: SerializationContext<T>; populate?: PopulateOptions<T>[] } = {};
+  __loadedProperties = new Set<string>();
 
   /** holds last entity data snapshot so we can compute changes when persisting managed entities */
   __originalEntityData?: EntityData<T>;

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -113,6 +113,7 @@ export interface IWrappedEntityInternal<T, PK extends keyof T | unknown = Primar
   __platform: Platform;
   __initialized: boolean;
   __originalEntityData?: EntityData<T>;
+  __loadedProperties: Set<string>;
   __identifier?: EntityIdentifier;
   __managed: boolean;
   __populated: boolean;

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -77,6 +77,7 @@ export class UnitOfWork {
     if (data && helper!.__initialized && (refresh || !helper!.__originalEntityData)) {
       // we can't use the `data` directly here as it can contain fetch joined data, that can't be used for diffing the state
       helper!.__originalEntityData = this.comparator.prepareEntity(entity);
+      Object.keys(data).forEach(key => entity.__helper!.__loadedProperties.add(key));
     }
 
     return entity;

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@mikro-orm/core';
 import { MySqlDriver, MySqlConnection } from '@mikro-orm/mysql';
 import { Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, PublisherType, Test2 } from './entities-sql';
-import { initORMMySql, wipeDatabaseMySql } from './bootstrap';
+import { initORMMySql, mockLogger, wipeDatabaseMySql } from './bootstrap';
 import { Author2Subscriber } from './subscribers/Author2Subscriber';
 import { EverythingSubscriber } from './subscribers/EverythingSubscriber';
 import { FlushSubscriber } from './subscribers/FlushSubscriber';
@@ -2407,10 +2407,10 @@ describe('EntityManagerMySql', () => {
   });
 
   test('refreshing already loaded entity', async () => {
-    const god = new Author2(`God `, `hello@heaven.god`);
-    new Book2(`Bible 1`, god);
-    new Book2(`Bible 2`, god);
-    new Book2(`Bible 3`, god);
+    const god = new Author2('God', 'hello@heaven.god');
+    new Book2('Bible 1', god);
+    new Book2('Bible 2', god);
+    new Book2('Bible 3', god);
     await orm.em.persistAndFlush(god);
     orm.em.clear();
 
@@ -2422,6 +2422,7 @@ describe('EntityManagerMySql', () => {
     expect(r2).toHaveLength(1);
     expect(r2[0].id).toBe(god.id);
     expect(r2[0].name).toBe(god.name);
+    expect(r1[0]).toBe(r2[0]);
   });
 
   test('batch update with changing OneToOne relation (GH issue #1025)', async () => {

--- a/tests/features/auto-refreshing.postgre.test.ts
+++ b/tests/features/auto-refreshing.postgre.test.ts
@@ -1,0 +1,279 @@
+import type { MikroORM } from '@mikro-orm/core';
+import { LoadStrategy, Logger, wrap } from '@mikro-orm/core';
+import type { PostgreSqlDriver } from '@mikro-orm/postgresql';
+
+import { initORMPostgreSql, mockLogger, wipeDatabasePostgreSql } from '../bootstrap';
+import { Author2, Book2, FooBar2, FooBaz2 } from '../entities-sql';
+
+describe('automatic refreshing of already loaded entities', () => {
+
+  let orm: MikroORM<PostgreSqlDriver>;
+
+  beforeAll(async () => orm = await initORMPostgreSql());
+  beforeEach(async () => wipeDatabasePostgreSql(orm.em));
+  afterAll(async () => orm.close(true));
+
+  async function createEntities() {
+    const god = new Author2('God', 'hello@heaven.god');
+    god.favouriteAuthor = new Author2('God 2', 'hello2@heaven.god');
+    god.favouriteAuthor.age = 21;
+    god.age = 999;
+    god.identities = ['a', 'b', 'c'];
+    const b1 = new Book2('Bible 1', god);
+    b1.perex = 'b1 perex';
+    b1.price = 123;
+    const b2 = new Book2('Bible 2', god);
+    b2.perex = 'b2 perex';
+    b2.price = 456;
+    const b3 = new Book2('Bible 3', god);
+    b3.perex = 'b3 perex';
+    b3.price = 789;
+    await orm.em.fork().persistAndFlush(god);
+
+    return { god };
+  }
+
+  test('em.find()', async () => {
+    const { god } = await createEntities();
+
+    const r1 = await orm.em.find(Author2, god, { fields: ['id'], populate: ['books'] });
+    r1[0].email = 'lol';
+    expect(r1).toHaveLength(1);
+    expect(r1[0].id).toBe(god.id);
+    expect(r1[0].name).toBeUndefined();
+    expect(r1[0].termsAccepted).toBeUndefined();
+    const r2 = await orm.em.find(Author2, god, { populate: ['books'] });
+    expect(r2).toHaveLength(1);
+    expect(r2[0].id).toBe(god.id);
+    expect(r2[0].name).toBe(god.name);
+    expect(r2[0].termsAccepted).toBe(false);
+    expect(r2[0].email).toBe('lol');
+    expect(r1[0]).toBe(r2[0]);
+
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch(/update "author2" set "email" = 'lol', "updated_at" = '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z' where "id" = 2/);
+    expect(mock.mock.calls[2][0]).toMatch('commit');
+  });
+
+  test('em.find() with relations and joined strategy 1', async () => {
+    const { god } = await createEntities();
+
+    const r1 = await orm.em.find(Author2, god, { fields: ['id'] });
+    r1[0].email = 'lol@lol.lol';
+    expect(r1).toHaveLength(1);
+    expect(r1[0].id).toBe(god.id);
+    expect(r1[0].name).toBeUndefined();
+    expect(r1[0].termsAccepted).toBeUndefined();
+    const r2 = await orm.em.find(Author2, god, { populate: ['books', 'books.perex'], strategy: LoadStrategy.JOINED });
+    expect(r2).toHaveLength(1);
+    expect(r2[0].id).toBe(god.id);
+    expect(r2[0].name).toBe(god.name);
+    expect(r2[0].termsAccepted).toBe(false);
+    expect(r2[0].email).toBe('lol@lol.lol');
+    expect(r2[0].books[0].title).toBe('Bible 1');
+    expect(r2[0].books[0].price).toBe('123.00');
+    expect(r2[0].books[0].perex).toBe('b1 perex');
+    expect(r1[0]).toBe(r2[0]);
+
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch(/update "author2" set "email" = 'lol@lol\.lol', "updated_at" = '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z' where "id" = 2/);
+    expect(mock.mock.calls[2][0]).toMatch('commit');
+  });
+
+  test('em.find() with relations and joined strategy 2', async () => {
+    const { god } = await createEntities();
+
+    const r1 = await orm.em.find(Author2, god, { fields: ['id', 'books.title', 'books.author'], populate: ['books'], strategy: LoadStrategy.JOINED });
+    r1[0].email = 'lol@lol.lol';
+    r1[0].books[0].title = 'lol';
+    expect(r1).toHaveLength(1);
+    expect(r1[0].id).toBe(god.id);
+    expect(r1[0].name).toBeUndefined();
+    expect(r1[0].termsAccepted).toBeUndefined();
+    expect(r1[0].books[0].uuid).toBeDefined();
+    expect(r1[0].books[0].title).toBeDefined();
+    expect(r1[0].books[0].author).toBeDefined();
+    expect(r1[0].books[0].price).toBeUndefined();
+    expect(r1[0].books[0].perex).toBeUndefined();
+    const r2 = await orm.em.find(Author2, god, { populate: ['books', 'books.perex'], strategy: LoadStrategy.JOINED });
+    expect(r2).toHaveLength(1);
+    expect(r2[0].id).toBe(god.id);
+    expect(r2[0].name).toBe(god.name);
+    expect(r2[0].termsAccepted).toBe(false);
+    expect(r2[0].email).toBe('lol@lol.lol');
+    expect(r2[0].books[0].title).toBe('lol');
+    expect(r2[0].books[0].price).toBe('123.00');
+    expect(r2[0].books[0].perex).toBe('b1 perex');
+    expect(r1[0]).toBe(r2[0]);
+
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch(/update "author2" set "email" = 'lol@lol\.lol', "updated_at" = '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z' where "id" = 2/);
+    expect(mock.mock.calls[2][0]).toMatch(/update "book2" set "title" = 'lol' where "uuid_pk" = '[\w-]{36}'/);
+    expect(mock.mock.calls[3][0]).toMatch('commit');
+  });
+
+  test('em.find() with relations and joined strategy 3', async () => {
+    const { god } = await createEntities();
+
+    const r1 = await orm.em.find(Author2, god, { fields: ['id', 'favouriteAuthor.name'], populate: ['favouriteAuthor'], strategy: LoadStrategy.JOINED });
+    r1[0].email = 'lol@lol.lol';
+    expect(r1).toHaveLength(1);
+    expect(r1[0].id).toBe(god.id);
+    expect(r1[0].name).toBeUndefined();
+    expect(r1[0].termsAccepted).toBeUndefined();
+    expect(r1[0].favouriteAuthor!.id).toBeDefined();
+    expect(r1[0].favouriteAuthor!.name).toBeDefined();
+    expect(r1[0].favouriteAuthor!.age).toBeUndefined();
+    r1[0].favouriteAuthor!.name = 'lol';
+    console.log(r1[0]);
+    console.log((r1[0] as any).__helper.__originalEntityData);
+    const r2 = await orm.em.find(Author2, god, { populate: ['favouriteAuthor'], strategy: LoadStrategy.JOINED });
+    console.log(r2[0]);
+    console.log((r2[0] as any).__helper.__originalEntityData);
+    expect(r2).toHaveLength(1);
+    expect(r2[0].id).toBe(god.id);
+    expect(r2[0].name).toBe(god.name);
+    expect(r2[0].termsAccepted).toBe(false);
+    expect(r2[0].email).toBe('lol@lol.lol');
+    expect(r2[0].favouriteAuthor!.name).toBe('lol');
+    expect(r2[0].favouriteAuthor!.age).toBe(21);
+    expect(r1[0]).toBe(r2[0]);
+
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch(/update "author2" set "email" = case when \("id" = 2\) then 'lol@lol\.lol' else "email" end, "updated_at" = case when \("id" = 2\) then '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z' when \("id" = 1\) then '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z' else "updated_at" end, "name" = case when \("id" = 1\) then 'lol' else "name" end where "id" in \(2, 1\)/);
+    expect(mock.mock.calls[2][0]).toMatch('commit');
+  });
+
+  test('em.findOne()', async () => {
+    const { god } = await createEntities();
+
+    const mock = mockLogger(orm);
+    const a1 = await orm.em.findOneOrFail(Author2, god, { fields: ['id', 'email'], populate: ['books'] });
+    expect(mock).toBeCalledTimes(2);
+    expect(a1.id).toBe(god.id);
+    expect(a1.email).toBe(god.email);
+    a1.email = 'lol';
+    expect(a1.name).toBeUndefined();
+    expect(a1.termsAccepted).toBeUndefined();
+    expect(a1.age).toBeUndefined();
+    expect(a1.identities).toBeUndefined();
+
+    // reloading with same fields won't fire the query
+    const a11 = await orm.em.findOneOrFail(Author2, god, { fields: ['email'] });
+    expect(a11).toBe(a1);
+    expect(mock).toBeCalledTimes(2);
+
+    // reloading with additional fields will work without `refresh: true`
+    const a12 = await orm.em.findOneOrFail(Author2, god, { fields: ['id', 'age'] });
+    expect(a12).toBe(a1);
+    expect(a1.age).toBe(999);
+    a1.age = 1000;
+    expect(mock).toBeCalledTimes(3);
+
+    // reloading without partial loading will work without `refresh: true`
+    const a2 = await orm.em.findOneOrFail(Author2, god, { populate: ['books'] });
+    expect(mock).toBeCalledTimes(4);
+    expect(a2.id).toBe(god.id);
+    expect(a2.name).toBe(god.name);
+    expect(a2.termsAccepted).toBe(false);
+    expect(a2.email).toBe('lol');
+    expect(a1).toBe(a2);
+
+    // no query should be fired as the entity was fully loaded before too
+    const b11 = await orm.em.findOneOrFail(Book2, god.books[0].uuid, { filters: false });
+    expect(mock).toBeCalledTimes(4);
+    expect(b11).toBe(a1.books[0]);
+
+    // reloading with additional lazy scalar properties will work without `refresh: true`
+    const b12 = await orm.em.findOneOrFail(Book2, god.books[0], { populate: ['perex'], filters: false });
+    expect(mock).toBeCalledTimes(5);
+    expect(b11).toBe(b12);
+
+    mock.mockReset();
+    await orm.em.flush();
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch(/update "author2" set "email" = 'lol', "age" = 1000, "updated_at" = '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z' where "id" = 2/);
+    expect(mock.mock.calls[2][0]).toMatch('commit');
+  });
+
+  test('em.findOne() with joined strategy', async () => {
+    const { god } = await createEntities();
+
+    const mock = mockLogger(orm);
+    const a1 = await orm.em.findOneOrFail(Author2, god, { fields: ['id', 'email'], populate: ['books'], strategy: LoadStrategy.JOINED });
+    expect(mock).toBeCalledTimes(1);
+    expect(a1.id).toBe(god.id);
+    expect(a1.email).toBe(god.email);
+    a1.email = 'lol';
+    expect(a1.name).toBeUndefined();
+    expect(a1.termsAccepted).toBeUndefined();
+    expect(a1.age).toBeUndefined();
+    expect(a1.identities).toBeUndefined();
+
+    // reloading with same fields won't fire the query
+    const a11 = await orm.em.findOneOrFail(Author2, god, { fields: ['email'] });
+    expect(a11).toBe(a1);
+    expect(mock).toBeCalledTimes(1);
+
+    // reloading with additional fields will work without `refresh: true`
+    const a12 = await orm.em.findOneOrFail(Author2, god, { fields: ['id', 'age'] });
+    expect(a12).toBe(a1);
+    expect(a1.age).toBe(999);
+    a1.age = 1000;
+    expect(mock).toBeCalledTimes(2);
+
+    // reloading without partial loading will work without `refresh: true`
+    const a2 = await orm.em.findOneOrFail(Author2, god, { populate: ['books'], strategy: LoadStrategy.JOINED });
+    expect(mock).toBeCalledTimes(3);
+    expect(a2.id).toBe(god.id);
+    expect(a2.name).toBe(god.name);
+    expect(a2.termsAccepted).toBe(false);
+    expect(a2.email).toBe('lol');
+    expect(a1).toBe(a2);
+
+    // no query should be fired as the entity was fully loaded before too
+    const b11 = await orm.em.findOneOrFail(Book2, god.books[0].uuid, { filters: false });
+    expect(mock).toBeCalledTimes(3);
+    expect(b11).toBe(a1.books[0]);
+
+    // reloading with additional lazy scalar properties will work without `refresh: true`
+    const b12 = await orm.em.findOneOrFail(Book2, god.books[0], { populate: ['perex'], filters: false });
+    expect(mock).toBeCalledTimes(4);
+    expect(b11).toBe(b12);
+
+    mock.mockReset();
+    await orm.em.flush();
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch(/update "author2" set "email" = 'lol', "age" = 1000, "updated_at" = '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z' where "id" = 2/);
+    expect(mock.mock.calls[2][0]).toMatch('commit');
+  });
+
+  test('populate OneToOne relation', async () => {
+    const bar = FooBar2.create('bar');
+    const baz = new FooBaz2('baz');
+    bar.baz = baz;
+    await orm.em.persistAndFlush(bar);
+    orm.em.clear();
+
+    const b1 = await orm.em.findOneOrFail(FooBar2, { id: bar.id }, { populate: ['baz'] });
+    expect(b1.baz).toBeInstanceOf(FooBaz2);
+    expect(b1.baz!.id).toBe(baz.id);
+    expect(wrap(b1).toJSON()).toMatchObject({ baz: { id: baz.id, bar: bar.id, name: 'baz' } });
+
+    const mock = jest.fn();
+    const logger = new Logger(mock, ['query']);
+    Object.assign(orm.config, { logger });
+
+    await orm.em.flush();
+    expect(mock.mock.calls.length).toBe(0);
+  });
+
+});

--- a/tests/features/partial-loading/partial-loading.mongo.test.ts
+++ b/tests/features/partial-loading/partial-loading.mongo.test.ts
@@ -125,7 +125,7 @@ describe('partial loading (mongo)', () => {
     const logger = new Logger(mock, ['query']);
     Object.assign(orm.config, { logger });
 
-    const r1 = await orm.em.find(BookTag, {}, { fields: ['name', 'books.title', 'books.tags'], populate: ['books'], filters: false, refresh: true });
+    const r1 = await orm.em.find(BookTag, {}, { fields: ['name', 'books.title', 'books.tags'], populate: ['books'], filters: false });
     expect(r1).toHaveLength(6);
     expect(r1[0].name).toBe('t1');
     expect(r1[0].books[0].title).toBe('Bible 1');

--- a/tests/issues/GH1346.test.ts
+++ b/tests/issues/GH1346.test.ts
@@ -59,7 +59,7 @@ describe('GH issue 1346', () => {
     await orm.em.persistAndFlush([user, name]);
     orm.em.clear();
 
-    const entity = await orm.em.findOneOrFail(User, user, { populate: ['names'], refresh: true });
+    const entity = await orm.em.findOneOrFail(User, user, { populate: ['names'] });
     expect(entity.names[0].name).toEqual('this is my name');
   });
 


### PR DESCRIPTION
Previously when entity was loaded and we needed to reload it, providing explicit `refresh: true` in the options was necessary. Refreshing of entity also had one problematic side effect - the entity data (used for computing change sets) was always updated based on the newly loaded entity, hence forgetting the previous state (resulting in possibly lost updates done on entity before refreshing).

Now we always merge the newly loaded data with current state, and when we see updated property, we keep the changed value instead. More over for `em.findOne()` with a PK condition, we try to detect whether it makes sense to reload an entity, by comparing the options and already loaded property names. In this step the `fields` and `populate` options are taken into account to support both partial loading and lazy properties.

```ts
// first partially load author with `id` and `email` only
const a1 = await em.findOneOrFail(Author, 123, { fields: ['id', 'email'] });
a1.email = 'lol'; // let's change the email

// reloading with same fields won't fire the query (as before)
const a2 = await em.findOneOrFail(Author, 123, { fields: ['email'] });
console.log(a1 === a2); // true, same entity instance, no query was fired

// reloading with additional fields will work without `refresh: true`
const a3 = await em.findOneOrFail(Author, 123, { fields: ['id', 'age'] });
console.log(a1 === a3); // true, same entity instance, but updated!
console.log(a1.age); // new values are loaded
a1.age = 1000; // let's override them

// reloading full entity will work without `refresh: true`
const a4 = await em.findOneOrFail(Author, 123, { populate: ['books'] });
console.log(a1 === a4); // true, same entity instance, but updated!
console.log(a1.termsAccepted); // new values are loaded

await em.flush(); // updates the author with new email and age
```

For complex conditions in `em.findOne()` and for any queries via `em.find()`, we always do the query anyway, but now instead of ignoring the data in case such entity was loaded, we merge them in the same manner.

```ts
// first partially load author entities
const r1 = await em.find(Author, {}, { fields: ['id'] });
r1[0].email = 'lol'; // let's change one of the emails
console.log(r1[0].name); // undefined, not loaded

// reload full entities - no `refresh: true` needed!
const r2 = await em.find(Author, {});
console.log(r2[0]); // fully loaded author entity, but `email` is changed to 'lol'
console.log(r1[0] === r2[0]); // true, same entity instance, just updated!

// flushing will now fire one update query to change the email of one author
await em.flush();
```

Closes #2292