### PR TITLE
fix(sqlite): throwing ForeignKeyConstraintViolationException instead of the DriverException

### DIFF
--- a/packages/better-sqlite/src/BetterSqliteExceptionConverter.ts
+++ b/packages/better-sqlite/src/BetterSqliteExceptionConverter.ts
@@ -2,6 +2,7 @@ import type { Dictionary, DriverException } from '@mikro-orm/core';
 import {
   ConnectionException, ExceptionConverter, InvalidFieldNameException, LockWaitTimeoutException, NonUniqueFieldNameException, CheckConstraintViolationException,
   NotNullConstraintViolationException, ReadOnlyException, SyntaxErrorException, TableExistsException, TableNotFoundException, UniqueConstraintViolationException,
+  ForeignKeyConstraintViolationException,
 } from '@mikro-orm/core';
 
 export class BetterSqliteExceptionConverter extends ExceptionConverter {
@@ -60,6 +61,10 @@ export class BetterSqliteExceptionConverter extends ExceptionConverter {
 
     if (exception.message.includes('unable to open database file')) {
       return new ConnectionException(exception);
+    }
+
+    if (exception.message.includes('FOREIGN KEY constraint failed')) {
+      return new ForeignKeyConstraintViolationException(exception);
     }
 
     return super.convertException(exception);

--- a/packages/sqlite/src/SqliteExceptionConverter.ts
+++ b/packages/sqlite/src/SqliteExceptionConverter.ts
@@ -1,7 +1,7 @@
 import type { Dictionary, DriverException } from '@mikro-orm/core';
 import {
   ConnectionException, ExceptionConverter, InvalidFieldNameException, LockWaitTimeoutException, NonUniqueFieldNameException, CheckConstraintViolationException,
-  NotNullConstraintViolationException, ReadOnlyException, SyntaxErrorException, TableExistsException, TableNotFoundException, UniqueConstraintViolationException,
+  NotNullConstraintViolationException, ReadOnlyException, SyntaxErrorException, TableExistsException, TableNotFoundException, UniqueConstraintViolationException, ForeignKeyConstraintViolationException,
 } from '@mikro-orm/core';
 
 export class SqliteExceptionConverter extends ExceptionConverter {
@@ -60,6 +60,10 @@ export class SqliteExceptionConverter extends ExceptionConverter {
 
     if (exception.message.includes('unable to open database file')) {
       return new ConnectionException(exception);
+    }
+
+    if (exception.message.includes('FOREIGN KEY constraint failed')) {
+      return new ForeignKeyConstraintViolationException(exception);
     }
 
     return super.convertException(exception);

--- a/tests/sqlite-constraints.test.ts
+++ b/tests/sqlite-constraints.test.ts
@@ -1,0 +1,98 @@
+import { Entity, type EntityManager, ManyToOne, MikroORM, PrimaryKey, Property, IdentifiedReference, Reference, ForeignKeyConstraintViolationException } from '@mikro-orm/core';
+import type { SqliteDriver } from '@mikro-orm/sqlite';
+import type { BetterSqliteDriver } from '@mikro-orm/better-sqlite';
+
+
+@Entity()
+export class Author {
+
+  @PrimaryKey({ type: 'string' })
+  id!: string;
+
+  @Property({ type: 'string' })
+  name!: string;
+
+}
+
+
+@Entity()
+export class Book {
+
+  @PrimaryKey({ type: 'string' })
+  id!: string;
+
+  @Property({ type: 'string' })
+  name!: string;
+
+  @ManyToOne(() => Author, { wrappedReference: true })
+  author!: IdentifiedReference<Author>;
+
+}
+
+
+async function createEntities(em: EntityManager) {
+  const author = new Author();
+  author.id = '1';
+  author.name = 'Bradley Jones';
+
+  const book = new Book();
+  book.id = '2';
+  book.name = 'C++ in 21 days';
+  book.author = Reference.create(author);
+
+  await em.persistAndFlush([author, book]);
+  return author;
+}
+
+
+describe('sqlite driver', () => {
+
+  let orm: MikroORM<SqliteDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Author, Book],
+      dbName: ':memory:',
+      type: 'sqlite',
+    });
+    await orm.getSchemaGenerator().createSchema();
+  });
+  afterAll(async () => await orm.close(true));
+
+  test('delete operation should throw ForeignKeyConstraintViolationException, when we have corresponding constraint in db', async () => {
+    const entity = await createEntities(orm.em);
+    expect.assertions(1);
+    try {
+      await orm.em.removeAndFlush(entity);
+    } catch (e) {
+      expect(e).toBeInstanceOf(ForeignKeyConstraintViolationException);
+    }
+  });
+});
+
+
+describe('better-sqlite driver', () => {
+
+  let orm: MikroORM<BetterSqliteDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Author, Book],
+      dbName: ':memory:',
+      type: 'better-sqlite',
+    });
+    await orm.getSchemaGenerator().createSchema();
+  });
+  afterAll(async () => await orm.close(true));
+
+  test('delete operation should throw ForeignKeyConstraintViolationException, when we have corresponding constraint in db', async () => {
+    const entity = await createEntities(orm.em);
+    expect.assertions(1);
+    try {
+      await orm.em.removeAndFlush(entity);
+    } catch (e) {
+      expect(e).toBeInstanceOf(ForeignKeyConstraintViolationException);
+    }
+  });
+});
+


### PR DESCRIPTION
Two database drivers sqlite and better-sqlite were changed according to [this](https://github.com/doctrine/dbal/blob/4.0.x/src/Driver/API/SQLite/ExceptionConverter.php#L83) link, which i found in [source code documentation](https://github.com/mikro-orm/mikro-orm/blob/master/packages/sqlite/src/SqliteExceptionConverter.ts#L13).