### PR TITLE
feat(query-builder): allow awaiting the `QueryBuilder` instance

### DIFF
--- a/docs/docs/upgrading-v4-to-v5.md
+++ b/docs/docs/upgrading-v4-to-v5.md
@@ -153,3 +153,8 @@ You can use destructing if you want to have a single entity return type:
 ```ts
 const [loadedAuthor] = await em.populate(author, ...);
 ```
+
+## QueryBuilder is awaitable
+
+Previously awaiting of QB instance was a no-op. In v5, QB is promise-like interface,
+so we can await it. More about this in [Awaiting the QueryBuilder](./query-builder.md#awaiting-the-querybuilder) section.

--- a/packages/knex/src/SqlEntityManager.ts
+++ b/packages/knex/src/SqlEntityManager.ts
@@ -19,6 +19,13 @@ export class SqlEntityManager<D extends AbstractSqlDriver = AbstractSqlDriver> e
   }
 
   /**
+   * Shortcut for `createQueryBuilder()`
+   */
+  qb<T>(entityName: EntityName<T>, alias?: string, type?: 'read' | 'write') {
+    return this.createQueryBuilder(entityName, alias, type);
+  }
+
+  /**
    * Creates raw SQL query that won't be escaped when used as a parameter.
    */
   raw<R = Knex.Raw>(sql: string, bindings: Knex.RawBinding[] | Knex.ValueDict = []): R {

--- a/packages/knex/src/SqlEntityRepository.ts
+++ b/packages/knex/src/SqlEntityRepository.ts
@@ -19,6 +19,13 @@ export class SqlEntityRepository<T> extends EntityRepository<T> {
   }
 
   /**
+   * Shortcut for `createQueryBuilder()`
+   */
+  qb(alias?: string): QueryBuilder<T> {
+    return this.createQueryBuilder(alias);
+  }
+
+  /**
    * Returns configured knex instance.
    */
   getKnex(type?: 'read' | 'write'): Knex {

--- a/tests/EntityRepository.test.ts
+++ b/tests/EntityRepository.test.ts
@@ -12,6 +12,7 @@ const methods = {
   persistAndFlush: jest.fn(),
   persistLater: jest.fn(),
   createQueryBuilder: jest.fn(),
+  qb: jest.fn(),
   findOne: jest.fn(),
   findOneOrFail: jest.fn(),
   find: jest.fn(),
@@ -62,6 +63,8 @@ describe('EntityRepository', () => {
     await repo.findOneOrFail('bar');
     expect(methods.findOneOrFail.mock.calls[0]).toEqual([Publisher, 'bar', undefined]);
     await repo.createQueryBuilder();
+    expect(methods.createQueryBuilder.mock.calls[0]).toEqual([Publisher, undefined]);
+    await repo.qb();
     expect(methods.createQueryBuilder.mock.calls[0]).toEqual([Publisher, undefined]);
     repo.remove(e);
     expect(methods.remove.mock.calls[0]).toEqual([e]);

--- a/tests/issues/GH572.test.ts
+++ b/tests/issues/GH572.test.ts
@@ -51,11 +51,11 @@ describe('GH issue 572', () => {
     });
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`id` as `b_id` from `a` as `a0` left join `b` as `b1` on `a0`.`id` = `b1`.`a_id` order by `b1`.`camel_case_field` asc');
     expect(res1).toHaveLength(0);
-    const qb1 = await orm.em.createQueryBuilder(A, 'a').select('a.*').orderBy({ b: { camelCaseField: QueryOrder.ASC } });
+    const qb1 = orm.em.createQueryBuilder(A, 'a').select('a.*').orderBy({ b: { camelCaseField: QueryOrder.ASC } });
     expect(qb1.getQuery()).toMatch('select `a`.* from `a` as `a` left join `b` as `b1` on `a`.`id` = `b1`.`a_id` order by `b1`.`camel_case_field` asc');
-    const qb2 = await orm.em.createQueryBuilder(B, 'b').select('b.*').orderBy({ 'b.camelCaseField': QueryOrder.ASC });
+    const qb2 = orm.em.createQueryBuilder(B, 'b').select('b.*').orderBy({ 'b.camelCaseField': QueryOrder.ASC });
     expect(qb2.getQuery()).toMatch('select `b`.* from `b` as `b` order by `b`.`camel_case_field` asc');
-    const qb3 = await orm.em.createQueryBuilder(A, 'a').select('a.*').leftJoin('a.b', 'b_').orderBy({ 'b_.camelCaseField': QueryOrder.ASC });
+    const qb3 = orm.em.createQueryBuilder(A, 'a').select('a.*').leftJoin('a.b', 'b_').orderBy({ 'b_.camelCaseField': QueryOrder.ASC });
     expect(qb3.getQuery()).toMatch('select `a`.* from `a` as `a` left join `b` as `b_` on `a`.`id` = `b_`.`a_id` order by `b_`.`camel_case_field` asc');
   });
 });


### PR DESCRIPTION
Since v5 we can await the `QueryBuilder` instance, which will automatically execute the QB and return appropriate response. The QB instance is now typed based on usage of `select/insert/update/delete/truncate` methods to one of:

- `SelectQueryBuilder`
  - awaiting yields array of entities (as `qb.getResultList()`)
- `CountQueryBuilder`
  - awaiting yields number (as `qb.getCount()`)
- `InsertQueryBuilder` (extends `RunQueryBuilder`)
  - awaiting yields `QueryResult`
- `UpdateQueryBuilder` (extends `RunQueryBuilder`)
  - awaiting yields `QueryResult`
- `DeleteQueryBuilder` (extends `RunQueryBuilder`)
  - awaiting yields `QueryResult`
- `TruncateQueryBuilder` (extends `RunQueryBuilder`)
  - awaiting yields `QueryResult`

```ts
const res1 = await em.qb(Publisher).insert({
  name: 'p1',
  type: PublisherType.GLOBAL,
});
// res1 is of type `QueryResult<Publisher>`
console.log(res1.insertId);

const res2 = await em.qb(Publisher)
        .select('*')
        .where({ name: 'p1' })
        .limit(5);
// res2 is Publisher[]
console.log(res2.map(p => p.name));

const res3 = await em.qb(Publisher).count().where({ name: 'p1' });
// res3 is number
console.log(res3 > 0);

const res4 = await em.qb(Publisher)
        .update({ type: PublisherType.LOCAL })
        .where({ name: 'p1' });
// res4 is QueryResult<Publisher>
console.log(res4.affectedRows > 0);

const res5 = await em.qb(Publisher).delete().where({ name: 'p1' });
// res4 is QueryResult<Publisher>
console.log(res4.affectedRows > 0);
expect(res5.affectedRows > 0).toBe(true); // test the type
```