### PR TITLE
perf(core): improve support for large collections

### DIFF
--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -10,6 +10,7 @@ import { Reference } from './Reference';
 import type { EntityField, FindOptions } from '../drivers/IDatabaseDriver';
 import type { MetadataStorage } from '../metadata/MetadataStorage';
 import type { Platform } from '../platforms/Platform';
+import { helper } from './wrap';
 
 export type EntityLoaderOptions<T, P extends string = never> = {
   where?: FilterQuery<T>;
@@ -220,10 +221,10 @@ export class EntityLoader {
   }
 
   private initializeOneToMany<T>(filtered: T[], children: AnyEntity[], prop: EntityProperty, field: keyof T): void {
-    for (const entity of (filtered as (T & AnyEntity)[])) {
+    for (const entity of filtered) {
       const items = children.filter(child => {
         if (prop.targetMeta!.properties[prop.mappedBy].mapToPk) {
-          return child[prop.mappedBy] as unknown === entity.__helper!.getPrimaryKey();
+          return child[prop.mappedBy] as unknown === helper(entity).getPrimaryKey();
         }
 
         return Reference.unwrapReference(child[prop.mappedBy]) as unknown === entity;
@@ -234,8 +235,8 @@ export class EntityLoader {
   }
 
   private initializeManyToMany<T>(filtered: T[], children: AnyEntity[], prop: EntityProperty, field: keyof T): void {
-    for (const entity of (filtered as (T & AnyEntity)[])) {
-      const items = children.filter(child => (child[prop.mappedBy] as unknown as Collection<AnyEntity>).contains(entity));
+    for (const entity of filtered) {
+      const items = children.filter(child => (child[prop.mappedBy] as unknown as Collection<AnyEntity>).contains(entity as AnyEntity));
       (entity[field] as unknown as Collection<AnyEntity>).hydrate(items, true);
     }
   }

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -1129,7 +1129,6 @@ describe('EntityManagerMySql', () => {
     expect(tags[0].books.isDirty()).toBe(false);
     expect(() => tags[0].books.getItems()).toThrowError(/Collection<Book2> of entity BookTag2\[\d+] not initialized/);
     expect(() => tags[0].books.remove(book1, book2)).toThrowError(/Collection<Book2> of entity BookTag2\[\d+] not initialized/);
-    expect(() => tags[0].books.removeAll()).toThrowError(/Collection<Book2> of entity BookTag2\[\d+] not initialized/);
     expect(() => tags[0].books.contains(book1)).toThrowError(/Collection<Book2> of entity BookTag2\[\d+] not initialized/);
 
     // test M:N lazy load

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -1882,7 +1882,7 @@ describe('EntityManagerPostgre', () => {
     expect(author.books.getItems().every(b => b.uuid)).toBe(true);
   });
 
-  // this should run in ~150ms (when running single test locally)
+  // this should run in ~70ms (when running single test locally)
   test('perf: one to many via em.create()', async () => {
     const books = [] as Book2[];
     for (let i = 1; i <= 10000; i++) {

--- a/tests/EntityManager.sqlite2.test.ts
+++ b/tests/EntityManager.sqlite2.test.ts
@@ -1275,7 +1275,7 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
     // n:m relations
     let taggedBook = orm.em.create(Book4, { title: 'FullyTagged' });
     await orm.em.persistAndFlush(taggedBook);
-    const tags = [orm.em.create(BookTag4, { name: 'science-fiction' }), orm.em.create(BookTag4, { name: 'adventure' }), orm.em.create(BookTag4, { name: 'horror' })];
+    const tags = [orm.em.create(BookTag4, { name: 'science-fiction' }), orm.em.create(BookTag4, { name: 'adventure' }), orm.em.create(BookTag4, { name: 'horror' })] as const;
     taggedBook.tags.add(...tags);
     await expect(taggedBook.tags.loadCount()).resolves.toEqual(0);
     await orm.em.flush();

--- a/tests/features/paginate-flag.postgres.test.ts
+++ b/tests/features/paginate-flag.postgres.test.ts
@@ -35,7 +35,7 @@ export class User {
   constructor(id: string, name: string, groups: Group[]) {
     this.id = id;
     this.name = name;
-    this.groups.add(...groups);
+    this.groups.add(groups);
   }
 
 }

--- a/tests/issues/GH910.test.ts
+++ b/tests/issues/GH910.test.ts
@@ -43,7 +43,7 @@ export class Cart {
 
   constructor(id: string, items: CartItem[]) {
     this.id = id;
-    this.items.add(...items);
+    this.items.add(items);
   }
 
   addItem(item: CartItem): void {


### PR DESCRIPTION
Previously `Collection.add/remove` were defined with a spread parameter, which could result in perf degradation in very large collections. This change makes the first parameter accept also an array of items, skipping unnecessary copying of arrays when hydarting the collection.

This is slightly breaking on type level, as it is no longer possible to do `coll.add(...items)` with a generic array - it only works with a tuple. The solution is to do `coll.add(items)` instead, which will type check and is also more performant (no array copies).

Closes #3572