### PR TITLE
fix(postgres): fix escaping of special chars in string arrays

### DIFF
--- a/packages/postgresql/src/PostgreSqlPlatform.ts
+++ b/packages/postgresql/src/PostgreSqlPlatform.ts
@@ -126,7 +126,7 @@ export class PostgreSqlPlatform extends AbstractSqlPlatform {
   }
 
   marshallArray(values: string[]): string {
-    const quote = (v: string) => v === '' || v.match(/["{}]/) ? `"${v}"` : v;
+    const quote = (v: string) => v === '' || v.match(/["{}]/) ? JSON.stringify(v) : v;
     return `{${values.map(v => quote('' + v)).join(',')}}`;
   }
 

--- a/tests/issues/GH2679.test.ts
+++ b/tests/issues/GH2679.test.ts
@@ -99,4 +99,15 @@ describe('GH issue 2679', () => {
     const loaded = (await orm.em.find(User, {}))[0];
     expect(loaded.groups).toEqual(['', 'f{o}o', '', '{bar}', '']);
   });
+
+  test('special chars in array items (#3037) - With double quotes', async () => {
+    const create = orm.em.create(User, {
+      groups: ['', 'f"o', '', '"bar"', ''],
+    });
+    await orm.em.persistAndFlush(create);
+    orm.em.clear();
+
+    const loaded = (await orm.em.find(User, {}))[0];
+    expect(loaded.groups).toEqual(['', 'f"o', '', '"bar"', '']);
+  });
 });


### PR DESCRIPTION
The fix in #3037 did not cover using of double quotes which broke the insert of values