### PR TITLE
feat(core): allow JsonType to use a stable JSON.stringify algorithm

### DIFF
--- a/docs/docs/custom-types.md
+++ b/docs/docs/custom-types.md
@@ -313,6 +313,14 @@ and `stringify` only when needed).
 object?: { foo: string; bar: number };
 ```
 
+The default `stringify` will output diffs for changes in object key order.  
+If you want to minimize diffs, you can use a slower, more precise, serialization function that will serialize `{a: 1, b: 2}` and `{b: 2, a: 1}` in identical ways.
+
+```ts
+@Property({ type: new JsonType({ useStableStringify: true }) })
+object: { foo: string; bar: number };
+```
+
 ### DateType
 
 To store dates without time information, we can use `DateType`. It does use `date`

--- a/packages/core/src/types/JsonType.ts
+++ b/packages/core/src/types/JsonType.ts
@@ -2,14 +2,24 @@ import { Type } from './Type';
 import type { Platform } from '../platforms';
 import type { EntityProperty } from '../typings';
 import { Utils } from '../utils';
+import { stableStringify } from '../utils/stableStringify';
 
 export class JsonType extends Type<unknown, string | null> {
+
+  constructor(
+    private opts: { useStableStringify?: boolean } = {},
+  ) {
+    super();
+  }
 
   convertToDatabaseValue(value: unknown, platform: Platform): string | null {
     if (platform.convertsJsonAutomatically(true) || value === null) {
       return value as string;
     }
 
+    if (this.opts.useStableStringify) {
+      return stableStringify(value);
+    }
     return JSON.stringify(value);
   }
 

--- a/packages/core/src/utils/stableStringify.ts
+++ b/packages/core/src/utils/stableStringify.ts
@@ -1,0 +1,41 @@
+// extracted and modified from npm package "fast-json-stable-hash"
+export function stableStringify(obj: any): string {
+    const type = typeof obj;
+    if (type === 'string') {
+      return JSON.stringify(obj);
+    }
+    if (Array.isArray(obj)) {
+      let str = '[';
+      const al = obj.length - 1;
+      for (let i = 0; i < obj.length; i++) {
+        str += stableStringify(obj[i]);
+        if (i !== al) {
+          str += ',';
+        }
+      }
+      return `${str}]`;
+    }
+    if (type === 'object' && obj !== null) {
+      let str = '{';
+      const keys = Object.keys(obj).sort();
+      const kl = keys.length - 1;
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i];
+        const val = (obj as any)[key];
+        if (val === undefined) {
+          continue;
+        }
+        if (i !== 0) {
+          str += ',';
+        }
+        str += `${JSON.stringify(key)}:${stableStringify(val)}`;
+      }
+      return `${str}}`;
+    }
+    if (type === 'number' || type === 'boolean' || obj == null) {
+      // bool, num, null have correct auto-coercions
+      return `${obj}`;
+    }
+
+    throw new TypeError(`Invalid JSON type of ${type}, value ${obj}. FJSH can only hash JSON objects.`);
+  }


### PR DESCRIPTION
fixes #3583 

We introduced an option on JsonType to allow user to choose between speed or better serialization.

I'm not sure if the option is required, or if stable stringify should simply be the only option because it's more robust ?  
I'm not sure either of what you prefer as a default: slightly more speed or less diffs. In doubt, we kept the the old behaviour by default.