### PR TITLE
fix(postgres): fix runtime support for native pg enum arrays

### DIFF
--- a/packages/postgresql/src/PostgreSqlPlatform.ts
+++ b/packages/postgresql/src/PostgreSqlPlatform.ts
@@ -96,6 +96,14 @@ export class PostgreSqlPlatform extends AbstractSqlPlatform {
     return `{${values.join(',')}}`;
   }
 
+  unmarshallArray(value: string): string[] {
+    if (value === '{}') {
+      return [];
+    }
+
+    return value.substring(1, value.length - 1).split(',');
+  }
+
   getBlobDeclarationSQL(): string {
     return 'bytea';
   }

--- a/tests/issues/GH2583.test.ts
+++ b/tests/issues/GH2583.test.ts
@@ -1,93 +1,60 @@
-import { Entity, MikroORM, PrimaryKey, Enum, EntityManager } from '@mikro-orm/core';
+import { Entity, MikroORM, PrimaryKey, Enum } from '@mikro-orm/core';
 import type { PostgreSqlDriver } from '@mikro-orm/postgresql';
 
 export enum WithEnumArrayValue {
-    First = 'first',
-    Second = 'second',
-    Third = 'third'
+  First = 'first',
+  Second = 'second',
+  Third = 'third',
 }
 
 @Entity()
 export class WithEnumArray {
 
-    @PrimaryKey()
-    id!: number;
+  @PrimaryKey()
+  id!: number;
 
-    @Enum({ items: () => WithEnumArrayValue, array: true })
-    values!: WithEnumArrayValue[];
+  @Enum({ items: () => WithEnumArrayValue, array: true })
+  values: WithEnumArrayValue[] = [];
 
 }
 
-async function getOrmInstance(): Promise<MikroORM<PostgreSqlDriver>> {
-    const orm = await MikroORM.init({
-        entities: [WithEnumArray],
-        dbName: 'mikro_orm_test_2583',
-        type: 'postgresql',
+describe('enum array with native PG enums (GH issue 2583)', () => {
+  let orm: MikroORM<PostgreSqlDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init<PostgreSqlDriver>({
+      entities: [WithEnumArray],
+      dbName: 'mikro_orm_test_2583',
+      type: 'postgresql',
     });
+    await orm.getSchemaGenerator().dropDatabase('mikro_orm_test_2583');
+    await orm.getSchemaGenerator().createDatabase('mikro_orm_test_2583');
+    await orm.em.execute(`
+      create type with_enum_array_value as enum ('first', 'second', 'third');
+      create table with_enum_array (id serial primary key, values with_enum_array_value[] not null);
+    `);
+  });
 
-    return orm as MikroORM<PostgreSqlDriver>;
-}
+  afterAll(async () => {
+    await orm.close();
+  });
 
-describe('GH issue 2583', () => {
-    let orm: MikroORM<PostgreSqlDriver>;
-    let em: EntityManager;
+  test('values are properly marshalled/unmarshalled', async () => {
+    const values = [WithEnumArrayValue.First, WithEnumArrayValue.Second];
+    const entity = new WithEnumArray();
+    entity.values = values;
+    await orm.em.fork().persistAndFlush(entity);
 
-    beforeAll(async () => {
-        orm = await getOrmInstance();
-        await orm.getSchemaGenerator().dropDatabase('mikro_orm_test_2583');
-        await orm.getSchemaGenerator().createDatabase('mikro_orm_test_2583');
-    });
+    const expected = await orm.em.findOneOrFail(WithEnumArray, entity.id);
+    expect(expected.values).toEqual(values);
+  });
 
-    afterAll(async () => {
-        await orm.close();
-    });
+  test('empty array', async () => {
+    const entity = new WithEnumArray();
+    await orm.em.fork().persistAndFlush(entity);
 
-    beforeEach(() => {
-        em = orm.em.fork();
-    });
-
-    describe('enum array values', () => {
-
-        beforeAll(async () => {
-            const orm = await getOrmInstance();
-
-            await orm.em.getConnection().execute(
-                `
-        drop table if exists with_enum_array cascade;
-        drop type if exists with_enum_array_value;
-
-        create type with_enum_array_value as enum ('first', 'second', 'third');
-        create table with_enum_array (id serial primary key, values with_enum_array_value[] not null);
-          `,
-            );
-            await orm.close();
-        });
-
-        afterAll(() => orm.close(true));
-
-        test('values are properly marshalled/unmarshalled', async () => {
-            const values = [WithEnumArrayValue.First, WithEnumArrayValue.Second];
-            const entity = new WithEnumArray();
-            entity.values = values;
-
-            await orm.em.persistAndFlush(entity);
-            orm.em.clear();
-
-            const expected = await orm.em.findOneOrFail(WithEnumArray, entity.id);
-            expect(expected.values).toEqual(values);
-        });
-
-        test('empty array', async () => {
-            const entity = new WithEnumArray();
-            entity.values = [];
-
-            await orm.em.persistAndFlush(entity);
-            orm.em.clear();
-
-            const expected = await orm.em.findOneOrFail(WithEnumArray, entity.id);
-            expect(expected.values).toEqual([]);
-        });
-
-    });
+    const expected = await orm.em.findOneOrFail(WithEnumArray, entity.id);
+    expect(expected.values).toEqual([]);
+  });
 
 });

--- a/tests/issues/GH2583.test.ts
+++ b/tests/issues/GH2583.test.ts
@@ -1,0 +1,93 @@
+import { Entity, MikroORM, PrimaryKey, Enum, EntityManager } from '@mikro-orm/core';
+import type { PostgreSqlDriver } from '@mikro-orm/postgresql';
+
+export enum WithEnumArrayValue {
+    First = 'first',
+    Second = 'second',
+    Third = 'third'
+}
+
+@Entity()
+export class WithEnumArray {
+
+    @PrimaryKey()
+    id!: number;
+
+    @Enum({ items: () => WithEnumArrayValue, array: true })
+    values!: WithEnumArrayValue[];
+
+}
+
+async function getOrmInstance(): Promise<MikroORM<PostgreSqlDriver>> {
+    const orm = await MikroORM.init({
+        entities: [WithEnumArray],
+        dbName: 'mikro_orm_test_2583',
+        type: 'postgresql',
+    });
+
+    return orm as MikroORM<PostgreSqlDriver>;
+}
+
+describe('GH issue 2583', () => {
+    let orm: MikroORM<PostgreSqlDriver>;
+    let em: EntityManager;
+
+    beforeAll(async () => {
+        orm = await getOrmInstance();
+        await orm.getSchemaGenerator().dropDatabase('mikro_orm_test_2583');
+        await orm.getSchemaGenerator().createDatabase('mikro_orm_test_2583');
+    });
+
+    afterAll(async () => {
+        await orm.close();
+    });
+
+    beforeEach(() => {
+        em = orm.em.fork();
+    });
+
+    describe('enum array values', () => {
+
+        beforeAll(async () => {
+            const orm = await getOrmInstance();
+
+            await orm.em.getConnection().execute(
+                `
+        drop table if exists with_enum_array cascade;
+        drop type if exists with_enum_array_value;
+
+        create type with_enum_array_value as enum ('first', 'second', 'third');
+        create table with_enum_array (id serial primary key, values with_enum_array_value[] not null);
+          `,
+            );
+            await orm.close();
+        });
+
+        afterAll(() => orm.close(true));
+
+        test('values are properly marshalled/unmarshalled', async () => {
+            const values = [WithEnumArrayValue.First, WithEnumArrayValue.Second];
+            const entity = new WithEnumArray();
+            entity.values = values;
+
+            await orm.em.persistAndFlush(entity);
+            orm.em.clear();
+
+            const expected = await orm.em.findOneOrFail(WithEnumArray, entity.id);
+            expect(expected.values).toEqual(values);
+        });
+
+        test('empty array', async () => {
+            const entity = new WithEnumArray();
+            entity.values = [];
+
+            await orm.em.persistAndFlush(entity);
+            orm.em.clear();
+
+            const expected = await orm.em.findOneOrFail(WithEnumArray, entity.id);
+            expect(expected.values).toEqual([]);
+        });
+
+    });
+
+});


### PR DESCRIPTION
Adding support for pg native enum arrays, for example:

```ts
export enum WithEnumArrayValue {
    First = 'first',
    Second = 'second',
    Third = 'third'
}

@Entity()
export class WithEnumArray {
    @PrimaryKey()
    id!: number;

    @Enum({ name: 'values', nullable: false, items: () => WithEnumArrayValue, array: true })
    values!: WithEnumArrayValue[];
}
```

Looks like it works fine, but not sure it will work for all cases.

Closes #2583