### PR TITLE
fix(core): add missing `MIKRO_ORM_SCHEMA` env var

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -594,6 +594,7 @@ Full list of supported options:
 | `MIKRO_ORM_USER` | `user` |
 | `MIKRO_ORM_PASSWORD` | `password` |
 | `MIKRO_ORM_DB_NAME` | `dbName` |
+| `MIKRO_ORM_SCHEMA`  | `schema` |
 | `MIKRO_ORM_LOAD_STRATEGY` | `loadStrategy` |
 | `MIKRO_ORM_BATCH_SIZE` | `batchSize` |
 | `MIKRO_ORM_USE_BATCH_INSERTS` | `useBatchInserts` |

--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -172,6 +172,7 @@ export class ConfigurationLoader {
     read(ret, 'MIKRO_ORM_USER', 'user');
     read(ret, 'MIKRO_ORM_PASSWORD', 'password');
     read(ret, 'MIKRO_ORM_DB_NAME', 'dbName');
+    read(ret, 'MIKRO_ORM_SCHEMA', 'schema');
     read(ret, 'MIKRO_ORM_LOAD_STRATEGY', 'loadStrategy');
     read(ret, 'MIKRO_ORM_BATCH_SIZE', 'batchSize', num);
     read(ret, 'MIKRO_ORM_USE_BATCH_INSERTS', 'useBatchInserts', bool);


### PR DESCRIPTION
Added MIKRO_ORM_SCHEMA to the environment variables being read from .env file.