### PR TITLE
feat(core): validate usage of global context

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -405,9 +405,24 @@ constructors, we can use `forceEntityConstructor` toggle:
 
 ```ts
 MikroORM.init({
-  ...
   forceEntityConstructor: true, // or specify just some entities via `[Author, 'Book', ...]` 
-  ...
+});
+```
+
+## Using global Identity Map
+
+In v5, it is no longer possible to use the global identity map. This was a
+common issue that led to weird bugs, as using the global EM without request
+context is almost always wrong, we always need to have a dedicated context for
+each request, so they do not interfere.
+
+We still can disable this check via `allowGlobalContext` configuration, or
+a connected environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can
+be handy especially in unit tests.
+
+```ts
+MikroORM.init({
+  allowGlobalContext: true, 
 });
 ```
 

--- a/docs/docs/identity-map.md
+++ b/docs/docs/identity-map.md
@@ -31,6 +31,17 @@ With `fork()` method you can simply get clean entity manager with its own contex
 const em = orm.em.fork();
 ```
 
+## Global Identity Map
+
+In v5, it is no longer possible to use the global identity map. This was a
+common issue that led to weird bugs, as using the global EM without request
+context is almost always wrong, we always need to have a dedicated context for 
+each request, so they do not interfere.
+
+We still can disable this check via `allowGlobalContext` configuration, or 
+a connected environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can 
+be handy especially in unit tests.
+
 ## <a name="request-context"></a> RequestContext helper for DI containers
 
 If you use dependency injection container like `inversify` or the one in `nestjs` framework, it 

--- a/docs/docs/upgrading-v4-to-v5.md
+++ b/docs/docs/upgrading-v4-to-v5.md
@@ -78,3 +78,15 @@ registered at all.
 
 Use `@Entity({ customRepository: () => CustomRepository })` in the entity definition
 instead.
+
+## Disallowed global identity map
+
+In v5, it is no longer possible to use the global identity map. This was a 
+common issue that led to weird bugs, as using the global EM without request
+context is wrong, we always need to have a dedicated context for each request,
+so they do not interfere.
+
+Now we get a validation error if we try to use the global context. We still can
+disable this check via `allowGlobalContext` configuration, or a connected 
+environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can be handy 
+especially in unit tests.

--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
     "coveragePathIgnorePatterns": [
       "<rootDir>/packages/cli/src/cli.ts"
     ],
+    "setupFiles": [
+      "<rootDir>/tests/setup.ts"
+    ],
     "globals": {
       "ts-jest": {
         "tsconfig": "tests/tsconfig.json"

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -778,6 +778,10 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       em = this.useContext ? (this.config.get('context')(this.name) || this) : this;
     }
 
+    if (this.useContext && em === this && !this.config.get('allowGlobalContext')) {
+      throw ValidationError.cannotUseGlobalContext();
+    }
+
     return em;
   }
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -97,6 +97,10 @@ export class ValidationError<T extends AnyEntity = AnyEntity> extends Error {
     return new ValidationError('You cannot call em.flush() from inside lifecycle hook handlers');
   }
 
+  static cannotUseGlobalContext(): ValidationError {
+    return new ValidationError('Using global EntityManager instance methods for context specific actions is disallowed. If you need to work with the global instance\'s identity map, use `allowGlobalContext` configuration option or `fork()` instead.');
+  }
+
   static cannotUseOperatorsInsideEmbeddables(className: string, propName: string, payload: Dictionary): ValidationError {
     return new ValidationError(`Using operators inside embeddables is not allowed, move the operator above. (property: ${className}.${propName}, payload: ${inspect(payload)})`);
   }

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -56,6 +56,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     validate: false,
     context: (name: string) => RequestContext.getEntityManager(name),
     contextName: 'default',
+    allowGlobalContext: false,
     // eslint-disable-next-line no-console
     logger: console.log.bind(console),
     findOneOrFailHandler: (entityName: string, where: Dictionary | IPrimaryKey) => NotFoundError.findOneFailed(entityName, where),
@@ -398,6 +399,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
   validate: boolean;
   context: (name: string) => EntityManager | undefined;
   contextName: string;
+  allowGlobalContext: boolean;
   logger: (message: string) => void;
   findOneOrFailHandler: (entityName: string, where: Dictionary | IPrimaryKey) => Error;
   debug: boolean | LoggerNamespace[];

--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -154,6 +154,7 @@ export class ConfigurationLoader {
     read(ret, 'MIKRO_ORM_USE_BATCH_UPDATES', 'useBatchUpdates', bool);
     read(ret, 'MIKRO_ORM_STRICT', 'strict', bool);
     read(ret, 'MIKRO_ORM_VALIDATE', 'validate', bool);
+    read(ret, 'MIKRO_ORM_ALLOW_GLOBAL_CONTEXT', 'allowGlobalContext', bool);
     read(ret, 'MIKRO_ORM_AUTO_JOIN_ONE_TO_ONE_OWNER', 'autoJoinOneToOneOwner', bool);
     read(ret, 'MIKRO_ORM_PROPAGATE_TO_ONE_OWNER', 'propagateToOneOwner', bool);
     read(ret, 'MIKRO_ORM_POPULATE_AFTER_FLUSH', 'populateAfterFlush', bool);

--- a/tests/DatabaseDriver.test.ts
+++ b/tests/DatabaseDriver.test.ts
@@ -60,7 +60,7 @@ class Driver extends DatabaseDriver<Connection> {
 describe('DatabaseDriver', () => {
 
   test('should load entities', async () => {
-    const config = new Configuration({ type: 'mongo' } as any, false);
+    const config = new Configuration({ type: 'mongo', allowGlobalContext: true } as any, false);
     const driver = new Driver(config, []);
     expect(driver.createEntityManager()).toBeInstanceOf(EntityManager);
     expect(driver.getPlatform().getRepositoryClass()).toBe(EntityRepository);

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -118,6 +118,7 @@ describe('CLIHelper', () => {
   });
 
   test('gets ORM configuration [no mikro-orm.config]', async () => {
+    delete process.env.MIKRO_ORM_ALLOW_GLOBAL_CONTEXT;
     await expect(CLIHelper.getConfiguration()).rejects.toThrowError(`MikroORM config file not found in ['./mikro-orm.config.js']`);
 
     process.env.MIKRO_ORM_ENV = __dirname + '/../../mikro-orm.env';

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,1 @@
+process.env.MIKRO_ORM_ALLOW_GLOBAL_CONTEXT = '1';


### PR DESCRIPTION
It is no longer possible to use the global identity map. This was a
common issue that led to weird bugs, as using the global EM without request
context is wrong, we always need to have a dedicated context for each request,
so they do not interfere.

Now we get a validation error if we try to use the global context. We still can
disable this check via `allowGlobalContext` configuration, or a connected
environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can be handy
especially in unit tests.