### PR TITLE
Speeding up the creation of a large number of entities

### DIFF
--- a/packages/core/src/entity/ArrayCollection.ts
+++ b/packages/core/src/entity/ArrayCollection.ts
@@ -111,7 +111,6 @@ export class ArrayCollection<T, O> {
       if (this.items.delete(entity)) {
         this.incrementCount(-1);
         delete this[this.items.size]; // remove last item
-        Object.assign(this, [...this.items]); // reassign array access
         this.propagate(entity, 'remove');
       }
     }
@@ -137,7 +136,6 @@ export class ArrayCollection<T, O> {
 
     this.incrementCount(-1);
     delete this[this.items.size];
-    Object.assign(this, [...this.items]);
   }
 
   contains(item: T | Reference<T>, check?: boolean): boolean {


### PR DESCRIPTION
Hello, @B4nan,

First, thanks for a really good ORM for the Node.js world.

## What's the problem?

Simplifying, we have two related entities in our project: `TestRunEntity` and `TestCaseEntity`. There is a 1:M relationship between these entities.

According to the specifics of our project, we can have up to 10_000 test cases in a test run.

The problem here is that creating such a large set of entities takes up to 12 seconds:

```ts
orm.em.create(TestRunEntity, {
    cases: Array(10_000).fill(undefined).map((_, index) => ({
        title: `Test Case #${index}`
    }))
});
```

I have a repository that makes it easy to reproduce the problem.

https://github.com/mrmlnc/mikro-orm-performance-issue

## Investigation

Most likely related issues

* #732

I investigated and found that most of the time it takes to clone a set of entities at each iteration in the code below:

https://github.com/mikro-orm/mikro-orm/blob/2b5cabc102103b8d2852ca3af5916af6f782d7d7/packages/core/src/entity/ArrayCollection.ts#L111-L116

Some screenshots obtained during investigation:

<details>

<summary>npx clinic flame and doctor</summary>

<img width="960" alt="clinic-current" src="https://user-images.githubusercontent.com/7034281/173189017-524e1b91-108d-47d6-9ef9-3cef97bd707f.png">

<img width="949" alt="clinic-current-doctor" src="https://user-images.githubusercontent.com/7034281/173189064-f04cba66-c00b-4326-bb3a-93bae523c747.png">

</details>

I believe that the `Object.assign` operation is not necessary here. Let me describe it to you as I see it.

The operations above do literally the following on each iteration:

1. Remove the current entity from the `Set`.
1. Remove the current entity from the context (`this`).
1. Converts a `Set` to an array and writes it to the context (`this`).

After steps 1 and 2, both of these sets are *synchronized*. Both of these sets refer to the same classes by reference.

In the third step, we simply overwrite all existing entries in the context (`this`) with the same ones from `Set` as `this['0']`, `this['1']`, …. These are all the same references to instantiated entity classes. This is the same context for all methods in the `ArrayCollection` class. So, after overwriting the context properties, nothing changes.

⚠️ Maybe I'm wrong. But I can't find one reason to do it. Please tell me what you think about it.

## What is the purpose of this pull request?

So, I propose to stop doing the third step, since both sets are synchronized by calling the corresponding methods earlier.

Time measurements for 10_000 entities:

* Time before making changes: **~12s**.
* Time after making changes: **~150ms**.

Some screenshots obtained after changes:

<details>

<summary>npx clinic flame and doctor</summary>

<img width="960" alt="clinic-next" src="https://user-images.githubusercontent.com/7034281/173189075-f4fa7b54-e41a-44b1-b461-57d9a41c264d.png">

<img width="942" alt="clinic-next-doctor" src="https://user-images.githubusercontent.com/7034281/173189078-ea38dc44-307e-4996-ab8f-c8b4229d8f3a.png">

</details>
