### PR TITLE
docs: fix link to EM API docs from sidebar

### DIFF
--- a/docs/versioned_sidebars/version-4.5-sidebars.json
+++ b/docs/versioned_sidebars/version-4.5-sidebars.json
@@ -177,7 +177,7 @@
         {
           "type": "link",
           "label": "EntityManager API",
-          "href": "/api/core/class/EventManager"
+          "href": "/api/core/class/EntityManager"
         },
         {
           "type": "link",

--- a/docs/versioned_sidebars/version-5.0-sidebars.json
+++ b/docs/versioned_sidebars/version-5.0-sidebars.json
@@ -48,7 +48,7 @@
       {
         "type": "link",
         "label": "EntityManager API",
-        "href": "/api/next/core/class/EventManager"
+        "href": "/api/next/core/class/EntityManager"
       },
       {
         "type": "link",


### PR DESCRIPTION
The sidebar link goes to the wrong page. 

1. Go here: https://mikro-orm.io/docs
2. Click References
3. Click Entity Manager API
4. Repeat from step 1 and wonder why you keep clicking on the wrong link 😆 