### PR TITLE
fix(knex): respect explicit transaction in `em.count()`

### DIFF
--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -182,10 +182,10 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     }
   }
 
-  async count<T extends AnyEntity<T>>(entityName: string, where: any, options: CountOptions<T> = {}, ctx?: Transaction<Knex.Transaction>): Promise<number> {
+  async count<T extends AnyEntity<T>>(entityName: string, where: any, options: CountOptions<T> = {}): Promise<number> {
     const meta = this.metadata.find(entityName)!;
     const pks = meta.primaryKeys;
-    const qb = this.createQueryBuilder(entityName, ctx, !!ctx, false)
+    const qb = this.createQueryBuilder(entityName, options.ctx, !!options.ctx, false)
       .groupBy(options.groupBy!)
       .having(options.having!)
       .populate(options.populate as unknown as PopulateOptions<T>[] ?? [])


### PR DESCRIPTION
Looks like something got left behind during the refactoring to a single-options-object pattern