### PR TITLE
cli for schema generator should use orm config more

### DIFF
--- a/packages/cli/src/commands/SchemaCommandFactory.ts
+++ b/packages/cli/src/commands/SchemaCommandFactory.ts
@@ -97,7 +97,8 @@ export class SchemaCommandFactory {
 
     const orm = await CLIHelper.getORM() as MikroORM<AbstractSqlDriver>;
     const generator = new SchemaGenerator(orm.em);
-    const params = { wrap: !args.fkChecks, ...args };
+    let params = args.fkChecks !== undefined ? {wrap: !args.fkChecks} : {};
+    params = {...params, ...args};
 
     if (args.dump) {
       const m = `get${method.substr(0, 1).toUpperCase()}${method.substr(1)}SchemaSQL` as 'getCreateSchemaSQL' | 'getUpdateSchemaSQL' | 'getDropSchemaSQL';


### PR DESCRIPTION
There are a number of issues with [postgres and session_replication_role](https://github.com/mikro-orm/mikro-orm/search?q=session_replication_role&type=issues)

I think I found another one here, I could not use the recommended fixes (add disableForeignKeys to orm config) with success.

In my case, I needed the following code fix, then I could run cli command like `schema:create` without the `--fk-checks`  cli flag and it would use the config specified in orm configuration like:

```
{
  ...
  schemaGenerator: {
    disableForeignKeys: false,
  }
}
```  

We can see why we might want this to be 'tri state' at the place I made the change by looking what happens down in the [schema generator](https://github.com/mikro-orm/mikro-orm/blob/master/packages/knex/src/schema/SchemaGenerator.ts#L61)