### PR TITLE
feat(core): add `populateWhere` option

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -283,6 +283,42 @@ MikroORM.init({
 });
 ```
 
+## Population where condition
+
+> This applies only to SELECT_IN strategy, as JOINED strategy implies the inference.
+
+In v4, when we used populate hints in `em.find()` and similar methods, the
+query for our entity would be analysed and parts of it extracted and used for
+the population. Following example would find all authors that have books with
+given IDs, and populate their books collection, again using this PK condition,
+resulting in only such books being in those collections.
+
+```ts
+// this would end up with `Author.books` collections having only books of PK 1, 2, 3
+const a = await em.find(Author, { books: [1, 2, 3] }, { populate: ['books'] });
+```
+
+Following this example, if we wanted to load all books, we would need a separate
+`em.populate()` call:
+
+```ts
+const a = await em.find(Author, { books: [1, 2, 3] });
+await em.populate(a, ['books']);
+```
+
+This behaviour changed and is now configurable both globally and locally, via
+`populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and
+`PopulateHint.INFER`, the former being the default in v5, the latter being the
+default behaviour in v4. Locally (via `FindOptions`) we can also specify custom
+where condition that will be passed to `em.populate()` call.
+
+```ts
+MikroORM.init({
+  // defaults to PopulateHint.ALL in v5
+  populateWhere: PopulateHint.INFER, // revert to v4 behaviour
+});
+```
+
 ## Custom Hydrator
 
 Hydrator is responsible for assigning values from the database to entities. 

--- a/docs/docs/loading-strategies.md
+++ b/docs/docs/loading-strategies.md
@@ -90,3 +90,42 @@ MikroORM.init({
 
 This value will be used as the default, specifying the loading strategy on 
 property level has precedence, as well as specifying it in the `FindOptions`.
+
+## Population where condition
+
+> This applies only to SELECT_IN strategy, as JOINED strategy implies the inference.
+
+In v4, when we used populate hints in `em.find()` and similar methods, the
+query for our entity would be analysed and parts of it extracted and used for
+the population. Following example would find all authors that have books with
+given IDs, and populate their books collection, again using this PK condition,
+resulting in only such books being in those collections.
+
+```ts
+// this would end up with `Author.books` collections having only books of PK 1, 2, 3
+const a = await em.find(Author, { books: [1, 2, 3] }, { populate: ['books'] });
+```
+
+Following this example, if we wanted to load all books, we would need a separate
+`em.populate()` call:
+
+```ts
+const a = await em.find(Author, { books: [1, 2, 3] });
+await em.populate(a, ['books']);
+```
+
+This behaviour changed and is now configurable both globally and locally, via
+`populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and
+`PopulateHint.INFER`, the former being the default in v5, the latter being the
+default behaviour in v4. Locally (via `FindOptions`) we can also specify custom
+where condition that will be passed to `em.populate()` call.
+
+```ts
+await em.find(Author, { ... }, {
+  // defaults to PopulateHint.ALL in v5
+  populateWhere: PopulateHint.INFER, // revert to v4 behaviour
+
+  // or we can specify custom condition for the population:
+  // populateWhere: { ... },
+});
+```

--- a/docs/docs/upgrading-v4-to-v5.md
+++ b/docs/docs/upgrading-v4-to-v5.md
@@ -187,3 +187,40 @@ and has been replaced with `glob`. This change is also reflected in MikroORM.
 The default value for `glob` is `!(*.d).{js,ts}`, so both JS and TS files are matched
 (but not .d.ts files). You should usually not need to change this option as this default
 suits both development and production environments.
+
+## Population no longer infers the where condition by default
+
+> This applies only to SELECT_IN strategy, as JOINED strategy implies the inference.
+
+Previously when we used populate hints in `em.find()` and similar methods, the
+query for our entity would be analysed and parts of it extracted and used for 
+the population. Following example would find all authors that have books with 
+given IDs, and populate their books collection, again using this PK condition,
+resulting in only such books being in those collections. 
+
+```ts
+// this would end up with `Author.books` collections having only books of PK 1, 2, 3
+const a = await em.find(Author, { books: [1, 2, 3] }, { populate: ['books'] });
+```
+
+Following this example, if we wanted to load all books, we would need a separate 
+`em.populate()` call:
+
+```ts
+const a = await em.find(Author, { books: [1, 2, 3] });
+await em.populate(a, ['books']);
+```
+
+This behaviour changed and is now configurable both globally and locally, via 
+`populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and 
+`PopulateHint.INFER`, the former being the default in v5, the latter being the
+default behaviour in v4. Locally (via `FindOptions`) we can also specify custom
+where condition that will be passed to `em.populate()` call.
+
+```ts
+// revert back to the old behaviour locally
+const a = await em.find(Author, { books: [1, 2, 3] }, {
+  populate: ['books'],
+  populateWhere: PopulateHint.INFER,
+});
+```

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -1,9 +1,9 @@
 import type {
   EntityData, EntityMetadata, EntityProperty, AnyEntity, FilterQuery, Primary, Dictionary, QBFilterQuery,
-  IPrimaryKey, PopulateOptions, EntityDictionary, ExpandProperty, AutoPath,
+  IPrimaryKey, PopulateOptions, EntityDictionary, ExpandProperty, AutoPath, ObjectQuery,
 } from '../typings';
 import type { Connection, QueryResult, Transaction } from '../connections';
-import type { FlushMode, LockMode, QueryOrderMap, QueryFlag, LoadStrategy } from '../enums';
+import type { FlushMode, LockMode, QueryOrderMap, QueryFlag, LoadStrategy, PopulateHint } from '../enums';
 import type { Platform } from '../platforms';
 import type { MetadataStorage } from '../metadata';
 import type { Collection } from '../entity';
@@ -89,6 +89,7 @@ export type EntityField<T, P extends string = never> = keyof T | AutoPath<T, P> 
 
 export interface FindOptions<T, P extends string = never> {
   populate?: readonly AutoPath<T, P>[] | boolean;
+  populateWhere?: ObjectQuery<T> | PopulateHint;
   orderBy?: QueryOrderMap<T> | QueryOrderMap<T>[];
   cache?: boolean | number | [string, number];
   limit?: number;

--- a/packages/core/src/enums.ts
+++ b/packages/core/src/enums.ts
@@ -10,6 +10,11 @@ export const enum FlushMode {
   ALWAYS,
 }
 
+export enum PopulateHint {
+  INFER,
+  ALL,
+}
+
 export enum GroupOperator {
   $and = 'and',
   $or = 'or',

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -34,7 +34,7 @@ import type { EventSubscriber } from '../events';
 import type { IDatabaseDriver } from '../drivers/IDatabaseDriver';
 import { NotFoundError } from '../errors';
 import { RequestContext } from './RequestContext';
-import { FlushMode, LoadStrategy } from '../enums';
+import { FlushMode, LoadStrategy, PopulateHint } from '../enums';
 import { MemoryCacheAdapter } from '../cache/MemoryCacheAdapter';
 import { EntityComparator } from './EntityComparator';
 
@@ -64,6 +64,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     hydrator: ObjectHydrator,
     flushMode: FlushMode.AUTO,
     loadStrategy: LoadStrategy.SELECT_IN,
+    populateWhere: PopulateHint.ALL,
     autoJoinOneToOneOwner: true,
     propagateToOneOwner: true,
     populateAfterFlush: true,
@@ -149,7 +150,11 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
    * Gets specific configuration option. Falls back to specified `defaultValue` if provided.
    */
   get<T extends keyof MikroORMOptions<D>, U extends MikroORMOptions<D>[T]>(key: T, defaultValue?: U): U {
-    return (Utils.isDefined(this.options[key]) ? this.options[key] : defaultValue) as U;
+    if (typeof this.options[key] !== 'undefined') {
+      return this.options[key] as U;
+    }
+
+    return defaultValue as U;
   }
 
   getAll(): MikroORMOptions<D> {
@@ -419,6 +424,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
   batchSize: number;
   hydrator: HydratorConstructor;
   loadStrategy: LoadStrategy;
+  populateWhere: PopulateHint;
   flushMode: FlushMode;
   entityRepository?: Constructor<EntityRepository<any>>;
   replicas?: Partial<ConnectionOptions>[];

--- a/tests/issues/GH2121.test.ts
+++ b/tests/issues/GH2121.test.ts
@@ -60,7 +60,7 @@ describe('GH issue 2121', () => {
       limit: 10,
       offset: 8,
     });
-    expect(result[0].tags).toHaveLength(1);
+    expect(result[0].tags).toHaveLength(2);
     await orm.em.clear();
 
     const result2 = await orm.em.find(Product, { tags: { slug: ['slug0'] } }, {
@@ -68,7 +68,7 @@ describe('GH issue 2121', () => {
       limit: 10,
       offset: 9,
     });
-    expect(result2[0].tags).toHaveLength(1);
+    expect(result2[0].tags).toHaveLength(2);
     await result2[0].tags.init();
   });
 

--- a/tests/issues/GH234.test.ts
+++ b/tests/issues/GH234.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, ManyToMany, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
+import { Collection, Entity, ManyToMany, MikroORM, PopulateHint, PrimaryKey, Property } from '@mikro-orm/core';
 import type { SqliteDriver } from '@mikro-orm/sqlite';
 import { SchemaGenerator } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
@@ -62,17 +62,33 @@ describe('GH issue 234', () => {
     orm.em.clear();
 
     const mock = mockLogger(orm, ['query']);
-    const res1 = await orm.em.find(B, { aCollection: [1, 2, 3] }, { populate: ['aCollection'] });
+    const res1 = await orm.em.find(B, { aCollection: [1, 2, 3] }, { populate: ['aCollection'], populateWhere: PopulateHint.INFER });
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.* from `b` as `b0` left join `b_a_collection` as `b1` on `b0`.`id` = `b1`.`b_id` where `b1`.`a_id` in (?, ?, ?)');
     expect(mock.mock.calls[1][0]).toMatch('select `a0`.*, `b1`.`a_id` as `fk__a_id`, `b1`.`b_id` as `fk__b_id` from `a` as `a0` left join `b_a_collection` as `b1` on `a0`.`id` = `b1`.`a_id` where `a0`.`id` in (?, ?, ?) and `b1`.`b_id` in (?) order by `b1`.`id` asc');
     expect(res1.map(b => b.id)).toEqual([b.id]);
 
     orm.em.clear();
     mock.mock.calls.length = 0;
-    const res2 = await orm.em.find(A, { bCollection: [1, 2, 3] }, { populate: ['bCollection'] });
+    const res2 = await orm.em.find(A, { bCollection: [1, 2, 3] }, { populate: ['bCollection'], populateWhere: PopulateHint.INFER });
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.* from `a` as `a0` left join `b_a_collection` as `b1` on `a0`.`id` = `b1`.`a_id` where `b1`.`b_id` in (?, ?, ?)');
     expect(mock.mock.calls[1][0]).toMatch('select `b0`.*, `b1`.`b_id` as `fk__b_id`, `b1`.`a_id` as `fk__a_id` from `b` as `b0` left join `b_a_collection` as `b1` on `b0`.`id` = `b1`.`b_id` where `b0`.`id` in (?, ?, ?) and `b1`.`a_id` in (?, ?, ?) order by `b1`.`id` asc');
     expect(res2.map(a => a.id)).toEqual([a1.id, a2.id, a3.id]);
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const res3 = await orm.em.find(B, { aCollection: [1, 2, 3] }, { populate: ['aCollection'] });
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.* from `b` as `b0` left join `b_a_collection` as `b1` on `b0`.`id` = `b1`.`b_id` where `b1`.`a_id` in (?, ?, ?)');
+    expect(mock.mock.calls[1][0]).toMatch('select `a0`.*, `b1`.`a_id` as `fk__a_id`, `b1`.`b_id` as `fk__b_id` from `a` as `a0` left join `b_a_collection` as `b1` on `a0`.`id` = `b1`.`a_id` where `b1`.`b_id` in (?) order by `b1`.`id` asc');
+    expect(res3.map(b => b.id)).toEqual([b.id]);
+
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+    const res4 = await orm.em.find(A, { bCollection: [1, 2, 3] }, { populate: ['bCollection'] });
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.* from `a` as `a0` left join `b_a_collection` as `b1` on `a0`.`id` = `b1`.`a_id` where `b1`.`b_id` in (?, ?, ?)');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.*, `b1`.`b_id` as `fk__b_id`, `b1`.`a_id` as `fk__a_id` from `b` as `b0` left join `b_a_collection` as `b1` on `b0`.`id` = `b1`.`b_id` where `b1`.`a_id` in (?, ?, ?) order by `b1`.`id` asc');
+    expect(res4.map(a => a.id)).toEqual([a1.id, a2.id, a3.id]);
+    orm.em.clear();
+    mock.mock.calls.length = 0;
   });
 
 });


### PR DESCRIPTION
BREAKING CHANGE:

> This applies only to SELECT_IN strategy, as JOINED strategy implies the inference.

In v4, when we used populate hints in `em.find()` and similar methods, the
query for our entity would be analysed and parts of it extracted and used for
the population. Following example would find all authors that have books with
given IDs, and populate their books collection, again using this PK condition,
resulting in only such books being in those collections.

```ts
// this would end up with `Author.books` collections having only books of PK 1, 2, 3
const a = await em.find(Author, { books: [1, 2, 3] }, { populate: ['books'] });
```

Following this example, if we wanted to load all books, we would need a separate
`em.populate()` call:

```ts
const a = await em.find(Author, { books: [1, 2, 3] });
await em.populate(a, ['books']);
```

This behaviour changed and is now configurable both globally and locally, via
`populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and
`PopulateHint.INFER`, the former being the default in v5, the latter being the
default behaviour in v4. Locally (via `FindOptions`) we can also specify custom
where condition that will be passed to `em.populate()` call.

```ts
await em.find(Author, { ... }, {
  // defaults to PopulateHint.ALL in v5
  populateWhere: PopulateHint.INFER, // revert to v4 behaviour

  // or we can specify custom condition for the population:
  // populateWhere: { ... },
});
```