### PR TITLE
feat(cli): added option to generate cache via ts-node

### DIFF
--- a/packages/cli/src/commands/GenerateCacheCommand.ts
+++ b/packages/cli/src/commands/GenerateCacheCommand.ts
@@ -5,7 +5,7 @@ import { CLIHelper } from '../CLIHelper';
 export class GenerateCacheCommand<T> implements CommandModule<T, {tsNode?: boolean}> {
 
   command = 'cache:generate';
-  describe = 'Generate metadata cache for production or test use';
+  describe = 'Generate metadata cache';
   builder = (args: Argv<T>) => {
     args.option('ts', {
       alias: 'tsNode',

--- a/packages/cli/src/commands/GenerateCacheCommand.ts
+++ b/packages/cli/src/commands/GenerateCacheCommand.ts
@@ -1,17 +1,25 @@
-import type { ArgumentsCamelCase, CommandModule } from 'yargs';
+import type { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import { MetadataDiscovery, MetadataStorage, colors } from '@mikro-orm/core';
 import { CLIHelper } from '../CLIHelper';
 
-export class GenerateCacheCommand implements CommandModule {
+export class GenerateCacheCommand<T> implements CommandModule<T, {tsNode?: boolean}> {
 
   command = 'cache:generate';
-  describe = 'Generate metadata cache for production';
+  describe = 'Generate metadata cache for production or test use';
+  builder = (args: Argv<T>) => {
+    args.option('ts', {
+      alias: 'tsNode',
+      type: 'boolean',
+      desc: 'Use tsNode to generate `.ts` cache',
+    });
+    return args as Argv<{tsNode?: boolean}>;
+  };
 
   /**
    * @inheritDoc
    */
-  async handler(args: ArgumentsCamelCase) {
-    const config = await CLIHelper.getConfiguration();
+  async handler(args: ArgumentsCamelCase<{tsNode?: boolean}>) {
+    const config = await CLIHelper.getConfiguration(true, args.tsNode ? { tsNode: true } : {});
 
     if (!config.get('cache').enabled) {
       return CLIHelper.dump(colors.red('Metadata cache is disabled in your configuration. Set cache.enabled to true to use this command.'));
@@ -20,9 +28,9 @@ export class GenerateCacheCommand implements CommandModule {
     config.set('logger', CLIHelper.dump.bind(null));
     config.set('debug', true);
     const discovery = new MetadataDiscovery(MetadataStorage.init(), config.getDriver().getPlatform(), config);
-    await discovery.discover(false);
+    await discovery.discover(args.tsNode ?? false);
 
-    CLIHelper.dump(colors.green('Metadata cache was successfully generated'));
+    CLIHelper.dump(colors.green(`${args.tsNode ? 'TS' : 'JS'} metadata cache was successfully generated`));
   }
 
 }

--- a/packages/cli/src/commands/GenerateCacheCommand.ts
+++ b/packages/cli/src/commands/GenerateCacheCommand.ts
@@ -2,24 +2,25 @@ import type { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import { MetadataDiscovery, MetadataStorage, colors } from '@mikro-orm/core';
 import { CLIHelper } from '../CLIHelper';
 
-export class GenerateCacheCommand<T> implements CommandModule<T, {tsNode?: boolean}> {
+type CacheArgs = { ts?: boolean };
+export class GenerateCacheCommand<T> implements CommandModule<T, CacheArgs> {
 
   command = 'cache:generate';
   describe = 'Generate metadata cache';
   builder = (args: Argv<T>) => {
-    args.option('ts', {
-      alias: 'tsNode',
+    args.option('ts-node', {
+      alias: 'ts',
       type: 'boolean',
-      desc: 'Use tsNode to generate `.ts` cache',
+      desc: `Use ts-node to generate '.ts' cache`,
     });
-    return args as Argv<{tsNode?: boolean}>;
+    return args as Argv<CacheArgs>;
   };
 
   /**
    * @inheritDoc
    */
-  async handler(args: ArgumentsCamelCase<{tsNode?: boolean}>) {
-    const config = await CLIHelper.getConfiguration(true, args.tsNode ? { tsNode: true } : {});
+  async handler(args: ArgumentsCamelCase<CacheArgs>) {
+    const config = await CLIHelper.getConfiguration();
 
     if (!config.get('cache').enabled) {
       return CLIHelper.dump(colors.red('Metadata cache is disabled in your configuration. Set cache.enabled to true to use this command.'));
@@ -28,9 +29,9 @@ export class GenerateCacheCommand<T> implements CommandModule<T, {tsNode?: boole
     config.set('logger', CLIHelper.dump.bind(null));
     config.set('debug', true);
     const discovery = new MetadataDiscovery(MetadataStorage.init(), config.getDriver().getPlatform(), config);
-    await discovery.discover(args.tsNode ?? false);
+    await discovery.discover(args.ts ?? false);
 
-    CLIHelper.dump(colors.green(`${args.tsNode ? 'TS' : 'JS'} metadata cache was successfully generated`));
+    CLIHelper.dump(colors.green(`${args.ts ? 'TS' : 'JS'} metadata cache was successfully generated`));
   }
 
 }

--- a/tests/features/cli/GenerateCacheCommand.test.ts
+++ b/tests/features/cli/GenerateCacheCommand.test.ts
@@ -1,12 +1,18 @@
 import type { MetadataStorage } from '@mikro-orm/core';
 import { Configuration, MetadataDiscovery } from '@mikro-orm/core';
 import { CLIHelper } from '@mikro-orm/cli';
-import { GenerateCacheCommand } from '../../../packages/cli/src/commands/GenerateCacheCommand';
+import {
+  GenerateCacheCommand,
+} from '../../../packages/cli/src/commands/GenerateCacheCommand';
 
 (global as any).console.log = jest.fn();
 
 const getConfigurationMock = jest.spyOn(CLIHelper, 'getConfiguration');
-getConfigurationMock.mockResolvedValue(new Configuration({ type: 'mysql', cache: { enabled: true }, getDriver: () => ({ getPlatform: jest.fn() }) } as any, false));
+getConfigurationMock.mockResolvedValue(new Configuration({
+  type: 'mysql',
+  cache: { enabled: true },
+  getDriver: () => ({ getPlatform: jest.fn() }),
+} as any, false));
 const discoverMock = jest.spyOn(MetadataDiscovery.prototype, 'discover');
 discoverMock.mockResolvedValue({} as MetadataStorage);
 
@@ -15,14 +21,31 @@ describe('GenerateCacheCommand', () => {
   test('handler', async () => {
     const cmd = new GenerateCacheCommand();
 
+    const mockOption = jest.fn();
+    const args = { option: mockOption };
+    cmd.builder(args as any);
+    expect(mockOption).toBeCalledWith('ts', {
+      alias: 'tsNode',
+      type: 'boolean',
+      desc: 'Use tsNode to generate `.ts` cache',
+    });
+
     expect(discoverMock.mock.calls.length).toBe(0);
     await expect(cmd.handler({} as any)).resolves.toBeUndefined();
     expect(discoverMock.mock.calls.length).toBe(1);
     expect(discoverMock.mock.calls[0][0]).toBe(false);
+
+    await expect(cmd.handler({ tsNode: true } as any)).resolves.toBeUndefined();
+    expect(discoverMock.mock.calls.length).toBe(2);
+    expect(discoverMock.mock.calls[1][0]).toBe(true);
   });
 
   test('handler throws when cache is disabled', async () => {
-    getConfigurationMock.mockResolvedValue(new Configuration({ type: 'mysql', cache: { enabled: false }, getDriver: () => ({ getPlatform: jest.fn() }) } as any, false));
+    getConfigurationMock.mockResolvedValue(new Configuration({
+      type: 'mysql',
+      cache: { enabled: false },
+      getDriver: () => ({ getPlatform: jest.fn() }),
+    } as any, false));
     discoverMock.mockReset();
     discoverMock.mockResolvedValue({} as MetadataStorage);
 

--- a/tests/features/cli/GenerateCacheCommand.test.ts
+++ b/tests/features/cli/GenerateCacheCommand.test.ts
@@ -24,10 +24,10 @@ describe('GenerateCacheCommand', () => {
     const mockOption = jest.fn();
     const args = { option: mockOption };
     cmd.builder(args as any);
-    expect(mockOption).toBeCalledWith('ts', {
-      alias: 'tsNode',
+    expect(mockOption).toBeCalledWith('ts-node', {
+      alias: 'ts',
       type: 'boolean',
-      desc: 'Use tsNode to generate `.ts` cache',
+      desc: `Use ts-node to generate '.ts' cache`,
     });
 
     expect(discoverMock.mock.calls.length).toBe(0);
@@ -35,7 +35,7 @@ describe('GenerateCacheCommand', () => {
     expect(discoverMock.mock.calls.length).toBe(1);
     expect(discoverMock.mock.calls[0][0]).toBe(false);
 
-    await expect(cmd.handler({ tsNode: true } as any)).resolves.toBeUndefined();
+    await expect(cmd.handler({ ts: true } as any)).resolves.toBeUndefined();
     expect(discoverMock.mock.calls.length).toBe(2);
     expect(discoverMock.mock.calls[1][0]).toBe(true);
   });


### PR DESCRIPTION
[References](https://github.com/mikro-orm/mikro-orm/discussions/3795#discussioncomment-4253521)

Allow user to generate ts cache via CLI.