### PR TITLE
fix(query-builder): respect `0` as limit

### DIFF
--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -371,7 +371,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
         return qb.orderByRaw(queryOrder);
       }
     }, this._orderBy);
-    Utils.runIfNotEmpty(() => qb.limit(this._limit!), this._limit);
+    Utils.runIfNotEmpty(() => qb.limit(this._limit!), this._limit != null);
     Utils.runIfNotEmpty(() => qb.offset(this._offset!), this._offset);
     Utils.runIfNotEmpty(() => this.helper.appendOnConflictClause(this.type, this._onConflict!, qb), this._onConflict);
 

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -2518,6 +2518,12 @@ describe('QueryBuilder', () => {
     spy.mockRestore();
   });
 
+  test('limit of 0 limits results to 0',()=>{
+    const expected = 'select `e0`.`id` from `book2` as `e0` limit 0';
+    const sql = orm.em.createQueryBuilder(Book2).select('id').limit(0).getFormattedQuery();
+    expect(sql).toBe(expected);
+  });
+
   afterAll(async () => orm.close(true));
 
 });


### PR DESCRIPTION
Providing `0` as the limit (with the intention of not returning any records) would not add a LIMIT clause to the resulting query.