### PR TITLE
feat(entity-generator): add import extension for referenced entities

### DIFF
--- a/docs/docs/entity-generator.md
+++ b/docs/docs/entity-generator.md
@@ -51,7 +51,7 @@ By default, the `EntityGenerator` generates only owning sides of relations (e.g.
 - `bidirectionalRelations` to generate also the inverse sides for them
 - `identifiedReferences` to generate M:1 and 1:1 relations as wrapped references
 - `entitySchema` to generate the entities using `EntitySchema` instead of decorators
-- `importExtension` one of `'js' | 'cjs' | 'mjs'` that can be added as a extenstion to imported entities e.x. when `importExtension=js`, generated entities include `import Author from './Author.js'`
+- `esmImport` to use esm style import for imported entities e.x. when `esmImport=true`, generated entities include `import Author from './Author.js'`
 
 ## Current limitations
 

--- a/docs/docs/entity-generator.md
+++ b/docs/docs/entity-generator.md
@@ -51,6 +51,7 @@ By default, the `EntityGenerator` generates only owning sides of relations (e.g.
 - `bidirectionalRelations` to generate also the inverse sides for them
 - `identifiedReferences` to generate M:1 and 1:1 relations as wrapped references
 - `entitySchema` to generate the entities using `EntitySchema` instead of decorators
+- `importExtension` one of `'js' | 'cjs' | 'mjs'` that can be added as a extenstion to imported entities e.x. when `importExtension=js`, generated entities include `import Author from './Author.js'`
 
 ## Current limitations
 

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -486,7 +486,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
     bidirectionalRelations?: boolean;
     identifiedReferences?: boolean;
     entitySchema?: boolean;
-    importExtension?: 'js' | 'mjs' | 'cjs';
+    esmImport?: boolean;
   };
   cache: {
     enabled?: boolean;

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -486,6 +486,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
     bidirectionalRelations?: boolean;
     identifiedReferences?: boolean;
     entitySchema?: boolean;
+    importExtension?: 'js' | 'mjs' | 'cjs';
   };
   cache: {
     enabled?: boolean;

--- a/packages/entity-generator/src/EntityGenerator.ts
+++ b/packages/entity-generator/src/EntityGenerator.ts
@@ -37,12 +37,14 @@ export class EntityGenerator {
       this.generateIdentifiedReferences(metadata);
     }
 
+    const importExtension = this.config.get('entityGenerator').importExtension ?? '';
+
     for (const meta of metadata) {
       if (!meta.pivotTable) {
         if (this.config.get('entityGenerator').entitySchema) {
-          this.sources.push(new EntitySchemaSourceFile(meta, this.namingStrategy, this.platform));
+          this.sources.push(new EntitySchemaSourceFile(meta, this.namingStrategy, this.platform, importExtension));
         } else {
-          this.sources.push(new SourceFile(meta, this.namingStrategy, this.platform));
+          this.sources.push(new SourceFile(meta, this.namingStrategy, this.platform, importExtension));
         }
       }
     }

--- a/packages/entity-generator/src/EntityGenerator.ts
+++ b/packages/entity-generator/src/EntityGenerator.ts
@@ -37,14 +37,14 @@ export class EntityGenerator {
       this.generateIdentifiedReferences(metadata);
     }
 
-    const importExtension = this.config.get('entityGenerator').importExtension ?? '';
+    const esmImport = this.config.get('entityGenerator').esmImport ?? false;
 
     for (const meta of metadata) {
       if (!meta.pivotTable) {
         if (this.config.get('entityGenerator').entitySchema) {
-          this.sources.push(new EntitySchemaSourceFile(meta, this.namingStrategy, this.platform, importExtension));
+          this.sources.push(new EntitySchemaSourceFile(meta, this.namingStrategy, this.platform, esmImport));
         } else {
-          this.sources.push(new SourceFile(meta, this.namingStrategy, this.platform, importExtension));
+          this.sources.push(new SourceFile(meta, this.namingStrategy, this.platform, esmImport));
         }
       }
     }

--- a/packages/entity-generator/src/SourceFile.ts
+++ b/packages/entity-generator/src/SourceFile.ts
@@ -9,7 +9,7 @@ export class SourceFile {
   constructor(protected readonly meta: EntityMetadata,
               protected readonly namingStrategy: NamingStrategy,
               protected readonly platform: Platform,
-              protected readonly importExtension: '' | 'js' | 'mjs' | 'cjs') { }
+              protected readonly esmImport: boolean) { }
 
   generate(): string {
     this.coreImports.add('Entity');
@@ -49,12 +49,10 @@ export class SourceFile {
     ret += '}\n';
 
     const imports = [`import { ${([...this.coreImports].sort().join(', '))} } from '@mikro-orm/core';`];
+    const entityImportExtension = this.esmImport ? '.js' : '';
     const entityImports = [...this.entityImports].filter(e => e !== this.meta.className);
     entityImports.sort().forEach(entity => {
-      imports.push(
-        `import { ${entity} } from './${entity}${
-          this.importExtension ? `.${this.importExtension}` : ''
-        }';`);
+      imports.push(`import { ${entity} } from './${entity}${entityImportExtension}';`);
     });
 
     ret = `${imports.join('\n')}\n\n${ret}`;

--- a/packages/entity-generator/src/SourceFile.ts
+++ b/packages/entity-generator/src/SourceFile.ts
@@ -8,7 +8,8 @@ export class SourceFile {
 
   constructor(protected readonly meta: EntityMetadata,
               protected readonly namingStrategy: NamingStrategy,
-              protected readonly platform: Platform) { }
+              protected readonly platform: Platform,
+              protected readonly importExtension: '' | 'js' | 'mjs' | 'cjs') { }
 
   generate(): string {
     this.coreImports.add('Entity');
@@ -50,7 +51,10 @@ export class SourceFile {
     const imports = [`import { ${([...this.coreImports].sort().join(', '))} } from '@mikro-orm/core';`];
     const entityImports = [...this.entityImports].filter(e => e !== this.meta.className);
     entityImports.sort().forEach(entity => {
-      imports.push(`import { ${entity} } from './${entity}';`);
+      imports.push(
+        `import { ${entity} } from './${entity}${
+          this.importExtension ? `.${this.importExtension}` : ''
+        }';`);
     });
 
     ret = `${imports.join('\n')}\n\n${ret}`;

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -411,6 +411,16 @@ Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
     pathExistsMock.mockRestore();
   });
 
+  test('getModuleFormatFromPackage gets the type from package.json', async () => {
+    const mikroPackage = await ConfigurationLoader.getModuleFormatFromPackage();
+    expect(mikroPackage).toEqual('');
+
+    const packageSpy = jest.spyOn(ConfigurationLoader, 'getPackageConfig');
+    packageSpy.mockResolvedValue({ type: 'module' });
+    const esmModulePackage = await ConfigurationLoader.getModuleFormatFromPackage();
+    expect(esmModulePackage).toEqual('module');
+  });
+
   test('dumpTable', async () => {
     const dumpSpy = jest.spyOn(CLIHelper, 'dump');
     dumpSpy.mockImplementation(() => void 0);

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -419,6 +419,13 @@ Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
     packageSpy.mockResolvedValue({ type: 'module' });
     const esmModulePackage = await ConfigurationLoader.getModuleFormatFromPackage();
     expect(esmModulePackage).toEqual('module');
+    const pathExistsMock = jest.spyOn(require('fs-extra'), 'pathExists');
+    pathExistsMock.mockResolvedValue(true);
+    const conf = await CLIHelper.getConfiguration();
+    expect(conf).toBeInstanceOf(Configuration);
+    expect(conf.get('entityGenerator')?.esmImport).toEqual(true);
+    pathExistsMock.mockRestore();
+    packageSpy.mockRestore();
   });
 
   test('dumpTable', async () => {

--- a/tests/features/entity-generator/EntityGenerator.test.ts
+++ b/tests/features/entity-generator/EntityGenerator.test.ts
@@ -68,6 +68,22 @@ describe('EntityGenerator', () => {
     await remove('./temp/entities');
   });
 
+  test('generate entities with reference wrappers and named import [mysql]', async () => {
+    const orm = await initORMMySql('mysql', {
+      entityGenerator: {
+        identifiedReferences: true,
+        importExtension: 'js',
+      },
+    }, true);
+    const generator = orm.getEntityGenerator();
+    const dump = await generator.generate({ save: true, baseDir: './temp/entities' });
+    expect(dump).toMatchSnapshot('mysql-entity-named-dump');
+    await expect(pathExists('./temp/entities/Author2.ts')).resolves.toBe(true);
+    await remove('./temp/entities');
+
+    await orm.close(true);
+  });
+
   test('generate entities from schema [sqlite]', async () => {
     const orm = await initORMSqlite();
     const generator = new EntityGenerator(orm.em);

--- a/tests/features/entity-generator/EntityGenerator.test.ts
+++ b/tests/features/entity-generator/EntityGenerator.test.ts
@@ -72,7 +72,7 @@ describe('EntityGenerator', () => {
     const orm = await initORMMySql('mysql', {
       entityGenerator: {
         identifiedReferences: true,
-        importExtension: 'js',
+        esmImport: true,
       },
     }, true);
     const generator = orm.getEntityGenerator();

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
@@ -2912,6 +2912,484 @@ export class User2 {
 ]
 `;
 
+exports[`EntityGenerator generate entities with reference wrappers and named import [mysql]: mysql-entity-named-dump 1`] = `
+Array [
+  "import { Entity, IdentifiedReference, OneToOne, Property } from '@mikro-orm/core';
+import { Author2 } from './Author2.js';
+
+@Entity()
+export class Address2 {
+
+  @OneToOne({ entity: () => Author2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade', primary: true })
+  author!: IdentifiedReference<Author2>;
+
+  @Property({ length: 255 })
+  value!: string;
+
+}
+",
+  "import { Collection, Entity, IdentifiedReference, Index, ManyToMany, ManyToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+import { Book2 } from './Book2.js';
+
+@Entity()
+@Index({ name: 'author2_name_age_index', properties: ['name', 'age'] })
+@Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
+export class Author2 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  createdAt!: Date;
+
+  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  updatedAt!: Date;
+
+  @Index({ name: 'custom_idx_name_123' })
+  @Property({ length: 255 })
+  name!: string;
+
+  @Index({ name: 'custom_email_index_name' })
+  @Unique({ name: 'custom_email_unique_name' })
+  @Property({ length: 255 })
+  email!: string;
+
+  @Property({ nullable: true })
+  age?: number;
+
+  @Index({ name: 'author2_terms_accepted_index' })
+  @Property({ default: false })
+  termsAccepted: boolean = false;
+
+  @Property({ nullable: true })
+  optional?: boolean;
+
+  @Property({ columnType: 'text', length: 65535, nullable: true })
+  identities?: string;
+
+  @Index({ name: 'author2_born_index' })
+  @Property({ columnType: 'date', nullable: true })
+  born?: string;
+
+  @Index({ name: 'born_time_idx' })
+  @Property({ columnType: 'time', nullable: true })
+  bornTime?: string;
+
+  @ManyToOne({ entity: () => Book2, wrappedReference: true, onDelete: 'cascade', nullable: true })
+  favouriteBook?: IdentifiedReference<Book2>;
+
+  @ManyToOne({ entity: () => Author2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  favouriteAuthor?: IdentifiedReference<Author2>;
+
+  @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
+  authorToFriend = new Collection<Author2>(this);
+
+  @ManyToMany({ entity: () => Author2, joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
+  following = new Collection<Author2>(this);
+
+}
+",
+  "import { Entity, Enum, IdentifiedReference, Index, ManyToOne, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity()
+export class BaseUser2 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 100 })
+  firstName!: string;
+
+  @Property({ length: 100 })
+  lastName!: string;
+
+  @Index({ name: 'base_user2_type_index' })
+  @Enum({ items: () => BaseUser2Type })
+  type!: BaseUser2Type;
+
+  @Property({ length: 255, nullable: true })
+  ownerProp?: string;
+
+  @ManyToOne({ entity: () => BaseUser2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  favouriteEmployee?: IdentifiedReference<BaseUser2>;
+
+  @OneToOne({ entity: () => BaseUser2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  favouriteManager?: IdentifiedReference<BaseUser2>;
+
+  @Property({ nullable: true })
+  employeeProp?: number;
+
+  @Property({ length: 255, nullable: true })
+  managerProp?: string;
+
+}
+
+export enum BaseUser2Type {
+  EMPLOYEE = 'employee',
+  MANAGER = 'manager',
+  OWNER = 'owner',
+}
+",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity()
+export class BookTag2 {
+
+  @PrimaryKey({ columnType: 'bigint' })
+  id!: string;
+
+  @Property({ length: 50 })
+  name!: string;
+
+}
+",
+  "import { Collection, Entity, IdentifiedReference, Index, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Author2 } from './Author2.js';
+import { BookTag2 } from './BookTag2.js';
+import { Publisher2 } from './Publisher2.js';
+
+@Entity()
+export class Book2 {
+
+  @PrimaryKey({ length: 36 })
+  uuidPk!: string;
+
+  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  createdAt!: Date;
+
+  @Index({ name: 'book2_title_index' })
+  @Property({ length: 255, nullable: true })
+  title?: string;
+
+  @Property({ columnType: 'text', length: 65535, nullable: true })
+  perex?: string;
+
+  @Property({ columnType: 'decimal(8,2)', nullable: true })
+  price?: string;
+
+  @Property({ columnType: 'double', nullable: true })
+  double?: string;
+
+  @Property({ columnType: 'json', nullable: true })
+  meta?: any;
+
+  @ManyToOne({ entity: () => Author2, wrappedReference: true })
+  author!: IdentifiedReference<Author2>;
+
+  @ManyToOne({ entity: () => Publisher2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade', nullable: true })
+  publisher?: IdentifiedReference<Publisher2>;
+
+  @Property({ length: 255, nullable: true, default: 'lol' })
+  foo?: string;
+
+  @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
+  bookToTagUnordered = new Collection<BookTag2>(this);
+
+}
+",
+  "import { Entity, IdentifiedReference, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+import { Book2 } from './Book2.js';
+import { BookTag2 } from './BookTag2.js';
+
+@Entity({ tableName: 'book2_tags' })
+export class Book2Tags {
+
+  @PrimaryKey()
+  order!: number;
+
+  @ManyToOne({ entity: () => Book2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
+  book2!: IdentifiedReference<Book2>;
+
+  @ManyToOne({ entity: () => BookTag2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
+  bookTag2!: IdentifiedReference<BookTag2>;
+
+}
+",
+  "import { Entity, IdentifiedReference, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Car2 } from './Car2.js';
+
+@Entity()
+export class CarOwner2 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 255 })
+  name!: string;
+
+  @ManyToOne({ entity: () => Car2, wrappedReference: true, onUpdateIntegrity: 'cascade' })
+  car!: IdentifiedReference<Car2>;
+
+}
+",
+  "import { Entity, Index, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity()
+export class Car2 {
+
+  @Index({ name: 'car2_name_index' })
+  @PrimaryKey({ length: 100 })
+  name!: string;
+
+  @Index({ name: 'car2_year_index' })
+  @PrimaryKey()
+  year!: number;
+
+  @Property()
+  price!: number;
+
+}
+",
+  "import { Entity, IdentifiedReference, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Test2 } from './Test2.js';
+
+@Entity()
+export class Configuration2 {
+
+  @PrimaryKey({ length: 255 })
+  property!: string;
+
+  @ManyToOne({ entity: () => Test2, wrappedReference: true, onUpdateIntegrity: 'cascade', primary: true })
+  test!: IdentifiedReference<Test2>;
+
+  @Property({ length: 255 })
+  value!: string;
+
+}
+",
+  "import { Entity, PrimaryKey } from '@mikro-orm/core';
+
+@Entity()
+export class Dummy2 {
+
+  @PrimaryKey()
+  id!: number;
+
+}
+",
+  "import { Entity, IdentifiedReference, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { FooBaz2 } from './FooBaz2.js';
+
+@Entity()
+export class FooBar2 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 255 })
+  name!: string;
+
+  @Property({ fieldName: 'name with space', length: 255, nullable: true })
+  nameWithSpace?: string;
+
+  @OneToOne({ entity: () => FooBaz2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  baz?: IdentifiedReference<FooBaz2>;
+
+  @OneToOne({ entity: () => FooBar2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  fooBar?: IdentifiedReference<FooBar2>;
+
+  @Property({ defaultRaw: \`CURRENT_TIMESTAMP\` })
+  version!: Date;
+
+  @Property({ length: 65535, nullable: true })
+  blob?: Buffer;
+
+  @Property({ columnType: 'text', length: 65535, nullable: true })
+  array?: string;
+
+  @Property({ columnType: 'json', nullable: true })
+  objectProperty?: any;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity()
+export class FooBaz2 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 255 })
+  name!: string;
+
+  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  version!: Date;
+
+}
+",
+  "import { Entity, IdentifiedReference, ManyToOne, Property } from '@mikro-orm/core';
+import { FooBar2 } from './FooBar2.js';
+import { FooBaz2 } from './FooBaz2.js';
+
+@Entity()
+export class FooParam2 {
+
+  @ManyToOne({ entity: () => FooBar2, wrappedReference: true, onUpdateIntegrity: 'cascade', primary: true })
+  bar!: IdentifiedReference<FooBar2>;
+
+  @ManyToOne({ entity: () => FooBaz2, wrappedReference: true, onUpdateIntegrity: 'cascade', primary: true })
+  baz!: IdentifiedReference<FooBaz2>;
+
+  @Property({ length: 255 })
+  value!: string;
+
+  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  version!: Date;
+
+}
+",
+  "import { Entity, Enum, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity()
+export class Publisher2 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 255 })
+  name!: string;
+
+  @Enum({ items: () => Publisher2Type })
+  type!: Publisher2Type;
+
+  @Enum({ items: () => Publisher2Type2 })
+  type2!: Publisher2Type2;
+
+  @Property({ columnType: 'tinyint', nullable: true })
+  enum1?: number;
+
+  @Property({ columnType: 'tinyint', nullable: true })
+  enum2?: number;
+
+  @Property({ columnType: 'tinyint', nullable: true })
+  enum3?: number;
+
+  @Enum({ items: () => Publisher2Enum4, nullable: true })
+  enum4?: Publisher2Enum4;
+
+  @Enum({ items: () => Publisher2Enum5, nullable: true })
+  enum5?: Publisher2Enum5;
+
+}
+
+export enum Publisher2Type {
+  LOCAL = 'local',
+  GLOBAL = 'global',
+}
+
+export enum Publisher2Type2 {
+  LOCAL = 'LOCAL',
+  GLOBAL = 'GLOBAL',
+}
+
+export enum Publisher2Enum4 {
+  A = 'a',
+  B = 'b',
+  C = 'c',
+}
+
+export enum Publisher2Enum5 {
+  A = 'a',
+}
+",
+  "import { Entity, IdentifiedReference, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+import { Publisher2 } from './Publisher2.js';
+import { Test2 } from './Test2.js';
+
+@Entity({ tableName: 'publisher2_tests' })
+export class Publisher2Tests {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne({ entity: () => Publisher2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
+  publisher2!: IdentifiedReference<Publisher2>;
+
+  @ManyToOne({ entity: () => Test2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
+  test2!: IdentifiedReference<Test2>;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity()
+export class Sandwich {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 255 })
+  name!: string;
+
+  @Property()
+  price!: number;
+
+}
+",
+  "import { Collection, Entity, IdentifiedReference, ManyToMany, ManyToOne, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Book2 } from './Book2.js';
+import { FooBar2 } from './FooBar2.js';
+
+@Entity()
+export class Test2 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 255, nullable: true })
+  name?: string;
+
+  @OneToOne({ entity: () => Book2, wrappedReference: true, onDelete: 'set null', nullable: true })
+  book?: IdentifiedReference<Book2>;
+
+  @ManyToOne({ entity: () => Test2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  parent?: IdentifiedReference<Test2>;
+
+  @Property({ default: 1 })
+  version: number = 1;
+
+  @OneToOne({ entity: () => FooBar2, wrappedReference: true, fieldName: 'foo___bar', onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  fooBar?: IdentifiedReference<FooBar2>;
+
+  @Property({ fieldName: 'foo___baz', nullable: true })
+  fooBaz?: number;
+
+  @ManyToMany({ entity: () => FooBar2, joinColumn: 'test2_id', inverseJoinColumn: 'foo_bar2_id' })
+  bars = new Collection<FooBar2>(this);
+
+}
+",
+  "import { Collection, Entity, IdentifiedReference, ManyToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Car2 } from './Car2.js';
+import { Sandwich } from './Sandwich.js';
+
+@Entity()
+export class User2 {
+
+  @PrimaryKey({ length: 100 })
+  firstName!: string;
+
+  @PrimaryKey({ length: 100 })
+  lastName!: string;
+
+  @Property({ nullable: true })
+  foo?: number;
+
+  @OneToOne({ entity: () => Car2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  favouriteCar?: IdentifiedReference<Car2>;
+
+  @ManyToMany({ entity: () => Car2, joinColumns: ['user2_first_name', 'user2_last_name'], inverseJoinColumns: ['car2_name', 'car2_year'] })
+  cars = new Collection<Car2>(this);
+
+  @ManyToMany({ entity: () => Sandwich, joinColumns: ['user2_first_name', 'user2_last_name'], inverseJoinColumn: 'sandwich_id' })
+  sandwiches = new Collection<Sandwich>(this);
+
+}
+",
+]
+`;
+
 exports[`EntityGenerator numeric nullable columns with null default [mariadb]: mariadb-entity-gh-3285 1`] = `
 Array [
   "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';


### PR DESCRIPTION
In a generated entity, add the ability for referenced entities to be imported by a named import.

Most common case is a extension of '.js' but node does support '.cjs' and '.mjs'. Supported ESM_FILE_FORMAT can be found in the node docs https://nodejs.org/docs/latest-v16.x/api/esm.html#resolution-algorithm

Another possible approach is to check package.json for `"type": "module"` but that felt like I was being too smart as I wouldn't know for sure which supported file format the consumer would want.