### PR TITLE
feat(migrations): implemented multitenancy (wildcard) migrations

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,7 @@ export {
   Constructor, ConnectionType, Dictionary, PrimaryKeyType, PrimaryKeyProp, Primary, IPrimaryKey, ObjectQuery, FilterQuery, IWrappedEntity, EntityName, EntityData, Highlighter,
   AnyEntity, EntityClass, EntityProperty, EntityMetadata, QBFilterQuery, PopulateOptions, Populate, Loaded, New, LoadedReference, LoadedCollection, IMigrator, IMigrationGenerator,
   GetRepository, EntityRepositoryType, MigrationObject, DeepPartial, PrimaryProperty, Cast, IsUnknown, EntityDictionary, EntityDTO, MigrationDiff,
-  IEntityGenerator, ISeedManager, EntityClassGroup, OptionalProps, RequiredEntityData, CheckCallback, SimpleColumnMeta,
+  IEntityGenerator, ISeedManager, EntityClassGroup, OptionalProps, RequiredEntityData, CheckCallback, SimpleColumnMeta, ITenantHelperGenerator,
 } from './typings';
 export * from './enums';
 export * from './errors';

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -742,3 +742,8 @@ export interface Seeder<T extends Dictionary = Dictionary> {
 export type MaybePromise<T> = T | Promise<T>;
 
 export type ConnectionType = 'read' | 'write';
+
+export interface ITenantHelperGenerator {
+  generate(): Promise<void>;
+  generateTenantHelperFile(className: string, tenantCreateSql: string[], tenantDropSql: string[]): string;
+}

--- a/packages/core/src/utils/AbstractSchemaGenerator.ts
+++ b/packages/core/src/utils/AbstractSchemaGenerator.ts
@@ -1,7 +1,7 @@
 import type { EntityMetadata, ISchemaGenerator } from '../typings';
 import { CommitOrderCalculator } from '../unit-of-work/CommitOrderCalculator';
 import type { IDatabaseDriver } from '../drivers/IDatabaseDriver';
-import type { MetadataStorage } from '../metadata/MetadataStorage';
+import { MetadataStorage, MetadataDiscovery } from '../metadata';
 import type { Configuration } from './Configuration';
 import { EntityManager } from '../EntityManager';
 
@@ -45,7 +45,8 @@ export abstract class AbstractSchemaGenerator<D extends IDatabaseDriver> impleme
   }
 
   async clearDatabase(options?: { schema?: string }): Promise<void> {
-    for (const meta of this.getOrderedMetadata(options?.schema).reverse()) {
+    const metadata = await this.getOrderedMetadata(options?.schema);
+    for (const meta of metadata.reverse()) {
       await this.driver.nativeDelete(meta.className, {}, options);
     }
 
@@ -100,8 +101,21 @@ export abstract class AbstractSchemaGenerator<D extends IDatabaseDriver> impleme
     this.notImplemented();
   }
 
-  protected getOrderedMetadata(schema?: string): EntityMetadata[] {
-    const metadata = Object.values(this.metadata.getAll()).filter(meta => {
+  protected async getOrderedMetadata(schema?: string): Promise<EntityMetadata[]> {
+    let metadataStorage = this.metadata;
+
+    const options = this.config.get('migrations');
+    if (options?.multitenancy) {
+        const cloneMetadataForMultinenancy = async () => {
+            const discovery = new MetadataDiscovery(new MetadataStorage(), this.driver.getPlatform(), this.config);
+            metadataStorage = await discovery.discover(this.config.get('tsNode'));
+            Object.values(metadataStorage.getAll()).forEach(m => m.schema === '*' ? m.schema = '${tenant}': m.schema);
+        };
+
+        await cloneMetadataForMultinenancy();
+    }
+
+    const metadata = Object.values(metadataStorage.getAll()).filter(meta => {
       const isRootEntity = meta.root.className === meta.className;
       return isRootEntity && !meta.embeddable && !meta.virtual;
     });
@@ -118,7 +132,7 @@ export abstract class AbstractSchemaGenerator<D extends IDatabaseDriver> impleme
     }
 
     return calc.sort()
-      .map(cls => this.metadata.find(cls)!)
+      .map(cls => metadataStorage.find(cls)!)
       .filter(meta => schema ? [schema, '*'].includes(meta.schema!) : meta.schema !== '*');
   }
 

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -16,6 +16,7 @@ import type {
   IHydrator,
   IMigrationGenerator,
   IPrimaryKey,
+  ITenantHelperGenerator,
   MaybePromise,
   MigrationObject,
 } from '../typings';
@@ -38,6 +39,8 @@ import { FlushMode, LoadStrategy, PopulateHint } from '../enums';
 import { MemoryCacheAdapter } from '../cache/MemoryCacheAdapter';
 import { EntityComparator } from './EntityComparator';
 import type { Type } from '../types/Type';
+import type { DatabaseDriver } from '../drivers/DatabaseDriver';
+import type { Connection, Transaction } from '../connections/Connection';
 
 export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
 
@@ -348,6 +351,11 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     if (this.options.entities.length === 0 && this.options.discovery.warnWhenNoEntities) {
       throw new Error('No entities found, please use `entities` option');
     }
+
+    if (this.options.migrations?.multitenancy) {
+      if (this.options.type !== 'postgresql') { throw new Error('Multitenancy only available on postgres platform. Please remove `multitenancy` option or switch to postgres platform.'); }
+      if (this.options.migrations.snapshot === false) { throw new Error('Please enable `snapshot` option to use multitenancy.'); }
+    }
   }
 
   private initDriver(): D {
@@ -396,6 +404,14 @@ export type MigrationsOptions = {
   generator?: Constructor<IMigrationGenerator>;
   fileName?: (timestamp: string) => string;
   migrationsList?: MigrationObject[];
+  multitenancy?: {
+    tenants: (driver: DatabaseDriver<Connection>, ctx: Transaction) => Promise<string[]>;
+    tenantEntity?: string;
+    tenantHelperPath?: string;
+    tenantHelperPathTs?: string;
+    tenantHelperClassName?: string;
+    tenantHelperGenerator?: Constructor<ITenantHelperGenerator>;
+  };
 };
 
 export type SeederOptions = {

--- a/packages/knex/src/schema/SchemaGenerator.ts
+++ b/packages/knex/src/schema/SchemaGenerator.ts
@@ -51,15 +51,15 @@ export class SchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDriver> 
     return false;
   }
 
-  getTargetSchema(schema?: string): DatabaseSchema {
-    const metadata = this.getOrderedMetadata(schema);
+  async getTargetSchema(schema?: string): Promise<DatabaseSchema> {
+    const metadata = await this.getOrderedMetadata(schema);
     const schemaName = schema ?? this.config.get('schema') ?? this.platform.getDefaultSchemaName();
     return DatabaseSchema.fromMetadata(metadata, this.platform, this.config, schemaName);
   }
 
   async getCreateSchemaSQL(options: { wrap?: boolean; schema?: string } = {}): Promise<string> {
     const wrap = options.wrap ?? this.options.disableForeignKeys;
-    const toSchema = this.getTargetSchema(options.schema);
+    const toSchema = await this.getTargetSchema(options.schema);
     let ret = '';
 
     for (const namespace of toSchema.getNamespaces()) {
@@ -100,7 +100,8 @@ export class SchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDriver> 
 
     await this.execute(this.helper.disableForeignKeysSQL());
 
-    for (const meta of this.getOrderedMetadata(options?.schema).reverse()) {
+    const metadata = await this.getOrderedMetadata(options?.schema);
+    for (const meta of metadata.reverse()) {
       await this.driver.createQueryBuilder(meta.className, this.em?.getTransactionContext(), 'write', false)
         .withSchema(options?.schema)
         .truncate();
@@ -118,7 +119,7 @@ export class SchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDriver> 
 
   async getDropSchemaSQL(options: { wrap?: boolean; dropMigrationsTable?: boolean; schema?: string } = {}): Promise<string> {
     const wrap = options.wrap ?? this.options.disableForeignKeys;
-    const metadata = this.getOrderedMetadata(options.schema).reverse();
+    const metadata = (await this.getOrderedMetadata(options.schema)).reverse();
     const schema = await DatabaseSchema.create(this.connection, this.platform, this.config, options.schema);
     let ret = '';
 
@@ -182,7 +183,7 @@ export class SchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDriver> 
     options.wrap ??= this.options.disableForeignKeys;
     options.safe ??= false;
     options.dropTables ??= true;
-    const toSchema = this.getTargetSchema(options.schema);
+    const toSchema = await this.getTargetSchema(options.schema);
     const fromSchema = options.fromSchema ?? await DatabaseSchema.create(this.connection, this.platform, this.config, options.schema);
     const wildcardSchemaTables = Object.values(this.metadata.getAll()).filter(meta => meta.schema === '*').map(meta => meta.tableName);
     fromSchema.prune(options.schema, wildcardSchemaTables);

--- a/packages/migrations/src/JSMigrationGenerator.ts
+++ b/packages/migrations/src/JSMigrationGenerator.ts
@@ -6,6 +6,11 @@ export class JSMigrationGenerator extends MigrationGenerator {
    * @inheritDoc
    */
   generateMigrationFile(className: string, diff: { up: string[]; down: string[] }): string {
+    if (this.options.multitenancy) { return this.generateMultitenancyMigrationFile(className, diff); }
+    return this.generateDefaultMigrationFile(className, diff);
+  }
+
+  generateDefaultMigrationFile(className: string, diff: { up: string[]; down: string[] }) {
     let ret = `'use strict';\n`;
     ret += `Object.defineProperty(exports, '__esModule', { value: true });\n`;
     ret += `const { Migration } = require('@mikro-orm/migrations');\n\n`;
@@ -13,14 +18,96 @@ export class JSMigrationGenerator extends MigrationGenerator {
     ret += `  async up() {\n`;
     diff.up.forEach(sql => ret += this.createStatement(sql, 4));
     ret += `  }\n\n`;
-
     /* istanbul ignore else */
     if (diff.down.length > 0) {
-      ret += `  async down() {\n`;
-      diff.down.forEach(sql => ret += this.createStatement(sql, 4));
+        ret += `  async down() {\n`;
+        diff.down.forEach(sql => ret += this.createStatement(sql, 4));
+        ret += `  }\n\n`;
+    }
+    ret += `}\n`;
+    ret += `exports.${className} = ${className};\n`;
+    return ret;
+  }
+
+  generateMultitenancyMigrationFile(className: string, diff: { up: string[]; down: string[] }) {
+    const regExTenantSchemaTag = new RegExp('"\\$\\{tenant\\}"');
+
+    const tenantEntityMetadata = this.driver
+      .getMetadata()
+      .find(this.options.multitenancy?.tenantEntity || 'Tenant');
+
+    if (!tenantEntityMetadata) { throw new Error(`Multitenancy - Tenant entity '${this.options.multitenancy?.tenantEntity}' not found.`); }
+
+    let tenantUpSql = ``;
+    let commonUpSql = ``;
+    let includeTenantUpSql = true;
+    diff.up.forEach(sql => {
+      if (sql) {
+        if (sql.match(regExTenantSchemaTag)) {
+          tenantUpSql += this.createStatement(sql, 8);
+        } else {
+          if (sql.match(`create table.+${tenantEntityMetadata.tableName}`)) {
+            includeTenantUpSql = false;
+          }
+          commonUpSql += this.createStatement(sql, 4);
+        }
+      }
+    });
+    let tenantDownSql = ``;
+    let commonDownSql = ``;
+    let includeTenantDownSql = true;
+    if (diff.down.length > 0) {
+      diff.down.forEach(sql => {
+        if (sql) {
+          if (sql.match(regExTenantSchemaTag)) {
+            tenantDownSql += this.createStatement(sql, 8);
+          } else {
+            if (sql.match(`drop table.+${tenantEntityMetadata.tableName}`)) {
+              includeTenantDownSql = false;
+            }
+            commonDownSql += this.createStatement(sql, 4);
+          }
+        }
+      });
+    }
+    const hasTenantUpSql = tenantUpSql !== '' && includeTenantUpSql;
+    const hasTenantDownSql = tenantDownSql !== '' && includeTenantDownSql;
+    const hasTenantSql = hasTenantUpSql && hasTenantDownSql;
+
+    let ret = `'use strict';\n`;
+        ret += `Object.defineProperty(exports, '__esModule', { value: true });\n`;
+        ret += `const { Migration } = require('@mikro-orm/migrations');\n`;
+    if (hasTenantSql) {
+      ret += `const { Configuration, MigrationsOptions } = require('@mikro-orm/core');\n`;
+      ret += `const { AbstractSqlDriver } = require('@mikro-orm/knex');\n`;
+    }
+    ret += `\nclass ${className} extends Migration {\n`;
+    if (hasTenantSql) {
+      ret += `  constructor(driver, config) {\n`;
+      ret += `      super(driver, config);\n`;
+      ret += `      this.options = config.get("migrations");\n`;
       ret += `  }\n\n`;
     }
-
+    ret += `  async up() {\n`;
+    ret += commonUpSql;
+    if (hasTenantUpSql) {
+      if (commonUpSql !== '') { ret += '\n'; }
+      ret += `    const tenants = await this.options.multitenancy.tenants(this.driver, this.ctx);\n`;
+      ret += `    tenants.forEach((tenant) => {\n`;
+      ret += tenantUpSql;
+      ret += `    });\n`;
+    }
+    ret += `  }\n\n`;
+    ret += `  async down() {\n`;
+    if (hasTenantDownSql) {
+      ret += `    const tenants = await this.options.multitenancy.tenants(this.driver, this.ctx);\n`;
+      ret += `    tenants.forEach((tenant) => {\n`;
+      ret += tenantDownSql;
+      ret += `    });\n`;
+      if (commonDownSql !== '') { ret += '\n'; }
+    }
+    ret += commonDownSql;
+    ret += `  }\n`;
     ret += `}\n`;
     ret += `exports.${className} = ${className};\n`;
 

--- a/packages/migrations/src/JSTenantHelperGenerator.ts
+++ b/packages/migrations/src/JSTenantHelperGenerator.ts
@@ -1,0 +1,23 @@
+import { TenantHelperGenerator } from './TenantHelperGenerator';
+
+export class JSTenantHelperGenerator extends TenantHelperGenerator {
+
+  generateTenantHelperFile(className: string, tenantCreateSql: string[], tenantDropSql: string[]): string {
+    let ret = ``;
+    ret += `export class ${className} {\n`;
+    ret += `  public static GetCreateSql(tenant) {\n`;
+    ret += `    return [\n`;
+    tenantCreateSql.forEach(sql => ret += `      \`${sql};\`,\n`);
+    ret += `    ];\n`;
+    ret += `  }\n\n`;
+    ret += `  public static GetDropSql(tenant) {\n`;
+    ret += `    return [\n`;
+    tenantDropSql.forEach(sql => ret += `      \`${sql};\`,\n`);
+    ret += `    ];\n`;
+    ret += `  }\n`;
+    ret += `}`;
+
+    return ret;
+  }
+
+}

--- a/packages/migrations/src/MigrationGenerator.ts
+++ b/packages/migrations/src/MigrationGenerator.ts
@@ -32,7 +32,7 @@ export abstract class MigrationGenerator implements IMigrationGenerator {
   createStatement(sql: string, padLeft: number): string {
     if (sql) {
       const padding = ' '.repeat(padLeft);
-      return `${padding}this.addSql('${sql.replace(/['\\]/g, '\\\'')}');\n`;
+      return `${padding}this.addSql(\`${sql.replace(/['\\]/g, '\\\'')}\`);\n`;
     }
 
     return '\n';

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -12,6 +12,8 @@ import { MigrationStorage } from './MigrationStorage';
 import type { MigrateOptions, MigrationResult, MigrationRow, UmzugMigration } from './typings';
 import { TSMigrationGenerator } from './TSMigrationGenerator';
 import { JSMigrationGenerator } from './JSMigrationGenerator';
+import { TSTenantHelperGenerator } from './TSTenantHelperGenerator';
+import { JSTenantHelperGenerator } from './JSTenantHelperGenerator';
 
 export class Migrator implements IMigrator {
 
@@ -56,6 +58,22 @@ export class Migrator implements IMigrator {
 
     await this.storeCurrentSchema();
     const migration = await this.generator.generate(diff, path);
+
+    if (this.options.multitenancy) {
+      // Generating TenantHelper class file. This file should be re-generated right after each created migration to make sure
+      // tenant creation code is in sync.
+
+      let tenantHelperGenerator;
+      if (this.options.multitenancy.tenantHelperGenerator) {
+          tenantHelperGenerator = new this.options.multitenancy.tenantHelperGenerator(this.schemaGenerator, this.options);
+      } else if (this.options.emit === 'js') {
+          tenantHelperGenerator = new JSTenantHelperGenerator(this.schemaGenerator, this.config);
+      } else {
+          tenantHelperGenerator = new TSTenantHelperGenerator(this.schemaGenerator, this.config);
+      }
+
+      await tenantHelperGenerator.generate();
+    }
 
     return {
       fileName: migration[1],
@@ -259,7 +277,7 @@ export class Migrator implements IMigrator {
       return;
     }
 
-    const schema = this.schemaGenerator.getTargetSchema();
+    const schema = await this.schemaGenerator.getTargetSchema();
     await writeJSON(this.snapshotPath, schema, { spaces: 2 });
   }
 

--- a/packages/migrations/src/TSMigrationGenerator.ts
+++ b/packages/migrations/src/TSMigrationGenerator.ts
@@ -6,18 +6,103 @@ export class TSMigrationGenerator extends MigrationGenerator {
    * @inheritDoc
    */
   generateMigrationFile(className: string, diff: { up: string[]; down: string[] }): string {
+    if (this.options.multitenancy) { return this.generateMultitenancyMigrationFile(className, diff); }
+    return this.generateDefaultMigrationFile(className, diff);
+  }
+
+  generateDefaultMigrationFile(className: string, diff: { up: string[]; down: string[] }) {
     let ret = `import { Migration } from '@mikro-orm/migrations';\n\n`;
     ret += `export class ${className} extends Migration {\n\n`;
     ret += `  async up(): Promise<void> {\n`;
     diff.up.forEach(sql => ret += this.createStatement(sql, 4));
     ret += `  }\n\n`;
-
     if (diff.down.length > 0) {
-      ret += `  async down(): Promise<void> {\n`;
-      diff.down.forEach(sql => ret += this.createStatement(sql, 4));
+        ret += `  async down(): Promise<void> {\n`;
+        diff.down.forEach(sql => ret += this.createStatement(sql, 4));
+        ret += `  }\n\n`;
+    }
+    ret += `}\n`;
+    return ret;
+  }
+
+  generateMultitenancyMigrationFile(className: string, diff: { up: string[]; down: string[] }) {
+    const regExTenantSchemaTag = new RegExp('"\\$\\{tenant\\}"');
+
+    const tenantEntityMetadata = this.driver
+      .getMetadata()
+      .find(this.options.multitenancy?.tenantEntity || 'Tenant');
+
+    if (!tenantEntityMetadata) { throw new Error(`Multitenancy - Tenant entity '${this.options.multitenancy?.tenantEntity}' not found.`); }
+
+    let tenantUpSql = ``;
+    let commonUpSql = ``;
+    let includeTenantUpSql = true;
+    diff.up.forEach(sql => {
+      if (sql) {
+        if (sql.match(regExTenantSchemaTag)) {
+          tenantUpSql += this.createStatement(sql, 8);
+        } else {
+          if (sql.match(`create table.+${tenantEntityMetadata.tableName}`)) {
+            includeTenantUpSql = false;
+          }
+          commonUpSql += this.createStatement(sql, 4);
+        }
+      }
+    });
+    let tenantDownSql = ``;
+    let commonDownSql = ``;
+    let includeTenantDownSql = true;
+    if (diff.down.length > 0) {
+      diff.down.forEach(sql => {
+        if (sql) {
+          if (sql.match(regExTenantSchemaTag)) {
+            tenantDownSql += this.createStatement(sql, 8);
+          } else {
+            if (sql.match(`drop table.+${tenantEntityMetadata.tableName}`)) {
+              includeTenantDownSql = false;
+            }
+            commonDownSql += this.createStatement(sql, 4);
+          }
+        }
+      });
+    }
+    const hasTenantUpSql = tenantUpSql !== '' && includeTenantUpSql;
+    const hasTenantDownSql = tenantDownSql !== '' && includeTenantDownSql;
+    const hasTenantSql = hasTenantUpSql && hasTenantDownSql;
+
+    let ret = `import { Migration } from '@mikro-orm/migrations';\n`;
+    if (hasTenantSql) {
+      ret += `import { Configuration, MigrationsOptions } from '@mikro-orm/core';\n`;
+      ret += `import { AbstractSqlDriver } from '@mikro-orm/knex';\n`;
+    }
+    ret += `\nexport class ${className} extends Migration {\n`;
+    if (hasTenantSql) {
+      ret += `  private options: MigrationsOptions;\n\n`;
+      ret += `  constructor(driver: AbstractSqlDriver, config: Configuration) {\n`;
+      ret += `      super(driver, config);\n`;
+      ret += `      this.options = config.get("migrations");\n`;
       ret += `  }\n\n`;
     }
-
+    ret += `  async up(): Promise<void> {\n`;
+    ret += commonUpSql;
+    if (hasTenantUpSql) {
+      if (commonUpSql !== '') { ret += '\n'; }
+      ret += `    const tenants = await this.options.multitenancy.tenants(this.driver, this.ctx);\n`;
+      ret += `    tenants.forEach((tenant) => {\n`;
+      ret += tenantUpSql;
+      ret += `    });\n`;
+    }
+    ret += `  }\n\n`;
+    ret += `  async down(): Promise<void> {\n`;
+    if (hasTenantDownSql) {
+      ret += `    const tenants = await this.options.multitenancy.tenants(this.driver, this.ctx);\n`;
+      ret += `    tenants.forEach((tenant) => {\n`;
+      ret += tenantDownSql;
+      ret += `    });\n`;
+      if (commonDownSql !== '') { ret += '\n'; }
+    }
+    ret += commonDownSql;
+    ret += `  }\n`;
     ret += `}\n`;
 
     return ret;

--- a/packages/migrations/src/TSTenantHelperGenerator.ts
+++ b/packages/migrations/src/TSTenantHelperGenerator.ts
@@ -1,0 +1,23 @@
+import { TenantHelperGenerator } from './TenantHelperGenerator';
+
+export class TSTenantHelperGenerator extends TenantHelperGenerator {
+
+  generateTenantHelperFile(className: string, tenantCreateSql: string[], tenantDropSql: string[]): string {
+    let ret = ``;
+    ret += `export class ${className} {\n`;
+    ret += `  public static GetCreateSql(tenant: string): string[] {\n`;
+    ret += `    return [\n`;
+    tenantCreateSql.forEach(sql => ret += `      \`${sql};\`,\n`);
+    ret += `    ];\n`;
+    ret += `  }\n\n`;
+    ret += `  public static GetDropSql(tenant: string): string[] {\n`;
+    ret += `    return [\n`;
+    tenantDropSql.forEach(sql => ret += `      \`${sql};\`,\n`);
+    ret += `    ];\n`;
+    ret += `  }\n`;
+    ret += `}`;
+
+    return ret;
+  }
+
+}

--- a/packages/migrations/src/TenantHelperGenerator.ts
+++ b/packages/migrations/src/TenantHelperGenerator.ts
@@ -1,0 +1,41 @@
+import { ensureDir, writeFile } from 'fs-extra';
+import type { Configuration, ITenantHelperGenerator } from '@mikro-orm/core';
+import { Utils } from '@mikro-orm/core';
+import type { SchemaGenerator } from '@mikro-orm/knex';
+
+export abstract class TenantHelperGenerator implements ITenantHelperGenerator {
+
+  constructor(
+    protected readonly schemaGenerator: SchemaGenerator,
+    protected readonly config: Configuration,
+  ) {}
+
+  async generate(): Promise<void> {
+    const tenantCreateSql = (await this.schemaGenerator.getCreateSchemaSQL({ schema: '${tenant}' }))
+      .replace(/\n/g, '')
+      .split(';')
+      .slice(0, -1);
+    const tenantDropSql = (await this.schemaGenerator.getDropSchemaSQL({ schema: '${tenant}' }))
+      .replace(/\n/g, '')
+      .split(';')
+      .slice(0, -1);
+
+    const options = this.config.get('migrations');
+    const className = options.multitenancy!.tenantHelperClassName || 'TenantHelper';
+
+    const ret = this.generateTenantHelperFile(
+      className,
+      tenantCreateSql,
+      tenantDropSql);
+
+    const defaultPath = options.emit === 'ts' && options.multitenancy!.tenantHelperPathTs ? options.multitenancy!.tenantHelperPathTs : options.multitenancy!.tenantHelperPath!;
+    const path = Utils.normalizePath(this.config.get('baseDir'), defaultPath);
+    const fileName = `${className}.${options.emit}`;
+    await ensureDir(path);
+
+    await writeFile(path + '/' + fileName, ret);
+  }
+
+  abstract generateTenantHelperFile(className: string, tenantCreateSql: string[], tenantDropSql: string[]): string;
+
+}

--- a/packages/mongodb/src/MongoSchemaGenerator.ts
+++ b/packages/mongodb/src/MongoSchemaGenerator.ts
@@ -7,7 +7,7 @@ export class MongoSchemaGenerator extends AbstractSchemaGenerator<MongoDriver> {
   async createSchema(options: CreateSchemaOptions = {}): Promise<void> {
     options.ensureIndexes ??= true;
     const existing = await this.connection.listCollections();
-    const metadata = this.getOrderedMetadata();
+    const metadata = await this.getOrderedMetadata();
 
     const promises = metadata
       .filter(meta => !existing.includes(meta.collection))
@@ -24,7 +24,7 @@ export class MongoSchemaGenerator extends AbstractSchemaGenerator<MongoDriver> {
     const db = this.connection.getDb();
     const collections = await db.listCollections().toArray();
     const existing = collections.map(c => c.name);
-    const metadata = this.getOrderedMetadata();
+    const metadata = await this.getOrderedMetadata();
     const promises = metadata
       .filter(meta => existing.includes(meta.collection))
       .map(meta => this.connection.dropCollection(meta.collection));


### PR DESCRIPTION
This adds the ability for Mikro-orm to manage multitenant architectures.
Mikro-orm is now able to generate migration files to migrate dynamic db schemas.

Example of a multitenant architecture:

```js
"public" (schema)
    "Tenant" (entity)
      - id
      - name
      - description
"mytenant1" (schema)
    "Photo" (entity)
      - id
      - author_id
      - url
    "Author" (entity)
      - id
      - name
"mytenant2" (schema)
    "Photo" (entity)
      - id
      - author_id
      - url
    "Author" (entity)
      - id
      - name
... (other tenant schema)
... (other tenant schema)
```

In this architecture, we have:  

- a Tenant entity, sitting in the public/default schema (or a specific schema of your choice, like "admin"). This entity is used to identify each tenant.  
- a list of schemas (mytenant1, mytenant2, ...), each tenant sitting in its own schemas.  

Regarding the Tenant entity used to identify a tenant, usually one property is used to store the schema name of the tenant. For example, we can model the entity using the id property to identify the tenant schema:  
```js
[id]            [name]              [description]  
"mytenant1"     "My Tenant 1"       "bla bla bla..."  
"mytenant2"     "My Tenant 2"       "bla bla bla..."  
"mytenantxxx"   "My Tenant xxx"     "bla bla bla..."  
"mytenantyyy"   "My Tenant yyy"     "bla bla bla..."  
```
 
**To activate multitenancy mode in Mikro-orm, set and configure the ```migrations.multitenancy``` config option** (see details below).

**In multitenancy mode, every entity set with ```Entity({schema: '*'})``` is considered part of a tenant schema.**

In our example, each tenant is composed of two entities: ```Photo``` and ```Author```.  
This means that we need to set those two entities with the ```{schema: '*'}``` option:

```js
// Photo.ts
Entity({schema: '*'})
export class Photo {
  // ...
}

// Author.ts
Entity({schema: '*'})
export class Author {
  // ...
}
```

The ```Tenant``` entity is just set as normal, residing in the public/default schema or a specific schema of your choice:

```js
// Tenants.ts
Entity() // default schema
export class Tenant {
  // ...
}
```

The ```migrations.multitenancy``` option is configurable according to the following signature:  

```js
multitenancy?: {
  // Tenants callback
  tenants: (driver: DatabaseDriver<Connection>, ctx: Transaction) => Promise<string[]>;
  // Name of the Tenant entity residing in the default/public schema
  // (default value: "Tenant")
  tenantEntity?: string;
  // Path of the folder in which the TenantHelper class will be generated
  // (default value: Mikro-orm baseDir config)
  // tenantHelperPath or tenantHelperPathTs is choosen depending on how you set migrations.emit
  tenantHelperPath?: string;
  tenantHelperPathTs?: string;
  // Custom class name you can set for the TenantHelper class
  // (default value: "TenantHelper")
  tenantHelperClassName?: string;
  // Custom TenantHelper generator
  tenantHelperGenerator?: Constructor<ITenantHelperGenerator>;
};
```

The ```tenants``` option is mandatory. It is a callback function that you need to implement in order to provide Mikro-orm the list of tenant schemas to migrate.

What happens is: when a migration is executed (using `migration:up` or `migration:down` commands), Mikro-orm is basically now asking 'please give me the list of tenant schemas that I need to migrate', providing you a callback from which you need to return that list of tenants (as an array of string).  

Example:  

```js
const mikroOrmConfig: Options = {
  // ...
  migrations: {
    // ...
    multitenancy: {
      tenants: async (driver: AbstractSqlDriver<AbstractSqlConnection>, ctx: Transaction) =>
        // retrieving the list of tenant schemas.
        // would return ['mytenant1', 'mytenant2'] in our example
        (await driver.createEntityManager().find('Tenant', {}, { ctx: ctx })).map((t:Tenant) => t.Id)
    }
  }
}
```

**In multitenancy mode, when creating a migration (using `migration:create` command), Mikro-orm now generates the proper migration file in order to dynamically migrate the tenants:**

```js
async up(): Promise<void> {
  // Migrating "static" schemas (public schemas and others) ...
  this.addSql(`alter table "Tenant" add column "active" boolean not null default true;`);
  this.addSql(`alter table "mySchema"."MyTable" add column "myColumn" varchar(255) not null;`);
  // ...

  // Migrating tenant schemas (dynamic schemas) ...
  const tenants = await this.options.multitenancy.tenants(this.driver, this.ctx);
  tenants.forEach((tenant) => {
      this.addSql(`alter table "${tenant}"."Photo" add column "description" varchar(255) not null;`);
      this.addSql(`alter table "${tenant}"."Author" add column "bio" varchar(255) not null;`);
      // ...
  });
}
```

**Alongside with the migration file, Mikro-orm also now generates a `TenantHelper` class. You want to use this helper class in your application codebase whenever your need to create or delete a Tenant:**

```js
export class TenantHelper {
  public static GetCreateSql(tenant: string): string[] {
    return [
      `create schema if not exists "${tenant}";`,
      `create table "${tenant}"."Author" ("id" serial primary key, "name" varchar(255) not null);`,
      `create table "${tenant}"."Photo" ("id" serial primary key, "url" varchar(255) not null, "author_id" int not null);`,
      `alter table "${tenant}"."Photo" add constraint "Photo_author_id_foreign" foreign key ("author_id") references "${tenant}"."Author" ("id");`,
    ];
  }

  public static GetDropSql(tenant: string): string[] {
    return [
      `drop table if exists "${tenant}"."Photo" cascade;`,
      `drop table if exists "${tenant}"."Author" cascade;`,
    ];
  }
}
```

Prerequisite for the new multitenancy mode to work:
- Mikro-orm `type` config option must be set to `postgresql`
- Mikro-orm `migrations.snapshot` config options must be enabled


_Notes about this PR:_

- _This new feature is non-breaking. Mikro-orm keeps working as before, and it is only by activating `multitenancy` option that we introduce a new behaviour._

- _Feel free to use the above description as the documentation for this new feature._

- _Main idea under the hood is as follow:  when creating a new migration under multitenancy mode, Mikro-orm clones the entities metadata and dynamically replace all the `*` schemas with a tag `${tenant}`: by replacing the `*` schema with a proper value, Mikro-orm is now outputting those tagged-schemas-entities in the generated SQL instructions. Mikro-orm can then properly re-arrange those generated SQL instructions to create a migration file dealing with dynamic multitenant schemas._

- _At the moment, the chosen solution to clone metadatas is to re-discover them from scratch (see `cloneMetadataForMultinenancy` function in `AbstractSchemaGenerator.ts`). It might be more efficient/cleaner to copy/clone the metadata storage object graph in-memory instead of re-triggering the discovery process._

- _This implementation has been thoroughly tested locally with a postgresql database. I did not have time/resource to write proper test and submit them along this PR. I'd thus be glad if someone can take this work further by writing tests, if needed._

- _Related to #3319 #2074 #2296, and all other discussions about multitenancy support in Mikro-orm._