### PR TITLE
feat(core): add `defineConfig` helper

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -255,6 +255,28 @@ export default {
 };
 ```
 
+To have the config type-safe, we can define the options variable first, with the `Options` type:
+
+```ts
+import { Options } from '@mikro-orm/core';
+
+const config: Options = {
+  // ...
+};
+
+export default config;
+```
+
+Alternatively, we can use the `defineConfig` helper that should provide intellisense even in JavaScript files, without the need for type hints via jsdoc:
+
+```ts
+import { defineConfig } from '@mikro-orm/core';
+
+export default defineConfig({
+  // ...
+});
+```
+
 When we have `useTsNode` disabled and `ts-node` is not already registered and detected,
 TS config files will be ignored.
 

--- a/packages/better-sqlite/src/BetterSqliteMikroORM.ts
+++ b/packages/better-sqlite/src/BetterSqliteMikroORM.ts
@@ -1,4 +1,4 @@
-import { MikroORM } from '@mikro-orm/core';
+import { defineConfig, MikroORM } from '@mikro-orm/core';
 import type { Options } from '@mikro-orm/core';
 import { BetterSqliteDriver } from './BetterSqliteDriver';
 
@@ -12,3 +12,7 @@ export class BetterSqliteMikroORM extends MikroORM<BetterSqliteDriver> {
 }
 
 export type BetterSqliteOptions = Options<BetterSqliteDriver>;
+
+export function defineBetterSqliteConfig(options: BetterSqliteOptions) {
+  return defineConfig({ driver: BetterSqliteDriver, ...options });
+}

--- a/packages/better-sqlite/src/index.ts
+++ b/packages/better-sqlite/src/index.ts
@@ -4,4 +4,8 @@ export * from './BetterSqliteDriver';
 export * from './BetterSqlitePlatform';
 export * from './BetterSqliteSchemaHelper';
 export * from './BetterSqliteExceptionConverter';
-export { BetterSqliteMikroORM as MikroORM, BetterSqliteOptions as Options } from './BetterSqliteMikroORM';
+export {
+  BetterSqliteMikroORM as MikroORM,
+  BetterSqliteOptions as Options,
+  defineBetterSqliteConfig as defineConfig,
+} from './BetterSqliteMikroORM';

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -396,6 +396,13 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
 
 }
 
+/**
+ * Type helper to make it easier to use `mikro-orm.config.js`.
+ */
+export function defineConfig<D extends IDatabaseDriver>(options: Options<D>) {
+  return options;
+}
+
 export interface DynamicPassword {
   password: string;
   expirationChecker?: () => boolean;

--- a/packages/mariadb/src/MariaDbMikroORM.ts
+++ b/packages/mariadb/src/MariaDbMikroORM.ts
@@ -1,4 +1,4 @@
-import { MikroORM } from '@mikro-orm/core';
+import { defineConfig, MikroORM } from '@mikro-orm/core';
 import type { Options } from '@mikro-orm/core';
 import { MariaDbDriver } from './MariaDbDriver';
 
@@ -12,3 +12,7 @@ export class MariaDbMikroORM extends MikroORM<MariaDbDriver> {
 }
 
 export type MariaDbOptions = Options<MariaDbDriver>;
+
+export function defineMariaDbConfig(options: MariaDbOptions) {
+  return defineConfig({ driver: MariaDbDriver, ...options });
+}

--- a/packages/mariadb/src/index.ts
+++ b/packages/mariadb/src/index.ts
@@ -4,4 +4,8 @@ export * from './MariaDbSchemaHelper';
 export * from './MariaDbPlatform';
 export * from './MariaDbDriver';
 export * from './MariaDbExceptionConverter';
-export { MariaDbMikroORM as MikroORM, MariaDbOptions as Options } from './MariaDbMikroORM';
+export {
+  MariaDbMikroORM as MikroORM,
+  MariaDbOptions as Options,
+  defineMariaDbConfig as defineConfig,
+} from './MariaDbMikroORM';

--- a/packages/mongodb/src/MongoMikroORM.ts
+++ b/packages/mongodb/src/MongoMikroORM.ts
@@ -1,4 +1,4 @@
-import { MikroORM } from '@mikro-orm/core';
+import { defineConfig, MikroORM } from '@mikro-orm/core';
 import type { Options } from '@mikro-orm/core';
 import { MongoDriver } from './MongoDriver';
 
@@ -12,3 +12,7 @@ export class MongoMikroORM extends MikroORM<MongoDriver> {
 }
 
 export type MongoOptions = Options<MongoDriver>;
+
+export function defineMongoConfig(options: MongoOptions) {
+  return defineConfig({ driver: MongoDriver, ...options });
+}

--- a/packages/mongodb/src/index.ts
+++ b/packages/mongodb/src/index.ts
@@ -7,5 +7,9 @@ export * from './MongoEntityRepository';
 export * from './MongoSchemaGenerator';
 export { MongoEntityManager as EntityManager } from './MongoEntityManager';
 export { MongoEntityRepository as EntityRepository } from './MongoEntityRepository';
-export { MongoMikroORM as MikroORM, MongoOptions as Options } from './MongoMikroORM';
+export {
+  MongoMikroORM as MikroORM,
+  MongoOptions as Options,
+  defineMongoConfig as defineConfig,
+} from './MongoMikroORM';
 export { ObjectId } from 'bson';

--- a/packages/mysql/src/MySqlMikroORM.ts
+++ b/packages/mysql/src/MySqlMikroORM.ts
@@ -1,4 +1,4 @@
-import { MikroORM } from '@mikro-orm/core';
+import { defineConfig, MikroORM } from '@mikro-orm/core';
 import type { Options } from '@mikro-orm/core';
 import { MySqlDriver } from './MySqlDriver';
 
@@ -12,3 +12,7 @@ export class MySqlMikroORM extends MikroORM<MySqlDriver> {
 }
 
 export type MySqlOptions = Options<MySqlDriver>;
+
+export function defineMySqlConfig(options: MySqlOptions) {
+  return defineConfig({ driver: MySqlDriver, ...options });
+}

--- a/packages/mysql/src/index.ts
+++ b/packages/mysql/src/index.ts
@@ -4,4 +4,8 @@ export * from './MySqlDriver';
 export * from './MySqlPlatform';
 export * from './MySqlSchemaHelper';
 export * from './MySqlExceptionConverter';
-export { MySqlMikroORM as MikroORM, MySqlOptions as Options } from './MySqlMikroORM';
+export {
+  MySqlMikroORM as MikroORM,
+  MySqlOptions as Options,
+  defineMySqlConfig as defineConfig,
+} from './MySqlMikroORM';

--- a/packages/postgresql/src/PostgreSqlMikroORM.ts
+++ b/packages/postgresql/src/PostgreSqlMikroORM.ts
@@ -1,4 +1,4 @@
-import { MikroORM } from '@mikro-orm/core';
+import { defineConfig, MikroORM } from '@mikro-orm/core';
 import type { Options } from '@mikro-orm/core';
 import { PostgreSqlDriver } from './PostgreSqlDriver';
 
@@ -12,3 +12,7 @@ export class PostgreSqlMikroORM extends MikroORM<PostgreSqlDriver> {
 }
 
 export type PostgreSqlOptions = Options<PostgreSqlDriver>;
+
+export function definePostgreSqlConfig(options: PostgreSqlOptions) {
+  return defineConfig({ driver: PostgreSqlDriver, ...options });
+}

--- a/packages/postgresql/src/index.ts
+++ b/packages/postgresql/src/index.ts
@@ -5,4 +5,8 @@ export * from './PostgreSqlPlatform';
 export * from './PostgreSqlSchemaHelper';
 export * from './PostgreSqlExceptionConverter';
 export * from './types';
-export { PostgreSqlMikroORM as MikroORM, PostgreSqlOptions as Options } from './PostgreSqlMikroORM';
+export {
+  PostgreSqlMikroORM as MikroORM,
+  PostgreSqlOptions as Options,
+  definePostgreSqlConfig as defineConfig,
+} from './PostgreSqlMikroORM';

--- a/packages/sqlite/src/SqliteMikroORM.ts
+++ b/packages/sqlite/src/SqliteMikroORM.ts
@@ -1,4 +1,4 @@
-import { MikroORM } from '@mikro-orm/core';
+import { defineConfig, MikroORM } from '@mikro-orm/core';
 import type { Options } from '@mikro-orm/core';
 import { SqliteDriver } from './SqliteDriver';
 
@@ -12,3 +12,7 @@ export class SqliteMikroORM extends MikroORM<SqliteDriver> {
 }
 
 export type SqliteOptions = Options<SqliteDriver>;
+
+export function defineSqliteConfig(options: SqliteOptions) {
+  return defineConfig({ driver: SqliteDriver, ...options });
+}

--- a/packages/sqlite/src/index.ts
+++ b/packages/sqlite/src/index.ts
@@ -4,4 +4,8 @@ export * from './SqliteDriver';
 export * from './SqlitePlatform';
 export * from './SqliteSchemaHelper';
 export * from './SqliteExceptionConverter';
-export { SqliteMikroORM as MikroORM, SqliteOptions as Options } from './SqliteMikroORM';
+export {
+  SqliteMikroORM as MikroORM,
+  SqliteOptions as Options,
+  defineSqliteConfig as defineConfig,
+} from './SqliteMikroORM';

--- a/tests/cli-config.ts
+++ b/tests/cli-config.ts
@@ -1,15 +1,14 @@
 import { JavaScriptMetadataProvider } from '@mikro-orm/core';
-import { Options, SqliteDriver } from '@mikro-orm/sqlite';
+import { defineConfig } from '@mikro-orm/sqlite';
 import { BASE_DIR } from './helpers';
 
 const { BaseEntity4, Test3 } = require('./entities-js/index');
 
-const config: Options = {
+const config = defineConfig({
   entities: [Test3, BaseEntity4],
   dbName: './mikro_orm_test.db',
   baseDir: BASE_DIR,
-  driver: SqliteDriver,
   metadataProvider: JavaScriptMetadataProvider,
-};
+});
 
 export default async () => config;


### PR DESCRIPTION
To have the config type-safe, we can define the options variable first, with the `Options` type:

```ts
import { Options } from '@mikro-orm/core';

const config: Options = {
  // ...
};

export default config;
```

Alternatively, we can use the `defineConfig` helper that should provide intellisense even in JavaScript files, without the need for type hints via jsdoc:

```ts
import { defineConfig } from '@mikro-orm/core';

export default defineConfig({
  // ...
});
```