### PR TITLE
feat(core): automatically detect `src/dist/build` folders and adjust configuration

### DIFF
--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -1,4 +1,5 @@
 import { inspect } from 'util';
+import { pathExistsSync } from 'fs-extra';
 
 import type { NamingStrategy } from '../naming-strategy';
 import type { CacheAdapter } from '../cache';
@@ -163,6 +164,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     this.driver = this.initDriver();
     this.platform = this.driver.getPlatform();
     this.platform.setConfig(this);
+    this.detectSourceFolder(options);
     this.init();
   }
 
@@ -329,6 +331,39 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
 
     if (!colors.enabled()) {
       this.options.highlighter = new NullHighlighter();
+    }
+  }
+
+  /**
+   * Checks if `src` folder exists, it so, tries to adjust the migrations and seeders paths automatically to use it.
+   * If there is a `dist` or `build` folder, it will be used for the JS variant (`path` option), while the `src` folder will be
+   * used for the TS variant (`pathTs` option).
+   *
+   * If the default folder exists (e.g. `/migrations`), the config will respect that, so this auto-detection should not
+   * break existing projects, only help with the new ones.
+   */
+  private detectSourceFolder(options: Options): void {
+    if (!pathExistsSync(this.options.baseDir + '/src')) {
+      return;
+    }
+
+    const migrationsPathExists = pathExistsSync(this.options.baseDir + '/' + this.options.migrations.path);
+    const seedersPathExists = pathExistsSync(this.options.baseDir + '/' + this.options.seeder.path);
+    const distDir = pathExistsSync(this.options.baseDir + '/dist');
+    const buildDir = pathExistsSync(this.options.baseDir + '/build');
+    // if neither `dist` nor `build` exist, we use the `src` folder as it might be a JS project without building, but with `src` folder
+    const path = distDir ? './dist' : (buildDir ? './build' : './src');
+
+    // only if the user did not provide any values and if the default path does not exist
+    if (!options.migrations?.path && !options.migrations?.pathTs && !migrationsPathExists) {
+      this.options.migrations.path = `${path}/migrations`;
+      this.options.migrations.pathTs = './src/migrations';
+    }
+
+    // only if the user did not provide any values and if the default path does not exist
+    if (!options.seeder?.path && !options.seeder?.pathTs && !seedersPathExists) {
+      this.options.seeder.path = `${path}/seeders`;
+      this.options.seeder.pathTs = './src/seeders';
     }
   }
 

--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -1,5 +1,5 @@
 import dotenv from 'dotenv';
-import { pathExists, realpath } from 'fs-extra';
+import { pathExists, pathExistsSync, realpath } from 'fs-extra';
 import { isAbsolute, join } from 'path';
 import { platform } from 'os';
 import { fileURLToPath } from 'url';
@@ -96,9 +96,14 @@ export class ConfigurationLoader {
     paths.push(...(settings.configPaths || []));
 
     if (settings.useTsNode) {
+      paths.push('./src/mikro-orm.config.ts');
       paths.push('./mikro-orm.config.ts');
     }
 
+    const distDir = pathExistsSync(process.cwd() + '/dist');
+    const buildDir = pathExistsSync(process.cwd() + '/build');
+    const path = distDir ? 'dist' : (buildDir ? 'build' : 'src');
+    paths.push(`./${path}/mikro-orm.config.js`);
     paths.push('./mikro-orm.config.js');
     const tsNode = Utils.detectTsNode();
 

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -33,7 +33,7 @@ describe('MikroORM', () => {
 
   test('should work with Configuration object instance', async () => {
     expect(() => new MikroORM(new Configuration({ type: 'mongo', dbName: 'test', entities: [Author], clientUrl: 'test' }))).not.toThrowError();
-    expect(() => new MikroORM(new Configuration({ type: 'mongo', dbName: 'test', entities: ['entities'], clientUrl: 'test' }))).not.toThrowError();
+    expect(() => new MikroORM(new Configuration({ type: 'mongo', dbName: 'test', baseDir: __dirname + '/../packages/core', entities: [__dirname + '/entities'], clientUrl: 'test' }))).not.toThrowError();
   });
 
   test('should throw when no entity discovered', async () => {
@@ -77,7 +77,7 @@ describe('MikroORM', () => {
       discovery: { tsConfigPath: BASE_DIR + '/tsconfig.test.json', alwaysAnalyseProperties: false },
     };
     const pathExistsMock = jest.spyOn(fs as any, 'pathExists');
-    pathExistsMock.mockResolvedValue(true);
+    pathExistsMock.mockImplementation(async path => (path as string).endsWith('.json') || (path as string).includes('/mikro-orm/mikro-orm.config.ts'));
     jest.mock('../mikro-orm.config.ts', () => options, { virtual: true });
     const pkg = { 'mikro-orm': { useTsNode: true } } as any;
     jest.mock('../package.json', () => pkg, { virtual: true });
@@ -94,6 +94,8 @@ describe('MikroORM', () => {
 
     await orm.close();
     expect(await orm.isConnected()).toBe(false);
+
+    pathExistsMock.mockRestore();
   });
 
   test('CLI config can export async function', async () => {


### PR DESCRIPTION
If there is a `src` folder, the ORM will now automatically detect it and adjust the `seeder` and `migrations` configs to have both `path` and `pathTs` set based on that. This happens only if there are no values provided by user and the default folders don't exist.

For a fresh project, this means that if you omit the configuration, but your project has a `src` and `dist` folders existing, the ORM will automatically set the following:

- `migrations.path` to `./dist/migrations`
- `migrations.pathTs` to `./src/migrations`
- `seeder.path` to `./dist/seeders`
- `seeder.pathTs` to `./src/seeders`

In addition to this, the CLI no longer requires explicit configuration of `configPaths` in `package.json`, as long as your config is called `mikro-orm.config.js/ts` and is located in `src` or `dist/build` folder. `useTsNode` flag is still required.