### PR TITLE
refactor: don't include enum check constraint in type

### DIFF
--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -81,7 +81,7 @@ export class DatabaseTable {
         precision: prop.precision,
         scale: prop.scale,
         default: prop.defaultRaw,
-        enumItems: prop.items as string[],
+        enumItems: prop.items?.every(Utils.isString) ? prop.items as string[] : undefined,
         comment: prop.comment,
       };
       this.columns[field].unsigned ||= this.columns[field].autoincrement;

--- a/packages/knex/src/schema/SchemaComparator.ts
+++ b/packages/knex/src/schema/SchemaComparator.ts
@@ -5,8 +5,6 @@ import type { DatabaseSchema } from './DatabaseSchema';
 import type { DatabaseTable } from './DatabaseTable';
 import type { AbstractSqlPlatform } from '../AbstractSqlPlatform';
 
-const empty: readonly string[] = [];
-
 /**
  * Compares two Schemas and return an instance of SchemaDifference.
  */
@@ -375,7 +373,7 @@ export class SchemaComparator {
     return changedProperties;
   }
 
-  diffEnumItems(items1: readonly string[] = empty, items2: readonly string[] = empty): boolean {
+  diffEnumItems(items1: string[] = [], items2: string[] = []): boolean {
     return items1.length !== items2.length || items1.some((v, i) => v !== items2[i]);
   }
 

--- a/packages/knex/src/schema/SchemaComparator.ts
+++ b/packages/knex/src/schema/SchemaComparator.ts
@@ -5,6 +5,8 @@ import type { DatabaseSchema } from './DatabaseSchema';
 import type { DatabaseTable } from './DatabaseTable';
 import type { AbstractSqlPlatform } from '../AbstractSqlPlatform';
 
+const empty: readonly string[] = [];
+
 /**
  * Compares two Schemas and return an instance of SchemaDifference.
  */
@@ -366,7 +368,15 @@ export class SchemaComparator {
       changedProperties.add('comment');
     }
 
+    if (this.diffEnumItems(column1.enumItems, column2.enumItems)) {
+      changedProperties.add('enumItems');
+    }
+
     return changedProperties;
+  }
+
+  diffEnumItems(items1: readonly string[] = empty, items2: readonly string[] = empty): boolean {
+    return items1.length !== items2.length || items1.some((v, i) => v !== items2[i]);
   }
 
   diffComment(comment1?: string, comment2?: string): boolean {

--- a/packages/postgresql/src/PostgreSqlPlatform.ts
+++ b/packages/postgresql/src/PostgreSqlPlatform.ts
@@ -86,7 +86,7 @@ export class PostgreSqlPlatform extends AbstractSqlPlatform {
 
   getEnumTypeDeclarationSQL(column: { fieldNames: string[]; items?: unknown[] }): string {
     if (column.items?.every(item => Utils.isString(item))) {
-      return `text check (${this.quoteIdentifier(column.fieldNames[0])} in ('${column.items.join("', '")}'))`;
+      return 'text';
     }
 
     return `smallint`;

--- a/packages/sqlite/src/SqlitePlatform.ts
+++ b/packages/sqlite/src/SqlitePlatform.ts
@@ -26,7 +26,7 @@ export class SqlitePlatform extends AbstractSqlPlatform {
   getEnumTypeDeclarationSQL(column: { items?: unknown[]; fieldNames: string[]; length?: number; unsigned?: boolean; autoincrement?: boolean }): string {
     /* istanbul ignore next */
     if (column.items?.every(item => Utils.isString(item))) {
-      return `text check (${this.quoteIdentifier(column.fieldNames[0])} in ('${column.items.join("', '")}')`;
+      return 'text';
     }
 
     return this.getTinyIntTypeDeclarationSQL(column);

--- a/tests/features/schema-generator/__snapshots__/enum-foreign-key.postgres.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/enum-foreign-key.postgres.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`using enum as a foreign key value schema generator creates the correct type 1`] = `
+"create table \\"brand\\" (\\"id\\" text check (\\"id\\" in ('foo', 'bar', 'baz')) not null);
+alter table \\"brand\\" add constraint \\"brand_pkey\\" primary key (\\"id\\");
+
+create table \\"product\\" (\\"id\\" serial primary key, \\"brand_id\\" text not null);
+
+alter table \\"product\\" add constraint \\"product_brand_id_foreign\\" foreign key (\\"brand_id\\") references \\"brand\\" (\\"id\\") on update cascade;
+
+"
+`;

--- a/tests/features/schema-generator/enum-foreign-key.postgres.test.ts
+++ b/tests/features/schema-generator/enum-foreign-key.postgres.test.ts
@@ -1,0 +1,48 @@
+import { Entity, Enum, ManyToOne, MikroORM, PrimaryKey } from '@mikro-orm/core';
+
+export enum BrandType {
+    Foo = 'foo',
+    Bar = 'bar',
+    Baz = 'baz'
+}
+
+@Entity({ tableName: 'brand' })
+export class Brand {
+
+  @Enum({ primary: true, items: () => BrandType })
+  id!: BrandType;
+
+}
+
+@Entity({ tableName: 'product' })
+export class Product {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Brand)
+  brand!: Brand;
+
+}
+
+describe('using enum as a foreign key value', () => {
+
+  test('schema generator creates the correct type', async () => {
+    const orm = await MikroORM.init({
+      entities: [Brand, Product],
+      dbName: `mikro_orm_test_enum_foreign_key`,
+      type: 'postgresql',
+    });
+
+    await orm.getSchemaGenerator().ensureDatabase();
+    await orm.getSchemaGenerator().execute('drop table if exists brand cascade');
+    await orm.getSchemaGenerator().execute('drop table if exists product cascade');
+
+    const diff = await orm.getSchemaGenerator().getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toMatchSnapshot();
+    await orm.getSchemaGenerator().execute(diff);
+
+    await orm.close(true);
+  });
+
+});


### PR DESCRIPTION
Resolves: #2343

I'm not super confident about this particular fix, however it does seem to revert the original behaviour back to how it worked in 4.x.