### PR TITLE
feat(core): add `em.upsert()` method

### DIFF
--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -132,6 +132,8 @@ export interface NativeInsertUpdateOptions<T> {
   convertCustomTypes?: boolean;
   ctx?: Transaction;
   schema?: string;
+  /** `nativeUpdate()` only option */
+  upsert?: boolean;
 }
 
 export interface NativeInsertUpdateManyOptions<T> extends NativeInsertUpdateOptions<T> {

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -92,7 +92,7 @@ export class EntityFactory {
     return entity as New<T, P>;
   }
 
-  mergeData<T extends object>(meta: EntityMetadata<T>, entity: T, data: EntityData<T>, options: FactoryOptions): void {
+  mergeData<T extends object>(meta: EntityMetadata<T>, entity: T, data: EntityData<T>, options: FactoryOptions = {}): void {
     // merge unchanged properties automatically
     data = { ...data };
     const existsData = this.comparator.prepareEntity(entity);

--- a/packages/core/src/entity/EntityHelper.ts
+++ b/packages/core/src/entity/EntityHelper.ts
@@ -113,7 +113,7 @@ export class EntityHelper {
           set(val) {
             Object.defineProperty(this, prop.name, {
               get() {
-                return this.__helper.__data[prop.name];
+                return this.__helper?.__data[prop.name];
               },
               set(val) {
                 this.__helper.__data[prop.name] = val;

--- a/packages/core/src/logging/DefaultLogger.ts
+++ b/packages/core/src/logging/DefaultLogger.ts
@@ -5,9 +5,9 @@ import { colors } from './colors';
 export class DefaultLogger implements Logger {
 
   public debugMode = this.options.debugMode ?? false;
+  readonly writer = this.options.writer;
   private readonly usesReplicas = this.options.usesReplicas;
   private readonly highlighter = this.options.highlighter;
-  private readonly writer = this.options.writer;
 
   constructor(private readonly options: LoggerOptions) {}
 

--- a/packages/core/src/logging/SimpleLogger.ts
+++ b/packages/core/src/logging/SimpleLogger.ts
@@ -1,0 +1,56 @@
+import type { LogContext, LoggerNamespace } from './Logger';
+import { DefaultLogger } from './DefaultLogger';
+
+export class SimpleLogger extends DefaultLogger {
+
+  /**
+   * @inheritDoc
+   */
+  log(namespace: LoggerNamespace, message: string, context?: LogContext): void {
+    if (!this.isEnabled(namespace)) {
+      return;
+    }
+
+    // clean up the whitespace
+    message = message.replace(/\n/g, '').replace(/ +/g, ' ').trim();
+
+    this.writer(`[${namespace}] ${message}`);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  error(namespace: LoggerNamespace, message: string, context?: LogContext): void {
+    this.log(namespace, message, { ...context, level: 'error' });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  warn(namespace: LoggerNamespace, message: string, context?: LogContext): void {
+    this.log(namespace, message, { ...context, level: 'warning' });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setDebugMode(debugMode: boolean | LoggerNamespace[]): void {
+    this.debugMode = debugMode;
+  }
+
+  isEnabled(namespace: LoggerNamespace): boolean {
+    return !!this.debugMode && (!Array.isArray(this.debugMode) || this.debugMode.includes(namespace));
+  }
+
+  /**
+   * @inheritDoc
+   */
+  logQuery(context: { query: string } & LogContext): void {
+    if (!this.isEnabled('query')) {
+      return;
+    }
+
+    return this.log('query', context.query, context);
+  }
+
+}

--- a/packages/core/src/logging/index.ts
+++ b/packages/core/src/logging/index.ts
@@ -1,3 +1,4 @@
 export * from './colors';
 export * from './Logger';
 export * from './DefaultLogger';
+export * from './SimpleLogger';

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -390,7 +390,7 @@ export class EntityMetadata<T = any> {
 
       o[prop.name] = {
         get() {
-          return this.__helper.__data[prop.name];
+          return this.__helper?.__data[prop.name];
         },
         set(val: unknown) {
           this.__helper.__data[prop.name] = val;

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -100,7 +100,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     where = this.renameFields(entityName, where, true);
     data = this.renameFields(entityName, data);
 
-    return this.rethrow(this.getConnection('write').updateMany(entityName, where as object, data, options.ctx)) as Promise<QueryResult<T>>;
+    return this.rethrow(this.getConnection('write').updateMany(entityName, where as object, data, options.ctx, options.upsert)) as Promise<QueryResult<T>>;
   }
 
   async nativeUpdateMany<T extends object>(entityName: string, where: FilterQuery<T>[], data: EntityDictionary<T>[], options: NativeInsertUpdateOptions<T> = {}): Promise<QueryResult<T>> {

--- a/tests/features/__snapshots__/upsert.test.ts.snap
+++ b/tests/features/__snapshots__/upsert.test.ts.snap
@@ -1,0 +1,298 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`em.upsert [better-sqlite] em.upsert(Type, data) with PK 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (2, 42, 'a2') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (3, 43, 'a3') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`",
+  ],
+]
+`;
+
+exports[`em.upsert [better-sqlite] em.upsert(Type, data) with unique property 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (41, 'a1') on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\`",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a1' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (42, 'a2') on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\`",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (43, 'a3') on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\`",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a3' limit 1",
+  ],
+]
+`;
+
+exports[`em.upsert [better-sqlite] em.upsert(entity) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (2, 42, 'a2') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (3, 43, 'a3') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`",
+  ],
+]
+`;
+
+exports[`em.upsert [mariadb] em.upsert(Type, data) with PK 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (2, 42, 'a2') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (3, 43, 'a3') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+  ],
+]
+`;
+
+exports[`em.upsert [mariadb] em.upsert(Type, data) with unique property 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (41, 'a1') on duplicate key update \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a1' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (42, 'a2') on duplicate key update \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (43, 'a3') on duplicate key update \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a3' limit 1",
+  ],
+]
+`;
+
+exports[`em.upsert [mariadb] em.upsert(entity) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (2, 42, 'a2') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (3, 43, 'a3') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+  ],
+]
+`;
+
+exports[`em.upsert [mongo] em.upsert(Type, data) with PK 1`] = `
+[
+  [
+    "[query] db.getCollection('author').updateMany({ _id: 1 }, { '$set': { _id: 1, email: 'a1', current_age: 41 } }, { session: undefined, upsert: true });",
+  ],
+  [
+    "[query] db.getCollection('author').updateMany({ _id: 2 }, { '$set': { _id: 2, email: 'a2', current_age: 42 } }, { session: undefined, upsert: true });",
+  ],
+  [
+    "[query] db.getCollection('author').updateMany({ _id: 3 }, { '$set': { _id: 3, email: 'a3', current_age: 43 } }, { session: undefined, upsert: true });",
+  ],
+]
+`;
+
+exports[`em.upsert [mongo] em.upsert(Type, data) with unique property 1`] = `
+[
+  [
+    "[query] db.getCollection('author').updateMany({ email: 'a1' }, { '$set': { email: 'a1', current_age: 41 } }, { session: undefined, upsert: true });",
+  ],
+  [
+    "[query] db.getCollection('author').find({ email: 'a1' }, { session: undefined, projection: { _id: 1 } }).limit(1).toArray();",
+  ],
+  [
+    "[query] db.getCollection('author').updateMany({ email: 'a2' }, { '$set': { email: 'a2', current_age: 42 } }, { session: undefined, upsert: true });",
+  ],
+  [
+    "[query] db.getCollection('author').find({ email: 'a2' }, { session: undefined, projection: { _id: 1 } }).limit(1).toArray();",
+  ],
+  [
+    "[query] db.getCollection('author').updateMany({ email: 'a3' }, { '$set': { email: 'a3', current_age: 43 } }, { session: undefined, upsert: true });",
+  ],
+  [
+    "[query] db.getCollection('author').find({ email: 'a3' }, { session: undefined, projection: { _id: 1 } }).limit(1).toArray();",
+  ],
+]
+`;
+
+exports[`em.upsert [mongo] em.upsert(entity) 1`] = `
+[
+  [
+    "[query] db.getCollection('author').updateMany({ _id: 1 }, { '$set': { _id: 1, email: 'a1', current_age: 41 } }, { session: undefined, upsert: true });",
+  ],
+  [
+    "[query] db.getCollection('author').updateMany({ _id: 2 }, { '$set': { _id: 2, email: 'a2', current_age: 42 } }, { session: undefined, upsert: true });",
+  ],
+  [
+    "[query] db.getCollection('author').updateMany({ _id: 3 }, { '$set': { _id: 3, email: 'a3', current_age: 43 } }, { session: undefined, upsert: true });",
+  ],
+]
+`;
+
+exports[`em.upsert [mysql] em.upsert(Type, data) with PK 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (2, 42, 'a2') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (3, 43, 'a3') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+  ],
+]
+`;
+
+exports[`em.upsert [mysql] em.upsert(Type, data) with unique property 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (41, 'a1') on duplicate key update \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a1' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (42, 'a2') on duplicate key update \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (43, 'a3') on duplicate key update \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a3' limit 1",
+  ],
+]
+`;
+
+exports[`em.upsert [mysql] em.upsert(entity) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (2, 42, 'a2') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (3, 43, 'a3') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+  ],
+]
+`;
+
+exports[`em.upsert [postgresql] em.upsert(Type, data) with PK 1`] = `
+[
+  [
+    "[query] insert into "author" ("_id", "current_age", "email") values (1, 41, 'a1') on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age" returning "_id"",
+  ],
+  [
+    "[query] insert into "author" ("_id", "current_age", "email") values (2, 42, 'a2') on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age" returning "_id"",
+  ],
+  [
+    "[query] insert into "author" ("_id", "current_age", "email") values (3, 43, 'a3') on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age" returning "_id"",
+  ],
+]
+`;
+
+exports[`em.upsert [postgresql] em.upsert(Type, data) with unique property 1`] = `
+[
+  [
+    "[query] insert into "author" ("current_age", "email") values (41, 'a1') on conflict ("email") do update set "current_age" = excluded."current_age" returning "_id"",
+  ],
+  [
+    "[query] insert into "author" ("current_age", "email") values (42, 'a2') on conflict ("email") do update set "current_age" = excluded."current_age" returning "_id"",
+  ],
+  [
+    "[query] insert into "author" ("current_age", "email") values (43, 'a3') on conflict ("email") do update set "current_age" = excluded."current_age" returning "_id"",
+  ],
+]
+`;
+
+exports[`em.upsert [postgresql] em.upsert(entity) 1`] = `
+[
+  [
+    "[query] insert into "author" ("_id", "current_age", "email") values (1, 41, 'a1') on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age" returning "_id"",
+  ],
+  [
+    "[query] insert into "author" ("_id", "current_age", "email") values (2, 42, 'a2') on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age" returning "_id"",
+  ],
+  [
+    "[query] insert into "author" ("_id", "current_age", "email") values (3, 43, 'a3') on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age" returning "_id"",
+  ],
+]
+`;
+
+exports[`em.upsert [sqlite] em.upsert(Type, data) with PK 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (2, 42, 'a2') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (3, 43, 'a3') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`",
+  ],
+]
+`;
+
+exports[`em.upsert [sqlite] em.upsert(Type, data) with unique property 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (41, 'a1') on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\`",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a1' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (42, 'a2') on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\`",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (43, 'a3') on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\`",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a3' limit 1",
+  ],
+]
+`;
+
+exports[`em.upsert [sqlite] em.upsert(entity) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (2, 42, 'a2') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (3, 43, 'a3') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`",
+  ],
+]
+`;

--- a/tests/features/upsert.test.ts
+++ b/tests/features/upsert.test.ts
@@ -1,0 +1,164 @@
+import { MikroORM, Entity, PrimaryKey, ManyToOne, Property, SimpleLogger } from '@mikro-orm/core';
+import { mockLogger } from '../helpers';
+
+@Entity()
+export class Author {
+
+  static id = 1;
+
+  @PrimaryKey({ name: '_id' })
+  id: number = Author.id++;
+
+  @Property({ unique: true })
+  email: string;
+
+  @Property({ name: 'current_age' })
+  age: number;
+
+  constructor(email: string, age: number) {
+    this.email = email;
+    this.age = age;
+  }
+
+}
+
+@Entity()
+export class Book {
+
+  static id = 1;
+
+  @PrimaryKey({ name: '_id' })
+  id: number = Book.id++;
+
+  @ManyToOne(() => Author)
+  author: Author;
+
+  @Property()
+  name: string;
+
+  constructor(name: string, author: Author) {
+    this.name = name;
+    this.author = author;
+  }
+
+}
+
+const options = {
+  'sqlite': { dbName: ':memory:' },
+  'better-sqlite': { dbName: ':memory:' },
+  'mysql': { dbName: 'mikro_orm_upsert', port: 3308 },
+  'mariadb': { dbName: 'mikro_orm_upsert', port: 3309 },
+  'postgresql': { dbName: 'mikro_orm_upsert' },
+  'mongo': { dbName: 'mikro_orm_upsert' },
+};
+
+describe.each(Object.keys(options))('em.upsert [%s]',  type => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Author, Book],
+      type,
+      loggerFactory: options => new SimpleLogger(options),
+      ...options[type],
+    });
+    await orm.schema.refreshDatabase();
+  });
+
+  beforeEach(async () => {
+    await orm.schema.clearDatabase();
+    Author.id = Book.id = 1;
+  });
+
+  afterAll(() => orm.close());
+
+  async function createEntities() {
+    const books = [
+      new Book('b1', new Author('a1', 31)),
+      new Book('b2', new Author('a2', 32)),
+      new Book('b3', new Author('a3', 33)),
+    ];
+    await orm.em.persist(books).flush();
+    expect(books.map(b => b.id)).toEqual([1, 2, 3]);
+    expect(books.map(b => b.author.id)).toEqual([1, 2, 3]);
+
+    return books;
+  }
+
+  async function assert(author: Author, mock: jest.Mock) {
+    expect(mock.mock.calls).toMatchSnapshot();
+    mock.mockReset();
+    await orm.em.flush();
+    expect(mock).not.toBeCalled();
+
+    author.age = 123;
+    await orm.em.flush();
+    expect(mock).toBeCalled();
+
+    orm.em.clear();
+    const authors = await orm.em.find(Author, {}, { orderBy: { email: 'asc' } });
+    expect(authors).toHaveLength(3);
+
+    mock.mockReset();
+    authors[1].age = 321;
+    const author12 = await orm.em.upsert(authors[0]); // exists
+    const author22 = await orm.em.upsert(authors[1]); // exists
+    const author32 = await orm.em.upsert(authors[2]); // exists
+    expect(author12).toBe(authors[0]);
+    expect(author22).toBe(authors[1]);
+    expect(author32).toBe(authors[2]);
+    expect(author22.age).toBe(321);
+    expect(mock).not.toBeCalled();
+    await orm.em.flush();
+    await orm.em.refresh(author22);
+    expect(author22.age).toBe(321);
+  }
+
+  test('em.upsert(Type, data) with PK', async () => {
+    await createEntities();
+
+    await orm.em.nativeDelete(Book, [2, 3]);
+    orm.em.clear();
+
+    const mock = mockLogger(orm);
+    const author1 = await orm.em.upsert(Author, { id: 1, email: 'a1', age: 41 }); // exists
+    const author2 = await orm.em.upsert(Author, { id: 2, email: 'a2', age: 42 }); // inserts
+    const author3 = await orm.em.upsert(Author, { id: 3, email: 'a3', age: 43 }); // inserts
+
+    await assert(author2, mock);
+  });
+
+  test('em.upsert(Type, data) with unique property', async () => {
+    await createEntities();
+
+    await orm.em.nativeDelete(Book, [2, 3]);
+    orm.em.clear();
+
+    const mock = mockLogger(orm);
+    const author1 = await orm.em.upsert(Author, { email: 'a1', age: 41 }); // exists
+    const author2 = await orm.em.upsert(Author, { email: 'a2', age: 42 }); // inserts
+    const author3 = await orm.em.upsert(Author, { email: 'a3', age: 43 }); // inserts
+
+    await assert(author2, mock);
+  });
+
+  test('em.upsert(entity)', async () => {
+    await createEntities();
+
+    await orm.em.nativeDelete(Book, [2, 3]);
+    orm.em.clear();
+
+    const mock = mockLogger(orm);
+    const a1 = orm.em.create(Author, { id: 1, email: 'a1', age: 41 });
+    const a2 = orm.em.create(Author, { id: 2, email: 'a2', age: 42 });
+    const a3 = orm.em.create(Author, { id: 3, email: 'a3', age: 43 });
+    const author1 = await orm.em.upsert(a1); // exists
+    const author2 = await orm.em.upsert(a2); // inserts
+    const author3 = await orm.em.upsert(a3); // inserts
+    expect(a1).toBe(author1);
+    expect(a2).toBe(author2);
+    expect(a3).toBe(author3);
+
+    await assert(author2, mock);
+  });
+});


### PR DESCRIPTION
We can use `em.upsert()` create or update the entity, based on whether it is already present in the database. This method performs an `insert on conflict merge` query ensuring the database is in sync, returning a managed entity instance. The method accepts either `entityName` together with the entity `data`, or just entity instance.

```ts
// insert into "author" ("age", "email") values (33, 'foo@bar.com') on conflict ("email") do update set "age" = 41
const author = await em.upsert(Author, { email: 'foo@bar.com', age: 33 });
```

The entity data needs to contain either the primary key, or any other unique property. Let's consider the following example, where `Author.email` is a unique property:

```ts
// insert into "author" ("age", "email") values (33, 'foo@bar.com') on conflict ("email") do update set "age" = 41
// select "id" from "author" where "email" = 'foo@bar.com'
const author = await em.upsert(Author, { email: 'foo@bar.com', age: 33 });
```

Depending on the driver support, this will either use a returning query, or a separate select query, to fetch the primary key if it's missing from the `data`.

If the entity is already present in current context, there won't be any queries - instead, the entity data will be assigned and an explicit `flush` will be required for those changes to be persisted.

Closes #3515