### PR TITLE
feat(core): introduce ORM extensions

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -70,7 +70,25 @@ MikroORM.init({
 
 Read more about this in [Metadata Providers](metadata-providers.md) sections.
 
-### Adjusting the default type mapping
+## Extensions
+
+Since v5.6, the ORM extensions like `SchemaGenerator`, `Migrator` or `EntityGenerator` can be registered via the `extensions` config option. This will be the only supported way to have the shortcuts like `orm.migrator` available in v6, so we no longer need to dynamically require those dependencies or specify them as optional peer dependencies (both of those things cause issues with various bundling tools like Webpack, or those used in Remix or Next.js).
+
+```ts
+import { defineConfig } from '@mikro-orm/postgres';
+import { Migrator } from '@mikro-orm/migrations';
+import { EntityGenerator } from '@mikro-orm/entity-generator';
+import { SeedManager } from '@mikro-orm/seeder';
+
+export default defineConfig({
+  dbName: 'test',
+  extensions: [Migrator, EntityGenerator, SeedManager],
+});
+```
+
+> The `SchemaGenerator` (as well as `MongoSchemaGenerator`) is registered automatically as it does not require any 3rd party dependencies to be installed.
+
+## Adjusting default type mapping
 
 Since v5.2 we can alter how the ORM picks the default mapped type representation based on the inferred type of a property. One example is a mapping of `foo: string` to `varchar(255)`. If we wanted to change this default to a `text` type in postgres, we can use the `discover.getMappedType` callback:
 

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -13,6 +13,7 @@ import {
 } from '../types';
 import { Utils } from '../utils/Utils';
 import { ReferenceType } from '../enums';
+import type { MikroORM } from '../MikroORM';
 
 export const JsonProperty = Symbol('JsonProperty');
 
@@ -325,6 +326,13 @@ export abstract class Platform {
 
   getExceptionConverter(): ExceptionConverter {
     return this.exceptionConverter;
+  }
+
+  /**
+   * Allows to register extensions of the driver automatically (e.g. `SchemaGenerator` extension in SQL drivers).
+   */
+  lookupExtensions(orm: MikroORM): void {
+    // no extensions by default
   }
 
   getSchemaGenerator(driver: IDatabaseDriver, em?: EntityManager): ISchemaGenerator {

--- a/packages/entity-generator/src/EntityGenerator.ts
+++ b/packages/entity-generator/src/EntityGenerator.ts
@@ -1,5 +1,5 @@
 import { ensureDir, writeFile } from 'fs-extra';
-import type { EntityProperty , EntityMetadata } from '@mikro-orm/core';
+import type { EntityProperty, EntityMetadata, MikroORM } from '@mikro-orm/core';
 import { ReferenceType, Utils } from '@mikro-orm/core';
 import type { EntityManager } from '@mikro-orm/knex';
 import { DatabaseSchema } from '@mikro-orm/knex';
@@ -17,6 +17,10 @@ export class EntityGenerator {
   private readonly sources: SourceFile[] = [];
 
   constructor(private readonly em: EntityManager) { }
+
+  static register(orm: MikroORM): void {
+    orm.config.registerExtension('@mikro-orm/entity-generator', new EntityGenerator(orm.em as EntityManager));
+  }
 
   async generate(options: { baseDir?: string; save?: boolean; schema?: string } = {}): Promise<string[]> {
     const baseDir = Utils.normalizePath(options.baseDir ?? (this.config.get('baseDir') + '/generated-entities'));

--- a/packages/knex/src/AbstractSqlPlatform.ts
+++ b/packages/knex/src/AbstractSqlPlatform.ts
@@ -1,5 +1,5 @@
 import { escape } from 'sqlstring';
-import type { Constructor, EntityManager, EntityRepository, IDatabaseDriver } from '@mikro-orm/core';
+import type { Constructor, EntityManager, EntityRepository, IDatabaseDriver, MikroORM } from '@mikro-orm/core';
 import { JsonProperty, Platform, Utils } from '@mikro-orm/core';
 import { SqlEntityRepository } from './SqlEntityRepository';
 import type { SchemaHelper } from './schema';
@@ -25,17 +25,25 @@ export abstract class AbstractSqlPlatform extends Platform {
     return this.schemaHelper;
   }
 
+  /** @inheritDoc */
+  lookupExtensions(orm: MikroORM): void {
+    SchemaGenerator.register(orm);
+  }
+
+  // TODO remove in v6 (https://github.com/mikro-orm/mikro-orm/issues/3743)
   getSchemaGenerator(driver: IDatabaseDriver, em?: EntityManager): SchemaGenerator {
     /* istanbul ignore next */
     return this.config.getCachedService(SchemaGenerator, em ?? driver as any); // cast as `any` to get around circular dependencies
   }
 
+  // TODO remove in v6 (https://github.com/mikro-orm/mikro-orm/issues/3743)
   getEntityGenerator(em: EntityManager) {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { EntityGenerator } = require('@mikro-orm/entity-generator');
     return this.config.getCachedService(EntityGenerator, em);
   }
 
+  // TODO remove in v6 (https://github.com/mikro-orm/mikro-orm/issues/3743)
   getMigrator(em: EntityManager) {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { Migrator } = require('@mikro-orm/migrations');

--- a/packages/knex/src/schema/SchemaGenerator.ts
+++ b/packages/knex/src/schema/SchemaGenerator.ts
@@ -1,5 +1,5 @@
 ﻿import type { Knex } from 'knex';
-import type { Dictionary, EntityMetadata } from '@mikro-orm/core';
+import type { Dictionary, EntityMetadata, MikroORM } from '@mikro-orm/core';
 import { AbstractSchemaGenerator, Utils } from '@mikro-orm/core';
 import type { Check, ForeignKey, Index, SchemaDifference, TableDifference } from '../typings';
 import { DatabaseSchema } from './DatabaseSchema';
@@ -15,6 +15,10 @@ export class SchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDriver> 
   private readonly helper = this.platform.getSchemaHelper()!;
   private readonly options = this.config.get('schemaGenerator');
   protected lastEnsuredDatabase?: string;
+
+  static register(orm: MikroORM): void {
+    orm.config.registerExtension('@mikro-orm/schema-generator', new SchemaGenerator(orm.em));
+  }
 
   /** @deprecated use `dropSchema` and `createSchema` commands respectively */
   async generate(): Promise<string> {

--- a/packages/migrations-mongodb/src/Migrator.ts
+++ b/packages/migrations-mongodb/src/Migrator.ts
@@ -2,7 +2,7 @@ import type { InputMigrations, MigrateDownOptions, MigrateUpOptions, MigrationPa
 import { Umzug } from 'umzug';
 import { join } from 'path';
 import { ensureDir } from 'fs-extra';
-import type { Constructor, IMigrationGenerator, IMigrator, Transaction } from '@mikro-orm/core';
+import type { Constructor, IMigrationGenerator, IMigrator, MikroORM, Transaction } from '@mikro-orm/core';
 import { Utils } from '@mikro-orm/core';
 import type { EntityManager } from '@mikro-orm/mongodb';
 import type { Migration } from './Migration';
@@ -28,6 +28,10 @@ export class Migrator implements IMigrator {
     const key = (this.config.get('tsNode', Utils.detectTsNode()) && this.options.pathTs) ? 'pathTs' : 'path';
     this.absolutePath = Utils.absolutePath(this.options[key]!, this.config.get('baseDir'));
     this.createUmzug();
+  }
+
+  static register(orm: MikroORM): void {
+    orm.config.registerExtension('@mikro-orm/migrator', new Migrator(orm.em as EntityManager));
   }
 
   /**

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -2,7 +2,7 @@ import type { InputMigrations, MigrateDownOptions, MigrateUpOptions, MigrationPa
 import { Umzug } from 'umzug';
 import { basename, join } from 'path';
 import { ensureDir, pathExists, writeJSON } from 'fs-extra';
-import type { Constructor, Dictionary, IMigrationGenerator, IMigrator, Transaction } from '@mikro-orm/core';
+import type { Constructor, Dictionary, IMigrationGenerator, IMigrator, MikroORM, Transaction } from '@mikro-orm/core';
 import { t, Type, UnknownType, Utils } from '@mikro-orm/core';
 import type { EntityManager } from '@mikro-orm/knex';
 import { DatabaseSchema, DatabaseTable, SchemaGenerator } from '@mikro-orm/knex';
@@ -38,6 +38,10 @@ export class Migrator implements IMigrator {
     const snapshotName = this.options.snapshotName ?? `.snapshot-${dbName}`;
     this.snapshotPath = Utils.normalizePath(absoluteSnapshotPath, `${snapshotName}.json`);
     this.createUmzug();
+  }
+
+  static register(orm: MikroORM): void {
+    orm.config.registerExtension('@mikro-orm/migrator', new Migrator(orm.em as EntityManager));
   }
 
   /**

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from 'bson';
 import type {
   IPrimaryKey, Primary, NamingStrategy, Constructor, EntityRepository, EntityProperty,
-  PopulateOptions, EntityMetadata, IDatabaseDriver, EntityManager, Configuration,
+  PopulateOptions, EntityMetadata, IDatabaseDriver, EntityManager, Configuration, MikroORM,
 } from '@mikro-orm/core';
 import { Platform, MongoNamingStrategy, Utils, ReferenceType, MetadataError } from '@mikro-orm/core';
 import { MongoExceptionConverter } from './MongoExceptionConverter';
@@ -25,10 +25,17 @@ export class MongoPlatform extends Platform {
     return MongoEntityRepository as Constructor<EntityRepository<T>>;
   }
 
+  /** @inheritDoc */
+  lookupExtensions(orm: MikroORM): void {
+    MongoSchemaGenerator.register(orm);
+  }
+
+  // TODO remove in v6 (https://github.com/mikro-orm/mikro-orm/issues/3743)
   getSchemaGenerator(driver: IDatabaseDriver, em?: EntityManager): MongoSchemaGenerator {
     return new MongoSchemaGenerator(em ?? driver as any);
   }
 
+  // TODO remove in v6 (https://github.com/mikro-orm/mikro-orm/issues/3743)
   getMigrator(em: EntityManager) {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { Migrator } = require('@mikro-orm/migrations-mongodb');

--- a/packages/mongodb/src/MongoSchemaGenerator.ts
+++ b/packages/mongodb/src/MongoSchemaGenerator.ts
@@ -1,14 +1,19 @@
-import type { Dictionary, EntityMetadata, EntityProperty } from '@mikro-orm/core';
+import type { Dictionary, EntityMetadata, EntityProperty, MikroORM } from '@mikro-orm/core';
 import { AbstractSchemaGenerator, Utils } from '@mikro-orm/core';
 import type { MongoDriver } from './MongoDriver';
 
 export class MongoSchemaGenerator extends AbstractSchemaGenerator<MongoDriver> {
+
+  static register(orm: MikroORM): void {
+    orm.config.registerExtension('@mikro-orm/schema-generator', new MongoSchemaGenerator(orm.em));
+  }
 
   async createSchema(options: CreateSchemaOptions = {}): Promise<void> {
     options.ensureIndexes ??= true;
     const existing = await this.connection.listCollections();
     const metadata = this.getOrderedMetadata();
 
+    /* istanbul ignore next */
     const promises = metadata
       .filter(meta => !existing.includes(meta.collection))
       .map(meta => this.connection.createCollection(meta.collection).catch(err => {

--- a/packages/seeder/src/SeedManager.ts
+++ b/packages/seeder/src/SeedManager.ts
@@ -1,5 +1,5 @@
 import globby from 'globby';
-import type { Constructor, EntityManager, ISeedManager } from '@mikro-orm/core';
+import type { Constructor, EntityManager, ISeedManager , MikroORM } from '@mikro-orm/core';
 import { Utils } from '@mikro-orm/core';
 import type { Seeder } from './Seeder';
 import { ensureDir, writeFile } from 'fs-extra';
@@ -16,6 +16,10 @@ export class SeedManager implements ISeedManager {
     /* istanbul ignore next */
     const key = (this.config.get('tsNode', Utils.detectTsNode()) && this.options.pathTs) ? 'pathTs' : 'path';
     this.absolutePath = Utils.absolutePath(this.options[key]!, this.config.get('baseDir'));
+  }
+
+  static register(orm: MikroORM): void {
+    orm.config.registerExtension('@mikro-orm/seeder', new SeedManager(orm.em));
   }
 
   async seed(...classNames: Constructor<Seeder>[]): Promise<void> {

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -3,7 +3,7 @@ import type { EventSubscriber, ChangeSet, AnyEntity, FlushEventArgs, FilterQuery
 import {
   Collection, Configuration, EntityManager, LockMode, MikroORM, QueryFlag, QueryOrder, Reference, ValidationError, ChangeSetType, wrap, expr,
   UniqueConstraintViolationException, TableNotFoundException, NotNullConstraintViolationException, TableExistsException, SyntaxErrorException,
-  NonUniqueFieldNameException, InvalidFieldNameException, LoadStrategy, IsolationLevel, PopulateHint,
+  NonUniqueFieldNameException, InvalidFieldNameException, LoadStrategy, IsolationLevel, PopulateHint, ref,
 } from '@mikro-orm/core';
 import { PostgreSqlDriver, PostgreSqlConnection } from '@mikro-orm/postgresql';
 import { Address2, Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, PublisherType, PublisherType2, Test2, Label2 } from './entities-sql';
@@ -21,9 +21,9 @@ describe('EntityManagerPostgre', () => {
     const book2 = new Book2('My Life on The Wall, part 2', author);
     const book3 = new Book2('My Life on The Wall, part 3', author);
     const publisher = new Publisher2();
-    book1.publisher = wrap(publisher).toReference();
-    book2.publisher = wrap(publisher).toReference();
-    book3.publisher = wrap(publisher).toReference();
+    book1.publisher = ref(publisher);
+    book2.publisher = ref(publisher);
+    book3.publisher = ref(publisher);
     const tag1 = new BookTag2('silly');
     const tag2 = new BookTag2('funny');
     const tag3 = new BookTag2('sick');

--- a/tests/features/embeddables/extensions.test.ts
+++ b/tests/features/embeddables/extensions.test.ts
@@ -1,0 +1,60 @@
+import { EntitySchema } from '@mikro-orm/core';
+import { MikroORM, SchemaGenerator } from '@mikro-orm/sqlite';
+import { EntityGenerator } from '@mikro-orm/entity-generator';
+import { Migrator } from '@mikro-orm/migrations';
+import { Migrator as MongoMigrator } from '@mikro-orm/migrations-mongodb';
+import { MongoSchemaGenerator, MikroORM as MongoMikroORM } from '@mikro-orm/mongodb';
+import { SeedManager } from '@mikro-orm/seeder';
+
+const User = new EntitySchema({
+  name: 'User',
+  properties: {
+    id: { type: 'number', name: '_id', primary: true },
+  },
+});
+
+test('default extensions', async () => {
+  const orm = await MikroORM.init({
+    entities: [User],
+    dbName: ':memory:',
+  });
+
+  expect(orm.config.getExtension('@mikro-orm/schema-generator')).toBeInstanceOf(SchemaGenerator);
+  expect(() => orm.schema).not.toThrow();
+
+  await orm.close(true);
+});
+
+test('explicit extensions', async () => {
+  const orm = await MikroORM.init({
+    entities: [User],
+    dbName: ':memory:',
+    extensions: [EntityGenerator, Migrator, SeedManager],
+  });
+
+  expect(orm.config.getExtension('@mikro-orm/schema-generator')).toBeInstanceOf(SchemaGenerator);
+  expect(orm.config.getExtension('@mikro-orm/entity-generator')).toBeInstanceOf(EntityGenerator);
+  expect(orm.config.getExtension('@mikro-orm/migrator')).toBeInstanceOf(Migrator);
+  expect(orm.config.getExtension('@mikro-orm/seeder')).toBeInstanceOf(SeedManager);
+  expect(() => orm.schema).not.toThrow();
+  expect(() => orm.seeder).not.toThrow();
+  expect(() => orm.entityGenerator).not.toThrow();
+
+  await orm.close(true);
+});
+
+test('explicit extensions in mongo', async () => {
+  const orm = await MongoMikroORM.init({
+    entities: [User],
+    clientUrl: 'mongodb://localhost:27017/mikro_orm_extensions',
+    extensions: [MongoMigrator],
+  });
+
+  expect(orm.config.getExtension('@mikro-orm/schema-generator')).toBeInstanceOf(MongoSchemaGenerator);
+  expect(orm.config.getExtension('@mikro-orm/migrator')).toBeInstanceOf(MongoMigrator);
+  expect(() => orm.schema).not.toThrow();
+  expect(() => orm.migrator).not.toThrow();
+  expect(() => orm.entityGenerator).toThrow();
+
+  await orm.close(true);
+});


### PR DESCRIPTION
Register your extensions in the ORM config this way:

```ts
import { defineConfig } from '@mikro-orm/postgres';
import { Migrator } from '@mikro-orm/migrations';
import { EntityGenerator } from '@mikro-orm/entity-generator';
import { SeedManager } from '@mikro-orm/seeder';

export default defineConfig({
  dbName: 'test',
  extensions: [Migrator, EntityGenerator, SeedManager],
});
```

This will replace the static requires we use for extensions like entity generator or seeder in v6 (right now they are still there as a fallback to the extension).

Related: #3743