### PR TITLE
fix(core): rework orphan removal and cascading

### DIFF
--- a/docs/docs/upgrading-v4-to-v5.md
+++ b/docs/docs/upgrading-v4-to-v5.md
@@ -158,3 +158,12 @@ const [loadedAuthor] = await em.populate(author, ...);
 
 Previously awaiting of QB instance was a no-op. In v5, QB is promise-like interface,
 so we can await it. More about this in [Awaiting the QueryBuilder](./query-builder.md#awaiting-the-querybuilder) section.
+
+## `UnitOfWork.getScheduledCollectionDeletions()` has been removed
+
+Previously scheduled collection deletions were used for a hack when removing 
+1:m collection via orphan removal might require early deletes - in case we were 
+adding the same entity (but different instance), so with same PK - inserting it 
+in the same unit would cause unique constraint failures.
+
+Also `IDatabaseDriver.clearCollection()` method is no longer present in the driver API.

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -648,6 +648,12 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * To remove entities by condition, use `em.nativeDelete()`.
    */
   remove<T extends AnyEntity<T>>(entity: T | Reference<T> | (T | Reference<T>)[]): this {
+    if (Utils.isEntity<T>(entity)) {
+      // do not cascade just yet, cascading of entities in persist stack is done when flushing
+      this.getUnitOfWork().remove(entity, undefined, { cascade: true });
+      return this;
+    }
+
     const entities = Utils.asArray(entity, true);
 
     for (const ent of entities) {
@@ -655,7 +661,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
         throw new Error(`You need to pass entity instance or reference to 'em.remove()'. To remove entities by condition, use 'em.nativeDelete()'.`);
       }
 
-      this.getUnitOfWork().remove(Reference.unwrapReference(ent));
+      // do not cascade just yet, cascading of entities in remove stack is done when flushing
+      this.getUnitOfWork().remove(Reference.unwrapReference(ent), undefined, { cascade: true });
     }
 
     return this;

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -1,16 +1,6 @@
-import type {
-  CountOptions,
-  LockOptions,
-  DeleteOptions,
-  FindOneOptions,
-  FindOptions,
-  IDatabaseDriver,
-  NativeInsertUpdateManyOptions,
-  NativeInsertUpdateOptions,
-  DriverMethodOptions,
-} from './IDatabaseDriver';
+import type { CountOptions, LockOptions, DeleteOptions, FindOneOptions, FindOptions, IDatabaseDriver, NativeInsertUpdateManyOptions, NativeInsertUpdateOptions, DriverMethodOptions } from './IDatabaseDriver';
 import { EntityManagerType } from './IDatabaseDriver';
-import type { AnyEntity, Dictionary, EntityData, EntityDictionary, EntityMetadata, EntityProperty, ObjectQuery, FilterQuery, PopulateOptions, Primary } from '../typings';
+import type { AnyEntity, Dictionary, EntityData, EntityDictionary, EntityMetadata, EntityProperty, FilterQuery, PopulateOptions, Primary } from '../typings';
 import type { MetadataStorage } from '../metadata';
 import type { Connection, QueryResult, Transaction } from '../connections';
 import type { Configuration, ConnectionOptions } from '../utils';
@@ -71,21 +61,6 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     const pk = this.metadata.find(coll.property.type)!.primaryKeys[0];
     const data = { [coll.property.name]: coll.getIdentifiers(pk) } as EntityData<T>;
     await this.nativeUpdate<T>(coll.owner.constructor.name, coll.owner.__helper!.getPrimaryKey() as FilterQuery<T>, data, options);
-  }
-
-  async clearCollection<T, O>(coll: Collection<T, O>, options?: DriverMethodOptions): Promise<void> {
-    // this currently serves only for 1:m collections with orphan removal, m:n ones are handled via `syncCollection` method
-    const snapshot = coll.getSnapshot();
-    /* istanbul ignore next */
-    const deleteDiff = snapshot?.map(item => (item as AnyEntity<T>).__helper!.__primaryKeyCond) ?? [];
-
-    /* istanbul ignore next */
-    if (deleteDiff.length === 0) {
-      return;
-    }
-
-    const cond = { [Utils.getPrimaryKeyHash(coll.property.targetMeta!.primaryKeys)]: deleteDiff } as ObjectQuery<T>;
-    await this.nativeDelete<T>(coll.property.type, cond, options);
   }
 
   mapResult<T>(result: EntityDictionary<T>, meta: EntityMetadata<T>, populate: PopulateOptions<T>[] = []): EntityData<T> | null {

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -48,8 +48,6 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
 
   syncCollection<T, O>(collection: Collection<T, O>, options?: { ctx?: Transaction }): Promise<void>;
 
-  clearCollection<T, O>(collection: Collection<T, O>, options?: { ctx?: Transaction }): Promise<void>;
-
   count<T extends AnyEntity<T>, P extends string = never>(entityName: string, where: FilterQuery<T>, options?: CountOptions<T, P>): Promise<number>;
 
   aggregate(entityName: string, pipeline: any[]): Promise<any[]>;

--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -129,18 +129,12 @@ export class Collection<T, O = unknown> extends ArrayCollection<T, O> {
   }
 
   set(items: (T | Reference<T>)[]): void {
-    const unwrapped = items.map(i => Reference.unwrapReference(i));
-    unwrapped.forEach(item => this.validateItemType(item));
-    this.validateModification(unwrapped);
-
     if (!this.initialized) {
       this.initialized = true;
       this.snapshot = undefined;
     }
 
-    super.set(unwrapped);
-    this.setDirty();
-    this.cancelOrphanRemoval(unwrapped);
+    super.set(items);
   }
 
   /**
@@ -150,18 +144,6 @@ export class Collection<T, O = unknown> extends ArrayCollection<T, O> {
     this.initialized = true;
     super.hydrate(items);
     this.takeSnapshot();
-  }
-
-  removeAll(): void {
-    const em = this.getEntityManager([], false);
-
-    if (this.property.reference === ReferenceType.ONE_TO_MANY && this.property.orphanRemoval && em) {
-      em.getUnitOfWork().scheduleCollectionDeletion(this);
-      const unwrapped = this.getItems(false).map(i => Reference.unwrapReference(i));
-      this.modify('remove', unwrapped);
-    } else {
-      super.removeAll();
-    }
   }
 
   remove(...items: (T | Reference<T> | ((item: T) => boolean))[]): void {

--- a/packages/core/src/enums.ts
+++ b/packages/core/src/enums.ts
@@ -102,6 +102,11 @@ export enum Cascade {
   MERGE = 'merge',
   REMOVE = 'remove',
   ALL = 'all',
+
+  /** @internal */
+  SCHEDULE_ORPHAN_REMOVAL = 'schedule_orphan_removal',
+  /** @internal */
+  CANCEL_ORPHAN_REMOVAL = 'cancel_orphan_removal',
 }
 
 export enum LoadStrategy {

--- a/packages/core/src/unit-of-work/ChangeSet.ts
+++ b/packages/core/src/unit-of-work/ChangeSet.ts
@@ -3,6 +3,7 @@ import type { EntityData, AnyEntity, EntityMetadata, EntityDictionary, Primary }
 export class ChangeSet<T extends AnyEntity<T>> {
 
   private primaryKey?: Primary<T> | Primary<T>[] | null;
+  private serializedPrimaryKey?: string;
 
   constructor(public entity: T,
               public type: ChangeSetType,
@@ -17,6 +18,11 @@ export class ChangeSet<T extends AnyEntity<T>> {
   getPrimaryKey(): Primary<T> | Primary<T>[] | null {
     this.primaryKey ??= this.entity.__helper!.getPrimaryKey(true);
     return this.primaryKey;
+  }
+
+  getSerializedPrimaryKey(): string | null {
+    this.serializedPrimaryKey ??= this.entity.__helper!.getSerializedPrimaryKey();
+    return this.serializedPrimaryKey;
   }
 
 }
@@ -37,4 +43,5 @@ export enum ChangeSetType {
   CREATE = 'create',
   UPDATE = 'update',
   DELETE = 'delete',
+  DELETE_EARLY = 'delete_early',
 }

--- a/tests/features/unit-of-work/UnitOfWork.test.ts
+++ b/tests/features/unit-of-work/UnitOfWork.test.ts
@@ -120,7 +120,6 @@ describe('UnitOfWork', () => {
     expect(uow.getRemoveStack().size).toBe(1);
     expect(uow.getCollectionUpdates().length).toBe(0);
     expect(uow.getExtraUpdates().size).toBe(0);
-    expect(uow.getScheduledCollectionDeletions().length).toBe(0);
   });
 
   test('getters', async () => {

--- a/tests/issues/GH1126.test.ts
+++ b/tests/issues/GH1126.test.ts
@@ -1,0 +1,187 @@
+import { Collection, Entity, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
+import type { SqliteDriver } from '@mikro-orm/sqlite';
+import { mockLogger } from '../helpers';
+
+@Entity()
+export class Author {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToMany({
+    entity: 'Book',
+    mappedBy: 'author',
+    eager: true,
+    orphanRemoval: true,
+  })
+  books = new Collection<Book>(this);
+
+}
+
+@Entity()
+export class Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title: string;
+
+  @ManyToOne(() => Author)
+  author!: Author;
+
+  @OneToMany({
+    entity: 'Page',
+    mappedBy: 'book',
+    eager: true,
+    orphanRemoval: true,
+  })
+  pages = new Collection<Page>(this);
+
+  constructor(title: string) {
+    this.title = title;
+  }
+
+}
+
+@Entity()
+export class Page {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Book)
+  book!: Book;
+
+  @Property()
+  text: string;
+
+  constructor(text: string) {
+    this.text = text;
+  }
+
+}
+
+async function createEntities(orm: MikroORM) {
+  const author = new Author();
+  author.name = 'John';
+
+  const page = new Page('p1');
+  const book = new Book('b1');
+  book.pages.set([page]);
+  author.books.set([book]);
+
+  await orm.em.persistAndFlush(author);
+  orm.em.clear();
+}
+
+describe('GH issue 1126', () => {
+
+  let orm: MikroORM<SqliteDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      type: 'sqlite',
+      dbName: ':memory:',
+      entities: [Author, Book, Page],
+      loadStrategy: LoadStrategy.JOINED,
+    });
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    await orm.getSchemaGenerator().dropSchema();
+    await orm.getSchemaGenerator().createSchema();
+  });
+
+  test(`1/3`, async () => {
+    await createEntities(orm);
+    const mock = mockLogger(orm, ['query']);
+
+    {
+      const author = await orm.em.findOneOrFail(Author, 1);
+      const book = new Book('b2');
+      const oldPages = author.books[0].pages.getItems();
+      book.pages.set(oldPages);
+      author.books.set([book]);
+      await orm.em.flush();
+      orm.em.clear();
+    }
+
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `a0`.`name`, `b1`.`id` as `b1__id`, `b1`.`title` as `b1__title`, `b1`.`author_id` as `b1__author_id`, `p2`.`id` as `p2__id`, `p2`.`book_id` as `p2__book_id`, `p2`.`text` as `p2__text` from `author` as `a0` left join `book` as `b1` on `a0`.`id` = `b1`.`author_id` left join `page` as `p2` on `b1`.`id` = `p2`.`book_id` where `a0`.`id` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('begin');
+    expect(mock.mock.calls[2][0]).toMatch('insert into `book` (`author_id`, `title`) values (?, ?)');
+    expect(mock.mock.calls[3][0]).toMatch('update `page` set `book_id` = ? where `id` = ?');
+    expect(mock.mock.calls[4][0]).toMatch('delete from `book` where `id` in (?)');
+    expect(mock.mock.calls[5][0]).toMatch('commit');
+
+    {
+      const author = await orm.em.findOneOrFail(Author, 1);
+      expect(author.books[0].pages).toHaveLength(1);
+    }
+  });
+
+  test(`2/3`, async () => {
+    await createEntities(orm);
+    const mock = mockLogger(orm, ['query']);
+
+    {
+      const author = await orm.em.findOneOrFail(Author, 1);
+      const book = new Book('b2');
+      const page2 = new Page('p2');
+      book.pages.set([page2]);
+      author.books.removeAll();
+      author.books.add(book);
+      await orm.em.flush();
+      orm.em.clear();
+    }
+
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `a0`.`name`, `b1`.`id` as `b1__id`, `b1`.`title` as `b1__title`, `b1`.`author_id` as `b1__author_id`, `p2`.`id` as `p2__id`, `p2`.`book_id` as `p2__book_id`, `p2`.`text` as `p2__text` from `author` as `a0` left join `book` as `b1` on `a0`.`id` = `b1`.`author_id` left join `page` as `p2` on `b1`.`id` = `p2`.`book_id` where `a0`.`id` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('begin');
+    expect(mock.mock.calls[2][0]).toMatch('insert into `book` (`author_id`, `title`) values (?, ?)');
+    expect(mock.mock.calls[3][0]).toMatch('insert into `page` (`book_id`, `text`) values (?, ?)');
+    expect(mock.mock.calls[4][0]).toMatch('delete from `page` where `id` in (?)');
+    expect(mock.mock.calls[5][0]).toMatch('delete from `book` where `id` in (?)');
+    expect(mock.mock.calls[6][0]).toMatch('commit');
+
+    {
+      const author = await orm.em.findOneOrFail(Author, 1);
+      expect(author.books[0].pages).toHaveLength(1);
+    }
+  });
+
+  test(`3/3`, async () => {
+    await createEntities(orm);
+    const mock = mockLogger(orm, ['query']);
+
+    {
+      const author = await orm.em.findOneOrFail(Author, 1);
+      const book = new Book('b2');
+      const page2 = new Page('p2');
+      book.pages.set([page2]);
+      author.books.set([book]);
+      await orm.em.flush();
+      orm.em.clear();
+    }
+
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `a0`.`name`, `b1`.`id` as `b1__id`, `b1`.`title` as `b1__title`, `b1`.`author_id` as `b1__author_id`, `p2`.`id` as `p2__id`, `p2`.`book_id` as `p2__book_id`, `p2`.`text` as `p2__text` from `author` as `a0` left join `book` as `b1` on `a0`.`id` = `b1`.`author_id` left join `page` as `p2` on `b1`.`id` = `p2`.`book_id` where `a0`.`id` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('begin');
+    expect(mock.mock.calls[2][0]).toMatch('insert into `book` (`author_id`, `title`) values (?, ?)');
+    expect(mock.mock.calls[3][0]).toMatch('insert into `page` (`book_id`, `text`) values (?, ?)');
+    expect(mock.mock.calls[4][0]).toMatch('delete from `page` where `id` in (?)');
+    expect(mock.mock.calls[5][0]).toMatch('delete from `book` where `id` in (?)');
+    expect(mock.mock.calls[6][0]).toMatch('commit');
+
+    {
+      const author = await orm.em.findOneOrFail(Author, 1);
+      expect(author.books[0].pages).toHaveLength(1);
+    }
+  });
+
+});


### PR DESCRIPTION
Closes #1126

BREAKING CHANGE:
`UnitOfWork.getScheduledCollectionDeletions()` has been removed.
Previously scheduled collection deletions were used for a hack when removing
1:m collection via orphan removal might require early deletes - in case we were
adding the same entity (but different instance), so with same PK - inserting it
in the same unit would cause unique constraint failures.

Also `IDatabaseDriver.clearCollection()` method is no longer present in the driver API.