### PR TITLE
fix(core): improve entity path detection with SWC 1.3.4+

### DIFF
--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -610,13 +610,14 @@ export class Utils {
   static lookupPathFromDecorator(name: string, stack?: string[]): string {
     // use some dark magic to get source path to caller
     stack = stack || new Error().stack!.split('\n');
-    let line = stack.findIndex(line => line.includes('__decorate'))!;
-
+    // In some situations (e.g. swc 1.3.4+), the presence of a source map can obscure the call to
+    // __decorate(), replacing it with the constructor name. To support these cases we look for
+    // Reflect.decorate() as well.
+    let line = stack.findIndex(line => line.includes('__decorate') || line.includes('Reflect.decorate'))!;
     if (line === -1) {
       return name;
     }
-
-    if (Utils.normalizePath(stack[line]).includes('node_modules/tslib/tslib')) {
+    if (stack[line].includes('Reflect.decorate') || Utils.normalizePath(stack[line]).includes('node_modules/tslib/tslib')) {
       line++;
     }
 

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -368,7 +368,51 @@ describe('Utils', () => {
 
     // no decorated line found
     expect(Utils.lookupPathFromDecorator('Customer')).toBe('Customer');
-  });
+
+    // when the constructor name is used in place of `__decorate` then try `Reflect.decorate`
+    expect(Utils.lookupPathFromDecorator('AuthorizationTokenEntity', [
+      '    at Function.lookupPathFromDecorator (/opt/app/node_modules/@mikro-orm/core/utils/Utils.js:502:26)',
+      '    at Function.getMetadataFromDecorator (/opt/app/node_modules/@mikro-orm/core/metadata/MetadataStorage.js:33:36)',
+      '    at /opt/app/node_modules/@mikro-orm/core/decorators/Entity.js:8:49',
+      '    at DecorateConstructor (/opt/app/node_modules/reflect-metadata/Reflect.js:541:33)',
+      '    at Reflect.decorate (/opt/app/node_modules/reflect-metadata/Reflect.js:130:24)',
+      '    at AuthorizationTokenEntity (/opt/app/packages/entity/dist/node/entity/AuthorizationTokenEntity.js:19:92)',
+      '    at Object.<anonymous> (/opt/app/packages/entity/src/entity/AuthorizationTokenEntity.ts:14:38)',
+      '    at Module._compile (node:internal/modules/cjs/loader:1149:14)',
+      '    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1203:10)',
+      '    at Module.load (node:internal/modules/cjs/loader:1027:32)',
+    ])).toBe('/opt/app/packages/entity/dist/node/entity/AuthorizationTokenEntity.js');
+
+    // when both `__decorate` and `Reflect.decorator` exist in the stack (`__decorate` first)
+    expect(Utils.lookupPathFromDecorator('AuthorizationTokenEntity', [
+      '    at Function.lookupPathFromDecorator (/opt/app/node_modules/@mikro-orm/core/utils/Utils.js:502:26)',
+      '    at Function.getMetadataFromDecorator (/opt/app/node_modules/@mikro-orm/core/metadata/MetadataStorage.js:33:36)',
+      '    at /opt/app/node_modules/@mikro-orm/core/decorators/Entity.js:8:49',
+      '    at DecorateConstructor (/opt/app/node_modules/reflect-metadata/Reflect.js:541:33)',
+      '    at __decorate (/opt/app/packages/entity/dist/node/entity/AuthorizationTokenEntityFromDecorate.js:14:38)',
+      '    at Reflect.decorate (/opt/app/node_modules/reflect-metadata/Reflect.js:130:24)',
+      '    at AuthorizationTokenEntity (/opt/app/packages/entity/dist/node/entity/AuthorizationTokenEntityFromReflectDecorate.js:19:92)',
+      '    at Object.<anonymous> (/opt/app/packages/entity/src/entity/AuthorizationTokenEntity.ts:14:38)',
+      '    at Module._compile (node:internal/modules/cjs/loader:1149:14)',
+      '    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1203:10)',
+      '    at Module.load (node:internal/modules/cjs/loader:1027:32)',
+    ])).toBe('/opt/app/packages/entity/dist/node/entity/AuthorizationTokenEntityFromDecorate.js');
+
+    // when both `__decorate` and `Reflect.decorator` exist in the stack (`__decorate` last)
+    expect(Utils.lookupPathFromDecorator('AuthorizationTokenEntity', [
+      '    at Function.lookupPathFromDecorator (/opt/app/node_modules/@mikro-orm/core/utils/Utils.js:502:26)',
+      '    at Function.getMetadataFromDecorator (/opt/app/node_modules/@mikro-orm/core/metadata/MetadataStorage.js:33:36)',
+      '    at /opt/app/node_modules/@mikro-orm/core/decorators/Entity.js:8:49',
+      '    at DecorateConstructor (/opt/app/node_modules/reflect-metadata/Reflect.js:541:33)',
+      '    at Reflect.decorate (/opt/app/node_modules/reflect-metadata/Reflect.js:130:24)',
+      '    at AuthorizationTokenEntity (/opt/app/packages/entity/dist/node/entity/AuthorizationTokenEntityFromReflectDecorate.js:19:92)',
+      '    at __decorate (/opt/app/packages/entity/dist/node/entity/AuthorizationTokenEntityFromDecorate.js:14:38)',
+      '    at Object.<anonymous> (/opt/app/packages/entity/src/entity/AuthorizationTokenEntity.ts:14:38)',
+      '    at Module._compile (node:internal/modules/cjs/loader:1149:14)',
+      '    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1203:10)',
+      '    at Module.load (node:internal/modules/cjs/loader:1027:32)',
+    ])).toBe('/opt/app/packages/entity/dist/node/entity/AuthorizationTokenEntityFromReflectDecorate.js');
+  })
 
   test('lookup path from decorator on windows', () => {
     // with tslib, via ts-node


### PR DESCRIPTION
A recent update to @swc/core (since 1.3.4) causes Mikro-ORM init to fail with errors such as:

```
ERROR Entity AuthorizationTokenEntity has wrong unique definition: 'activeToken' does not exist. You need to use property name, not column name.
```

During discovery of a class, some decorators are resolving the class path fine - populating the metadata along the way - but at some point it gets to a decorator (`@Unique`, in my case) which fails to determine the path to the class (because the stack trace didn't contain a call to `__decorate()`), wiping out all the previously-populated metadata (`properties`, in my case). So while it _did_ know about the `activeToken` property, the path-lookup-failure during the processing of the `@Unique` decorator lost it, giving me that error.

It boils down to the "dark magic" where stack traces are examined to figure out the path to the calling class.

Here are the stack traces compared between @swc/core 1.3.3 and 1.3.5 (current latest):

**@swc/core 1.3.3**
```
Error:
    at Function.lookupPathFromDecorator (/opt/app/node_modules/@mikro-orm/core/utils/Utils.js:502:26)
    at Function.getMetadataFromDecorator (/opt/app/node_modules/@mikro-orm/core/metadata/MetadataStorage.js:33:36)
    at /opt/app/node_modules/@mikro-orm/core/decorators/Entity.js:8:49
    at DecorateConstructor (/opt/app/node_modules/reflect-metadata/Reflect.js:541:33)
    at Reflect.decorate (/opt/app/node_modules/reflect-metadata/Reflect.js:130:24)
>   at __decorate (/opt/app/packages/entity/dist/node/entity/AuthorizationTokenEntity.js:19:92)
    at Object.<anonymous> (/opt/app/packages/entity/src/entity/AuthorizationTokenEntity.ts:14:38)
    at Module._compile (node:internal/modules/cjs/loader:1149:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1203:10)
    at Module.load (node:internal/modules/cjs/loader:1027:32)
```

**@swc/core 1.3.5**
```
Error:
    at Function.lookupPathFromDecorator (/opt/app/node_modules/@mikro-orm/core/utils/Utils.js:502:26)
    at Function.getMetadataFromDecorator (/opt/app/node_modules/@mikro-orm/core/metadata/MetadataStorage.js:33:36)
    at /opt/app/node_modules/@mikro-orm/core/decorators/Entity.js:8:49
    at DecorateConstructor (/opt/app/node_modules/reflect-metadata/Reflect.js:541:33)
    at Reflect.decorate (/opt/app/node_modules/reflect-metadata/Reflect.js:130:24)
>   at AuthorizationTokenEntity (/opt/app/packages/entity/dist/node/entity/AuthorizationTokenEntity.js:19:92)
    at Object.<anonymous> (/opt/app/packages/entity/src/entity/AuthorizationTokenEntity.ts:14:38)
    at Module._compile (node:internal/modules/cjs/loader:1149:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1203:10)
    at Module.load (node:internal/modules/cjs/loader:1027:32)
```

Note that my entity classes are imported from a monorepo package which exports CJS transpiled by SWC including source maps. When I disable source maps, all is good.

It's not entirely clear if the fault lies within @swc/core and how it generates the source maps - but no issues are being flagged by a source map validator I found. Either way, dodgy or not, source maps should not be affecting Mikro-ORM.

This PR adds a fallback (if `__decorate` is not found) to try searching for `Reflect.decorate` instead (and bumps to the next line if found).