### PR TITLE
feat(core): allow overriding ORM config path via `--config`

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -212,16 +212,21 @@ For CLI to be able to access our database, we will need to create `mikro-orm.con
 > ORM configuration file can export the Promise, like:
 > `export default Promise.resolve({...});`.
 
-TypeScript is also supported, just enable `useTsNode` flag in our
-`package.json` file. There we can also set up array of possible paths to `mikro-orm.config` file,
-as well as use different file name. The `package.json` file can be located in 
-the current working directory, or in one of its parent folders.
+TypeScript is also supported, just enable `useTsNode` flag in our `package.json` file. There we can also set up array of possible paths to `mikro-orm.config` file, as well as use different file name. The `package.json` file can be located in the current working directory, or in one of its parent folders.
 
-We can use these environment variables to override CLI settings:
+You can use these environment variables to override the CLI settings:
 
 - `MIKRO_ORM_CLI`: the path to ORM config file
 - `MIKRO_ORM_CLI_USE_TS_NODE`: register ts-node
 - `MIKRO_ORM_CLI_TS_CONFIG_PATH`: path to the tsconfig.json (for ts-node)
+
+Alternatively, you can also specify the config path via `--config` option:
+
+```sh
+$ npx mikro-orm debug --config ./my-config.ts
+```
+
+This option will be respected also when you run your app, not just when you use the CLI.
 
 > Do not forget to install `ts-node` when enabling `useTsNode` flag.
 

--- a/packages/cli/src/CLIConfigurator.ts
+++ b/packages/cli/src/CLIConfigurator.ts
@@ -32,12 +32,15 @@ export class CLIConfigurator {
       }
     }
 
-    // noinspection HtmlDeprecatedTag
     return yargs
       .scriptName('mikro-orm')
       .version(version)
       .usage('Usage: $0 <command> [options]')
       .example('$0 schema:update --run', 'Runs schema synchronization')
+      .option('config', {
+        type: 'string',
+        desc: `Set path to the ORM configuration file`,
+      })
       .alias('v', 'version')
       .alias('h', 'help')
       .command(new ClearCacheCommand())

--- a/packages/cli/src/commands/DebugCommand.ts
+++ b/packages/cli/src/commands/DebugCommand.ts
@@ -1,5 +1,4 @@
 import type { CommandModule } from 'yargs';
-import type { Configuration } from '@mikro-orm/core';
 import { ConfigurationLoader, Utils, colors, MikroORM } from '@mikro-orm/core';
 
 import { CLIHelper } from '../CLIHelper';

--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -86,6 +86,12 @@ export class ConfigurationLoader {
   }
 
   static async getConfigPaths(): Promise<string[]> {
+    const options = Utils.parseArgs();
+
+    if (options.config) {
+      return [options.config];
+    }
+
     const paths: string[] = [];
     const settings = await ConfigurationLoader.getSettings();
 

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -1090,4 +1090,25 @@ export class Utils {
 
   }
 
+  /**
+   * simple process.argv parser, supports only properties with long names, prefixed with `--`
+   */
+  static parseArgs<T extends Dictionary = Dictionary>(): T {
+    let lastKey: string | undefined;
+
+    return process.argv.slice(2).reduce((args, arg) => {
+      if (arg.includes('=')) {
+        const [key, value] = arg.split('=');
+        args[key.substring(2)] = value;
+      } else if (lastKey) {
+        args[lastKey] = arg;
+        lastKey = undefined;
+      } else if (arg.startsWith('--')) {
+        lastKey = arg.substring(2);
+      }
+
+      return args;
+    }, {} as Dictionary) as T;
+  }
+
 }

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -401,6 +401,13 @@ Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
   });
 
   test('getConfigPaths', async () => {
+    (global as any).process.argv = ['node', 'start.js', '--config', './override1/orm-config.ts'];
+    await expect(CLIHelper.getConfigPaths()).resolves.toEqual(['./override1/orm-config.ts']);
+    (global as any).process.argv = ['node', 'start.js', '--config=./override2/orm-config.ts'];
+    await expect(CLIHelper.getConfigPaths()).resolves.toEqual(['./override2/orm-config.ts']);
+    (global as any).process.argv = ['npx', 'mikro-orm', 'debug', '--config', './override3/orm-config.ts'];
+    await expect(CLIHelper.getConfigPaths()).resolves.toEqual(['./override3/orm-config.ts']);
+    (global as any).process.argv = ['node', 'start.js'];
     (global as any).process.env.MIKRO_ORM_CLI = './override/orm-config.ts';
     await expect(CLIHelper.getConfigPaths()).resolves.toEqual(['./override/orm-config.ts', './src/mikro-orm.config.ts', './mikro-orm.config.ts', './src/mikro-orm.config.js', './mikro-orm.config.js']);
     delete (global as any).process.env.MIKRO_ORM_CLI;


### PR DESCRIPTION
Allows to override the config path via `--config` option:

```sh
$ npx mikro-orm debug --config ./my-config.ts
```

This option will be respected also when you run your app, not just when you use the CLI.