### PR TITLE
docs: fix typos in multiple schemas

### DIFF
--- a/docs/docs/multiple-schemas.md
+++ b/docs/docs/multiple-schemas.md
@@ -2,8 +2,8 @@
 title: Using Multiple Schemas
 ---
 
-In MySQL and PostgreSQL is is possible to define your entities in multiple schemas. In MySQL 
-terminology, it is called database, but from implementation point of view, it is a schema. 
+In MySQL and PostgreSQL it is possible to define your entities in multiple schemas. In MySQL 
+terminology, it is called database, but from an implementation point of view, it is a schema. 
 
 > To use multiple schemas, your connection needs to have access to all of them (multiple 
 > connections are not supported in a single MikroORM instance).

--- a/docs/versioned_docs/version-3.6/multiple-schemas.md
+++ b/docs/versioned_docs/version-3.6/multiple-schemas.md
@@ -2,8 +2,8 @@
 title: Using Multiple Schemas
 ---
 
-In MySQL and PostgreSQL is is possible to define your entities in multiple schemas. In MySQL 
-terminology, it is called database, but from implementation point of view, it is a schema. 
+In MySQL and PostgreSQL it is possible to define your entities in multiple schemas. In MySQL 
+terminology, it is called database, but from an implementation point of view, it is a schema. 
 
 > To use multiple schemas, your connection needs to have access to all of them (multiple 
 > connections are not supported).

--- a/docs/versioned_docs/version-4.5/multiple-schemas.md
+++ b/docs/versioned_docs/version-4.5/multiple-schemas.md
@@ -2,8 +2,8 @@
 title: Using Multiple Schemas
 ---
 
-In MySQL and PostgreSQL is is possible to define your entities in multiple schemas. In MySQL 
-terminology, it is called database, but from implementation point of view, it is a schema. 
+In MySQL and PostgreSQL it is possible to define your entities in multiple schemas. In MySQL 
+terminology, it is called database, but from an implementation point of view, it is a schema. 
 
 > To use multiple schemas, your connection needs to have access to all of them (multiple 
 > connections are not supported).

--- a/docs/versioned_docs/version-5.0/multiple-schemas.md
+++ b/docs/versioned_docs/version-5.0/multiple-schemas.md
@@ -2,8 +2,8 @@
 title: Using Multiple Schemas
 ---
 
-In MySQL and PostgreSQL is is possible to define your entities in multiple schemas. In MySQL 
-terminology, it is called database, but from implementation point of view, it is a schema. 
+In MySQL and PostgreSQL it is possible to define your entities in multiple schemas. In MySQL 
+terminology, it is called database, but from an implementation point of view, it is a schema. 
 
 > To use multiple schemas, your connection needs to have access to all of them (multiple 
 > connections are not supported in a single MikroORM instance).


### PR DESCRIPTION
Just fix a couple of typos in the multiple schemas docs