### PR TITLE
feat(core): allow forcing write connection via `forceWriteConnection`

### DIFF
--- a/docs/docs/read-connections.md
+++ b/docs/docs/read-connections.md
@@ -41,5 +41,5 @@ await em.transactional(async em => {
   a.name = 'test'; // will trigger update on write connection once flushed
 });
 
-const res4 = await em.findOne(Author, 1, { forceMasterRead: true }); // write connection
+const res4 = await em.findOne(Author, 1, { forceWriteConnection: true }); // write connection
 ```

--- a/docs/docs/read-connections.md
+++ b/docs/docs/read-connections.md
@@ -40,4 +40,6 @@ await em.transactional(async em => {
   const a = await em.findOne(Author, 1); // write connection
   a.name = 'test'; // will trigger update on write connection once flushed
 });
+
+const res4 = await em.findOne(Author, 1, { forceMasterRead: true }); // write connection
 ```

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -113,6 +113,7 @@ export interface FindOptions<T, P extends string = never> {
   lockMode?: Exclude<LockMode, LockMode.OPTIMISTIC>;
   lockTableAliases?: string[];
   ctx?: Transaction;
+  forceWriteConnection?: boolean;
 }
 
 export interface FindOneOptions<T, P extends string = never> extends Omit<FindOptions<T, P>, 'limit' | 'offset' | 'lockMode'> {

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -40,7 +40,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     const meta = this.metadata.find<T>(entityName)!;
     const populate = this.autoJoinOneToOneOwner(meta, options.populate as unknown as PopulateOptions<T>[], options.fields);
     const joinedProps = this.joinedProps(meta, populate);
-    const qb = this.createQueryBuilder<T>(entityName, options.ctx, !!options.ctx, false);
+    const qb = this.createQueryBuilder<T>(entityName, options.ctx, !!options.ctx || !!options.forceWriteConnection, false);
     const fields = this.buildFields(meta, populate, joinedProps, qb, options.fields as Field<T>[]);
     const joinedPropsOrderBy = this.buildJoinedPropsOrderBy(entityName, qb, meta, joinedProps);
 

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -1981,6 +1981,9 @@ describe('EntityManagerMySql', () => {
     expect(mock.mock.calls[12][0]).toMatch(/select.*via write connection '127\.0\.0\.1'/);
     expect(mock.mock.calls[13][0]).toMatch(/update.*via write connection '127\.0\.0\.1'/);
     expect(mock.mock.calls[14][0]).toMatch(/commit.*via write connection '127\.0\.0\.1'/);
+
+    await orm.em.findOne(Author2, author, { forceWriteConnection: true, refresh: true });
+    expect(mock.mock.calls[15][0]).toMatch(/select `a0`\.\*, `a1`\.`author_id` as `address_author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`\.`id` = `a1`\.`author_id` where `a0`.`id` = \? limit \?.*via write connection '127\.0\.0\.1'/);
   });
 
   test('datetime is stored in correct timezone', async () => {


### PR DESCRIPTION
This allows to bypass replica read attempts through the `FindOptions`, by setting the `forceWriteConnection` flag.

The intent is to allow users to force reads onto a master, if the user assumes that an entity has not been replicated yet.