### PR TITLE
feat(core): remove static require calls

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -195,7 +195,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0 # we need to pull everything to have correct dev version suffix
-          ref: master
 
       - name: Use Node.js 16
         uses: actions/setup-node@v3

--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -11,3 +11,64 @@ Support for older node versions was dropped.
 ## TypeScript 4.9+ required
 
 Support for older TypeScript versions was dropped. 
+
+## Removal of static require calls
+
+There were some places where we did a static `require()` call, e.g. when loading the driver implementation based on the `type` option. Those places were problematic for bundlers like webpack, as well as new school build systems like vite.
+
+### The `type` option is removed in favour of driver exports
+
+Instead of specifying the `type` we now have several options:
+
+1. use `defineConfig()` helper imported from the driver package to create your ORM config:
+   ```ts title='mikro-orm.config.ts'
+   import { defineConfig } from '@mikro-orm/mysql';
+   
+   export default defineConfig({ ... });
+   ```
+2. use `MikroORM.init()` on class imported from the driver package:
+   ```ts title='app.ts'
+   import { MikroORM } from '@mikro-orm/mysql';
+
+   const orm = await MikroORM.init({ ... });
+   ```
+3. specify the `driver` option:
+   ```ts title='mikro-orm.config.ts'
+   import { MySqlDriver } from '@mikro-orm/mysql'; 
+
+   export default {
+     driver: MySqlDriver,
+     ...
+   };
+   ```
+
+> The `MIKRO_ORM_TYPE` is still supported, but no longer does a static require of the driver class. Its usage is rather discouraged and it might be removed in future versions too.
+
+### ORM extensions
+
+Similarly, we had to get rid of the `require()` calls for extensions like `Migrator`, `EntityGenerator` and `Seeder`. Those need to be registered as extensions in your ORM config. `SchemaGenerator` extension is registered automatically.
+
+> This is required only for the shortcuts available on `MikroORM` object, e.g. `orm.migrator.up()`, alternatively you can instantiate the `Migrator` yourself explicitly.
+
+```ts title='mikro-orm.config.ts'
+import { defineConfig } from '@mikro-orm/mysql';
+import { Migrator } from '@mikro-orm/migrations';
+import { EntityGenerator } from '@mikro-orm/entity-generator';
+import { SeedManager } from '@mikro-orm/seeder';
+
+export default defineConfig({
+  dbName: 'test',
+  extensions: [Migrator, EntityGenerator, SeedManager], // those would have a static `register` method
+});
+```
+
+## `MikroORM.init()` no longer accepts a `Configuration` instance
+
+The options always needs to be plain JS object now. This was always only an internal way, partially useful in tests, never meant to be a user API (while many people since the infamous Ben Awad video mistakenly complicated their typings with it).
+
+## Removed `MongoDriver` methods
+
+- `createCollections` in favour of `orm.schema.createSchema()`
+- `dropCollections` in favour of `orm.schema.dropSchema()`
+- `refreshCollections` in favour of `orm.schema.refreshDatabase()`
+- `ensureIndexes` in favour of `orm.schema.ensureIndexes()`

--- a/lerna.json
+++ b/lerna.json
@@ -14,7 +14,6 @@
     "**/tests/**",
     "**/*.md"
   ],
-  "useNx": false,
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/better-sqlite/package.json
+++ b/packages/better-sqlite/package.json
@@ -67,20 +67,6 @@
     "@mikro-orm/core": "^5.5.3"
   },
   "peerDependencies": {
-    "@mikro-orm/core": "^5.0.0",
-    "@mikro-orm/entity-generator": "^5.0.0",
-    "@mikro-orm/migrations": "^5.0.0",
-    "@mikro-orm/seeder": "^5.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@mikro-orm/entity-generator": {
-      "optional": true
-    },
-    "@mikro-orm/migrations": {
-      "optional": true
-    },
-    "@mikro-orm/seeder": {
-      "optional": true
-    }
+    "@mikro-orm/core": "^5.0.0"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,54 +68,5 @@
     "tsconfig-paths": "4.1.1",
     "yargonaut": "1.1.4",
     "yargs": "15.4.1"
-  },
-  "devDependencies": {
-    "@mikro-orm/entity-generator": "^5.5.3",
-    "@mikro-orm/migrations": "^5.5.3",
-    "@mikro-orm/seeder": "^5.5.3"
-  },
-  "peerDependencies": {
-    "@mikro-orm/better-sqlite": "^5.0.0",
-    "@mikro-orm/entity-generator": "^5.0.0",
-    "@mikro-orm/mariadb": "^5.0.0",
-    "@mikro-orm/migrations": "^5.0.0",
-    "@mikro-orm/migrations-mongodb": "^5.0.0",
-    "@mikro-orm/mongodb": "^5.0.0",
-    "@mikro-orm/mysql": "^5.0.0",
-    "@mikro-orm/postgresql": "^5.0.0",
-    "@mikro-orm/seeder": "^5.0.0",
-    "@mikro-orm/sqlite": "^5.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@mikro-orm/better-sqlite": {
-      "optional": true
-    },
-    "@mikro-orm/entity-generator": {
-      "optional": true
-    },
-    "@mikro-orm/mariadb": {
-      "optional": true
-    },
-    "@mikro-orm/migrations": {
-      "optional": true
-    },
-    "@mikro-orm/migrations-mongodb": {
-      "optional": true
-    },
-    "@mikro-orm/mongodb": {
-      "optional": true
-    },
-    "@mikro-orm/mysql": {
-      "optional": true
-    },
-    "@mikro-orm/postgresql": {
-      "optional": true
-    },
-    "@mikro-orm/seeder": {
-      "optional": true
-    },
-    "@mikro-orm/sqlite": {
-      "optional": true
-    }
   }
 }

--- a/packages/cli/src/CLIHelper.ts
+++ b/packages/cli/src/CLIHelper.ts
@@ -1,7 +1,5 @@
 import { pathExists } from 'fs-extra';
 import yargs from 'yargs';
-import { platform } from 'os';
-import { fileURLToPath } from 'url';
 import type { Configuration, IDatabaseDriver, Options } from '@mikro-orm/core';
 import { colors, ConfigurationLoader, MikroORM, Utils } from '@mikro-orm/core';
 
@@ -35,7 +33,7 @@ export class CLIHelper {
       options.get('discovery').warnWhenNoEntities = warnWhenNoEntities;
     }
 
-    return MikroORM.init(options);
+    return MikroORM.init(options.getAll());
   }
 
   static getNodeVersion(): string {

--- a/packages/cli/src/commands/GenerateEntitiesCommand.ts
+++ b/packages/cli/src/commands/GenerateEntitiesCommand.ts
@@ -1,6 +1,4 @@
 import type { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
-import { Utils } from '@mikro-orm/core';
-import type { EntityManager } from '@mikro-orm/knex';
 import { CLIHelper } from '../CLIHelper';
 
 export type Options = { dump: boolean; save: boolean; path: string; schema: string };
@@ -46,9 +44,11 @@ export class GenerateEntitiesCommand<U extends Options = Options> implements Com
     }
 
     const orm = await CLIHelper.getORM(false);
-    const { EntityGenerator } = await Utils.dynamicImport('@mikro-orm/entity-generator');
-    const generator = new EntityGenerator(orm.em as EntityManager);
-    const dump = await generator.generate({ save: args.save, baseDir: args.path, schema: args.schema });
+    const dump = await orm.entityGenerator.generate({
+      save: args.save,
+      baseDir: args.path,
+      schema: args.schema,
+    });
 
     if (args.dump) {
       CLIHelper.dump(dump.join('\n\n'));

--- a/packages/cli/src/commands/MigrationCommandFactory.ts
+++ b/packages/cli/src/commands/MigrationCommandFactory.ts
@@ -1,7 +1,6 @@
 import type { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
-import type { Configuration, MikroORM, MikroORMOptions, IMigrator } from '@mikro-orm/core';
+import type { Configuration, MikroORM, MikroORMOptions, IMigrator, MigrateOptions } from '@mikro-orm/core';
 import { Utils, colors } from '@mikro-orm/core';
-import type { MigrateOptions } from '@mikro-orm/migrations';
 import { CLIHelper } from '../CLIHelper';
 
 export class MigrationCommandFactory {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,49 +65,5 @@
     "globby": "11.1.0",
     "mikro-orm": "^5.5.3",
     "reflect-metadata": "0.1.13"
-  },
-  "peerDependencies": {
-    "@mikro-orm/better-sqlite": "^5.0.0",
-    "@mikro-orm/entity-generator": "^5.0.0",
-    "@mikro-orm/mariadb": "^5.0.0",
-    "@mikro-orm/migrations": "^5.0.0",
-    "@mikro-orm/migrations-mongodb": "^5.0.0",
-    "@mikro-orm/mongodb": "^5.0.0",
-    "@mikro-orm/mysql": "^5.0.0",
-    "@mikro-orm/postgresql": "^5.0.0",
-    "@mikro-orm/seeder": "^5.0.0",
-    "@mikro-orm/sqlite": "^5.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@mikro-orm/better-sqlite": {
-      "optional": true
-    },
-    "@mikro-orm/entity-generator": {
-      "optional": true
-    },
-    "@mikro-orm/mariadb": {
-      "optional": true
-    },
-    "@mikro-orm/migrations": {
-      "optional": true
-    },
-    "@mikro-orm/migrations-mongodb": {
-      "optional": true
-    },
-    "@mikro-orm/mongodb": {
-      "optional": true
-    },
-    "@mikro-orm/mysql": {
-      "optional": true
-    },
-    "@mikro-orm/postgresql": {
-      "optional": true
-    },
-    "@mikro-orm/seeder": {
-      "optional": true
-    },
-    "@mikro-orm/sqlite": {
-      "optional": true
-    }
   }
 }

--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -25,24 +25,23 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
    * Initialize the ORM, load entity metadata, create EntityManager and connect to the database.
    * If you omit the `options` parameter, your CLI config will be used.
    */
-  static async init<D extends IDatabaseDriver = IDatabaseDriver>(options?: Options<D> | Configuration<D>, connect = true): Promise<MikroORM<D>> {
+  static async init<D extends IDatabaseDriver = IDatabaseDriver>(options?: Options<D>, connect = true): Promise<MikroORM<D>> {
     ConfigurationLoader.registerDotenv(options);
     const coreVersion = await ConfigurationLoader.checkPackageVersion();
     const env = ConfigurationLoader.loadEnvironmentVars<D>();
 
     if (!options) {
-      options = await ConfigurationLoader.getConfiguration<D>();
+      options = (await ConfigurationLoader.getConfiguration<D>()).getAll();
     }
 
-    let opts = options instanceof Configuration ? options.getAll() : options;
-    opts = Utils.merge(opts, env);
-    await ConfigurationLoader.commonJSCompat(opts as object);
+    options = Utils.merge(options, env);
+    await ConfigurationLoader.commonJSCompat(options!);
 
-    if ('DRIVER' in this && !opts.driver && !opts.type) {
-      (opts as Options).driver = (this as unknown as { DRIVER: Constructor<IDatabaseDriver> }).DRIVER;
+    if ('DRIVER' in this && !options!.driver) {
+      (options as Options).driver = (this as unknown as { DRIVER: Constructor<IDatabaseDriver> }).DRIVER;
     }
 
-    const orm = new MikroORM(opts);
+    const orm = new MikroORM(options!);
     orm.logger.log('info', `MikroORM version: ${colors.green(coreVersion)}`);
 
     // we need to allow global context here as we are not in a scope of requests yet
@@ -169,9 +168,8 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
       return extension;
     }
 
-    // TODO remove in v6 (https://github.com/mikro-orm/mikro-orm/issues/3743)
     /* istanbul ignore next */
-    return this.driver.getPlatform().getSchemaGenerator(this.driver, this.em) as any;
+    throw new Error(`SchemaGenerator extension not registered.`);
   }
 
   /**
@@ -184,8 +182,7 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
       return extension;
     }
 
-    // TODO remove in v6 (https://github.com/mikro-orm/mikro-orm/issues/3743)
-    return this.driver.getPlatform().getEntityGenerator(this.em) as T;
+    throw new Error(`EntityGenerator extension not registered.`);
   }
 
   /**
@@ -198,8 +195,7 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
       return extension;
     }
 
-    // TODO remove in v6 (https://github.com/mikro-orm/mikro-orm/issues/3743)
-    return this.driver.getPlatform().getMigrator(this.em) as T;
+    throw new Error(`Migrator extension not registered.`);
   }
 
   /**
@@ -212,10 +208,7 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
       return extension;
     }
 
-    // TODO remove in v6 (https://github.com/mikro-orm/mikro-orm/issues/3743)
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { SeedManager } = require('@mikro-orm/seeder');
-    return this.config.getCachedService(SeedManager, this.em);
+    throw new Error(`SeedManager extension not registered.`);
   }
 
   /**

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -140,10 +140,6 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     return this.dependencies;
   }
 
-  async ensureIndexes(): Promise<void> {
-    throw new Error(`${this.constructor.name} does not use ensureIndexes`);
-  }
-
   protected inlineEmbeddables<T>(meta: EntityMetadata<T>, data: T, where?: boolean): void {
     Object.keys(data as Dictionary).forEach(k => {
       if (Utils.isOperator(k)) {

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -69,8 +69,6 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
 
   getMetadata(): MetadataStorage;
 
-  ensureIndexes(): Promise<void>;
-
   /**
    * Returns name of the underlying database dependencies (e.g. `mongodb` or `mysql2`)
    * for SQL drivers it also returns `knex` in the array as connectors are not used directly there

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,8 @@ export {
   Constructor, ConnectionType, Dictionary, PrimaryKeyType, PrimaryKeyProp, Primary, IPrimaryKey, ObjectQuery, FilterQuery, IWrappedEntity, EntityName, EntityData, Highlighter,
   AnyEntity, EntityClass, EntityProperty, EntityMetadata, QBFilterQuery, PopulateOptions, Populate, Loaded, New, LoadedReference, LoadedCollection, IMigrator, IMigrationGenerator,
   GetRepository, EntityRepositoryType, MigrationObject, DeepPartial, PrimaryProperty, Cast, IsUnknown, EntityDictionary, EntityDTO, MigrationDiff,
-  IEntityGenerator, ISeedManager, EntityClassGroup, OptionalProps, RequiredEntityData, CheckCallback, SimpleColumnMeta, Rel, Ref,
+  IEntityGenerator, ISeedManager, EntityClassGroup, OptionalProps, RequiredEntityData, CheckCallback, SimpleColumnMeta, Rel, Ref, ISchemaGenerator,
+  UmzugMigration, MigrateOptions, MigrationResult, MigrationRow,
 } from './typings';
 export * from './enums';
 export * from './errors';

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -343,16 +343,9 @@ export abstract class Platform {
     // no extensions by default
   }
 
+  /* istanbul ignore next: kept for type inference only */
   getSchemaGenerator(driver: IDatabaseDriver, em?: EntityManager): ISchemaGenerator {
     throw new Error(`${driver.constructor.name} does not support SchemaGenerator`);
-  }
-
-  getEntityGenerator(em: EntityManager): IEntityGenerator {
-    throw new Error(`${this.constructor.name} does not support EntityGenerator`);
-  }
-
-  getMigrator(em: EntityManager): IMigrator {
-    throw new Error(`${this.constructor.name} does not support Migrator`);
   }
 
   processDateProperty(value: unknown): string | number | Date {

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -524,7 +524,7 @@ export interface ISchemaGenerator {
   dropDatabase(name: string): Promise<void>;
   execute(sql: string, options?: { wrap?: boolean }): Promise<void>;
   ensureIndexes(): Promise<void>;
-  refreshDatabase(): Promise<void>;
+  refreshDatabase(options?: { ensureIndexes?: boolean }): Promise<void>;
   clearDatabase(options?: { schema?: string }): Promise<void>;
 }
 
@@ -532,10 +532,10 @@ export interface IEntityGenerator {
   generate(options?: { baseDir?: string; save?: boolean; schema?: string }): Promise<string[]>;
 }
 
-type UmzugMigration = { name: string; path?: string };
-type MigrateOptions = { from?: string | number; to?: string | number; migrations?: string[]; transaction?: Transaction };
-type MigrationResult = { fileName: string; code: string; diff: MigrationDiff };
-type MigrationRow = { name: string; executed_at: Date };
+export type UmzugMigration = { name: string; path?: string };
+export type MigrateOptions = { from?: string | number; to?: string | number; migrations?: string[]; transaction?: Transaction };
+export type MigrationResult = { fileName: string; code: string; diff: MigrationDiff };
+export type MigrationRow = { name: string; executed_at: Date };
 
 /**
  * @internal

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -1,6 +1,4 @@
-import { inspect } from 'util';
 import { pathExistsSync } from 'fs-extra';
-
 import type { NamingStrategy } from '../naming-strategy';
 import type { CacheAdapter } from '../cache';
 import { FileCacheAdapter, NullCacheAdapter } from '../cache';
@@ -129,22 +127,12 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     dynamicImportProvider: /* istanbul ignore next */ (id: string) => import(id),
   };
 
-  // TODO remove in v6 (https://github.com/mikro-orm/mikro-orm/issues/3743)
-  static readonly PLATFORMS = {
-    'mongo': { className: 'MongoDriver', module: () => require('@mikro-orm/mongodb') },
-    'mysql': { className: 'MySqlDriver', module: () => require('@mikro-orm/mysql') },
-    'mariadb': { className: 'MariaDbDriver', module: () => require('@mikro-orm/mariadb') },
-    'postgresql': { className: 'PostgreSqlDriver', module: () => require('@mikro-orm/postgresql') },
-    'sqlite': { className: 'SqliteDriver', module: () => require('@mikro-orm/sqlite') },
-    'better-sqlite': { className: 'BetterSqliteDriver', module: () => require('@mikro-orm/better-sqlite') },
-  };
-
   private readonly options: MikroORMOptions<D>;
   private readonly logger: Logger;
   private readonly driver: D;
   private readonly platform: Platform;
   private readonly cache = new Map<string, any>();
-  private readonly extensions = new Map<string, unknown>();
+  private readonly extensions = new Map<string, () => unknown>();
 
   constructor(options: Options, validate = true) {
     if (options.dynamicImportProvider) {
@@ -165,7 +153,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
       highlighter: this.options.highlighter,
       writer: this.options.logger,
     });
-    this.driver = this.initDriver();
+    this.driver = new this.options.driver!(this);
     this.platform = this.driver.getPlatform();
     this.platform.setConfig(this);
     this.detectSourceFolder(options);
@@ -226,12 +214,23 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     return this.driver;
   }
 
-  registerExtension(name: string, instance: unknown): void {
-    this.extensions.set(name, instance);
+  registerExtension(name: string, cb: () => unknown): void {
+    this.extensions.set(name, cb);
   }
 
   getExtension<T>(name: string): T | undefined {
-    return this.extensions.get(name) as T;
+    if (this.cache.has(name)) {
+      return this.cache.get(name);
+    }
+
+    const ext = this.extensions.get(name);
+
+    if (ext) {
+      this.cache.set(name, ext());
+      return this.cache.get(name);
+    }
+
+    return undefined;
   }
 
   /**
@@ -380,12 +379,12 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
   }
 
   private validateOptions(): void {
-    if (!this.options.type && !this.options.driver) {
-      throw new Error('No platform type specified, please fill in `type` or provide custom driver class in `driver` option. Available platforms types: ' + inspect(Object.keys(Configuration.PLATFORMS)));
+    if ('type' in this.options) {
+      throw new Error('The `type` option has been removed in v6, please fill in the `driver` option instead or use `defineConfig` helper (to define your ORM config) or `MikroORM` class (to call the `init` method) exported from the driver package (e.g. `import { defineConfig } from \'@mikro-orm/mysql\'; export default defineConfig({ ... })`).');
     }
 
-    if (this.options.type && !(this.options.type in Configuration.PLATFORMS)) {
-      throw new Error(`Invalid platform type specified: '${this.options.type}', please fill in valid \`type\` or provide custom driver class in \`driver\` option. Available platforms types: ${inspect(Object.keys(Configuration.PLATFORMS))}`);
+    if (!this.options.driver) {
+      throw new Error('No driver specified, please fill in the `driver` option or use `defineConfig` helper (to define your ORM config) or `MikroORM` class (to call the `init` method) exported from the driver package (e.g. `import { defineConfig } from \'@mikro-orm/mysql\'; export defineConfig({ ... })`).');
     }
 
     if (!this.options.dbName && !this.options.clientUrl) {
@@ -395,15 +394,6 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     if (this.options.entities.length === 0 && this.options.discovery.warnWhenNoEntities) {
       throw new Error('No entities found, please use `entities` option');
     }
-  }
-
-  private initDriver(): D {
-    if (!this.options.driver) {
-      const { className, module } = Configuration.PLATFORMS[this.options.type!];
-      this.options.driver = module()[className];
-    }
-
-    return new this.options.driver!(this);
   }
 
 }
@@ -499,8 +489,6 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
     disableDynamicFileAccess?: boolean;
     getMappedType?: (type: string, platform: Platform) => Type<unknown> | undefined;
   };
-  /** @deprecated type option will be removed in v6, use `defineConfig` exported from the driver package to define your ORM config */
-  type?: keyof typeof Configuration.PLATFORMS;
   driver?: { new(config: Configuration): D };
   driverOptions: Dictionary;
   namingStrategy?: { new(): NamingStrategy };

--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -158,9 +158,21 @@ export class ConfigurationLoader {
 
   static loadEnvironmentVars<D extends IDatabaseDriver>(): Partial<Options<D>> {
     const ret: Dictionary = {};
+
+    // only to keep some sort of back compatibility with those using env vars only, to support `MIKRO_ORM_TYPE`
+    const PLATFORMS = {
+      'mongo': { className: 'MongoDriver', module: '@mikro-orm/mongodb' },
+      'mysql': { className: 'MySqlDriver', module: '@mikro-orm/mysql' },
+      'mariadb': { className: 'MariaDbDriver', module: '@mikro-orm/mariadb' },
+      'postgresql': { className: 'PostgreSqlDriver', module: '@mikro-orm/postgresql' },
+      'sqlite': { className: 'SqliteDriver', module: '@mikro-orm/sqlite' },
+      'better-sqlite': { className: 'BetterSqliteDriver', module: '@mikro-orm/better-sqlite' },
+    };
+
     const array = (v: string) => v.split(',').map(vv => vv.trim());
     const bool = (v: string) => ['true', 't', '1'].includes(v.toLowerCase());
     const num = (v: string) => +v;
+    const driver = (v: string) => Utils.requireFrom(PLATFORMS[v].module)[PLATFORMS[v].className];
     const read = (o: Dictionary, envKey: string, key: string, mapper: (v: string) => unknown = v => v) => {
       if (!(envKey in process.env)) {
         return;
@@ -172,7 +184,7 @@ export class ConfigurationLoader {
     const cleanup = (o: Dictionary, k: string) => Utils.hasObjectKeys(o[k]) ? {} : delete o[k];
 
     read(ret, 'MIKRO_ORM_BASE_DIR', 'baseDir');
-    read(ret, 'MIKRO_ORM_TYPE', 'type');
+    read(ret, 'MIKRO_ORM_TYPE', 'driver', driver);
     read(ret, 'MIKRO_ORM_ENTITIES', 'entities', array);
     read(ret, 'MIKRO_ORM_ENTITIES_TS', 'entitiesTs', array);
     read(ret, 'MIKRO_ORM_CLIENT_URL', 'clientUrl');

--- a/packages/entity-generator/src/EntityGenerator.ts
+++ b/packages/entity-generator/src/EntityGenerator.ts
@@ -19,7 +19,7 @@ export class EntityGenerator {
   constructor(private readonly em: EntityManager) { }
 
   static register(orm: MikroORM): void {
-    orm.config.registerExtension('@mikro-orm/entity-generator', new EntityGenerator(orm.em as EntityManager));
+    orm.config.registerExtension('@mikro-orm/entity-generator', () => new EntityGenerator(orm.em as EntityManager));
   }
 
   async generate(options: { baseDir?: string; save?: boolean; schema?: string } = {}): Promise<string[]> {

--- a/packages/knex/package.json
+++ b/packages/knex/package.json
@@ -66,40 +66,6 @@
     "@mikro-orm/core": "^5.5.3"
   },
   "peerDependencies": {
-    "@mikro-orm/core": "^5.0.0",
-    "@mikro-orm/entity-generator": "^5.0.0",
-    "@mikro-orm/migrations": "^5.0.0",
-    "better-sqlite3": "^8.0.0",
-    "mssql": "^7.0.0",
-    "mysql": "^2.18.1",
-    "mysql2": "^2.1.0",
-    "pg": "^8.0.3",
-    "sqlite3": "^5.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@mikro-orm/entity-generator": {
-      "optional": true
-    },
-    "@mikro-orm/migrations": {
-      "optional": true
-    },
-    "better-sqlite3": {
-      "optional": true
-    },
-    "mssql": {
-      "optional": true
-    },
-    "mysql": {
-      "optional": true
-    },
-    "mysql2": {
-      "optional": true
-    },
-    "pg": {
-      "optional": true
-    },
-    "sqlite3": {
-      "optional": true
-    }
+    "@mikro-orm/core": "^5.0.0"
   }
 }

--- a/packages/knex/src/AbstractSqlPlatform.ts
+++ b/packages/knex/src/AbstractSqlPlatform.ts
@@ -30,24 +30,9 @@ export abstract class AbstractSqlPlatform extends Platform {
     SchemaGenerator.register(orm);
   }
 
-  // TODO remove in v6 (https://github.com/mikro-orm/mikro-orm/issues/3743)
+  /* istanbul ignore next: kept for type inference only */
   getSchemaGenerator(driver: IDatabaseDriver, em?: EntityManager): SchemaGenerator {
-    /* istanbul ignore next */
-    return this.config.getCachedService(SchemaGenerator, em ?? driver as any); // cast as `any` to get around circular dependencies
-  }
-
-  // TODO remove in v6 (https://github.com/mikro-orm/mikro-orm/issues/3743)
-  getEntityGenerator(em: EntityManager) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { EntityGenerator } = require('@mikro-orm/entity-generator');
-    return this.config.getCachedService(EntityGenerator, em);
-  }
-
-  // TODO remove in v6 (https://github.com/mikro-orm/mikro-orm/issues/3743)
-  getMigrator(em: EntityManager) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { Migrator } = require('@mikro-orm/migrations');
-    return this.config.getCachedService(Migrator, em);
+    return new SchemaGenerator(em ?? driver as any);
   }
 
   quoteValue(value: any): string {

--- a/packages/knex/src/schema/SchemaGenerator.ts
+++ b/packages/knex/src/schema/SchemaGenerator.ts
@@ -1,5 +1,5 @@
 ﻿import type { Knex } from 'knex';
-import type { Dictionary, EntityMetadata, MikroORM } from '@mikro-orm/core';
+import type { Dictionary, EntityMetadata, MikroORM, ISchemaGenerator } from '@mikro-orm/core';
 import { AbstractSchemaGenerator, Utils } from '@mikro-orm/core';
 import type { Check, ForeignKey, Index, SchemaDifference, TableDifference } from '../typings';
 import { DatabaseSchema } from './DatabaseSchema';
@@ -10,14 +10,14 @@ import { SchemaComparator } from './SchemaComparator';
 /**
  * Should be renamed to `SqlSchemaGenerator` in v6
  */
-export class SchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDriver> {
+export class SchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDriver> implements ISchemaGenerator {
 
   private readonly helper = this.platform.getSchemaHelper()!;
   private readonly options = this.config.get('schemaGenerator');
   protected lastEnsuredDatabase?: string;
 
   static register(orm: MikroORM): void {
-    orm.config.registerExtension('@mikro-orm/schema-generator', new SchemaGenerator(orm.em));
+    orm.config.registerExtension('@mikro-orm/schema-generator', () => new SchemaGenerator(orm.em));
   }
 
   /** @deprecated use `dropSchema` and `createSchema` commands respectively */

--- a/packages/mariadb/package.json
+++ b/packages/mariadb/package.json
@@ -65,20 +65,6 @@
     "@mikro-orm/core": "^5.5.3"
   },
   "peerDependencies": {
-    "@mikro-orm/core": "^5.0.0",
-    "@mikro-orm/entity-generator": "^5.0.0",
-    "@mikro-orm/migrations": "^5.0.0",
-    "@mikro-orm/seeder": "^5.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@mikro-orm/entity-generator": {
-      "optional": true
-    },
-    "@mikro-orm/migrations": {
-      "optional": true
-    },
-    "@mikro-orm/seeder": {
-      "optional": true
-    }
+    "@mikro-orm/core": "^5.0.0"
   }
 }

--- a/packages/migrations-mongodb/src/Migrator.ts
+++ b/packages/migrations-mongodb/src/Migrator.ts
@@ -31,7 +31,7 @@ export class Migrator implements IMigrator {
   }
 
   static register(orm: MikroORM): void {
-    orm.config.registerExtension('@mikro-orm/migrator', new Migrator(orm.em as EntityManager));
+    orm.config.registerExtension('@mikro-orm/migrator', () => new Migrator(orm.em as EntityManager));
   }
 
   /**

--- a/packages/migrations-mongodb/src/typings.ts
+++ b/packages/migrations-mongodb/src/typings.ts
@@ -1,6 +1,1 @@
-import type { Transaction, MigrationDiff } from '@mikro-orm/core';
-
-export type UmzugMigration = { name: string; path?: string };
-export type MigrateOptions = { from?: string | number; to?: string | number; migrations?: string[]; transaction?: Transaction };
-export type MigrationResult = { fileName: string; code: string; diff: MigrationDiff };
-export type MigrationRow = { name: string; executed_at: Date };
+export { UmzugMigration, MigrateOptions, MigrationResult, MigrationRow } from '@mikro-orm/core';

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -41,7 +41,7 @@ export class Migrator implements IMigrator {
   }
 
   static register(orm: MikroORM): void {
-    orm.config.registerExtension('@mikro-orm/migrator', new Migrator(orm.em as EntityManager));
+    orm.config.registerExtension('@mikro-orm/migrator', () => new Migrator(orm.em as EntityManager));
   }
 
   /**

--- a/packages/migrations/src/typings.ts
+++ b/packages/migrations/src/typings.ts
@@ -1,6 +1,1 @@
-import type { Transaction, MigrationDiff } from '@mikro-orm/core';
-
-export type UmzugMigration = { name: string; path?: string };
-export type MigrateOptions = { from?: string | number; to?: string | number; migrations?: string[]; transaction?: Transaction };
-export type MigrationResult = { fileName: string; code: string; diff: MigrationDiff };
-export type MigrationRow = { name: string; executed_at: Date };
+export { UmzugMigration, MigrateOptions, MigrationResult, MigrationRow } from '@mikro-orm/core';

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -65,24 +65,6 @@
     "@mikro-orm/core": "^5.5.3"
   },
   "peerDependencies": {
-    "@mikro-orm/core": "^5.0.0",
-    "@mikro-orm/entity-generator": "^5.0.0",
-    "@mikro-orm/migrations": "^5.0.0",
-    "@mikro-orm/migrations-mongodb": "^5.0.0",
-    "@mikro-orm/seeder": "^5.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@mikro-orm/entity-generator": {
-      "optional": true
-    },
-    "@mikro-orm/migrations": {
-      "optional": true
-    },
-    "@mikro-orm/migrations-mongodb": {
-      "optional": true
-    },
-    "@mikro-orm/seeder": {
-      "optional": true
-    }
+    "@mikro-orm/core": "^5.0.0"
   }
 }

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -262,32 +262,4 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     return ret.length > 0 ? ret : undefined;
   }
 
-  /**
-   * @deprecated use `orm.getSchemaGenerator().createSchema()` instead
-   */
-  async createCollections(): Promise<void> {
-    await this.platform.getSchemaGenerator(this).createSchema();
-  }
-
-  /**
-   * @deprecated use `orm.getSchemaGenerator().dropSchema()` instead
-   */
-  async dropCollections(): Promise<void> {
-    await this.platform.getSchemaGenerator(this).dropSchema();
-  }
-
-  /**
-   * @deprecated use `orm.getSchemaGenerator().refreshDatabase()` instead
-   */
-  async refreshCollections(options: CreateSchemaOptions = {}): Promise<void> {
-    await this.platform.getSchemaGenerator(this).refreshDatabase(options);
-  }
-
-  /**
-   * @deprecated use `orm.getSchemaGenerator().ensureIndexes()` instead
-   */
-  async ensureIndexes(): Promise<void> {
-    await this.platform.getSchemaGenerator(this).ensureIndexes();
-  }
-
 }

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -30,16 +30,9 @@ export class MongoPlatform extends Platform {
     MongoSchemaGenerator.register(orm);
   }
 
-  // TODO remove in v6 (https://github.com/mikro-orm/mikro-orm/issues/3743)
+  /* istanbul ignore next: kept for type inference only */
   getSchemaGenerator(driver: IDatabaseDriver, em?: EntityManager): MongoSchemaGenerator {
     return new MongoSchemaGenerator(em ?? driver as any);
-  }
-
-  // TODO remove in v6 (https://github.com/mikro-orm/mikro-orm/issues/3743)
-  getMigrator(em: EntityManager) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { Migrator } = require('@mikro-orm/migrations-mongodb');
-    return this.config.getCachedService(Migrator, em);
   }
 
   normalizePrimaryKey<T extends number | string = number | string>(data: Primary<T> | IPrimaryKey | ObjectId): T {

--- a/packages/mongodb/src/MongoSchemaGenerator.ts
+++ b/packages/mongodb/src/MongoSchemaGenerator.ts
@@ -5,7 +5,7 @@ import type { MongoDriver } from './MongoDriver';
 export class MongoSchemaGenerator extends AbstractSchemaGenerator<MongoDriver> {
 
   static register(orm: MikroORM): void {
-    orm.config.registerExtension('@mikro-orm/schema-generator', new MongoSchemaGenerator(orm.em));
+    orm.config.registerExtension('@mikro-orm/schema-generator', () => new MongoSchemaGenerator(orm.em));
   }
 
   async createSchema(options: CreateSchemaOptions = {}): Promise<void> {

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -65,20 +65,6 @@
     "@mikro-orm/core": "^5.5.3"
   },
   "peerDependencies": {
-    "@mikro-orm/core": "^5.0.0",
-    "@mikro-orm/entity-generator": "^5.0.0",
-    "@mikro-orm/migrations": "^5.0.0",
-    "@mikro-orm/seeder": "^5.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@mikro-orm/entity-generator": {
-      "optional": true
-    },
-    "@mikro-orm/migrations": {
-      "optional": true
-    },
-    "@mikro-orm/seeder": {
-      "optional": true
-    }
+    "@mikro-orm/core": "^5.0.0"
   }
 }

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -65,20 +65,6 @@
     "@mikro-orm/core": "^5.5.3"
   },
   "peerDependencies": {
-    "@mikro-orm/core": "^5.0.0",
-    "@mikro-orm/entity-generator": "^5.0.0",
-    "@mikro-orm/migrations": "^5.0.0",
-    "@mikro-orm/seeder": "^5.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@mikro-orm/entity-generator": {
-      "optional": true
-    },
-    "@mikro-orm/migrations": {
-      "optional": true
-    },
-    "@mikro-orm/seeder": {
-      "optional": true
-    }
+    "@mikro-orm/core": "^5.0.0"
   }
 }

--- a/packages/seeder/src/SeedManager.ts
+++ b/packages/seeder/src/SeedManager.ts
@@ -19,7 +19,7 @@ export class SeedManager implements ISeedManager {
   }
 
   static register(orm: MikroORM): void {
-    orm.config.registerExtension('@mikro-orm/seeder', new SeedManager(orm.em));
+    orm.config.registerExtension('@mikro-orm/seeder', () => new SeedManager(orm.em));
   }
 
   async seed(...classNames: Constructor<Seeder>[]): Promise<void> {

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -67,20 +67,6 @@
     "@mikro-orm/core": "^5.5.3"
   },
   "peerDependencies": {
-    "@mikro-orm/core": "^5.0.0",
-    "@mikro-orm/entity-generator": "^5.0.0",
-    "@mikro-orm/migrations": "^5.0.0",
-    "@mikro-orm/seeder": "^5.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@mikro-orm/entity-generator": {
-      "optional": true
-    },
-    "@mikro-orm/migrations": {
-      "optional": true
-    },
-    "@mikro-orm/seeder": {
-      "optional": true
-    }
+    "@mikro-orm/core": "^5.0.0"
   }
 }

--- a/tests/DatabaseDriver.test.ts
+++ b/tests/DatabaseDriver.test.ts
@@ -79,11 +79,9 @@ describe('DatabaseDriver', () => {
     const e1 = driver.convertException(new Error('test'));
     const e2 = driver.convertException(e1);
     expect(e1).toBe(e2);
-    expect(() => driver.getPlatform().getSchemaGenerator(driver)).toThrowError('Driver does not support SchemaGenerator');
   });
 
   test('not supported', async () => {
-    expect(() => driver.getPlatform().getMigrator({} as any)).toThrowError('Platform1 does not support Migrator');
     expect(() => driver.getPlatform().getFullTextWhereClause({} as any)).toThrowError('Full text searching is not supported by this driver.');
     expect(() => driver.getPlatform().supportsCreatingFullTextIndex()).toThrowError('Full text searching is not supported by this driver.');
     expect(() => driver.getPlatform().getFullTextIndexExpression({} as any, {} as any, {} as any, {} as any)).toThrowError('Full text searching is not supported by this driver.');

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -97,7 +97,6 @@ describe('EntityManagerMySql', () => {
     expect(driver.getPlatform().denormalizePrimaryKey('1')).toBe('1');
     await expect(driver.find<BookTag2>(BookTag2.name, { books: { $in: ['1'] } })).resolves.not.toBeNull();
     await expect(driver.count(BookTag2.name, {})).resolves.toBe(1);
-    await expect(driver.ensureIndexes()).rejects.toThrowError('MySqlDriver does not use ensureIndexes');
 
     const conn = driver.getConnection();
     const tx = await conn.begin();

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -23,10 +23,8 @@ import { MongoDriver } from '@mikro-orm/mongodb';
 describe('MikroORM', () => {
 
   test('should throw when not enough config provided', async () => {
-    const err = `No platform type specified, please fill in \`type\` or provide custom driver class in \`driver\` option. Available platforms types: [\n  'mongo',\n  'mysql',\n  'mariadb',\n  'postgresql',\n  'sqlite',\n  'better-sqlite'\n]`;
+    const err = `No driver specified, please fill in the \`driver\` option or use \`defineConfig\` helper (to define your ORM config) or \`MikroORM\` class (to call the \`init\` method) exported from the driver package (e.g. \`import { defineConfig } from '@mikro-orm/mysql'; export defineConfig({ ... })\`).`;
     expect(() => new MikroORM({ entities: ['entities'], clientUrl: '' })).toThrowError(err);
-    const err2 = `Invalid platform type specified: 'wut', please fill in valid \`type\` or provide custom driver class in \`driver\` option. Available platforms types: [\n  'mongo',\n  'mysql',\n  'mariadb',\n  'postgresql',\n  'sqlite',\n  'better-sqlite'\n]`;
-    expect(() => new MikroORM({ type: 'wut' as any, entities: ['entities'], clientUrl: '' })).toThrowError(err2);
     expect(() => new MikroORM({ driver: MongoDriver, entities: ['entities'], dbName: '' })).toThrowError('No database specified, please fill in `dbName` or `clientUrl` option');
     expect(() => new MikroORM({ driver: MongoDriver, entities: [], dbName: 'test' })).toThrowError('No entities found, please use `entities` option');
     expect(() => new MikroORM({ driver: MongoDriver, entities: ['entities/*.js'], dbName: 'test' })).not.toThrowError();
@@ -116,15 +114,15 @@ describe('MikroORM', () => {
 
   test('should prefer environment variables', async () => {
     process.env.MIKRO_ORM_ENV = __dirname + '/mikro-orm.env';
-    const orm = await MikroORM.init({ type: 'mongo' }, false);
+    const orm = await MikroORM.init({ driver: SqliteDriver, host: '123.0.0.321' }, false);
     Object.keys(process.env).filter(k => k.startsWith('MIKRO_ORM_')).forEach(k => delete process.env[k]);
 
     expect(orm).toBeInstanceOf(MikroORM);
     expect(orm.em).toBeInstanceOf(EntityManager);
     expect(orm.config.getAll()).toMatchObject({
-      type: 'sqlite', // env vars have preference
+      driver: SqliteDriver,
       entities: [ './entities-schema' ],
-      host: '123.0.0.4',
+      host: '123.0.0.4', // env vars have preference
       port: 1234,
       user: 'string',
       password: 'lol',

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -6,6 +6,10 @@ import type { AbstractSqlDriver } from '@mikro-orm/knex';
 import { SqlEntityRepository } from '@mikro-orm/knex';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 import { MongoDriver } from '@mikro-orm/mongodb';
+import { Migrator } from '@mikro-orm/migrations';
+import { Migrator as MongoMigrator } from '@mikro-orm/migrations-mongodb';
+import { SeedManager } from '@mikro-orm/seeder';
+import { EntityGenerator } from '@mikro-orm/entity-generator';
 import { MySqlDriver } from '@mikro-orm/mysql';
 import { MariaDbDriver } from '@mikro-orm/mariadb';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
@@ -24,6 +28,15 @@ import { BASE_DIR } from './helpers';
 import { Book5 } from './entities-5';
 
 const { BaseEntity4, Author3, Book3, BookTag3, Publisher3, Test3 } = require('./entities-js/index');
+
+export const PLATFORMS = {
+  'mongo': MongoDriver,
+  'mysql': MySqlDriver,
+  'mariadb': MariaDbDriver,
+  'postgresql': PostgreSqlDriver,
+  'sqlite': SqliteDriver,
+  'better-sqlite': BetterSqliteDriver,
+};
 
 let ensureIndexes = true; // ensuring indexes is slow, and it is enough to make it once
 
@@ -70,6 +83,7 @@ export async function initORMMongo(replicaSet = false) {
     filters: { allowedFooBars: { cond: args => ({ id: { $in: args.allowed } }), entity: ['FooBar'], default: false } },
     pool: { min: 1, max: 3 },
     migrations: { path: BASE_DIR + '/../temp/migrations-mongo' },
+    extensions: [MongoMigrator, SeedManager, EntityGenerator],
   });
 
   ensureIndexes = false;
@@ -94,6 +108,7 @@ export async function initORMMySql<D extends MySqlDriver | MariaDbDriver = MySql
     driver: type === 'mysql' ? MySqlDriver : MariaDbDriver,
     replicas: [{ name: 'read-1' }, { name: 'read-2' }], // create two read replicas with same configuration, just for testing purposes
     migrations: { path: BASE_DIR + '/../temp/migrations', snapshot: false },
+    extensions: [Migrator, SeedManager, EntityGenerator],
   }, additionalOptions));
 
   await orm.schema.ensureDatabase();
@@ -107,7 +122,7 @@ export async function initORMMySql<D extends MySqlDriver | MariaDbDriver = MySql
     await connection.loadFile(__dirname + '/mysql-schema.sql');
     await orm.close(true);
     orm.config.set('dbName', 'mikro_orm_test');
-    orm = await MikroORM.init(orm.config);
+    orm = await MikroORM.init(orm.config.getAll());
   }
 
   Author2Subscriber.log.length = 0;
@@ -132,6 +147,7 @@ export async function initORMPostgreSql(loadStrategy = LoadStrategy.SELECT_IN, e
     migrations: { path: BASE_DIR + '/../temp/migrations', snapshot: false },
     forceEntityConstructor: [FooBar2],
     loadStrategy,
+    extensions: [Migrator, SeedManager, EntityGenerator],
   });
 
   await orm.schema.ensureDatabase();
@@ -157,6 +173,7 @@ export async function initORMSqlite() {
     metadataProvider: JavaScriptMetadataProvider,
     cache: { enabled: true, pretty: true },
     persistOnCreate: false,
+    extensions: [Migrator, SeedManager, EntityGenerator],
   });
 
   const connection = orm.em.getConnection();
@@ -177,6 +194,7 @@ export async function initORMSqlite2(type: 'sqlite' | 'better-sqlite' = 'sqlite'
     logger: i => i,
     cache: { pretty: true },
     migrations: { path: BASE_DIR + '/../temp/migrations', snapshot: false },
+    extensions: [Migrator, SeedManager, EntityGenerator],
   });
   await orm.schema.refreshDatabase();
 
@@ -194,6 +212,7 @@ export async function initORMSqlite3() {
     logger: i => i,
     metadataProvider: ReflectMetadataProvider,
     cache: { enabled: true, pretty: true },
+    extensions: [Migrator, SeedManager, EntityGenerator],
   });
 
   const connection = orm.em.getConnection();

--- a/tests/features/embeddables/GH3327.test.ts
+++ b/tests/features/embeddables/GH3327.test.ts
@@ -1,4 +1,5 @@
 import { Embeddable, Embedded, Entity, MikroORM, Options, PrimaryKey, Property, t } from '@mikro-orm/core';
+import { PLATFORMS } from '../../bootstrap';
 
 @Embeddable()
 class FieldValue {
@@ -45,7 +46,7 @@ describe.each(['sqlite', 'better-sqlite', 'mysql', 'postgresql', 'mongo'] as con
     orm = await MikroORM.init({
       entities: [Field],
       dbName: type.includes('sqlite') ? ':memory:' : 'mikro_orm_3327',
-      type,
+      driver: PLATFORMS[type],
       ...options,
     });
     await orm.schema.refreshDatabase();

--- a/tests/features/entity-generator/EntityGenerator.test.ts
+++ b/tests/features/entity-generator/EntityGenerator.test.ts
@@ -134,7 +134,7 @@ describe('EntityGenerator', () => {
 
   test('not supported [mongodb]', async () => {
     const orm = await MikroORM.init({ driver: MongoDriver, dbName: 'mikro-orm-test', discovery: { warnWhenNoEntities: false } }, false);
-    expect(() => orm.entityGenerator).toThrowError('MongoPlatform does not support EntityGenerator');
+    expect(() => orm.entityGenerator).toThrowError('EntityGenerator extension not registered.');
   });
 
   test('table name starting with number [mysql]', async () => {

--- a/tests/features/migrations/Migrator.mongo.test.ts
+++ b/tests/features/migrations/Migrator.mongo.test.ts
@@ -34,9 +34,7 @@ describe('Migrator (mongo)', () => {
 
   beforeAll(async () => {
     orm = await initORMMongo(true);
-
-    const schemaGenerator = orm.schema;
-    await schemaGenerator.refreshDatabase();
+    await orm.schema.refreshDatabase();
     await remove(process.cwd() + '/temp/migrations-mongo');
   });
 
@@ -52,8 +50,7 @@ describe('Migrator (mongo)', () => {
     dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
     const migrationsSettings = orm.config.get('migrations');
     orm.config.set('migrations', { ...migrationsSettings, emit: 'js' }); // Set migration type to js
-    const migrator = orm.migrator;
-    const migration = await migrator.createMigration();
+    const migration = await orm.migrator.createMigration();
     expect(migration).toMatchSnapshot('migration-js-dump');
     orm.config.set('migrations', migrationsSettings); // Revert migration config changes
     await remove(process.cwd() + '/temp/migrations-mongo/' + migration.fileName);

--- a/tests/features/migrations/Migrator.postgres.test.ts
+++ b/tests/features/migrations/Migrator.postgres.test.ts
@@ -6,7 +6,18 @@ import { Migration, MigrationStorage, Migrator, TSMigrationGenerator } from '@mi
 import type { DatabaseTable } from '@mikro-orm/postgresql';
 import { DatabaseSchema, PostgreSqlDriver } from '@mikro-orm/postgresql';
 import { remove } from 'fs-extra';
-import { Address2, Author2, Book2, BookTag2, Configuration2, FooBar2, FooBaz2, FooParam2, Publisher2, Test2 } from '../../entities-sql';
+import {
+  Address2,
+  Author2,
+  Book2,
+  BookTag2,
+  Configuration2,
+  FooBar2,
+  FooBaz2,
+  FooParam2,
+  Publisher2,
+  Test2,
+} from '../../entities-sql';
 import { BASE_DIR, mockLogger } from '../../bootstrap';
 
 class MigrationTest1 extends Migration {
@@ -46,6 +57,7 @@ describe('Migrator (postgres)', () => {
       schema: 'custom',
       logger: () => void 0,
       migrations: { path: BASE_DIR + '/../temp/migrations', snapshot: false },
+      extensions: [Migrator],
     });
 
     const schemaGenerator = orm.schema;
@@ -63,8 +75,7 @@ describe('Migrator (postgres)', () => {
     dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
     const migrationsSettings = orm.config.get('migrations');
     orm.config.set('migrations', { ...migrationsSettings, emit: 'js' }); // Set migration type to js
-    const migrator = orm.migrator;
-    const migration = await migrator.createMigration();
+    const migration = await orm.migrator.createMigration();
     expect(migration).toMatchSnapshot('migration-js-dump');
     orm.config.set('migrations', migrationsSettings); // Revert migration config changes
     await remove(process.cwd() + '/temp/migrations/' + migration.fileName);
@@ -410,6 +421,7 @@ test('ensureTable when the schema does not exist', async () => {
     driver: PostgreSqlDriver,
     schema: 'custom2',
     migrations: { path: BASE_DIR + '/../temp/migrations', snapshot: false },
+    extensions: [Migrator],
   });
   await orm.schema.ensureDatabase();
   await orm.schema.execute('drop schema if exists "custom2" cascade');

--- a/tests/features/migrations/Migrator.sqlite.test.ts
+++ b/tests/features/migrations/Migrator.sqlite.test.ts
@@ -310,6 +310,7 @@ describe('Migrator (sqlite)', () => {
       entities: [FooBar4, FooBaz4, BaseEntity5],
       dbName: TEMP_DIR + '/test.db',
       baseDir: TEMP_DIR,
+      extensions: [Migrator],
     });
     await expect(orm.migrator.createMigration()).resolves.not.toThrow();
     await orm.close();

--- a/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
+++ b/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
@@ -1,6 +1,7 @@
 import { BaseEntity, Cascade, Collection, Entity, LockMode, ManyToMany, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, Property, wrap } from '@mikro-orm/core';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 import { mockLogger } from '../../helpers';
+import { EntityGenerator } from '@mikro-orm/entity-generator';
 
 @Entity({ schema: 'n1' })
 export class Author {
@@ -59,6 +60,7 @@ describe('multiple connected schemas in postgres', () => {
       entities: [Author, Book, BookTag],
       dbName: `mikro_orm_test_multi_schemas`,
       driver: PostgreSqlDriver,
+      extensions: [EntityGenerator],
     });
     await orm.schema.ensureDatabase();
 

--- a/tests/features/schema-generator/SchemaGenerator.mongo.test.ts
+++ b/tests/features/schema-generator/SchemaGenerator.mongo.test.ts
@@ -71,32 +71,4 @@ describe('SchemaGenerator', () => {
     ensureIndexesSpy.mockRestore();
   });
 
-  test('deprecated driver methods that are now in MongoSchemaGenerator', async () => {
-    const driver = orm.em.getDriver();
-    const createSchemaSpy = jest.spyOn(MongoSchemaGenerator.prototype, 'createSchema');
-    const dropSchemaSpy = jest.spyOn(MongoSchemaGenerator.prototype, 'dropSchema');
-    const refreshDatabaseSpy = jest.spyOn(MongoSchemaGenerator.prototype, 'refreshDatabase');
-    const ensureIndexesSpy = jest.spyOn(MongoSchemaGenerator.prototype, 'ensureIndexes');
-    createSchemaSpy.mockImplementation();
-    dropSchemaSpy.mockImplementation();
-    refreshDatabaseSpy.mockImplementation();
-
-    await driver.createCollections();
-    expect(createSchemaSpy).toBeCalledTimes(1);
-
-    await driver.dropCollections();
-    expect(dropSchemaSpy).toBeCalledTimes(1);
-
-    await driver.refreshCollections();
-    expect(refreshDatabaseSpy).toBeCalledTimes(1);
-
-    await driver.ensureIndexes();
-    expect(ensureIndexesSpy).toBeCalledTimes(1);
-
-    createSchemaSpy.mockRestore();
-    dropSchemaSpy.mockRestore();
-    refreshDatabaseSpy.mockRestore();
-    ensureIndexesSpy.mockRestore();
-  });
-
 });

--- a/tests/features/upsert/upsert.test.ts
+++ b/tests/features/upsert/upsert.test.ts
@@ -1,5 +1,6 @@
 import { MikroORM, Entity, PrimaryKey, ManyToOne, Property, SimpleLogger, Unique } from '@mikro-orm/core';
 import { mockLogger } from '../../helpers';
+import { PLATFORMS } from '../../bootstrap';
 
 @Entity()
 export class Author {
@@ -83,7 +84,7 @@ describe.each(Object.keys(options))('em.upsert [%s]',  type => {
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Author, Book, FooBar],
-      type,
+      driver: PLATFORMS[type],
       loggerFactory: options => new SimpleLogger(options),
       ...options[type],
     });

--- a/tests/issues/GH3738.test.ts
+++ b/tests/issues/GH3738.test.ts
@@ -7,7 +7,7 @@ import {
   PrimaryKey,
   Property,
 } from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/postgresql';
+import { MikroORM } from '@mikro-orm/sqlite';
 import { randomUUID } from 'crypto';
 
 @Entity()
@@ -54,7 +54,6 @@ describe('GH issue 3738', () => {
     orm = await MikroORM.init({
       entities: [Answer, Question],
       dbName: ':memory:',
-      type: 'sqlite',
       loadStrategy: LoadStrategy.JOINED,
     });
     await orm.schema.createSchema();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2689,16 +2689,6 @@ __metadata:
     sqlstring-sqlite: 0.1.1
   peerDependencies:
     "@mikro-orm/core": ^5.0.0
-    "@mikro-orm/entity-generator": ^5.0.0
-    "@mikro-orm/migrations": ^5.0.0
-    "@mikro-orm/seeder": ^5.0.0
-  peerDependenciesMeta:
-    "@mikro-orm/entity-generator":
-      optional: true
-    "@mikro-orm/migrations":
-      optional: true
-    "@mikro-orm/seeder":
-      optional: true
   languageName: unknown
   linkType: soft
 
@@ -2707,46 +2697,11 @@ __metadata:
   resolution: "@mikro-orm/cli@workspace:packages/cli"
   dependencies:
     "@mikro-orm/core": ^5.5.3
-    "@mikro-orm/entity-generator": ^5.5.3
     "@mikro-orm/knex": ^5.5.3
-    "@mikro-orm/migrations": ^5.5.3
-    "@mikro-orm/seeder": ^5.5.3
     fs-extra: 11.1.0
     tsconfig-paths: 4.1.1
     yargonaut: 1.1.4
     yargs: 15.4.1
-  peerDependencies:
-    "@mikro-orm/better-sqlite": ^5.0.0
-    "@mikro-orm/entity-generator": ^5.0.0
-    "@mikro-orm/mariadb": ^5.0.0
-    "@mikro-orm/migrations": ^5.0.0
-    "@mikro-orm/migrations-mongodb": ^5.0.0
-    "@mikro-orm/mongodb": ^5.0.0
-    "@mikro-orm/mysql": ^5.0.0
-    "@mikro-orm/postgresql": ^5.0.0
-    "@mikro-orm/seeder": ^5.0.0
-    "@mikro-orm/sqlite": ^5.0.0
-  peerDependenciesMeta:
-    "@mikro-orm/better-sqlite":
-      optional: true
-    "@mikro-orm/entity-generator":
-      optional: true
-    "@mikro-orm/mariadb":
-      optional: true
-    "@mikro-orm/migrations":
-      optional: true
-    "@mikro-orm/migrations-mongodb":
-      optional: true
-    "@mikro-orm/mongodb":
-      optional: true
-    "@mikro-orm/mysql":
-      optional: true
-    "@mikro-orm/postgresql":
-      optional: true
-    "@mikro-orm/seeder":
-      optional: true
-    "@mikro-orm/sqlite":
-      optional: true
   bin:
     mikro-orm: ./dist/cli.js
     mikro-orm-esm: ./dist/esm.js
@@ -2764,42 +2719,10 @@ __metadata:
     globby: 11.1.0
     mikro-orm: ^5.5.3
     reflect-metadata: 0.1.13
-  peerDependencies:
-    "@mikro-orm/better-sqlite": ^5.0.0
-    "@mikro-orm/entity-generator": ^5.0.0
-    "@mikro-orm/mariadb": ^5.0.0
-    "@mikro-orm/migrations": ^5.0.0
-    "@mikro-orm/migrations-mongodb": ^5.0.0
-    "@mikro-orm/mongodb": ^5.0.0
-    "@mikro-orm/mysql": ^5.0.0
-    "@mikro-orm/postgresql": ^5.0.0
-    "@mikro-orm/seeder": ^5.0.0
-    "@mikro-orm/sqlite": ^5.0.0
-  peerDependenciesMeta:
-    "@mikro-orm/better-sqlite":
-      optional: true
-    "@mikro-orm/entity-generator":
-      optional: true
-    "@mikro-orm/mariadb":
-      optional: true
-    "@mikro-orm/migrations":
-      optional: true
-    "@mikro-orm/migrations-mongodb":
-      optional: true
-    "@mikro-orm/mongodb":
-      optional: true
-    "@mikro-orm/mysql":
-      optional: true
-    "@mikro-orm/postgresql":
-      optional: true
-    "@mikro-orm/seeder":
-      optional: true
-    "@mikro-orm/sqlite":
-      optional: true
   languageName: unknown
   linkType: soft
 
-"@mikro-orm/entity-generator@^5.5.3, @mikro-orm/entity-generator@workspace:packages/entity-generator":
+"@mikro-orm/entity-generator@workspace:packages/entity-generator":
   version: 0.0.0-use.local
   resolution: "@mikro-orm/entity-generator@workspace:packages/entity-generator"
   dependencies:
@@ -2821,31 +2744,6 @@ __metadata:
     sqlstring: 2.3.3
   peerDependencies:
     "@mikro-orm/core": ^5.0.0
-    "@mikro-orm/entity-generator": ^5.0.0
-    "@mikro-orm/migrations": ^5.0.0
-    better-sqlite3: ^8.0.0
-    mssql: ^7.0.0
-    mysql: ^2.18.1
-    mysql2: ^2.1.0
-    pg: ^8.0.3
-    sqlite3: ^5.0.0
-  peerDependenciesMeta:
-    "@mikro-orm/entity-generator":
-      optional: true
-    "@mikro-orm/migrations":
-      optional: true
-    better-sqlite3:
-      optional: true
-    mssql:
-      optional: true
-    mysql:
-      optional: true
-    mysql2:
-      optional: true
-    pg:
-      optional: true
-    sqlite3:
-      optional: true
   languageName: unknown
   linkType: soft
 
@@ -2858,16 +2756,6 @@ __metadata:
     mariadb: 2.5.6
   peerDependencies:
     "@mikro-orm/core": ^5.0.0
-    "@mikro-orm/entity-generator": ^5.0.0
-    "@mikro-orm/migrations": ^5.0.0
-    "@mikro-orm/seeder": ^5.0.0
-  peerDependenciesMeta:
-    "@mikro-orm/entity-generator":
-      optional: true
-    "@mikro-orm/migrations":
-      optional: true
-    "@mikro-orm/seeder":
-      optional: true
   languageName: unknown
   linkType: soft
 
@@ -2885,7 +2773,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@mikro-orm/migrations@^5.5.3, @mikro-orm/migrations@workspace:packages/migrations":
+"@mikro-orm/migrations@workspace:packages/migrations":
   version: 0.0.0-use.local
   resolution: "@mikro-orm/migrations@workspace:packages/migrations"
   dependencies:
@@ -2917,19 +2805,6 @@ __metadata:
     mongodb: 4.12.1
   peerDependencies:
     "@mikro-orm/core": ^5.0.0
-    "@mikro-orm/entity-generator": ^5.0.0
-    "@mikro-orm/migrations": ^5.0.0
-    "@mikro-orm/migrations-mongodb": ^5.0.0
-    "@mikro-orm/seeder": ^5.0.0
-  peerDependenciesMeta:
-    "@mikro-orm/entity-generator":
-      optional: true
-    "@mikro-orm/migrations":
-      optional: true
-    "@mikro-orm/migrations-mongodb":
-      optional: true
-    "@mikro-orm/seeder":
-      optional: true
   languageName: unknown
   linkType: soft
 
@@ -2942,16 +2817,6 @@ __metadata:
     mysql2: 2.3.3
   peerDependencies:
     "@mikro-orm/core": ^5.0.0
-    "@mikro-orm/entity-generator": ^5.0.0
-    "@mikro-orm/migrations": ^5.0.0
-    "@mikro-orm/seeder": ^5.0.0
-  peerDependenciesMeta:
-    "@mikro-orm/entity-generator":
-      optional: true
-    "@mikro-orm/migrations":
-      optional: true
-    "@mikro-orm/seeder":
-      optional: true
   languageName: unknown
   linkType: soft
 
@@ -2964,16 +2829,6 @@ __metadata:
     pg: 8.8.0
   peerDependencies:
     "@mikro-orm/core": ^5.0.0
-    "@mikro-orm/entity-generator": ^5.0.0
-    "@mikro-orm/migrations": ^5.0.0
-    "@mikro-orm/seeder": ^5.0.0
-  peerDependenciesMeta:
-    "@mikro-orm/entity-generator":
-      optional: true
-    "@mikro-orm/migrations":
-      optional: true
-    "@mikro-orm/seeder":
-      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3030,7 +2885,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@mikro-orm/seeder@^5.5.3, @mikro-orm/seeder@workspace:packages/seeder":
+"@mikro-orm/seeder@workspace:packages/seeder":
   version: 0.0.0-use.local
   resolution: "@mikro-orm/seeder@workspace:packages/seeder"
   dependencies:
@@ -3063,16 +2918,6 @@ __metadata:
     sqlstring-sqlite: 0.1.1
   peerDependencies:
     "@mikro-orm/core": ^5.0.0
-    "@mikro-orm/entity-generator": ^5.0.0
-    "@mikro-orm/migrations": ^5.0.0
-    "@mikro-orm/seeder": ^5.0.0
-  peerDependenciesMeta:
-    "@mikro-orm/entity-generator":
-      optional: true
-    "@mikro-orm/migrations":
-      optional: true
-    "@mikro-orm/seeder":
-      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
There were some places where we did a static `require()` call, e.g. when loading the driver implementation based on the `type` option. Those places were problematic for bundlers like webpack, as well as new school build systems like vite.

### The `type` option is removed in favour of driver exports

Instead of specifying the `type` we now have several options:

1. use `defineConfig()` helper imported from the driver package to create your ORM config: 
   ```ts title='mikro-orm.config.ts'
   import { defineConfig } from '@mikro-orm/mysql';

   export default defineConfig({ ... });
   ```
3. use `MikroORM.init()` on class imported from the driver package: 
   ```ts title='app.ts'
   import { MikroORM } from '@mikro-orm/mysql';

   const orm = await MikroORM.init({ ... });
   ```
5. specify the `driver` option: 
   ```ts title='mikro-orm.config.ts'
   import { MySqlDriver } from '@mikro-orm/mysql';

   export default { driver: MySqlDriver, ... };
   ```

> The `MIKRO_ORM_TYPE` is still supported, but no longer does a static require of the driver class. Its usage is rather discouraged and it might be removed in future versions too.

### ORM extensions

Similarly, we had to get rid of the `require()` calls for extensions like `Migrator`, `EntityGenerator` and `Seeder`. Those need to be registered as extensions in your ORM config. `SchemaGenerator` extension is registered automatically.

> This is required only for the shortcuts available on `MikroORM` object, e.g. `orm.migrator.up()`, alternatively you can instantiate the `Migrator` yourself explicitly.

```ts title='mikro-orm.config.ts'
import { defineConfig } from '@mikro-orm/mysql';
import { Migrator } from '@mikro-orm/migrations';
import { EntityGenerator } from '@mikro-orm/entity-generator';
import { SeedManager } from '@mikro-orm/seeder';

export default defineConfig({
  dbName: 'test',
  extensions: [Migrator, EntityGenerator, SeedManager], // those would have a static `register` method
});
```

Closes #3743