### PR TITLE
fix(core): allow onUpdate access to other onUpdate results from earlier properties

### DIFF
--- a/packages/core/src/unit-of-work/ChangeSetComputer.ts
+++ b/packages/core/src/unit-of-work/ChangeSetComputer.ts
@@ -73,7 +73,7 @@ export class ChangeSetComputer {
 
     if (prop.onUpdate && type === ChangeSetType.UPDATE) {
       const pairs = map.get(entity) ?? [];
-      pairs.push([prop.name, prop.onUpdate(entity)]);
+      pairs.push([prop.name, prop.onUpdate({ ...entity, ...Object.fromEntries(pairs) })]);
       map.set(entity, pairs);
     }
 

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -9,6 +9,7 @@ import { AuthorRepository } from './repositories/AuthorRepository';
 import { initORMMongo, mockLogger } from './bootstrap';
 import FooBar from './entities/FooBar';
 import { FooBaz } from './entities/FooBaz';
+import { UpdateCreatePropAccess } from './entities/UpdateCreatePropAccess';
 
 describe('EntityManagerMongo', () => {
 
@@ -2040,6 +2041,25 @@ describe('EntityManagerMongo', () => {
     expect(bar.onUpdateTest).toBe(true);
     expect(bar.meta.onCreateCalled).toBe(true);
     expect(bar.meta.onUpdateCalled).toBe(true);
+  });
+
+  test('property onCreate and onUpdate have reference to updated values from previous onUpdate/onCreate calls', async () => {
+    const propAccess = UpdateCreatePropAccess.create('b1');
+    expect(propAccess.onCreatePropertyAccessTestSource).toBeUndefined();
+    expect(propAccess.onCreatePropertyAccessTestReceive).toBeUndefined();
+    expect(propAccess.onUpdatePropertyAccessTestSource).toEqual(0);
+    expect(propAccess.onUpdatePropertyAccessTestReceive).toEqual(1);
+    await orm.em.persistAndFlush(propAccess);
+
+    expect(propAccess.onCreatePropertyAccessTestSource).toEqual(propAccess.onCreatePropertyAccessTestReceive);
+    expect(propAccess.onUpdatePropertyAccessTestSource).toEqual(0);
+    expect(propAccess.onUpdatePropertyAccessTestReceive).toEqual(1);
+
+    propAccess.name = 'newName';
+    await orm.em.persistAndFlush(propAccess);
+
+    expect(propAccess.onCreatePropertyAccessTestSource).toEqual(propAccess.onCreatePropertyAccessTestReceive);
+    expect(propAccess.onUpdatePropertyAccessTestSource).toEqual(propAccess.onUpdatePropertyAccessTestReceive);
   });
 
   test('custom types', async () => {

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -64,7 +64,7 @@ describe('MikroORM', () => {
 
   test('folder based discover with multiple entities in single file', async () => {
     const orm = await MikroORM.init({ type: 'mongo', dbName: 'test', baseDir: BASE_DIR, entities: ['entities'] }, false);
-    expect(Object.keys(orm.getMetadata().getAll()).sort()).toEqual(['Author', 'Book', 'BookTag', 'Dummy', 'Foo1', 'Foo2',  'Foo3', 'FooBar', 'FooBaz', 'Publisher', 'Test']);
+    expect(Object.keys(orm.getMetadata().getAll()).sort()).toEqual(['Author', 'Book', 'BookTag', 'Dummy', 'Foo1', 'Foo2',  'Foo3', 'FooBar', 'FooBaz', 'Publisher', 'Test', 'UpdateCreatePropAccess']);
     await orm.close();
   });
 

--- a/tests/entities/UpdateCreatePropAccess.ts
+++ b/tests/entities/UpdateCreatePropAccess.ts
@@ -1,0 +1,36 @@
+import { ObjectId } from 'bson';
+import { Entity, PrimaryKey, Property, SerializedPrimaryKey } from '@mikro-orm/core';
+
+@Entity()
+export class UpdateCreatePropAccess {
+
+  @PrimaryKey()
+  _id!: ObjectId;
+
+  @SerializedPrimaryKey()
+  id!: string;
+
+  @Property()
+  name!: string;
+
+  @Property({ onCreate: () => Math.random() })
+  onCreatePropertyAccessTestSource?: number;
+
+  @Property({ onCreate: (propAccess: UpdateCreatePropAccess) => propAccess.onCreatePropertyAccessTestSource })
+  onCreatePropertyAccessTestReceive?: number;
+
+  @Property({ onUpdate: () => Math.random() })
+  onUpdatePropertyAccessTestSource = 0;
+
+  @Property({ onUpdate: (propAccess: UpdateCreatePropAccess) => propAccess.onUpdatePropertyAccessTestSource })
+  onUpdatePropertyAccessTestReceive = 1;
+
+  static create(name: string) {
+    const propAccess = new UpdateCreatePropAccess();
+    propAccess.name = name;
+
+    return propAccess;
+  }
+
+}
+


### PR DESCRIPTION
Allow onUpdate to get access to previous entity values returned via onUpdate,
which can be useful for ensuring created and updated dates have the exact same time
or basing the value of one property off the value of another.

This already worked for onCreate, as onCreate directly updates the entity.
The onUpdate hook however stores its values in a map to ensure values are not updated
unless they actually need to be, which means onUpdate would always get property values
not accounting for prior onUpdate hooks.