### PR TITLE
fix(knex): fully qualify sub-query order-by fields

### DIFF
--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -843,7 +843,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
       for (const orderMap of this._orderBy) {
         for (const [field, direction] of Object.entries(orderMap)) {
           orderBy.push({
-            [`min(${this.ref(field)})`]: direction,
+            [`min(${this.ref(this.helper.mapper(field, this.type))})`]: direction,
           });
         }
       }

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -2608,12 +2608,11 @@ describe('QueryBuilder', () => {
     expect(sql).toBe(expected);
   });
 
-  test.only('sub-query order-by fields are always fully qualified',()=>{
+  test('sub-query order-by fields are always fully qualified', () => {
     const expected = 'select `e0`.*, `books`.`uuid_pk` as `books__uuid_pk`, `books`.`created_at` as `books__created_at`, `books`.`title` as `books__title`, `books`.`price` as `books__price`, `books`.price * 1.19 as `books__price_taxed`, `books`.`double` as `books__double`, `books`.`meta` as `books__meta`, `books`.`author_id` as `books__author_id`, `books`.`publisher_id` as `books__publisher_id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` where `e0`.`id` in (select `e0`.`id` from (select `e0`.`id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` group by `e0`.`id` order by min(`e0`.`id`) desc limit 10) as `e0`) order by `e0`.`id` desc';
     const sql = orm.em.createQueryBuilder(Author2).select('*').joinAndSelect('books','books').orderBy({ id: QueryOrder.DESC }).limit(10).getFormattedQuery();
     expect(sql).toBe(expected);
   });
-
 
   afterAll(async () => orm.close(true));
 

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -2608,6 +2608,13 @@ describe('QueryBuilder', () => {
     expect(sql).toBe(expected);
   });
 
+  test.only('sub-query order-by fields are always fully qualified',()=>{
+    const expected = 'select `e0`.*, `books`.`uuid_pk` as `books__uuid_pk`, `books`.`created_at` as `books__created_at`, `books`.`title` as `books__title`, `books`.`price` as `books__price`, `books`.price * 1.19 as `books__price_taxed`, `books`.`double` as `books__double`, `books`.`meta` as `books__meta`, `books`.`author_id` as `books__author_id`, `books`.`publisher_id` as `books__publisher_id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` where `e0`.`id` in (select `e0`.`id` from (select `e0`.`id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` group by `e0`.`id` order by min(`e0`.`id`) desc limit 10) as `e0`) order by `e0`.`id` desc';
+    const sql = orm.em.createQueryBuilder(Author2).select('*').joinAndSelect('books','books').orderBy({ id: QueryOrder.DESC }).limit(10).getFormattedQuery();
+    expect(sql).toBe(expected);
+  });
+
+
   afterAll(async () => orm.close(true));
 
 });


### PR DESCRIPTION
When specifying an `order by` rule on a QB query that has joins and the column/s being sorted on exist on more than one table (e.g. `id`) we end up with an `Column 'id' in order clause is ambiguous` error.

This is a side-effect of [this change](https://github.com/mikro-orm/mikro-orm/commit/db9963fff8ceb980354b328f2d59353b9177aef3) to pagination handling in joined queries.

Ensuring field names are always fully qualified resolves this.

How do you prefer these kind of scenarios to be handled? Should I be first opening an issue, and then referencing it in the PR etc ?  Since I am providing the solution - rather than asking for support - I wasn't sure what would be the right way. Am happy to follow your preference here.