### PR TITLE
fix(core): respect mapToPk when expanding properties

### DIFF
--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -502,7 +502,7 @@ export class UnitOfWork {
   private expandUniqueProps<T extends AnyEntity<T>>(entity: T): string[] {
     return entity.__meta!.uniqueProps.map(prop => {
       if (entity[prop.name]) {
-        return prop.reference === ReferenceType.SCALAR ? entity[prop.name] : (entity[prop.name] as AnyEntity).__helper!.getSerializedPrimaryKey();
+        return prop.reference === ReferenceType.SCALAR  || prop.mapToPk ? entity[prop.name] : (entity[prop.name] as AnyEntity).__helper!.getSerializedPrimaryKey();
       }
 
       return undefined;


### PR DESCRIPTION
When using references that are mapped to Primary Key (`mapToPk`), the expanding will result in an error as we are actually dealing with a scalar value.

Adding this constraint into the expansion logic.