### PR TITLE
feat(schema): try to infer runtime default values automatically

### DIFF
--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -2409,7 +2409,7 @@ describe('QueryBuilder', () => {
 
     const qb9 = pg.em.createQueryBuilder(Author2);
     qb9.insert({ email: 'ignore@example.com', name: 'John Doe' }).onConflict('email').ignore();
-    expect(qb9.getQuery()).toEqual('insert into "author2" ("email", "name") values ($1, $2) on conflict ("email") do nothing returning "id", "created_at", "updated_at", "age", "terms_accepted"');
+    expect(qb9.getQuery()).toEqual('insert into "author2" ("email", "name") values ($1, $2) on conflict ("email") do nothing returning "id", "hook_test", "created_at", "updated_at", "age", "terms_accepted"');
     expect(qb9.getParams()).toEqual(['ignore@example.com', 'John Doe']);
 
     const timestamp = new Date();
@@ -2427,7 +2427,7 @@ describe('QueryBuilder', () => {
       })
       .where({ updatedAt: { $lt: timestamp } });
 
-    expect(qb10.getQuery()).toEqual('insert into "author2" ("created_at", "email", "name", "updated_at") values ($1, $2, $3, $4) on conflict ("email") do update set "name" = $5,"updated_at" = $6 where "updated_at" < $7 returning "id", "created_at", "updated_at", "age", "terms_accepted"');
+    expect(qb10.getQuery()).toEqual('insert into "author2" ("created_at", "email", "name", "updated_at") values ($1, $2, $3, $4) on conflict ("email") do update set "name" = $5,"updated_at" = $6 where "updated_at" < $7 returning "id", "hook_test", "created_at", "updated_at", "age", "terms_accepted"');
     expect(qb10.getParams()).toEqual([timestamp, 'ignore@example.com', 'John Doe', timestamp, 'John Doe', timestamp, timestamp]);
 
     const qb11 = pg.em.createQueryBuilder(Book2).where({ meta: { foo: 123 } });

--- a/tests/features/composite-keys/__snapshots__/custom-pivot-entity-uni.sqlite.test.ts.snap
+++ b/tests/features/composite-keys/__snapshots__/custom-pivot-entity-uni.sqlite.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`custom pivot entity for m:n with additional properties (unidirectional) schema 1`] = `
 "pragma foreign_keys = off;
 
-create table \`order\` (\`id\` integer not null primary key autoincrement, \`paid\` integer not null, \`shipped\` integer not null, \`created\` datetime not null);
+create table \`order\` (\`id\` integer not null primary key autoincrement, \`paid\` integer not null default false, \`shipped\` integer not null default false, \`created\` datetime not null);
 
 create table \`product\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`current_price\` integer not null);
 

--- a/tests/features/composite-keys/__snapshots__/custom-pivot-entity-wrong-order.sqlite.test.ts.snap
+++ b/tests/features/composite-keys/__snapshots__/custom-pivot-entity-wrong-order.sqlite.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`custom pivot entity for m:n with additional properties (bidirectional, with wrong property order in pivot entity) schema 1`] = `
 "pragma foreign_keys = off;
 
-create table \`order\` (\`id\` integer not null primary key autoincrement, \`paid\` integer not null, \`shipped\` integer not null, \`created\` datetime not null);
+create table \`order\` (\`id\` integer not null primary key autoincrement, \`paid\` integer not null default false, \`shipped\` integer not null default false, \`created\` datetime not null);
 
 create table \`product\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`current_price\` integer not null);
 

--- a/tests/features/composite-keys/__snapshots__/custom-pivot-entity.sqlite.test.ts.snap
+++ b/tests/features/composite-keys/__snapshots__/custom-pivot-entity.sqlite.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`custom pivot entity for m:n with additional properties (bidirectional) schema 1`] = `
 "pragma foreign_keys = off;
 
-create table \`order\` (\`id\` integer not null primary key autoincrement, \`paid\` integer not null, \`shipped\` integer not null, \`created\` datetime not null);
+create table \`order\` (\`id\` integer not null primary key autoincrement, \`paid\` integer not null default false, \`shipped\` integer not null default false, \`created\` datetime not null);
 
 create table \`product\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`current_price\` integer not null);
 

--- a/tests/features/default-values/__snapshots__/default-values.mysql.test.ts.snap
+++ b/tests/features/default-values/__snapshots__/default-values.mysql.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`default values in mysql runtime default values are inferred if the entity can be created without any constructor parameters 1`] = `
+"set names utf8mb4;
+set foreign_key_checks = 0;
+
+create table \`a\` (\`id\` int unsigned not null auto_increment primary key, \`foo1\` int not null default 50, \`foo2\` int not null default 50, \`foo3\` int not null default 50, \`version\` int not null default 1) default character set utf8mb4 engine = InnoDB;
+
+set foreign_key_checks = 1;
+"
+`;

--- a/tests/features/default-values/default-values.mysql.test.ts
+++ b/tests/features/default-values/default-values.mysql.test.ts
@@ -37,6 +37,10 @@ describe('default values in mysql', () => {
 
   afterAll(() => orm.close(true));
 
+  test(`runtime default values are inferred if the entity can be created without any constructor parameters`, async () => {
+    expect(await orm.schema.getCreateSchemaSQL()).toMatchSnapshot();
+  });
+
   test(`database defaults will be available after flush`, async () => {
     const mock = mockLogger(orm, ['query']);
 

--- a/tests/features/optimistic-lock/GH2401.test.ts
+++ b/tests/features/optimistic-lock/GH2401.test.ts
@@ -10,7 +10,7 @@ export class Versioned {
   @Property()
   name!: string;
 
-  @Property({ version: true, default: 0 })
+  @Property({ version: true })
   version: number = 0;
 
 }

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.mysql.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.mysql.test.ts.snap
@@ -30,7 +30,7 @@ create table \`foo_param2\` (\`bar_id\` int unsigned not null, \`baz_id\` int un
 alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);
 alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);
 
-create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` enum('local', 'global') not null, \`type2\` enum('LOCAL', 'GLOBAL') not null, \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null, \`enum5\` enum('a') null) default character set utf8mb4 engine = InnoDB;
+create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null default 'asd', \`type\` enum('local', 'global') not null default 'local', \`type2\` enum('LOCAL', 'GLOBAL') not null default 'LOCAL', \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null, \`enum5\` enum('a') null) default character set utf8mb4 engine = InnoDB;
 
 create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table \`author2\` add index \`custom_email_index_name\`(\`email\`);
@@ -270,7 +270,7 @@ create table \`foo_param2\` (\`bar_id\` int unsigned not null, \`baz_id\` int un
 alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);
 alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);
 
-create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` enum('local', 'global') not null, \`type2\` enum('LOCAL', 'GLOBAL') not null, \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null, \`enum5\` enum('a') null) default character set utf8mb4 engine = InnoDB;
+create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null default 'asd', \`type\` enum('local', 'global') not null default 'local', \`type2\` enum('LOCAL', 'GLOBAL') not null default 'LOCAL', \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null, \`enum5\` enum('a') null) default character set utf8mb4 engine = InnoDB;
 
 create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table \`author2\` add index \`custom_email_index_name\`(\`email\`);
@@ -395,6 +395,8 @@ set foreign_key_checks = 0;
 
 alter table \`test2\` drop foreign key \`test2_foo___bar_foreign\`;
 
+alter table \`publisher2\` modify \`name\` varchar(255) not null default 'asd', modify \`type\` enum('local', 'global') not null default 'local', modify \`type2\` enum('LOCAL', 'GLOBAL') not null default 'LOCAL';
+
 alter table \`book2\` drop \`foo\`;
 
 alter table \`test2\` drop index \`test2_foo___bar_unique\`;
@@ -435,7 +437,7 @@ create table \`foo_param2\` (\`bar_id\` int unsigned not null, \`baz_id\` int un
 alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);
 alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);
 
-create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` enum('local', 'global') not null, \`type2\` enum('LOCAL', 'GLOBAL') not null, \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null, \`enum5\` enum('a') null) default character set utf8mb4 engine = InnoDB;
+create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null default 'asd', \`type\` enum('local', 'global') not null default 'local', \`type2\` enum('LOCAL', 'GLOBAL') not null default 'LOCAL', \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null, \`enum5\` enum('a') null) default character set utf8mb4 engine = InnoDB;
 
 create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table \`author2\` add index \`custom_email_index_name\`(\`email\`);
@@ -675,7 +677,7 @@ create table \`foo_param2\` (\`bar_id\` int unsigned not null, \`baz_id\` int un
 alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);
 alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);
 
-create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` enum('local', 'global') not null, \`type2\` enum('LOCAL', 'GLOBAL') not null, \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null, \`enum5\` enum('a') null) default character set utf8mb4 engine = InnoDB;
+create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null default 'asd', \`type\` enum('local', 'global') not null default 'local', \`type2\` enum('LOCAL', 'GLOBAL') not null default 'LOCAL', \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null, \`enum5\` enum('a') null) default character set utf8mb4 engine = InnoDB;
 
 create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table \`author2\` add index \`custom_email_index_name\`(\`email\`);
@@ -800,6 +802,8 @@ set foreign_key_checks = 0;
 
 alter table \`test2\` drop foreign key \`test2_foo___bar_foreign\`;
 
+alter table \`publisher2\` modify \`name\` varchar(255) not null default 'asd', modify \`type\` enum('local', 'global') not null default 'local', modify \`type2\` enum('LOCAL', 'GLOBAL') not null default 'LOCAL';
+
 alter table \`book2\` drop \`foo\`;
 
 alter table \`test2\` drop index \`test2_foo___bar_unique\`;
@@ -814,6 +818,8 @@ exports[`SchemaGenerator rename column [mysql]: mysql-update-schema-rename-colum
 "alter table \`author2\` drop foreign key \`author2_favourite_author_id_foreign\`;
 
 alter table \`test2\` drop foreign key \`test2_foo___bar_foreign\`;
+
+alter table \`publisher2\` modify \`name\` varchar(255) not null default 'asd', modify \`type\` enum('local', 'global') not null default 'local', modify \`type2\` enum('LOCAL', 'GLOBAL') not null default 'LOCAL';
 
 alter table \`author2\` drop index \`author2_favourite_author_id_index\`;
 alter table \`author2\` drop index \`author2_name_age_index\`;
@@ -869,6 +875,8 @@ exports[`SchemaGenerator update schema [mysql]: mysql-update-schema-create-table
 "create table \`new_table\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
 
 alter table \`test2\` drop foreign key \`test2_foo___bar_foreign\`;
+
+alter table \`publisher2\` modify \`name\` varchar(255) not null default 'asd', modify \`type\` enum('local', 'global') not null default 'local', modify \`type2\` enum('LOCAL', 'GLOBAL') not null default 'LOCAL';
 
 alter table \`book2\` drop \`foo\`;
 
@@ -957,6 +965,8 @@ exports[`SchemaGenerator update schema enums [mysql]: mysql-update-schema-enums-
 "create table \`new_table\` (\`id\` int unsigned not null auto_increment primary key, \`enum_test\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
 
 alter table \`test2\` drop foreign key \`test2_foo___bar_foreign\`;
+
+alter table \`publisher2\` modify \`name\` varchar(255) not null default 'asd', modify \`type\` enum('local', 'global') not null default 'local', modify \`type2\` enum('LOCAL', 'GLOBAL') not null default 'LOCAL';
 
 alter table \`book2\` drop \`foo\`;
 

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.mysql2.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.mysql2.test.ts.snap
@@ -27,7 +27,7 @@ create table \`foo_param2\` (\`bar_id\` int unsigned not null, \`baz_id\` int un
 alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);
 alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);
 
-create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` enum('local', 'global') not null, \`type2\` enum('LOCAL', 'GLOBAL') not null, \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null, \`enum5\` enum('a') null) default character set utf8mb4 engine = InnoDB;
+create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null default 'asd', \`type\` enum('local', 'global') not null default 'local', \`type2\` enum('LOCAL', 'GLOBAL') not null default 'LOCAL', \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null, \`enum5\` enum('a') null) default character set utf8mb4 engine = InnoDB;
 
 create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table \`author2\` add index \`custom_email_index_name\`(\`email\`);
@@ -242,7 +242,7 @@ create table \`foo_param2\` (\`bar_id\` int unsigned not null, \`baz_id\` int un
 alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);
 alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);
 
-create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` enum('local', 'global') not null, \`type2\` enum('LOCAL', 'GLOBAL') not null, \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null, \`enum5\` enum('a') null) default character set utf8mb4 engine = InnoDB;
+create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null default 'asd', \`type\` enum('local', 'global') not null default 'local', \`type2\` enum('LOCAL', 'GLOBAL') not null default 'LOCAL', \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a', 'b', 'c') null, \`enum5\` enum('a') null) default character set utf8mb4 engine = InnoDB;
 
 create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int unsigned null) default character set utf8mb4 engine = InnoDB;
 alter table \`author2\` add index \`custom_email_index_name\`(\`email\`);
@@ -313,6 +313,8 @@ alter table \`user2_sandwiches\` add index \`user2_sandwiches_user2_first_name_u
 exports[`SchemaGenerator (no FKs) generate schema from metadata [mysql]: mysql-update-schema-dump 1`] = `
 "alter table \`test2\` drop foreign key \`test2_foo___bar_foreign\`;
 
+alter table \`publisher2\` modify \`name\` varchar(255) not null default 'asd', modify \`type\` enum('local', 'global') not null default 'local', modify \`type2\` enum('LOCAL', 'GLOBAL') not null default 'LOCAL';
+
 alter table \`book2\` drop \`foo\`;
 
 alter table \`test2\` drop index \`test2_foo___bar_unique\`;
@@ -326,6 +328,8 @@ exports[`SchemaGenerator (no FKs) rename column [mysql]: mysql-update-schema-ren
 "alter table \`author2\` drop foreign key \`author2_favourite_author_id_foreign\`;
 
 alter table \`test2\` drop foreign key \`test2_foo___bar_foreign\`;
+
+alter table \`publisher2\` modify \`name\` varchar(255) not null default 'asd', modify \`type\` enum('local', 'global') not null default 'local', modify \`type2\` enum('LOCAL', 'GLOBAL') not null default 'LOCAL';
 
 alter table \`author2\` drop index \`author2_favourite_author_id_index\`;
 alter table \`author2\` drop index \`author2_name_age_index\`;
@@ -378,6 +382,8 @@ exports[`SchemaGenerator (no FKs) update schema [mysql]: mysql-update-schema-cre
 "create table \`new_table\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
 
 alter table \`test2\` drop foreign key \`test2_foo___bar_foreign\`;
+
+alter table \`publisher2\` modify \`name\` varchar(255) not null default 'asd', modify \`type\` enum('local', 'global') not null default 'local', modify \`type2\` enum('LOCAL', 'GLOBAL') not null default 'LOCAL';
 
 alter table \`book2\` drop \`foo\`;
 
@@ -466,6 +472,8 @@ exports[`SchemaGenerator (no FKs) update schema enums [mysql]: mysql-update-sche
 "create table \`new_table\` (\`id\` int unsigned not null auto_increment primary key, \`enum_test\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
 
 alter table \`test2\` drop foreign key \`test2_foo___bar_foreign\`;
+
+alter table \`publisher2\` modify \`name\` varchar(255) not null default 'asd', modify \`type\` enum('local', 'global') not null default 'local', modify \`type2\` enum('LOCAL', 'GLOBAL') not null default 'LOCAL';
 
 alter table \`book2\` drop \`foo\`;
 

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.postgres.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.postgres.test.ts.snap
@@ -18,7 +18,7 @@ create table "foo_param2" ("bar_id" int not null, "baz_id" int not null, "value"
 
 create table "label2" ("uuid" uuid not null, "name" varchar(255) not null, constraint "label2_pkey" primary key ("uuid"));
 
-create table "publisher2" ("id" serial primary key, "name" varchar(255) not null, "type" text check ("type" in ('local', 'global')) not null, "type2" text check ("type2" in ('LOCAL', 'GLOBAL')) not null, "enum1" smallint null, "enum2" smallint null, "enum3" smallint null, "enum4" text check ("enum4" in ('a', 'b', 'c')) null, "enum5" text check ("enum5" in ('a')) null);
+create table "publisher2" ("id" serial primary key, "name" varchar(255) not null default 'asd', "type" text check ("type" in ('local', 'global')) not null default 'local', "type2" text check ("type2" in ('LOCAL', 'GLOBAL')) not null default 'LOCAL', "enum1" smallint null, "enum2" smallint null, "enum3" smallint null, "enum4" text check ("enum4" in ('a', 'b', 'c')) null, "enum5" text check ("enum5" in ('a')) null);
 
 create table "author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), "updated_at" timestamptz(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int null default null, "terms_accepted" boolean not null default false, "optional" boolean null, "identities" text[] null, "born" date null, "born_time" time(0) null, "favourite_book_uuid_pk" uuid null, "favourite_author_id" int null);
 create index "custom_email_index_name" on "author2" ("email");
@@ -164,7 +164,7 @@ create table "foo_param2" ("bar_id" int not null, "baz_id" int not null, "value"
 
 create table "label2" ("uuid" uuid not null, "name" varchar(255) not null, constraint "label2_pkey" primary key ("uuid"));
 
-create table "publisher2" ("id" serial primary key, "name" varchar(255) not null, "type" text check ("type" in ('local', 'global')) not null, "type2" text check ("type2" in ('LOCAL', 'GLOBAL')) not null, "enum1" smallint null, "enum2" smallint null, "enum3" smallint null, "enum4" text check ("enum4" in ('a', 'b', 'c')) null, "enum5" text check ("enum5" in ('a')) null);
+create table "publisher2" ("id" serial primary key, "name" varchar(255) not null default 'asd', "type" text check ("type" in ('local', 'global')) not null default 'local', "type2" text check ("type2" in ('LOCAL', 'GLOBAL')) not null default 'LOCAL', "enum1" smallint null, "enum2" smallint null, "enum3" smallint null, "enum4" text check ("enum4" in ('a', 'b', 'c')) null, "enum5" text check ("enum5" in ('a')) null);
 
 create table "author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), "updated_at" timestamptz(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int null default null, "terms_accepted" boolean not null default false, "optional" boolean null, "identities" text[] null, "born" date null, "born_time" time(0) null, "favourite_book_uuid_pk" uuid null, "favourite_author_id" int null);
 create index "custom_email_index_name" on "author2" ("email");
@@ -266,7 +266,7 @@ create table "foo_param2" ("bar_id" int not null, "baz_id" int not null, "value"
 
 create table "label2" ("uuid" uuid not null, "name" varchar(255) not null, constraint "label2_pkey" primary key ("uuid"));
 
-create table "publisher2" ("id" serial primary key, "name" varchar(255) not null, "type" text check ("type" in ('local', 'global')) not null, "type2" text check ("type2" in ('LOCAL', 'GLOBAL')) not null, "enum1" smallint null, "enum2" smallint null, "enum3" smallint null, "enum4" text check ("enum4" in ('a', 'b', 'c')) null, "enum5" text check ("enum5" in ('a')) null);
+create table "publisher2" ("id" serial primary key, "name" varchar(255) not null default 'asd', "type" text check ("type" in ('local', 'global')) not null default 'local', "type2" text check ("type2" in ('LOCAL', 'GLOBAL')) not null default 'LOCAL', "enum1" smallint null, "enum2" smallint null, "enum3" smallint null, "enum4" text check ("enum4" in ('a', 'b', 'c')) null, "enum5" text check ("enum5" in ('a')) null);
 
 create table "author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), "updated_at" timestamptz(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int null default null, "terms_accepted" boolean not null default false, "optional" boolean null, "identities" text[] null, "born" date null, "born_time" time(0) null, "favourite_book_uuid_pk" uuid null, "favourite_author_id" int null);
 create index "custom_email_index_name" on "author2" ("email");

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.sqlite.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.sqlite.test.ts.snap
@@ -103,7 +103,7 @@ exports[`SchemaGenerator [sqlite] update empty schema from metadata [sqlite]: sq
 
 create table \`book_tag3\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`version\` datetime not null default current_timestamp);
 
-create table \`publisher3\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`type\` text not null);
+create table \`publisher3\` (\`id\` integer not null primary key autoincrement, \`name\` text not null default 'asd', \`type\` text not null default 'local');
 
 create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null, \`email\` text not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` date(3) null, \`born_time\` time(3) null, \`favourite_book_id\` integer null, constraint \`author3_favourite_book_id_foreign\` foreign key(\`favourite_book_id\`) references \`book3\`(\`id\`) on delete set null on update cascade);
 create unique index \`author3_email_unique\` on \`author3\` (\`email\`);

--- a/tests/issues/__snapshots__/GH529.test.ts.snap
+++ b/tests/issues/__snapshots__/GH529.test.ts.snap
@@ -6,7 +6,7 @@ set session_replication_role = 'replica';
 
 create table "customer" ("id" serial primary key);
 
-create table "order" ("id" serial primary key, "customer_id" int not null, "paid" boolean not null, "shipped" boolean not null, "created" timestamptz(0) not null);
+create table "order" ("id" serial primary key, "customer_id" int not null, "paid" boolean not null default false, "shipped" boolean not null default false, "created" timestamptz(0) not null);
 
 create table "product" ("id" serial primary key, "name" varchar(255) not null, "current_price" int not null);
 


### PR DESCRIPTION
When a runtime default value is provided and the entity instance can be constructed without providing any parameters, the default values will be inferred automatically.

We try to create two entity instances to detect the value is stable, and compare the values by reference, this will discard things like `new Date()` or any object values in general.