### PR TITLE
fix(core): dynamically retrieve MikroORM constructor when constructing

### DIFF
--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -34,7 +34,7 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     options = options instanceof Configuration ? options.getAll() : options;
-    const orm = new MikroORM<D>(Utils.merge(options, env));
+    const orm = new this<D>(Utils.merge(options, env));
     orm.logger.log('info', `MikroORM version: ${colors.green(coreVersion)}`);
 
     // we need to allow global context here as we are not in a scope of requests yet

--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -25,7 +25,7 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
    * Initialize the ORM, load entity metadata, create EntityManager and connect to the database.
    * If you omit the `options` parameter, your CLI config will be used.
    */
-  static async init<D extends IDatabaseDriver = IDatabaseDriver>(options?: Options<D> | Configuration<D>, connect = true): Promise<MikroORM<D>> {
+  static async init<D extends IDatabaseDriver = IDatabaseDriver, I>(this: { new (): I }, options?: Options<D> | Configuration<D>, connect = true): Promise<I<D>> {
     const coreVersion = await ConfigurationLoader.checkPackageVersion();
     const env = ConfigurationLoader.loadEnvironmentVars<D>(options);
 


### PR DESCRIPTION
This change will allow extensions of the `MikroORM` to return instances of the new class when calling `MikroORM.init()`. Example:

```ts
class CustomMikroORM extends MikroORM {
  public test = 1;
}

// before change:

const orm = await CustomMikroORM.init(...);
console.log(orm.test); // undefined
console.log(orm instanceof CustomMikroORM); // false

// after change:

const orm = await CustomMikroORM.init(...);
console.log(orm.test); // 1
console.log(orm instanceof CustomMikroORM); // true
```