### PR TITLE
feat(core): add the `offset` into `FindOneOptions`

### DIFF
--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -118,7 +118,7 @@ export interface FindOptions<T, P extends string = never> {
   connectionType?: ConnectionType;
 }
 
-export interface FindOneOptions<T extends object, P extends string = never> extends Omit<FindOptions<T, P>, 'limit' | 'offset' | 'lockMode'> {
+export interface FindOneOptions<T extends object, P extends string = never> extends Omit<FindOptions<T, P>, 'limit' | 'lockMode'> {
   lockMode?: LockMode;
   lockVersion?: number | Date;
 }

--- a/tests/issues/GH3292.test.ts
+++ b/tests/issues/GH3292.test.ts
@@ -9,27 +9,25 @@ beforeEach(async () => orm.schema.clearDatabase());
 afterAll(() => orm.close(true));
 
 test('test findOne without a offset', async () => {
-
   const author = new Author2('Bartleby', 'bartelby@writer.org');
   const book = new Book2('My Life on The Wall, part 1', author);
   new Book2('My Life on The Wall, part 2', author);
 
   await orm.em.fork().persistAndFlush(author);
 
-  const myBook = await orm.em.transactional(async () => await orm.em.findOne(Book2, {}));
+  const myBook = await orm.em.findOne(Book2, {});
 
   expect(myBook?.title).toEqual(book.title);
 });
 
 test('test findOne but with a offset', async () => {
-
   const author = new Author2('Bartleby', 'bartelby@writer.org');
   new Book2('My Life on The Wall, part 1', author);
   const book2 = new Book2('My Life on The Wall, part 2', author);
 
   await orm.em.fork().persistAndFlush(author);
 
-  const myBook = await orm.em.transactional(async () => await orm.em.findOne(Book2, {}, { offset: 1 }));
+  const myBook = await orm.em.findOne(Book2, {}, { offset: 1 });
 
   expect(myBook?.title).toEqual(book2.title);
 });

--- a/tests/issues/GH3292.test.ts
+++ b/tests/issues/GH3292.test.ts
@@ -1,5 +1,4 @@
 import type { MikroORM } from '@mikro-orm/core';
-import { mockLogger } from '../helpers';
 import { initORMPostgreSql } from '../bootstrap';
 import { Author2, Book2 } from '../entities-sql';
 
@@ -10,31 +9,19 @@ beforeEach(async () => orm.schema.clearDatabase());
 afterAll(() => orm.close(true));
 
 test('test findOne without a offset', async () => {
-    mockLogger(orm, ['query', 'query-params']);
 
-    const author = new Author2('Bartleby', 'bartelby@writer.org');
-    const book = new Book2('My Life on The Wall, part 1', author);
-    new Book2('My Life on The Wall, part 2', author);
+  const author = new Author2('Bartleby', 'bartelby@writer.org');
+  const book = new Book2('My Life on The Wall, part 1', author);
+  new Book2('My Life on The Wall, part 2', author);
 
-    await orm.em.fork().persistAndFlush(author);
+  await orm.em.fork().persistAndFlush(author);
 
-    async function requestCommonService() {
-      const b = await orm.em.findOne(Book2, {});
-      return b?.title;
-    }
+  const myBook = await orm.em.transactional(async () => await orm.em.findOne(Book2, {}));
 
-    const { titleA, titleB } = await orm.em.transactional(async () => {
-      const b = await orm.em.findOneOrFail(Book2, book.uuid);
-      const titleA = await requestCommonService();
-      const titleB = b.title;
-      return { titleA, titleB };
-    });
-
-    expect(titleA).toEqual(titleB);
+  expect(myBook?.title).toEqual(book.title);
 });
 
 test('test findOne but with a offset', async () => {
-  mockLogger(orm, ['query', 'query-params']);
 
   const author = new Author2('Bartleby', 'bartelby@writer.org');
   new Book2('My Life on The Wall, part 1', author);
@@ -42,19 +29,7 @@ test('test findOne but with a offset', async () => {
 
   await orm.em.fork().persistAndFlush(author);
 
-  async function requestCommonService() {
-    const b = await orm.em.findOne(Book2, {}, {
-        offset: 1,
-    });
-    return b?.title;
-  }
+  const myBook = await orm.em.transactional(async () => await orm.em.findOne(Book2, {}, { offset: 1 }));
 
-  const { titleA, titleB } = await orm.em.transactional(async () => {
-    const b = await orm.em.findOneOrFail(Book2, book2.uuid);
-    const titleA = await requestCommonService();
-    const titleB = b.title;
-    return { titleA, titleB };
-  });
-
-  expect(titleA).toEqual(titleB);
+  expect(myBook?.title).toEqual(book2.title);
 });

--- a/tests/issues/GH3292.test.ts
+++ b/tests/issues/GH3292.test.ts
@@ -1,0 +1,60 @@
+import type { MikroORM } from '@mikro-orm/core';
+import { mockLogger } from '../helpers';
+import { initORMPostgreSql } from '../bootstrap';
+import { Author2, Book2 } from '../entities-sql';
+
+let orm: MikroORM;
+
+beforeAll(async () => orm = await initORMPostgreSql());
+beforeEach(async () => orm.schema.clearDatabase());
+afterAll(() => orm.close(true));
+
+test('test findOne without a offset', async () => {
+    mockLogger(orm, ['query', 'query-params']);
+
+    const author = new Author2('Bartleby', 'bartelby@writer.org');
+    const book = new Book2('My Life on The Wall, part 1', author);
+    new Book2('My Life on The Wall, part 2', author);
+
+    await orm.em.fork().persistAndFlush(author);
+
+    async function requestCommonService() {
+      const b = await orm.em.findOne(Book2, {});
+      return b?.title;
+    }
+
+    const { titleA, titleB } = await orm.em.transactional(async () => {
+      const b = await orm.em.findOneOrFail(Book2, book.uuid);
+      const titleA = await requestCommonService();
+      const titleB = b.title;
+      return { titleA, titleB };
+    });
+
+    expect(titleA).toEqual(titleB);
+});
+
+test('test findOne but with a offset', async () => {
+  mockLogger(orm, ['query', 'query-params']);
+
+  const author = new Author2('Bartleby', 'bartelby@writer.org');
+  new Book2('My Life on The Wall, part 1', author);
+  const book2 = new Book2('My Life on The Wall, part 2', author);
+
+  await orm.em.fork().persistAndFlush(author);
+
+  async function requestCommonService() {
+    const b = await orm.em.findOne(Book2, {}, {
+        offset: 1,
+    });
+    return b?.title;
+  }
+
+  const { titleA, titleB } = await orm.em.transactional(async () => {
+    const b = await orm.em.findOneOrFail(Book2, book2.uuid);
+    const titleA = await requestCommonService();
+    const titleB = b.title;
+    return { titleA, titleB };
+  });
+
+  expect(titleA).toEqual(titleB);
+});


### PR DESCRIPTION
Just add the possibility of using findOne with an offset in case that is needed.
This PR doesn't have breaking changes.

Closes #3292 