### PR TITLE
fix: respect postgresql no timestamptz precision default

### DIFF
--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -110,7 +110,7 @@ export abstract class Platform {
     return 'current_timestamp' + (length ? `(${length})` : '');
   }
 
-  getDateTimeTypeDeclarationSQL(column: { length?: number }): string {
+  getDateTimeTypeDeclarationSQL(column: { length?: number } = { length: 0 }): string {
     return 'datetime' + (column.length ? `(${column.length})` : '');
   }
 

--- a/packages/core/src/types/DateTimeType.ts
+++ b/packages/core/src/types/DateTimeType.ts
@@ -5,7 +5,7 @@ import type { EntityProperty } from '../typings';
 export class DateTimeType extends Type<Date, string> {
 
   getColumnType(prop: EntityProperty, platform: Platform): string {
-    return platform.getDateTimeTypeDeclarationSQL({ length: prop.length ?? 0 });
+    return platform.getDateTimeTypeDeclarationSQL({ length: prop.length });
   }
 
   compareAsType(): string {

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -1611,8 +1611,7 @@ describe('EntityManagerPostgre', () => {
     author.createdAt = new Date('2000-01-01T00:00:00Z');
     await orm.em.persistAndFlush(author);
     orm.em.clear();
-
-    const res = await orm.em.getConnection().execute<{ created_at: string }[]>(`select to_char(created_at, 'YYYY-MM-DD HH24:MI:SS.US') as created_at from author2 where id = ${author.id}`);
+    const res = await orm.em.getConnection().execute<{ created_at: string }[]>(`select to_char(created_at at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS.US') as created_at from author2 where id = ${author.id}`);
     expect(res[0].created_at).toBe('2000-01-01 00:00:00.000000');
     const a = await orm.em.findOneOrFail(Author2, author.id);
     expect(+a.createdAt!).toBe(+author.createdAt);

--- a/tests/features/schema-generator/__snapshots__/diffing-default-values.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/diffing-default-values.test.ts.snap
@@ -24,7 +24,7 @@ exports[`diffing default values (GH #2385) string defaults do not produce additi
 "set names 'utf8';
 set session_replication_role = 'replica';
 
-create table "foo2" ("id" serial primary key, "bar0" varchar(255) not null default 'test', "bar1" varchar(255) not null default 'test', "bar2" timestamptz(0) not null default now(), "bar3" timestamptz(6) not null default now());
+create table "foo2" ("id" serial primary key, "bar0" varchar(255) not null default 'test', "bar1" varchar(255) not null default 'test', "bar2" timestamptz not null default now(), "bar3" timestamptz(6) not null default now());
 
 set session_replication_role = 'origin';
 "

--- a/tests/issues/__snapshots__/GH529.test.ts.snap
+++ b/tests/issues/__snapshots__/GH529.test.ts.snap
@@ -6,7 +6,7 @@ set session_replication_role = 'replica';
 
 create table "customer" ("id" serial primary key);
 
-create table "order" ("id" serial primary key, "customer_id" int not null, "paid" boolean not null default false, "shipped" boolean not null default false, "created" timestamptz(0) not null);
+create table "order" ("id" serial primary key, "customer_id" int not null, "paid" boolean not null default false, "shipped" boolean not null default false, "created" timestamptz not null);
 
 create table "product" ("id" serial primary key, "name" varchar(255) not null, "current_price" int not null);
 


### PR DESCRIPTION
See details in https://github.com/mikro-orm/mikro-orm/issues/3824. This PR removes the default fallback to a precision of `0` so that for postgresql the correct type for Date (`timestamptz` with no precision) is generated, and it adds the fallback to 0 downstream in platform-specific contexts.