### PR TITLE
perf(core): reuse EntityComparator on fork()

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -28,7 +28,6 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   private readonly validator = new EntityValidator(this.config.get('strict'));
   private readonly repositoryMap: Dictionary<EntityRepository<AnyEntity>> = {};
   private readonly entityLoader: EntityLoader = new EntityLoader(this);
-  private readonly comparator = new EntityComparator(this.metadata, this.driver.getPlatform());
   private readonly unitOfWork: UnitOfWork = new UnitOfWork(this);
   private readonly entityFactory: EntityFactory = new EntityFactory(this.unitOfWork, this);
   private readonly resultCache = this.config.getResultCacheAdapter();
@@ -43,7 +42,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
               private readonly driver: D,
               private readonly metadata: MetadataStorage,
               private readonly useContext = true,
-              private readonly eventManager = new EventManager(config.get('subscribers'))) { }
+              private readonly eventManager = new EventManager(config.get('subscribers')),
+              private readonly comparator = new EntityComparator(metadata, driver.getPlatform())) { }
 
   /**
    * Gets the Driver instance used by this EntityManager.
@@ -733,7 +733,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     // we need to allow global context here as forking from global EM is fine
     const allowGlobalContext = this.config.get('allowGlobalContext');
     this.config.set('allowGlobalContext', true);
-    const em = new (this.constructor as typeof EntityManager)(this.config, this.driver, this.metadata, options.useContext, eventManager);
+    const em = new (this.constructor as typeof EntityManager)(this.config, this.driver, this.metadata, options.useContext, eventManager, this.comparator);
     this.config.set('allowGlobalContext', allowGlobalContext);
 
     em.filters = { ...this.filters };

--- a/packages/core/src/unit-of-work/ChangeSetComputer.ts
+++ b/packages/core/src/unit-of-work/ChangeSetComputer.ts
@@ -10,14 +10,14 @@ import { EntityComparator } from '../utils/EntityComparator';
 
 export class ChangeSetComputer {
 
-  private readonly comparator = new EntityComparator(this.metadata, this.platform);
 
   constructor(private readonly validator: EntityValidator,
               private readonly collectionUpdates: Set<Collection<AnyEntity>>,
               private readonly removeStack: Set<AnyEntity>,
               private readonly metadata: MetadataStorage,
               private readonly platform: Platform,
-              private readonly config: Configuration) { }
+              private readonly config: Configuration,
+              private readonly comparator = new EntityComparator(metadata, platform)) { }
 
   computeChangeSet<T extends AnyEntity<T>>(entity: T): ChangeSet<T> | null {
     const meta = this.metadata.get(entity.constructor.name);

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -29,7 +29,7 @@ export class UnitOfWork {
   private readonly platform = this.em.getPlatform();
   private readonly eventManager = this.em.getEventManager();
   private readonly comparator = this.em.getComparator();
-  private readonly changeSetComputer = new ChangeSetComputer(this.em.getValidator(), this.collectionUpdates, this.removeStack, this.metadata, this.platform, this.em.config);
+  private readonly changeSetComputer = new ChangeSetComputer(this.em.getValidator(), this.collectionUpdates, this.removeStack, this.metadata, this.platform, this.em.config, this.comparator);
   private readonly changeSetPersister = new ChangeSetPersister(this.em.getDriver(), this.metadata, this.em.config.getHydrator(this.metadata), this.em.getEntityFactory(), this.em.config);
   private readonly queue: (() => Promise<void>)[] = [];
   private working = false;


### PR DESCRIPTION
I've noticed a memory leak on my server. After profiling it, I was able to see compiled functions being allocated and never released. It could be a bug in v8, but parsing and compiling code every request is expensive nonetheless.

This is caused by the `EntityManager` creating a new `EntityComparator` on each fork. Reusing `EntityComparator` shows a clear decrease in the `System Objects` report of the v8 profile.

Will post profiling screenshots later today.

A workaround I'm using in the meantime:
```ts
const comparator = orm.em.getComparator()
const em = orm.em.fork(true, true)
const patchEm: any = em

patchEm.comparator = comparator
patchEm.unitOfWork.comparator = comparator
patchEm.unitOfWork.changeSetComputer.comparator = comparator

OrmContext.set(em, { req, next })
```