### PR TITLE
fix(core): updating JSON properties should be shallow by default

### DIFF
--- a/tests/issues/GHx3.test.ts
+++ b/tests/issues/GHx3.test.ts
@@ -1,0 +1,71 @@
+import { Entity, IdentifiedReference, JsonType, ManyToOne, MikroORM, OneToOne, PrimaryKey, PrimaryKeyType, Property, wrap } from '@mikro-orm/core';
+import type { PostgreSqlDriver } from '@mikro-orm/postgresl';
+
+interface Test {
+  t1: string;
+  t2: {
+    t3: string | null;
+    t4?: {
+      t5: string;
+    };
+  };
+}
+
+@Entity()
+export class A {
+
+  @PrimaryKey({ type: Number })
+  id!: number;
+
+  @Property({ type: JsonType })
+  test: Test;
+
+}
+
+describe('GH issue GHx3', () => {
+
+  let orm: MikroORM<PostgreSqlDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [A],
+      dbName: ':memory:',
+      type: 'postgresql',
+      debug: true,
+    });
+    await orm.getSchemaGenerator().createSchema();
+  });
+
+  afterAll(async () => {
+    await orm.getSchemaGenerator().dropSchema();
+    orm.close(true);
+  });
+
+  test('Persist JSON', async () => {
+    await orm.em.transactional(em => {
+      const a = em.create(A, { test: { t1: 'a', t2: { t3: null } } });
+      em.persist(a);
+    });
+
+    orm.em.clear();
+
+    await orm.em.transactional(async em => {
+      const a = await em.find(A);
+
+      wrap(a[0]).assign({
+        test: { t2: { t3: 'x', t4: { t5: 'y' } } },
+      });
+    });
+
+    orm.em.clear();
+
+    const a = await orm.em.find(A);
+
+    expect(a.length).toBe(1);
+    expect(a[0]).not.toBeNull();
+    expect(a[0].test.t1).not.toBeDefined();
+    expect(a[0].test.t2).not.toBeNull();
+    expect(a[0].test.t2.t3).toBe('x');
+    expect(a[0].test.t2.t4.t5).toBe('y');
+  });
+});


### PR DESCRIPTION
I'm not really sure this is a bug, but it started to happen to me after upgrading to V5.

This happens when updating a plain JSON property. I expect the full JSON to be replaced, but I'm getting merged results when reading the JSON back from the database. Look at the failing test, `t1` should not be defined.

I managed to fix this with `{ mergeObjects: false }` but it doesn't feel right. 

According to the V5 docs, the default should be `false` already, so I shouldn't have to do this.

Is this a bug or are the docs outdated?
