### PR TITLE
feat(core): implement auto-flush mode

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -761,7 +761,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     const allowGlobalContext = this.config.get('allowGlobalContext');
     this.config.set('allowGlobalContext', true);
     const em = new (this.constructor as typeof EntityManager)(this.config, this.driver, this.metadata, options.useContext, eventManager);
-    em.setFlushMode(options.flushMode);
+    em.setFlushMode(options.flushMode ?? this.flushMode);
     this.config.set('allowGlobalContext', allowGlobalContext);
 
     em.filters = { ...this.filters };

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -7,8 +7,8 @@ import { EntityAssigner, EntityFactory, EntityLoader, EntityValidator, Reference
 import { UnitOfWork } from './unit-of-work';
 import type { CountOptions, DeleteOptions, EntityManagerType, FindOneOptions, FindOneOrFailOptions, FindOptions, IDatabaseDriver, InsertOptions, LockOptions, UpdateOptions, GetReferenceOptions } from './drivers';
 import type { AnyEntity, AutoPath, Dictionary, EntityData, EntityDictionary, EntityDTO, EntityMetadata, EntityName, FilterDef, FilterQuery, GetRepository, Loaded, New, Populate, PopulateOptions, Primary } from './typings';
-import type { IsolationLevel } from './enums';
 import { FlushMode, LoadStrategy, LockMode, ReferenceType, SCALAR_TYPES } from './enums';
+import type { TransactionOptions } from './enums';
 import type { MetadataStorage } from './metadata';
 import type { Transaction } from './connections';
 import { EventManager, TransactionEventBroadcaster } from './events';
@@ -35,6 +35,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   private filters: Dictionary<FilterDef<any>> = {};
   private filterParams: Dictionary<Dictionary> = {};
   private transactionContext?: Transaction;
+  private flushMode?: FlushMode;
 
   /**
    * @internal
@@ -179,6 +180,10 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    */
   getFilterParams<T extends Dictionary = Dictionary>(name: string): T {
     return this.getContext().filterParams[name] as T;
+  }
+
+  setFlushMode(flushMode?: FlushMode): void {
+    this.flushMode = flushMode;
   }
 
   protected async processWhere<T extends AnyEntity<T>, P extends string = never>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, P> | FindOneOptions<T, P>, type: 'read' | 'update' | 'delete'): Promise<FilterQuery<T>> {
@@ -345,8 +350,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Runs your callback wrapped inside a database transaction.
    */
-  async transactional<T>(cb: (em: D[typeof EntityManagerType]) => Promise<T>, options: { ctx?: Transaction; isolationLevel?: IsolationLevel } = {}): Promise<T> {
-    const em = this.fork({ clear: false });
+  async transactional<T>(cb: (em: D[typeof EntityManagerType]) => Promise<T>, options: TransactionOptions = {}): Promise<T> {
+    const em = this.fork({ clear: false, flushMode: options.flushMode });
     options.ctx ??= this.transactionContext;
 
     return TransactionContext.createAsync(em, async () => {
@@ -363,7 +368,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Starts new transaction bound to this EntityManager. Use `ctx` parameter to provide the parent when nesting transactions.
    */
-  async begin(options: { ctx?: Transaction; isolationLevel?: IsolationLevel } = {}): Promise<void> {
+  async begin(options: TransactionOptions = {}): Promise<void> {
     this.transactionContext = await this.getConnection('write').begin({ ...options, eventBroadcaster: new TransactionEventBroadcaster(this) });
   }
 
@@ -470,19 +475,19 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
 
   /**
    * Merges given entity to this EntityManager so it becomes managed. You can force refreshing of existing entities
-   * via second parameter. By default it will return already loaded entities without modifying them.
+   * via second parameter. By default, it will return already loaded entities without modifying them.
    */
   merge<T extends AnyEntity<T>>(entity: T, options?: MergeOptions): T;
 
   /**
    * Merges given entity to this EntityManager so it becomes managed. You can force refreshing of existing entities
-   * via second parameter. By default it will return already loaded entities without modifying them.
+   * via second parameter. By default, it will return already loaded entities without modifying them.
    */
   merge<T extends AnyEntity<T>>(entityName: EntityName<T>, data: EntityData<T> | EntityDTO<T>, options?: MergeOptions): T;
 
   /**
    * Merges given entity to this EntityManager so it becomes managed. You can force refreshing of existing entities
-   * via second parameter. By default it will return already loaded entities without modifying them.
+   * via second parameter. By default, it will return already loaded entities without modifying them.
    */
   merge<T extends AnyEntity<T>>(entityName: EntityName<T> | T, data?: EntityData<T> | EntityDTO<T> | MergeOptions, options: MergeOptions = {}): T {
     if (Utils.isEntity(entityName)) {
@@ -682,8 +687,11 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     await this.getUnitOfWork().commit();
   }
 
-  protected async tryFlush<T>(entityName: EntityName<T>, options: { flushMode?: FlushMode }): Promise<void> {
-    const flushMode = options.flushMode ?? this.config.get('flushMode');
+  /**
+   * @internal
+   */
+  async tryFlush<T>(entityName: EntityName<T>, options: { flushMode?: FlushMode }): Promise<void> {
+    const flushMode = options.flushMode ?? this.getContext().flushMode ?? this.config.get('flushMode');
     entityName = Utils.className(entityName);
     const meta = this.metadata.get(entityName);
 
@@ -753,6 +761,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     const allowGlobalContext = this.config.get('allowGlobalContext');
     this.config.set('allowGlobalContext', true);
     const em = new (this.constructor as typeof EntityManager)(this.config, this.driver, this.metadata, options.useContext, eventManager);
+    em.setFlushMode(options.flushMode);
     this.config.set('allowGlobalContext', allowGlobalContext);
 
     em.filters = { ...this.filters };
@@ -986,11 +995,12 @@ export interface MergeOptions {
   schema?: string;
 }
 
-interface ForkOptions {
+export interface ForkOptions {
   /** do we want clear identity map? defaults to true */
   clear?: boolean;
   /** use request context? should be used only for top level request scope EM, defaults to false */
   useContext?: boolean;
   /** do we want to use fresh EventManager instance? defaults to false (global instance) */
   freshEventManager?: boolean;
+  flushMode?: FlushMode;
 }

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -3,7 +3,7 @@ import type {
   IPrimaryKey, PopulateOptions, EntityDictionary, ExpandProperty, AutoPath,
 } from '../typings';
 import type { Connection, QueryResult, Transaction } from '../connections';
-import type { LockMode, QueryOrderMap, QueryFlag, LoadStrategy } from '../enums';
+import type { FlushMode, LockMode, QueryOrderMap, QueryFlag, LoadStrategy } from '../enums';
 import type { Platform } from '../platforms';
 import type { MetadataStorage } from '../metadata';
 import type { Collection } from '../entity';
@@ -100,6 +100,7 @@ export interface FindOptions<T, P extends string = never> {
   groupBy?: string | string[];
   having?: QBFilterQuery<T>;
   strategy?: LoadStrategy;
+  flushMode?: FlushMode;
   filters?: Dictionary<boolean | Dictionary> | string[] | boolean;
   lockMode?: Exclude<LockMode, LockMode.OPTIMISTIC>;
   lockTableAliases?: string[];

--- a/packages/core/src/entity/BaseEntity.ts
+++ b/packages/core/src/entity/BaseEntity.ts
@@ -13,6 +13,10 @@ export abstract class BaseEntity<T, PK extends keyof T, P extends string = never
     return (this as unknown as AnyEntity<T>).__helper!.__initialized;
   }
 
+  isTouched(): boolean {
+    return (this as unknown as AnyEntity<T>).__helper!.__touched;
+  }
+
   populated(populated = true): void {
     (this as unknown as AnyEntity<T>).__helper!.populated(populated);
   }

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -54,6 +54,7 @@ export class EntityFactory {
     const entity = exists ?? this.createEntity<T>(data, meta2, options);
     entity.__helper!.__initialized = options.initialized;
     this.hydrate(entity, meta2, data, options);
+    entity.__helper!.__touched = false;
 
     if (exists && meta.discriminatorColumn && !(entity instanceof meta2.class)) {
       Object.setPrototypeOf(entity, meta2.prototype);
@@ -117,6 +118,8 @@ export class EntityFactory {
         this.create(prop.type, data[prop.name] as EntityData<T>, options); // we can ignore the value, we just care about the `mergeData` call
       }
     });
+
+    entity.__helper!.__touched = false;
   }
 
   createReference<T>(entityName: EntityName<T>, id: Primary<T> | Primary<T>[] | Record<string, Primary<T>>, options: Pick<FactoryOptions, 'merge' | 'convertCustomTypes' | 'schema'> = {}): T {

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -169,6 +169,10 @@ export class EntityFactory {
         meta.relations
           .filter(prop => [ReferenceType.ONE_TO_MANY, ReferenceType.MANY_TO_MANY].includes(prop.reference))
           .forEach(prop => delete entity[prop.name]);
+
+        if (options.initialized && !(entity as Dictionary).__gettersDefined) {
+          Object.defineProperties(entity, meta.definedProperties);
+        }
       }
 
       return entity;
@@ -182,6 +186,10 @@ export class EntityFactory {
     if (meta.selfReferencing && !options.newEntity) {
       this.hydrator.hydrateReference(entity, meta, data, this, options.convertCustomTypes);
       this.unitOfWork.registerManaged(entity);
+    }
+
+    if (options.initialized && !(entity as Dictionary).__gettersDefined) {
+      Object.defineProperties(entity, meta.definedProperties);
     }
 
     return entity;

--- a/packages/core/src/entity/EntityHelper.ts
+++ b/packages/core/src/entity/EntityHelper.ts
@@ -83,7 +83,9 @@ export class EntityHelper {
 
   /**
    * Defines getter and setter for every owning side of m:1 and 1:1 relation. This is then used for propagation of
-   * changes to the inverse side of bi-directional relations.
+   * changes to the inverse side of bi-directional relations. Rest of the properties are also defined this way to
+   * achieve dirtyness, which is then used for fast checks whether we need to auto-flush because of managed entities.
+   *
    * First defines a setter on the prototype, once called, actual get/set handlers are registered on the instance rather
    * than on its prototype. Thanks to this we still have those properties enumerable (e.g. part of `Object.keys(entity)`).
    */

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -15,6 +15,7 @@ import type { EntityIdentifier } from './EntityIdentifier';
 export class WrappedEntity<T extends AnyEntity<T>, PK extends keyof T> {
 
   __initialized = true;
+  __touched = false;
   __populated?: boolean;
   __lazyInitialized?: boolean;
   __managed?: boolean;
@@ -22,6 +23,7 @@ export class WrappedEntity<T extends AnyEntity<T>, PK extends keyof T> {
   __em?: EntityManager;
   __serializationContext: { root?: SerializationContext<T>; populate?: PopulateOptions<T>[] } = {};
   __loadedProperties = new Set<string>();
+  __data: Dictionary = {};
 
   /** holds last entity data snapshot so we can compute changes when persisting managed entities */
   __originalEntityData?: EntityData<T>;
@@ -36,6 +38,10 @@ export class WrappedEntity<T extends AnyEntity<T>, PK extends keyof T> {
 
   isInitialized(): boolean {
     return this.__initialized;
+  }
+
+  isTouched(): boolean {
+    return this.__touched;
   }
 
   populated(populated = true): void {

--- a/packages/core/src/enums.ts
+++ b/packages/core/src/enums.ts
@@ -4,7 +4,7 @@ import type { Transaction } from './connections';
 export const enum FlushMode {
   /** The `EntityManager` tries to delay the flush until the current Transaction is committed, although it might flush prematurely too. */
   COMMIT,
-  /** This is the default mode and it flushes the `EntityManager` only if necessary. */
+  /** This is the default mode, and it flushes the `EntityManager` only if necessary. */
   AUTO,
   /** Flushes the `EntityManager` before every query. */
   ALWAYS,

--- a/packages/core/src/enums.ts
+++ b/packages/core/src/enums.ts
@@ -1,4 +1,5 @@
 import type { ExpandProperty } from './typings';
+import type { Transaction } from './connections';
 
 export const enum FlushMode {
   /** The `EntityManager` tries to delay the flush until the current Transaction is committed, although it might flush prematurely too. */
@@ -147,3 +148,9 @@ export enum EventType {
 }
 
 export type TransactionEventType = EventType.beforeTransactionStart | EventType.afterTransactionStart | EventType.beforeTransactionCommit | EventType.afterTransactionCommit | EventType.beforeTransactionRollback | EventType.afterTransactionRollback;
+
+export interface TransactionOptions {
+  ctx?: Transaction;
+  isolationLevel?: IsolationLevel;
+  flushMode?: FlushMode;
+}

--- a/packages/core/src/enums.ts
+++ b/packages/core/src/enums.ts
@@ -1,5 +1,14 @@
 import type { ExpandProperty } from './typings';
 
+export const enum FlushMode {
+  /** The `EntityManager` tries to delay the flush until the current Transaction is committed, although it might flush prematurely too. */
+  COMMIT,
+  /** This is the default mode and it flushes the `EntityManager` only if necessary. */
+  AUTO,
+  /** Flushes the `EntityManager` before every query. */
+  ALWAYS,
+}
+
 export enum GroupOperator {
   $and = 'and',
   $or = 'or',

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -92,6 +92,7 @@ export type QBFilterQuery<T = any> = FilterQuery<T> | Dictionary;
 
 export interface IWrappedEntity<T extends AnyEntity<T>, PK extends keyof T | unknown = PrimaryProperty<T>, P extends string = string> {
   isInitialized(): boolean;
+  isTouched(): boolean;
   populated(populated?: boolean): void;
   init<P extends Populate<T> = Populate<T>>(populated?: boolean, populate?: P, lockMode?: LockMode): Promise<T>;
   toReference<PK2 extends PK | unknown = PrimaryProperty<T>, P2 extends string = string>(): IdentifiedReference<T, PK2> & LoadedReference<T>;
@@ -115,6 +116,7 @@ export interface IWrappedEntityInternal<T, PK extends keyof T | unknown = Primar
   __platform: Platform;
   __factory: EntityFactory; // internal factory instance that has its own global fork
   __initialized: boolean;
+  __touched: boolean;
   __originalEntityData?: EntityData<T>;
   __loadedProperties: Set<string>;
   __identifier?: EntityIdentifier;

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -1,4 +1,4 @@
-import type { AnyEntity, EntityData, EntityMetadata, EntityProperty, FilterQuery, IPrimaryKeyValue, Primary } from '../typings';
+import type { AnyEntity, Dictionary, EntityData, EntityMetadata, EntityProperty, FilterQuery, IPrimaryKeyValue, Primary } from '../typings';
 import { Collection, EntityIdentifier, Reference } from '../entity';
 import { ChangeSet, ChangeSetType } from './ChangeSet';
 import { ChangeSetComputer } from './ChangeSetComputer';
@@ -78,7 +78,7 @@ export class UnitOfWork {
     }
 
     const helper = entity.__helper!;
-    helper!.__em ??= this.em;
+    helper.__em ??= this.em;
 
     if (data && helper!.__initialized && (refresh || !helper!.__originalEntityData)) {
       // we can't use the `data` directly here as it can contain fetch joined data, that can't be used for diffing the state
@@ -86,6 +86,11 @@ export class UnitOfWork {
       Object.keys(data).forEach(key => entity.__helper!.__loadedProperties.add(key));
       this.queuedActions.delete(helper.__meta.className);
       helper.__touched = false;
+
+      if (!(entity as Dictionary).__gettersDefined) {
+        helper.__data = { ...entity };
+        Object.defineProperties(entity, helper.__meta.definedProperties);
+      }
     }
 
     return entity;

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -31,7 +31,8 @@ export class UnitOfWork {
   private readonly comparator = this.em.getComparator();
   private readonly changeSetComputer = new ChangeSetComputer(this.em.getValidator(), this.collectionUpdates, this.removeStack, this.metadata, this.platform, this.em.config);
   private readonly changeSetPersister = new ChangeSetPersister(this.em.getDriver(), this.metadata, this.em.config.getHydrator(this.metadata), this.em.getEntityFactory(), this.em.config);
-  private readonly queue: (() => Promise<void>)[] = [];
+  private readonly queuedActions = new Set<string>();
+  private readonly flushQueue: (() => Promise<void>)[] = [];
   private working = false;
   private insideHooks = false;
 
@@ -59,6 +60,8 @@ export class UnitOfWork {
     // as there can be some entity with already changed state that is not yet flushed
     if (wrapped.__initialized && (!visited || !wrapped.__originalEntityData)) {
       wrapped.__originalEntityData = this.comparator.prepareEntity(entity);
+      this.queuedActions.delete(wrapped.__meta.className);
+      wrapped.__touched = false;
     }
 
     this.cascade(entity, Cascade.MERGE, visited ?? new Set<AnyEntity>());
@@ -81,6 +84,8 @@ export class UnitOfWork {
       // we can't use the `data` directly here as it can contain fetch joined data, that can't be used for diffing the state
       helper!.__originalEntityData = this.comparator.prepareEntity(entity);
       Object.keys(data).forEach(key => entity.__helper!.__loadedProperties.add(key));
+      this.queuedActions.delete(helper.__meta.className);
+      helper.__touched = false;
     }
 
     return entity;
@@ -165,6 +170,28 @@ export class UnitOfWork {
     return this.extraUpdates;
   }
 
+  shouldAutoFlush<T extends AnyEntity<T>>(meta: EntityMetadata<T>): boolean {
+    if (this.insideHooks) {
+      return false;
+    }
+
+    if (this.queuedActions.has(meta.className) || this.queuedActions.has(meta.root.className)) {
+      return true;
+    }
+
+    for (const entity of this.identityMap.getStore(meta).values()) {
+      if (entity.__helper!.isTouched()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  clearActionsQueue(): void {
+    this.queuedActions.clear();
+  }
+
   computeChangeSet<T extends AnyEntity<T>>(entity: T): void {
     const cs = this.changeSetComputer.computeChangeSet(entity);
 
@@ -176,7 +203,9 @@ export class UnitOfWork {
     this.checkOrphanRemoval(cs);
     this.changeSets.set(entity, cs);
     this.persistStack.delete(entity);
+    this.queuedActions.delete(cs.name);
     entity.__helper!.__originalEntityData = this.comparator.prepareEntity(entity);
+    entity.__helper!.__touched = false;
   }
 
   recomputeSingleChangeSet<T extends AnyEntity<T>>(entity: T): void {
@@ -193,6 +222,7 @@ export class UnitOfWork {
       this.checkOrphanRemoval(cs);
       Object.assign(changeSet.payload, cs.payload);
       entity.__helper!.__originalEntityData = this.comparator.prepareEntity(entity);
+      entity.__helper!.__touched = false;
     }
   }
 
@@ -206,6 +236,7 @@ export class UnitOfWork {
     }
 
     this.persistStack.add(entity);
+    this.queuedActions.add(entity.__meta!.className);
     this.removeStack.delete(entity);
 
     if (options.cascade ?? true) {
@@ -220,6 +251,7 @@ export class UnitOfWork {
 
     if (entity.__helper!.hasPrimaryKey()) {
       this.removeStack.add(entity);
+      this.queuedActions.add(entity.__meta!.className);
     }
 
     this.persistStack.delete(entity);
@@ -233,7 +265,7 @@ export class UnitOfWork {
       }
 
       return await new Promise<void>((resolve, reject) => {
-        this.queue.push(async () => {
+        this.flushQueue.push(async () => {
           await this.doCommit().then(resolve, reject);
         });
       });
@@ -242,8 +274,8 @@ export class UnitOfWork {
     this.working = true;
     await this.doCommit();
 
-    while (this.queue.length) {
-      await this.queue.shift()!();
+    while (this.flushQueue.length) {
+      await this.flushQueue.shift()!();
     }
 
     this.working = false;
@@ -311,6 +343,7 @@ export class UnitOfWork {
 
     delete wrapped.__identifier;
     delete wrapped.__originalEntityData;
+    wrapped.__touched = false;
   }
 
   computeChangeSets(): void {
@@ -354,6 +387,7 @@ export class UnitOfWork {
   scheduleOrphanRemoval(entity?: AnyEntity): void {
     if (entity) {
       this.orphanRemoveStack.add(entity);
+      this.queuedActions.add(entity.__meta!.className);
     }
   }
 
@@ -476,15 +510,18 @@ export class UnitOfWork {
   }
 
   private async runHooks<T extends AnyEntity<T>>(type: EventType, changeSet: ChangeSet<T>, sync = false): Promise<unknown> {
-    this.insideHooks = true;
     const hasListeners = this.eventManager.hasListeners(type, changeSet.entity.__meta!);
 
     if (!hasListeners) {
       return;
     }
 
+    this.insideHooks = true;
+
     if (!sync) {
-      return this.eventManager.dispatchEvent(type, { entity: changeSet.entity, em: this.em, changeSet });
+      await this.eventManager.dispatchEvent(type, { entity: changeSet.entity, em: this.em, changeSet });
+      this.insideHooks = false;
+      return;
     }
 
     const copy = this.comparator.prepareEntity(changeSet.entity) as T;
@@ -509,6 +546,7 @@ export class UnitOfWork {
     this.collectionUpdates.clear();
     this.collectionDeletions.clear();
     this.extraUpdates.clear();
+    this.queuedActions.clear();
     this.working = false;
     this.insideHooks = false;
   }
@@ -740,6 +778,7 @@ export class UnitOfWork {
 
     for (const changeSet of changeSets) {
       changeSet.entity.__helper!.__originalEntityData = this.comparator.prepareEntity(changeSet.entity);
+      changeSet.entity.__helper!.__touched = false;
       await this.runHooks(EventType.afterUpdate, changeSet);
     }
   }

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -86,11 +86,6 @@ export class UnitOfWork {
       Object.keys(data).forEach(key => entity.__helper!.__loadedProperties.add(key));
       this.queuedActions.delete(helper.__meta.className);
       helper.__touched = false;
-
-      if (!(entity as Dictionary).__gettersDefined) {
-        helper.__data = { ...entity };
-        Object.defineProperties(entity, helper.__meta.definedProperties);
-      }
     }
 
     return entity;

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -34,7 +34,7 @@ import type { EventSubscriber } from '../events';
 import type { IDatabaseDriver } from '../drivers/IDatabaseDriver';
 import { NotFoundError } from '../errors';
 import { RequestContext } from './RequestContext';
-import { LoadStrategy } from '../enums';
+import { FlushMode, LoadStrategy } from '../enums';
 import { MemoryCacheAdapter } from '../cache/MemoryCacheAdapter';
 
 export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
@@ -61,6 +61,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     findOneOrFailHandler: (entityName: string, where: Dictionary | IPrimaryKey) => NotFoundError.findOneFailed(entityName, where),
     baseDir: process.cwd(),
     hydrator: ObjectHydrator,
+    flushMode: FlushMode.AUTO,
     loadStrategy: LoadStrategy.SELECT_IN,
     autoJoinOneToOneOwner: true,
     propagateToOneOwner: true,
@@ -402,6 +403,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
   batchSize: number;
   hydrator: HydratorConstructor;
   loadStrategy: LoadStrategy;
+  flushMode: FlushMode;
   entityRepository?: Constructor<EntityRepository<any>>;
   replicas?: Partial<ConnectionOptions>[];
   strict: boolean;

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -246,9 +246,9 @@ export class EntityComparator {
           lines.push(...prop.fieldNames.map(field => `    ${propName(field, 'mapped')} = true;`), '  }');
         } else {
           if (prop.type === 'boolean') {
-            lines.push(`  if ('${prop.fieldNames[0]}' in result) { ret${this.wrap(prop.name)} = ${propName(prop.fieldNames[0])} == null ? ${propName(prop.fieldNames[0])} : !!${propName(prop.fieldNames[0])}; mapped.${prop.fieldNames[0]} = true; }`);
+            lines.push(`  if (typeof ${propName(prop.fieldNames[0])} !== 'undefined') { ret${this.wrap(prop.name)} = ${propName(prop.fieldNames[0])} == null ? ${propName(prop.fieldNames[0])} : !!${propName(prop.fieldNames[0])}; mapped.${prop.fieldNames[0]} = true; }`);
           } else {
-            lines.push(`  if ('${prop.fieldNames[0]}' in result) { ret${this.wrap(prop.name)} = ${propName(prop.fieldNames[0])}; ${propName(prop.fieldNames[0], 'mapped')} = true; }`);
+            lines.push(`  if (typeof ${propName(prop.fieldNames[0])} !== 'undefined') { ret${this.wrap(prop.name)} = ${propName(prop.fieldNames[0])}; ${propName(prop.fieldNames[0], 'mapped')} = true; }`);
           }
         }
       }
@@ -278,7 +278,7 @@ export class EntityComparator {
           return '';
         }
 
-        const mapped = `'${k}' in entity${tail ? '.' + tail : ''}`;
+        const mapped = `typeof entity${tail ? '.' + tail : ''}${this.wrap(k)} !== 'undefined'`;
         tail += tail ? ('.' + k) : k;
 
         return mapped;

--- a/tests/EntityHelper.mongo.test.ts
+++ b/tests/EntityHelper.mongo.test.ts
@@ -80,8 +80,9 @@ describe('EntityHelperMongo', () => {
   test('BaseEntity methods', async () => {
     const god = new Author('God', 'hello@heaven.god');
     expect(wrap(god, true).__populated).toBeUndefined();
-    expect(wrap(god, true).__touched).toBe(true);
-    expect(god.isTouched()).toBe(true);
+    // not managed entities do not track changes (before being flushed)
+    expect(wrap(god, true).__touched).toBe(false);
+    expect(god.isTouched()).toBe(false);
     god.populated();
     expect(wrap(god, true).__populated).toBe(true);
     expect(wrap(god, true).__platform).toBe(orm.em.getDriver().getPlatform());
@@ -90,7 +91,8 @@ describe('EntityHelperMongo', () => {
     expect(ref).toBeInstanceOf(Reference);
     expect(ref.getEntity()).toBe(god);
 
-    wrap(god, true).__touched = false;
+    await orm.em.persistAndFlush(god);
+    expect(wrap(god, true).__touched).toBe(false);
     expect(god.isTouched()).toBe(false);
     god.name = '123';
     expect(wrap(god, true).__touched).toBe(true);

--- a/tests/EntityHelper.mongo.test.ts
+++ b/tests/EntityHelper.mongo.test.ts
@@ -80,9 +80,8 @@ describe('EntityHelperMongo', () => {
   test('BaseEntity methods', async () => {
     const god = new Author('God', 'hello@heaven.god');
     expect(wrap(god, true).__populated).toBeUndefined();
-    // not managed entities do not track changes (before being flushed)
-    expect(wrap(god, true).__touched).toBe(false);
-    expect(god.isTouched()).toBe(false);
+    expect(wrap(god, true).__touched).toBe(true);
+    expect(god.isTouched()).toBe(true);
     god.populated();
     expect(wrap(god, true).__populated).toBe(true);
     expect(wrap(god, true).__platform).toBe(orm.em.getDriver().getPlatform());

--- a/tests/EntityHelper.mongo.test.ts
+++ b/tests/EntityHelper.mongo.test.ts
@@ -80,6 +80,8 @@ describe('EntityHelperMongo', () => {
   test('BaseEntity methods', async () => {
     const god = new Author('God', 'hello@heaven.god');
     expect(wrap(god, true).__populated).toBeUndefined();
+    expect(wrap(god, true).__touched).toBe(true);
+    expect(god.isTouched()).toBe(true);
     god.populated();
     expect(wrap(god, true).__populated).toBe(true);
     expect(wrap(god, true).__platform).toBe(orm.em.getDriver().getPlatform());
@@ -87,6 +89,12 @@ describe('EntityHelperMongo', () => {
     const ref = god.toReference();
     expect(ref).toBeInstanceOf(Reference);
     expect(ref.getEntity()).toBe(god);
+
+    wrap(god, true).__touched = false;
+    expect(god.isTouched()).toBe(false);
+    god.name = '123';
+    expect(wrap(god, true).__touched).toBe(true);
+    expect(god.isTouched()).toBe(true);
   });
 
   test('#load() should populate the entity', async () => {

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -276,8 +276,7 @@ describe('EntityManagerMySql', () => {
 
   test(`1:1 relationships with an inverse side primary key of 0 should link`, async () => {
     // Set up static data with id of 0
-    const driver = orm.em.getDriver();
-    const response = await driver.getConnection().execute('SET sql_mode = \'NO_AUTO_VALUE_ON_ZERO\';insert into foo_baz2 (id, name) values (?, ?)', [0, 'testBaz'], 'run');
+    const response = await orm.em.execute('set sql_mode = \'NO_AUTO_VALUE_ON_ZERO\'; insert into foo_baz2 (id, name) values (?, ?); set sql_mode = \'\'', [0, 'testBaz'], 'run');
     expect(response[1]).toMatchObject({
       affectedRows: 1,
       insertId: 0,
@@ -306,7 +305,7 @@ describe('EntityManagerMySql', () => {
   test('transactions', async () => {
     const god1 = new Author2('God1', 'hello@heaven1.god');
     await orm.em.begin();
-    await orm.em.persist(god1);
+    orm.em.persist(god1);
     await orm.em.rollback();
     const res1 = await orm.em.findOne(Author2, { name: 'God1' });
     expect(res1).toBeNull();

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -1868,6 +1868,7 @@ describe('EntityManagerPostgre', () => {
     expect(Subscriber.log).toHaveLength(2);
     const updates = Subscriber.log.reduce((x, y) => x.concat(y), []).filter(c => c.type === ChangeSetType.UPDATE);
     expect(updates).toHaveLength(0);
+    Subscriber.log.length = 0;
   });
 
   test('getConnection() with replicas (GH issue #1963)', async () => {

--- a/tests/EntityManager.sqlite2.test.ts
+++ b/tests/EntityManager.sqlite2.test.ts
@@ -939,7 +939,7 @@ describe('EntityManagerSqlite2', () => {
 
     const mock = mockLogger(orm, ['query']);
 
-    await setTimeout(10);
+    await new Promise(resolve => setTimeout(resolve, 10));
     await orm.em.flush();
 
     expect(mock.mock.calls[0][0]).toMatch('begin');

--- a/tests/EntityManager.sqlite2.test.ts
+++ b/tests/EntityManager.sqlite2.test.ts
@@ -1,5 +1,4 @@
 import type { EntityName } from '@mikro-orm/core';
-import { setTimeout } from 'timers/promises';
 import { ArrayCollection, Collection, EntityManager, LockMode, MikroORM, QueryOrder, ValidationError, wrap } from '@mikro-orm/core';
 import type { SqliteDriver } from '@mikro-orm/sqlite';
 import { initORMSqlite2, mockLogger, wipeDatabaseSqlite2 } from './bootstrap';
@@ -847,7 +846,7 @@ describe('EntityManagerSqlite2', () => {
     expect(+author.updatedAt - +author.createdAt).toBeLessThanOrEqual(1);
 
     author.name = 'name1';
-    await setTimeout(10);
+    await new Promise(resolve => setTimeout(resolve, 10));
     await repo.persistAndFlush(author);
     await expect(author.createdAt).toBeDefined();
     await expect(author.updatedAt).toBeDefined();

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import type { EntityManager, Options } from '@mikro-orm/core';
+import type { Constructor, EntityManager, Options } from '@mikro-orm/core';
 import { JavaScriptMetadataProvider, LoadStrategy, MikroORM, Utils } from '@mikro-orm/core';
 import type { AbstractSqlDriver, SqlEntityManager } from '@mikro-orm/knex';
 import { SchemaGenerator, SqlEntityRepository } from '@mikro-orm/knex';
@@ -91,9 +91,9 @@ export async function initORMMySql<D extends MySqlDriver | MariaDbDriver = MySql
   return orm as MikroORM<D>;
 }
 
-export async function initORMPostgreSql(loadStrategy = LoadStrategy.SELECT_IN) {
+export async function initORMPostgreSql(loadStrategy = LoadStrategy.SELECT_IN, entities: Constructor[]) {
   const orm = await MikroORM.init<PostgreSqlDriver>({
-    entities: [Author2, Address2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, FooParam2, Label2, Configuration2],
+    entities: [Author2, Address2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, FooParam2, Label2, Configuration2, ...entities],
     dbName: `mikro_orm_test`,
     baseDir: BASE_DIR,
     type: 'postgresql',

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -91,7 +91,7 @@ export async function initORMMySql<D extends MySqlDriver | MariaDbDriver = MySql
   return orm as MikroORM<D>;
 }
 
-export async function initORMPostgreSql(loadStrategy = LoadStrategy.SELECT_IN, entities: Constructor[]) {
+export async function initORMPostgreSql(loadStrategy = LoadStrategy.SELECT_IN, entities: any[] = []) {
   const orm = await MikroORM.init<PostgreSqlDriver>({
     entities: [Author2, Address2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, FooParam2, Label2, Configuration2, ...entities],
     dbName: `mikro_orm_test`,

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -28,7 +28,7 @@ export class Book2 {
   price?: number;
 
   @Formula(alias => `${alias}.price * 1.19`)
-  priceTaxed?: number;
+  priceTaxed?: string;
 
   @Property({ type: t.double, nullable: true })
   double?: number;

--- a/tests/features/auto-flush.postgre.test.ts
+++ b/tests/features/auto-flush.postgre.test.ts
@@ -9,7 +9,6 @@ describe('automatic flushing when querying for overlapping entities via em.find/
 
   let orm: MikroORM<PostgreSqlDriver>;
 
-  // @ts-ignore
   beforeAll(async () => orm = await initORMPostgreSql(undefined, [CompanyOwner2, Employee2, Manager2, BaseUser2]));
   beforeEach(async () => wipeDatabasePostgreSql(orm.em));
   afterAll(async () => orm.close(true));

--- a/tests/features/auto-flush.postgre.test.ts
+++ b/tests/features/auto-flush.postgre.test.ts
@@ -241,6 +241,8 @@ describe('automatic flushing when querying for overlapping entities via em.find/
     expect(ret[1]).toHaveLength(1);
     expect(ret[2]).toHaveLength(1);
     expect(mock.mock.calls).toHaveLength(7);
+
+    await orm.getSchemaGenerator().dropSchema();
   });
 
 });

--- a/tests/features/auto-flush.postgre.test.ts
+++ b/tests/features/auto-flush.postgre.test.ts
@@ -1,0 +1,139 @@
+import type { MikroORM } from '@mikro-orm/core';
+import { FlushMode } from '@mikro-orm/core';
+import type { PostgreSqlDriver } from '@mikro-orm/postgresql';
+
+import { initORMPostgreSql, mockLogger, wipeDatabasePostgreSql } from '../bootstrap';
+import { Author2, Book2 } from '../entities-sql';
+
+describe('automatic flushing when querying for overlapping entities via em.find/One', () => {
+
+  let orm: MikroORM<PostgreSqlDriver>;
+
+  beforeAll(async () => orm = await initORMPostgreSql());
+  beforeEach(async () => wipeDatabasePostgreSql(orm.em));
+  afterAll(async () => orm.close(true));
+
+  async function createEntities() {
+    const god = new Author2('God', 'hello@heaven.god');
+    god.favouriteAuthor = new Author2('God 2', 'hello2@heaven.god');
+    god.favouriteAuthor.age = 21;
+    god.age = 999;
+    god.identities = ['a', 'b', 'c'];
+    const b1 = new Book2('Bible 1', god);
+    b1.perex = 'b1 perex';
+    b1.price = 123;
+    const b2 = new Book2('Bible 2', god);
+    b2.perex = 'b2 perex';
+    b2.price = 456;
+    const b3 = new Book2('Bible 3', god);
+    b3.perex = 'b3 perex';
+    b3.price = 789;
+    await orm.em.fork().persistAndFlush(god);
+
+    return { god };
+  }
+
+  test('em.find() triggers auto-flush', async () => {
+    await createEntities();
+    const mock = mockLogger(orm, ['query']);
+
+    // querying for author will trigger auto-flush if we have new author persisted
+    const a1 = new Author2('A1', 'a1@example.com');
+    orm.em.persist(a1);
+    const r1 = await orm.em.find(Author2, {});
+    expect(mock).toBeCalledTimes(4);
+    expect(r1).toHaveLength(3);
+    mock.mockReset();
+
+    // querying author won't trigger auto-flush if we have new book
+    const b4 = new Book2('b4', a1, 444);
+    orm.em.persist(b4);
+    const r2 = await orm.em.find(Author2, {});
+    expect(mock).toBeCalledTimes(1);
+    expect(r2).toHaveLength(3);
+    mock.mockReset();
+
+    // but querying for book will trigger auto-flush
+    const r3 = await orm.em.find(Book2, {});
+    expect(mock).toBeCalledTimes(4);
+    expect(r3).toHaveLength(4);
+  });
+
+  test('changes to managed entities are detected automatically', async () => {
+    await createEntities();
+    const mock = mockLogger(orm, ['query']);
+
+    const books = await orm.em.find(Book2, {});
+    expect(books).toHaveLength(3);
+    books[0].price = 1000;
+
+    const ret = await Promise.all(books.map(async () => {
+      return orm.em.find(Book2, { price: { $gt: 500 } });
+    }));
+    expect(ret[0]).toHaveLength(2);
+    expect(ret[1]).toHaveLength(2);
+    expect(ret[2]).toHaveLength(2);
+    expect(mock.mock.calls).toHaveLength(7);
+  });
+
+  test('em.find() supports `FindOptions.flushMode` to allow disabling auto-flush for given query', async () => {
+    await createEntities();
+    const mock = mockLogger(orm, ['query']);
+
+    const books = await orm.em.find(Book2, {});
+    expect(books).toHaveLength(3);
+    books[0].price = 1000;
+
+    const ret = await Promise.all(books.map(async () => {
+      return orm.em.find(Book2, { price: { $gt: 500 } }, { flushMode: FlushMode.COMMIT });
+    }));
+    expect(ret[0]).toHaveLength(1);
+    expect(ret[1]).toHaveLength(1);
+    expect(ret[2]).toHaveLength(1);
+    expect(mock.mock.calls).toHaveLength(4);
+  });
+
+  test('performance', async () => {
+    const fork = orm.em.fork();
+
+    for (let i = 1; i <= 300; i++) {
+      const god = new Author2('God', `hello-${i}@heaven.god`);
+      god.favouriteAuthor = new Author2('God 2', `hello2-${i}@heaven.god`);
+      god.favouriteAuthor.age = 21;
+      god.age = 999;
+      god.identities = ['a', 'b', 'c'];
+      const b1 = new Book2(`Bible 1-${i}`, god);
+      b1.perex = `b1-${i} perex`;
+      b1.price = 123;
+      const b2 = new Book2(`Bible 2-${i}`, god);
+      b2.perex = `b2-${i} perex`;
+      b2.price = 456;
+      const b3 = new Book2(`Bible 3-${i}`, god);
+      b3.perex = `b3-${i} perex`;
+      b3.price = 789;
+      fork.persist(god);
+    }
+
+    await fork.flush();
+    const mock = mockLogger(orm, ['query']);
+
+    const books = await orm.em.find(Book2, {});
+    expect(books).toHaveLength(900);
+    books[0].price = 1000;
+
+    const ret = await Promise.all(books.slice(0, 3).map(async () => {
+      return orm.em.find(Book2, { price: { $gt: 500 } });
+    }));
+    expect(ret[0]).toHaveLength(301);
+    expect(ret[1]).toHaveLength(301);
+    expect(ret[2]).toHaveLength(301);
+    expect(mock.mock.calls).toHaveLength(7);
+  });
+
+  test.todo('em.find() triggers auto-flush when STI entity changed');
+  test.todo('QB triggers auto-flushing');
+  test.todo('QB supports `setFlushMode()` to allow disabling auto-flush for given query');
+  test.todo('em.fork() supports flushMode option');
+  test.todo('em.transactional() supports flushMode option');
+
+});

--- a/tests/features/auto-flush.postgre.test.ts
+++ b/tests/features/auto-flush.postgre.test.ts
@@ -65,7 +65,7 @@ describe('automatic flushing when querying for overlapping entities via em.find/
     god.favouriteAuthor.age = 21;
     god.age = 999;
 
-    expect(wrap(god, true).__touched).toBe(false);
+    expect(wrap(god, true).__touched).toBe(true);
     await orm.em.persistAndFlush(god);
     expect(wrap(god, true).__touched).toBe(false);
 

--- a/tests/features/auto-refreshing.postgre.test.ts
+++ b/tests/features/auto-refreshing.postgre.test.ts
@@ -1,5 +1,5 @@
 import type { MikroORM } from '@mikro-orm/core';
-import { LoadStrategy, wrap } from '@mikro-orm/core';
+import { FlushMode, LoadStrategy, wrap } from '@mikro-orm/core';
 import type { PostgreSqlDriver } from '@mikro-orm/postgresql';
 
 import { initORMPostgreSql, mockLogger, wipeDatabasePostgreSql } from '../bootstrap';
@@ -42,7 +42,8 @@ describe('automatic refreshing of already loaded entities', () => {
     expect(r1[0].id).toBe(god.id);
     expect(r1[0].name).toBeUndefined();
     expect(r1[0].termsAccepted).toBeUndefined();
-    const r2 = await orm.em.find(Author2, god, { populate: ['books'] });
+    // with auto-flush mode, this would trigger flushing as we have dirty author and we query for authors
+    const r2 = await orm.em.find(Author2, god, { populate: ['books'], flushMode: FlushMode.COMMIT });
     expect(r2).toHaveLength(1);
     expect(r2[0].id).toBe(god.id);
     expect(r2[0].name).toBe(god.name);
@@ -66,7 +67,8 @@ describe('automatic refreshing of already loaded entities', () => {
     expect(r1[0].id).toBe(god.id);
     expect(r1[0].name).toBeUndefined();
     expect(r1[0].termsAccepted).toBeUndefined();
-    const r2 = await orm.em.find(Author2, god, { populate: ['books', 'books.perex'], strategy: LoadStrategy.JOINED });
+    // with auto-flush mode, this would trigger flushing as we have dirty author and we query for authors
+    const r2 = await orm.em.find(Author2, god, { populate: ['books', 'books.perex'], strategy: LoadStrategy.JOINED, flushMode: FlushMode.COMMIT });
     expect(r2).toHaveLength(1);
     expect(r2[0].id).toBe(god.id);
     expect(r2[0].name).toBe(god.name);
@@ -99,7 +101,8 @@ describe('automatic refreshing of already loaded entities', () => {
     expect(r1[0].books[0].author).toBeDefined();
     expect(r1[0].books[0].price).toBeUndefined();
     expect(r1[0].books[0].perex).toBeUndefined();
-    const r2 = await orm.em.find(Author2, god, { populate: ['books', 'books.perex'], strategy: LoadStrategy.JOINED });
+    // with auto-flush mode, this would trigger flushing as we have dirty author and we query for authors
+    const r2 = await orm.em.find(Author2, god, { populate: ['books', 'books.perex'], strategy: LoadStrategy.JOINED, flushMode: FlushMode.COMMIT });
     expect(r2).toHaveLength(1);
     expect(r2[0].id).toBe(god.id);
     expect(r2[0].name).toBe(god.name);
@@ -131,7 +134,8 @@ describe('automatic refreshing of already loaded entities', () => {
     expect(r1[0].favouriteAuthor!.name).toBeDefined();
     expect(r1[0].favouriteAuthor!.age).toBeUndefined();
     r1[0].favouriteAuthor!.name = 'lol';
-    const r2 = await orm.em.find(Author2, god, { populate: ['favouriteAuthor'], strategy: LoadStrategy.JOINED });
+    // with auto-flush mode, this would trigger flushing as we have dirty author and we query for authors
+    const r2 = await orm.em.find(Author2, god, { populate: ['favouriteAuthor'], strategy: LoadStrategy.JOINED, flushMode: FlushMode.COMMIT });
     expect(r2).toHaveLength(1);
     expect(r2[0].id).toBe(god.id);
     expect(r2[0].name).toBe(god.name);
@@ -163,19 +167,22 @@ describe('automatic refreshing of already loaded entities', () => {
     expect(a1.identities).toBeUndefined();
 
     // reloading with same fields won't fire the query
-    const a11 = await orm.em.findOneOrFail(Author2, god, { fields: ['email'] });
+    // with auto-flush mode, this would trigger flushing as we have dirty author and we query for authors
+    const a11 = await orm.em.findOneOrFail(Author2, god, { fields: ['email'], flushMode: FlushMode.COMMIT });
     expect(a11).toBe(a1);
     expect(mock).toBeCalledTimes(2);
 
     // reloading with additional fields will work without `refresh: true`
-    const a12 = await orm.em.findOneOrFail(Author2, god, { fields: ['id', 'age'] });
+    // with auto-flush mode, this would trigger flushing as we have dirty author and we query for authors
+    const a12 = await orm.em.findOneOrFail(Author2, god, { fields: ['id', 'age'], flushMode: FlushMode.COMMIT });
     expect(a12).toBe(a1);
     expect(a1.age).toBe(999);
     a1.age = 1000;
     expect(mock).toBeCalledTimes(3);
 
     // reloading without partial loading will work without `refresh: true`
-    const a2 = await orm.em.findOneOrFail(Author2, god, { populate: ['books'] });
+    // with auto-flush mode, this would trigger flushing as we have dirty author and we query for authors
+    const a2 = await orm.em.findOneOrFail(Author2, god, { populate: ['books'], flushMode: FlushMode.COMMIT });
     expect(mock).toBeCalledTimes(4);
     expect(a2.id).toBe(god.id);
     expect(a2.name).toBe(god.name);
@@ -215,19 +222,22 @@ describe('automatic refreshing of already loaded entities', () => {
     expect(a1.identities).toBeUndefined();
 
     // reloading with same fields won't fire the query
-    const a11 = await orm.em.findOneOrFail(Author2, god, { fields: ['email'] });
+    // with auto-flush mode, this would trigger flushing as we have dirty author and we query for authors
+    const a11 = await orm.em.findOneOrFail(Author2, god, { fields: ['email'], flushMode: FlushMode.COMMIT });
     expect(a11).toBe(a1);
     expect(mock).toBeCalledTimes(1);
 
     // reloading with additional fields will work without `refresh: true`
-    const a12 = await orm.em.findOneOrFail(Author2, god, { fields: ['id', 'age'] });
+    // with auto-flush mode, this would trigger flushing as we have dirty author and we query for authors
+    const a12 = await orm.em.findOneOrFail(Author2, god, { fields: ['id', 'age'], flushMode: FlushMode.COMMIT });
     expect(a12).toBe(a1);
     expect(a1.age).toBe(999);
     a1.age = 1000;
     expect(mock).toBeCalledTimes(2);
 
     // reloading without partial loading will work without `refresh: true`
-    const a2 = await orm.em.findOneOrFail(Author2, god, { populate: ['books'], strategy: LoadStrategy.JOINED });
+    // with auto-flush mode, this would trigger flushing as we have dirty author and we query for authors
+    const a2 = await orm.em.findOneOrFail(Author2, god, { populate: ['books'], strategy: LoadStrategy.JOINED, flushMode: FlushMode.COMMIT });
     expect(mock).toBeCalledTimes(3);
     expect(a2.id).toBe(god.id);
     expect(a2.name).toBe(god.name);
@@ -236,12 +246,14 @@ describe('automatic refreshing of already loaded entities', () => {
     expect(a1).toBe(a2);
 
     // no query should be fired as the entity was fully loaded before too
-    const b11 = await orm.em.findOneOrFail(Book2, god.books[0].uuid, { filters: false });
+    // with auto-flush mode, this would trigger flushing as we have dirty author and we query for authors
+    const b11 = await orm.em.findOneOrFail(Book2, god.books[0].uuid, { filters: false, flushMode: FlushMode.COMMIT });
     expect(mock).toBeCalledTimes(3);
     expect(b11).toBe(a1.books[0]);
 
     // reloading with additional lazy scalar properties will work without `refresh: true`
-    const b12 = await orm.em.findOneOrFail(Book2, god.books[0], { populate: ['perex'], filters: false });
+    // with auto-flush mode, this would trigger flushing as we have dirty author and we query for authors
+    const b12 = await orm.em.findOneOrFail(Book2, god.books[0], { populate: ['perex'], filters: false, flushMode: FlushMode.COMMIT });
     expect(mock).toBeCalledTimes(4);
     expect(b11).toBe(b12);
 

--- a/tests/features/embeddables/__snapshots__/embeddable-custom-types.postgres.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/embeddable-custom-types.postgres.test.ts.snap
@@ -20,7 +20,7 @@ drop table if exists \\"user\\" cascade;
 exports[`embedded entities with custom types snapshot generator 1`] = `
 "function(entity) {
   const ret = {};
-  if ('id' in entity && entity.id != null) {
+  if (typeof entity.id !== 'undefined' && entity.id != null) {
     ret.id = entity.id;
   }
 
@@ -45,11 +45,11 @@ exports[`embedded entities with custom types snapshot generator 1`] = `
     ret.nested2 = cloneEmbeddable(ret.nested2);
   }
 
-  if ('after' in entity) {
+  if (typeof entity.after !== 'undefined') {
     ret.after = entity.after;
   }
 
-  if ('someValue' in entity) {
+  if (typeof entity.someValue !== 'undefined') {
     ret.someValue = clone(convertToDatabaseValue_someValue(entity.someValue));
   }
 

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.mongo.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.mongo.test.ts.snap
@@ -3,11 +3,11 @@
 exports[`embedded entities in mongo diffing 1`] = `
 "function(entity) {
   const ret = {};
-  if ('_id' in entity && entity._id != null) {
+  if (typeof entity._id !== 'undefined' && entity._id != null) {
     ret._id = clone(entity._id);
   }
 
-  if ('name' in entity) {
+  if (typeof entity.name !== 'undefined') {
     ret.name = entity.name;
   }
 
@@ -20,7 +20,7 @@ exports[`embedded entities in mongo diffing 1`] = `
       if (entity.profile1.identity.meta != null) {
         ret.profile1_identity_meta_foo = clone(entity.profile1.identity.meta.foo);
         ret.profile1_identity_meta_bar = clone(entity.profile1.identity.meta.bar);
-        if ('profile1' in entity && 'identity' in entity.profile1 && 'meta' in entity.profile1.identity && (entity.profile1.identity.meta.source == null || entity.profile1.identity.meta.source.__helper.hasPrimaryKey())) {
+        if (typeof entity.profile1 !== 'undefined' && typeof entity.profile1.identity !== 'undefined' && typeof entity.profile1.identity.meta !== 'undefined' && (entity.profile1.identity.meta.source == null || entity.profile1.identity.meta.source.__helper.hasPrimaryKey())) {
           ret.profile1_identity_meta_source = getPrimaryKeyValues_profile1_identity_meta_source(entity.profile1.identity.meta.source);
         }
       
@@ -39,7 +39,7 @@ exports[`embedded entities in mongo diffing 1`] = `
               ret.profile1_identity_links[idx_0].meta = {};
               ret.profile1_identity_links[idx_0].meta.foo = clone(entity.profile1.identity.links[idx_0].meta.foo);
               ret.profile1_identity_links[idx_0].meta.bar = clone(entity.profile1.identity.links[idx_0].meta.bar);
-              if ('profile1' in entity && 'identity' in entity.profile1 && 'links' in entity.profile1.identity && 'meta' in entity.profile1.identity.links[idx_0] && (entity.profile1.identity.links[idx_0].meta.source == null || entity.profile1.identity.links[idx_0].meta.source.__helper.hasPrimaryKey())) {
+              if (typeof entity.profile1 !== 'undefined' && typeof entity.profile1.identity !== 'undefined' && typeof entity.profile1.identity.links !== 'undefined' && typeof entity.profile1.identity.links[idx_0].meta !== 'undefined' && (entity.profile1.identity.links[idx_0].meta.source == null || entity.profile1.identity.links[idx_0].meta.source.__helper.hasPrimaryKey())) {
                 ret.profile1_identity_links[idx_0].meta.source = getPrimaryKeyValues_profile1_identity_links_meta_source(entity.profile1.identity.links[idx_0].meta.source);
               }
             
@@ -53,7 +53,7 @@ exports[`embedded entities in mongo diffing 1`] = `
                   ret.profile1_identity_links[idx_0].metas[idx_1] = {};
                   ret.profile1_identity_links[idx_0].metas[idx_1].foo = clone(entity.profile1.identity.links[idx_0].metas[idx_1].foo);
                   ret.profile1_identity_links[idx_0].metas[idx_1].bar = clone(entity.profile1.identity.links[idx_0].metas[idx_1].bar);
-                  if ('profile1' in entity && 'identity' in entity.profile1 && 'links' in entity.profile1.identity && 'metas' in entity.profile1.identity.links[idx_0] && (entity.profile1.identity.links[idx_0].metas[idx_1].source == null || entity.profile1.identity.links[idx_0].metas[idx_1].source.__helper.hasPrimaryKey())) {
+                  if (typeof entity.profile1 !== 'undefined' && typeof entity.profile1.identity !== 'undefined' && typeof entity.profile1.identity.links !== 'undefined' && typeof entity.profile1.identity.links[idx_0].metas !== 'undefined' && (entity.profile1.identity.links[idx_0].metas[idx_1].source == null || entity.profile1.identity.links[idx_0].metas[idx_1].source.__helper.hasPrimaryKey())) {
                     ret.profile1_identity_links[idx_0].metas[idx_1].source = getPrimaryKeyValues_profile1_identity_links_metas_source(entity.profile1.identity.links[idx_0].metas[idx_1].source);
                   }
                 
@@ -61,7 +61,7 @@ exports[`embedded entities in mongo diffing 1`] = `
               });
             }
 
-            if ('profile1' in entity && 'identity' in entity.profile1 && 'links' in entity.profile1.identity && (entity.profile1.identity.links[idx_0].source == null || entity.profile1.identity.links[idx_0].source.__helper.hasPrimaryKey())) {
+            if (typeof entity.profile1 !== 'undefined' && typeof entity.profile1.identity !== 'undefined' && typeof entity.profile1.identity.links !== 'undefined' && (entity.profile1.identity.links[idx_0].source == null || entity.profile1.identity.links[idx_0].source.__helper.hasPrimaryKey())) {
               ret.profile1_identity_links[idx_0].source = getPrimaryKeyValues_profile1_identity_links_source(entity.profile1.identity.links[idx_0].source);
             }
           
@@ -70,13 +70,13 @@ exports[`embedded entities in mongo diffing 1`] = `
         ret.profile1_identity_links = cloneEmbeddable(ret.profile1_identity_links);
       }
 
-      if ('profile1' in entity && 'identity' in entity.profile1 && (entity.profile1.identity.source == null || entity.profile1.identity.source.__helper.hasPrimaryKey())) {
+      if (typeof entity.profile1 !== 'undefined' && typeof entity.profile1.identity !== 'undefined' && (entity.profile1.identity.source == null || entity.profile1.identity.source.__helper.hasPrimaryKey())) {
         ret.profile1_identity_source = getPrimaryKeyValues_profile1_identity_source(entity.profile1.identity.source);
       }
     
     }
 
-    if ('profile1' in entity && (entity.profile1.source == null || entity.profile1.source.__helper.hasPrimaryKey())) {
+    if (typeof entity.profile1 !== 'undefined' && (entity.profile1.source == null || entity.profile1.source.__helper.hasPrimaryKey())) {
       ret.profile1_source = getPrimaryKeyValues_profile1_source(entity.profile1.source);
     }
   
@@ -94,7 +94,7 @@ exports[`embedded entities in mongo diffing 1`] = `
         ret.profile2.identity.meta = {};
         ret.profile2.identity.meta.foo = clone(entity.profile2.identity.meta.foo);
         ret.profile2.identity.meta.bar = clone(entity.profile2.identity.meta.bar);
-        if ('profile2' in entity && 'identity' in entity.profile2 && 'meta' in entity.profile2.identity && (entity.profile2.identity.meta.source == null || entity.profile2.identity.meta.source.__helper.hasPrimaryKey())) {
+        if (typeof entity.profile2 !== 'undefined' && typeof entity.profile2.identity !== 'undefined' && typeof entity.profile2.identity.meta !== 'undefined' && (entity.profile2.identity.meta.source == null || entity.profile2.identity.meta.source.__helper.hasPrimaryKey())) {
           ret.profile2.identity.meta.source = getPrimaryKeyValues_profile2_identity_meta_source(entity.profile2.identity.meta.source);
         }
       
@@ -113,7 +113,7 @@ exports[`embedded entities in mongo diffing 1`] = `
               ret.profile2.identity.links[idx_2].meta = {};
               ret.profile2.identity.links[idx_2].meta.foo = clone(entity.profile2.identity.links[idx_2].meta.foo);
               ret.profile2.identity.links[idx_2].meta.bar = clone(entity.profile2.identity.links[idx_2].meta.bar);
-              if ('profile2' in entity && 'identity' in entity.profile2 && 'links' in entity.profile2.identity && 'meta' in entity.profile2.identity.links[idx_2] && (entity.profile2.identity.links[idx_2].meta.source == null || entity.profile2.identity.links[idx_2].meta.source.__helper.hasPrimaryKey())) {
+              if (typeof entity.profile2 !== 'undefined' && typeof entity.profile2.identity !== 'undefined' && typeof entity.profile2.identity.links !== 'undefined' && typeof entity.profile2.identity.links[idx_2].meta !== 'undefined' && (entity.profile2.identity.links[idx_2].meta.source == null || entity.profile2.identity.links[idx_2].meta.source.__helper.hasPrimaryKey())) {
                 ret.profile2.identity.links[idx_2].meta.source = getPrimaryKeyValues_profile2_identity_links_meta_source(entity.profile2.identity.links[idx_2].meta.source);
               }
             
@@ -127,7 +127,7 @@ exports[`embedded entities in mongo diffing 1`] = `
                   ret.profile2.identity.links[idx_2].metas[idx_3] = {};
                   ret.profile2.identity.links[idx_2].metas[idx_3].foo = clone(entity.profile2.identity.links[idx_2].metas[idx_3].foo);
                   ret.profile2.identity.links[idx_2].metas[idx_3].bar = clone(entity.profile2.identity.links[idx_2].metas[idx_3].bar);
-                  if ('profile2' in entity && 'identity' in entity.profile2 && 'links' in entity.profile2.identity && 'metas' in entity.profile2.identity.links[idx_2] && (entity.profile2.identity.links[idx_2].metas[idx_3].source == null || entity.profile2.identity.links[idx_2].metas[idx_3].source.__helper.hasPrimaryKey())) {
+                  if (typeof entity.profile2 !== 'undefined' && typeof entity.profile2.identity !== 'undefined' && typeof entity.profile2.identity.links !== 'undefined' && typeof entity.profile2.identity.links[idx_2].metas !== 'undefined' && (entity.profile2.identity.links[idx_2].metas[idx_3].source == null || entity.profile2.identity.links[idx_2].metas[idx_3].source.__helper.hasPrimaryKey())) {
                     ret.profile2.identity.links[idx_2].metas[idx_3].source = getPrimaryKeyValues_profile2_identity_links_metas_source(entity.profile2.identity.links[idx_2].metas[idx_3].source);
                   }
                 
@@ -135,7 +135,7 @@ exports[`embedded entities in mongo diffing 1`] = `
               });
             }
 
-            if ('profile2' in entity && 'identity' in entity.profile2 && 'links' in entity.profile2.identity && (entity.profile2.identity.links[idx_2].source == null || entity.profile2.identity.links[idx_2].source.__helper.hasPrimaryKey())) {
+            if (typeof entity.profile2 !== 'undefined' && typeof entity.profile2.identity !== 'undefined' && typeof entity.profile2.identity.links !== 'undefined' && (entity.profile2.identity.links[idx_2].source == null || entity.profile2.identity.links[idx_2].source.__helper.hasPrimaryKey())) {
               ret.profile2.identity.links[idx_2].source = getPrimaryKeyValues_profile2_identity_links_source(entity.profile2.identity.links[idx_2].source);
             }
           
@@ -143,13 +143,13 @@ exports[`embedded entities in mongo diffing 1`] = `
         });
       }
 
-      if ('profile2' in entity && 'identity' in entity.profile2 && (entity.profile2.identity.source == null || entity.profile2.identity.source.__helper.hasPrimaryKey())) {
+      if (typeof entity.profile2 !== 'undefined' && typeof entity.profile2.identity !== 'undefined' && (entity.profile2.identity.source == null || entity.profile2.identity.source.__helper.hasPrimaryKey())) {
         ret.profile2.identity.source = getPrimaryKeyValues_profile2_identity_source(entity.profile2.identity.source);
       }
     
     }
 
-    if ('profile2' in entity && (entity.profile2.source == null || entity.profile2.source.__helper.hasPrimaryKey())) {
+    if (typeof entity.profile2 !== 'undefined' && (entity.profile2.source == null || entity.profile2.source.__helper.hasPrimaryKey())) {
       ret.profile2.source = getPrimaryKeyValues_profile2_source(entity.profile2.source);
     }
   

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
@@ -3,11 +3,11 @@
 exports[`embedded entities in postgres diffing 1`] = `
 "function(entity) {
   const ret = {};
-  if ('id' in entity && entity.id != null) {
+  if (typeof entity.id !== 'undefined' && entity.id != null) {
     ret.id = entity.id;
   }
 
-  if ('name' in entity) {
+  if (typeof entity.name !== 'undefined') {
     ret.name = entity.name;
   }
 
@@ -20,7 +20,7 @@ exports[`embedded entities in postgres diffing 1`] = `
       if (entity.profile1.identity.meta != null) {
         ret.profile1_identity_meta_foo = clone(entity.profile1.identity.meta.foo);
         ret.profile1_identity_meta_bar = clone(entity.profile1.identity.meta.bar);
-        if ('profile1' in entity && 'identity' in entity.profile1 && 'meta' in entity.profile1.identity && (entity.profile1.identity.meta.source == null || entity.profile1.identity.meta.source.__helper.hasPrimaryKey())) {
+        if (typeof entity.profile1 !== 'undefined' && typeof entity.profile1.identity !== 'undefined' && typeof entity.profile1.identity.meta !== 'undefined' && (entity.profile1.identity.meta.source == null || entity.profile1.identity.meta.source.__helper.hasPrimaryKey())) {
           ret.profile1_identity_meta_source = getPrimaryKeyValues_profile1_identity_meta_source(entity.profile1.identity.meta.source);
         }
       
@@ -39,7 +39,7 @@ exports[`embedded entities in postgres diffing 1`] = `
               ret.profile1_identity_links[idx_0].meta = {};
               ret.profile1_identity_links[idx_0].meta.foo = clone(entity.profile1.identity.links[idx_0].meta.foo);
               ret.profile1_identity_links[idx_0].meta.bar = clone(entity.profile1.identity.links[idx_0].meta.bar);
-              if ('profile1' in entity && 'identity' in entity.profile1 && 'links' in entity.profile1.identity && 'meta' in entity.profile1.identity.links[idx_0] && (entity.profile1.identity.links[idx_0].meta.source == null || entity.profile1.identity.links[idx_0].meta.source.__helper.hasPrimaryKey())) {
+              if (typeof entity.profile1 !== 'undefined' && typeof entity.profile1.identity !== 'undefined' && typeof entity.profile1.identity.links !== 'undefined' && typeof entity.profile1.identity.links[idx_0].meta !== 'undefined' && (entity.profile1.identity.links[idx_0].meta.source == null || entity.profile1.identity.links[idx_0].meta.source.__helper.hasPrimaryKey())) {
                 ret.profile1_identity_links[idx_0].meta.source = getPrimaryKeyValues_profile1_identity_links_meta_source(entity.profile1.identity.links[idx_0].meta.source);
               }
             
@@ -53,7 +53,7 @@ exports[`embedded entities in postgres diffing 1`] = `
                   ret.profile1_identity_links[idx_0].metas[idx_1] = {};
                   ret.profile1_identity_links[idx_0].metas[idx_1].foo = clone(entity.profile1.identity.links[idx_0].metas[idx_1].foo);
                   ret.profile1_identity_links[idx_0].metas[idx_1].bar = clone(entity.profile1.identity.links[idx_0].metas[idx_1].bar);
-                  if ('profile1' in entity && 'identity' in entity.profile1 && 'links' in entity.profile1.identity && 'metas' in entity.profile1.identity.links[idx_0] && (entity.profile1.identity.links[idx_0].metas[idx_1].source == null || entity.profile1.identity.links[idx_0].metas[idx_1].source.__helper.hasPrimaryKey())) {
+                  if (typeof entity.profile1 !== 'undefined' && typeof entity.profile1.identity !== 'undefined' && typeof entity.profile1.identity.links !== 'undefined' && typeof entity.profile1.identity.links[idx_0].metas !== 'undefined' && (entity.profile1.identity.links[idx_0].metas[idx_1].source == null || entity.profile1.identity.links[idx_0].metas[idx_1].source.__helper.hasPrimaryKey())) {
                     ret.profile1_identity_links[idx_0].metas[idx_1].source = getPrimaryKeyValues_profile1_identity_links_metas_source(entity.profile1.identity.links[idx_0].metas[idx_1].source);
                   }
                 
@@ -61,7 +61,7 @@ exports[`embedded entities in postgres diffing 1`] = `
               });
             }
 
-            if ('profile1' in entity && 'identity' in entity.profile1 && 'links' in entity.profile1.identity && (entity.profile1.identity.links[idx_0].source == null || entity.profile1.identity.links[idx_0].source.__helper.hasPrimaryKey())) {
+            if (typeof entity.profile1 !== 'undefined' && typeof entity.profile1.identity !== 'undefined' && typeof entity.profile1.identity.links !== 'undefined' && (entity.profile1.identity.links[idx_0].source == null || entity.profile1.identity.links[idx_0].source.__helper.hasPrimaryKey())) {
               ret.profile1_identity_links[idx_0].source = getPrimaryKeyValues_profile1_identity_links_source(entity.profile1.identity.links[idx_0].source);
             }
           
@@ -70,13 +70,13 @@ exports[`embedded entities in postgres diffing 1`] = `
         ret.profile1_identity_links = cloneEmbeddable(ret.profile1_identity_links);
       }
 
-      if ('profile1' in entity && 'identity' in entity.profile1 && (entity.profile1.identity.source == null || entity.profile1.identity.source.__helper.hasPrimaryKey())) {
+      if (typeof entity.profile1 !== 'undefined' && typeof entity.profile1.identity !== 'undefined' && (entity.profile1.identity.source == null || entity.profile1.identity.source.__helper.hasPrimaryKey())) {
         ret.profile1_identity_source = getPrimaryKeyValues_profile1_identity_source(entity.profile1.identity.source);
       }
     
     }
 
-    if ('profile1' in entity && (entity.profile1.source == null || entity.profile1.source.__helper.hasPrimaryKey())) {
+    if (typeof entity.profile1 !== 'undefined' && (entity.profile1.source == null || entity.profile1.source.__helper.hasPrimaryKey())) {
       ret.profile1_source = getPrimaryKeyValues_profile1_source(entity.profile1.source);
     }
   
@@ -94,7 +94,7 @@ exports[`embedded entities in postgres diffing 1`] = `
         ret.profile2.identity.meta = {};
         ret.profile2.identity.meta.foo = clone(entity.profile2.identity.meta.foo);
         ret.profile2.identity.meta.bar = clone(entity.profile2.identity.meta.bar);
-        if ('profile2' in entity && 'identity' in entity.profile2 && 'meta' in entity.profile2.identity && (entity.profile2.identity.meta.source == null || entity.profile2.identity.meta.source.__helper.hasPrimaryKey())) {
+        if (typeof entity.profile2 !== 'undefined' && typeof entity.profile2.identity !== 'undefined' && typeof entity.profile2.identity.meta !== 'undefined' && (entity.profile2.identity.meta.source == null || entity.profile2.identity.meta.source.__helper.hasPrimaryKey())) {
           ret.profile2.identity.meta.source = getPrimaryKeyValues_profile2_identity_meta_source(entity.profile2.identity.meta.source);
         }
       
@@ -113,7 +113,7 @@ exports[`embedded entities in postgres diffing 1`] = `
               ret.profile2.identity.links[idx_2].meta = {};
               ret.profile2.identity.links[idx_2].meta.foo = clone(entity.profile2.identity.links[idx_2].meta.foo);
               ret.profile2.identity.links[idx_2].meta.bar = clone(entity.profile2.identity.links[idx_2].meta.bar);
-              if ('profile2' in entity && 'identity' in entity.profile2 && 'links' in entity.profile2.identity && 'meta' in entity.profile2.identity.links[idx_2] && (entity.profile2.identity.links[idx_2].meta.source == null || entity.profile2.identity.links[idx_2].meta.source.__helper.hasPrimaryKey())) {
+              if (typeof entity.profile2 !== 'undefined' && typeof entity.profile2.identity !== 'undefined' && typeof entity.profile2.identity.links !== 'undefined' && typeof entity.profile2.identity.links[idx_2].meta !== 'undefined' && (entity.profile2.identity.links[idx_2].meta.source == null || entity.profile2.identity.links[idx_2].meta.source.__helper.hasPrimaryKey())) {
                 ret.profile2.identity.links[idx_2].meta.source = getPrimaryKeyValues_profile2_identity_links_meta_source(entity.profile2.identity.links[idx_2].meta.source);
               }
             
@@ -127,7 +127,7 @@ exports[`embedded entities in postgres diffing 1`] = `
                   ret.profile2.identity.links[idx_2].metas[idx_3] = {};
                   ret.profile2.identity.links[idx_2].metas[idx_3].foo = clone(entity.profile2.identity.links[idx_2].metas[idx_3].foo);
                   ret.profile2.identity.links[idx_2].metas[idx_3].bar = clone(entity.profile2.identity.links[idx_2].metas[idx_3].bar);
-                  if ('profile2' in entity && 'identity' in entity.profile2 && 'links' in entity.profile2.identity && 'metas' in entity.profile2.identity.links[idx_2] && (entity.profile2.identity.links[idx_2].metas[idx_3].source == null || entity.profile2.identity.links[idx_2].metas[idx_3].source.__helper.hasPrimaryKey())) {
+                  if (typeof entity.profile2 !== 'undefined' && typeof entity.profile2.identity !== 'undefined' && typeof entity.profile2.identity.links !== 'undefined' && typeof entity.profile2.identity.links[idx_2].metas !== 'undefined' && (entity.profile2.identity.links[idx_2].metas[idx_3].source == null || entity.profile2.identity.links[idx_2].metas[idx_3].source.__helper.hasPrimaryKey())) {
                     ret.profile2.identity.links[idx_2].metas[idx_3].source = getPrimaryKeyValues_profile2_identity_links_metas_source(entity.profile2.identity.links[idx_2].metas[idx_3].source);
                   }
                 
@@ -135,7 +135,7 @@ exports[`embedded entities in postgres diffing 1`] = `
               });
             }
 
-            if ('profile2' in entity && 'identity' in entity.profile2 && 'links' in entity.profile2.identity && (entity.profile2.identity.links[idx_2].source == null || entity.profile2.identity.links[idx_2].source.__helper.hasPrimaryKey())) {
+            if (typeof entity.profile2 !== 'undefined' && typeof entity.profile2.identity !== 'undefined' && typeof entity.profile2.identity.links !== 'undefined' && (entity.profile2.identity.links[idx_2].source == null || entity.profile2.identity.links[idx_2].source.__helper.hasPrimaryKey())) {
               ret.profile2.identity.links[idx_2].source = getPrimaryKeyValues_profile2_identity_links_source(entity.profile2.identity.links[idx_2].source);
             }
           
@@ -143,13 +143,13 @@ exports[`embedded entities in postgres diffing 1`] = `
         });
       }
 
-      if ('profile2' in entity && 'identity' in entity.profile2 && (entity.profile2.identity.source == null || entity.profile2.identity.source.__helper.hasPrimaryKey())) {
+      if (typeof entity.profile2 !== 'undefined' && typeof entity.profile2.identity !== 'undefined' && (entity.profile2.identity.source == null || entity.profile2.identity.source.__helper.hasPrimaryKey())) {
         ret.profile2.identity.source = getPrimaryKeyValues_profile2_identity_source(entity.profile2.identity.source);
       }
     
     }
 
-    if ('profile2' in entity && (entity.profile2.source == null || entity.profile2.source.__helper.hasPrimaryKey())) {
+    if (typeof entity.profile2 !== 'undefined' && (entity.profile2.source == null || entity.profile2.source.__helper.hasPrimaryKey())) {
       ret.profile2.source = getPrimaryKeyValues_profile2_source(entity.profile2.source);
     }
   

--- a/tests/features/embeddables/__snapshots__/nested-embeddables.mongo.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/nested-embeddables.mongo.test.ts.snap
@@ -3,11 +3,11 @@
 exports[`embedded entities in mongo diffing 1`] = `
 "function(entity) {
   const ret = {};
-  if ('_id' in entity && entity._id != null) {
+  if (typeof entity._id !== 'undefined' && entity._id != null) {
     ret._id = clone(entity._id);
   }
 
-  if ('name' in entity) {
+  if (typeof entity.name !== 'undefined') {
     ret.name = entity.name;
   }
 

--- a/tests/features/embeddables/__snapshots__/nested-embeddables.postgres.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/nested-embeddables.postgres.test.ts.snap
@@ -3,11 +3,11 @@
 exports[`embedded entities in postgres diffing 1`] = `
 "function(entity) {
   const ret = {};
-  if ('id' in entity && entity.id != null) {
+  if (typeof entity.id !== 'undefined' && entity.id != null) {
     ret.id = entity.id;
   }
 
-  if ('name' in entity) {
+  if (typeof entity.name !== 'undefined') {
     ret.name = entity.name;
   }
 

--- a/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
@@ -52,11 +52,11 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
 exports[`polymorphic embeddables in sqlite diffing 2`] = `
 "function(entity) {
   const ret = {};
-  if ('id' in entity && entity.id != null) {
+  if (typeof entity.id !== 'undefined' && entity.id != null) {
     ret.id = entity.id;
   }
 
-  if ('name' in entity) {
+  if (typeof entity.name !== 'undefined') {
     ret.name = entity.name;
   }
 

--- a/tests/features/single-table-inheritance/single-table-inheritance.mysql.test.ts
+++ b/tests/features/single-table-inheritance/single-table-inheritance.mysql.test.ts
@@ -23,6 +23,7 @@ describe('single table inheritance in mysql', () => {
     owner.managerProp = 'i said i am owner';
     owner.favouriteEmployee = employee2;
     owner.favouriteManager = manager;
+    expect(Object.keys(owner)).not.toHaveLength(0);
 
     expect((owner as any).type).not.toBeDefined();
     await orm.em.persistAndFlush([owner, employee1]);
@@ -123,7 +124,7 @@ describe('single table inheritance in mysql', () => {
     expect(Object.keys(users[0])).toEqual(['id', 'firstName', 'lastName', 'type', 'employeeProp']);
     expect(Object.keys(users[1])).toEqual(['id', 'firstName', 'lastName', 'type', 'employeeProp']);
     expect(Object.keys(users[2])).toEqual(['id', 'firstName', 'lastName', 'type', 'managerProp']);
-    expect(Object.keys(users[3])).toEqual(['id', 'firstName', 'lastName', 'type', 'ownerProp', 'favouriteEmployee', 'favouriteManager', 'managerProp']);
+    expect(Object.keys(users[3])).toEqual(['firstName', 'lastName', 'type', 'ownerProp', 'favouriteEmployee', 'favouriteManager', 'managerProp', 'id']);
 
     expect([...orm.em.getUnitOfWork().getIdentityMap().keys()]).toEqual(['BaseUser2-4', 'BaseUser2-1', 'BaseUser2-2', 'BaseUser2-3']);
 

--- a/tests/issues/GH1523.test.ts
+++ b/tests/issues/GH1523.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, wrap } from '@mikro-orm/core';
+import { Collection, Entity, FlushMode, ManyToOne, MikroORM, OneToMany, PrimaryKey, wrap } from '@mikro-orm/core';
 import type { SqliteDriver } from '@mikro-orm/sqlite';
 
 abstract class Base {
@@ -44,6 +44,7 @@ describe('GH issue 1523', () => {
       entities: [Base, Parent, Child, Param],
       dbName: ':memory:',
       type: 'sqlite',
+      flushMode: FlushMode.COMMIT,
     });
     await orm.getSchemaGenerator().createSchema();
   });


### PR DESCRIPTION
Checks state before querying entities and flush automatically if we have queued changes to entities that are being queried.


The flushing strategy is given by the `flushMode` of the current running `EntityManager`.

- `FlushMode.COMMIT` - The `EntityManager` tries to delay the flush until the current Transaction is committed, although it might flush prematurely too.
- `FlushMode.AUTO` - This is the default mode, and it flushes the `EntityManager` only if necessary.
- `FlushMode.ALWAYS` - Flushes the `EntityManager` before every query.

`FlushMode.AUTO` will try to detect changes on the entity we are querying, and flush
if there is an overlap:

```ts
// querying for author will trigger auto-flush if we have new author persisted
const a1 = new Author(...);
orm.em.persist(a1);
const r1 = await orm.em.find(Author, {});

// querying author won't trigger auto-flush if we have new book, but no changes on author
const b4 = new Book(...);
orm.em.persist(b4);
const r2 = await orm.em.find(Author, {});

// but querying for book will trigger auto-flush
const r3 = await orm.em.find(Book, {});
```

We can set the flush mode on different places:

- in the ORM config via `Options.flushMode`
- for given `EntityManager` instance (and its forks) via `em.setFlushMode()`
- for given `EntityManager` fork via `em.fork({ flushMode })`
- for given QueryBuilder instance via `qb.setFlushMode()`
- for given transaction scope via `em.transactional(..., { flushMode })`


Based on https://docs.jboss.org/hibernate/orm/5.1/userguide/html_single/chapters/flushing/Flushing.html

Closes #2359