### PR TITLE
fix(knex): `order by` with a formula field should not include `as` for sub-queries

### DIFF
--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -866,7 +866,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
           const prop = this.helper.getProperty(f, a);
           const type = this.platform.castColumn(prop);
           orderBy.push({
-            [`min(${this.ref(this.helper.mapper(field, this.type))}${type})`]: direction,
+            [`min(${this.ref(this.helper.mapper(field, this.type, undefined, null))}${type})`]: direction,
           });
         }
       }

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -505,7 +505,7 @@ export class QueryBuilderHelper {
 
       Utils.splitPrimaryKeys(field).forEach(f => {
         const prop = this.getProperty(f, alias);
-        const noPrefix = (prop && prop.persist === false) || QueryBuilderHelper.isCustomExpression(f);
+        const noPrefix = (prop && prop.persist === false && !prop.formula) || QueryBuilderHelper.isCustomExpression(f);
         const column = this.mapper(noPrefix ? f : `${alias}.${f}`, type, undefined, null);
         /* istanbul ignore next */
         const rawColumn = Utils.isString(column) ? column.split('.').map(e => this.knex.ref(e)).join('.') : column;

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -2654,6 +2654,11 @@ describe('QueryBuilder', () => {
     expect(sql).toBe(expected);
   });
 
+  test(`sub-query order-by fields should not include 'as'`, async () => {
+    const sql = orm.em.createQueryBuilder(Author2).select('*').joinAndSelect('books', 'books').orderBy([{ books: { priceTaxed: QueryOrder.DESC } }, { id: QueryOrder.DESC }]).limit(10).getFormattedQuery();
+    expect(sql).toBe('select `e0`.*, `books`.`uuid_pk` as `books__uuid_pk`, `books`.`created_at` as `books__created_at`, `books`.`title` as `books__title`, `books`.`price` as `books__price`, `books`.price * 1.19 as `books__price_taxed`, `books`.`double` as `books__double`, `books`.`meta` as `books__meta`, `books`.`author_id` as `books__author_id`, `books`.`publisher_id` as `books__publisher_id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` where `e0`.`id` in (select `e0`.`id` from (select `e0`.`id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` group by `e0`.`id` order by min(`books`.price * 1.19) desc, min(`e0`.`id`) desc limit 10) as `e0`) order by `books`.price * 1.19 desc, `e0`.`id` desc');
+  });
+
   afterAll(async () => orm.close(true));
 
 });


### PR DESCRIPTION
follow on from #2848, noticed for sub-queries it was still adding `as` to formula field on `order by`