### PR TITLE
feat(core): add custom table check constraint support for postgres

### DIFF
--- a/packages/core/src/decorators/Check.ts
+++ b/packages/core/src/decorators/Check.ts
@@ -1,0 +1,16 @@
+import { MetadataStorage } from '../metadata';
+import type { AnyEntity } from '../typings';
+
+export function Check<T>(options: CheckOptions) {
+  return function <U>(target: U) {
+    const meta = MetadataStorage.getMetadataFromDecorator(target);
+    meta.checks.push(options);
+
+    return target;
+  };
+}
+
+export interface CheckOptions {
+  name: string;
+  expression: string;
+}

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -5,6 +5,7 @@ export * from './ManyToOne';
 export * from './ManyToMany';
 export { OneToMany, OneToManyOptions } from './OneToMany';
 export * from './Property';
+export * from './Check';
 export * from './Enum';
 export * from './Formula';
 export * from './Indexed';

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -284,6 +284,7 @@ export class EntityMetadata<T extends AnyEntity<T> = any> {
     this.hooks = {};
     this.indexes = [];
     this.uniques = [];
+    this.checks = [];
     this.concurrencyCheckKeys = new Set();
     Object.assign(this, meta);
   }
@@ -424,6 +425,7 @@ export interface EntityMetadata<T extends AnyEntity<T> = any> {
   uniqueProps: EntityProperty<T>[];
   indexes: { properties: (keyof T & string) | (keyof T & string)[]; name?: string; type?: string; options?: Dictionary; expression?: string }[];
   uniques: { properties: (keyof T & string) | (keyof T & string)[]; name?: string; options?: Dictionary }[];
+  checks: { name: string; expression: string }[];
   customRepository: () => Constructor<EntityRepository<T>>;
   hooks: Partial<Record<keyof typeof EventType, (string & keyof T)[]>>;
   prototype: T;

--- a/packages/knex/src/schema/DatabaseSchema.ts
+++ b/packages/knex/src/schema/DatabaseSchema.ts
@@ -61,10 +61,11 @@ export class DatabaseSchema {
       table.comment = t.table_comment;
       const cols = await platform.getSchemaHelper()!.getColumns(connection, table.name, table.schema);
       const indexes = await platform.getSchemaHelper()!.getIndexes(connection, table.name, table.schema);
+      const checks = await platform.getSchemaHelper()!.getChecks(connection, table.name, table.schema);
       const pks = await platform.getSchemaHelper()!.getPrimaryKeys(connection, indexes, table.name, table.schema);
       const fks = await platform.getSchemaHelper()!.getForeignKeys(connection, table.name, table.schema);
       const enums = await platform.getSchemaHelper()!.getEnumDefinitions(connection, table.name, table.schema);
-      table.init(cols, indexes, pks, fks, enums);
+      table.init(cols, indexes, checks, pks, fks, enums);
     }
 
     return schema;
@@ -82,6 +83,7 @@ export class DatabaseSchema {
       meta.indexes.forEach(index => table.addIndex(meta, index, 'index'));
       meta.uniques.forEach(index => table.addIndex(meta, index, 'unique'));
       table.addIndex(meta, { properties: meta.props.filter(prop => prop.primary).map(prop => prop.name) }, 'primary');
+      meta.checks.forEach(check => table.addCheck(check));
     }
 
     return schema;

--- a/packages/knex/src/schema/SchemaHelper.ts
+++ b/packages/knex/src/schema/SchemaHelper.ts
@@ -3,7 +3,7 @@ import type { Connection, Dictionary } from '@mikro-orm/core';
 import { BigIntType, EnumType, Utils } from '@mikro-orm/core';
 import type { AbstractSqlConnection } from '../AbstractSqlConnection';
 import type { AbstractSqlPlatform } from '../AbstractSqlPlatform';
-import type { Column, Index, TableDifference } from '../typings';
+import type { Check, Column, Index, TableDifference } from '../typings';
 import type { DatabaseTable } from './DatabaseTable';
 
 export abstract class SchemaHelper {
@@ -139,6 +139,10 @@ export abstract class SchemaHelper {
   }
 
   async getIndexes(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<Index[]> {
+    throw new Error('Not supported by given driver');
+  }
+
+  async getChecks(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<Check[]> {
     throw new Error('Not supported by given driver');
   }
 

--- a/packages/knex/src/typings.ts
+++ b/packages/knex/src/typings.ts
@@ -69,6 +69,11 @@ export interface Index {
   type?: string | Readonly<{ indexType?: string; storageEngineIndexType?: 'hash' | 'btree'; predicate?: Knex.QueryBuilder }>; // for back compatibility mainly, to allow using knex's `index.type` option (e.g. gin index)
 }
 
+export interface Check {
+  name: string;
+  expression: string;
+}
+
 export interface ColumnDifference {
   oldColumnName: string;
   column: Column;
@@ -88,6 +93,9 @@ export interface TableDifference {
   changedIndexes: Dictionary<Index>;
   removedIndexes: Dictionary<Index>;
   renamedIndexes: Dictionary<Index>;
+  addedChecks: Dictionary<Check>;
+  changedChecks: Dictionary<Check>;
+  removedChecks: Dictionary<Check>;
   addedForeignKeys: Dictionary<ForeignKey>;
   changedForeignKeys: Dictionary<ForeignKey>;
   removedForeignKeys: Dictionary<ForeignKey>;

--- a/packages/mysql-base/src/MySqlSchemaHelper.ts
+++ b/packages/mysql-base/src/MySqlSchemaHelper.ts
@@ -1,4 +1,4 @@
-import type { AbstractSqlConnection, Column, Index, Knex, TableDifference } from '@mikro-orm/knex';
+import type { AbstractSqlConnection, Check, Column, Index, Knex, TableDifference } from '@mikro-orm/knex';
 import { SchemaHelper } from '@mikro-orm/knex';
 import type { Dictionary , Type } from '@mikro-orm/core';
 import { EnumType, StringType, TextType } from '@mikro-orm/core';
@@ -162,6 +162,11 @@ export class MySqlSchemaHelper extends SchemaHelper {
       unique: !index.Non_unique,
       primary: index.Key_name === 'PRIMARY',
     })));
+  }
+
+  async getChecks(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<Check[]> {
+    // @todo No support for CHECK constraints in current test MySQL version (minimum version is 8.0.16).
+    return [];
   }
 
   normalizeDefaultValue(defaultValue: string, length: number) {

--- a/packages/sqlite/src/SqliteSchemaHelper.ts
+++ b/packages/sqlite/src/SqliteSchemaHelper.ts
@@ -1,5 +1,5 @@
 import type { Connection, Dictionary } from '@mikro-orm/core';
-import type { AbstractSqlConnection, Index } from '@mikro-orm/knex';
+import type { AbstractSqlConnection, Index, Check } from '@mikro-orm/knex';
 import { SchemaHelper } from '@mikro-orm/knex';
 
 export class SqliteSchemaHelper extends SchemaHelper {
@@ -100,6 +100,11 @@ export class SqliteSchemaHelper extends SchemaHelper {
     }
 
     return this.mapIndexes(ret);
+  }
+
+  async getChecks(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<Check[]> {
+    // Not supported at the moment.
+    return [];
   }
 
   getForeignKeysSQL(tableName: string): string {

--- a/tests/SchemaHelper.test.ts
+++ b/tests/SchemaHelper.test.ts
@@ -16,6 +16,7 @@ describe('SchemaHelper', () => {
     expect(() => helper.getForeignKeysSQL('table')).toThrowError('Not supported by given driver');
     await expect(helper.getColumns({} as any, 'table')).rejects.toThrowError('Not supported by given driver');
     await expect(helper.getIndexes({} as any, 'table')).rejects.toThrowError('Not supported by given driver');
+    await expect(helper.getChecks({} as any, 'table')).rejects.toThrowError('Not supported by given driver');
   });
 
   test('mysql schema helper', async () => {

--- a/tests/features/schema-generator/__snapshots__/check-constraint.postgres.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/check-constraint.postgres.test.ts.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`check constraint [postgres] check constraint diff [postgres]: postgres-check-constraint-diff-1 1`] = `
+"create table \\"new_table\\" (\\"id\\" serial primary key, \\"price\\" int not null, constraint foo_custom check (price >= 0));
+
+"
+`;
+
+exports[`check constraint [postgres] check constraint diff [postgres]: postgres-check-constraint-diff-2 1`] = `
+"alter table \\"new_table\\" drop constraint foo_custom;
+alter table \\"new_table\\" add constraint foo_custom check(price > 0);
+
+"
+`;
+
+exports[`check constraint [postgres] check constraint diff [postgres]: postgres-check-constraint-diff-3 1`] = `
+"alter table \\"new_table\\" drop constraint foo_custom;
+
+"
+`;
+
+exports[`check constraint [postgres] check constraint diff [postgres]: postgres-check-constraint-diff-4 1`] = `
+"alter table \\"new_table\\" add constraint bar_custom check(price > 0);
+
+"
+`;
+
+exports[`check constraint [postgres] check constraint diff [postgres]: postgres-check-constraint-diff-5 1`] = `""`;
+
+exports[`check constraint [postgres] check constraint is generated for decorator [postgres]: postgres-check-constraint-decorator 1`] = `
+"create table \\"foo_entity\\" (\\"id\\" serial primary key, \\"price\\" int not null, constraint foo_custom check (price >= 0));
+
+"
+`;

--- a/tests/features/schema-generator/check-constraint.postgres.test.ts
+++ b/tests/features/schema-generator/check-constraint.postgres.test.ts
@@ -1,0 +1,92 @@
+import { Check, Entity, EntitySchema, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
+import { SchemaGenerator } from '@mikro-orm/knex';
+import { initORMPostgreSql } from '../../bootstrap';
+
+@Entity()
+@Check({ name: 'foo', expression: 'price >= 0' })
+export class FooEntity {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  price!: number;
+
+}
+
+describe('check constraint [postgres]', () => {
+
+  test('check constraint is generated for decorator [postgres]', async () => {
+    const orm = await MikroORM.init({
+      entities: [FooEntity],
+      dbName: `mikro_orm_test`,
+      type: 'postgresql',
+    });
+
+    const diff = await orm.getSchemaGenerator().getCreateSchemaSQL({ wrap: false });
+    expect(diff).toMatchSnapshot('postgres-check-constraint-decorator');
+
+    await orm.close();
+  });
+
+  test('check constraint diff [postgres]', async () => {
+    const orm = await initORMPostgreSql();
+    const meta = orm.getMetadata();
+    const generator = orm.getSchemaGenerator();
+    await generator.updateSchema();
+
+    const newTableMeta = new EntitySchema({
+      properties: {
+        id: {
+          primary: true,
+          name: 'id',
+          type: 'number',
+          fieldName: 'id',
+          columnType: 'int',
+        },
+        price: {
+          type: 'number',
+          name: 'price',
+          fieldName: 'price',
+          columnType: 'int',
+        },
+      },
+      name: 'NewTable',
+      tableName: 'new_table',
+      checks: [
+        { name: 'foo', expression: 'price >= 0' },
+      ],
+    }).init().meta;
+    meta.set('NewTable', newTableMeta);
+
+    let diff = await orm.getSchemaGenerator().getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toMatchSnapshot('postgres-check-constraint-diff-1');
+    await generator.execute(diff);
+
+    // Update a check expression
+    newTableMeta.checks = [{ name: 'foo', expression: 'price > 0' }];
+    diff = await orm.getSchemaGenerator().getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toMatchSnapshot('postgres-check-constraint-diff-2');
+    await generator.execute(diff);
+
+    // Remove a check constraint
+    newTableMeta.checks = [];
+    diff = await orm.getSchemaGenerator().getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toMatchSnapshot('postgres-check-constraint-diff-3');
+    await generator.execute(diff);
+
+    // Add new check
+    newTableMeta.checks = [{ name: 'bar', expression: 'price > 0' }];
+    diff = await orm.getSchemaGenerator().getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toMatchSnapshot('postgres-check-constraint-diff-4');
+    await generator.execute(diff);
+
+    // Skip existing check
+    diff = await orm.getSchemaGenerator().getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toMatchSnapshot('postgres-check-constraint-diff-5');
+    await generator.execute(diff);
+
+    await orm.close();
+  });
+
+});


### PR DESCRIPTION
Adds a new `@Check` decorator for entities, allowing to set up custom check
constraints. At the moment, this is only for Postgres, as MySQL only supports
check constraints as of version 8, which is above the minimum test version.

While SQLite does in theory support check constraints already, tests broke due
to some bug in Knex, which is why the implementation was skipped for now.

This partially addresses #1711

> **Note:**
> Due to already existing other check constraints (namely, enums in Postgres), I decided to suffix all custom check constraint names with `_custom`, so I can filter them out where necessary.