### PR TITLE
fix(core): subsribers should receive m to n collection changes

### DIFF
--- a/tests/issues/GHx3.test.ts
+++ b/tests/issues/GHx3.test.ts
@@ -1,0 +1,88 @@
+import type { ChangeSet, EventSubscriber, FlushEventArgs } from '@mikro-orm/core';
+import { Collection, Entity, ManyToMany, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
+import type { SqliteDriver } from '@mikro-orm/sqlite';
+
+@Entity()
+class User {
+
+  @PrimaryKey()
+  id: number;
+
+  @Property()
+  name: string;
+
+}
+
+@Entity()
+class Project {
+
+  @PrimaryKey()
+  id: number;
+
+  @Property()
+  name: string;
+
+  @ManyToMany({
+    entity: () => User,
+    nullable: true,
+    fixedOrder: true,
+  })
+  users?: Collection<User>;
+
+}
+
+export class ChangesSubscriber implements EventSubscriber {
+
+  public changeSets?: ChangeSet[];
+
+  async afterFlush(args: FlushEventArgs): Promise<void> {
+    this.changeSets = args.uow.getChangeSets();
+  }
+
+}
+
+describe('GH issue x3', () => {
+  let orm: MikroORM<SqliteDriver>;
+  const subscriber = new ChangesSubscriber();
+  const afterFlush = jest.spyOn(subscriber, 'afterFlush');
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [User, Project],
+      dbName: ':memory:',
+      type: 'postgresql',
+      subscribers: [subscriber],
+      debug: true,
+    });
+    await orm.getSchemaGenerator().createSchema();
+  });
+
+  afterEach(() => {
+    afterFlush.mockClear();
+    subscriber.changeSets = undefined;
+  });
+
+  afterAll(async () => {
+    await orm.getSchemaGenerator().dropSchema();
+    await orm.close(true);
+  });
+
+  it(`notifies m to n collection flush`, async () => {
+
+    await orm.em.transactional(em => {
+      const user1 = em.create(User, { id: 1, name: 'User 1' });
+      const user2 = em.create(User, { id: 2, name: 'User 2' });
+      const project = em.create(Project, { id: 1, name: 'Project 1', users: [user1, user2] });
+      em.persist(user1);
+      em.persist(user2);
+      em.persist(project);
+    });
+
+    expect(subscriber.afterFlush).toHaveBeenCalledTimes(1);
+    expect(subscriber.changeSets).toEqual(expect.arrayContaining([
+      expect.objectContaining({ payload: expect.objectContaining({ id: 1, name: 'User 1' }) }),
+      expect.objectContaining({ payload: expect.objectContaining({ id: 2, name: 'User 2' }) }),
+      expect.objectContaining({ payload: expect.objectContaining({ id: 1, name: 'Project 1', users: expect.anything() }) }),
+    ]));
+  });
+});


### PR DESCRIPTION
This is just a faling test for now. I am using v5.1.

I have a subscriber I need to keep track of all entity changes and log them to a separate system.

The problem I have is on the `afterFlush` event, the payload in change sets don't contain the changes for the m to n collection.

Basically after doing this:

```
    await orm.em.transactional(em => {
      const user1 = em.create(User, { id: 1, name: 'User 1' });
      const user2 = em.create(User, { id: 2, name: 'User 2' });
      const project = em.create(Project, { id: 1, name: 'Project 1', users: [user1, user2] });
      em.persist(user1);
      em.persist(user2);
      em.persist(project);
    });
```

I get everything in the payloads, except the `users` collection. Also there is no separate change set for the collection, so it seems to be completely ignored.

I'm not sure if m to n collections should be reported in the parent entity payload or as a separate change set (because it's a separate table) but I think they should be reported somehow.
