### PR TITLE
feat(core): allow custom ORM prop name in `@UseRequestContext()`

### DIFF
--- a/packages/core/src/decorators/UseRequestContext.ts
+++ b/packages/core/src/decorators/UseRequestContext.ts
@@ -1,7 +1,7 @@
 import { MikroORM } from '../MikroORM';
 import { RequestContext } from '../utils/RequestContext';
 
-export function UseRequestContext<T>(getContext?: MikroORM | ((type: T) => MikroORM)): MethodDecorator {
+export function UseRequestContext<T>(getContext?: MikroORM | ((type?: T) => MikroORM)): MethodDecorator {
   return function (target: any, propertyKey: string | symbol, descriptor: PropertyDescriptor) {
     const originalMethod = descriptor.value;
     descriptor.value = async function (this: T, ...args: any[]) {

--- a/packages/core/src/decorators/UseRequestContext.ts
+++ b/packages/core/src/decorators/UseRequestContext.ts
@@ -9,7 +9,7 @@ export function UseRequestContext<T>(getContext?: MikroORM | ((type?: T) => Mikr
       const orm = getContext instanceof MikroORM ? getContext : (getContext?.(this) ?? (this as any).orm);
 
       if (!(orm as unknown instanceof MikroORM)) {
-        throw new Error('@UseRequestContext() decorator can only be applied to methods of classes with `orm: MikroORM` property, or with a callback parameter like `@UseRequestContext(type => type.orm)`');
+        throw new Error('@UseRequestContext() decorator can only be applied to methods of classes with `orm: MikroORM` property, or with a callback parameter like `@UseRequestContext(() => orm)`');
       }
 
       return await RequestContext.createAsync(orm.em, async () => {

--- a/packages/core/src/decorators/UseRequestContext.ts
+++ b/packages/core/src/decorators/UseRequestContext.ts
@@ -1,15 +1,15 @@
 import { MikroORM } from '../MikroORM';
 import { RequestContext } from '../utils/RequestContext';
 
-export function UseRequestContext(getContext?: MikroORM | (() => MikroORM)) {
+export function UseRequestContext<T>(getContext?: MikroORM | ((type: T) => MikroORM)): MethodDecorator {
   return function (target: any, propertyKey: string | symbol, descriptor: PropertyDescriptor) {
     const originalMethod = descriptor.value;
-    descriptor.value = async function (this: { orm: MikroORM }, ...args: any[]) {
+    descriptor.value = async function (this: T, ...args: any[]) {
       /* istanbul ignore next */
-      const orm = getContext instanceof MikroORM ? getContext : (getContext?.() ?? this.orm);
+      const orm = getContext instanceof MikroORM ? getContext : (getContext?.(this) ?? (this as any).orm);
 
       if (!(orm as unknown instanceof MikroORM)) {
-        throw new Error('@UseRequestContext() decorator can only be applied to methods of classes with `orm: MikroORM` property, or with a callback parameter like `@UseRequestContext(() => orm)`');
+        throw new Error('@UseRequestContext() decorator can only be applied to methods of classes with `orm: MikroORM` property, or with a callback parameter like `@UseRequestContext(type) => type.orm)`');
       }
 
       return await RequestContext.createAsync(orm.em, async () => {

--- a/packages/core/src/decorators/UseRequestContext.ts
+++ b/packages/core/src/decorators/UseRequestContext.ts
@@ -9,7 +9,7 @@ export function UseRequestContext<T>(getContext?: MikroORM | ((type?: T) => Mikr
       const orm = getContext instanceof MikroORM ? getContext : (getContext?.(this) ?? (this as any).orm);
 
       if (!(orm as unknown instanceof MikroORM)) {
-        throw new Error('@UseRequestContext() decorator can only be applied to methods of classes with `orm: MikroORM` property, or with a callback parameter like `@UseRequestContext(type) => type.orm)`');
+        throw new Error('@UseRequestContext() decorator can only be applied to methods of classes with `orm: MikroORM` property, or with a callback parameter like `@UseRequestContext(type => type.orm)`');
       }
 
       return await RequestContext.createAsync(orm.em, async () => {


### PR DESCRIPTION
We can customize the parameter name of `MikroORM` in `@UseRequestContext` decorator

```ts

@Injectable()
export class SomeService {

  constructor(
      private readonly mikroORM: MikroORM) {

  }

  @UseRequestContext<SomeService>(type => type.mikroORM)
  public someFunction(id: number) {
    // ...
  }

}
```

---

Closes #3474