### PR TITLE
docs: fix logo size

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -74,7 +74,6 @@ html[data-theme="light"] .admonition-info {
 
 .navbar .navbar__logo {
   max-height: 100%;
-  height: auto;
 }
 
 .navbar .navbar__link[href*=github],


### PR DESCRIPTION
Just a suggestion, but removing the svg links would make the navbar align better. I've just removed them in the browser to show an example.

![image](https://user-images.githubusercontent.com/35864046/137619582-ecc68826-c5ef-461e-9610-cf5412b95a7a.png)
