### PR TITLE
test: add failing tests for m:n relations with custom pivot table, fieldName and discriminator

### DIFF
--- a/tests/features/composite-keys/__snapshots__/custom-pivot-entity-with-field-name-and-discriminator.test.ts.snap
+++ b/tests/features/composite-keys/__snapshots__/custom-pivot-entity-with-field-name-and-discriminator.test.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`mikroOrm schema 1`] = `
+"pragma foreign_keys = off;
+
+create table \`Task\` (\`id\` integer not null primary key autoincrement);
+
+create table \`User\` (\`id\` integer not null primary key autoincrement, \`role\` text not null default 'CREATOR');
+create index \`User_role_index\` on \`User\` (\`role\`);
+
+create table \`CreatorsOnTasks\` (\`creatorId\` integer not null, \`taskId\` integer not null, constraint \`CreatorsOnTasks_creatorId_foreign\` foreign key(\`creatorId\`) references \`User\`(\`id\`) on update cascade, primary key (\`creatorId\`, \`taskId\`));
+create index \`CreatorsOnTasks_creatorId_index\` on \`CreatorsOnTasks\` (\`creatorId\`);
+
+create table \`CreatorsOnTasks_task\` (\`creatorsOnTasks_creatorId\` integer not null, \`creatorsOnTasks_taskId\` integer not null, \`task\` integer not null, constraint \`CreatorsOnTasks_task_creatorsOnTasks_creatorId_creatorsOnTasks_taskId_foreign\` foreign key(\`creatorsOnTasks_creatorId\`, \`creatorsOnTasks_taskId\`) references \`CreatorsOnTasks\`(\`creatorId\`, \`taskId\`) on delete cascade on update cascade, constraint \`CreatorsOnTasks_task_task_foreign\` foreign key(\`task\`) references \`Task\`(\`id\`) on delete cascade on update cascade, primary key (\`creatorsOnTasks_creatorId\`, \`creatorsOnTasks_taskId\`, \`task\`));
+create index \`CreatorsOnTasks_task_task_index\` on \`CreatorsOnTasks_task\` (\`task\`);
+create index \`CreatorsOnTasks_task_creatorsOnTasks_creatorId_creatorsOnTasks_taskId_index\` on \`CreatorsOnTasks_task\` (\`creatorsOnTasks_creatorId\`, \`creatorsOnTasks_taskId\`);
+
+pragma foreign_keys = on;
+"
+`;

--- a/tests/features/composite-keys/__snapshots__/custom-pivot-entity-with-field-name.test.ts.snap
+++ b/tests/features/composite-keys/__snapshots__/custom-pivot-entity-with-field-name.test.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`mikroOrm schema 1`] = `
+"pragma foreign_keys = off;
+
+create table \`Order\` (\`id\` integer not null primary key autoincrement, \`paid\` integer not null default false, \`shipped\` integer not null default false, \`created\` datetime not null);
+
+create table \`Product\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`currentPrice\` integer not null);
+
+create table \`OrderItem\` (\`orderId\` integer not null, \`productId\` integer not null, \`amount\` integer not null default 1, \`offeredPrice\` integer not null default 0, constraint \`OrderItem_orderId_foreign\` foreign key(\`orderId\`) references \`Order\`(\`id\`) on update cascade, constraint \`OrderItem_productId_foreign\` foreign key(\`productId\`) references \`Product\`(\`id\`) on update cascade, primary key (\`orderId\`, \`productId\`));
+create index \`OrderItem_orderId_index\` on \`OrderItem\` (\`orderId\`);
+create index \`OrderItem_productId_index\` on \`OrderItem\` (\`productId\`);
+
+pragma foreign_keys = on;
+"
+`;

--- a/tests/features/composite-keys/custom-pivot-entity-with-field-name-and-discriminator.test.ts
+++ b/tests/features/composite-keys/custom-pivot-entity-with-field-name-and-discriminator.test.ts
@@ -1,0 +1,108 @@
+import {
+  Collection,
+  Entity,
+  EntityCaseNamingStrategy,
+  ManyToMany,
+  ManyToOne,
+  MikroORM,
+  PrimaryKey,
+  Property,
+} from '@mikro-orm/core';
+
+@Entity({ abstract: true })
+export abstract class AbstractEntity {
+
+  @PrimaryKey()
+  public id!: number;
+
+}
+
+@Entity({
+  discriminatorColumn: 'role',
+  discriminatorMap: {
+    CREATOR: 'Creator',
+  },
+})
+class User extends AbstractEntity {
+
+  @Property({ default: 'CREATOR' })
+  public role: 'CREATOR' = 'CREATOR' as const;
+
+}
+
+@Entity()
+class Creator extends User {
+
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  @ManyToMany({ entity: () => Task, pivotEntity: () => CreatorsOnTasks })
+  public tasks = new Collection<Task>(this);
+
+}
+
+@Entity({ tableName: 'Task' })
+class Task extends AbstractEntity {
+
+  @ManyToMany(() => Creator, c => c.tasks)
+  public creators = new Collection<Creator>(this);
+
+}
+
+@Entity({ tableName: 'CreatorsOnTasks' })
+class CreatorsOnTasks {
+
+  @ManyToOne({ primary: true, fieldName: 'creatorId', entity: () => Creator })
+  public creator!: Creator;
+
+  @ManyToMany({ primary: true, fieldName: 'taskId', entity: () => Task })
+  public task!: Task;
+
+}
+
+describe('mikroOrm', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [User, Creator, CreatorsOnTasks, Task],
+      dbName: ':memory:',
+      type: 'sqlite',
+      namingStrategy: EntityCaseNamingStrategy,
+    });
+    await orm.schema.createSchema();
+  });
+
+  afterAll(async () => await orm.close(true));
+
+  beforeEach(() => orm.schema.clearDatabase());
+
+  test('schema', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+
+    expect(sql).toMatchSnapshot();
+  });
+
+  async function createEntities() {
+    const task = new Task();
+    const creator = new Creator();
+
+    task.creators.add(creator);
+
+    await orm.em.fork().persistAndFlush(task);
+
+    return { task };
+  }
+
+  test('should insert', async () => {
+    await expect(createEntities()).resolves.not.toThrow();
+  });
+
+  test('shouldnt findOne and populate m:n relation', async () => {
+    const { task } = await createEntities();
+
+    const taskRepository = orm.em.fork().getRepository(Task);
+    await expect(
+      taskRepository.findOne({ id: task.id }, { populate: ['creators'] }),
+    ).resolves.not.toThrow();
+  });
+
+});

--- a/tests/features/composite-keys/custom-pivot-entity-with-field-name-and-discriminator.test.ts
+++ b/tests/features/composite-keys/custom-pivot-entity-with-field-name-and-discriminator.test.ts
@@ -13,7 +13,7 @@ import {
 export abstract class AbstractEntity {
 
   @PrimaryKey()
-  public id!: number;
+  id!: number;
 
 }
 
@@ -26,7 +26,7 @@ export abstract class AbstractEntity {
 class User extends AbstractEntity {
 
   @Property({ default: 'CREATOR' })
-  public role: 'CREATOR' = 'CREATOR' as const;
+  role: 'CREATOR' = 'CREATOR' as const;
 
 }
 
@@ -35,7 +35,7 @@ class Creator extends User {
 
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   @ManyToMany({ entity: () => Task, pivotEntity: () => CreatorsOnTasks })
-  public tasks = new Collection<Task>(this);
+  tasks = new Collection<Task>(this);
 
 }
 
@@ -43,7 +43,7 @@ class Creator extends User {
 class Task extends AbstractEntity {
 
   @ManyToMany(() => Creator, c => c.tasks)
-  public creators = new Collection<Creator>(this);
+  creators = new Collection<Creator>(this);
 
 }
 
@@ -51,10 +51,10 @@ class Task extends AbstractEntity {
 class CreatorsOnTasks {
 
   @ManyToOne({ primary: true, fieldName: 'creatorId', entity: () => Creator })
-  public creator!: Creator;
+  creator!: Creator;
 
   @ManyToMany({ primary: true, fieldName: 'taskId', entity: () => Task })
-  public task!: Task;
+  task!: Task;
 
 }
 

--- a/tests/features/composite-keys/custom-pivot-entity-with-field-name.test.ts
+++ b/tests/features/composite-keys/custom-pivot-entity-with-field-name.test.ts
@@ -1,0 +1,137 @@
+import {
+  Collection,
+  Entity,
+  EntityCaseNamingStrategy,
+  ManyToMany,
+  ManyToOne,
+  MikroORM,
+  OneToMany,
+  PrimaryKey,
+  PrimaryKeyType,
+  Property,
+} from '@mikro-orm/core';
+
+@Entity()
+export class Order {
+
+  @PrimaryKey()
+  id!: number;
+
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  @OneToMany(() => OrderItem, item => item.order)
+  items = new Collection<OrderItem>(this);
+
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  @ManyToMany({ entity: () => Product, pivotEntity: () => OrderItem })
+  products = new Collection<Product>(this);
+
+  @Property()
+  paid: boolean = false;
+
+  @Property()
+  shipped: boolean = false;
+
+  @Property()
+  created: Date = new Date();
+
+}
+
+@Entity()
+export class Product {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name: string;
+
+  @Property()
+  currentPrice: number;
+
+  @ManyToMany(() => Order, o => o.products)
+  orders = new Collection<Order>(this);
+
+  constructor(name: string, currentPrice: number) {
+    this.name = name;
+    this.currentPrice = currentPrice;
+  }
+
+}
+
+@Entity()
+export class OrderItem {
+
+  @ManyToOne({ primary: true, fieldName: 'orderId' })
+  order: Order;
+
+  @ManyToOne({ primary: true, fieldName: 'productId' })
+  product: Product;
+
+  @Property({ default: 1 })
+  amount!: number;
+
+  @Property({ default: 0 })
+  offeredPrice: number;
+
+  [PrimaryKeyType]?: [number, number];
+
+  constructor(order: Order, product: Product) {
+    this.order = order;
+    this.product = product;
+    this.offeredPrice = product.currentPrice;
+  }
+
+}
+
+describe('mikroOrm', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Product, OrderItem, Order],
+      dbName: ':memory:',
+      type: 'sqlite',
+      namingStrategy: EntityCaseNamingStrategy,
+    });
+    await orm.schema.createSchema();
+  });
+
+  afterAll(async () => {
+    await orm.schema.dropSchema();
+    await orm.close(true);
+  });
+
+  beforeEach(() => orm.schema.clearDatabase());
+
+  test('schema', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+
+    expect(sql).toMatchSnapshot();
+  });
+
+  async function creatEntities() {
+    const order1 = new Order();
+    const product1 = new Product('p1', 111);
+
+    const item11 = new OrderItem(order1, product1);
+    item11.offeredPrice = 123;
+
+    await orm.em.fork().persistAndFlush(order1);
+
+    return { order1 };
+  }
+
+  test('should populate m:n with custom fieldName', async () => {
+    await creatEntities();
+
+    await expect(
+      orm.em.fork().find(Order, {}, { populate: ['products'] }),
+    ).resolves.not.toThrow();
+
+    const orderRepository = orm.em.fork().getRepository(Order);
+
+    await expect(
+      orderRepository.findAll({ populate: ['products'] }),
+    ).resolves.not.toThrow();
+  });
+});

--- a/tests/features/composite-keys/custom-pivot-entity-with-field-name.test.ts
+++ b/tests/features/composite-keys/custom-pivot-entity-with-field-name.test.ts
@@ -96,10 +96,7 @@ describe('mikroOrm', () => {
     await orm.schema.createSchema();
   });
 
-  afterAll(async () => {
-    await orm.schema.dropSchema();
-    await orm.close(true);
-  });
+  afterAll(async () => await orm.close(true));
 
   beforeEach(() => orm.schema.clearDatabase());
 


### PR DESCRIPTION
Hi Martin, as discussed today and yesterday in MikroOrm slack [Thread](https://mikroorm.slack.com/archives/CFSAF8DEX/p1666189658734029), I'm sending two failing cases that causes my app not to work.