### PR TITLE
feat(cli): add check for migrations command

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,3 @@
 nodeLinker: node-modules
+
+yarnPath: .yarn/releases/yarn-3.3.0.cjs

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,1 @@
 nodeLinker: node-modules
-
-yarnPath: .yarn/releases/yarn-3.3.0.cjs

--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -161,10 +161,10 @@ You can use it via CLI:
 
 ```sh
 npx mikro-orm migration:create   # Create new migration with current schema diff
-npx mikro-orm migration:check    # Check if schema is up to date
 npx mikro-orm migration:up       # Migrate up to the latest version
 npx mikro-orm migration:down     # Migrate one step down
 npx mikro-orm migration:list     # List all executed migrations
+npx mikro-orm migration:check    # Check if schema is up to date
 npx mikro-orm migration:pending  # List all pending migrations
 npx mikro-orm migration:fresh    # Drop the database and migrate up to the latest version
 ```

--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -161,6 +161,7 @@ You can use it via CLI:
 
 ```sh
 npx mikro-orm migration:create   # Create new migration with current schema diff
+npx mikro-orm migration:check    # Check if schema is up to date
 npx mikro-orm migration:up       # Migrate up to the latest version
 npx mikro-orm migration:down     # Migrate one step down
 npx mikro-orm migration:list     # List all executed migrations

--- a/packages/cli/src/commands/MigrationCommandFactory.ts
+++ b/packages/cli/src/commands/MigrationCommandFactory.ts
@@ -169,13 +169,12 @@ export class MigrationCommandFactory {
   }
 
   private static async handleCheckCommand(migrator: IMigrator, orm: MikroORM): Promise<void> {
-    const diff = await migrator.checkMigrationNeeded();
-
-    if (diff.up.length === 0) {
+    if (!await migrator.checkMigrationNeeded()) {
       return CLIHelper.dump(colors.green(`No changes required, schema is up-to-date`));
     }
     await orm.close(true);
-    throw new Error(`Changes detected. Please create migrations to update schema.`);
+    CLIHelper.dump(colors.yellow(`Changes detected. Please create migrations to update schema.`));
+    process.exit(1);
   }
 
   private static async handleFreshCommand(args: ArgumentsCamelCase<Options>, migrator: IMigrator, orm: MikroORM) {

--- a/packages/cli/src/commands/MigrationCommandFactory.ts
+++ b/packages/cli/src/commands/MigrationCommandFactory.ts
@@ -8,10 +8,10 @@ export class MigrationCommandFactory {
 
   static readonly DESCRIPTIONS = {
     create: 'Create new migration with current schema diff',
-    check: 'Check if migrations are needed. Useful for bash scripts.',
     up: 'Migrate up to the latest version',
     down: 'Migrate one step down',
     list: 'List all executed migrations',
+    check: 'Check if migrations are needed. Useful for bash scripts.',
     pending: 'List all pending migrations',
     fresh: 'Clear the database and rerun all migrations',
   };
@@ -173,7 +173,7 @@ export class MigrationCommandFactory {
       return CLIHelper.dump(colors.green(`No changes required, schema is up-to-date`));
     }
     await orm.close(true);
-    CLIHelper.dump(colors.yellow(`Changes detected. Please create migrations to update schema.`));
+    CLIHelper.dump(colors.yellow(`Changes detected. Please create migration to update schema.`));
     process.exit(1);
   }
 

--- a/packages/cli/src/commands/MigrationCommandFactory.ts
+++ b/packages/cli/src/commands/MigrationCommandFactory.ts
@@ -8,6 +8,7 @@ export class MigrationCommandFactory {
 
   static readonly DESCRIPTIONS = {
     create: 'Create new migration with current schema diff',
+    check: 'Check if migrations are needed. Useful for bash scripts.',
     up: 'Migrate up to the latest version',
     down: 'Migrate one step down',
     list: 'List all executed migrations',
@@ -90,6 +91,9 @@ export class MigrationCommandFactory {
       case 'create':
         await this.handleCreateCommand(migrator, args, orm.config);
         break;
+      case 'check':
+        await this.handleCheckCommand(migrator, orm);
+        break;
       case 'list':
         await this.handleListCommand(migrator);
         break;
@@ -164,6 +168,16 @@ export class MigrationCommandFactory {
     CLIHelper.dump(colors.green(`${ret.fileName} successfully created`));
   }
 
+  private static async handleCheckCommand(migrator: IMigrator, orm: MikroORM): Promise<void> {
+    const diff = await migrator.checkMigrationNeeded();
+
+    if (diff.up.length === 0) {
+      return CLIHelper.dump(colors.green(`No changes required, schema is up-to-date`));
+    }
+    await orm.close(true);
+    throw new Error(`Changes detected. Please create migrations to update schema.`);
+  }
+
   private static async handleFreshCommand(args: ArgumentsCamelCase<Options>, migrator: IMigrator, orm: MikroORM) {
     const generator = orm.getSchemaGenerator();
     await generator.dropSchema({ dropMigrationsTable: true });
@@ -222,7 +236,7 @@ export class MigrationCommandFactory {
 
 }
 
-type MigratorMethod = 'create' | 'up' | 'down' | 'list' | 'pending' | 'fresh';
+type MigratorMethod = 'create' | 'check' | 'up' | 'down' | 'list' | 'pending' | 'fresh';
 type CliUpDownOptions = { to?: string | number; from?: string | number; only?: string };
 type GenerateOptions = { dump?: boolean; blank?: boolean; initial?: boolean; path?: string; disableFkChecks?: boolean; seed: string };
 type Options = GenerateOptions & CliUpDownOptions;

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -559,6 +559,11 @@ export interface IMigrator {
   createMigration(path?: string, blank?: boolean, initial?: boolean): Promise<MigrationResult>;
 
   /**
+   * Checks current schema for changes.
+   */
+  checkMigrationNeeded(): Promise<{up: string[]; down: string[]}>;
+
+  /**
    * Creates initial migration. This generates the schema based on metadata, and checks whether all the tables
    * are already present. If yes, it will also automatically log the migration as executed.
    * Initial migration can be created only if the schema is already aligned with the metadata, or when no schema

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -561,7 +561,7 @@ export interface IMigrator {
   /**
    * Checks current schema for changes.
    */
-  checkMigrationNeeded(): Promise<{up: string[]; down: string[]}>;
+  checkMigrationNeeded(): Promise<boolean>;
 
   /**
    * Creates initial migration. This generates the schema based on metadata, and checks whether all the tables

--- a/packages/migrations-mongodb/src/Migrator.ts
+++ b/packages/migrations-mongodb/src/Migrator.ts
@@ -52,6 +52,13 @@ export class Migrator implements IMigrator {
   /**
    * @inheritDoc
    */
+  async checkMigrationNeeded(): Promise<{ up: []; down: [] }> {
+    return { up: [], down: [] };
+  }
+
+  /**
+   * @inheritDoc
+   */
   async createInitialMigration(path?: string): Promise<MigrationResult> {
     return this.createMigration(path);
   }

--- a/packages/migrations-mongodb/src/Migrator.ts
+++ b/packages/migrations-mongodb/src/Migrator.ts
@@ -52,8 +52,8 @@ export class Migrator implements IMigrator {
   /**
    * @inheritDoc
    */
-  async checkMigrationNeeded(): Promise<{ up: []; down: [] }> {
-    return { up: [], down: [] };
+  async checkMigrationNeeded(): Promise<boolean> {
+    return true;
   }
 
   /**

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -52,8 +52,7 @@ export class Migrator implements IMigrator {
       return this.createInitialMigration(path);
     }
 
-    await this.ensureMigrationsDirExists();
-    const diff = await this.getSchemaDiff(blank, initial);
+    const diff = await this.checkMigrationNeeded(blank, initial);
 
     if (diff.up.length === 0) {
       return { fileName: '', code: '', diff };
@@ -67,6 +66,11 @@ export class Migrator implements IMigrator {
       code: migration[0],
       diff,
     };
+  }
+
+  async checkMigrationNeeded(blank = false, initial = false): Promise<{up: string[]; down: string[]}> {
+    await this.ensureMigrationsDirExists();
+    return this.getSchemaDiff(blank, blank);
   }
 
   /**

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -52,7 +52,8 @@ export class Migrator implements IMigrator {
       return this.createInitialMigration(path);
     }
 
-    const diff = await this.checkMigrationNeeded(blank, initial);
+    await this.ensureMigrationsDirExists();
+    const diff = await this.getSchemaDiff(blank, initial);
 
     if (diff.up.length === 0) {
       return { fileName: '', code: '', diff };
@@ -68,9 +69,10 @@ export class Migrator implements IMigrator {
     };
   }
 
-  async checkMigrationNeeded(blank = false, initial = false): Promise<{up: string[]; down: string[]}> {
+  async checkMigrationNeeded(): Promise<boolean> {
     await this.ensureMigrationsDirExists();
-    return this.getSchemaDiff(blank, blank);
+    const diff = await this.getSchemaDiff(false, false);
+    return diff.up.length > 0;
   }
 
   /**

--- a/tests/features/cli/CheckMigrationsCommand.test.ts
+++ b/tests/features/cli/CheckMigrationsCommand.test.ts
@@ -40,7 +40,7 @@ describe('CheckMigrationCommand', () => {
     await expect(cmd.handler({} as any)).rejects.toThrowError('Mock');
     expect(checkMigrationMock.mock.calls.length).toBe(1);
     expect(closeSpy).toBeCalledTimes(1);
-    expect(dumpMock).toHaveBeenLastCalledWith('Changes detected. Please create migrations to update schema.');
+    expect(dumpMock).toHaveBeenLastCalledWith('Changes detected. Please create migration to update schema.');
     expect(mockExit).toBeCalledTimes(1);
 
     checkMigrationMock.mockImplementationOnce(async () => false);

--- a/tests/features/cli/CheckMigrationsCommand.test.ts
+++ b/tests/features/cli/CheckMigrationsCommand.test.ts
@@ -1,0 +1,48 @@
+(global as any).process.env.FORCE_COLOR = 0;
+
+import { Migrator } from '@mikro-orm/migrations';
+import { MikroORM } from '@mikro-orm/core';
+import type { SqliteDriver } from '@mikro-orm/sqlite';
+import { CLIHelper } from '@mikro-orm/cli';
+import { MigrationCommandFactory } from '../../../packages/cli/src/commands/MigrationCommandFactory';
+import { initORMSqlite } from '../../bootstrap';
+
+const closeSpy = jest.spyOn(MikroORM.prototype, 'close');
+jest.spyOn(CLIHelper, 'showHelp').mockImplementation(() => void 0);
+const checkMigrationMock = jest.spyOn(Migrator.prototype, 'checkMigrationNeeded');
+checkMigrationMock.mockResolvedValue({ up: ['3'], down: [] });
+const dumpMock = jest.spyOn(CLIHelper, 'dump');
+dumpMock.mockImplementation(() => void 0);
+
+describe('CheckMigrationCommand', () => {
+
+  let orm: MikroORM<SqliteDriver>;
+
+  beforeAll(async () => {
+    orm = await initORMSqlite();
+    const getORMMock = jest.spyOn(CLIHelper, 'getORM');
+    getORMMock.mockResolvedValue(orm);
+  });
+
+  afterAll(async () => await orm.close(true));
+
+  test('builder', async () => {
+    const cmd = MigrationCommandFactory.create('check');
+    const args = { option: jest.fn() };
+    cmd.builder(args as any);
+  });
+
+  test('handler', async () => {
+    const cmd = MigrationCommandFactory.create('check');
+
+    await expect(cmd.handler({} as any)).rejects.toThrowError(`Changes detected. Please create migrations to update schema.`);
+    expect(checkMigrationMock.mock.calls.length).toBe(1);
+    expect(closeSpy).toBeCalledTimes(1);
+
+    checkMigrationMock.mockImplementationOnce(async () => ({ up: [], down: [] }));
+    await expect(cmd.handler({} as any)).resolves.toBeUndefined();
+    expect(checkMigrationMock.mock.calls.length).toBe(2);
+    expect(closeSpy).toBeCalledTimes(2);
+    expect(dumpMock).toHaveBeenLastCalledWith('No changes required, schema is up-to-date');
+  });
+});


### PR DESCRIPTION
Allow checking for migrations. This would be useful for adding to git hooks to ensure that any changes to ORM entities are captured in migrations.