### PR TITLE
fix(core): consider two `NaN` as equal when computing changesets

### DIFF
--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -112,6 +112,10 @@ export function equals(a: any, b: any): boolean {
     return compareObjects(a, b);
   }
 
+  if (typeof a === 'number' && typeof b === 'number' && Number.isNaN(a) && Number.isNaN(b)) {
+    return true;
+  }
+
   return false;
 }
 

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -112,7 +112,7 @@ export function equals(a: any, b: any): boolean {
     return compareObjects(a, b);
   }
 
-  if (typeof a === 'number' && typeof b === 'number' && Number.isNaN(a) && Number.isNaN(b)) {
+  if (Number.isNaN(a) && Number.isNaN(b)) {
     return true;
   }
 

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -79,6 +79,7 @@ describe('Utils', () => {
     expect(Utils.equals({ a: 'a', b: 'c', c: { d: 'e', f: ['g', 'h'] } }, { a: 'a', b: 'c', c: { d: 'e', f: ['g', 'h'] } })).toBe(true);
     expect(compareObjects(null, undefined)).toBe(true);
     expect(compareObjects(new Test(), new Author('n', 'e'))).toBe(false);
+    expect(Utils.equals(NaN, NaN)).toBe(true);
   });
 
   test('merge', () => {


### PR DESCRIPTION
This behavior leads to redundant changesets being created
whenever entity is added to the unit-of-work.