### PR TITLE
refactor: fix path on windows for esmodules

### DIFF
--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -3,6 +3,8 @@ import clone from 'clone';
 import type { GlobbyOptions } from 'globby';
 import globby from 'globby';
 import { extname, isAbsolute, join, normalize, relative, resolve } from 'path';
+import { platform } from 'os';
+import { pathToFileURL } from 'url'
 import { pathExists } from 'fs-extra';
 import { createHash } from 'crypto';
 import { recovery } from 'escaya';
@@ -604,8 +606,8 @@ export class Utils {
       // eslint-disable-next-line no-prototype-builtins
       && (value.constructor.prototype.hasOwnProperty('isPrototypeOf') || Object.getPrototypeOf(value.constructor.prototype) === null)
     )
-    || (value && Object.getPrototypeOf(value) === null)
-    || value instanceof PlainObject;
+      || (value && Object.getPrototypeOf(value) === null)
+      || value instanceof PlainObject;
   }
 
   /**
@@ -760,6 +762,10 @@ export class Utils {
   static async dynamicImport<T = any>(id: string): Promise<T> {
     if (!process.env.MIKRO_ORM_DYNAMIC_IMPORTS) {
       return import(id);
+    }
+
+    if (platform() === 'win32') {
+      id = pathToFileURL(id).toString();
     }
 
     /* istanbul ignore next */

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -4,7 +4,7 @@ import type { GlobbyOptions } from 'globby';
 import globby from 'globby';
 import { extname, isAbsolute, join, normalize, relative, resolve } from 'path';
 import { platform } from 'os';
-import { pathToFileURL } from 'url'
+import { pathToFileURL } from 'url';
 import { pathExists } from 'fs-extra';
 import { createHash } from 'crypto';
 import { recovery } from 'escaya';

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -764,6 +764,7 @@ export class Utils {
       return import(id);
     }
 
+    /* istanbul ignore next */
     if (platform() === 'win32') {
       id = pathToFileURL(id).toString();
     }


### PR DESCRIPTION
I was no able to remove those `eslint` things on line 609-610.

This closes https://github.com/mikro-orm/mikro-orm/issues/2631#issuecomment-1013506198.

Edit: I would really appreciate if you can merge this since I really can't work on windows without this. ( only with `wsl` and that is really slow ).