### PR TITLE
docs: fix typo

### DIFF
--- a/docs/docs/custom-types.md
+++ b/docs/docs/custom-types.md
@@ -286,9 +286,7 @@ You can use `BigIntType` to support `bigint`s. By default, it will represent the
 
 ```ts
 @PrimaryKey({ type: BigIntType })
-id
-:
-string;
+id: string;
 ```
 
 ### BlobType

--- a/docs/versioned_docs/version-5.0/custom-types.md
+++ b/docs/versioned_docs/version-5.0/custom-types.md
@@ -286,9 +286,7 @@ You can use `BigIntType` to support `bigint`s. By default, it will represent the
 
 ```ts
 @PrimaryKey({ type: BigIntType })
-id
-:
-string;
+id: string;
 ```
 
 ### BlobType


### PR DESCRIPTION
fix minor typo in docs