### PR TITLE
feat(mongo): add support for migrations in mongo driver

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -79,6 +79,7 @@
     "@mikro-orm/entity-generator": "^5.0.0",
     "@mikro-orm/mariadb": "^5.0.0",
     "@mikro-orm/migrations": "^5.0.0",
+    "@mikro-orm/migrations-mongodb": "^5.0.0",
     "@mikro-orm/mongodb": "^5.0.0",
     "@mikro-orm/mysql": "^5.0.0",
     "@mikro-orm/postgresql": "^5.0.0",
@@ -90,6 +91,9 @@
       "optional": true
     },
     "@mikro-orm/migrations": {
+      "optional": true
+    },
+    "@mikro-orm/migrations-mongodb": {
       "optional": true
     },
     "@mikro-orm/seeder": {

--- a/packages/cli/src/commands/MigrationCommandFactory.ts
+++ b/packages/cli/src/commands/MigrationCommandFactory.ts
@@ -1,8 +1,6 @@
 import type { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import type { Configuration, MikroORM, MikroORMOptions, IMigrator } from '@mikro-orm/core';
 import { Utils, colors } from '@mikro-orm/core';
-import type { AbstractSqlDriver } from '@mikro-orm/knex';
-import { SchemaGenerator } from '@mikro-orm/knex';
 import type { MigrateOptions } from '@mikro-orm/migrations';
 import { CLIHelper } from '../CLIHelper';
 
@@ -85,9 +83,8 @@ export class MigrationCommandFactory {
 
   static async handleMigrationCommand(args: ArgumentsCamelCase<Options>, method: MigratorMethod): Promise<void> {
     const options = { pool: { min: 1, max: 1 } } as Partial<MikroORMOptions>;
-    const orm = await CLIHelper.getORM(undefined, options) as MikroORM<AbstractSqlDriver>;
-    const { Migrator } = await import('@mikro-orm/migrations');
-    const migrator = new Migrator(orm.em);
+    const orm = await CLIHelper.getORM(undefined, options);
+    const migrator = orm.getMigrator();
 
     switch (method) {
       case 'create':
@@ -167,8 +164,8 @@ export class MigrationCommandFactory {
     CLIHelper.dump(colors.green(`${ret.fileName} successfully created`));
   }
 
-  private static async handleFreshCommand(args: ArgumentsCamelCase<Options>, migrator: IMigrator, orm: MikroORM<AbstractSqlDriver>) {
-    const generator = new SchemaGenerator(orm.em);
+  private static async handleFreshCommand(args: ArgumentsCamelCase<Options>, migrator: IMigrator, orm: MikroORM) {
+    const generator = orm.getSchemaGenerator();
     await generator.dropSchema({ dropMigrationsTable: true });
     CLIHelper.dump(colors.green('Dropped schema successfully'));
     const opts = MigrationCommandFactory.getUpDownOptions(args);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,6 +71,7 @@
     "@mikro-orm/entity-generator": "^5.0.0",
     "@mikro-orm/mariadb": "^5.0.0",
     "@mikro-orm/migrations": "^5.0.0",
+    "@mikro-orm/migrations-mongodb": "^5.0.0",
     "@mikro-orm/mongodb": "^5.0.0",
     "@mikro-orm/mysql": "^5.0.0",
     "@mikro-orm/postgresql": "^5.0.0",
@@ -85,6 +86,9 @@
       "optional": true
     },
     "@mikro-orm/migrations": {
+      "optional": true
+    },
+    "@mikro-orm/migrations-mongodb": {
       "optional": true
     },
     "@mikro-orm/mongodb": {

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -63,9 +63,9 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     await this.nativeUpdate<T>(coll.owner.constructor.name, coll.owner.__helper!.getPrimaryKey() as FilterQuery<T>, data, options);
   }
 
-  mapResult<T>(result: EntityDictionary<T>, meta: EntityMetadata<T>, populate: PopulateOptions<T>[] = []): EntityData<T> | null {
+  mapResult<T>(result: EntityDictionary<T>, meta?: EntityMetadata<T>, populate: PopulateOptions<T>[] = []): EntityData<T> | null {
     if (!result || !meta) {
-      return null;
+      return result ?? null;
     }
 
     return this.comparator.mapResult(meta.className, result);

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -497,11 +497,11 @@ export interface IMigratorStorage {
   logMigration(params: Dictionary): Promise<void>;
   unlogMigration(params: Dictionary): Promise<void>;
   getExecutedMigrations(): Promise<MigrationRow[]>;
-  ensureTable(): Promise<void>;
+  ensureTable?(): Promise<void>;
   setMasterMigration(trx: Transaction): void;
   unsetMasterMigration(): void;
   getMigrationName(name: string): string;
-  getTableName(): { schemaName: string; tableName: string };
+  getTableName?(): { schemaName?: string; tableName: string };
 }
 
 export interface IMigrator {

--- a/packages/migrations-mongodb/.npmignore
+++ b/packages/migrations-mongodb/.npmignore
@@ -1,0 +1,8 @@
+node_modules
+src
+tests
+coverage
+temp
+yarn-error.log
+data
+tsconfig.*

--- a/packages/migrations-mongodb/package.json
+++ b/packages/migrations-mongodb/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mikro-orm/mongodb",
+  "name": "@mikro-orm/migrations-mongodb",
   "version": "5.2.4",
   "description": "TypeScript ORM for Node.js based on Data Mapper, Unit of Work and Identity Map patterns. Supports MongoDB, MySQL, PostgreSQL and SQLite databases as well as usage with vanilla JavaScript.",
   "main": "dist/index.js",
@@ -59,31 +59,15 @@
     "access": "public"
   },
   "dependencies": {
-    "bson": "^4.6.5",
-    "mongodb": "4.8.1"
+    "@mikro-orm/mongodb": "^5.2.4",
+    "fs-extra": "10.1.0",
+    "mongodb": "^4.8.1",
+    "umzug": "3.1.1"
   },
   "devDependencies": {
     "@mikro-orm/core": "^5.2.4"
   },
   "peerDependencies": {
-    "@mikro-orm/core": "^5.0.0",
-    "@mikro-orm/entity-generator": "^5.0.0",
-    "@mikro-orm/migrations": "^5.0.0",
-    "@mikro-orm/migrations-mongodb": "^5.0.0",
-    "@mikro-orm/seeder": "^5.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@mikro-orm/entity-generator": {
-      "optional": true
-    },
-    "@mikro-orm/migrations": {
-      "optional": true
-    },
-    "@mikro-orm/migrations-mongodb": {
-      "optional": true
-    },
-    "@mikro-orm/seeder": {
-      "optional": true
-    }
+    "@mikro-orm/core": "^5.0.0"
   }
 }

--- a/packages/migrations-mongodb/src/JSMigrationGenerator.ts
+++ b/packages/migrations-mongodb/src/JSMigrationGenerator.ts
@@ -1,0 +1,31 @@
+import { MigrationGenerator } from './MigrationGenerator';
+
+export class JSMigrationGenerator extends MigrationGenerator {
+
+  /**
+   * @inheritDoc
+   */
+  generateMigrationFile(className: string, diff: { up: string[]; down: string[] }): string {
+    let ret = `'use strict';\n`;
+    ret += `Object.defineProperty(exports, '__esModule', { value: true });\n`;
+    ret += `const { Migration } = require('@mikro-orm/migrations-mongodb');\n\n`;
+    ret += `class ${className} extends Migration {\n\n`;
+    ret += `  async up() {\n`;
+    /* istanbul ignore next */
+    diff.up.forEach(sql => ret += this.createStatement(sql, 4));
+    ret += `  }\n\n`;
+
+    /* istanbul ignore next */
+    if (diff.down.length > 0) {
+      ret += `  async down() {\n`;
+      diff.down.forEach(sql => ret += this.createStatement(sql, 4));
+      ret += `  }\n\n`;
+    }
+
+    ret += `}\n`;
+    ret += `exports.${className} = ${className};\n`;
+
+    return ret;
+  }
+
+}

--- a/packages/migrations-mongodb/src/Migration.ts
+++ b/packages/migrations-mongodb/src/Migration.ts
@@ -1,0 +1,34 @@
+import type { Configuration, Transaction, EntityName } from '@mikro-orm/core';
+import type { MongoDriver } from '@mikro-orm/mongodb';
+import type { Collection, ClientSession } from 'mongodb';
+
+export abstract class Migration {
+
+  protected ctx?: Transaction<ClientSession>;
+
+  constructor(protected readonly driver: MongoDriver,
+              protected readonly config: Configuration) { }
+
+  abstract up(): Promise<void>;
+
+  async down(): Promise<void> {
+    throw new Error('This migration cannot be reverted');
+  }
+
+  isTransactional(): boolean {
+    return true;
+  }
+
+  reset(): void {
+    this.ctx = undefined;
+  }
+
+  setTransactionContext(ctx: Transaction): void {
+    this.ctx = ctx;
+  }
+
+  getCollection(entityName: EntityName<any>): Collection {
+    return this.driver.getConnection().getCollection(entityName);
+  }
+
+}

--- a/packages/migrations-mongodb/src/MigrationGenerator.ts
+++ b/packages/migrations-mongodb/src/MigrationGenerator.ts
@@ -1,0 +1,47 @@
+import { ensureDir, writeFile } from 'fs-extra';
+import type { IMigrationGenerator, MigrationsOptions, NamingStrategy } from '@mikro-orm/core';
+import { Utils } from '@mikro-orm/core';
+import type { MongoDriver } from '@mikro-orm/mongodb';
+
+/* istanbul ignore next */
+export abstract class MigrationGenerator implements IMigrationGenerator {
+
+  constructor(protected readonly driver: MongoDriver,
+              protected readonly namingStrategy: NamingStrategy,
+              protected readonly options: MigrationsOptions) { }
+
+  /**
+   * @inheritDoc
+   */
+  async generate(diff: { up: string[]; down: string[] }, path?: string): Promise<[string, string]> {
+    /* istanbul ignore next */
+    const defaultPath = this.options.emit === 'ts' && this.options.pathTs ? this.options.pathTs : this.options.path!;
+    path = Utils.normalizePath(this.driver.config.get('baseDir'), path ?? defaultPath);
+    await ensureDir(path);
+    const timestamp = new Date().toISOString().replace(/[-T:]|\.\d{3}z$/ig, '');
+    const className = this.namingStrategy.classToMigrationName(timestamp);
+    const fileName = `${this.options.fileName!(timestamp)}.${this.options.emit}`;
+    const ret = this.generateMigrationFile(className, diff);
+    await writeFile(path + '/' + fileName, ret);
+
+    return [ret, fileName];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  createStatement(query: string, padLeft: number): string {
+    if (query) {
+      const padding = ' '.repeat(padLeft);
+      return `${padding}console.log('${query}');\n`;
+    }
+
+    return '\n';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  abstract generateMigrationFile(className: string, diff: { up: string[]; down: string[] }): string;
+
+}

--- a/packages/migrations-mongodb/src/MigrationRunner.ts
+++ b/packages/migrations-mongodb/src/MigrationRunner.ts
@@ -1,0 +1,37 @@
+import type { MigrationsOptions, Transaction } from '@mikro-orm/core';
+import type { MongoDriver } from '@mikro-orm/mongodb';
+import type { Migration } from './Migration';
+
+export class MigrationRunner {
+
+  private readonly connection = this.driver.getConnection();
+  private masterTransaction?: Transaction;
+
+  constructor(protected readonly driver: MongoDriver,
+              protected readonly options: MigrationsOptions) { }
+
+  async run(migration: Migration, method: 'up' | 'down'): Promise<void> {
+    migration.reset();
+
+    if (!this.options.transactional || !migration.isTransactional()) {
+      await migration[method]();
+    } else if (this.masterTransaction) {
+      migration.setTransactionContext(this.masterTransaction);
+      await migration[method]();
+    } else {
+      await this.connection.transactional(async tx => {
+        migration.setTransactionContext(tx);
+        await migration[method]();
+      }, { ctx: this.masterTransaction });
+    }
+  }
+
+  setMasterMigration(trx: Transaction) {
+    this.masterTransaction = trx;
+  }
+
+  unsetMasterMigration() {
+    delete this.masterTransaction;
+  }
+
+}

--- a/packages/migrations-mongodb/src/MigrationStorage.ts
+++ b/packages/migrations-mongodb/src/MigrationStorage.ts
@@ -1,0 +1,58 @@
+import type { Dictionary, MigrationsOptions, Transaction } from '@mikro-orm/core';
+import type { MongoDriver } from '@mikro-orm/mongodb';
+import type { MigrationParams, UmzugStorage } from 'umzug';
+import * as path from 'path';
+import type { MigrationRow } from './typings';
+
+export class MigrationStorage implements UmzugStorage {
+
+  private masterTransaction?: Transaction;
+
+  constructor(protected readonly driver: MongoDriver,
+              protected readonly options: MigrationsOptions) { }
+
+  async executed(): Promise<string[]> {
+    const migrations = await this.getExecutedMigrations();
+    return migrations.map(({ name }) => `${this.getMigrationName(name)}`);
+  }
+
+  async logMigration(params: MigrationParams<any>): Promise<void> {
+    const tableName = this.options.tableName!;
+    const name = this.getMigrationName(params.name);
+    await this.driver.nativeInsert(tableName, { name, created_at: new Date() }, { ctx: this.masterTransaction });
+  }
+
+  async unlogMigration(params: MigrationParams<any>): Promise<void> {
+    const tableName = this.options.tableName!;
+    const withoutExt = this.getMigrationName(params.name);
+    await this.driver.nativeDelete(tableName, { name: { $in: [params.name, withoutExt] } }, { ctx: this.masterTransaction });
+  }
+
+  async getExecutedMigrations(): Promise<MigrationRow[]> {
+    const tableName = this.options.tableName!;
+    return this.driver.find(tableName, {}, { ctx: this.masterTransaction, orderBy: { _id: 'asc' } as Dictionary }) as Promise<MigrationRow[]>;
+  }
+
+  setMasterMigration(trx: Transaction) {
+    this.masterTransaction = trx;
+  }
+
+  unsetMasterMigration() {
+    delete this.masterTransaction;
+  }
+
+  /**
+   * @internal
+   */
+  getMigrationName(name: string) {
+    const parsedName = path.parse(name);
+
+    if (['.js', '.ts'].includes(parsedName.ext)) {
+      // strip extension
+      return parsedName.name;
+    }
+
+    return name;
+  }
+
+}

--- a/packages/migrations-mongodb/src/Migrator.ts
+++ b/packages/migrations-mongodb/src/Migrator.ts
@@ -1,0 +1,209 @@
+import type { InputMigrations, MigrateDownOptions, MigrateUpOptions, MigrationParams, RunnableMigration } from 'umzug';
+import { Umzug } from 'umzug';
+import { join } from 'path';
+import { ensureDir } from 'fs-extra';
+import type { Constructor, IMigrationGenerator, IMigrator, Transaction } from '@mikro-orm/core';
+import { Utils } from '@mikro-orm/core';
+import type { EntityManager } from '@mikro-orm/mongodb';
+import type { Migration } from './Migration';
+import { MigrationRunner } from './MigrationRunner';
+import { MigrationStorage } from './MigrationStorage';
+import type { MigrateOptions, MigrationResult, MigrationRow, UmzugMigration } from './typings';
+import { TSMigrationGenerator } from './TSMigrationGenerator';
+import { JSMigrationGenerator } from './JSMigrationGenerator';
+
+export class Migrator implements IMigrator {
+
+  private umzug!: Umzug;
+  private runner!: MigrationRunner;
+  private storage!: MigrationStorage;
+  private generator!: IMigrationGenerator;
+  private readonly driver = this.em.getDriver();
+  private readonly config = this.em.config;
+  private readonly options = this.config.get('migrations');
+  private readonly absolutePath: string;
+
+  constructor(private readonly em: EntityManager) {
+    /* istanbul ignore next */
+    const key = (this.config.get('tsNode', Utils.detectTsNode()) && this.options.pathTs) ? 'pathTs' : 'path';
+    this.absolutePath = Utils.absolutePath(this.options[key]!, this.config.get('baseDir'));
+    this.createUmzug();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  async createMigration(path?: string): Promise<MigrationResult> {
+    await this.ensureMigrationsDirExists();
+    const diff = { up: [], down: [] };
+    const migration = await this.generator.generate(diff, path);
+
+    return {
+      fileName: migration[1],
+      code: migration[0],
+      diff,
+    };
+  }
+
+  /**
+   * @inheritDoc
+   */
+  async createInitialMigration(path?: string): Promise<MigrationResult> {
+    return this.createMigration(path);
+  }
+
+  private createUmzug(): void {
+    this.runner = new MigrationRunner(this.driver, this.options);
+    this.storage = new MigrationStorage(this.driver, this.options);
+
+    let migrations: InputMigrations<any> = {
+      glob: join(this.absolutePath, this.options.glob!),
+      resolve: (params: MigrationParams<any>) => this.resolve(params),
+    };
+
+    /* istanbul ignore next */
+    if (this.options.migrationsList) {
+      migrations = this.options.migrationsList.map(migration => this.initialize(migration.class as Constructor<Migration>, migration.name));
+    }
+
+    this.umzug = new Umzug({
+      storage: this.storage,
+      logger: undefined,
+      migrations,
+    });
+
+    const logger = this.config.get('logger');
+    this.umzug.on('migrating', event => logger(`Processing '${event.name}'`));
+    this.umzug.on('migrated', event => logger(`Applied '${event.name}'`));
+    this.umzug.on('reverting', event => logger(`Processing '${event.name}'`));
+    this.umzug.on('reverted', event => logger(`Reverted '${event.name}'`));
+
+    /* istanbul ignore next */
+    if (this.options.generator) {
+      this.generator = new this.options.generator(this.driver, this.config.getNamingStrategy(), this.options);
+    } else if (this.options.emit === 'js') {
+      this.generator = new JSMigrationGenerator(this.driver, this.config.getNamingStrategy(), this.options);
+    } else {
+      this.generator = new TSMigrationGenerator(this.driver, this.config.getNamingStrategy(), this.options);
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  async getExecutedMigrations(): Promise<MigrationRow[]> {
+    await this.ensureMigrationsDirExists();
+    return this.storage.getExecutedMigrations();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  async getPendingMigrations(): Promise<UmzugMigration[]> {
+    await this.ensureMigrationsDirExists();
+    return this.umzug.pending();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  async up(options?: string | string[] | MigrateOptions): Promise<UmzugMigration[]> {
+    return this.runMigrations('up', options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  async down(options?: string | string[] | MigrateOptions): Promise<UmzugMigration[]> {
+    return this.runMigrations('down', options);
+  }
+
+  getStorage(): MigrationStorage {
+    return this.storage;
+  }
+
+  protected resolve(params: MigrationParams<any>): RunnableMigration<any> {
+    const createMigrationHandler = async (method: 'up' | 'down') => {
+      const migration = await Utils.dynamicImport(params.path!);
+      const MigrationClass = Object.values(migration)[0] as Constructor<Migration>;
+      const instance = new MigrationClass(this.driver, this.config);
+
+      await this.runner.run(instance, method);
+    };
+
+    return {
+      name: this.storage.getMigrationName(params.name),
+      up: () => createMigrationHandler('up'),
+      down: () => createMigrationHandler('down'),
+    };
+  }
+
+  /* istanbul ignore next */
+  protected initialize(MigrationClass: Constructor<Migration>, name: string): RunnableMigration<any> {
+    const instance = new MigrationClass(this.driver, this.config);
+
+    return {
+      name: this.storage.getMigrationName(name),
+      up: () => this.runner.run(instance, 'up'),
+      down: () => this.runner.run(instance, 'down'),
+    };
+  }
+
+  private getMigrationFilename(name: string): string {
+    name = name.replace(/\.[jt]s$/, '');
+    return name.match(/^\d{14}$/) ? this.options.fileName!(name) : name;
+  }
+
+  private prefix<T extends string | string[] | { from?: string | number; to?: string | number; migrations?: string[]; transaction?: Transaction }>(options?: T): MigrateUpOptions & MigrateDownOptions {
+    if (Utils.isString(options) || Array.isArray(options)) {
+      return { migrations: Utils.asArray(options).map(name => this.getMigrationFilename(name)) };
+    }
+
+    if (!options) {
+      return {};
+    }
+
+    if (options.migrations) {
+      options.migrations = options.migrations.map(name => this.getMigrationFilename(name));
+    }
+
+    if (options.transaction) {
+      delete options.transaction;
+    }
+
+    ['from', 'to'].filter(k => options[k]).forEach(k => options[k] = this.getMigrationFilename(options[k]));
+
+    return options as MigrateUpOptions;
+  }
+
+  private async runMigrations(method: 'up' | 'down', options?: string | string[] | MigrateOptions) {
+    await this.ensureMigrationsDirExists();
+
+    if (!this.options.transactional || !this.options.allOrNothing) {
+      return this.umzug[method](this.prefix(options as string[]));
+    }
+
+    if (Utils.isObject<MigrateOptions>(options) && options.transaction) {
+      return this.runInTransaction(options.transaction, method, options);
+    }
+
+    return this.driver.getConnection().transactional(trx => this.runInTransaction(trx, method, options));
+  }
+
+  private async runInTransaction(trx: Transaction, method: 'up' | 'down', options: string | string[] | undefined | MigrateOptions) {
+    this.runner.setMasterMigration(trx);
+    this.storage.setMasterMigration(trx);
+    const ret = await this.umzug[method](this.prefix(options));
+    this.runner.unsetMasterMigration();
+    this.storage.unsetMasterMigration();
+
+    return ret;
+  }
+
+  private async ensureMigrationsDirExists() {
+    if (!this.options.migrationsList) {
+      await ensureDir(this.absolutePath);
+    }
+  }
+
+}

--- a/packages/migrations-mongodb/src/TSMigrationGenerator.ts
+++ b/packages/migrations-mongodb/src/TSMigrationGenerator.ts
@@ -1,0 +1,28 @@
+import { MigrationGenerator } from './MigrationGenerator';
+
+export class TSMigrationGenerator extends MigrationGenerator {
+
+  /**
+   * @inheritDoc
+   */
+  generateMigrationFile(className: string, diff: { up: string[]; down: string[] }): string {
+    let ret = `import { Migration } from '@mikro-orm/migrations-mongodb';\n\n`;
+    ret += `export class ${className} extends Migration {\n\n`;
+    ret += `  async up(): Promise<void> {\n`;
+    /* istanbul ignore next */
+    diff.up.forEach(sql => ret += this.createStatement(sql, 4));
+    ret += `  }\n\n`;
+
+    /* istanbul ignore next */
+    if (diff.down.length > 0) {
+      ret += `  async down(): Promise<void> {\n`;
+      diff.down.forEach(sql => ret += this.createStatement(sql, 4));
+      ret += `  }\n\n`;
+    }
+
+    ret += `}\n`;
+
+    return ret;
+  }
+
+}

--- a/packages/migrations-mongodb/src/index.ts
+++ b/packages/migrations-mongodb/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @packageDocumentation
+ * @module migrations-mongodb
+ */
+export * from './Migrator';
+export * from './Migration';
+export * from './MigrationRunner';
+export * from './MigrationGenerator';
+export * from './JSMigrationGenerator';
+export * from './TSMigrationGenerator';
+export * from './MigrationStorage';
+export * from './typings';

--- a/packages/migrations-mongodb/src/typings.ts
+++ b/packages/migrations-mongodb/src/typings.ts
@@ -1,0 +1,6 @@
+import type { Transaction, MigrationDiff } from '@mikro-orm/core';
+
+export type UmzugMigration = { name: string; path?: string };
+export type MigrateOptions = { from?: string | number; to?: string | number; migrations?: string[]; transaction?: Transaction };
+export type MigrationResult = { fileName: string; code: string; diff: MigrationDiff };
+export type MigrationRow = { name: string; executed_at: Date };

--- a/packages/migrations-mongodb/tsconfig.build.json
+++ b/packages/migrations-mongodb/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/migrations-mongodb/tsconfig.json
+++ b/packages/migrations-mongodb/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"]
+}

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -33,7 +33,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     where = this.renameFields(entityName, where, true);
     const res = await this.rethrow(this.getConnection('read').find<T>(entityName, where, options.orderBy, options.limit, options.offset, fields, options.ctx));
 
-    return res.map(r => this.mapResult<T>(r, this.metadata.find(entityName)!)!);
+    return res.map(r => this.mapResult<T>(r, this.metadata.find(entityName))!);
   }
 
   async findOne<T extends AnyEntity<T>, P extends string = never>(entityName: string, where: FilterQuery<T>, options: FindOneOptions<T, P> = { populate: [], orderBy: {} }): Promise<EntityData<T> | null> {
@@ -186,7 +186,12 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
   }
 
   protected buildFields<T extends AnyEntity<T>, P extends string = never>(entityName: string, populate: PopulateOptions<T>[], fields?: readonly EntityField<T, P>[]): string[] | undefined {
-    const meta = this.metadata.find<T>(entityName)!;
+    const meta = this.metadata.find<T>(entityName);
+
+    if (!meta) {
+      return fields as string[];
+    }
+
     const lazyProps = meta.props.filter(prop => prop.lazy && !populate.some(p => p.field === prop.name || p.all));
     const ret: string[] = [];
 

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -24,6 +24,12 @@ export class MongoPlatform extends Platform {
     return new MongoSchemaGenerator(em ?? driver as any);
   }
 
+  getMigrator(em: EntityManager) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { Migrator } = require('@mikro-orm/migrations-mongodb');
+    return this.config.getCachedService(Migrator, em);
+  }
+
   normalizePrimaryKey<T extends number | string = number | string>(data: Primary<T> | IPrimaryKey | ObjectId): T {
     if (data instanceof ObjectId) {
       return data.toHexString() as T;

--- a/packages/mongodb/src/MongoSchemaGenerator.ts
+++ b/packages/mongodb/src/MongoSchemaGenerator.ts
@@ -37,7 +37,7 @@ export class MongoSchemaGenerator extends AbstractSchemaGenerator<MongoDriver> {
   }
 
   async ensureDatabase(): Promise<boolean> {
-    return true;
+    return false;
   }
 
   async refreshDatabase(options: CreateSchemaOptions = {}): Promise<void> {

--- a/tests/DatabaseDriver.test.ts
+++ b/tests/DatabaseDriver.test.ts
@@ -18,7 +18,7 @@ import {
   DatabaseDriver,
   EntityManager,
   EntityRepository,
-  LockMode,
+  LockMode, MikroORM,
   Platform,
 } from '@mikro-orm/core';
 
@@ -65,9 +65,10 @@ class Driver extends DatabaseDriver<Connection> implements IDatabaseDriver {
 
 describe('DatabaseDriver', () => {
 
+  const config = new Configuration({ type: 'mongo', allowGlobalContext: true } as any, false);
+  const driver = new Driver(config, []);
+
   test('default validations', async () => {
-    const config = new Configuration({ type: 'mongo', allowGlobalContext: true } as any, false);
-    const driver = new Driver(config, []);
     expect(driver.createEntityManager()).toBeInstanceOf(EntityManager);
     expect(driver.getPlatform().getRepositoryClass()).toBe(EntityRepository);
     expect(driver.getPlatform().quoteValue('a')).toBe('a');
@@ -78,6 +79,10 @@ describe('DatabaseDriver', () => {
     const e2 = driver.convertException(e1);
     expect(e1).toBe(e2);
     expect(() => driver.getPlatform().getSchemaGenerator(driver)).toThrowError('Driver does not support SchemaGenerator');
+  });
+
+  test('not supported', async () => {
+    expect(() => driver.getPlatform().getMigrator({} as any)).toThrowError('Platform1 does not support Migrator');
   });
 
 });

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -394,7 +394,7 @@ describe('EntityManagerMongo', () => {
   test('transactions', async () => {
     const god1 = new Author('God1', 'hello@heaven1.god');
     await orm.em.begin();
-    await orm.em.persist(god1);
+    await orm.em.persist(god1).flush();
     await orm.em.rollback();
     const res1 = await orm.em.findOne(Author, { name: 'God1' });
     expect(res1).toBeNull();

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -68,6 +68,7 @@ export async function initORMMongo(replicaSet = false) {
     validate: true,
     filters: { allowedFooBars: { cond: args => ({ id: { $in: args.allowed } }), entity: ['FooBar'], default: false } },
     pool: { min: 1, max: 3 },
+    migrations: { path: BASE_DIR + '/../temp/migrations-mongo' },
   });
 
   ensureIndexes = false;

--- a/tests/features/migrations/Migrator.mongo.test.ts
+++ b/tests/features/migrations/Migrator.mongo.test.ts
@@ -1,10 +1,267 @@
-import { MikroORM } from '@mikro-orm/core';
+(global as any).process.env.FORCE_COLOR = 0;
+import { Umzug } from 'umzug';
+import type { MikroORM } from '@mikro-orm/core';
+import { Migration, Migrator } from '@mikro-orm/migrations-mongodb';
+import type { MongoDriver } from '@mikro-orm/mongodb';
+import { remove } from 'fs-extra';
+import { closeReplSets, initORMMongo, mockLogger } from '../../bootstrap';
 
-describe('Migrator', () => {
+class MigrationTest1 extends Migration {
 
-  test('not supported [mongodb]', async () => {
-    const orm = await MikroORM.init({ type: 'mongo', dbName: 'mikro-orm-test', discovery: { warnWhenNoEntities: false } }, false);
-    expect(() => orm.getMigrator()).toThrowError('MongoPlatform does not support Migrator');
+  async up(): Promise<void> {
+    await this.getCollection('Book').updateMany({}, { $set: { updatedAt: new Date() } });
+    await this.driver.nativeDelete('Book', { foo: true }, { ctx: this.ctx });
+  }
+
+}
+
+class MigrationTest2 extends Migration {
+
+  async up(): Promise<void> {
+    await this.getCollection('Book').updateMany({}, { $unset: { title: 1 } }, { session: this.ctx });
+    await this.driver.nativeDelete('Book', { foo: false }, { ctx: this.ctx });
+  }
+
+  isTransactional(): boolean {
+    return false;
+  }
+
+}
+
+describe('Migrator (mongo)', () => {
+
+  let orm: MikroORM<MongoDriver>;
+
+  beforeAll(async () => {
+    orm = await initORMMongo(true);
+
+    const schemaGenerator = orm.getSchemaGenerator();
+    await schemaGenerator.refreshDatabase();
+    await remove(process.cwd() + '/temp/migrations-mongo');
+  });
+
+  beforeEach(() => orm.config.resetServiceCache());
+
+  afterAll(async () => {
+    await orm.close(true);
+    await closeReplSets();
+  });
+
+  test('generate js schema migration', async () => {
+    const dateMock = jest.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
+    const migrationsSettings = orm.config.get('migrations');
+    orm.config.set('migrations', { ...migrationsSettings, emit: 'js' }); // Set migration type to js
+    const migrator = orm.getMigrator();
+    const migration = await migrator.createMigration();
+    expect(migration).toMatchSnapshot('migration-js-dump');
+    orm.config.set('migrations', migrationsSettings); // Revert migration config changes
+    await remove(process.cwd() + '/temp/migrations-mongo/' + migration.fileName);
+  });
+
+  test('generate migration with custom name', async () => {
+    const dateMock = jest.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
+    const migrationsSettings = orm.config.get('migrations');
+    orm.config.set('migrations', { ...migrationsSettings, fileName: time => `migration-${time}` });
+    const migrator = orm.getMigrator();
+    const migration = await migrator.createMigration();
+    expect(migration).toMatchSnapshot('migration-dump');
+    const upMock = jest.spyOn(Umzug.prototype, 'up');
+    upMock.mockImplementation(() => void 0 as any);
+    const downMock = jest.spyOn(Umzug.prototype, 'down');
+    downMock.mockImplementation(() => void 0 as any);
+    await migrator.up();
+    await migrator.down(migration.fileName.replace('.ts', ''));
+    await migrator.up();
+    await migrator.down(migration.fileName);
+    await migrator.up();
+    await migrator.down(migration.fileName.replace('migration-', '').replace('.ts', ''));
+    orm.config.set('migrations', migrationsSettings); // Revert migration config changes
+    await remove(process.cwd() + '/temp/migrations-mongo/' + migration.fileName);
+    upMock.mockRestore();
+    downMock.mockRestore();
+  });
+
+  test('generate blank migration', async () => {
+    const dateMock = jest.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
+    const migrator = orm.getMigrator();
+    const migration = await migrator.createMigration();
+    expect(migration).toMatchSnapshot('migration-dump');
+    await remove(process.cwd() + '/temp/migrations-mongo/' + migration.fileName);
+  });
+
+  test('generate initial migration', async () => {
+    const migrator = orm.getMigrator();
+    const spy = jest.spyOn(Migrator.prototype, 'createMigration');
+    spy.mockImplementation();
+    await migrator.createInitialMigration('abc');
+    expect(spy).toBeCalledWith('abc');
+    spy.mockRestore();
+  });
+
+  test('run migration', async () => {
+    const upMock = jest.spyOn(Umzug.prototype, 'up');
+    const downMock = jest.spyOn(Umzug.prototype, 'down');
+    upMock.mockImplementationOnce(() => void 0 as any);
+    downMock.mockImplementationOnce(() => void 0 as any);
+    const migrator = orm.getMigrator();
+    await migrator.up();
+    expect(upMock).toBeCalledTimes(1);
+    expect(downMock).toBeCalledTimes(0);
+    await orm.em.begin();
+    await migrator.down({ transaction: orm.em.getTransactionContext() });
+    await orm.em.commit();
+    expect(upMock).toBeCalledTimes(1);
+    expect(downMock).toBeCalledTimes(1);
+    upMock.mockRestore();
+  });
+
+  test('run schema migration without existing migrations folder (GH #907)', async () => {
+    await remove(process.cwd() + '/temp/migrations-mongo');
+    const migrator = orm.getMigrator();
+    await migrator.up();
+  });
+
+  test('list executed migrations', async () => {
+    const migrator = orm.getMigrator();
+    const storage = migrator.getStorage();
+
+    await storage.logMigration({ name: 'test', context: null });
+    await expect(storage.getExecutedMigrations()).resolves.toMatchObject([{ name: 'test' }]);
+    await expect(storage.executed()).resolves.toEqual(['test']);
+
+    await storage.unlogMigration({ name: 'test', context: null });
+    await expect(storage.executed()).resolves.toEqual([]);
+
+    await expect(migrator.getPendingMigrations()).resolves.toEqual([]);
+  });
+
+  test('runner', async () => {
+    const migrator = orm.getMigrator();
+    // @ts-ignore
+    const runner = migrator.runner;
+
+    const mock = mockLogger(orm, ['query']);
+
+    const migration1 = new MigrationTest1(orm.em.getDriver(), orm.config);
+    const spy1 = jest.spyOn(Migration.prototype, 'getCollection');
+    mock.mock.calls.length = 0;
+    await runner.run(migration1, 'up');
+    expect(spy1).toBeCalledWith('Book');
+    // no logging for collection methods, only for driver ones
+    expect(mock.mock.calls).toHaveLength(3);
+    expect(mock.mock.calls[0][0]).toMatch('db.begin()');
+    expect(mock.mock.calls[1][0]).toMatch(`db.getCollection('books-table').deleteMany({ foo: true }, { session: '[ClientSession]' })`);
+    expect(mock.mock.calls[2][0]).toMatch('db.commit()');
+    mock.mock.calls.length = 0;
+
+    await expect(runner.run(migration1, 'down')).rejects.toThrowError('This migration cannot be reverted');
+    const executed = await migrator.getExecutedMigrations();
+    expect(executed).toEqual([]);
+
+    mock.mock.calls.length = 0;
+    const migration2 = new MigrationTest2(orm.em.getDriver(), orm.config);
+    await runner.run(migration2, 'up');
+    expect(mock.mock.calls).toHaveLength(1);
+    expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('books-table').deleteMany({ foo: false }, { session: undefined })`);
+  });
+
+  test('up/down params [all or nothing enabled]', async () => {
+    const migrator = orm.getMigrator();
+    const path = process.cwd() + '/temp/migrations-mongo';
+
+    const migration = await migrator.createMigration(path, true);
+    const migratorMock = jest.spyOn(Migration.prototype, 'down');
+    migratorMock.mockImplementation();
+
+    const mock = mockLogger(orm, ['query']);
+
+    await migrator.up(migration.fileName);
+    await migrator.down(migration.fileName.replace('Migration', '').replace('.ts', ''));
+    await migrator.up({ migrations: [migration.fileName] });
+    await migrator.down({ from: 0, to: 0 } as any);
+    await migrator.up({ to: migration.fileName });
+    await migrator.up({ from: migration.fileName } as any);
+    await migrator.down();
+
+    await remove(path + '/' + migration.fileName);
+    const calls = mock.mock.calls.map(call => {
+      return call[0]
+        .replace(/ \[took \d+ ms]/, '')
+        .replace(/\[query] /, '')
+        .replace(/ trx\d+/, 'trx\\d+');
+    });
+    expect(calls).toMatchSnapshot('all-or-nothing');
+  });
+
+  test('up/down with explicit transaction', async () => {
+    const migrator = orm.getMigrator();
+    const path = process.cwd() + '/temp/migrations-mongo';
+
+    const dateMock = jest.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-09-22T10:00:01.000Z');
+    const migration1 = await migrator.createMigration(path, true);
+    dateMock.mockReturnValueOnce('2020-09-22T10:00:02.000Z');
+    const migration2 = await migrator.createMigration(path, true);
+    const migrationMock = jest.spyOn(Migration.prototype, 'down');
+    migrationMock.mockImplementation();
+
+    const mock = mockLogger(orm, ['query']);
+
+    await orm.em.transactional(async em => {
+      const ret1 = await migrator.up({ transaction: em.getTransactionContext() });
+      const ret2 = await migrator.down({ transaction: em.getTransactionContext() });
+      const ret3 = await migrator.down({ transaction: em.getTransactionContext() });
+      const ret4 = await migrator.down({ transaction: em.getTransactionContext() });
+      expect(ret1).toHaveLength(2);
+      expect(ret2).toHaveLength(1);
+      expect(ret3).toHaveLength(1);
+      expect(ret4).toHaveLength(0);
+    });
+
+    await remove(path + '/' + migration1.fileName);
+    await remove(path + '/' + migration2.fileName);
+    const calls = mock.mock.calls.map(call => {
+      return call[0]
+        .replace(/ \[took \d+ ms]/, '')
+        .replace(/\[query] /, '')
+        .replace(/ISODate\('.*'\)/, 'ISODate(...)')
+        .replace(/ trx\d+/, 'trx_xx');
+    });
+    expect(calls).toMatchSnapshot('explicit-tx');
+  });
+
+  test('up/down params [all or nothing disabled]', async () => {
+    const migrator = orm.getMigrator();
+    // @ts-ignore
+    migrator.options.allOrNothing = false;
+    const path = process.cwd() + '/temp/migrations-mongo';
+
+    const migration = await migrator.createMigration(path, true);
+    const migratorMock = jest.spyOn(Migration.prototype, 'down');
+    migratorMock.mockImplementation(async () => void 0);
+
+    const mock = mockLogger(orm, ['query']);
+
+    await migrator.up(migration.fileName);
+    await migrator.down(migration.fileName.replace('Migration', ''));
+    await migrator.up({ migrations: [migration.fileName] });
+    await migrator.down({ from: 0, to: 0 } as any);
+    await migrator.up({ to: migration.fileName });
+    await migrator.up({ from: migration.fileName } as any);
+    await migrator.down();
+
+    await remove(path + '/' + migration.fileName);
+    const calls = mock.mock.calls.map(call => {
+      return call[0]
+        .replace(/ \[took \d+ ms]/, '')
+        .replace(/\[query] /, '')
+        .replace(/ISODate\('.*'\)/, 'ISODate(...)')
+        .replace(/ trx\d+/, 'trx_xx');
+    });
+    expect(calls).toMatchSnapshot('all-or-nothing-disabled');
   });
 
 });

--- a/tests/features/migrations/Migrator.postgres.test.ts
+++ b/tests/features/migrations/Migrator.postgres.test.ts
@@ -195,14 +195,14 @@ describe('Migrator (postgres)', () => {
     const migrator = orm.getMigrator();
     expect(migrator.getStorage()).toBeInstanceOf(MigrationStorage);
 
-    expect(migrator.getStorage().getTableName()).toEqual({
+    expect(migrator.getStorage().getTableName!()).toEqual({
       schemaName: 'custom',
       tableName: 'mikro_orm_migrations',
     });
 
     // @ts-expect-error private property
     migrator.options.tableName = 'custom.mikro_orm_migrations';
-    expect(migrator.getStorage().getTableName()).toEqual({
+    expect(migrator.getStorage().getTableName!()).toEqual({
       schemaName: 'custom',
       tableName: 'mikro_orm_migrations',
     });
@@ -246,12 +246,12 @@ describe('Migrator (postgres)', () => {
     const migrator = orm.getMigrator();
     const storage = migrator.getStorage();
 
-    await storage.ensureTable(); // creates the table
+    await storage.ensureTable!(); // creates the table
     await storage.logMigration({ name: 'test', context: null });
     await expect(storage.getExecutedMigrations()).resolves.toMatchObject([{ name: 'test' }]);
     await expect(storage.executed()).resolves.toEqual(['test']);
 
-    await storage.ensureTable(); // table exists, no-op
+    await storage.ensureTable!(); // table exists, no-op
     await storage.unlogMigration({ name: 'test', context: null });
     await expect(storage.executed()).resolves.toEqual([]);
 
@@ -261,7 +261,7 @@ describe('Migrator (postgres)', () => {
   test('runner', async () => {
     await orm.em.getKnex().schema.dropTableIfExists(orm.config.get('migrations').tableName!).withSchema('custom');
     const migrator = orm.getMigrator();
-    await migrator.getStorage().ensureTable();
+    await migrator.getStorage().ensureTable!();
     // @ts-ignore
     const runner = migrator.runner;
 
@@ -416,7 +416,7 @@ test('ensureTable when the schema does not exist', async () => {
   const storage = orm.getMigrator().getStorage();
 
   const mock = mockLogger(orm);
-  await storage.ensureTable(); // ensures the schema first
+  await storage.ensureTable!(); // ensures the schema first
   expect(mock.mock.calls[0][0]).toMatch(`select table_name, table_schema as schema_name, (select pg_catalog.obj_description(c.oid) from pg_catalog.pg_class c where c.oid = (select ('"' || table_schema || '"."' || table_name || '"')::regclass::oid) and c.relname = table_name) as table_comment from information_schema.tables where "table_schema" not like 'pg_%' and "table_schema" not like 'crdb_%' and "table_schema" not in ('information_schema', 'tiger', 'topology') and table_name != 'geometry_columns' and table_name != 'spatial_ref_sys' and table_type != 'VIEW' order by table_name`);
   expect(mock.mock.calls[1][0]).toMatch(`select schema_name from information_schema.schemata where "schema_name" not like 'pg_%' and "schema_name" not like 'crdb_%' and "schema_name" not in ('information_schema', 'tiger', 'topology') order by schema_name`);
   expect(mock.mock.calls[2][0]).toMatch(`create schema "custom2"`);

--- a/tests/features/migrations/__snapshots__/Migrator.mongo.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.mongo.test.ts.snap
@@ -1,0 +1,138 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Migrator (mongo) generate blank migration: migration-dump 1`] = `
+Object {
+  "code": "import { Migration } from '@mikro-orm/migrations-mongodb';
+
+export class Migration20191013214813 extends Migration {
+
+  async up(): Promise<void> {
+  }
+
+}
+",
+  "diff": Object {
+    "down": Array [],
+    "up": Array [],
+  },
+  "fileName": "Migration20191013214813.ts",
+}
+`;
+
+exports[`Migrator (mongo) generate js schema migration: migration-js-dump 1`] = `
+Object {
+  "code": "'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const { Migration } = require('@mikro-orm/migrations-mongodb');
+
+class Migration20191013214813 extends Migration {
+
+  async up() {
+  }
+
+}
+exports.Migration20191013214813 = Migration20191013214813;
+",
+  "diff": Object {
+    "down": Array [],
+    "up": Array [],
+  },
+  "fileName": "Migration20191013214813.js",
+}
+`;
+
+exports[`Migrator (mongo) generate migration with custom name: migration-dump 1`] = `
+Object {
+  "code": "import { Migration } from '@mikro-orm/migrations-mongodb';
+
+export class Migration20191013214813 extends Migration {
+
+  async up(): Promise<void> {
+  }
+
+}
+",
+  "diff": Object {
+    "down": Array [],
+    "up": Array [],
+  },
+  "fileName": "migration-20191013214813.ts",
+}
+`;
+
+exports[`Migrator (mongo) up/down params [all or nothing disabled]: all-or-nothing-disabled 1`] = `
+Array [
+  "db.getCollection('mikro_orm_migrations').find({}, { session: undefined }).sort([ [ '_id', 1 ] ]).toArray();",
+  "db.begin();",
+  "db.commit();",
+  "db.getCollection('mikro_orm_migrations').insertOne({ name: 'Migration20191013214813', created_at: ISODate(...) }, { session: undefined });",
+  "db.getCollection('mikro_orm_migrations').find({}, { session: undefined }).sort([ [ '_id', 1 ] ]).toArray();",
+  "db.begin();",
+  "db.commit();",
+  "db.getCollection('mikro_orm_migrations').deleteMany({ name: { '$in': [ 'Migration20191013214813', 'Migration20191013214813' ] } }, { session: undefined });",
+  "db.getCollection('mikro_orm_migrations').find({}, { session: undefined }).sort([ [ '_id', 1 ] ]).toArray();",
+  "db.begin();",
+  "db.commit();",
+  "db.getCollection('mikro_orm_migrations').insertOne({ name: 'Migration20191013214813', created_at: ISODate(...) }, { session: undefined });",
+  "db.getCollection('mikro_orm_migrations').find({}, { session: undefined }).sort([ [ '_id', 1 ] ]).toArray();",
+  "db.begin();",
+  "db.commit();",
+  "db.getCollection('mikro_orm_migrations').deleteMany({ name: { '$in': [ 'Migration20191013214813', 'Migration20191013214813' ] } }, { session: undefined });",
+  "db.getCollection('mikro_orm_migrations').find({}, { session: undefined }).sort([ [ '_id', 1 ] ]).toArray();",
+  "db.begin();",
+  "db.commit();",
+  "db.getCollection('mikro_orm_migrations').insertOne({ name: 'Migration20191013214813', created_at: ISODate(...) }, { session: undefined });",
+  "db.getCollection('mikro_orm_migrations').find({}, { session: undefined }).sort([ [ '_id', 1 ] ]).toArray();",
+  "db.getCollection('mikro_orm_migrations').find({}, { session: undefined }).sort([ [ '_id', 1 ] ]).toArray();",
+  "db.begin();",
+  "db.commit();",
+  "db.getCollection('mikro_orm_migrations').deleteMany({ name: { '$in': [ 'Migration20191013214813', 'Migration20191013214813' ] } }, { session: undefined });",
+]
+`;
+
+exports[`Migrator (mongo) up/down params [all or nothing enabled]: all-or-nothing 1`] = `
+Array [
+  "db.begin();",
+  "db.getCollection('mikro_orm_migrations').find({}, { session: '[ClientSession]' }).sort([ [ '_id', 1 ] ]).toArray();",
+  "db.getCollection('mikro_orm_migrations').insertOne({ name: 'Migration20191013214813', created_at: ISODate('2019-10-13T21:48:13.382Z') }, { session: '[ClientSession]' });",
+  "db.commit();",
+  "db.begin();",
+  "db.getCollection('mikro_orm_migrations').find({}, { session: '[ClientSession]' }).sort([ [ '_id', 1 ] ]).toArray();",
+  "db.getCollection('mikro_orm_migrations').deleteMany({ name: { '$in': [ 'Migration20191013214813', 'Migration20191013214813' ] } }, { session: '[ClientSession]' });",
+  "db.commit();",
+  "db.begin();",
+  "db.getCollection('mikro_orm_migrations').find({}, { session: '[ClientSession]' }).sort([ [ '_id', 1 ] ]).toArray();",
+  "db.getCollection('mikro_orm_migrations').insertOne({ name: 'Migration20191013214813', created_at: ISODate('2019-10-13T21:48:13.382Z') }, { session: '[ClientSession]' });",
+  "db.commit();",
+  "db.begin();",
+  "db.getCollection('mikro_orm_migrations').find({}, { session: '[ClientSession]' }).sort([ [ '_id', 1 ] ]).toArray();",
+  "db.getCollection('mikro_orm_migrations').deleteMany({ name: { '$in': [ 'Migration20191013214813', 'Migration20191013214813' ] } }, { session: '[ClientSession]' });",
+  "db.commit();",
+  "db.begin();",
+  "db.getCollection('mikro_orm_migrations').find({}, { session: '[ClientSession]' }).sort([ [ '_id', 1 ] ]).toArray();",
+  "db.getCollection('mikro_orm_migrations').insertOne({ name: 'Migration20191013214813', created_at: ISODate('2019-10-13T21:48:13.382Z') }, { session: '[ClientSession]' });",
+  "db.commit();",
+  "db.begin();",
+  "db.getCollection('mikro_orm_migrations').find({}, { session: '[ClientSession]' }).sort([ [ '_id', 1 ] ]).toArray();",
+  "db.commit();",
+  "db.begin();",
+  "db.getCollection('mikro_orm_migrations').find({}, { session: '[ClientSession]' }).sort([ [ '_id', 1 ] ]).toArray();",
+  "db.getCollection('mikro_orm_migrations').deleteMany({ name: { '$in': [ 'Migration20191013214813', 'Migration20191013214813' ] } }, { session: '[ClientSession]' });",
+  "db.commit();",
+]
+`;
+
+exports[`Migrator (mongo) up/down with explicit transaction: explicit-tx 1`] = `
+Array [
+  "db.begin();",
+  "db.getCollection('mikro_orm_migrations').find({}, { session: '[ClientSession]' }).sort([ [ '_id', 1 ] ]).toArray();",
+  "db.getCollection('mikro_orm_migrations').insertOne({ name: 'Migration20200922100001', created_at: ISODate(...) }, { session: '[ClientSession]' });",
+  "db.getCollection('mikro_orm_migrations').insertOne({ name: 'Migration20200922100002', created_at: ISODate(...) }, { session: '[ClientSession]' });",
+  "db.getCollection('mikro_orm_migrations').find({}, { session: '[ClientSession]' }).sort([ [ '_id', 1 ] ]).toArray();",
+  "db.getCollection('mikro_orm_migrations').deleteMany({ name: { '$in': [ 'Migration20200922100002', 'Migration20200922100002' ] } }, { session: '[ClientSession]' });",
+  "db.getCollection('mikro_orm_migrations').find({}, { session: '[ClientSession]' }).sort([ [ '_id', 1 ] ]).toArray();",
+  "db.getCollection('mikro_orm_migrations').deleteMany({ name: { '$in': [ 'Migration20200922100001', 'Migration20200922100001' ] } }, { session: '[ClientSession]' });",
+  "db.getCollection('mikro_orm_migrations').find({}, { session: '[ClientSession]' }).sort([ [ '_id', 1 ] ]).toArray();",
+  "db.commit();",
+]
+`;


### PR DESCRIPTION
Adds new `@mikro-orm/migrations-mongodb` package that needs to be explicitly installed. Current CLI commands will work with it transparently.

Mongo migrations have some limitations:
- no nested transaction support
- no schema diffing
- only blank migrations are generated
- use `this.driver` or `this.getCollection()` to manipulate with the database

Closes #295