### PR TITLE
feat(mongo): add `SchemaGenerator` support for mongo

### DIFF
--- a/docs/docs/usage-with-mongo.md
+++ b/docs/docs/usage-with-mongo.md
@@ -83,7 +83,7 @@ are several things you need to respect:
     - use `implicitTransactions: true` to enable them globally
     - or use explicit transaction demarcation via `em.transactional()`
 - you need to explicitly create all collections before working with them
-    - use `em.getDriver().createCollections()` method to do so
+    - use `orm.getSchemaGenerator().createSchema()` method to do so
 
 ```sh
 # first create replica set
@@ -102,7 +102,7 @@ const orm = await MikroORM.init<MongoDriver>({
   implicitTransactions: true, // defaults to false
 });
 
-await orm.em.getDriver().createCollections();
+await orm.getSchemaGenerator().createSchema();
 ```
 
 > The `createCollections` method is present on the `MongoDriver` class only. You need 
@@ -124,10 +124,12 @@ const orm = await MikroORM.init<MongoDriver>({
 });
 ``` 
 
-Alternatively you can call `ensureIndexes()` method on the `MongoDriver`:
+Alternatively you can call `ensureIndexes()` method on the `SchemaGenerator`:
+
+> SchemaGenerator support for mongo was introduced in v5.
 
 ```typescript
-await orm.em.getDriver().ensureIndexes();
+await orm.getSchemaGenerator().ensureIndexes();
 ```
 
 > You can pass additional index/unique options via `options` parameter:

--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -5,7 +5,7 @@ import type { Logger } from './logging';
 import { Configuration, ConfigurationLoader, Utils } from './utils';
 import { NullCacheAdapter } from './cache';
 import type { EntityManager } from './EntityManager';
-import type { AnyEntity, Constructor, IEntityGenerator, IMigrator, ISchemaGenerator, ISeedManager } from './typings';
+import type { AnyEntity, Constructor, IEntityGenerator, IMigrator, ISeedManager } from './typings';
 import { colors } from './logging';
 
 /**
@@ -45,7 +45,7 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
       await orm.connect();
 
       if (orm.config.get('ensureIndexes')) {
-        await orm.driver.ensureIndexes();
+        await orm.getSchemaGenerator().ensureIndexes();
       }
     }
 
@@ -132,8 +132,8 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Gets the SchemaGenerator.
    */
-  getSchemaGenerator<T extends ISchemaGenerator = ISchemaGenerator>(): T {
-    return this.driver.getPlatform().getSchemaGenerator(this.em) as T;
+  getSchemaGenerator(): ReturnType<ReturnType<D['getPlatform']>['getSchemaGenerator']> {
+    return this.driver.getPlatform().getSchemaGenerator(this.driver) as any;
   }
 
   /**

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -121,6 +121,10 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     });
   }
 
+  getMetadata(): MetadataStorage {
+    return this.metadata;
+  }
+
   getDependencies(): string[] {
     return this.dependencies;
   }

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -9,12 +9,14 @@ import type { MetadataStorage } from '../metadata';
 import type { Collection } from '../entity';
 import type { EntityManager } from '../EntityManager';
 import type { DriverException } from '../exceptions';
+import type { Configuration } from '../utils/Configuration';
 
 export const EntityManagerType = Symbol('EntityManagerType');
 
 export interface IDatabaseDriver<C extends Connection = Connection> {
 
   [EntityManagerType]: EntityManager<this>;
+  readonly config: Configuration;
 
   createEntityManager<D extends IDatabaseDriver = IDatabaseDriver>(useContext?: boolean): D[typeof EntityManagerType];
 
@@ -62,6 +64,8 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   getPlatform(): Platform;
 
   setMetadata(metadata: MetadataStorage): void;
+
+  getMetadata(): MetadataStorage;
 
   ensureIndexes(): Promise<void>;
 

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -960,6 +960,7 @@ export class MetadataDiscovery {
   private async initEnumValues(prop: EntityProperty, path: string): Promise<void> {
     path = Utils.normalizePath(this.config.get('baseDir'), path);
     const exports = await Utils.dynamicImport(path);
+    /* istanbul ignore next */
     const target = exports[prop.type] || exports.default;
 
     if (target) {

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -6,6 +6,7 @@ import type { AnyEntity, Constructor, EntityProperty, IEntityGenerator, IMigrato
 import { ExceptionConverter } from './ExceptionConverter';
 import type { EntityManager } from '../EntityManager';
 import type { Configuration } from '../utils/Configuration';
+import type { IDatabaseDriver } from '../drivers/IDatabaseDriver';
 import {
   ArrayType, BigIntType, BlobType, BooleanType, DateType, DecimalType, DoubleType, JsonType, SmallIntType, TimeType,
   TinyIntType, Type, UuidType, StringType, IntegerType, FloatType, DateTimeType, TextType, EnumType, UnknownType,
@@ -304,8 +305,8 @@ export abstract class Platform {
     return this.exceptionConverter;
   }
 
-  getSchemaGenerator(em: EntityManager): ISchemaGenerator {
-    throw new Error(`${this.constructor.name} does not support SchemaGenerator`);
+  getSchemaGenerator(driver: IDatabaseDriver): ISchemaGenerator {
+    throw new Error(`${driver.constructor.name} does not support SchemaGenerator`);
   }
 
   getEntityGenerator(em: EntityManager): IEntityGenerator {

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -438,6 +438,7 @@ export interface ISchemaGenerator {
   createDatabase(name: string): Promise<void>;
   dropDatabase(name: string): Promise<void>;
   execute(sql: string, options?: { wrap?: boolean }): Promise<void>;
+  ensureIndexes(): Promise<void>;
 }
 
 export interface IEntityGenerator {

--- a/packages/core/src/utils/AbstractSchemaGenerator.ts
+++ b/packages/core/src/utils/AbstractSchemaGenerator.ts
@@ -1,0 +1,103 @@
+import type { EntityMetadata, ISchemaGenerator } from '../typings';
+import { CommitOrderCalculator } from '../unit-of-work/CommitOrderCalculator';
+import type { IDatabaseDriver } from '../drivers/IDatabaseDriver';
+
+export abstract class AbstractSchemaGenerator<D extends IDatabaseDriver> implements ISchemaGenerator {
+
+  protected readonly config = this.driver.config;
+  protected readonly metadata = this.driver.getMetadata();
+  protected readonly platform: ReturnType<D['getPlatform']> = this.driver.getPlatform() as ReturnType<D['getPlatform']>;
+  protected readonly connection: ReturnType<D['getConnection']> = this.driver.getConnection() as ReturnType<D['getConnection']>;
+
+  constructor(protected readonly driver: D) { }
+
+  async generate(): Promise<string> {
+    this.notImplemented();
+  }
+
+  async createSchema(): Promise<void> {
+    this.notImplemented();
+  }
+
+  /**
+   * Returns true if the database was created.
+   */
+  async ensureDatabase(): Promise<boolean> {
+    this.notImplemented();
+  }
+
+  async refreshDatabase(): Promise<void> {
+    await this.dropSchema();
+    await this.createSchema();
+  }
+
+  async getCreateSchemaSQL(): Promise<string> {
+    this.notImplemented();
+  }
+
+  async dropSchema(): Promise<void> {
+    this.notImplemented();
+  }
+
+  async getDropSchemaSQL(): Promise<string> {
+    this.notImplemented();
+  }
+
+  async updateSchema(): Promise<void> {
+    this.notImplemented();
+  }
+
+  async getUpdateSchemaSQL(): Promise<string> {
+    this.notImplemented();
+  }
+
+  async getUpdateSchemaMigrationSQL(): Promise<{ up: string; down: string }> {
+    this.notImplemented();
+  }
+
+  /**
+   * creates new database and connects to it
+   */
+  async createDatabase(name: string): Promise<void> {
+    this.notImplemented();
+  }
+
+  async dropDatabase(name: string): Promise<void> {
+    this.notImplemented();
+  }
+
+  async execute(query: string) {
+    this.notImplemented();
+  }
+
+  async ensureIndexes() {
+    this.notImplemented();
+  }
+
+  protected getOrderedMetadata(schema?: string): EntityMetadata[] {
+    const metadata = Object.values(this.metadata.getAll()).filter(meta => {
+      const isRootEntity = meta.root.className === meta.className;
+      return isRootEntity && !meta.embeddable;
+    });
+    const calc = new CommitOrderCalculator();
+    metadata.forEach(meta => calc.addNode(meta.root.className));
+    let meta = metadata.pop();
+
+    while (meta) {
+      for (const prop of meta.props) {
+        calc.discoverProperty(prop, meta.root.className);
+      }
+
+      meta = metadata.pop();
+    }
+
+    return calc.sort()
+      .map(cls => this.metadata.find(cls)!)
+      .filter(meta => schema ? [schema, '*'].includes(meta.schema!) : meta.schema !== '*');
+  }
+
+  protected notImplemented(): never {
+    throw new Error(`This method is not supported by ${this.driver.constructor.name} driver`);
+  }
+
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from './TransactionContext';
 export * from './QueryHelper';
 export * from './NullHighlighter';
 export * from './EntityComparator';
+export * from './AbstractSchemaGenerator';

--- a/packages/knex/src/AbstractSqlPlatform.ts
+++ b/packages/knex/src/AbstractSqlPlatform.ts
@@ -1,5 +1,5 @@
 import { escape } from 'sqlstring';
-import type { Constructor, EntityManager, EntityRepository } from '@mikro-orm/core';
+import type { Constructor, EntityManager, EntityRepository, IDatabaseDriver } from '@mikro-orm/core';
 import { JsonProperty, Platform, Utils } from '@mikro-orm/core';
 import { SqlEntityRepository } from './SqlEntityRepository';
 import type { SchemaHelper } from './schema';
@@ -25,8 +25,8 @@ export abstract class AbstractSqlPlatform extends Platform {
     return this.schemaHelper;
   }
 
-  getSchemaGenerator(em: EntityManager): SchemaGenerator {
-    return new SchemaGenerator(em as any); // cast as `any` to get around circular dependencies
+  getSchemaGenerator(driver: IDatabaseDriver): SchemaGenerator {
+    return new SchemaGenerator(driver as any); // cast as `any` to get around circular dependencies
   }
 
   getEntityGenerator(em: EntityManager) {

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -1,8 +1,9 @@
 import type { ClientSession } from 'mongodb';
 import { ObjectId } from 'bson';
 import type {
-  EntityData, AnyEntity, FilterQuery, EntityMetadata, EntityProperty, Configuration, FindOneOptions, FindOptions,
-  QueryResult, Transaction, IDatabaseDriver, EntityManager, Dictionary, PopulateOptions, CountOptions, EntityDictionary, EntityField, NativeInsertUpdateOptions, NativeInsertUpdateManyOptions,
+  EntityData, AnyEntity, FilterQuery, Configuration, FindOneOptions, FindOptions,
+  QueryResult, Transaction, IDatabaseDriver, EntityManager, Dictionary, PopulateOptions,
+  CountOptions, EntityDictionary, EntityField, NativeInsertUpdateOptions, NativeInsertUpdateManyOptions,
 } from '@mikro-orm/core';
 import {
   DatabaseDriver, Utils, ReferenceType, EntityManagerType,
@@ -10,6 +11,7 @@ import {
 import { MongoConnection } from './MongoConnection';
 import { MongoPlatform } from './MongoPlatform';
 import { MongoEntityManager } from './MongoEntityManager';
+import type { CreateSchemaOptions } from './MongoSchemaGenerator';
 
 export class MongoDriver extends DatabaseDriver<MongoConnection> {
 
@@ -97,115 +99,8 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     return this.rethrow(this.getConnection('read').aggregate(entityName, pipeline, ctx));
   }
 
-  async createCollections(): Promise<void> {
-    const existing = await this.getConnection('write').listCollections();
-    const metadata = Object.values(this.metadata.getAll()).filter(meta => {
-      const isRootEntity = meta.root.className === meta.className;
-      return isRootEntity && !meta.embeddable;
-    });
-
-    const promises = metadata
-      .filter(meta => !existing.includes(meta.collection))
-      .map(meta => this.getConnection('write').createCollection(meta.collection));
-
-    await this.rethrow(Promise.all(promises));
-  }
-
-  async dropCollections(): Promise<void> {
-    const db = this.getConnection('write').getDb();
-    const collections = await this.rethrow(db.listCollections().toArray());
-    const existing = collections.map(c => c.name);
-    const promises = Object.values(this.metadata.getAll())
-      .filter(meta => existing.includes(meta.collection))
-      .map(meta => this.getConnection('write').dropCollection(meta.collection));
-
-    await this.rethrow(Promise.all(promises));
-  }
-
-  async refreshCollections(options: RefreshCollectionsOptions = {}): Promise<void> {
-    options.ensureIndexes ??= true;
-
-    await this.dropCollections();
-    await this.createCollections();
-
-    if (options.ensureIndexes) {
-      await this.ensureIndexes();
-    }
-  }
-
-  async ensureIndexes(): Promise<void> {
-    await this.rethrow(this.createCollections());
-    const promises: Promise<string>[] = [];
-
-    for (const meta of Object.values(this.metadata.getAll())) {
-      promises.push(...this.createIndexes(meta));
-      promises.push(...this.createUniqueIndexes(meta));
-
-      for (const prop of meta.props) {
-        promises.push(...this.createPropertyIndexes(meta, prop, 'index'));
-        promises.push(...this.createPropertyIndexes(meta, prop, 'unique'));
-      }
-    }
-
-    await this.rethrow(Promise.all(promises));
-  }
-
-  private createIndexes(meta: EntityMetadata) {
-    const promises: Promise<string>[] = [];
-    meta.indexes.forEach(index => {
-      let fieldOrSpec: string | Dictionary;
-      const properties = Utils.flatten(Utils.asArray(index.properties).map(prop => meta.properties[prop].fieldNames));
-      const collection = this.getConnection('write').getCollection(meta.name!);
-
-      if (index.options && properties.length === 0) {
-        return promises.push(collection.createIndex(index.options));
-      }
-
-      if (index.type) {
-        const spec: Dictionary<string> = {};
-        properties.forEach(prop => spec[prop] = index.type!);
-        fieldOrSpec = spec;
-      } else {
-        fieldOrSpec = properties.reduce((o, i) => { o[i] = 1; return o; }, {});
-      }
-
-      promises.push(collection.createIndex(fieldOrSpec, {
-        name: index.name,
-        unique: false,
-        ...(index.options || {}),
-      }));
-    });
-
-    return promises;
-  }
-
-  private createUniqueIndexes(meta: EntityMetadata) {
-    const promises: Promise<string>[] = [];
-    meta.uniques.forEach(index => {
-      const properties = Utils.flatten(Utils.asArray(index.properties).map(prop => meta.properties[prop].fieldNames));
-      const fieldOrSpec = properties.reduce((o, i) => { o[i] = 1; return o; }, {});
-      promises.push(this.getConnection('write').getCollection(meta.name!).createIndex(fieldOrSpec, {
-        name: index.name,
-        unique: true,
-        ...(index.options || {}),
-      }));
-    });
-
-    return promises;
-  }
-
-  private createPropertyIndexes(meta: EntityMetadata, prop: EntityProperty, type: 'index' | 'unique') {
-    if (!prop[type]) {
-      return [];
-    }
-
-    const fieldOrSpec = prop.fieldNames.reduce((o, i) => { o[i] = 1; return o; }, {});
-
-    return [this.getConnection('write').getCollection(meta.name!).createIndex(fieldOrSpec, {
-      name: (Utils.isString(prop[type]) ? prop[type] : undefined) as string,
-      unique: type === 'unique',
-      sparse: prop.nullable === true,
-    })];
+  getPlatform(): MongoPlatform {
+    return this.platform;
   }
 
   private renameFields<T>(entityName: string, data: T, where = false): T {
@@ -321,9 +216,32 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     return ret.length > 0 ? ret : undefined;
   }
 
-}
+  /**
+   * @deprecated use `orm.getSchemaGenerator().createSchema()` instead
+   */
+  async createCollections(): Promise<void> {
+    await this.platform.getSchemaGenerator(this).createSchema();
+  }
 
-export interface RefreshCollectionsOptions {
-  /** create indexes? defaults to true */
-  ensureIndexes?: boolean;
+  /**
+   * @deprecated use `orm.getSchemaGenerator().dropSchema()` instead
+   */
+  async dropCollections(): Promise<void> {
+    await this.platform.getSchemaGenerator(this).dropSchema();
+  }
+
+  /**
+   * @deprecated use `orm.getSchemaGenerator().dropSchema()` instead
+   */
+  async refreshCollections(options: CreateSchemaOptions = {}): Promise<void> {
+    await this.platform.getSchemaGenerator(this).refreshCollections(options);
+  }
+
+  /**
+   * @deprecated use `orm.getSchemaGenerator().ensureIndexes()` instead
+   */
+  async ensureIndexes(): Promise<void> {
+    await this.platform.getSchemaGenerator(this).ensureIndexes();
+  }
+
 }

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -1,8 +1,9 @@
 import { ObjectId } from 'bson';
-import type { IPrimaryKey, Primary, NamingStrategy, Constructor, EntityRepository, EntityProperty, PopulateOptions, EntityMetadata } from '@mikro-orm/core';
+import type { IPrimaryKey, Primary, NamingStrategy, Constructor, EntityRepository, EntityProperty, PopulateOptions, EntityMetadata, IDatabaseDriver } from '@mikro-orm/core';
 import { Platform, MongoNamingStrategy, Utils, ReferenceType, MetadataError } from '@mikro-orm/core';
 import { MongoExceptionConverter } from './MongoExceptionConverter';
 import { MongoEntityRepository } from './MongoEntityRepository';
+import { MongoSchemaGenerator } from './MongoSchemaGenerator';
 
 export class MongoPlatform extends Platform {
 
@@ -14,6 +15,10 @@ export class MongoPlatform extends Platform {
 
   getRepositoryClass<T>(): Constructor<EntityRepository<T>> {
     return MongoEntityRepository;
+  }
+
+  getSchemaGenerator(driver: IDatabaseDriver): MongoSchemaGenerator {
+    return new MongoSchemaGenerator(driver as any); // cast as `any` to get around circular dependencies
   }
 
   normalizePrimaryKey<T extends number | string = number | string>(data: Primary<T> | IPrimaryKey | ObjectId): T {

--- a/packages/mongodb/src/MongoSchemaGenerator.ts
+++ b/packages/mongodb/src/MongoSchemaGenerator.ts
@@ -1,0 +1,143 @@
+import type { Dictionary, EntityMetadata, EntityProperty } from '@mikro-orm/core';
+import { AbstractSchemaGenerator, Utils } from '@mikro-orm/core';
+import type { MongoDriver } from './MongoDriver';
+
+export class MongoSchemaGenerator extends AbstractSchemaGenerator<MongoDriver> {
+
+  async createSchema(options: CreateSchemaOptions = {}): Promise<void> {
+    options.ensureIndexes ??= true;
+    const existing = await this.connection.listCollections();
+    const metadata = this.getOrderedMetadata();
+
+    const promises = metadata
+      .filter(meta => !existing.includes(meta.collection))
+      .map(meta => this.connection.createCollection(meta.collection));
+
+    if (options.ensureIndexes) {
+      await this.ensureIndexes({ ensureCollections: false });
+    }
+
+    await Promise.all(promises);
+  }
+
+  async dropSchema(): Promise<void> {
+    const db = this.connection.getDb();
+    const collections = await db.listCollections().toArray();
+    const existing = collections.map(c => c.name);
+    const metadata = this.getOrderedMetadata();
+    const promises = metadata
+      .filter(meta => existing.includes(meta.collection))
+      .map(meta => this.connection.dropCollection(meta.collection));
+
+    await Promise.all(promises);
+  }
+
+  async updateSchema(options: CreateSchemaOptions = {}): Promise<void> {
+    await this.createSchema(options);
+  }
+
+  async refreshCollections(options: CreateSchemaOptions = {}): Promise<void> {
+    options.ensureIndexes ??= true;
+
+    await this.dropSchema();
+    await this.createSchema();
+
+    if (options.ensureIndexes) {
+      await this.ensureIndexes();
+    }
+  }
+
+  async ensureIndexes(options: EnsureIndexesOptions = {}): Promise<void> {
+    options.ensureCollections ??= true;
+
+    if (options.ensureCollections) {
+      await this.createSchema({ ensureIndexes: false });
+    }
+
+    const promises: Promise<string>[] = [];
+
+    for (const meta of Object.values(this.metadata.getAll())) {
+      promises.push(...this.createIndexes(meta));
+      promises.push(...this.createUniqueIndexes(meta));
+
+      for (const prop of meta.props) {
+        promises.push(...this.createPropertyIndexes(meta, prop, 'index'));
+        promises.push(...this.createPropertyIndexes(meta, prop, 'unique'));
+      }
+    }
+
+    await Promise.all(promises);
+  }
+
+  private createIndexes(meta: EntityMetadata) {
+    const promises: Promise<string>[] = [];
+    meta.indexes.forEach(index => {
+      let fieldOrSpec: string | Dictionary;
+      const properties = Utils.flatten(Utils.asArray(index.properties).map(prop => meta.properties[prop].fieldNames));
+      const collection = this.connection.getCollection(meta.name!);
+
+      if (index.options && properties.length === 0) {
+        return promises.push(collection.createIndex(index.options));
+      }
+
+      if (index.type) {
+        const spec: Dictionary<string> = {};
+        properties.forEach(prop => spec[prop] = index.type!);
+        fieldOrSpec = spec;
+      } else {
+        fieldOrSpec = properties.reduce((o, i) => { o[i] = 1; return o; }, {});
+      }
+
+      promises.push(collection.createIndex(fieldOrSpec, {
+        name: index.name,
+        unique: false,
+        ...(index.options || {}),
+      }));
+    });
+
+    return promises;
+  }
+
+  private createUniqueIndexes(meta: EntityMetadata) {
+    const promises: Promise<string>[] = [];
+    meta.uniques.forEach(index => {
+      const properties = Utils.flatten(Utils.asArray(index.properties).map(prop => meta.properties[prop].fieldNames));
+      const fieldOrSpec = properties.reduce((o, i) => { o[i] = 1; return o; }, {});
+      promises.push(this.connection.getCollection(meta.name!).createIndex(fieldOrSpec, {
+        name: index.name,
+        unique: true,
+        ...(index.options || {}),
+      }));
+    });
+
+    return promises;
+  }
+
+  private createPropertyIndexes(meta: EntityMetadata, prop: EntityProperty, type: 'index' | 'unique') {
+    if (!prop[type]) {
+      return [];
+    }
+
+    const fieldOrSpec = prop.fieldNames.reduce((o, i) => { o[i] = 1; return o; }, {});
+
+    return [this.connection.getCollection(meta.name!).createIndex(fieldOrSpec, {
+      name: (Utils.isString(prop[type]) ? prop[type] : undefined) as string,
+      unique: type === 'unique',
+      sparse: prop.nullable === true,
+    })];
+  }
+
+}
+
+export interface CreateSchemaOptions {
+  /** create indexes? defaults to true */
+  ensureIndexes?: boolean;
+  /** not valid for mongo driver */
+  wrap?: boolean;
+  /** not valid for mongo driver */
+  schema?: string;
+}
+
+export interface EnsureIndexesOptions {
+  ensureCollections?: boolean;
+}

--- a/packages/mongodb/src/index.ts
+++ b/packages/mongodb/src/index.ts
@@ -4,6 +4,7 @@ export * from './MongoDriver';
 export * from './MongoPlatform';
 export * from './MongoEntityManager';
 export * from './MongoEntityRepository';
+export * from './MongoSchemaGenerator';
 export { MongoEntityManager as EntityManager } from './MongoEntityManager';
 export { MongoEntityRepository as EntityRepository } from './MongoEntityRepository';
 export { ObjectId } from 'bson';

--- a/tests/DatabaseDriver.test.ts
+++ b/tests/DatabaseDriver.test.ts
@@ -6,7 +6,13 @@ import type {
   FindOneOptions,
   FindOptions, Primary,
   QueryResult,
-  Transaction } from '@mikro-orm/core';
+  Transaction,
+  IDatabaseDriver,
+  AnyEntity,
+  EntityDictionary,
+  NativeInsertUpdateManyOptions,
+  NativeInsertUpdateOptions,
+} from '@mikro-orm/core';
 import {
   Configuration,
   DatabaseDriver,
@@ -18,7 +24,7 @@ import {
 
 class Platform1 extends Platform { }
 
-class Driver extends DatabaseDriver<Connection> {
+class Driver extends DatabaseDriver<Connection> implements IDatabaseDriver {
 
   protected readonly platform = new Platform1();
 
@@ -43,11 +49,11 @@ class Driver extends DatabaseDriver<Connection> {
     return { affectedRows: 0, insertId: 0 as Primary<T> };
   }
 
-  async nativeInsert<T>(entityName: string, data: EntityData<T>, ctx: Transaction | undefined): Promise<QueryResult<T>> {
+  async nativeInsert<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>, options?: NativeInsertUpdateOptions<T>): Promise<QueryResult<T>> {
     return { affectedRows: 0, insertId: 0 as Primary<T> };
   }
 
-  async nativeInsertMany<T>(entityName: string, data: EntityData<T>[], ctx: Transaction | undefined): Promise<QueryResult<T>> {
+  async nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>[], options?: NativeInsertUpdateManyOptions<T>): Promise<QueryResult<T>> {
     return { affectedRows: 0, insertId: 0 as Primary<T> };
   }
 
@@ -59,7 +65,7 @@ class Driver extends DatabaseDriver<Connection> {
 
 describe('DatabaseDriver', () => {
 
-  test('should load entities', async () => {
+  test('default validations', async () => {
     const config = new Configuration({ type: 'mongo', allowGlobalContext: true } as any, false);
     const driver = new Driver(config, []);
     expect(driver.createEntityManager()).toBeInstanceOf(EntityManager);
@@ -71,6 +77,7 @@ describe('DatabaseDriver', () => {
     const e1 = driver.convertException(new Error('test'));
     const e2 = driver.convertException(e1);
     expect(e1).toBe(e2);
+    expect(() => driver.getPlatform().getSchemaGenerator(driver)).toThrowError('Driver does not support SchemaGenerator');
   });
 
 });

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -159,43 +159,6 @@ describe('EntityManagerMongo', () => {
     await orm.em.getRepository(Book).remove(lastBook[0]).flush();
   });
 
-  test('create/drop collection', async () => {
-    const driver = orm.em.getDriver();
-    await driver.getConnection().dropCollection(FooBar);
-    let collections = await driver.getConnection().listCollections();
-    expect(collections).not.toContain('foo-bar');
-    await driver.createCollections();
-    collections = await driver.getConnection().listCollections();
-    expect(collections).toContain('foo-bar');
-  });
-
-  test('refresh collections', async () => {
-    const driver = orm.em.getDriver();
-    const createCollection = jest.spyOn(MongoDriver.prototype, 'createCollections');
-    const dropCollections = jest.spyOn(MongoDriver.prototype, 'dropCollections');
-    const ensureIndexes = jest.spyOn(MongoDriver.prototype, 'ensureIndexes');
-
-    createCollection.mockImplementation(() => Promise.resolve());
-    dropCollections.mockImplementation(() => Promise.resolve());
-    ensureIndexes.mockImplementation(() => Promise.resolve());
-
-    await driver.refreshCollections();
-
-    expect(dropCollections).toBeCalledTimes(1);
-    expect(createCollection).toBeCalledTimes(1);
-    expect(ensureIndexes).toBeCalledTimes(1);
-
-    await driver.refreshCollections({ ensureIndexes: false });
-
-    expect(dropCollections).toBeCalledTimes(2);
-    expect(createCollection).toBeCalledTimes(2);
-    expect(ensureIndexes).toBeCalledTimes(1);
-
-    createCollection.mockRestore();
-    dropCollections.mockRestore();
-    ensureIndexes.mockRestore();
-  });
-
   test('should provide custom repository', async () => {
     const repo = orm.em.getRepository(Author);
     expect(repo).toBeInstanceOf(AuthorRepository);
@@ -538,6 +501,7 @@ describe('EntityManagerMongo', () => {
     expect(driver.getPlatform().usesPivotTable()).toBe(false);
     expect(driver.getPlatform().usesImplicitTransactions()).toBe(false);
     await expect(driver.loadFromPivotTable({} as EntityProperty, [])).rejects.toThrowError('MongoDriver does not use pivot tables');
+    await expect(driver.getConnection().execute('')).rejects.toThrowError('MongoConnection does not support generic execute method');
     await expect(driver.getConnection().execute('')).rejects.toThrowError('MongoConnection does not support generic execute method');
     expect(driver.getConnection().getCollection(BookTag).collectionName).toBe('book-tag');
     expect(orm.em.getCollection(BookTag).collectionName).toBe('book-tag');

--- a/tests/features/embeddables/embedded-entities.mongo.test.ts
+++ b/tests/features/embeddables/embedded-entities.mongo.test.ts
@@ -195,7 +195,7 @@ describe('embedded entities in mongo', () => {
   });
 
   afterAll(async () => {
-    await orm.em.getDriver().dropCollections();
+    await orm.getSchemaGenerator().dropSchema();
     await orm.close(true);
   });
 
@@ -243,8 +243,8 @@ describe('embedded entities in mongo', () => {
   test('create collections', async () => {
     const createCollection = jest.spyOn(MongoConnection.prototype, 'createCollection');
     createCollection.mockResolvedValue({} as any);
-    await orm.em.getDriver().createCollections();
-    expect(createCollection.mock.calls.map(c => c[0])).toEqual(['user', 'custom-user', 'parent']);
+    await orm.getSchemaGenerator().createSchema();
+    expect(createCollection.mock.calls.map(c => c[0])).toEqual(['parent', 'custom-user', 'user']);
     createCollection.mockRestore();
   });
 

--- a/tests/features/embeddables/nested-embeddables.mongo.test.ts
+++ b/tests/features/embeddables/nested-embeddables.mongo.test.ts
@@ -81,14 +81,14 @@ describe('embedded entities in mongo', () => {
   });
 
   afterAll(async () => {
-    await orm.em.getDriver().dropCollections();
+    await orm.getSchemaGenerator().dropSchema();
     await orm.close(true);
   });
 
   test('create collections', async () => {
     const createCollection = jest.spyOn(MongoConnection.prototype, 'createCollection');
     createCollection.mockResolvedValue({} as any);
-    await orm.em.getDriver().createCollections();
+    await orm.getSchemaGenerator().createSchema();
     expect(createCollection.mock.calls.map(c => c[0])).toEqual(['user']);
     createCollection.mockRestore();
   });

--- a/tests/features/embeddables/polymorphic-embedded-entities.mongo.test.ts
+++ b/tests/features/embeddables/polymorphic-embedded-entities.mongo.test.ts
@@ -81,7 +81,7 @@ describe('polymorphic embeddables in mongo', () => {
   });
 
   afterAll(async () => {
-    await orm.em.getDriver().dropCollections();
+    await orm.getSchemaGenerator().dropSchema();
     await orm.close();
   });
 

--- a/tests/features/schema-generator/AbstractSchemaGenerator.test.ts
+++ b/tests/features/schema-generator/AbstractSchemaGenerator.test.ts
@@ -1,0 +1,27 @@
+import { AbstractSchemaGenerator, Configuration } from '@mikro-orm/core';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+
+class MySchemaGenerator extends AbstractSchemaGenerator<any> { }
+
+describe('AbstractSchemaGenerator', () => {
+
+  test('default validations for not implemented methods', async () => {
+    const config = new Configuration({ type: 'sqlite' }, false);
+    const driver = new SqliteDriver(config);
+    const generator = new MySchemaGenerator(driver);
+    await expect(generator.generate()).rejects.toThrowError('This method is not supported by SqliteDriver driver');
+    await expect(generator.createSchema()).rejects.toThrowError('This method is not supported by SqliteDriver driver');
+    await expect(generator.ensureDatabase()).rejects.toThrowError('This method is not supported by SqliteDriver driver');
+    await expect(generator.getCreateSchemaSQL()).rejects.toThrowError('This method is not supported by SqliteDriver driver');
+    await expect(generator.dropSchema()).rejects.toThrowError('This method is not supported by SqliteDriver driver');
+    await expect(generator.getDropSchemaSQL()).rejects.toThrowError('This method is not supported by SqliteDriver driver');
+    await expect(generator.updateSchema()).rejects.toThrowError('This method is not supported by SqliteDriver driver');
+    await expect(generator.getUpdateSchemaSQL()).rejects.toThrowError('This method is not supported by SqliteDriver driver');
+    await expect(generator.getUpdateSchemaMigrationSQL()).rejects.toThrowError('This method is not supported by SqliteDriver driver');
+    await expect(generator.createDatabase('')).rejects.toThrowError('This method is not supported by SqliteDriver driver');
+    await expect(generator.dropDatabase('')).rejects.toThrowError('This method is not supported by SqliteDriver driver');
+    await expect(generator.execute('')).rejects.toThrowError('This method is not supported by SqliteDriver driver');
+    await expect(generator.ensureIndexes()).rejects.toThrowError('This method is not supported by SqliteDriver driver');
+  });
+
+});

--- a/tests/features/schema-generator/SchemaGenerator.mongo.test.ts
+++ b/tests/features/schema-generator/SchemaGenerator.mongo.test.ts
@@ -1,10 +1,87 @@
-import { MikroORM } from '@mikro-orm/core';
+import type { MikroORM } from '@mikro-orm/core';
+import type { MongoDriver } from '@mikro-orm/mongodb';
+import { MongoSchemaGenerator } from '@mikro-orm/mongodb';
+import FooBar from '../../entities/FooBar';
+import { initORMMongo, wipeDatabase } from '../../bootstrap';
 
 describe('SchemaGenerator', () => {
 
-  test('not supported [mongodb]', async () => {
-    const orm = await MikroORM.init({ type: 'mongo', dbName: 'mikro-orm-test', discovery: { warnWhenNoEntities: false } }, false);
-    expect(() => orm.getSchemaGenerator()).toThrowError('MongoPlatform does not support SchemaGenerator');
+  let orm: MikroORM<MongoDriver>;
+
+  beforeAll(async () => orm = await initORMMongo());
+  afterAll(async () => await orm.close(true));
+  beforeEach(async () => wipeDatabase(orm.em));
+
+  test('create/drop collection', async () => {
+    const driver = orm.em.getDriver();
+    await driver.getConnection().dropCollection(FooBar);
+    let collections = await driver.getConnection().listCollections();
+    expect(collections).not.toContain('foo-bar');
+    await orm.getSchemaGenerator().createSchema();
+    collections = await driver.getConnection().listCollections();
+    expect(collections).toContain('foo-bar');
+  });
+
+  test('refresh collections', async () => {
+    const createCollection = jest.spyOn(MongoSchemaGenerator.prototype, 'createSchema');
+    const dropCollections = jest.spyOn(MongoSchemaGenerator.prototype, 'dropSchema');
+    const ensureIndexes = jest.spyOn(MongoSchemaGenerator.prototype, 'ensureIndexes');
+
+    createCollection.mockResolvedValue();
+    dropCollections.mockResolvedValue();
+    ensureIndexes.mockResolvedValue();
+
+    await orm.getSchemaGenerator().refreshCollections();
+
+    expect(dropCollections).toBeCalledTimes(1);
+    expect(createCollection).toBeCalledTimes(1);
+    expect(ensureIndexes).toBeCalledTimes(1);
+
+    await orm.getSchemaGenerator().refreshCollections({ ensureIndexes: false });
+
+    expect(dropCollections).toBeCalledTimes(2);
+    expect(createCollection).toBeCalledTimes(2);
+    expect(ensureIndexes).toBeCalledTimes(1);
+
+    createCollection.mockRestore();
+    dropCollections.mockRestore();
+    ensureIndexes.mockRestore();
+  });
+
+  test('updateSchema just forwards to createSchema', async () => {
+    const spy = jest.spyOn(MongoSchemaGenerator.prototype, 'createSchema');
+    spy.mockImplementation();
+    await orm.getSchemaGenerator().updateSchema();
+    expect(spy).toBeCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  test('deprecated driver methods that are now in MongoSchemaGenerator', async () => {
+    const driver = orm.em.getDriver();
+    const createSchemaSpy = jest.spyOn(MongoSchemaGenerator.prototype, 'createSchema');
+    const dropSchemaSpy = jest.spyOn(MongoSchemaGenerator.prototype, 'dropSchema');
+    const refreshCollectionsSpy = jest.spyOn(MongoSchemaGenerator.prototype, 'refreshCollections');
+    const ensureIndexesSpy = jest.spyOn(MongoSchemaGenerator.prototype, 'ensureIndexes');
+    createSchemaSpy.mockImplementation();
+    dropSchemaSpy.mockImplementation();
+    refreshCollectionsSpy.mockImplementation();
+
+    await driver.createCollections();
+    expect(createSchemaSpy).toBeCalledTimes(1);
+
+    await driver.dropCollections();
+    expect(dropSchemaSpy).toBeCalledTimes(1);
+
+    await driver.refreshCollections();
+    expect(refreshCollectionsSpy).toBeCalledTimes(1);
+
+    await driver.ensureIndexes();
+    expect(ensureIndexesSpy).toBeCalledTimes(1);
+
+    createSchemaSpy.mockRestore();
+    dropSchemaSpy.mockRestore();
+    refreshCollectionsSpy.mockRestore();
+    ensureIndexesSpy.mockRestore();
   });
 
 });

--- a/tests/issues/GH1175.test.ts
+++ b/tests/issues/GH1175.test.ts
@@ -604,7 +604,7 @@ describe('GH issue 1175', () => {
       });
       await orm.em.nativeDelete(Entity1175, {});
       await orm.em.nativeInsert(Entity1175, { username: 'test1' });
-      await orm.em.getDriver().ensureIndexes();
+      await orm.getSchemaGenerator().ensureIndexes();
     });
 
     afterAll(async () => {


### PR DESCRIPTION
- `em.getDriver().createCollections()` -> `orm.getSchemaGenerator().createSchema()`
- `em.getDriver().dropCollections()` -> `orm.getSchemaGenerator().dropSchema()`
- `em.getDriver().refreshCollections()` -> `orm.getSchemaGenerator().refreshCollections()`
- `em.getDriver().ensureIndexes()` -> `orm.getSchemaGenerator().ensureIndexes()`