### PR TITLE
feat(core): add `MikroORM` and `Options` exports to each driver package

### DIFF
--- a/packages/better-sqlite/src/BetterSqliteMikroORM.ts
+++ b/packages/better-sqlite/src/BetterSqliteMikroORM.ts
@@ -1,0 +1,14 @@
+import { MikroORM } from '@mikro-orm/core';
+import type { Options } from '@mikro-orm/core';
+import { BetterSqliteDriver } from './BetterSqliteDriver';
+
+/**
+ * @inheritDoc
+ */
+export class BetterSqliteMikroORM extends MikroORM<BetterSqliteDriver> {
+
+  private static DRIVER = BetterSqliteDriver;
+
+}
+
+export type BetterSqliteOptions = Options<BetterSqliteDriver>;

--- a/packages/better-sqlite/src/index.ts
+++ b/packages/better-sqlite/src/index.ts
@@ -4,3 +4,4 @@ export * from './BetterSqliteDriver';
 export * from './BetterSqlitePlatform';
 export * from './BetterSqliteSchemaHelper';
 export * from './BetterSqliteExceptionConverter';
+export { BetterSqliteMikroORM as MikroORM, BetterSqliteOptions as Options } from './BetterSqliteMikroORM';

--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -34,11 +34,15 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
       options = await ConfigurationLoader.getConfiguration<D>();
     }
 
-    options = options instanceof Configuration ? options.getAll() : options;
-    options = Utils.merge(options, env);
-    await ConfigurationLoader.commonJSCompat(options as object);
+    let opts = options instanceof Configuration ? options.getAll() : options;
+    opts = Utils.merge(opts, env);
+    await ConfigurationLoader.commonJSCompat(opts as object);
 
-    const orm = new MikroORM<D>(options as Options<D>);
+    if ('DRIVER' in this && !opts.driver && !opts.type) {
+      (opts as Options).driver = (this as unknown as { DRIVER: Constructor<IDatabaseDriver> }).DRIVER;
+    }
+
+    const orm = new MikroORM(opts);
     orm.logger.log('info', `MikroORM version: ${colors.green(coreVersion)}`);
 
     // we need to allow global context here as we are not in a scope of requests yet

--- a/packages/mariadb/src/MariaDbMikroORM.ts
+++ b/packages/mariadb/src/MariaDbMikroORM.ts
@@ -1,0 +1,14 @@
+import { MikroORM } from '@mikro-orm/core';
+import type { Options } from '@mikro-orm/core';
+import { MariaDbDriver } from './MariaDbDriver';
+
+/**
+ * @inheritDoc
+ */
+export class MariaDbMikroORM extends MikroORM<MariaDbDriver> {
+
+  private static DRIVER = MariaDbDriver;
+
+}
+
+export type MariaDbOptions = Options<MariaDbDriver>;

--- a/packages/mariadb/src/index.ts
+++ b/packages/mariadb/src/index.ts
@@ -4,3 +4,4 @@ export * from './MariaDbSchemaHelper';
 export * from './MariaDbPlatform';
 export * from './MariaDbDriver';
 export * from './MariaDbExceptionConverter';
+export { MariaDbMikroORM as MikroORM, MariaDbOptions as Options } from './MariaDbMikroORM';

--- a/packages/mongodb/src/MongoMikroORM.ts
+++ b/packages/mongodb/src/MongoMikroORM.ts
@@ -1,0 +1,14 @@
+import { MikroORM } from '@mikro-orm/core';
+import type { Options } from '@mikro-orm/core';
+import { MongoDriver } from './MongoDriver';
+
+/**
+ * @inheritDoc
+ */
+export class MongoMikroORM extends MikroORM<MongoDriver> {
+
+  private static DRIVER = MongoDriver;
+
+}
+
+export type MongoOptions = Options<MongoDriver>;

--- a/packages/mongodb/src/index.ts
+++ b/packages/mongodb/src/index.ts
@@ -7,4 +7,5 @@ export * from './MongoEntityRepository';
 export * from './MongoSchemaGenerator';
 export { MongoEntityManager as EntityManager } from './MongoEntityManager';
 export { MongoEntityRepository as EntityRepository } from './MongoEntityRepository';
+export { MongoMikroORM as MikroORM, MongoOptions as Options } from './MongoMikroORM';
 export { ObjectId } from 'bson';

--- a/packages/mysql/src/MySqlMikroORM.ts
+++ b/packages/mysql/src/MySqlMikroORM.ts
@@ -1,0 +1,14 @@
+import { MikroORM } from '@mikro-orm/core';
+import type { Options } from '@mikro-orm/core';
+import { MySqlDriver } from './MySqlDriver';
+
+/**
+ * @inheritDoc
+ */
+export class MySqlMikroORM extends MikroORM<MySqlDriver> {
+
+  private static DRIVER = MySqlDriver;
+
+}
+
+export type MySqlOptions = Options<MySqlDriver>;

--- a/packages/mysql/src/index.ts
+++ b/packages/mysql/src/index.ts
@@ -4,3 +4,4 @@ export * from './MySqlDriver';
 export * from './MySqlPlatform';
 export * from './MySqlSchemaHelper';
 export * from './MySqlExceptionConverter';
+export { MySqlMikroORM as MikroORM, MySqlOptions as Options } from './MySqlMikroORM';

--- a/packages/postgresql/src/PostgreSqlMikroORM.ts
+++ b/packages/postgresql/src/PostgreSqlMikroORM.ts
@@ -1,0 +1,14 @@
+import { MikroORM } from '@mikro-orm/core';
+import type { Options } from '@mikro-orm/core';
+import { PostgreSqlDriver } from './PostgreSqlDriver';
+
+/**
+ * @inheritDoc
+ */
+export class PostgreSqlMikroORM extends MikroORM<PostgreSqlDriver> {
+
+  private static DRIVER = PostgreSqlDriver;
+
+}
+
+export type PostgreSqlOptions = Options<PostgreSqlDriver>;

--- a/packages/postgresql/src/index.ts
+++ b/packages/postgresql/src/index.ts
@@ -5,3 +5,4 @@ export * from './PostgreSqlPlatform';
 export * from './PostgreSqlSchemaHelper';
 export * from './PostgreSqlExceptionConverter';
 export * from './types';
+export { PostgreSqlMikroORM as MikroORM, PostgreSqlOptions as Options } from './PostgreSqlMikroORM';

--- a/packages/sqlite/src/SqliteMikroORM.ts
+++ b/packages/sqlite/src/SqliteMikroORM.ts
@@ -1,0 +1,14 @@
+import { MikroORM } from '@mikro-orm/core';
+import type { Options } from '@mikro-orm/core';
+import { SqliteDriver } from './SqliteDriver';
+
+/**
+ * @inheritDoc
+ */
+export class SqliteMikroORM extends MikroORM<SqliteDriver> {
+
+  private static DRIVER = SqliteDriver;
+
+}
+
+export type SqliteOptions = Options<SqliteDriver>;

--- a/packages/sqlite/src/index.ts
+++ b/packages/sqlite/src/index.ts
@@ -4,3 +4,4 @@ export * from './SqliteDriver';
 export * from './SqlitePlatform';
 export * from './SqliteSchemaHelper';
 export * from './SqliteExceptionConverter';
+export { SqliteMikroORM as MikroORM, SqliteOptions as Options } from './SqliteMikroORM';

--- a/scripts/copy.mjs
+++ b/scripts/copy.mjs
@@ -39,7 +39,7 @@ async function getRootVersion(increment = true) {
     return rootVersion;
   }
 
-  const pkg = require(resolve(root, './lerna.json'), { assert: { type: 'json' } });
+  const pkg = require(resolve(root, './lerna.json'));
   rootVersion = pkg.version.replace(/^(\d+\.\d+\.\d+)-?.*$/, '$1');
 
   const parts = rootVersion.split('.');

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from 'bson';
 import type { EntityProperty } from '@mikro-orm/core';
-import { Collection, Configuration, MikroORM, QueryOrder, Reference, wrap, UniqueConstraintViolationException, IdentityMap, EntitySchema, NullHighlighter } from '@mikro-orm/core';
-import { EntityManager, MongoConnection, MongoDriver, MongoPlatform } from '@mikro-orm/mongodb';
+import { Collection, Configuration, QueryOrder, Reference, wrap, UniqueConstraintViolationException, IdentityMap, EntitySchema, NullHighlighter } from '@mikro-orm/core';
+import { EntityManager, MongoConnection, MongoDriver, MongoPlatform, MikroORM } from '@mikro-orm/mongodb';
 import { MongoHighlighter } from '@mikro-orm/mongo-highlighter';
 
 import { Author, Book, BookTag, Publisher, PublisherType, Test } from './entities';
@@ -12,7 +12,7 @@ import { FooBaz } from './entities/FooBaz';
 
 describe('EntityManagerMongo', () => {
 
-  let orm: MikroORM<MongoDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => orm = await initORMMongo(true));
   beforeEach(async () => orm.schema.clearDatabase());
@@ -23,7 +23,6 @@ describe('EntityManagerMongo', () => {
   });
 
   test('should load entities', async () => {
-    expect(orm).toBeInstanceOf(MikroORM);
     expect(orm.em).toBeInstanceOf(EntityManager);
 
     const god = new Author('God', 'hello@heaven.god');

--- a/tests/EntityManager.sqlite2.test.ts
+++ b/tests/EntityManager.sqlite2.test.ts
@@ -1,13 +1,13 @@
 import type { EntityName } from '@mikro-orm/core';
-import { ArrayCollection, Collection, EntityManager, LockMode, MikroORM, QueryOrder, ValidationError, wrap } from '@mikro-orm/core';
-import type { SqliteDriver } from '@mikro-orm/sqlite';
+import { ArrayCollection, Collection, EntityManager, LockMode, QueryOrder, ValidationError, wrap } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/sqlite';
 import { initORMSqlite2, mockLogger } from './bootstrap';
 import type { IAuthor4, IPublisher4, ITest4 } from './entities-schema';
 import { Author4, Book4, BookTag4, FooBar4, Publisher4, PublisherType, Test4 } from './entities-schema';
 
 describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => orm = await initORMSqlite2(driver));
   beforeEach(async () => orm.schema.clearDatabase());
@@ -165,7 +165,6 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
   });
 
   test('should load entities', async () => {
-    expect(orm).toBeInstanceOf(MikroORM);
     expect(orm.em).toBeInstanceOf(EntityManager);
 
     const god = orm.em.create(Author4, { name: 'God', email: 'hello@heaven.god' });

--- a/tests/cli-config.ts
+++ b/tests/cli-config.ts
@@ -1,6 +1,5 @@
-import type { Options } from '@mikro-orm/core';
 import { JavaScriptMetadataProvider } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Options, SqliteDriver } from '@mikro-orm/sqlite';
 import { BASE_DIR } from './helpers';
 
 const { BaseEntity4, Test3 } = require('./entities-js/index');

--- a/tests/features/embeddables/nested-embeddables.postgres.test.ts
+++ b/tests/features/embeddables/nested-embeddables.postgres.test.ts
@@ -1,5 +1,5 @@
-import { Embeddable, Embedded, Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import type { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Embeddable, Embedded, Entity, PrimaryKey, Property } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/postgresql';
 import { mockLogger } from '../../helpers';
 
 @Embeddable()
@@ -97,7 +97,7 @@ class User {
 
 describe('embedded entities in postgres', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({

--- a/tests/issues/GH1003.test.ts
+++ b/tests/issues/GH1003.test.ts
@@ -1,6 +1,6 @@
 import type { IdentifiedReference } from '@mikro-orm/core';
-import { BaseEntity, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/core';
-import type { SqliteDriver } from '@mikro-orm/sqlite';
+import { BaseEntity, Collection, Entity, ManyToOne, OneToMany, PrimaryKey } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Parent extends BaseEntity<Parent, 'id'> {
@@ -31,7 +31,7 @@ export class Child extends BaseEntity<Parent, 'id'> {
 
 describe('GH issue 1003', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({


### PR DESCRIPTION
Those driver specific implementations automatically fill the driver type:

Before:

```ts
import { MikroORM, Options } from '@mikro-orm/core';
import { SqliteDriver } from '@mikro-orm/sqlite';

const options: Options<SqliteDriver> = { type: 'sqlite', ... };
const orm = await MikroORM.init<SqliteDriver>(options);
```

After:

```ts
import { MikroORM, Options } from '@mikro-orm/sqlite';

// no need for `type: 'sqlite'` if we use the MikroORM class from driver package
const options: Options = { ... };
const orm = await MikroORM.init(options);
```