### PR TITLE
Specify error type caught from findOneOrFail

### DIFF
--- a/docs/versioned_docs/version-5.2/entity-manager.md
+++ b/docs/versioned_docs/version-5.2/entity-manager.md
@@ -270,7 +270,11 @@ try {
   const author = await em.findOneOrFail(Author, { name: 'does-not-exist' });
   // author will be always found here
 } catch (e) {
-  console.error('Not found', e);
+  if (e instanceof NotFoundError) {
+    console.error('Not found', e);
+  }
+  
+  throw e;
 }
 ```
 


### PR DESCRIPTION
To avoid leakage of errors that might not be NotFoundError