### PR TITLE
fix(core): respect `orphanRemoval` in 1:1 relations

### DIFF
--- a/packages/core/src/entity/EntityHelper.ts
+++ b/packages/core/src/entity/EntityHelper.ts
@@ -176,7 +176,7 @@ export class EntityHelper {
         EntityHelper.propagateOneToOne(entity, owner, prop, prop2);
       }
 
-      if (prop.reference === ReferenceType.ONE_TO_ONE && entity && entity.__helper!.__initialized && entity[prop2.name] != null && value == null) {
+      if (prop.reference === ReferenceType.ONE_TO_ONE && entity && entity.__helper!.__initialized && entity[prop2.name] != null && value == null && prop.orphanRemoval !== false) {
         entity[prop2.name] = value;
         entity.__helper!.__em?.getUnitOfWork().scheduleOrphanRemoval(entity);
       }

--- a/packages/core/src/entity/EntityHelper.ts
+++ b/packages/core/src/entity/EntityHelper.ts
@@ -176,9 +176,11 @@ export class EntityHelper {
         EntityHelper.propagateOneToOne(entity, owner, prop, prop2);
       }
 
-      if (prop.reference === ReferenceType.ONE_TO_ONE && entity && entity.__helper!.__initialized && entity[prop2.name] != null && value == null && prop.orphanRemoval !== false) {
+      if (prop.reference === ReferenceType.ONE_TO_ONE && entity && entity.__helper!.__initialized && entity[prop2.name] != null && value == null) {
         entity[prop2.name] = value;
-        entity.__helper!.__em?.getUnitOfWork().scheduleOrphanRemoval(entity);
+        if (prop.orphanRemoval) {
+          entity.__helper!.__em?.getUnitOfWork().scheduleOrphanRemoval(entity);
+        }
       }
     }
   }

--- a/tests/issues/GH2815.test.ts
+++ b/tests/issues/GH2815.test.ts
@@ -8,7 +8,7 @@ export class Position {
   id!: number;
 
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
-  @OneToOne(() => Leg, (leg: Leg) => leg.position, { owner: true, nullable: true, orphanRemoval: false })
+  @OneToOne(() => Leg, (leg: Leg) => leg.position, { owner: true, nullable: true })
   leg?: any;
 
 }
@@ -31,7 +31,7 @@ export class Position2 {
   id!: number;
 
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
-  @OneToOne(() => Leg2, (leg: Leg2) => leg.position, { owner: true, nullable: true })
+  @OneToOne(() => Leg2, (leg: Leg2) => leg.position, { owner: true, nullable: true , orphanRemoval: true })
   leg?: any;
 
 }
@@ -55,7 +55,6 @@ describe('GH issue 2815', () => {
     orm = await MikroORM.init({
       type: 'sqlite',
       dbName: ':memory:',
-      debug: true,
       entities: [Position, Leg, Position2, Leg2],
     });
     await orm.getSchemaGenerator().createSchema();

--- a/tests/issues/GH2815.test.ts
+++ b/tests/issues/GH2815.test.ts
@@ -1,0 +1,118 @@
+import { Entity, MikroORM, OneToOne, PrimaryKey } from '@mikro-orm/core';
+import type { SqliteDriver } from '@mikro-orm/sqlite';
+
+@Entity()
+export class Position {
+
+  @PrimaryKey()
+  id!: number;
+
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  @OneToOne(() => Leg, (leg: Leg) => leg.position, { owner: true, nullable: true, orphanRemoval: false })
+  leg?: any;
+
+}
+
+@Entity()
+export class Leg {
+
+  @PrimaryKey()
+  id!: number;
+
+  @OneToOne(() => Position, (position: Position) => position.leg, { nullable: true })
+  position?: Position;
+
+}
+
+@Entity()
+export class Position2 {
+
+  @PrimaryKey()
+  id!: number;
+
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  @OneToOne(() => Leg2, (leg: Leg2) => leg.position, { owner: true, nullable: true })
+  leg?: any;
+
+}
+
+@Entity()
+export class Leg2 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @OneToOne(() => Position2, (position: Position2) => position.leg, { nullable: true })
+  position?: Position2;
+
+}
+
+describe('GH issue 2815', () => {
+
+  let orm: MikroORM<SqliteDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      type: 'sqlite',
+      dbName: ':memory:',
+      debug: true,
+      entities: [Position, Leg, Position2, Leg2],
+    });
+    await orm.getSchemaGenerator().createSchema();
+  });
+
+  beforeEach(async () => {
+    await orm.getSchemaGenerator().refreshDatabase();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test(`find in transaction finds previously inserted entities`, async () => {
+    const b = orm.em.create(Leg, {});
+    await orm.em.persistAndFlush(b);
+    orm.em.clear();
+
+    const p = orm.em.create(Position, { leg: b });
+    await orm.em.persistAndFlush(p);
+
+    p.leg = null;
+
+    await orm.em.flush();
+
+    orm.em.clear();
+
+    const leg = await orm.em.findOne(Leg, 1);
+    expect(leg).toBeTruthy();
+  });
+
+  test(`test 1-1 propagation for orphanremoval false`, async () => {
+    const b = orm.em.create(Leg, {});
+    await orm.em.persistAndFlush(b);
+
+    const p = orm.em.create(Position, { leg: b });
+    await orm.em.persistAndFlush(p);
+
+    p.leg = null;
+
+    const uow = orm.em.getUnitOfWork();
+    uow.computeChangeSets();
+    expect(uow.getRemoveStack().size).toEqual(0);
+  });
+
+  test(`test 1-1 propagation for orphanremoval true`, async () => {
+    const b = orm.em.create(Leg2, {});
+    await orm.em.persistAndFlush(b);
+
+    const p = orm.em.create(Position2, { leg: b });
+    await orm.em.persistAndFlush(p);
+
+    p.leg = null;
+
+    const uow = orm.em.getUnitOfWork();
+    uow.computeChangeSets();
+    expect(uow.getRemoveStack().size).toEqual(1);
+  });
+
+});


### PR DESCRIPTION
Fixing this to the doc defaults would be a backwards compatibility break (the current behaviour is that 1-1's are treated as `orphanRemoval = true`, where the docs state that the default is really `false`). Doing it this way passes all tests, but requires the user to explicitly define their relationship as `orphanRemoval = false` - not defining it at all will result in the current behaviour.

Fixes #2815 