### PR TITLE
docs: Specify what is thrown on `em.findOneOrFail` failure

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -419,7 +419,7 @@ Read more about this in [Debugging](logging.md) section.
 
 ## Custom Fail Handler
 
-When no entity is found during `em.findOneOrFail()` call, `new Error()` will be thrown. 
+When no entity is found during `em.findOneOrFail()` call, `new NotFoundError()` will be thrown. 
 You can customize how the `Error` instance is created via `findOneOrFailHandler`:
 
 ```ts

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -420,7 +420,7 @@ Read more about this in [Debugging](logging.md) section.
 ## Custom Fail Handler
 
 When no entity is found during `em.findOneOrFail()` call, `new NotFoundError()` will be thrown. 
-You can customize how the `Error` instance is created via `findOneOrFailHandler`:
+You can customize how the `Error` instance is created via `findOneOrFailHandler` (or `findExactlyOneOrFailHandler` if [strict mode](#strict-mode-and-property-validation) is enabled):
 
 ```ts
 MikroORM.init({


### PR DESCRIPTION
Resolves https://github.com/mikro-orm/mikro-orm/issues/3620

This PR updates the documentation section of "Custom Fail Handler" on the page about "Configuration".
- Clarifies during a failure of `em.findOneOrFail()` call, the specific error type `NotFoundError` will be thrown instead of a plain `Error`.
- Clarifies to customize the behavior of a failure of `em.findOneOrFail()` call, the [`findExactlyOneOrFailHandler` option will be used under strict mode](https://github.com/mikro-orm/mikro-orm/blob/881b8d0d8e655e241856caa5189ad9386ad4000b/packages/core/src/EntityManager.ts#L447-L448)