### PR TITLE
feat(core): add `serialize()` helper for explicit serialization

### DIFF
--- a/packages/core/src/entity/EntityHelper.ts
+++ b/packages/core/src/entity/EntityHelper.ts
@@ -2,7 +2,7 @@ import { inspect } from 'util';
 
 import type { EntityManager } from '../EntityManager';
 import type { AnyEntity, Dictionary, EntityMetadata, EntityProperty } from '../typings';
-import { EntityTransformer } from './EntityTransformer';
+import { EntityTransformer } from '../serialization/EntityTransformer';
 import { Reference } from './Reference';
 import type { Platform } from '../platforms';
 import { Utils } from '../utils/Utils';

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -6,8 +6,7 @@ import type {
 } from '../typings';
 import type { IdentifiedReference } from './Reference';
 import { Reference } from './Reference';
-import type { SerializationContext } from './EntityTransformer';
-import { EntityTransformer } from './EntityTransformer';
+import { EntityTransformer } from '../serialization/EntityTransformer';
 import type { AssignOptions } from './EntityAssigner';
 import { EntityAssigner } from './EntityAssigner';
 import { Utils } from '../utils/Utils';
@@ -15,6 +14,7 @@ import type { LockMode } from '../enums';
 import { ValidationError } from '../errors';
 import type { EntityIdentifier } from './EntityIdentifier';
 import { helper } from './wrap';
+import type { SerializationContext } from '../serialization/SerializationContext';
 
 export class WrappedEntity<T extends object, PK extends keyof T> {
 

--- a/packages/core/src/entity/index.ts
+++ b/packages/core/src/entity/index.ts
@@ -2,7 +2,6 @@ export * from './EntityRepository';
 export * from './EntityIdentifier';
 export * from './EntityValidator';
 export * from './EntityAssigner';
-export * from './EntityTransformer';
 export * from './EntityHelper';
 export * from './EntityFactory';
 export * from './ArrayCollection';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from './errors';
 export * from './exceptions';
 export * from './MikroORM';
 export * from './entity';
+export * from './serialization';
 export * from './events';
 export * from './EntityManager';
 export * from './unit-of-work';

--- a/packages/core/src/serialization/EntitySerializer.ts
+++ b/packages/core/src/serialization/EntitySerializer.ts
@@ -1,0 +1,245 @@
+import type { Collection } from '../entity/Collection';
+import type { AutoPath, EntityDTO, EntityMetadata, IPrimaryKey, Loaded } from '../typings';
+import { helper } from '../entity/wrap';
+import type { Platform } from '../platforms';
+import { Utils } from '../utils/Utils';
+import { ReferenceType } from '../enums';
+import { Reference } from '../entity/Reference';
+import { SerializationContext } from './SerializationContext';
+
+function isVisible<T extends object>(meta: EntityMetadata<T>, propName: string, options: SerializeOptions<T, any>): boolean {
+  if (options.populate === true) {
+    return options.populate;
+  }
+
+  if (Array.isArray(options.populate) && options.populate?.find(item => item === propName || item.startsWith(propName + '.'))) {
+    return true;
+  }
+
+  if (options.exclude?.find(item => item === propName)) {
+    return false;
+  }
+
+  const prop = meta.properties[propName];
+  const visible = prop && !prop.hidden;
+  const prefixed = prop && !prop.primary && propName.startsWith('_'); // ignore prefixed properties, if it's not a PK
+
+  return visible && !prefixed;
+}
+
+function isPopulated<T extends object>(entity: T, propName: string, options: SerializeOptions<T, any>): boolean {
+  if (typeof options.populate !== 'boolean' && options.populate?.find(item => item === propName || item.startsWith(propName + '.'))) {
+    return true;
+  }
+
+  if (typeof options.populate === 'boolean') {
+    return options.populate;
+  }
+
+  return false;
+}
+
+export class EntitySerializer {
+
+  static serialize<T extends object, P extends string = never>(entity: T, options: SerializeOptions<T, P> = {}): EntityDTO<Loaded<T, P>> {
+    const wrapped = helper(entity);
+    const meta = wrapped.__meta;
+    let contextCreated = false;
+
+    if (!wrapped.__serializationContext.root) {
+      const root = new SerializationContext<T>();
+      SerializationContext.propagate(root, entity, (meta, prop) => meta.properties[prop]?.reference !== ReferenceType.SCALAR);
+      contextCreated = true;
+    }
+
+    const root = wrapped.__serializationContext.root!;
+    const ret = {} as EntityDTO<Loaded<T, P>>;
+    const keys = new Set<string>(meta.primaryKeys);
+    Object.keys(entity).forEach(prop => keys.add(prop));
+    const visited = root.visited.has(entity);
+
+    if (!visited) {
+      root.visited.add(entity);
+    }
+
+    [...keys]
+      .filter(prop => isVisible<T>(meta, prop, options))
+      .map(prop => {
+        const cycle = root.visit(meta.className, prop);
+
+        if (cycle && visited) {
+          return [prop, undefined];
+        }
+
+        const val = this.processProperty<T>(prop as keyof T & string, entity, options);
+
+        if (!cycle) {
+          root.leave(meta.className, prop);
+        }
+
+        return [prop, val];
+      })
+      .filter(([, value]) => typeof value !== 'undefined' && !(value === null && options.skipNull))
+      .forEach(([prop, value]) => ret[this.propertyName(meta, prop as keyof T & string, wrapped.__platform)] = value as T[keyof T & string]);
+
+    if (contextCreated) {
+      root.close();
+    }
+
+    if (!wrapped.isInitialized()) {
+      return ret;
+    }
+
+    // decorated getters
+    meta.props
+      .filter(prop => prop.getter && typeof entity[prop.name] !== 'undefined' && isVisible(meta, prop.name, options))
+      .forEach(prop => ret[this.propertyName(meta, prop.name, wrapped.__platform)] = entity[prop.name]);
+
+    // decorated get methods
+    meta.props
+      .filter(prop => prop.getterName && entity[prop.getterName] as unknown instanceof Function && isVisible(meta, prop.name, options))
+      .forEach(prop => ret[this.propertyName(meta, prop.name, wrapped.__platform)] = (entity[prop.getterName!] as unknown as () => T[keyof T & string])());
+
+    return ret;
+  }
+
+  private static propertyName<T>(meta: EntityMetadata<T>, prop: keyof T & string, platform?: Platform): string {
+    /* istanbul ignore next */
+    if (meta.properties[prop]?.serializedName) {
+      return meta.properties[prop].serializedName as keyof T & string;
+    }
+
+    if (meta.properties[prop]?.primary && platform) {
+      return platform.getSerializedPrimaryKeyField(prop) as keyof T & string;
+    }
+
+    return prop;
+  }
+
+  private static processProperty<T extends object>(prop: keyof T & string, entity: T, options: SerializeOptions<T, any>): T[keyof T] | undefined {
+    const parts = prop.split('.');
+    prop = parts[0] as string & keyof T;
+    const wrapped = helper(entity);
+    const property = wrapped.__meta.properties[prop];
+    const serializer = property?.serializer;
+
+    /* istanbul ignore next */
+    if (!options.ignoreSerializers && serializer) {
+      return serializer(entity[prop]);
+    }
+
+    if (Utils.isCollection(entity[prop])) {
+      return this.processCollection(prop, entity, options);
+    }
+
+    if (Utils.isEntity(entity[prop], true)) {
+      return this.processEntity(prop, entity, wrapped.__platform, options);
+    }
+
+    /* istanbul ignore next */
+    if (property?.reference === ReferenceType.EMBEDDED) {
+      if (Array.isArray(entity[prop])) {
+        return (entity[prop] as object[]).map(item => helper(item).toJSON()) as T[keyof T];
+      }
+
+      if (Utils.isObject(entity[prop])) {
+        return helper(entity[prop]).toJSON() as T[keyof T];
+      }
+    }
+
+    const customType = property?.customType;
+
+    if (customType) {
+      return customType.toJSON(entity[prop], wrapped.__platform);
+    }
+
+    return wrapped.__platform.normalizePrimaryKey(entity[prop] as unknown as IPrimaryKey) as unknown as T[keyof T];
+  }
+
+  private static extractChildOptions<T extends object, U extends object>(options: SerializeOptions<T, any>, prop: keyof T & string): SerializeOptions<U, any> {
+    const extractChildElements = (items: string[]) => {
+      return items
+        .filter(field => field.startsWith(`${prop}.`))
+        .map(field => field.substring(prop.length + 1));
+    };
+
+    return {
+      ...options,
+      populate: Array.isArray(options.populate) ? extractChildElements(options.populate) : options.populate,
+      exclude: Array.isArray(options.exclude) ? extractChildElements(options.exclude) : options.exclude,
+    } as SerializeOptions<U, any>;
+  }
+
+  private static processEntity<T extends object>(prop: keyof T & string, entity: T, platform: Platform, options: SerializeOptions<T, any>): T[keyof T] | undefined {
+    const child = Reference.unwrapReference(entity[prop] as T);
+    const wrapped = helper(child);
+
+    if (isPopulated(child, prop, options) && wrapped.isInitialized()) {
+      const childOptions = this.extractChildOptions(options, prop);
+      return this.serialize(child, childOptions) as T[keyof T];
+    }
+
+    if (options.forceObject) {
+      return this.serialize(child, this.extractChildOptions(options, prop)) as T[keyof T];
+    }
+
+    return platform.normalizePrimaryKey(wrapped.getPrimaryKey() as IPrimaryKey) as T[keyof T];
+  }
+
+  private static processCollection<T extends object>(prop: keyof T & string, entity: T, options: SerializeOptions<T, any>): T[keyof T] | undefined {
+    const col = entity[prop] as unknown as Collection<T>;
+
+    if (!col.isInitialized()) {
+      return undefined;
+    }
+
+    return col.getItems(false).map(item => {
+      if (isPopulated(item, prop, options)) {
+        return this.serialize(item, this.extractChildOptions(options, prop));
+      }
+
+      return helper(item).getPrimaryKey();
+    }) as unknown as T[keyof T];
+  }
+
+}
+
+export interface SerializeOptions<T extends object, P extends string = never> {
+  /** Specify which relation should be serialized as populated and which as a FK. */
+  populate?: AutoPath<T, P>[] | boolean;
+
+  /** Specify which properties should be omitted. */
+  exclude?: AutoPath<T, P>[];
+
+  /** Enforce unpopulated references to be returned as objects, e.g. `{ author: { id: 1 } }` instead of `{ author: 1 }`. */
+  forceObject?: boolean;
+
+  /** Ignore custom property serializers. */
+  ignoreSerializers?: boolean;
+
+  /** Skip properties with `null` value. */
+  skipNull?: boolean;
+}
+
+/**
+ * Converts entity instance to POJO, converting the `Collection`s to arrays and unwrapping the `Reference` wrapper, while respecting the serialization options.
+ */
+export function serialize<T extends object, P extends string = never>(entity: T, options?: SerializeOptions<T, P>): EntityDTO<Loaded<T, P>>;
+
+/**
+ * Converts entity instance to POJO, converting the `Collection`s to arrays and unwrapping the `Reference` wrapper, while respecting the serialization options.
+ */
+export function serialize<T extends object, P extends string = never>(entities: T[], options?: SerializeOptions<T, P>): EntityDTO<Loaded<T, P>>[];
+
+/**
+ * Converts entity instance to POJO, converting the `Collection`s to arrays and unwrapping the `Reference` wrapper, while respecting the serialization options.
+ */
+export function serialize<T extends object, P extends string = never>(entities: T | T[], options?: SerializeOptions<T, P>): EntityDTO<Loaded<T, P>> | EntityDTO<Loaded<T, P>>[] {
+  const ret = Utils.asArray(entities).map(e => EntitySerializer.serialize(e, options));
+
+  if (Array.isArray(entities)) {
+    return ret;
+  }
+
+  return ret[0];
+}

--- a/packages/core/src/serialization/SerializationContext.ts
+++ b/packages/core/src/serialization/SerializationContext.ts
@@ -1,0 +1,95 @@
+import type { AnyEntity, EntityMetadata, PopulateOptions } from '../typings';
+import type { Collection } from '../entity/Collection';
+import { Utils } from '../utils/Utils';
+import { helper } from '../entity/wrap';
+
+/**
+ * Helper that allows to keep track of where we are currently at when serializing complex entity graph with cycles.
+ * Before we process a property, we call `visit` that checks if it is not a cycle path (but allows to pass cycles that
+ * are defined in populate hint). If not, we proceed and call `leave` afterwards.
+ */
+export class SerializationContext<T> {
+
+  readonly path: [string, string][] = [];
+  readonly visited = new Set<AnyEntity>();
+  private entities = new Set<AnyEntity>();
+
+  constructor(private readonly populate: PopulateOptions<T>[] = []) {}
+
+  visit(entityName: string, prop: string): boolean {
+    if (!this.path.find(([cls, item]) => entityName === cls && prop === item)) {
+      this.path.push([entityName, prop]);
+      return false;
+    }
+
+    // check if the path is explicitly populated
+    if (!this.isMarkedAsPopulated(prop)) {
+      return true;
+    }
+
+    this.path.push([entityName, prop]);
+    return false;
+  }
+
+  leave<U>(entityName: string, prop: string) {
+    const last = this.path.pop();
+
+    /* istanbul ignore next */
+    if (!last || last[0] !== entityName || last[1] !== prop) {
+      throw new Error(`Trying to leave wrong property: ${entityName}.${prop} instead of ${last?.join('.')}`);
+    }
+  }
+
+  close() {
+    this.entities.forEach(entity => {
+      delete helper(entity).__serializationContext.root;
+    });
+  }
+
+  /**
+   * When initializing new context, we need to propagate it to the whole entity graph recursively.
+   */
+  static propagate(root: SerializationContext<AnyEntity>, entity: AnyEntity, isVisible: (meta: EntityMetadata, prop: string) => boolean): void {
+    root.register(entity);
+    const meta = helper(entity).__meta;
+
+    const items: AnyEntity[] = [];
+    Object.keys(entity)
+      .filter(key => isVisible(meta, key))
+      .forEach(key => {
+        if (Utils.isEntity(entity[key], true)) {
+          items.push(entity[key]);
+        } else if (Utils.isCollection(entity[key])) {
+          items.push(...(entity[key] as Collection<any>).getItems(false));
+        }
+      });
+
+    items
+      .filter(item => !item.__helper!.__serializationContext.root)
+      .forEach(item => this.propagate(root, item, isVisible));
+  }
+
+  private isMarkedAsPopulated(prop: string): boolean {
+    let populate: PopulateOptions<T>[] | undefined = this.populate;
+
+    for (const segment of this.path) {
+      if (!populate) {
+        return false;
+      }
+
+      const exists = populate.find(p => p.field === segment[1]) as PopulateOptions<T>;
+
+      if (exists) {
+        populate = exists.children;
+      }
+    }
+
+    return !!populate?.find(p => p.field === prop);
+  }
+
+  private register(entity: AnyEntity) {
+    helper(entity).__serializationContext.root = this;
+    this.entities.add(entity);
+  }
+
+}

--- a/packages/core/src/serialization/index.ts
+++ b/packages/core/src/serialization/index.ts
@@ -1,0 +1,3 @@
+export * from './EntityTransformer';
+export * from './EntitySerializer';
+export * from './SerializationContext';

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1,7 +1,8 @@
 import type { Transaction } from './connections';
 import type { Cascade, EventType, LoadStrategy, LockMode, QueryOrderMap } from './enums';
 import { ReferenceType } from './enums';
-import type { AssignOptions, Collection, EntityFactory, EntityIdentifier, EntityRepository, IdentifiedReference, Reference, SerializationContext } from './entity';
+import type { AssignOptions, Collection, EntityFactory, EntityIdentifier, EntityRepository, IdentifiedReference, Reference } from './entity';
+import type { SerializationContext } from './serialization';
 import type { EntitySchema, MetadataStorage } from './metadata';
 import type { Type, types } from './types';
 import type { Platform } from './platforms';

--- a/tests/entities-sql/Author2.ts
+++ b/tests/entities-sql/Author2.ts
@@ -13,7 +13,7 @@ import { Address2 } from './Address2';
 @Unique({ properties: ['name', 'email'] })
 export class Author2 extends BaseEntity2 {
 
-  [OptionalProps]?: 'createdAt' | 'updatedAt' | 'termsAccepted' | 'version' | 'versionAsString' | 'code' | 'booksTotal' | 'hookParams' | 'hookTest' | 'onLoadCalled';
+  [OptionalProps]?: 'createdAt' | 'updatedAt' | 'termsAccepted' | 'version' | 'versionAsString' | 'code' | 'code2' | 'booksTotal' | 'hookParams' | 'hookTest' | 'onLoadCalled';
 
   static beforeDestroyCalled = 0;
   static afterDestroyCalled = 0;
@@ -138,6 +138,16 @@ export class Author2 extends BaseEntity2 {
   @AfterDelete()
   afterDelete() {
     Author2.afterDestroyCalled += 1;
+  }
+
+  @Property({ name: 'code' })
+  getCode() {
+    return `${this.email} - ${this.name}`;
+  }
+
+  @Property({ persist: false })
+  get code2() {
+    return `${this.email} - ${this.name}`;
   }
 
 }

--- a/tests/features/serialize.test.ts
+++ b/tests/features/serialize.test.ts
@@ -1,0 +1,206 @@
+import { wrap, serialize } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/postgresql';
+import { initORMPostgreSql } from '../bootstrap';
+import { Author2, Book2, Publisher2, PublisherType } from '../entities-sql';
+
+let orm: MikroORM;
+
+beforeAll(async () => orm = await initORMPostgreSql());
+beforeEach(() => orm.schema.clearDatabase());
+afterAll(() => orm.close(true));
+
+async function createEntities() {
+  const god = new Author2('God', 'hello@heaven.god');
+  const bible = new Book2('Bible', god);
+  bible.double = 123.45;
+  const author = new Author2('Jon Snow', 'snow@wall.st');
+  author.born = new Date('1990-03-23');
+  author.favouriteBook = bible;
+  const publisher = new Publisher2('7K publisher', PublisherType.GLOBAL);
+  const book1 = new Book2('My Life on The Wall, part 1', author);
+  book1.publisher = wrap(publisher).toReference();
+  const book2 = new Book2('My Life on The Wall, part 2', author);
+  book2.publisher = wrap(publisher).toReference();
+  const book3 = new Book2('My Life on The Wall, part 3', author);
+  book3.publisher = wrap(publisher).toReference();
+  await orm.em.persist(author).flush();
+  orm.em.clear();
+
+  return { god, author, publisher, book1, book2, book3 };
+}
+
+test('explicit serialization', async () => {
+  const { god, author, publisher, book1, book2, book3 } = await createEntities();
+  const jon = await orm.em.findOneOrFail(Author2, author, { populate: true })!;
+
+  const o1 = serialize(jon);
+  expect(o1).toMatchObject({
+    id: jon.id,
+    createdAt: jon.createdAt,
+    updatedAt: jon.updatedAt,
+    books: [book1.uuid, book2.uuid, book3.uuid],
+    favouriteBook: jon.favouriteBook!.uuid,
+    born: '1990-03-23',
+    email: 'snow@wall.st',
+    name: 'Jon Snow',
+    age: null,
+  });
+
+  const o1s = serialize([jon, jon, jon]);
+  expect(o1s).toHaveLength(3);
+  expect(o1s[0]).toMatchObject({
+    id: jon.id,
+    createdAt: jon.createdAt,
+    updatedAt: jon.updatedAt,
+    books: [book1.uuid, book2.uuid, book3.uuid],
+    favouriteBook: jon.favouriteBook!.uuid,
+    born: '1990-03-23',
+    email: 'snow@wall.st',
+    name: 'Jon Snow',
+  });
+
+  const o2 = serialize(jon, { populate: ['books'], skipNull: true });
+  expect(o2).toMatchObject({
+    id: jon.id,
+    createdAt: jon.createdAt,
+    updatedAt: jon.updatedAt,
+    books: [
+      { author: jon.id, publisher: publisher.id, title: 'My Life on The Wall, part 1' },
+      { author: jon.id, publisher: publisher.id, title: 'My Life on The Wall, part 2' },
+      { author: jon.id, publisher: publisher.id, title: 'My Life on The Wall, part 3' },
+    ],
+    favouriteBook: jon.favouriteBook!.uuid,
+    born: '1990-03-23',
+    email: 'snow@wall.st',
+    name: 'Jon Snow',
+  });
+  expect('age' in o2).toBe(false);
+
+  const o3 = serialize(jon, { populate: ['books', 'favouriteBook'] });
+  expect(o3).toMatchObject({
+    id: jon.id,
+    createdAt: jon.createdAt,
+    updatedAt: jon.updatedAt,
+    books: [
+      { author: jon.id, publisher: publisher.id, title: 'My Life on The Wall, part 1' },
+      { author: jon.id, publisher: publisher.id, title: 'My Life on The Wall, part 2' },
+      { author: jon.id, publisher: publisher.id, title: 'My Life on The Wall, part 3' },
+    ],
+    favouriteBook: { author: god.id, title: 'Bible' },
+    born: '1990-03-23',
+    email: 'snow@wall.st',
+    name: 'Jon Snow',
+  });
+
+  const o4 = serialize(jon, { populate: ['books.author', 'favouriteBook'] });
+  expect(o4).toMatchObject({
+    id: jon.id,
+    createdAt: jon.createdAt,
+    updatedAt: jon.updatedAt,
+    books: [
+      { author: { id: jon.id, name: 'Jon Snow', email: 'snow@wall.st' }, publisher: publisher.id, title: 'My Life on The Wall, part 1' },
+      { author: { id: jon.id, name: 'Jon Snow', email: 'snow@wall.st' }, publisher: publisher.id, title: 'My Life on The Wall, part 2' },
+      { author: { id: jon.id, name: 'Jon Snow', email: 'snow@wall.st' }, publisher: publisher.id, title: 'My Life on The Wall, part 3' },
+    ],
+    favouriteBook: { author: god.id, title: 'Bible' },
+    born: '1990-03-23',
+    email: 'snow@wall.st',
+    name: 'Jon Snow',
+  });
+
+  const o5 = serialize(jon, { populate: ['books.author', 'favouriteBook'], forceObject: true });
+  expect(o5).toMatchObject({
+    id: jon.id,
+    createdAt: jon.createdAt,
+    updatedAt: jon.updatedAt,
+    books: [
+      { author: { id: jon.id, name: 'Jon Snow', email: 'snow@wall.st' }, publisher: { id: publisher.id }, title: 'My Life on The Wall, part 1' },
+      { author: { id: jon.id, name: 'Jon Snow', email: 'snow@wall.st' }, publisher: { id: publisher.id }, title: 'My Life on The Wall, part 2' },
+      { author: { id: jon.id, name: 'Jon Snow', email: 'snow@wall.st' }, publisher: { id: publisher.id }, title: 'My Life on The Wall, part 3' },
+    ],
+    favouriteBook: { author: { id: god.id }, title: 'Bible' },
+    born: '1990-03-23',
+    email: 'snow@wall.st',
+    name: 'Jon Snow',
+  });
+
+  const o6 = serialize(jon, { populate: ['books.author', 'books.publisher', 'favouriteBook'] });
+  expect(o6).toMatchObject({
+    id: jon.id,
+    createdAt: jon.createdAt,
+    updatedAt: jon.updatedAt,
+    books: [
+      { author: { id: jon.id, name: 'Jon Snow', email: 'snow@wall.st' }, publisher: { id: publisher.id, name: publisher.name }, title: 'My Life on The Wall, part 1' },
+      { author: { id: jon.id, name: 'Jon Snow', email: 'snow@wall.st' }, publisher: { id: publisher.id, name: publisher.name }, title: 'My Life on The Wall, part 2' },
+      { author: { id: jon.id, name: 'Jon Snow', email: 'snow@wall.st' }, publisher: { id: publisher.id, name: publisher.name }, title: 'My Life on The Wall, part 3' },
+    ],
+    favouriteBook: { author: god.id, title: 'Bible' },
+    born: '1990-03-23',
+    email: 'snow@wall.st',
+    name: 'Jon Snow',
+  });
+
+  const o7 = serialize(jon, {
+    populate: ['books.author', 'books.publisher', 'favouriteBook'],
+    exclude: ['books.author.email'],
+  });
+
+  expect(o7.email).toBeDefined();
+  expect(o7.books[0].author.email).toBeUndefined();
+  expect(o7).toMatchObject({
+    id: jon.id,
+    createdAt: jon.createdAt,
+    updatedAt: jon.updatedAt,
+    books: [
+      { author: { id: jon.id, name: 'Jon Snow' }, publisher: { id: publisher.id, name: publisher.name }, title: 'My Life on The Wall, part 1' },
+      { author: { id: jon.id, name: 'Jon Snow' }, publisher: { id: publisher.id, name: publisher.name }, title: 'My Life on The Wall, part 2' },
+      { author: { id: jon.id, name: 'Jon Snow' }, publisher: { id: publisher.id, name: publisher.name }, title: 'My Life on The Wall, part 3' },
+    ],
+    favouriteBook: { author: god.id, title: 'Bible' },
+    born: '1990-03-23',
+    email: 'snow@wall.st',
+    name: 'Jon Snow',
+  });
+});
+
+test('explicit serialization with populate: true', async () => {
+  const { god, author, publisher } = await createEntities();
+  const jon = await orm.em.findOneOrFail(Author2, author, { populate: true })!;
+
+  const o8 = serialize(jon, { populate: true });
+  expect(o8).toMatchObject({
+    id: jon.id,
+    createdAt: jon.createdAt,
+    updatedAt: jon.updatedAt,
+    books: [
+      { author: { id: jon.id, name: 'Jon Snow' }, publisher: { id: publisher.id, name: publisher.name }, title: 'My Life on The Wall, part 1' },
+      { author: { id: jon.id, name: 'Jon Snow' }, publisher: { id: publisher.id, name: publisher.name }, title: 'My Life on The Wall, part 2' },
+      { author: { id: jon.id, name: 'Jon Snow' }, publisher: { id: publisher.id, name: publisher.name }, title: 'My Life on The Wall, part 3' },
+    ],
+    favouriteBook: { author: { id: god.id, name: 'God', books: [{ title: 'Bible' }] }, title: 'Bible' },
+    born: '1990-03-23',
+    email: 'snow@wall.st',
+    name: 'Jon Snow',
+  });
+});
+
+test('explicit serialization with not initialized properties', async () => {
+  const { author } = await createEntities();
+  const jon = await orm.em.findOneOrFail(Author2, author)!;
+
+  const o = serialize(jon, { populate: true });
+  expect(o).toMatchObject({
+    id: jon.id,
+    createdAt: jon.createdAt,
+    updatedAt: jon.updatedAt,
+    favouriteBook: jon.favouriteBook!.uuid,
+    born: '1990-03-23',
+    email: 'snow@wall.st',
+    name: 'Jon Snow',
+  });
+
+  const o2 = serialize(jon.favouriteBook!, { populate: true });
+  expect(o2).toEqual({
+    uuid: jon.favouriteBook!.uuid,
+  });
+});


### PR DESCRIPTION
The serialization process is normally driven by the `populate` hints. If you want to take control over this, you can use the `serialize()` helper:

```ts
import { serialize } from '@mikro-orm/core';

const dto = serialize(user); // serialize single entity
// { name: '...', books: [1, 2, 3], identity: 123 }

const dtos = serialize(users); // supports arrays as well
// [{ name: '...', books: [1, 2, 3], identity: 123 }, ...]
```

By default, every relation is considered as not populated - this will result in the foreign key values to be present. Loaded collections will be represented as arrays of the foreign keys. To control the shape of the serialized response we can use the second `options` parameter:

```ts
export interface SerializeOptions<T extends object, P extends string = never> {
  /** Specify which relation should be serialized as populated and which as a FK. */
  populate?: AutoPath<T, P>[] | boolean;

  /** Specify which properties should be omitted. */
  exclude?: AutoPath<T, P>[];

  /** Enforce unpopulated references to be returned as objects, e.g. `{ author: { id: 1 } }` instead of `{ author: 1 }`. */
  forceObject?: boolean;

  /** Ignore custom property serializers. */
  ignoreSerializers?: boolean;

  /** Skip properties with `null` value. */
  skipNull?: boolean;
}
```