### PR TITLE
feat(schema): support mysql 8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,21 +3,21 @@ version: "3.4"
 services:
   # mongodb is managed via `run-rs`
 
-  mysql:
-    image: mysql:5.7
-    platform: linux/x86_64
+  mysql8:
+    image: mysql:8-oracle
     restart: unless-stopped
     ports:
-      - 3307:3306
+      - "3308:3306"
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
+    command: [ "mysqld", "--default-authentication-plugin=mysql_native_password" ]
     volumes:
-      - mysql:/var/lib/mysql
+      - mysql8:/var/lib/mysql
 
   mariadb:
     image: mariadb:10.8
     ports:
-      - 3309:3306
+      - "3309:3306"
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
     volumes:
@@ -26,13 +26,17 @@ services:
   postgre:
     image: postgres:14.2
     ports:
-      - 5432:5432
+      - "5432:5432"
     volumes:
       - postgre:/var/lib/postgresql/data
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
 
 volumes:
+  mysql8:
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
   mysql:
     driver_opts:
       type: tmpfs

--- a/packages/better-sqlite/src/BetterSqlitePlatform.ts
+++ b/packages/better-sqlite/src/BetterSqlitePlatform.ts
@@ -112,10 +112,6 @@ export class BetterSqlitePlatform extends AbstractSqlPlatform {
     return `json_extract(${this.quoteIdentifier(a)}, '$.${b.join('.')}')`;
   }
 
-  getDefaultIntegrityRule(): string {
-    return 'no action';
-  }
-
   getIndexName(tableName: string, columns: string[], type: 'index' | 'unique' | 'foreign' | 'primary' | 'sequence'): string {
     if (type === 'primary') {
       return this.getDefaultPrimaryName(tableName, columns);

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -257,10 +257,6 @@ export abstract class Platform {
     return 'text';
   }
 
-  getDefaultIntegrityRule(): string {
-    return 'restrict';
-  }
-
   marshallArray(values: string[]): string {
     return values.join(',');
   }

--- a/packages/knex/src/schema/SchemaComparator.ts
+++ b/packages/knex/src/schema/SchemaComparator.ts
@@ -362,7 +362,10 @@ export class SchemaComparator {
       return true;
     }
 
-    const rule = (key: ForeignKey, method: 'updateRule' | 'deleteRule') => (key[method] ?? this.platform.getDefaultIntegrityRule()).toLowerCase();
+    const defaultRule = ['restrict', 'no action'];
+    const rule = (key: ForeignKey, method: 'updateRule' | 'deleteRule') => {
+      return (key[method] ?? defaultRule[0]).toLowerCase().replace(defaultRule[1], defaultRule[0]);
+    };
     const compare = (method: 'updateRule' | 'deleteRule') => rule(key1, method) === rule(key2, method);
 
     return !compare('updateRule') || !compare('deleteRule');

--- a/packages/mysql/src/MySqlSchemaHelper.ts
+++ b/packages/mysql/src/MySqlSchemaHelper.ts
@@ -5,6 +5,8 @@ import { EnumType, StringType, TextType } from '@mikro-orm/core';
 
 export class MySqlSchemaHelper extends SchemaHelper {
 
+  private readonly _cache: Dictionary = {};
+
   static readonly DEFAULT_VALUES = {
     'now()': ['now()', 'current_timestamp'],
     'current_timestamp(?)': ['current_timestamp(?)'],
@@ -131,7 +133,8 @@ export class MySqlSchemaHelper extends SchemaHelper {
       ifnull(datetime_precision, character_maximum_length) length
       from information_schema.columns where table_schema = database() and table_name = '${tableName}'`;
     const columns = await connection.execute<any[]>(sql);
-    const str = (val: string | number | undefined) => val != null ? '' + val : val;
+    const str = (val?: string | number) => val != null ? '' + val : val;
+    const extra = (val: string) => val.replace(/auto_increment|default_generated/i, '').trim();
 
     return columns.map(col => {
       const platform = connection.getPlatform();
@@ -151,7 +154,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
         precision: col.numeric_precision,
         scale: col.numeric_scale,
         comment: col.column_comment,
-        extra: col.extra.replace('auto_increment', ''),
+        extra: extra(col.extra),
       };
     });
   }
@@ -168,9 +171,47 @@ export class MySqlSchemaHelper extends SchemaHelper {
     })));
   }
 
-  async getChecks(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<Check[]> {
-    // @todo No support for CHECK constraints in current test MySQL version (minimum version is 8.0.16).
-    return [];
+  private async supportsCheckConstraints(connection: AbstractSqlConnection): Promise<boolean> {
+    if (this._cache.supportsCheckConstraints != null) {
+      return this._cache.supportsCheckConstraints;
+    }
+
+    const sql = `select 1 from information_schema.tables where table_name = 'CHECK_CONSTRAINTS' and table_schema = 'information_schema'`;
+    const res = await connection.execute(sql);
+
+    return this._cache.supportsCheckConstraints = res.length > 0;
+  }
+
+  private getChecksSQL(tableName: string, _schemaName: string): string {
+    return `select cc.constraint_schema as table_schema, tc.table_name as table_name, cc.constraint_name as name, cc.check_clause as expression
+      from information_schema.check_constraints cc
+      join information_schema.table_constraints tc
+        on tc.constraint_schema = cc.constraint_schema
+        and tc.constraint_name = cc.constraint_name
+        and constraint_type = 'CHECK'
+      where tc.table_name = '${tableName}' and tc.constraint_schema = database()`;
+  }
+
+  async getChecks(connection: AbstractSqlConnection, tableName: string, schemaName: string, columns?: Column[]): Promise<Check[]> {
+    /* istanbul ignore next */
+    if (!await this.supportsCheckConstraints(connection)) {
+      return [];
+    }
+
+    const sql = this.getChecksSQL(tableName, schemaName);
+    const checks = await connection.execute<{ name: string; column_name: string; expression: string }[]>(sql);
+    const ret: Check[] = [];
+
+    for (const check of checks) {
+      ret.push({
+        name: check.name,
+        columnName: check.column_name,
+        definition: `check ${check.expression}`,
+        expression: check.expression.replace(/^\((.*)\)$/, '$1'),
+      });
+    }
+
+    return ret;
   }
 
   normalizeDefaultValue(defaultValue: string, length: number) {

--- a/packages/postgresql/src/PostgreSqlPlatform.ts
+++ b/packages/postgresql/src/PostgreSqlPlatform.ts
@@ -165,10 +165,6 @@ export class PostgreSqlPlatform extends AbstractSqlPlatform {
     return super.quoteValue(value);
   }
 
-  getDefaultIntegrityRule(): string {
-    return 'no action';
-  }
-
   indexForeignKeys() {
     return false;
   }

--- a/packages/sqlite/src/SqlitePlatform.ts
+++ b/packages/sqlite/src/SqlitePlatform.ts
@@ -112,10 +112,6 @@ export class SqlitePlatform extends AbstractSqlPlatform {
     return `json_extract(${this.quoteIdentifier(a)}, '$.${b.join('.')}')`;
   }
 
-  getDefaultIntegrityRule(): string {
-    return 'no action';
-  }
-
   getIndexName(tableName: string, columns: string[], type: 'index' | 'unique' | 'foreign' | 'primary' | 'sequence'): string {
     if (type === 'primary') {
       return this.getDefaultPrimaryName(tableName, columns);

--- a/tests/Webpack.test.ts
+++ b/tests/Webpack.test.ts
@@ -8,7 +8,7 @@ describe('Webpack', () => {
   test('should create entity', async () => {
     const orm = await MikroORM.init({
       dbName: `mikro_orm_test`,
-      port: 3307,
+      port: 3308,
       multipleStatements: true,
       type: 'mysql',
       discovery: { disableDynamicFileAccess: true },

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -50,7 +50,7 @@ export async function initORMMySql<D extends MySqlDriver | MariaDbDriver = MySql
     entities: ['entities-sql/**/*.js', '!**/Label2.js'],
     entitiesTs: ['entities-sql/**/*.ts', '!**/Label2.ts'],
     clientUrl: `mysql://root@127.0.0.1:3306/mikro_orm_test`,
-    port: type === 'mysql' ? 3307 : 3309,
+    port: type === 'mysql' ? 3308 : 3309,
     baseDir: BASE_DIR,
     debug: ['query', 'query-params'],
     timezone: 'Z',

--- a/tests/features/custom-order/custom-order.mysql.test.ts
+++ b/tests/features/custom-order/custom-order.mysql.test.ts
@@ -93,7 +93,7 @@ describe('custom order [mysql]', () => {
       entities: [Task, User],
       dbName: `mikro_orm_test_custom_order`,
       type: 'mysql',
-      port: 3307,
+      port: 3308,
     });
 
     await orm.getSchemaGenerator().refreshDatabase();

--- a/tests/features/custom-types/GH1930.test.ts
+++ b/tests/features/custom-types/GH1930.test.ts
@@ -60,7 +60,7 @@ describe('GH issue 1930', () => {
       entities: [A, B],
       dbName: `mikro_orm_test_gh_1930`,
       type: 'mysql',
-      port: 3307,
+      port: 3308,
     });
     await orm.getSchemaGenerator().refreshDatabase();
   });

--- a/tests/features/custom-types/GH446.test.ts
+++ b/tests/features/custom-types/GH446.test.ts
@@ -67,7 +67,7 @@ describe('GH issue 446', () => {
       entities: [A, B, C, D],
       dbName: `mikro_orm_test_gh_446`,
       type: 'mysql',
-      port: 3307,
+      port: 3308,
     });
     await orm.getSchemaGenerator().refreshDatabase();
   });

--- a/tests/features/custom-types/custom-types.mysql.test.ts
+++ b/tests/features/custom-types/custom-types.mysql.test.ts
@@ -86,7 +86,7 @@ describe('custom types [mysql]', () => {
       entities: [Location, Address],
       dbName: `mikro_orm_test_custom_types`,
       type: 'mysql',
-      port: 3307,
+      port: 3308,
     });
 
     await orm.getSchemaGenerator().refreshDatabase();

--- a/tests/features/default-values/default-values.mysql.test.ts
+++ b/tests/features/default-values/default-values.mysql.test.ts
@@ -30,7 +30,7 @@ describe('default values in mysql', () => {
       entities: [A],
       dbName: `mikro_orm_test_default_values`,
       type: 'mysql',
-      port: 3307,
+      port: 3308,
     });
     await orm.getSchemaGenerator().refreshDatabase();
   });

--- a/tests/features/embeddables/embedded-entities.mysql.test.ts
+++ b/tests/features/embeddables/embedded-entities.mysql.test.ts
@@ -99,7 +99,7 @@ describe('embedded entities in mysql', () => {
       entities: [Address1, Address2, User],
       dbName: `mikro_orm_test_embeddables`,
       type: 'mysql',
-      port: 3307,
+      port: 3308,
     });
     await orm.getSchemaGenerator().refreshDatabase();
   });
@@ -289,7 +289,7 @@ describe('embedded entities in mysql', () => {
       entities: [Address1, UserWithCity],
       dbName: `mikro_orm_test_embeddables`,
       type: 'mysql',
-      port: 3307,
+      port: 3308,
     })).rejects.toThrow(err);
   });
 

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
@@ -411,13 +411,13 @@ export class Publisher2 {
   @Enum({ items: () => Publisher2Type2 })
   type2!: Publisher2Type2;
 
-  @Property({ columnType: 'tinyint(4)', nullable: true })
+  @Property({ columnType: 'tinyint', nullable: true })
   enum1?: number;
 
-  @Property({ columnType: 'tinyint(4)', nullable: true })
+  @Property({ columnType: 'tinyint', nullable: true })
   enum2?: number;
 
-  @Property({ columnType: 'tinyint(4)', nullable: true })
+  @Property({ columnType: 'tinyint', nullable: true })
   enum3?: number;
 
   @Enum({ items: () => Publisher2Enum4, nullable: true })

--- a/tests/features/schema-generator/GH2386.test.ts
+++ b/tests/features/schema-generator/GH2386.test.ts
@@ -52,7 +52,7 @@ describe('changing column in mysql (GH 2386)', () => {
       entities: [Book1],
       dbName: `mikro_orm_test_gh_2386`,
       type: 'mysql',
-      port: 3307,
+      port: 3308,
     });
     await orm.getSchemaGenerator().refreshDatabase();
   });

--- a/tests/features/schema-generator/SchemaGenerator.mysql.test.ts
+++ b/tests/features/schema-generator/SchemaGenerator.mysql.test.ts
@@ -12,7 +12,7 @@ describe('SchemaGenerator', () => {
     const orm = await MikroORM.init({
       entities: [FooBar2, FooBaz2, Test2, Book2, Author2, Configuration2, Publisher2, BookTag2, Address2, BaseEntity2, BaseEntity22],
       dbName,
-      port: 3307,
+      port: 3308,
       baseDir: BASE_DIR,
       type: 'mysql',
     });
@@ -28,7 +28,7 @@ describe('SchemaGenerator', () => {
     const orm = await MikroORM.init({
       entities: [FooBar2, FooBaz2, Test2, Book2, Author2, Configuration2, Publisher2, BookTag2, Address2, BaseEntity2, BaseEntity22],
       dbName,
-      port: 3307,
+      port: 3308,
       baseDir: BASE_DIR,
       type: 'mysql',
       migrations: { path: BASE_DIR + '/../temp/migrations' },
@@ -47,7 +47,7 @@ describe('SchemaGenerator', () => {
     const orm = await MikroORM.init({
       entities: [FooBar2, FooBaz2, Test2, Book2, Author2, Configuration2, Publisher2, BookTag2, Address2, BaseEntity2, BaseEntity22],
       dbName,
-      port: 3307,
+      port: 3308,
       baseDir: BASE_DIR,
       type: 'mariadb',
     });
@@ -64,7 +64,7 @@ describe('SchemaGenerator', () => {
     const orm = await MikroORM.init({
       entities: [FooBar2, FooBaz2, Test2, Book2, Author2, Configuration2, Publisher2, BookTag2, Address2, BaseEntity2, BaseEntity22],
       dbName,
-      port: 3307,
+      port: 3308,
       baseDir: BASE_DIR,
       type: 'mariadb',
       migrations: { path: BASE_DIR + '/../temp/migrations' },

--- a/tests/features/schema-generator/SchemaGenerator.mysql2.test.ts
+++ b/tests/features/schema-generator/SchemaGenerator.mysql2.test.ts
@@ -12,7 +12,7 @@ describe('SchemaGenerator (no FKs)', () => {
     const orm = await MikroORM.init({
       entities: [FooBar2, FooBaz2, Test2, Book2, Author2, Configuration2, Publisher2, BookTag2, Address2, BaseEntity2, BaseEntity22],
       dbName,
-      port: 3307,
+      port: 3308,
       baseDir: BASE_DIR,
       type: 'mysql',
       schemaGenerator: { createForeignKeyConstraints: false, disableForeignKeys: false },
@@ -29,7 +29,7 @@ describe('SchemaGenerator (no FKs)', () => {
     const orm = await MikroORM.init({
       entities: [FooBar2, FooBaz2, Test2, Book2, Author2, Configuration2, Publisher2, BookTag2, Address2, BaseEntity2, BaseEntity22],
       dbName,
-      port: 3307,
+      port: 3308,
       baseDir: BASE_DIR,
       type: 'mysql',
       migrations: { path: BASE_DIR + '/../temp/migrations' },

--- a/tests/features/schema-generator/__snapshots__/check-constraint.mysql.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/check-constraint.mysql.test.ts.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`check constraint [mysql8] check constraint diff [mysql8]: mysql8-check-constraint-diff-1 1`] = `
+"create table \`new_table\` (\`id\` int unsigned not null auto_increment primary key, \`priceColumn\` int not null, constraint foo check (priceColumn >= 0)) default character set utf8mb4 engine = InnoDB;
+
+"
+`;
+
+exports[`check constraint [mysql8] check constraint diff [mysql8]: mysql8-check-constraint-diff-2 1`] = `
+"alter table \`new_table\` drop constraint foo;
+alter table \`new_table\` add constraint foo check(priceColumn > 0);
+
+"
+`;
+
+exports[`check constraint [mysql8] check constraint diff [mysql8]: mysql8-check-constraint-diff-3 1`] = `
+"alter table \`new_table\` drop constraint foo;
+
+"
+`;
+
+exports[`check constraint [mysql8] check constraint diff [mysql8]: mysql8-check-constraint-diff-4 1`] = `
+"alter table \`new_table\` add constraint bar check(priceColumn > 0);
+
+"
+`;
+
+exports[`check constraint [mysql8] check constraint diff [mysql8]: mysql8-check-constraint-diff-5 1`] = `""`;
+
+exports[`check constraint [mysql8] check constraint is generated for decorator [mysql8]: mysql8-check-constraint-decorator 1`] = `
+"create table \`foo_entity\` (\`id\` int unsigned not null auto_increment primary key, \`price\` int not null, \`price2\` int not null, \`price3\` int not null, constraint foo_entity_price2_check check (price2 >= 0), constraint foo_entity_price3_check check (price3 >= 0), constraint foo_entity_check check (price >= 0)) default character set utf8mb4 engine = InnoDB;
+
+"
+`;

--- a/tests/features/schema-generator/changing-column-type.mysql.test.ts
+++ b/tests/features/schema-generator/changing-column-type.mysql.test.ts
@@ -65,7 +65,7 @@ describe('changing column in mysql (GH 2407)', () => {
       entities: [Book1],
       dbName: `mikro_orm_test_gh_2407`,
       type: 'mysql',
-      port: 3307,
+      port: 3308,
     });
     await orm.getSchemaGenerator().refreshDatabase();
   });

--- a/tests/features/schema-generator/changing-pk-type.mysql.test.ts
+++ b/tests/features/schema-generator/changing-pk-type.mysql.test.ts
@@ -63,7 +63,7 @@ describe('changing PK column type [mysql] (GH 1480)', () => {
     orm = await MikroORM.init({
       entities: [User0],
       dbName: 'mikro_orm_test_gh_1480',
-      port: 3307,
+      port: 3308,
       type: 'mysql',
     });
     generator = orm.getSchemaGenerator();

--- a/tests/features/schema-generator/check-constraint.mysql.test.ts
+++ b/tests/features/schema-generator/check-constraint.mysql.test.ts
@@ -1,0 +1,105 @@
+import { Check, Entity, EntitySchema, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity()
+@Check<FooEntity>({ expression: columns => `${columns.price} >= 0` })
+export class FooEntity {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  price!: number;
+
+  @Property()
+  @Check<FooEntity>({ expression: columns => `${columns.price2} >= 0` })
+  price2!: number;
+
+  @Property({ check: 'price3 >= 0' })
+  price3!: number;
+
+}
+
+describe('check constraint [mysql8]', () => {
+
+  test('check constraint is generated for decorator [mysql8]', async () => {
+    const orm = await MikroORM.init({
+      entities: [FooEntity],
+      dbName: `mikro_orm_test_checks`,
+      type: 'mysql',
+      port: 3308,
+    });
+
+    const diff = await orm.getSchemaGenerator().getCreateSchemaSQL({ wrap: false });
+    expect(diff).toMatchSnapshot('mysql8-check-constraint-decorator');
+
+    await orm.close();
+  });
+
+  test('check constraint diff [mysql8]', async () => {
+    const orm = await MikroORM.init({
+      entities: [FooEntity],
+      dbName: `mikro_orm_test_checks`,
+      type: 'mysql',
+      port: 3308,
+    });
+
+    const meta = orm.getMetadata();
+    const generator = orm.getSchemaGenerator();
+    await generator.refreshDatabase();
+    await generator.execute('drop table if exists new_table');
+
+    const newTableMeta = new EntitySchema({
+      properties: {
+        id: {
+          primary: true,
+          name: 'id',
+          type: 'number',
+          fieldName: 'id',
+          columnType: 'int',
+        },
+        price: {
+          type: 'number',
+          name: 'price',
+          fieldName: 'priceColumn',
+          columnType: 'int',
+        },
+      },
+      name: 'NewTable',
+      tableName: 'new_table',
+      checks: [
+        { name: 'foo', expression: 'priceColumn >= 0' },
+      ],
+    }).init().meta;
+    meta.set('NewTable', newTableMeta);
+
+    let diff = await orm.getSchemaGenerator().getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toMatchSnapshot('mysql8-check-constraint-diff-1');
+    await generator.execute(diff);
+
+    // Update a check expression
+    newTableMeta.checks = [{ name: 'foo', expression: 'priceColumn > 0' }];
+    diff = await orm.getSchemaGenerator().getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toMatchSnapshot('mysql8-check-constraint-diff-2');
+    await generator.execute(diff);
+
+    // Remove a check constraint
+    newTableMeta.checks = [];
+    diff = await orm.getSchemaGenerator().getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toMatchSnapshot('mysql8-check-constraint-diff-3');
+    await generator.execute(diff);
+
+    // Add new check
+    newTableMeta.checks = [{ name: 'bar', expression: 'priceColumn > 0' }];
+    diff = await orm.getSchemaGenerator().getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toMatchSnapshot('mysql8-check-constraint-diff-4');
+    await generator.execute(diff);
+
+    // Skip existing check
+    diff = await orm.getSchemaGenerator().getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toMatchSnapshot('mysql8-check-constraint-diff-5');
+    await generator.execute(diff);
+
+    await orm.close();
+  });
+
+});

--- a/tests/features/schema-generator/comment-diffing.mysql.test.ts
+++ b/tests/features/schema-generator/comment-diffing.mysql.test.ts
@@ -55,7 +55,7 @@ describe('comment diffing in mysql', () => {
       entities: [Book0],
       dbName: `mikro_orm_test_comments`,
       type: 'mysql',
-      port: 3307,
+      port: 3308,
     });
     generator = orm.getSchemaGenerator();
     await generator.ensureDatabase();

--- a/tests/features/schema-generator/diffing-default-values.test.ts
+++ b/tests/features/schema-generator/diffing-default-values.test.ts
@@ -50,7 +50,7 @@ describe('diffing default values (GH #2385)', () => {
       entities: [Foo1],
       dbName: 'mikro_orm_test_gh_2385',
       type: 'mysql',
-      port: 3307,
+      port: 3308,
     });
     await orm.getSchemaGenerator().refreshDatabase();
     expect(await orm.getSchemaGenerator().getCreateSchemaSQL()).toMatchSnapshot();

--- a/tests/features/schema-generator/index-diffing.mysql.test.ts
+++ b/tests/features/schema-generator/index-diffing.mysql.test.ts
@@ -142,7 +142,7 @@ describe('indexes on FKs in postgres (GH 1518)', () => {
       entities: [Author],
       dbName: `mikro_orm_test_gh_1518`,
       type: 'mysql',
-      port: 3307,
+      port: 3308,
     });
     await orm.getSchemaGenerator().ensureDatabase();
     await orm.getSchemaGenerator().execute('set foreign_key_checks = 0');

--- a/tests/features/schema-generator/length-diffing.mysql.test.ts
+++ b/tests/features/schema-generator/length-diffing.mysql.test.ts
@@ -96,7 +96,7 @@ describe('length diffing in mysql', () => {
       entities: [Book0],
       dbName: `mikro_orm_test_length_diffing`,
       type: 'mysql',
-      port: 3307,
+      port: 3308,
     });
     generator = orm.getSchemaGenerator();
     await generator.ensureDatabase();

--- a/tests/features/schema-generator/max-index-name-length.mysql.test.ts
+++ b/tests/features/schema-generator/max-index-name-length.mysql.test.ts
@@ -34,7 +34,7 @@ describe('index and FK names should be a max of 64 chars in mysql (GH 1271)', ()
     orm = await MikroORM.init({
       entities: [ParentEntity, ChildEntity],
       dbName: `mikro_orm_test_gh_1271`,
-      port: 3307,
+      port: 3308,
       type: 'mysql',
     });
     await orm.getSchemaGenerator().ensureDatabase();

--- a/tests/issues/GH1326.test.ts
+++ b/tests/issues/GH1326.test.ts
@@ -54,7 +54,7 @@ describe('GH issue 1326', () => {
     orm = await MikroORM.init({
       type: 'mysql',
       dbName: `mikro_orm_test_gh_1326`,
-      port: 3307,
+      port: 3308,
       entities: [Driver, License, LicenseType],
     });
     await orm.getSchemaGenerator().refreshDatabase();

--- a/tests/issues/GH603.test.ts
+++ b/tests/issues/GH603.test.ts
@@ -72,7 +72,7 @@ describe('GH issue 603', () => {
       entities: [TaskSchema, ProjectSchema],
       dbName: `mikro_orm_test_gh_603`,
       type: 'mysql',
-      port: 3307,
+      port: 3308,
     });
     await orm.getSchemaGenerator().refreshDatabase();
 


### PR DESCRIPTION
All ORM tests are now using mysql8, which supports check constraints.
Also fixes several issues with schema diffing in mysql8 (additional queries).