### PR TITLE
chore: use `preserveConstEnums: true`

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,7 +10,8 @@
     "suppressImplicitAnyIndexErrors": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
+    "preserveConstEnums": true
   },
   "exclude": [
     "**/node_modules",


### PR DESCRIPTION
Currenly, since the `const` keyword is used in this export, no code is generated for the enum and attempts to reference it in application code would fail (`trying to read from undefined ....`)