### PR TITLE
docs: provide more details on `wrappedReference`

### DIFF
--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -121,6 +121,8 @@ export const Book = new EntitySchema<IBook, CustomBaseEntity>({
   </TabItem>
 </Tabs>
 
+> Including `{ wrappedEntity: true }` in your `IdentifiedReference` property definitions will wrap the reference, providing access to helper methods like `.load` and `.unwrap`, which can be helpful for loading data and changing the type of your references where you plan to use them.
+
 Here is another example of `Author` entity, that was referenced from the `Book` one, this
 time defined for mongo:
 

--- a/docs/docs/entity-references.md
+++ b/docs/docs/entity-references.md
@@ -51,7 +51,7 @@ console.log(book.author.isInitialized()); // false
 console.log(book.author.name); // undefined as `Author` is not loaded yet
 ```
 
-You can overcome this issue by using the `Reference<T>` wrapper. It simply wraps the entity, 
+> You can overcome this issue by using the `Reference<T>` wrapper. It simply wraps the entity, 
 defining `load(): Promise<T>` method that will first lazy load the association if not already
 available. You can also use `unwrap(): T` method to access the underlying entity without loading
 it.

--- a/docs/docs/query-builder.md
+++ b/docs/docs/query-builder.md
@@ -160,8 +160,7 @@ console.log(qb.getQuery());
 // order by `e1`.`tags` asc
 ```
 
-This is currently available only for filtering (`where`) and sorting (`orderBy`), only the root entity will be selected. To populate its relationships, you can
-use [`em.populate()`](nested-populate.md).
+This is currently available only for filtering (`where`) and sorting (`orderBy`), only the root entity will be selected. To populate its relationships, you can use [`em.populate()`](nested-populate.md). If your populated references are _not_ wrapped (methods like `.unwrap()` are `undefined`, make sure that property was defined with `{ wrappedEntity: true }` as described in [Defining Entities](defining-entities.md).
 
 ## Explicit Joining
 

--- a/docs/versioned_docs/version-5.1/defining-entities.md
+++ b/docs/versioned_docs/version-5.1/defining-entities.md
@@ -121,6 +121,8 @@ export const Book = new EntitySchema<IBook, CustomBaseEntity>({
   </TabItem>
 </Tabs>
 
+> Including `{ wrappedEntity: true }` in your `IdentifiedReference` property definitions will wrap the reference, providing access to helper methods like `.load` and `.unwrap`, which can be helpful for loading data and changing the type of your references where you plan to use them.
+
 Here is another example of `Author` entity, that was referenced from the `Book` one, this
 time defined for mongo:
 

--- a/docs/versioned_docs/version-5.1/entity-references.md
+++ b/docs/versioned_docs/version-5.1/entity-references.md
@@ -51,7 +51,7 @@ console.log(book.author.isInitialized()); // false
 console.log(book.author.name); // undefined as `Author` is not loaded yet
 ```
 
-You can overcome this issue by using the `Reference<T>` wrapper. It simply wraps the entity, 
+> You can overcome this issue by using the `Reference<T>` wrapper. It simply wraps the entity, 
 defining `load(): Promise<T>` method that will first lazy load the association if not already
 available. You can also use `unwrap(): T` method to access the underlying entity without loading
 it.

--- a/docs/versioned_docs/version-5.1/query-builder.md
+++ b/docs/versioned_docs/version-5.1/query-builder.md
@@ -160,8 +160,7 @@ console.log(qb.getQuery());
 // order by `e1`.`tags` asc
 ```
 
-This is currently available only for filtering (`where`) and sorting (`orderBy`), only the root entity will be selected. To populate its relationships, you can
-use [`em.populate()`](nested-populate.md).
+> This is currently available only for filtering (`where`) and sorting (`orderBy`), only the root entity will be selected. To populate its relationships, you can use [`em.populate()`](nested-populate.md). If your populated references are _not_ wrapped (methods like `.unwrap()` are `undefined`, make sure that property was defined with `{ wrappedEntity: true }` as described in [Defining Entities](defining-entities.md).
 
 ## Explicit Joining
 


### PR DESCRIPTION
Updated several pages to add details and add emphasis around the use of the `wrappedReference` option for defining entities. I also added some extra details and emphasis on pages where the lack of this option might cause issues.

I know verbiage for docs is super important; please let me know if you'd like to modify/remove any of what I added 😉 

I also think I got the link right in `query-builder.md`, but double check me.