### PR TITLE
feat(core): propagate add operation to m:n owner even if not initialized

### DIFF
--- a/docs/docs/collections.md
+++ b/docs/docs/collections.md
@@ -213,7 +213,7 @@ tag.books.add(book);
 console.log(book.tags.contains(tag)); // true
 ``` 
 
-> Collections on both sides have to be initialized, otherwise propagation won't work.
+>  Since v5.2.2 propagation of adding new items to inverse side M:N relation also works if the owning collection is not initialized. For propagation of remove operation, both sides still have to be initialized.
 
 > Although this propagation works also for M:N inverse side, we should always use owning side to manipulate the collection.
 

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -320,6 +320,7 @@ describe('QueryBuilder', () => {
     expect(res[0].tests.getItems()).toHaveLength(0);
     expect(res[1].tests.isInitialized()).toBe(true);
     expect(res[1].tests.getItems()).toHaveLength(1);
+    await orm.getSchemaGenerator().clearDatabase();
   });
 
   test('select leftJoin 1:1 inverse', async () => {

--- a/tests/issues/GH3240.test.ts
+++ b/tests/issues/GH3240.test.ts
@@ -1,0 +1,91 @@
+import { Collection, Entity, ManyToMany, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
+import type { SqliteDriver } from '@mikro-orm/sqlite';
+
+type SquadType = 'GROUND' | 'AIR';
+
+@Entity()
+export class Soldier {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  firstName!: string;
+
+  @Property()
+  lastName!: string;
+
+  @ManyToMany({ entity: 'Squad' })
+  squads = new Collection<Squad>(this);
+
+}
+
+@Entity()
+export class Squad {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  type!: SquadType;
+
+  @Property()
+  formedAt!: Date;
+
+  @Property({ nullable: true })
+  disbandedAt?: Date;
+
+  @ManyToMany({ entity: 'Soldier', mappedBy: 'squads' })
+  soldiers = new Collection<Soldier>(this);
+
+}
+
+let orm: MikroORM<SqliteDriver>;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Soldier, Squad],
+    dbName: ':memory:',
+    type: 'sqlite',
+  });
+  await orm.getSchemaGenerator().createSchema();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test(`GH issue 3240`, async () => {
+  const luke = orm.em.create(Soldier, {
+    firstName: 'Luke',
+    lastName: 'Skywalker',
+  });
+
+  const leia = orm.em.create(Soldier, {
+    firstName: 'Leia',
+    lastName: 'Organa',
+  });
+
+  await orm.em.persistAndFlush([luke, leia]);
+  orm.em.clear();
+
+  const soldiers = await orm.em.find(Soldier, {});
+
+  const squad = orm.em.create(Squad, {
+    type: 'AIR',
+    formedAt: new Date(),
+    soldiers,
+  });
+
+  await orm.em.persistAndFlush(squad);
+  orm.em.clear();
+
+  const fetchedSquad = await orm.em.findOneOrFail(
+    Squad,
+    { type: 'AIR' },
+    { populate: ['soldiers'] },
+  );
+  expect(fetchedSquad.soldiers).toHaveLength(2);
+
+  await orm.close();
+});


### PR DESCRIPTION
Previously we propagated adding only to initialized collections. This means that we could ignore some changes like adding items from the inverse side that. Now we propagate the `add` operation to the owning sides of M:N relations even if they are not initialized.

Closes #3240