### PR TITLE
fix(core): update to TypeScript 4.8 and improve `EntityDTO` type

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
     "docusaurus-plugin-typedoc-api": "2.4.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "typescript": "4.7.4"
+    "typescript": "4.8.2"
   },
   "browserslist": {
     "production": [

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -8015,10 +8015,10 @@ typedoc@^0.23.10:
     minimatch "^5.1.0"
     shiki "^0.10.1"
 
-typescript@4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
+  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
 
 ua-parser-js@^0.7.18:
   version "0.7.28"

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "sql-formatter": "8.0.2",
     "ts-jest": "28.0.8",
     "ts-node": "10.9.1",
-    "typescript": "4.7.4",
+    "typescript": "4.8.2",
     "uuid": "8.3.2"
   }
 }

--- a/packages/better-sqlite/src/BetterSqliteDriver.ts
+++ b/packages/better-sqlite/src/BetterSqliteDriver.ts
@@ -1,4 +1,4 @@
-import type { AnyEntity, Configuration, EntityDictionary, NativeInsertUpdateManyOptions, QueryResult } from '@mikro-orm/core';
+import type { Configuration, EntityDictionary, NativeInsertUpdateManyOptions, QueryResult } from '@mikro-orm/core';
 import { AbstractSqlDriver } from '@mikro-orm/knex';
 import { BetterSqliteConnection } from './BetterSqliteConnection';
 import { BetterSqlitePlatform } from './BetterSqlitePlatform';
@@ -9,7 +9,7 @@ export class BetterSqliteDriver extends AbstractSqlDriver<BetterSqliteConnection
     super(config, new BetterSqlitePlatform(), BetterSqliteConnection, ['knex', 'better-sqlite3']);
   }
 
-  async nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>[], options: NativeInsertUpdateManyOptions<T> = {}): Promise<QueryResult<T>> {
+  async nativeInsertMany<T extends object>(entityName: string, data: EntityDictionary<T>[], options: NativeInsertUpdateManyOptions<T> = {}): Promise<QueryResult<T>> {
     options.processCollections ??= true;
     const res = await super.nativeInsertMany(entityName, data, options);
     const pks = this.getPrimaryKeyFields(entityName);

--- a/packages/cli/src/commands/CreateSeederCommand.ts
+++ b/packages/cli/src/commands/CreateSeederCommand.ts
@@ -6,7 +6,7 @@ export class CreateSeederCommand<T> implements CommandModule<T, { seeder: string
 
   command = 'seeder:create <seeder>';
   describe = 'Create a new seeder class';
-  builder = (args: Argv) => {
+  builder = (args: Argv<T>) => {
     args.positional('seeder', {
       describe: 'Name for the seeder class. (e.g. "test" will generate "TestSeeder" or "TestSeeder" will generate "TestSeeder")',
     });

--- a/packages/cli/src/commands/DatabaseSeedCommand.ts
+++ b/packages/cli/src/commands/DatabaseSeedCommand.ts
@@ -6,7 +6,7 @@ export class DatabaseSeedCommand<T> implements CommandModule<T, { class: string 
 
   command = 'seeder:run';
   describe = 'Seed the database using the seeder class';
-  builder = (args: Argv) => {
+  builder = (args: Argv<T>) => {
     args.option('c', {
       alias: 'class',
       type: 'string',

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -2,7 +2,7 @@ import { inspect } from 'util';
 import type { Configuration } from './utils';
 import { QueryHelper, TransactionContext, Utils } from './utils';
 import type { AssignOptions, EntityLoaderOptions, EntityRepository, IdentifiedReference } from './entity';
-import { EntityAssigner, EntityFactory, EntityLoader, EntityValidator, Reference } from './entity';
+import { EntityAssigner, EntityFactory, EntityLoader, EntityValidator, helper, Reference } from './entity';
 import { ChangeSetType, UnitOfWork } from './unit-of-work';
 import type { CountOptions, DeleteOptions, EntityManagerType, FindOneOptions, FindOneOrFailOptions, FindOptions, IDatabaseDriver, LockOptions, NativeInsertUpdateOptions, UpdateOptions, GetReferenceOptions, EntityField } from './drivers';
 import type { AnyEntity, AutoPath, ConnectionType, Dictionary, EntityData, EntityDictionary, EntityDTO, EntityMetadata, EntityName, FilterDef, FilterQuery, GetRepository, Loaded, Populate, PopulateOptions, Primary, RequiredEntityData } from './typings';
@@ -27,7 +27,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   readonly global = false;
   readonly name = this.config.get('contextName');
   private readonly validator = new EntityValidator(this.config.get('strict'));
-  private readonly repositoryMap: Dictionary<EntityRepository<AnyEntity>> = {};
+  private readonly repositoryMap: Dictionary<EntityRepository<any>> = {};
   private readonly entityLoader: EntityLoader = new EntityLoader(this);
   private readonly comparator = this.config.getComparator(this.metadata);
   private readonly entityFactory: EntityFactory = new EntityFactory(this);
@@ -72,7 +72,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Gets repository for given entity. You can pass either string name or entity class reference.
    */
-  getRepository<T extends AnyEntity<T>, U extends EntityRepository<T> = EntityRepository<T>>(entityName: EntityName<T>): GetRepository<T, U> {
+  getRepository<T extends object, U extends EntityRepository<T> = EntityRepository<T>>(entityName: EntityName<T>): GetRepository<T, U> {
     entityName = Utils.className(entityName);
 
     if (!this.repositoryMap[entityName]) {
@@ -94,7 +94,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Finds all entities matching your `where` query. You can pass additional options via the `options` parameter.
    */
-  async find<T extends AnyEntity<T>, P extends string = never>(entityName: EntityName<T>, where: FilterQuery<T>, options: FindOptions<T, P> = {}): Promise<Loaded<T, P>[]> {
+  async find<T extends object, P extends string = never>(entityName: EntityName<T>, where: FilterQuery<T>, options: FindOptions<T, P> = {}): Promise<Loaded<T, P>[]> {
     if (options.disableIdentityMap) {
       const em = this.getContext(false);
       const fork = em.fork();
@@ -167,12 +167,12 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       lookup: false,
     });
     await em.unitOfWork.dispatchOnLoadEvent();
-    await em.storeCache(options.cache, cached!, () => unique.map(e => e.__helper!.toPOJO()));
+    await em.storeCache(options.cache, cached!, () => unique.map(e => helper(e).toPOJO()));
 
     return unique as Loaded<T, P>[];
   }
 
-  private getPopulateWhere<T, P extends string>(where: FilterQuery<T>, options: Pick<FindOptions<T, P>, 'populateWhere'>): { where: FilterQuery<T>; populateWhere?: PopulateHint } {
+  private getPopulateWhere<T extends object, P extends string>(where: FilterQuery<T>, options: Pick<FindOptions<T, P>, 'populateWhere'>): { where: FilterQuery<T>; populateWhere?: PopulateHint } {
     if (options.populateWhere === undefined) {
       options.populateWhere = this.config.get('populateWhere');
     }
@@ -191,17 +191,17 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Registers global filter to this entity manager. Global filters are enabled by default (unless disabled via last parameter).
    */
-  addFilter<T1 extends AnyEntity<T1>>(name: string, cond: FilterQuery<T1> | ((args: Dictionary) => FilterQuery<T1>), entityName?: EntityName<T1> | [EntityName<T1>], enabled?: boolean): void;
+  addFilter<T1>(name: string, cond: FilterQuery<T1> | ((args: Dictionary) => FilterQuery<T1>), entityName?: EntityName<T1> | [EntityName<T1>], enabled?: boolean): void;
 
   /**
    * Registers global filter to this entity manager. Global filters are enabled by default (unless disabled via last parameter).
    */
-  addFilter<T1 extends AnyEntity<T1>, T2 extends AnyEntity<T2>>(name: string, cond: FilterQuery<T1 | T2> | ((args: Dictionary) => FilterQuery<T1 | T2>), entityName?: [EntityName<T1>, EntityName<T2>], enabled?: boolean): void;
+  addFilter<T1, T2>(name: string, cond: FilterQuery<T1 | T2> | ((args: Dictionary) => FilterQuery<T1 | T2>), entityName?: [EntityName<T1>, EntityName<T2>], enabled?: boolean): void;
 
   /**
    * Registers global filter to this entity manager. Global filters are enabled by default (unless disabled via last parameter).
    */
-  addFilter<T1 extends AnyEntity<T1>, T2 extends AnyEntity<T2>, T3 extends AnyEntity<T3>>(name: string, cond: FilterQuery<T1 | T2 | T3> | ((args: Dictionary) => FilterQuery<T1 | T2 | T3>), entityName?: [EntityName<T1>, EntityName<T2>, EntityName<T3>], enabled?: boolean): void;
+  addFilter<T1, T2, T3>(name: string, cond: FilterQuery<T1 | T2 | T3> | ((args: Dictionary) => FilterQuery<T1 | T2 | T3>), entityName?: [EntityName<T1>, EntityName<T2>, EntityName<T3>], enabled?: boolean): void;
 
   /**
    * Registers global filter to this entity manager. Global filters are enabled by default (unless disabled via last parameter).
@@ -235,7 +235,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     this.getContext(false).flushMode = flushMode;
   }
 
-  protected async processWhere<T extends AnyEntity<T>, P extends string = never>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, P> | FindOneOptions<T, P>, type: 'read' | 'update' | 'delete'): Promise<FilterQuery<T>> {
+  protected async processWhere<T extends object, P extends string = never>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, P> | FindOneOptions<T, P>, type: 'read' | 'update' | 'delete'): Promise<FilterQuery<T>> {
     where = QueryHelper.processWhere({
       where: where as FilterQuery<T>,
       entityName,
@@ -250,7 +250,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     return where;
   }
 
-  protected applyDiscriminatorCondition<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>): FilterQuery<T> {
+  protected applyDiscriminatorCondition<T extends object>(entityName: string, where: FilterQuery<T>): FilterQuery<T> {
     const meta = this.metadata.find(entityName);
 
     if (!meta || !meta.discriminatorValue) {
@@ -275,7 +275,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * @internal
    */
-  async applyFilters<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, options: Dictionary<boolean | Dictionary> | string[] | boolean, type: 'read' | 'update' | 'delete'): Promise<FilterQuery<T>> {
+  async applyFilters<T extends object>(entityName: string, where: FilterQuery<T>, options: Dictionary<boolean | Dictionary> | string[] | boolean, type: 'read' | 'update' | 'delete'): Promise<FilterQuery<T>> {
     const meta = this.metadata.find<T>(entityName);
     const filters: FilterDef[] = [];
     const ret: Dictionary[] = [];
@@ -333,7 +333,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * Calls `em.find()` and `em.count()` with the same arguments (where applicable) and returns the results as tuple
    * where first element is the array of entities and the second is the count.
    */
-  async findAndCount<T extends AnyEntity<T>, P extends string = never>(entityName: EntityName<T>, where: FilterQuery<T>, options: FindOptions<T, P> = {}): Promise<[Loaded<T, P>[], number]> {
+  async findAndCount<T extends object, P extends string = never>(entityName: EntityName<T>, where: FilterQuery<T>, options: FindOptions<T, P> = {}): Promise<[Loaded<T, P>[], number]> {
     const [entities, count] = await Promise.all([
       this.find<T, P>(entityName, where, options),
       this.count(entityName, where, options),
@@ -345,7 +345,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Finds first entity matching your `where` query.
    */
-  async findOne<T extends AnyEntity<T>, P extends string = never>(entityName: EntityName<T>, where: FilterQuery<T>, options: FindOneOptions<T, P> = {}): Promise<Loaded<T, P> | null> {
+  async findOne<T extends object, P extends string = never>(entityName: EntityName<T>, where: FilterQuery<T>, options: FindOneOptions<T, P> = {}): Promise<Loaded<T, P> | null> {
     if (options.disableIdentityMap) {
       const em = this.getContext(false);
       const fork = em.fork();
@@ -405,7 +405,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     await em.unitOfWork.dispatchOnLoadEvent();
-    await em.storeCache(options.cache, cached!, () => entity!.__helper!.toPOJO());
+    await em.storeCache(options.cache, cached!, () => helper(entity).toPOJO());
 
     return entity as Loaded<T, P>;
   }
@@ -416,7 +416,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * You can override the factory for creating this method via `options.failHandler` locally
    * or via `Configuration.findOneOrFailHandler` (`findExactlyOneOrFailHandler` when specifying `strict`) globally.
    */
-  async findOneOrFail<T extends AnyEntity<T>, P extends string = never>(entityName: EntityName<T>, where: FilterQuery<T>, options: FindOneOrFailOptions<T, P> = {}): Promise<Loaded<T, P>> {
+  async findOneOrFail<T extends object, P extends string = never>(entityName: EntityName<T>, where: FilterQuery<T>, options: FindOneOrFailOptions<T, P> = {}): Promise<Loaded<T, P>> {
     let entity: Loaded<T, P> | null;
     let isStrictViolation = false;
 
@@ -515,7 +515,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Runs your callback wrapped inside a database transaction.
    */
-  async lock<T>(entity: T, lockMode: LockMode, options: LockOptions | number | Date = {}): Promise<void> {
+  async lock<T extends object>(entity: T, lockMode: LockMode, options: LockOptions | number | Date = {}): Promise<void> {
     options = Utils.isPlainObject(options) ? options as LockOptions : { lockVersion: options };
     await this.getUnitOfWork().lock(entity, { lockMode, ...options });
   }
@@ -523,13 +523,13 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Fires native insert query. Calling this has no side effects on the context (identity map).
    */
-  async nativeInsert<T extends AnyEntity<T>>(entityNameOrEntity: EntityName<T> | T, data?: EntityData<T> | T, options: NativeInsertUpdateOptions<T> = {}): Promise<Primary<T>> {
+  async nativeInsert<T extends object>(entityNameOrEntity: EntityName<T> | T, data?: EntityData<T> | T, options: NativeInsertUpdateOptions<T> = {}): Promise<Primary<T>> {
     const em = this.getContext(false);
 
     let entityName;
 
     if (data === undefined) {
-      entityName = entityNameOrEntity.constructor.name;
+      entityName = (entityNameOrEntity as Dictionary).constructor.name;
       data = entityNameOrEntity as T;
     } else {
       entityName = Utils.className(entityNameOrEntity as EntityName<T>);
@@ -549,7 +549,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Fires native update query. Calling this has no side effects on the context (identity map).
    */
-  async nativeUpdate<T extends AnyEntity<T>>(entityName: EntityName<T>, where: FilterQuery<T>, data: EntityData<T>, options: UpdateOptions<T> = {}): Promise<number> {
+  async nativeUpdate<T extends object>(entityName: EntityName<T>, where: FilterQuery<T>, data: EntityData<T>, options: UpdateOptions<T> = {}): Promise<number> {
     const em = this.getContext(false);
 
     entityName = Utils.className(entityName);
@@ -565,7 +565,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Fires native delete query. Calling this has no side effects on the context (identity map).
    */
-  async nativeDelete<T extends AnyEntity<T>>(entityName: EntityName<T>, where: FilterQuery<T>, options: DeleteOptions<T> = {}): Promise<number> {
+  async nativeDelete<T extends object>(entityName: EntityName<T>, where: FilterQuery<T>, options: DeleteOptions<T> = {}): Promise<number> {
     const em = this.getContext(false);
 
     entityName = Utils.className(entityName);
@@ -579,7 +579,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Maps raw database result to an entity and merges it to this EntityManager.
    */
-  map<T extends AnyEntity<T>>(entityName: EntityName<T>, result: EntityDictionary<T>, options: { schema?: string } = {}): T {
+  map<T extends object>(entityName: EntityName<T>, result: EntityDictionary<T>, options: { schema?: string } = {}): T {
     entityName = Utils.className(entityName);
     const meta = this.metadata.get(entityName);
     const data = this.driver.mapResult(result, meta) as Dictionary;
@@ -599,30 +599,30 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * Merges given entity to this EntityManager so it becomes managed. You can force refreshing of existing entities
    * via second parameter. By default, it will return already loaded entities without modifying them.
    */
-  merge<T extends AnyEntity<T>>(entity: T, options?: MergeOptions): T;
+  merge<T extends object>(entity: T, options?: MergeOptions): T;
 
   /**
    * Merges given entity to this EntityManager so it becomes managed. You can force refreshing of existing entities
    * via second parameter. By default, it will return already loaded entities without modifying them.
    */
-  merge<T extends AnyEntity<T>>(entityName: EntityName<T>, data: EntityData<T> | EntityDTO<T>, options?: MergeOptions): T;
+  merge<T extends object>(entityName: EntityName<T>, data: EntityData<T> | EntityDTO<T>, options?: MergeOptions): T;
 
   /**
    * Merges given entity to this EntityManager so it becomes managed. You can force refreshing of existing entities
    * via second parameter. By default, it will return already loaded entities without modifying them.
    */
-  merge<T extends AnyEntity<T>>(entityName: EntityName<T> | T, data?: EntityData<T> | EntityDTO<T> | MergeOptions, options: MergeOptions = {}): T {
+  merge<T extends object>(entityName: EntityName<T> | T, data?: EntityData<T> | EntityDTO<T> | MergeOptions, options: MergeOptions = {}): T {
     const em = this.getContext();
 
     if (Utils.isEntity(entityName)) {
-      return em.merge(entityName.constructor.name, entityName as unknown as EntityData<T>, data as MergeOptions);
+      return em.merge((entityName as Dictionary).constructor.name, entityName as unknown as EntityData<T>, data as MergeOptions);
     }
 
     entityName = Utils.className(entityName as string);
     em.validator.validatePrimaryKey(data as EntityData<T>, em.metadata.get(entityName));
     let entity = em.unitOfWork.tryGetById<T>(entityName, data as FilterQuery<T>, options.schema, false);
 
-    if (entity && entity.__helper!.__initialized && !options.refresh) {
+    if (entity && helper(entity).__initialized && !options.refresh) {
       return entity;
     }
 
@@ -633,7 +633,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     em.validator.validate(entity, data, childMeta ?? meta);
     em.unitOfWork.merge(entity);
 
-    return entity;
+    return entity!;
   }
 
   /**
@@ -644,7 +644,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * the whole `data` parameter will be passed. This means we can also define `constructor(data: Partial<T>)` and
    * `em.create()` will pass the data into it (unless we have a property named `data` too).
    */
-  create<T extends AnyEntity<T>>(entityName: EntityName<T>, data: RequiredEntityData<T>, options: CreateOptions = {}): T {
+  create<T extends object>(entityName: EntityName<T>, data: RequiredEntityData<T>, options: CreateOptions = {}): T {
     const em = this.getContext();
     const entity = em.entityFactory.create(entityName, data, { ...options, newEntity: !options.managed });
     options.persist ??= em.config.get('persistOnCreate');
@@ -659,34 +659,34 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Shortcut for `wrap(entity).assign(data, { em })`
    */
-  assign<T extends AnyEntity<T>>(entity: T, data: EntityData<T> | Partial<EntityDTO<T>>, options: AssignOptions = {}): T {
+  assign<T extends object>(entity: T, data: EntityData<T> | Partial<EntityDTO<T>>, options: AssignOptions = {}): T {
     return EntityAssigner.assign(entity, data, { em: this.getContext(), ...options });
   }
 
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<T extends AnyEntity<T>, PK extends keyof T>(entityName: EntityName<T>, id: Primary<T>, options: Omit<GetReferenceOptions, 'wrapped'> & { wrapped: true }): IdentifiedReference<T, PK>;
+  getReference<T extends object, PK extends keyof T>(entityName: EntityName<T>, id: Primary<T>, options: Omit<GetReferenceOptions, 'wrapped'> & { wrapped: true }): IdentifiedReference<T, PK>;
 
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<T extends AnyEntity<T>>(entityName: EntityName<T>, id: Primary<T> | Primary<T>[]): T;
+  getReference<T extends object>(entityName: EntityName<T>, id: Primary<T> | Primary<T>[]): T;
 
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<T extends AnyEntity<T>>(entityName: EntityName<T>, id: Primary<T>, options: Omit<GetReferenceOptions, 'wrapped'> & { wrapped: false }): T;
+  getReference<T extends object>(entityName: EntityName<T>, id: Primary<T>, options: Omit<GetReferenceOptions, 'wrapped'> & { wrapped: false }): T;
 
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<T extends AnyEntity<T>>(entityName: EntityName<T>, id: Primary<T>, options?: GetReferenceOptions): T | Reference<T>;
+  getReference<T extends object>(entityName: EntityName<T>, id: Primary<T>, options?: GetReferenceOptions): T | Reference<T>;
 
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<T extends AnyEntity<T>>(entityName: EntityName<T>, id: Primary<T>, options: GetReferenceOptions = {}): T | Reference<T> {
+  getReference<T extends object>(entityName: EntityName<T>, id: Primary<T>, options: GetReferenceOptions = {}): T | Reference<T> {
     options.convertCustomTypes ??= false;
     const meta = this.metadata.get(Utils.className(entityName));
 
@@ -710,7 +710,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Returns total number of entities matching your `where` query.
    */
-  async count<T, P extends string = never>(entityName: EntityName<T>, where: FilterQuery<T> = {} as FilterQuery<T>, options: CountOptions<T, P> = {}): Promise<number> {
+  async count<T extends object, P extends string = never>(entityName: EntityName<T>, where: FilterQuery<T> = {} as FilterQuery<T>, options: CountOptions<T, P> = {}): Promise<number> {
     const em = this.getContext(false);
     entityName = Utils.className(entityName);
     where = await em.processWhere<T, P>(entityName, where, options as FindOptions<T, P>, 'read');
@@ -733,7 +733,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * Tells the EntityManager to make an instance managed and persistent.
    * The entity will be entered into the database at or before transaction commit or as a result of the flush operation.
    */
-  persist(entity: AnyEntity | Reference<AnyEntity> | (AnyEntity | Reference<AnyEntity>)[]): this {
+  persist<T extends object>(entity: T | Reference<T> | (T | Reference<T>)[]): this {
     const em = this.getContext();
 
     if (Utils.isEntity(entity)) {
@@ -747,7 +747,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     for (const ent of entities) {
       if (!Utils.isEntity(ent, true)) {
         /* istanbul ignore next */
-        const meta = typeof ent === 'object' ? em.metadata.find(ent.constructor.name) : undefined;
+        const meta = typeof ent === 'object' ? em.metadata.find((ent as Dictionary).constructor.name) : undefined;
         throw ValidationError.notDiscoveredEntity(ent, meta);
       }
 
@@ -782,7 +782,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    *
    * To remove entities by condition, use `em.nativeDelete()`.
    */
-  remove<T extends AnyEntity<T>>(entity: T | Reference<T> | (T | Reference<T>)[]): this {
+  remove<T extends object>(entity: T | Reference<T> | (T | Reference<T>)[]): this {
     const em = this.getContext();
 
     if (Utils.isEntity<T>(entity)) {
@@ -834,7 +834,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * @internal
    */
-  async tryFlush<T>(entityName: EntityName<T>, options: { flushMode?: FlushMode }): Promise<void> {
+  async tryFlush<T extends object>(entityName: EntityName<T>, options: { flushMode?: FlushMode }): Promise<void> {
     const em = this.getContext();
     const flushMode = options.flushMode ?? em.flushMode ?? em.config.get('flushMode');
     entityName = Utils.className(entityName);
@@ -859,7 +859,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Checks whether given property can be populated on the entity.
    */
-  canPopulate<T extends AnyEntity<T>>(entityName: EntityName<T>, property: string): boolean {
+  canPopulate<T extends object>(entityName: EntityName<T>, property: string): boolean {
     entityName = Utils.className(entityName);
     const [p, ...parts] = property.split('.');
     const meta = this.metadata.find(entityName);
@@ -884,7 +884,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Loads specified relations in batch. This will execute one query for each relation, that will populate it on all of the specified entities.
    */
-  async populate<T extends AnyEntity<T>, P extends string = never>(entities: T | T[], populate: AutoPath<T, P>[] | boolean, options: EntityLoaderOptions<T, P> = {}): Promise<Loaded<T, P>[]> {
+  async populate<T extends object, P extends string = never>(entities: T | T[], populate: AutoPath<T, P>[] | boolean, options: EntityLoaderOptions<T, P> = {}): Promise<Loaded<T, P>[]> {
     entities = Utils.asArray(entities);
 
     if (entities.length === 0) {
@@ -892,7 +892,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     const em = this.getContext();
-    const entityName = entities[0].constructor.name;
+    const entityName = (entities[0] as Dictionary).constructor.name;
     const preparedPopulate = em.preparePopulate<T>(entityName, { populate: populate as true });
     await em.entityLoader.populate(entityName, entities, preparedPopulate, options);
 
@@ -1035,7 +1035,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }
   }
 
-  private async lockAndPopulate<T extends AnyEntity<T>, P extends string = never>(entityName: string, entity: T, where: FilterQuery<T>, options: FindOneOptions<T, P>): Promise<Loaded<T, P>> {
+  private async lockAndPopulate<T extends object, P extends string = never>(entityName: string, entity: T, where: FilterQuery<T>, options: FindOneOptions<T, P>): Promise<Loaded<T, P>> {
     if (options.lockMode === LockMode.OPTIMISTIC) {
       await this.lock(entity, options.lockMode, {
         lockVersion: options.lockVersion,
@@ -1055,7 +1055,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     return entity as Loaded<T, P>;
   }
 
-  private buildFields<T, P extends string>(fields: readonly EntityField<T, P>[]): readonly AutoPath<T, P>[] {
+  private buildFields<T extends object, P extends string>(fields: readonly EntityField<T, P>[]): readonly AutoPath<T, P>[] {
     return fields.reduce((ret, f) => {
       if (Utils.isPlainObject(f)) {
         Object.keys(f).forEach(ff => ret.push(...this.buildFields(f[ff]).map(field => `${ff}.${field}` as never)));
@@ -1067,7 +1067,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }, [] as AutoPath<T, P>[]);
   }
 
-  private preparePopulate<T extends AnyEntity<T>, P extends string = never>(entityName: string, options: Pick<FindOptions<T, P>, 'populate' | 'strategy' | 'fields'>): PopulateOptions<T>[] {
+  private preparePopulate<T extends object, P extends string = never>(entityName: string, options: Pick<FindOptions<T, P>, 'populate' | 'strategy' | 'fields'>): PopulateOptions<T>[] {
     // infer populate hint if only `fields` are available
     if (!options.populate && options.fields) {
       options.populate = this.buildFields(options.fields);
@@ -1105,17 +1105,17 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * when the entity is found in identity map, we check if it was partially loaded or we are trying to populate
    * some additional lazy properties, if so, we reload and merge the data from database
    */
-  protected shouldRefresh<T extends AnyEntity<T>, P extends string = never>(meta: EntityMetadata<T>, entity: T, options: FindOneOptions<T, P>) {
-    if (!entity.__helper!.__initialized || options.refresh) {
+  protected shouldRefresh<T extends object, P extends string = never>(meta: EntityMetadata<T>, entity: T, options: FindOneOptions<T, P>) {
+    if (!helper(entity).__initialized || options.refresh) {
       return true;
     }
 
     let autoRefresh: boolean;
 
     if (options.fields) {
-      autoRefresh = options.fields.some(field => !entity!.__helper!.__loadedProperties.has(field as string));
+      autoRefresh = options.fields.some(field => !helper(entity).__loadedProperties.has(field as string));
     } else {
-      autoRefresh = meta.comparableProps.some(prop => !prop.lazy && !entity!.__helper!.__loadedProperties.has(prop.name));
+      autoRefresh = meta.comparableProps.some(prop => !prop.lazy && !helper(entity).__loadedProperties.has(prop.name));
     }
 
     if (autoRefresh) {
@@ -1123,7 +1123,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     if (Array.isArray(options.populate)) {
-      return options.populate.some(field => !entity!.__helper!.__loadedProperties.has(field as string));
+      return options.populate.some(field => !helper(entity).__loadedProperties.has(field as string));
     }
 
     return !!options.populate;
@@ -1132,7 +1132,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * @internal
    */
-  async tryCache<T extends AnyEntity, R>(entityName: string, config: boolean | number | [string, number] | undefined, key: unknown, refresh?: boolean, merge?: boolean): Promise<{ data?: R; key: string } | undefined> {
+  async tryCache<T extends object, R>(entityName: string, config: boolean | number | [string, number] | undefined, key: unknown, refresh?: boolean, merge?: boolean): Promise<{ data?: R; key: string } | undefined> {
     if (!config) {
       return undefined;
     }

--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -5,7 +5,7 @@ import type { Logger } from './logging';
 import { Configuration, ConfigurationLoader, Utils } from './utils';
 import { NullCacheAdapter } from './cache';
 import type { EntityManager } from './EntityManager';
-import type { AnyEntity, Constructor, IEntityGenerator, IMigrator, ISeedManager } from './typings';
+import type { Constructor, IEntityGenerator, IMigrator, ISeedManager } from './typings';
 import { colors } from './logging';
 
 /**
@@ -136,7 +136,7 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Allows dynamically discovering new entity by reference, handy for testing schema diffing.
    */
-  async discoverEntity<T>(entities: Constructor<T> | Constructor<AnyEntity>[]): Promise<void> {
+  async discoverEntity(entities: Constructor | Constructor[]): Promise<void> {
     entities = Utils.asArray(entities);
     const tmp = await this.discovery.discoverReferences(entities);
     new MetadataValidator().validateDiscovered([...Object.values(this.metadata.getAll()), ...tmp], this.config.get('discovery').warnWhenNoEntities!);

--- a/packages/core/src/connections/Connection.ts
+++ b/packages/core/src/connections/Connection.ts
@@ -2,7 +2,7 @@ import { URL } from 'url';
 import type { Configuration, ConnectionOptions, DynamicPassword } from '../utils';
 import type { LogContext } from '../logging';
 import type { MetadataStorage } from '../metadata';
-import type { AnyEntity, ConnectionType, Dictionary, MaybePromise, Primary } from '../typings';
+import type { ConnectionType, Dictionary, MaybePromise, Primary } from '../typings';
 import type { Platform } from '../platforms/Platform';
 import type { TransactionEventBroadcaster } from '../events/TransactionEventBroadcaster';
 import type { IsolationLevel } from '../enums';
@@ -130,7 +130,7 @@ export abstract class Connection {
 
 }
 
-export interface QueryResult<T extends AnyEntity<T> = { id: number }> {
+export interface QueryResult<T = { id: number }> {
   affectedRows: number;
   insertId: Primary<T>;
   row?: Dictionary;

--- a/packages/core/src/decorators/Indexed.ts
+++ b/packages/core/src/decorators/Indexed.ts
@@ -2,7 +2,7 @@ import { MetadataStorage } from '../metadata';
 import type { AnyEntity, Dictionary } from '../typings';
 import { Utils } from '../utils/Utils';
 
-function createDecorator<T extends AnyEntity<T>>(options: IndexOptions<T> | UniqueOptions<T>, unique: boolean) {
+function createDecorator<T>(options: IndexOptions<T> | UniqueOptions<T>, unique: boolean) {
   return function (target: AnyEntity, propertyName?: string) {
     const meta = MetadataStorage.getMetadataFromDecorator(propertyName ? target.constructor : target);
     options.properties = options.properties || propertyName as keyof T;
@@ -25,13 +25,13 @@ export function Unique<T>(options: UniqueOptions<T> = {}) {
   return createDecorator(options, true);
 }
 
-export interface UniqueOptions<T extends AnyEntity<T>> {
+export interface UniqueOptions<T> {
   name?: string;
   properties?: keyof T | (keyof T)[];
   options?: Dictionary;
 }
 
-export interface IndexOptions<T extends AnyEntity<T>> extends UniqueOptions<T> {
+export interface IndexOptions<T> extends UniqueOptions<T> {
   type?: string;
   expression?: string;
 }

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -1,12 +1,12 @@
 import type {
-  ConnectionType, EntityData, EntityMetadata, EntityProperty, AnyEntity, FilterQuery, Primary, Dictionary, QBFilterQuery,
+  ConnectionType, EntityData, EntityMetadata, EntityProperty, FilterQuery, Primary, Dictionary, QBFilterQuery,
   IPrimaryKey, PopulateOptions, EntityDictionary, ExpandProperty, AutoPath, ObjectQuery,
 } from '../typings';
 import type { Connection, QueryResult, Transaction } from '../connections';
 import type { FlushMode, LockMode, QueryOrderMap, QueryFlag, LoadStrategy, PopulateHint } from '../enums';
 import type { Platform } from '../platforms';
 import type { MetadataStorage } from '../metadata';
-import type { Collection } from '../entity';
+import type { Collection } from '../entity/Collection';
 import type { EntityManager } from '../EntityManager';
 import type { DriverException } from '../exceptions';
 import type { Configuration } from '../utils/Configuration';
@@ -31,37 +31,37 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   /**
    * Finds selection of entities
    */
-  find<T extends AnyEntity<T>, P extends string = never>(entityName: string, where: FilterQuery<T>, options?: FindOptions<T, P>): Promise<EntityData<T>[]>;
+  find<T extends object, P extends string = never>(entityName: string, where: FilterQuery<T>, options?: FindOptions<T, P>): Promise<EntityData<T>[]>;
 
   /**
    * Finds single entity (table row, document)
    */
-  findOne<T extends AnyEntity<T>, P extends string = never>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T, P>): Promise<EntityData<T> | null>;
+  findOne<T extends object, P extends string = never>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T, P>): Promise<EntityData<T> | null>;
 
-  findVirtual<T>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, any>): Promise<EntityData<T>[]>;
+  findVirtual<T extends object>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, any>): Promise<EntityData<T>[]>;
 
-  nativeInsert<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>, options?: NativeInsertUpdateOptions<T>): Promise<QueryResult<T>>;
+  nativeInsert<T extends object>(entityName: string, data: EntityDictionary<T>, options?: NativeInsertUpdateOptions<T>): Promise<QueryResult<T>>;
 
-  nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>[], options?: NativeInsertUpdateManyOptions<T>): Promise<QueryResult<T>>;
+  nativeInsertMany<T extends object>(entityName: string, data: EntityDictionary<T>[], options?: NativeInsertUpdateManyOptions<T>): Promise<QueryResult<T>>;
 
-  nativeUpdate<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, data: EntityDictionary<T>, options?: NativeInsertUpdateOptions<T>): Promise<QueryResult<T>>;
+  nativeUpdate<T extends object>(entityName: string, where: FilterQuery<T>, data: EntityDictionary<T>, options?: NativeInsertUpdateOptions<T>): Promise<QueryResult<T>>;
 
-  nativeUpdateMany<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>[], data: EntityDictionary<T>[], options?: NativeInsertUpdateManyOptions<T>): Promise<QueryResult<T>>;
+  nativeUpdateMany<T extends object>(entityName: string, where: FilterQuery<T>[], data: EntityDictionary<T>[], options?: NativeInsertUpdateManyOptions<T>): Promise<QueryResult<T>>;
 
-  nativeDelete<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, options?: NativeDeleteOptions<T>): Promise<QueryResult<T>>;
+  nativeDelete<T extends object>(entityName: string, where: FilterQuery<T>, options?: NativeDeleteOptions<T>): Promise<QueryResult<T>>;
 
-  syncCollection<T, O>(collection: Collection<T, O>, options?: DriverMethodOptions): Promise<void>;
+  syncCollection<T extends object, O extends object>(collection: Collection<T, O>, options?: DriverMethodOptions): Promise<void>;
 
-  count<T extends AnyEntity<T>, P extends string = never>(entityName: string, where: FilterQuery<T>, options?: CountOptions<T, P>): Promise<number>;
+  count<T extends object, P extends string = never>(entityName: string, where: FilterQuery<T>, options?: CountOptions<T, P>): Promise<number>;
 
   aggregate(entityName: string, pipeline: any[]): Promise<any[]>;
 
-  mapResult<T>(result: EntityDictionary<T>, meta: EntityMetadata<T>, populate?: PopulateOptions<T>[]): EntityData<T> | null;
+  mapResult<T extends object>(result: EntityDictionary<T>, meta: EntityMetadata<T>, populate?: PopulateOptions<T>[]): EntityData<T> | null;
 
   /**
    * When driver uses pivot tables for M:N, this method will load identifiers for given collections from them
    */
-  loadFromPivotTable<T extends AnyEntity<T>, O extends AnyEntity<O>>(prop: EntityProperty, owners: Primary<O>[][], where?: FilterQuery<T>, orderBy?: QueryOrderMap<T>[], ctx?: Transaction, options?: FindOptions<T>): Promise<Dictionary<T[]>>;
+  loadFromPivotTable<T extends object, O extends object>(prop: EntityProperty, owners: Primary<O>[][], where?: FilterQuery<T>, orderBy?: QueryOrderMap<T>[], ctx?: Transaction, options?: FindOptions<T, any>): Promise<Dictionary<T[]>>;
 
   getPlatform(): Platform;
 
@@ -77,7 +77,7 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
    */
   getDependencies(): string[];
 
-  lockPessimistic<T extends AnyEntity<T>>(entity: T, options: LockOptions): Promise<void>;
+  lockPessimistic<T extends object>(entity: T, options: LockOptions): Promise<void>;
 
   /**
    * Converts native db errors to standardized driver exceptions
@@ -118,12 +118,12 @@ export interface FindOptions<T, P extends string = never> {
   connectionType?: ConnectionType;
 }
 
-export interface FindOneOptions<T, P extends string = never> extends Omit<FindOptions<T, P>, 'limit' | 'offset' | 'lockMode'> {
+export interface FindOneOptions<T extends object, P extends string = never> extends Omit<FindOptions<T, P>, 'limit' | 'offset' | 'lockMode'> {
   lockMode?: LockMode;
   lockVersion?: number | Date;
 }
 
-export interface FindOneOrFailOptions<T, P extends string = never> extends FindOneOptions<T, P> {
+export interface FindOneOrFailOptions<T extends object, P extends string = never> extends FindOneOptions<T, P> {
   failHandler?: (entityName: string, where: Dictionary | IPrimaryKey | any) => Error;
   strict?: boolean;
 }
@@ -138,7 +138,7 @@ export interface NativeInsertUpdateManyOptions<T> extends NativeInsertUpdateOpti
   processCollections?: boolean;
 }
 
-export interface CountOptions<T, P extends string = never>  {
+export interface CountOptions<T extends object, P extends string = never>  {
   filters?: Dictionary<boolean | Dictionary> | string[] | boolean;
   schema?: string;
   groupBy?: string | readonly string[];

--- a/packages/core/src/entity/BaseEntity.ts
+++ b/packages/core/src/entity/BaseEntity.ts
@@ -1,52 +1,55 @@
+import type { IdentifiedReference } from './Reference';
 import { Reference } from './Reference';
-import type { AnyEntity, EntityData, EntityDTO, IWrappedEntity, Loaded } from '../typings';
+import type { EntityData, EntityDTO, Loaded } from '../typings';
 import type { AssignOptions } from './EntityAssigner';
 import { EntityAssigner } from './EntityAssigner';
+import { helper } from './wrap';
 
-export abstract class BaseEntity<T, PK extends keyof T, P extends string = never> implements IWrappedEntity<T, PK, P> {
+export abstract class BaseEntity<Entity extends object, Primary extends keyof Entity, Populate extends string = string> {
 
   isInitialized(): boolean {
-    return (this as unknown as AnyEntity<T>).__helper!.__initialized;
+    return helper(this).__initialized;
   }
 
   isTouched(): boolean {
-    return (this as unknown as AnyEntity<T>).__helper!.__touched;
+    return helper(this).__touched;
   }
 
   populated(populated = true): void {
-    (this as unknown as AnyEntity<T>).__helper!.populated(populated);
+    helper(this).populated(populated);
   }
 
-  toReference() {
-    return Reference.create(this) as any; // maintain the type from IWrappedEntity
+  toReference(): IdentifiedReference<Entity, Primary> {
+    return Reference.create(this as unknown as Entity);
   }
 
-  toObject(ignoreFields: string[] = []): EntityDTO<T> {
-    return (this as unknown as AnyEntity<T>).__helper!.toObject(ignoreFields);
+  toObject(ignoreFields: string[] = []): EntityDTO<this> {
+    return helper(this).toObject(ignoreFields);
   }
 
-  toJSON(...args: any[]): EntityDTO<T> {
+  toJSON(...args: any[]): EntityDTO<this> {
     return this.toObject(...args);
   }
 
-  toPOJO(): EntityDTO<T> {
-    return (this as unknown as AnyEntity<T>).__helper!.toPOJO();
+  toPOJO(): EntityDTO<this> {
+    return helper(this).toPOJO();
   }
 
-  assign(data: EntityData<T>, options?: AssignOptions): T {
-    return EntityAssigner.assign(this as unknown as T, data, options);
+  assign(data: EntityData<Entity>, options?: AssignOptions): Entity {
+    return EntityAssigner.assign(this as object, data, options) as Entity;
   }
 
-  init<P extends string = never>(populated = true): Promise<Loaded<T, P>> {
-    return (this as unknown as AnyEntity<T>).__helper!.init<P>(populated);
+  init<Populate extends string = never>(populated = true): Promise<Loaded<Entity, Populate>> {
+    // using `Loaded<this>` results in issues with assignability unfortunately
+    return helper(this as unknown as Entity).init<Populate>(populated);
   }
 
   getSchema(): string | undefined {
-    return (this as unknown as AnyEntity<T>).__helper!.getSchema();
+    return helper(this).getSchema();
   }
 
   setSchema(schema?: string): void {
-    (this as unknown as AnyEntity<T>).__helper!.setSchema(schema);
+    helper(this).setSchema(schema);
   }
 
 }

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -5,7 +5,8 @@ import type { CountOptions, DeleteOptions, FindOneOptions, FindOneOrFailOptions,
 import type { IdentifiedReference, Reference } from './Reference';
 import type { EntityLoaderOptions } from './EntityLoader';
 
-export class EntityRepository<T extends AnyEntity<T>> {
+// eslint-disable-next-line @typescript-eslint/ban-types
+export class EntityRepository<T extends {}> {
 
   constructor(protected readonly _em: EntityManager,
               protected readonly entityName: EntityName<T>) { }
@@ -207,7 +208,7 @@ export class EntityRepository<T extends AnyEntity<T>> {
    * Returns total number of entities matching your `where` query.
    */
   async count<P extends string = never>(where: FilterQuery<T> = {} as FilterQuery<T>, options: CountOptions<T, P> = {}): Promise<number> {
-    return this.em.count(this.entityName, where, options);
+    return this.em.count<T, P>(this.entityName, where, options);
   }
 
   protected get em(): EntityManager {

--- a/packages/core/src/entity/wrap.ts
+++ b/packages/core/src/entity/wrap.ts
@@ -1,4 +1,4 @@
-import type { AnyEntity, Dictionary, IWrappedEntity, IWrappedEntityInternal, PrimaryProperty } from '../typings';
+import type { Dictionary, IWrappedEntity, IWrappedEntityInternal, PrimaryProperty } from '../typings';
 
 /**
  * returns WrappedEntity instance associated with this entity. This includes all the internal properties like `__meta` or `__em`.
@@ -14,7 +14,7 @@ export function wrap<T, PK extends keyof T | unknown = PrimaryProperty<T>>(entit
  * wraps entity type with WrappedEntity internal properties and helpers like init/isInitialized/populated/toJSON
  * use `preferHelper = true` to have access to the internal `__` properties like `__meta` or `__em`
  */
-export function wrap<T extends AnyEntity<T>, PK extends keyof T | unknown = PrimaryProperty<T>>(entity: T & Dictionary, preferHelper = false): IWrappedEntity<T, PK> | IWrappedEntityInternal<T, PK> {
+export function wrap<T, PK extends keyof T | unknown = PrimaryProperty<T>>(entity: T & Dictionary, preferHelper = false): IWrappedEntity<T, PK> | IWrappedEntityInternal<T, PK> {
   if (entity?.__baseEntity && !preferHelper) {
     return entity as unknown as IWrappedEntity<T, PK>;
   }
@@ -24,4 +24,13 @@ export function wrap<T extends AnyEntity<T>, PK extends keyof T | unknown = Prim
   }
 
   return entity as unknown as IWrappedEntity<T, PK>;
+}
+
+/**
+ * wraps entity type with WrappedEntity internal properties and helpers like init/isInitialized/populated/toJSON
+ * use `preferHelper = true` to have access to the internal `__` properties like `__meta` or `__em`
+ * @internal
+ */
+export function helper<T, PK extends keyof T | unknown = PrimaryProperty<T>>(entity: T): IWrappedEntityInternal<T, PK> {
+  return (entity as Dictionary).__helper!;
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -106,7 +106,7 @@ export class ValidationError<T extends AnyEntity = AnyEntity> extends Error {
     return new ValidationError('Using global EntityManager instance methods for context specific actions is disallowed. If you need to work with the global instance\'s identity map, use `allowGlobalContext` configuration option or `fork()` instead.');
   }
 
-  static cannotUseOperatorsInsideEmbeddables(className: string, propName: string, payload: Dictionary): ValidationError {
+  static cannotUseOperatorsInsideEmbeddables(className: string, propName: string, payload: unknown): ValidationError {
     return new ValidationError(`Using operators inside embeddables is not allowed, move the operator above. (property: ${className}.${propName}, payload: ${inspect(payload)})`);
   }
 

--- a/packages/core/src/events/EventManager.ts
+++ b/packages/core/src/events/EventManager.ts
@@ -23,15 +23,15 @@ export class EventManager {
       });
   }
 
-  dispatchEvent<T extends AnyEntity<T>>(event: TransactionEventType, args: TransactionEventArgs): unknown;
-  dispatchEvent<T extends AnyEntity<T>>(event: EventType.onInit, args: Partial<EventArgs<T>>): unknown;
-  dispatchEvent<T extends AnyEntity<T>>(event: EventType, args: Partial<EventArgs<T> | FlushEventArgs>): Promise<unknown>;
-  dispatchEvent<T extends AnyEntity<T>>(event: EventType, args: Partial<AnyEventArgs<T>>): Promise<unknown> | unknown {
+  dispatchEvent<T>(event: TransactionEventType, args: TransactionEventArgs): unknown;
+  dispatchEvent<T>(event: EventType.onInit, args: Partial<EventArgs<T>>): unknown;
+  dispatchEvent<T>(event: EventType, args: Partial<EventArgs<T> | FlushEventArgs>): Promise<unknown>;
+  dispatchEvent<T>(event: EventType, args: Partial<AnyEventArgs<T>>): Promise<unknown> | unknown {
     const listeners: AsyncFunction[] = [];
     const entity = (args as EventArgs<T>).entity;
 
     // execute lifecycle hooks first
-    const hooks = (entity?.__meta!.hooks[event] || []) as AsyncFunction[];
+    const hooks = ((entity as AnyEntity)?.__meta!.hooks[event] || []) as AsyncFunction[];
     listeners.push(...hooks.map(hook => {
       const handler = typeof hook === 'function' ? hook : entity[hook!] as AsyncFunction;
       return handler!.bind(entity);
@@ -52,7 +52,7 @@ export class EventManager {
     return Utils.runSerial(listeners, listener => listener(args));
   }
 
-  hasListeners<T extends AnyEntity<T>>(event: EventType, meta: EntityMetadata<T>): boolean {
+  hasListeners<T>(event: EventType, meta: EntityMetadata<T>): boolean {
     const hasHooks = meta.hooks[event]?.length;
 
     if (hasHooks) {
@@ -80,4 +80,4 @@ export class EventManager {
 
 }
 
-type AnyEventArgs<T extends AnyEntity<T>> = EventArgs<T> | FlushEventArgs | TransactionEventArgs;
+type AnyEventArgs<T> = EventArgs<T> | FlushEventArgs | TransactionEventArgs;

--- a/packages/core/src/hydration/Hydrator.ts
+++ b/packages/core/src/hydration/Hydrator.ts
@@ -1,5 +1,5 @@
-import type { AnyEntity, EntityData, EntityMetadata, EntityProperty, IHydrator } from '../typings';
-import type { EntityFactory } from '../entity';
+import type { EntityData, EntityMetadata, EntityProperty, IHydrator } from '../typings';
+import type { EntityFactory } from '../entity/EntityFactory';
 import type { Platform } from '../platforms/Platform';
 import type { MetadataStorage } from '../metadata/MetadataStorage';
 import type { Configuration } from '../utils/Configuration';
@@ -14,7 +14,7 @@ export abstract class Hydrator implements IHydrator {
   /**
    * @inheritDoc
    */
-  hydrate<T extends AnyEntity<T>>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, factory: EntityFactory, type: 'full' | 'returning' | 'reference', newEntity = false, convertCustomTypes = false, schema?: string): void {
+  hydrate<T>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, factory: EntityFactory, type: 'full' | 'returning' | 'reference', newEntity = false, convertCustomTypes = false, schema?: string): void {
     const props = this.getProperties(meta, type);
 
     for (const prop of props) {
@@ -25,13 +25,13 @@ export abstract class Hydrator implements IHydrator {
   /**
    * @inheritDoc
    */
-  hydrateReference<T extends AnyEntity<T>>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, factory: EntityFactory, convertCustomTypes?: boolean, schema?: string): void {
+  hydrateReference<T>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, factory: EntityFactory, convertCustomTypes?: boolean, schema?: string): void {
     meta.primaryKeys.forEach(pk => {
       this.hydrateProperty<T>(entity, meta.properties[pk], data, factory, false, convertCustomTypes);
     });
   }
 
-  protected getProperties<T extends AnyEntity<T>>(meta: EntityMetadata<T>, type: 'full' | 'returning' | 'reference'): EntityProperty<T>[] {
+  protected getProperties<T>(meta: EntityMetadata<T>, type: 'full' | 'returning' | 'reference'): EntityProperty<T>[] {
     if (type === 'reference') {
       return meta.primaryKeys.map(pk => meta.properties[pk]);
     }
@@ -43,7 +43,7 @@ export abstract class Hydrator implements IHydrator {
     return meta.hydrateProps;
   }
 
-  protected hydrateProperty<T extends AnyEntity<T>>(entity: T, prop: EntityProperty, data: EntityData<T>, factory: EntityFactory, newEntity?: boolean, convertCustomTypes?: boolean): void {
+  protected hydrateProperty<T>(entity: T, prop: EntityProperty, data: EntityData<T>, factory: EntityFactory, newEntity?: boolean, convertCustomTypes?: boolean): void {
     entity[prop.name] = data[prop.name];
   }
 

--- a/packages/core/src/hydration/ObjectHydrator.ts
+++ b/packages/core/src/hydration/ObjectHydrator.ts
@@ -1,4 +1,4 @@
-import type { AnyEntity, EntityData, EntityMetadata, EntityProperty } from '../typings';
+import type { EntityData, EntityMetadata, EntityProperty } from '../typings';
 import { Hydrator } from './Hydrator';
 import { Collection } from '../entity/Collection';
 import { Reference } from '../entity/Reference';
@@ -21,7 +21,7 @@ export class ObjectHydrator extends Hydrator {
   /**
    * @inheritDoc
    */
-  hydrate<T extends AnyEntity<T>>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, factory: EntityFactory, type: 'full' | 'returning' | 'reference', newEntity = false, convertCustomTypes = false, schema?: string): void {
+  hydrate<T>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, factory: EntityFactory, type: 'full' | 'returning' | 'reference', newEntity = false, convertCustomTypes = false, schema?: string): void {
     const hydrate = this.getEntityHydrator(meta, type);
     Utils.callCompiledFunction(hydrate, entity, data, factory, newEntity, convertCustomTypes, schema);
   }
@@ -29,7 +29,7 @@ export class ObjectHydrator extends Hydrator {
   /**
    * @inheritDoc
    */
-  hydrateReference<T extends AnyEntity<T>>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, factory: EntityFactory, convertCustomTypes = false, schema?: string): void {
+  hydrateReference<T>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, factory: EntityFactory, convertCustomTypes = false, schema?: string): void {
     const hydrate = this.getEntityHydrator(meta, 'reference');
     Utils.callCompiledFunction(hydrate, entity, data, factory, false, convertCustomTypes, schema);
   }
@@ -37,7 +37,7 @@ export class ObjectHydrator extends Hydrator {
   /**
    * @internal Highly performance-sensitive method.
    */
-  getEntityHydrator<T extends AnyEntity<T>>(meta: EntityMetadata<T>, type: 'full' | 'returning' | 'reference'): EntityHydrator<T> {
+  getEntityHydrator<T>(meta: EntityMetadata<T>, type: 'full' | 'returning' | 'reference'): EntityHydrator<T> {
     const exists = this.hydrators[type].get(meta.className);
 
     if (exists) {

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -184,11 +184,11 @@ export class MetadataDiscovery {
     }
   }
 
-  async discoverReferences(refs: Constructor<AnyEntity>[]): Promise<EntityMetadata[]> {
-    const found: Constructor<AnyEntity>[] = [];
+  async discoverReferences<T>(refs: Constructor<T>[]): Promise<EntityMetadata<T>[]> {
+    const found: Constructor<T>[] = [];
 
     for (const entity of refs) {
-      const schema = this.getSchema(this.prepare(entity) as Constructor<AnyEntity>);
+      const schema = this.getSchema(this.prepare(entity) as Constructor<T>);
       const meta = schema.init().meta;
       this.metadata.set(meta.className, meta);
       found.push(entity);
@@ -214,7 +214,7 @@ export class MetadataDiscovery {
     return this.discovered.filter(meta => found.find(m => m.name === meta.className));
   }
 
-  private prepare<T extends AnyEntity<T>>(entity: EntityClass<T> | EntityClassGroup<T> | EntitySchema<T>): EntityClass<T> | EntitySchema<T> {
+  private prepare<T>(entity: EntityClass<T> | EntityClassGroup<T> | EntitySchema<T>): EntityClass<T> | EntitySchema<T> {
     if ('schema' in entity && entity.schema instanceof EntitySchema) {
       return entity.schema;
     }
@@ -230,7 +230,7 @@ export class MetadataDiscovery {
     return entity;
   }
 
-  private getSchema<T extends AnyEntity<T>>(entity: Constructor<T> | EntitySchema<T>): EntitySchema<T> {
+  private getSchema<T>(entity: Constructor<T> | EntitySchema<T>): EntitySchema<T> {
     if (entity instanceof EntitySchema) {
       return entity;
     }
@@ -253,7 +253,7 @@ export class MetadataDiscovery {
     return schema;
   }
 
-  private async discoverEntity<T extends AnyEntity<T>>(entity: EntityClass<T> | EntityClassGroup<T> | EntitySchema<T>, path?: string): Promise<void> {
+  private async discoverEntity<T>(entity: EntityClass<T> | EntityClassGroup<T> | EntitySchema<T>, path?: string): Promise<void> {
     entity = this.prepare(entity);
     this.logger.log('discovery', `- processing entity ${colors.cyan((entity as EntityClass<T>).name)}${colors.grey(path ? ` (${path})` : '')}`);
     const schema = this.getSchema(entity as Constructor<T>);
@@ -287,7 +287,7 @@ export class MetadataDiscovery {
     this.discovered.push(meta);
   }
 
-  private async saveToCache<T extends AnyEntity<T>>(meta: EntityMetadata): Promise<void> {
+  private async saveToCache<T>(meta: EntityMetadata): Promise<void> {
     if (!meta.useCache) {
       return;
     }

--- a/packages/core/src/metadata/MetadataStorage.ts
+++ b/packages/core/src/metadata/MetadataStorage.ts
@@ -1,4 +1,4 @@
-import type { AnyEntity, Dictionary, EntityData } from '../typings';
+import type { Dictionary, EntityData } from '../typings';
 import { EntityMetadata } from '../typings';
 import { Utils } from '../utils/Utils';
 import { MetadataError } from '../errors';
@@ -17,8 +17,8 @@ export class MetadataStorage {
   }
 
   static getMetadata(): Dictionary<EntityMetadata>;
-  static getMetadata<T extends AnyEntity<T> = any>(entity: string, path: string): EntityMetadata<T>;
-  static getMetadata<T extends AnyEntity<T> = any>(entity?: string, path?: string): Dictionary<EntityMetadata> | EntityMetadata<T> {
+  static getMetadata<T = any>(entity: string, path: string): EntityMetadata<T>;
+  static getMetadata<T = any>(entity?: string, path?: string): Dictionary<EntityMetadata> | EntityMetadata<T> {
     const key = entity && path ? entity + '-' + Utils.hash(path) : null;
 
     if (key && !MetadataStorage.metadata[key]) {
@@ -73,7 +73,7 @@ export class MetadataStorage {
     return this.metadata[type];
   }
 
-  get<T extends AnyEntity<T> = any>(entity: string, init = false, validate = true): EntityMetadata<T> {
+  get<T = any>(entity: string, init = false, validate = true): EntityMetadata<T> {
     if (validate && !init && !this.has(entity)) {
       throw MetadataError.missingMetadata(entity);
     }
@@ -85,7 +85,7 @@ export class MetadataStorage {
     return this.metadata[entity];
   }
 
-  find<T extends AnyEntity<T> = any>(entity: string): EntityMetadata<T> | undefined {
+  find<T = any>(entity: string): EntityMetadata<T> | undefined {
     return this.metadata[entity];
   }
 

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -2,7 +2,7 @@ import { clone } from '../utils/clone';
 import { EntityRepository } from '../entity';
 import type { NamingStrategy } from '../naming-strategy';
 import { UnderscoreNamingStrategy } from '../naming-strategy';
-import type { AnyEntity, Constructor, EntityProperty, IEntityGenerator, IMigrator, IPrimaryKey, ISchemaGenerator, PopulateOptions, Primary, EntityMetadata, SimpleColumnMeta } from '../typings';
+import type { Constructor, EntityProperty, IEntityGenerator, IMigrator, IPrimaryKey, ISchemaGenerator, PopulateOptions, Primary, EntityMetadata, SimpleColumnMeta } from '../typings';
 import { ExceptionConverter } from './ExceptionConverter';
 import type { EntityManager } from '../EntityManager';
 import type { Configuration } from '../utils/Configuration';
@@ -311,7 +311,7 @@ export abstract class Platform {
     return !marshall;
   }
 
-  getRepositoryClass<T>(): Constructor<EntityRepository<T>> {
+  getRepositoryClass<T extends object>(): Constructor<EntityRepository<T>> {
     return EntityRepository;
   }
 
@@ -394,7 +394,7 @@ export abstract class Platform {
     return false;
   }
 
-  shouldHaveColumn<T extends AnyEntity<T>>(prop: EntityProperty<T>, populate: PopulateOptions<T>[] | boolean, includeFormulas = true): boolean {
+  shouldHaveColumn<T>(prop: EntityProperty<T>, populate: PopulateOptions<T>[] | boolean, includeFormulas = true): boolean {
     if (prop.formula) {
       return includeFormulas && (!prop.lazy || populate === true || (populate !== false && populate.some(p => p.field === prop.name)));
     }

--- a/packages/core/src/unit-of-work/ChangeSet.ts
+++ b/packages/core/src/unit-of-work/ChangeSet.ts
@@ -1,6 +1,7 @@
-import type { EntityData, AnyEntity, EntityMetadata, EntityDictionary, Primary } from '../typings';
+import type { EntityData, EntityMetadata, EntityDictionary, Primary } from '../typings';
+import { helper } from '../entity/wrap';
 
-export class ChangeSet<T extends AnyEntity<T>> {
+export class ChangeSet<T> {
 
   private primaryKey?: Primary<T> | null;
   private serializedPrimaryKey?: string;
@@ -8,16 +9,16 @@ export class ChangeSet<T extends AnyEntity<T>> {
   constructor(public entity: T,
               public type: ChangeSetType,
               public payload: EntityDictionary<T>,
-              private meta: EntityMetadata<T>) {
+              public meta: EntityMetadata<T>) {
     this.name = meta.className;
     this.rootName = meta.root.className;
     this.collection = meta.root.collection;
-    this.schema = entity.__helper!.__schema ?? meta.root.schema;
+    this.schema = helper(entity).__schema ?? meta.root.schema;
   }
 
   getPrimaryKey(object = false): Primary<T> | null {
     if (!this.originalEntity) {
-      this.primaryKey ??= this.entity.__helper!.getPrimaryKey(true);
+      this.primaryKey ??= helper(this.entity).getPrimaryKey(true);
     } else if (this.meta.compositePK || object) {
       this.primaryKey = this.meta.primaryKeys.reduce((o, pk) => {
         o[pk] = (this.originalEntity as T)[pk];
@@ -31,13 +32,13 @@ export class ChangeSet<T extends AnyEntity<T>> {
   }
 
   getSerializedPrimaryKey(): string | null {
-    this.serializedPrimaryKey ??= this.entity.__helper!.getSerializedPrimaryKey();
+    this.serializedPrimaryKey ??= helper(this.entity).getSerializedPrimaryKey();
     return this.serializedPrimaryKey;
   }
 
 }
 
-export interface ChangeSet<T extends AnyEntity<T>> {
+export interface ChangeSet<T> {
   name: string;
   rootName: string;
   collection: string;

--- a/packages/core/src/unit-of-work/ChangeSetComputer.ts
+++ b/packages/core/src/unit-of-work/ChangeSetComputer.ts
@@ -6,6 +6,7 @@ import { ChangeSet, ChangeSetType } from './ChangeSet';
 import type { Collection, EntityValidator } from '../entity';
 import type { Platform } from '../platforms';
 import { ReferenceType } from '../enums';
+import { helper } from '../entity';
 
 export class ChangeSetComputer {
 
@@ -17,14 +18,14 @@ export class ChangeSetComputer {
               private readonly platform: Platform,
               private readonly config: Configuration) { }
 
-  computeChangeSet<T extends AnyEntity<T>>(entity: T): ChangeSet<T> | null {
-    const meta = this.metadata.get(entity.constructor.name);
+  computeChangeSet<T>(entity: T): ChangeSet<T> | null {
+    const meta = this.metadata.get((entity as AnyEntity).constructor.name);
 
     if (meta.readonly) {
       return null;
     }
 
-    const type = entity.__helper!.__originalEntityData ? ChangeSetType.UPDATE : ChangeSetType.CREATE;
+    const type = helper(entity).__originalEntityData ? ChangeSetType.UPDATE : ChangeSetType.CREATE;
     const map = new Map<T, [string, unknown][]>();
 
     // Execute `onCreate` and `onUpdate` on properties recursively, saves `onUpdate` results
@@ -36,10 +37,10 @@ export class ChangeSetComputer {
     }
 
     const changeSet = new ChangeSet(entity, type, this.computePayload(entity), meta);
-    changeSet.originalEntity = entity.__helper!.__originalEntityData;
+    changeSet.originalEntity = helper(entity).__originalEntityData;
 
     if (this.config.get('validate')) {
-      this.validator.validate<T>(changeSet.entity, changeSet.payload, meta);
+      this.validator.validate(changeSet.entity, changeSet.payload, meta);
     }
 
     for (const prop of meta.relations) {
@@ -76,7 +77,7 @@ export class ChangeSetComputer {
   /**
    * Traverses entity graph and executes `onCreate` and `onUpdate` methods, assigning the values to given properties.
    */
-  private processPropertyInitializers<T extends AnyEntity<T>>(entity: T, prop: EntityProperty<T>, type: ChangeSetType, map: Map<T, [string, unknown][]>, nested?: boolean): void {
+  private processPropertyInitializers<T>(entity: T, prop: EntityProperty<T>, type: ChangeSetType, map: Map<T, [string, unknown][]>, nested?: boolean): void {
     if (prop.onCreate && type === ChangeSetType.CREATE && entity[prop.name] == null) {
       entity[prop.name] = prop.onCreate(entity);
     }
@@ -94,10 +95,10 @@ export class ChangeSetComputer {
     }
   }
 
-  private computePayload<T extends AnyEntity<T>>(entity: T, ignoreUndefined = false): EntityData<T> {
+  private computePayload<T>(entity: T, ignoreUndefined = false): EntityData<T> {
     const data = this.comparator.prepareEntity(entity);
-    const entityName = entity.__meta!.root.className;
-    const originalEntityData = entity.__helper!.__originalEntityData;
+    const entityName = helper(entity).__meta!.root.className;
+    const originalEntityData = helper(entity).__originalEntityData;
 
     if (originalEntityData) {
       const comparator = this.comparator.getEntityComparator(entityName);
@@ -115,9 +116,9 @@ export class ChangeSetComputer {
     return data;
   }
 
-  private processProperty<T extends AnyEntity<T>>(changeSet: ChangeSet<T>, prop: EntityProperty<T>, target?: unknown): void {
+  private processProperty<T>(changeSet: ChangeSet<T>, prop: EntityProperty<T>, target?: unknown): void {
     if (!target) {
-      const targets = Utils.unwrapProperty(changeSet.entity, changeSet.entity.__meta!, prop);
+      const targets = Utils.unwrapProperty(changeSet.entity, changeSet.meta, prop);
       targets.forEach(([t]) => this.processProperty(changeSet, prop, t));
 
       if (targets.length === 0) {
@@ -138,14 +139,14 @@ export class ChangeSetComputer {
     }
   }
 
-  private processToOne<T extends AnyEntity<T>>(prop: EntityProperty<T>, changeSet: ChangeSet<T>): void {
+  private processToOne<T>(prop: EntityProperty<T>, changeSet: ChangeSet<T>): void {
     const isToOneOwner = prop.reference === ReferenceType.MANY_TO_ONE || (prop.reference === ReferenceType.ONE_TO_ONE && prop.owner);
 
     if (!isToOneOwner || prop.mapToPk) {
       return;
     }
 
-    const targets = Utils.unwrapProperty(changeSet.entity, changeSet.entity.__meta!, prop) as [AnyEntity, number[]][];
+    const targets = Utils.unwrapProperty(changeSet.entity, changeSet.meta, prop) as [AnyEntity, number[]][];
 
     targets.forEach(([target, idx]) => {
       if (!target.__helper!.hasPrimaryKey()) {
@@ -154,7 +155,7 @@ export class ChangeSetComputer {
     });
   }
 
-  private processToMany<T extends AnyEntity<T>>(prop: EntityProperty<T>, changeSet: ChangeSet<T>): void {
+  private processToMany<T>(prop: EntityProperty<T>, changeSet: ChangeSet<T>): void {
     const target = changeSet.entity[prop.name] as unknown as Collection<any>;
 
     if (!target.isDirty()) {

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -1,7 +1,7 @@
 import type { MetadataStorage } from '../metadata';
 import type { AnyEntity, Dictionary, EntityData, EntityMetadata, EntityProperty, FilterQuery, IHydrator, IPrimaryKey } from '../typings';
-import type { EntityFactory, EntityValidator } from '../entity';
-import { EntityIdentifier } from '../entity';
+import type { EntityFactory, EntityValidator, Collection } from '../entity';
+import { EntityIdentifier, helper } from '../entity';
 import type { ChangeSet } from './ChangeSet';
 import { ChangeSetType } from './ChangeSet';
 import type { QueryResult } from '../connections';
@@ -22,7 +22,7 @@ export class ChangeSetPersister {
               private readonly validator: EntityValidator,
               private readonly config: Configuration) { }
 
-  async executeInserts<T extends AnyEntity<T>>(changeSets: ChangeSet<T>[], options?: DriverMethodOptions, withSchema?: boolean): Promise<void> {
+  async executeInserts<T extends object>(changeSets: ChangeSet<T>[], options?: DriverMethodOptions, withSchema?: boolean): Promise<void> {
     if (!withSchema) {
       return this.runForEachSchema(changeSets, 'executeInserts', options);
     }
@@ -39,7 +39,7 @@ export class ChangeSetPersister {
     }
   }
 
-  async executeUpdates<T extends AnyEntity<T>>(changeSets: ChangeSet<T>[], batched: boolean, options?: DriverMethodOptions, withSchema?: boolean): Promise<void> {
+  async executeUpdates<T extends object>(changeSets: ChangeSet<T>[], batched: boolean, options?: DriverMethodOptions, withSchema?: boolean): Promise<void> {
     if (!withSchema) {
       return this.runForEachSchema(changeSets, 'executeUpdates', options, batched);
     }
@@ -56,13 +56,13 @@ export class ChangeSetPersister {
     }
   }
 
-  async executeDeletes<T extends AnyEntity<T>>(changeSets: ChangeSet<T>[], options?: DriverMethodOptions, withSchema?: boolean): Promise<void> {
+  async executeDeletes<T extends object>(changeSets: ChangeSet<T>[], options?: DriverMethodOptions, withSchema?: boolean): Promise<void> {
     if (!withSchema) {
       return this.runForEachSchema(changeSets, 'executeDeletes', options);
     }
 
     const size = this.config.get('batchSize');
-    const meta = changeSets[0].entity.__meta!;
+    const meta = changeSets[0].meta;
     const pk = Utils.getPrimaryKeyHash(meta.primaryKeys);
 
     for (let i = 0; i < changeSets.length; i += size) {
@@ -73,7 +73,7 @@ export class ChangeSetPersister {
     }
   }
 
-  private async runForEachSchema<T extends AnyEntity<T>>(changeSets: ChangeSet<T>[], method: string, options?: DriverMethodOptions, ...args: unknown[]): Promise<void> {
+  private async runForEachSchema<T extends object>(changeSets: ChangeSet<T>[], method: string, options?: DriverMethodOptions, ...args: unknown[]): Promise<void> {
     const groups = new Map<string, ChangeSet<T>[]>();
     changeSets.forEach(cs => {
       const group = groups.get(cs.schema!) ?? [];
@@ -87,7 +87,7 @@ export class ChangeSetPersister {
     }
   }
 
-  private processProperties<T extends AnyEntity<T>>(changeSet: ChangeSet<T>): void {
+  private processProperties<T extends object>(changeSet: ChangeSet<T>): void {
     const meta = this.metadata.find(changeSet.name)!;
 
     for (const prop of meta.props) {
@@ -99,8 +99,8 @@ export class ChangeSetPersister {
     }
   }
 
-  private async persistNewEntity<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSet: ChangeSet<T>, options?: DriverMethodOptions): Promise<void> {
-    const wrapped = changeSet.entity.__helper!;
+  private async persistNewEntity<T extends object>(meta: EntityMetadata<T>, changeSet: ChangeSet<T>, options?: DriverMethodOptions): Promise<void> {
+    const wrapped = helper(changeSet.entity);
     options = this.propagateSchemaFromMetadata(meta, options, {
       convertCustomTypes: false,
     });
@@ -122,7 +122,7 @@ export class ChangeSetPersister {
     changeSet.persisted = true;
   }
 
-  private async persistNewEntities<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], options?: DriverMethodOptions): Promise<void> {
+  private async persistNewEntities<T extends object>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], options?: DriverMethodOptions): Promise<void> {
     const size = this.config.get('batchSize');
 
     for (let i = 0; i < changeSets.length; i += size) {
@@ -135,7 +135,7 @@ export class ChangeSetPersister {
     }
   }
 
-  private propagateSchemaFromMetadata<T>(meta: EntityMetadata<T>, options?: DriverMethodOptions, additionalOptions?: Dictionary): DriverMethodOptions {
+  private propagateSchemaFromMetadata<T extends object>(meta: EntityMetadata<T>, options?: DriverMethodOptions, additionalOptions?: Dictionary): DriverMethodOptions {
     return {
       ...options,
       ...additionalOptions,
@@ -143,7 +143,7 @@ export class ChangeSetPersister {
     };
   }
 
-  private async persistNewEntitiesBatch<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], options?: DriverMethodOptions): Promise<void> {
+  private async persistNewEntitiesBatch<T extends object>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], options?: DriverMethodOptions): Promise<void> {
     options = this.propagateSchemaFromMetadata(meta, options, {
       convertCustomTypes: false,
       processCollections: false,
@@ -152,7 +152,7 @@ export class ChangeSetPersister {
 
     for (let i = 0; i < changeSets.length; i++) {
       const changeSet = changeSets[i];
-      const wrapped = changeSet.entity.__helper!;
+      const wrapped = helper(changeSet.entity);
 
       if (!wrapped.hasPrimaryKey()) {
         const field = meta.getPrimaryProps()[0].fieldNames[0];
@@ -167,7 +167,7 @@ export class ChangeSetPersister {
     }
   }
 
-  private async persistManagedEntity<T extends AnyEntity<T>>(changeSet: ChangeSet<T>, options?: DriverMethodOptions): Promise<void> {
+  private async persistManagedEntity<T extends object>(changeSet: ChangeSet<T>, options?: DriverMethodOptions): Promise<void> {
     const meta = this.metadata.find(changeSet.name)!;
     const res = await this.updateEntity(meta, changeSet, options);
     this.checkOptimisticLock(meta, changeSet, res);
@@ -175,7 +175,7 @@ export class ChangeSetPersister {
     changeSet.persisted = true;
   }
 
-  private async persistManagedEntities<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], options?: DriverMethodOptions): Promise<void> {
+  private async persistManagedEntities<T extends object>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], options?: DriverMethodOptions): Promise<void> {
     const size = this.config.get('batchSize');
 
     for (let i = 0; i < changeSets.length; i += size) {
@@ -185,7 +185,7 @@ export class ChangeSetPersister {
     }
   }
 
-  private checkConcurrencyKeys<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSet: ChangeSet<T>, cond: Dictionary): void {
+  private checkConcurrencyKeys<T extends object>(meta: EntityMetadata<T>, changeSet: ChangeSet<T>, cond: Dictionary): void {
     const tmp: string[] = [];
     cond = Utils.isPlainObject(cond) ? cond : { [meta.primaryKeys[0]]: cond };
 
@@ -202,7 +202,7 @@ export class ChangeSetPersister {
     }
   }
 
-  private async persistManagedEntitiesBatch<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], options?: DriverMethodOptions): Promise<void> {
+  private async persistManagedEntitiesBatch<T extends object>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], options?: DriverMethodOptions): Promise<void> {
     await this.checkOptimisticLocks(meta, changeSets, options);
     options = this.propagateSchemaFromMetadata(meta, options, {
       convertCustomTypes: false,
@@ -218,10 +218,10 @@ export class ChangeSetPersister {
     changeSets.forEach(cs => cs.persisted = true);
   }
 
-  private mapPrimaryKey<T extends AnyEntity<T>>(meta: EntityMetadata<T>, value: IPrimaryKey, changeSet: ChangeSet<T>): void {
+  private mapPrimaryKey<T extends object>(meta: EntityMetadata<T>, value: IPrimaryKey, changeSet: ChangeSet<T>): void {
     const prop = meta.properties[meta.primaryKeys[0]];
     const insertId = prop.customType ? prop.customType.convertToJSValue(value, this.platform) : value;
-    const wrapped = changeSet.entity.__helper!;
+    const wrapped = helper(changeSet.entity);
 
     if (!wrapped.hasPrimaryKey()) {
       wrapped.setPrimaryKey(insertId);
@@ -238,26 +238,26 @@ export class ChangeSetPersister {
   /**
    * Sets populate flag to new entities so they are serialized like if they were loaded from the db
    */
-  private markAsPopulated<T extends AnyEntity<T>>(changeSet: ChangeSet<T>, meta: EntityMetadata<T>) {
-    changeSet.entity.__helper!.__schema = this.driver.getSchemaName(meta, changeSet);
+  private markAsPopulated<T extends object>(changeSet: ChangeSet<T>, meta: EntityMetadata<T>) {
+    helper(changeSet.entity).__schema = this.driver.getSchemaName(meta, changeSet);
 
     if (!this.config.get('populateAfterFlush')) {
       return;
     }
 
-    changeSet.entity.__helper!.populated();
+    helper(changeSet.entity).populated();
     meta.relations.forEach(prop => {
       const value = changeSet.entity[prop.name];
 
       if (Utils.isEntity(value, true)) {
         (value as AnyEntity).__helper!.populated();
       } else if (Utils.isCollection(value)) {
-        value.populated();
+        (value as Collection<any>).populated();
       }
     });
   }
 
-  private async updateEntity<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSet: ChangeSet<T>, options?: DriverMethodOptions): Promise<QueryResult<T>> {
+  private async updateEntity<T extends object>(meta: EntityMetadata<T>, changeSet: ChangeSet<T>, options?: DriverMethodOptions): Promise<QueryResult<T>> {
     options = this.propagateSchemaFromMetadata(meta, options, {
       convertCustomTypes: false,
     });
@@ -277,7 +277,7 @@ export class ChangeSetPersister {
     return this.driver.nativeUpdate<T>(changeSet.name, cond as FilterQuery<T>, changeSet.payload, options);
   }
 
-  private async checkOptimisticLocks<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], options?: DriverMethodOptions): Promise<void> {
+  private async checkOptimisticLocks<T extends object>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], options?: DriverMethodOptions): Promise<void> {
     if (meta.concurrencyCheckKeys.size === 0 && (!meta.versionProperty || changeSets.every(cs => !cs.entity[meta.versionProperty]))) {
       return;
     }
@@ -307,7 +307,7 @@ export class ChangeSetPersister {
     }
   }
 
-  private checkOptimisticLock<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSet: ChangeSet<T>, res?: QueryResult) {
+  private checkOptimisticLock<T extends object>(meta: EntityMetadata<T>, changeSet: ChangeSet<T>, res?: QueryResult) {
     if ((meta.versionProperty || meta.concurrencyCheckKeys.size > 0) && res && !res.affectedRows) {
       throw OptimisticLockError.lockFailed(changeSet.entity);
     }
@@ -317,7 +317,7 @@ export class ChangeSetPersister {
    * This method also handles reloading of database default values for inserts, so we use
    * a single query in case of both versioning and default values is used.
    */
-  private async reloadVersionValues<T extends AnyEntity<T>>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], options?: DriverMethodOptions) {
+  private async reloadVersionValues<T extends object>(meta: EntityMetadata<T>, changeSets: ChangeSet<T>[], options?: DriverMethodOptions) {
     const reloadProps = meta.versionProperty ? [meta.properties[meta.versionProperty]] : [];
 
     if (changeSets[0].type === ChangeSetType.CREATE) {
@@ -330,7 +330,7 @@ export class ChangeSetPersister {
     }
 
     const pk = Utils.getPrimaryKeyHash(meta.primaryKeys);
-    const pks = changeSets.map(cs => cs.entity.__helper!.getPrimaryKey());
+    const pks = changeSets.map(cs => helper(cs.entity).getPrimaryKey());
     options = this.propagateSchemaFromMetadata(meta, options, {
       fields: reloadProps.map(prop => prop.fieldNames[0]),
     });
@@ -339,12 +339,12 @@ export class ChangeSetPersister {
     data.forEach(item => map.set(Utils.getCompositeKeyHash(item, meta, true, this.platform), item));
 
     for (const changeSet of changeSets) {
-      const data = map.get(changeSet.entity.__helper!.getSerializedPrimaryKey());
+      const data = map.get(helper(changeSet.entity).getSerializedPrimaryKey());
       this.hydrator.hydrate<T>(changeSet.entity, meta, data as EntityData<T>, this.factory, 'returning', false, true);
     }
   }
 
-  private processProperty<T extends AnyEntity<T>>(changeSet: ChangeSet<T>, prop: EntityProperty<T>): void {
+  private processProperty<T extends object>(changeSet: ChangeSet<T>, prop: EntityProperty<T>): void {
     const meta = this.metadata.find(changeSet.name)!;
     const values = Utils.unwrapProperty(changeSet.payload, meta, prop, true); // for object embeddables
     const value = changeSet.payload[prop.name] as unknown; // for inline embeddables
@@ -369,10 +369,10 @@ export class ChangeSetPersister {
    * No need to handle composite keys here as they need to be set upfront.
    * We do need to map to the change set payload too, as it will be used in the originalEntityData for new entities.
    */
-  private mapReturnedValues<T extends AnyEntity<T>>(changeSet: ChangeSet<T>, res: QueryResult<T>, meta: EntityMetadata<T>): void {
+  private mapReturnedValues<T extends object>(changeSet: ChangeSet<T>, res: QueryResult<T>, meta: EntityMetadata<T>): void {
     if (this.platform.usesReturningStatement() && res.row && Utils.hasObjectKeys(res.row)) {
       const data = meta.props.reduce((ret, prop) => {
-        if (prop.primary && !changeSet.entity.__helper!.hasPrimaryKey()) {
+        if (prop.primary && !helper(changeSet.entity).hasPrimaryKey()) {
           this.mapPrimaryKey(meta, res.row![prop.fieldNames[0]], changeSet);
           return ret;
         }
@@ -385,7 +385,7 @@ export class ChangeSetPersister {
       }, {} as Dictionary);
 
       if (Utils.hasObjectKeys(data)) {
-        this.hydrator.hydrate<T>(changeSet.entity, meta, data as EntityData<T>, this.factory, 'returning', false, true);
+        this.hydrator.hydrate(changeSet.entity, meta, data as EntityData<T>, this.factory, 'returning', false, true);
       }
     }
   }

--- a/packages/core/src/unit-of-work/IdentityMap.ts
+++ b/packages/core/src/unit-of-work/IdentityMap.ts
@@ -4,12 +4,12 @@ export class IdentityMap {
 
   private readonly registry = new Map<Constructor<AnyEntity>, Map<string, AnyEntity>>();
 
-  store<T extends AnyEntity<T>>(item: T) {
-    this.getStore(item.__meta!.root).set(this.getPkHash(item), item);
+  store<T>(item: T) {
+    this.getStore((item as AnyEntity).__meta!.root).set(this.getPkHash(item), item);
   }
 
-  delete<T extends AnyEntity<T>>(item: T) {
-    this.getStore(item.__meta!.root).delete(this.getPkHash(item));
+  delete<T>(item: T) {
+    this.getStore((item as AnyEntity).__meta!.root).delete(this.getPkHash(item));
   }
 
   getByHash<T>(meta: EntityMetadata<T>, hash: string): T | undefined {
@@ -17,15 +17,15 @@ export class IdentityMap {
     return store.has(hash) ? store.get(hash) : undefined;
   }
 
-  getStore<T extends AnyEntity<T>>(meta: EntityMetadata<T>): Map<string, T> {
-    const store = this.registry.get(meta.class) as Map<string, T>;
+  getStore<T>(meta: EntityMetadata<T>): Map<string, T> {
+    const store = this.registry.get(meta.class as Constructor<AnyEntity>) as Map<string, T>;
 
     if (store) {
       return store;
     }
 
     const newStore = new Map();
-    this.registry.set(meta.class, newStore);
+    this.registry.set(meta.class as Constructor<AnyEntity>, newStore);
 
     return newStore;
   }
@@ -77,9 +77,9 @@ export class IdentityMap {
     return store.has(id) ? store.get(id) : undefined;
   }
 
-  private getPkHash<T extends AnyEntity<T>>(item: T): string {
-    const pkHash = item.__helper!.getSerializedPrimaryKey();
-    const schema = item.__helper!.__schema || item.__meta!.root.schema;
+  private getPkHash<T>(item: T): string {
+    const pkHash = (item as AnyEntity).__helper!.getSerializedPrimaryKey();
+    const schema = (item as AnyEntity).__helper!.__schema || (item as AnyEntity).__meta!.root.schema;
 
     if (schema) {
       return schema + ':' + pkHash;

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -3,7 +3,7 @@ import { inspect } from 'util';
 import type { NamingStrategy } from '../naming-strategy';
 import type { CacheAdapter } from '../cache';
 import { FileCacheAdapter, NullCacheAdapter } from '../cache';
-import type { EntityRepository } from '../entity';
+import type { EntityRepository } from '../entity/EntityRepository';
 import type {
   AnyEntity,
   Constructor,

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -1,5 +1,5 @@
 import { clone } from './clone';
-import type { AnyEntity, EntityData, EntityDictionary, EntityMetadata, EntityProperty, IMetadataStorage, Primary } from '../typings';
+import type { Dictionary, EntityData, EntityDictionary, EntityMetadata, EntityProperty, IMetadataStorage, Primary } from '../typings';
 import { ReferenceType } from '../enums';
 import type { Platform } from '../platforms';
 import { compareArrays, compareBuffers, compareObjects, equals, Utils } from './Utils';
@@ -35,15 +35,15 @@ export class EntityComparator {
    * Removes ORM specific code from entities and prepares it for serializing. Used before change set computation.
    * References will be mapped to primary keys, collections to arrays of primary keys.
    */
-  prepareEntity<T extends AnyEntity<T>>(entity: T): EntityData<T> {
-    const generator = this.getSnapshotGenerator<T>(entity.constructor.name);
+  prepareEntity<T>(entity: T): EntityData<T> {
+    const generator = this.getSnapshotGenerator<T>((entity as Dictionary).constructor.name);
     return Utils.callCompiledFunction(generator, entity);
   }
 
   /**
    * Maps database columns to properties.
    */
-  mapResult<T extends AnyEntity<T>>(entityName: string, result: EntityDictionary<T>): EntityData<T> | null {
+  mapResult<T>(entityName: string, result: EntityDictionary<T>): EntityData<T> | null {
     const mapper = this.getResultMapper<T>(entityName);
     return Utils.callCompiledFunction(mapper, result);
   }
@@ -51,7 +51,7 @@ export class EntityComparator {
   /**
    * @internal Highly performance-sensitive method.
    */
-  getPkGetter<T extends AnyEntity<T>>(meta: EntityMetadata<T>) {
+  getPkGetter<T>(meta: EntityMetadata<T>) {
     const exists = this.pkGetters.get(meta.className);
 
     /* istanbul ignore next */
@@ -95,7 +95,7 @@ export class EntityComparator {
   /**
    * @internal Highly performance-sensitive method.
    */
-  getPkGetterConverted<T extends AnyEntity<T>>(meta: EntityMetadata<T>) {
+  getPkGetterConverted<T>(meta: EntityMetadata<T>) {
     const exists = this.pkGettersConverted.get(meta.className);
 
     /* istanbul ignore next */
@@ -144,7 +144,7 @@ export class EntityComparator {
   /**
    * @internal Highly performance-sensitive method.
    */
-  getPkSerializer<T extends AnyEntity<T>>(meta: EntityMetadata<T>) {
+  getPkSerializer<T>(meta: EntityMetadata<T>) {
     const exists = this.pkSerializers.get(meta.className);
 
     /* istanbul ignore next */
@@ -187,7 +187,7 @@ export class EntityComparator {
   /**
    * @internal Highly performance-sensitive method.
    */
-  getSnapshotGenerator<T extends AnyEntity<T>>(entityName: string): SnapshotGenerator<T> {
+  getSnapshotGenerator<T>(entityName: string): SnapshotGenerator<T> {
     const exists = this.snapshotGenerators.get(entityName);
 
     if (exists) {
@@ -224,7 +224,7 @@ export class EntityComparator {
   /**
    * @internal Highly performance-sensitive method.
    */
-  getResultMapper<T extends AnyEntity<T>>(entityName: string): ResultMapper<T> {
+  getResultMapper<T>(entityName: string): ResultMapper<T> {
     const exists = this.mappers.get(entityName);
 
     if (exists) {
@@ -460,7 +460,7 @@ export class EntityComparator {
   /**
    * @internal Highly performance-sensitive method.
    */
-  getEntityComparator<T>(entityName: string): Comparator<T> {
+  getEntityComparator<T extends object>(entityName: string): Comparator<T> {
     const exists = this.comparators.get(entityName);
 
     if (exists) {
@@ -555,7 +555,7 @@ export class EntityComparator {
   /**
    * perf: used to generate list of comparable properties during discovery, so we speed up the runtime comparison
    */
-  static isComparable<T extends AnyEntity<T>>(prop: EntityProperty<T>, root: EntityMetadata) {
+  static isComparable<T>(prop: EntityProperty<T>, root: EntityMetadata) {
     const virtual = prop.persist === false;
     const inverse = prop.reference === ReferenceType.ONE_TO_ONE && !prop.owner;
     const discriminator = prop.name === root.discriminatorColumn;

--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -1,10 +1,11 @@
 import { Reference } from '../entity/Reference';
 import { Utils } from './Utils';
-import type { AnyEntity, Dictionary, EntityMetadata, EntityProperty, FilterDef, ObjectQuery, FilterQuery } from '../typings';
+import type { Dictionary, EntityMetadata, EntityProperty, FilterDef, ObjectQuery, FilterQuery } from '../typings';
 import { ARRAY_OPERATORS, GroupOperator, ReferenceType } from '../enums';
 import type { Platform } from '../platforms';
 import type { MetadataStorage } from '../metadata/MetadataStorage';
 import { JsonType } from '../types/JsonType';
+import { helper } from '../entity/wrap';
 
 export class QueryHelper {
 
@@ -16,11 +17,11 @@ export class QueryHelper {
     }
 
     if (Utils.isEntity(params)) {
-      if (params.__meta!.compositePK) {
-        return params.__helper!.__primaryKeys;
+      if (helper(params).__meta.compositePK) {
+        return helper(params).__primaryKeys;
       }
 
-      return params.__helper!.getPrimaryKey();
+      return helper(params).getPrimaryKey();
     }
 
     if (params === undefined) {
@@ -28,7 +29,7 @@ export class QueryHelper {
     }
 
     if (Array.isArray(params)) {
-      return params.map(item => QueryHelper.processParams(item));
+      return (params as unknown[]).map(item => QueryHelper.processParams(item));
     }
 
     if (Utils.isPlainObject(params)) {
@@ -46,7 +47,7 @@ export class QueryHelper {
     return params;
   }
 
-  static inlinePrimaryKeyObjects<T extends AnyEntity<T>>(where: Dictionary, meta: EntityMetadata<T>, metadata: MetadataStorage, key?: string): boolean {
+  static inlinePrimaryKeyObjects<T extends object>(where: Dictionary, meta: EntityMetadata<T>, metadata: MetadataStorage, key?: string): boolean {
     if (Array.isArray(where)) {
       where.forEach((item, i) => {
         if (this.inlinePrimaryKeyObjects(item, meta, metadata, key)) {
@@ -84,7 +85,7 @@ export class QueryHelper {
     return false;
   }
 
-  static processWhere<T>(options: ProcessWhereOptions<T>): FilterQuery<T> {
+  static processWhere<T extends object>(options: ProcessWhereOptions<T>): FilterQuery<T> {
     // eslint-disable-next-line prefer-const
     let { where, entityName, metadata, platform, aliased = true, convertCustomTypes = true, root = true } = options;
     const meta = metadata.find<T>(entityName);

--- a/packages/knex/package.json
+++ b/packages/knex/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "fs-extra": "10.1.0",
-    "knex": "2.2.0",
+    "knex": "2.3.0",
     "sqlstring": "2.3.3"
   },
   "devDependencies": {

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -5,7 +5,7 @@ import type {
   FindOneOptions, FindOptions, IDatabaseDriver, LockOptions, NativeInsertUpdateManyOptions, NativeInsertUpdateOptions,
   PopulateOptions, Primary, QueryOrderMap, QueryResult, RequiredEntityData, Transaction,
 } from '@mikro-orm/core';
-import { DatabaseDriver, EntityManagerType, LoadStrategy, QueryFlag, QueryHelper, ReferenceType, Utils } from '@mikro-orm/core';
+import { DatabaseDriver, EntityManagerType, helper, LoadStrategy, QueryFlag, QueryHelper, ReferenceType, Utils } from '@mikro-orm/core';
 import type { AbstractSqlConnection } from './AbstractSqlConnection';
 import type { AbstractSqlPlatform } from './AbstractSqlPlatform';
 import { QueryBuilder } from './query/QueryBuilder';
@@ -36,7 +36,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return new SqlEntityManager(this.config, this, this.metadata, useContext) as unknown as EntityManager<D>;
   }
 
-  async find<T, P extends string = never>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, P> = {}): Promise<EntityData<T>[]> {
+  async find<T extends object, P extends string = never>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, P> = {}): Promise<EntityData<T>[]> {
     options = { populate: [], orderBy: [], ...options };
     const meta = this.metadata.find<T>(entityName)!;
 
@@ -80,7 +80,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return result;
   }
 
-  async findOne<T, P extends string = never>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T, P>): Promise<EntityData<T> | null> {
+  async findOne<T extends object, P extends string = never>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T, P>): Promise<EntityData<T> | null> {
     const opts = { populate: [], ...(options || {}) } as FindOptions<T>;
     const meta = this.metadata.find(entityName)!;
     const populate = this.autoJoinOneToOneOwner(meta, opts.populate as unknown as PopulateOptions<T>[], opts.fields);
@@ -100,7 +100,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return res[0] || null;
   }
 
-  async findVirtual<T>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, any>): Promise<EntityData<T>[]> {
+  async findVirtual<T extends object>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, any>): Promise<EntityData<T>[]> {
     const meta = this.metadata.get<T>(entityName);
 
     /* istanbul ignore next */
@@ -123,7 +123,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return res as EntityData<T>[];
   }
 
-  async countVirtual<T>(entityName: string, where: FilterQuery<T>, options: CountOptions<T>): Promise<number> {
+  async countVirtual<T extends object>(entityName: string, where: FilterQuery<T>, options: CountOptions<T>): Promise<number> {
     const meta = this.metadata.get<T>(entityName);
 
     /* istanbul ignore next */
@@ -146,10 +146,10 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return res as any;
   }
 
-  protected async wrapVirtualExpressionInSubquery<T>(meta: EntityMetadata<T>, expression: string, where: FilterQuery<T>, options: FindOptions<T, any>, type: QueryType.COUNT): Promise<number>;
-  protected async wrapVirtualExpressionInSubquery<T>(meta: EntityMetadata<T>, expression: string, where: FilterQuery<T>, options: FindOptions<T, any>, type: QueryType.SELECT): Promise<T[]>;
-  protected async wrapVirtualExpressionInSubquery<T>(meta: EntityMetadata<T>, expression: string, where: FilterQuery<T>, options: FindOptions<T, any>): Promise<T[]>;
-  protected async wrapVirtualExpressionInSubquery<T>(meta: EntityMetadata<T>, expression: string, where: FilterQuery<T>, options: FindOptions<T, any>, type = QueryType.SELECT): Promise<unknown> {
+  protected async wrapVirtualExpressionInSubquery<T extends object>(meta: EntityMetadata<T>, expression: string, where: FilterQuery<T>, options: FindOptions<T, any>, type: QueryType.COUNT): Promise<number>;
+  protected async wrapVirtualExpressionInSubquery<T extends object>(meta: EntityMetadata<T>, expression: string, where: FilterQuery<T>, options: FindOptions<T, any>, type: QueryType.SELECT): Promise<T[]>;
+  protected async wrapVirtualExpressionInSubquery<T extends object>(meta: EntityMetadata<T>, expression: string, where: FilterQuery<T>, options: FindOptions<T, any>): Promise<T[]>;
+  protected async wrapVirtualExpressionInSubquery<T extends object>(meta: EntityMetadata<T>, expression: string, where: FilterQuery<T>, options: FindOptions<T, any>, type = QueryType.SELECT): Promise<unknown> {
     const qb = this.createQueryBuilder(meta.className, options?.ctx, options.connectionType, options.convertCustomTypes)
       .limit(options?.limit, options?.offset);
 
@@ -177,7 +177,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return res.map(row => this.mapResult(row, meta)!);
   }
 
-  mapResult<T>(result: EntityData<T>, meta: EntityMetadata<T>, populate: PopulateOptions<T>[] = [], qb?: QueryBuilder<T>, map: Dictionary = {}): EntityData<T> | null {
+  mapResult<T extends object>(result: EntityData<T>, meta: EntityMetadata<T>, populate: PopulateOptions<T>[] = [], qb?: QueryBuilder<T>, map: Dictionary = {}): EntityData<T> | null {
     const ret = super.mapResult(result, meta);
 
     /* istanbul ignore if */
@@ -192,7 +192,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return ret;
   }
 
-  private mapJoinedProps<T extends AnyEntity<T>>(result: EntityData<T>, meta: EntityMetadata<T>, populate: PopulateOptions<T>[], qb: QueryBuilder<T>, root: EntityData<T>, map: Dictionary, parentJoinPath?: string) {
+  private mapJoinedProps<T extends object>(result: EntityData<T>, meta: EntityMetadata<T>, populate: PopulateOptions<T>[], qb: QueryBuilder<T>, root: EntityData<T>, map: Dictionary, parentJoinPath?: string) {
     const joinedProps = this.joinedProps(meta, populate);
 
     joinedProps.forEach(p => {
@@ -256,7 +256,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     });
   }
 
-  private appendToCollection<T extends AnyEntity<T>>(meta: EntityMetadata<T>, collection: EntityData<T>[], relationPojo: EntityData<T>): void {
+  private appendToCollection<T extends object>(meta: EntityMetadata<T>, collection: EntityData<T>[], relationPojo: EntityData<T>): void {
     if (collection.length === 0) {
       return void collection.push(relationPojo);
     }
@@ -270,7 +270,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     }
   }
 
-  async count<T extends AnyEntity<T>>(entityName: string, where: any, options: CountOptions<T> = {}): Promise<number> {
+  async count<T extends object>(entityName: string, where: any, options: CountOptions<T> = {}): Promise<number> {
     const meta = this.metadata.find(entityName);
 
     if (meta?.virtual) {
@@ -287,7 +287,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return this.rethrow(qb.getCount());
   }
 
-  async nativeInsert<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>, options: NativeInsertUpdateOptions<T> = {}): Promise<QueryResult<T>> {
+  async nativeInsert<T extends object>(entityName: string, data: EntityDictionary<T>, options: NativeInsertUpdateOptions<T> = {}): Promise<QueryResult<T>> {
     options.convertCustomTypes ??= true;
     const meta = this.metadata.find<T>(entityName)!;
     const collections = this.extractManyToMany(entityName, data);
@@ -309,7 +309,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return res;
   }
 
-  async nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>[], options: NativeInsertUpdateManyOptions<T> = {}): Promise<QueryResult<T>> {
+  async nativeInsertMany<T extends object>(entityName: string, data: EntityDictionary<T>[], options: NativeInsertUpdateManyOptions<T> = {}): Promise<QueryResult<T>> {
     options.processCollections ??= true;
     options.convertCustomTypes ??= true;
     const meta = this.metadata.get<T>(entityName);
@@ -378,7 +378,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return res;
   }
 
-  async nativeUpdate<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>, data: EntityDictionary<T>, options: NativeInsertUpdateOptions<T> = {}): Promise<QueryResult<T>> {
+  async nativeUpdate<T extends object>(entityName: string, where: FilterQuery<T>, data: EntityDictionary<T>, options: NativeInsertUpdateOptions<T> = {}): Promise<QueryResult<T>> {
     options.convertCustomTypes ??= true;
     const meta = this.metadata.find<T>(entityName);
     const pks = this.getPrimaryKeyFields(entityName);
@@ -405,7 +405,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return res;
   }
 
-  async nativeUpdateMany<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T>[], data: EntityDictionary<T>[], options: NativeInsertUpdateManyOptions<T> = {}): Promise<QueryResult<T>> {
+  async nativeUpdateMany<T extends object>(entityName: string, where: FilterQuery<T>[], data: EntityDictionary<T>[], options: NativeInsertUpdateManyOptions<T> = {}): Promise<QueryResult<T>> {
     options.processCollections ??= true;
     options.convertCustomTypes ??= true;
     const meta = this.metadata.get<T>(entityName);
@@ -479,7 +479,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return res;
   }
 
-  async nativeDelete<T extends AnyEntity<T>>(entityName: string, where: FilterQuery<T> | string | any, options: DeleteOptions<T> = {}): Promise<QueryResult<T>> {
+  async nativeDelete<T extends object>(entityName: string, where: FilterQuery<T> | string | any, options: DeleteOptions<T> = {}): Promise<QueryResult<T>> {
     const meta = this.metadata.find(entityName);
     const pks = this.getPrimaryKeyFields(entityName);
 
@@ -492,14 +492,14 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return this.rethrow(qb.execute('run', false));
   }
 
-  async syncCollection<T extends AnyEntity<T>, O extends AnyEntity<O>>(coll: Collection<T, O>, options?: DriverMethodOptions): Promise<void> {
-    const wrapped = coll.owner.__helper!;
+  async syncCollection<T extends object, O extends object>(coll: Collection<T, O>, options?: DriverMethodOptions): Promise<void> {
+    const wrapped = helper(coll.owner);
     const meta = wrapped.__meta;
     const pks = wrapped.getPrimaryKeys(true)!;
     const snap = coll.getSnapshot();
     const includes = <T>(arr: T[], item: T) => !!arr.find(i => Utils.equals(i, item));
-    const snapshot = snap ? snap.map(item => item.__helper!.getPrimaryKeys(true)!) : [];
-    const current = coll.getItems(false).map(item => item.__helper!.getPrimaryKeys(true)!);
+    const snapshot = snap ? snap.map(item => helper(item).getPrimaryKeys(true)!) : [];
+    const current = coll.getItems(false).map(item => helper(item).getPrimaryKeys(true)!);
     const deleteDiff = snap ? snapshot.filter(item => !includes(current, item)) : true;
     const insertDiff = current.filter(item => !includes(snapshot, item));
     const target = snapshot.filter(item => includes(current, item)).concat(...insertDiff);
@@ -537,7 +537,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return this.rethrow(this.updateCollectionDiff<T, O>(meta, coll.property, pks, deleteDiff, insertDiff, options));
   }
 
-  async loadFromPivotTable<T, O>(prop: EntityProperty, owners: Primary<O>[][], where: FilterQuery<T> = {} as FilterQuery<T>, orderBy?: QueryOrderMap<T>[], ctx?: Transaction, options?: FindOptions<T>): Promise<Dictionary<T[]>> {
+  async loadFromPivotTable<T extends object, O extends object>(prop: EntityProperty, owners: Primary<O>[][], where: FilterQuery<any> = {} as FilterQuery<any>, orderBy?: QueryOrderMap<T>[], ctx?: Transaction, options?: FindOptions<T, any>): Promise<Dictionary<T[]>> {
     const pivotProp2 = this.getPivotInverseProperty(prop);
     const ownerMeta = this.metadata.find(pivotProp2.type)!;
     const pivotMeta = this.metadata.find(prop.pivotEntity)!;
@@ -603,7 +603,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
   /**
    * 1:1 owner side needs to be marked for population so QB auto-joins the owner id
    */
-  protected autoJoinOneToOneOwner<T, P extends string = never>(meta: EntityMetadata, populate: PopulateOptions<T>[], fields: readonly EntityField<T, P>[] = []): PopulateOptions<T>[] {
+  protected autoJoinOneToOneOwner<T extends object, P extends string = never>(meta: EntityMetadata, populate: PopulateOptions<T>[], fields: readonly EntityField<T, P>[] = []): PopulateOptions<T>[] {
     if (!this.config.get('autoJoinOneToOneOwner')) {
       return populate;
     }
@@ -627,7 +627,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
   /**
    * @internal
    */
-  mergeJoinedResult<T extends AnyEntity<T>>(rawResults: EntityData<T>[], meta: EntityMetadata<T>): EntityData<T>[] {
+  mergeJoinedResult<T extends object>(rawResults: EntityData<T>[], meta: EntityMetadata<T>): EntityData<T>[] {
     // group by the root entity primary key first
     const map: Dictionary = {};
     const res: EntityData<T>[] = [];
@@ -645,7 +645,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return res;
   }
 
-  protected getFieldsForJoinedLoad<T extends AnyEntity<T>>(qb: QueryBuilder<T>, meta: EntityMetadata<T>, explicitFields?: Field<T>[], populate: PopulateOptions<T>[] = [], parentTableAlias?: string, parentJoinPath?: string): Field<T>[] {
+  protected getFieldsForJoinedLoad<T extends object>(qb: QueryBuilder<T>, meta: EntityMetadata<T>, explicitFields?: Field<T>[], populate: PopulateOptions<T>[] = [], parentTableAlias?: string, parentJoinPath?: string): Field<T>[] {
     const fields: Field<T>[] = [];
     const joinedProps = this.joinedProps(meta, populate);
 
@@ -690,7 +690,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
   /**
    * @internal
    */
-  mapPropToFieldNames<T extends AnyEntity<T>>(qb: QueryBuilder<T>, prop: EntityProperty<T>, tableAlias?: string): Field<T>[] {
+  mapPropToFieldNames<T extends object>(qb: QueryBuilder<T>, prop: EntityProperty<T>, tableAlias?: string): Field<T>[] {
     const aliased = qb.ref(tableAlias ? `${tableAlias}__${prop.fieldNames[0]}` : prop.fieldNames[0]).toString();
 
     if (prop.customType?.convertToJSValueSQL && tableAlias) {
@@ -711,7 +711,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
   }
 
   /** @internal */
-  createQueryBuilder<T extends AnyEntity<T>>(entityName: string, ctx?: Transaction<Knex.Transaction>, preferredConnectionType?: ConnectionType, convertCustomTypes?: boolean): QueryBuilder<T> {
+  createQueryBuilder<T extends object>(entityName: string, ctx?: Transaction<Knex.Transaction>, preferredConnectionType?: ConnectionType, convertCustomTypes?: boolean): QueryBuilder<T> {
     const connectionType = this.resolveConnectionType({ ctx, connectionType: preferredConnectionType });
     const qb = new QueryBuilder<T>(entityName, this.metadata, this, ctx, undefined, connectionType);
 
@@ -734,7 +734,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return 'write';
   }
 
-  protected extractManyToMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>): EntityData<T> {
+  protected extractManyToMany<T>(entityName: string, data: EntityDictionary<T>): EntityData<T> {
     if (!this.metadata.has(entityName)) {
       return {};
     }
@@ -751,7 +751,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return ret;
   }
 
-  protected async processManyToMany<T extends AnyEntity<T>>(meta: EntityMetadata<T> | undefined, pks: Primary<T>[], collections: EntityData<T>, clear: boolean, options?: DriverMethodOptions) {
+  protected async processManyToMany<T extends object>(meta: EntityMetadata<T> | undefined, pks: Primary<T>[], collections: EntityData<T>, clear: boolean, options?: DriverMethodOptions) {
     if (!meta) {
       return;
     }
@@ -763,7 +763,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     }
   }
 
-  protected async updateCollectionDiff<T extends AnyEntity<T>, O extends AnyEntity<O>>(
+  protected async updateCollectionDiff<T extends object, O extends object>(
     meta: EntityMetadata<O>,
     prop: EntityProperty<T>,
     pks: Primary<O>[],
@@ -815,15 +815,15 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     }
   }
 
-  async lockPessimistic<T extends AnyEntity<T>>(entity: T, options: LockOptions): Promise<void> {
-    const meta = entity.__helper!.__meta;
-    const qb = this.createQueryBuilder(entity.constructor.name, options.ctx).unsetFlag(QueryFlag.CONVERT_CUSTOM_TYPES).withSchema(options.schema ?? meta.schema);
+  async lockPessimistic<T>(entity: T, options: LockOptions): Promise<void> {
+    const meta = helper(entity).__meta;
+    const qb = this.createQueryBuilder((entity as object).constructor.name, options.ctx).unsetFlag(QueryFlag.CONVERT_CUSTOM_TYPES).withSchema(options.schema ?? meta.schema);
     const cond = Utils.getPrimaryKeyCond(entity, meta.primaryKeys);
     qb.select('1').where(cond!).setLockMode(options.lockMode, options.lockTableAliases);
     await this.rethrow(qb.execute());
   }
 
-  protected buildJoinedPropsOrderBy<T extends AnyEntity<T>>(entityName: string, qb: QueryBuilder<T>, meta: EntityMetadata<T>, populate: PopulateOptions<T>[], parentPath?: string): QueryOrderMap<T>[] {
+  protected buildJoinedPropsOrderBy<T extends object>(entityName: string, qb: QueryBuilder<T>, meta: EntityMetadata<T>, populate: PopulateOptions<T>[], parentPath?: string): QueryOrderMap<T>[] {
     const orderBy: QueryOrderMap<T>[] = [];
     const joinedProps = this.joinedProps(meta, populate);
 
@@ -848,7 +848,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
     return orderBy;
   }
 
-  protected buildFields<T extends AnyEntity<T>>(meta: EntityMetadata<T>, populate: PopulateOptions<T>[], joinedProps: PopulateOptions<T>[], qb: QueryBuilder<T>, fields?: Field<T>[]): Field<T>[] {
+  protected buildFields<T extends object>(meta: EntityMetadata<T>, populate: PopulateOptions<T>[], joinedProps: PopulateOptions<T>[], qb: QueryBuilder<T>, fields?: Field<T>[]): Field<T>[] {
     const lazyProps = meta.props.filter(prop => prop.lazy && !populate.some(p => p.field === prop.name || p.all));
     const hasLazyFormulas = meta.props.some(p => p.lazy && p.formula);
     const requiresSQLConversion = meta.props.some(p => p.customType?.convertToJSValueSQL);

--- a/packages/knex/src/AbstractSqlPlatform.ts
+++ b/packages/knex/src/AbstractSqlPlatform.ts
@@ -4,7 +4,6 @@ import { JsonProperty, Platform, Utils } from '@mikro-orm/core';
 import { SqlEntityRepository } from './SqlEntityRepository';
 import type { SchemaHelper } from './schema';
 import { SchemaGenerator } from './schema';
-import type { SqlEntityManager } from './SqlEntityManager';
 
 export abstract class AbstractSqlPlatform extends Platform {
 
@@ -18,15 +17,15 @@ export abstract class AbstractSqlPlatform extends Platform {
     return true;
   }
 
-  getRepositoryClass<T>(): Constructor<EntityRepository<T>> {
-    return SqlEntityRepository;
+  getRepositoryClass<T extends object>(): Constructor<EntityRepository<T>> {
+    return SqlEntityRepository as Constructor<EntityRepository<T>>;
   }
 
   getSchemaHelper(): SchemaHelper | undefined {
     return this.schemaHelper;
   }
 
-  getSchemaGenerator(driver: IDatabaseDriver, em?: SqlEntityManager): SchemaGenerator {
+  getSchemaGenerator(driver: IDatabaseDriver, em?: EntityManager): SchemaGenerator {
     /* istanbul ignore next */
     return this.config.getCachedService(SchemaGenerator, em ?? driver as any); // cast as `any` to get around circular dependencies
   }

--- a/packages/knex/src/SqlEntityManager.ts
+++ b/packages/knex/src/SqlEntityManager.ts
@@ -13,7 +13,7 @@ export class SqlEntityManager<D extends AbstractSqlDriver = AbstractSqlDriver> e
   /**
    * Creates a QueryBuilder instance
    */
-  createQueryBuilder<T>(entityName: EntityName<T>, alias?: string, type?: ConnectionType): QueryBuilder<T> {
+  createQueryBuilder<T extends object>(entityName: EntityName<T>, alias?: string, type?: ConnectionType): QueryBuilder<T> {
     entityName = Utils.className(entityName);
     const context = this.getContext();
 
@@ -23,7 +23,7 @@ export class SqlEntityManager<D extends AbstractSqlDriver = AbstractSqlDriver> e
   /**
    * Shortcut for `createQueryBuilder()`
    */
-  qb<T>(entityName: EntityName<T>, alias?: string, type?: ConnectionType) {
+  qb<T extends object>(entityName: EntityName<T>, alias?: string, type?: ConnectionType) {
     return this.createQueryBuilder(entityName, alias, type);
   }
 
@@ -48,7 +48,7 @@ export class SqlEntityManager<D extends AbstractSqlDriver = AbstractSqlDriver> e
     return this.getDriver().execute(queryOrKnex, params, method, this.getTransactionContext());
   }
 
-  getRepository<T extends AnyEntity<T>, U extends EntityRepository<T> = SqlEntityRepository<T>>(entityName: EntityName<T>): GetRepository<T, U> {
+  getRepository<T extends object, U extends EntityRepository<T> = SqlEntityRepository<T>>(entityName: EntityName<T>): GetRepository<T, U> {
     return super.getRepository<T, U>(entityName);
   }
 

--- a/packages/knex/src/SqlEntityRepository.ts
+++ b/packages/knex/src/SqlEntityRepository.ts
@@ -4,7 +4,8 @@ import { EntityRepository } from '@mikro-orm/core';
 import type { SqlEntityManager } from './SqlEntityManager';
 import type { QueryBuilder } from './query';
 
-export class SqlEntityRepository<T> extends EntityRepository<T> {
+// eslint-disable-next-line @typescript-eslint/ban-types
+export class SqlEntityRepository<T extends {}> extends EntityRepository<T> {
 
   constructor(protected readonly _em: SqlEntityManager,
               protected readonly entityName: EntityName<T>) {

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -30,7 +30,7 @@ import type { Field, JoinOptions } from '../typings';
  * const publisher = await qb.getSingleResult();
  * ```
  */
-export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
+export class QueryBuilder<T extends object = AnyEntity> {
 
   readonly alias: string;
 
@@ -175,7 +175,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     return this.joinAndSelect(field, alias, cond, 'leftJoin');
   }
 
-  protected getFieldsForJoinedLoad<U extends AnyEntity<U>>(prop: EntityProperty<U>, alias: string): Field<U>[] {
+  protected getFieldsForJoinedLoad<U extends object>(prop: EntityProperty<U>, alias: string): Field<U>[] {
     const fields: Field<U>[] = [];
     prop.targetMeta!.props
       .filter(prop => this.platform.shouldHaveColumn(prop, this._populate))
@@ -503,7 +503,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
       return mapped;
     }
 
-    const mapped = this.driver.mapResult(res as unknown as T, meta, this._populate, this) as unknown as U;
+    const mapped = this.driver.mapResult(res, meta, this._populate, this) as unknown as U;
     await this.em?.storeCache(this._cache, cached!, mapped);
 
     return mapped;
@@ -684,7 +684,7 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
     return prop;
   }
 
-  private prepareFields<T extends AnyEntity<T>, U extends string | Knex.Raw>(fields: Field<T>[], type: 'where' | 'groupBy' | 'sub-query' = 'where'): U[] {
+  private prepareFields<T, U extends string | Knex.Raw>(fields: Field<T>[], type: 'where' | 'groupBy' | 'sub-query' = 'where'): U[] {
     const ret: Field<T>[] = [];
 
     fields.forEach(field => {
@@ -953,13 +953,13 @@ export class QueryBuilder<T extends AnyEntity<T> = AnyEntity> {
 
 }
 
-export interface RunQueryBuilder<T> extends Omit<QueryBuilder<T>, 'getResult' | 'getSingleResult' | 'getResultList' | 'where'> {
+export interface RunQueryBuilder<T extends object> extends Omit<QueryBuilder<T>, 'getResult' | 'getSingleResult' | 'getResultList' | 'where'> {
   where(cond: QBFilterQuery<T> | string, params?: keyof typeof GroupOperator | any[], operator?: keyof typeof GroupOperator): this;
   execute<U = QueryResult<T>>(method?: 'all' | 'get' | 'run', mapResults?: boolean): Promise<U>;
   then<TResult1 = QueryResult<T>, TResult2 = never>(onfulfilled?: ((value: QueryResult<T>) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<QueryResult<T>>;
 }
 
-export interface SelectQueryBuilder<T> extends QueryBuilder<T> {
+export interface SelectQueryBuilder<T extends object> extends QueryBuilder<T> {
   execute<U = T[]>(method?: 'all' | 'get' | 'run', mapResults?: boolean): Promise<U>;
   execute<U = T[]>(method: 'all', mapResults?: boolean): Promise<U>;
   execute<U = T>(method: 'get', mapResults?: boolean): Promise<U>;
@@ -967,7 +967,7 @@ export interface SelectQueryBuilder<T> extends QueryBuilder<T> {
   then<TResult1 = T[], TResult2 = never>(onfulfilled?: ((value: T[]) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<T[]>;
 }
 
-export interface CountQueryBuilder<T> extends QueryBuilder<T> {
+export interface CountQueryBuilder<T extends object> extends QueryBuilder<T> {
   execute<U = { count: number }[]>(method?: 'all' | 'get' | 'run', mapResults?: boolean): Promise<U>;
   execute<U = { count: number }[]>(method: 'all', mapResults?: boolean): Promise<U>;
   execute<U = { count: number }>(method: 'get', mapResults?: boolean): Promise<U>;
@@ -975,10 +975,10 @@ export interface CountQueryBuilder<T> extends QueryBuilder<T> {
   then<TResult1 = number, TResult2 = never>(onfulfilled?: ((value: number) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<number>;
 }
 
-export interface InsertQueryBuilder<T> extends RunQueryBuilder<T> {}
+export interface InsertQueryBuilder<T extends object> extends RunQueryBuilder<T> {}
 
-export interface UpdateQueryBuilder<T> extends RunQueryBuilder<T> {}
+export interface UpdateQueryBuilder<T extends object> extends RunQueryBuilder<T> {}
 
-export interface DeleteQueryBuilder<T> extends RunQueryBuilder<T> {}
+export interface DeleteQueryBuilder<T extends object> extends RunQueryBuilder<T> {}
 
-export interface TruncateQueryBuilder<T> extends RunQueryBuilder<T> {}
+export interface TruncateQueryBuilder<T extends object> extends RunQueryBuilder<T> {}

--- a/packages/mariadb/src/MariaDbDriver.ts
+++ b/packages/mariadb/src/MariaDbDriver.ts
@@ -1,4 +1,4 @@
-import type { AnyEntity, Configuration, EntityDictionary, NativeInsertUpdateManyOptions, QueryResult } from '@mikro-orm/core';
+import type { Configuration, EntityDictionary, NativeInsertUpdateManyOptions, QueryResult } from '@mikro-orm/core';
 import { AbstractSqlDriver } from '@mikro-orm/knex';
 import { MariaDbConnection } from './MariaDbConnection';
 import { MariaDbPlatform } from './MariaDbPlatform';
@@ -9,7 +9,7 @@ export class MariaDbDriver extends AbstractSqlDriver<MariaDbConnection> {
     super(config, new MariaDbPlatform(), MariaDbConnection, ['knex', 'mariadb']);
   }
 
-  async nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>[], options: NativeInsertUpdateManyOptions<T> = {}): Promise<QueryResult<T>> {
+  async nativeInsertMany<T extends object>(entityName: string, data: EntityDictionary<T>[], options: NativeInsertUpdateManyOptions<T> = {}): Promise<QueryResult<T>> {
     options.processCollections ??= true;
     const res = await super.nativeInsertMany(entityName, data, options);
     const pks = this.getPrimaryKeyFields(entityName);

--- a/packages/migrations-mongodb/src/Migration.ts
+++ b/packages/migrations-mongodb/src/Migration.ts
@@ -1,6 +1,6 @@
 import type { Configuration, Transaction, EntityName } from '@mikro-orm/core';
 import type { MongoDriver } from '@mikro-orm/mongodb';
-import type { Collection, ClientSession } from 'mongodb';
+import type { Collection, ClientSession, Document } from 'mongodb';
 
 export abstract class Migration {
 
@@ -27,7 +27,7 @@ export abstract class Migration {
     this.ctx = ctx;
   }
 
-  getCollection<T>(entityName: EntityName<any>): Collection<T> {
+  getCollection<T extends Document>(entityName: EntityName<any>): Collection<T> {
     return this.driver.getConnection().getCollection(entityName);
   }
 

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@mikro-orm/knex": "^5.3.1",
     "fs-extra": "10.1.0",
-    "knex": "2.2.0",
+    "knex": "2.3.0",
     "umzug": "3.2.1"
   },
   "devDependencies": {

--- a/packages/mongodb/src/MongoEntityManager.ts
+++ b/packages/mongodb/src/MongoEntityManager.ts
@@ -1,8 +1,8 @@
-import type { AnyEntity, EntityName, EntityRepository, GetRepository } from '@mikro-orm/core';
+import type { EntityName, EntityRepository, GetRepository } from '@mikro-orm/core';
 import { EntityManager, Utils } from '@mikro-orm/core';
 import type { MongoDriver } from './MongoDriver';
 import type { MongoEntityRepository } from './MongoEntityRepository';
-import type { Collection } from 'mongodb';
+import type { Collection, Document } from 'mongodb';
 
 /**
  * @inheritDoc
@@ -17,11 +17,11 @@ export class MongoEntityManager<D extends MongoDriver = MongoDriver> extends Ent
     return this.getDriver().aggregate(entityName, pipeline);
   }
 
-  getCollection<T>(entityName: EntityName<any>): Collection<T> {
+  getCollection<T extends Document>(entityName: EntityName<any>): Collection<T> {
     return this.getConnection().getCollection(entityName);
   }
 
-  getRepository<T extends AnyEntity<T>, U extends EntityRepository<T> = MongoEntityRepository<T>>(entityName: EntityName<T>): GetRepository<T, U> {
+  getRepository<T extends object, U extends EntityRepository<T> = MongoEntityRepository<T>>(entityName: EntityName<T>): GetRepository<T, U> {
     return super.getRepository<T, U>(entityName);
   }
 

--- a/packages/mongodb/src/MongoEntityRepository.ts
+++ b/packages/mongodb/src/MongoEntityRepository.ts
@@ -2,7 +2,8 @@ import type { EntityName } from '@mikro-orm/core';
 import { EntityRepository } from '@mikro-orm/core';
 import type { MongoEntityManager } from './MongoEntityManager';
 
-export class MongoEntityRepository<T> extends EntityRepository<T> {
+// eslint-disable-next-line @typescript-eslint/ban-types
+export class MongoEntityRepository<T extends {}> extends EntityRepository<T> {
 
   constructor(protected readonly _em: MongoEntityManager,
               protected readonly entityName: EntityName<T>) {

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -16,8 +16,8 @@ export class MongoPlatform extends Platform {
     return MongoNamingStrategy;
   }
 
-  getRepositoryClass<T>(): Constructor<EntityRepository<T>> {
-    return MongoEntityRepository;
+  getRepositoryClass<T extends object>(): Constructor<EntityRepository<T>> {
+    return MongoEntityRepository as Constructor<EntityRepository<T>>;
   }
 
   getSchemaGenerator(driver: IDatabaseDriver, em?: EntityManager): MongoSchemaGenerator {

--- a/packages/mysql/src/MySqlDriver.ts
+++ b/packages/mysql/src/MySqlDriver.ts
@@ -1,4 +1,4 @@
-import type { AnyEntity, Configuration, EntityDictionary, NativeInsertUpdateManyOptions, QueryResult } from '@mikro-orm/core';
+import type { Configuration, EntityDictionary, NativeInsertUpdateManyOptions, QueryResult } from '@mikro-orm/core';
 import { AbstractSqlDriver } from '@mikro-orm/knex';
 import { MySqlConnection } from './MySqlConnection';
 import { MySqlPlatform } from './MySqlPlatform';
@@ -9,7 +9,7 @@ export class MySqlDriver extends AbstractSqlDriver<MySqlConnection> {
     super(config, new MySqlPlatform(), MySqlConnection, ['knex', 'mysql2']);
   }
 
-  async nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>[], options: NativeInsertUpdateManyOptions<T> = {}): Promise<QueryResult<T>> {
+  async nativeInsertMany<T extends object>(entityName: string, data: EntityDictionary<T>[], options: NativeInsertUpdateManyOptions<T> = {}): Promise<QueryResult<T>> {
     options.processCollections ??= true;
     const res = await super.nativeInsertMany(entityName, data, options);
     const pks = this.getPrimaryKeyFields(entityName);

--- a/packages/seeder/src/Factory.ts
+++ b/packages/seeder/src/Factory.ts
@@ -2,7 +2,7 @@ import type { Faker } from '@faker-js/faker';
 import { faker } from '@faker-js/faker';
 import type { RequiredEntityData, EntityData, EntityManager, Constructor } from '@mikro-orm/core';
 
-export abstract class Factory<T> {
+export abstract class Factory<T extends object> {
 
   abstract readonly model: Constructor<T>;
   private eachFunction?: (entity: T) => void;

--- a/packages/sqlite/src/SqliteDriver.ts
+++ b/packages/sqlite/src/SqliteDriver.ts
@@ -1,4 +1,4 @@
-import type { AnyEntity, Configuration, EntityDictionary, NativeInsertUpdateManyOptions, QueryResult } from '@mikro-orm/core';
+import type { Configuration, EntityDictionary, NativeInsertUpdateManyOptions, QueryResult } from '@mikro-orm/core';
 import { AbstractSqlDriver } from '@mikro-orm/knex';
 import { SqliteConnection } from './SqliteConnection';
 import { SqlitePlatform } from './SqlitePlatform';
@@ -9,7 +9,7 @@ export class SqliteDriver extends AbstractSqlDriver<SqliteConnection> {
     super(config, new SqlitePlatform(), SqliteConnection, ['knex', 'sqlite3']);
   }
 
-  async nativeInsertMany<T extends AnyEntity<T>>(entityName: string, data: EntityDictionary<T>[], options: NativeInsertUpdateManyOptions<T> = {}): Promise<QueryResult<T>> {
+  async nativeInsertMany<T extends object>(entityName: string, data: EntityDictionary<T>[], options: NativeInsertUpdateManyOptions<T> = {}): Promise<QueryResult<T>> {
     options.processCollections ??= true;
     const res = await super.nativeInsertMany(entityName, data, options);
     const pks = this.getPrimaryKeyFields(entityName);

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
   rules: {
     '@typescript-eslint/no-inferrable-types': 'off',
     '@typescript-eslint/no-var-requires': 'off',
+    '@typescript-eslint/consistent-type-imports': 'off',
     'no-console': ['error', { allow: ['time', 'timeEnd'] }],
     'no-control-regex': 'off',
     'no-empty': 'off',

--- a/tests/DatabaseDriver.test.ts
+++ b/tests/DatabaseDriver.test.ts
@@ -18,7 +18,7 @@ import {
   DatabaseDriver,
   EntityManager,
   EntityRepository,
-  LockMode, MikroORM,
+  LockMode,
   Platform,
 } from '@mikro-orm/core';
 
@@ -33,15 +33,15 @@ class Driver extends DatabaseDriver<Connection> implements IDatabaseDriver {
     super(config, dependencies);
   }
 
-  async count<T>(entityName: string, where: ObjectQuery<T>, options: CountOptions<T>): Promise<number> {
+  async count<T extends object>(entityName: string, where: ObjectQuery<T>, options: CountOptions<T>): Promise<number> {
     return 0;
   }
 
-  async find<T, P extends string = never>(entityName: string, where: ObjectQuery<T>, options: FindOptions<T, P> | undefined): Promise<EntityData<T>[]> {
+  async find<T extends object, P extends string = never>(entityName: string, where: ObjectQuery<T>, options: FindOptions<T, P> | undefined): Promise<EntityData<T>[]> {
     return [];
   }
 
-  async findOne<T, P extends string = never>(entityName: string, where: ObjectQuery<T>, options: FindOneOptions<T, P> | undefined): Promise<EntityData<T> | null> {
+  async findOne<T extends object, P extends string = never>(entityName: string, where: ObjectQuery<T>, options: FindOneOptions<T, P> | undefined): Promise<EntityData<T> | null> {
     return null;
   }
 

--- a/tests/EntityHelper.mongo.test.ts
+++ b/tests/EntityHelper.mongo.test.ts
@@ -65,7 +65,7 @@ describe('EntityHelperMongo', () => {
     await orm.em.persistAndFlush(bible);
     orm.em.clear();
 
-    const author = (await orm.em.findOne(Author, god.id, { populate: ['favouriteAuthor', 'books.author.books', 'books.publisher'] }))!;
+    const author = await orm.em.findOneOrFail(Author, god.id, { populate: ['favouriteAuthor', 'books.author.books', 'books.publisher'] });
     const json = wrap(author).toObject();
     expect(json.termsAccepted).toBe(false);
     expect(json.favouriteAuthor).toBe(god.id); // self reference will be ignored even when explicitly populated

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -922,7 +922,7 @@ describe('EntityManagerMongo', () => {
     });
     orm.em.clear();
 
-    a = (await orm.em.findOne(Author, a.id, { populate: ['books'] }))!;
+    a = await orm.em.findOneOrFail(Author, a.id, { populate: ['books'] });
     expect(a.toJSON()).toMatchObject({
       books: [],
     });

--- a/tests/entities/Author.ts
+++ b/tests/entities/Author.ts
@@ -127,7 +127,7 @@ export class Author extends BaseEntity<Author, 'termsAccepted' | 'code2' | 'vers
     return EntityAssigner.assign<Author>(this, data);
   }
 
-  toJSON(strict = true, strip = ['id', 'email'], ...args: any[]): EntityDTO<Author> {
+  toJSON(strict = true, strip = ['id', 'email'], ...args: any[]): EntityDTO<this> {
     const o = this.toObject(...args);
     (o as Dictionary).fooBar = 123;
 

--- a/tests/entities/BaseEntity.ts
+++ b/tests/entities/BaseEntity.ts
@@ -3,7 +3,7 @@ import { BeforeCreate, PrimaryKey, Property, SerializedPrimaryKey, BaseEntity as
 
 export type BaseEntityOptional = 'updatedAt' | 'hookTest';
 
-export abstract class BaseEntity<T extends BaseEntity<T, any>, Optional extends keyof T = never> extends MikroBaseEntity<T, 'id' | '_id'> {
+export abstract class BaseEntity<T extends { id: unknown; _id: unknown }, Optional extends keyof T = never> extends MikroBaseEntity<T, 'id' | '_id'> {
 
   [OptionalProps]?: BaseEntityOptional | Optional;
 

--- a/tests/entities/BaseEntity3.ts
+++ b/tests/entities/BaseEntity3.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from '@mikro-orm/mongodb';
 import { BaseEntity, PrimaryKey, SerializedPrimaryKey } from '@mikro-orm/core';
 
-export abstract class BaseEntity3<T> extends BaseEntity<T & BaseEntity3<T>, 'id' | '_id'> {
+export abstract class BaseEntity3<T extends object> extends BaseEntity<T, keyof T> {
 
   @PrimaryKey()
   _id!: ObjectId;

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -1,6 +1,5 @@
 import { ObjectId } from 'bson';
-import type { EntityDTO, IdentifiedReference } from '@mikro-orm/core';
-import { Collection, Cascade, Entity, Index, ManyToMany, ManyToOne, PrimaryKey, Property, Unique, wrap, Filter, Dictionary, OptionalProps } from '@mikro-orm/core';
+import { EntityDTO, IdentifiedReference, Dictionary, Collection, Cascade, Entity, Index, ManyToMany, ManyToOne, PrimaryKey, Property, Unique, wrap, Filter, OptionalProps } from '@mikro-orm/core';
 import { Publisher } from './Publisher';
 import { Author } from './Author';
 import { BookTag } from './book-tag';
@@ -60,8 +59,8 @@ export class Book extends BaseEntity3<Book> {
     this.author = author!;
   }
 
-  toJSON(strict = true, strip = ['metaObject', 'metaArray', 'metaArrayOfStrings'], ...args: any[]): EntityDTO<Book> {
-    const o = wrap(this as Book).toObject(...args);
+  toJSON(strict = true, strip = ['metaObject', 'metaArray', 'metaArrayOfStrings'], ...args: any[]): EntityDTO<this> {
+    const o = wrap(this).toObject(...args);
 
     if (strict) {
       strip.forEach(k => delete o[k]);

--- a/tests/features/migrations/Migrator.mongo.test.ts
+++ b/tests/features/migrations/Migrator.mongo.test.ts
@@ -9,7 +9,7 @@ import { closeReplSets, initORMMongo, mockLogger } from '../../bootstrap';
 class MigrationTest1 extends Migration {
 
   async up(): Promise<void> {
-    await this.getCollection('Book').updateMany({}, { $set: { updatedAt: new Date() } });
+    await this.getCollection<any>('Book').updateMany({}, { $set: { updatedAt: new Date() } });
     await this.driver.nativeDelete('Book', { foo: true }, { ctx: this.ctx });
   }
 

--- a/tests/features/reflection/TsMorphMetadataProvider.test.ts
+++ b/tests/features/reflection/TsMorphMetadataProvider.test.ts
@@ -6,9 +6,9 @@ import { Author, Book, Publisher, BaseEntity, BaseEntity3, BookTagSchema, Test, 
 import FooBar from './entities/FooBar';
 
 // we need to define those to get around typescript issues with reflection (ts-morph would return `any` for the type otherwise)
-export class Collection<T> extends Collection_<T> { }
-export class Reference<T> extends Reference_<T> { }
-export type IdentifiedReference<T extends AnyEntity<T>, PK extends keyof T | unknown = PrimaryProperty<T>> = true extends IsUnknown<PK> ? Reference<T> : ({ [K in Cast<PK, keyof T>]?: T[K] } & Reference<T>);
+export class Collection<T extends object> extends Collection_<T> { }
+export class Reference<T extends object> extends Reference_<T> { }
+export type IdentifiedReference<T extends object, PK extends keyof T | unknown = PrimaryProperty<T>> = true extends IsUnknown<PK> ? Reference<T> : ({ [K in Cast<PK, keyof T>]?: T[K] } & Reference<T>);
 
 describe('TsMorphMetadataProvider', () => {
 

--- a/tests/issues/GH1003.test.ts
+++ b/tests/issues/GH1003.test.ts
@@ -1,4 +1,5 @@
-import { BaseEntity, Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/core';
+import type { IdentifiedReference } from '@mikro-orm/core';
+import { BaseEntity, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/core';
 import type { SqliteDriver } from '@mikro-orm/sqlite';
 
 @Entity()

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -5,7 +5,7 @@ import { assert } from 'conditional-type-checks';
 import type { ObjectId } from 'bson';
 import type { EntityData, EntityDTO, FilterQuery, FilterValue, Loaded, OperatorMap, Primary, PrimaryKeyType, Query } from '../packages/core/src/typings';
 import type { Author2, Book2, BookTag2, Car2, FooBar2, FooParam2, Publisher2, User2 } from './entities-sql';
-import type { Author } from './entities';
+import type { Author, Book } from './entities';
 
 type IsAssignable<T, Expected> = Expected extends T ? true : false;
 
@@ -77,7 +77,7 @@ describe('check typings', () => {
   });
 
   test('EntityDTO', async () => {
-    const b = { author: { books: [{}], identities: [''] } } as EntityDTO<Book2>;
+    const b = { author: { books: [{}], identities: [''] } } as unknown as EntityDTO<Loaded<Book2, 'publisher'>>;
     const b1 = b.author.name;
     const b2 = b.test?.name;
     const b3 = b.test?.book?.author.books2;
@@ -98,7 +98,7 @@ describe('check typings', () => {
     // @ts-expect-error
     b.test?.getConfiguration?.();
 
-    const a = { books: [{ tags: [{}] }] } as EntityDTO<Loaded<Author2, 'books.tags' | 'books.publisher'>>;
+    const a = { books: [{ tags: [{}] }] } as unknown as EntityDTO<Loaded<Author2, 'books.tags' | 'books.publisher'>>;
     const a11 = a.books;
     const a12 = a.books[0];
     const a1 = a.books[0].tags;
@@ -433,6 +433,55 @@ describe('check typings', () => {
     fail02 = { author: { born: [123] } };
     // @ts-expect-error
     fail02 = { author: { born: { $in: [123] } } };
+  });
+
+  test('Loaded<T> type is assignable to T', async () => {
+    let b1 = {} as Book2;
+    b1 = {} as Loaded<Book2>;
+    let b2 = {} as Book2;
+    b2 = {} as Loaded<Book2, 'publisher'>;
+
+    function test<T>() {
+      let b3 = {} as T;
+      b3 = {} as Loaded<T, 'publisher'>;
+    }
+  });
+
+  function createEntity<T>(): T {
+    const ret = {} as any;
+    ret.__helper = ret;
+    ret.toObject = () => ({});
+
+    return ret;
+  }
+
+  test('Loaded type with EntityDTO (no base entities)', async () => {
+    const b1 = createEntity<Loaded<Book2>>();
+    const o1 = wrap(b1).toObject();
+    // @ts-expect-error o1.publisher is now just number, as it's not populated
+    const id1 = o1.publisher?.id;
+    const b2 = createEntity<Loaded<Book2, 'publisher'>>();
+    const o2 = wrap(b2).toObject();
+    const id2 = o2.publisher?.id;
+    // @ts-expect-error Book2 should not have methods from base entity
+    const o22 = b2.toObject();
+  });
+
+  test('Loaded type with EntityDTO (with ORM base entities)', async () => {
+    const b1 = createEntity<Loaded<Book>>();
+    const o11 = wrap(b1).toObject();
+    const o12 = b1.toObject();
+    // @ts-expect-error o11.publisher is now just number, as it's not populated
+    const id11 = o11.publisher?.id;
+    // @ts-expect-error o12.publisher is now just number, as it's not populated
+    const id12 = o12.publisher?.id;
+    const b2 = createEntity<Loaded<Book, 'publisher'>>();
+    const o21 = wrap(b2).toObject();
+    const o22 = b2.toObject();
+    const id21 = o21.publisher?.id;
+    const id22 = o22.publisher?.id;
+    assert<IsExact<typeof id21, string | undefined>>(true);
+    assert<IsExact<typeof id22, string | undefined>>(true);
   });
 
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1672,19 +1672,19 @@
     read-package-json-fast "^2.0.3"
     which "^2.0.2"
 
-"@nrwl/cli@14.6.0":
-  version "14.6.0"
-  resolved "https://registry.yarnpkg.com/@nrwl/cli/-/cli-14.6.0.tgz#b037720898b4eba0fb5b57c84cb5897ded3f57a8"
-  integrity sha512-EzJLMA8ovQImkRjKfHt2PwzUFTkO9lsDadbnM7it6WP7RTgfy7y8x0quL+L+7CvDbo3xY7RJDtummWl/ytDRxw==
+"@nrwl/cli@14.6.1":
+  version "14.6.1"
+  resolved "https://registry.yarnpkg.com/@nrwl/cli/-/cli-14.6.1.tgz#1da38bd3f29b85cbe2254c6c87a182a99607ad76"
+  integrity sha512-iPs5LL+yI8ER8+XVOD+mqjuOW6nozwMvsik/FAQ0cfaD1dTGM4//i9BXZVdVIZYiRgN1keumjPSOo7vucJYU/g==
   dependencies:
-    nx "14.6.0"
+    nx "14.6.1"
 
-"@nrwl/tao@14.6.0":
-  version "14.6.0"
-  resolved "https://registry.yarnpkg.com/@nrwl/tao/-/tao-14.6.0.tgz#777b74e32812d1d5b6e5433e74bda2385992268e"
-  integrity sha512-BUf1b0mzocL61quw9JIX8EHzLlwDbLdKZEyAXbGusJIvwZEZS+4r6qEiigE5HfU4Oi+7AOfWBd1bZf0bPqyjvg==
+"@nrwl/tao@14.6.1":
+  version "14.6.1"
+  resolved "https://registry.yarnpkg.com/@nrwl/tao/-/tao-14.6.1.tgz#88b9be0c4c47a2350e29df02f8ca89399b37b52d"
+  integrity sha512-dxeKotjrAIgByCaa8x1zMvoyZQH4MvCN3QZ2JqfFwRja8dJMGrsrfZcZu+3J+rStRzvVZHDa+joLuy1u7tXl+w==
   dependencies:
-    nx "14.6.0"
+    nx "14.6.1"
 
 "@octokit/auth-token@^3.0.0":
   version "3.0.1"
@@ -1816,9 +1816,9 @@
   integrity sha512-YlbLreG6Gs9zrVHQWzv+AbYH78J311yPaDpUZpAiNsSCeNmc/gbXNRK/AlzlX3UoR/X9CLZjHhsJt9htb1/vaQ==
 
 "@sinclair/typebox@^0.24.1":
-  version "0.24.32"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.32.tgz#214a03e430122d239a6414a5d5412c23964cafbd"
-  integrity sha512-NWNTW284AOFhxgYofPef5IqDq6Y7ghZkZAkWJcUBp1r9ljfrFOKBDsiQJnLNp9tLcaSXFK9OgsS72W4RXe0jvw==
+  version "0.24.34"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.34.tgz#35b799cf98a203d1940c8ce06688f9a09fbc0f50"
+  integrity sha512-x3ejWKw7rpy30Bvm6U0AQMOHdjqe2E3YJrBHlTxH0KFsp77bBa+MH324nJxtXZFpnTy/JW2h5HPYVm0vG2WPnw==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -4960,10 +4960,10 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-knex@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/knex/-/knex-2.2.0.tgz#86a3176924d37303b3f9ff7f70087418c263ce7a"
-  integrity sha512-yhm1Qe9Ok0TeXBq3nNHqZYJPrQ4Iw2tq9k/HxjrZ/EWec2ifOjJlkNHr26v8cQrWtk5iG3iwfUazTIWy+VKG5g==
+knex@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/knex/-/knex-2.3.0.tgz#87fa2a9553d7cafb125d7a0645256fbe29ef5967"
+  integrity sha512-WMizPaq9wRMkfnwKXKXgBZeZFOSHGdtoSz5SaLAVNs3WRDfawt9O89T4XyH52PETxjV8/kRk0Yf+8WBEP/zbYw==
   dependencies:
     colorette "2.0.19"
     commander "^9.1.0"
@@ -5533,10 +5533,22 @@ mongodb-memory-server@^8.8.0:
     mongodb-memory-server-core "8.9.0"
     tslib "^2.4.0"
 
-mongodb@4.9.0, mongodb@~4.9.0:
+mongodb@4.9.0:
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-4.9.0.tgz#58618439b721f2d6f7d38bb10a4612e29d7f1c8a"
   integrity sha512-tJJEFJz7OQTQPZeVHZJIeSOjMRqc5eSyXTt86vSQENEErpkiG7279tM/GT5AVZ7TgXNh9HQxoa2ZkbrANz5GQw==
+  dependencies:
+    bson "^4.7.0"
+    denque "^2.1.0"
+    mongodb-connection-string-url "^2.5.3"
+    socks "^2.7.0"
+  optionalDependencies:
+    saslprep "^1.0.3"
+
+mongodb@~4.9.0:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-4.9.1.tgz#0c769448228bcf9a6aa7d16daa3625b48312479e"
+  integrity sha512-ZhgI/qBf84fD7sI4waZBoLBNJYPQN5IOC++SBCiPiyhzpNKOxN/fi0tBHvH2dEC42HXtNEbFB0zmNz4+oVtorQ==
   dependencies:
     bson "^4.7.0"
     denque "^2.1.0"
@@ -5854,13 +5866,13 @@ npmlog@^6.0.0, npmlog@^6.0.2:
     gauge "^4.0.3"
     set-blocking "^2.0.0"
 
-nx@14.6.0, "nx@>=14.5.4 < 16":
-  version "14.6.0"
-  resolved "https://registry.yarnpkg.com/nx/-/nx-14.6.0.tgz#deaa4be4fc736babee5f2cc53a4c3f46efe1aa16"
-  integrity sha512-7f7MixBpcX4+v+JAioJfWrvNTzQOq2vaSizjeFIMfOh37hxdgI4JuxNJbfJyUM5ti/hWuM4ZaQp59oWTDoNSyg==
+nx@14.6.1, "nx@>=14.5.4 < 16":
+  version "14.6.1"
+  resolved "https://registry.yarnpkg.com/nx/-/nx-14.6.1.tgz#57b1bd19c018cc125330e91a05523e6a081c2dce"
+  integrity sha512-dJH6A2ff7AO3hXYkjh7qRBZjCEvmjoJ5IQaoi7aEDcLQES5ujePmSS5TZK7NokrdrekDs3MYw3ecPZcVw7lCyg==
   dependencies:
-    "@nrwl/cli" "14.6.0"
-    "@nrwl/tao" "14.6.0"
+    "@nrwl/cli" "14.6.1"
+    "@nrwl/tao" "14.6.1"
     "@parcel/watcher" "2.0.4"
     chalk "4.1.0"
     chokidar "^3.5.1"
@@ -7460,12 +7472,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
-
-typescript@^4.6.4:
+typescript@4.8.2, typescript@^4.6.4:
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
   integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==


### PR DESCRIPTION
Due to changes in TS 4.8 we had to simplify the `AnyEntity` type, it no longer contains the `__helper` and `__meta` properties. Those are considered internal, and they are in fact still present, just not on the type level. Most places now use just `object` instead of `AnyEntity` for the type signatures (e.g. `em.find<T extends object>()`).

Another semi type level breaking change is the return type of `toJSON/toObject/toPOJO`, which now uses `EntityDTO<this>` and respects the populate hints (`Loaded` type) too, narrowing relations to their PK if they are not populated.

Closes #3417
Closes #2414