### PR TITLE
fix: wrap nested property names

### DIFF
--- a/packages/core/src/hydration/ObjectHydrator.ts
+++ b/packages/core/src/hydration/ObjectHydrator.ts
@@ -140,8 +140,8 @@ export class ObjectHydrator extends Hydrator {
         const prop2 = meta2.properties[prop.inversedBy || prop.mappedBy];
 
         if (prop2 && !prop2.mapToPk) {
-          ret.push(`  if (entity${entityKey} && !entity${entityKey}.${prop2.name}) {`);
-          ret.push(`    entity${entityKey}.${prop.wrappedReference ? 'unwrap().' : ''}${prop2.name} = ${prop2.wrappedReference ? 'Reference.create(entity)' : 'entity'};`);
+          ret.push(`  if (entity${entityKey} && !entity${entityKey}${this.wrap(prop2.name)}) {`);
+          ret.push(`    entity${entityKey}${prop.wrappedReference ? 'unwrap()' : ''}${this.wrap(prop2.name)} = ${prop2.wrappedReference ? 'Reference.create(entity)' : 'entity'};`);
           ret.push(`  }`);
         }
       }


### PR DESCRIPTION
We have entities with relations using property names in kebab case, like
```ts
export class ParentEntity {
  @PrimaryKey()
  id: number;

  @ApiProperty()
  @OneToOne({ entity: () => SomeOtherEntity, nullable: true, mappedBy: 'parent' })
  'kebab-case-property': SomeOtherEntity;
}
```

When I use an entity factory the hydrator generates code like
```ts
if (entity.parent && !entity.parent.kebab-case-property) {
        entity.parent.kebab-case-property = entity;
      }
```
Which leads to an error because the above code is not valid JS.

This would be fine if only `entity.parent.kebab-case-property` was formatted like `entity.parent['kebab-case-property']`.

I noticed we have the `this.wrap()` method which does this manipulation for us for other properties, but we are not using it in this particular part of the code.

This PR will just add that in so that all properties are "fixed".