### PR TITLE
feat(core): add support for multiple schemas (including UoW)

### DIFF
--- a/docs/docs/entity-manager-api.md
+++ b/docs/docs/entity-manager-api.md
@@ -203,9 +203,9 @@ Shortcut for `wrap(entity).assign(data, { em })`
 
 ----
 
-#### `getReference(entityName: EntityName<T>, id: Primary<T>, wrapped?: boolean, convertCustomTypes?: boolean): T | Reference<T>`
+#### `getReference(entityName: EntityName<T>, id: Primary<T>, options?: GetReferenceOptions): T | Reference<T>`
 
-Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
+Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded.
 
 ----
 

--- a/docs/docs/entity-references.md
+++ b/docs/docs/entity-references.md
@@ -170,13 +170,13 @@ author!: IdentifiedReference<Author>;
 
 When you define the property as `Reference` wrapper, you will need to assign the `Reference`
 to it instead of the entity. You can create it via `Reference.create()` factory, or use `wrapped`
-parameter of `em.getReference()`:
+option of `em.getReference()`:
 
 ```typescript
 const book = await orm.em.findOne(Book, 1);
 const repo = orm.em.getRepository(Author);
 
-book.author = repo.getReference(2, true);
+book.author = repo.getReference(2, { wrapped: true });
 
 // same as:
 book.author = Reference.create(repo.getReference(2));

--- a/docs/docs/multiple-schemas.md
+++ b/docs/docs/multiple-schemas.md
@@ -6,14 +6,16 @@ In MySQL and PostgreSQL is is possible to define your entities in multiple schem
 terminology, it is called database, but from implementation point of view, it is a schema. 
 
 > To use multiple schemas, your connection needs to have access to all of them (multiple 
-> connections are not supported).
+> connections are not supported in a single MikroORM instance).
 
-All you need to do is simply define the table name including schema name in `collection` option:
+All you need to do is simply define the schema name via `schema` options, or 
+table name including schema name in `tableName` option:
 
 ```typescript
-@Entity({ tableName: 'first_schema.foo' })
+@Entity({ schema: 'first_schema' })
 export class Foo { ... }
 
+// or alternatively we can specify it inside custom table name
 @Entity({ tableName: 'second_schema.bar' })
 export class Bar { ... }
 ```
@@ -35,3 +37,44 @@ To create entity in specific schema, you will need to use `QueryBuilder`:
 const qb = em.createQueryBuilder(User);
 await qb.insert({ email: 'foo@bar.com' }).withSchema('client-123');
 ```
+
+## Wildcard Schema
+
+Since v5, MikroORM also supports defining entities that can exist in multiple
+schemas. To do that, we just specify wildcard schema:
+
+```ts
+@Entity({ schema: '*' })
+export class Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+  @ManyToOne(() => Author, { nullable: true, onDelete: 'cascade' })
+  author?: Author;
+
+  @ManyToOne(() => Book, { nullable: true })
+  basedOn?: Book;
+
+}
+```
+
+Entities like this will be by default ignored when using `SchemaGenerator`, 
+as we need to specify which schema to use. For that we need to use the `schema`
+option of the `createSchema/updateSchema/dropSchema` methods or the `--schema` 
+CLI parameter.
+
+On runtime, the wildcard schema will be replaced with either `FindOptions.schema`,
+or with the `schema` option from the ORM config.
+
+### Note about migrations
+
+Currently, this is not supported via migrations, they will always ignore
+wildcard schema entities, and `SchemaGenerator` needs to be used explicitly.
+Given the dynamic nature of such entities, it makes sense to only sync the 
+schema dynamically, e.g. in an API endpoint. We could still use the ORM 
+migrations, but we need to add the dynamic schema queries manually to migration
+files. It makes sense to use the `safe` mode for such queries.

--- a/docs/docs/upgrading-v4-to-v5.md
+++ b/docs/docs/upgrading-v4-to-v5.md
@@ -26,16 +26,22 @@ List of such methods:
 - `em.findOne()`
 - `em.findOneOrFail()`
 - `em.findAndCount()`
+- `em.getReference()`
 - `em.merge()`
 - `em.fork()`
 - `em.begin()`
+- `em.assign()`
+- `em.create()`
 - `repo.find()`
 - `repo.findOne()`
 - `repo.findOneOrFail()`
 - `repo.findAndCount()`
 - `repo.findAll()`
+- `repo.getReference()`
 - `repo.merge()`
 - `collection.init()`
+- `repo.create()`
+- `repo.assign()`
 
 This also applies to the methods on `IDatabaseDriver` interface.
 

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -44,7 +44,7 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
 
   nativeUpdateMany<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>[], data: EntityDictionary<T>[], options?: NativeInsertUpdateManyOptions<T>): Promise<QueryResult<T>>;
 
-  nativeDelete<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, options?: { ctx?: Transaction }): Promise<QueryResult<T>>;
+  nativeDelete<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, options?: NativeDeleteOptions<T>): Promise<QueryResult<T>>;
 
   syncCollection<T, O>(collection: Collection<T, O>, options?: { ctx?: Transaction }): Promise<void>;
 
@@ -73,7 +73,7 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
    */
   getDependencies(): string[];
 
-  lockPessimistic<T extends AnyEntity<T>>(entity: T, mode: LockMode, tables?: string[], ctx?: Transaction): Promise<void>;
+  lockPessimistic<T extends AnyEntity<T>>(entity: T, options: LockOptions): Promise<void>;
 
   /**
    * Converts native db errors to standardized driver exceptions
@@ -118,6 +118,7 @@ export interface FindOneOrFailOptions<T, P extends string = never> extends FindO
 export interface NativeInsertUpdateOptions<T> {
   convertCustomTypes?: boolean;
   ctx?: Transaction;
+  schema?: string;
 }
 
 export interface NativeInsertUpdateManyOptions<T> extends NativeInsertUpdateOptions<T> {
@@ -134,10 +135,38 @@ export interface CountOptions<T, P extends string = never>  {
   ctx?: Transaction;
 }
 
+export interface InsertOptions<T>  {
+  schema?: string;
+  ctx?: Transaction;
+}
+
 export interface UpdateOptions<T>  {
+  filters?: Dictionary<boolean | Dictionary> | string[] | boolean;
+  schema?: string;
+  ctx?: Transaction;
+}
+
+export interface DeleteOptions<T> extends DriverMethodOptions {
   filters?: Dictionary<boolean | Dictionary> | string[] | boolean;
 }
 
-export interface DeleteOptions<T>  {
+export interface NativeDeleteOptions<T> extends DriverMethodOptions {
   filters?: Dictionary<boolean | Dictionary> | string[] | boolean;
+}
+
+export interface LockOptions extends DriverMethodOptions {
+  lockMode?: LockMode;
+  lockVersion?: number | Date;
+  lockTableAliases?: string[];
+}
+
+export interface DriverMethodOptions {
+  ctx?: Transaction;
+  schema?: string;
+}
+
+export interface GetReferenceOptions {
+  wrapped?: boolean;
+  convertCustomTypes?: boolean;
+  schema?: string;
 }

--- a/packages/core/src/entity/BaseEntity.ts
+++ b/packages/core/src/entity/BaseEntity.ts
@@ -41,4 +41,12 @@ export abstract class BaseEntity<T, PK extends keyof T, P extends string = never
     return (this as unknown as AnyEntity<T>).__helper!.init(populated);
   }
 
+  getSchema(): string | undefined {
+    return (this as unknown as AnyEntity<T>).__helper!.getSchema();
+  }
+
+  setSchema(schema?: string): void {
+    (this as unknown as AnyEntity<T>).__helper!.setSchema(schema);
+  }
+
 }

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -10,6 +10,7 @@ export interface FactoryOptions {
   merge?: boolean;
   refresh?: boolean;
   convertCustomTypes?: boolean;
+  schema?: string;
 }
 
 export class EntityFactory {
@@ -40,7 +41,7 @@ export class EntityFactory {
     }
 
     const meta2 = this.processDiscriminatorColumn<T>(meta, data);
-    const exists = this.findEntity<T>(data, meta2, options.convertCustomTypes);
+    const exists = this.findEntity<T>(data, meta2, options);
 
     if (exists && exists.__helper!.__initialized && !options.refresh) {
       exists.__helper!.__initialized = options.initialized;
@@ -113,8 +114,8 @@ export class EntityFactory {
     });
   }
 
-  createReference<T>(entityName: EntityName<T>, id: Primary<T> | Primary<T>[] | Record<string, Primary<T>>, options: Pick<FactoryOptions, 'merge' | 'convertCustomTypes'> = {}): T {
-    options.convertCustomTypes = options.convertCustomTypes ?? true;
+  createReference<T>(entityName: EntityName<T>, id: Primary<T> | Primary<T>[] | Record<string, Primary<T>>, options: Pick<FactoryOptions, 'merge' | 'convertCustomTypes' | 'schema'> = {}): T {
+    options.convertCustomTypes ??= true;
     entityName = Utils.className(entityName);
     const meta = this.metadata.get(entityName);
 
@@ -128,7 +129,7 @@ export class EntityFactory {
       id = { [meta.primaryKeys[0]]: id as Primary<T> };
     }
 
-    const exists = this.unitOfWork.getById<T>(entityName, pks);
+    const exists = this.unitOfWork.getById<T>(entityName, pks, options.schema);
 
     if (exists) {
       return exists;
@@ -139,17 +140,21 @@ export class EntityFactory {
 
   private createEntity<T extends AnyEntity<T>>(data: EntityData<T>, meta: EntityMetadata<T>, options: FactoryOptions): T {
     if (options.newEntity || meta.forceConstructor) {
-      const params = this.extractConstructorParams<T>(meta, data);
+      const params = this.extractConstructorParams<T>(meta, data, options);
       const Entity = meta.class;
       meta.constructorParams.forEach(prop => delete data[prop]);
 
       // creates new instance via constructor as this is the new entity
-      return new Entity(...params);
+      const entity = new Entity(...params);
+      entity.__helper!.__schema = options.schema;
+
+      return entity;
     }
 
     // creates new entity instance, bypassing constructor call as its already persisted entity
     const entity = Object.create(meta.class.prototype) as T;
     entity.__helper!.__managed = true;
+    entity.__helper!.__schema = options.schema;
 
     if (meta.selfReferencing && !options.newEntity) {
       this.hydrator.hydrateReference(entity, meta, data, this, options.convertCustomTypes);
@@ -168,18 +173,18 @@ export class EntityFactory {
     Object.keys(data).forEach(key => entity.__helper!.__loadedProperties.add(key));
   }
 
-  private findEntity<T>(data: EntityData<T>, meta: EntityMetadata<T>, convertCustomTypes?: boolean): T | undefined {
+  private findEntity<T>(data: EntityData<T>, meta: EntityMetadata<T>, options: FactoryOptions): T | undefined {
     if (!meta.compositePK && !meta.properties[meta.primaryKeys[0]].customType) {
-      return this.unitOfWork.getById<T>(meta.name!, data[meta.primaryKeys[0]] as Primary<T>);
+      return this.unitOfWork.getById<T>(meta.name!, data[meta.primaryKeys[0]] as Primary<T>, options.schema);
     }
 
     if (meta.primaryKeys.some(pk => !Utils.isDefined(data[pk as keyof T], true))) {
       return undefined;
     }
 
-    const pks = Utils.getOrderedPrimaryKeys<T>(data as Dictionary, meta, this.platform, convertCustomTypes);
+    const pks = Utils.getOrderedPrimaryKeys<T>(data as Dictionary, meta, this.platform, options.convertCustomTypes);
 
-    return this.unitOfWork.getById<T>(meta.name!, pks);
+    return this.unitOfWork.getById<T>(meta.name!, pks, options.schema);
   }
 
   private processDiscriminatorColumn<T>(meta: EntityMetadata<T>, data: EntityData<T>): EntityMetadata<T> {
@@ -221,10 +226,10 @@ export class EntityFactory {
   /**
    * returns parameters for entity constructor, creating references from plain ids
    */
-  private extractConstructorParams<T>(meta: EntityMetadata<T>, data: EntityData<T>): T[keyof T][] {
+  private extractConstructorParams<T>(meta: EntityMetadata<T>, data: EntityData<T>, options: FactoryOptions): T[keyof T][] {
     return meta.constructorParams.map(k => {
       if (meta.properties[k] && [ReferenceType.MANY_TO_ONE, ReferenceType.ONE_TO_ONE].includes(meta.properties[k].reference) && data[k]) {
-        const entity = this.unitOfWork.getById(meta.properties[k].type, data[k]) as T[keyof T];
+        const entity = this.unitOfWork.getById(meta.properties[k].type, data[k], options.schema) as T[keyof T];
 
         if (entity) {
           return entity;
@@ -234,7 +239,7 @@ export class EntityFactory {
           return data[k];
         }
 
-        return this.createReference(meta.properties[k].type, data[k]);
+        return this.createReference(meta.properties[k].type, data[k], options);
       }
 
       if (!meta.properties[k]) {

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -165,6 +165,7 @@ export class EntityFactory {
   }
 
   private getSchemaName(options: { schema?: string }): string | undefined {
+    /* istanbul ignore next */
     return options.schema === '*' ? this.config.get('schema') : options.schema;
   }
 

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -146,7 +146,7 @@ export class EntityFactory {
 
       // creates new instance via constructor as this is the new entity
       const entity = new Entity(...params);
-      entity.__helper!.__schema = options.schema;
+      entity.__helper!.__schema = this.getSchemaName(options);
 
       return entity;
     }
@@ -154,7 +154,7 @@ export class EntityFactory {
     // creates new entity instance, bypassing constructor call as its already persisted entity
     const entity = Object.create(meta.class.prototype) as T;
     entity.__helper!.__managed = true;
-    entity.__helper!.__schema = options.schema;
+    entity.__helper!.__schema = this.getSchemaName(options);
 
     if (meta.selfReferencing && !options.newEntity) {
       this.hydrator.hydrateReference(entity, meta, data, this, options.convertCustomTypes);
@@ -162,6 +162,10 @@ export class EntityFactory {
     }
 
     return entity;
+  }
+
+  private getSchemaName(options: { schema?: string }): string | undefined {
+    return options.schema === '*' ? this.config.get('schema') : options.schema;
   }
 
   private hydrate<T extends AnyEntity<T>>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, options: FactoryOptions): void {

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -1,6 +1,6 @@
 import type { EntityManager, MergeOptions } from '../EntityManager';
 import type { EntityData, EntityName, AnyEntity, Primary, Loaded, New, FilterQuery, EntityDictionary, AutoPath } from '../typings';
-import type { CountOptions, DeleteOptions, FindOneOptions, FindOneOrFailOptions, FindOptions, UpdateOptions } from '../drivers/IDatabaseDriver';
+import type { CountOptions, DeleteOptions, FindOneOptions, FindOneOrFailOptions, FindOptions, GetReferenceOptions, UpdateOptions } from '../drivers/IDatabaseDriver';
 import type { IdentifiedReference, Reference } from './Reference';
 import type { EntityLoaderOptions } from './EntityLoader';
 
@@ -135,30 +135,30 @@ export class EntityRepository<T extends AnyEntity<T>> {
   /**
    * Maps raw database result to an entity and merges it to this EntityManager.
    */
-  map(result: EntityDictionary<T>): T {
-    return this.em.map(this.entityName, result);
+  map(result: EntityDictionary<T>, options?: { schema?: string }): T {
+    return this.em.map(this.entityName, result, options);
   }
 
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<PK extends keyof T>(id: Primary<T>, wrapped: true): IdentifiedReference<T, PK>;
+  getReference<PK extends keyof T>(id: Primary<T>, options: Omit<GetReferenceOptions, 'wrapped'> & { wrapped: true }): IdentifiedReference<T, PK>;
 
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<PK extends keyof T = keyof T>(id: Primary<T>): T;
+  getReference(id: Primary<T> | Primary<T>[]): T;
 
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<PK extends keyof T = keyof T>(id: Primary<T>, wrapped: false): T;
+  getReference(id: Primary<T>, options: Omit<GetReferenceOptions, 'wrapped'> & { wrapped: false }): T;
 
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<PK extends keyof T = keyof T>(id: Primary<T>, wrapped = false): T | Reference<T> {
-    return this.em.getReference<T>(this.entityName, id, wrapped);
+  getReference<PK extends keyof T = keyof T>(id: Primary<T>, options?: GetReferenceOptions): T | Reference<T> {
+    return this.em.getReference<T>(this.entityName, id, options);
   }
 
   /**

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -18,6 +18,7 @@ export class WrappedEntity<T extends AnyEntity<T>, PK extends keyof T> {
   __populated?: boolean;
   __lazyInitialized?: boolean;
   __managed?: boolean;
+  __schema?: string;
   __em?: EntityManager;
   __serializationContext: { root?: SerializationContext<T>; populate?: PopulateOptions<T>[] } = {};
   __loadedProperties = new Set<string>();
@@ -115,6 +116,14 @@ export class WrappedEntity<T extends AnyEntity<T>, PK extends keyof T> {
     }
 
     return [pk];
+  }
+
+  getSchema(): string | undefined {
+    return this.__schema;
+  }
+
+  setSchema(schema?: string): void {
+    this.__schema = schema;
   }
 
   setPrimaryKey(id: Primary<T> | null) {

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -425,10 +425,18 @@ export class MetadataDiscovery {
   }
 
   private async definePivotTableEntity(meta: EntityMetadata, prop: EntityProperty): Promise<EntityMetadata> {
+    let tableName = prop.pivotTable;
+    let schemaName: string | undefined;
+
+    if (prop.pivotTable.includes('.')) {
+      [schemaName, tableName] = prop.pivotTable.split('.');
+    }
+
     const data = new EntityMetadata({
       name: prop.pivotTable,
       className: prop.pivotTable,
-      collection: prop.pivotTable,
+      collection: tableName,
+      schema: schemaName,
       pivotTable: true,
     });
 

--- a/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
+++ b/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
@@ -14,6 +14,7 @@ export abstract class AbstractNamingStrategy implements NamingStrategy {
   }
 
   indexName(tableName: string, columns: string[], type: 'primary' | 'foreign' | 'unique' | 'index' | 'sequence'): string {
+    /* istanbul ignore next */
     if (tableName.includes('.')) {
       tableName = tableName.substr(tableName.indexOf('.') + 1);
     }

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -99,6 +99,8 @@ export interface IWrappedEntity<T extends AnyEntity<T>, PK extends keyof T | unk
   toJSON(...args: any[]): EntityDTO<T>;
   toPOJO(): EntityDTO<T>;
   assign(data: EntityData<T> | Partial<EntityDTO<T>>, options?: AssignOptions | boolean): T;
+  getSchema(): string | undefined;
+  setSchema(schema?: string): void;
 }
 
 export interface IWrappedEntityInternal<T, PK extends keyof T | unknown = PrimaryProperty<T>, P extends string = string> extends IWrappedEntity<T, PK, P> {
@@ -116,6 +118,7 @@ export interface IWrappedEntityInternal<T, PK extends keyof T | unknown = Primar
   __loadedProperties: Set<string>;
   __identifier?: EntityIdentifier;
   __managed: boolean;
+  __schema?: string;
   __populated: boolean;
   __lazyInitialized: boolean;
   __primaryKeys: Primary<T>[];

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -379,13 +379,13 @@ export interface EntityMetadata<T extends AnyEntity<T> = any> {
 
 export interface ISchemaGenerator {
   generate(): Promise<string>;
-  createSchema(options?: { wrap?: boolean }): Promise<void>;
+  createSchema(options?: { wrap?: boolean; schema?: string }): Promise<void>;
   ensureDatabase(): Promise<void>;
-  getCreateSchemaSQL(options?: { wrap?: boolean }): Promise<string>;
-  dropSchema(options?: { wrap?: boolean; dropMigrationsTable?: boolean; dropDb?: boolean }): Promise<void>;
-  getDropSchemaSQL(options?: { wrap?: boolean; dropMigrationsTable?: boolean }): Promise<string>;
-  updateSchema(options?: { wrap?: boolean; safe?: boolean; dropDb?: boolean; dropTables?: boolean }): Promise<void>;
-  getUpdateSchemaSQL(options?: { wrap?: boolean; safe?: boolean; dropDb?: boolean; dropTables?: boolean }): Promise<string>;
+  getCreateSchemaSQL(options?: { wrap?: boolean; schema?: string }): Promise<string>;
+  dropSchema(options?: { wrap?: boolean; dropMigrationsTable?: boolean; dropDb?: boolean; schema?: string }): Promise<void>;
+  getDropSchemaSQL(options?: { wrap?: boolean; dropMigrationsTable?: boolean; schema?: string }): Promise<string>;
+  updateSchema(options?: { wrap?: boolean; safe?: boolean; dropDb?: boolean; dropTables?: boolean; schema?: string }): Promise<void>;
+  getUpdateSchemaSQL(options?: { wrap?: boolean; safe?: boolean; dropDb?: boolean; dropTables?: boolean; schema?: string }): Promise<string>;
   getUpdateSchemaMigrationSQL(options?: { wrap?: boolean; safe?: boolean; dropDb?: boolean; dropTables?: boolean }): Promise<{ up: string; down: string }>;
   createDatabase(name: string): Promise<void>;
   dropDatabase(name: string): Promise<void>;

--- a/packages/core/src/unit-of-work/ChangeSet.ts
+++ b/packages/core/src/unit-of-work/ChangeSet.ts
@@ -11,6 +11,7 @@ export class ChangeSet<T extends AnyEntity<T>> {
     this.name = meta.className;
     this.rootName = meta.root.className;
     this.collection = meta.root.collection;
+    this.schema = entity.__helper!.__schema ?? meta.root.schema;
   }
 
   getPrimaryKey(): Primary<T> | Primary<T>[] | null {
@@ -24,6 +25,7 @@ export interface ChangeSet<T extends AnyEntity<T>> {
   name: string;
   rootName: string;
   collection: string;
+  schema?: string;
   type: ChangeSetType;
   entity: T;
   payload: EntityDictionary<T>;

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -4,10 +4,10 @@ import type { EntityFactory } from '../entity';
 import { EntityIdentifier } from '../entity';
 import type { ChangeSet } from './ChangeSet';
 import { ChangeSetType } from './ChangeSet';
-import type { QueryResult, Transaction } from '../connections';
+import type { QueryResult } from '../connections';
 import type { Configuration } from '../utils';
 import { Utils } from '../utils';
-import type { IDatabaseDriver } from '../drivers';
+import type { DriverMethodOptions, IDatabaseDriver } from '../drivers';
 import { OptimisticLockError } from '../errors';
 
 export class ChangeSetPersister {
@@ -20,33 +20,45 @@ export class ChangeSetPersister {
               private readonly factory: EntityFactory,
               private readonly config: Configuration) { }
 
-  async executeInserts<T extends AnyEntity<T>>(changeSets: ChangeSet<T>[], ctx?: Transaction): Promise<void> {
+  async executeInserts<T extends AnyEntity<T>>(changeSets: ChangeSet<T>[], options?: DriverMethodOptions, withSchema?: boolean): Promise<void> {
+    if (!withSchema) {
+      return this.runForEachSchema(changeSets, 'executeInserts', options);
+    }
+
     const meta = this.metadata.find(changeSets[0].name)!;
     changeSets.forEach(changeSet => this.processProperties(changeSet));
 
     if (changeSets.length > 1 && this.config.get('useBatchInserts', this.platform.usesBatchInserts())) {
-      return this.persistNewEntities(meta, changeSets, ctx);
+      return this.persistNewEntities(meta, changeSets, options);
     }
 
     for (const changeSet of changeSets) {
-      await this.persistNewEntity(meta, changeSet, ctx);
+      await this.persistNewEntity(meta, changeSet, options);
     }
   }
 
-  async executeUpdates<T extends AnyEntity<T>>(changeSets: ChangeSet<T>[], batched: boolean, ctx?: Transaction): Promise<void> {
+  async executeUpdates<T extends AnyEntity<T>>(changeSets: ChangeSet<T>[], batched: boolean, options?: DriverMethodOptions, withSchema?: boolean): Promise<void> {
+    if (!withSchema) {
+      return this.runForEachSchema(changeSets, 'executeUpdates', options, batched);
+    }
+
     const meta = this.metadata.find(changeSets[0].name)!;
     changeSets.forEach(changeSet => this.processProperties(changeSet));
 
     if (batched && changeSets.length > 1 && this.config.get('useBatchUpdates', this.platform.usesBatchUpdates())) {
-      return this.persistManagedEntities(meta, changeSets, ctx);
+      return this.persistManagedEntities(meta, changeSets, options);
     }
 
     for (const changeSet of changeSets) {
-      await this.persistManagedEntity(changeSet, ctx);
+      await this.persistManagedEntity(changeSet, options);
     }
   }
 
-  async executeDeletes<T extends AnyEntity<T>>(changeSets: ChangeSet<T>[], ctx?: Transaction): Promise<void> {
+  async executeDeletes<T extends AnyEntity<T>>(changeSets: ChangeSet<T>[], options?: DriverMethodOptions, withSchema?: boolean): Promise<void> {
+    if (!withSchema) {
+      return this.runForEachSchema(changeSets, 'executeDeletes', options);
+    }
+
     const size = this.config.get('batchSize');
     const meta = changeSets[0].entity.__meta!;
     const pk = Utils.getPrimaryKeyHash(meta.primaryKeys);
@@ -54,7 +66,22 @@ export class ChangeSetPersister {
     for (let i = 0; i < changeSets.length; i += size) {
       const chunk = changeSets.slice(i, i + size);
       const pks = chunk.map(cs => cs.getPrimaryKey());
-      await this.driver.nativeDelete(meta.className, { [pk]: { $in: pks } }, { ctx });
+      options = this.propagateSchemaFromMetadata(meta, options);
+      await this.driver.nativeDelete(meta.className, { [pk]: { $in: pks } }, options);
+    }
+  }
+
+  private async runForEachSchema<T extends AnyEntity<T>>(changeSets: ChangeSet<T>[], method: string, options?: DriverMethodOptions, ...args: unknown[]): Promise<void> {
+    const groups = new Map<string, ChangeSet<T>[]>();
+    changeSets.forEach(cs => {
+      const group = groups.get(cs.schema!) ?? [];
+      group.push(cs);
+      groups.set(cs.schema!, group);
+    });
+
+    for (const [key, group] of groups.entries()) {
+      options = { ...options, schema: key };
+      await this[method](group, ...args, options, true);
     }
   }
 
@@ -66,12 +93,12 @@ export class ChangeSetPersister {
     }
   }
 
-  private async persistNewEntity<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSet: ChangeSet<T>, ctx?: Transaction): Promise<void> {
+  private async persistNewEntity<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSet: ChangeSet<T>, options?: DriverMethodOptions): Promise<void> {
     const wrapped = changeSet.entity.__helper!;
-    const res = await this.driver.nativeInsert(changeSet.name, changeSet.payload, {
+    options = this.propagateSchemaFromMetadata(meta, options, {
       convertCustomTypes: false,
-      ctx,
     });
+    const res = await this.driver.nativeInsert(changeSet.name, changeSet.payload, options);
 
     if (!wrapped.hasPrimaryKey()) {
       this.mapPrimaryKey(meta, res.insertId as number, changeSet);
@@ -83,31 +110,40 @@ export class ChangeSetPersister {
     wrapped.__managed = true;
 
     if (!this.platform.usesReturningStatement()) {
-      await this.reloadVersionValues(meta, [changeSet], ctx);
+      await this.reloadVersionValues(meta, [changeSet], options);
     }
 
     changeSet.persisted = true;
   }
 
-  private async persistNewEntities<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], ctx?: Transaction): Promise<void> {
+  private async persistNewEntities<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], options?: DriverMethodOptions): Promise<void> {
     const size = this.config.get('batchSize');
 
     for (let i = 0; i < changeSets.length; i += size) {
       const chunk = changeSets.slice(i, i + size);
-      await this.persistNewEntitiesBatch(meta, chunk, ctx);
+      await this.persistNewEntitiesBatch(meta, chunk, options);
 
       if (!this.platform.usesReturningStatement()) {
-        await this.reloadVersionValues(meta, chunk, ctx);
+        await this.reloadVersionValues(meta, chunk, options);
       }
     }
   }
 
-  private async persistNewEntitiesBatch<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], ctx?: Transaction): Promise<void> {
-    const res = await this.driver.nativeInsertMany(meta.className, changeSets.map(cs => cs.payload), {
+  private propagateSchemaFromMetadata<T>(meta: EntityMetadata<T>, options?: DriverMethodOptions, additionalOptions?: Dictionary): DriverMethodOptions {
+    /* istanbul ignore next */
+    return {
+      ...options,
+      ...additionalOptions,
+      schema: options?.schema ?? meta.schema,
+    };
+  }
+
+  private async persistNewEntitiesBatch<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], options?: DriverMethodOptions): Promise<void> {
+    options = this.propagateSchemaFromMetadata(meta, options, {
       convertCustomTypes: false,
       processCollections: false,
-      ctx,
     });
+    const res = await this.driver.nativeInsertMany(meta.className, changeSets.map(cs => cs.payload), options);
 
     for (let i = 0; i < changeSets.length; i++) {
       const changeSet = changeSets[i];
@@ -126,31 +162,31 @@ export class ChangeSetPersister {
     }
   }
 
-  private async persistManagedEntity<T extends AnyEntity<T>>(changeSet: ChangeSet<T>, ctx?: Transaction): Promise<void> {
+  private async persistManagedEntity<T extends AnyEntity<T>>(changeSet: ChangeSet<T>, options?: DriverMethodOptions): Promise<void> {
     const meta = this.metadata.find(changeSet.name)!;
-    const res = await this.updateEntity(meta, changeSet, ctx);
+    const res = await this.updateEntity(meta, changeSet, options);
     this.checkOptimisticLock(meta, changeSet, res);
-    await this.reloadVersionValues(meta, [changeSet], ctx);
+    await this.reloadVersionValues(meta, [changeSet], options);
     changeSet.persisted = true;
   }
 
-  private async persistManagedEntities<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], ctx?: Transaction): Promise<void> {
+  private async persistManagedEntities<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], options?: DriverMethodOptions): Promise<void> {
     const size = this.config.get('batchSize');
 
     for (let i = 0; i < changeSets.length; i += size) {
       const chunk = changeSets.slice(i, i + size);
-      await this.persistManagedEntitiesBatch(meta, chunk, ctx);
-      await this.reloadVersionValues(meta, chunk, ctx);
+      await this.persistManagedEntitiesBatch(meta, chunk, options);
+      await this.reloadVersionValues(meta, chunk, options);
     }
   }
 
-  private async persistManagedEntitiesBatch<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], ctx?: Transaction): Promise<void> {
-    await this.checkOptimisticLocks(meta, changeSets, ctx);
-    await this.driver.nativeUpdateMany(meta.className, changeSets.map(cs => cs.getPrimaryKey() as Dictionary), changeSets.map(cs => cs.payload), {
+  private async persistManagedEntitiesBatch<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], options?: DriverMethodOptions): Promise<void> {
+    await this.checkOptimisticLocks(meta, changeSets, options);
+    options = this.propagateSchemaFromMetadata(meta, options, {
       convertCustomTypes: false,
       processCollections: false,
-      ctx,
     });
+    await this.driver.nativeUpdateMany(meta.className, changeSets.map(cs => cs.getPrimaryKey() as Dictionary), changeSets.map(cs => cs.payload), options);
     changeSets.forEach(cs => cs.persisted = true);
   }
 
@@ -175,6 +211,8 @@ export class ChangeSetPersister {
    * Sets populate flag to new entities so they are serialized like if they were loaded from the db
    */
   private markAsPopulated<T extends AnyEntity<T>>(changeSet: ChangeSet<T>, meta: EntityMetadata<T>) {
+    changeSet.entity.__helper!.__schema = changeSet.schema;
+
     if (!this.config.get('populateAfterFlush')) {
       return;
     }
@@ -191,20 +229,26 @@ export class ChangeSetPersister {
     });
   }
 
-  private async updateEntity<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSet: ChangeSet<T>, ctx?: Transaction): Promise<QueryResult<T>> {
+  private async updateEntity<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSet: ChangeSet<T>, options?: DriverMethodOptions): Promise<QueryResult<T>> {
     if (!meta.versionProperty || !changeSet.entity[meta.versionProperty]) {
-      return this.driver.nativeUpdate(changeSet.name, changeSet.getPrimaryKey() as Dictionary, changeSet.payload, { ctx, convertCustomTypes: false });
+      options = this.propagateSchemaFromMetadata(meta, options, {
+        convertCustomTypes: false,
+      });
+      return this.driver.nativeUpdate(changeSet.name, changeSet.getPrimaryKey() as Dictionary, changeSet.payload, options);
     }
 
     const cond = {
       ...Utils.getPrimaryKeyCond<T>(changeSet.entity, meta.primaryKeys),
       [meta.versionProperty]: this.platform.quoteVersionValue(changeSet.entity[meta.versionProperty] as unknown as Date, meta.properties[meta.versionProperty]),
     } as FilterQuery<T>;
+    options = this.propagateSchemaFromMetadata(meta, options, {
+      convertCustomTypes: false,
+    });
 
-    return this.driver.nativeUpdate<T>(changeSet.name, cond, changeSet.payload, { ctx, convertCustomTypes: false });
+    return this.driver.nativeUpdate<T>(changeSet.name, cond, changeSet.payload, options);
   }
 
-  private async checkOptimisticLocks<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], ctx?: Transaction): Promise<void> {
+  private async checkOptimisticLocks<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], options?: DriverMethodOptions): Promise<void> {
     if (!meta.versionProperty || changeSets.every(cs => !cs.entity[meta.versionProperty])) {
       return;
     }
@@ -214,7 +258,10 @@ export class ChangeSetPersister {
       [meta.versionProperty]: this.platform.quoteVersionValue(cs.entity[meta.versionProperty] as unknown as Date, meta.properties[meta.versionProperty]),
     }));
 
-    const res = await this.driver.find<T>(meta.className, { $or } as FilterQuery<T>, { fields: meta.primaryKeys, ctx });
+    options = this.propagateSchemaFromMetadata(meta, options, {
+      fields: meta.primaryKeys,
+    });
+    const res = await this.driver.find<T>(meta.className, { $or } as FilterQuery<T>, options);
 
     if (res.length !== changeSets.length) {
       const compare = (a: Dictionary, b: Dictionary, keys: string[]) => keys.every(k => a[k] === b[k]);
@@ -229,17 +276,17 @@ export class ChangeSetPersister {
     }
   }
 
-  private async reloadVersionValues<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], ctx?: Transaction) {
+  private async reloadVersionValues<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], options?: DriverMethodOptions) {
     if (!meta.versionProperty) {
       return;
     }
 
     const pk = Utils.getPrimaryKeyHash(meta.primaryKeys);
     const pks = changeSets.map(cs => cs.getPrimaryKey());
-    const data = await this.driver.find<T>(meta.name!, { [pk]: { $in: pks } } as FilterQuery<T>, {
+    options = this.propagateSchemaFromMetadata(meta, options, {
       fields: [meta.versionProperty],
-      ctx,
     });
+    const data = await this.driver.find<T>(meta.name!, { [pk]: { $in: pks } } as FilterQuery<T>, options);
     const map = new Map<string, Date>();
     data.forEach(e => map.set(Utils.getCompositeKeyHash<T>(e as T, meta), e[meta.versionProperty] as Date));
 

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -211,7 +211,7 @@ export class ChangeSetPersister {
    * Sets populate flag to new entities so they are serialized like if they were loaded from the db
    */
   private markAsPopulated<T extends AnyEntity<T>>(changeSet: ChangeSet<T>, meta: EntityMetadata<T>) {
-    changeSet.entity.__helper!.__schema = changeSet.schema;
+    changeSet.entity.__helper!.__schema = changeSet.schema === '*' ? this.config.get('schema') : changeSet.schema;
 
     if (!this.config.get('populateAfterFlush')) {
       return;

--- a/packages/core/src/unit-of-work/IdentityMap.ts
+++ b/packages/core/src/unit-of-work/IdentityMap.ts
@@ -5,11 +5,11 @@ export class IdentityMap {
   private readonly registry = new Map<Constructor<AnyEntity>, Map<string, AnyEntity>>();
 
   store<T extends AnyEntity<T>>(item: T) {
-    this.getStore(item.__meta!.root).set(item.__helper!.getSerializedPrimaryKey(), item);
+    this.getStore(item.__meta!.root).set(this.getPkHash(item), item);
   }
 
   delete<T extends AnyEntity<T>>(item: T) {
-    this.getStore(item.__meta!.root).delete(item.__helper!.getSerializedPrimaryKey());
+    this.getStore(item.__meta!.root).delete(this.getPkHash(item));
   }
 
   getByHash<T>(meta: EntityMetadata<T>, hash: string): T | undefined {
@@ -75,6 +75,17 @@ export class IdentityMap {
 
     const store = this.registry.get(cls) as Map<string, T>;
     return store.has(id) ? store.get(id) : undefined;
+  }
+
+  private getPkHash<T extends AnyEntity<T>>(item: T): string {
+    const pkHash = item.__helper!.getSerializedPrimaryKey();
+    const schema = item.__helper!.__schema || item.__meta!.root.schema;
+
+    if (schema) {
+      return schema + ':' + pkHash;
+    }
+
+    return pkHash;
   }
 
 }

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -329,6 +329,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
   }
 
   private getSchemaName(meta: EntityMetadata | undefined, options: { schema?: string }): string | undefined {
+    /* istanbul ignore next */
     return options.schema === '*' ? this.config.get('schema') : options.schema ?? (meta?.schema === '*' ? this.config.get('schema') : meta?.schema);
   }
 
@@ -668,6 +669,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     }
   }
 
+  /* istanbul ignore next */
   protected async updateCollectionDiff<T extends AnyEntity<T>, O extends AnyEntity<O>>(meta: EntityMetadata<O>, prop: EntityProperty<T>, pks: Primary<O>[], deleteDiff: Primary<T>[][] | boolean, insertDiff: Primary<T>[][], options: DriverMethodOptions = {}): Promise<void> {
     if (!deleteDiff) {
       deleteDiff = [];

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -1,11 +1,33 @@
 import type { Knex } from 'knex';
 import type {
-  AnyEntity, Collection, Configuration, Constructor, Dictionary, EntityData, EntityManager,
-  EntityMetadata, EntityProperty, FilterQuery, FindOneOptions, FindOptions, IDatabaseDriver, LockMode, Primary,
-  QueryOrderMap, QueryResult, Transaction, PopulateOptions, CountOptions, EntityDictionary, EntityField, NativeInsertUpdateOptions, NativeInsertUpdateManyOptions,
+  AnyEntity,
+  Collection,
+  Configuration,
+  Constructor,
+  CountOptions,
+  DeleteOptions,
+  Dictionary,
+  DriverMethodOptions,
+  EntityData,
+  EntityDictionary,
+  EntityField,
+  EntityManager,
+  EntityMetadata,
+  EntityProperty,
+  FilterQuery,
+  FindOneOptions,
+  FindOptions,
+  IDatabaseDriver,
+  LockOptions,
+  NativeInsertUpdateManyOptions,
+  NativeInsertUpdateOptions,
+  PopulateOptions,
+  Primary,
+  QueryOrderMap,
+  QueryResult,
+  Transaction,
 } from '@mikro-orm/core';
-import { DatabaseDriver, EntityManagerType, QueryFlag, ReferenceType, Utils, LoadStrategy,
-} from '@mikro-orm/core';
+import { DatabaseDriver, EntityManagerType, LoadStrategy, QueryFlag, ReferenceType, Utils } from '@mikro-orm/core';
 import type { AbstractSqlConnection } from './AbstractSqlConnection';
 import type { AbstractSqlPlatform } from './AbstractSqlPlatform';
 import { QueryBuilder } from './query/QueryBuilder';
@@ -193,7 +215,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     const meta = this.metadata.find<T>(entityName);
     const collections = this.extractManyToMany(entityName, data);
     const pks = this.getPrimaryKeyFields(entityName);
-    const qb = this.createQueryBuilder<T>(entityName, options.ctx, true, options.convertCustomTypes);
+    const qb = this.createQueryBuilder<T>(entityName, options.ctx, true, options.convertCustomTypes).withSchema(options.schema);
     const res = await this.rethrow(qb.insert(data).execute('run', false));
     res.row = res.row || {};
     let pk: any;
@@ -206,7 +228,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
       pk = [res.insertId];
     }
 
-    await this.processManyToMany<T>(meta, pk, collections, false, options.ctx);
+    await this.processManyToMany<T>(meta, pk, collections, false, options);
 
     return res as unknown as QueryResult<T>;
   }
@@ -224,10 +246,10 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     let res: QueryResult;
 
     if (fields.length === 0) {
-      const qb = this.createQueryBuilder<T>(entityName, options.ctx, true, options.convertCustomTypes);
+      const qb = this.createQueryBuilder<T>(entityName, options.ctx, true, options.convertCustomTypes).withSchema(options.schema);
       res = await this.rethrow(qb.insert(data).execute('run', false));
     } else {
-      let sql = `insert into ${this.platform.quoteIdentifier(meta.collection)} `;
+      let sql = `insert into ${(this.getTableName(meta, options))} `;
       /* istanbul ignore next */
       sql += fields.length > 0 ? '(' + fields.map(k => this.platform.quoteIdentifier(k)).join(', ') + ')' : 'default';
       sql += ` values `;
@@ -273,7 +295,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     }
 
     for (let i = 0; i < collections.length; i++) {
-      await this.processManyToMany<T>(meta, pk[i], collections[i], false, options.ctx);
+      await this.processManyToMany<T>(meta, pk[i], collections[i], false, options);
     }
 
     return res as unknown as QueryResult<T>;
@@ -293,13 +315,14 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     if (Utils.hasObjectKeys(data)) {
       const qb = this.createQueryBuilder<T>(entityName, options.ctx, true, options.convertCustomTypes)
         .update(data)
+        .withSchema(options.schema)
         .where(where);
 
       res = await this.rethrow(qb.execute('run', false));
     }
 
     const pk = pks.map(pk => Utils.extractPK<T>(data[pk] || where, meta)!) as Primary<T>[];
-    await this.processManyToMany<T>(meta, pk, collections, true, options.ctx);
+    await this.processManyToMany<T>(meta, pk, collections, true, options);
 
     return res as unknown as QueryResult<T>;
   }
@@ -313,7 +336,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     data.forEach(row => Object.keys(row).forEach(k => keys.add(k)));
     const pkCond = Utils.flatten(meta.primaryKeys.map(pk => meta.properties[pk].fieldNames)).map(pk => `${this.platform.quoteIdentifier(pk)} = ?`).join(' and ');
     const params: any[] = [];
-    let sql = `update ${this.platform.quoteIdentifier(meta.collection)} set `;
+    let sql = `update ${this.getTableName(meta, options)} set `;
 
     keys.forEach(key => {
       const prop = meta.properties[key];
@@ -372,25 +395,25 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     const res = await this.rethrow(this.execute<QueryResult>(sql, params, 'run', options.ctx));
 
     for (let i = 0; i < collections.length; i++) {
-      await this.processManyToMany<T>(meta, where[i] as Primary<T>[], collections[i], false, options.ctx);
+      await this.processManyToMany<T>(meta, where[i] as Primary<T>[], collections[i], false, options);
     }
 
     return res as unknown as QueryResult<T>;
   }
 
-  async nativeDelete<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T> | string | any, options: { ctx?: Transaction<Knex.Transaction> } = {}): Promise<QueryResult<T>> {
+  async nativeDelete<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T> | string | any, options: DeleteOptions<T> = {}): Promise<QueryResult<T>> {
     const pks = this.getPrimaryKeyFields(entityName);
 
     if (Utils.isPrimaryKey(where) && pks.length === 1) {
       where = { [pks[0]]: where };
     }
 
-    const qb = this.createQueryBuilder(entityName, options.ctx, true, false).delete(where);
+    const qb = this.createQueryBuilder(entityName, options.ctx, true, false).delete(where).withSchema(options.schema);
 
     return this.rethrow(qb.execute('run', false));
   }
 
-  async syncCollection<T extends AnyEntity<T>, O extends AnyEntity<O>>(coll: Collection<T, O>, options?: { ctx?: Transaction }): Promise<void> {
+  async syncCollection<T extends AnyEntity<T>, O extends AnyEntity<O>>(coll: Collection<T, O>, options?: DriverMethodOptions): Promise<void> {
     const wrapped = coll.owner.__helper!;
     const meta = wrapped.__meta;
     const pks = wrapped.getPrimaryKeys(true);
@@ -422,7 +445,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
       return this.rethrow(this.execute<any>(qb));
     }
 
-    return this.rethrow(this.updateCollectionDiff<T, O>(meta, coll.property, pks as any, deleteDiff as any, insertDiff as any, ctx));
+    return this.rethrow(this.updateCollectionDiff<T, O>(meta, coll.property, pks as any, deleteDiff as any, insertDiff as any, options));
   }
 
   async loadFromPivotTable<T, O>(prop: EntityProperty, owners: Primary<O>[][], where: FilterQuery<T> = {} as FilterQuery<T>, orderBy?: QueryOrderMap<T>[], ctx?: Transaction, options?: FindOptions<T>): Promise<Dictionary<T[]>> {
@@ -439,7 +462,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     }
 
     orderBy = this.getPivotOrderBy(prop, orderBy);
-    const qb = this.createQueryBuilder<T>(prop.type, ctx, !!ctx).unsetFlag(QueryFlag.CONVERT_CUSTOM_TYPES);
+    const qb = this.createQueryBuilder<T>(prop.type, ctx, !!ctx).unsetFlag(QueryFlag.CONVERT_CUSTOM_TYPES).withSchema(options?.schema);
     const populate = this.autoJoinOneToOneOwner(targetMeta, [{ field: prop.pivotTable }]);
     const fields = this.buildFields(targetMeta, (options?.populate ?? []) as unknown as PopulateOptions<T>[], [], qb, options?.fields as Field<T>[]);
     qb.select(fields).populate(populate).where(where).orderBy(orderBy!);
@@ -475,6 +498,16 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
 
   async execute<T extends QueryResult | EntityData<AnyEntity> | EntityData<AnyEntity>[] = EntityData<AnyEntity>[]>(queryOrKnex: string | Knex.QueryBuilder | Knex.Raw, params: any[] = [], method: 'all' | 'get' | 'run' = 'all', ctx?: Transaction): Promise<T> {
     return this.rethrow(this.connection.execute(queryOrKnex, params, method, ctx));
+  }
+
+  protected getTableName<T>(meta: EntityMetadata<T>, options: NativeInsertUpdateManyOptions<T>): string {
+    let tableName = this.platform.quoteIdentifier(meta.collection);
+
+    if (meta.schema || options.schema) {
+      tableName = this.platform.quoteIdentifier(options.schema ?? meta.schema!) + '.' + tableName;
+    }
+
+    return tableName;
   }
 
   /**
@@ -613,25 +646,25 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return ret;
   }
 
-  protected async processManyToMany<T extends AnyEntity<T>>(meta: EntityMetadata<T> | undefined, pks: Primary<T>[], collections: EntityData<T>, clear: boolean, ctx?: Transaction<Knex.Transaction>) {
+  protected async processManyToMany<T extends AnyEntity<T>>(meta: EntityMetadata<T> | undefined, pks: Primary<T>[], collections: EntityData<T>, clear: boolean, options?: DriverMethodOptions) {
     if (!meta) {
       return;
     }
 
     for (const prop of meta.relations) {
       if (collections[prop.name]) {
-        await this.rethrow(this.updateCollectionDiff(meta, prop, pks, clear, collections[prop.name] as Primary<T>[][], ctx));
+        await this.rethrow(this.updateCollectionDiff(meta, prop, pks, clear, collections[prop.name] as Primary<T>[][], options));
       }
     }
   }
 
-  protected async updateCollectionDiff<T extends AnyEntity<T>, O extends AnyEntity<O>>(meta: EntityMetadata<O>, prop: EntityProperty<T>, pks: Primary<O>[], deleteDiff: Primary<T>[][] | boolean, insertDiff: Primary<T>[][], ctx?: Transaction): Promise<void> {
+  protected async updateCollectionDiff<T extends AnyEntity<T>, O extends AnyEntity<O>>(meta: EntityMetadata<O>, prop: EntityProperty<T>, pks: Primary<O>[], deleteDiff: Primary<T>[][] | boolean, insertDiff: Primary<T>[][], options: DriverMethodOptions = {}): Promise<void> {
     if (!deleteDiff) {
       deleteDiff = [];
     }
 
     if (deleteDiff === true || deleteDiff.length > 0) {
-      const qb1 = this.createQueryBuilder(prop.pivotTable, ctx, true).unsetFlag(QueryFlag.CONVERT_CUSTOM_TYPES);
+      const qb1 = this.createQueryBuilder(prop.pivotTable, options.ctx, true).withSchema(options.schema).unsetFlag(QueryFlag.CONVERT_CUSTOM_TYPES);
       const knex = qb1.getKnex();
 
       if (Array.isArray(deleteDiff)) {
@@ -656,17 +689,24 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
 
     /* istanbul ignore else */
     if (this.platform.allowsMultiInsert()) {
-      await this.nativeInsertMany<T>(prop.pivotTable, items as EntityData<T>[], { ctx, convertCustomTypes: false, processCollections: false });
+      await this.nativeInsertMany<T>(prop.pivotTable, items as EntityData<T>[], { ...options, convertCustomTypes: false, processCollections: false });
     } else {
-      await Utils.runSerial(items, item => this.createQueryBuilder(prop.pivotTable, ctx, true).unsetFlag(QueryFlag.CONVERT_CUSTOM_TYPES).insert(item).execute('run', false));
+      await Utils.runSerial(items, item => {
+        return this.createQueryBuilder(prop.pivotTable, options.ctx, true)
+          .unsetFlag(QueryFlag.CONVERT_CUSTOM_TYPES)
+          .withSchema(options.schema)
+          .insert(item)
+          .execute('run', false);
+      });
     }
   }
 
-  async lockPessimistic<T extends AnyEntity<T>>(entity: T, mode: LockMode, tables?: string[], ctx?: Transaction): Promise<void> {
-    const qb = this.createQueryBuilder(entity.constructor.name, ctx).unsetFlag(QueryFlag.CONVERT_CUSTOM_TYPES);
+  async lockPessimistic<T extends AnyEntity<T>>(entity: T, options: LockOptions): Promise<void> {
     const meta = entity.__helper!.__meta;
+    /* istanbul ignore next */
+    const qb = this.createQueryBuilder(entity.constructor.name, options.ctx).unsetFlag(QueryFlag.CONVERT_CUSTOM_TYPES).withSchema(options.schema ?? meta.schema);
     const cond = Utils.getPrimaryKeyCond(entity, meta.primaryKeys);
-    qb.select('1').where(cond!).setLockMode(mode, tables);
+    qb.select('1').where(cond!).setLockMode(options.lockMode, options.lockTableAliases);
     await this.rethrow(qb.execute());
   }
 

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -488,7 +488,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
       res = this.driver.mergeJoinedResult(res, this.metadata.find(this.entityName)!);
     }
 
-    return res.map(r => this.em!.map<T>(this.entityName, r));
+    return res.map(r => this.em!.map<T>(this.entityName, r, { schema: this._schema }));
   }
 
   /**

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -778,7 +778,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
       subQuery.offset(this._offset);
     }
 
-    if (this._orderBy) {
+    if (this._orderBy.length > 0) {
       const orderBy = [];
       for (const orderMap of this._orderBy) {
         for (const [field, direction] of Object.entries(orderMap)) {

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -659,15 +659,18 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
 
   private getQueryBase(): Knex.QueryBuilder {
     const qb = this.getKnex();
+    const meta = this.metadata.find(this.entityName);
+    const metaSchema = meta?.schema && meta.schema !== '*' ? meta.schema : undefined;
+    const schema = this._schema ?? metaSchema ?? this.em?.config.get('schema');
 
-    if (this._schema) {
-      qb.withSchema(this._schema);
+    if (schema) {
+      qb.withSchema(schema);
     }
 
     if (this._indexHint) {
       const alias = this.helper.isTableNameAliasRequired(this.type) ? ` as ${this.platform.quoteIdentifier(this.alias)}` : '';
-      const schema = this._schema ? this.platform.quoteIdentifier(this._schema) + '.' : '';
-      const tableName = schema + this.platform.quoteIdentifier(this.helper.getTableName(this.entityName)) + alias;
+      const schemaQuoted = schema ? this.platform.quoteIdentifier(schema) + '.' : '';
+      const tableName = schemaQuoted + this.platform.quoteIdentifier(this.helper.getTableName(this.entityName)) + alias;
       qb.from(this.knex.raw(`${tableName} ${this._indexHint}`));
     }
 
@@ -679,12 +682,12 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
           qb.distinct();
         }
 
-        this.helper.processJoins(qb, this._joins);
+        this.helper.processJoins(qb, this._joins, schema);
         break;
       case QueryType.COUNT: {
         const m = this.flags.has(QueryFlag.DISTINCT) ? 'countDistinct' : 'count';
         qb[m]({ count: this._fields!.map(f => this.helper.mapper(f as string, this.type)) });
-        this.helper.processJoins(qb, this._joins);
+        this.helper.processJoins(qb, this._joins, schema);
         break;
       }
       case QueryType.INSERT:

--- a/packages/knex/src/schema/DatabaseSchema.ts
+++ b/packages/knex/src/schema/DatabaseSchema.ts
@@ -49,6 +49,7 @@ export class DatabaseSchema {
   }
 
   static async create(connection: AbstractSqlConnection, platform: AbstractSqlPlatform, config: Configuration, schemaName?: string): Promise<DatabaseSchema> {
+    /* istanbul ignore next */
     const schema = new DatabaseSchema(platform, schemaName ?? config.get('schema'));
     const tables = await connection.execute<Table[]>(platform.getSchemaHelper()!.getListTablesSQL());
 

--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -323,8 +323,9 @@ export class DatabaseTable {
     });
   }
 
+  // TODO remove param?
   isInDefaultNamespace(defaultNamespaceName: string) {
-    return this.schema === defaultNamespaceName || this.schema == null;
+    return this.schema == null;
   }
 
   toJSON(): Dictionary {

--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -91,12 +91,13 @@ export class DatabaseTable {
 
     if ([ReferenceType.MANY_TO_ONE, ReferenceType.ONE_TO_ONE].includes(prop.reference)) {
       const constraintName = this.getIndexName(true, prop.fieldNames, 'foreign');
+      const schema = prop.targetMeta!.schema === '*' ? this.schema : prop.targetMeta!.schema;
       this.foreignKeys[constraintName] = {
         constraintName,
         columnNames: prop.fieldNames,
         localTableName: this.getShortestName(),
         referencedColumnNames: prop.referencedColumnNames,
-        referencedTableName: prop.targetMeta!.schema ? `${prop.targetMeta!.schema}.${prop.referencedTableName}` : prop.referencedTableName,
+        referencedTableName: schema ? `${schema}.${prop.referencedTableName}` : prop.referencedTableName,
       };
 
       const cascade = prop.cascade.includes(Cascade.REMOVE) || prop.cascade.includes(Cascade.ALL);
@@ -321,11 +322,6 @@ export class DatabaseTable {
       type: index.type,
       expression: index.expression,
     });
-  }
-
-  // TODO remove param?
-  isInDefaultNamespace(defaultNamespaceName: string) {
-    return this.schema == null;
   }
 
   toJSON(): Dictionary {

--- a/packages/knex/src/schema/SchemaGenerator.ts
+++ b/packages/knex/src/schema/SchemaGenerator.ts
@@ -118,6 +118,9 @@ export class SchemaGenerator {
     /* istanbul ignore next */
     const fromSchema = options.fromSchema ?? await DatabaseSchema.create(this.connection, this.platform, this.config, options.schema);
     const comparator = new SchemaComparator(this.platform);
+    const wildcardSchemaTables = Object.values(this.metadata.getAll()).filter(meta => meta.schema === '*').map(meta => meta.tableName);
+    fromSchema.prune(options.schema, wildcardSchemaTables);
+    toSchema.prune(options.schema, wildcardSchemaTables);
     const diffUp = comparator.compare(fromSchema, toSchema);
 
     return this.diffToSQL(diffUp, options);
@@ -130,6 +133,9 @@ export class SchemaGenerator {
     const toSchema = this.getTargetSchema(options.schema);
     const fromSchema = options.fromSchema ?? await DatabaseSchema.create(this.connection, this.platform, this.config, options.schema);
     const comparator = new SchemaComparator(this.platform);
+    const wildcardSchemaTables = Object.values(this.metadata.getAll()).filter(meta => meta.schema === '*').map(meta => meta.tableName);
+    fromSchema.prune(options.schema, wildcardSchemaTables);
+    toSchema.prune(options.schema, wildcardSchemaTables);
     const diffUp = comparator.compare(fromSchema, toSchema);
     const diffDown = comparator.compare(toSchema, fromSchema);
 
@@ -192,6 +198,7 @@ export class SchemaGenerator {
   private getReferencedTableName(referencedTableName: string, schema?: string) {
     schema ??= this.config.get('schema');
 
+    /* istanbul ignore next */
     if (schema && referencedTableName.startsWith('*.')) {
       return `${schema}.${referencedTableName.replace(/^\*\./, '')}`;
     }

--- a/packages/knex/src/schema/SchemaGenerator.ts
+++ b/packages/knex/src/schema/SchemaGenerator.ts
@@ -66,7 +66,7 @@ export class SchemaGenerator {
     }
 
     for (const tableDef of toSchema.getTables()) {
-      ret += await this.dump(this.knex.schema.alterTable(tableDef.getShortestName(), table => this.createForeignKeys(table, tableDef, options.schema)));
+      ret += await this.dump(this.knex.schema.withSchema(tableDef.schema!).alterTable(tableDef.name, table => this.createForeignKeys(table, tableDef, options.schema)));
     }
 
     return this.wrapSchema(ret, { wrap });
@@ -158,7 +158,7 @@ export class SchemaGenerator {
     }
 
     for (const newTable of Object.values(schemaDiff.newTables)) {
-      ret += await this.dump(this.knex.schema.alterTable(newTable.getShortestName(), table => this.createForeignKeys(table, newTable, options.schema)));
+      ret += await this.dump(this.knex.schema.withSchema(newTable.schema!).alterTable(newTable.name, table => this.createForeignKeys(table, newTable, options.schema)));
     }
 
     if (options.dropTables && !options.safe) {
@@ -362,7 +362,7 @@ export class SchemaGenerator {
   }
 
   private createTable(tableDef: DatabaseTable): Knex.SchemaBuilder {
-    return this.knex.schema.createTable(tableDef.getShortestName(), table => {
+    return this.knex.schema.withSchema(tableDef.schema!).createTable(tableDef.name, table => {
       tableDef.getColumns().forEach(column => {
         const col = this.helper.createTableColumn(table, column, tableDef);
         this.configureColumn(column, col);

--- a/packages/knex/src/schema/SchemaGenerator.ts
+++ b/packages/knex/src/schema/SchemaGenerator.ts
@@ -101,6 +101,7 @@ export class SchemaGenerator {
   }
 
   private getSchemaName(meta: EntityMetadata, options: { schema?: string }): string | undefined {
+    /* istanbul ignore next */
     return meta.schema === '*' ? options.schema : meta.schema;
   }
 
@@ -392,6 +393,7 @@ export class SchemaGenerator {
     }
 
     if (index.primary) {
+      /* istanbul ignore next */
       const keyName = tableName.includes('.') ? tableName.split('.').pop()! + '_pkey' : undefined;
       table.primary(index.columnNames, keyName);
     } else if (index.unique) {

--- a/packages/knex/src/schema/SchemaHelper.ts
+++ b/packages/knex/src/schema/SchemaHelper.ts
@@ -48,7 +48,7 @@ export abstract class SchemaHelper {
     return {};
   }
 
-  getListTablesSQL(): string {
+  getListTablesSQL(schemaName?: string): string {
     throw new Error('Not supported by given driver');
   }
 

--- a/packages/knex/src/typings.ts
+++ b/packages/knex/src/typings.ts
@@ -17,6 +17,7 @@ export type Field<T> = string | keyof T | KnexStringRef | Knex.QueryBuilder;
 
 export interface JoinOptions {
   table: string;
+  schema?: string;
   type: 'leftJoin' | 'innerJoin' | 'pivotJoin';
   alias: string;
   ownerAlias: string;

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -195,7 +195,7 @@ export class Migrator implements IMigrator {
 
     const data = await import(this.snapshotPath);
     const schema = new DatabaseSchema(this.driver.getPlatform(), this.config.get('schema'));
-    const { tables, ...rest } = data;
+    const { tables, namespaces, ...rest } = data;
     const tableInstances = tables.map((tbl: Dictionary) => {
       const table = new DatabaseTable(this.driver.getPlatform(), tbl.name);
       const { columns, ...restTable } = tbl;
@@ -209,7 +209,7 @@ export class Migrator implements IMigrator {
 
       return table;
     });
-    Object.assign(schema, { tables: tableInstances, ...rest });
+    Object.assign(schema, { tables: tableInstances, namespaces: new Set(namespaces), ...rest });
 
     return schema;
   }

--- a/packages/postgresql/src/PostgreSqlSchemaHelper.ts
+++ b/packages/postgresql/src/PostgreSqlSchemaHelper.ts
@@ -24,8 +24,8 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     return `${this.enableForeignKeysSQL()}\n`;
   }
 
-  getListTablesSQL(): string {
-    return `select table_name, nullif(table_schema, 'public') as schema_name, `
+  getListTablesSQL(schemaName = 'public'): string {
+    return `select table_name, nullif(table_schema, '${schemaName}') as schema_name, `
       + `(select pg_catalog.obj_description(c.oid) from pg_catalog.pg_class c
           where c.oid = (select ('"' || table_schema || '"."' || table_name || '"')::regclass::oid) and c.relname = table_name) as table_comment `
       + `from information_schema.tables `

--- a/tests/DatabaseDriver.test.ts
+++ b/tests/DatabaseDriver.test.ts
@@ -67,7 +67,7 @@ describe('DatabaseDriver', () => {
     expect(driver.getPlatform().quoteValue('a')).toBe('a');
     await expect(driver.aggregate('', [])).rejects.toThrowError('Aggregations are not supported by Driver driver');
     await expect(driver.nativeUpdateMany('', [], [])).rejects.toThrowError('Batch updates are not supported by Driver driver');
-    await expect(driver.lockPessimistic({}, LockMode.NONE)).rejects.toThrowError('Pessimistic locks are not supported by Driver driver');
+    await expect(driver.lockPessimistic({}, { lockMode: LockMode.NONE })).rejects.toThrowError('Pessimistic locks are not supported by Driver driver');
     const e1 = driver.convertException(new Error('test'));
     const e2 = driver.convertException(e1);
     expect(e1).toBe(e2);

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -1801,8 +1801,8 @@ describe('EntityManagerMongo', () => {
     await orm.em.persistAndFlush([author, author2]);
     orm.em.clear();
 
-    const ref = orm.em.getReference<Author, 'id' | '_id'>(Author, author.id, true);
-    const ref1 = orm.em.getRepository(Author).getReference<'id' | '_id'>(author.id, true);
+    const ref = orm.em.getReference<Author, 'id' | '_id'>(Author, author.id, { wrapped: true });
+    const ref1 = orm.em.getRepository(Author).getReference<'id' | '_id'>(author.id, { wrapped: true });
     expect(ref).not.toBe(ref1);
     expect(ref.unwrap()).toBe(ref1.unwrap());
     expect(ref.isInitialized()).toBe(false);
@@ -1829,7 +1829,7 @@ describe('EntityManagerMongo', () => {
     expect(wrap(ent).isInitialized()).toBe(true);
     orm.em.clear();
 
-    const ref4 = orm.em.getReference<Author, 'id' | '_id'>(Author, author.id, true);
+    const ref4 = orm.em.getReference<Author, 'id' | '_id'>(Author, author.id, { wrapped: true });
     expect(ref4.isInitialized()).toBe(false);
     await expect(ref4.load('name')).resolves.toBe('God');
     expect(ref4.isInitialized()).toBe(true);

--- a/tests/EntityRepository.test.ts
+++ b/tests/EntityRepository.test.ts
@@ -45,7 +45,7 @@ describe('EntityRepository', () => {
 
   test('should forward calls to EntityManager', async () => {
     repo.getReference('bar');
-    expect(methods.getReference.mock.calls[0]).toEqual([Publisher, 'bar', false]);
+    expect(methods.getReference.mock.calls[0]).toEqual([Publisher, 'bar', undefined]);
     const e = Object.create(Publisher.prototype);
     repo.persist(e);
     expect(methods.persist.mock.calls[0]).toEqual([e]);

--- a/tests/features/auto-refreshing.postgre.test.ts
+++ b/tests/features/auto-refreshing.postgre.test.ts
@@ -131,11 +131,7 @@ describe('automatic refreshing of already loaded entities', () => {
     expect(r1[0].favouriteAuthor!.name).toBeDefined();
     expect(r1[0].favouriteAuthor!.age).toBeUndefined();
     r1[0].favouriteAuthor!.name = 'lol';
-    console.log(r1[0]);
-    console.log((r1[0] as any).__helper.__originalEntityData);
     const r2 = await orm.em.find(Author2, god, { populate: ['favouriteAuthor'], strategy: LoadStrategy.JOINED });
-    console.log(r2[0]);
-    console.log((r2[0] as any).__helper.__originalEntityData);
     expect(r2).toHaveLength(1);
     expect(r2[0].id).toBe(god.id);
     expect(r2[0].name).toBe(god.name);

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -134,6 +134,7 @@ describe('CLIHelper', () => {
     register.mockReturnValue({ config: {} });
     await expect(ConfigurationLoader.registerTsNode(__dirname + '/../tsconfig.json')).resolves.toBeUndefined();
     await expect(ConfigurationLoader.registerTsNode('./tests/tsconfig.json')).resolves.toBeUndefined();
+    register.mockRestore();
     requireFromMock.mockRestore();
   });
 
@@ -207,43 +208,49 @@ describe('CLIHelper', () => {
   test('builder (schema drop)', async () => {
     const args = { option: jest.fn() };
     SchemaCommandFactory.configureSchemaCommand(args as any, 'drop');
-    expect(args.option.mock.calls.length).toBe(5);
+    expect(args.option.mock.calls).toHaveLength(6);
     expect(args.option.mock.calls[0][0]).toBe('r');
     expect(args.option.mock.calls[0][1]).toMatchObject({ alias: 'run', type: 'boolean' });
     expect(args.option.mock.calls[1][0]).toBe('d');
     expect(args.option.mock.calls[1][1]).toMatchObject({ alias: 'dump', type: 'boolean' });
     expect(args.option.mock.calls[2][0]).toBe('fk-checks');
     expect(args.option.mock.calls[2][1]).toMatchObject({ type: 'boolean' });
-    expect(args.option.mock.calls[3][0]).toBe('drop-migrations-table');
-    expect(args.option.mock.calls[3][1]).toMatchObject({ type: 'boolean' });
-    expect(args.option.mock.calls[4][0]).toBe('drop-db');
+    expect(args.option.mock.calls[3][0]).toBe('schema');
+    expect(args.option.mock.calls[3][1]).toMatchObject({ type: 'string' });
+    expect(args.option.mock.calls[4][0]).toBe('drop-migrations-table');
     expect(args.option.mock.calls[4][1]).toMatchObject({ type: 'boolean' });
+    expect(args.option.mock.calls[5][0]).toBe('drop-db');
+    expect(args.option.mock.calls[5][1]).toMatchObject({ type: 'boolean' });
   });
 
   test('builder (schema update)', async () => {
     const args = { option: jest.fn() };
     SchemaCommandFactory.configureSchemaCommand(args as any, 'update');
-    expect(args.option.mock.calls.length).toBe(5);
+    expect(args.option.mock.calls).toHaveLength(6);
     expect(args.option.mock.calls[0][0]).toBe('r');
     expect(args.option.mock.calls[0][1]).toMatchObject({ alias: 'run', type: 'boolean' });
     expect(args.option.mock.calls[1][0]).toBe('d');
     expect(args.option.mock.calls[1][1]).toMatchObject({ alias: 'dump', type: 'boolean' });
     expect(args.option.mock.calls[2][0]).toBe('fk-checks');
     expect(args.option.mock.calls[2][1]).toMatchObject({ type: 'boolean' });
-    expect(args.option.mock.calls[3][0]).toBe('safe');
-    expect(args.option.mock.calls[3][1]).toMatchObject({ type: 'boolean' });
-    expect(args.option.mock.calls[4][0]).toBe('drop-tables');
+    expect(args.option.mock.calls[3][0]).toBe('schema');
+    expect(args.option.mock.calls[3][1]).toMatchObject({ type: 'string' });
+    expect(args.option.mock.calls[4][0]).toBe('safe');
     expect(args.option.mock.calls[4][1]).toMatchObject({ type: 'boolean' });
+    expect(args.option.mock.calls[5][0]).toBe('drop-tables');
+    expect(args.option.mock.calls[5][1]).toMatchObject({ type: 'boolean' });
   });
 
   test('builder (schema fresh)', async () => {
     const args = { option: jest.fn() };
     SchemaCommandFactory.configureSchemaCommand(args as any, 'fresh');
-    expect(args.option.mock.calls.length).toBe(2);
+    expect(args.option.mock.calls).toHaveLength(3);
     expect(args.option.mock.calls[0][0]).toBe('r');
     expect(args.option.mock.calls[0][1]).toMatchObject({ alias: 'run', type: 'boolean' });
-    expect(args.option.mock.calls[1][0]).toBe('seed');
+    expect(args.option.mock.calls[1][0]).toBe('schema');
     expect(args.option.mock.calls[1][1]).toMatchObject({ type: 'string' });
+    expect(args.option.mock.calls[2][0]).toBe('seed');
+    expect(args.option.mock.calls[2][1]).toMatchObject({ type: 'string' });
   });
 
   test('dump', async () => {

--- a/tests/features/cli/DropSchemaCommand.test.ts
+++ b/tests/features/cli/DropSchemaCommand.test.ts
@@ -44,7 +44,7 @@ describe('DropSchemaCommand', () => {
 
     await expect(cmd.handler({ run: true, dropMigrationsTable: true } as any)).resolves.toBeUndefined();
     expect(dropSchema.mock.calls.length).toBe(2);
-    expect(dropSchema.mock.calls[1][0]).toEqual({ wrap: true, dropMigrationsTable: true, dropDb: undefined });
+    expect(dropSchema.mock.calls[1][0]).toEqual({ wrap: true, dropMigrationsTable: true, run: true });
     expect(closeSpy).toBeCalledTimes(2);
 
     expect(getDropSchemaSQL.mock.calls.length).toBe(0);
@@ -54,12 +54,12 @@ describe('DropSchemaCommand', () => {
 
     await expect(cmd.handler({ dump: true, dropMigrationsTable: true } as any)).resolves.toBeUndefined();
     expect(getDropSchemaSQL.mock.calls.length).toBe(2);
-    expect(getDropSchemaSQL.mock.calls[1][0]).toEqual({ wrap: true, dropMigrationsTable: true });
+    expect(getDropSchemaSQL.mock.calls[1][0]).toEqual({ wrap: true, dropMigrationsTable: true, dump: true });
     expect(closeSpy).toBeCalledTimes(4);
 
     await expect(cmd.handler({ run: true, dropDb: true } as any)).resolves.toBeUndefined();
     expect(dropSchema.mock.calls.length).toBe(3);
-    expect(dropSchema.mock.calls[2][0]).toEqual({ wrap: true, dropMigrationsTable: undefined, dropDb: true });
+    expect(dropSchema.mock.calls[2][0]).toEqual({ wrap: true, dropMigrationsTable: undefined, dropDb: true, run: true });
     expect(closeSpy).toBeCalledTimes(5);
   });
 

--- a/tests/features/composite-keys/composite-keys.mysql.test.ts
+++ b/tests/features/composite-keys/composite-keys.mysql.test.ts
@@ -275,7 +275,7 @@ describe('composite keys in mysql', () => {
   });
 
   test('composite key references', async () => {
-    const ref = orm.em.getReference(Car2, ['n', 1], true);
+    const ref = orm.em.getReference(Car2, ['n', 1], { wrapped: true });
     expect(ref.unwrap()).toBeInstanceOf(Car2);
     expect(wrap(ref, true).__primaryKeys).toEqual(['n', 1]);
     expect(() => orm.em.getReference(Car2, 1 as any)).toThrowError('Composite key required for entity Car2.');

--- a/tests/features/composite-keys/composite-keys.sqlite.test.ts
+++ b/tests/features/composite-keys/composite-keys.sqlite.test.ts
@@ -549,7 +549,7 @@ describe('composite keys in sqlite', () => {
   });
 
   test('composite key references', async () => {
-    const ref = orm.em.getReference(Car2, ['n', 1], true);
+    const ref = orm.em.getReference(Car2, ['n', 1], { wrapped: true });
     expect(ref.unwrap()).toBeInstanceOf(Car2);
     expect(wrap(ref, true).__primaryKeys).toEqual(['n', 1]);
     expect(() => orm.em.getReference(Car2, 1 as any)).toThrowError('Composite key required for entity Car2.');

--- a/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
+++ b/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
@@ -70,9 +70,8 @@ describe('multiple connected schemas in postgres', () => {
   });
 
   beforeEach(async () => {
-    // TODO withSchema should not be needed for author (use default from metadata)
-    await orm.em.createQueryBuilder(Author).withSchema('n1').truncate().execute();
-    await orm.em.createQueryBuilder(Book).withSchema('n2').truncate().execute();
+    await orm.em.createQueryBuilder(Author).truncate().execute(); // schema from metadata
+    await orm.em.createQueryBuilder(Book).truncate().execute(); // current schema from config
     await orm.em.createQueryBuilder(Book).withSchema('n3').truncate().execute();
     await orm.em.createQueryBuilder(Book).withSchema('n4').truncate().execute();
     await orm.em.createQueryBuilder(Book).withSchema('n5').truncate().execute();
@@ -106,7 +105,9 @@ describe('multiple connected schemas in postgres', () => {
     author.name = 'a1';
 
     // each book has different schema, such collection can be used for persisting, but it can't be loaded (as we can load only from single schema at a time)
-    author.books.add(orm.em.create(Book, {}, { schema: 'n3' }), orm.em.create(Book, {}, { schema: 'n4' }), orm.em.create(Book, {}, { schema: 'n5' }));
+    const book4 = orm.em.create(Book, {});
+    wrap(book4).setSchema('n5');
+    author.books.add(orm.em.create(Book, {}, { schema: 'n3' }), orm.em.create(Book, {}, { schema: 'n4' }), book4);
     author.books[1].basedOn = author.books[0];
     author.books[2].basedOn = author.books[0];
 

--- a/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
+++ b/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
@@ -1,5 +1,6 @@
-import { Collection, Entity, LockMode, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, Property, wrap } from '@mikro-orm/core';
+import { BaseEntity, Cascade, Collection, Entity, LockMode, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, Property, wrap } from '@mikro-orm/core';
 import type { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { mockLogger } from '../../bootstrap';
 
 @Entity({ schema: 'n1' })
 export class Author {
@@ -14,18 +15,21 @@ export class Author {
   mentor?: Author;
 
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
-  @OneToMany(() => Book, e => e.author)
+  @OneToMany(() => Book, e => e.author, { cascade: [Cascade.REMOVE, Cascade.PERSIST] })
   books = new Collection<Book>(this);
 
 }
 
 @Entity({ schema: '*' })
-export class Book {
+export class Book extends BaseEntity<Book, 'id'> {
 
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne(() => Author, { nullable: true })
+  @Property({ nullable: true })
+  name?: string;
+
+  @ManyToOne(() => Author, { nullable: true, onDelete: 'cascade' })
   author?: Author;
 
   @ManyToOne(() => Book, { nullable: true })
@@ -105,27 +109,79 @@ describe('multiple connected schemas in postgres', () => {
     author.name = 'a1';
 
     // each book has different schema, such collection can be used for persisting, but it can't be loaded (as we can load only from single schema at a time)
-    const book4 = orm.em.create(Book, {});
-    wrap(book4).setSchema('n5');
-    author.books.add(orm.em.create(Book, {}, { schema: 'n3' }), orm.em.create(Book, {}, { schema: 'n4' }), book4);
+    const book51 = orm.em.create(Book, {});
+    book51.setSchema('n5');
+    const book52 = orm.em.create(Book, {});
+    wrap(book52).setSchema('n5');
+    author.books.add(orm.em.create(Book, {}, { schema: 'n3' }), orm.em.create(Book, {}, { schema: 'n4' }), book51, book52);
     author.books[1].basedOn = author.books[0];
     author.books[2].basedOn = author.books[0];
 
     // schema not specified yet, will be used from metadata
     expect(wrap(author).getSchema()).toBeUndefined();
+    const mock = mockLogger(orm);
     await orm.em.persistAndFlush(author);
     expect(orm.em.getUnitOfWork().getIdentityMap().keys()).toEqual([
       'Author-n1:1',
       'Book-n3:1',
       'Book-n4:1',
       'Book-n5:1',
+      'Book-n5:2',
     ]);
+    expect(mock.mock.calls[0][0]).toMatch(`begin`);
+    expect(mock.mock.calls[1][0]).toMatch(`insert into "n1"."author" ("name") values ('a1') returning "id"`);
+    expect(mock.mock.calls[2][0]).toMatch(`insert into "n3"."book" ("author_id") values (1) returning "id"`);
+    expect(mock.mock.calls[3][0]).toMatch(`insert into "n4"."book" ("author_id") values (1) returning "id"`);
+    expect(mock.mock.calls[4][0]).toMatch(`insert into "n5"."book" ("author_id") values (1), (1) returning "id"`);
+    expect(mock.mock.calls[5][0]).toMatch(`update "n4"."book" set "based_on_id" = 1 where "id" = 1`);
+    expect(mock.mock.calls[6][0]).toMatch(`update "n5"."book" set "based_on_id" = 1 where "id" = 1`);
+    expect(mock.mock.calls[7][0]).toMatch(`commit`);
+    mock.mockReset();
 
     // schema is saved after flush as if the entity was loaded from db
     expect(wrap(author).getSchema()).toBe('n1');
     expect(wrap(author.books[0]).getSchema()).toBe('n3');
     expect(wrap(author.books[1]).getSchema()).toBe('n4');
-    expect(wrap(author.books[2]).getSchema()).toBe('n5');
+    expect(author.books[2].getSchema()).toBe('n5');
+    expect(author.books[3].getSchema()).toBe('n5');
+
+    // update entities and flush
+    author.name = 'new name';
+    author.books[0].name = 'new name 1';
+    author.books[1].name = 'new name 2';
+    author.books[2].name = 'new name 3';
+    author.books[3].name = 'new name 4';
+    await orm.em.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch(`begin`);
+    expect(mock.mock.calls[1][0]).toMatch(`update "n1"."author" set "name" = 'new name' where "id" = 1`);
+    expect(mock.mock.calls[2][0]).toMatch(`update "n3"."book" set "name" = 'new name 1' where "id" = 1`);
+    expect(mock.mock.calls[3][0]).toMatch(`update "n4"."book" set "name" = 'new name 2' where "id" = 1`);
+    expect(mock.mock.calls[4][0]).toMatch(`update "n5"."book" set "name" = case when ("id" = 1) then 'new name 3' when ("id" = 2) then 'new name 4' else "name" end where "id" in (1, 2)`);
+    expect(mock.mock.calls[5][0]).toMatch(`commit`);
+    mock.mockReset();
+
+    // remove entity
+    orm.em.remove(author);
+    await orm.em.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch(`begin`);
+    expect(mock.mock.calls[1][0]).toMatch(`delete from "n3"."book" where "id" in (1)`);
+    expect(mock.mock.calls[2][0]).toMatch(`delete from "n4"."book" where "id" in (1)`);
+    expect(mock.mock.calls[3][0]).toMatch(`delete from "n5"."book" where "id" in (1, 2)`);
+    expect(mock.mock.calls[4][0]).toMatch(`delete from "n1"."author" where "id" in (1)`);
+    expect(mock.mock.calls[5][0]).toMatch(`commit`);
+
+    orm.em.clear();
+
+    const n1 = await orm.em.find(Author, {});
+    const n3 = await orm.em.find(Book, {}, { schema: 'n3' });
+    const n4 = await orm.em.find(Book, {}, { schema: 'n4' });
+    const n5 = await orm.em.find(Book, {}, { schema: 'n5' });
+    expect(n1).toHaveLength(0);
+    expect(n3).toHaveLength(0);
+    expect(n4).toHaveLength(0);
+    expect(n5).toHaveLength(0);
   });
 
   test('pessimistic locking', async () => {

--- a/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
+++ b/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
@@ -1,0 +1,142 @@
+import { Collection, Entity, LockMode, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, Property, wrap } from '@mikro-orm/core';
+import type { PostgreSqlDriver } from '@mikro-orm/postgresql';
+
+@Entity({ schema: 'n1' })
+export class Author {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToOne(() => Author, undefined, { nullable: true })
+  mentor?: Author;
+
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  @OneToMany(() => Book, e => e.author)
+  books = new Collection<Book>(this);
+
+}
+
+@Entity({ schema: '*' })
+export class Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Author, { nullable: true })
+  author?: Author;
+
+  @ManyToOne(() => Book, { nullable: true })
+  basedOn?: Book;
+
+}
+
+describe('multiple connected schemas in postgres', () => {
+
+  let orm: MikroORM<PostgreSqlDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Author, Book],
+      dbName: `mikro_orm_test_multi_schemas`,
+      type: 'postgresql',
+    });
+    await orm.getSchemaGenerator().ensureDatabase();
+
+    for (const ns of ['n1', 'n2', 'n3', 'n4', 'n5']) {
+      await orm.getSchemaGenerator().execute(`drop schema if exists ${ns} cascade`);
+    }
+
+    // `*` schema will be ignored
+    await orm.getSchemaGenerator().createSchema();
+    // TODO this is not working, tries to remove FKs from table that does not exist yet
+    // TODO looks like updateSchema() is removing all the other schemas just created by previous runs,
+    //   we need to ignore the other namespaces somehow? maybe when the schema option is specified, let's not remove any other namespaces?
+    // await orm.getSchemaGenerator().updateSchema(); // `*` schema will be ignored
+
+    // we need to pass schema for book
+    await orm.getSchemaGenerator().createSchema({ schema: 'n2' });
+    await orm.getSchemaGenerator().createSchema({ schema: 'n3' });
+    await orm.getSchemaGenerator().createSchema({ schema: 'n4' });
+    await orm.getSchemaGenerator().createSchema({ schema: 'n5' });
+    orm.config.set('schema', 'n2'); // set the schema so we can work with book entities without options param
+    // TODO we should probably validate usage of `*` when creating queries (if no schema is provided in config nor options)
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    // TODO withSchema should not be needed for author (use default from metadata)
+    await orm.em.createQueryBuilder(Author).withSchema('n1').truncate().execute();
+    await orm.em.createQueryBuilder(Book).withSchema('n2').truncate().execute();
+    await orm.em.createQueryBuilder(Book).withSchema('n3').truncate().execute();
+    await orm.em.createQueryBuilder(Book).withSchema('n4').truncate().execute();
+    await orm.em.createQueryBuilder(Book).withSchema('n5').truncate().execute();
+    orm.em.clear();
+  });
+
+  // if we have schema specified on entity level, it only exists in that schema
+  // if we have * schema on entity, it can exist in any schema, always controlled by the parameter
+  // no schema on entity - default schema or from global orm config
+  test('should work', async () => {
+    const author = new Author();
+    author.name = 'a1';
+    author.books.add(new Book(), new Book(), new Book());
+    author.books[1].basedOn = author.books[0];
+    author.books[2].basedOn = author.books[0];
+
+    // schema not specified yet, will be used from metadata
+    expect(wrap(author).getSchema()).toBeUndefined();
+    await orm.em.persistAndFlush(author);
+
+    // schema is saved after flush
+    expect(wrap(author).getSchema()).toBe('n1');
+    expect(wrap(author.books[0]).getSchema()).toBe('n2');
+    expect(wrap(author.books[1]).getSchema()).toBe('n2');
+    expect(wrap(author.books[2]).getSchema()).toBe('n2');
+  });
+
+  test('use different schema via options', async () => {
+    // author is always in schema `n1`
+    const author = new Author();
+    author.name = 'a1';
+
+    // each book has different schema, such collection can be used for persisting, but it can't be loaded (as we can load only from single schema at a time)
+    author.books.add(orm.em.create(Book, {}, { schema: 'n3' }), orm.em.create(Book, {}, { schema: 'n4' }), orm.em.create(Book, {}, { schema: 'n5' }));
+    author.books[1].basedOn = author.books[0];
+    author.books[2].basedOn = author.books[0];
+
+    // schema not specified yet, will be used from metadata
+    expect(wrap(author).getSchema()).toBeUndefined();
+    await orm.em.persistAndFlush(author);
+    expect(orm.em.getUnitOfWork().getIdentityMap().keys()).toEqual([
+      'Author-n1:1',
+      'Book-n3:1',
+      'Book-n4:1',
+      'Book-n5:1',
+    ]);
+
+    // schema is saved after flush as if the entity was loaded from db
+    expect(wrap(author).getSchema()).toBe('n1');
+    expect(wrap(author.books[0]).getSchema()).toBe('n3');
+    expect(wrap(author.books[1]).getSchema()).toBe('n4');
+    expect(wrap(author.books[2]).getSchema()).toBe('n5');
+  });
+
+  test('pessimistic locking', async () => {
+    await orm.getSchemaGenerator().updateSchema();
+    const author = new Author();
+    author.name = 'a1';
+    await orm.em.persistAndFlush(author);
+
+    await orm.em.transactional(async em => {
+      await orm.em.lock(author, LockMode.PESSIMISTIC_PARTIAL_WRITE);
+      await orm.em.getDriver().lockPessimistic(author, { lockMode: LockMode.PESSIMISTIC_PARTIAL_WRITE, ctx: em.getTransactionContext() });
+    });
+  });
+
+});

--- a/tests/features/schema-generator/multiple-schemas.postgres.test.ts
+++ b/tests/features/schema-generator/multiple-schemas.postgres.test.ts
@@ -54,6 +54,8 @@ describe('multiple connected schemas in postgres', () => {
       type: 'postgresql',
     });
     await orm.getSchemaGenerator().ensureDatabase();
+    await orm.getSchemaGenerator().execute('drop schema if exists n1 cascade');
+    await orm.getSchemaGenerator().execute('drop schema if exists n2 cascade');
   });
 
   afterAll(async () => {
@@ -61,9 +63,6 @@ describe('multiple connected schemas in postgres', () => {
   });
 
   test('schema generator allows creating FKs across different schemas', async () => {
-    await orm.getSchemaGenerator().execute('drop schema if exists n1 cascade');
-    await orm.getSchemaGenerator().execute('drop schema if exists n2 cascade');
-
     const diff0 = await orm.getSchemaGenerator().getUpdateSchemaSQL({ wrap: false });
     expect(diff0).toMatchSnapshot();
     await orm.getSchemaGenerator().execute(diff0);

--- a/tests/features/schema-generator/multiple-schemas.postgres.test.ts
+++ b/tests/features/schema-generator/multiple-schemas.postgres.test.ts
@@ -1,4 +1,5 @@
 import { Entity, ManyToOne, MikroORM, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import type { PostgreSqlDriver } from '@mikro-orm/postgresql';
 
 @Entity({ tableName: 'author', schema: 'n1' })
 export class Author0 {
@@ -44,13 +45,22 @@ export class Book1 {
 
 describe('multiple connected schemas in postgres', () => {
 
-  test('schema generator allows creating FKs across different schemas', async () => {
-    const orm = await MikroORM.init({
+  let orm: MikroORM<PostgreSqlDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
       entities: [Author0, Book0],
       dbName: `mikro_orm_test_schemas`,
       type: 'postgresql',
     });
     await orm.getSchemaGenerator().ensureDatabase();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('schema generator allows creating FKs across different schemas', async () => {
     await orm.getSchemaGenerator().execute('drop schema if exists n1 cascade');
     await orm.getSchemaGenerator().execute('drop schema if exists n2 cascade');
 
@@ -66,8 +76,6 @@ describe('multiple connected schemas in postgres', () => {
 
     const diff2 = await orm.getSchemaGenerator().getUpdateSchemaSQL({ wrap: false });
     expect(diff2).toBe('');
-
-    await orm.close(true);
   });
 
 });


### PR DESCRIPTION
Entity instances now hold schema name (as part of `WrappedEntity`). Managed entities will have the schema from `FindOptions` or metadata. Methods that create new entity instances like `em.create()` or `em.getReference()` now have an options parameter to allow setting the schema. We can also use `wrap(entity).setSchema()`.

Entities can now specify `@Entity({ schema: '*' })`, that way they will be ignored in `SchemaGenerator` unless `schema` option is specified.
    
- if we have schema specified on entity level, it only exists in that schema
- if we have * schema on entity, it can exist in any schema, always controlled by the parameter
- no schema on entity - default schema or from global orm config

Closes #2074

BREAKING CHANGE:
`em.getReference()` now has options parameter.