### PR TITLE
fix(seeder): fix type of Factory methods

### DIFF
--- a/packages/seeder/src/Factory.ts
+++ b/packages/seeder/src/Factory.ts
@@ -9,9 +9,9 @@ export abstract class Factory<T> {
 
   constructor(private readonly em: EntityManager) { }
 
-  protected abstract definition(faker: Faker): Partial<T>;
+  protected abstract definition(faker: Faker): Partial<RequiredEntityData<T>>;
 
-  private makeEntity(overrideParameters?: Partial<T>): T {
+  private makeEntity(overrideParameters?: Partial<RequiredEntityData<T>>): T {
     const entity = this.em.create(this.model, {
       ...this.definition(faker),
       ...overrideParameters,
@@ -28,7 +28,7 @@ export abstract class Factory<T> {
    * Make a single entity and persist (not flush)
    * @param overrideParameters Object specifying what default attributes of the entity factory should be overridden
    */
-  makeOne(overrideParameters?: Partial<T>): T {
+  makeOne(overrideParameters?: Partial<RequiredEntityData<T>>): T {
     const entity = this.makeEntity(overrideParameters);
     this.em.persist(entity);
     return entity;
@@ -39,7 +39,7 @@ export abstract class Factory<T> {
    * @param amount Number of entities that should be generated
    * @param overrideParameters Object specifying what default attributes of the entity factory should be overridden
    */
-  make(amount: number, overrideParameters?: Partial<T>): T[] {
+  make(amount: number, overrideParameters?: Partial<RequiredEntityData<T>>): T[] {
     const entities = [...Array(amount)].map(() => {
       return this.makeEntity(overrideParameters);
     });
@@ -51,7 +51,7 @@ export abstract class Factory<T> {
    * Create (and flush) a single entity
    * @param overrideParameters Object specifying what default attributes of the entity factory should be overridden
    */
-  async createOne(overrideParameters?: Partial<T>): Promise<T> {
+  async createOne(overrideParameters?: Partial<RequiredEntityData<T>>): Promise<T> {
     const entity = this.makeOne(overrideParameters);
     await this.em.flush();
     return entity;
@@ -62,7 +62,7 @@ export abstract class Factory<T> {
    * @param amount Number of entities that should be generated
    * @param overrideParameters Object specifying what default attributes of the entity factory should be overridden
    */
-  async create(amount: number, overrideParameters?: Partial<T>): Promise<T[]> {
+  async create(amount: number, overrideParameters?: Partial<RequiredEntityData<T>>): Promise<T[]> {
     const entities = this.make(amount, overrideParameters);
     await this.em.flush();
     return entities;

--- a/tests/features/seeder/entities/project.entity.ts
+++ b/tests/features/seeder/entities/project.entity.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, ManyToOne, OneToMany, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+import { Collection, Entity, IdentifiedReference, ManyToOne, OneToMany, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
 import { House } from './house.entity';
 import { User } from './user.entity';
 
@@ -13,8 +13,8 @@ export class Project {
   @Property()
   name!: string;
 
-  @ManyToOne(() => User)
-  owner!: User;
+  @ManyToOne({ entity: () => User, wrappedReference: true })
+  owner!: IdentifiedReference<User>;
 
   @Property()
   worth!: number;

--- a/tests/features/seeder/factory.test.ts
+++ b/tests/features/seeder/factory.test.ts
@@ -1,4 +1,5 @@
 import { MikroORM } from '@mikro-orm/core';
+import type { RequiredEntityData } from '@mikro-orm/core';
 import { Factory } from '@mikro-orm/seeder';
 import type { Faker } from '@mikro-orm/seeder';
 import { House } from './entities/house.entity';
@@ -10,7 +11,7 @@ export class ProjectFactory extends Factory<Project> {
 
   model = Project;
 
-  definition(faker: Faker): Partial<Project> {
+  definition(faker: Faker): Partial<RequiredEntityData<Project>> {
     return {
       name: 'Money vault',
       owner: {


### PR DESCRIPTION
As asked by [B4nan](https://github.com/B4nan) in related issue, I opened this PR.

Closes #3062

### Description

See issue above

### Tests

Only types were changed, so no useful test which I can think of can cover that besides TypeScript itself (`yarn tsc-check-tests`). Existing tests are running successful.

### Docu

Only [here](https://mikro-orm.io/docs/seeding#entity-factories) the documentation could be updated, but I think for the majority of people a simple partial is enough - so let's keep it how it is instead of:

```diff
- definition(faker: Faker): Partial<Author>
+ definition(faker: Faker): Partial<RequiredEntityData<Author>>
```