### PR TITLE
feat(postgres): add support for weighted tsvectors and a custom regconfig

### DIFF
--- a/docs/docs/query-conditions.md
+++ b/docs/docs/query-conditions.md
@@ -2,6 +2,9 @@
 title: Smart Query Conditions
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 When you want to make complex queries, we can easily end up with a lot of boilerplate code full of curly brackets:
 
 ```ts
@@ -82,22 +85,22 @@ The implementation and requirements differs per driver so it's important that fi
 
 ### PostgreSQL
 
-PosgreSQL allows to execute queries (pg-query) on the type pg-vector. The pg-vector type can be a column (more performant) or be created in the query (no excess columns in the database).
+PosgreSQL allows to execute queries (pg-query) on the type pg-vector. The pg-vector type can be a column (more performant) or be created in the query (no excess columns in the database).  When using a column, advanced functionality such as [a custom `regconfig` or `setweight`](https://www.postgresql.org/docs/current/textsearch-controls.html) (the default `regconfig` is `simple`) is also supported.
 
 Refer to the [PostgreSQL documentation](https://www.postgresql.org/docs/current/functions-textsearch.html) for possible queries.
 
 <Tabs
-groupId="entity-def"
+groupId="postgres-full-text"
 defaultValue="as-column"
 values={[
-{label: 'reflect-metadata', value: 'as-column'},
-{label: 'ts-morph', value: 'in-query'},
+{label: 'Using a column', value: 'as-column'},
+{label: 'Using an index', value: 'in-query'},
 ]
 }>
 <TabItem value="as-column">
 
 ```ts title="./entities/Book.ts"
-import { FullTextType } from '@mikro-orm/postgresql';
+import { FullTextType, WeightedFullTextValue } from '@mikro-orm/postgresql';
 
 @Entity()
 export class Book {
@@ -105,17 +108,27 @@ export class Book {
   @Property()
   title!: string;
 
+  // example when using default settings
   @Index({ type: 'fulltext' })
   @Property({ type: FullTextType, onUpdate: (book) => book.title })
   searchableTitle!: string;
 
+  // example when using a custom regconfig
+  @Index({ type: 'fulltext' })
+  @Property({ type: new FullTextType('english'), onUpdate: (book) => book.title })
+  searchableTitle!: string;
+
+  // example when using weights
+  @Index({ type: 'fulltext' })
+  @Property({ type: FullTextType, onUpdate: (book) => ({ A: book.title, B: book.description }) })
+  searchableTitle!: WeightedFullTextValue;
 }
 ```
 
-And to find results: `repository.findOne({ searchableTitle: { $fulltext: 'query' } })`
+And to find results: `repository.findOne({ searchableTitle: { $fulltext: 'query' } })`.
 
-  </TabItem>
-  <TabItem value="in-query">
+</TabItem>
+<TabItem value="in-query">
 
 ```ts title="./entities/Book.ts"
 @Entity()

--- a/docs/versioned_docs/version-5.4/query-conditions.md
+++ b/docs/versioned_docs/version-5.4/query-conditions.md
@@ -2,6 +2,9 @@
 title: Smart Query Conditions
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 When you want to make complex queries, we can easily end up with a lot of boilerplate code full of curly brackets:
 
 ```ts
@@ -87,11 +90,11 @@ PosgreSQL allows to execute queries (pg-query) on the type pg-vector. The pg-vec
 Refer to the [PostgreSQL documentation](https://www.postgresql.org/docs/current/functions-textsearch.html) for possible queries.
 
 <Tabs
-  groupId="entity-def"
+  groupId="postgres-full-text"
   defaultValue="as-column"
   values={[
-    {label: 'reflect-metadata', value: 'as-column'},
-    {label: 'ts-morph', value: 'in-query'},
+    {label: 'Using a column', value: 'as-column'},
+    {label: 'Using an index', value: 'in-query'},
   ]}>
   <TabItem value="as-column">
 

--- a/docs/versioned_docs/version-5.5/query-conditions.md
+++ b/docs/versioned_docs/version-5.5/query-conditions.md
@@ -2,6 +2,9 @@
 title: Smart Query Conditions
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 When you want to make complex queries, we can easily end up with a lot of boilerplate code full of curly brackets:
 
 ```ts
@@ -87,11 +90,11 @@ PosgreSQL allows to execute queries (pg-query) on the type pg-vector. The pg-vec
 Refer to the [PostgreSQL documentation](https://www.postgresql.org/docs/current/functions-textsearch.html) for possible queries.
 
 <Tabs
-  groupId="entity-def"
+  groupId="postgres-full-text"
   defaultValue="as-column"
   values={[
-    {label: 'reflect-metadata', value: 'as-column'},
-    {label: 'ts-morph', value: 'in-query'},
+    {label: 'Using a column', value: 'as-column'},
+    {label: 'Using an index', value: 'in-query'},
   ]}>
   <TabItem value="as-column">
 

--- a/docs/versioned_docs/version-5.6/query-conditions.md
+++ b/docs/versioned_docs/version-5.6/query-conditions.md
@@ -2,6 +2,9 @@
 title: Smart Query Conditions
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 When you want to make complex queries, we can easily end up with a lot of boilerplate code full of curly brackets:
 
 ```ts
@@ -87,11 +90,11 @@ PosgreSQL allows to execute queries (pg-query) on the type pg-vector. The pg-vec
 Refer to the [PostgreSQL documentation](https://www.postgresql.org/docs/current/functions-textsearch.html) for possible queries.
 
 <Tabs
-  groupId="entity-def"
+  groupId="postgres-full-text"
   defaultValue="as-column"
   values={[
-    {label: 'reflect-metadata', value: 'as-column'},
-    {label: 'ts-morph', value: 'in-query'},
+    {label: 'Using a column', value: 'as-column'},
+    {label: 'Using an index', value: 'in-query'},
   ]}>
   <TabItem value="as-column">
 

--- a/docs/versioned_docs/version-5.7/query-conditions.md
+++ b/docs/versioned_docs/version-5.7/query-conditions.md
@@ -2,6 +2,9 @@
 title: Smart Query Conditions
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 When you want to make complex queries, we can easily end up with a lot of boilerplate code full of curly brackets:
 
 ```ts

--- a/packages/postgresql/src/PostgreSqlPlatform.ts
+++ b/packages/postgresql/src/PostgreSqlPlatform.ts
@@ -1,9 +1,10 @@
 import { Client } from 'pg';
-import type { EntityProperty, Type, SimpleColumnMeta, Dictionary } from '@mikro-orm/core';
-import { ALIAS_REPLACEMENT, JsonProperty, raw, Utils } from '@mikro-orm/core';
+import type { EntityProperty, SimpleColumnMeta, Dictionary } from '@mikro-orm/core';
+import { ALIAS_REPLACEMENT, JsonProperty, raw, Utils, Type } from '@mikro-orm/core';
 import { AbstractSqlPlatform } from '@mikro-orm/knex';
 import { PostgreSqlSchemaHelper } from './PostgreSqlSchemaHelper';
 import { PostgreSqlExceptionConverter } from './PostgreSqlExceptionConverter';
+import { FullTextType } from './types/FullTextType';
 
 export class PostgreSqlPlatform extends AbstractSqlPlatform {
 
@@ -78,6 +79,10 @@ export class PostgreSqlPlatform extends AbstractSqlPlatform {
   }
 
   override getFullTextWhereClause(prop: EntityProperty): string {
+    if (prop.customType instanceof FullTextType) {
+      return `:column: @@ plainto_tsquery('${prop.customType.regconfig}', :query)`;
+    }
+
     if (prop.columnTypes[0] === 'tsvector') {
       return `:column: @@ plainto_tsquery('simple', :query)`;
     }
@@ -100,6 +105,13 @@ export class PostgreSqlPlatform extends AbstractSqlPlatform {
     }
 
     return `create index ${quotedIndexName} on ${quotedTableName} using gin(to_tsvector('simple', ${quotedColumnNames.join(` || ' ' || `)}))`;
+  }
+
+  override getMappedType(type: string): Type<unknown> {
+    switch (this.extractSimpleType(type)) {
+      case 'tsvector': return Type.getType(FullTextType);
+      default: return super.getMappedType(type);
+    }
   }
 
   override getRegExpOperator(val?: unknown, flags?: string): string {

--- a/packages/postgresql/src/types/FullTextType.ts
+++ b/packages/postgresql/src/types/FullTextType.ts
@@ -1,6 +1,22 @@
-import { Type } from '@mikro-orm/core';
+import { raw, Type } from '@mikro-orm/core';
+import type { TransformContext } from '@mikro-orm/core';
+import type { PostgreSqlPlatform } from '../PostgreSqlPlatform';
+import type { Knex } from '@mikro-orm/knex';
 
-export class FullTextType extends Type<string, string> {
+// Postgres has four levels of full text weights
+// https://www.postgresql.org/docs/current/textsearch-controls.html
+type FullTextWeight = 'A' | 'B' | 'C' | 'D';
+
+// Null types are allowed, mainly for readability so the user does not have to do null checks
+// themselves and keep using `onUpdate: (book: Book) => { A: book.title, B: book.description }`
+// with nullable properties.
+export type WeightedFullTextValue = { [K in FullTextWeight]?: string | null };
+
+export class FullTextType extends Type<string | WeightedFullTextValue, string | null | Knex.Raw> {
+
+  constructor(public regconfig: string = 'simple') {
+    super();
+  }
 
   override compareAsType(): string {
     return 'string';
@@ -10,8 +26,57 @@ export class FullTextType extends Type<string, string> {
     return 'tsvector';
   }
 
-  override convertToDatabaseValueSQL(key: string) {
-    return `to_tsvector('simple', ${key})`;
+  // Use convertToDatabaseValue to prepare insert queries as this method has
+  // access to the raw JS value. Return Knex#raw to prevent QueryBuilderHelper#mapData
+  // from sanitizing the returned chaing of SQL functions.
+  override convertToDatabaseValue(value: string | WeightedFullTextValue, platform: PostgreSqlPlatform, context?: TransformContext | boolean): string | null | Knex.Raw {
+    // Don't convert to values from select queries to the to_tsvector notation
+    // these should be compared as string using a special oparator or function
+    // this behaviour is defined in Platform#getFullTextWhereClause.
+    // This is always a string.
+    if (typeof context === 'object' && context.fromQuery) {
+      return value as string;
+    }
+
+    // Null values should not be processed
+    if (!value) {
+      return null;
+    }
+
+    // the object from that looks like { A: 'test data', B: 'test data2' ... }
+    // must be converted to
+    // setweight(to_tsvector(regconfig, value), A) || setweight(to_tsvector(regconfig, value), B)... etc
+    // use Knex#raw to do binding of the values sanitization of the boundvalues
+    // as we return a raw string which should not be sanitzed anymore
+    if (typeof value === 'object') {
+      const bindings: string[] = [];
+      const sqlParts: string[] = [];
+
+      for (const [weight, data] of Object.entries(value)) {
+        // Check whether the weight is valid according to Postgres,
+        // Postgres allows the weight to be upper and lowercase.
+        if (!['A', 'B', 'C', 'D'].includes(weight.toUpperCase())) {
+          throw new Error('Weight should be one of A, B, C, D.');
+        }
+
+        // Ignore all values that are not a string
+        if (typeof data === 'string') {
+          sqlParts.push('setweight(to_tsvector(?, ?), ?)');
+          bindings.push(this.regconfig, data, weight);
+        }
+      }
+
+      // Return null if the object has no valid strings
+      if (sqlParts.length === 0) {
+        return null;
+      }
+
+      // Join all the `setweight` parts using the PostgreSQL tsvector `||` concatenation operator
+      return raw(sqlParts.join(' || '), bindings);
+    }
+
+    // if it's not an object, it is expected to be string which does not have to be wrapped in setweight.
+    return raw('to_tsvector(?, ?)', [this.regconfig, value]);
   }
 
 }

--- a/packages/postgresql/src/types/FullTextType.ts
+++ b/packages/postgresql/src/types/FullTextType.ts
@@ -1,7 +1,6 @@
 import { raw, Type } from '@mikro-orm/core';
-import type { TransformContext } from '@mikro-orm/core';
+import type { TransformContext, RawQueryFragment } from '@mikro-orm/core';
 import type { PostgreSqlPlatform } from '../PostgreSqlPlatform';
-import type { Knex } from '@mikro-orm/knex';
 
 // Postgres has four levels of full text weights
 // https://www.postgresql.org/docs/current/textsearch-controls.html
@@ -12,7 +11,7 @@ type FullTextWeight = 'A' | 'B' | 'C' | 'D';
 // with nullable properties.
 export type WeightedFullTextValue = { [K in FullTextWeight]?: string | null };
 
-export class FullTextType extends Type<string | WeightedFullTextValue, string | null | Knex.Raw> {
+export class FullTextType extends Type<string | WeightedFullTextValue, string | null | RawQueryFragment> {
 
   constructor(public regconfig: string = 'simple') {
     super();
@@ -29,7 +28,7 @@ export class FullTextType extends Type<string | WeightedFullTextValue, string | 
   // Use convertToDatabaseValue to prepare insert queries as this method has
   // access to the raw JS value. Return Knex#raw to prevent QueryBuilderHelper#mapData
   // from sanitizing the returned chaing of SQL functions.
-  override convertToDatabaseValue(value: string | WeightedFullTextValue, platform: PostgreSqlPlatform, context?: TransformContext | boolean): string | null | Knex.Raw {
+  override convertToDatabaseValue(value: string | WeightedFullTextValue, platform: PostgreSqlPlatform, context?: TransformContext | boolean): string | null | RawQueryFragment {
     // Don't convert to values from select queries to the to_tsvector notation
     // these should be compared as string using a special oparator or function
     // this behaviour is defined in Platform#getFullTextWhereClause.

--- a/tests/features/fulltext/full-text-search-tsvector.postgres.test.ts
+++ b/tests/features/fulltext/full-text-search-tsvector.postgres.test.ts
@@ -1,5 +1,8 @@
 import { Entity, Index, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { FullTextType, PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { PostgreSqlDriver, WeightedFullTextValue, SchemaGenerator, FullTextType } from '@mikro-orm/postgresql';
+import { mockLogger } from '../../helpers';
+
+const createWeightedValue = (book: Book): WeightedFullTextValue => ({ A: book.title!, B: book.description! });
 
 @Entity({ tableName: 'book' })
 export class Book {
@@ -10,9 +13,24 @@ export class Book {
   @Property({ type: 'string', nullable: true })
   title!: string | null;
 
+  @Property({ type: 'string', nullable: true })
+  description!: string | null;
+
   @Index({ type: 'fulltext' })
   @Property({ type: FullTextType, nullable: true, onUpdate: (book: Book) => book.title, onCreate: (book: Book) => book.title })
   searchableTitle!: string;
+
+  @Index({ type: 'fulltext' })
+  @Property({ type: 'tsvector', nullable: true, onUpdate: (book: Book) => book.title, onCreate: (book: Book) => book.title })
+  searchableTitleNoType!: string;
+
+  @Index({ type: 'fulltext' })
+  @Property({ type: new FullTextType('english'), nullable: true, onUpdate: (book: Book) => book.title, onCreate: (book: Book) => book.title })
+  searchableTitleEnglish!: string;
+
+  @Index({ type: 'fulltext' })
+  @Property({ type: FullTextType, nullable: true, onUpdate: createWeightedValue, onCreate: createWeightedValue })
+  searchableTitleWeighted!: WeightedFullTextValue | string;
 
   constructor(title: string | null) {
     this.title = title;
@@ -23,6 +41,7 @@ export class Book {
 describe('full text search tsvector in postgres', () => {
 
   let orm: MikroORM<PostgreSqlDriver>;
+  let generator: SchemaGenerator;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
@@ -30,24 +49,31 @@ describe('full text search tsvector in postgres', () => {
       dbName: `mikro_orm_test_tsvector`,
       driver: PostgreSqlDriver,
     });
-    await orm.schema.ensureDatabase();
-    await orm.schema.execute('drop table if exists book');
-    await orm.schema.createSchema();
+    generator = orm.schema;
+    await generator.ensureDatabase();
+    await generator.execute('drop table if exists book');
+    await generator.createSchema();
   });
 
   beforeEach(() => orm.schema.clearDatabase());
   afterAll(() => orm.close(true));
 
   test('load entities', async () => {
+    const repo = orm.em.getRepository(Book);
+
     const book1 = new Book('My Life on The ? Wall, part 1');
     await orm.em.persist(book1).flush();
 
-    const repo = orm.em.getRepository(Book);
     const fullTextBooks = (await repo.find({ searchableTitle: { $fulltext: 'life wall' } }))!;
     expect(fullTextBooks.length).toBe(1);
+
+    const fullTextBooks2 = (await repo.find({ searchableTitleNoType: { $fulltext: 'life wall' } }))!;
+    expect(fullTextBooks2).toHaveLength(1);
   });
 
   test('load entities (multi)', async () => {
+    const repo = orm.em.getRepository(Book);
+
     const book1 = new Book('My Life on The ? Wall, part 1');
     const book2 = new Book('My Life on The Wall, part 2');
     const book3 = new Book('My Life on The Wall, part 3');
@@ -55,11 +81,108 @@ describe('full text search tsvector in postgres', () => {
     const book5 = new Book('My Life on The House');
     const book6 = new Book(null);
 
-    await orm.em.persist([book1, book2, book3, book4, book5, book6]).flush();
+    orm.em.persist([book1, book2, book3, book4, book5, book6]);
+    await orm.em.flush();
 
-    const repo = orm.em.getRepository(Book);
     const fullTextBooks = (await repo.find({ searchableTitle: { $fulltext: 'life wall' } }))!;
     expect(fullTextBooks).toHaveLength(3);
+  });
+
+  test('should insert/update entities with custom regconfig + weighted', async () => {
+    const repo = orm.em.getRepository(Book);
+
+    const book = new Book('My Life on The ? Wall, part 1');
+    orm.em.persist(book);
+
+    const mock = mockLogger(orm);
+
+    await orm.em.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch(`begin`);
+    expect(mock.mock.calls[1][0]).toMatch(`insert into "book" ("title", "searchable_title", "searchable_title_no_type", "searchable_title_english", "searchable_title_weighted") values ('My Life on The ? Wall, part 1', to_tsvector('simple', 'My Life on The ? Wall, part 1'), to_tsvector('simple', 'My Life on The ? Wall, part 1'), to_tsvector('english', 'My Life on The ? Wall, part 1'), setweight(to_tsvector('simple', 'My Life on The ? Wall, part 1'), 'A')) returning "id"`);
+    expect(mock.mock.calls[2][0]).toMatch(`commit`);
+
+    book.title = 'Test title';
+    book.description = 'Test description of book';
+
+    mock.mockReset();
+
+    await orm.em.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch(`begin`);
+    expect(mock.mock.calls[1][0]).toMatch(`update "book" set "title" = 'Test title', "description" = 'Test description of book', "searchable_title" = to_tsvector('simple', 'Test title'), "searchable_title_no_type" = to_tsvector('simple', 'Test title'), "searchable_title_english" = to_tsvector('english', 'Test title'), "searchable_title_weighted" = setweight(to_tsvector('simple', 'Test title'), 'A') || setweight(to_tsvector('simple', 'Test description of book'), 'B') where "id" = 1`);
+    expect(mock.mock.calls[2][0]).toMatch(`commit`);
+  });
+
+  test('should insert null when empty weight object is used', async () => {
+    const repo = orm.em.getRepository(Book);
+
+    const book = new Book('My Life on The ? Wall, part 1');
+    orm.em.persist(book);
+
+    book.searchableTitleWeighted = {};
+
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch(`begin`);
+    expect(mock.mock.calls[1][0]).toMatch(`insert into "book" ("title", "searchable_title", "searchable_title_no_type", "searchable_title_english", "searchable_title_weighted") values ('My Life on The ? Wall, part 1', to_tsvector('simple', 'My Life on The ? Wall, part 1'), to_tsvector('simple', 'My Life on The ? Wall, part 1'), to_tsvector('english', 'My Life on The ? Wall, part 1'), NULL) returning "id`);
+    expect(mock.mock.calls[2][0]).toMatch(`commit`);
+
+    orm.em.clear();
+
+    const book2 = new Book('My Life on The ? Wall, part 1');
+    orm.em.persist(book2);
+
+    book2.searchableTitleWeighted = { A: undefined };
+
+    mock.mockClear();
+    await orm.em.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch(`begin`);
+    expect(mock.mock.calls[1][0]).toMatch(`insert into "book" ("title", "searchable_title", "searchable_title_no_type", "searchable_title_english", "searchable_title_weighted") values ('My Life on The ? Wall, part 1', to_tsvector('simple', 'My Life on The ? Wall, part 1'), to_tsvector('simple', 'My Life on The ? Wall, part 1'), to_tsvector('english', 'My Life on The ? Wall, part 1'), NULL) returning "id"`);
+    expect(mock.mock.calls[2][0]).toMatch(`commit`);
+  });
+
+  test('should throw error when invalid weight is used', async () => {
+    const repo = orm.em.getRepository(Book);
+
+    const book = new Book('My Life on The ? Wall, part 1');
+    orm.em.persist(book);
+
+    // Cast to any as directly assigning this property is typechecked.
+    // However, when updating from onUpdate or onCreate,
+    // the value is not type checked and therefore should
+    // throw an error when an invalid object is passed
+    book.searchableTitleWeighted = { E: 'invalid weight' } as any;
+
+    expect(orm.em.flush()).rejects.toThrowError('Weight should be one of A, B, C, D.');
+  });
+
+  test('should find entities with custom regconfig', async () => {
+    const repo = orm.em.getRepository(Book);
+
+    const book = new Book('My Life on The ? Wall, part 1');
+    orm.em.persist(book);
+    await orm.em.flush();
+
+    orm.em.clear();
+
+    const mock = mockLogger(orm);
+
+    const fullTextBooks = (await repo.find({ searchableTitle: { $fulltext: 'life wall' } }))!;
+    expect(mock.mock.calls[0][0]).toMatch(`select "b0".* from "book" as "b0" where "b0"."searchable_title" @@ plainto_tsquery('simple', 'life wall')`);
+    expect(fullTextBooks).toHaveLength(1);
+    mock.mockReset();
+
+    const fullTextBooks2 = (await repo.find({ searchableTitleEnglish: { $fulltext: 'life wall' } }))!;
+    expect(mock.mock.calls[0][0]).toMatch(`select "b0".* from "book" as "b0" where "b0"."searchable_title_english" @@ plainto_tsquery('english', 'life wall')`);
+    expect(fullTextBooks2).toHaveLength(1);
+    mock.mockReset();
+
+    const fullTextBooks3 = (await repo.find({ searchableTitleWeighted: { $fulltext: 'life wall' } }))!;
+    expect(mock.mock.calls[0][0]).toMatch(`select "b0".* from "book" as "b0" where "b0"."searchable_title_weighted" @@ plainto_tsquery('simple', 'life wall')`);
+    expect(fullTextBooks3).toHaveLength(1);
   });
 
 });

--- a/tests/features/fulltext/full-text-search-tsvector.postgres.test.ts
+++ b/tests/features/fulltext/full-text-search-tsvector.postgres.test.ts
@@ -30,7 +30,7 @@ export class Book {
 
   @Index({ type: 'fulltext' })
   @Property({ type: FullTextType, nullable: true, onUpdate: createWeightedValue, onCreate: createWeightedValue })
-  searchableTitleWeighted!: WeightedFullTextValue | string;
+  searchableTitleWeighted!: WeightedFullTextValue;
 
   constructor(title: string | null) {
     this.title = title;


### PR DESCRIPTION
Adds support for a custom regconfig and weighted tsvectors as requested by https://github.com/mikro-orm/mikro-orm/pull/3317#issuecomment-1330035868. 

For more context, see https://github.com/mikro-orm/mikro-orm/pull/3317#issuecomment-1330555809.

Docs: also (hopefully) fixed the tabs which caused the confusion as seen here: https://github.com/mikro-orm/mikro-orm/pull/3317#issuecomment-1279882693.
