### PR TITLE
feat(seeder): refactor seeder to support running compiled files

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -607,4 +607,7 @@ Full list of supported options:
 | `MIKRO_ORM_SCHEMA_GENERATOR_DISABLE_FOREIGN_KEYS` | `migrations.disableForeignKeys` |
 | `MIKRO_ORM_SCHEMA_GENERATOR_CREATE_FOREIGN_KEY_CONSTRAINTS` | `migrations.createForeignKeyConstraints` |
 | `MIKRO_ORM_SEEDER_PATH` | `seeder.path` |
+| `MIKRO_ORM_SEEDER_PATH_TS` | `seeder.pathTs` |
+| `MIKRO_ORM_SEEDER_GLOB` | `seeder.glob` |
+| `MIKRO_ORM_SEEDER_EMIT` | `seeder.emit` |
 | `MIKRO_ORM_SEEDER_DEFAULT_SEEDER` | `seeder.defaultSeeder` |

--- a/docs/docs/seeding.md
+++ b/docs/docs/seeding.md
@@ -7,18 +7,31 @@ script or combine multiple seed scripts.
 
 ## Configuration
 
+> `seeder.path` and `seeder.pathTs` works the same way as `entities` and
+> `entitiesTs` in entity discovery.
+
 The seeder has a few default settings that can be changed easily through the MikroORM config. Underneath you find the configuration options with their defaults.
 
 ```ts
 MikroORM.init({
   seeder: {
     path: './seeders', // path to the folder with seeders
-    defaultSeeder: 'DatabaseSeeder' // default seeder class name
-  }
+    pathTs: undefined, // path to the folder with TS seeders (if used, we should put path to compiled files in `path`)
+    defaultSeeder: 'DatabaseSeeder', // default seeder class name
+    glob: '!(*.d).{js,ts}', // how to match seeder files (all .js and .ts files, but not .d.ts)
+    emit: 'ts', // seeder generation mode
+    fileName: (className: string) => className, // seeder file naming convention
+  },
 });
 ```
 
-You can also override these default using the [environment variables](configuration.md#using-environment-variables) `MIKRO_ORM_SEEDER_PATH` and `MIKRO_ORM_SEEDER_DEFAULT_SEEDER`.
+We can also override these default using the [environment variables](configuration.md#using-environment-variables):
+
+- `MIKRO_ORM_SEEDER_PATH`
+- `MIKRO_ORM_SEEDER_PATH_TS`
+- `MIKRO_ORM_SEEDER_EMIT`
+- `MIKRO_ORM_SEEDER_GLOB`
+- `MIKRO_ORM_SEEDER_DEFAULT_SEEDER`.
 
 ## Seeders
 
@@ -266,3 +279,27 @@ afterAll(async () => {
   await orm.close();
 });
 ```
+
+## Running migrations in production
+
+In production environment we might want to use compiled seeder files. All we need to do is to configure the seeder path accordingly:
+
+```ts
+import { MikroORM, Utils } from '@mikro-orm/core';
+
+await MikroORM.init({
+  seeder: {
+    path: 'dist/seeders',
+    pathTs: 'src/seeders',
+  },
+  // or alternatively
+  // seeder: {
+  //   path: Utils.detectTsNode() ? 'src/seeders' : 'dist/seeders',
+  // },
+  // ...
+});
+```
+
+This should allow using CLI to generate TS seeder files (as in CLI we probably
+have TS support enabled), while using compiled JS files in production, where ts-node
+is not registered.

--- a/docs/versioned_docs/version-5.0/configuration.md
+++ b/docs/versioned_docs/version-5.0/configuration.md
@@ -607,4 +607,7 @@ Full list of supported options:
 | `MIKRO_ORM_SCHEMA_GENERATOR_DISABLE_FOREIGN_KEYS` | `migrations.disableForeignKeys` |
 | `MIKRO_ORM_SCHEMA_GENERATOR_CREATE_FOREIGN_KEY_CONSTRAINTS` | `migrations.createForeignKeyConstraints` |
 | `MIKRO_ORM_SEEDER_PATH` | `seeder.path` |
+| `MIKRO_ORM_SEEDER_PATH_TS` | `seeder.pathTs` |
+| `MIKRO_ORM_SEEDER_GLOB` | `seeder.glob` |
+| `MIKRO_ORM_SEEDER_EMIT` | `seeder.emit` |
 | `MIKRO_ORM_SEEDER_DEFAULT_SEEDER` | `seeder.defaultSeeder` |

--- a/docs/versioned_docs/version-5.0/seeding.md
+++ b/docs/versioned_docs/version-5.0/seeding.md
@@ -7,18 +7,31 @@ script or combine multiple seed scripts.
 
 ## Configuration
 
+> `seeder.path` and `seeder.pathTs` works the same way as `entities` and
+> `entitiesTs` in entity discovery.
+
 The seeder has a few default settings that can be changed easily through the MikroORM config. Underneath you find the configuration options with their defaults.
 
 ```ts
 MikroORM.init({
   seeder: {
     path: './seeders', // path to the folder with seeders
-    defaultSeeder: 'DatabaseSeeder' // default seeder class name
-  }
+    pathTs: undefined, // path to the folder with TS seeders (if used, we should put path to compiled files in `path`)
+    defaultSeeder: 'DatabaseSeeder', // default seeder class name
+    glob: '!(*.d).{js,ts}', // how to match seeder files (all .js and .ts files, but not .d.ts)
+    emit: 'ts', // seeder generation mode
+    fileName: (className: string) => className, // seeder file naming convention
+  },
 });
 ```
 
-You can also override these default using the [environment variables](configuration.md#using-environment-variables) `MIKRO_ORM_SEEDER_PATH` and `MIKRO_ORM_SEEDER_DEFAULT_SEEDER`.
+We can also override these default using the [environment variables](configuration.md#using-environment-variables):
+
+- `MIKRO_ORM_SEEDER_PATH`
+- `MIKRO_ORM_SEEDER_PATH_TS`
+- `MIKRO_ORM_SEEDER_EMIT`
+- `MIKRO_ORM_SEEDER_GLOB`
+- `MIKRO_ORM_SEEDER_DEFAULT_SEEDER`.
 
 ## Seeders
 
@@ -266,3 +279,27 @@ afterAll(async () => {
   await orm.close();
 });
 ```
+
+## Running migrations in production
+
+In production environment we might want to use compiled seeder files. All we need to do is to configure the seeder path accordingly:
+
+```ts
+import { MikroORM, Utils } from '@mikro-orm/core';
+
+await MikroORM.init({
+  seeder: {
+    path: 'dist/seeders',
+    pathTs: 'src/seeders',
+  },
+  // or alternatively
+  // seeder: {
+  //   path: Utils.detectTsNode() ? 'src/seeders' : 'dist/seeders',
+  // },
+  // ...
+});
+```
+
+This should allow using CLI to generate TS seeder files (as in CLI we probably
+have TS support enabled), while using compiled JS files in production, where ts-node
+is not registered.

--- a/packages/cli/src/commands/CreateSeederCommand.ts
+++ b/packages/cli/src/commands/CreateSeederCommand.ts
@@ -1,7 +1,5 @@
 import type { Arguments, Argv, CommandModule } from 'yargs';
-import type { MikroORM } from '@mikro-orm/core';
 import { colors } from '@mikro-orm/core';
-import type { AbstractSqlDriver } from '@mikro-orm/knex';
 import { CLIHelper } from '../CLIHelper';
 
 export class CreateSeederCommand<T> implements CommandModule<T, { seeder: string }> {
@@ -20,28 +18,22 @@ export class CreateSeederCommand<T> implements CommandModule<T, { seeder: string
    * @inheritDoc
    */
   async handler(args: Arguments<{ seeder: string }>) {
-    const seederName = CreateSeederCommand.getSeederClassName(args.seeder);
-    const orm = await CLIHelper.getORM(undefined) as MikroORM<AbstractSqlDriver>;
+    const className = CreateSeederCommand.getSeederClassName(args.seeder);
+    const orm = await CLIHelper.getORM();
     const seeder = orm.getSeeder();
-    const path = await seeder.createSeeder(seederName);
+    const path = await seeder.createSeeder(className);
     CLIHelper.dump(colors.green(`Seeder ${args.seeder} successfully created at ${path}`));
     await orm.close(true);
   }
 
   /**
    * Will return a seeder name that is formatted like this EntitySeeder
-   * @param seedName
-   * @private
    */
-  static getSeederClassName(seedName: string): string {
-    const seedNameMatches = seedName.match(/(.+)(seeder)/i);
-    if (seedNameMatches) {
-      seedName = seedNameMatches[1];
-    }
-    const seedNameSplit = seedName.split('-');
-    return seedNameSplit.map(name => {
-      return name.charAt(0).toUpperCase() + name.slice(1);
-    }).join('') + 'Seeder';
+  private static getSeederClassName(name: string): string {
+    name = name.match(/(.+)seeder/i)?.[1] ?? name;
+    const parts = name.split('-');
+
+    return parts.map(name => name.charAt(0).toUpperCase() + name.slice(1)).join('') + 'Seeder';
   }
 
 }

--- a/packages/cli/src/commands/DatabaseSeedCommand.ts
+++ b/packages/cli/src/commands/DatabaseSeedCommand.ts
@@ -1,7 +1,5 @@
 import type { Arguments, Argv, CommandModule } from 'yargs';
-import type { MikroORM } from '@mikro-orm/core';
 import { colors } from '@mikro-orm/core';
-import type { AbstractSqlDriver } from '@mikro-orm/knex';
 import { CLIHelper } from '../CLIHelper';
 
 export class DatabaseSeedCommand<T> implements CommandModule<T, { class: string }> {
@@ -21,11 +19,10 @@ export class DatabaseSeedCommand<T> implements CommandModule<T, { class: string 
    * @inheritDoc
    */
   async handler(args: Arguments<{ class?: string }>) {
-    const orm = await CLIHelper.getORM(undefined) as MikroORM<AbstractSqlDriver>;
-    const seeder = orm.getSeeder();
-    const seederClass = args.class || orm.config.get('seeder').defaultSeeder;
-    await seeder.seedString(seederClass);
-    CLIHelper.dump(colors.green(`Seeder ${seederClass} successfully seeded`));
+    const orm = await CLIHelper.getORM();
+    const className = args.class ?? orm.config.get('seeder').defaultSeeder!;
+    await orm.getSeeder().seedString(className);
+    CLIHelper.dump(colors.green(`Seeder ${className} successfully executed`));
     await orm.close(true);
   }
 

--- a/packages/cli/src/commands/MigrationCommandFactory.ts
+++ b/packages/cli/src/commands/MigrationCommandFactory.ts
@@ -178,7 +178,7 @@ export class MigrationCommandFactory {
 
     if (args.seed !== undefined) {
       const seeder = orm.getSeeder();
-      const seederClass = args.seed || orm.config.get('seeder').defaultSeeder;
+      const seederClass = args.seed || orm.config.get('seeder').defaultSeeder!;
       await seeder.seedString(seederClass);
       CLIHelper.dump(colors.green(`Database seeded successfully with seeder class ${seederClass}`));
     }

--- a/packages/cli/src/commands/SchemaCommandFactory.ts
+++ b/packages/cli/src/commands/SchemaCommandFactory.ts
@@ -113,7 +113,7 @@ export class SchemaCommandFactory {
 
     if (args.seed !== undefined) {
       const seeder = orm.getSeeder();
-      await seeder.seedString(args.seed || orm.config.get('seeder').defaultSeeder);
+      await seeder.seedString(args.seed || orm.config.get('seeder').defaultSeeder!);
     }
 
     CLIHelper.dump(colors.green(successMessage));

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -666,9 +666,10 @@ export interface HydratorConstructor {
 }
 
 export interface ISeedManager {
-  seed(...seederClasses: { new(): Seeder }[]): Promise<void>;
-  seedString(...seederClasses: string[]): Promise<void>;
-  createSeeder(seederClass: string): Promise<string>;
+  seed(...classNames: Constructor<Seeder>[]): Promise<void>;
+  /** @internal */
+  seedString(...classNames: string[]): Promise<void>;
+  createSeeder(className: string): Promise<string>;
 }
 
 export interface Seeder {

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -110,6 +110,9 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     seeder: {
       path: './seeders',
       defaultSeeder: 'DatabaseSeeder',
+      glob: '!(*.d).{js,ts}',
+      emit: 'ts',
+      fileName: (className: string) => className,
     },
   };
 
@@ -373,6 +376,15 @@ export type MigrationsOptions = {
   migrationsList?: MigrationObject[];
 };
 
+export type SeederOptions = {
+  path?: string;
+  pathTs?: string;
+  glob?: string;
+  defaultSeeder?: string;
+  emit?: 'js' | 'ts';
+  fileName?: (className: string) => string;
+};
+
 export interface PoolConfig {
   name?: string;
   afterCreate?: (...a: unknown[]) => unknown;
@@ -461,7 +473,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
     options?: Dictionary;
   };
   metadataProvider: { new(config: Configuration): MetadataProvider };
-  seeder: { path: string; defaultSeeder: string };
+  seeder: SeederOptions;
 }
 
 export type Options<D extends IDatabaseDriver = IDatabaseDriver> =

--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -202,6 +202,9 @@ export class ConfigurationLoader {
 
     ret.seeder = {};
     read(ret.seeder, 'MIKRO_ORM_SEEDER_PATH', 'path');
+    read(ret.seeder, 'MIKRO_ORM_SEEDER_PATH_TS', 'pathTs');
+    read(ret.seeder, 'MIKRO_ORM_SEEDER_GLOB', 'glob');
+    read(ret.seeder, 'MIKRO_ORM_SEEDER_EMIT', 'emit');
     read(ret.seeder, 'MIKRO_ORM_SEEDER_DEFAULT_SEEDER', 'defaultSeeder');
     cleanup(ret, 'seeder');
 

--- a/packages/seeder/src/Seeder.ts
+++ b/packages/seeder/src/Seeder.ts
@@ -5,11 +5,8 @@ export abstract class Seeder {
   abstract run(em: EntityManager): Promise<void>;
 
   protected call(em: EntityManager, seeders: { new(): Seeder }[]): Promise<void> {
-    return new Promise((resolve, reject) => {
-      Promise.all(seeders.map(s => {
-        return (new s()).run(em.fork());
-      })).then(() => resolve()).catch(reject);
-    });
+    const promises = seeders.map(s => (new s()).run(em.fork()));
+    return Promise.all(promises).then();
   }
 
 }

--- a/tests/features/cli/CreateSeederCommand.test.ts
+++ b/tests/features/cli/CreateSeederCommand.test.ts
@@ -43,6 +43,7 @@ describe('CreateSeederCommand', () => {
 
   test('should generate seeder class with all kind of names', async () => {
     const cmd = new CreateSeederCommand();
+    // @ts-expect-error private method
     const spy = jest.spyOn(CreateSeederCommand, 'getSeederClassName');
     await cmd.handler({ seeder: 'DatabaseSeeder' } as any);
     expect(spy).toHaveLastReturnedWith('DatabaseSeeder');

--- a/tests/features/seeder/factory.test.ts
+++ b/tests/features/seeder/factory.test.ts
@@ -1,6 +1,5 @@
 import { MikroORM } from '@mikro-orm/core';
 import { Factory } from '@mikro-orm/seeder';
-import type { SqliteDriver } from '@mikro-orm/sqlite';
 import type { Faker } from '@mikro-orm/seeder';
 import { House } from './entities/house.entity';
 import { Project } from './entities/project.entity';
@@ -34,7 +33,7 @@ export class HouseFactory extends Factory<House> {
 
 describe('Factory', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
   let persistSpy: SpyInstance;
   let flushSpy: SpyInstance;
 

--- a/tests/features/seeder/run-seeders.test.ts
+++ b/tests/features/seeder/run-seeders.test.ts
@@ -1,5 +1,4 @@
 import { MikroORM } from '@mikro-orm/core';
-import type { SqliteDriver } from '@mikro-orm/sqlite';
 import { House } from './entities/house.entity';
 import { Project } from './entities/project.entity';
 import { User } from './entities/user.entity';
@@ -7,7 +6,7 @@ import { DatabaseSeeder } from '../../database/seeder/database.seeder';
 
 describe('Run seeders', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
@@ -21,7 +20,6 @@ describe('Run seeders', () => {
   afterAll(() => orm.close(true));
 
   test('that by calling DatabaseSeeder both ProjectSeeder and UserSeeder have been called', async () => {
-
     const seeder = new DatabaseSeeder();
     await seeder.run(orm.em);
 
@@ -31,4 +29,5 @@ describe('Run seeders', () => {
     const users = await orm.em.findAndCount(User, {});
     expect(users[1]).toBe(1);
   });
+
 });


### PR DESCRIPTION
This makes the whole seeding more in line with how migrations already work.

- adds `pathTs` option to support having different paths for JS and TS
- adds `emit` to support generating JS seeder files directly
- adds `glob` and rework how we require files, so we don't care about their names
- adds `fileName` to allow control over generated seeder names
- no longer uses the "nest file name strategy" for seeders (`foo.seeder.ts` -> `FooSeeder.ts`)

Closes #2728