### PR TITLE
fix(query-builder): fix `qb.insert()/update()` on embeddables in inline mode

### DIFF
--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -104,7 +104,7 @@ export class QueryBuilderHelper {
 
     const meta = this.metadata.find(this.entityName);
 
-    data = this.mapData(data, meta?.properties, { convertCustomTypes });
+    data = this.mapData(data, meta?.properties, convertCustomTypes);
 
     if (!Utils.hasObjectKeys(data) && meta && multi) {
       /* istanbul ignore next */
@@ -638,7 +638,7 @@ export class QueryBuilderHelper {
     return [QueryType.SELECT, QueryType.COUNT].includes(type);
   }
 
-  private mapData(data: Dictionary, properties: undefined | Record<string, EntityProperty>, options: {convertCustomTypes: boolean}) {
+  private mapData(data: Dictionary, properties?: Record<string, EntityProperty>, convertCustomTypes?: boolean) {
     if (!properties) {
       return data;
     }
@@ -655,7 +655,7 @@ export class QueryBuilderHelper {
       if (prop.embeddedProps && !prop.object) {
         const copy = data[k];
         delete data[k];
-        Object.assign(data, this.mapData(copy, prop.embeddedProps, options));
+        Object.assign(data, this.mapData(copy, prop.embeddedProps, convertCustomTypes));
 
         return;
       }
@@ -668,7 +668,7 @@ export class QueryBuilderHelper {
         return;
       }
 
-      if (prop.customType && options.convertCustomTypes && !this.platform.isRaw(data[k])) {
+      if (prop.customType && convertCustomTypes && !this.platform.isRaw(data[k])) {
         data[k] = prop.customType.convertToDatabaseValue(data[k], this.platform, true);
       }
 

--- a/tests/features/embeddables/query-builder-embeddable.test.ts
+++ b/tests/features/embeddables/query-builder-embeddable.test.ts
@@ -1,0 +1,77 @@
+import type { BetterSqliteDriver } from '@mikro-orm/better-sqlite';
+import {
+  Entity,
+  MikroORM,
+  PrimaryKey,
+  Embedded,
+  Embeddable,
+  Property,
+} from '@mikro-orm/core';
+
+@Embeddable()
+export class Settings {
+
+  @Property()
+  name: string;
+
+  constructor(settings: Settings) {
+    this.name = settings.name;
+  }
+
+}
+
+@Entity()
+export class User {
+
+  @PrimaryKey()
+  id: number;
+
+  @Embedded({ entity: 'Settings' })
+  settings: Settings;
+
+  constructor(user: User) {
+    this.id = user.id;
+    this.settings = new Settings(user.settings);
+  }
+
+}
+
+let orm: MikroORM<BetterSqliteDriver>;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [User, Settings],
+    dbName: ':memory:',
+    type: 'better-sqlite',
+  });
+
+  const generator = orm.getSchemaGenerator();
+  await generator.ensureDatabase();
+  await generator.dropSchema();
+  await generator.createSchema();
+});
+
+afterAll(() => orm.close(true));
+
+test('insert an object with embeddable using a QueryBuilder', async () => {
+  const foo = new User({ id: 1, settings: { name: 'foo' } });
+  const bar = new User({ id: 2, settings: { name: 'bar' } });
+  const repo = orm.em.getRepository(User);
+
+  await repo.createQueryBuilder().insert([foo, bar]);
+
+  expect(await repo.findOneOrFail(1)).toEqual(foo);
+  expect(await repo.findOneOrFail(2)).toEqual(bar);
+});
+
+test('update an object with embeddable using a QueryBuilder', async () => {
+  const foo = new User({ id: 1, settings: { name: 'eh' } });
+  const bar = new User({ id: 2, settings: { name: 'oh' } });
+  const repo = orm.em.getRepository(User);
+
+  await repo.createQueryBuilder().update({ settings: foo.settings }).where({ id: foo.id });
+  await repo.createQueryBuilder().update({ settings: bar.settings }).where({ id: bar.id });
+
+  expect(await repo.findOneOrFail(1)).toEqual(foo);
+  expect(await repo.findOneOrFail(2)).toEqual(bar);
+});


### PR DESCRIPTION
Fix a bug where inserting embeddables using a `QueryBuilder` would throw the following error:
```
  ● insert an object with embeddable using a QueryBuilder

    SqliteError: insert into `user` (`id`, `settings`) select 1 as `id`, '[object Object]' as `settings` union all select 2 as `id`, '[object Object]' as `settings` - table user has no column named settings

      223 |       this.emit('query', Object.assign({ __knexUid, __knexTxId }, obj));
      224 |
    > 225 |       return MonkeyPatchable.QueryExecutioner.executeQuery(connection, obj, this);
          |                                               ^
      226 |     };
      227 |
      228 |     TableCompiler.prototype.raw = function (this: any, query: string) {

      at Database.prepare (node_modules/better-sqlite3/lib/methods/wrappers.js:5:21)
      at Client_BetterSQLite3._query (node_modules/knex/lib/dialects/better-sqlite3/index.js:30:34)
      at Object.executeQuery (node_modules/knex/lib/execution/internal/query-executioner.js:37:17)
      at Client_BetterSQLite3.Client.query (packages/knex/src/AbstractSqlConnection.ts:225:47)
      at Runner.query (node_modules/knex/lib/execution/runner.js:123:36)
      at ensureConnectionCallback (node_modules/knex/lib/execution/internal/ensure-connection-callback.js:13:17)
      at Runner.ensureConnection (node_modules/knex/lib/execution/runner.js:300:20)
      at async Runner.run (node_modules/knex/lib/execution/runner.js:30:19)
      at async BetterSqliteConnection.executeQuery (packages/core/src/connections/Connection.ts:109:19)
      at async BetterSqliteConnection.execute (packages/knex/src/AbstractSqlConnection.ts:116:17)
```

Closes #3325.