### PR TITLE
feat(core): add `em.refresh(entity)` method

### DIFF
--- a/docs/docs/entity-manager.md
+++ b/docs/docs/entity-manager.md
@@ -259,6 +259,24 @@ await em.flush();
 
 This is a rough equivalent to calling `em.nativeUpdate()`, with one significant difference - we use the flush operation which handles event execution, so all life cycle hooks as well as flush events will be fired.
 
+### Refreshing entity state
+
+We can use `em.refresh(entity)` to synchronize the entity state with database. This is a shortcut for calling `em.findOne()` with `refresh: true` and disabled auto-flush.
+
+> This results in loss of any changes done to that entity.
+
+```ts
+const author = await em.findOneOrFail(Author, { name: 'Jon' });
+console.log(author.name); // 'Jon'
+
+// changes to entity will be lost!
+author.name = '123';
+
+// refresh the value, ignore any changes
+await em.refresh(author);
+console.log(author.name); // 'Jon'
+```
+
 ### Fetching Paginated Results
 
 If we are going to paginate our results, we can use `em.findAndCount()` that will return

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -343,6 +343,20 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   }
 
   /**
+   * Refreshes the persistent state of an entity from the database, overriding any local changes that have not yet been persisted.
+   */
+  async refresh<T extends object, P extends string = never>(entity: T, options: FindOneOptions<T, P> = {}): Promise<T> {
+    await this.findOne(entity.constructor.name, entity, {
+      schema: helper(entity).__schema,
+      ...options,
+      refresh: true,
+      flushMode: FlushMode.COMMIT,
+    });
+
+    return entity;
+  }
+
+  /**
    * Finds first entity matching your `where` query.
    */
   async findOne<T extends object, P extends string = never>(entityName: EntityName<T>, where: FilterQuery<T>, options: FindOneOptions<T, P> = {}): Promise<Loaded<T, P> | null> {

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -85,7 +85,7 @@ export class WrappedEntity<T extends object, PK extends keyof T> {
       throw ValidationError.entityNotManaged(this.entity);
     }
 
-    await this.__em.findOne((this.entity as object).constructor.name, this.entity, { refresh: true, lockMode, populate, connectionType, schema: this.__schema });
+    await this.__em.findOne(this.entity.constructor.name, this.entity, { refresh: true, lockMode, populate, connectionType, schema: this.__schema });
     this.populated(populated);
     this.__lazyInitialized = true;
 

--- a/tests/EntityManager.sqlite2.test.ts
+++ b/tests/EntityManager.sqlite2.test.ts
@@ -1115,6 +1115,34 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
     expect(res[0].count).toBe(1);
   });
 
+  test('em.refresh', async () => {
+    const e = orm.em.create(Author4, { name: 'lalala', email: '123' });
+    await orm.em.persistAndFlush(e);
+    expect(e.name).toBe('lalala');
+    e.name = '123';
+
+    // refresh the value, ignore changes
+    expect(e.name).toBe('123');
+    await orm.em.refresh(e);
+    expect(e.name).toBe('lalala');
+
+    // no queries as we dropped the state by refreshing
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock).not.toBeCalled();
+
+    orm.em.clear();
+
+    const e2 = await orm.em.findOneOrFail(Author4, { email: '123' });
+    expect(e2.name).toBe('lalala');
+    e2.name = '123';
+
+    // refresh the value, ignore changes
+    expect(e2.name).toBe('123');
+    await orm.em.refresh(e2);
+    expect(e2.name).toBe('lalala');
+  });
+
   test('qb.getCount()`', async () => {
     for (let i = 1; i <= 50; i++) {
       const author = orm.em.create(Author4, {


### PR DESCRIPTION
Allows to synchronize the entity state with database. This is a shortcut for calling `em.findOne()` with `refresh: true` and disabled auto-flush.

> This results in loss of any changes done to that entity.

```ts
const author = await em.findOneOrFail(Author, { name: 'Jon' });
console.log(author.name); // 'Jon'

// changes to entity will be lost!
author.name = '123';

// refresh the value, ignore any changes
await em.refresh(author);
console.log(author.name); // 'Jon'
```