### PR TITLE
feat(core): allow creating entity from PK via `rel()` and `ref()`

### DIFF
--- a/docs/docs/entity-constructors.md
+++ b/docs/docs/entity-constructors.md
@@ -2,12 +2,9 @@
 title: Using Entity Constructors
 ---
 
-Internally, `MikroORM` never calls entity constructor, so you are free to use it as you wish.
-The constructor will be called only when you instantiate the class yourself via `new` operator,
-so it is a handy place to require your data when creating new entity.
+Internally, `MikroORM` never calls entity constructor on managed entities (those loaded via `EntityManager`), so you are free to use it as you wish. The constructor will be called only when you instantiate the class yourself via `new` operator (or when using `em.create()` to create new entity instance), so it is a handy place to require your data when creating new entity.
 
-For example following `Book` entity definition will always require to set `title` and `author`, 
-but `publisher` will be optional:
+For example following `Book` entity definition will always require to set `title` and `author`, but `publisher` will be optional:
 
 ```ts
 @Entity()
@@ -17,10 +14,13 @@ export class Book {
   id!: number;
 
   @Property()
-  title!: string;
+  title: string;
+
+  @Property()
+  foo!: number;
 
   @ManyToOne()
-  author!: Author;
+  author: Author;
 
   @ManyToOne()
   publisher?: Publisher;
@@ -36,9 +36,78 @@ export class Book {
 }
 ```
 
+Now you can construct your entity this way:
+
+```ts
+const author = new Author();
+const book = new Book('Foo', author);
+```
+
+The constructor parameters will be automatically detected and respected by `em.create()` too:
+
+```ts
+const author = new Author();
+const book = em.create(Book, { title: 'Foo', author, foo: 123 });
+```
+
+This will extract `title` and `author` from the data and pass it to the constructor, and assign only the rest (so here only the `foo` property) to the created entity.
+
+> Constructor parameter inference works based on the entity property names. In other words, your parameters need to be called exactly the same as entity properties.
+
+## POJO vs entity instance in constructor
+
+It might be tempting to just define your constructor with a DTO as follows:
+
+```ts
+constructor(dto: { title: string; author: number }) {
+  this.title = dto.title;
+  // fails to compile, `number` is assignable not `Author`!
+  this.author = dto.author;
+}
+```
+
+Similar (but more hidden) problem would appear if your `dto.author` was a POJO (so an object, but not an instance of the `Author` entity), as that might type check, although it won't work either. The ORM expects entity instances in relation properties, nothing else.
+
+But worry not, since v5.6 there is an easy way to convert a primary key to the entity reference, the `rel()` helper:
+
+```ts
+@ManyToOne({ entity: () => Author })
+author: Rel<Author>;
+
+constructor(dto: { title: string; author: number }) {
+  this.title = dto.title;
+  this.author = rel(Author, dto.author);
+}
+```
+
+The `rel()` helper will create entity instance that is not yet managed (as we don't pass it any `EntityManager` instance), but it will be considered as existing entity reference once it becomes managed. This is in fact an equivalent to `em.getReference()`, but without having the `EntityManager` instance at hand.
+
+> `rel()` is a shortcut for `Reference.createNakedFromPK()`.
+
+And if you want to be safer and use the `Reference` wrapper, the `ref()` helper also accepts this new signature: 
+
+```ts
+@ManyToOne({ entity: () => Author, ref: true })
+author: Ref<Author>;
+
+constructor(dto: { title: string; author: number }) {
+  this.title = dto.title;
+  this.author = ref(Author, dto.author);
+}
+```
+
+The `rel` and `ref` helpers will accept both primary key and entity instance, as well as empty value (`null` or `undefined`).
+
+```ts
+book.author = ref(Author, null);
+book.author = ref(Author, undefined);
+book.author = ref(null);
+book.author = ref(undefined);
+book.author = ref(Author, 1);
+book.author = ref(Author, author);
+book.author = ref(author);
+```
+
 ## Using native private properties
 
-If we want to use native private properties inside entities, the default approach of
-how MikroORM creates entity instances via `Object.create()` is not viable (more about this
-in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity
-constructors, we can use [`forceEntityConstructor`](./configuration.md#using-native-private-properties) toggle.
+If you want to use native private properties inside entities, the default approach of how MikroORM creates entity instances via `Object.create()` is not viable (more about this in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity constructors, you can use [`forceEntityConstructor`](./configuration.md#using-native-private-properties) toggle.

--- a/packages/core/src/entity/wrap.ts
+++ b/packages/core/src/entity/wrap.ts
@@ -1,4 +1,4 @@
-import type { Dictionary, IWrappedEntity, IWrappedEntityInternal, PrimaryProperty, Ref } from '../typings';
+import type { Dictionary, IWrappedEntity, IWrappedEntityInternal, PrimaryProperty } from '../typings';
 
 /**
  * returns WrappedEntity instance associated with this entity. This includes all the internal properties like `__meta` or `__em`.
@@ -20,13 +20,6 @@ export function wrap<T, PK extends keyof T | unknown = PrimaryProperty<T>>(entit
   }
 
   return entity?.__helper ?? entity;
-}
-
-/**
- * shortcut for `wrap(entity).toReference()`
- */
-export function ref<T, PK extends keyof T | unknown = PrimaryProperty<T>>(entity?: T | Ref<T, any>): Ref<T, PK> {
-  return (entity as Dictionary)?.__helper.toReference();
 }
 
 /**

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -11,9 +11,19 @@ import { createHash } from 'crypto';
 import { parse } from 'acorn-loose';
 import { simple as walk } from 'acorn-walk';
 import { clone } from './clone';
-import type { Dictionary, EntityData, EntityDictionary, EntityMetadata, EntityName, EntityProperty, IMetadataStorage, Primary } from '../typings';
+import type {
+  Dictionary,
+  EntityClass,
+  EntityData,
+  EntityDictionary,
+  EntityMetadata,
+  EntityName,
+  EntityProperty,
+  IMetadataStorage,
+  Primary,
+} from '../typings';
 import { GroupOperator, PlainObject, QueryOperator, ReferenceType } from '../enums';
-import type { Collection } from '../entity';
+import type { Collection } from '../entity/Collection';
 import type { Platform } from '../platforms';
 import { helper } from '../entity/wrap';
 
@@ -565,6 +575,21 @@ export class Utils {
     }
 
     return !!data.__entity;
+  }
+
+  /**
+   * Checks whether given object is an entity instance.
+   */
+  static isEntityClass<T = unknown>(data: any, allowReference = false): data is EntityClass<T> {
+    if (!('prototype' in data)) {
+      return false;
+    }
+
+    if (allowReference && !!data.prototype.__reference) {
+      return true;
+    }
+
+    return !!data.prototype.__entity;
   }
 
   /**

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -1,5 +1,23 @@
 import { v4 } from 'uuid';
-import { Cascade, Collection, Entity, Filter, Formula, IdentifiedReference, Index, ManyToMany, ManyToOne, OneToOne, OptionalProps, PrimaryKey, Property, QueryOrder, t } from '@mikro-orm/core';
+import {
+  Cascade,
+  Collection,
+  Entity,
+  Filter,
+  Formula,
+  IdentifiedReference,
+  Index,
+  ManyToMany,
+  ManyToOne,
+  OneToOne,
+  OptionalProps,
+  PrimaryKey,
+  Property,
+  QueryOrder,
+  ref,
+  rel,
+  t,
+} from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
@@ -54,9 +72,10 @@ export class Book2 {
   @ManyToMany(() => BookTag2, undefined, { pivotTable: 'book_to_tag_unordered', orderBy: { name: QueryOrder.ASC } })
   tagsUnordered = new Collection<BookTag2>(this);
 
-  constructor(title: string, author: Author2, price?: number) {
+  constructor(title: string, author: number | Author2, price?: number, publisher?: number | Publisher2) {
     this.title = title;
-    this.author = author;
+    this.author = rel(Author2, author);
+    this.publisher = ref(Publisher2, publisher);
 
     if (price) {
       this.price = price;


### PR DESCRIPTION
```ts
@ManyToOne({ entity: () => Author })
author: Rel<Author>;

constructor(dto: { title: string; author: number }) {
  this.title = dto.title;
  this.author = rel(Author, dto.author);
}
```

The `rel()` helper will create entity instance that is not yet managed (as we don't pass it any `EntityManager` instance), but it will be considered as existing entity reference once it becomes managed. This is in fact an equivalent to `em.getReference()`, but without having the `EntityManager` instance at hand.

> `rel()` is a shortcut for `Reference.createNakedFromPK()`.

And if you want to be safer and use the `Reference` wrapper, the `ref()` helper also accepts this new signature: 

```ts
@ManyToOne({ entity: () => Author, ref: true })
author: Ref<Author>;

constructor(dto: { title: string; author: number }) {
  this.title = dto.title;
  this.author = ref(Author, dto.author);
}
```

The `rel` and `ref` helpers will accept both primary key and entity instance, as well as empty value (`null` or `undefined`).

```ts
book.author = ref(Author, null);
book.author = ref(Author, undefined);
book.author = ref(null);
book.author = ref(undefined);
book.author = ref(Author, 1);
book.author = ref(Author, author);
book.author = ref(author);
```

Related: #3835