### PR TITLE
refactor(core): remove unnecessary storage.run() promise

### DIFF
--- a/packages/core/src/utils/RequestContext.ts
+++ b/packages/core/src/utils/RequestContext.ts
@@ -33,9 +33,7 @@ export class RequestContext {
    */
   static async createAsync<T>(em: EntityManager | EntityManager[], next: (...args: any[]) => Promise<T>): Promise<T> {
     const ctx = this.createContext(em);
-    return new Promise((resolve, reject) => {
-      this.storage.run(ctx, () => next().then(resolve).catch(reject));
-    });
+    return this.storage.run(ctx, next);
   }
 
   /**

--- a/packages/core/src/utils/TransactionContext.ts
+++ b/packages/core/src/utils/TransactionContext.ts
@@ -11,12 +11,10 @@ export class TransactionContext {
   /**
    * Creates new TransactionContext instance and runs the code inside its domain.
    */
-  static async createAsync<T>(em: EntityManager, next: (...args: any[]) => Promise<T>): Promise<T> {
+  static createAsync<T>(em: EntityManager, next: (...args: any[]) => Promise<T>): Promise<T> {
     const context = new TransactionContext(em);
 
-    return new Promise((resolve, reject) => {
-      this.storage.run(context, () => next().then(resolve).catch(reject));
-    });
+    return this.storage.run(context, next);
   }
 
   /**


### PR DESCRIPTION
remove unnecessary storage.run() promise

```ts
  static createAsync<T>(em: EntityManager, next: (...args: any[]) => Promise<T>): Promise<T> {
    const context = new TransactionContext(em);
    // async_hooks.d.ts
    // AsyncLocalStorage<T>.run<R, TArgs extends any[]>(store: T, callback: (...args: TArgs) => R, ...args: TArgs): R;
    // AsyncLocalStorage<TransactionContext>.run<Promise<T>, []>(store: TransactionContext, callback: () => Promise<T>): Promise<T>
    return this.storage.run(context, next);
  }
```
