### PR TITLE
fix(cli): fix using `npx --workspace` with `mikro-orm-esm`

### DIFF
--- a/packages/cli/src/esm.ts
+++ b/packages/cli/src/esm.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --loader ts-node/esm --no-warnings
+#!/usr/bin/env -S node --loader ts-node/esm --no-warnings
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('yargonaut')


### PR DESCRIPTION
Shebang require add `-S` to pass parameters. See, for example, this article https://alexewerlof.medium.com/node-shebang-e1d4b02f731d#:~:text=Pass%20parameters%20to%20Node.js

Related to https://github.com/mikro-orm/mikro-orm/issues/3485#issuecomment-1265237154