### PR TITLE
feat(core): add support for virtual entities

### DIFF
--- a/docs/docs/virtual-entities.md
+++ b/docs/docs/virtual-entities.md
@@ -1,0 +1,242 @@
+---
+title: Virtual Entities
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Virtual entities don't represent any database table. Instead, they dynamically resolve to an SQL query (or an aggregation in mongo), allowing to map any kind of results onto an entity. Such entities are mean for read purposes, they don't have a primary key and therefore cannot be tracked for changes. In a sense they are similar to (currently unsupported) database views. 
+
+To define a virtual entity, provide an `expression`, either as a string (SQL query):
+
+> We need to use the virtual column names based on current naming strategy. Note the `authorName` property being represented as `author_name` column.
+
+<Tabs
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
+
+```ts title="./entities/BookWithAuthor.ts"
+@Entity({
+  expression: 'select name, age, ' +
+    '(select count(*) from book b where b.author_id = a.id) as total_books, ' +
+    '(select group_concat(distinct t.name) from book b ' +
+      'join tags_ordered bt on bt.book_id = b.id ' +
+      'join book_tag t on t.id = bt.book_tag_id ' +
+      'where b.author_id = a.id ' +
+      'group by b.author_id) as used_tags ' +
+    'from author a group by a.id',
+})
+export class BookWithAuthor {
+
+  @Property()
+  title!: string;
+
+  @Property()
+  authorName!: string;
+
+  @Property()
+  tags!: string[];
+
+}
+```
+
+  </TabItem>
+  <TabItem value="ts-morph">
+
+```ts title="./entities/BookWithAuthor.ts"
+@Entity({
+  expression: 'select name, age, ' +
+    '(select count(*) from book b where b.author_id = a.id) as total_books, ' +
+    '(select group_concat(distinct t.name) from book b ' +
+      'join tags_ordered bt on bt.book_id = b.id ' +
+      'join book_tag t on t.id = bt.book_tag_id ' +
+      'where b.author_id = a.id ' +
+      'group by b.author_id) as used_tags ' +
+    'from author a group by a.id',
+})
+export class BookWithAuthor {
+
+  @Property()
+  title!: string;
+
+  @Property()
+  authorName!: string;
+
+  @Property()
+  tags!: string[];
+
+}
+```
+
+  </TabItem>
+  <TabItem value="entity-schema">
+
+```ts title="./entities/BookWithAuthor.ts"
+export interface IBookWithAuthor{
+  title: string;
+  authorName: string;
+  tags: string[];
+}
+
+export const BookWithAuthor = new EntitySchema<IBookWithAuthor>({ 
+  name: 'BookWithAuthor',
+  expression: 'select name, age, ' +
+    '(select count(*) from book b where b.author_id = a.id) as total_books, ' +
+    '(select group_concat(distinct t.name) from book b ' +
+    'join tags_ordered bt on bt.book_id = b.id ' +
+    'join book_tag t on t.id = bt.book_tag_id ' +
+    'where b.author_id = a.id ' +
+    'group by b.author_id) as used_tags ' +
+    'from author a group by a.id',
+  properties: {
+    title: { type: 'string' },
+    authorName: { type: 'string' },
+    tags: { type: 'string[]' },
+  },
+});
+```
+
+  </TabItem>
+</Tabs>
+
+Or as a callback:
+
+<Tabs
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
+
+```ts title="./entities/BookWithAuthor.ts"
+@Entity({
+  expression: (em: EntityManager) => {
+    return em.createQueryBuilder(Book, 'b')
+      .select(['b.title', 'a.name as author_name', 'group_concat(t.name) as tags'])
+      .join('b.author', 'a')
+      .join('b.tags', 't')
+      .groupBy('b.id');
+  },
+})
+export class BookWithAuthor {
+
+  @Property()
+  title!: string;
+
+  @Property()
+  authorName!: string;
+
+  @Property()
+  tags!: string[];
+
+}
+```
+
+  </TabItem>
+  <TabItem value="ts-morph">
+
+```ts title="./entities/BookWithAuthor.ts"
+@Entity({
+  expression: (em: EntityManager) => {
+    return em.createQueryBuilder(Book, 'b')
+      .select(['b.title', 'a.name as author_name', 'group_concat(t.name) as tags'])
+      .join('b.author', 'a')
+      .join('b.tags', 't')
+      .groupBy('b.id');
+  },
+})
+export class BookWithAuthor {
+
+  @Property()
+  title!: string;
+
+  @Property()
+  authorName!: string;
+
+  @Property()
+  tags!: string[];
+
+}
+```
+
+  </TabItem>
+  <TabItem value="entity-schema">
+
+```ts title="./entities/BookWithAuthor.ts"
+export interface IBookWithAuthor{
+  title: string;
+  authorName: string;
+  tags: string[];
+}
+
+export const BookWithAuthor = new EntitySchema<IBookWithAuthor>({
+  name: 'BookWithAuthor',
+  expression: (em: EntityManager) => {
+    return em.createQueryBuilder(Book, 'b')
+      .select(['b.title', 'a.name as author_name', 'group_concat(t.name) as tags'])
+      .join('b.author', 'a')
+      .join('b.tags', 't')
+      .groupBy('b.id');
+  },
+  properties: {
+    title: { type: 'string' },
+    authorName: { type: 'string' },
+    tags: { type: 'string[]' },
+  },
+});
+```
+
+  </TabItem>
+</Tabs>
+
+In MongoDB, we can use aggregations, although it is not very ergonomic due to their nature. Following example is a rough equivalent of the previous SQL ones.
+
+> The `where` query as well as the options like `orderBy`, `limit` and `offset` needs to be explicitly handled in your pipeline.
+
+```ts
+@Entity({
+  expression: (em: EntityManager, where, options) => {
+    const $sort = { ...options.orderBy } as Dictionary;
+    $sort._id = 1;
+    const pipeline: Dictionary[] = [
+      { $project: { _id: 0, title: 1, author: 1 } },
+      { $sort },
+      { $match: where ?? {} },
+      { $lookup: { from: 'author', localField: 'author', foreignField: '_id', as: 'author', pipeline: [{ $project: { name: 1 } }] } },
+      { $unwind: '$author' },
+      { $set: { authorName: '$author.name' } },
+      { $unset: ['author'] },
+    ];
+
+    if (options.offset != null) {
+      pipeline.push({ $skip: options.offset });
+    }
+
+    if (options.limit != null) {
+      pipeline.push({ $limit: options.limit });
+    }
+
+    return em.aggregate(Book, pipeline);
+  },
+})
+export class BookWithAuthor {
+
+  @Property()
+  title!: string;
+
+  @Property()
+  authorName!: string;
+
+}
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -54,6 +54,7 @@ module.exports = {
         'events',
         'composite-keys',
         'custom-types',
+        'virtual-entities',
         'embeddables',
         'entity-schema',
         'json-properties',

--- a/packages/core/src/decorators/Entity.ts
+++ b/packages/core/src/decorators/Entity.ts
@@ -1,6 +1,7 @@
 import { MetadataStorage } from '../metadata';
 import { Utils } from '../utils';
-import type { Constructor, Dictionary } from '../typings';
+import type { Constructor, Dictionary, FilterQuery } from '../typings';
+import type { FindOptions } from '../drivers/IDatabaseDriver';
 
 export function Entity(options: EntityOptions<any> = {}) {
   return function <T>(target: T & Dictionary) {
@@ -26,5 +27,9 @@ export type EntityOptions<T> = {
   comment?: string;
   abstract?: boolean;
   readonly?: boolean;
+  virtual?: boolean;
+  // we need to use `em: any` here otherwise an expression would not be assignable with more narrow type like `SqlEntityManager`
+  // also return type is unknown as it can be either QB instance (which we cannot type here) or array of POJOs (e.g. for mongodb)
+  expression?: string | ((em: any, where: FilterQuery<T>, options: FindOptions<T, any>) => object);
   customRepository?: () => Constructor;
 };

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -49,6 +49,11 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     return new EntityManager(this.config, this, this.metadata, useContext) as unknown as EntityManager<D>;
   }
 
+  /* istanbul ignore next */
+  async findVirtual<T>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, any>): Promise<EntityData<T>[]> {
+    throw new Error(`Virtual entities are not supported by ${this.constructor.name} driver.`);
+  }
+
   async aggregate(entityName: string, pipeline: any[]): Promise<any[]> {
     throw new Error(`Aggregations are not supported by ${this.constructor.name} driver`);
   }

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -38,6 +38,8 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
    */
   findOne<T extends AnyEntity<T>, P extends string = never>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T, P>): Promise<EntityData<T> | null>;
 
+  findVirtual<T>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, any>): Promise<EntityData<T>[]>;
+
   nativeInsert<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>, options?: NativeInsertUpdateOptions<T>): Promise<QueryResult<T>>;
 
   nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>[], options?: NativeInsertUpdateManyOptions<T>): Promise<QueryResult<T>>;

--- a/packages/core/src/hydration/ObjectHydrator.ts
+++ b/packages/core/src/hydration/ObjectHydrator.ts
@@ -316,7 +316,7 @@ export class ObjectHydrator extends Hydrator {
   }
 
   private createCollectionItemMapper<T>(prop: EntityProperty): string[] {
-    const meta = this.metadata.find(prop.type)!;
+    const meta = this.metadata.get(prop.type);
     const lines: string[] = [];
 
     lines.push(`  const createCollectionItem_${this.safeKey(prop.name)} = value => {`);

--- a/packages/core/src/metadata/MetadataStorage.ts
+++ b/packages/core/src/metadata/MetadataStorage.ts
@@ -103,7 +103,7 @@ export class MetadataStorage {
 
   decorate(em: EntityManager): void {
     Object.values(this.metadata)
-      .filter(meta => meta.prototype && !meta.prototype.__meta)
+      .filter(meta => meta.prototype && !meta.prototype.__meta && !meta.virtual)
       .forEach(meta => EntityHelper.decorate(meta, em));
   }
 

--- a/packages/core/src/metadata/MetadataValidator.ts
+++ b/packages/core/src/metadata/MetadataValidator.ts
@@ -23,6 +23,20 @@ export class MetadataValidator {
   validateEntityDefinition(metadata: MetadataStorage, name: string): void {
     const meta = metadata.get(name);
 
+    if (meta.virtual || meta.expression) {
+      for (const prop of Object.values(meta.properties)) {
+        if (prop.reference !== ReferenceType.SCALAR) {
+          throw new MetadataError(`Only scalar properties are allowed inside virtual entity. Found '${prop.reference}' in ${meta.className}.${prop.name}`);
+        }
+
+        if (prop.primary) {
+          throw new MetadataError(`Virtual entity ${meta.className} cannot have primary key ${meta.className}.${prop.name}`);
+        }
+      }
+
+      return;
+    }
+
     // entities have PK
     if (!meta.embeddable && (!meta.primaryKeys || meta.primaryKeys.length === 0)) {
       throw MetadataError.fromMissingPrimaryKey(meta);

--- a/packages/core/src/utils/AbstractSchemaGenerator.ts
+++ b/packages/core/src/utils/AbstractSchemaGenerator.ts
@@ -103,7 +103,7 @@ export abstract class AbstractSchemaGenerator<D extends IDatabaseDriver> impleme
   protected getOrderedMetadata(schema?: string): EntityMetadata[] {
     const metadata = Object.values(this.metadata.getAll()).filter(meta => {
       const isRootEntity = meta.root.className === meta.className;
-      return isRootEntity && !meta.embeddable;
+      return isRootEntity && !meta.embeddable && !meta.virtual;
     });
     const calc = new CommitOrderCalculator();
     metadata.forEach(meta => calc.addNode(meta.root.className));

--- a/packages/entity-generator/src/EntitySchemaSourceFile.ts
+++ b/packages/entity-generator/src/EntitySchemaSourceFile.ts
@@ -140,6 +140,7 @@ export class EntitySchemaSourceFile extends SourceFile {
       }
 
       const defaultName = this.platform.getIndexName(this.meta.collection, prop.fieldNames, type);
+      /* istanbul ignore next */
       options[type] = defaultName === prop[type] ? 'true' : `'${prop[type]}'`;
       const expected = {
         index: this.platform.indexForeignKeys(),

--- a/tests/features/virtual-entities/__snapshots__/virtual-entities.sqlite.test.ts.snap
+++ b/tests/features/virtual-entities/__snapshots__/virtual-entities.sqlite.test.ts.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`virtual entities (sqlite) schema 1`] = `
+"create table \`book_tag4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null, \`version\` datetime not null default current_timestamp);
+
+create table \`foo_baz4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null, \`version\` datetime not null default current_timestamp);
+
+create table \`foo_bar4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null default 'asd', \`baz_id\` integer null, \`foo_bar_id\` integer null, \`version\` integer not null default 1, \`blob\` blob null, \`array\` text null, \`object\` json null, constraint \`foo_bar4_baz_id_foreign\` foreign key(\`baz_id\`) references \`foo_baz4\`(\`id\`) on delete set null on update cascade, constraint \`foo_bar4_foo_bar_id_foreign\` foreign key(\`foo_bar_id\`) references \`foo_bar4\`(\`id\`) on delete set null on update cascade);
+create unique index \`foo_bar4_baz_id_unique\` on \`foo_bar4\` (\`baz_id\`);
+create unique index \`foo_bar4_foo_bar_id_unique\` on \`foo_bar4\` (\`foo_bar_id\`);
+
+create table \`publisher4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null default 'asd', \`type\` text check (\`type\` in ('local', 'global')) not null default 'local', \`enum3\` integer null);
+
+create table \`book4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`title\` text not null, \`price\` real null, \`author_id\` integer null, \`publisher_id\` integer null, \`meta\` json null, constraint \`book4_author_id_foreign\` foreign key(\`author_id\`) references \`author4\`(\`id\`) on delete set null on update cascade, constraint \`book4_publisher_id_foreign\` foreign key(\`publisher_id\`) references \`publisher4\`(\`id\`) on delete set null on update cascade);
+create index \`book4_author_id_index\` on \`book4\` (\`author_id\`);
+create index \`book4_publisher_id_index\` on \`book4\` (\`publisher_id\`);
+
+create table \`author4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null, \`email\` text not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` date(3) null, \`born_time\` time(3) null, \`favourite_book_id\` integer null, constraint \`author4_favourite_book_id_foreign\` foreign key(\`favourite_book_id\`) references \`book4\`(\`id\`) on delete set null on update cascade);
+create unique index \`author4_email_unique\` on \`author4\` (\`email\`);
+create index \`author4_favourite_book_id_index\` on \`author4\` (\`favourite_book_id\`);
+
+create table \`tags_ordered\` (\`id\` integer not null primary key autoincrement, \`book4_id\` integer not null, \`book_tag4_id\` integer not null, constraint \`tags_ordered_book4_id_foreign\` foreign key(\`book4_id\`) references \`book4\`(\`id\`) on delete cascade on update cascade, constraint \`tags_ordered_book_tag4_id_foreign\` foreign key(\`book_tag4_id\`) references \`book_tag4\`(\`id\`) on delete cascade on update cascade);
+create index \`tags_ordered_book4_id_index\` on \`tags_ordered\` (\`book4_id\`);
+create index \`tags_ordered_book_tag4_id_index\` on \`tags_ordered\` (\`book_tag4_id\`);
+
+create table \`tags_unordered\` (\`book4_id\` integer not null, \`book_tag4_id\` integer not null, constraint \`tags_unordered_book4_id_foreign\` foreign key(\`book4_id\`) references \`book4\`(\`id\`) on delete cascade on update cascade, constraint \`tags_unordered_book_tag4_id_foreign\` foreign key(\`book_tag4_id\`) references \`book_tag4\`(\`id\`) on delete cascade on update cascade, primary key (\`book4_id\`, \`book_tag4_id\`));
+create index \`tags_unordered_book4_id_index\` on \`tags_unordered\` (\`book4_id\`);
+create index \`tags_unordered_book_tag4_id_index\` on \`tags_unordered\` (\`book_tag4_id\`);
+
+create table \`test4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text null, \`version\` integer not null default 1);
+
+create table \`publisher4_tests\` (\`id\` integer not null primary key autoincrement, \`publisher4_id\` integer not null, \`test4_id\` integer not null, constraint \`publisher4_tests_publisher4_id_foreign\` foreign key(\`publisher4_id\`) references \`publisher4\`(\`id\`) on delete cascade on update cascade, constraint \`publisher4_tests_test4_id_foreign\` foreign key(\`test4_id\`) references \`test4\`(\`id\`) on delete cascade on update cascade);
+create index \`publisher4_tests_publisher4_id_index\` on \`publisher4_tests\` (\`publisher4_id\`);
+create index \`publisher4_tests_test4_id_index\` on \`publisher4_tests\` (\`test4_id\`);
+
+"
+`;
+
+exports[`virtual entities (sqlite) schema 2`] = `""`;
+
+exports[`virtual entities (sqlite) schema 3`] = `
+"drop table if exists \`publisher4_tests\`;
+drop table if exists \`test4\`;
+drop table if exists \`tags_unordered\`;
+drop table if exists \`tags_ordered\`;
+drop table if exists \`author4\`;
+drop table if exists \`book4\`;
+drop table if exists \`publisher4\`;
+drop table if exists \`foo_bar4\`;
+drop table if exists \`foo_baz4\`;
+drop table if exists \`book_tag4\`;
+
+"
+`;

--- a/tests/features/virtual-entities/virtual-entities.mongo.test.ts
+++ b/tests/features/virtual-entities/virtual-entities.mongo.test.ts
@@ -1,0 +1,151 @@
+import type { Dictionary } from '@mikro-orm/core';
+import { Entity, MikroORM, Property } from '@mikro-orm/core';
+import type { EntityManager } from '@mikro-orm/mongodb';
+import { mockLogger } from '../../bootstrap';
+import { Author, Book, schema } from '../../entities';
+
+@Entity({
+  expression: (em: EntityManager, where, options) => {
+    const $sort = { ...options.orderBy } as Dictionary;
+    $sort._id = 1;
+    const pipeline: Dictionary[] = [
+      { $project: { _id: 0, title: 1, author: 1 } },
+      { $sort },
+      { $match: where ?? {} },
+      { $lookup: { from: 'author', localField: 'author', foreignField: '_id', as: 'author', pipeline: [{ $project: { name: 1 } }] } },
+      { $unwind: '$author' },
+      { $set: { authorName: '$author.name' } },
+      { $unset: ['author'] },
+    ];
+
+    if (options.offset != null) {
+      pipeline.push({ $skip: options.offset });
+    }
+
+    if (options.limit != null) {
+      pipeline.push({ $limit: options.limit });
+    }
+
+    return em.aggregate(Book, pipeline);
+  },
+})
+class BookWithAuthor {
+
+  @Property()
+  title!: string;
+
+  @Property()
+  authorName!: string;
+
+}
+
+describe('virtual entities (mongo)', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      type: 'mongo',
+      dbName: 'mikro_orm_virtual_entities',
+      entities: [Author, schema, BookWithAuthor],
+    });
+    await orm.getSchemaGenerator().createSchema();
+  });
+  beforeEach(async () => orm.getSchemaGenerator().clearDatabase());
+  afterAll(async () => orm.close(true));
+
+  async function createEntities(index: number): Promise<Author> {
+    const author = orm.em.create(Author, { name: 'Jon Snow ' + index, email: 'snow@wall.st-' + index, age: Math.floor(Math.random() * 100) });
+    orm.em.create(Book, { title: 'My Life on the Wall, part 1/' + index, author });
+    orm.em.create(Book, { title: 'My Life on the Wall, part 2/' + index, author });
+    orm.em.create(Book, { title: 'My Life on the Wall, part 3/' + index, author });
+    await orm.em.persist(author).flush();
+    orm.em.clear();
+
+    return author;
+  }
+
+  test('with callback', async () => {
+    await createEntities(1);
+    await createEntities(2);
+    await createEntities(3);
+
+    const mock = mockLogger(orm);
+    const book = await orm.em.findOneOrFail(BookWithAuthor, { title: 'My Life on the Wall, part 3/1' });
+    expect(book).toEqual({
+      title: 'My Life on the Wall, part 3/1',
+      authorName: 'Jon Snow 1',
+    });
+    expect(book).toBeInstanceOf(BookWithAuthor);
+    const books = await orm.em.find(BookWithAuthor, {});
+    expect(books).toEqual([
+      {
+        title: 'My Life on the Wall, part 1/1',
+        authorName: 'Jon Snow 1',
+      },
+      {
+        title: 'My Life on the Wall, part 2/1',
+        authorName: 'Jon Snow 1',
+      },
+      {
+        title: 'My Life on the Wall, part 3/1',
+        authorName: 'Jon Snow 1',
+      },
+      {
+        title: 'My Life on the Wall, part 1/2',
+        authorName: 'Jon Snow 2',
+      },
+      {
+        title: 'My Life on the Wall, part 2/2',
+        authorName: 'Jon Snow 2',
+      },
+      {
+        title: 'My Life on the Wall, part 3/2',
+        authorName: 'Jon Snow 2',
+      },
+      {
+        title: 'My Life on the Wall, part 1/3',
+        authorName: 'Jon Snow 3',
+      },
+      {
+        title: 'My Life on the Wall, part 2/3',
+        authorName: 'Jon Snow 3',
+      },
+      {
+        title: 'My Life on the Wall, part 3/3',
+        authorName: 'Jon Snow 3',
+      },
+    ]);
+
+    for (const book of books) {
+      expect(book).toBeInstanceOf(BookWithAuthor);
+    }
+
+    const someBooks1 = await orm.em.find(BookWithAuthor, {}, { limit: 2, offset: 1, orderBy: { title: 1 } });
+    expect(someBooks1).toHaveLength(2);
+    expect(someBooks1.map(p => p.title)).toEqual(['My Life on the Wall, part 1/2', 'My Life on the Wall, part 1/3']);
+
+    const someBooks2 = await orm.em.find(BookWithAuthor, {}, { limit: 2, orderBy: { title: 1 } });
+    expect(someBooks2).toHaveLength(2);
+    expect(someBooks2.map(p => p.title)).toEqual(['My Life on the Wall, part 1/1', 'My Life on the Wall, part 1/2']);
+
+    const someBooks3 = await orm.em.find(BookWithAuthor, { title: /^My Life/ }, { limit: 2, orderBy: { title: 1 } });
+    expect(someBooks3).toHaveLength(2);
+    expect(someBooks3.map(p => p.title)).toEqual(['My Life on the Wall, part 1/1', 'My Life on the Wall, part 1/2']);
+
+    const someBooks4 = await orm.em.find(BookWithAuthor, { title: { $in: ['My Life on the Wall, part 1/2', 'My Life on the Wall, part 1/3'] } });
+    expect(someBooks4).toHaveLength(2);
+    expect(someBooks4.map(p => p.title)).toEqual(['My Life on the Wall, part 1/2', 'My Life on the Wall, part 1/3']);
+
+    expect(mock.mock.calls).toHaveLength(6);
+    expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('books-table').aggregate([ { '$project': { _id: 0, title: 1, author: 1 } }, { '$sort': { _id: 1 } }, { '$match': { title: 'My Life on the Wall, part 3/1' } }, { '$lookup': { from: 'author', localField: 'author', foreignField: '_id', as: 'author', pipeline: [ { '$project': { name: 1 } } ] } }, { '$unwind': '$author' }, { '$set': { authorName: '$author.name' } }, { '$unset': [ 'author' ] } ], { session: undefined }).toArray()`);
+    expect(mock.mock.calls[1][0]).toMatch(`db.getCollection('books-table').aggregate([ { '$project': { _id: 0, title: 1, author: 1 } }, { '$sort': { _id: 1 } }, { '$match': {} }, { '$lookup': { from: 'author', localField: 'author', foreignField: '_id', as: 'author', pipeline: [ { '$project': { name: 1 } } ] } }, { '$unwind': '$author' }, { '$set': { authorName: '$author.name' } }, { '$unset': [ 'author' ] } ], { session: undefined }).toArray()`);
+    expect(mock.mock.calls[2][0]).toMatch(`db.getCollection('books-table').aggregate([ { '$project': { _id: 0, title: 1, author: 1 } }, { '$sort': { title: 1, _id: 1 } }, { '$match': {} }, { '$lookup': { from: 'author', localField: 'author', foreignField: '_id', as: 'author', pipeline: [ { '$project': { name: 1 } } ] } }, { '$unwind': '$author' }, { '$set': { authorName: '$author.name' } }, { '$unset': [ 'author' ] }, { '$skip': 1 }, { '$limit': 2 } ], { session: undefined }).toArray();`);
+    expect(mock.mock.calls[3][0]).toMatch(`db.getCollection('books-table').aggregate([ { '$project': { _id: 0, title: 1, author: 1 } }, { '$sort': { title: 1, _id: 1 } }, { '$match': {} }, { '$lookup': { from: 'author', localField: 'author', foreignField: '_id', as: 'author', pipeline: [ { '$project': { name: 1 } } ] } }, { '$unwind': '$author' }, { '$set': { authorName: '$author.name' } }, { '$unset': [ 'author' ] }, { '$limit': 2 } ], { session: undefined }).toArray();`);
+    expect(mock.mock.calls[4][0]).toMatch(`db.getCollection('books-table').aggregate([ { '$project': { _id: 0, title: 1, author: 1 } }, { '$sort': { title: 1, _id: 1 } }, { '$match': { title: /^My Life/ } }, { '$lookup': { from: 'author', localField: 'author', foreignField: '_id', as: 'author', pipeline: [ { '$project': { name: 1 } } ] } }, { '$unwind': '$author' }, { '$set': { authorName: '$author.name' } }, { '$unset': [ 'author' ] }, { '$limit': 2 } ], { session: undefined }).toArray();`);
+    expect(mock.mock.calls[5][0]).toMatch(`db.getCollection('books-table').aggregate([ { '$project': { _id: 0, title: 1, author: 1 } }, { '$sort': { _id: 1 } }, { '$match': { title: { '$in': [ 'My Life on the Wall, part 1/2', 'My Life on the Wall, part 1/3' ] } } }, { '$lookup': { from: 'author', localField: 'author', foreignField: '_id', as: 'author', pipeline: [ { '$project': { name: 1 } } ] } }, { '$unwind': '$author' }, { '$set': { authorName: '$author.name' } }, { '$unset': [ 'author' ] } ], { session: undefined }).toArray();`);
+
+    expect(orm.em.getUnitOfWork().getIdentityMap().keys()).toHaveLength(0);
+  });
+
+});

--- a/tests/features/virtual-entities/virtual-entities.sqlite.test.ts
+++ b/tests/features/virtual-entities/virtual-entities.sqlite.test.ts
@@ -1,0 +1,245 @@
+import { EntitySchema, MikroORM } from '@mikro-orm/core';
+import type { EntityManager } from '@mikro-orm/better-sqlite';
+import { mockLogger } from '../../bootstrap';
+import type { IAuthor4 } from '../../entities-schema';
+import { Author4, BaseEntity5, Book4, BookTag4, FooBar4, FooBaz4, Publisher4, Test4 } from '../../entities-schema';
+
+class AuthorProfile {
+
+  name!: string;
+  age!: number;
+  totalBooks!: number;
+  usedTags!: string[];
+
+}
+
+const authorProfilesSQL = 'select name, age, ' +
+  '(select count(*) from book4 b where b.author_id = a.id) as total_books, ' +
+  '(select group_concat(distinct t.name) from book4 b join tags_ordered bt on bt.book4_id = b.id join book_tag4 t on t.id = bt.book_tag4_id where b.author_id = a.id group by b.author_id) as used_tags ' +
+  'from author4 a group by a.id';
+
+const AuthorProfileSchema = new EntitySchema({
+  class: AuthorProfile,
+  expression: authorProfilesSQL,
+  properties: {
+    name: { type: 'string' },
+    age: { type: 'string' },
+    totalBooks: { type: 'number' },
+    usedTags: { type: 'string[]' },
+  },
+});
+
+interface IBookWithAuthor{
+  title: string;
+  authorName: string;
+  tags: string[];
+}
+
+const BookWithAuthor = new EntitySchema<IBookWithAuthor>({
+  name: 'BookWithAuthor',
+  expression: (em: EntityManager) => {
+    return em.createQueryBuilder(Book4, 'b')
+      .select(['b.title', 'a.name as author_name', 'group_concat(t.name) as tags'])
+      .join('b.author', 'a')
+      .join('b.tags', 't')
+      .groupBy('b.id');
+  },
+  properties: {
+    title: { type: 'string' },
+    authorName: { type: 'string' },
+    tags: { type: 'string[]' },
+  },
+});
+
+describe('virtual entities (sqlite)', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      type: 'better-sqlite',
+      dbName: ':memory:',
+      entities: [Author4, Book4, BookTag4, Publisher4, Test4, FooBar4, FooBaz4, BaseEntity5, AuthorProfileSchema, BookWithAuthor],
+    });
+    await orm.getSchemaGenerator().createSchema();
+  });
+  beforeEach(async () => orm.getSchemaGenerator().clearDatabase());
+  afterAll(async () => orm.close(true));
+
+  async function createEntities(index: number): Promise<IAuthor4> {
+    const author = orm.em.create(Author4, { name: 'Jon Snow ' + index, email: 'snow@wall.st-' + index, age: Math.floor(Math.random() * 100) });
+    const book1 = orm.em.create(Book4, { title: 'My Life on the Wall, part 1/' + index, author });
+    const book2 = orm.em.create(Book4, { title: 'My Life on the Wall, part 2/' + index, author });
+    const book3 = orm.em.create(Book4, { title: 'My Life on the Wall, part 3/' + index, author });
+    const tag1 = orm.em.create(BookTag4, { name: 'silly-' + index });
+    const tag2 = orm.em.create(BookTag4, { name: 'funny-' + index });
+    const tag3 = orm.em.create(BookTag4, { name: 'sick-' + index });
+    const tag4 = orm.em.create(BookTag4, { name: 'strange-' + index });
+    const tag5 = orm.em.create(BookTag4, { name: 'sexy-' + index });
+    book1.tags.add(tag1, tag3);
+    book2.tags.add(tag1, tag2, tag5);
+    book3.tags.add(tag2, tag4, tag5);
+
+    await orm.em.persist(author).flush();
+    orm.em.clear();
+
+    return author;
+  }
+
+  test('schema', async () => {
+    await expect(orm.getSchemaGenerator().getCreateSchemaSQL({ wrap: false })).resolves.toMatchSnapshot();
+    await expect(orm.getSchemaGenerator().getUpdateSchemaSQL({ wrap: false })).resolves.toMatchSnapshot();
+    await expect(orm.getSchemaGenerator().getDropSchemaSQL({ wrap: false })).resolves.toMatchSnapshot();
+  });
+
+  test('with SQL expression', async () => {
+    await createEntities(1);
+    await createEntities(2);
+    await createEntities(3);
+
+    const mock = mockLogger(orm);
+    const profiles = await orm.em.find(AuthorProfile, {});
+    expect(profiles).toEqual([
+      {
+        name: 'Jon Snow 1',
+        age: expect.any(Number),
+        totalBooks: 3,
+        usedTags: ['silly-1', 'sick-1', 'funny-1', 'sexy-1', 'strange-1'],
+      },
+      {
+        name: 'Jon Snow 2',
+        age: expect.any(Number),
+        totalBooks: 3,
+        usedTags: ['silly-2', 'sick-2', 'funny-2', 'sexy-2', 'strange-2'],
+      },
+      {
+        name: 'Jon Snow 3',
+        age: expect.any(Number),
+        totalBooks: 3,
+        usedTags: ['silly-3', 'sick-3', 'funny-3', 'sexy-3', 'strange-3'],
+      },
+    ]);
+
+    for (const profile of profiles) {
+      expect(profile).toBeInstanceOf(AuthorProfile);
+    }
+
+    const someProfiles1 = await orm.em.find(AuthorProfile, {}, { limit: 2, offset: 1, orderBy: { name: 'asc' } });
+    expect(someProfiles1).toHaveLength(2);
+    expect(someProfiles1.map(p => p.name)).toEqual(['Jon Snow 2', 'Jon Snow 3']);
+
+    const someProfiles2 = await orm.em.find(AuthorProfile, {}, { limit: 2, orderBy: { name: 'asc' } });
+    expect(someProfiles2).toHaveLength(2);
+    expect(someProfiles2.map(p => p.name)).toEqual(['Jon Snow 1', 'Jon Snow 2']);
+
+    const someProfiles3 = await orm.em.find(AuthorProfile, { $and: [{ name: { $like: 'Jon%' } }, { age: { $gte: 0 } }] }, { limit: 2, orderBy: { name: 'asc' } });
+    expect(someProfiles3).toHaveLength(2);
+    expect(someProfiles3.map(p => p.name)).toEqual(['Jon Snow 1', 'Jon Snow 2']);
+
+    const someProfiles4 = await orm.em.find(AuthorProfile, { name: ['Jon Snow 2', 'Jon Snow 3'] });
+    expect(someProfiles4).toHaveLength(2);
+    expect(someProfiles4.map(p => p.name)).toEqual(['Jon Snow 2', 'Jon Snow 3']);
+
+    expect(mock.mock.calls).toHaveLength(5);
+    expect(mock.mock.calls[0][0]).toMatch(`select * from (${authorProfilesSQL}) as \`a0\``);
+    expect(mock.mock.calls[1][0]).toMatch(`select * from (${authorProfilesSQL}) as \`a0\` order by \`a0\`.\`name\` asc limit 2 offset 1`);
+    expect(mock.mock.calls[2][0]).toMatch(`select * from (${authorProfilesSQL}) as \`a0\` order by \`a0\`.\`name\` asc limit 2`);
+    expect(mock.mock.calls[3][0]).toMatch(`select * from (${authorProfilesSQL}) as \`a0\` where \`a0\`.\`name\` like 'Jon%' and \`a0\`.\`age\` >= 0 order by \`a0\`.\`name\` asc limit 2`);
+    expect(mock.mock.calls[4][0]).toMatch(`select * from (${authorProfilesSQL}) as \`a0\` where \`a0\`.\`name\` in ('Jon Snow 2', 'Jon Snow 3')`);
+    expect(orm.em.getUnitOfWork().getIdentityMap().keys()).toHaveLength(0);
+  });
+
+  test('with callback', async () => {
+    await createEntities(1);
+    await createEntities(2);
+    await createEntities(3);
+
+    const mock = mockLogger(orm);
+    const books = await orm.em.find(BookWithAuthor, {});
+    expect(books).toEqual([
+      {
+        title: 'My Life on the Wall, part 1/1',
+        authorName: 'Jon Snow 1',
+        tags: ['silly-1', 'sick-1'],
+      },
+      {
+        title: 'My Life on the Wall, part 2/1',
+        authorName: 'Jon Snow 1',
+        tags: ['silly-1', 'funny-1', 'sexy-1'],
+      },
+      {
+        title: 'My Life on the Wall, part 3/1',
+        authorName: 'Jon Snow 1',
+        tags: ['funny-1', 'strange-1', 'sexy-1'],
+      },
+      {
+        title: 'My Life on the Wall, part 1/2',
+        authorName: 'Jon Snow 2',
+        tags: ['silly-2', 'sick-2'],
+      },
+      {
+        title: 'My Life on the Wall, part 2/2',
+        authorName: 'Jon Snow 2',
+        tags: ['silly-2', 'funny-2', 'sexy-2'],
+      },
+      {
+        title: 'My Life on the Wall, part 3/2',
+        authorName: 'Jon Snow 2',
+        tags: ['funny-2', 'strange-2', 'sexy-2'],
+      },
+      {
+        title: 'My Life on the Wall, part 1/3',
+        authorName: 'Jon Snow 3',
+        tags: ['silly-3', 'sick-3'],
+      },
+      {
+        title: 'My Life on the Wall, part 2/3',
+        authorName: 'Jon Snow 3',
+        tags: ['silly-3', 'funny-3', 'sexy-3'],
+      },
+      {
+        title: 'My Life on the Wall, part 3/3',
+        authorName: 'Jon Snow 3',
+        tags: ['funny-3', 'strange-3', 'sexy-3'],
+      },
+    ]);
+
+    for (const book of books) {
+      expect(book.constructor.name).toBe('BookWithAuthor');
+    }
+
+    const someBooks1 = await orm.em.find(BookWithAuthor, {}, { limit: 2, offset: 1, orderBy: { title: 'asc' } });
+    expect(someBooks1).toHaveLength(2);
+    expect(someBooks1.map(p => p.title)).toEqual(['My Life on the Wall, part 1/2', 'My Life on the Wall, part 1/3']);
+
+    const someBooks2 = await orm.em.find(BookWithAuthor, {}, { limit: 2, orderBy: { title: 'asc' } });
+    expect(someBooks2).toHaveLength(2);
+    expect(someBooks2.map(p => p.title)).toEqual(['My Life on the Wall, part 1/1', 'My Life on the Wall, part 1/2']);
+
+    const someBooks3 = await orm.em.find(BookWithAuthor, { $and: [{ title: { $like: 'My Life%' } }, { authorName: { $ne: null } }] }, { limit: 2, orderBy: { title: 'asc' } });
+    expect(someBooks3).toHaveLength(2);
+    expect(someBooks3.map(p => p.title)).toEqual(['My Life on the Wall, part 1/1', 'My Life on the Wall, part 1/2']);
+
+    const someBooks4 = await orm.em.find(BookWithAuthor, { title: ['My Life on the Wall, part 1/2', 'My Life on the Wall, part 1/3'] });
+    expect(someBooks4).toHaveLength(2);
+    expect(someBooks4.map(p => p.title)).toEqual(['My Life on the Wall, part 1/2', 'My Life on the Wall, part 1/3']);
+
+    const sql = 'select `b`.`title`, `a`.`name` as `author_name`, group_concat(t.name) as tags ' +
+      'from `book4` as `b` ' +
+      'inner join `author4` as `a` on `b`.`author_id` = `a`.`id` ' +
+      'inner join `tags_ordered` as `t1` on `b`.`id` = `t1`.`book4_id` ' +
+      'inner join `book_tag4` as `t` on `t1`.`book_tag4_id` = `t`.`id` ' +
+      'group by `b`.`id`';
+    expect(mock.mock.calls).toHaveLength(5);
+    expect(mock.mock.calls[0][0]).toMatch(`select * from (${sql}) as \`b0\``);
+    expect(mock.mock.calls[1][0]).toMatch(`select * from (${sql}) as \`b0\` order by \`b0\`.\`title\` asc limit 2 offset 1`);
+    expect(mock.mock.calls[2][0]).toMatch(`select * from (${sql}) as \`b0\` order by \`b0\`.\`title\` asc limit 2`);
+    expect(mock.mock.calls[3][0]).toMatch(`select * from (${sql}) as \`b0\` where \`b0\`.\`title\` like 'My Life%' and \`b0\`.\`author_name\` is not null order by \`b0\`.\`title\` asc limit 2`);
+    expect(mock.mock.calls[4][0]).toMatch(`select * from (${sql}) as \`b0\` where \`b0\`.\`title\` in ('My Life on the Wall, part 1/2', 'My Life on the Wall, part 1/3')`);
+
+    expect(orm.em.getUnitOfWork().getIdentityMap().keys()).toHaveLength(0);
+    expect(mock.mock.calls[0][0]).toMatch(sql);
+    expect(orm.em.getUnitOfWork().getIdentityMap().keys()).toHaveLength(0);
+  });
+
+});


### PR DESCRIPTION
Virtual entities don't represent any database table. Instead, they dynamically resolve to an SQL query (or an aggregation in mongo), allowing to map any kind of results onto an entity. Such entities are mean for read purposes, they don't have a primary key and therefore cannot be tracked for changes. In a sense they are similar to (currently unsupported) database views.

To define a virtual entity, provide an expression, either as a string (SQL query):

```
@Entity({
  expression: 'select name, age, ' +
    '(select count(*) from book b where b.author_id = a.id) as total_books, ' +
    '(select group_concat(distinct t.name) from book b ' +
      'join tags_ordered bt on bt.book_id = b.id ' +
      'join book_tag t on t.id = bt.book_tag_id ' +
      'where b.author_id = a.id ' +
      'group by b.author_id) as used_tags ' +
    'from author a group by a.id',
})
export class BookWithAuthor {

  @Property()
  title!: string;

  @Property()
  authorName!: string;

  @Property()
  tags!: string[];

}
```

Closes #1104