### PR TITLE
feat(knex): allow changing `FROM` clause using `QueryBuilder`

### DIFF
--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -1,17 +1,16 @@
 import type { Knex } from 'knex';
 import type {
   AnyEntity, Collection, ConnectionType, Configuration, Constructor, CountOptions, DeleteOptions, Dictionary,
-  DriverMethodOptions, EntityData, EntityDictionary, EntityField, EntityManager, EntityMetadata, EntityProperty, FilterQuery,
+  DriverMethodOptions, EntityData, EntityDictionary, EntityField, EntityManager, EntityMetadata, EntityName, EntityProperty, FilterQuery,
   FindOneOptions, FindOptions, IDatabaseDriver, LockOptions, NativeInsertUpdateManyOptions, NativeInsertUpdateOptions,
   PopulateOptions, Primary, QueryOrderMap, QueryResult, RequiredEntityData, Transaction,
 } from '@mikro-orm/core';
 import { DatabaseDriver, EntityManagerType, helper, LoadStrategy, QueryFlag, QueryHelper, ReferenceType, Utils } from '@mikro-orm/core';
 import type { AbstractSqlConnection } from './AbstractSqlConnection';
 import type { AbstractSqlPlatform } from './AbstractSqlPlatform';
-import { QueryBuilder } from './query/QueryBuilder';
+import { QueryBuilder, QueryType } from './query';
 import { SqlEntityManager } from './SqlEntityManager';
 import type { Field } from './typings';
-import { QueryType } from './query';
 
 export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = AbstractSqlConnection> extends DatabaseDriver<C> {
 
@@ -712,7 +711,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
   }
 
   /** @internal */
-  createQueryBuilder<T extends object>(entityName: string, ctx?: Transaction<Knex.Transaction>, preferredConnectionType?: ConnectionType, convertCustomTypes?: boolean): QueryBuilder<T> {
+  createQueryBuilder<T extends object>(entityName: EntityName<T> | QueryBuilder<T>, ctx?: Transaction<Knex.Transaction>, preferredConnectionType?: ConnectionType, convertCustomTypes?: boolean): QueryBuilder<T> {
     const connectionType = this.resolveConnectionType({ ctx, connectionType: preferredConnectionType });
     const qb = new QueryBuilder<T>(entityName, this.metadata, this, ctx, undefined, connectionType);
 

--- a/packages/knex/src/SqlEntityManager.ts
+++ b/packages/knex/src/SqlEntityManager.ts
@@ -1,6 +1,6 @@
 import type { Knex } from 'knex';
 import type { AnyEntity, ConnectionType, Dictionary, EntityData, EntityName, EntityRepository, GetRepository, QueryResult } from '@mikro-orm/core';
-import { EntityManager, Utils } from '@mikro-orm/core';
+import { EntityManager } from '@mikro-orm/core';
 import type { AbstractSqlDriver } from './AbstractSqlDriver';
 import { QueryBuilder } from './query';
 import type { SqlEntityRepository } from './SqlEntityRepository';
@@ -13,8 +13,7 @@ export class SqlEntityManager<D extends AbstractSqlDriver = AbstractSqlDriver> e
   /**
    * Creates a QueryBuilder instance
    */
-  createQueryBuilder<T extends object>(entityName: EntityName<T>, alias?: string, type?: ConnectionType): QueryBuilder<T> {
-    entityName = Utils.className(entityName);
+  createQueryBuilder<T extends object>(entityName: EntityName<T> | QueryBuilder<T>, alias?: string, type?: ConnectionType): QueryBuilder<T> {
     const context = this.getContext();
 
     return new QueryBuilder<T>(entityName, this.getMetadata(), this.getDriver(), context.getTransactionContext(), alias, type, context);

--- a/packages/knex/src/query/Alias.ts
+++ b/packages/knex/src/query/Alias.ts
@@ -1,0 +1,9 @@
+import type { Knex } from 'knex';
+import type { EntityMetadata } from '@mikro-orm/core';
+
+export interface Alias {
+  aliasName: string;
+  entityName: string;
+  metadata?: EntityMetadata;
+  subQuery?: Knex.QueryBuilder;
+}

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -5,6 +5,7 @@ import { LockMode, OptimisticLockError, QueryOperator, QueryOrderNumeric, Refere
 import { QueryType } from './enums';
 import type { Field, JoinOptions } from '../typings';
 import type { AbstractSqlDriver } from '../AbstractSqlDriver';
+import type { Alias } from './Alias';
 
 /**
  * @internal
@@ -16,7 +17,7 @@ export class QueryBuilderHelper {
 
   constructor(private readonly entityName: string,
               private readonly alias: string,
-              private readonly aliasMap: Dictionary<string>,
+              private readonly aliasMap: Dictionary<Alias>,
               private readonly subQueries: Dictionary<string>,
               private readonly knex: Knex,
               private readonly driver: AbstractSqlDriver) { }
@@ -695,7 +696,7 @@ export class QueryBuilderHelper {
   }
 
   getProperty(field: string, alias?: string): EntityProperty | undefined {
-    const entityName = this.aliasMap[alias!] || this.entityName;
+    const entityName = this.aliasMap[alias!]?.entityName || this.entityName;
     const meta = this.metadata.find(entityName);
 
     // check if `alias` is not matching an embedded property name instead of alias, e.g. `address.city`


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feat | No          |


## Usage example

You can specify the table used in the `FROM` clause, replacing the current table name if one has already been specified. This is typically used to specify a sub-query expression in SQL.

```ts
const qb = em.createQueryBuilder(Book2);
qb.select('*').from(Author2).where({ id: { $gt: 2 } });

console.log(qb.getQuery());
// select `e0`.* from `author2` as `e0` where `e0`.`id` > 2;
```

You can also use sub-queries in the `FROM` like this:

```ts
const qb1 = em.createQueryBuilder(Book2).where({ id: { $lte: new Date() } }).orderBy({ id: 'DESC' }).limit(10);
const qb2 = em.createQueryBuilder(qb1.clone())
qb2.select('*').orderBy({ id: 'ASC' });

console.log(qb2.getQuery());
// select `e1`.* from (select `e0`.* from `book2` as `e0` where `e0`.`id` <= ? order by `e0`.`id` desc limit ?) as `e1` order by `e1`.`id`;
```

To set up an alias to refer to a table in a `SELECT` statement, pass the second argument as follows:

```ts
const qb1 = em.createQueryBuilder(Book2, 'b1').where({ id: { $lte: new Date() } }).orderBy({ id: 'DESC' }).limit(10);
const qb2 = em.createQueryBuilder(qb1.clone(), 'b2')
qb2.select('*').orderBy({ id: 'ASC' });

console.log(qb2.getQuery());
// select `b2`.* from (select `b1`.* from `book2` as `b1` where `b1`.`id` <= ? order by `b1`.`id` desc limit ?) as `b2` order by `b2`.`id`;
```

## Further improvements

To give the ability to create a clean query builder without `FROM` clause, we can change the signature of the `createQueryBuilder` as follows:

```diff
- createQueryBuilder<T>(entityName: EntityName<T>, alias?: string, type?: ConnectionType): QueryBuilder<T> {
+ createQueryBuilder<T>(entityName?: EntityName<T>, alias?: string, type?: ConnectionType): QueryBuilder<T> {
```
Thus, the example above can look more elegant:
```ts
const qb1 = em.createQueryBuilder(Book2, 'b1').where({ id: { $lte: new Date() } }).orderBy({ id: 'DESC' }).limit(10);
const qb2 = em.createQueryBuilder().from(qb.clone(), 'b2')
qb.select('*').orderBy({ id: 'ASC' });
```

closes #3374