### PR TITLE
Check for multiple decorator lines

### DIFF
--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -620,23 +620,14 @@ export class Utils {
     // In some situations (e.g. swc 1.3.4+), the presence of a source map can obscure the call to
     // __decorate(), replacing it with the constructor name. To support these cases we look for
     // Reflect.decorate() as well.
-    const hasDecorate = (index: number) => stack?.[index].includes('__decorate') || stack?.[index].includes('Reflect.decorate');
-    let line = -1;
-    for (let i = 0; i < stack.length; i++) {
-      if (
-        hasDecorate(i) && !hasDecorate(i + 1)
-      ) {
-        line = i;
-        break;
-      }
-    }
+    let line = stack.findIndex(line => line.includes('__decorate') || line.includes('Reflect.decorate'))!;
     if (line === -1) {
       return name;
     }
-    if (
-      stack[line].includes('Reflect.decorate') ||
-      Utils.normalizePath(stack[line]).includes('node_modules/tslib/tslib')
-    ) {
+    if (stack[line].includes('Reflect.decorate') || Utils.normalizePath(stack[line]).includes('node_modules/tslib/tslib')) {
+      line++;
+    }
+    if (stack[line].includes('Reflect.decorate') || Utils.normalizePath(stack[line]).includes('node_modules/tslib/tslib')) {
       line++;
     }
 

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -620,30 +620,30 @@ export class Utils {
     // In some situations (e.g. swc 1.3.4+), the presence of a source map can obscure the call to
     // __decorate(), replacing it with the constructor name. To support these cases we look for
     // Reflect.decorate() as well.
+    const hasDecorate = (index: number) => stack?.[index].includes('__decorate') || stack?.[index].includes('Reflect.decorate');
     let line = -1;
     for (let i = 0; i < stack.length; i++) {
       if (
-        (stack[i].includes('__decorate') ||
-          stack[i].includes('Reflect.decorate')) &&
-        line < 0
+        hasDecorate(i) && !hasDecorate(i + 1)
       ) {
         line = i;
-      }
-      if (
-        i >= line &&
-        (stack[line].includes('Reflect.decorate') ||
-          Utils.normalizePath(stack[line]).includes('node_modules/tslib/tslib'))
-      ) {
-        line++;
+        break;
       }
     }
     if (line === -1) {
       return name;
     }
-
+    if (
+      stack[line].includes('Reflect.decorate') ||
+      Utils.normalizePath(stack[line]).includes('node_modules/tslib/tslib')
+    ) {
+      line++;
+    }
 
     try {
-      const re = stack[line].match(/\(.+\)/i) ? /\((.*):\d+:\d+\)/ : /at\s*(.*):\d+:\d+$/;
+      const re = stack[line].match(/\(.+\)/i)
+        ? /\((.*):\d+:\d+\)/
+        : /at\s*(.*):\d+:\d+$/;
       return Utils.normalizePath(stack[line].match(re)![1]);
     } catch {
       return name;

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -627,6 +627,7 @@ export class Utils {
     if (stack[line].includes('Reflect.decorate') || Utils.normalizePath(stack[line]).includes('node_modules/tslib/tslib')) {
       line++;
     }
+
     if (stack[line].includes('Reflect.decorate') || Utils.normalizePath(stack[line]).includes('node_modules/tslib/tslib')) {
       line++;
     }

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -620,13 +620,27 @@ export class Utils {
     // In some situations (e.g. swc 1.3.4+), the presence of a source map can obscure the call to
     // __decorate(), replacing it with the constructor name. To support these cases we look for
     // Reflect.decorate() as well.
-    let line = stack.findIndex(line => line.includes('__decorate') || line.includes('Reflect.decorate'))!;
+    let line = -1;
+    for (let i = 0; i < stack.length; i++) {
+      if (
+        (stack[i].includes('__decorate') ||
+          stack[i].includes('Reflect.decorate')) &&
+        line < 0
+      ) {
+        line = i;
+      }
+      if (
+        line > -1 &&
+        (stack[line].includes('Reflect.decorate') ||
+          Utils.normalizePath(stack[line]).includes('node_modules/tslib/tslib'))
+      ) {
+        line++;
+      }
+    }
     if (line === -1) {
       return name;
     }
-    if (stack[line].includes('Reflect.decorate') || Utils.normalizePath(stack[line]).includes('node_modules/tslib/tslib')) {
-      line++;
-    }
+
 
     try {
       const re = stack[line].match(/\(.+\)/i) ? /\((.*):\d+:\d+\)/ : /at\s*(.*):\d+:\d+$/;

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -630,7 +630,7 @@ export class Utils {
         line = i;
       }
       if (
-        line > -1 &&
+        i >= line &&
         (stack[line].includes('Reflect.decorate') ||
           Utils.normalizePath(stack[line]).includes('node_modules/tslib/tslib'))
       ) {


### PR DESCRIPTION
When upgrading from 5.4.2 to 5.5.0 I received an error saying the path of the entity couldn't be found, after find where the path is resolved, I logged out the stack from the error thrown in `Utils.lookupPathFromDecorator` and it looks like the assumption was only one line would have a decorator identifier, but mine had two as seen in the logged output below. This PR is an attempt to fix account for multiple lines or just a single. Thank you.
```
[
  'Error',
  '    at Function.lookupPathFromDecorator (/Users/rstimmler/Code/mpx-api-service/node_modules/@mikro-orm/core/utils/Utils.js:508:26)',
  '    at Function.getMetadataFromDecorator (/Users/rstimmler/Code/mpx-api-service/node_modules/@mikro-orm/core/metadata/MetadataStorage.js:26:36)',
  '    at /Users/rstimmler/Code/mpx-api-service/node_modules/@mikro-orm/core/decorators/Entity.js:8:49',
  '    at DecorateConstructor (/Users/rstimmler/Code/mpx-api-service/node_modules/reflect-metadata/Reflect.js:541:33)',
  '    at Reflect.decorate (/Users/rstimmler/Code/mpx-api-service/node_modules/reflect-metadata/Reflect.js:130:24)',
  '    at Object.__decorate (/Users/rstimmler/Code/mpx-api-service/node_modules/tslib/tslib.js:99:96)',
  '    at Object.<anonymous> (/Users/rstimmler/Code/mpx-api-service/src/entity/requirement.ts:23:23)',
  '    at Module._compile (node:internal/modules/cjs/loader:1159:14)',
  '    at Module.m._compile (/Users/rstimmler/Code/mpx-api-service/node_modules/ts-node/src/index.ts:1618:23)',
  '    at Module.m._compile (/Users/rstimmler/Code/mpx-api-service/node_modules/ts-node/src/index.ts:1618:23)'
]
```