### PR TITLE
fix(query-builder): support more operators in join conditions

### DIFF
--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -428,56 +428,75 @@ export class QueryBuilderHelper {
   }
 
   private appendJoinSubClause(clause: Knex.JoinClause, cond: Dictionary, key: string, operator?: '$and' | '$or'): void {
-    const m = operator === '$or' ? 'orOn' : 'andOn';
+    const c = operator === '$or' ? 'or' : 'and';
+    const m = `${c}On`;
 
-    if (cond[key] instanceof RegExp) {
+    if (this.isSimpleRegExp(cond[key])) {
       return void clause[m](this.mapper(key), 'like', this.knex.raw('?', this.getRegExpParam(cond[key])));
     }
 
-    if (Utils.isPlainObject(cond[key])) {
-      return this.processObjectSubClause(cond, key, clause, m);
+    if (Utils.isPlainObject(cond[key]) || cond[key] instanceof RegExp) {
+      return this.processObjectSubClause(cond, key, clause, c);
     }
 
     if (QueryBuilderHelper.isCustomExpression(key)) {
       return this.processCustomExpression(clause, m, key, cond);
     }
 
-    const op = cond[key] === null ? 'is' : '=';
-    clause[m](this.knex.raw(`${this.knex.ref(this.mapper(key, QueryType.SELECT, cond[key]))} ${op} ?`, cond[key]));
+    if (cond[key] === null) {
+      clause[`${c}OnNull`](this.mapper(key));
+    } else {
+      clause[m](this.knex.raw(`${this.knex.ref(this.mapper(key, QueryType.SELECT, cond[key]))} = ?`, cond[key]));
+    }
   }
 
-  private processObjectSubClause(cond: any, key: string, clause: Knex.JoinClause, m: 'andOn' | 'orOn'): void {
+  private processObjectSubClause(cond: any, key: string, clause: Knex.JoinClause, c: 'and' | 'or'): void {
     // grouped condition for one field
-    const value = cond[key];
+    let value = cond[key];
 
     if (Utils.getObjectKeysSize(value) > 1) {
       const subCondition = Object.entries(value).map(([subKey, subValue]) => ({ [key]: { [subKey]: subValue } }));
-      return void clause[m](inner => subCondition.map(sub => this.appendJoinClause(inner, sub, '$and')));
+      return void clause[`${c}On`](inner => subCondition.map(sub => this.appendJoinClause(inner, sub, '$and')));
     }
 
-    // operators
+    if (value instanceof RegExp) {
+      value = { $re: value.source };
+    }
+
     const op = Object.keys(QueryOperator).find(op => op in value);
 
     if (!op) {
       return;
     }
 
-    const replacement = this.getOperatorReplacement(op, value);
+    if (['$eq', '$ne'].includes(op) && value[op] === null) {
+      return void clause[`${c}${op === '$eq' ? 'OnNull' : 'OnNotNull'}`](this.mapper(key));
+    }
+
+    if (op === '$exists') {
+      return void clause[`${c}${value[op] ? 'OnNotNull' : 'OnNull'}`](this.mapper(key));
+    }
+
+    if (op === '$in') {
+      return void clause[`${c}OnIn`](this.mapper(key), value[op]);
+    }
+
+    if (op === '$nin') {
+      return void clause[`${c}OnNotIn`](this.mapper(key), value[op]);
+    }
 
     if (op === '$fulltext') {
       const [fromAlias, fromField] = this.splitField(key);
-      const entityName = this.aliasMap[fromAlias];
-      const meta = this.metadata.get(entityName);
+      const property = this.getProperty(fromField, fromAlias);
 
-      clause[m](this.knex.raw(this.platform.getFullTextWhereClause(meta.properties[fromField]), {
+      return void clause[`${c}On`](this.knex.raw(this.platform.getFullTextWhereClause(property!), {
         column: this.mapper(key),
         query: value[op],
       }));
-    } else if (value[op] === null) {
-      clause[m](this.knex.raw(`${this.knex.ref(this.mapper(key))} ${replacement} ?`, value[op]));
-    } else {
-      clause[m](this.mapper(key), replacement, this.knex.raw('?', value[op]));
     }
+
+    const replacement = this.getOperatorReplacement(op, value);
+    clause[`${c}On`](this.mapper(key), replacement, this.knex.raw('?', value[op]));
   }
 
   getQueryOrder(type: QueryType, orderBy: FlatQueryOrderMap | FlatQueryOrderMap[], populate: Dictionary<string>): string {

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -448,15 +448,11 @@ export class QueryBuilderHelper {
 
   private processObjectSubClause(cond: any, key: string, clause: Knex.JoinClause, m: 'andOn' | 'orOn'): void {
     // grouped condition for one field
-    let value = cond[key];
+    const value = cond[key];
 
     if (Utils.getObjectKeysSize(value) > 1) {
       const subCondition = Object.entries(value).map(([subKey, subValue]) => ({ [key]: { [subKey]: subValue } }));
       return void clause[m](inner => subCondition.map(sub => this.appendJoinClause(inner, sub, '$and')));
-    }
-
-    if (value instanceof RegExp) {
-      value = { $re: value.source };
     }
 
     // operators

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -459,6 +459,16 @@ export class QueryBuilderHelper {
         continue;
       }
 
+      if (cond[key][op] === null) {
+        if (replacement === QueryOperator.$ne) {
+          clause[m](this.knex.raw(`${this.knex.ref(this.mapper(key))} is not ?`, cond[key][op]));
+          continue;
+        } else if (replacement === QueryOperator.$eq) {
+          clause[m](this.knex.raw(`${this.knex.ref(this.mapper(key))} is ?`, cond[key][op]));
+          continue;
+        }
+      }
+
       clause[m](this.mapper(key), replacement, this.knex.raw('?', cond[key][op]));
 
       break;

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -469,10 +469,11 @@ export class QueryBuilderHelper {
     const replacement = this.getOperatorReplacement(op, value);
 
     if (op === '$fulltext') {
-      const meta = this.metadata.get(this.entityName);
-      const columnName = key.includes('.') ?  key.split('.')[1] : key;
+      const [fromAlias, fromField] = this.splitField(key);
+      const entityName = this.aliasMap[fromAlias];
+      const meta = this.metadata.get(entityName);
 
-      clause[m](this.knex.raw(this.platform.getFullTextWhereClause(meta.properties[columnName]), {
+      clause[m](this.knex.raw(this.platform.getFullTextWhereClause(meta.properties[fromField]), {
         column: this.mapper(key),
         query: value[op],
       }));

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -368,6 +368,7 @@ describe('QueryBuilder', () => {
         'b.foo:gte': '123',
         'b.baz': { $gt: 1, $lte: 10 },
         'b.title': { $fulltext: 'test' },
+        'b.qux': {},
         '$or': [
           { 'b.foo': null, 'b.qux': { $ne: null }, 'b.quux': { $eq: null }, 'b.baz': 0, 'b.bar:ne': 1 },
           { 'b.bar': /321.*/ },

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -367,7 +367,7 @@ describe('QueryBuilder', () => {
       .leftJoin('a.books', 'b', {
         'b.foo:gte': '123',
         'b.baz': { $gt: 1, $lte: 10 },
-        'b.bar': { $fulltext: 'test' },
+        'b.title': { $fulltext: 'test' },
         '$or': [
           { 'b.foo': null, 'b.qux': { $ne: null }, 'b.quux': { $eq: null }, 'b.baz': 0, 'b.bar:ne': 1 },
           { 'b.bar': /321.*/ },
@@ -380,7 +380,7 @@ describe('QueryBuilder', () => {
       })
       .where({ 'b.title': 'test 123' });
     const sql = 'select `a`.*, `b`.* from `author2` as `a` ' +
-      'left join `book2` as `b` on `a`.`id` = `b`.`author_id` and `b`.`foo` >= ? and (`b`.`baz` > ? and `b`.`baz` <= ?) and match(`b`.`bar`) against (? in boolean mode) and ((`b`.`foo` is ? and `b`.`qux` is not ? and `b`.`quux` is ? and `b`.`baz` = ? and `b`.`bar` != ?) or `b`.`bar` like ? or (json_contains(`a`.`meta`, ?) and json_contains(`a`.`meta`, ?) = ? and lower(b.bar) = ?)) ' +
+      'left join `book2` as `b` on `a`.`id` = `b`.`author_id` and `b`.`foo` >= ? and (`b`.`baz` > ? and `b`.`baz` <= ?) and match(`b`.`title`) against (? in boolean mode) and ((`b`.`foo` is ? and `b`.`qux` is not ? and `b`.`quux` is ? and `b`.`baz` = ? and `b`.`bar` != ?) or `b`.`bar` like ? or (json_contains(`a`.`meta`, ?) and json_contains(`a`.`meta`, ?) = ? and lower(b.bar) = ?)) ' +
       'where `b`.`title` = ?';
     expect(qb.getQuery()).toEqual(sql);
     expect(qb.getParams()).toEqual(['123', 1, 10, 'test', null, null, null, 0, 1, '%321%%', '{"b.foo":"bar"}', '{"b.foo":"bar"}', false, '321', 'test 123']);

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -368,7 +368,7 @@ describe('QueryBuilder', () => {
         'b.foo:gte': '123',
         'b.baz': { $gt: 1, $lte: 10 },
         '$or': [
-          { 'b.foo': null, 'b.baz': 0, 'b.bar:ne': 1 },
+          { 'b.foo': null, 'b.qux': { $ne: null }, 'b.quux': { $eq: null }, 'b.baz': 0, 'b.bar:ne': 1 },
           { 'b.bar': /321.*/ },
           { $and: [
             { 'json_contains(`a`.`meta`, ?)': [{ 'b.foo': 'bar' }] },
@@ -379,10 +379,10 @@ describe('QueryBuilder', () => {
       })
       .where({ 'b.title': 'test 123' });
     const sql = 'select `a`.*, `b`.* from `author2` as `a` ' +
-      'left join `book2` as `b` on `a`.`id` = `b`.`author_id` and `b`.`foo` >= ? and (`b`.`baz` > ? and `b`.`baz` <= ?) and ((`b`.`foo` is ? and `b`.`baz` = ? and `b`.`bar` != ?) or `b`.`bar` like ? or (json_contains(`a`.`meta`, ?) and json_contains(`a`.`meta`, ?) = ? and lower(b.bar) = ?)) ' +
+      'left join `book2` as `b` on `a`.`id` = `b`.`author_id` and `b`.`foo` >= ? and (`b`.`baz` > ? and `b`.`baz` <= ?) and ((`b`.`foo` is ? and `b`.`qux` is not ? and `b`.`quux` is ? and `b`.`baz` = ? and `b`.`bar` != ?) or `b`.`bar` like ? or (json_contains(`a`.`meta`, ?) and json_contains(`a`.`meta`, ?) = ? and lower(b.bar) = ?)) ' +
       'where `b`.`title` = ?';
     expect(qb.getQuery()).toEqual(sql);
-    expect(qb.getParams()).toEqual(['123', 1, 10, null, 0, 1, '%321%%', '{"b.foo":"bar"}', '{"b.foo":"bar"}', false, '321', 'test 123']);
+    expect(qb.getParams()).toEqual(['123', 1, 10, null, null, null, 0, 1, '%321%%', '{"b.foo":"bar"}', '{"b.foo":"bar"}', false, '321', 'test 123']);
   });
 
   test('select leftJoin m:n owner', async () => {

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -370,21 +370,38 @@ describe('QueryBuilder', () => {
         'b.title': { $fulltext: 'test' },
         'b.qux': {},
         '$or': [
-          { 'b.foo': null, 'b.qux': { $ne: null }, 'b.quux': { $eq: null }, 'b.baz': 0, 'b.bar:ne': 1 },
-          { 'b.bar': /321.*/ },
-          { $and: [
-            { 'json_contains(`a`.`meta`, ?)': [{ 'b.foo': 'bar' }] },
-            { 'json_contains(`a`.`meta`, ?) = ?': [{ 'b.foo': 'bar' }, false] },
-            { 'lower(b.bar)': '321' },
-          ] },
+          {
+            'b.foo': null,
+            'b.qux': { $ne: null },
+            'b.quux': { $eq: null },
+            'b.baz': 0,
+            'b.bar:ne': 1,
+          },
+          {
+            'b.foo': { $nin: [0,1] },
+            'b.baz': { $in: [2,3] },
+            'b.qux': { $exists: true },
+            'b.bar': /test/,
+          },
+          {
+            'b.qux': { $exists: false },
+            'b.bar': /^(te){1,3}st$/,
+          },
+          {
+            $and: [
+              { 'json_contains(`a`.`meta`, ?)': [{ 'b.foo': 'bar' }] },
+              { 'json_contains(`a`.`meta`, ?) = ?': [{ 'b.foo': 'bar' }, false] },
+              { 'lower(b.bar)': '321' },
+            ],
+          },
         ],
       })
       .where({ 'b.title': 'test 123' });
     const sql = 'select `a`.*, `b`.* from `author2` as `a` ' +
-      'left join `book2` as `b` on `a`.`id` = `b`.`author_id` and `b`.`foo` >= ? and (`b`.`baz` > ? and `b`.`baz` <= ?) and match(`b`.`title`) against (? in boolean mode) and ((`b`.`foo` is ? and `b`.`qux` is not ? and `b`.`quux` is ? and `b`.`baz` = ? and `b`.`bar` != ?) or `b`.`bar` like ? or (json_contains(`a`.`meta`, ?) and json_contains(`a`.`meta`, ?) = ? and lower(b.bar) = ?)) ' +
+      'left join `book2` as `b` on `a`.`id` = `b`.`author_id` and `b`.`foo` >= ? and (`b`.`baz` > ? and `b`.`baz` <= ?) and match(`b`.`title`) against (? in boolean mode) and ((`b`.`foo` is null and `b`.`qux` is not null and `b`.`quux` is null and `b`.`baz` = ? and `b`.`bar` != ?) or (`b`.`foo` not in (?, ?) and `b`.`baz` in (?, ?) and `b`.`qux` is not null and `b`.`bar` like ?) or (`b`.`qux` is null and `b`.`bar` regexp ?) or (json_contains(`a`.`meta`, ?) and json_contains(`a`.`meta`, ?) = ? and lower(b.bar) = ?)) ' +
       'where `b`.`title` = ?';
     expect(qb.getQuery()).toEqual(sql);
-    expect(qb.getParams()).toEqual(['123', 1, 10, 'test', null, null, null, 0, 1, '%321%%', '{"b.foo":"bar"}', '{"b.foo":"bar"}', false, '321', 'test 123']);
+    expect(qb.getParams()).toEqual(['123', 1, 10, 'test', 0, 1, 0, 1, 2, 3, '%test%', '^(te){1,3}st$', '{"b.foo":"bar"}', '{"b.foo":"bar"}', false, '321', 'test 123']);
   });
 
   test('select leftJoin m:n owner', async () => {

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -367,6 +367,7 @@ describe('QueryBuilder', () => {
       .leftJoin('a.books', 'b', {
         'b.foo:gte': '123',
         'b.baz': { $gt: 1, $lte: 10 },
+        'b.bar': { $fulltext: 'test' },
         '$or': [
           { 'b.foo': null, 'b.qux': { $ne: null }, 'b.quux': { $eq: null }, 'b.baz': 0, 'b.bar:ne': 1 },
           { 'b.bar': /321.*/ },
@@ -379,10 +380,10 @@ describe('QueryBuilder', () => {
       })
       .where({ 'b.title': 'test 123' });
     const sql = 'select `a`.*, `b`.* from `author2` as `a` ' +
-      'left join `book2` as `b` on `a`.`id` = `b`.`author_id` and `b`.`foo` >= ? and (`b`.`baz` > ? and `b`.`baz` <= ?) and ((`b`.`foo` is ? and `b`.`qux` is not ? and `b`.`quux` is ? and `b`.`baz` = ? and `b`.`bar` != ?) or `b`.`bar` like ? or (json_contains(`a`.`meta`, ?) and json_contains(`a`.`meta`, ?) = ? and lower(b.bar) = ?)) ' +
+      'left join `book2` as `b` on `a`.`id` = `b`.`author_id` and `b`.`foo` >= ? and (`b`.`baz` > ? and `b`.`baz` <= ?) and match(`b`.`bar`) against (? in boolean mode) and ((`b`.`foo` is ? and `b`.`qux` is not ? and `b`.`quux` is ? and `b`.`baz` = ? and `b`.`bar` != ?) or `b`.`bar` like ? or (json_contains(`a`.`meta`, ?) and json_contains(`a`.`meta`, ?) = ? and lower(b.bar) = ?)) ' +
       'where `b`.`title` = ?';
     expect(qb.getQuery()).toEqual(sql);
-    expect(qb.getParams()).toEqual(['123', 1, 10, null, null, null, 0, 1, '%321%%', '{"b.foo":"bar"}', '{"b.foo":"bar"}', false, '321', 'test 123']);
+    expect(qb.getParams()).toEqual(['123', 1, 10, 'test', null, null, null, 0, 1, '%321%%', '{"b.foo":"bar"}', '{"b.foo":"bar"}', false, '321', 'test 123']);
   });
 
   test('select leftJoin m:n owner', async () => {


### PR DESCRIPTION
Small fix for joining table using operator `$ne`  (`$eq`) with null value.

### Example

```
em.createQueryBuilder(Table, 't').join('relation', 'r', { 'r.nullableField': { $ne: null } });
```

This should create sql ``` `r`.`nullableField` is not null ```, but created sql was  ``` `r`.`nullableField` != null ```

Closes #3412