### PR TITLE
feat(core): track changes on entity references

### DIFF
--- a/docs/docs/entity-manager.md
+++ b/docs/docs/entity-manager.md
@@ -246,6 +246,19 @@ const author = await em.findOne(Author, '...', { fields: ['name', { books: ['tit
 > Same problem can occur in mongo with M:N collections - those are stored as array property 
 > on the owning entity, so we need to make sure to mark such properties too.
 
+### Updating references (not loaded entities)
+
+Since v5.4.3, we can update references via Unit of Work, just like if it was a loaded entity. This way it is possible to issue update queries without loading the entity.
+
+```ts
+const ref = em.getReference(Author, 123);
+ref.name = 'new name';
+ref.email = 'new email';
+await em.flush();
+```
+
+This is a rough equivalent to calling `em.nativeUpdate()`, with one significant difference - we use the flush operation which handles event execution, so all life cycle hooks as well as flush events will be fired.
+
 ### Fetching Paginated Results
 
 If we are going to paginate our results, we can use `em.findAndCount()` that will return

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -381,6 +381,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
         ignoreLazyScalarProperties: true,
         lookup: false,
       });
+      em.unitOfWork.saveSnapshots();
 
       return cached.data;
     }
@@ -632,6 +633,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     entity = Utils.isEntity<T>(data) ? data : em.entityFactory.create<T>(entityName, data as EntityData<T>, { merge: true, ...options });
     em.validator.validate(entity, data, childMeta ?? meta);
     em.unitOfWork.merge(entity);
+    em.unitOfWork.saveSnapshots();
 
     return entity!;
   }

--- a/packages/core/src/entity/EntityValidator.ts
+++ b/packages/core/src/entity/EntityValidator.ts
@@ -50,6 +50,7 @@ export class EntityValidator {
         !prop.defaultRaw &&
         !prop.onCreate &&
         !prop.embedded &&
+        ![ReferenceType.ONE_TO_MANY, ReferenceType.MANY_TO_MANY].includes(prop.reference) &&
         prop.name !== wrapped.__meta.root.discriminatorColumn &&
         prop.type.toLowerCase() !== 'objectid' &&
         prop.persist !== false &&

--- a/packages/core/src/entity/wrap.ts
+++ b/packages/core/src/entity/wrap.ts
@@ -27,6 +27,6 @@ export function wrap<T, PK extends keyof T | unknown = PrimaryProperty<T>>(entit
  * use `preferHelper = true` to have access to the internal `__` properties like `__meta` or `__em`
  * @internal
  */
-export function helper<T, PK extends keyof T | unknown = PrimaryProperty<T>>(entity: T): IWrappedEntityInternal<T, PK> {
-  return (entity as Dictionary).__helper!;
+export function helper<T, PK extends keyof T | unknown = PrimaryProperty<T>>(entity?: T): IWrappedEntityInternal<T, PK> {
+  return (entity as Dictionary)?.__helper;
 }

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -104,7 +104,6 @@ export class ChangeSetPersister {
     options = this.propagateSchemaFromMetadata(meta, options, {
       convertCustomTypes: false,
     });
-    // const res = await this.driver.nativeInsertMany(meta.className, [changeSet.payload], options);
     const res = await this.driver.nativeInsert(changeSet.name, changeSet.payload, options);
 
     if (!wrapped.hasPrimaryKey()) {


### PR DESCRIPTION
Previously, only an initialized entities were considered during the change set tracking. With this change, all entities are tracked and checked for changes during the flush operation.

This unlocks one important use case - running update queries without loading the entity first. As opposed to the `em.nativeUpdate()`, this approach brings all the regular UoW features like lifecycle hooks (as well as `onUpdate` property hook).

```ts
const ref = em.getReference(Author, 123);
ref.name = 'new name';
ref.email = 'new email';
await em.flush();
```