### PR TITLE
feat(core): allow configuring aliasing naming strategy

### DIFF
--- a/docs/docs/naming-strategy.md
+++ b/docs/docs/naming-strategy.md
@@ -96,3 +96,18 @@ Return a join table name. This is used as default value for `pivotTable`.
 Return the foreign key column name for the given parameters.
 
 ---
+
+#### `NamingStrategy.indexName(tableName: string, columns: string[], type: 'primary' | 'foreign' | 'unique' | 'index' | 'sequence'): string`
+
+Returns key/constraint name for given type. Some drivers might not support all 
+the types (e.g. mysql and sqlite enforce the PK name).
+
+---
+
+#### `NamingStrategy.aliasName(entityName: string, index: number): string`
+
+Returns alias name for given entity. The alias needs to be unique across the 
+query, which is by default ensured via appended index parameter. It is optional 
+to use it as long as you ensure it will be unique.
+
+---

--- a/docs/docs/upgrading-v4-to-v5.md
+++ b/docs/docs/upgrading-v4-to-v5.md
@@ -97,3 +97,27 @@ Previously those dynamically added getters returned the array copy of collection
 items. In v5, we return the collection instance, which is also iterable and has
 a `length` getter and indexed access support, so it mimics the array. To get the
 array copy as before, call `getItems()` as with a regular collection.
+
+## Different table aliasing for select-in loading strategy and for QueryBuilder
+
+Previously with select-in strategy as well as with QueryBuilder, table aliases
+were always the letter `e` followed by unique index. In v5, we use the same 
+method as with joined strategy - the letter is inferred from the entity name.
+
+This can be breaking if you used the aliases somewhere, e.g. in custom SQL 
+fragments. We can restore to the old behaviour by implementing custom naming
+strategy, overriding the `aliasName` method:
+
+```ts
+import { AbstractNamingStrategy } from '@mikro-orm/core';
+
+class CustomNamingStrategy extends AbstractNamingStrategy {
+  aliasName(entityName: string, index: number) {
+    return 'e' + index;
+  }
+}
+```
+
+Note that in v5 it is possible to use `expr()` helper to access the alias name
+dynamically, e.g. ``expr(alias => `lower('${alias}.name')`)``, which should be 
+now preferred way instead of hardcoding the aliases.

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -34,7 +34,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
   protected comparator!: EntityComparator;
   protected metadata!: MetadataStorage;
 
-  protected constructor(protected readonly config: Configuration,
+  protected constructor(readonly config: Configuration,
                         protected readonly dependencies: string[]) { }
 
   abstract find<T>(entityName: string, where: FilterQuery<T>, options?: FindOptions<T>): Promise<EntityData<T>[]>;

--- a/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
+++ b/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
@@ -34,6 +34,11 @@ export abstract class AbstractNamingStrategy implements NamingStrategy {
     return columnName.replace(/[_ ](\w)/g, m => m[1].toUpperCase()).replace(/_+/g, '');
   }
 
+  aliasName(entityName: string, index: number): string {
+    // Take only the first letter of the prefix to keep character counts down since some engines have character limits
+    return entityName.charAt(0).toLowerCase() + index;
+  }
+
   abstract classToTableName(entityName: string): string;
 
   abstract joinColumnName(propertyName: string): string;

--- a/packages/core/src/naming-strategy/NamingStrategy.ts
+++ b/packages/core/src/naming-strategy/NamingStrategy.ts
@@ -50,4 +50,10 @@ export interface NamingStrategy {
    */
   indexName(tableName: string, columns: string[], type: 'primary' | 'foreign' | 'unique' | 'index' | 'sequence'): string;
 
+  /**
+   * Returns alias name for given entity. The alias needs to be unique across the query, which is by default
+   * ensured via appended index parameter. It is optional to use it as long as you ensure it will be unique.
+   */
+  aliasName(entityName: string, index: number): string;
+
 }

--- a/packages/knex/src/query/ObjectCriteriaNode.ts
+++ b/packages/knex/src/query/ObjectCriteriaNode.ts
@@ -112,7 +112,7 @@ export class ObjectCriteriaNode extends CriteriaNode {
   }
 
   private autoJoin<T>(qb: IQueryBuilder<T>, alias: string): string {
-    const nestedAlias = qb.getNextAlias();
+    const nestedAlias = qb.getNextAlias(this.prop?.pivotTable ?? this.entityName);
     const customExpression = ObjectCriteriaNode.isCustomExpression(this.key!);
     const scalar = Utils.isPrimaryKey(this.payload) || this.payload instanceof RegExp || this.payload instanceof Date || customExpression;
     const operator = Utils.isPlainObject(this.payload) && Object.keys(this.payload).every(k => Utils.isOperator(k, false));

--- a/packages/knex/src/query/ScalarCriteriaNode.ts
+++ b/packages/knex/src/query/ScalarCriteriaNode.ts
@@ -11,7 +11,7 @@ export class ScalarCriteriaNode extends CriteriaNode {
     if (this.shouldJoin()) {
       const path = this.getPath();
       const parentPath = this.parent!.getPath(); // the parent is always there, otherwise `shouldJoin` would return `false`
-      const nestedAlias = qb.getAliasForJoinPath(path) || qb.getNextAlias();
+      const nestedAlias = qb.getAliasForJoinPath(path) || qb.getNextAlias(this.prop?.pivotTable ?? this.entityName);
       const field = `${alias}.${this.prop!.name}`;
       const type = this.prop!.reference === ReferenceType.MANY_TO_MANY ? 'pivotJoin' : 'leftJoin';
       qb.join(field, nestedAlias, undefined, type, path);

--- a/packages/knex/src/typings.ts
+++ b/packages/knex/src/typings.ts
@@ -127,7 +127,7 @@ export interface IQueryBuilder<T> {
   groupBy(fields: (string | keyof T) | (string | keyof T)[]): this;
   having(cond?: QBFilterQuery | string, params?: any[]): this;
   getAliasForJoinPath(path: string): string | undefined;
-  getNextAlias(prefix?: string): string;
+  getNextAlias(entityName?: string): string;
 }
 
 export interface ICriteriaNode {

--- a/tests/DatabaseDriver.test.ts
+++ b/tests/DatabaseDriver.test.ts
@@ -22,7 +22,7 @@ class Driver extends DatabaseDriver<Connection> {
 
   protected readonly platform = new Platform1();
 
-  constructor(protected readonly config: Configuration,
+  constructor(readonly config: Configuration,
               protected readonly dependencies: string[]) {
     super(config, dependencies);
   }

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -519,10 +519,10 @@ describe('EntityManagerPostgre', () => {
     expect(b0).toBe(b3);
 
     expect(mock.mock.calls).toHaveLength(4);
-    expect(mock.mock.calls[0][0]).toMatch(`select "e0".*, (select 123) as "random" from "foo_bar2" as "e0" where "e0"."id" = 1 limit 1`);
-    expect(mock.mock.calls[1][0]).toMatch(`select "e0".*, (select 123) as "random" from "foo_bar2" as "e0" where ("object_property"->'myPropName'->>'nestedProperty')::float8 = 123 limit 1`);
-    expect(mock.mock.calls[2][0]).toMatch(`select "e0".*, (select 123) as "random" from "foo_bar2" as "e0" where "object_property"->'myPropName'->>'somethingElse' is null limit 1`);
-    expect(mock.mock.calls[3][0]).toMatch(`select "e0".*, (select 123) as "random" from "foo_bar2" as "e0" where ("object_property"->'myPropName'->>'nestedProperty')::float8 = 123 and "object_property"->'myPropName'->>'somethingElse' is null limit 1`);
+    expect(mock.mock.calls[0][0]).toMatch(`select "f0".*, (select 123) as "random" from "foo_bar2" as "f0" where "f0"."id" = 1 limit 1`);
+    expect(mock.mock.calls[1][0]).toMatch(`select "f0".*, (select 123) as "random" from "foo_bar2" as "f0" where ("object_property"->'myPropName'->>'nestedProperty')::float8 = 123 limit 1`);
+    expect(mock.mock.calls[2][0]).toMatch(`select "f0".*, (select 123) as "random" from "foo_bar2" as "f0" where "object_property"->'myPropName'->>'somethingElse' is null limit 1`);
+    expect(mock.mock.calls[3][0]).toMatch(`select "f0".*, (select 123) as "random" from "foo_bar2" as "f0" where ("object_property"->'myPropName'->>'nestedProperty')::float8 = 123 and "object_property"->'myPropName'->>'somethingElse' is null limit 1`);
   });
 
   test('findOne should initialize entity that is already in IM', async () => {
@@ -695,7 +695,7 @@ describe('EntityManagerPostgre', () => {
 
     expect(mock.mock.calls.length).toBe(3);
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('select 1 from "author2" as "e0" where "e0"."id" = $1 for update');
+    expect(mock.mock.calls[1][0]).toMatch('select 1 from "author2" as "a0" where "a0"."id" = $1 for update');
     expect(mock.mock.calls[2][0]).toMatch('commit');
   });
 
@@ -712,7 +712,7 @@ describe('EntityManagerPostgre', () => {
     });
     expect(mock.mock.calls.length).toBe(3);
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('select 1 from "author2" as "e0" where "e0"."id" = $1 for share');
+    expect(mock.mock.calls[1][0]).toMatch('select 1 from "author2" as "a0" where "a0"."id" = $1 for share');
     expect(mock.mock.calls[2][0]).toMatch('commit');
 
     mock.mock.calls.length = 0;
@@ -721,30 +721,30 @@ describe('EntityManagerPostgre', () => {
     });
     expect(mock.mock.calls.length).toBe(3);
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('select 1 from "author2" as "e0" where "e0"."id" = $1 for update skip locked');
+    expect(mock.mock.calls[1][0]).toMatch('select 1 from "author2" as "a0" where "a0"."id" = $1 for update skip locked');
     expect(mock.mock.calls[2][0]).toMatch('commit');
 
     mock.mock.calls.length = 0;
     await orm.em.transactional(async em => {
-      await em.lock(author, LockMode.PESSIMISTIC_PARTIAL_WRITE, { lockTableAliases: ['e0'] });
+      await em.lock(author, LockMode.PESSIMISTIC_PARTIAL_WRITE, { lockTableAliases: ['a0'] });
     });
     expect(mock.mock.calls.length).toBe(3);
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('select 1 from "author2" as "e0" where "e0"."id" = $1 for update of "e0" skip locked');
+    expect(mock.mock.calls[1][0]).toMatch('select 1 from "author2" as "a0" where "a0"."id" = $1 for update of "a0" skip locked');
     expect(mock.mock.calls[2][0]).toMatch('commit');
 
     mock.mock.calls.length = 0;
     await orm.em.transactional(async em => {
       await em.find(Book2, {}, {
         lockMode: LockMode.PESSIMISTIC_PARTIAL_WRITE,
-        lockTableAliases: ['e0'],
+        lockTableAliases: ['b0'],
         populate: ['author'],
         strategy: LoadStrategy.JOINED,
       });
     });
     expect(mock.mock.calls.length).toBe(3);
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('select "e0"."uuid_pk", "e0"."created_at", "e0"."title", "e0"."price", "e0".price * 1.19 as "price_taxed", "e0"."double", "e0"."meta", "e0"."author_id", "e0"."publisher_id", "a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "e0".price * 1.19 as "price_taxed" from "book2" as "e0" left join "author2" as "a1" on "e0"."author_id" = "a1"."id" where "e0"."author_id" is not null for update of "e0" skip locked');
+    expect(mock.mock.calls[1][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."price", "b0".price * 1.19 as "price_taxed", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" left join "author2" as "a1" on "b0"."author_id" = "a1"."id" where "b0"."author_id" is not null for update of "b0" skip locked');
     expect(mock.mock.calls[2][0]).toMatch('commit');
   });
 
@@ -886,21 +886,21 @@ describe('EntityManagerPostgre', () => {
 
     // autoJoinOneToOneOwner: false
     const b0 = await orm.em.findOneOrFail(FooBaz2, { id: baz.id });
-    expect(mock.mock.calls[0][0]).toMatch('select "e0".* from "foo_baz2" as "e0" where "e0"."id" = $1 limit $2');
+    expect(mock.mock.calls[0][0]).toMatch('select "f0".* from "foo_baz2" as "f0" where "f0"."id" = $1 limit $2');
     expect(b0.bar).toBeUndefined();
     orm.em.clear();
 
     const b1 = await orm.em.findOneOrFail(FooBaz2, { id: baz.id }, { populate: ['bar'] });
-    expect(mock.mock.calls[1][0]).toMatch('select "e0".*, "e1"."id" as "bar_id" from "foo_baz2" as "e0" left join "foo_bar2" as "e1" on "e0"."id" = "e1"."baz_id" where "e0"."id" = $1 limit $2');
-    expect(mock.mock.calls[2][0]).toMatch('select "e0".*, (select 123) as "random" from "foo_bar2" as "e0" where "e0"."baz_id" in ($1) order by "e0"."baz_id" asc');
+    expect(mock.mock.calls[1][0]).toMatch('select "f0".*, "f1"."id" as "bar_id" from "foo_baz2" as "f0" left join "foo_bar2" as "f1" on "f0"."id" = "f1"."baz_id" where "f0"."id" = $1 limit $2');
+    expect(mock.mock.calls[2][0]).toMatch('select "f0".*, (select 123) as "random" from "foo_bar2" as "f0" where "f0"."baz_id" in ($1) order by "f0"."baz_id" asc');
     expect(b1.bar).toBeInstanceOf(FooBar2);
     expect(b1.bar!.id).toBe(bar.id);
     expect(wrap(b1).toJSON()).toMatchObject({ bar: { id: bar.id, baz: baz.id, name: 'bar' } });
     orm.em.clear();
 
     const b2 = await orm.em.findOneOrFail(FooBaz2, { bar: bar.id }, { populate: ['bar'] });
-    expect(mock.mock.calls[3][0]).toMatch('select "e0".*, "e1"."id" as "bar_id" from "foo_baz2" as "e0" left join "foo_bar2" as "e1" on "e0"."id" = "e1"."baz_id" where "e1"."id" = $1 limit $2');
-    expect(mock.mock.calls[4][0]).toMatch('select "e0".*, (select 123) as "random" from "foo_bar2" as "e0" where "e0"."baz_id" in ($1) order by "e0"."baz_id" asc');
+    expect(mock.mock.calls[3][0]).toMatch('select "f0".*, "f1"."id" as "bar_id" from "foo_baz2" as "f0" left join "foo_bar2" as "f1" on "f0"."id" = "f1"."baz_id" where "f1"."id" = $1 limit $2');
+    expect(mock.mock.calls[4][0]).toMatch('select "f0".*, (select 123) as "random" from "foo_bar2" as "f0" where "f0"."baz_id" in ($1) order by "f0"."baz_id" asc');
     expect(b2.bar).toBeInstanceOf(FooBar2);
     expect(b2.bar!.id).toBe(bar.id);
     expect(wrap(b2).toJSON()).toMatchObject({ bar: { id: bar.id, baz: baz.id, name: 'bar' } });
@@ -935,9 +935,9 @@ describe('EntityManagerPostgre', () => {
     await orm.em.flush();
     expect(mock.mock.calls[0][0]).toMatch('begin');
     expect(mock.mock.calls[1][0]).toMatch('update "foo_bar2" set "foo_bar_id" = $1, "version" = current_timestamp(0) where "id" = $2 and "version" = $3');
-    expect(mock.mock.calls[2][0]).toMatch('select "e0"."id", "e0"."version" from "foo_bar2" as "e0" where "e0"."id" in ($1)');
+    expect(mock.mock.calls[2][0]).toMatch('select "f0"."id", "f0"."version" from "foo_bar2" as "f0" where "f0"."id" in ($1)');
     expect(mock.mock.calls[3][0]).toMatch('update "foo_bar2" set "foo_bar_id" = $1, "version" = current_timestamp(0) where "id" = $2 and "version" = $3');
-    expect(mock.mock.calls[4][0]).toMatch('select "e0"."id", "e0"."version" from "foo_bar2" as "e0" where "e0"."id" in ($1)');
+    expect(mock.mock.calls[4][0]).toMatch('select "f0"."id", "f0"."version" from "foo_bar2" as "f0" where "f0"."id" in ($1)');
     expect(mock.mock.calls[5][0]).toMatch('commit');
   });
 
@@ -1117,7 +1117,7 @@ describe('EntityManagerPostgre', () => {
       'new book',
     ]);
 
-    expect(mock.mock.calls[0][0]).toMatch(`select "e0"."uuid_pk", "e0"."created_at", "e0"."title", "e0"."price", "e0"."double", "e0"."meta", "e0"."author_id", "e0"."publisher_id", "e0".price * 1.19 as "price_taxed" from "book2" as "e0" where "e0"."author_id" is not null and "e0"."author_id" = $1 order by "e0"."title" asc`);
+    expect(mock.mock.calls[0][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."author_id" = $1 order by "b0"."title" asc`);
     expect(mock.mock.calls[1][0]).toMatch(`begin`);
     expect(mock.mock.calls[2][0]).toMatch(`insert into "book2" ("author_id", "created_at", "price", "title", "uuid_pk") values ($1, $2, $3, $4, $5) returning "uuid_pk", "created_at", "title"`);
     expect(mock.mock.calls[3][0]).toMatch(`commit`);
@@ -1230,8 +1230,8 @@ describe('EntityManagerPostgre', () => {
     const res = await orm.em.find(Author2, { books: { title: { $in: ['b1', 'b2'] } } }, { populate: ['books.perex'] });
     expect(res).toHaveLength(1);
     expect(res[0].books.length).toBe(2);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0".* from "author2" as "e0" left join "book2" as "e1" on "e0"."id" = "e1"."author_id" where "e1"."title" in ($1, $2)');
-    expect(mock.mock.calls[1][0]).toMatch('select "e0".*, "e0".price * 1.19 as "price_taxed" from "book2" as "e0" where "e0"."author_id" is not null and "e0"."author_id" in ($1) and "e0"."title" in ($2, $3) order by "e0"."title" asc');
+    expect(mock.mock.calls[0][0]).toMatch('select "a0".* from "author2" as "a0" left join "book2" as "b1" on "a0"."id" = "b1"."author_id" where "b1"."title" in ($1, $2)');
+    expect(mock.mock.calls[1][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."author_id" in ($1) and "b0"."title" in ($2, $3) order by "b0"."title" asc');
   });
 
   test('trying to populate non-existing or non-reference property will throw', async () => {
@@ -1359,7 +1359,7 @@ describe('EntityManagerPostgre', () => {
     expect(mock.mock.calls[2][0]).toMatch('insert into "book2" ("uuid_pk", "created_at", "title", "author_id") values ($1, $2, $3, $4), ($5, $6, $7, $8), ($9, $10, $11, $12)');
     expect(mock.mock.calls[3][0]).toMatch('update "author2" set "favourite_author_id" = $1, "updated_at" = $2 where "id" = $3');
     expect(mock.mock.calls[4][0]).toMatch('commit');
-    expect(mock.mock.calls[5][0]).toMatch('select "e0".* from "author2" as "e0" where "e0"."id" = $1');
+    expect(mock.mock.calls[5][0]).toMatch('select "a0".* from "author2" as "a0" where "a0"."id" = $1');
   });
 
   test('EM supports smart search conditions', async () => {
@@ -1412,14 +1412,14 @@ describe('EntityManagerPostgre', () => {
       },
     }, { populate: ['perex'] });
     expect(books1).toHaveLength(2);
-    expect(mock.mock.calls[0][0]).toMatch(`select "e0".*, "e0".price * 1.19 as "price_taxed" from "book2" as "e0" left join "author2" as "e1" on "e0"."author_id" = "e1"."id" where "e0"."author_id" is not null and upper(title) in ('B1', 'B2') and e1.age::text ilike '%2%'`);
+    expect(mock.mock.calls[0][0]).toMatch(`select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" left join "author2" as "a1" on "b0"."author_id" = "a1"."id" where "b0"."author_id" is not null and upper(title) in ('B1', 'B2') and a1.age::text ilike '%2%'`);
     orm.em.clear();
 
     const books2 = await orm.em.find(Book2, {
       [expr('upper(title)')]: orm.em.getKnex().raw('upper(?)', ['b2']),
     }, { populate: ['perex'] });
     expect(books2).toHaveLength(1);
-    expect(mock.mock.calls[1][0]).toMatch(`select "e0".*, "e0".price * 1.19 as "price_taxed" from "book2" as "e0" where "e0"."author_id" is not null and upper(title) = upper('b2')`);
+    expect(mock.mock.calls[1][0]).toMatch(`select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and upper(title) = upper('b2')`);
   });
 
   test('find by joined property', async () => {
@@ -1446,44 +1446,44 @@ describe('EntityManagerPostgre', () => {
     expect(res1).toHaveLength(3);
     expect(res1[0].test).toBeUndefined();
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0".*, "e0".price * 1.19 as "price_taxed" ' +
-      'from "book2" as "e0" ' +
-      'left join "author2" as "e1" on "e0"."author_id" = "e1"."id" ' +
-      'where "e0"."author_id" is not null and "e1"."name" = $1');
+    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed" ' +
+      'from "book2" as "b0" ' +
+      'left join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
+      'where "b0"."author_id" is not null and "a1"."name" = $1');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     const res2 = await orm.em.find(Book2, { author: { favouriteBook: { author: { name: 'Jon Snow' } } } }, { populate: ['perex'] });
     expect(res2).toHaveLength(3);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0".*, "e0".price * 1.19 as "price_taxed" ' +
-      'from "book2" as "e0" ' +
-      'left join "author2" as "e1" on "e0"."author_id" = "e1"."id" ' +
-      'left join "book2" as "e2" on "e1"."favourite_book_uuid_pk" = "e2"."uuid_pk" ' +
-      'left join "author2" as "e3" on "e2"."author_id" = "e3"."id" ' +
-      'where "e0"."author_id" is not null and "e3"."name" = $1');
+    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed" ' +
+      'from "book2" as "b0" ' +
+      'left join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
+      'left join "book2" as "b2" on "a1"."favourite_book_uuid_pk" = "b2"."uuid_pk" ' +
+      'left join "author2" as "a3" on "b2"."author_id" = "a3"."id" ' +
+      'where "b0"."author_id" is not null and "a3"."name" = $1');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     const res3 = await orm.em.find(Book2, { author: { favouriteBook: book3 } }, { populate: ['perex'] });
     expect(res3).toHaveLength(3);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0".*, "e0".price * 1.19 as "price_taxed" ' +
-      'from "book2" as "e0" ' +
-      'left join "author2" as "e1" on "e0"."author_id" = "e1"."id" ' +
-      'where "e0"."author_id" is not null and "e1"."favourite_book_uuid_pk" = $1');
+    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed" ' +
+      'from "book2" as "b0" ' +
+      'left join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
+      'where "b0"."author_id" is not null and "a1"."favourite_book_uuid_pk" = $1');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     const res4 = await orm.em.find(Book2, { author: { favouriteBook: { $or: [{ author: { name: 'Jon Snow' } }] } } }, { populate: ['perex'] });
     expect(res4).toHaveLength(3);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0".*, "e0".price * 1.19 as "price_taxed" ' +
-      'from "book2" as "e0" ' +
-      'left join "author2" as "e1" on "e0"."author_id" = "e1"."id" ' +
-      'left join "book2" as "e2" on "e1"."favourite_book_uuid_pk" = "e2"."uuid_pk" ' +
-      'left join "author2" as "e3" on "e2"."author_id" = "e3"."id" ' +
-      'where "e0"."author_id" is not null and "e3"."name" = $1');
+    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed" ' +
+      'from "book2" as "b0" ' +
+      'left join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
+      'left join "book2" as "b2" on "a1"."favourite_book_uuid_pk" = "b2"."uuid_pk" ' +
+      'left join "author2" as "a3" on "b2"."author_id" = "a3"."id" ' +
+      'where "b0"."author_id" is not null and "a3"."name" = $1');
   });
 
   test('result caching (find)', async () => {
@@ -1678,15 +1678,15 @@ describe('EntityManagerPostgre', () => {
 
     expect(res2).toHaveLength(5);
     expect(res2.map(a => a.name)).toEqual(['God 04', 'God 05', 'God 06', 'God 07', 'God 08']);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0".* ' +
-      'from "author2" as "e0" ' +
-      'left join "book2" as "e1" on "e0"."id" = "e1"."author_id" where "e0"."id" in (select "e0"."id" ' +
-      'from (select "e0"."id" ' +
-      'from "author2" as "e0" ' +
-      'left join "book2" as "e1" on "e0"."id" = "e1"."author_id" ' +
-      'where "e1"."title" like $1 group by "e0"."id" order by min("e0"."name") asc, min("e1"."title") asc limit $2 offset $3' +
-      ') as "e0"' +
-      ') order by "e0"."name" asc, "e1"."title" asc');
+    expect(mock.mock.calls[0][0]).toMatch('select "a0".* ' +
+      'from "author2" as "a0" ' +
+      'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" where "a0"."id" in (select "a0"."id" ' +
+      'from (select "a0"."id" ' +
+      'from "author2" as "a0" ' +
+      'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" ' +
+      'where "b1"."title" like $1 group by "a0"."id" order by min("a0"."name") asc, min("b1"."title") asc limit $2 offset $3' +
+      ') as "a0"' +
+      ') order by "a0"."name" asc, "b1"."title" asc');
   });
 
   test('custom types', async () => {

--- a/tests/EntityManager.sqlite.test.ts
+++ b/tests/EntityManager.sqlite.test.ts
@@ -196,13 +196,13 @@ describe('EntityManagerSqlite', () => {
     expect(mock.mock.calls).toHaveLength(10);
     expect(mock.mock.calls[0][0]).toMatch('begin');
     expect(mock.mock.calls[1][0]).toMatch('savepoint trx');
-    expect(mock.mock.calls[2][0]).toMatch('select `e0`.* from `book3` as `e0` where `e0`.`title` is not null limit ?'); // test from beforeCreate hook
+    expect(mock.mock.calls[2][0]).toMatch('select `b0`.* from `book3` as `b0` where `b0`.`title` is not null limit ?'); // test from beforeCreate hook
     expect(mock.mock.calls[3][0]).toMatch('insert into `author3` (`created_at`, `email`, `name`, `terms_accepted`, `updated_at`) values (?, ?, ?, ?, ?)');
-    expect(mock.mock.calls[4][0]).toMatch('select `e0`.* from `book3` as `e0` where `e0`.`title` not in (?) limit ?'); // test from afterCreate hook
+    expect(mock.mock.calls[4][0]).toMatch('select `b0`.* from `book3` as `b0` where `b0`.`title` not in (?) limit ?'); // test from afterCreate hook
     expect(mock.mock.calls[5][0]).toMatch('rollback to savepoint trx');
-    expect(mock.mock.calls[6][0]).toMatch('select `e0`.* from `book3` as `e0` where `e0`.`title` is not null limit ?'); // test from beforeCreate hook
+    expect(mock.mock.calls[6][0]).toMatch('select `b0`.* from `book3` as `b0` where `b0`.`title` is not null limit ?'); // test from beforeCreate hook
     expect(mock.mock.calls[7][0]).toMatch('insert into `author3` (`created_at`, `email`, `name`, `terms_accepted`, `updated_at`) values (?, ?, ?, ?, ?)');
-    expect(mock.mock.calls[8][0]).toMatch('select `e0`.* from `book3` as `e0` where `e0`.`title` not in (?) limit ?'); // test from afterCreate hook
+    expect(mock.mock.calls[8][0]).toMatch('select `b0`.* from `book3` as `b0` where `b0`.`title` not in (?) limit ?'); // test from afterCreate hook
     expect(mock.mock.calls[9][0]).toMatch('commit');
     await expect(orm.em.findOne(Author3, { name: 'God Persisted!' })).resolves.not.toBeNull();
   });
@@ -479,7 +479,7 @@ describe('EntityManagerSqlite', () => {
 
     expect(mock.mock.calls.length).toBe(3);
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('select 1 from `author3` as `e0` where `e0`.`id` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select 1 from `author3` as `a0` where `a0`.`id` = ?');
     expect(mock.mock.calls[2][0]).toMatch('commit');
   });
 
@@ -497,7 +497,7 @@ describe('EntityManagerSqlite', () => {
 
     expect(mock.mock.calls.length).toBe(3);
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('select 1 from `author3` as `e0` where `e0`.`id` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select 1 from `author3` as `a0` where `a0`.`id` = ?');
     expect(mock.mock.calls[2][0]).toMatch('commit');
   });
 

--- a/tests/EntityManager.sqlite2.test.ts
+++ b/tests/EntityManager.sqlite2.test.ts
@@ -441,7 +441,7 @@ describe('EntityManagerSqlite2', () => {
 
     expect(mock.mock.calls.length).toBe(3);
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('select 1 from `author4` as `e0` where `e0`.`id` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select 1 from `author4` as `a0` where `a0`.`id` = ?');
     expect(mock.mock.calls[2][0]).toMatch('commit');
   });
 
@@ -459,7 +459,7 @@ describe('EntityManagerSqlite2', () => {
 
     expect(mock.mock.calls.length).toBe(3);
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('select 1 from `author4` as `e0` where `e0`.`id` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select 1 from `author4` as `a0` where `a0`.`id` = ?');
     expect(mock.mock.calls[2][0]).toMatch('commit');
   });
 
@@ -948,9 +948,9 @@ describe('EntityManagerSqlite2', () => {
 
     await orm.em.flush();
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('select `e0`.`id` from `foo_bar4` as `e0` where ((`e0`.`id` = ? and `e0`.`version` = ?) or (`e0`.`id` = ? and `e0`.`version` = ?))');
+    expect(mock.mock.calls[1][0]).toMatch('select `f0`.`id` from `foo_bar4` as `f0` where ((`f0`.`id` = ? and `f0`.`version` = ?) or (`f0`.`id` = ? and `f0`.`version` = ?))');
     expect(mock.mock.calls[2][0]).toMatch('update `foo_bar4` set `foo_bar_id` = case when (`id` = ?) then ? when (`id` = ?) then ? else `foo_bar_id` end, `updated_at` = case when (`id` = ?) then ? when (`id` = ?) then ? else `updated_at` end, `version` = `version` + 1 where `id` in (?, ?)');
-    expect(mock.mock.calls[3][0]).toMatch('select `e0`.`id`, `e0`.`version` from `foo_bar4` as `e0` where `e0`.`id` in (?, ?)');
+    expect(mock.mock.calls[3][0]).toMatch('select `f0`.`id`, `f0`.`version` from `foo_bar4` as `f0` where `f0`.`id` in (?, ?)');
     expect(mock.mock.calls[4][0]).toMatch('commit');
   });
 
@@ -1028,8 +1028,8 @@ describe('EntityManagerSqlite2', () => {
       '`t`.`id` as `t__id`, `t`.`created_at` as `t__created_at`, `t`.`updated_at` as `t__updated_at`, `t`.`name` as `t__name`, `t`.`version` as `t__version` ' +
       'from `author4` as `a` ' +
       'left join `book4` as `b` on `a`.`id` = `b`.`author_id` ' +
-      'left join `tags_ordered` as `e1` on `b`.`id` = `e1`.`book4_id` ' +
-      'left join `book_tag4` as `t` on `e1`.`book_tag4_id` = `t`.`id` ' +
+      'left join `tags_ordered` as `t1` on `b`.`id` = `t1`.`book4_id` ' +
+      'left join `book_tag4` as `t` on `t1`.`book_tag4_id` = `t`.`id` ' +
       'where `t`.`name` in (\'sick\', \'sexy\')';
     expect(qb.getFormattedQuery()).toEqual(sql);
     const res = await qb.getSingleResult();
@@ -1070,10 +1070,10 @@ describe('EntityManagerSqlite2', () => {
     expect(count3).toBe(2);
     const count4 = await orm.em.createQueryBuilder(Author4).where({ email: '123' }).getCount();
     expect(count4).toBe(0);
-    expect(mock.mock.calls[0][0]).toMatch('select count(`e0`.`id`) as `count` from `author4` as `e0`');
-    expect(mock.mock.calls[1][0]).toMatch('select count(`e0`.`terms_accepted`) as `count` from `author4` as `e0`');
-    expect(mock.mock.calls[2][0]).toMatch('select count(distinct `e0`.`terms_accepted`) as `count` from `author4` as `e0`');
-    expect(mock.mock.calls[3][0]).toMatch('select count(`e0`.`id`) as `count` from `author4` as `e0` where `e0`.`email` = \'123\'');
+    expect(mock.mock.calls[0][0]).toMatch('select count(`a0`.`id`) as `count` from `author4` as `a0`');
+    expect(mock.mock.calls[1][0]).toMatch('select count(`a0`.`terms_accepted`) as `count` from `author4` as `a0`');
+    expect(mock.mock.calls[2][0]).toMatch('select count(distinct `a0`.`terms_accepted`) as `count` from `author4` as `a0`');
+    expect(mock.mock.calls[3][0]).toMatch('select count(`a0`.`id`) as `count` from `author4` as `a0` where `a0`.`email` = \'123\'');
   });
 
   test('using collection methods with null/undefined (GH issue #1408)', async () => {

--- a/tests/features/composite-keys/GH1079.test.ts
+++ b/tests/features/composite-keys/GH1079.test.ts
@@ -126,7 +126,7 @@ describe('GH issue 1079', () => {
     expect(queries[2]).toMatch(`insert into "wallet" ("currency_ref", "main_balance", "owner__id") values ($1, $2, $3)`);
     expect(queries[3]).toMatch(`insert into "deposit" ("amount", "created_at", "gateway_key", "status", "tx_ref", "updated_at", "wallet_currency_ref", "wallet_owner__id") values ($1, $2, $3, $4, $5, $6, $7, $8)`);
     expect(queries[4]).toMatch(`commit`);
-    expect(queries[5]).toMatch(`select "e0".* from "wallet" as "e0" where "e0"."currency_ref" = $1 and "e0"."owner__id" = $2 limit $3`);
+    expect(queries[5]).toMatch(`select "w0".* from "wallet" as "w0" where "w0"."currency_ref" = $1 and "w0"."owner__id" = $2 limit $3`);
     expect(queries[6]).toMatch(`begin`);
     expect(queries[7]).toMatch(`insert into "deposit" ("amount", "created_at", "gateway_key", "status", "tx_ref", "updated_at", "wallet_currency_ref", "wallet_owner__id") values ($1, $2, $3, $4, $5, $6, $7, $8)`);
     expect(queries[8]).toMatch(`commit`);

--- a/tests/features/custom-types/custom-types.mysql.test.ts
+++ b/tests/features/custom-types/custom-types.mysql.test.ts
@@ -119,7 +119,7 @@ describe('custom types [mysql]', () => {
     expect(mock.mock.calls[1][0]).toMatch('insert into `location` (`extended_point`, `point`) values (ST_PointFromText(\'point(5.23 9.56)\'), ST_PointFromText(\'point(1.23 4.56)\'))');
     expect(mock.mock.calls[2][0]).toMatch('insert into `address` (`location_id`) values (?)');
     expect(mock.mock.calls[3][0]).toMatch('commit');
-    expect(mock.mock.calls[4][0]).toMatch('select `e0`.*, ST_AsText(`e0`.`point`) as `point`, ST_AsText(`e0`.`extended_point`) as `extended_point` from `location` as `e0` where `e0`.`id` = ? limit ?');
+    expect(mock.mock.calls[4][0]).toMatch('select `l0`.*, ST_AsText(`l0`.`point`) as `point`, ST_AsText(`l0`.`extended_point`) as `extended_point` from `location` as `l0` where `l0`.`id` = ? limit ?');
     expect(mock.mock.calls).toHaveLength(5);
     await orm.em.flush(); // ensure we do not fire queries when nothing changed
     expect(mock.mock.calls).toHaveLength(5);
@@ -139,15 +139,15 @@ describe('custom types [mysql]', () => {
     orm.em.clear();
 
     const qb2 = orm.em.createQueryBuilder(Location);
-    const res2 = await qb2.select(['e0.*']).where({ id: loc.id }).getSingleResult();
-    expect(mock.mock.calls[9][0]).toMatch('select `e0`.*, ST_AsText(`e0`.`point`) as `point`, ST_AsText(`e0`.`extended_point`) as `extended_point` from `location` as `e0` where `e0`.`id` = ?');
+    const res2 = await qb2.select(['l0.*']).where({ id: loc.id }).getSingleResult();
+    expect(mock.mock.calls[9][0]).toMatch('select `l0`.*, ST_AsText(`l0`.`point`) as `point`, ST_AsText(`l0`.`extended_point`) as `extended_point` from `location` as `l0` where `l0`.`id` = ?');
     expect(res2).toMatchObject(l1);
     mock.mock.calls.length = 0;
     orm.em.clear();
 
     // custom types with SQL fragments with joined strategy (GH #1594)
     const a2 = await orm.em.findOneOrFail(Address, addr, { populate: ['location'], strategy: LoadStrategy.JOINED });
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`id`, `e0`.`location_id`, `l1`.`id` as `l1__id`, `l1`.`rank` as `l1__rank`, ST_AsText(`l1`.`point`) as `l1__point`, ST_AsText(`l1`.`extended_point`) as `l1__extended_point` from `address` as `e0` left join `location` as `l1` on `e0`.`location_id` = `l1`.`id` where `e0`.`id` = ?');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `a0`.`location_id`, `l1`.`id` as `l1__id`, `l1`.`rank` as `l1__rank`, ST_AsText(`l1`.`point`) as `l1__point`, ST_AsText(`l1`.`extended_point`) as `l1__extended_point` from `address` as `a0` left join `location` as `l1` on `a0`.`location_id` = `l1`.`id` where `a0`.`id` = ?');
     expect(a2.location.point).toBeInstanceOf(Point);
     expect(a2.location.point).toMatchObject({ latitude: 2.34, longitude: 9.87 });
     expect(a2.location.extendedPoint).toBeInstanceOf(Point);
@@ -202,7 +202,7 @@ describe('custom types [mysql]', () => {
       extendedPoint: null,
     });
 
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.*, ST_AsText(`e0`.`point`) as `point`, ST_AsText(`e0`.`extended_point`) as `extended_point` from `location` as `e0` where ST_AsText(`e0`.`point`) = \'point(1 1)\' and ST_AsText(`e0`.`extended_point`) is null limit 1');
+    expect(mock.mock.calls[0][0]).toMatch('select `l0`.*, ST_AsText(`l0`.`point`) as `point`, ST_AsText(`l0`.`extended_point`) as `extended_point` from `location` as `l0` where ST_AsText(`l0`.`point`) = \'point(1 1)\' and ST_AsText(`l0`.`extended_point`) is null limit 1');
     expect(mock.mock.calls).toHaveLength(1);
 
     expect(foundLocation).toBeInstanceOf(Location);
@@ -225,7 +225,7 @@ describe('custom types [mysql]', () => {
       extendedPoint: { $ne: null },
     });
 
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.*, ST_AsText(`e0`.`point`) as `point`, ST_AsText(`e0`.`extended_point`) as `extended_point` from `location` as `e0` where ST_AsText(`e0`.`point`) = \'point(1 1)\' and ST_AsText(`e0`.`extended_point`) is not null limit 1');
+    expect(mock.mock.calls[0][0]).toMatch('select `l0`.*, ST_AsText(`l0`.`point`) as `point`, ST_AsText(`l0`.`extended_point`) as `extended_point` from `location` as `l0` where ST_AsText(`l0`.`point`) = \'point(1 1)\' and ST_AsText(`l0`.`extended_point`) is not null limit 1');
     expect(mock.mock.calls).toHaveLength(1);
 
     expect(foundLocation).toBeInstanceOf(Location);

--- a/tests/features/embeddables/embeddable-custom-types.postgres.test.ts
+++ b/tests/features/embeddables/embeddable-custom-types.postgres.test.ts
@@ -147,7 +147,7 @@ describe('embedded entities with custom types', () => {
     expect(mock.mock.calls[2][0]).toMatch(`commit`);
 
     const p = await orm.em.findOneOrFail(Parent, parent.id);
-    expect(mock.mock.calls[3][0]).toMatch('select "e0".* from "parent" as "e0" where "e0"."id" = 1 limit 1');
+    expect(mock.mock.calls[3][0]).toMatch('select "p0".* from "parent" as "p0" where "p0"."id" = 1 limit 1');
     expect(p.nested).toBeInstanceOf(Nested);
     expect(p.nested2).toBeInstanceOf(Nested);
     expect(p).toMatchObject({
@@ -182,7 +182,7 @@ describe('embedded entities with custom types', () => {
     expect(mock.mock.calls[2][0]).toMatch('commit');
 
     const u = await orm.em.findOneOrFail(User, user.id);
-    expect(mock.mock.calls[3][0]).toMatch('select "e0".* from "user" as "e0" where "e0"."id" = $1 limit $2');
+    expect(mock.mock.calls[3][0]).toMatch('select "u0".* from "user" as "u0" where "u0"."id" = $1 limit $2');
     expect(u.savings).toBeInstanceOf(Savings);
     expect(u.savings).toEqual({
       amount: 15200.23,
@@ -196,7 +196,7 @@ describe('embedded entities with custom types', () => {
     const u1 = await orm.em.findOneOrFail(User, {
       savings: { amount: 15200.23 },
     });
-    expect(mock.mock.calls[0][0]).toMatch('select "e0".* from "user" as "e0" where "e0"."savings_amount" = $1 limit $2');
+    expect(mock.mock.calls[0][0]).toMatch('select "u0".* from "user" as "u0" where "u0"."savings_amount" = $1 limit $2');
     expect(u1.savings.amount).toBe(15200.23);
   });
 

--- a/tests/features/embeddables/embedded-entities.mysql.test.ts
+++ b/tests/features/embeddables/embedded-entities.mysql.test.ts
@@ -171,7 +171,7 @@ describe('embedded entities in mysql', () => {
     expect(mock.mock.calls[2][0]).toMatch('commit');
 
     const u = await orm.em.findOneOrFail(User, user.id);
-    expect(mock.mock.calls[3][0]).toMatch('select `e0`.* from `user` as `e0` where `e0`.`id` = ? limit ?');
+    expect(mock.mock.calls[3][0]).toMatch('select `u0`.* from `user` as `u0` where `u0`.`id` = ? limit ?');
     expect(u.address1).toBeInstanceOf(Address1);
     expect(u.address1).toEqual({
       street: 'Downing street 10',
@@ -210,16 +210,16 @@ describe('embedded entities in mysql', () => {
     orm.em.clear();
 
     const u1 = await orm.em.findOneOrFail(User, { address1: { city: 'London 1', postalCode: '123' } });
-    expect(mock.mock.calls[7][0]).toMatch('select `e0`.* from `user` as `e0` where `e0`.`address1_city` = ? and `e0`.`address1_postal_code` = ? limit ?');
+    expect(mock.mock.calls[7][0]).toMatch('select `u0`.* from `user` as `u0` where `u0`.`address1_city` = ? and `u0`.`address1_postal_code` = ? limit ?');
     expect(u1.address1.city).toBe('London 1');
     expect(u1.address1.postalCode).toBe('123');
     const u2 = await orm.em.findOneOrFail(User, { address1: { city: /^London/ } });
-    expect(mock.mock.calls[8][0]).toMatch('select `e0`.* from `user` as `e0` where `e0`.`address1_city` like ? limit ?');
+    expect(mock.mock.calls[8][0]).toMatch('select `u0`.* from `user` as `u0` where `u0`.`address1_city` like ? limit ?');
     expect(u2.address1.city).toBe('London 1');
     expect(u2.address1.postalCode).toBe('123');
     expect(u2).toBe(u1);
     const u3 = await orm.em.findOneOrFail(User, { $or: [{ address1: { city: 'London 1' } }, { address1: { city: 'Berlin' } }] });
-    expect(mock.mock.calls[9][0]).toMatch('select `e0`.* from `user` as `e0` where (`e0`.`address1_city` = ? or `e0`.`address1_city` = ?) limit ?');
+    expect(mock.mock.calls[9][0]).toMatch('select `u0`.* from `user` as `u0` where (`u0`.`address1_city` = ? or `u0`.`address1_city` = ?) limit ?');
     expect(u3.address1.city).toBe('London 1');
     expect(u3.address1.postalCode).toBe('123');
     expect(u3).toBe(u1);
@@ -227,7 +227,7 @@ describe('embedded entities in mysql', () => {
     await expect(orm.em.findOneOrFail(User, { address1: { $or: [{ city: 'London 1' }, { city: 'Berlin' }] } })).rejects.toThrowError(err);
     const u4 = await orm.em.findOneOrFail(User, { address4: { postalCode: '999' } });
     expect(u4).toBe(u1);
-    expect(mock.mock.calls[10][0]).toMatch('select `e0`.* from `user` as `e0` where `e0`.`address4`->\'$.postalCode\' = ? limit ?');
+    expect(mock.mock.calls[10][0]).toMatch('select `u0`.* from `user` as `u0` where `u0`.`address4`->\'$.postalCode\' = ? limit ?');
   });
 
   test('assign', async () => {

--- a/tests/features/embeddables/embedded-entities.postgres.test.ts
+++ b/tests/features/embeddables/embedded-entities.postgres.test.ts
@@ -193,7 +193,7 @@ describe('embedded entities in postgresql', () => {
     expect(mock.mock.calls[2][0]).toMatch('commit');
 
     const u = await orm.em.findOneOrFail(User, user.id);
-    expect(mock.mock.calls[3][0]).toMatch('select "e0".* from "user" as "e0" where "e0"."id" = $1 limit $2');
+    expect(mock.mock.calls[3][0]).toMatch('select "u0".* from "user" as "u0" where "u0"."id" = $1 limit $2');
     expect(u.address1).toBeInstanceOf(Address1);
     expect(u.address1).toEqual({
       street: 'Downing street 10',
@@ -237,16 +237,16 @@ describe('embedded entities in postgresql', () => {
     orm.em.clear();
 
     const u1 = await orm.em.findOneOrFail(User, { address1: { city: 'London 1', postalCode: '123' } });
-    expect(mock.mock.calls[7][0]).toMatch('select "e0".* from "user" as "e0" where "e0"."address1_city" = $1 and "e0"."address1_postal_code" = $2 limit $3');
+    expect(mock.mock.calls[7][0]).toMatch('select "u0".* from "user" as "u0" where "u0"."address1_city" = $1 and "u0"."address1_postal_code" = $2 limit $3');
     expect(u1.address1.city).toBe('London 1');
     expect(u1.address1.postalCode).toBe('123');
     const u2 = await orm.em.findOneOrFail(User, { address1: { city: /^London/ } });
-    expect(mock.mock.calls[8][0]).toMatch('select "e0".* from "user" as "e0" where "e0"."address1_city" like $1 limit $2');
+    expect(mock.mock.calls[8][0]).toMatch('select "u0".* from "user" as "u0" where "u0"."address1_city" like $1 limit $2');
     expect(u2.address1.city).toBe('London 1');
     expect(u2.address1.postalCode).toBe('123');
     expect(u2).toBe(u1);
     const u3 = await orm.em.findOneOrFail(User, { $or: [{ address1: { city: 'London 1' } }, { address1: { city: 'Berlin' } }] });
-    expect(mock.mock.calls[9][0]).toMatch('select "e0".* from "user" as "e0" where ("e0"."address1_city" = $1 or "e0"."address1_city" = $2) limit $3');
+    expect(mock.mock.calls[9][0]).toMatch('select "u0".* from "user" as "u0" where ("u0"."address1_city" = $1 or "u0"."address1_city" = $2) limit $3');
     expect(u3.address1.city).toBe('London 1');
     expect(u3.address1.postalCode).toBe('123');
     expect(u3).toBe(u1);
@@ -254,11 +254,11 @@ describe('embedded entities in postgresql', () => {
     await expect(orm.em.findOneOrFail(User, { address1: { $or: [{ city: 'London 1' }, { city: 'Berlin' }] } })).rejects.toThrowError(err);
     const u4 = await orm.em.findOneOrFail(User, { address4: { postalCode: '999' } });
     expect(u4).toBe(u1);
-    expect(mock.mock.calls[10][0]).toMatch('select "e0".* from "user" as "e0" where "e0"."address4"->>\'postalCode\' = $1 limit $2');
+    expect(mock.mock.calls[10][0]).toMatch('select "u0".* from "user" as "u0" where "u0"."address4"->>\'postalCode\' = $1 limit $2');
 
     const u5 = await orm.em.findOneOrFail(User, { address4: { number: { $gt: 2 } } });
     expect(u5).toBe(u1);
-    expect(mock.mock.calls[11][0]).toMatch('select "e0".* from "user" as "e0" where ("e0"."address4"->>\'number\')::float8 > $1 limit $2');
+    expect(mock.mock.calls[11][0]).toMatch('select "u0".* from "user" as "u0" where ("u0"."address4"->>\'number\')::float8 > $1 limit $2');
   });
 
   test('assign', async () => {
@@ -341,8 +341,8 @@ describe('embedded entities in postgresql', () => {
     expect(r[0].address4).toBeInstanceOf(Address1);
     expect(r[0].address4.city).toBe('Prague');
     expect(r[0].address4.postalCode).toBe('12000');
-    expect(mock.mock.calls[0][0]).toMatch('select "e0".* ' +
-      'from "user" as "e0" ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "u0".* ' +
+      'from "user" as "u0" ' +
       'where (address4->>\'street\')::text != \'\' and ' +
       'lower((address4->>\'city\')::text) = \'prague\' and ' +
       '(address4->>\'city\')::text = \'Prague\' and ' +

--- a/tests/features/embeddables/entities-in-embeddables.postgres.test.ts
+++ b/tests/features/embeddables/entities-in-embeddables.postgres.test.ts
@@ -217,7 +217,7 @@ describe('embedded entities in postgres', () => {
 
     const u1 = await orm.em.findOneOrFail(User, user1.id);
     const u2 = await orm.em.findOneOrFail(User, user2.id);
-    expect(mock.mock.calls[4][0]).toMatch(`select "e0".* from "user" as "e0" where "e0"."id" = 1 limit 1`);
+    expect(mock.mock.calls[4][0]).toMatch(`select "u0".* from "user" as "u0" where "u0"."id" = 1 limit 1`);
     expect(u1.profile1).toBeInstanceOf(Profile);
     expect(u1.profile1.identity).toBeInstanceOf(Identity);
     expect(u1.profile1.identity.meta).toBeInstanceOf(IdentityMeta);
@@ -335,7 +335,7 @@ describe('embedded entities in postgres', () => {
       profile1: { identity: { email: 'e123', meta: { foo: 'foooooooo' } } },
       profile2: { identity: { email: 'e2', meta: { foo: 'f2', bar: 'bababar' } } },
     });
-    expect(mock.mock.calls[0][0]).toMatch(`select "e0".* from "user" as "e0" where "e0"."profile1_identity_email" = 'e123' and "e0"."profile1_identity_meta_foo" = 'foooooooo' and "e0"."profile2"->'identity'->>'email' = 'e2' and "e0"."profile2"->'identity'->'meta'->>'foo' = 'f2' and "e0"."profile2"->'identity'->'meta'->>'bar' = 'bababar' limit 1`);
+    expect(mock.mock.calls[0][0]).toMatch(`select "u0".* from "user" as "u0" where "u0"."profile1_identity_email" = 'e123' and "u0"."profile1_identity_meta_foo" = 'foooooooo' and "u0"."profile2"->'identity'->>'email' = 'e2' and "u0"."profile2"->'identity'->'meta'->>'foo' = 'f2' and "u0"."profile2"->'identity'->'meta'->>'bar' = 'bababar' limit 1`);
     expect(u3.id).toEqual(u1.id);
     orm.em.clear();
     mock.mock.calls.length = 0;
@@ -345,12 +345,12 @@ describe('embedded entities in postgres', () => {
       profile2: { identity: { email: 'e2', meta: { foo: 'f2', bar: { $re: '(ba)+r' } } } },
     });
     expect(u4.id).toEqual(u1.id);
-    expect(mock.mock.calls[0][0]).toMatch(`select "e0".* from "user" as "e0" where "e0"."profile1_identity_email" = 'e123' and "e0"."profile1_identity_meta_foo" ~ 'fo+' and "e0"."profile2"->'identity'->>'email' = 'e2' and "e0"."profile2"->'identity'->'meta'->>'foo' = 'f2' and "e0"."profile2"->'identity'->'meta'->>'bar' ~ '(ba)+r' limit 1`);
+    expect(mock.mock.calls[0][0]).toMatch(`select "u0".* from "user" as "u0" where "u0"."profile1_identity_email" = 'e123' and "u0"."profile1_identity_meta_foo" ~ 'fo+' and "u0"."profile2"->'identity'->>'email' = 'e2' and "u0"."profile2"->'identity'->'meta'->>'foo' = 'f2' and "u0"."profile2"->'identity'->'meta'->>'bar' ~ '(ba)+r' limit 1`);
     orm.em.clear();
     mock.mock.calls.length = 0;
 
     const u5 = await orm.em.findOneOrFail(User, { $or: [{ profile1: { identity: { meta: { foo: 'foooooooo' } } } }, { profile2: { identity: { meta: { bar: 'bababar' } } } }] });
-    expect(mock.mock.calls[0][0]).toMatch(`select "e0".* from "user" as "e0" where ("e0"."profile1_identity_meta_foo" = 'foooooooo' or "e0"."profile2"->'identity'->'meta'->>'bar' = 'bababar') limit 1`);
+    expect(mock.mock.calls[0][0]).toMatch(`select "u0".* from "user" as "u0" where ("u0"."profile1_identity_meta_foo" = 'foooooooo' or "u0"."profile2"->'identity'->'meta'->>'bar' = 'bababar') limit 1`);
     expect(u5.id).toEqual(u1.id);
 
     const err1 = `Invalid query for entity 'User', property 'city' does not exist in embeddable 'Identity'`;
@@ -377,11 +377,11 @@ describe('embedded entities in postgres', () => {
       orderBy: { name: 'desc' },
     });
 
-    expect(mock.mock.calls[0][0]).toMatch(`select "e0".* from "user" as "e0" order by "e0"."name" desc`);
-    expect(mock.mock.calls[1][0]).toMatch(`select "e0".* from "source" as "e0" where "e0"."id" in (1, 7) order by "e0"."id" asc`);
-    expect(mock.mock.calls[2][0]).toMatch(`select "e0".* from "source" as "e0" where "e0"."id" in (2, 8) order by "e0"."id" asc`);
-    expect(mock.mock.calls[3][0]).toMatch(`select "e0".* from "source" as "e0" where "e0"."id" in (3) order by "e0"."id" asc`);
-    expect(mock.mock.calls[4][0]).toMatch(`select "e0".* from "source" as "e0" where "e0"."id" in (11, 12, 13, 14, 15, 16) order by "e0"."id" asc`);
+    expect(mock.mock.calls[0][0]).toMatch(`select "u0".* from "user" as "u0" order by "u0"."name" desc`);
+    expect(mock.mock.calls[1][0]).toMatch(`select "s0".* from "source" as "s0" where "s0"."id" in (1, 7) order by "s0"."id" asc`);
+    expect(mock.mock.calls[2][0]).toMatch(`select "s0".* from "source" as "s0" where "s0"."id" in (2, 8) order by "s0"."id" asc`);
+    expect(mock.mock.calls[3][0]).toMatch(`select "s0".* from "source" as "s0" where "s0"."id" in (3) order by "s0"."id" asc`);
+    expect(mock.mock.calls[4][0]).toMatch(`select "s0".* from "source" as "s0" where "s0"."id" in (11, 12, 13, 14, 15, 16) order by "s0"."id" asc`);
     expect(wrap(users[1].profile1.identity.links[1].metas[2].source).isInitialized()).toBe(true);
     expect(users[1].profile1.identity.links[1].metas[2].source!.name).toBe('ilms323');
 

--- a/tests/features/embeddables/nested-embeddables.postgres.test.ts
+++ b/tests/features/embeddables/nested-embeddables.postgres.test.ts
@@ -147,7 +147,7 @@ describe('embedded entities in postgres', () => {
 
     const u1 = await orm.em.findOneOrFail(User, user1.id);
     const u2 = await orm.em.findOneOrFail(User, user2.id);
-    expect(mock.mock.calls[3][0]).toMatch(`select "e0".* from "user" as "e0" where "e0"."id" = 1 limit 1`);
+    expect(mock.mock.calls[3][0]).toMatch(`select "u0".* from "user" as "u0" where "u0"."id" = 1 limit 1`);
     expect(u1.profile1).toBeInstanceOf(Profile);
     expect(u1.profile1.identity).toBeInstanceOf(Identity);
     expect(u1.profile1.identity.meta).toBeInstanceOf(IdentityMeta);
@@ -242,7 +242,7 @@ describe('embedded entities in postgres', () => {
       profile1: { identity: { email: 'e123', meta: { foo: 'foooooooo' } } },
       profile2: { identity: { email: 'e2', meta: { foo: 'f2', bar: 'bababar' } } },
     });
-    expect(mock.mock.calls[0][0]).toMatch(`select "e0".* from "user" as "e0" where "e0"."profile1_identity_email" = 'e123' and "e0"."profile1_identity_meta_foo" = 'foooooooo' and "e0"."profile2"->'identity'->>'email' = 'e2' and "e0"."profile2"->'identity'->'meta'->>'foo' = 'f2' and "e0"."profile2"->'identity'->'meta'->>'bar' = 'bababar' limit 1`);
+    expect(mock.mock.calls[0][0]).toMatch(`select "u0".* from "user" as "u0" where "u0"."profile1_identity_email" = 'e123' and "u0"."profile1_identity_meta_foo" = 'foooooooo' and "u0"."profile2"->'identity'->>'email' = 'e2' and "u0"."profile2"->'identity'->'meta'->>'foo' = 'f2' and "u0"."profile2"->'identity'->'meta'->>'bar' = 'bababar' limit 1`);
     expect(u3.id).toEqual(u1.id);
     orm.em.clear();
     mock.mock.calls.length = 0;
@@ -252,12 +252,12 @@ describe('embedded entities in postgres', () => {
       profile2: { identity: { email: 'e2', meta: { foo: 'f2', bar: { $re: '(ba)+r' } } } },
     });
     expect(u4.id).toEqual(u1.id);
-    expect(mock.mock.calls[0][0]).toMatch(`select "e0".* from "user" as "e0" where "e0"."profile1_identity_email" = 'e123' and "e0"."profile1_identity_meta_foo" ~ 'fo+' and "e0"."profile2"->'identity'->>'email' = 'e2' and "e0"."profile2"->'identity'->'meta'->>'foo' = 'f2' and "e0"."profile2"->'identity'->'meta'->>'bar' ~ '(ba)+r' limit 1`);
+    expect(mock.mock.calls[0][0]).toMatch(`select "u0".* from "user" as "u0" where "u0"."profile1_identity_email" = 'e123' and "u0"."profile1_identity_meta_foo" ~ 'fo+' and "u0"."profile2"->'identity'->>'email' = 'e2' and "u0"."profile2"->'identity'->'meta'->>'foo' = 'f2' and "u0"."profile2"->'identity'->'meta'->>'bar' ~ '(ba)+r' limit 1`);
     orm.em.clear();
     mock.mock.calls.length = 0;
 
     const u5 = await orm.em.findOneOrFail(User, { $or: [{ profile1: { identity: { meta: { foo: 'foooooooo' } } } }, { profile2: { identity: { meta: { bar: 'bababar' } } } }] });
-    expect(mock.mock.calls[0][0]).toMatch(`select "e0".* from "user" as "e0" where ("e0"."profile1_identity_meta_foo" = 'foooooooo' or "e0"."profile2"->'identity'->'meta'->>'bar' = 'bababar') limit 1`);
+    expect(mock.mock.calls[0][0]).toMatch(`select "u0".* from "user" as "u0" where ("u0"."profile1_identity_meta_foo" = 'foooooooo' or "u0"."profile2"->'identity'->'meta'->>'bar' = 'bababar') limit 1`);
     expect(u5.id).toEqual(u1.id);
 
     const err1 = `Invalid query for entity 'User', property 'city' does not exist in embeddable 'Identity'`;

--- a/tests/features/filters/filters.mysql.test.ts
+++ b/tests/features/filters/filters.mysql.test.ts
@@ -35,61 +35,61 @@ describe('filters [mysql]', () => {
       orderBy: { title: QueryOrder.DESC },
       filters: ['long', 'expensive'],
     });
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.*, `e0`.price * 1.19 as `price_taxed`, `e1`.`id` as `test_id` ' +
-      'from `book2` as `e0` ' +
-      'left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` ' +
-      'where `e0`.`author_id` is not null and length(perex) > 10000 and `e0`.`price` > 1000 and `e0`.`title` = \'123\' ' +
-      'order by `e0`.`title` desc');
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `test_id` ' +
+      'from `book2` as `b0` ' +
+      'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
+      'where `b0`.`author_id` is not null and length(perex) > 10000 and `b0`.`price` > 1000 and `b0`.`title` = \'123\' ' +
+      'order by `b0`.`title` desc');
 
     const books2 = await orm.em.find(Book2, { title: '123' }, {
       filters: { hasAuthor: false, long: true, writtenBy: { name: 'God' } },
     });
-    expect(mock.mock.calls[1][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`created_at`, `e0`.`title`, `e0`.`price`, `e0`.`double`, `e0`.`meta`, `e0`.`author_id`, `e0`.`publisher_id`, `e0`.price * 1.19 as `price_taxed`, `e2`.`id` as `test_id` ' +
-      'from `book2` as `e0` ' +
-      'left join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` ' +
-      'left join `test2` as `e2` on `e0`.`uuid_pk` = `e2`.`book_uuid_pk` ' +
-      'where `e1`.`name` = \'God\' and length(perex) > 10000 and `e0`.`title` = \'123\'');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `test_id` ' +
+      'from `book2` as `b0` ' +
+      'left join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
+      'left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` ' +
+      'where `a1`.`name` = \'God\' and length(perex) > 10000 and `b0`.`title` = \'123\'');
 
     const books3 = await orm.em.find(Book2, { title: '123' }, {
       filters: false,
     });
-    expect(mock.mock.calls[2][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`created_at`, `e0`.`title`, `e0`.`price`, `e0`.`double`, `e0`.`meta`, `e0`.`author_id`, `e0`.`publisher_id`, `e0`.price * 1.19 as `price_taxed`, `e1`.`id` as `test_id` ' +
-      'from `book2` as `e0` ' +
-      'left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` ' +
-      'where `e0`.`title` = \'123\'');
+    expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `test_id` ' +
+      'from `book2` as `b0` ' +
+      'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
+      'where `b0`.`title` = \'123\'');
 
     const books4 = await orm.em.find(Book2, { title: '123' }, {
       filters: true,
     });
-    expect(mock.mock.calls[3][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`created_at`, `e0`.`title`, `e0`.`price`, `e0`.`double`, `e0`.`meta`, `e0`.`author_id`, `e0`.`publisher_id`, `e0`.price * 1.19 as `price_taxed`, `e1`.`id` as `test_id` ' +
-      'from `book2` as `e0` ' +
-      'left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` ' +
-      'where `e0`.`author_id` is not null and `e0`.`title` = \'123\'');
+    expect(mock.mock.calls[3][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `test_id` ' +
+      'from `book2` as `b0` ' +
+      'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
+      'where `b0`.`author_id` is not null and `b0`.`title` = \'123\'');
 
     const b1 = await orm.em.findOne(Book2, '123', {
       filters: { long: true },
     });
-    expect(mock.mock.calls[4][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`created_at`, `e0`.`title`, `e0`.`price`, `e0`.`double`, `e0`.`meta`, `e0`.`author_id`, `e0`.`publisher_id`, `e0`.price * 1.19 as `price_taxed`, `e1`.`id` as `test_id` ' +
-      'from `book2` as `e0` ' +
-      'left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` ' +
-      'where `e0`.`author_id` is not null and length(perex) > 10000 and `e0`.`uuid_pk` = \'123\' limit 1');
+    expect(mock.mock.calls[4][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `test_id` ' +
+      'from `book2` as `b0` ' +
+      'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
+      'where `b0`.`author_id` is not null and length(perex) > 10000 and `b0`.`uuid_pk` = \'123\' limit 1');
 
     const b2 = await orm.em.findOne(Book2, { author: { name: 'Jon' } }, {
       filters: { hasAuthor: false, long: true },
     });
-    expect(mock.mock.calls[5][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`created_at`, `e0`.`title`, `e0`.`price`, `e0`.`double`, `e0`.`meta`, `e0`.`author_id`, `e0`.`publisher_id`, `e0`.price * 1.19 as `price_taxed`, `e2`.`id` as `test_id` ' +
-      'from `book2` as `e0` ' +
-      'left join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` ' +
-      'left join `test2` as `e2` on `e0`.`uuid_pk` = `e2`.`book_uuid_pk` ' +
-      'where length(perex) > 10000 and `e1`.`name` = \'Jon\' limit 1');
+    expect(mock.mock.calls[5][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `test_id` ' +
+      'from `book2` as `b0` ' +
+      'left join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
+      'left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` ' +
+      'where length(perex) > 10000 and `a1`.`name` = \'Jon\' limit 1');
 
     await orm.em.count(Book2, { author: { name: 'Jon' } }, {
       filters: { hasAuthor: false, long: true },
     });
-    expect(mock.mock.calls[6][0]).toMatch('select count(distinct `e0`.`uuid_pk`) as `count` ' +
-      'from `book2` as `e0` ' +
-      'left join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` ' +
-      'where length(perex) > 10000 and `e1`.`name` = \'Jon\'');
+    expect(mock.mock.calls[6][0]).toMatch('select count(distinct `b0`.`uuid_pk`) as `count` ' +
+      'from `book2` as `b0` ' +
+      'left join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
+      'where length(perex) > 10000 and `a1`.`name` = \'Jon\'');
 
     await orm.em.nativeUpdate(Book2, '123', { title: 'b123' }, {
       filters: { hasAuthor: false, long: true },

--- a/tests/features/filters/filters.postgres.test.ts
+++ b/tests/features/filters/filters.postgres.test.ts
@@ -123,9 +123,9 @@ describe('filters [postgres]', () => {
     expect(mock.mock.calls[2][0]).toMatch(`insert into "benefit" ("benefit_status") values ($1) returning "id"`);
     expect(mock.mock.calls[3][0]).toMatch(`insert into "employee_benefits" ("employee_id", "benefit_id") values ($1, $2)`);
     expect(mock.mock.calls[4][0]).toMatch(`commit`);
-    expect(mock.mock.calls[5][0]).toMatch(`select "e0".* from "benefit" as "e0" where "e0"."benefit_status" = $1`);
+    expect(mock.mock.calls[5][0]).toMatch(`select "b0".* from "benefit" as "b0" where "b0"."benefit_status" = $1`);
     expect(mock.mock.calls[6][0]).toMatch(`select "e0".* from "employee" as "e0" where "e0"."id" = $1 limit $2`);
-    expect(mock.mock.calls[7][0]).toMatch(`select "e0".*, "e1"."benefit_id" as "fk__benefit_id", "e1"."employee_id" as "fk__employee_id" from "benefit" as "e0" left join "employee_benefits" as "e1" on "e0"."id" = "e1"."benefit_id" where "e0"."benefit_status" = $1 and "e1"."employee_id" in ($2)`);
+    expect(mock.mock.calls[7][0]).toMatch(`select "b0".*, "e1"."benefit_id" as "fk__benefit_id", "e1"."employee_id" as "fk__employee_id" from "benefit" as "b0" left join "employee_benefits" as "e1" on "b0"."id" = "e1"."benefit_id" where "b0"."benefit_status" = $1 and "e1"."employee_id" in ($2)`);
   });
 
   test('merging $or conditions', async () => {
@@ -148,9 +148,9 @@ describe('filters [postgres]', () => {
       },
     }, { filters: false });
 
-    expect(mock.mock.calls[0][0]).toMatch(`select "e0".* from "user" as "e0" where ("e0"."age" = $1 or "e0"."age" = $2) and ("e0"."first_name" = $3 or "e0"."last_name" = $4)`);
-    expect(mock.mock.calls[1][0]).toMatch(`select "e0".* from "membership" as "e0" left join "user" as "e1" on "e0"."user_id" = "e1"."id" where ("e1"."first_name" = $1 or "e1"."last_name" = $2 or "e1"."age" = (select 1 + 1)) and ("e0"."role" = $3 or "e0"."role" = $4)`);
-    expect(mock.mock.calls[2][0]).toMatch(`select "e0".* from "membership" as "e0" left join "user" as "e1" on "e0"."user_id" = "e1"."id" where ("e0"."role" = $1 or "e0"."role" = $2) and ("e1"."first_name" = $3 or "e1"."last_name" = $4)`);
+    expect(mock.mock.calls[0][0]).toMatch(`select "u0".* from "user" as "u0" where ("u0"."age" = $1 or "u0"."age" = $2) and ("u0"."first_name" = $3 or "u0"."last_name" = $4)`);
+    expect(mock.mock.calls[1][0]).toMatch(`select "m0".* from "membership" as "m0" left join "user" as "u1" on "m0"."user_id" = "u1"."id" where ("u1"."first_name" = $1 or "u1"."last_name" = $2 or "u1"."age" = (select 1 + 1)) and ("m0"."role" = $3 or "m0"."role" = $4)`);
+    expect(mock.mock.calls[2][0]).toMatch(`select "m0".* from "membership" as "m0" left join "user" as "u1" on "m0"."user_id" = "u1"."id" where ("m0"."role" = $1 or "m0"."role" = $2) and ("u1"."first_name" = $3 or "u1"."last_name" = $4)`);
   });
 
 });

--- a/tests/features/joined-strategy.postgre.test.ts
+++ b/tests/features/joined-strategy.postgre.test.ts
@@ -108,41 +108,41 @@ describe('Joined loading strategy', () => {
 
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books2.perex'] });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."created_at", "e0"."updated_at", "e0"."name", "e0"."email", "e0"."age", "e0"."terms_accepted", "e0"."optional", "e0"."identities", "e0"."born", "e0"."born_time", "e0"."favourite_book_uuid_pk", "e0"."favourite_author_id", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "a0"."id", "a0"."created_at", "a0"."updated_at", "a0"."name", "a0"."email", "a0"."age", "a0"."terms_accepted", "a0"."optional", "a0"."identities", "a0"."born", "a0"."born_time", "a0"."favourite_book_uuid_pk", "a0"."favourite_author_id", ' +
       '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
-      'from "author2" as "e0" ' +
-      'left join "book2" as "b1" on "e0"."id" = "b1"."author_id" ' +
-      'where "e0"."id" = $1');
+      'from "author2" as "a0" ' +
+      'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" ' +
+      'where "a0"."id" = $1');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books2'] });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."created_at", "e0"."updated_at", "e0"."name", "e0"."email", "e0"."age", "e0"."terms_accepted", "e0"."optional", "e0"."identities", "e0"."born", "e0"."born_time", "e0"."favourite_book_uuid_pk", "e0"."favourite_author_id", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "a0"."id", "a0"."created_at", "a0"."updated_at", "a0"."name", "a0"."email", "a0"."age", "a0"."terms_accepted", "a0"."optional", "a0"."identities", "a0"."born", "a0"."born_time", "a0"."favourite_book_uuid_pk", "a0"."favourite_author_id", ' +
       '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
-      'from "author2" as "e0" ' +
-      'left join "book2" as "b1" on "e0"."id" = "b1"."author_id" ' +
-      'where "e0"."id" = $1');
+      'from "author2" as "a0" ' +
+      'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" ' +
+      'where "a0"."id" = $1');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books'] });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."created_at", "e0"."updated_at", "e0"."name", "e0"."email", "e0"."age", "e0"."terms_accepted", "e0"."optional", "e0"."identities", "e0"."born", "e0"."born_time", "e0"."favourite_book_uuid_pk", "e0"."favourite_author_id", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "a0"."id", "a0"."created_at", "a0"."updated_at", "a0"."name", "a0"."email", "a0"."age", "a0"."terms_accepted", "a0"."optional", "a0"."identities", "a0"."born", "a0"."born_time", "a0"."favourite_book_uuid_pk", "a0"."favourite_author_id", ' +
       '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
-      'from "author2" as "e0" ' +
-      'left join "book2" as "b1" on "e0"."id" = "b1"."author_id" ' +
-      'where "e0"."id" = $1');
+      'from "author2" as "a0" ' +
+      'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" ' +
+      'where "a0"."id" = $1');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books.perex'] });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."created_at", "e0"."updated_at", "e0"."name", "e0"."email", "e0"."age", "e0"."terms_accepted", "e0"."optional", "e0"."identities", "e0"."born", "e0"."born_time", "e0"."favourite_book_uuid_pk", "e0"."favourite_author_id", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "a0"."id", "a0"."created_at", "a0"."updated_at", "a0"."name", "a0"."email", "a0"."age", "a0"."terms_accepted", "a0"."optional", "a0"."identities", "a0"."born", "a0"."born_time", "a0"."favourite_book_uuid_pk", "a0"."favourite_author_id", ' +
       '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
-      'from "author2" as "e0" ' +
-      'left join "book2" as "b1" on "e0"."id" = "b1"."author_id" ' +
-      'where "e0"."id" = $1');
+      'from "author2" as "a0" ' +
+      'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" ' +
+      'where "a0"."id" = $1');
   });
 
   test('should only fire one query [find()]', async () => {
@@ -159,41 +159,41 @@ describe('Joined loading strategy', () => {
 
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books2.perex'] });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."created_at", "e0"."updated_at", "e0"."name", "e0"."email", "e0"."age", "e0"."terms_accepted", "e0"."optional", "e0"."identities", "e0"."born", "e0"."born_time", "e0"."favourite_book_uuid_pk", "e0"."favourite_author_id", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "a0"."id", "a0"."created_at", "a0"."updated_at", "a0"."name", "a0"."email", "a0"."age", "a0"."terms_accepted", "a0"."optional", "a0"."identities", "a0"."born", "a0"."born_time", "a0"."favourite_book_uuid_pk", "a0"."favourite_author_id", ' +
       '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
-      'from "author2" as "e0" ' +
-      'left join "book2" as "b1" on "e0"."id" = "b1"."author_id" ' +
-      'where "e0"."id" = $1');
+      'from "author2" as "a0" ' +
+      'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" ' +
+      'where "a0"."id" = $1');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books2'] });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."created_at", "e0"."updated_at", "e0"."name", "e0"."email", "e0"."age", "e0"."terms_accepted", "e0"."optional", "e0"."identities", "e0"."born", "e0"."born_time", "e0"."favourite_book_uuid_pk", "e0"."favourite_author_id", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "a0"."id", "a0"."created_at", "a0"."updated_at", "a0"."name", "a0"."email", "a0"."age", "a0"."terms_accepted", "a0"."optional", "a0"."identities", "a0"."born", "a0"."born_time", "a0"."favourite_book_uuid_pk", "a0"."favourite_author_id", ' +
       '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
-      'from "author2" as "e0" ' +
-      'left join "book2" as "b1" on "e0"."id" = "b1"."author_id" ' +
-      'where "e0"."id" = $1');
+      'from "author2" as "a0" ' +
+      'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" ' +
+      'where "a0"."id" = $1');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books'], strategy: LoadStrategy.JOINED });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."created_at", "e0"."updated_at", "e0"."name", "e0"."email", "e0"."age", "e0"."terms_accepted", "e0"."optional", "e0"."identities", "e0"."born", "e0"."born_time", "e0"."favourite_book_uuid_pk", "e0"."favourite_author_id", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "a0"."id", "a0"."created_at", "a0"."updated_at", "a0"."name", "a0"."email", "a0"."age", "a0"."terms_accepted", "a0"."optional", "a0"."identities", "a0"."born", "a0"."born_time", "a0"."favourite_book_uuid_pk", "a0"."favourite_author_id", ' +
       '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
-      'from "author2" as "e0" ' +
-      'left join "book2" as "b1" on "e0"."id" = "b1"."author_id" ' +
-      'where "e0"."id" = $1');
+      'from "author2" as "a0" ' +
+      'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" ' +
+      'where "a0"."id" = $1');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books.perex'] });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."created_at", "e0"."updated_at", "e0"."name", "e0"."email", "e0"."age", "e0"."terms_accepted", "e0"."optional", "e0"."identities", "e0"."born", "e0"."born_time", "e0"."favourite_book_uuid_pk", "e0"."favourite_author_id", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "a0"."id", "a0"."created_at", "a0"."updated_at", "a0"."name", "a0"."email", "a0"."age", "a0"."terms_accepted", "a0"."optional", "a0"."identities", "a0"."born", "a0"."born_time", "a0"."favourite_book_uuid_pk", "a0"."favourite_author_id", ' +
       '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
-      'from "author2" as "e0" ' +
-      'left join "book2" as "b1" on "e0"."id" = "b1"."author_id" ' +
-      'where "e0"."id" = $1');
+      'from "author2" as "a0" ' +
+      'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" ' +
+      'where "a0"."id" = $1');
   });
 
   test('populate ManyToMany with joined strategy', async () => {
@@ -224,12 +224,12 @@ describe('Joined loading strategy', () => {
     mock.mock.calls.length = 0;
     const books = await orm.em.find(Book2, {}, { populate: ['tags'], strategy: LoadStrategy.JOINED, orderBy: { tags: { name: 'desc' } } });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0"."uuid_pk", "e0"."created_at", "e0"."title", "e0"."price", "e0".price * 1.19 as "price_taxed", "e0"."double", "e0"."meta", "e0"."author_id", "e0"."publisher_id", ' +
-      '"t1"."id" as "t1__id", "t1"."name" as "t1__name", "e0".price * 1.19 as "price_taxed" ' +
-      'from "book2" as "e0" ' +
-      'left join "book2_tags" as "e2" on "e0"."uuid_pk" = "e2"."book2_uuid_pk" ' +
-      'left join "book_tag2" as "t1" on "e2"."book_tag2_id" = "t1"."id" ' +
-      'where "e0"."author_id" is not null ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."price", "b0".price * 1.19 as "price_taxed", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", ' +
+      '"t1"."id" as "t1__id", "t1"."name" as "t1__name", "b0".price * 1.19 as "price_taxed" ' +
+      'from "book2" as "b0" ' +
+      'left join "book2_tags" as "b2" on "b0"."uuid_pk" = "b2"."book2_uuid_pk" ' +
+      'left join "book_tag2" as "t1" on "b2"."book_tag2_id" = "t1"."id" ' +
+      'where "b0"."author_id" is not null ' +
       'order by "t1"."name" desc');
 
     expect(books.map(b => b.title)).toEqual(['b4', 'b2', 'b1', 'b5', 'b3']);
@@ -310,17 +310,17 @@ describe('Joined loading strategy', () => {
     // autoJoinOneToOneOwner: false
     const b0 = await orm.em.findOneOrFail(FooBaz2, { id: baz.id });
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0".* from "foo_baz2" as "e0" where "e0"."id" = $1 limit $2');
+    expect(mock.mock.calls[0][0]).toMatch('select "f0".* from "foo_baz2" as "f0" where "f0"."id" = $1 limit $2');
     expect(b0.bar).toBeUndefined();
     orm.em.clear();
 
     const b1 = (await orm.em.findOne(FooBaz2, { id: baz.id }, { populate: ['bar'], strategy: LoadStrategy.JOINED }))!;
     expect(mock.mock.calls).toHaveLength(2);
-    expect(mock.mock.calls[1][0]).toMatch('select "e0"."id", "e0"."name", "e0"."version", ' +
+    expect(mock.mock.calls[1][0]).toMatch('select "f0"."id", "f0"."name", "f0"."version", ' +
       '"b1"."id" as "b1__id", "b1"."name" as "b1__name", "b1"."name with space" as "b1__name with space", "b1"."baz_id" as "b1__baz_id", "b1"."foo_bar_id" as "b1__foo_bar_id", "b1"."version" as "b1__version", "b1"."blob" as "b1__blob", "b1"."array" as "b1__array", "b1"."object_property" as "b1__object_property", (select 123) as "b1__random", "b1"."id" as "bar_id" ' +
-      'from "foo_baz2" as "e0" ' +
-      'left join "foo_bar2" as "b1" on "e0"."id" = "b1"."baz_id" ' +
-      'where "e0"."id" = $1');
+      'from "foo_baz2" as "f0" ' +
+      'left join "foo_bar2" as "b1" on "f0"."id" = "b1"."baz_id" ' +
+      'where "f0"."id" = $1');
     expect(b1.bar).toBeInstanceOf(FooBar2);
     expect(b1.bar!.id).toBe(bar.id);
     expect(b1.bar!.random).toBe(123);
@@ -330,10 +330,10 @@ describe('Joined loading strategy', () => {
 
     const b2 = await orm.em.findOneOrFail(FooBaz2, { bar: bar.id }, { populate: ['bar'] });
     expect(mock.mock.calls).toHaveLength(3);
-    expect(mock.mock.calls[2][0]).toMatch('select "e0"."id", "e0"."name", "e0"."version", ' +
+    expect(mock.mock.calls[2][0]).toMatch('select "f0"."id", "f0"."name", "f0"."version", ' +
       '"b1"."id" as "b1__id", "b1"."name" as "b1__name", "b1"."name with space" as "b1__name with space", "b1"."baz_id" as "b1__baz_id", "b1"."foo_bar_id" as "b1__foo_bar_id", "b1"."version" as "b1__version", "b1"."blob" as "b1__blob", "b1"."array" as "b1__array", "b1"."object_property" as "b1__object_property", (select 123) as "b1__random", "b1"."id" as "bar_id" ' +
-      'from "foo_baz2" as "e0" ' +
-      'left join "foo_bar2" as "b1" on "e0"."id" = "b1"."baz_id" ' +
+      'from "foo_baz2" as "f0" ' +
+      'left join "foo_bar2" as "b1" on "f0"."id" = "b1"."baz_id" ' +
       'where "b1"."id" = $1');
     expect(b2.bar).toBeInstanceOf(FooBar2);
     expect(b2.bar!.id).toBe(bar.id);
@@ -344,10 +344,10 @@ describe('Joined loading strategy', () => {
 
     const b3 = await orm.em.findOneOrFail(FooBaz2, { bar: bar.id }, { populate: ['bar.lazyRandom'] });
     expect(mock.mock.calls).toHaveLength(4);
-    expect(mock.mock.calls[3][0]).toMatch('select "e0"."id", "e0"."name", "e0"."version", ' +
+    expect(mock.mock.calls[3][0]).toMatch('select "f0"."id", "f0"."name", "f0"."version", ' +
       '"b1"."id" as "b1__id", "b1"."name" as "b1__name", "b1"."name with space" as "b1__name with space", "b1"."baz_id" as "b1__baz_id", "b1"."foo_bar_id" as "b1__foo_bar_id", "b1"."version" as "b1__version", "b1"."blob" as "b1__blob", "b1"."array" as "b1__array", "b1"."object_property" as "b1__object_property", (select 123) as "b1__random", (select 456) as "b1__lazy_random", "b1"."id" as "bar_id" ' +
-      'from "foo_baz2" as "e0" ' +
-      'left join "foo_bar2" as "b1" on "e0"."id" = "b1"."baz_id" ' +
+      'from "foo_baz2" as "f0" ' +
+      'left join "foo_bar2" as "b1" on "f0"."id" = "b1"."baz_id" ' +
       'where "b1"."id" = $1');
     expect(b3.bar).toBeInstanceOf(FooBar2);
     expect(b3.bar!.id).toBe(bar.id);
@@ -358,15 +358,15 @@ describe('Joined loading strategy', () => {
     // paginate with joined loading strategy
     await orm.em.find(FooBaz2, { id: baz.id }, { populate: ['bar'], strategy: LoadStrategy.JOINED, flags: [QueryFlag.PAGINATE], limit: 3, offset: 10 });
     expect(mock.mock.calls).toHaveLength(5);
-    expect(mock.mock.calls[4][0]).toMatch('select "e0"."id", "e0"."name", "e0"."version", ' +
+    expect(mock.mock.calls[4][0]).toMatch('select "f0"."id", "f0"."name", "f0"."version", ' +
       '"b1"."id" as "b1__id", "b1"."name" as "b1__name", "b1"."name with space" as "b1__name with space", "b1"."baz_id" as "b1__baz_id", "b1"."foo_bar_id" as "b1__foo_bar_id", "b1"."version" as "b1__version", "b1"."blob" as "b1__blob", "b1"."array" as "b1__array", "b1"."object_property" as "b1__object_property", (select 123) as "b1__random", "b1"."id" as "bar_id" ' +
-      'from "foo_baz2" as "e0" ' +
-      'left join "foo_bar2" as "b1" on "e0"."id" = "b1"."baz_id" ' +
-      'where "e0"."id" in (' +
-      'select "e0"."id" from (' +
-      'select "e0"."id" from "foo_baz2" as "e0" ' +
-      'left join "foo_bar2" as "b1" on "e0"."id" = "b1"."baz_id" ' +
-      'where "e0"."id" = $1 group by "e0"."id" limit $2 offset $3) as "e0")');
+      'from "foo_baz2" as "f0" ' +
+      'left join "foo_bar2" as "b1" on "f0"."id" = "b1"."baz_id" ' +
+      'where "f0"."id" in (' +
+      'select "f0"."id" from (' +
+      'select "f0"."id" from "foo_baz2" as "f0" ' +
+      'left join "foo_bar2" as "b1" on "f0"."id" = "b1"."baz_id" ' +
+      'where "f0"."id" = $1 group by "f0"."id" limit $2 offset $3) as "f0")');
   });
 
   test('nested populating', async () => {
@@ -402,19 +402,19 @@ describe('Joined loading strategy', () => {
       strategy: LoadStrategy.JOINED,
     });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "e0"."name", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0"."id", "b0"."name", ' +
       '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
       '"a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", "a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", ' +
       '"p4"."id" as "p4__id", "p4"."name" as "p4__name", "p4"."type" as "p4__type", "p4"."type2" as "p4__type2", "p4"."enum1" as "p4__enum1", "p4"."enum2" as "p4__enum2", "p4"."enum3" as "p4__enum3", "p4"."enum4" as "p4__enum4", "p4"."enum5" as "p4__enum5", ' +
       '"t5"."id" as "t5__id", "t5"."name" as "t5__name", "t5"."book_uuid_pk" as "t5__book_uuid_pk", "t5"."parent_id" as "t5__parent_id", "t5"."version" as "t5__version" ' +
-      'from "book_tag2" as "e0" ' +
-      'left join "book2_tags" as "e2" on "e0"."id" = "e2"."book_tag2_id" ' +
-      'left join "book2" as "b1" on "e2"."book2_uuid_pk" = "b1"."uuid_pk" ' +
+      'from "book_tag2" as "b0" ' +
+      'left join "book2_tags" as "b2" on "b0"."id" = "b2"."book_tag2_id" ' +
+      'left join "book2" as "b1" on "b2"."book2_uuid_pk" = "b1"."uuid_pk" ' +
       'left join "author2" as "a3" on "b1"."author_id" = "a3"."id" ' +
       'left join "publisher2" as "p4" on "b1"."publisher_id" = "p4"."id" ' +
-      'left join "publisher2_tests" as "e6" on "p4"."id" = "e6"."publisher2_id" ' +
-      'left join "test2" as "t5" on "e6"."test2_id" = "t5"."id" ' +
-      'order by "e0"."name" asc, "t5"."name" asc');
+      'left join "publisher2_tests" as "p6" on "p4"."id" = "p6"."publisher2_id" ' +
+      'left join "test2" as "t5" on "p6"."test2_id" = "t5"."id" ' +
+      'order by "b0"."name" asc, "t5"."name" asc');
 
     expect(tags.length).toBe(5);
     expect(tags[0]).toBeInstanceOf(BookTag2);
@@ -476,51 +476,51 @@ describe('Joined loading strategy', () => {
     expect(res1).toHaveLength(3);
     expect(res1[0].test).toBeUndefined();
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0"."uuid_pk", "e0"."created_at", "e0"."title", "e0"."perex", "e0"."price", "e0".price * 1.19 as "price_taxed", "e0"."double", "e0"."meta", "e0"."author_id", "e0"."publisher_id", ' +
-      '"a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "e0".price * 1.19 as "price_taxed" ' +
-      'from "book2" as "e0" ' +
-      'left join "author2" as "a1" on "e0"."author_id" = "a1"."id" ' +
-      'where "e0"."author_id" is not null and "a1"."name" = $1');
+    expect(mock.mock.calls[0][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."perex", "b0"."price", "b0".price * 1.19 as "price_taxed", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", ' +
+      '"a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "b0".price * 1.19 as "price_taxed" ' +
+      'from "book2" as "b0" ' +
+      'left join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
+      'where "b0"."author_id" is not null and "a1"."name" = $1');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     const res2 = await orm.em.find(Book2, { author: { favouriteBook: { author: { name: 'Jon Snow' } } } }, { populate: ['perex', 'author.favouriteBook.author'] });
     expect(res2).toHaveLength(3);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0"."uuid_pk", "e0"."created_at", "e0"."title", "e0"."perex", "e0"."price", "e0".price * 1.19 as "price_taxed", "e0"."double", "e0"."meta", "e0"."author_id", "e0"."publisher_id", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."perex", "b0"."price", "b0".price * 1.19 as "price_taxed", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", ' +
       '"a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", ' +
       '"f2"."uuid_pk" as "f2__uuid_pk", "f2"."created_at" as "f2__created_at", "f2"."title" as "f2__title", "f2"."price" as "f2__price", "f2".price * 1.19 as "f2__price_taxed", "f2"."double" as "f2__double", "f2"."meta" as "f2__meta", "f2"."author_id" as "f2__author_id", "f2"."publisher_id" as "f2__publisher_id", ' +
-      '"a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", "a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", "e0".price * 1.19 as "price_taxed" ' +
-      'from "book2" as "e0" ' +
-      'left join "author2" as "a1" on "e0"."author_id" = "a1"."id" ' +
+      '"a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", "a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", "b0".price * 1.19 as "price_taxed" ' +
+      'from "book2" as "b0" ' +
+      'left join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
       'left join "book2" as "f2" on "a1"."favourite_book_uuid_pk" = "f2"."uuid_pk" ' +
       'left join "author2" as "a3" on "f2"."author_id" = "a3"."id" ' +
-      'where "e0"."author_id" is not null and "a3"."name" = $1');
+      'where "b0"."author_id" is not null and "a3"."name" = $1');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     const res3 = await orm.em.find(Book2, { author: { favouriteBook: book3 } }, { populate: ['perex'] });
     expect(res3).toHaveLength(3);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0".*, "e0".price * 1.19 as "price_taxed" ' +
-      'from "book2" as "e0" ' +
-      'left join "author2" as "e1" on "e0"."author_id" = "e1"."id" ' +
-      'where "e0"."author_id" is not null and "e1"."favourite_book_uuid_pk" = $1');
+    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed" ' +
+      'from "book2" as "b0" ' +
+      'left join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
+      'where "b0"."author_id" is not null and "a1"."favourite_book_uuid_pk" = $1');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     const res4 = await orm.em.find(Book2, { author: { favouriteBook: { $or: [{ author: { name: 'Jon Snow' } }] } } }, { populate: ['perex', 'author.favouriteBook.author'] });
     expect(res4).toHaveLength(3);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "e0"."uuid_pk", "e0"."created_at", "e0"."title", "e0"."perex", "e0"."price", "e0".price * 1.19 as "price_taxed", "e0"."double", "e0"."meta", "e0"."author_id", "e0"."publisher_id", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."perex", "b0"."price", "b0".price * 1.19 as "price_taxed", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", ' +
       '"a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", ' +
       '"f2"."uuid_pk" as "f2__uuid_pk", "f2"."created_at" as "f2__created_at", "f2"."title" as "f2__title", "f2"."price" as "f2__price", "f2".price * 1.19 as "f2__price_taxed", "f2"."double" as "f2__double", "f2"."meta" as "f2__meta", "f2"."author_id" as "f2__author_id", "f2"."publisher_id" as "f2__publisher_id", ' +
       '"a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", "a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", ' +
-      '"e0".price * 1.19 as "price_taxed" ' +
-      'from "book2" as "e0" left join "author2" as "a1" on "e0"."author_id" = "a1"."id" ' +
+      '"b0".price * 1.19 as "price_taxed" ' +
+      'from "book2" as "b0" left join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
       'left join "book2" as "f2" on "a1"."favourite_book_uuid_pk" = "f2"."uuid_pk" ' +
       'left join "author2" as "a3" on "f2"."author_id" = "a3"."id" ' +
-      'where "e0"."author_id" is not null and "a3"."name" = $1');
+      'where "b0"."author_id" is not null and "a3"."name" = $1');
   });
 
 });

--- a/tests/features/partial-loading/partial-loading.mysql.test.ts
+++ b/tests/features/partial-loading/partial-loading.mysql.test.ts
@@ -47,8 +47,8 @@ describe('partial loading (mysql)', () => {
     expect(r1[0].books[0].title).toBe('Bible 1');
     expect(r1[0].books[0].price).toBeUndefined();
     expect(r1[0].books[0].author).toBeDefined();
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`id` from `author2` as `e0` where `e0`.`id` = ?');
-    expect(mock.mock.calls[1][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`author_id`, `e0`.`title` from `book2` as `e0` where `e0`.`author_id` is not null and `e0`.`author_id` in (?) order by `e0`.`title` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id` from `author2` as `a0` where `a0`.`id` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`author_id`, `b0`.`title` from `book2` as `b0` where `b0`.`author_id` is not null and `b0`.`author_id` in (?) order by `b0`.`title` asc');
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -60,8 +60,8 @@ describe('partial loading (mysql)', () => {
     expect(r2[0].books[0].title).toBe('Bible 1');
     expect(r2[0].books[0].price).toBeUndefined();
     expect(r2[0].books[0].author).toBeDefined();
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`id` from `author2` as `e0` where `e0`.`id` = ?');
-    expect(mock.mock.calls[1][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`author_id`, `e0`.`title` from `book2` as `e0` where `e0`.`author_id` is not null and `e0`.`author_id` in (?) order by `e0`.`title` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id` from `author2` as `a0` where `a0`.`id` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`author_id`, `b0`.`title` from `book2` as `b0` where `b0`.`author_id` is not null and `b0`.`author_id` in (?) order by `b0`.`title` asc');
   });
 
   test('partial nested loading (m:1)', async () => {
@@ -88,8 +88,8 @@ describe('partial loading (mysql)', () => {
     expect(r1[0].author.id).toBe(god.id);
     expect(r1[0].author.name).toBeUndefined();
     expect(r1[0].author.email).toBeDefined();
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`title`, `e0`.`author_id` from `book2` as `e0` where `e0`.`uuid_pk` = ?');
-    expect(mock.mock.calls[1][0]).toMatch('select `e0`.`id`, `e0`.`email` from `author2` as `e0` where `e0`.`id` in (?) order by `e0`.`id` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`title`, `b0`.`author_id` from `book2` as `b0` where `b0`.`uuid_pk` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select `a0`.`id`, `a0`.`email` from `author2` as `a0` where `a0`.`id` in (?) order by `a0`.`id` asc');
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -102,8 +102,8 @@ describe('partial loading (mysql)', () => {
     expect(r2[0].author.id).toBe(god.id);
     expect(r2[0].author.name).toBeUndefined();
     expect(r2[0].author.email).toBeDefined();
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`title`, `e0`.`author_id` from `book2` as `e0` where `e0`.`uuid_pk` = ?');
-    expect(mock.mock.calls[1][0]).toMatch('select `e0`.`id`, `e0`.`email` from `author2` as `e0` where `e0`.`id` in (?) order by `e0`.`id` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`title`, `b0`.`author_id` from `book2` as `b0` where `b0`.`uuid_pk` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select `a0`.`id`, `a0`.`email` from `author2` as `a0` where `a0`.`id` in (?) order by `a0`.`id` asc');
   });
 
   test('partial nested loading (m:n)', async () => {
@@ -130,8 +130,8 @@ describe('partial loading (mysql)', () => {
     expect(r1[0].books[0].title).toBe('Bible 1');
     expect(r1[0].books[0].price).toBeUndefined();
     expect(r1[0].books[0].author).toBeUndefined();
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`id`, `e0`.`name` from `book_tag2` as `e0`');
-    expect(mock.mock.calls[1][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`title`, `e1`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `e1`.`book_tag2_id` as `fk__book_tag2_id`, `e2`.`id` as `test_id` from `book2` as `e0` left join `book2_tags` as `e1` on `e0`.`uuid_pk` = `e1`.`book2_uuid_pk` left join `test2` as `e2` on `e0`.`uuid_pk` = `e2`.`book_uuid_pk` where `e1`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) order by `e1`.`order` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name` from `book_tag2` as `b0`');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`title`, `b1`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `b1`.`book_tag2_id` as `fk__book_tag2_id`, `t2`.`id` as `test_id` from `book2` as `b0` left join `book2_tags` as `b1` on `b0`.`uuid_pk` = `b1`.`book2_uuid_pk` left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` where `b1`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) order by `b1`.`order` asc');
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -141,8 +141,8 @@ describe('partial loading (mysql)', () => {
     expect(r2[0].books[0].title).toBe('Bible 1');
     expect(r2[0].books[0].price).toBeUndefined();
     expect(r2[0].books[0].author).toBeUndefined();
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`id`, `e0`.`name` from `book_tag2` as `e0` where `e0`.`name` = ?');
-    expect(mock.mock.calls[1][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`title`, `e1`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `e1`.`book_tag2_id` as `fk__book_tag2_id`, `e2`.`id` as `test_id` from `book2` as `e0` left join `book2_tags` as `e1` on `e0`.`uuid_pk` = `e1`.`book2_uuid_pk` left join `test2` as `e2` on `e0`.`uuid_pk` = `e2`.`book_uuid_pk` where `e1`.`book_tag2_id` in (?) order by `e1`.`order` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name` from `book_tag2` as `b0` where `b0`.`name` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`title`, `b1`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `b1`.`book_tag2_id` as `fk__book_tag2_id`, `t2`.`id` as `test_id` from `book2` as `b0` left join `book2_tags` as `b1` on `b0`.`uuid_pk` = `b1`.`book2_uuid_pk` left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` where `b1`.`book_tag2_id` in (?) order by `b1`.`order` asc');
   });
 
   async function createEntities() {
@@ -176,9 +176,9 @@ describe('partial loading (mysql)', () => {
     expect(r1[0].books[0].author.id).toBeDefined();
     expect(r1[0].books[0].author.name).toBeUndefined();
     expect(r1[0].books[0].author.email).toBe(god.email);
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`id`, `e0`.`name` from `book_tag2` as `e0`');
-    expect(mock.mock.calls[1][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`title`, `e0`.`author_id`, `e1`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `e1`.`book_tag2_id` as `fk__book_tag2_id`, `e2`.`id` as `test_id` from `book2` as `e0` left join `book2_tags` as `e1` on `e0`.`uuid_pk` = `e1`.`book2_uuid_pk` left join `test2` as `e2` on `e0`.`uuid_pk` = `e2`.`book_uuid_pk` where `e1`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) order by `e1`.`order` asc');
-    expect(mock.mock.calls[2][0]).toMatch('select `e0`.`id`, `e0`.`email` from `author2` as `e0` where `e0`.`id` in (?) order by `e0`.`id` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name` from `book_tag2` as `b0`');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`title`, `b0`.`author_id`, `b1`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `b1`.`book_tag2_id` as `fk__book_tag2_id`, `t2`.`id` as `test_id` from `book2` as `b0` left join `book2_tags` as `b1` on `b0`.`uuid_pk` = `b1`.`book2_uuid_pk` left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` where `b1`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) order by `b1`.`order` asc');
+    expect(mock.mock.calls[2][0]).toMatch('select `a0`.`id`, `a0`.`email` from `author2` as `a0` where `a0`.`id` in (?) order by `a0`.`id` asc');
   });
 
   test('partial nested loading (with joined strategy and dot notation)', async () => {
@@ -202,12 +202,12 @@ describe('partial loading (mysql)', () => {
     expect(r3[0].books[0].author.name).toBeUndefined();
     expect(r3[0].books[0].author.email).toBe(god.email);
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`id`, `e0`.`name`, ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name`, ' +
       '`b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`title` as `b1__title`, `b1`.`author_id` as `b1__author_id`, ' +
       '`a3`.`id` as `a3__id`, `a3`.`email` as `a3__email` ' +
-      'from `book_tag2` as `e0` ' +
-      'left join `book2_tags` as `e2` on `e0`.`id` = `e2`.`book_tag2_id` ' +
-      'left join `book2` as `b1` on `e2`.`book2_uuid_pk` = `b1`.`uuid_pk` ' +
+      'from `book_tag2` as `b0` ' +
+      'left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` ' +
+      'left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` ' +
       'left join `author2` as `a3` on `b1`.`author_id` = `a3`.`id`');
   });
 
@@ -226,9 +226,9 @@ describe('partial loading (mysql)', () => {
     expect(r2[0].books[0].author.id).toBeDefined();
     expect(r2[0].books[0].author.name).toBeUndefined();
     expect(r2[0].books[0].author.email).toBe(god.email);
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`id`, `e0`.`name` from `book_tag2` as `e0`');
-    expect(mock.mock.calls[1][0]).toMatch('select `e0`.`uuid_pk`, `e0`.`title`, `e0`.`author_id`, `e1`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `e1`.`book_tag2_id` as `fk__book_tag2_id`, `e2`.`id` as `test_id` from `book2` as `e0` left join `book2_tags` as `e1` on `e0`.`uuid_pk` = `e1`.`book2_uuid_pk` left join `test2` as `e2` on `e0`.`uuid_pk` = `e2`.`book_uuid_pk` where `e1`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) order by `e1`.`order` asc');
-    expect(mock.mock.calls[2][0]).toMatch('select `e0`.`id`, `e0`.`email` from `author2` as `e0` where `e0`.`id` in (?) order by `e0`.`id` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name` from `book_tag2` as `b0`');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`title`, `b0`.`author_id`, `b1`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `b1`.`book_tag2_id` as `fk__book_tag2_id`, `t2`.`id` as `test_id` from `book2` as `b0` left join `book2_tags` as `b1` on `b0`.`uuid_pk` = `b1`.`book2_uuid_pk` left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` where `b1`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) order by `b1`.`order` asc');
+    expect(mock.mock.calls[2][0]).toMatch('select `a0`.`id`, `a0`.`email` from `author2` as `a0` where `a0`.`id` in (?) order by `a0`.`id` asc');
   });
 
   test('partial nested loading (with joined strategy)', async () => {
@@ -252,12 +252,12 @@ describe('partial loading (mysql)', () => {
     expect(r3[0].books[0].author.name).toBeUndefined();
     expect(r3[0].books[0].author.email).toBe(god.email);
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`id`, `e0`.`name`, ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name`, ' +
       '`b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`title` as `b1__title`, `b1`.`author_id` as `b1__author_id`, ' +
       '`a3`.`id` as `a3__id`, `a3`.`email` as `a3__email` ' +
-      'from `book_tag2` as `e0` ' +
-      'left join `book2_tags` as `e2` on `e0`.`id` = `e2`.`book_tag2_id` ' +
-      'left join `book2` as `b1` on `e2`.`book2_uuid_pk` = `b1`.`uuid_pk` ' +
+      'from `book_tag2` as `b0` ' +
+      'left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` ' +
+      'left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` ' +
       'left join `author2` as `a3` on `b1`.`author_id` = `a3`.`id`');
   });
 

--- a/tests/features/single-table-inheritance.mysql.test.ts
+++ b/tests/features/single-table-inheritance.mysql.test.ts
@@ -62,12 +62,12 @@ describe('single table inheritance in mysql', () => {
     Object.assign(orm.config, { logger });
 
     const managers = await orm.em.find(Manager2, {});
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.* from `base_user2` as `e0` where `e0`.`type` in (\'manager\', \'owner\')');
+    expect(mock.mock.calls[0][0]).toMatch('select `m0`.* from `base_user2` as `m0` where `m0`.`type` in (\'manager\', \'owner\')');
     expect(managers.length).toBe(2);
     expect(managers.map(u => u.constructor.name)).toEqual(['Manager2', 'CompanyOwner2']);
 
     const owners = await orm.em.find(CompanyOwner2, {});
-    expect(mock.mock.calls[1][0]).toMatch('select `e0`.* from `base_user2` as `e0` where `e0`.`type` = \'owner\'');
+    expect(mock.mock.calls[1][0]).toMatch('select `c0`.* from `base_user2` as `c0` where `c0`.`type` = \'owner\'');
     expect(owners.length).toBe(1);
     expect(owners.map(u => u.constructor.name)).toEqual(['CompanyOwner2']);
 
@@ -77,7 +77,7 @@ describe('single table inheritance in mysql', () => {
     expect(employees.map(u => u.constructor.name)).toEqual(['Employee2', 'Employee2']);
 
     const users = await orm.em.find(BaseUser2, {});
-    expect(mock.mock.calls[3][0]).toMatch('select `e0`.* from `base_user2` as `e0`');
+    expect(mock.mock.calls[3][0]).toMatch('select `b0`.* from `base_user2` as `b0`');
     expect(users.length).toBe(4);
     expect(users.map(u => u.constructor.name).sort()).toEqual(['CompanyOwner2', 'Employee2', 'Employee2', 'Manager2']);
   });

--- a/tests/features/unit-of-work/map-to-pk.test.ts
+++ b/tests/features/unit-of-work/map-to-pk.test.ts
@@ -83,7 +83,7 @@ describe('mapToPk works with flushing and cascades', () => {
     expect(mock.mock.calls[3][0]).toMatch('begin');
     expect(mock.mock.calls[4][0]).toMatch("insert into `team` (`current_order_id`, `id`, `status`) values ('order1', 'team1', 'status1')");
     expect(mock.mock.calls[5][0]).toMatch('commit');
-    expect(mock.mock.calls[6][0]).toMatch("select `e0`.* from `team` as `e0` where `e0`.`id` = 'team1' limit 1");
+    expect(mock.mock.calls[6][0]).toMatch("select `t0`.* from `team` as `t0` where `t0`.`id` = 'team1' limit 1");
     expect(mock.mock.calls[7][0]).toMatch('begin');
     expect(mock.mock.calls[8][0]).toMatch("update `team` set `current_order_id` = NULL where `id` = 'team1'");
     expect(mock.mock.calls[9][0]).toMatch('commit');

--- a/tests/issues/GH1041.test.ts
+++ b/tests/issues/GH1041.test.ts
@@ -90,27 +90,27 @@ describe('GH issue 1041, 1043', () => {
   test('select-in strategy: find by many-to-many relation ID', async () => {
     const findPromise = orm.em.findOne(User, { apps: 1 }, { populate: ['apps'], strategy: LoadStrategy.SELECT_IN });
     await expect(findPromise).resolves.toBeInstanceOf(User);
-    expect(log.mock.calls[0][0]).toMatch('select `e0`.* from `user` as `e0` left join `user_apps` as `e1` on `e0`.`id` = `e1`.`user_id` where `e1`.`app_id` = 1 limit 1');
-    expect(log.mock.calls[1][0]).toMatch('select `e0`.*, `e1`.`app_id` as `fk__app_id`, `e1`.`user_id` as `fk__user_id` from `app` as `e0` left join `user_apps` as `e1` on `e0`.`id` = `e1`.`app_id` where `e1`.`user_id` in (123)');
+    expect(log.mock.calls[0][0]).toMatch('select `u0`.* from `user` as `u0` left join `user_apps` as `u1` on `u0`.`id` = `u1`.`user_id` where `u1`.`app_id` = 1 limit 1');
+    expect(log.mock.calls[1][0]).toMatch('select `a0`.*, `u1`.`app_id` as `fk__app_id`, `u1`.`user_id` as `fk__user_id` from `app` as `a0` left join `user_apps` as `u1` on `a0`.`id` = `u1`.`app_id` where `u1`.`user_id` in (123)');
   });
 
   test('joined strategy: find by many-to-many relation ID', async () => {
     const findPromise = orm.em.findOne(User, { apps: 1 }, { populate: ['apps'], strategy: LoadStrategy.JOINED });
     await expect(findPromise).resolves.toBeInstanceOf(User);
-    expect(log.mock.calls[0][0]).toMatch('select `e0`.`id`, `e0`.`name`, `a1`.`id` as `a1__id`, `a1`.`name` as `a1__name` from `user` as `e0` left join `user_apps` as `e2` on `e0`.`id` = `e2`.`user_id` left join `app` as `a1` on `e2`.`app_id` = `a1`.`id` where `e2`.`app_id` = 1');
+    expect(log.mock.calls[0][0]).toMatch('select `u0`.`id`, `u0`.`name`, `a1`.`id` as `a1__id`, `a1`.`name` as `a1__name` from `user` as `u0` left join `user_apps` as `u2` on `u0`.`id` = `u2`.`user_id` left join `app` as `a1` on `u2`.`app_id` = `a1`.`id` where `u2`.`app_id` = 1');
   });
 
   test('select-in strategy: find by many-to-many relation IDs', async () => {
     const findPromise = orm.em.findOne(User, { apps: [1, 2, 3] }, { populate: ['apps'], strategy: LoadStrategy.SELECT_IN });
     await expect(findPromise).resolves.toBeInstanceOf(User);
-    expect(log.mock.calls[0][0]).toMatch('select `e0`.* from `user` as `e0` left join `user_apps` as `e1` on `e0`.`id` = `e1`.`user_id` where `e1`.`app_id` in (1, 2, 3) limit 1');
-    expect(log.mock.calls[1][0]).toMatch('select `e0`.*, `e1`.`app_id` as `fk__app_id`, `e1`.`user_id` as `fk__user_id` from `app` as `e0` left join `user_apps` as `e1` on `e0`.`id` = `e1`.`app_id` where `e0`.`id` in (1, 2, 3) and `e1`.`user_id` in (123)');
+    expect(log.mock.calls[0][0]).toMatch('select `u0`.* from `user` as `u0` left join `user_apps` as `u1` on `u0`.`id` = `u1`.`user_id` where `u1`.`app_id` in (1, 2, 3) limit 1');
+    expect(log.mock.calls[1][0]).toMatch('select `a0`.*, `u1`.`app_id` as `fk__app_id`, `u1`.`user_id` as `fk__user_id` from `app` as `a0` left join `user_apps` as `u1` on `a0`.`id` = `u1`.`app_id` where `a0`.`id` in (1, 2, 3) and `u1`.`user_id` in (123)');
   });
 
   test('joined strategy: find by many-to-many relation IDs', async () => {
     const findPromise = orm.em.findOne(User, { apps: [1, 2, 3] }, { populate: ['apps'], strategy: LoadStrategy.JOINED });
     await expect(findPromise).resolves.toBeInstanceOf(User);
-    expect(log.mock.calls[0][0]).toMatch('select `e0`.`id`, `e0`.`name`, `a1`.`id` as `a1__id`, `a1`.`name` as `a1__name` from `user` as `e0` left join `user_apps` as `e2` on `e0`.`id` = `e2`.`user_id` left join `app` as `a1` on `e2`.`app_id` = `a1`.`id` where `e2`.`app_id` in (1, 2, 3)');
+    expect(log.mock.calls[0][0]).toMatch('select `u0`.`id`, `u0`.`name`, `a1`.`id` as `a1__id`, `a1`.`name` as `a1__name` from `user` as `u0` left join `user_apps` as `u2` on `u0`.`id` = `u2`.`user_id` left join `app` as `a1` on `u2`.`app_id` = `a1`.`id` where `u2`.`app_id` in (1, 2, 3)');
   });
 
 });

--- a/tests/issues/GH1657.test.ts
+++ b/tests/issues/GH1657.test.ts
@@ -80,9 +80,9 @@ describe('GH issue 1657', () => {
     expect(wrap(res1[1].order2).isInitialized()).toBe(true);
 
     // first query loads item and joins the order2 relation (eager + joined strategy)
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.`id`, `e0`.`order1_id`, `e0`.`order2_id`, `o1`.`id` as `o1__id` from `order_item` as `e0` left join `order` as `o1` on `e0`.`order2_id` = `o1`.`id` where `e0`.`id` <= 100');
+    expect(mock.mock.calls[0][0]).toMatch('select `o0`.`id`, `o0`.`order1_id`, `o0`.`order2_id`, `o1`.`id` as `o1__id` from `order_item` as `o0` left join `order` as `o1` on `o0`.`order2_id` = `o1`.`id` where `o0`.`id` <= 100');
     // second query loads order1 relation (eager + select-in strategy)
-    expect(mock.mock.calls[1][0]).toMatch('select `e0`.* from `order` as `e0` where `e0`.`id` in (1) order by `e0`.`id` asc');
+    expect(mock.mock.calls[1][0]).toMatch('select `o0`.* from `order` as `o0` where `o0`.`id` in (1) order by `o0`.`id` asc');
 
     expect(mock.mock.calls).toHaveLength(2);
   });

--- a/tests/issues/GH1721.test.ts
+++ b/tests/issues/GH1721.test.ts
@@ -76,7 +76,7 @@ describe('GH issue 1721', () => {
     expect(mock.mock.calls[0][0]).toMatch('begin');
     expect(mock.mock.calls[1][0]).toMatch("insert into `couch` (`id`, `name`, `user_id`) values ('aaaaaaaa-c65f-42b8-408a-034a6948448f', 'n1', 'bbbbbbbb-c65f-42b8-408a-034a6948448f')");
     expect(mock.mock.calls[2][0]).toMatch('commit');
-    expect(mock.mock.calls[3][0]).toMatch("select `e0`.* from `couch` as `e0` where `e0`.`id` = 'aaaaaaaa-c65f-42b8-408a-034a6948448f' limit 1");
+    expect(mock.mock.calls[3][0]).toMatch("select `c0`.* from `couch` as `c0` where `c0`.`id` = 'aaaaaaaa-c65f-42b8-408a-034a6948448f' limit 1");
     expect(mock.mock.calls[4][0]).toMatch('begin');
     expect(mock.mock.calls[5][0]).toMatch("update `couch` set `name` = 'n2' where `id` = 'aaaaaaaa-c65f-42b8-408a-034a6948448f'");
     expect(mock.mock.calls[6][0]).toMatch('commit');

--- a/tests/issues/GH1882.test.ts
+++ b/tests/issues/GH1882.test.ts
@@ -70,8 +70,8 @@ describe('GH issue 1882', () => {
     );
 
     const queries = mock.mock.calls;
-    expect(queries[0][0]).toMatch('select `e0`.* from `foo` as `e0` left join `bar` as `e1` on `e0`.`id` = `e1`.`foo_id` where (`e1`.`id` = ? or `e0`.`name` = ?)');
-    expect(queries[1][0]).toMatch('select `e0`.* from `bar` as `e0` where `e0`.`foo_id` in (?) and `e0`.`id` = ? order by `e0`.`foo_id` asc');
+    expect(queries[0][0]).toMatch('select `f0`.* from `foo` as `f0` left join `bar` as `b1` on `f0`.`id` = `b1`.`foo_id` where (`b1`.`id` = ? or `f0`.`name` = ?)');
+    expect(queries[1][0]).toMatch('select `b0`.* from `bar` as `b0` where `b0`.`foo_id` in (?) and `b0`.`id` = ? order by `b0`.`foo_id` asc');
   });
 
   test(`GH issue 1882-2`, async () => {
@@ -100,8 +100,8 @@ describe('GH issue 1882', () => {
     orm.em.clear();
 
     const queries = mock.mock.calls;
-    expect(queries[0][0]).toMatch('select `e0`.* from `foo` as `e0` left join `bar` as `e1` on `e0`.`id` = `e1`.`foo_id` where `e1`.`id` = ?');
-    expect(queries[1][0]).toMatch('select `e0`.* from `bar` as `e0` where `e0`.`foo_id` in (?) and `e0`.`id` = ? order by `e0`.`foo_id` asc');
+    expect(queries[0][0]).toMatch('select `f0`.* from `foo` as `f0` left join `bar` as `b1` on `f0`.`id` = `b1`.`foo_id` where `b1`.`id` = ?');
+    expect(queries[1][0]).toMatch('select `b0`.* from `bar` as `b0` where `b0`.`foo_id` in (?) and `b0`.`id` = ? order by `b0`.`foo_id` asc');
   });
 
 });

--- a/tests/issues/GH228.test.ts
+++ b/tests/issues/GH228.test.ts
@@ -61,8 +61,8 @@ describe('GH issue 228', () => {
 
     const queries: string[] = mock.mock.calls.map(c => c[0]).sort();
     expect(queries).toHaveLength(3);
-    expect(queries[0]).toMatch('select `e0`.* from `a` as `e0` order by `e0`.`type_id` asc');
-    expect(queries[1]).toMatch('select `e0`.* from `b` as `e0` where `e0`.`id` in (?)');
+    expect(queries[0]).toMatch('select `a0`.* from `a` as `a0` order by `a0`.`type_id` asc');
+    expect(queries[1]).toMatch('select `b0`.* from `b` as `b0` where `b0`.`id` in (?)');
   });
 
 });

--- a/tests/issues/GH234.test.ts
+++ b/tests/issues/GH234.test.ts
@@ -64,15 +64,15 @@ describe('GH issue 234', () => {
     const logger = new Logger(mock, ['query']);
     Object.assign(orm.config, { logger });
     const res1 = await orm.em.find(B, { aCollection: [1, 2, 3] }, { populate: ['aCollection'] });
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.* from `b` as `e0` left join `b_a_collection` as `e1` on `e0`.`id` = `e1`.`b_id` where `e1`.`a_id` in (?, ?, ?)');
-    expect(mock.mock.calls[1][0]).toMatch('select `e0`.*, `e1`.`a_id` as `fk__a_id`, `e1`.`b_id` as `fk__b_id` from `a` as `e0` left join `b_a_collection` as `e1` on `e0`.`id` = `e1`.`a_id` where `e0`.`id` in (?, ?, ?) and `e1`.`b_id` in (?) order by `e1`.`id` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.* from `b` as `b0` left join `b_a_collection` as `b1` on `b0`.`id` = `b1`.`b_id` where `b1`.`a_id` in (?, ?, ?)');
+    expect(mock.mock.calls[1][0]).toMatch('select `a0`.*, `b1`.`a_id` as `fk__a_id`, `b1`.`b_id` as `fk__b_id` from `a` as `a0` left join `b_a_collection` as `b1` on `a0`.`id` = `b1`.`a_id` where `a0`.`id` in (?, ?, ?) and `b1`.`b_id` in (?) order by `b1`.`id` asc');
     expect(res1.map(b => b.id)).toEqual([b.id]);
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     const res2 = await orm.em.find(A, { bCollection: [1, 2, 3] }, { populate: ['bCollection'] });
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.* from `a` as `e0` left join `b_a_collection` as `e1` on `e0`.`id` = `e1`.`a_id` where `e1`.`b_id` in (?, ?, ?)');
-    expect(mock.mock.calls[1][0]).toMatch('select `e0`.*, `e1`.`b_id` as `fk__b_id`, `e1`.`a_id` as `fk__a_id` from `b` as `e0` left join `b_a_collection` as `e1` on `e0`.`id` = `e1`.`b_id` where `e0`.`id` in (?, ?, ?) and `e1`.`a_id` in (?, ?, ?) order by `e1`.`id` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.* from `a` as `a0` left join `b_a_collection` as `b1` on `a0`.`id` = `b1`.`a_id` where `b1`.`b_id` in (?, ?, ?)');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.*, `b1`.`b_id` as `fk__b_id`, `b1`.`a_id` as `fk__a_id` from `b` as `b0` left join `b_a_collection` as `b1` on `b0`.`id` = `b1`.`b_id` where `b0`.`id` in (?, ?, ?) and `b1`.`a_id` in (?, ?, ?) order by `b1`.`id` asc');
     expect(res2.map(a => a.id)).toEqual([a1.id, a2.id, a3.id]);
   });
 

--- a/tests/issues/GH372.test.ts
+++ b/tests/issues/GH372.test.ts
@@ -83,11 +83,11 @@ describe('GH issue 372', () => {
     expect(mock.mock.calls[0][0]).toMatch('begin');
     expect(mock.mock.calls[1][0]).toMatch('insert into "a" ("prop") values (point($1,$2)) returning "id"');
     expect(mock.mock.calls[2][0]).toMatch('commit');
-    expect(mock.mock.calls[3][0]).toMatch('select "e0".* from "a" as "e0" where "e0"."id" = $1 limit $2');
+    expect(mock.mock.calls[3][0]).toMatch('select "a0".* from "a" as "a0" where "a0"."id" = $1 limit $2');
     expect(mock.mock.calls[4][0]).toMatch('begin');
     expect(mock.mock.calls[5][0]).toMatch('update "a" set "prop" = point($1,$2) where "id" = $3');
     expect(mock.mock.calls[6][0]).toMatch('commit');
-    expect(mock.mock.calls[7][0]).toMatch('select "e0".* from "a" as "e0" where "e0"."id" = $1 limit $2');
+    expect(mock.mock.calls[7][0]).toMatch('select "a0".* from "a" as "a0" where "a0"."id" = $1 limit $2');
   });
 
 });

--- a/tests/issues/GH519.test.ts
+++ b/tests/issues/GH519.test.ts
@@ -78,8 +78,8 @@ describe('GH issue 519', () => {
     expect(count).toBe(3);
     const queries: string[] = mock.mock.calls.map(c => c[0]).sort();
     expect(queries).toHaveLength(2);
-    expect(queries[0]).toMatch('select "e0".* from "registration" as "e0" where "e0"."competition_id" = $1');
-    expect(queries[1]).toMatch('select count(distinct("e0"."competition_id", "e0"."user_id")) as "count" from "registration" as "e0" where "e0"."competition_id" = $1');
+    expect(queries[0]).toMatch('select "r0".* from "registration" as "r0" where "r0"."competition_id" = $1');
+    expect(queries[1]).toMatch('select count(distinct("r0"."competition_id", "r0"."user_id")) as "count" from "registration" as "r0" where "r0"."competition_id" = $1');
   });
 
 });

--- a/tests/issues/GH572.test.ts
+++ b/tests/issues/GH572.test.ts
@@ -50,10 +50,10 @@ describe('GH issue 572', () => {
       orderBy: { b: { camelCaseField: QueryOrder.ASC } },
       populate: ['b'],
     });
-    expect(mock.mock.calls[0][0]).toMatch('select `e0`.*, `e1`.`id` as `b_id` from `a` as `e0` left join `b` as `e1` on `e0`.`id` = `e1`.`a_id` order by `e1`.`camel_case_field` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`id` as `b_id` from `a` as `a0` left join `b` as `b1` on `a0`.`id` = `b1`.`a_id` order by `b1`.`camel_case_field` asc');
     expect(res1).toHaveLength(0);
     const qb1 = await orm.em.createQueryBuilder(A, 'a').select('a.*').orderBy({ b: { camelCaseField: QueryOrder.ASC } });
-    expect(qb1.getQuery()).toMatch('select `a`.* from `a` as `a` left join `b` as `e1` on `a`.`id` = `e1`.`a_id` order by `e1`.`camel_case_field` asc');
+    expect(qb1.getQuery()).toMatch('select `a`.* from `a` as `a` left join `b` as `b1` on `a`.`id` = `b1`.`a_id` order by `b1`.`camel_case_field` asc');
     const qb2 = await orm.em.createQueryBuilder(B, 'b').select('b.*').orderBy({ 'b.camelCaseField': QueryOrder.ASC });
     expect(qb2.getQuery()).toMatch('select `b`.* from `b` as `b` order by `b`.`camel_case_field` asc');
     const qb3 = await orm.em.createQueryBuilder(A, 'a').select('a.*').leftJoin('a.b', 'b_').orderBy({ 'b_.camelCaseField': QueryOrder.ASC });


### PR DESCRIPTION
Implements different table aliasing for select-in loading strategy and for QueryBuilder
and makes it configurable.

BREAKING CHANGE:
Previously with select-in strategy as well as with QueryBuilder, table aliases
were always the letter `e` followed by unique index. In v5, we use the same
method as with joined strategy - the letter is inferred from the entity name.

This can be breaking if you used the aliases somewhere, e.g. in custom SQL
fragments. We can restore to the old behaviour by implementing custom naming
strategy, overriding the `aliasName` method:

```ts
import { AbstractNamingStrategy } from '@mikro-orm/core';

class CustomNamingStrategy extends AbstractNamingStrategy {
  aliasName(entityName: string, index: number) {
    return 'e' + index;
  }
}
```

Note that in v5 it is possible to use `expr()` helper to access the alias name
dynamically, e.g. ``expr(alias => `lower('${alias}.name')`)``, which should be
now preferred way instead of hardcoding the aliases.