### PR TITLE
fix(core): respect filters when loading m:n relations

### DIFF
--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -83,7 +83,8 @@ export class Collection<T extends object, O extends object = object> extends Arr
     let items: Loaded<T, P>[];
 
     if (this.property.reference === ReferenceType.MANY_TO_MANY && em.getPlatform().usesPivotTable()) {
-      const map = await em.getDriver().loadFromPivotTable(this.property, [helper(this.owner).__primaryKeys], where, opts.orderBy, ctx, options);
+      const cond = await em.applyFilters(this.property.type, where, options.filters ?? {}, 'read');
+      const map = await em.getDriver().loadFromPivotTable(this.property, [helper(this.owner).__primaryKeys], cond, opts.orderBy, ctx, options);
       items = map[helper(this.owner).getSerializedPrimaryKey()].map((item: EntityData<T>) => em.merge(this.property.type, item, { convertCustomTypes: true }));
     } else {
       items = await em.find(this.property.type, this.createCondition(where), opts);
@@ -212,7 +213,8 @@ export class Collection<T extends object, O extends object = object> extends Arr
     const em = this.getEntityManager();
 
     if (!this.initialized && this.property.reference === ReferenceType.MANY_TO_MANY && em.getPlatform().usesPivotTable()) {
-      const map = await em.getDriver().loadFromPivotTable(this.property, [helper(this.owner).__primaryKeys], options.where, options.orderBy, undefined, options);
+      const cond = await em.applyFilters(this.property.type, options.where, {}, 'read');
+      const map = await em.getDriver().loadFromPivotTable(this.property, [helper(this.owner).__primaryKeys], cond, options.orderBy, undefined, options);
       this.hydrate(map[helper(this.owner).getSerializedPrimaryKey()].map((item: EntityData<T>) => em.merge(this.property.type, item, { convertCustomTypes: true })), true);
       this._lazyInitialized = true;
 

--- a/tests/EntityManager.sqlite2.test.ts
+++ b/tests/EntityManager.sqlite2.test.ts
@@ -718,6 +718,11 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
     expect(wrap(books[0]).toObject()).toMatchObject({
       tags: books[0].tags.getItems().map(t => ({ name: t.name })),
     });
+
+    orm.em.addFilter('testFilter', { name: 'tag 11-08' }, BookTag4, false);
+    const filteredTags = await books[0].tags.matching({ filters: { testFilter: true } });
+    expect(filteredTags).toHaveLength(1);
+    expect(filteredTags[0].name).toBe('tag 11-08');
   });
 
   test('disabling identity map', async () => {


### PR DESCRIPTION
i have found that if you load items (or initing) from m:n collection with pivot table, you will get query without filters