### PR TITLE
fix(knex): do not require virtual properties when seeding

### DIFF
--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -356,7 +356,7 @@ export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = Abstra
 
     if (this.platform.usesReturningStatement()) {
       /* istanbul ignore next */
-      const returningProps = meta!.hydrateProps.filter(prop => prop.primary || prop.defaultRaw);
+      const returningProps = meta!.hydrateProps.filter(prop => prop.persist === false ? false : (prop.primary || prop.defaultRaw));
       const returningFields = Utils.flatten(returningProps.map(prop => prop.fieldNames));
       /* istanbul ignore next */
       sql += returningFields.length > 0 ? ` returning ${returningFields.map(field => this.platform.quoteIdentifier(field)).join(', ')}` : '';


### PR DESCRIPTION
When trying to seed database entity that has virtual properties, they are required and `InvalidFieldNameException` is thrown.

Here is the reproduction and contextualization of the bug:
[mlsm-trl/mikro-orm-bug-virtual-properties-required-when-seeding](https://github.com/mlsm-trl/mikro-orm-bug-virtual-properties-required-when-seeding)

It appears to ignore `persist` property on verification, thus requiring virtual property if it met condition defined `primary || defaultRaw`.

This PR is a possible fix after a quick look at code. I only tested on my use case, so I don't know if this bug happens on other cases, like updates, neither if this verification should be replicated to other parts.