### PR TITLE
fix(knex): `order by` with a formula field should not include `as`

### DIFF
--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -506,7 +506,7 @@ export class QueryBuilderHelper {
       Utils.splitPrimaryKeys(field).forEach(f => {
         const prop = this.getProperty(f, alias);
         const noPrefix = (prop && prop.persist === false) || QueryBuilderHelper.isCustomExpression(f);
-        const column = this.mapper(noPrefix ? f : `${alias}.${f}`, type);
+        const column = this.mapper(noPrefix ? f : `${alias}.${f}`, type, undefined, null);
         /* istanbul ignore next */
         const rawColumn = Utils.isString(column) ? column.split('.').map(e => this.knex.ref(e)).join('.') : column;
         const customOrder = prop?.customOrder;

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -2568,6 +2568,11 @@ describe('QueryBuilder', () => {
     expect(sql2).toBe(expected);
   });
 
+  test(`order by forumla field should not include 'as'`, async () => {
+    const sql = orm.em.createQueryBuilder(Book2).select('*').orderBy({ priceTaxed: QueryOrder.DESC }).getFormattedQuery();
+    expect(sql).toBe('select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` order by `e0`.price * 1.19 desc');
+  });
+
   test('execute return type works based on qb.select/insert/update/delete() being used', async () => {
     const spy = jest.spyOn(QueryBuilder.prototype, 'execute');
 


### PR DESCRIPTION
When doing an `order by` with a formula field it is generating it with an `as` which causes an invalid SQL error 