### PR TITLE
docs(migrations): fix webpack context module api link

### DIFF
--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -221,7 +221,7 @@ await MikroORM.init({
 });
 ```
 
-With the help of (webpacks context module api)[https://webpack.js.org/guides/dependency-management/#context-module-api]
+With the help of [webpack context module api](https://webpack.js.org/guides/dependency-management/#context-module-api)
 we can dynamically import the migrations making it possible to import all files in a folder.
 
 ```typescript


### PR DESCRIPTION
Couple of typos fixed:
- webpack extra 's' removed
- switched brackets from the link to the message and vice versa