### PR TITLE
feat(core): automatically discover target embeddables and relationships

### DIFF
--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -54,7 +54,7 @@ describe('MikroORM', () => {
   });
 
   test('should throw when a relation is pointing to not discovered entity', async () => {
-    const err = 'Entity \'Book2\' was not discovered, please make sure to provide it in \'entities\' array when initializing the ORM';
+    const err = 'Entity \'FooBaz2\' was not discovered, please make sure to provide it in \'entities\' array when initializing the ORM';
     await expect(MikroORM.init({ type: 'mongo', dbName: 'test', entities: [Author2, BaseEntity2] })).rejects.toThrowError(err);
   });
 

--- a/tests/features/embeddables/GH1912.test.ts
+++ b/tests/features/embeddables/GH1912.test.ts
@@ -109,7 +109,7 @@ describe('GH issue 1912', () => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      entities: [Example, Metadata],
+      entities: [Example],
       dbName: ':memory:',
       type: 'sqlite',
     });

--- a/tests/features/embeddables/GH2149.test.ts
+++ b/tests/features/embeddables/GH2149.test.ts
@@ -36,7 +36,7 @@ describe('GH issue 2149', () => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      entities: [Options, LoopOptions, PlayerEntity],
+      entities: [PlayerEntity],
       dbName: ':memory:',
       type: 'sqlite',
     });

--- a/tests/features/embeddables/GH2357.test.ts
+++ b/tests/features/embeddables/GH2357.test.ts
@@ -22,7 +22,7 @@ describe('validating not discovered emebddables', () => {
 
   test(`GH issue 2357`, async () => {
     await expect(MikroORM.init({
-      entities: [Options, PlayerEntity],
+      entities: [PlayerEntity],
       dbName: ':memory:',
       type: 'sqlite',
     }, false)).rejects.toThrowError(`Entity 'Options' was not discovered, please make sure to provide it in 'entities' array when initializing the ORM (used in PlayerEntity.options)`);

--- a/tests/features/embeddables/GH2391.test.ts
+++ b/tests/features/embeddables/GH2391.test.ts
@@ -55,7 +55,7 @@ describe('onCreate and onUpdate in embeddables (GH 2283 and 2391)', () => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      entities: [MyEntity, Audit, NestedAudit],
+      entities: [MyEntity],
       dbName: ':memory:',
       type: 'sqlite',
     });

--- a/tests/features/embeddables/GH2717.test.ts
+++ b/tests/features/embeddables/GH2717.test.ts
@@ -46,7 +46,7 @@ describe('GH issue #2717', () => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      entities: [User, Profile, Cat],
+      entities: [User],
       dbName: ':memory:',
       type: 'sqlite',
       loadStrategy: LoadStrategy.JOINED,

--- a/tests/features/embeddables/GH2948.test.ts
+++ b/tests/features/embeddables/GH2948.test.ts
@@ -96,7 +96,7 @@ describe('GH issue 2948', () => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      entities: [BazEntity, FooEntity, Bar, Fiz],
+      entities: [FooEntity],
       dbName: ':memory:',
       type: 'sqlite',
       namingStrategy: CustomNamingStrategy,

--- a/tests/features/embeddables/GH2975.test.ts
+++ b/tests/features/embeddables/GH2975.test.ts
@@ -54,7 +54,7 @@ let orm: MikroORM;
 
 beforeAll(async () => {
   orm = await MikroORM.init({
-    entities: [Country, Address, Provider],
+    entities: [Provider],
     dbName: ':memory:',
     type: 'better-sqlite',
   });

--- a/tests/features/embeddables/GH3134.test.ts
+++ b/tests/features/embeddables/GH3134.test.ts
@@ -47,7 +47,7 @@ let orm: MikroORM;
 
 beforeAll(async () => {
   orm = await MikroORM.init({
-    entities: [Parent, Nested],
+    entities: [Parent],
     dbName: ':memory:',
     type: 'sqlite',
   });

--- a/tests/features/embeddables/embeddable-custom-types.postgres.test.ts
+++ b/tests/features/embeddables/embeddable-custom-types.postgres.test.ts
@@ -101,7 +101,7 @@ class User {
   @PrimaryKey()
   id!: number;
 
-  @Embedded()
+  @Embedded(() => Savings)
   savings!: Savings;
 
   @Property({ nullable: true })
@@ -115,7 +115,7 @@ describe('embedded entities with custom types', () => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      entities: [Parent, Nested, Inner, Savings, User],
+      entities: [Parent, User],
       dbName: 'mikro_orm_test_embeddables_custom_types',
       type: 'postgresql',
     });

--- a/tests/features/embeddables/embedded-entities.mongo.test.ts
+++ b/tests/features/embeddables/embedded-entities.mongo.test.ts
@@ -145,7 +145,7 @@ class CustomUser {
   @SerializedPrimaryKey()
   id!: string;
 
-  @Embedded()
+  @Embedded(() => CustomAddress)
   address!: CustomAddress;
 
 }
@@ -187,7 +187,7 @@ describe('embedded entities in mongo', () => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      entities: [Address1Base, Address1, Address2Base, Address2, User, CustomAddress, CustomUser, childSchema, parentSchema],
+      entities: [User, CustomUser, childSchema, parentSchema],
       clientUrl: 'mongodb://localhost:27017,localhost:27018,localhost:27019/mikro-orm-test-embeddables?replicaSet=rs',
       type: 'mongo',
       validate: true,

--- a/tests/features/embeddables/embedded-entities.mysql.test.ts
+++ b/tests/features/embeddables/embedded-entities.mysql.test.ts
@@ -56,10 +56,10 @@ class User {
   @PrimaryKey()
   id!: number;
 
-  @Embedded()
+  @Embedded(() => Address1)
   address1!: Address1;
 
-  @Embedded({ prefix: 'addr_', nullable: true })
+  @Embedded(() => Address2, { prefix: 'addr_', nullable: true })
   address2?: Address2;
 
   @Embedded({ prefix: false })
@@ -82,7 +82,7 @@ class UserWithCity {
   @PrimaryKey()
   id!: number;
 
-  @Embedded({ object: false, prefix: false })
+  @Embedded(() => Address1, { object: false, prefix: false })
   address1!: Address1;
 
   @Property({ type: String })
@@ -96,7 +96,7 @@ describe('embedded entities in mysql', () => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      entities: [Address1, Address2, User],
+      entities: [User],
       dbName: `mikro_orm_test_embeddables`,
       type: 'mysql',
       port: 3308,

--- a/tests/features/embeddables/embedded-entities.postgres.test.ts
+++ b/tests/features/embeddables/embedded-entities.postgres.test.ts
@@ -66,7 +66,7 @@ class User {
   @Embedded()
   address1!: Address1;
 
-  @Embedded({ prefix: 'addr_', nullable: true })
+  @Embedded(() => Address2, { prefix: 'addr_', nullable: true })
   address2?: Address2;
 
   @Embedded({ prefix: false })
@@ -89,7 +89,7 @@ describe('embedded entities in postgresql', () => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      entities: [Address1, Address2, User],
+      entities: [User],
       dbName: 'mikro_orm_test_embeddables',
       type: 'postgresql',
     });

--- a/tests/features/embeddables/entities-in-embeddables.mongo.test.ts
+++ b/tests/features/embeddables/entities-in-embeddables.mongo.test.ts
@@ -130,7 +130,7 @@ describe('embedded entities in mongo', () => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      entities: [User, Profile, Identity, IdentityMeta, IdentityLink, Source],
+      entities: [User],
       clientUrl: 'mongodb://localhost:27017,localhost:27018,localhost:27019/mikro-orm-test-entities-in-embeddables?replicaSet=rs',
       type: 'mongo',
     });

--- a/tests/features/embeddables/entities-in-embeddables.postgres.test.ts
+++ b/tests/features/embeddables/entities-in-embeddables.postgres.test.ts
@@ -129,7 +129,7 @@ describe('embedded entities in postgres', () => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      entities: [User, Profile, Identity, IdentityMeta, IdentityLink, Source],
+      entities: [User],
       type: 'postgresql',
       dbName: `mikro_orm_test_entities_in_embedddables`,
     });

--- a/tests/features/embeddables/nested-embeddables.mongo.test.ts
+++ b/tests/features/embeddables/nested-embeddables.mongo.test.ts
@@ -74,7 +74,7 @@ describe('embedded entities in mongo', () => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      entities: [User, Profile, Identity, IdentityMeta],
+      entities: [User],
       clientUrl: 'mongodb://localhost:27017,localhost:27018,localhost:27019/mikro-orm-test-nested-embeddables?replicaSet=rs',
       type: 'mongo',
     });

--- a/tests/features/embeddables/nested-embeddables.postgres.test.ts
+++ b/tests/features/embeddables/nested-embeddables.postgres.test.ts
@@ -101,7 +101,7 @@ describe('embedded entities in postgres', () => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      entities: [User, Profile, Identity, IdentityMeta, IdentityLink],
+      entities: [User],
       type: 'postgresql',
       dbName: `mikro_orm_test_nested_embedddables`,
     });

--- a/tests/features/embeddables/polymorphic-embedded-entities.mongo.test.ts
+++ b/tests/features/embeddables/polymorphic-embedded-entities.mongo.test.ts
@@ -73,7 +73,7 @@ describe('polymorphic embeddables in mongo', () => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      entities: [Dog, Cat, Owner],
+      entities: [Owner],
       clientUrl: 'mongodb://localhost:27017,localhost:27018,localhost:27019/mikro-orm-test-poly-embeddables?replicaSet=rs',
       type: 'mongo',
       validate: true,
@@ -124,7 +124,7 @@ describe('polymorphic embeddables in mongo', () => {
 
     const mock = mockLogger(orm, ['query']);
     await orm.em.persistAndFlush([ent1, ent2, ent3]);
-    expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('owner').insertMany([ { _id: ObjectId('600000000000000000000001'), name: 'o1', pet_canBark: true, pet_type: 1, pet_name: 'd1', pet_canMeow: undefined, pet2: { type: 0, name: 'c3', canMeow: true } }, { _id: ObjectId('600000000000000000000002'), name: 'o2', pet_canBark: undefined, pet_type: 0, pet_name: 'c1', pet_canMeow: true, pet2: { canBark: true, type: 1, name: 'd4' } }, { _id: ObjectId('600000000000000000000003'), name: 'o3', pet_canBark: true, pet_type: 1, pet_name: 'd2', pet_canMeow: undefined, pet2: { type: 0, name: 'c4', canMeow: true } } ], { session: undefined });`);
+    expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('owner').insertMany([ { _id: ObjectId('600000000000000000000001'), name: 'o1', pet_canMeow: undefined, pet_type: 1, pet_name: 'd1', pet_canBark: true, pet2: { canMeow: true, type: 0, name: 'c3' } }, { _id: ObjectId('600000000000000000000002'), name: 'o2', pet_canMeow: true, pet_type: 0, pet_name: 'c1', pet_canBark: undefined, pet2: { type: 1, name: 'd4', canBark: true } }, { _id: ObjectId('600000000000000000000003'), name: 'o3', pet_canMeow: undefined, pet_type: 1, pet_name: 'd2', pet_canBark: true, pet2: { canMeow: true, type: 0, name: 'c4' } } ], { session: undefined });`);
     orm.em.clear();
 
     const owners = await orm.em.find(Owner, {}, { orderBy: { name: 1 } });
@@ -154,7 +154,7 @@ describe('polymorphic embeddables in mongo', () => {
     mock.mock.calls.length = 0;
     await orm.em.flush();
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toMatch(`bulk = db.getCollection('owner').initializeUnorderedBulkOp({ session: undefined });bulk.find({ _id: ObjectId('600000000000000000000001') }).update({ '$set': { pet_canBark: undefined, pet_type: 0, pet_name: 'c2', pet_canMeow: true } });bulk.find({ _id: ObjectId('600000000000000000000002') }).update({ '$set': { pet_canBark: true, pet_type: 1, pet_name: 'd3', pet_canMeow: undefined } });bulk.find({ _id: ObjectId('600000000000000000000003') }).update({ '$set': { pet_name: 'old dog' } });bulk.execute()`);
+    expect(mock.mock.calls[0][0]).toMatch(`bulk = db.getCollection('owner').initializeUnorderedBulkOp({ session: undefined });bulk.find({ _id: ObjectId('600000000000000000000001') }).update({ '$set': { pet_canMeow: true, pet_type: 0, pet_name: 'c2', pet_canBark: undefined } });bulk.find({ _id: ObjectId('600000000000000000000002') }).update({ '$set': { pet_canMeow: undefined, pet_type: 1, pet_name: 'd3', pet_canBark: true } });bulk.find({ _id: ObjectId('600000000000000000000003') }).update({ '$set': { pet_name: 'old dog' } });bulk.execute()`);
     orm.em.clear();
 
     const owners2 = await orm.em.find(Owner, {}, { orderBy: { name: 1 } });
@@ -223,14 +223,14 @@ describe('polymorphic embeddables in mongo', () => {
 
     const mock = mockLogger(orm, ['query']);
     await orm.em.persistAndFlush(owner);
-    expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('owner').insertOne({ _id: ObjectId('600000000000000000000004'), name: 'o1', pet_canBark: undefined, pet_type: 0, pet_name: 'cat', pet_canMeow: true, pet2: { canBark: true, type: 1, name: 'dog' } }, { session: undefined });`);
+    expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('owner').insertOne({ _id: ObjectId('600000000000000000000004'), name: 'o1', pet_canMeow: true, pet_type: 0, pet_name: 'cat', pet_canBark: undefined, pet2: { type: 1, name: 'dog', canBark: true } }, { session: undefined });`);
 
     orm.em.assign(owner, {
       pet: { name: 'cat name' },
       pet2: { name: 'dog name' },
     });
     await orm.em.persistAndFlush(owner);
-    expect(mock.mock.calls[1][0]).toMatch(`db.getCollection('owner').updateMany({ _id: ObjectId('600000000000000000000004') }, { '$set': { pet_name: 'cat name', pet2: { canBark: true, type: 1, name: 'dog name' } } }, { session: undefined });`);
+    expect(mock.mock.calls[1][0]).toMatch(`db.getCollection('owner').updateMany({ _id: ObjectId('600000000000000000000004') }, { '$set': { pet_name: 'cat name', pet2: { type: 1, name: 'dog name', canBark: true } } }, { session: undefined });`);
 
     expect(wrap(owner).toObject()).toEqual({
       id: owner.id,


### PR DESCRIPTION
When we see a missing target entity or embeddable that is defined with a reference, e.g. `@Embedded(() => Profile)` or `@ManyToOne(() => Author)`, we now try to discover the target automatically. This means we no longer need to care about discovering embeddables explicitly as long as we specify them correctly in owning entities. This works recursively.