### PR TITLE
feat(core): re-export the core package from all drivers

### DIFF
--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -70,6 +70,16 @@ The options always needs to be plain JS object now. This was always only an inte
 
 Use the `connect` option instead.
 
+## All drivers now re-export the `@mikro-orm/core` package
+
+This means we no longer have to think about what package to use for imports, the driver package should be always preferred.
+
+```diff
+-import { Entity, PrimaryKey } from '@mikro-orm/core';
+-import { MikroORM, EntityManager } from '@mikro-orm/mysql';
++import { Entity, PrimaryKey, MikroORM, EntityManager } from '@mikro-orm/mysql';
+```
+
 ## Removed `MongoDriver` methods
 
 - `createCollections` in favour of `orm.schema.createSchema()`

--- a/packages/better-sqlite/src/BetterSqliteSchemaHelper.ts
+++ b/packages/better-sqlite/src/BetterSqliteSchemaHelper.ts
@@ -1,5 +1,5 @@
 import type { Connection, Dictionary } from '@mikro-orm/core';
-import type { AbstractSqlConnection, Index, Check } from '@mikro-orm/knex';
+import type { AbstractSqlConnection, IndexDef, CheckDef } from '@mikro-orm/knex';
 import { SchemaHelper } from '@mikro-orm/knex';
 
 export class BetterSqliteSchemaHelper extends SchemaHelper {
@@ -44,7 +44,7 @@ export class BetterSqliteSchemaHelper extends SchemaHelper {
     });
   }
 
-  async getEnumDefinitions(connection: AbstractSqlConnection, checks: Check[], tableName: string, schemaName: string): Promise<Dictionary<string[]>> {
+  async getEnumDefinitions(connection: AbstractSqlConnection, checks: CheckDef[], tableName: string, schemaName: string): Promise<Dictionary<string[]>> {
     const sql = `select sql from sqlite_master where type = ? and name = ?`;
     const tableDefinition = await connection.execute<{ sql: string }>(sql, ['table', tableName], 'get');
 
@@ -63,18 +63,18 @@ export class BetterSqliteSchemaHelper extends SchemaHelper {
     }, {} as Dictionary<string[]>);
   }
 
-  async getPrimaryKeys(connection: AbstractSqlConnection, indexes: Index[] = [], tableName: string, schemaName?: string): Promise<string[]> {
+  async getPrimaryKeys(connection: AbstractSqlConnection, indexes: IndexDef[] = [], tableName: string, schemaName?: string): Promise<string[]> {
     const sql = `pragma table_info(\`${tableName}\`)`;
     const cols = await connection.execute<{ pk: number; name: string }[]>(sql);
 
     return cols.filter(col => !!col.pk).map(col => col.name);
   }
 
-  async getIndexes(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<Index[]> {
+  async getIndexes(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<IndexDef[]> {
     const sql = `pragma table_info(\`${tableName}\`)`;
     const cols = await connection.execute<{ pk: number; name: string }[]>(sql);
     const indexes = await connection.execute<any[]>(`pragma index_list(\`${tableName}\`)`);
-    const ret: Index[] = [];
+    const ret: IndexDef[] = [];
 
     for (const col of cols.filter(c => c.pk)) {
       ret.push({
@@ -98,7 +98,7 @@ export class BetterSqliteSchemaHelper extends SchemaHelper {
     return this.mapIndexes(ret);
   }
 
-  async getChecks(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<Check[]> {
+  async getChecks(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<CheckDef[]> {
     // Not supported at the moment.
     return [];
   }

--- a/packages/cli/src/commands/MigrationCommandFactory.ts
+++ b/packages/cli/src/commands/MigrationCommandFactory.ts
@@ -1,5 +1,5 @@
 import type { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
-import type { Configuration, MikroORM, MikroORMOptions, IMigrator, MigrateOptions } from '@mikro-orm/core';
+import type { Configuration, MikroORM, Options, IMigrator, MigrateOptions } from '@mikro-orm/core';
 import { Utils, colors } from '@mikro-orm/core';
 import { CLIHelper } from '../CLIHelper';
 
@@ -14,7 +14,7 @@ export class MigrationCommandFactory {
     fresh: 'Clear the database and rerun all migrations',
   };
 
-  static create<U extends Options = Options>(command: MigratorMethod): CommandModule<unknown, U> & { builder: (args: Argv) => Argv<U>; handler: (args: ArgumentsCamelCase<U>) => Promise<void> } {
+  static create<U extends Opts = Opts>(command: MigratorMethod): CommandModule<unknown, U> & { builder: (args: Argv) => Argv<U>; handler: (args: ArgumentsCamelCase<U>) => Promise<void> } {
     return {
       command: `migration:${command}`,
       describe: MigrationCommandFactory.DESCRIPTIONS[command],
@@ -80,8 +80,8 @@ export class MigrationCommandFactory {
     });
   }
 
-  static async handleMigrationCommand(args: ArgumentsCamelCase<Options>, method: MigratorMethod): Promise<void> {
-    const options = { pool: { min: 1, max: 1 } } as Partial<MikroORMOptions>;
+  static async handleMigrationCommand(args: ArgumentsCamelCase<Opts>, method: MigratorMethod): Promise<void> {
+    const options = { pool: { min: 1, max: 1 } } as Options;
     const orm = await CLIHelper.getORM(undefined, options);
     const migrator = orm.getMigrator();
 
@@ -113,7 +113,7 @@ export class MigrationCommandFactory {
     });
   }
 
-  private static async handleUpDownCommand(args: ArgumentsCamelCase<Options>, migrator: IMigrator, method: MigratorMethod) {
+  private static async handleUpDownCommand(args: ArgumentsCamelCase<Opts>, migrator: IMigrator, method: MigratorMethod) {
     const opts = MigrationCommandFactory.getUpDownOptions(args);
     await migrator[method](opts as string[]);
     const message = this.getUpDownSuccessMessage(method as 'up' | 'down', opts);
@@ -139,7 +139,7 @@ export class MigrationCommandFactory {
     });
   }
 
-  private static async handleCreateCommand(migrator: IMigrator, args: ArgumentsCamelCase<Options>, config: Configuration): Promise<void> {
+  private static async handleCreateCommand(migrator: IMigrator, args: ArgumentsCamelCase<Opts>, config: Configuration): Promise<void> {
     const ret = await migrator.createMigration(args.path, args.blank, args.initial);
 
     if (ret.diff.up.length === 0) {
@@ -163,7 +163,7 @@ export class MigrationCommandFactory {
     CLIHelper.dump(colors.green(`${ret.fileName} successfully created`));
   }
 
-  private static async handleFreshCommand(args: ArgumentsCamelCase<Options>, migrator: IMigrator, orm: MikroORM) {
+  private static async handleFreshCommand(args: ArgumentsCamelCase<Opts>, migrator: IMigrator, orm: MikroORM) {
     const generator = orm.getSchemaGenerator();
     await generator.dropSchema({ dropMigrationsTable: true });
     CLIHelper.dump(colors.green('Dropped schema successfully'));
@@ -224,4 +224,4 @@ export class MigrationCommandFactory {
 type MigratorMethod = 'create' | 'up' | 'down' | 'list' | 'pending' | 'fresh';
 type CliUpDownOptions = { to?: string | number; from?: string | number; only?: string };
 type GenerateOptions = { dump?: boolean; blank?: boolean; initial?: boolean; path?: string; disableFkChecks?: boolean; seed: string };
-type Options = GenerateOptions & CliUpDownOptions;
+type Opts = GenerateOptions & CliUpDownOptions;

--- a/packages/knex/src/index.ts
+++ b/packages/knex/src/index.ts
@@ -17,3 +17,4 @@ export { SqlEntityRepository as EntityRepository } from './SqlEntityRepository';
 
 /** @ignore */
 export { Knex, knex } from 'knex';
+export * from '@mikro-orm/core';

--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -1,7 +1,7 @@
 import type { Dictionary, EntityMetadata, EntityProperty, NamingStrategy } from '@mikro-orm/core';
 import { Cascade, DateTimeType, DecimalType, EntitySchema, ReferenceType, t, Utils } from '@mikro-orm/core';
 import type { SchemaHelper } from './SchemaHelper';
-import type { Check, Column, ForeignKey, Index } from '../typings';
+import type { CheckDef, Column, ForeignKey, IndexDef } from '../typings';
 import type { AbstractSqlPlatform } from '../AbstractSqlPlatform';
 
 /**
@@ -10,8 +10,8 @@ import type { AbstractSqlPlatform } from '../AbstractSqlPlatform';
 export class DatabaseTable {
 
   private columns: Dictionary<Column> = {};
-  private indexes: Index[] = [];
-  private checks: Check[] = [];
+  private indexes: IndexDef[] = [];
+  private checks: CheckDef[] = [];
   private foreignKeys: Dictionary<ForeignKey> = {};
   public comment?: string;
 
@@ -31,15 +31,15 @@ export class DatabaseTable {
     return this.columns[name];
   }
 
-  getIndexes(): Index[] {
+  getIndexes(): IndexDef[] {
     return this.indexes;
   }
 
-  getChecks(): Check[] {
+  getChecks(): CheckDef[] {
     return this.checks;
   }
 
-  init(cols: Column[], indexes: Index[] = [], checks: Check[] = [], pks: string[], fks: Dictionary<ForeignKey> = {}, enums: Dictionary<string[]> = {}): void {
+  init(cols: Column[], indexes: IndexDef[] = [], checks: CheckDef[] = [], pks: string[], fks: Dictionary<ForeignKey> = {}, enums: Dictionary<string[]> = {}): void {
     this.indexes = indexes;
     this.checks = checks;
     this.foreignKeys = fks;
@@ -374,7 +374,7 @@ export class DatabaseTable {
     });
   }
 
-  addCheck(check: Check) {
+  addCheck(check: CheckDef) {
     this.checks.push(check);
   }
 

--- a/packages/knex/src/schema/SchemaComparator.ts
+++ b/packages/knex/src/schema/SchemaComparator.ts
@@ -1,7 +1,7 @@
 import { inspect } from 'util';
 import type { Dictionary, EntityProperty } from '@mikro-orm/core';
 import { BooleanType, DateTimeType, Utils } from '@mikro-orm/core';
-import type { Check, Column, ForeignKey, Index, SchemaDifference, TableDifference } from '../typings';
+import type { CheckDef, Column, ForeignKey, IndexDef, SchemaDifference, TableDifference } from '../typings';
 import type { DatabaseSchema } from './DatabaseSchema';
 import type { DatabaseTable } from './DatabaseTable';
 import type { AbstractSqlPlatform } from '../AbstractSqlPlatform';
@@ -332,7 +332,7 @@ export class SchemaComparator {
    * however ambiguities between different possibilities should not lead to renaming at all.
    */
   private detectIndexRenamings(tableDifferences: TableDifference): void {
-    const renameCandidates: Dictionary<[Index, Index][]> = {};
+    const renameCandidates: Dictionary<[IndexDef, IndexDef][]> = {};
 
     // Gather possible rename candidates by comparing each added and removed index based on semantics.
     for (const addedIndex of Object.values(tableDifferences.addedIndexes)) {
@@ -477,7 +477,7 @@ export class SchemaComparator {
    * Finds the difference between the indexes index1 and index2.
    * Compares index1 with index2 and returns index2 if there are any differences or false in case there are no differences.
    */
-  diffIndex(index1: Index, index2: Index): boolean {
+  diffIndex(index1: IndexDef, index2: IndexDef): boolean {
     // if one of them is a custom expression or full text index, compare only by name
     if (index1.expression || index2.expression || index1.type === 'fulltext' || index2.type === 'fulltext') {
       return index1.keyName !== index2.keyName;
@@ -489,7 +489,7 @@ export class SchemaComparator {
   /**
    * Checks if the other index already fulfills all the indexing and constraint needs of the current one.
    */
-  isIndexFulfilledBy(index1: Index, index2: Index): boolean {
+  isIndexFulfilledBy(index1: IndexDef, index2: IndexDef): boolean {
     // allow the other index to be equally large only. It being larger is an option but it creates a problem with scenarios of the kind PRIMARY KEY(foo,bar) UNIQUE(foo)
     if (index1.columnNames.length !== index2.columnNames.length) {
       return false;
@@ -523,7 +523,7 @@ export class SchemaComparator {
     return index1.primary === index2.primary && index1.unique === index2.unique;
   }
 
-  diffCheck(check1: Check, check2: Check): boolean {
+  diffCheck(check1: CheckDef, check2: CheckDef): boolean {
     const unquote = (str?: string) => str?.replace(/['"`]/g, '');
     return unquote(check1.expression as string) !== unquote(check2.expression as string);
   }

--- a/packages/knex/src/schema/SchemaHelper.ts
+++ b/packages/knex/src/schema/SchemaHelper.ts
@@ -3,7 +3,7 @@ import type { Connection, Dictionary } from '@mikro-orm/core';
 import { BigIntType, EnumType, Utils } from '@mikro-orm/core';
 import type { AbstractSqlConnection } from '../AbstractSqlConnection';
 import type { AbstractSqlPlatform } from '../AbstractSqlPlatform';
-import type { Check, Column, Index, Table, TableDifference } from '../typings';
+import type { CheckDef, Column, IndexDef, Table, TableDifference } from '../typings';
 import type { DatabaseTable } from './DatabaseTable';
 import type { DatabaseSchema } from './DatabaseSchema';
 
@@ -35,7 +35,7 @@ export abstract class SchemaHelper {
     return true;
   }
 
-  async getPrimaryKeys(connection: AbstractSqlConnection, indexes: Index[] = [], tableName: string, schemaName?: string): Promise<string[]> {
+  async getPrimaryKeys(connection: AbstractSqlConnection, indexes: IndexDef[] = [], tableName: string, schemaName?: string): Promise<string[]> {
     const pks = indexes.filter(i => i.primary).map(pk => pk.columnNames);
     return Utils.flatten(pks);
   }
@@ -60,7 +60,7 @@ export abstract class SchemaHelper {
     return unquote(t.table_name);
   }
 
-  async getEnumDefinitions(connection: AbstractSqlConnection, checks: Check[], tableName: string, schemaName?: string): Promise<Dictionary<string[]>> {
+  async getEnumDefinitions(connection: AbstractSqlConnection, checks: CheckDef[], tableName: string, schemaName?: string): Promise<Dictionary<string[]>> {
     return {};
   }
 
@@ -93,7 +93,7 @@ export abstract class SchemaHelper {
     return `alter table ${tableReference} rename column ${oldColumnName} to ${columnName}`;
   }
 
-  getCreateIndexSQL(tableName: string, index: Index): string {
+  getCreateIndexSQL(tableName: string, index: IndexDef): string {
     /* istanbul ignore if */
     if (index.expression) {
       return index.expression;
@@ -105,11 +105,11 @@ export abstract class SchemaHelper {
     return `create index ${keyName} on ${tableName} (${index.columnNames.map(c => this.platform.quoteIdentifier(c)).join(', ')})`;
   }
 
-  getDropIndexSQL(tableName: string, index: Index): string {
+  getDropIndexSQL(tableName: string, index: IndexDef): string {
     return `drop index ${this.platform.quoteIdentifier(index.keyName)}`;
   }
 
-  getRenameIndexSQL(tableName: string, index: Index, oldIndexName: string): string {
+  getRenameIndexSQL(tableName: string, index: IndexDef, oldIndexName: string): string {
     return [this.getDropIndexSQL(tableName, { ...index, keyName: oldIndexName }), this.getCreateIndexSQL(tableName, index)].join(';\n');
   }
 
@@ -189,15 +189,15 @@ export abstract class SchemaHelper {
     throw new Error('Not supported by given driver');
   }
 
-  async getIndexes(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<Index[]> {
+  async getIndexes(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<IndexDef[]> {
     throw new Error('Not supported by given driver');
   }
 
-  async getChecks(connection: AbstractSqlConnection, tableName: string, schemaName?: string, columns?: Column[]): Promise<Check[]> {
+  async getChecks(connection: AbstractSqlConnection, tableName: string, schemaName?: string, columns?: Column[]): Promise<CheckDef[]> {
     throw new Error('Not supported by given driver');
   }
 
-  protected async mapIndexes(indexes: Index[]): Promise<Index[]> {
+  protected async mapIndexes(indexes: IndexDef[]): Promise<IndexDef[]> {
     const map = {} as Dictionary;
 
     indexes.forEach(index => {

--- a/packages/knex/src/schema/SqlSchemaGenerator.ts
+++ b/packages/knex/src/schema/SqlSchemaGenerator.ts
@@ -1,7 +1,7 @@
 ﻿import type { Knex } from 'knex';
 import type { Dictionary, EntityMetadata, MikroORM, ISchemaGenerator } from '@mikro-orm/core';
 import { AbstractSchemaGenerator, Utils } from '@mikro-orm/core';
-import type { Check, ForeignKey, Index, SchemaDifference, TableDifference } from '../typings';
+import type { CheckDef, ForeignKey, IndexDef, SchemaDifference, TableDifference } from '../typings';
 import { DatabaseSchema } from './DatabaseSchema';
 import type { DatabaseTable } from './DatabaseTable';
 import type { AbstractSqlDriver } from '../AbstractSqlDriver';
@@ -520,7 +520,7 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
     });
   }
 
-  private createIndex(table: Knex.CreateTableBuilder, index: Index, tableDef: DatabaseTable, createPrimary = false) {
+  private createIndex(table: Knex.CreateTableBuilder, index: IndexDef, tableDef: DatabaseTable, createPrimary = false) {
     if (index.primary && !createPrimary) {
       return;
     }
@@ -543,7 +543,7 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
     }
   }
 
-  private dropIndex(table: Knex.CreateTableBuilder, index: Index, oldIndexName = index.keyName) {
+  private dropIndex(table: Knex.CreateTableBuilder, index: IndexDef, oldIndexName = index.keyName) {
     if (index.primary) {
       table.dropPrimary(oldIndexName);
     } else if (index.unique) {
@@ -553,11 +553,11 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
     }
   }
 
-  private createCheck(table: Knex.CreateTableBuilder, check: Check) {
+  private createCheck(table: Knex.CreateTableBuilder, check: CheckDef) {
     table.check(check.expression as string, {}, check.name);
   }
 
-  private dropCheck(table: Knex.CreateTableBuilder, check: Check) {
+  private dropCheck(table: Knex.CreateTableBuilder, check: CheckDef) {
     table.dropChecks(check.name);
   }
 

--- a/packages/knex/src/typings.ts
+++ b/packages/knex/src/typings.ts
@@ -63,7 +63,7 @@ export interface ForeignKey {
   deleteRule?: string;
 }
 
-export interface Index {
+export interface IndexDef {
   columnNames: string[];
   keyName: string;
   unique: boolean;
@@ -73,7 +73,7 @@ export interface Index {
   type?: string | Readonly<{ indexType?: string; storageEngineIndexType?: 'hash' | 'btree'; predicate?: Knex.QueryBuilder }>; // for back compatibility mainly, to allow using knex's `index.type` option (e.g. gin index)
 }
 
-export interface Check<T = unknown> {
+export interface CheckDef<T = unknown> {
   name: string;
   expression: string | CheckCallback<T>;
   definition?: string;
@@ -96,13 +96,13 @@ export interface TableDifference {
   changedColumns: Dictionary<ColumnDifference>;
   removedColumns: Dictionary<Column>;
   renamedColumns: Dictionary<Column>;
-  addedIndexes: Dictionary<Index>;
-  changedIndexes: Dictionary<Index>;
-  removedIndexes: Dictionary<Index>;
-  renamedIndexes: Dictionary<Index>;
-  addedChecks: Dictionary<Check>;
-  changedChecks: Dictionary<Check>;
-  removedChecks: Dictionary<Check>;
+  addedIndexes: Dictionary<IndexDef>;
+  changedIndexes: Dictionary<IndexDef>;
+  removedIndexes: Dictionary<IndexDef>;
+  renamedIndexes: Dictionary<IndexDef>;
+  addedChecks: Dictionary<CheckDef>;
+  changedChecks: Dictionary<CheckDef>;
+  removedChecks: Dictionary<CheckDef>;
   addedForeignKeys: Dictionary<ForeignKey>;
   changedForeignKeys: Dictionary<ForeignKey>;
   removedForeignKeys: Dictionary<ForeignKey>;

--- a/packages/mongodb/src/index.ts
+++ b/packages/mongodb/src/index.ts
@@ -13,3 +13,4 @@ export {
   defineMongoConfig as defineConfig,
 } from './MongoMikroORM';
 export { ObjectId } from 'bson';
+export * from '@mikro-orm/core';

--- a/packages/mysql/src/MySqlSchemaHelper.ts
+++ b/packages/mysql/src/MySqlSchemaHelper.ts
@@ -1,4 +1,4 @@
-import type { AbstractSqlConnection, Check, Column, Index, Knex, TableDifference, DatabaseTable, DatabaseSchema, Table, ForeignKey } from '@mikro-orm/knex';
+import type { AbstractSqlConnection, CheckDef, Column, IndexDef, Knex, TableDifference, DatabaseTable, DatabaseSchema, Table, ForeignKey } from '@mikro-orm/knex';
 import { SchemaHelper } from '@mikro-orm/knex';
 import type { Dictionary, Type } from '@mikro-orm/core';
 import { EnumType, StringType, TextType, MediumIntType } from '@mikro-orm/core';
@@ -57,7 +57,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
     }
   }
 
-  async getAllIndexes(connection: AbstractSqlConnection, tables: Table[]): Promise<Dictionary<Index[]>> {
+  async getAllIndexes(connection: AbstractSqlConnection, tables: Table[]): Promise<Dictionary<IndexDef[]>> {
     const sql = `select table_name as table_name, nullif(table_schema, schema()) as schema_name, index_name as index_name, non_unique as non_unique, column_name as column_name
         from information_schema.statistics where table_schema = database()
         and table_name in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(', ')})`;
@@ -129,7 +129,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
     return ret;
   }
 
-  async getAllChecks(connection: AbstractSqlConnection, tables: Table[]): Promise<Dictionary<Check[]>> {
+  async getAllChecks(connection: AbstractSqlConnection, tables: Table[]): Promise<Dictionary<CheckDef[]>> {
     /* istanbul ignore next */
     if (!await this.supportsCheckConstraints(connection)) {
       return {};
@@ -213,7 +213,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
     return `alter table ${tableName} change ${oldColumnName} ${columnName} ${this.getColumnDeclarationSQL(to)}`;
   }
 
-  getRenameIndexSQL(tableName: string, index: Index, oldIndexName: string): string {
+  getRenameIndexSQL(tableName: string, index: IndexDef, oldIndexName: string): string {
     tableName = this.platform.quoteIdentifier(tableName);
     oldIndexName = this.platform.quoteIdentifier(oldIndexName);
     const keyName = this.platform.quoteIdentifier(index.keyName);
@@ -305,13 +305,13 @@ export class MySqlSchemaHelper extends SchemaHelper {
   }
 
   /* istanbul ignore next */
-  async getChecks(connection: AbstractSqlConnection, tableName: string, schemaName: string, columns?: Column[]): Promise<Check[]> {
+  async getChecks(connection: AbstractSqlConnection, tableName: string, schemaName: string, columns?: Column[]): Promise<CheckDef[]> {
     const res = await this.getAllChecks(connection, [{ table_name: tableName, schema_name: schemaName }]);
     return res[tableName];
   }
 
   /* istanbul ignore next */
-  async getEnumDefinitions(connection: AbstractSqlConnection, checks: Check[], tableName: string, schemaName?: string): Promise<Dictionary<string[]>> {
+  async getEnumDefinitions(connection: AbstractSqlConnection, checks: CheckDef[], tableName: string, schemaName?: string): Promise<Dictionary<string[]>> {
     const res = await this.getAllEnumDefinitions(connection, [{ table_name: tableName, schema_name: schemaName }]);
     return res[tableName];
   }
@@ -323,7 +323,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
   }
 
   /* istanbul ignore next */
-  async getIndexes(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<Index[]> {
+  async getIndexes(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<IndexDef[]> {
     const res = await this.getAllIndexes(connection, [{ table_name: tableName, schema_name: schemaName }]);
     return res[tableName];
   }

--- a/packages/postgresql/src/PostgreSqlSchemaHelper.ts
+++ b/packages/postgresql/src/PostgreSqlSchemaHelper.ts
@@ -1,6 +1,6 @@
 import type { Dictionary } from '@mikro-orm/core';
 import { BigIntType, EnumType, Utils } from '@mikro-orm/core';
-import type { AbstractSqlConnection, Check, Column, DatabaseSchema, DatabaseTable, ForeignKey, Index, Table, TableDifference, Knex } from '@mikro-orm/knex';
+import type { AbstractSqlConnection, CheckDef, Column, DatabaseSchema, DatabaseTable, ForeignKey, IndexDef, Table, TableDifference, Knex } from '@mikro-orm/knex';
 import { SchemaHelper } from '@mikro-orm/knex';
 
 export class PostgreSqlSchemaHelper extends SchemaHelper {
@@ -69,7 +69,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     }
   }
 
-  async getAllIndexes(connection: AbstractSqlConnection, tables: Table[]): Promise<Dictionary<Index[]>> {
+  async getAllIndexes(connection: AbstractSqlConnection, tables: Table[]): Promise<Dictionary<IndexDef[]>> {
     const sql = this.getIndexesSQL(tables);
     const unquote = (str: string) => str.replace(/['"`]/g, '');
     const allIndexes = await connection.execute<any[]>(sql);
@@ -133,7 +133,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     return ret;
   }
 
-  async getAllChecks(connection: AbstractSqlConnection, tables: Table[]): Promise<Dictionary<Check[]>> {
+  async getAllChecks(connection: AbstractSqlConnection, tables: Table[]): Promise<Dictionary<CheckDef[]>> {
     const sql = this.getChecksSQL(tables);
     const allChecks = await connection.execute<{ name: string; column_name: string; schema_name: string; table_name: string; expression: string }[]>(sql);
     const ret = {};
@@ -188,7 +188,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     return ret;
   }
 
-  async getEnumDefinitions(connection: AbstractSqlConnection, checks: Check[], tableName?: string, schemaName?: string): Promise<Dictionary<string[]>> {
+  async getEnumDefinitions(connection: AbstractSqlConnection, checks: CheckDef[], tableName?: string, schemaName?: string): Promise<Dictionary<string[]>> {
     const found: number[] = [];
     const enums = checks.reduce((o, item, index) => {
       // check constraints are defined as one of:
@@ -345,7 +345,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     return `set session_replication_role = 'origin';`;
   }
 
-  getRenameIndexSQL(tableName: string, index: Index, oldIndexName: string): string {
+  getRenameIndexSQL(tableName: string, index: IndexDef, oldIndexName: string): string {
     oldIndexName = this.platform.quoteIdentifier(oldIndexName);
     const keyName = this.platform.quoteIdentifier(index.keyName);
 
@@ -377,7 +377,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
   }
 
   /* istanbul ignore next */
-  async getChecks(connection: AbstractSqlConnection, tableName: string, schemaName: string, columns?: Column[]): Promise<Check[]> {
+  async getChecks(connection: AbstractSqlConnection, tableName: string, schemaName: string, columns?: Column[]): Promise<CheckDef[]> {
     const res = await this.getAllChecks(connection, [{ table_name: tableName, schema_name: schemaName }]);
     return res[tableName];
   }
@@ -389,7 +389,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
   }
 
   /* istanbul ignore next */
-  async getIndexes(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<Index[]> {
+  async getIndexes(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<IndexDef[]> {
     const res = await this.getAllIndexes(connection, [{ table_name: tableName, schema_name: schemaName }]);
     return res[tableName];
   }

--- a/packages/sqlite/src/SqliteSchemaHelper.ts
+++ b/packages/sqlite/src/SqliteSchemaHelper.ts
@@ -1,5 +1,5 @@
 import type { Connection, Dictionary } from '@mikro-orm/core';
-import type { AbstractSqlConnection, Index, Check } from '@mikro-orm/knex';
+import type { AbstractSqlConnection, IndexDef, CheckDef } from '@mikro-orm/knex';
 import { SchemaHelper } from '@mikro-orm/knex';
 
 export class SqliteSchemaHelper extends SchemaHelper {
@@ -44,7 +44,7 @@ export class SqliteSchemaHelper extends SchemaHelper {
     });
   }
 
-  async getEnumDefinitions(connection: AbstractSqlConnection, checks: Check[], tableName: string, schemaName: string): Promise<Dictionary<string[]>> {
+  async getEnumDefinitions(connection: AbstractSqlConnection, checks: CheckDef[], tableName: string, schemaName: string): Promise<Dictionary<string[]>> {
     const sql = `select sql from sqlite_master where type = ? and name = ?`;
     const tableDefinition = await connection.execute<{ sql: string }>(sql, ['table', tableName], 'get');
 
@@ -63,18 +63,18 @@ export class SqliteSchemaHelper extends SchemaHelper {
     }, {} as Dictionary<string[]>);
   }
 
-  async getPrimaryKeys(connection: AbstractSqlConnection, indexes: Index[], tableName: string, schemaName?: string): Promise<string[]> {
+  async getPrimaryKeys(connection: AbstractSqlConnection, indexes: IndexDef[], tableName: string, schemaName?: string): Promise<string[]> {
     const sql = `pragma table_info(\`${tableName}\`)`;
     const cols = await connection.execute<{ pk: number; name: string }[]>(sql);
 
     return cols.filter(col => !!col.pk).map(col => col.name);
   }
 
-  async getIndexes(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<Index[]> {
+  async getIndexes(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<IndexDef[]> {
     const sql = `pragma table_info(\`${tableName}\`)`;
     const cols = await connection.execute<{ pk: number; name: string }[]>(sql);
     const indexes = await connection.execute<any[]>(`pragma index_list(\`${tableName}\`)`);
-    const ret: Index[] = [];
+    const ret: IndexDef[] = [];
 
     for (const col of cols.filter(c => c.pk)) {
       ret.push({
@@ -98,7 +98,7 @@ export class SqliteSchemaHelper extends SchemaHelper {
     return this.mapIndexes(ret);
   }
 
-  async getChecks(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<Check[]> {
+  async getChecks(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<CheckDef[]> {
     // Not supported at the moment.
     return [];
   }

--- a/tests/issues/GH1003.test.ts
+++ b/tests/issues/GH1003.test.ts
@@ -1,6 +1,5 @@
-import type { IdentifiedReference } from '@mikro-orm/core';
-import { BaseEntity, Collection, Entity, ManyToOne, OneToMany, PrimaryKey } from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/sqlite';
+import { BaseEntity, Collection, MikroORM, Entity, ManyToOne, OneToMany, PrimaryKey } from '@mikro-orm/sqlite';
+import type { IdentifiedReference } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Parent extends BaseEntity<Parent, 'id'> {

--- a/tests/issues/GH1009.test.ts
+++ b/tests/issues/GH1009.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity({ tableName: 'brands' })
 export class Brand {
@@ -73,13 +72,12 @@ export class Site {
 
 describe('GH issue 1009', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [BrandSiteRestriction, Site, Brand, Publisher, Placement],
       dbName: `:memory:`,
-      driver: SqliteDriver,
     });
 
     const generator = orm.schema;

--- a/tests/issues/GH1038.test.ts
+++ b/tests/issues/GH1038.test.ts
@@ -1,5 +1,4 @@
-import { BigIntType, Entity, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { BigIntType, Entity, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity({ abstract: true })
 abstract class BaseEntity {
@@ -57,13 +56,12 @@ class PositionBookmark extends BaseEntity {
 
 describe('GH issue 1038', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [BaseEntity, User, Position, PositionBookmark],
       dbName: `:memory:`,
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH1041.test.ts
+++ b/tests/issues/GH1041.test.ts
@@ -1,7 +1,5 @@
-import { Collection, Entity, LoadStrategy, ManyToMany, MikroORM, PopulateHint, PrimaryKey, Property } from '@mikro-orm/core';
-import type { AbstractSqlDriver } from '@mikro-orm/knex';
+import { Collection, Entity, LoadStrategy, ManyToMany, MikroORM, PopulateHint, PrimaryKey, Property } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
-import { SqliteDriver } from '@mikro-orm/sqlite';
 
 @Entity()
 export class App {
@@ -33,14 +31,13 @@ export class User {
 
 describe('GH issue 1041, 1043', () => {
 
-  let orm: MikroORM<AbstractSqlDriver>;
+  let orm: MikroORM;
   const log = jest.fn();
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [User, App],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     mockLogger(orm, ['query', 'query-params'], log);
     await orm.schema.createSchema();

--- a/tests/issues/GH1111.test.ts
+++ b/tests/issues/GH1111.test.ts
@@ -1,7 +1,5 @@
-import { Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, PrimaryKeyType, Property, Reference } from '@mikro-orm/core';
-import type { AbstractSqlDriver } from '@mikro-orm/knex';
+import { Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, PrimaryKeyType, Property, Reference } from '@mikro-orm/postgresql';
 import { mockLogger } from '../helpers';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 
 @Entity()
 class Node {
@@ -44,14 +42,13 @@ class B {
 
 describe('GH issue 1111', () => {
 
-  let orm: MikroORM<AbstractSqlDriver>;
+  let orm: MikroORM;
   const log = jest.fn();
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Node, A, B],
       dbName: `mikro_orm_test_gh_1111`,
-      driver: PostgreSqlDriver,
       cache: { enabled: false },
     });
     mockLogger(orm, ['query', 'query-params'], log);

--- a/tests/issues/GH1115.test.ts
+++ b/tests/issues/GH1115.test.ts
@@ -1,6 +1,4 @@
-import { Entity, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import type { AbstractSqlDriver } from '@mikro-orm/knex';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 export class B {
@@ -26,13 +24,12 @@ export class A {
 
 describe('GH issue 1115', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH1124.test.ts
+++ b/tests/issues/GH1124.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, OneToOne, PrimaryKey } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, OneToOne, PrimaryKey } from '@mikro-orm/sqlite';
 
 @Entity()
 export class B {
@@ -22,13 +21,12 @@ export class A {
 
 describe('GH issue 1124', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH1126.test.ts
+++ b/tests/issues/GH1126.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -80,11 +79,10 @@ async function createEntities(orm: MikroORM) {
 
 describe('GH issue 1126', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      driver: SqliteDriver,
       dbName: ':memory:',
       entities: [Author, Book, Page],
       loadStrategy: LoadStrategy.JOINED,

--- a/tests/issues/GH1128.test.ts
+++ b/tests/issues/GH1128.test.ts
@@ -1,6 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/core';
-import type { AbstractSqlDriver } from '@mikro-orm/knex';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/sqlite';
 
 @Entity()
 export class B {
@@ -26,13 +24,12 @@ export class A {
 
 describe('GH issue 1128', () => {
 
-  let orm: MikroORM<AbstractSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH1134.test.ts
+++ b/tests/issues/GH1134.test.ts
@@ -1,6 +1,5 @@
-import { Collection, Entity, LoadStrategy, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Collection, Entity, LoadStrategy, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/sqlite';
 import { v4 } from 'uuid';
-import { SqliteDriver } from '@mikro-orm/sqlite';
 
 @Entity()
 export class A {
@@ -113,13 +112,12 @@ async function createEntities(orm: MikroORM) {
 
 describe('GH issue 1134', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [E, T, A, V, I, N, M],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
     await createEntities(orm);

--- a/tests/issues/GH1143.test.ts
+++ b/tests/issues/GH1143.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/postgresql';
 
 @Entity({
   tableName: 'test.DEVICES',
@@ -16,13 +15,12 @@ export class Device {
 
 describe('GH issue 1143', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Device],
       dbName: `mikro_orm_test_gh_1143`,
-      driver: PostgreSqlDriver,
     });
 
     const generator = orm.schema;

--- a/tests/issues/GH1150.test.ts
+++ b/tests/issues/GH1150.test.ts
@@ -1,5 +1,4 @@
-import { Entity, Enum, MikroORM, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, Enum, MikroORM, OneToOne, PrimaryKey, Property } from '@mikro-orm/postgresql';
 
 @Entity()
 export class Person {
@@ -49,13 +48,12 @@ export class User {
 
 describe('GH issue 1150', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [User, Person],
       dbName: `mikro_orm_test_gh_1150`,
-      driver: PostgreSqlDriver,
     });
 
     const generator = orm.schema;

--- a/tests/issues/GH1171.test.ts
+++ b/tests/issues/GH1171.test.ts
@@ -1,7 +1,5 @@
-import { Entity, MikroORM, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import type { AbstractSqlDriver } from '@mikro-orm/knex';
+import { Entity, MikroORM, OneToOne, PrimaryKey, Property } from '@mikro-orm/sqlite';
 import { v4 } from 'uuid';
-import { SqliteDriver } from '@mikro-orm/sqlite';
 
 @Entity()
 export class B {
@@ -26,13 +24,12 @@ export class A {
 }
 
 describe('GH issue 1171', () => {
-  let orm: MikroORM<AbstractSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH1176.test.ts
+++ b/tests/issues/GH1176.test.ts
@@ -1,12 +1,5 @@
-import type {
-  EntityManager } from '@mikro-orm/core';
-import {
-  Entity,
-  MikroORM,
-  PrimaryKey,
-  Property,
-} from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import type { EntityManager } from '@mikro-orm/postgresql';
+import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/postgresql';
 import { v4 as uuid } from 'uuid';
 
 @Entity({ tableName: 'users' })
@@ -24,18 +17,17 @@ class User {
 
 }
 
-async function getOrmInstance(): Promise<MikroORM<PostgreSqlDriver>> {
+async function getOrmInstance(): Promise<MikroORM> {
   const orm = await MikroORM.init({
     entities: [User],
     dbName: 'mikro_orm_test_gh_1176',
-    driver: PostgreSqlDriver,
   });
 
-  return orm as MikroORM<PostgreSqlDriver>;
+  return orm as MikroORM;
 }
 
 describe('GH issue 1176', () => {
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
   let em: EntityManager;
 
   beforeAll(async () => {

--- a/tests/issues/GH1224.test.ts
+++ b/tests/issues/GH1224.test.ts
@@ -1,7 +1,5 @@
-import { Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, PrimaryKeyType, Property, Reference } from '@mikro-orm/core';
-import type { AbstractSqlDriver } from '@mikro-orm/knex';
+import { Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, PrimaryKeyType, Property, Reference } from '@mikro-orm/postgresql';
 import { mockLogger } from '../helpers';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 
 @Entity()
 class Node {
@@ -41,14 +39,13 @@ class A {
 
 describe('GH issue 1224', () => {
 
-  let orm: MikroORM<AbstractSqlDriver>;
+  let orm: MikroORM;
   const log = jest.fn();
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Node, A, B],
       dbName: `mikro_orm_test_gh_1224`,
-      driver: PostgreSqlDriver,
       cache: { enabled: false },
     });
     mockLogger(orm, ['query', 'query-params'], log);

--- a/tests/issues/GH1226.test.ts
+++ b/tests/issues/GH1226.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, PrimaryKey } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, PrimaryKey } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Example {
@@ -21,25 +20,22 @@ export class Example {
 
 describe('GH issue 1226', () => {
 
-  let orm1: MikroORM<SqliteDriver>;
-  let orm2: MikroORM<SqliteDriver>;
-  let orm3: MikroORM<SqliteDriver>;
+  let orm1: MikroORM;
+  let orm2: MikroORM;
+  let orm3: MikroORM;
 
   beforeAll(async () => {
     orm1 = await MikroORM.init({
-      driver: SqliteDriver,
       dbName: ':memory:',
       forceEntityConstructor: true,
       entities: [Example],
     });
     orm2 = await MikroORM.init({
-      driver: SqliteDriver,
       dbName: ':memory:',
       forceEntityConstructor: [Example],
       entities: [Example],
     });
     orm3 = await MikroORM.init({
-      driver: SqliteDriver,
       dbName: ':memory:',
       forceEntityConstructor: ['Example'],
       entities: [Example],

--- a/tests/issues/GH1231.test.ts
+++ b/tests/issues/GH1231.test.ts
@@ -1,5 +1,4 @@
-import { Cascade, Collection, Entity, EntityRepositoryType, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
-import { EntityRepository, PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Cascade, Collection, Entity, EntityRepository, EntityRepositoryType, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/postgresql';
 
 @Entity({ tableName: 'teachers', repository: () => TeacherRepository })
 class Teacher {
@@ -67,13 +66,12 @@ class TeacherRepository extends EntityRepository<Teacher> {
 }
 
 describe('one to many relations read with query builder in postgresql (GH issue 1231)', () => {
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Teacher, Student],
       dbName: 'mikro_orm_test_1231',
-      driver: PostgreSqlDriver,
     });
     await orm.schema.refreshDatabase();
 

--- a/tests/issues/GH1262.test.ts
+++ b/tests/issues/GH1262.test.ts
@@ -1,8 +1,7 @@
 import 'reflect-metadata';
-import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
+import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 import { remove } from 'fs-extra';
 import { TEMP_DIR } from '../helpers';
-import { SqliteDriver } from '@mikro-orm/sqlite';
 
 @Entity({ tableName: 'user' })
 class UserBefore {
@@ -42,7 +41,6 @@ describe('GH issue 1262', () => {
 
   async function createAndRunMigration(entities: any[]) {
     const db = await MikroORM.init({
-      driver: SqliteDriver,
       entities,
       dbName: TEMP_DIR + '/gh_1262.db',
     });

--- a/tests/issues/GH1263.test.ts
+++ b/tests/issues/GH1263.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, Property, Type } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, PrimaryKey, Property, Type } from '@mikro-orm/sqlite';
 import { parse, stringify, v4 as uuid } from 'uuid';
 
 class UUID extends Type<string, Buffer> {
@@ -32,13 +31,12 @@ class User {
 
 describe('GH issue 1263', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [User],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH1278.test.ts
+++ b/tests/issues/GH1278.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, OneToOne, PrimaryKey, Property } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -29,11 +28,10 @@ export class Group {
 
 describe('GH issue 1278', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      driver: SqliteDriver,
       dbName: ':memory:',
       entities: [Group, GroupCode],
     });

--- a/tests/issues/GH1326.test.ts
+++ b/tests/issues/GH1326.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, IdentifiedReference, ManyToOne, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/mysql';
+import { Collection, Entity, IdentifiedReference, MikroORM, ManyToOne, OneToMany, PrimaryKey, Property } from '@mikro-orm/mysql';
 import { mockLogger } from '../helpers';
 
 @Entity()

--- a/tests/issues/GH1331.test.ts
+++ b/tests/issues/GH1331.test.ts
@@ -9,8 +9,7 @@ import {
   PrimaryKey,
   Property,
   QueryOrder,
-} from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+} from '@mikro-orm/sqlite';
 
 @Entity()
 export class D {
@@ -108,11 +107,10 @@ export class A {
 
 describe('GH issue 1331', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      driver: SqliteDriver,
       dbName: ':memory:',
       entities: [A, B, C, D],
       loadStrategy: LoadStrategy.JOINED,

--- a/tests/issues/GH1334.test.ts
+++ b/tests/issues/GH1334.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, IdentifiedReference, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, QueryOrder } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, IdentifiedReference, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, QueryOrder } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -77,11 +76,10 @@ export class Project {
 
 describe('GH issue 1334', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      driver: SqliteDriver,
       dbName: ':memory:',
       entities: [Project, Radio, RadioOption],
       loadStrategy: LoadStrategy.JOINED,

--- a/tests/issues/GH1346.test.ts
+++ b/tests/issues/GH1346.test.ts
@@ -1,6 +1,4 @@
-import { Collection, Entity, ManyToMany, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import type { AbstractSqlDriver } from '@mikro-orm/knex';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Collection, Entity, ManyToMany, MikroORM, PrimaryKey, Property } from '@mikro-orm/postgresql';
 
 @Entity({ tableName: 'name' })
 class Name {
@@ -33,13 +31,12 @@ class User {
 
 describe('GH issue 1346', () => {
 
-  let orm: MikroORM<AbstractSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [User, Name],
       dbName: `mikro_orm_test_pivot_fields`,
-      driver: PostgreSqlDriver,
     });
 
     await orm.schema.ensureDatabase();

--- a/tests/issues/GH1352.test.ts
+++ b/tests/issues/GH1352.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, IdentifiedReference, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, IdentifiedReference, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Manager {
@@ -81,11 +80,10 @@ export class Project {
 
 describe('GH issue 1352', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      driver: SqliteDriver,
       dbName: ':memory:',
       entities: [Project, Owner, Risk, Manager],
       loadStrategy: LoadStrategy.JOINED,

--- a/tests/issues/GH1395.test.ts
+++ b/tests/issues/GH1395.test.ts
@@ -1,6 +1,4 @@
-import { ObjectId } from 'bson';
-import { Entity, PrimaryKey, Property, t, wrap } from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/mongodb';
+import { Entity, MikroORM, PrimaryKey, Property, t, wrap, ObjectId } from '@mikro-orm/mongodb';
 
 export interface EmailMessageTest {
   html?: string;

--- a/tests/issues/GH1429.test.ts
+++ b/tests/issues/GH1429.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToMany, MikroORM, PrimaryKey } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToMany, MikroORM, PrimaryKey } from '@mikro-orm/sqlite';
 
 @Entity()
 class A {
@@ -27,7 +26,6 @@ describe('GH issue 1429', () => {
     orm = await MikroORM.init({
       entities: [A],
       dbName: `:memory:`,
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH1444.test.ts
+++ b/tests/issues/GH1444.test.ts
@@ -1,6 +1,5 @@
-import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
+import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 import { v4 as uuid } from 'uuid';
-import { SqliteDriver } from '@mikro-orm/sqlite';
 
 @Entity()
 class A {
@@ -28,7 +27,6 @@ describe('GH issue 1444', () => {
     orm = await MikroORM.init({
       entities: [A],
       dbName: `:memory:`,
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH1523.test.ts
+++ b/tests/issues/GH1523.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, FlushMode, ManyToOne, MikroORM, OneToMany, PrimaryKey, wrap } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, FlushMode, ManyToOne, MikroORM, OneToMany, PrimaryKey, wrap } from '@mikro-orm/sqlite';
 
 abstract class Base {
 
@@ -37,13 +36,12 @@ class Parent extends Base {
 
 describe('GH issue 1523', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Base, Parent, Child, Param],
       dbName: ':memory:',
-      driver: SqliteDriver,
       flushMode: FlushMode.COMMIT,
     });
     await orm.schema.createSchema();

--- a/tests/issues/GH1538.test.ts
+++ b/tests/issues/GH1538.test.ts
@@ -1,5 +1,4 @@
-import { BigIntType, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { BigIntType, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Author {
@@ -39,13 +38,12 @@ export class Post {
 
 describe('GH issue 1538', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Author, Post],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH1553.test.ts
+++ b/tests/issues/GH1553.test.ts
@@ -8,8 +8,7 @@ import {
   OneToMany,
   Collection,
   LoadStrategy,
-} from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+} from '@mikro-orm/sqlite';
 
 @Entity()
 export class Owner {
@@ -79,11 +78,10 @@ export class Radio {
 
 describe('GH issue 1553', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      driver: SqliteDriver,
       dbName: ':memory:',
       entities: [Radio, RadioOption, Owner],
       loadStrategy: LoadStrategy.JOINED,

--- a/tests/issues/GH1592.test.ts
+++ b/tests/issues/GH1592.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, Property, IdentifiedReference, LoadStrategy, OneToOne } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, PrimaryKey, Property, IdentifiedReference, LoadStrategy, OneToOne } from '@mikro-orm/sqlite';
 
 @Entity()
 export class RadioOption {
@@ -38,12 +37,11 @@ export class Radio {
 
 describe('GH issue 1592', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       dbName: `:memory:`,
-      driver: SqliteDriver,
       entities: [Radio, RadioOption],
       loadStrategy: LoadStrategy.JOINED,
     });

--- a/tests/issues/GH1595.test.ts
+++ b/tests/issues/GH1595.test.ts
@@ -1,6 +1,5 @@
-import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
+import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/postgresql';
 import { mockLogger } from '../helpers';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 
 @Entity()
 export class A {
@@ -25,7 +24,6 @@ describe('GH issue 1595', () => {
     orm = await MikroORM.init({
       entities: [A],
       dbName: 'mikro_orm_test_gh_1595',
-      driver: PostgreSqlDriver,
     });
     await orm.schema.refreshDatabase();
   });

--- a/tests/issues/GH1616.test.ts
+++ b/tests/issues/GH1616.test.ts
@@ -1,5 +1,4 @@
-import { Embeddable, Embedded, Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Embeddable, Embedded, Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Embeddable()
 export class D {
@@ -45,7 +44,6 @@ describe('GH issue 1616', () => {
     const orm = await MikroORM.init({
       entities: [C, D, A, B],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     const schema = await orm.schema.getCreateSchemaSQL({ wrap: false });
     expect(schema).toMatchSnapshot();

--- a/tests/issues/GH1626.test.ts
+++ b/tests/issues/GH1626.test.ts
@@ -1,12 +1,10 @@
 import {
   BigIntType,
   Entity,
-  DefaultLogger,
   MikroORM,
   PrimaryKey,
   Property,
-} from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+} from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 export class NativeBigIntType extends BigIntType {
 
@@ -40,13 +38,12 @@ export class Author {
 }
 
 describe('GH issue 1626', () => {
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Author],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH1657.test.ts
+++ b/tests/issues/GH1657.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, wrap } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, wrap } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -49,13 +48,12 @@ class OrderItem {
 
 describe('GH issue 1657', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Order, OrderItem],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH1664.test.ts
+++ b/tests/issues/GH1664.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/postgresql';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -22,13 +21,12 @@ class MultipleUniqueNullableProperties {
 }
 
 describe('embedded entities in postgresql', () => {
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [MultipleUniqueNullableProperties],
       dbName: 'mikro_orm_test_unique_nullable_insert',
-      driver: PostgreSqlDriver,
     });
     await orm.schema.refreshDatabase();
   });

--- a/tests/issues/GH1704.test.ts
+++ b/tests/issues/GH1704.test.ts
@@ -1,5 +1,4 @@
-import { Entity, PrimaryKey, Property, OneToOne, MikroORM } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property, OneToOne, MikroORM } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -29,11 +28,10 @@ export class User {
 
 describe('GH issue 1704', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      driver: SqliteDriver,
       entities: [User, Profile],
       dbName: ':memory:',
     });

--- a/tests/issues/GH1721.test.ts
+++ b/tests/issues/GH1721.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, Property, Type } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, PrimaryKey, Property, Type } from '@mikro-orm/sqlite';
 import { Guid } from 'guid-typescript';
 import { mockLogger } from '../helpers';
 
@@ -43,13 +42,12 @@ export class Couch {
 
 describe('GH issue 1721', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Couch],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH1831.test.ts
+++ b/tests/issues/GH1831.test.ts
@@ -8,8 +8,7 @@ import {
   PrimaryKey,
   Property,
   PlainObject,
-} from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+} from '@mikro-orm/sqlite';
 
 @Entity()
 export class FilterValue {
@@ -80,11 +79,10 @@ export class ProjectDto extends PlainObject {
 
 describe('GH issue 1831', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      driver: SqliteDriver,
       dbName: ':memory:',
       entities: [Project, Filter, FilterValue],
     });

--- a/tests/issues/GH1882.test.ts
+++ b/tests/issues/GH1882.test.ts
@@ -1,6 +1,5 @@
-import { BigIntType, Collection, Entity, ManyToOne, MikroORM, OneToMany, PopulateHint, PrimaryKey, Property } from '@mikro-orm/core';
+import { BigIntType, Collection, Entity, ManyToOne, MikroORM, OneToMany, PopulateHint, PrimaryKey, Property } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
-import { SqliteDriver } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Foo {
@@ -32,13 +31,12 @@ export class Bar {
 
 describe('GH issue 1882', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Foo, Bar],
       dbName: `:memory:`,
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH1902.test.ts
+++ b/tests/issues/GH1902.test.ts
@@ -1,5 +1,4 @@
-import { MikroORM, Entity, PrimaryKey, PrimaryKeyType, Unique, Collection, ManyToOne, OneToMany, Property, Filter, LoadStrategy, OptionalProps } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { MikroORM, Entity, PrimaryKey, PrimaryKeyType, Unique, Collection, ManyToOne, OneToMany, Property, Filter, LoadStrategy, OptionalProps } from '@mikro-orm/sqlite';
 
 @Entity({ tableName: 'users' })
 export class UserEntity {
@@ -63,13 +62,12 @@ class UserTenantEntity {
 
 describe('GH issue 1902', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [UserEntity, TenantEntity, UserTenantEntity],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH1910.test.ts
+++ b/tests/issues/GH1910.test.ts
@@ -1,6 +1,5 @@
-import type { EntityManager } from '@mikro-orm/core';
-import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import type { EntityManager } from '@mikro-orm/postgresql';
+import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/postgresql';
 
 @Entity()
 export class A {
@@ -15,13 +14,12 @@ export class A {
 
 describe('GH issue 1910', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A],
       dbName: 'mikro_orm_test_gh_1910',
-      driver: PostgreSqlDriver,
     });
     await orm.schema.ensureDatabase();
     await orm.schema.dropSchema();

--- a/tests/issues/GH1927.test.ts
+++ b/tests/issues/GH1927.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -40,13 +39,12 @@ export class Book {
 
 describe('GH issue 1927', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Author, Book],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH1958.test.ts
+++ b/tests/issues/GH1958.test.ts
@@ -1,5 +1,4 @@
-import { Embeddable, Embedded, Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Embeddable, Embedded, Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Embeddable()
 export class LoopOptions {
@@ -42,7 +41,6 @@ describe('GH issue 1958', () => {
     orm = await MikroORM.init({
       entities: [PlayerEntity, Options, LoopOptions],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH1968.test.ts
+++ b/tests/issues/GH1968.test.ts
@@ -1,5 +1,4 @@
-import { BigIntType, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { BigIntType, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 class Author {
@@ -36,7 +35,6 @@ describe('GH issue 1968', () => {
     orm = await MikroORM.init({
       entities: [Author, Book],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
 
     await orm.schema.createSchema();

--- a/tests/issues/GH1990.test.ts
+++ b/tests/issues/GH1990.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/postgresql';
 
 @Entity()
 class A {
@@ -31,7 +30,6 @@ describe('GH issue 1990', () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: 'mikro_orm_test_1990',
-      driver: PostgreSqlDriver,
     });
     await orm.schema.refreshDatabase();
   });

--- a/tests/issues/GH2059.test.ts
+++ b/tests/issues/GH2059.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, wrap } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, wrap } from '@mikro-orm/sqlite';
 
 @Entity()
 class Category {
@@ -25,13 +24,12 @@ class Category {
 
 describe('GH issue 2059', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Category],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH2121.test.ts
+++ b/tests/issues/GH2121.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToMany, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToMany, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Tag {
@@ -28,13 +27,12 @@ export class Product {
 
 describe('GH issue 2121', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Tag, Product],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH2148.test.ts
+++ b/tests/issues/GH2148.test.ts
@@ -1,5 +1,4 @@
-import { Entity, IdentifiedReference, ManyToOne, MikroORM, PrimaryKey, Reference } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, IdentifiedReference, ManyToOne, MikroORM, PrimaryKey, Reference } from '@mikro-orm/postgresql';
 
 @Entity()
 export class First {
@@ -35,13 +34,12 @@ export class Third {
 
 describe('GH issue 2148', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [First, Second, Third],
       dbName: 'mikro_orm_test_2148',
-      driver: PostgreSqlDriver,
     });
     await orm.schema.refreshDatabase();
   });

--- a/tests/issues/GH222.test.ts
+++ b/tests/issues/GH222.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, Property, wrap } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, Property, wrap } from '@mikro-orm/sqlite';
 
 @Entity()
 export class A {
@@ -48,15 +47,13 @@ export class B {
 
 describe('GH issue 222', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B, C],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
-    await orm.schema.dropSchema();
     await orm.schema.createSchema();
   });
 

--- a/tests/issues/GH2233.test.ts
+++ b/tests/issues/GH2233.test.ts
@@ -1,5 +1,4 @@
-import { Embeddable, Embedded, Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Embeddable, Embedded, Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Embeddable()
 export class Lock {
@@ -25,13 +24,12 @@ export class File {
 
 describe('GH issue 2233', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Lock, File],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH2238.test.ts
+++ b/tests/issues/GH2238.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, OneToOne, PrimaryKey } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, OneToOne, PrimaryKey } from '@mikro-orm/sqlite';
 
 @Entity()
 export class First {
@@ -28,13 +27,12 @@ export class Second {
 }
 
 describe('GH issue 2238', () => {
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [First, Second],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH2273.test.ts
+++ b/tests/issues/GH2273.test.ts
@@ -1,5 +1,4 @@
-import { Entity, LoadStrategy, MikroORM, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, LoadStrategy, MikroORM, OneToOne, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Checkout {
@@ -72,7 +71,6 @@ describe('Remove entity issue (GH 2273)', () => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      driver: SqliteDriver,
       dbName: ':memory:',
       entities: [Discount, Checkout, Discount2, Checkout2],
     });

--- a/tests/issues/GH228.test.ts
+++ b/tests/issues/GH228.test.ts
@@ -1,5 +1,4 @@
-import { Entity, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -29,13 +28,12 @@ export class A {
 
 describe('GH issue 228', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.dropSchema();
     await orm.schema.createSchema();

--- a/tests/issues/GH2293.test.ts
+++ b/tests/issues/GH2293.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, Property, t } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, PrimaryKey, Property, t } from '@mikro-orm/sqlite';
 
 @Entity()
 export class TestEntity {
@@ -14,13 +13,12 @@ export class TestEntity {
 
 describe('GH issue 2293', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [TestEntity],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.ensureDatabase();
     await orm.schema.dropSchema();

--- a/tests/issues/GH234.test.ts
+++ b/tests/issues/GH234.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToMany, MikroORM, PopulateHint, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToMany, MikroORM, PopulateHint, PrimaryKey, Property } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -32,13 +31,12 @@ export class B {
 
 describe('GH issue 234', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.dropSchema();
     await orm.schema.createSchema();

--- a/tests/issues/GH2371.test.ts
+++ b/tests/issues/GH2371.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/sqlite';
 
 @Entity({ tableName: 'vehicle', discriminatorColumn: 'type', abstract: true })
 class Vehicle {
@@ -34,13 +33,12 @@ class Garage {
 
 describe('GH issue 2371', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Car, Vehicle, Truck, Garage],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH2379.test.ts
+++ b/tests/issues/GH2379.test.ts
@@ -1,5 +1,4 @@
-import { BigIntType, Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { BigIntType, Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, OptionalProps, PrimaryKey, Property } from '@mikro-orm/sqlite';
 import { performance } from 'perf_hooks';
 
 @Entity()
@@ -106,13 +105,12 @@ export class Order {
 }
 
 describe('GH issue 2379', () => {
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Order, Job, VendorBuyerRelationship,Member],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH2393.test.ts
+++ b/tests/issues/GH2393.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 export class A {
@@ -32,7 +31,6 @@ describe('GH issue 2393', () => {
     await expect(MikroORM.init({
       entities: [A, B],
       dbName: ':memory:',
-      driver: SqliteDriver,
       connect: false,
     })).rejects.toThrowError('A.coll has unknown \'mappedBy\' reference: B.undefined');
   });

--- a/tests/issues/GH2395.test.ts
+++ b/tests/issues/GH2395.test.ts
@@ -1,5 +1,4 @@
-import { Cascade, Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Cascade, Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Parent {
@@ -53,13 +52,12 @@ export class Child3 {
 
 describe('GH issue 2395', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Parent, Child, Child2, Child3],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH2406.test.ts
+++ b/tests/issues/GH2406.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Parent {
@@ -25,14 +24,13 @@ export class Child {
 
 describe('GH issue 2406', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Parent, Child],
       dbName: ':memory:',
       forceEntityConstructor: true,
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH2410.test.ts
+++ b/tests/issues/GH2410.test.ts
@@ -1,5 +1,4 @@
-import { BigIntType, Cascade, Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { BigIntType, Cascade, Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/sqlite';
 
 @Entity({ tableName: 'user' })
 class User {
@@ -42,13 +41,12 @@ class MemberUser {
 
 describe('GH issue 2410', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [User, Member, MemberUser],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH2489.test.ts
+++ b/tests/issues/GH2489.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, Property, Type } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, MikroORM, PrimaryKey, Property, Type } from '@mikro-orm/postgresql';
 
 export class IntegerArrayType extends Type<number[], string> {
 
@@ -56,7 +55,6 @@ describe('GH issue 2489', () => {
     orm = await MikroORM.init({
       entities: [Test],
       dbName: 'mikro_orm_test_2489',
-      driver: PostgreSqlDriver,
       cache: { enabled: true },
     });
     await orm.schema.refreshDatabase();

--- a/tests/issues/GH2583.test.ts
+++ b/tests/issues/GH2583.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, Enum } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, MikroORM, PrimaryKey, Enum } from '@mikro-orm/postgresql';
 
 export enum WithEnumArrayValue {
   First = 'first',
@@ -19,13 +18,12 @@ export class WithEnumArray {
 }
 
 describe('enum array with native PG enums (GH issue 2583)', () => {
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
-    orm = await MikroORM.init<PostgreSqlDriver>({
+    orm = await MikroORM.init({
       entities: [WithEnumArray],
       dbName: 'mikro_orm_test_2583',
-      driver: PostgreSqlDriver,
     });
     await orm.schema.dropDatabase('mikro_orm_test_2583');
     await orm.schema.createDatabase('mikro_orm_test_2583');

--- a/tests/issues/GH2647.test.ts
+++ b/tests/issues/GH2647.test.ts
@@ -1,6 +1,4 @@
-import { Entity, EntityRepositoryType, ManyToOne, MikroORM, PrimaryKey } from '@mikro-orm/core';
-import { EntityRepository } from '@mikro-orm/knex';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, EntityRepository, EntityRepositoryType, ManyToOne, MikroORM, PrimaryKey } from '@mikro-orm/sqlite';
 
 class ProviderRepository extends EntityRepository<Provider> {}
 class UserRepository extends EntityRepository<User> {}
@@ -107,7 +105,6 @@ describe('GH #2647, #2742', () => {
     orm = await MikroORM.init({
       entities: [Provider, User, Member, Session, Participant],
       dbName: `:memory:`,
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH2648.test.ts
+++ b/tests/issues/GH2648.test.ts
@@ -1,5 +1,4 @@
-import { Entity, IdentifiedReference, JsonType, ManyToOne, MikroORM, OneToOne, PrimaryKey, PrimaryKeyType, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, IdentifiedReference, JsonType, ManyToOne, MikroORM, OneToOne, PrimaryKey, PrimaryKeyType, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 export class A {
@@ -89,13 +88,12 @@ export class D {
 
 describe('GH issue 2648', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B1, B2, B3, B4, C, D],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH2663.test.ts
+++ b/tests/issues/GH2663.test.ts
@@ -1,5 +1,4 @@
-import { Embeddable, Embedded, Entity, LoadStrategy, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Embeddable, Embedded, Entity, LoadStrategy, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Embeddable()
 export class Z {
@@ -33,13 +32,12 @@ export class B {
 
 describe('GH issue 2663', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B, Z],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH2675.test.ts
+++ b/tests/issues/GH2675.test.ts
@@ -1,5 +1,4 @@
-import { Entity, LoadStrategy, ManyToOne, MikroORM, PrimaryKey, wrap } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, LoadStrategy, ManyToOne, MikroORM, PrimaryKey, wrap } from '@mikro-orm/postgresql';
 
 @Entity()
 export class A {
@@ -22,13 +21,12 @@ export class B {
 
 describe('GH issue 2675', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: 'mikro_orm_test_gh_2675',
-      driver: PostgreSqlDriver,
     });
     await orm.schema.ensureDatabase();
 

--- a/tests/issues/GH2679.test.ts
+++ b/tests/issues/GH2679.test.ts
@@ -1,5 +1,4 @@
-import { ArrayType, Entity, LoadStrategy, ManyToOne, MikroORM, PrimaryKey, Property, wrap } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { ArrayType, Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/postgresql';
 
 @Entity()
 export class User {
@@ -14,13 +13,12 @@ export class User {
 
 describe('GH issue 2679', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [User],
       dbName: 'mikro_orm_test_gh_2679',
-      driver: PostgreSqlDriver,
     });
 
     await orm.schema.refreshDatabase();

--- a/tests/issues/GH268.test.ts
+++ b/tests/issues/GH268.test.ts
@@ -1,6 +1,5 @@
 import { v4 } from 'uuid';
-import { Collection, Entity, ManyToMany, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToMany, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 export class A {
@@ -32,13 +31,12 @@ export class B {
 
 describe('GH issue 268', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.dropSchema();
     await orm.schema.createSchema();

--- a/tests/issues/GH269.test.ts
+++ b/tests/issues/GH269.test.ts
@@ -1,5 +1,4 @@
-import { Entity, IdentifiedReference, MikroORM, OneToOne, PrimaryKey, Property, wrap, Reference } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, IdentifiedReference, MikroORM, OneToOne, PrimaryKey, Property, wrap, Reference } from '@mikro-orm/sqlite';
 
 @Entity()
 export class A {
@@ -31,13 +30,12 @@ export class B {
 
 describe('GH issue 269', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: ':memory:',
-      driver: SqliteDriver,
       autoJoinOneToOneOwner: false,
     });
     await orm.schema.dropSchema();

--- a/tests/issues/GH2703.test.ts
+++ b/tests/issues/GH2703.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -26,13 +25,12 @@ export class Order {
 
 describe('GH issue 2703', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [User, Order],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH2729.test.ts
+++ b/tests/issues/GH2729.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToOne, OneToMany, PrimaryKey, Property, MikroORM } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToOne, OneToMany, PrimaryKey, Property, MikroORM } from '@mikro-orm/sqlite';
 
 @Entity({
   tableName: 'person',
@@ -39,7 +38,6 @@ describe('GH #2729', () => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      driver: SqliteDriver,
       dbName: ':memory:',
       entities: [PersonEntity, TaskEntity],
     });

--- a/tests/issues/GH2760.test.ts
+++ b/tests/issues/GH2760.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 export class User {
@@ -30,7 +29,6 @@ describe('GH issue 2760', () => {
     orm = await MikroORM.init({
       entities: [User],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH2774.test.ts
+++ b/tests/issues/GH2774.test.ts
@@ -1,5 +1,4 @@
-import { Embeddable, Embedded, Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Embeddable, Embedded, Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Embeddable()
 export class Nested {
@@ -39,7 +38,6 @@ describe('GH issue 2774', () => {
     orm = await MikroORM.init({
       entities: [User, Name, Nested],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH2777.test.ts
+++ b/tests/issues/GH2777.test.ts
@@ -1,5 +1,4 @@
-import { Entity, LoadStrategy, ManyToOne, MikroORM, OneToOne, PrimaryKey, Property, wrap } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, LoadStrategy, ManyToOne, MikroORM, OneToOne, PrimaryKey, Property, wrap } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Image {
@@ -72,7 +71,6 @@ describe('GH issue 2777', () => {
     orm = await MikroORM.init({
       entities: [Customer, Comment, Product, Image],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH2781.test.ts
+++ b/tests/issues/GH2781.test.ts
@@ -1,5 +1,4 @@
-import { Entity, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/postgresql';
 
 @Entity()
 export class Address {
@@ -54,7 +53,6 @@ describe('GH issue 2781', () => {
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Address, Customer],
-      driver: PostgreSqlDriver,
       dbName: 'mikro_orm_test_2781',
     });
     await orm.schema.refreshDatabase();

--- a/tests/issues/GH2784.test.ts
+++ b/tests/issues/GH2784.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/postgresql';
 
 @Entity()
 export class Address {
@@ -39,7 +38,6 @@ describe('GH issue 2784', () => {
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Address],
-      driver: PostgreSqlDriver,
       dbName: 'mikro_orm_test_2781',
     });
     await orm.schema.refreshDatabase();

--- a/tests/issues/GH2803.test.ts
+++ b/tests/issues/GH2803.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -33,11 +32,10 @@ export class Tag {
 
 describe('GH issue 2803', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      driver: SqliteDriver,
       dbName: ':memory:',
       entities: [Book, Tag],
     });

--- a/tests/issues/GH2806.test.ts
+++ b/tests/issues/GH2806.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, OneToOne, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 export class A {
@@ -37,7 +36,6 @@ describe('GH issue 2806', () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.refreshDatabase();
   });

--- a/tests/issues/GH2810.test.ts
+++ b/tests/issues/GH2810.test.ts
@@ -1,5 +1,4 @@
-import { Cascade, Collection, Entity, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, PrimaryKeyType } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Cascade, Collection, Entity, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, PrimaryKeyType } from '@mikro-orm/sqlite';
 
 @Entity()
 export class NodeEntity {
@@ -45,7 +44,6 @@ describe('GH issue 2810', () => {
     orm = await MikroORM.init({
       entities: [ElementEntity, DependentEntity, NodeEntity],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH2815.test.ts
+++ b/tests/issues/GH2815.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, OneToOne, PrimaryKey } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, OneToOne, PrimaryKey } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Position {
@@ -47,11 +46,10 @@ export class Leg2 {
 
 describe('GH issue 2815', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      driver: SqliteDriver,
       dbName: ':memory:',
       entities: [Position, Leg, Position2, Leg2],
     });

--- a/tests/issues/GH2821.test.ts
+++ b/tests/issues/GH2821.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, OneToOne, PrimaryKey } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, OneToOne, PrimaryKey } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Position {
@@ -31,11 +30,10 @@ export class Leg {
 
 describe('GH issue 2821', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      driver: SqliteDriver,
       dbName: ':memory:',
       entities: [Position, Leg],
     });

--- a/tests/issues/GH2829.test.ts
+++ b/tests/issues/GH2829.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, Property, wrap } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Author {
@@ -37,13 +36,12 @@ export class Book {
 
 describe('GH issue 2829', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Author, Book],
       dbName: ':memory:',
-      driver: SqliteDriver,
       connect: false,
     });
   });

--- a/tests/issues/GH2882.test.ts
+++ b/tests/issues/GH2882.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, wrap } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, wrap } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Parent {
@@ -25,11 +24,10 @@ export default class Child {
 
 describe('GH issue 2882', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      driver: SqliteDriver,
       dbName: ':memory:',
       entities: [Parent, Child],
     });

--- a/tests/issues/GH2886.test.ts
+++ b/tests/issues/GH2886.test.ts
@@ -1,5 +1,4 @@
-import { Entity, ManyToOne, OneToMany, Collection, MikroORM, PrimaryKey } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, OneToMany, Collection, MikroORM, PrimaryKey } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Provider {
@@ -84,7 +83,6 @@ describe('GH #2886', () => {
     orm = await MikroORM.init({
       entities: [Provider, User, Member, Session, Participant],
       dbName: `:memory:`,
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH2973.test.ts
+++ b/tests/issues/GH2973.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { BetterSqliteDriver } from '@mikro-orm/better-sqlite';
+import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/better-sqlite';
 
 @Entity()
 class Author {
@@ -18,7 +17,6 @@ beforeAll(async () => {
   orm = await MikroORM.init({
     entities: [Author],
     dbName: ':memory:',
-    driver: BetterSqliteDriver,
   });
   await orm.schema.createSchema();
 });

--- a/tests/issues/GH2974.test.ts
+++ b/tests/issues/GH2974.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, wrap } from '@mikro-orm/core';
-import { BetterSqliteDriver } from '@mikro-orm/better-sqlite';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, wrap } from '@mikro-orm/better-sqlite';
 
 @Entity()
 export class SomeMany {
@@ -35,7 +34,6 @@ beforeAll(async () => {
   orm = await MikroORM.init({
     entities: [Test, SomeMany],
     dbName: ':memory:',
-    driver: BetterSqliteDriver,
   });
   await orm.schema.createSchema();
 });

--- a/tests/issues/GH2990.test.ts
+++ b/tests/issues/GH2990.test.ts
@@ -1,5 +1,4 @@
-import { Entity, EntityLoader, ManyToOne, MikroORM, PrimaryKey } from '@mikro-orm/core';
-import { BetterSqliteDriver } from '@mikro-orm/better-sqlite';
+import { Entity, EntityLoader, ManyToOne, MikroORM, PrimaryKey } from '@mikro-orm/better-sqlite';
 
 @Entity()
 export class Provider {
@@ -68,7 +67,6 @@ describe('GH issue 2990', () => {
     orm = await MikroORM.init({
       entities: [Provider, User, Member, Session],
       dbName: `:memory:`,
-      driver: BetterSqliteDriver,
     });
   });
 

--- a/tests/issues/GH3005.test.ts
+++ b/tests/issues/GH3005.test.ts
@@ -1,6 +1,5 @@
-import type { EventSubscriber, FlushEventArgs } from '@mikro-orm/core';
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, Subscriber, wrap } from '@mikro-orm/core';
-import { BetterSqliteDriver } from '@mikro-orm/better-sqlite';
+import type { EventSubscriber, FlushEventArgs } from '@mikro-orm/better-sqlite';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, Subscriber, wrap } from '@mikro-orm/better-sqlite';
 
 @Entity({ tableName: 'customers' })
 class Customer {
@@ -49,13 +48,12 @@ class OrdersSubscriber implements EventSubscriber<Order> {
 
 }
 
-let orm: MikroORM<BetterSqliteDriver>;
+let orm: MikroORM;
 
 beforeAll(async () => {
   orm = await MikroORM.init({
     entities: [Order, Customer],
     dbName: ':memory:',
-    driver: BetterSqliteDriver,
   });
   await orm.schema.refreshDatabase();
 });

--- a/tests/issues/GH302.test.ts
+++ b/tests/issues/GH302.test.ts
@@ -1,5 +1,4 @@
-import { Entity, Ref, MikroORM, PrimaryKey, Property, Reference, ManyToOne, OneToMany, Collection } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, Ref, MikroORM, PrimaryKey, Property, Reference, ManyToOne, OneToMany, Collection } from '@mikro-orm/sqlite';
 
 @Entity()
 export class A {
@@ -36,13 +35,12 @@ export class B {
 
 describe('GH issue 302', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.dropSchema();
     await orm.schema.createSchema();

--- a/tests/issues/GH3026.test.ts
+++ b/tests/issues/GH3026.test.ts
@@ -1,6 +1,5 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, wrap } from '@mikro-orm/core';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, wrap } from '@mikro-orm/better-sqlite';
 import { mockLogger } from '../helpers';
-import { BetterSqliteDriver } from '@mikro-orm/better-sqlite';
 
 @Entity()
 export class Ingredient {
@@ -53,7 +52,6 @@ beforeAll(async () => {
   orm = await MikroORM.init({
     entities: [Ingredient, Recipe, RecipeIngredient],
     dbName: ':memory:',
-    driver: BetterSqliteDriver,
   });
   await orm.schema.createSchema();
 });

--- a/tests/issues/GH3053.test.ts
+++ b/tests/issues/GH3053.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, Enum, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, Enum, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 class Book {
@@ -30,13 +29,12 @@ class Author {
   book!: Book;
 
 }
-let orm: MikroORM<SqliteDriver>;
+let orm: MikroORM;
 
 beforeAll(async () => {
   orm = await MikroORM.init({
     entities: [Author, Book],
     dbName: ':memory:',
-    driver: SqliteDriver,
   });
   await orm.schema.createSchema();
 });

--- a/tests/issues/GH3054.test.ts
+++ b/tests/issues/GH3054.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 class User {
@@ -12,13 +11,12 @@ class User {
 
 }
 
-let orm: MikroORM<SqliteDriver>;
+let orm: MikroORM;
 
 beforeAll(async () => {
   orm = await MikroORM.init({
     entities: [User],
     dbName: ':memory:',
-    driver: SqliteDriver,
   });
   await orm.schema.createSchema();
 });

--- a/tests/issues/GH3221.test.ts
+++ b/tests/issues/GH3221.test.ts
@@ -1,6 +1,5 @@
 import 'reflect-metadata';
-import { Entity, MikroORM, PrimaryKey, Property, wrap } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 interface BookData {
   title: string;
@@ -20,7 +19,6 @@ class Book {
 test(`GH issue 3221`, async () => {
   const orm = await MikroORM.init({
     entities: [Book],
-    driver: SqliteDriver,
     dbName: ':memory:',
   });
 

--- a/tests/issues/GH3240.test.ts
+++ b/tests/issues/GH3240.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToMany, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToMany, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 type SquadType = 'GROUND' | 'AIR';
 
@@ -40,13 +39,12 @@ export class Squad {
 
 }
 
-let orm: MikroORM<SqliteDriver>;
+let orm: MikroORM;
 
 beforeAll(async () => {
   orm = await MikroORM.init({
     entities: [Soldier, Squad],
     dbName: ':memory:',
-    driver: SqliteDriver,
   });
   await orm.schema.createSchema();
 });

--- a/tests/issues/GH3269.test.ts
+++ b/tests/issues/GH3269.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, Property, ManyToOne, PrimaryKeyType } from '@mikro-orm/core';
-import { BetterSqliteDriver } from '@mikro-orm/better-sqlite';
+import { Entity, MikroORM, PrimaryKey, Property, ManyToOne, PrimaryKeyType } from '@mikro-orm/better-sqlite';
 
 @Entity()
 class Main {
@@ -51,7 +50,6 @@ let orm: MikroORM;
 
 beforeAll(async () => {
   orm = await MikroORM.init({
-    driver: BetterSqliteDriver,
     dbName: ':memory:',
     entities: [LogEntry],
   });

--- a/tests/issues/GH3271.test.ts
+++ b/tests/issues/GH3271.test.ts
@@ -1,5 +1,4 @@
-import type { MikroORM } from '@mikro-orm/core';
-import { wrap } from '@mikro-orm/core';
+import { MikroORM, wrap } from '@mikro-orm/postgresql';
 import { mockLogger } from '../helpers';
 import { initORMPostgreSql } from '../bootstrap';
 import { Author2, Book2 } from '../entities-sql';

--- a/tests/issues/GH3287.test.ts
+++ b/tests/issues/GH3287.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, LoadStrategy, ManyToMany, MikroORM, PrimaryKey } from '@mikro-orm/core';
-import { BetterSqliteDriver } from '@mikro-orm/better-sqlite';
+import { Collection, Entity, LoadStrategy, ManyToMany, MikroORM, PrimaryKey } from '@mikro-orm/better-sqlite';
 
 @Entity()
 export class Group {
@@ -35,7 +34,6 @@ beforeAll(async () => {
   orm = await MikroORM.init({
     entities: [Participant],
     dbName: ':memory:',
-    driver: BetterSqliteDriver,
   });
   await orm.schema.createSchema();
 });

--- a/tests/issues/GH3292.test.ts
+++ b/tests/issues/GH3292.test.ts
@@ -1,4 +1,4 @@
-import type { MikroORM } from '@mikro-orm/core';
+import type { MikroORM } from '@mikro-orm/postgresql';
 import { initORMPostgreSql } from '../bootstrap';
 import { Author2, Book2 } from '../entities-sql';
 

--- a/tests/issues/GH3301.test.ts
+++ b/tests/issues/GH3301.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, OneToMany, ManyToOne, MikroORM, PrimaryKey } from '@mikro-orm/core';
-import { BetterSqliteDriver } from '@mikro-orm/better-sqlite';
+import { Collection, Entity, OneToMany, ManyToOne, MikroORM, PrimaryKey } from '@mikro-orm/better-sqlite';
 
 @Entity()
 export class Collector {
@@ -43,17 +42,12 @@ export class Collect {
 
 }
 
-let orm: MikroORM<BetterSqliteDriver>;
+let orm: MikroORM;
 
 beforeAll(async () => {
   orm = await MikroORM.init({
-    entities: [
-      Collect,
-      Collector,
-      Collectable,
-    ],
+    entities: [Collect, Collector, Collectable],
     dbName: ':memory:',
-    driver: BetterSqliteDriver,
   });
   await orm.schema.createSchema();
 });

--- a/tests/issues/GH3339.test.ts
+++ b/tests/issues/GH3339.test.ts
@@ -1,6 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/postgresql';
 
 
 @Entity({
@@ -49,7 +47,6 @@ describe('GH issue 3339', () => {
   beforeAll(async () => {
     orm = await MikroORM.init({
       dbName: `mikro_orm_test_gh_3339`,
-      driver: PostgreSqlDriver,
       schema: 'gh3339',
       entities: [ Customer1 ],
     });

--- a/tests/issues/GH3345.test.ts
+++ b/tests/issues/GH3345.test.ts
@@ -1,6 +1,5 @@
-import type { EventSubscriber, FlushEventArgs } from '@mikro-orm/core';
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, Subscriber } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import type { EventSubscriber, FlushEventArgs } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, Subscriber } from '@mikro-orm/sqlite';
 
 @Entity({ tableName: 'customers' })
 class Customer {
@@ -49,13 +48,12 @@ class OrdersSubscriber implements EventSubscriber<Order> {
 
 }
 
-let orm: MikroORM<SqliteDriver>;
+let orm: MikroORM;
 
 beforeAll(async () => {
   orm = await MikroORM.init({
     entities: [Customer],
     dbName: ':memory:',
-    driver: SqliteDriver,
   });
   await orm.schema.createSchema();
 });

--- a/tests/issues/GH3354.test.ts
+++ b/tests/issues/GH3354.test.ts
@@ -1,5 +1,4 @@
-import { BaseEntity, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { BaseEntity, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Group extends BaseEntity<Group, 'id'> {
@@ -18,13 +17,12 @@ export class Group extends BaseEntity<Group, 'id'> {
 
 }
 
-let orm: MikroORM<SqliteDriver>;
+let orm: MikroORM;
 
 beforeAll(async () => {
   orm = await MikroORM.init({
     entities: [Group],
     dbName: ':memory:',
-    driver: SqliteDriver,
   });
   await orm.schema.createSchema();
 });

--- a/tests/issues/GH3360.test.ts
+++ b/tests/issues/GH3360.test.ts
@@ -1,6 +1,5 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/better-sqlite';
 import { mockLogger } from '../helpers';
-import { BetterSqliteDriver } from '@mikro-orm/better-sqlite';
 
 @Entity()
 export class Author {
@@ -50,11 +49,10 @@ async function createEntities(orm: MikroORM) {
   orm.em.clear();
 }
 
-let orm: MikroORM<BetterSqliteDriver>;
+let orm: MikroORM;
 
 beforeAll(async () => {
   orm = await MikroORM.init({
-    driver: BetterSqliteDriver,
     dbName: ':memory:',
     entities: [Book],
   });

--- a/tests/issues/GH3429.test.ts
+++ b/tests/issues/GH3429.test.ts
@@ -1,5 +1,4 @@
-import { SqliteDriver } from '@mikro-orm/sqlite';
-import { MikroORM, Embeddable, Embedded, Entity, PrimaryKey, Property } from '@mikro-orm/core';
+import { MikroORM, Embeddable, Embedded, Entity, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Embeddable()
 class Address {
@@ -34,11 +33,10 @@ export class Organization {
 
 }
 
-let orm: MikroORM<SqliteDriver>;
+let orm: MikroORM;
 
 beforeAll(async () => {
   orm = await MikroORM.init({
-    driver: SqliteDriver,
     dbName: ':memory:',
     entities: [Organization],
   });

--- a/tests/issues/GH3440.test.ts
+++ b/tests/issues/GH3440.test.ts
@@ -1,5 +1,4 @@
-import { Entity, PrimaryKey, Property, Type, ValidationError } from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/mysql';
+import { MikroORM, Entity, PrimaryKey, Property, Type, ValidationError } from '@mikro-orm/mysql';
 import { mockLogger } from '../helpers';
 
 export function toBinaryUuid(uuid: string): Buffer {

--- a/tests/issues/GH349.test.ts
+++ b/tests/issues/GH349.test.ts
@@ -1,6 +1,5 @@
-import { Entity, PrimaryKey, Property, SerializedPrimaryKey } from '@mikro-orm/core';
+import { Entity, MikroORM, PrimaryKey, Property, SerializedPrimaryKey } from '@mikro-orm/mongodb';
 import { Decimal128, ObjectId } from 'bson';
-import { MikroORM } from '@mikro-orm/mongodb';
 
 @Entity()
 class A {

--- a/tests/issues/GH3490.test.ts
+++ b/tests/issues/GH3490.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Contract {
@@ -29,13 +28,12 @@ export class Customer {
 
 }
 
-let orm: MikroORM<SqliteDriver>;
+let orm: MikroORM;
 
 beforeAll(async () => {
   orm = await MikroORM.init({
     entities: [Contract, Customer],
     dbName: ':memory:',
-    driver: SqliteDriver,
   });
   await orm.schema.createSchema();
 });

--- a/tests/issues/GH3540.test.ts
+++ b/tests/issues/GH3540.test.ts
@@ -1,5 +1,4 @@
-import { ArrayType, Entity, PrimaryKey, Property, SimpleLogger } from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/mysql';
+import { MikroORM, ArrayType, Entity, PrimaryKey, Property, SimpleLogger } from '@mikro-orm/mysql';
 import { mockLogger } from '../helpers';
 
 @Entity()

--- a/tests/issues/GH3543.test.ts
+++ b/tests/issues/GH3543.test.ts
@@ -7,8 +7,8 @@ import {
   OptionalProps,
   PrimaryKey,
   Property,
-} from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/postgresql';
+  MikroORM,
+} from '@mikro-orm/postgresql';
 import { v4 } from 'uuid';
 
 @Entity()

--- a/tests/issues/GH3548.test.ts
+++ b/tests/issues/GH3548.test.ts
@@ -1,5 +1,4 @@
-import { Entity, PrimaryKey, Property, OneToOne } from '@mikro-orm/core';
-import { MikroORM, ObjectId } from '@mikro-orm/mongodb';
+import { MikroORM, ObjectId, Entity, PrimaryKey, Property, OneToOne } from '@mikro-orm/mongodb';
 
 @Entity()
 export class Author {

--- a/tests/issues/GH3564.test.ts
+++ b/tests/issues/GH3564.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, IdentifiedReference, ManyToOne, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
-import { MikroORM, SqliteDriver } from '@mikro-orm/sqlite';
+import { MikroORM, Collection, Entity, IdentifiedReference, ManyToOne, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 class Part {
@@ -53,7 +52,6 @@ beforeAll(async () => {
   orm = await MikroORM.init({
     entities: [Car, Part],
     dbName: ':memory:',
-    driver: SqliteDriver,
   });
   await orm.getSchemaGenerator().createSchema();
 });

--- a/tests/issues/GH3576.test.ts
+++ b/tests/issues/GH3576.test.ts
@@ -1,6 +1,5 @@
-import { Entity, LoadStrategy, OneToOne, PrimaryKey, Property, SimpleLogger } from '@mikro-orm/core';
+import { MikroORM, Entity, LoadStrategy, OneToOne, PrimaryKey, Property, SimpleLogger } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
-import { MikroORM } from '@mikro-orm/sqlite';
 
 @Entity()
 class User {

--- a/tests/issues/GH3603.test.ts
+++ b/tests/issues/GH3603.test.ts
@@ -1,5 +1,4 @@
-import { EntitySchema } from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/sqlite';
+import { MikroORM, EntitySchema } from '@mikro-orm/sqlite';
 
 interface MyEntity {
   _id: number;

--- a/tests/issues/GH3614.test.ts
+++ b/tests/issues/GH3614.test.ts
@@ -1,5 +1,4 @@
-import { Entity, Ref, OneToOne, PrimaryKey, Property, wrap } from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, Ref, OneToOne, PrimaryKey, Property, wrap } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 @Entity()

--- a/tests/issues/GH3666.test.ts
+++ b/tests/issues/GH3666.test.ts
@@ -1,5 +1,4 @@
-import { Entity, PrimaryKey, ManyToOne, Collection, OneToMany } from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/sqlite';
+import { MikroORM, Entity, PrimaryKey, ManyToOne, Collection, OneToMany } from '@mikro-orm/sqlite';
 
 @Entity()
 class Competition {

--- a/tests/issues/GH3669.test.ts
+++ b/tests/issues/GH3669.test.ts
@@ -1,5 +1,4 @@
-import { Entity, ManyToOne, OneToOne, PrimaryKey, PrimaryKeyType, Property, Rel, SimpleLogger } from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/postgresql';
+import { Entity, MikroORM, ManyToOne, OneToOne, PrimaryKey, PrimaryKeyType, Property, Rel, SimpleLogger } from '@mikro-orm/postgresql';
 import { mockLogger } from '../helpers';
 
 @Entity()

--- a/tests/issues/GH369.test.ts
+++ b/tests/issues/GH369.test.ts
@@ -1,5 +1,4 @@
-import { Entity, ManyToOne, OneToMany, PrimaryKey, Property, Collection, MikroORM } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, OneToMany, PrimaryKey, Property, Collection, MikroORM } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -29,13 +28,12 @@ class B {
 
 describe('GH issue 369', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH3694.test.ts
+++ b/tests/issues/GH3694.test.ts
@@ -1,5 +1,4 @@
-import { Entity, PrimaryKey, Ref, OneToMany, Collection, ManyToOne, Enum, wrap, compareArrays } from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Ref, OneToMany, Collection, ManyToOne, Enum, wrap, MikroORM } from '@mikro-orm/sqlite';
 
 enum Enum1 {
   A = 'A',

--- a/tests/issues/GH3696.test.ts
+++ b/tests/issues/GH3696.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, Index, ManyToMany, PrimaryKey, Property, Unique } from '@mikro-orm/core';
-import { FullTextType, MikroORM } from '@mikro-orm/postgresql';
+import { FullTextType, MikroORM, Collection, Entity, Index, ManyToMany, PrimaryKey, Property, Unique } from '@mikro-orm/postgresql';
 
 @Entity()
 @Unique({ properties: ['name'] })

--- a/tests/issues/GH3737.test.ts
+++ b/tests/issues/GH3737.test.ts
@@ -9,8 +9,7 @@ import {
   OneToMany,
   PrimaryKey,
   Property,
-} from '@mikro-orm/core';
-import { BetterSqliteDriver } from '@mikro-orm/better-sqlite';
+} from '@mikro-orm/better-sqlite';
 
 @Entity()
 class Project {
@@ -94,7 +93,6 @@ let orm: MikroORM;
 beforeAll(async () => {
   orm = await MikroORM.init({
     entities: [Project, User],
-    driver: BetterSqliteDriver,
     dbName: ':memory:',
     subscribers: [new ProjectUsersSubscriber()],
   });

--- a/tests/issues/GH3738.test.ts
+++ b/tests/issues/GH3738.test.ts
@@ -2,12 +2,13 @@ import {
   Collection,
   Entity,
   LoadStrategy,
+  MikroORM,
   ManyToOne,
-  OneToMany, OptionalProps,
+  OneToMany,
+  OptionalProps,
   PrimaryKey,
   Property,
-} from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/sqlite';
+} from '@mikro-orm/sqlite';
 import { randomUUID } from 'crypto';
 
 @Entity()

--- a/tests/issues/GH3739.test.ts
+++ b/tests/issues/GH3739.test.ts
@@ -1,5 +1,4 @@
-import { Entity, PrimaryKey, Property, t } from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/mysql';
+import { Entity, MikroORM, PrimaryKey, Property, t } from '@mikro-orm/mysql';
 
 @Entity()
 export class Asset1 {

--- a/tests/issues/GH380.test.ts
+++ b/tests/issues/GH380.test.ts
@@ -1,5 +1,4 @@
-import { Entity, PrimaryKey, Property, MikroORM } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, PrimaryKey, Property, MikroORM } from '@mikro-orm/postgresql';
 
 @Entity()
 class A {
@@ -17,13 +16,12 @@ class A {
 
 describe('GH issue 380', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A],
       dbName: `mikro_orm_test_gh_380`,
-      driver: PostgreSqlDriver,
     });
     await orm.schema.ensureDatabase();
     await orm.schema.dropSchema();

--- a/tests/issues/GH3810.test.ts
+++ b/tests/issues/GH3810.test.ts
@@ -1,5 +1,4 @@
-import { Entity, OptionalProps, PrimaryKey, Property, SimpleLogger } from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/postgresql';
+import { MikroORM, Entity, OptionalProps, PrimaryKey, Property, SimpleLogger } from '@mikro-orm/postgresql';
 import { mockLogger } from '../helpers';
 
 @Entity()

--- a/tests/issues/GH435.test.ts
+++ b/tests/issues/GH435.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, Property, Type } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, PrimaryKey, Property, Type } from '@mikro-orm/sqlite';
 
 class MyType extends Type<string, number> {
 
@@ -30,13 +29,12 @@ class A {
 
 describe('GH issue 435', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.ensureDatabase();
     await orm.schema.dropSchema();

--- a/tests/issues/GH450.test.ts
+++ b/tests/issues/GH450.test.ts
@@ -1,6 +1,5 @@
 import 'reflect-metadata';
-import { Collection, Entity, ManyToMany, ManyToOne, MikroORM, PrimaryKey, Property, wrap } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Collection, Entity, ManyToMany, ManyToOne, MikroORM, PrimaryKey, Property, wrap } from '@mikro-orm/postgresql';
 
 @Entity({ tableName: 'auth.users' })
 class TaskAssignee {
@@ -41,13 +40,12 @@ class Task {
 
 describe('GH issue 450', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Task, TaskAssignee],
       dbName: `mikro_orm_test_gh_450`,
-      driver: PostgreSqlDriver,
       cache: { enabled: false },
     });
     await orm.schema.ensureDatabase();

--- a/tests/issues/GH459.test.ts
+++ b/tests/issues/GH459.test.ts
@@ -1,5 +1,4 @@
-import { Entity, PrimaryKey, Property, MikroORM } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property, MikroORM } from '@mikro-orm/sqlite';
 
 abstract class A {
 
@@ -32,13 +31,12 @@ class D extends C {
 
 describe('GH issue 459', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B, C, D],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.dropSchema();
     await orm.schema.createSchema();

--- a/tests/issues/GH463.test.ts
+++ b/tests/issues/GH463.test.ts
@@ -1,5 +1,4 @@
-import { Entity, PrimaryKey, Property, MikroORM, Index, Unique } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property, MikroORM, Index, Unique } from '@mikro-orm/sqlite';
 
 abstract class A {
 
@@ -26,13 +25,12 @@ class B extends A {
 
 describe('GH issue 463', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.dropSchema();
     await orm.schema.createSchema();

--- a/tests/issues/GH467.test.ts
+++ b/tests/issues/GH467.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, PrimaryKey, ManyToOne, OneToMany, MikroORM, IdentifiedReference } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, PrimaryKey, ManyToOne, OneToMany, MikroORM, IdentifiedReference } from '@mikro-orm/sqlite';
 
 @Entity()
 class A {
@@ -25,13 +24,12 @@ class B {
 
 describe('GH issue 467', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH472.test.ts
+++ b/tests/issues/GH472.test.ts
@@ -1,5 +1,4 @@
-import { Entity, PrimaryKey, Property, MikroORM, EntityCaseNamingStrategy } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, PrimaryKey, Property, MikroORM, EntityCaseNamingStrategy } from '@mikro-orm/postgresql';
 
 @Entity()
 class A {
@@ -14,13 +13,12 @@ class A {
 
 describe('GH issue 472', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A],
       dbName: 'mikro_orm_test_gh472',
-      driver: PostgreSqlDriver,
       namingStrategy: EntityCaseNamingStrategy,
     });
     await orm.schema.refreshDatabase();

--- a/tests/issues/GH482.test.ts
+++ b/tests/issues/GH482.test.ts
@@ -1,6 +1,5 @@
-import { Entity, PrimaryKey, BigIntType, OneToMany, Collection, Enum, ManyToOne, Property } from '@mikro-orm/core';
+import { Entity, MikroORM, PrimaryKey, BigIntType, OneToMany, Collection, Enum, ManyToOne, Property } from '@mikro-orm/postgresql';
 import { mockLogger } from '../helpers';
-import { MikroORM } from '@mikro-orm/postgresql';
 
 export enum LevelType {
   A = 'a',

--- a/tests/issues/GH486.test.ts
+++ b/tests/issues/GH486.test.ts
@@ -1,5 +1,4 @@
-import { Entity, PrimaryKey, Property, OneToMany, MikroORM, Collection, ManyToOne } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, PrimaryKey, Property, OneToMany, MikroORM, Collection, ManyToOne } from '@mikro-orm/postgresql';
 
 @Entity()
 class A {
@@ -28,13 +27,12 @@ class B {
 
 describe('GH issue 486', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: `mikro_orm_test_gh_486`,
-      driver: PostgreSqlDriver,
     });
     await orm.schema.refreshDatabase();
   });

--- a/tests/issues/GH493.test.ts
+++ b/tests/issues/GH493.test.ts
@@ -1,5 +1,4 @@
-import { BeforeDelete, BeforeUpdate, Entity, MikroORM, PrimaryKey, Property, wrap } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { BeforeDelete, BeforeUpdate, Entity, MikroORM, PrimaryKey, Property, wrap } from '@mikro-orm/sqlite';
 
 @Entity()
 export class A {
@@ -24,13 +23,12 @@ export class A {
 
 describe('GH issue 493', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.dropSchema();
     await orm.schema.createSchema();

--- a/tests/issues/GH519.test.ts
+++ b/tests/issues/GH519.test.ts
@@ -1,5 +1,4 @@
-import { Entity, PrimaryKey, MikroORM, ManyToOne, Collection, OneToMany } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, PrimaryKey, MikroORM, ManyToOne, Collection, OneToMany } from '@mikro-orm/postgresql';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -42,13 +41,12 @@ class Registration {
 
 describe('GH issue 519', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Competition, User, Registration],
       dbName: `mikro_orm_test_gh_519`,
-      driver: PostgreSqlDriver,
     });
     await orm.schema.refreshDatabase();
   });

--- a/tests/issues/GH529.test.ts
+++ b/tests/issues/GH529.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyType, Property } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyType, Property } from '@mikro-orm/postgresql';
 
 @Entity()
 export class Customer {
@@ -83,13 +82,12 @@ export class OrderItem {
 
 describe('GH issue 529', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Customer, Order, OrderItem, Product],
       dbName: `mikro_orm_test_gh_529`,
-      driver: PostgreSqlDriver,
     });
     await orm.schema.refreshDatabase();
   });

--- a/tests/issues/GH533.test.ts
+++ b/tests/issues/GH533.test.ts
@@ -1,5 +1,4 @@
-import { Entity, PrimaryKey, Property, MikroORM, wrap, ManyToOne } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, PrimaryKey, Property, MikroORM, wrap, ManyToOne } from '@mikro-orm/postgresql';
 
 @Entity()
 class A {
@@ -44,13 +43,12 @@ class C {
 
 describe('GH issue 533', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B, C],
       dbName: `mikro_orm_test_gh_533`,
-      driver: PostgreSqlDriver,
     });
     await orm.schema.refreshDatabase();
   });

--- a/tests/issues/GH535.test.ts
+++ b/tests/issues/GH535.test.ts
@@ -1,5 +1,4 @@
-import { Entity, PrimaryKey, Property, MikroORM, wrap, IdentifiedReference, OneToOne } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, PrimaryKey, Property, MikroORM, wrap, IdentifiedReference, OneToOne } from '@mikro-orm/postgresql';
 
 @Entity()
 class A {
@@ -38,13 +37,12 @@ class B {
 
 describe('GH issue 535', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: `mikro_orm_test_gh_535`,
-      driver: PostgreSqlDriver,
     });
     await orm.schema.refreshDatabase();
   });

--- a/tests/issues/GH557.test.ts
+++ b/tests/issues/GH557.test.ts
@@ -1,5 +1,4 @@
-import { MikroORM, Entity, ManyToOne, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { MikroORM, Entity, ManyToOne, OneToOne, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Rate {
@@ -44,13 +43,12 @@ export class Application {
 
 describe('GH issue 557', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Application, Rate],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.dropSchema();
     await orm.schema.createSchema();

--- a/tests/issues/GH560.test.ts
+++ b/tests/issues/GH560.test.ts
@@ -1,5 +1,4 @@
-import { EntitySchema, MikroORM } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { EntitySchema, MikroORM } from '@mikro-orm/postgresql';
 import { v4 } from 'uuid';
 
 class Base {
@@ -46,13 +45,12 @@ const ASchema = new EntitySchema<A, Base>({
 
 describe('GH issue 560', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [ASchema, BaseSchema],
       dbName: `mikro_orm_test_gh_560`,
-      driver: PostgreSqlDriver,
       cache: { enabled: false },
     });
     await orm.schema.refreshDatabase();

--- a/tests/issues/GH572.test.ts
+++ b/tests/issues/GH572.test.ts
@@ -1,6 +1,5 @@
-import { Entity, IdentifiedReference, MikroORM, OneToOne, PrimaryKey, Property, QueryOrder } from '@mikro-orm/core';
+import { Entity, IdentifiedReference, MikroORM, OneToOne, PrimaryKey, Property, QueryOrder } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
-import { SqliteDriver } from '@mikro-orm/sqlite';
 
 @Entity()
 export class A {
@@ -29,13 +28,12 @@ export class B {
 
 describe('GH issue 572', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.dropSchema();
     await orm.schema.createSchema();

--- a/tests/issues/GH589.test.ts
+++ b/tests/issues/GH589.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyType, Reference, IdentifiedReference } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyType, Reference, IdentifiedReference } from '@mikro-orm/postgresql';
 
 @Entity()
 export class User {
@@ -35,13 +34,12 @@ export class Chat {
 
 describe('GH issue 589', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [User, Chat],
       dbName: `mikro_orm_test_gh_589`,
-      driver: PostgreSqlDriver,
     });
     await orm.schema.refreshDatabase();
   });

--- a/tests/issues/GH603.test.ts
+++ b/tests/issues/GH603.test.ts
@@ -1,5 +1,4 @@
-import { Collection, EntitySchema, OptionalProps } from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/mysql';
+import { Collection, EntitySchema, MikroORM, OptionalProps } from '@mikro-orm/mysql';
 import { v4 } from 'uuid';
 
 class TaskProps {

--- a/tests/issues/GH610.test.ts
+++ b/tests/issues/GH610.test.ts
@@ -1,7 +1,5 @@
-import { Entity, PrimaryKey, ManyToOne, IdentifiedReference, Property, MikroORM, wrap, ObjectBindingPattern } from '@mikro-orm/core';
-import type { AbstractSqlDriver } from '@mikro-orm/knex';
+import { Entity, PrimaryKey, ManyToOne, IdentifiedReference, Property, MikroORM, wrap, ObjectBindingPattern } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
-import { SqliteDriver } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Test {
@@ -23,13 +21,12 @@ export class Test {
 
 describe('GH issue 610', () => {
 
-  let orm: MikroORM<AbstractSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Test],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.dropSchema();
     await orm.schema.createSchema();

--- a/tests/issues/GH755.test.ts
+++ b/tests/issues/GH755.test.ts
@@ -1,6 +1,4 @@
-import type { Options } from '@mikro-orm/core';
-import { EntitySchema, MikroORM } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { EntitySchema, MikroORM } from '@mikro-orm/sqlite';
 
 export class Test {
 
@@ -33,8 +31,7 @@ describe('GH issue 755', () => {
     const options = {
       entities: [TestSchema],
       dbName: ':memory:',
-      driver: SqliteDriver,
-    } as Options;
+    };
     const err = `Entity Test has wrong index definition: 'created_at' does not exist. You need to use property name, not column name.`;
     await expect(MikroORM.init(options)).rejects.toThrowError(err);
   });

--- a/tests/issues/GH811.test.ts
+++ b/tests/issues/GH811.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, MikroORM, OneToOne, PrimaryKey, Property } from '@mikro-orm/postgresql';
 import { v4 } from 'uuid';
 
 @Entity()
@@ -43,13 +42,12 @@ export class Employee {
 
 describe('GH issue 811', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Contact, Employee, Address],
       dbName: 'mikro_orm_test_gh811',
-      driver: PostgreSqlDriver,
     });
     await orm.schema.refreshDatabase();
   });

--- a/tests/issues/GH893.test.ts
+++ b/tests/issues/GH893.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, OneToMany, ManyToOne, Collection, BeforeCreate } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, PrimaryKey, OneToMany, ManyToOne, Collection, BeforeCreate } from '@mikro-orm/sqlite';
 import { v4 } from 'uuid';
 
 abstract class Base {
@@ -32,13 +31,12 @@ class Book extends Base {
 
 describe('GH issue 893', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Base, Book, Publisher],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH910.test.ts
+++ b/tests/issues/GH910.test.ts
@@ -1,7 +1,6 @@
-import type { Platform } from '@mikro-orm/core';
-import { Cascade, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyType, Property, Type } from '@mikro-orm/core';
+import type { Platform } from '@mikro-orm/sqlite';
+import { Cascade, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyType, Property, Type } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
-import { SqliteDriver } from '@mikro-orm/sqlite';
 
 export class Sku {
 
@@ -87,7 +86,6 @@ describe('GH issue 910', () => {
   test(`composite keys with custom type PK that uses object value`, async () => {
     const orm = await MikroORM.init({
       entities: [Cart, CartItem],
-      driver: SqliteDriver,
       dbName: ':memory:',
     });
     await orm.schema.createSchema();

--- a/tests/issues/GH915.test.ts
+++ b/tests/issues/GH915.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, OneToOne, PrimaryKey, PrimaryKeyType } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, OneToOne, PrimaryKey, PrimaryKeyType } from '@mikro-orm/sqlite';
 
 @Entity()
 export class A {
@@ -26,7 +25,6 @@ describe('GH issue 915', () => {
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B],
-      driver: SqliteDriver,
       dbName: ':memory:',
     });
     await orm.schema.createSchema();

--- a/tests/issues/GH940.test.ts
+++ b/tests/issues/GH940.test.ts
@@ -1,5 +1,4 @@
-import { BigIntType, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { BigIntType, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -34,13 +33,12 @@ class UserOrganization {
 
 describe('GH issue 940, 1117', () => {
 
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [User, UserOrganization],
       dbName: `:memory:`,
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GH949.test.ts
+++ b/tests/issues/GH949.test.ts
@@ -1,5 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, OneToMany, ManyToOne, Collection, ValidationError, ArrayCollection } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, PrimaryKey, OneToMany, ManyToOne, Collection, ValidationError, ArrayCollection } from '@mikro-orm/sqlite';
 
 @Entity()
 class A {
@@ -23,13 +22,12 @@ class B {
 
 }
 describe('GH issue 949', () => {
-  let orm: MikroORM<SqliteDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [A, B],
       dbName: ':memory:',
-      driver: SqliteDriver,
     });
     await orm.schema.createSchema();
   });

--- a/tests/issues/GHx2.test.ts
+++ b/tests/issues/GHx2.test.ts
@@ -1,5 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
-import { SqliteDriver } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 
 @Entity()
@@ -42,7 +41,6 @@ export class Book {
 test(`default value for relation property`, async () => {
   const orm = await MikroORM.init({
     entities: [Author, Book],
-    driver: SqliteDriver,
     dbName: ':memory:',
   });
   await orm.schema.refreshDatabase();


### PR DESCRIPTION
Every driver now reexport the whole `@mikro-orm/core` package. This means we no longer have to think about what package to use for imports, the driver package should be always preferred.

```diff
-import { Entity, PrimaryKey } from '@mikro-orm/core';
-import { MikroORM, EntityManager } from '@mikro-orm/mysql';
+import { Entity, PrimaryKey, MikroORM, EntityManager } from '@mikro-orm/mysql';
```