### PR TITLE
refactor(migrations): prevent excessive extension stripping

### DIFF
--- a/packages/migrations/src/MigrationStorage.ts
+++ b/packages/migrations/src/MigrationStorage.ts
@@ -1,6 +1,7 @@
 import type { MigrationsOptions, Transaction } from '@mikro-orm/core';
 import { Utils } from '@mikro-orm/core';
 import type { AbstractSqlDriver, Table } from '@mikro-orm/knex';
+import * as path from 'path';
 import type { MigrationRow } from './typings';
 
 export class MigrationStorage {
@@ -70,8 +71,13 @@ export class MigrationStorage {
   }
 
   protected getMigrationName(name: string) {
-    // strip extension
-    return name.replace(/\.\w+$/, '');
+    const parsedName = path.parse(name);
+    if (['.js', '.ts'].includes(parsedName.ext)) {
+      // strip extension
+      return parsedName.name;
+    }
+
+    return name;
   }
 
 }

--- a/tests/features/migrations/Migrator.test.ts
+++ b/tests/features/migrations/Migrator.test.ts
@@ -210,6 +210,24 @@ describe('Migrator', () => {
     await expect(migrator.getPendingMigrations()).resolves.toEqual([]);
   });
 
+  test('remove extension only', async () => {
+    await orm.em.getKnex().schema.dropTableIfExists(orm.config.get('migrations').tableName!);
+    const migrator = new Migrator(orm.em);
+    // @ts-ignore
+    const storage = migrator.storage;
+
+    await storage.ensureTable(); // creates the table
+    await storage.logMigration('test.migration.ts'); // can have extension
+    await expect(storage.getExecutedMigrations()).resolves.toMatchObject([{ name: 'test.migration' }]);
+    await expect(storage.executed()).resolves.toEqual(['test.migration.ts']);
+
+    await storage.ensureTable(); // table exists, no-op
+    await storage.unlogMigration('test.migration');
+    await expect(storage.executed()).resolves.toEqual([]);
+
+    await expect(migrator.getPendingMigrations()).resolves.toEqual([]);
+  });
+
   test('runner', async () => {
     await orm.em.getKnex().schema.dropTableIfExists(orm.config.get('migrations').tableName!);
     const migrator = new Migrator(orm.em);


### PR DESCRIPTION
The original code stripped `test.migration.ts` to `test` instead of `test.migration`.
This resulted in migrations reverts (down) failing since the migration file `test.{ext}` does not exist.

Bug introduced in 40367166f9e74a042e2f6314f31877f27a15a14d.