### PR TITLE
feat(core): add support for concurrency checks

### DIFF
--- a/docs/docs/decorators.md
+++ b/docs/docs/decorators.md
@@ -44,7 +44,8 @@ extend the `@Property()` decorator, so you can also use its parameters there.
 | `nullable` | `boolean` | yes | Set column as nullable for [Schema Generator](schema-generator.md).. **(SQL only)** |
 | `unsigned` | `boolean` | yes | Set column as unsigned for [Schema Generator](schema-generator.md).. **(SQL only)** |
 | `comment` | `string` | yes | Specify comment of column for [Schema Generator](schema-generator.md).. **(SQL only)** |
-| `version` | `boolean` | yes | Set to true to enable [Optimistic Locking](transactions.md#optimistic-locking). **(SQL only)** |
+| `version` | `boolean` | yes | Set to true to enable [Optimistic Locking] via version field (transactions.md#optimistic-locking). **(SQL only)** |
+| `concurrencyCheck` | `boolean` | yes | Set to true to enable [Optimistic Locking] via concurrency fields (transactions.md#concurrency-checks).|
 
 > You can use property initializers as usual.
 

--- a/packages/core/src/decorators/Property.ts
+++ b/packages/core/src/decorators/Property.ts
@@ -56,6 +56,7 @@ export type PropertyOptions<T> = {
   persist?: boolean;
   hidden?: boolean;
   version?: boolean;
+  concurrencyCheck?: boolean;
   index?: boolean | string;
   unique?: boolean | string;
   lazy?: boolean;

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -825,12 +825,14 @@ export class MetadataDiscovery {
   }
 
   private initVersionProperty(meta: EntityMetadata, prop: EntityProperty): void {
-    if (!prop.version) {
-      return;
+    if (prop.version) {
+      meta.versionProperty = prop.name;
+      prop.defaultRaw = this.getDefaultVersionValue(prop);
     }
 
-    meta.versionProperty = prop.name;
-    prop.defaultRaw = this.getDefaultVersionValue(prop);
+    if (prop.concurrencyCheck && !prop.primary) {
+      meta.concurrencyCheckKeys.add(prop.name);
+    }
   }
 
   private initCustomType(meta: EntityMetadata, prop: EntityProperty): void {

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -221,6 +221,7 @@ export interface EntityProperty<T extends AnyEntity<T> = any> {
   enum?: boolean;
   items?: (number | string)[];
   version?: boolean;
+  concurrencyCheck?: boolean;
   eager?: boolean;
   setter?: boolean;
   getter?: boolean;
@@ -264,6 +265,7 @@ export class EntityMetadata<T extends AnyEntity<T> = any> {
     this.hooks = {};
     this.indexes = [];
     this.uniques = [];
+    this.concurrencyCheckKeys = new Set();
     Object.assign(this, meta);
   }
 
@@ -359,6 +361,7 @@ export interface EntityMetadata<T extends AnyEntity<T> = any> {
   primaryKeys: (keyof T & string)[];
   compositePK: boolean;
   versionProperty: keyof T & string;
+  concurrencyCheckKeys: Set<keyof T & string>;
   serializedPrimaryKey: keyof T & string;
   properties: { [K in keyof T & string]: EntityProperty<T> };
   props: EntityProperty<T>[];

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -384,13 +384,14 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
       sql += `, `;
     }
 
-    sql = sql.substr(0, sql.length - 2) + ' where ';
-    const pks = Utils.flatten(meta.primaryKeys.map(pk => meta.properties[pk].fieldNames));
+    sql = sql.substring(0, sql.length - 2) + ' where ';
+    const pkProps = meta.primaryKeys.concat(...meta.concurrencyCheckKeys);
+    const pks = Utils.flatten(pkProps.map(pk => meta.properties[pk].fieldNames));
     sql += pks.length > 1 ? `(${pks.map(pk => `${this.platform.quoteIdentifier(pk)}`).join(', ')})` : this.platform.quoteIdentifier(pks[0]);
 
     const conds = where.map(cond => {
       if (pks.length > 1) {
-        meta.primaryKeys.forEach(pk => params.push(cond![pk as string]));
+        pkProps.forEach(pk => params.push(cond![pk as string]));
         return `(${new Array(pks.length).fill('?').join(', ')})`;
       }
 
@@ -597,7 +598,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
 
       explicitFields?.forEach(f => {
         if (typeof f === 'string' && f.startsWith(`${prop.name}.`)) {
-          childExplicitFields.push(f.substr(prop.name.length + 1));
+          childExplicitFields.push(f.substring(prop.name.length + 1));
         }
       });
 

--- a/tests/features/concurrency-checks/concurrency-checks.mongo.test.ts
+++ b/tests/features/concurrency-checks/concurrency-checks.mongo.test.ts
@@ -1,0 +1,170 @@
+import { MikroORM, Entity, PrimaryKey, Property, OptimisticLockError } from '@mikro-orm/core';
+import { mockLogger } from '../../bootstrap';
+
+@Entity()
+export class ConcurrencyCheckUser {
+
+  @PrimaryKey()
+  _id!: string;
+
+  @Property({ length: 100, concurrencyCheck: true })
+  firstName: string;
+
+  @Property({ length: 100, concurrencyCheck: true })
+  lastName: string;
+
+  @Property({ concurrencyCheck: true })
+  age: number;
+
+  @Property({ nullable: true })
+  other?: string;
+
+  constructor(_id: string, firstName: string, lastName: string, age: number) {
+    this._id = _id;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.age = age;
+  }
+
+}
+
+describe('optimistic locking - concurrency check (mongo)', () => {
+
+  let orm: MikroORM;
+  let mock: jest.Mock;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [ConcurrencyCheckUser],
+      clientUrl: 'mongodb://localhost:27017,localhost:27018,localhost:27019/mikro_orm_test_concurrency_check?replicaSet=rs',
+      type: 'mongo',
+    });
+    mock = mockLogger(orm, ['query', 'query-params']);
+  });
+
+  beforeEach(async () => {
+    await orm.em.nativeDelete(ConcurrencyCheckUser, {});
+    orm.em.clear();
+    mock.mockReset();
+  });
+
+  afterAll(async () => orm.close(true));
+
+  test('should compare original to database value on entity update', async () => {
+    const test = new ConcurrencyCheckUser('1', 'Jakub', 'Smith', 20);
+    test.other = 'dsa';
+
+    await orm.em.persistAndFlush(test);
+    expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('concurrency-check-user').insertOne({ _id: '1', firstName: 'Jakub', lastName: 'Smith', age: 20, other: 'dsa' }, { session: undefined });`);
+
+    mock.mockReset();
+
+    test.age = 30;
+    await orm.em.flush();
+    expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('concurrency-check-user').updateMany({ _id: '1', firstName: 'Jakub', lastName: 'Smith', age: 20 }, { '$set': { age: 30 } }, { session: undefined });`);
+
+    mock.mockReset();
+
+    test.age = 40;
+    await orm.em.flush();
+    expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('concurrency-check-user').updateMany({ _id: '1', firstName: 'Jakub', lastName: 'Smith', age: 30 }, { '$set': { age: 40 } }, { session: undefined });`);
+
+    mock.mockReset();
+
+    test.other = 'asd';
+    await expect(orm.em.flush()).rejects.toThrowError(`The optimistic lock on entity ConcurrencyCheckUser failed`);
+
+    mock.mockReset();
+
+    test.age = 41;
+    await orm.em.flush();
+    expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('concurrency-check-user').updateMany({ _id: '1', firstName: 'Jakub', lastName: 'Smith', age: 40 }, { '$set': { age: 41, other: 'asd' } }, { session: undefined });`);
+  });
+
+  test('throws when someone changed the state in the meantime', async () => {
+    const test = new ConcurrencyCheckUser('1', 'Jakub', 'Smith', 20);
+    test.other = 'dsa';
+    await orm.em.fork().persistAndFlush(test);
+
+    const test2 = await orm.em.findOneOrFail(ConcurrencyCheckUser, test);
+    await orm.em.nativeUpdate(ConcurrencyCheckUser, test, { age: 123 }); // simulate concurrent update
+    test2!.age = 50;
+    test2!.other = 'WHATT???';
+
+    try {
+      await orm.em.flush();
+      expect(1).toBe('should be unreachable');
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(OptimisticLockError);
+      expect(e.message).toBe(`The optimistic lock on entity ConcurrencyCheckUser failed`);
+      expect((e as OptimisticLockError).getEntity()).toBe(test2);
+    }
+  });
+
+  test('should compare original to database value on entity update (batch update)', async () => {
+    const test1 = new ConcurrencyCheckUser('1', 'Jakub', 'Smith', 20);
+    test1.other = 'dsa';
+    const test2 = new ConcurrencyCheckUser('2', 'John', 'Smith', 25);
+    test2.other = 'lol';
+
+    await orm.em.persistAndFlush([test1, test2]);
+    expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('concurrency-check-user').insertMany([ { _id: '1', firstName: 'Jakub', lastName: 'Smith', age: 20, other: 'dsa' }, { _id: '2', firstName: 'John', lastName: 'Smith', age: 25, other: 'lol' } ], { session: undefined });`);
+
+    mock.mockReset();
+
+    test1.age = 30;
+    test2.age = 35;
+    await orm.em.flush();
+    expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('concurrency-check-user').find({ '$or': [ { _id: '1', firstName: 'Jakub', lastName: 'Smith', age: 20 }, { _id: '2', firstName: 'John', lastName: 'Smith', age: 25 } ] }, { session: undefined, projection: { _id: 1, firstName: 1, lastName: 1, age: 1 } }).toArray();`);
+    expect(mock.mock.calls[1][0]).toMatch(`bulk = db.getCollection('concurrency-check-user').initializeUnorderedBulkOp({ session: undefined });bulk.find({ _id: '1' }).update({ '$set': { age: 30 } });bulk.find({ _id: '2' }).update({ '$set': { age: 35 } });bulk.execute()`);
+
+    mock.mockReset();
+
+    test1.age = 40;
+    test2.age = 45;
+    await orm.em.flush();
+    expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('concurrency-check-user').find({ '$or': [ { _id: '1', firstName: 'Jakub', lastName: 'Smith', age: 30 }, { _id: '2', firstName: 'John', lastName: 'Smith', age: 35 } ] }, { session: undefined, projection: { _id: 1, firstName: 1, lastName: 1, age: 1 } }).toArray();`);
+    expect(mock.mock.calls[1][0]).toMatch(`bulk = db.getCollection('concurrency-check-user').initializeUnorderedBulkOp({ session: undefined });bulk.find({ _id: '1' }).update({ '$set': { age: 40 } });bulk.find({ _id: '2' }).update({ '$set': { age: 45 } });bulk.execute()`);
+
+    mock.mockReset();
+
+    test1.other = 'asd';
+    test2.other = 'lololol';
+    await expect(orm.em.flush()).rejects.toThrowError(`The optimistic lock on entity ConcurrencyCheckUser failed`);
+
+    mock.mockReset();
+
+    test1.age = 41;
+    test2.age = 46;
+    await orm.em.flush();
+    expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('concurrency-check-user').find({ '$or': [ { _id: '1', firstName: 'Jakub', lastName: 'Smith', age: 40 }, { _id: '2', firstName: 'John', lastName: 'Smith', age: 45 } ] }, { session: undefined, projection: { _id: 1, firstName: 1, lastName: 1, age: 1 } }).toArray();`);
+    expect(mock.mock.calls[1][0]).toMatch(`bulk = db.getCollection('concurrency-check-user').initializeUnorderedBulkOp({ session: undefined });bulk.find({ _id: '1' }).update({ '$set': { age: 41, other: 'asd' } });bulk.find({ _id: '2' }).update({ '$set': { age: 46, other: 'lololol' } });bulk.execute()`);
+  });
+
+  test('throws when someone changed the state in the meantime (batch update)', async () => {
+    const test1 = new ConcurrencyCheckUser('1', 'Jakub', 'Smith', 20);
+    test1.other = 'dsa';
+    const test2 = new ConcurrencyCheckUser('2', 'John', 'Smith', 25);
+    test2.other = 'lol';
+
+    await orm.em.fork().persistAndFlush([test1, test2]);
+
+    const tests = await orm.em.find(ConcurrencyCheckUser, {}, { orderBy: { age: 1 } });
+    await orm.em.nativeUpdate(ConcurrencyCheckUser, tests[0], { age: 123 }); // simulate concurrent update
+    await orm.em.nativeUpdate(ConcurrencyCheckUser, tests[1], { age: 124 }); // simulate concurrent update
+    tests[0].age = 50;
+    tests[0].other = 'WHATT???';
+    tests[1].age = 51;
+    tests[1].other = 'WHATT???';
+
+    try {
+      await orm.em.flush();
+      expect(1).toBe('should be unreachable');
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(OptimisticLockError);
+      expect(e.message).toBe(`The optimistic lock on entity ConcurrencyCheckUser failed`);
+      expect((e as OptimisticLockError).getEntity()).toBe(tests[0]);
+    }
+  });
+
+});

--- a/tests/features/concurrency-checks/concurrency-checks.postgre.test.ts
+++ b/tests/features/concurrency-checks/concurrency-checks.postgre.test.ts
@@ -1,0 +1,185 @@
+import { MikroORM, Entity, PrimaryKey, Property, OptimisticLockError } from '@mikro-orm/core';
+import { mockLogger } from '../../bootstrap';
+
+@Entity()
+export class ConcurrencyCheckUser {
+
+  @PrimaryKey({ length: 100 })
+  firstName: string;
+
+  @PrimaryKey({ length: 100, concurrencyCheck: true })
+  lastName: string;
+
+  @Property({ concurrencyCheck: true })
+  age: number;
+
+  @Property({ nullable: true })
+  other?: string;
+
+  constructor(firstName: string, lastName: string, age: number) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.age = age;
+  }
+
+}
+
+describe('optimistic locking - concurrency check (postgres)', () => {
+
+  let orm: MikroORM;
+  let mock: jest.Mock;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [ConcurrencyCheckUser],
+      dbName: `mikro_orm_test_concurrency_check`,
+      type: 'postgresql',
+    });
+    await orm.getSchemaGenerator().ensureDatabase();
+    await orm.getSchemaGenerator().dropSchema();
+    await orm.getSchemaGenerator().createSchema();
+    mock = mockLogger(orm, ['query', 'query-params']);
+  });
+
+  beforeEach(async () => {
+    await orm.em.nativeDelete(ConcurrencyCheckUser, {});
+    orm.em.clear();
+    mock.mockReset();
+  });
+
+  afterAll(async () => orm.close(true));
+
+  test('should compare original to database value on entity update', async () => {
+    const test = new ConcurrencyCheckUser('Jakub', 'Smith', 20);
+    test.other = 'dsa';
+
+    await orm.em.persistAndFlush(test);
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch('insert into "concurrency_check_user" ("age", "first_name", "last_name", "other") values (20, \'Jakub\', \'Smith\', \'dsa\')');
+    expect(mock.mock.calls[2][0]).toMatch('commit');
+
+    mock.mockReset();
+
+    test.age = 30;
+    await orm.em.flush();
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch('update "concurrency_check_user" set "age" = 30 where "first_name" = \'Jakub\' and "last_name" = \'Smith\' and "age" = 20');
+    expect(mock.mock.calls[2][0]).toMatch('commit');
+
+    mock.mockReset();
+
+    test.age = 40;
+    await orm.em.flush();
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch('update "concurrency_check_user" set "age" = 40 where "first_name" = \'Jakub\' and "last_name" = \'Smith\' and "age" = 30');
+    expect(mock.mock.calls[2][0]).toMatch('commit');
+
+    mock.mockReset();
+
+    test.other = 'asd';
+    await expect(orm.em.flush()).rejects.toThrowError(`The optimistic lock on entity ConcurrencyCheckUser failed`);
+
+    mock.mockReset();
+
+    test.age = 41;
+    await orm.em.flush();
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch('update "concurrency_check_user" set "age" = 41, "other" = \'asd\' where "first_name" = \'Jakub\' and "last_name" = \'Smith\' and "age" = 40');
+    expect(mock.mock.calls[2][0]).toMatch('commit');
+  });
+
+  test('throws when someone changed the state in the meantime', async () => {
+    const test = new ConcurrencyCheckUser('Jakub', 'Smith', 20);
+    test.other = 'dsa';
+    await orm.em.fork().persistAndFlush(test);
+
+    const test2 = await orm.em.findOneOrFail(ConcurrencyCheckUser, test);
+    await orm.em.nativeUpdate(ConcurrencyCheckUser, test, { age: 123 }); // simulate concurrent update
+    test2!.age = 50;
+    test2!.other = 'WHATT???';
+
+    try {
+      await orm.em.flush();
+      expect(1).toBe('should be unreachable');
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(OptimisticLockError);
+      expect(e.message).toBe(`The optimistic lock on entity ConcurrencyCheckUser failed`);
+      expect((e as OptimisticLockError).getEntity()).toBe(test2);
+    }
+  });
+
+  test('should compare original to database value on entity update (batch update)', async () => {
+    const test1 = new ConcurrencyCheckUser('Jakub', 'Smith', 20);
+    test1.other = 'dsa';
+    const test2 = new ConcurrencyCheckUser('John', 'Smith', 25);
+    test2.other = 'lol';
+
+    await orm.em.persistAndFlush([test1, test2]);
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch(`insert into "concurrency_check_user" ("first_name", "last_name", "age", "other") values ('Jakub', 'Smith', 20, 'dsa'), ('John', 'Smith', 25, 'lol')`);
+    expect(mock.mock.calls[2][0]).toMatch('commit');
+
+    mock.mockReset();
+
+    test1.age = 30;
+    test2.age = 35;
+    await orm.em.flush();
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch(`select "c0"."first_name", "c0"."last_name", "c0"."age" from "concurrency_check_user" as "c0" where (("c0"."first_name" = 'Jakub' and "c0"."last_name" = 'Smith' and "c0"."age" = 20) or ("c0"."first_name" = 'John' and "c0"."last_name" = 'Smith' and "c0"."age" = 25))`);
+    expect(mock.mock.calls[2][0]).toMatch(`update "concurrency_check_user" set "age" = case when ("first_name" = 'Jakub' and "last_name" = 'Smith') then 30 when ("first_name" = 'John' and "last_name" = 'Smith') then 35 else "age" end where ("first_name", "last_name", "age") in (('Jakub', 'Smith', 20), ('John', 'Smith', 25))`);
+    expect(mock.mock.calls[3][0]).toMatch('commit');
+
+    mock.mockReset();
+
+    test1.age = 40;
+    test2.age = 45;
+    await orm.em.flush();
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch(`select "c0"."first_name", "c0"."last_name", "c0"."age" from "concurrency_check_user" as "c0" where (("c0"."first_name" = 'Jakub' and "c0"."last_name" = 'Smith' and "c0"."age" = 30) or ("c0"."first_name" = 'John' and "c0"."last_name" = 'Smith' and "c0"."age" = 35))`);
+    expect(mock.mock.calls[2][0]).toMatch(`update "concurrency_check_user" set "age" = case when ("first_name" = 'Jakub' and "last_name" = 'Smith') then 40 when ("first_name" = 'John' and "last_name" = 'Smith') then 45 else "age" end where ("first_name", "last_name", "age") in (('Jakub', 'Smith', 30), ('John', 'Smith', 35))`);
+    expect(mock.mock.calls[3][0]).toMatch('commit');
+
+    mock.mockReset();
+
+    test1.other = 'asd';
+    test2.other = 'lololol';
+    await expect(orm.em.flush()).rejects.toThrowError(`The optimistic lock on entity ConcurrencyCheckUser failed`);
+
+    mock.mockReset();
+
+    test1.age = 41;
+    test2.age = 46;
+    await orm.em.flush();
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch(`select "c0"."first_name", "c0"."last_name", "c0"."age" from "concurrency_check_user" as "c0" where (("c0"."first_name" = 'Jakub' and "c0"."last_name" = 'Smith' and "c0"."age" = 40) or ("c0"."first_name" = 'John' and "c0"."last_name" = 'Smith' and "c0"."age" = 45))`);
+    expect(mock.mock.calls[2][0]).toMatch(`update "concurrency_check_user" set "age" = case when ("first_name" = 'Jakub' and "last_name" = 'Smith') then 41 when ("first_name" = 'John' and "last_name" = 'Smith') then 46 else "age" end, "other" = case when ("first_name" = 'Jakub' and "last_name" = 'Smith') then 'asd' when ("first_name" = 'John' and "last_name" = 'Smith') then 'lololol' else "other" end where ("first_name", "last_name", "age") in (('Jakub', 'Smith', 40), ('John', 'Smith', 45))`);
+    expect(mock.mock.calls[3][0]).toMatch('commit');
+  });
+
+  test('throws when someone changed the state in the meantime (batch update)', async () => {
+    const test1 = new ConcurrencyCheckUser('Jakub', 'Smith', 20);
+    test1.other = 'dsa';
+    const test2 = new ConcurrencyCheckUser('John', 'Smith', 25);
+    test2.other = 'lol';
+
+    await orm.em.fork().persistAndFlush([test1, test2]);
+
+    const tests = await orm.em.find(ConcurrencyCheckUser, {}, { orderBy: { age: 1 } });
+    await orm.em.nativeUpdate(ConcurrencyCheckUser, tests[0], { age: 123 }); // simulate concurrent update
+    await orm.em.nativeUpdate(ConcurrencyCheckUser, tests[1], { age: 124 }); // simulate concurrent update
+    tests[0].age = 50;
+    tests[0].other = 'WHATT???';
+    tests[1].age = 51;
+    tests[1].other = 'WHATT???';
+
+    try {
+      await orm.em.flush();
+      expect(1).toBe('should be unreachable');
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(OptimisticLockError);
+      expect(e.message).toBe(`The optimistic lock on entity ConcurrencyCheckUser failed`);
+      expect((e as OptimisticLockError).getEntity()).toBe(tests[0]);
+    }
+  });
+
+});


### PR DESCRIPTION
As opposed to version fields that are handled automatically, we can use
concurrency checks. They allow us to mark specific properties to be included
in the concurrency check, just like the version field was. But this time, we
will be responsible for updating the fields explicitly.

When we try to update such entity without changing one of the concurrency fields,
`OptimisticLockError` will be thrown. Same mechanism is then used to check whether
the update succeeded, and throw the same type of error when not.

```ts
@Entity()
export class ConcurrencyCheckUser {

  // all primary keys are by default part of the concurrency check
  @PrimaryKey({ length: 100 })
  firstName: string;

  // all primary keys are by default part of the concurrency check
  @PrimaryKey({ length: 100 })
  lastName: string;

  @Property({ concurrencyCheck: true })
  age: number;

  @Property({ nullable: true })
  other?: string;

}
```

Closes #1638