### PR TITLE
refactor(seeder): path like migrations

### DIFF
--- a/docs/docs/seeding.md
+++ b/docs/docs/seeding.md
@@ -154,13 +154,13 @@ const books: Book[] = new BookFactory(orm.em).each(book => {
 }).make(5);
 ``` 
 
-## Default settings
+## Configuration
 The seeder has a few default settings that can be changed easily through the MikroORM config. Underneath you find the configuration options with their defaults.
 ```ts
 MikroORM.init({
     seeder: {
-        path: './database/seeders/', 
-        defaultSeeder: 'DatabaseSeeder'
+        path: './seeders', // path to the folder with seeders
+        defaultSeeder: 'DatabaseSeeder' // default seeder class name
     }
 });
 ```
@@ -198,7 +198,9 @@ beforeAll(async () => {
     const seeder = orm.getSeeder();
     
     // Refresh the database to start clean
-    await seeder.refreshDatabase();
+    await orm.getSchemaGenerator().refreshDatabase();
+    // Or for mongo
+    await orm.em.getDriver().refreshCollections();
     
     // Seed using a seeder defined by you
     await seeder.seed(DatabaseSeeder);

--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -153,7 +153,7 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
   getSeeder<T extends ISeedManager = ISeedManager>(): T {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { SeedManager } = require('@mikro-orm/seeder');
-    return new SeedManager(this);
+    return new SeedManager(this.em);
   }
 
 }

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -629,10 +629,9 @@ export interface HydratorConstructor {
 }
 
 export interface ISeedManager {
-  refreshDatabase(): Promise<void>;
   seed(...seederClasses: { new(): Seeder }[]): Promise<void>;
   seedString(...seederClasses: string[]): Promise<void>;
-  createSeeder(seederClass: string): Promise<void>;
+  createSeeder(seederClass: string): Promise<string>;
 }
 
 export interface Seeder {

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -100,7 +100,10 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     },
     metadataProvider: ReflectMetadataProvider,
     highlighter: new NullHighlighter(),
-    seeder: { path: './database/seeder', defaultSeeder: 'DatabaseSeeder' },
+    seeder: {
+      path: './seeders',
+      defaultSeeder: 'DatabaseSeeder',
+    },
   };
 
   static readonly PLATFORMS = {

--- a/packages/knex/src/schema/SchemaGenerator.ts
+++ b/packages/knex/src/schema/SchemaGenerator.ts
@@ -54,6 +54,11 @@ export class SchemaGenerator {
     return false;
   }
 
+  async refreshDatabase(): Promise<void> {
+    await this.dropSchema();
+    await this.createSchema();
+  }
+
   getTargetSchema(schema?: string): DatabaseSchema {
     const metadata = this.getOrderedMetadata(schema);
     return DatabaseSchema.fromMetadata(metadata, this.platform, this.config, schema);

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -122,6 +122,17 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     await this.rethrow(Promise.all(promises));
   }
 
+  async refreshCollections(options: RefreshCollectionsOptions = {}): Promise<void> {
+    options.ensureIndexes ??= true;
+
+    await this.dropCollections();
+    await this.createCollections();
+
+    if (options.ensureIndexes) {
+      await this.ensureIndexes();
+    }
+  }
+
   async ensureIndexes(): Promise<void> {
     await this.rethrow(this.createCollections());
     const promises: Promise<string>[] = [];
@@ -310,4 +321,9 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     return ret.length > 0 ? ret : undefined;
   }
 
+}
+
+export interface RefreshCollectionsOptions {
+  /** create indexes? defaults to true */
+  ensureIndexes?: boolean;
 }

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -169,6 +169,33 @@ describe('EntityManagerMongo', () => {
     expect(collections).toContain('foo-bar');
   });
 
+  test('refresh collections', async () => {
+    const driver = orm.em.getDriver();
+    const createCollection = jest.spyOn(MongoDriver.prototype, 'createCollections');
+    const dropCollections = jest.spyOn(MongoDriver.prototype, 'dropCollections');
+    const ensureIndexes = jest.spyOn(MongoDriver.prototype, 'ensureIndexes');
+
+    createCollection.mockImplementation(() => Promise.resolve());
+    dropCollections.mockImplementation(() => Promise.resolve());
+    ensureIndexes.mockImplementation(() => Promise.resolve());
+
+    await driver.refreshCollections();
+
+    expect(dropCollections).toBeCalledTimes(1);
+    expect(createCollection).toBeCalledTimes(1);
+    expect(ensureIndexes).toBeCalledTimes(1);
+
+    await driver.refreshCollections({ ensureIndexes: false });
+
+    expect(dropCollections).toBeCalledTimes(2);
+    expect(createCollection).toBeCalledTimes(2);
+    expect(ensureIndexes).toBeCalledTimes(1);
+
+    createCollection.mockRestore();
+    dropCollections.mockRestore();
+    ensureIndexes.mockRestore();
+  });
+
   test('should provide custom repository', async () => {
     const repo = orm.em.getRepository(Author);
     expect(repo).toBeInstanceOf(AuthorRepository);

--- a/tests/features/schema-generator/SchemaGenerator.mysql.test.ts
+++ b/tests/features/schema-generator/SchemaGenerator.mysql.test.ts
@@ -313,4 +313,24 @@ describe('SchemaGenerator', () => {
     await orm.close(true);
   });
 
+  test('refreshDatabase [mysql]', async () => {
+    const orm = await initORMMySql('mysql', {}, true);
+
+    const dropSchema = jest.spyOn(SchemaGenerator.prototype, 'dropSchema');
+    const createSchema = jest.spyOn(SchemaGenerator.prototype, 'createSchema');
+
+    dropSchema.mockImplementation(() => Promise.resolve());
+    createSchema.mockImplementation(() => Promise.resolve());
+
+    const generator = new SchemaGenerator(orm.em);
+    await generator.refreshDatabase();
+
+    expect(dropSchema).toBeCalledTimes(1);
+    expect(createSchema).toBeCalledTimes(1);
+
+    dropSchema.mockRestore();
+    createSchema.mockRestore();
+
+    await orm.close(true);
+  });
 });

--- a/tests/features/seeder/seed-manager.test.ts
+++ b/tests/features/seeder/seed-manager.test.ts
@@ -28,13 +28,6 @@ describe('MikroOrmSeeder', () => {
 
   afterAll(async () => await orm.close(true));
 
-  test('refreshDatabase', async () => {
-    const seeder = orm.getSeeder();
-    await seeder.refreshDatabase();
-    expect(dropSchema).toHaveBeenCalledTimes(1);
-    expect(createSchema).toHaveBeenCalledTimes(1);
-  });
-
   test('seed', async () => {
     const seeder = orm.getSeeder();
     const bookRunMock = jest.spyOn(Book3Seeder.prototype, 'run');
@@ -50,7 +43,7 @@ describe('MikroOrmSeeder', () => {
   });
 
   test('seedString', async () => {
-    orm.config.set('seeder', { path: 'tests/database/seeder', defaultSeeder: 'DatabaseSeeder' });
+    orm.config.set('seeder', { path: './database/seeder', defaultSeeder: 'DatabaseSeeder' });
     const seeder = orm.getSeeder();
     const seedMock = jest.spyOn(SeedManager.prototype, 'seed');
 
@@ -61,13 +54,13 @@ describe('MikroOrmSeeder', () => {
   });
 
   test('createSeeder', async () => {
-    orm.config.set('seeder', { path: './database/seeder', defaultSeeder: 'DatabaseSeeder' });
+    orm.config.set('seeder', { path: process.cwd() + '/temp/seeders', defaultSeeder: 'DatabaseSeeder' });
     const seeder = orm.getSeeder();
 
-    const seederFile = await seeder.createSeeder('Book3Seeder');
-    expect(seederFile).toBe(`./database/seeder/book3.seeder.ts`);
-    const fileContents = await readFile(`./database/seeder/book3.seeder.ts`, 'utf8');
-    expect(fileContents).toContain('export class Book3Seeder extends Seeder {');
-    await remove('./database');
+    const seederFile = await seeder.createSeeder('Publisher3Seeder');
+    expect(seederFile).toBe(process.cwd() + `/temp/seeders/publisher3.seeder.ts`);
+    const fileContents = await readFile(seederFile, 'utf8');
+    expect(fileContents).toContain('export class Publisher3Seeder extends Seeder {');
+    await remove(seederFile);
   });
 });


### PR DESCRIPTION
Hello

refactored seeder to be more consistent to migration package (`path` processing and default path): i think we shouldn't prepend `process.cwd()` to user provided path

deleted method `refreshDatabase`. `SchemaGenerator` exist only when user uses sql, but seeder for mongodb and custom drivers too, so user can explicit call `dropSchema` and `createSchema` methods on `SchemaGenerator`

BREAKING CHANGE:
- default seeders path: `./seeders` instead `./database/seeder` (like migrations `./migrations`). 
- removed `refreshDatabase` method on `SeedManager`

