### PR TITLE
fix: typing detection with typescript 4.7 node16

### DIFF
--- a/packages/better-sqlite/package.json
+++ b/packages/better-sqlite/package.json
@@ -8,7 +8,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/index.mjs",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
       "require": "./dist/index.js"
     }
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/index.mjs",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
       "require": "./dist/index.js"
     }
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/index.mjs",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
       "require": "./dist/index.js"
     }
   },

--- a/packages/entity-generator/package.json
+++ b/packages/entity-generator/package.json
@@ -8,7 +8,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/index.mjs",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
       "require": "./dist/index.js"
     }
   },

--- a/packages/knex/package.json
+++ b/packages/knex/package.json
@@ -8,7 +8,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/index.mjs",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
       "require": "./dist/index.js"
     }
   },

--- a/packages/mariadb/package.json
+++ b/packages/mariadb/package.json
@@ -8,7 +8,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/index.mjs",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
       "require": "./dist/index.js"
     }
   },

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -8,7 +8,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/index.mjs",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
       "require": "./dist/index.js"
     }
   },

--- a/packages/mikro-orm/package.json
+++ b/packages/mikro-orm/package.json
@@ -8,7 +8,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/index.mjs",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
       "require": "./dist/index.js"
     }
   },

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -8,7 +8,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/index.mjs",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
       "require": "./dist/index.js"
     }
   },

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -8,7 +8,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/index.mjs",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
       "require": "./dist/index.js"
     }
   },

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -8,7 +8,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/index.mjs",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
       "require": "./dist/index.js"
     }
   },

--- a/packages/reflection/package.json
+++ b/packages/reflection/package.json
@@ -8,7 +8,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/index.mjs",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
       "require": "./dist/index.js"
     }
   },

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -8,7 +8,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/index.mjs",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
       "require": "./dist/index.js"
     }
   },


### PR DESCRIPTION
If module is 'node16' (typescript 4.7, see tsconfig.json) and module type is 'module' (see package.js) then typescript currently searches for a file named index.d.mts (as the base file is index.d.ts) and doesn't find it (see image).

I read about it [here](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing):  "./commonjs/index.cjs" =>  "./commonjs/index.d.cts"

A solution is to declare 'index.d.ts' explicitly as the valid typing for 'index.mjs'.

~~~json
"import": "./dist/index.mjs"
~~~
=>
~~~json
 "import": {
        "types": "./dist/index.d.ts",
        "default": "./dist/index.mjs"
 },
~~~

_______


![image](https://user-images.githubusercontent.com/4943440/170993939-4b9070a5-f987-4b95-957e-883d9a2446d1.png)

package.json
~~~json
{
    "type": "module"
}
~~~

tsconfig.json
~~~json
"compilerOptions": {
        "module": "node16"
}
~~~