### PR TITLE
refactor(core): simplify generics in `BaseEntity` and PK type inference

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
     '@typescript-eslint/no-duplicate-imports': 'error',
     '@typescript-eslint/prefer-optional-chain': 'error',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/ban-types': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',

--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -106,3 +106,12 @@ foo: string[];
 - `em.removeLater()` -> `em.remove()`
 - `uow.getOriginalEntityData()` without parameters 
 - `orm.schema.generate()` 
+
+## `BaseEntity` no longer has generic type arguments
+
+Instead, the `this` type is used.
+
+```diff
+-class User extends BaseEntity<User> { ... }
++class User extends BaseEntity { ... }
+```

--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -116,3 +116,14 @@ Instead, the `this` type is used.
 -class User extends BaseEntity<User> { ... }
 +class User extends BaseEntity { ... }
 ```
+
+## `wrap` helper no longer accepts `undefined` on type level
+
+The runtime implementation still checks for this case and returns the argument, but on type level this will fail to compile. It was never correct to pass in nullable values inside as it were not allowed in the return type.
+
+Note that if you used it for converting entity instance to reference wrapper, the new `ref()` helper does a better job at that (and accepts nullable values).
+
+## Primary key inference
+
+Some methods allowed you to pass in the primary key property via second generic type argument, this is now removed in favour of the automatic inference. To set the PK type explicitly, use the `PrimaryKeyProp` symbol.
+

--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -127,3 +127,21 @@ Note that if you used it for converting entity instance to reference wrapper, th
 
 Some methods allowed you to pass in the primary key property via second generic type argument, this is now removed in favour of the automatic inference. To set the PK type explicitly, use the `PrimaryKeyProp` symbol.
 
+`PrimaryKeyType` symbol has been removed, use `PrimaryKeyProp` instead if needed. Moreover, the value for composite PKs now has to be a tuple instead of a union to ensure we preserve the order of keys:
+
+```diff
+@Entity()
+export class Foo {
+
+  @ManyToOne(() => Bar, { primary: true })
+  bar!: Bar;
+
+  @ManyToOne(() => Baz, { primary: true })
+  baz!: Baz;
+
+-  [PrimaryKeyType]?: [number, number];
+-  [PrimaryKeyProp]?: 'bar' | 'baz';
++  [PrimaryKeyProp]?: ['bar', 'baz'];
+
+}
+```

--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -104,8 +104,9 @@ foo: string[];
 - `em.nativeInsert()` -> `em.insert()`
 - `em.persistLater()` -> `em.persist()`
 - `em.removeLater()` -> `em.remove()`
-- `uow.getOriginalEntityData()` without parameters 
-- `orm.schema.generate()` 
+- `IdentifiedReference` -> `Ref`
+- `uow.getOriginalEntityData()` without parameters
+- `orm.schema.generate()`
 
 ## `BaseEntity` no longer has generic type arguments
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1416,7 +1416,7 @@ em.create(User, { someNotDefinedProp: 123 } as any); // works, using type cast
 
 * **core:** assign embedded properties from class objects ([#1087](https://github.com/mikro-orm/mikro-orm/issues/1087)) ([c2b4972](https://github.com/mikro-orm/mikro-orm/commit/c2b49726ad601516c36e8c289c1ef6a358d54780)), closes [#1083](https://github.com/mikro-orm/mikro-orm/issues/1083)
 * **core:** rework unique property extra updates ([bd19d03](https://github.com/mikro-orm/mikro-orm/commit/bd19d038879e6c95768703e78ed9f4236deea48a)), closes [#1025](https://github.com/mikro-orm/mikro-orm/issues/1025) [#1084](https://github.com/mikro-orm/mikro-orm/issues/1084)
-* **ts-morph:** fix discovery of `IdentifiedReference` with ts-morph ([d94bd91](https://github.com/mikro-orm/mikro-orm/commit/d94bd9106948d2ca583aaff9125486987ffc5243)), closes [#1088](https://github.com/mikro-orm/mikro-orm/issues/1088)
+* **ts-morph:** fix discovery of `Ref` with ts-morph ([d94bd91](https://github.com/mikro-orm/mikro-orm/commit/d94bd9106948d2ca583aaff9125486987ffc5243)), closes [#1088](https://github.com/mikro-orm/mikro-orm/issues/1088)
 
 
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1416,7 +1416,7 @@ em.create(User, { someNotDefinedProp: 123 } as any); // works, using type cast
 
 * **core:** assign embedded properties from class objects ([#1087](https://github.com/mikro-orm/mikro-orm/issues/1087)) ([c2b4972](https://github.com/mikro-orm/mikro-orm/commit/c2b49726ad601516c36e8c289c1ef6a358d54780)), closes [#1083](https://github.com/mikro-orm/mikro-orm/issues/1083)
 * **core:** rework unique property extra updates ([bd19d03](https://github.com/mikro-orm/mikro-orm/commit/bd19d038879e6c95768703e78ed9f4236deea48a)), closes [#1025](https://github.com/mikro-orm/mikro-orm/issues/1025) [#1084](https://github.com/mikro-orm/mikro-orm/issues/1084)
-* **ts-morph:** fix discovery of `Ref` with ts-morph ([d94bd91](https://github.com/mikro-orm/mikro-orm/commit/d94bd9106948d2ca583aaff9125486987ffc5243)), closes [#1088](https://github.com/mikro-orm/mikro-orm/issues/1088)
+* **ts-morph:** fix discovery of `IdentifiedReference` with ts-morph ([d94bd91](https://github.com/mikro-orm/mikro-orm/commit/d94bd9106948d2ca583aaff9125486987ffc5243)), closes [#1088](https://github.com/mikro-orm/mikro-orm/issues/1088)
 
 
 

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1,7 +1,7 @@
 import { inspect } from 'util';
 import type { Configuration } from './utils';
 import { Cursor, QueryHelper, TransactionContext, Utils } from './utils';
-import type { AssignOptions, EntityLoaderOptions, EntityRepository, IdentifiedReference } from './entity';
+import type { AssignOptions, EntityLoaderOptions, EntityRepository } from './entity';
 import { EntityAssigner, EntityFactory, EntityLoader, EntityValidator, helper, Reference } from './entity';
 import { ChangeSet, ChangeSetType, UnitOfWork } from './unit-of-work';
 import type {
@@ -37,6 +37,7 @@ import type {
   PopulateOptions,
   Primary,
   RequiredEntityData,
+  Ref,
 } from './typings';
 import type { TransactionOptions } from './enums';
 import { FlushMode, LoadStrategy, LockMode, PopulateHint, ReferenceType, SCALAR_TYPES } from './enums';
@@ -1159,7 +1160,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<Entity extends object, PK extends keyof Entity>(entityName: EntityName<Entity>, id: Primary<Entity>, options: Omit<GetReferenceOptions, 'wrapped'> & { wrapped: true }): IdentifiedReference<Entity, PK>;
+  getReference<Entity extends object, PK extends keyof Entity>(entityName: EntityName<Entity>, id: Primary<Entity>, options: Omit<GetReferenceOptions, 'wrapped'> & { wrapped: true }): Ref<Entity, PK>;
 
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -561,7 +561,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     await em.unitOfWork.dispatchOnLoadEvent();
-    await em.storeCache(options.cache, cached!, () => helper(entity).toPOJO());
+    await em.storeCache(options.cache, cached!, () => helper(entity!).toPOJO());
 
     return entity as Loaded<Entity, Hint>;
   }
@@ -1160,7 +1160,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<Entity extends object, PK extends keyof Entity>(entityName: EntityName<Entity>, id: Primary<Entity>, options: Omit<GetReferenceOptions, 'wrapped'> & { wrapped: true }): Ref<Entity, PK>;
+  getReference<Entity extends object>(entityName: EntityName<Entity>, id: Primary<Entity>, options: Omit<GetReferenceOptions, 'wrapped'> & { wrapped: true }): Ref<Entity>;
 
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -356,7 +356,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     return ret;
   }
 
-  async lockPessimistic<T>(entity: T, options: LockOptions): Promise<void> {
+  async lockPessimistic<T extends object>(entity: T, options: LockOptions): Promise<void> {
     throw new Error(`Pessimistic locks are not supported by ${this.constructor.name} driver`);
   }
 

--- a/packages/core/src/entity/ArrayCollection.ts
+++ b/packages/core/src/entity/ArrayCollection.ts
@@ -57,7 +57,7 @@ export class ArrayCollection<T extends object, O extends object> {
 
     return items.map(i => {
       if (Utils.isEntity(i[field as keyof T], true)) {
-        return wrap(i[field as keyof T], true).getPrimaryKey();
+        return wrap(i[field as keyof T]!, true).getPrimaryKey();
       }
 
       return i[field as keyof T];

--- a/packages/core/src/entity/BaseEntity.ts
+++ b/packages/core/src/entity/BaseEntity.ts
@@ -1,6 +1,5 @@
-import type { IdentifiedReference } from './Reference';
 import { Reference } from './Reference';
-import type { EntityData, EntityDTO, Loaded } from '../typings';
+import type { Ref, EntityData, EntityDTO, Loaded } from '../typings';
 import type { AssignOptions } from './EntityAssigner';
 import { EntityAssigner } from './EntityAssigner';
 import { helper } from './wrap';
@@ -19,7 +18,7 @@ export abstract class BaseEntity {
     helper(this).populated(populated);
   }
 
-  toReference(): IdentifiedReference<this> {
+  toReference(): Ref<this> {
     return Reference.create(this);
   }
 

--- a/packages/core/src/entity/BaseEntity.ts
+++ b/packages/core/src/entity/BaseEntity.ts
@@ -5,7 +5,7 @@ import type { AssignOptions } from './EntityAssigner';
 import { EntityAssigner } from './EntityAssigner';
 import { helper } from './wrap';
 
-export abstract class BaseEntity<Entity extends object, Primary extends keyof Entity, Populate extends string = string> {
+export abstract class BaseEntity {
 
   isInitialized(): boolean {
     return helper(this).__initialized;
@@ -19,8 +19,8 @@ export abstract class BaseEntity<Entity extends object, Primary extends keyof En
     helper(this).populated(populated);
   }
 
-  toReference(): IdentifiedReference<Entity, Primary> {
-    return Reference.create(this as unknown as Entity);
+  toReference(): IdentifiedReference<this> {
+    return Reference.create(this);
   }
 
   toObject(ignoreFields: string[] = []): EntityDTO<this> {
@@ -35,13 +35,12 @@ export abstract class BaseEntity<Entity extends object, Primary extends keyof En
     return helper(this).toPOJO();
   }
 
-  assign(data: EntityData<Entity>, options?: AssignOptions): Entity {
-    return EntityAssigner.assign(this as object, data, options) as Entity;
+  assign(data: EntityData<this>, options?: AssignOptions): this {
+    return EntityAssigner.assign(this as object, data, options) as this;
   }
 
-  init<Populate extends string = never>(populated = true): Promise<Loaded<Entity, Populate>> {
-    // using `Loaded<this>` results in issues with assignability unfortunately
-    return helper(this as unknown as Entity).init<Populate>(populated);
+  init<Populate extends string = never>(populated = true): Promise<Loaded<this, Populate>> {
+    return helper(this).init<Populate>(populated);
   }
 
   getSchema(): string | undefined {

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -135,7 +135,7 @@ export class EntityAssigner {
     if (Utils.isEntity(value, true)) {
       entity[prop.name] = Reference.wrapReference(value, prop);
     } else if (Utils.isPrimaryKey(value, true) && EntityAssigner.validateEM(em)) {
-      entity[prop.name] = prop.mapToPk ? value : Reference.wrapReference(em.getReference<T>(prop.type, value, options), prop);
+      entity[prop.name] = prop.mapToPk ? value : Reference.wrapReference(em.getReference<T>(prop.type, value as Primary<T>, options), prop);
     } else if (Utils.isPlainObject(value) && options.merge && EntityAssigner.validateEM(em)) {
       entity[prop.name] = Reference.wrapReference(em.merge(prop.type, value, options), prop);
     } else if (Utils.isPlainObject(value) && EntityAssigner.validateEM(em)) {
@@ -250,7 +250,7 @@ export class EntityAssigner {
 
     invalid.push(item);
 
-    return item;
+    return item as T;
   }
 
 }

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -136,7 +136,7 @@ export class EntityFactory {
         return;
       }
 
-      if ([ReferenceType.MANY_TO_ONE, ReferenceType.ONE_TO_ONE].includes(prop.reference) && Utils.isPlainObject(data[prop.name as string]) && entity[prop.name] && helper(entity[prop.name]).__initialized) {
+      if ([ReferenceType.MANY_TO_ONE, ReferenceType.ONE_TO_ONE].includes(prop.reference) && Utils.isPlainObject(data[prop.name as string]) && entity[prop.name] && helper(entity[prop.name]!).__initialized) {
         this.create(prop.type, data[prop.name as string] as EntityData<T>, options); // we can ignore the value, we just care about the `mergeData` call
       }
     });

--- a/packages/core/src/entity/EntityHelper.ts
+++ b/packages/core/src/entity/EntityHelper.ts
@@ -56,7 +56,7 @@ export class EntityHelper {
       __platform: { value: em.getPlatform() },
       __factory: { value: em.getEntityFactory() },
       __helper: {
-        get(): WrappedEntity<T, keyof T> {
+        get(): WrappedEntity<T> {
           Object.defineProperty(this, '__helper', {
             value: new WrappedEntity(this, ...helperParams),
             enumerable: false,
@@ -77,7 +77,7 @@ export class EntityHelper {
    * First defines a setter on the prototype, once called, actual get/set handlers are registered on the instance rather
    * than on its prototype. Thanks to this we still have those properties enumerable (e.g. part of `Object.keys(entity)`).
    */
-  private static defineProperties<T>(meta: EntityMetadata<T>, em: EntityManager): void {
+  private static defineProperties<T extends object>(meta: EntityMetadata<T>, em: EntityManager): void {
     const hydrator = em.config.getHydrator(em.getMetadata());
     Object
       .values<EntityProperty<T>>(meta.properties)
@@ -122,7 +122,7 @@ export class EntityHelper {
       // ensure we dont have internal symbols in the POJO
       [OptionalProps, EntityRepositoryType, PrimaryKeyType, PrimaryKeyProp].forEach(sym => delete object[sym]);
       const ret = inspect(object, { depth });
-      let name = (this as object).constructor.name;
+      let name = (this).constructor.name;
 
       // distinguish not initialized entities
       if (!helper(this).__initialized) {

--- a/packages/core/src/entity/EntityHelper.ts
+++ b/packages/core/src/entity/EntityHelper.ts
@@ -8,7 +8,7 @@ import { Utils } from '../utils/Utils';
 import { WrappedEntity } from './WrappedEntity';
 import { ReferenceType } from '../enums';
 import { helper } from './wrap';
-import { EntityRepositoryType, OptionalProps, PrimaryKeyProp, PrimaryKeyType } from '../typings';
+import { EntityRepositoryType, OptionalProps, PrimaryKeyProp } from '../typings';
 
 export class EntityHelper {
 
@@ -120,7 +120,7 @@ export class EntityHelper {
     meta.prototype[inspect.custom] ??= function (this: T, depth: number) {
       const object = { ...this };
       // ensure we dont have internal symbols in the POJO
-      [OptionalProps, EntityRepositoryType, PrimaryKeyType, PrimaryKeyProp].forEach(sym => delete object[sym]);
+      [OptionalProps, EntityRepositoryType, PrimaryKeyProp].forEach(sym => delete object[sym]);
       const ret = inspect(object, { depth });
       let name = (this).constructor.name;
 

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -210,7 +210,7 @@ export class EntityLoader {
     return data;
   }
 
-  private initializeCollections<T>(filtered: T[], prop: EntityProperty, field: keyof T, children: AnyEntity[]): void {
+  private initializeCollections<T extends object>(filtered: T[], prop: EntityProperty, field: keyof T, children: AnyEntity[]): void {
     if (prop.reference === ReferenceType.ONE_TO_MANY) {
       this.initializeOneToMany<T>(filtered, children, prop, field);
     }
@@ -220,7 +220,7 @@ export class EntityLoader {
     }
   }
 
-  private initializeOneToMany<T>(filtered: T[], children: AnyEntity[], prop: EntityProperty, field: keyof T): void {
+  private initializeOneToMany<T extends object>(filtered: T[], children: AnyEntity[], prop: EntityProperty, field: keyof T): void {
     for (const entity of filtered) {
       const items = children.filter(child => {
         if (prop.targetMeta!.properties[prop.mappedBy].mapToPk) {

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -1,6 +1,6 @@
 import type { CreateOptions, EntityManager, MergeOptions } from '../EntityManager';
 import type { AssignOptions } from './EntityAssigner';
-import type { EntityData, EntityName, AnyEntity, Primary, Loaded, FilterQuery, EntityDictionary, AutoPath, RequiredEntityData } from '../typings';
+import type { EntityData, EntityName, AnyEntity, Primary, Loaded, FilterQuery, EntityDictionary, AutoPath, RequiredEntityData, Ref } from '../typings';
 import type {
   CountOptions,
   DeleteOptions,
@@ -12,7 +12,7 @@ import type {
   NativeInsertUpdateOptions,
   UpdateOptions,
 } from '../drivers/IDatabaseDriver';
-import type { IdentifiedReference, Reference } from './Reference';
+import type { Reference } from './Reference';
 import type { EntityLoaderOptions } from './EntityLoader';
 import type { Cursor } from '../utils/Cursor';
 
@@ -174,7 +174,7 @@ export class EntityRepository<T extends object> {
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<PK extends keyof T>(id: Primary<T>, options: Omit<GetReferenceOptions, 'wrapped'> & { wrapped: true }): IdentifiedReference<T, PK>;
+  getReference<PK extends keyof T>(id: Primary<T>, options: Omit<GetReferenceOptions, 'wrapped'> & { wrapped: true }): Ref<T, PK>;
 
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -174,7 +174,7 @@ export class EntityRepository<T extends object> {
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<PK extends keyof T>(id: Primary<T>, options: Omit<GetReferenceOptions, 'wrapped'> & { wrapped: true }): Ref<T, PK>;
+  getReference(id: Primary<T>, options: Omit<GetReferenceOptions, 'wrapped'> & { wrapped: true }): Ref<T>;
 
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
@@ -189,7 +189,7 @@ export class EntityRepository<T extends object> {
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<PK extends keyof T = keyof T>(id: Primary<T>, options?: GetReferenceOptions): T | Reference<T> {
+  getReference(id: Primary<T>, options?: GetReferenceOptions): T | Reference<T> {
     return this.em.getReference<T>(this.entityName, id, options);
   }
 

--- a/packages/core/src/entity/Reference.ts
+++ b/packages/core/src/entity/Reference.ts
@@ -17,8 +17,6 @@ import type { LockMode } from '../enums';
 import { helper, wrap } from './wrap';
 import { Utils } from '../utils/Utils';
 
-export type IdentifiedReference<T, PK extends keyof T | unknown = PrimaryProperty<T>> = true extends IsUnknown<PK> ? Reference<T> : ({ [K in Cast<PK, keyof T>]: T[K] } & Reference<T>);
-
 export class Reference<T> {
 
   constructor(private entity: T) {
@@ -42,9 +40,9 @@ export class Reference<T> {
     }
   }
 
-  static create<T extends object, PK extends keyof T | unknown = PrimaryProperty<T>>(entity: T | IdentifiedReference<T, PK>): IdentifiedReference<T, PK> {
+  static create<T extends object, PK extends keyof T | unknown = PrimaryProperty<T>>(entity: T | Ref<T, PK>): Ref<T, PK> {
     const unwrapped = Reference.unwrapReference(entity);
-    const ref = helper(entity).toReference() as IdentifiedReference<T, PK>;
+    const ref = helper(entity).toReference() as Ref<T, PK>;
 
     if (unwrapped !== ref.unwrap()) {
       ref.set(unwrapped);
@@ -53,7 +51,7 @@ export class Reference<T> {
     return ref;
   }
 
-  static createFromPK<T extends object, PK extends keyof T | unknown = PrimaryProperty<T>>(entityType: EntityClass<T>, pk: Primary<T>, options?: { schema?: string }): IdentifiedReference<T, PK> {
+  static createFromPK<T extends object, PK extends keyof T | unknown = PrimaryProperty<T>>(entityType: EntityClass<T>, pk: Primary<T>, options?: { schema?: string }): Ref<T, PK> {
     const ref = this.createNakedFromPK(entityType, pk, options);
     return helper(ref).toReference();
   }
@@ -122,7 +120,7 @@ export class Reference<T> {
     return this.entity;
   }
 
-  set(entity: T | IdentifiedReference<T>): void {
+  set(entity: T | Ref<T>): void {
     this.entity = Reference.unwrapReference(entity as T & object);
     delete helper(this.entity).__reference;
   }

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -129,9 +129,9 @@ export class WrappedEntity<T extends object> {
 
         if (Utils.isEntity(child, true)) {
           const childPk = helper(child).getPrimaryKeys(convertCustomTypes);
-          ret.push(...childPk!);
+          ret.push(...childPk as Primary<T>[]);
         } else {
-          ret.push(child as Primary<unknown>);
+          ret.push(child as Primary<T>);
         }
 
         return ret;

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -15,7 +15,7 @@ import type { EntityIdentifier } from './EntityIdentifier';
 import { helper } from './wrap';
 import type { SerializationContext } from '../serialization/SerializationContext';
 
-export class WrappedEntity<T extends object, PK extends keyof T> {
+export class WrappedEntity<T extends object> {
 
   __initialized = true;
   __touched = false;
@@ -60,9 +60,9 @@ export class WrappedEntity<T extends object, PK extends keyof T> {
     this.__lazyInitialized = false;
   }
 
-  toReference(): Ref<T, PK> {
+  toReference(): Ref<T> {
     this.__reference ??= new Reference(this.entity);
-    return this.__reference as Ref<T, PK>;
+    return this.__reference as Ref<T>;
   }
 
   toObject(ignoreFields: string[] = []): EntityData<T> {

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -2,9 +2,8 @@ import { inspect } from 'util';
 import type { EntityManager } from '../EntityManager';
 import type {
   AnyEntity, ConnectionType, Dictionary, EntityData, EntityDictionary, EntityMetadata,
-  IWrappedEntityInternal, Populate, PopulateOptions, Primary,
+  IWrappedEntityInternal, Populate, PopulateOptions, Primary, Ref,
 } from '../typings';
-import type { IdentifiedReference } from './Reference';
 import { Reference } from './Reference';
 import { EntityTransformer } from '../serialization/EntityTransformer';
 import type { AssignOptions } from './EntityAssigner';
@@ -61,9 +60,9 @@ export class WrappedEntity<T extends object, PK extends keyof T> {
     this.__lazyInitialized = false;
   }
 
-  toReference(): IdentifiedReference<T, PK> {
+  toReference(): Ref<T, PK> {
     this.__reference ??= new Reference(this.entity);
-    return this.__reference as IdentifiedReference<T, PK>;
+    return this.__reference as Ref<T, PK>;
   }
 
   toObject(ignoreFields: string[] = []): EntityData<T> {

--- a/packages/core/src/entity/wrap.ts
+++ b/packages/core/src/entity/wrap.ts
@@ -1,25 +1,29 @@
-import type { Dictionary, IWrappedEntity, IWrappedEntityInternal, PrimaryProperty } from '../typings';
+import type { Dictionary, IWrappedEntity, IWrappedEntityInternal } from '../typings';
 
 /**
  * returns WrappedEntity instance associated with this entity. This includes all the internal properties like `__meta` or `__em`.
  */
-export function wrap<T, PK extends keyof T | unknown = PrimaryProperty<T>>(entity: T, preferHelper: true): IWrappedEntityInternal<T, PK>;
+export function wrap<T extends object>(entity: T, preferHelper: true): IWrappedEntityInternal<T>;
 
 /**
  * wraps entity type with WrappedEntity internal properties and helpers like init/isInitialized/populated/toJSON
  */
-export function wrap<T, PK extends keyof T | unknown = PrimaryProperty<T>>(entity: T, preferHelper?: false): IWrappedEntity<T, PK>;
+export function wrap<T extends object>(entity: T, preferHelper?: false): IWrappedEntity<T>;
 
 /**
  * wraps entity type with WrappedEntity internal properties and helpers like init/isInitialized/populated/toJSON
  * use `preferHelper = true` to have access to the internal `__` properties like `__meta` or `__em`
  */
-export function wrap<T, PK extends keyof T | unknown = PrimaryProperty<T>>(entity: T & Dictionary, preferHelper = false): IWrappedEntity<T, PK> | IWrappedEntityInternal<T, PK> {
-  if (entity?.__baseEntity && !preferHelper) {
-    return entity as unknown as IWrappedEntity<T, PK>;
+export function wrap<T extends object>(entity: T & Dictionary, preferHelper = false): IWrappedEntity<T> | IWrappedEntityInternal<T> {
+  if (!entity) {
+    return entity;
   }
 
-  return entity?.__helper ?? entity;
+  if (entity.__baseEntity && !preferHelper) {
+    return entity as unknown as IWrappedEntity<T>;
+  }
+
+  return entity.__helper ?? entity;
 }
 
 /**
@@ -27,6 +31,6 @@ export function wrap<T, PK extends keyof T | unknown = PrimaryProperty<T>>(entit
  * use `preferHelper = true` to have access to the internal `__` properties like `__meta` or `__em`
  * @internal
  */
-export function helper<T, PK extends keyof T | unknown = PrimaryProperty<T>>(entity: T): IWrappedEntityInternal<T, PK> {
+export function helper<T extends object>(entity: T): IWrappedEntityInternal<T> {
   return (entity as Dictionary).__helper;
 }

--- a/packages/core/src/events/EventManager.ts
+++ b/packages/core/src/events/EventManager.ts
@@ -25,10 +25,10 @@ export class EventManager {
       });
   }
 
-  dispatchEvent<T>(event: TransactionEventType, args: TransactionEventArgs): unknown;
-  dispatchEvent<T>(event: EventType.onInit, args: Partial<EventArgs<T>>): unknown;
-  dispatchEvent<T>(event: EventType, args: Partial<EventArgs<T> | FlushEventArgs>): Promise<unknown>;
-  dispatchEvent<T>(event: EventType, args: Partial<AnyEventArgs<T>>): Promise<unknown> | unknown {
+  dispatchEvent<T extends object>(event: TransactionEventType, args: TransactionEventArgs): unknown;
+  dispatchEvent<T extends object>(event: EventType.onInit, args: Partial<EventArgs<T>>): unknown;
+  dispatchEvent<T extends object>(event: EventType, args: Partial<EventArgs<T> | FlushEventArgs>): Promise<unknown>;
+  dispatchEvent<T extends object>(event: EventType, args: Partial<AnyEventArgs<T>>): Promise<unknown> | unknown {
     const listeners: AsyncFunction[] = [];
     const entity = (args as EventArgs<T>).entity;
 
@@ -86,4 +86,4 @@ export class EventManager {
 
 }
 
-type AnyEventArgs<T> = EventArgs<T> | FlushEventArgs | TransactionEventArgs;
+type AnyEventArgs<T extends object> = EventArgs<T> | FlushEventArgs | TransactionEventArgs;

--- a/packages/core/src/events/EventSubscriber.ts
+++ b/packages/core/src/events/EventSubscriber.ts
@@ -6,14 +6,14 @@ import type { Transaction } from '../connections';
 export interface EventArgs<T> {
   entity: T;
   em: EntityManager;
-  changeSet?: ChangeSet<T>;
+  changeSet?: ChangeSet<T & {}>;
 }
 
-export interface FlushEventArgs extends Omit<EventArgs<unknown>, 'entity'> {
+export interface FlushEventArgs extends Omit<EventArgs<any>, 'entity' | 'changeSet'> {
   uow: UnitOfWork;
 }
 
-export interface TransactionEventArgs extends Omit<EventArgs<unknown>, 'entity' | 'changeSet'> {
+export interface TransactionEventArgs extends Omit<EventArgs<any>, 'entity' | 'changeSet'> {
   transaction?: Transaction;
   uow?: UnitOfWork;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,7 @@
  */
 /* istanbul ignore file */
 export {
-  Constructor, ConnectionType, Dictionary, PrimaryKeyType, PrimaryKeyProp, Primary, IPrimaryKey, ObjectQuery, FilterQuery, IWrappedEntity, EntityName, EntityData, Highlighter,
+  Constructor, ConnectionType, Dictionary, PrimaryKeyProp, Primary, IPrimaryKey, ObjectQuery, FilterQuery, IWrappedEntity, EntityName, EntityData, Highlighter,
   AnyEntity, EntityClass, EntityProperty, EntityMetadata, QBFilterQuery, PopulateOptions, Populate, Loaded, New, LoadedReference, LoadedCollection, IMigrator, IMigrationGenerator,
   GetRepository, EntityRepositoryType, MigrationObject, DeepPartial, PrimaryProperty, Cast, IsUnknown, EntityDictionary, EntityDTO, MigrationDiff, FilterObject,
   IEntityGenerator, ISeedManager, EntityClassGroup, OptionalProps, RequiredEntityData, CheckCallback, SimpleColumnMeta, Rel, Ref, ISchemaGenerator,

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -213,8 +213,8 @@ export class EntitySchema<T = any, U = never> {
     this._meta.uniques.push(options as any);
   }
 
-  setCustomRepository(repository: () => Constructor<EntityRepository<any>>): void {
-    this._meta.customRepository = repository;
+  setCustomRepository(repository: () => Constructor): void {
+    this._meta.customRepository = repository as () => Constructor<EntityRepository<any>>;
   }
 
   setExtends(base: string): void {

--- a/packages/core/src/serialization/EntitySerializer.ts
+++ b/packages/core/src/serialization/EntitySerializer.ts
@@ -143,7 +143,7 @@ export class EntitySerializer {
       }
 
       if (Utils.isObject(entity[prop])) {
-        return helper(entity[prop]).toJSON() as T[keyof T];
+        return helper(entity[prop]!).toJSON() as T[keyof T];
       }
     }
 

--- a/packages/core/src/serialization/EntityTransformer.ts
+++ b/packages/core/src/serialization/EntityTransformer.ts
@@ -134,7 +134,7 @@ export class EntityTransformer {
         }) as T[keyof T];
       }
 
-      const wrapped = entity[prop] && helper(entity[prop]);
+      const wrapped = entity[prop] && helper(entity[prop]!);
       return wrapped ? wrapped.toJSON() as T[keyof T] : entity[prop];
     }
 

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1,7 +1,7 @@
 import type { Transaction } from './connections';
 import type { Cascade, EventType, LoadStrategy, LockMode, QueryOrderMap } from './enums';
 import { ReferenceType } from './enums';
-import type { AssignOptions, Collection, EntityFactory, EntityIdentifier, EntityRepository, IdentifiedReference, Reference } from './entity';
+import type { AssignOptions, Collection, EntityFactory, EntityIdentifier, EntityRepository, Reference } from './entity';
 import type { SerializationContext } from './serialization';
 import type { EntitySchema, MetadataStorage } from './metadata';
 import type { Type, types } from './types';
@@ -111,7 +111,7 @@ export interface IWrappedEntity<
   isTouched(): boolean;
   populated(populated?: boolean): void;
   init<P extends string = never>(populated?: boolean, populate?: Populate<T, P>, lockMode?: LockMode, connectionType?: ConnectionType): Promise<Loaded<T, P>>;
-  toReference<PK2 extends PK | unknown = PrimaryProperty<T>, P2 extends string = string>(): IdentifiedReference<T, PK2> & LoadedReference<T>;
+  toReference<PK2 extends PK | unknown = PrimaryProperty<T>, P2 extends string = string>(): Ref<T, PK2> & LoadedReference<T>;
   toObject(ignoreFields?: string[]): EntityDTO<T>;
   toJSON(...args: any[]): EntityDTO<T>;
   toPOJO(): EntityDTO<T>;
@@ -145,7 +145,7 @@ export interface IWrappedEntityInternal<
   __schema?: string;
   __populated: boolean;
   __onLoadFired: boolean;
-  __reference?: Reference<T>;
+  __reference?: Ref<T>;
   __lazyInitialized: boolean;
   __pk?: Primary<T>;
   __primaryKeys: Primary<T>[];
@@ -212,8 +212,7 @@ type Relation<T> = {
 /** Identity type that can be used to get around issues with cycles in bidirectional relations. */
 export type Rel<T> = T;
 
-/** Shortcut for `IdentifiedReference`. */
-export type Ref<T, PK extends keyof T | unknown = PrimaryProperty<T>> = IdentifiedReference<T, PK>;
+export type Ref<T, PK extends keyof T | unknown = PrimaryProperty<T>> = true extends IsUnknown<PK> ? Reference<T> : ({ [K in Cast<PK, keyof T>]: T[K] } & Reference<T>);
 
 export type EntityDTOProp<T> = T extends Scalar
   ? T

--- a/packages/core/src/unit-of-work/ChangeSet.ts
+++ b/packages/core/src/unit-of-work/ChangeSet.ts
@@ -3,7 +3,7 @@ import type { EntityData, EntityMetadata, EntityDictionary, Primary } from '../t
 import { helper } from '../entity/wrap';
 import { Utils } from '../utils/Utils';
 
-export class ChangeSet<T> {
+export class ChangeSet<T extends object> {
 
   private primaryKey?: Primary<T> | null;
   private serializedPrimaryKey?: string;

--- a/packages/core/src/unit-of-work/ChangeSetComputer.ts
+++ b/packages/core/src/unit-of-work/ChangeSetComputer.ts
@@ -18,7 +18,7 @@ export class ChangeSetComputer {
               private readonly platform: Platform,
               private readonly config: Configuration) { }
 
-  computeChangeSet<T>(entity: T): ChangeSet<T> | null {
+  computeChangeSet<T extends object>(entity: T): ChangeSet<T> | null {
     const meta = this.metadata.get((entity as AnyEntity).constructor.name);
 
     if (meta.readonly) {
@@ -100,7 +100,7 @@ export class ChangeSetComputer {
     }
   }
 
-  private computePayload<T>(entity: T, ignoreUndefined = false): EntityData<T> {
+  private computePayload<T extends object>(entity: T, ignoreUndefined = false): EntityData<T> {
     const data = this.comparator.prepareEntity(entity);
     const entityName = helper(entity).__meta!.root.className;
     const originalEntityData = helper(entity).__originalEntityData;
@@ -121,7 +121,7 @@ export class ChangeSetComputer {
     return data;
   }
 
-  private processProperty<T>(changeSet: ChangeSet<T>, prop: EntityProperty<T>, target?: unknown): void {
+  private processProperty<T extends object>(changeSet: ChangeSet<T>, prop: EntityProperty<T>, target?: unknown): void {
     if (!target) {
       const targets = Utils.unwrapProperty(changeSet.entity, changeSet.meta, prop);
       targets.forEach(([t]) => this.processProperty(changeSet, prop, t));
@@ -138,7 +138,7 @@ export class ChangeSetComputer {
     }
   }
 
-  private processToOne<T>(prop: EntityProperty<T>, changeSet: ChangeSet<T>): void {
+  private processToOne<T extends object>(prop: EntityProperty<T>, changeSet: ChangeSet<T>): void {
     const isToOneOwner = prop.reference === ReferenceType.MANY_TO_ONE || (prop.reference === ReferenceType.ONE_TO_ONE && prop.owner);
 
     if (!isToOneOwner || prop.mapToPk) {
@@ -154,7 +154,7 @@ export class ChangeSetComputer {
     });
   }
 
-  private processToMany<T>(prop: EntityProperty<T>, changeSet: ChangeSet<T>): void {
+  private processToMany<T extends object>(prop: EntityProperty<T>, changeSet: ChangeSet<T>): void {
     const target = changeSet.entity[prop.name] as unknown as Collection<any>;
 
     if (!target.isDirty()) {

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -559,7 +559,7 @@ export class UnitOfWork {
 
     return wrapped.__meta.uniqueProps.map(prop => {
       if (entity[prop.name]) {
-        return prop.reference === ReferenceType.SCALAR || prop.mapToPk ? entity[prop.name] : helper(entity[prop.name]).getSerializedPrimaryKey();
+        return prop.reference === ReferenceType.SCALAR || prop.mapToPk ? entity[prop.name] : helper(entity[prop.name]!).getSerializedPrimaryKey();
       }
 
       if (wrapped.__originalEntityData?.[prop.name as string]) {

--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -11,7 +11,7 @@ export class QueryHelper {
 
   static readonly SUPPORTED_OPERATORS = ['>', '<', '<=', '>=', '!', '!='];
 
-  static processParams(params: any): any {
+  static processParams(params: unknown): any {
     if (Reference.isReference(params)) {
       params = params.unwrap();
     }

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -569,7 +569,7 @@ export class Utils {
   /**
    * Checks whether given object is an entity instance.
    */
-  static isEntity<T = unknown>(data: any, allowReference = false): data is T {
+  static isEntity<T = unknown>(data: any, allowReference = false): data is T & {} {
     if (!Utils.isObject(data)) {
       return false;
     }

--- a/packages/entity-generator/src/SourceFile.ts
+++ b/packages/entity-generator/src/SourceFile.ts
@@ -1,4 +1,12 @@
-import type { Dictionary, EntityMetadata, EntityOptions, EntityProperty, NamingStrategy, Platform } from '@mikro-orm/core';
+import type {
+  Dictionary,
+  EntityMetadata,
+  EntityOptions,
+  EntityProperty,
+  NamingStrategy,
+  OneToOneOptions,
+  Platform,
+} from '@mikro-orm/core';
 import { ReferenceType, UnknownType, Utils } from '@mikro-orm/core';
 
 export class SourceFile {
@@ -98,9 +106,9 @@ export class SourceFile {
     const optional = prop.nullable ? '?' : (useDefault ? '' : '!');
 
     if (prop.wrappedReference) {
-      this.coreImports.add('IdentifiedReference');
+      this.coreImports.add('Ref');
       this.entityImports.add(prop.type);
-      return `${padding}${prop.name}${optional}: IdentifiedReference<${prop.type}>;\n`;
+      return `${padding}${prop.name}${optional}: Ref<${prop.type}>;\n`;
     }
 
     const ret = `${prop.name}${optional}: ${prop.type}`;
@@ -304,14 +312,14 @@ export class SourceFile {
     options.mappedBy = this.quote(prop.mappedBy);
   }
 
-  protected getForeignKeyDecoratorOptions(options: Dictionary, prop: EntityProperty) {
+  protected getForeignKeyDecoratorOptions(options: OneToOneOptions<any, any>, prop: EntityProperty) {
     const parts = prop.referencedTableName.split('.', 2);
     const className = this.namingStrategy.getClassName(parts.length > 1 ? parts[1] : parts[0], '_');
     this.entityImports.add(className);
     options.entity = `() => ${className}`;
 
     if (prop.wrappedReference) {
-      options.wrappedReference = true;
+      options.ref = true;
     }
 
     if (prop.mappedBy) {

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -906,7 +906,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
     }
   }
 
-  async lockPessimistic<T>(entity: T, options: LockOptions): Promise<void> {
+  async lockPessimistic<T extends object>(entity: T, options: LockOptions): Promise<void> {
     const meta = helper(entity).__meta;
     const qb = this.createQueryBuilder((entity as object).constructor.name, options.ctx).unsetFlag(QueryFlag.CONVERT_CUSTOM_TYPES).withSchema(options.schema ?? meta.schema);
     const cond = Utils.getPrimaryKeyCond(entity, meta.primaryKeys);

--- a/packages/knex/src/AbstractSqlPlatform.ts
+++ b/packages/knex/src/AbstractSqlPlatform.ts
@@ -18,7 +18,7 @@ export abstract class AbstractSqlPlatform extends Platform {
   }
 
   getRepositoryClass<T extends object>(): Constructor<EntityRepository<T>> {
-    return SqlEntityRepository as Constructor<EntityRepository<T>>;
+    return SqlEntityRepository as unknown as Constructor<EntityRepository<T>>;
   }
 
   getSchemaHelper(): SchemaHelper | undefined {

--- a/packages/knex/src/query/CriteriaNode.ts
+++ b/packages/knex/src/query/CriteriaNode.ts
@@ -56,7 +56,7 @@ export class CriteriaNode implements ICriteriaNode {
     const type = this.prop ? this.prop.reference : null;
     const composite = this.prop?.joinColumns ? this.prop.joinColumns.length > 1 : false;
     const customExpression = CriteriaNode.isCustomExpression(this.key!);
-    const scalar = payload === null || Utils.isPrimaryKey(payload) || payload instanceof RegExp || payload instanceof Date || customExpression;
+    const scalar = payload === null || Utils.isPrimaryKey(payload) || payload as unknown instanceof RegExp || payload as unknown instanceof Date || customExpression;
     const operator = Utils.isPlainObject(payload) && Object.keys(payload).every(k => Utils.isOperator(k, false));
 
     if (composite) {
@@ -111,7 +111,7 @@ export class CriteriaNode implements ICriteriaNode {
     }
 
     const customExpression = CriteriaNode.isCustomExpression(this.key);
-    const scalar = this.payload === null || Utils.isPrimaryKey(this.payload) || this.payload instanceof RegExp || this.payload instanceof Date || customExpression;
+    const scalar = this.payload === null || Utils.isPrimaryKey(this.payload) || this.payload as unknown instanceof RegExp || this.payload as unknown instanceof Date || customExpression;
     const operator = Utils.isObject(this.payload) && Object.keys(this.payload).every(k => Utils.isOperator(k, false));
 
     return this.prop.reference === ReferenceType.MANY_TO_MANY && (scalar || operator);

--- a/packages/knex/src/query/CriteriaNodeFactory.ts
+++ b/packages/knex/src/query/CriteriaNodeFactory.ts
@@ -13,7 +13,7 @@ export class CriteriaNodeFactory {
 
   static createNode(metadata: MetadataStorage, entityName: string, payload: any, parent?: ICriteriaNode, key?: string): ICriteriaNode {
     const customExpression = CriteriaNode.isCustomExpression(key || '');
-    const scalar = Utils.isPrimaryKey(payload) || payload instanceof RegExp || payload instanceof Date || customExpression;
+    const scalar = Utils.isPrimaryKey(payload) || payload as unknown instanceof RegExp || payload as unknown instanceof Date || customExpression;
 
     if (Array.isArray(payload) && !scalar) {
       return this.createArrayNode(metadata, entityName, payload, parent, key);

--- a/packages/knex/src/query/ObjectCriteriaNode.ts
+++ b/packages/knex/src/query/ObjectCriteriaNode.ts
@@ -66,7 +66,7 @@ export class ObjectCriteriaNode extends CriteriaNode {
 
   shouldInline(payload: any): boolean {
     const customExpression = ObjectCriteriaNode.isCustomExpression(this.key!);
-    const scalar = Utils.isPrimaryKey(payload) || payload instanceof RegExp || payload instanceof Date || customExpression;
+    const scalar = Utils.isPrimaryKey(payload) || payload as unknown instanceof RegExp || payload as unknown instanceof Date || customExpression;
     const operator = Utils.isObject(payload) && Object.keys(payload).every(k => Utils.isOperator(k, false));
 
     return !!this.prop && this.prop.reference !== ReferenceType.SCALAR && !scalar && !operator;
@@ -133,7 +133,7 @@ export class ObjectCriteriaNode extends CriteriaNode {
   private autoJoin<T>(qb: IQueryBuilder<T>, alias: string): string {
     const nestedAlias = qb.getNextAlias(this.prop?.pivotTable ?? this.entityName);
     const customExpression = ObjectCriteriaNode.isCustomExpression(this.key!);
-    const scalar = Utils.isPrimaryKey(this.payload) || this.payload instanceof RegExp || this.payload instanceof Date || customExpression;
+    const scalar = Utils.isPrimaryKey(this.payload) || this.payload as unknown instanceof RegExp || this.payload as unknown instanceof Date || customExpression;
     const operator = Utils.isPlainObject(this.payload) && Object.keys(this.payload).every(k => Utils.isOperator(k, false));
     const field = `${alias}.${this.prop!.name}`;
 

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -109,7 +109,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
 
   async nativeInsert<T extends object>(entityName: string, data: EntityDictionary<T>, options: NativeInsertUpdateOptions<T> = {}): Promise<QueryResult<T>> {
     data = this.renameFields(entityName, data);
-    return this.rethrow(this.getConnection('write').insertOne(entityName, data, options.ctx)) as Promise<QueryResult<T>>;
+    return this.rethrow(this.getConnection('write').insertOne(entityName, data, options.ctx)) as unknown as Promise<QueryResult<T>>;
   }
 
   async nativeInsertMany<T extends object>(entityName: string, data: EntityDictionary<T>[], options: NativeInsertUpdateManyOptions<T> = {}): Promise<QueryResult<T>> {
@@ -120,7 +120,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     const res = await this.rethrow(this.getConnection('write').insertMany(entityName, data as any[], options.ctx));
     res.rows = res.insertedIds!.map(id => ({ [pk]: id }));
 
-    return res as QueryResult<T>;
+    return res as unknown as QueryResult<T>;
   }
 
   async nativeUpdate<T extends object>(entityName: string, where: FilterQuery<T>, data: EntityDictionary<T>, options: NativeInsertUpdateOptions<T> = {}): Promise<QueryResult<T>> {
@@ -131,7 +131,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     where = this.renameFields(entityName, where, true);
     data = this.renameFields(entityName, data);
 
-    return this.rethrow(this.getConnection('write').updateMany(entityName, where as object, data, options.ctx, options.upsert)) as Promise<QueryResult<T>>;
+    return this.rethrow(this.getConnection('write').updateMany(entityName, where as object, data, options.ctx, options.upsert)) as unknown as Promise<QueryResult<T>>;
   }
 
   async nativeUpdateMany<T extends object>(entityName: string, where: FilterQuery<T>[], data: EntityDictionary<T>[], options: NativeInsertUpdateOptions<T> = {}): Promise<QueryResult<T>> {
@@ -144,7 +144,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     });
     data = data.map(row => this.renameFields(entityName, row));
 
-    return this.rethrow(this.getConnection('write').bulkUpdateMany(entityName, where as FilterQuery<object>[], data as object[], options.ctx, options.upsert)) as Promise<QueryResult<T>>;
+    return this.rethrow(this.getConnection('write').bulkUpdateMany(entityName, where as FilterQuery<object>[], data as object[], options.ctx, options.upsert)) as unknown as Promise<QueryResult<T>>;
   }
 
   async nativeDelete<T extends object>(entityName: string, where: FilterQuery<T>, options: { ctx?: Transaction<ClientSession> } = {}): Promise<QueryResult<T>> {
@@ -154,7 +154,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
 
     where = this.renameFields(entityName, where, true);
 
-    return this.rethrow(this.getConnection('write').deleteMany(entityName, where as object, options.ctx)) as Promise<QueryResult<T>>;
+    return this.rethrow(this.getConnection('write').deleteMany(entityName, where as object, options.ctx)) as unknown as Promise<QueryResult<T>>;
   }
 
   async aggregate(entityName: string, pipeline: any[], ctx?: Transaction<ClientSession>): Promise<any[]> {

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -22,7 +22,7 @@ export class MongoPlatform extends Platform {
   }
 
   getRepositoryClass<T extends object>(): Constructor<EntityRepository<T>> {
-    return MongoEntityRepository as Constructor<EntityRepository<T>>;
+    return MongoEntityRepository as unknown as Constructor<EntityRepository<T>>;
   }
 
   /** @inheritDoc */

--- a/packages/reflection/CHANGELOG.md
+++ b/packages/reflection/CHANGELOG.md
@@ -481,7 +481,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* **ts-morph:** fix discovery of `Ref` with ts-morph ([d94bd91](https://github.com/mikro-orm/mikro-orm/commit/d94bd9106948d2ca583aaff9125486987ffc5243)), closes [#1088](https://github.com/mikro-orm/mikro-orm/issues/1088)
+* **ts-morph:** fix discovery of `IdentifiedReference` with ts-morph ([d94bd91](https://github.com/mikro-orm/mikro-orm/commit/d94bd9106948d2ca583aaff9125486987ffc5243)), closes [#1088](https://github.com/mikro-orm/mikro-orm/issues/1088)
 
 
 

--- a/packages/reflection/CHANGELOG.md
+++ b/packages/reflection/CHANGELOG.md
@@ -481,7 +481,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* **ts-morph:** fix discovery of `IdentifiedReference` with ts-morph ([d94bd91](https://github.com/mikro-orm/mikro-orm/commit/d94bd9106948d2ca583aaff9125486987ffc5243)), closes [#1088](https://github.com/mikro-orm/mikro-orm/issues/1088)
+* **ts-morph:** fix discovery of `Ref` with ts-morph ([d94bd91](https://github.com/mikro-orm/mikro-orm/commit/d94bd9106948d2ca583aaff9125486987ffc5243)), closes [#1088](https://github.com/mikro-orm/mikro-orm/issues/1088)
 
 
 

--- a/packages/reflection/src/TsMorphMetadataProvider.ts
+++ b/packages/reflection/src/TsMorphMetadataProvider.ts
@@ -69,7 +69,7 @@ export class TsMorphMetadataProvider extends MetadataProvider {
       prop.optional = true;
     }
 
-    this.processWrapper(prop, 'IdentifiedReference');
+    this.processWrapper(prop, 'Ref');
     this.processWrapper(prop, 'Reference');
     this.processWrapper(prop, 'Ref');
     this.processWrapper(prop, 'Collection');
@@ -159,7 +159,7 @@ export class TsMorphMetadataProvider extends MetadataProvider {
 
     prop.type = m[1];
 
-    if (['Ref', 'Reference', 'IdentifiedReference'].includes(wrapper)) {
+    if (['Ref', 'Reference', 'Ref'].includes(wrapper)) {
       prop.wrappedReference = true;
     }
   }

--- a/tests/EntityFactory.test.ts
+++ b/tests/EntityFactory.test.ts
@@ -206,7 +206,7 @@ describe('EntityFactory', () => {
     expect(a1.books[0].title).toBe('B1');
     expect(a1.books[0].author).toBe(a1); // propagation to owning side
     expect(a1.books[0].publisher!.id).toBe('5b0d19b28b21c648c2c8a600');
-    expect(wrap(a1.books[0].publisher).isInitialized()).toBe(false);
+    expect(wrap(a1.books[0].publisher!).isInitialized()).toBe(false);
     expect(a1.books[0].tags.isInitialized()).toBe(true);
     expect(a1.books[0].tags.isDirty()).toBe(true); // owning side
     expect(a1.books[0].tags[0].name).toBe('t1');
@@ -237,7 +237,7 @@ describe('EntityFactory', () => {
     expect(a2.books[0].title).toBe('B1');
     expect(a2.books[0].author).toBe(a2); // propagation to owning side
     expect(a2.books[0].publisher!.id).toBe('5b0d19b28b21c648c2c8a600');
-    expect(wrap(a2.books[0].publisher).isInitialized()).toBe(false);
+    expect(wrap(a2.books[0].publisher!).isInitialized()).toBe(false);
     expect(a2.books[0].tags.isInitialized()).toBe(true);
     expect(a2.books[0].tags.isDirty()).toBe(true); // owning side
     expect(a2.books[0].tags[0].name).toBe('t1');

--- a/tests/EntityHelper.mongo.test.ts
+++ b/tests/EntityHelper.mongo.test.ts
@@ -122,11 +122,11 @@ describe('EntityHelperMongo', () => {
     await orm.em.persistAndFlush(author);
     orm.em.clear();
 
-    const jon = await orm.em.findOne(Author, author.id);
+    const jon = await orm.em.findOneOrFail(Author, author.id);
     await orm.em.nativeUpdate(Author, { id: author.id }, { name: 'Changed!' });
-    expect(jon!.name).toBe('Jon Snow');
+    expect(jon.name).toBe('Jon Snow');
     await wrap(jon).init();
-    expect(jon!.name).toBe('Changed!');
+    expect(jon.name).toBe('Changed!');
   });
 
   test('should have string id getter and setter', async () => {
@@ -142,7 +142,9 @@ describe('EntityHelperMongo', () => {
   });
 
   test('wrap helper returns the argument when its falsy', async () => {
+    // @ts-expect-error
     expect(wrap(null)).toBeNull();
+    // @ts-expect-error
     expect(wrap(undefined)).toBeUndefined();
   });
 

--- a/tests/EntityHelper.mysql.test.ts
+++ b/tests/EntityHelper.mysql.test.ts
@@ -25,8 +25,8 @@ describe('EntityHelperMySql', () => {
 
     const repo = orm.em.getRepository(FooBar2);
     const a = await repo.findOneOrFail(bar.id, { populate: ['baz.bar'] });
-    expect(wrap(a.baz).isInitialized()).toBe(true);
-    expect(wrap(a.baz!.bar).isInitialized()).toBe(true);
+    expect(wrap(a.baz!).isInitialized()).toBe(true);
+    expect(wrap(a.baz!.bar!).isInitialized()).toBe(true);
     expect(wrap(a).toJSON()).toEqual({
       baz: {
         bar: {

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -195,7 +195,7 @@ describe('EntityManagerMongo', () => {
     const repo = orm.em.getRepository(FooBar);
     const a = await repo.findOne(bar.id, { populate: ['baz.bar'] });
     expect(wrap(a!.baz!).isInitialized()).toBe(true);
-    expect(wrap(a!.baz!.book).isInitialized()).toBe(true);
+    expect(wrap(a!.baz!.book!).isInitialized()).toBe(true);
     expect(a!.baz!.book!.title).toBe('FooBar vs FooBaz');
   });
 
@@ -730,11 +730,11 @@ describe('EntityManagerMongo', () => {
     expect(jon.name).toBe('Jon Snow');
     expect(jon.born).toEqual(new Date('1990-03-23'));
     expect(jon.favouriteBook).toBeInstanceOf(Book);
-    expect(wrap(jon.favouriteBook).isInitialized()).toBe(false);
+    expect(wrap(jon.favouriteBook!).isInitialized()).toBe(false);
 
-    await wrap(jon.favouriteBook).init();
+    await wrap(jon.favouriteBook!).init();
     expect(jon.favouriteBook).toBeInstanceOf(Book);
-    expect(wrap(jon.favouriteBook).isInitialized()).toBe(true);
+    expect(wrap(jon.favouriteBook!).isInitialized()).toBe(true);
     expect(jon.favouriteBook?.title).toBe('Bible');
   });
 
@@ -1703,20 +1703,20 @@ describe('EntityManagerMongo', () => {
     a.name = 'test 1';
     a.favouriteBook!.title = 'test 2';
     expect(wrap(a, true).__originalEntityData).toMatchObject({ name: 'Jon Snow' });
-    expect(wrap(a.favouriteBook, true).__originalEntityData).toMatchObject({ title: 'b1' });
+    expect(wrap(a.favouriteBook!, true).__originalEntityData).toMatchObject({ title: 'b1' });
     const a1 = await orm.em.findOneOrFail(Author, { favouriteBook: a.favouriteBook });
     expect(wrap(a, true).__originalEntityData).toMatchObject({ name: 'Jon Snow' });
-    expect(wrap(a.favouriteBook, true).__originalEntityData).toMatchObject({ title: 'b1' });
+    expect(wrap(a.favouriteBook!, true).__originalEntityData).toMatchObject({ title: 'b1' });
     const b1 = await orm.em.findOneOrFail(Book, { author });
     expect(a.name).toBe('test 1');
     expect(a.favouriteBook?.title).toBe('test 2');
     expect(a1.name).toBe('test 1');
     expect(b1.title).toBe('test 2');
     expect(wrap(a, true).__originalEntityData).toMatchObject({ name: 'Jon Snow' });
-    expect(wrap(a.favouriteBook, true).__originalEntityData).toMatchObject({ title: 'b1' });
+    expect(wrap(a.favouriteBook!, true).__originalEntityData).toMatchObject({ title: 'b1' });
     await orm.em.flush();
     expect(wrap(a, true).__originalEntityData).toMatchObject({ name: 'test 1' });
-    expect(wrap(a.favouriteBook, true).__originalEntityData).toMatchObject({ title: 'test 2' });
+    expect(wrap(a.favouriteBook!, true).__originalEntityData).toMatchObject({ title: 'test 2' });
     orm.em.clear();
 
     const a2 = await orm.em.findOneOrFail(Author, author);
@@ -1841,8 +1841,8 @@ describe('EntityManagerMongo', () => {
     await orm.em.persistAndFlush([author, author2]);
     orm.em.clear();
 
-    const ref = orm.em.getReference<Author, 'id' | '_id'>(Author, author.id, { wrapped: true });
-    const ref1 = orm.em.getRepository(Author).getReference<'id' | '_id'>(author.id, { wrapped: true });
+    const ref = orm.em.getReference<Author>(Author, author.id, { wrapped: true });
+    const ref1 = orm.em.getRepository(Author).getReference(author.id, { wrapped: true });
     expect(ref).toBe(ref1);
     expect(ref.unwrap()).toBe(ref1.unwrap());
     // @ts-expect-error private getter
@@ -1871,7 +1871,7 @@ describe('EntityManagerMongo', () => {
     expect(wrap(ent).isInitialized()).toBe(true);
     orm.em.clear();
 
-    const ref4 = orm.em.getReference<Author, 'id' | '_id'>(Author, author.id, { wrapped: true });
+    const ref4 = orm.em.getReference(Author, author.id, { wrapped: true });
     expect(ref4.isInitialized()).toBe(false);
     await expect(ref4.load('name')).resolves.toBe('God');
     expect(ref4.isInitialized()).toBe(true);

--- a/tests/EntityManager.mongo2.test.ts
+++ b/tests/EntityManager.mongo2.test.ts
@@ -43,7 +43,7 @@ describe('EntityManagerMongo2', () => {
     expect(book5.tags.$[0].name).toBe('t1');
 
     const pub2 = orm.em.create(Publisher, { name: 'asd' });
-    const wrapped0 = wrap(pub2).toReference<'id' | '_id'>();
+    const wrapped0 = wrap(pub2).toReference();
     // @ts-expect-error
     expect(wrapped0.books).toBeUndefined();
     book5.publisher = wrapped0;

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -253,8 +253,8 @@ describe('EntityManagerMySql', () => {
 
     const repo = orm.em.getRepository(FooBar2);
     const a = await repo.findOne(bar.id, { populate: ['baz'], flags: [QueryFlag.DISTINCT] });
-    expect(wrap(a!.baz).isInitialized()).toBe(true);
-    expect(wrap(a!.baz!.bar).isInitialized()).toBe(true);
+    expect(wrap(a!.baz!).isInitialized()).toBe(true);
+    expect(wrap(a!.baz!.bar!).isInitialized()).toBe(true);
   });
 
   test('factory should support a primary key value of 0', async () => {
@@ -285,7 +285,7 @@ describe('EntityManagerMySql', () => {
     orm.em.clear();
     const repo = orm.em.getRepository(FooBar2);
     const a = await repo.findOne(fooBar.id, { populate: ['baz'] });
-    expect(wrap(a!.baz).isInitialized()).toBe(true);
+    expect(wrap(a!.baz!).isInitialized()).toBe(true);
     expect(a!.baz!.id).toBe(0);
     expect(a!.baz!.name).toBe('testBaz');
   });
@@ -311,7 +311,7 @@ describe('EntityManagerMySql', () => {
     expect(a1.name).toBe('fz');
     expect(a1.bar).toBeInstanceOf(FooBar2);
     expect(a1.version).toBeUndefined();
-    expect(wrap(a1.bar).isInitialized()).toBe(false);
+    expect(wrap(a1.bar!).isInitialized()).toBe(false);
   });
 
   test('transactions', async () => {
@@ -530,7 +530,7 @@ describe('EntityManagerMySql', () => {
         expect(wrap(book.author).isInitialized()).toBe(true);
         expect(book.publisher).toBeInstanceOf(Reference);
         expect(book.publisher!.unwrap()).toBeInstanceOf(Publisher2);
-        expect(wrap(book.publisher).isInitialized()).toBe(false);
+        expect(wrap(book.publisher!).isInitialized()).toBe(false);
       }
     }
 
@@ -856,7 +856,7 @@ describe('EntityManagerMySql', () => {
     expect(res1!.createdAt).toBeDefined();
     expect((res1 as any).created_at).not.toBeDefined();
     expect(res1!.meta).toEqual({ category: 'foo', items: 1 });
-    expect(wrap(res1).isInitialized()).toBe(true);
+    expect(wrap(res1!).isInitialized()).toBe(true);
     const qb2 = orm.em.createQueryBuilder(Book2);
     const res2 = await qb2.select('*').where({ title: 'not exists' }).getSingleResult();
     expect(res2).toBeNull();
@@ -943,11 +943,11 @@ describe('EntityManagerMySql', () => {
     expect(jon).not.toBeNull();
     expect(jon.name).toBe('Jon Snow');
     expect(jon.favouriteBook).toBeInstanceOf(Book2);
-    expect(wrap(jon.favouriteBook).isInitialized()).toBe(false);
+    expect(wrap(jon.favouriteBook!).isInitialized()).toBe(false);
 
-    await wrap(jon.favouriteBook).init();
+    await wrap(jon.favouriteBook!).init();
     expect(jon.favouriteBook).toBeInstanceOf(Book2);
-    expect(wrap(jon.favouriteBook).isInitialized()).toBe(true);
+    expect(wrap(jon.favouriteBook!).isInitialized()).toBe(true);
     expect(jon.favouriteBook!.title).toBe('Bible');
   });
 
@@ -977,7 +977,7 @@ describe('EntityManagerMySql', () => {
     expect(mock.mock.calls[0][0]).toMatch('select `f0`.*, `f1`.`id` as `bar_id` from `foo_baz2` as `f0` left join `foo_bar2` as `f1` on `f0`.`id` = `f1`.`baz_id` where `f0`.`id` = ? limit ?');
     expect(b0.bar).toBeDefined();
     expect(b0.bar).toBeInstanceOf(FooBar2);
-    expect(wrap(b0.bar).isInitialized()).toBe(false);
+    expect(wrap(b0.bar!).isInitialized()).toBe(false);
     orm.em.clear();
 
     const b1 = (await orm.em.findOne(FooBaz2, { id: baz.id }, { populate: ['bar'] }))!;
@@ -1338,7 +1338,7 @@ describe('EntityManagerMySql', () => {
     expect(tags[0].books[0].author.name).toBe('Jon Snow');
     expect(tags[0].books[0].publisher).toBeInstanceOf(Reference);
     expect(tags[0].books[0].publisher!.unwrap()).toBeInstanceOf(Publisher2);
-    expect(wrap(tags[0].books[0].publisher).isInitialized()).toBe(true);
+    expect(wrap(tags[0].books[0].publisher!).isInitialized()).toBe(true);
     expect(tags[0].books[0].publisher!.unwrap().tests.isInitialized(true)).toBe(true);
     expect(tags[0].books[0].publisher!.unwrap().tests.count()).toBe(2);
     expect(tags[0].books[0].publisher!.unwrap().tests[0].name).toBe('t11');
@@ -1357,7 +1357,7 @@ describe('EntityManagerMySql', () => {
     expect(books[0].author.name).toBe('Jon Snow');
     expect(books[0].publisher).toBeInstanceOf(Reference);
     expect(books[0].publisher!.unwrap()).toBeInstanceOf(Publisher2);
-    expect(wrap(books[0].publisher).isInitialized()).toBe(true);
+    expect(wrap(books[0].publisher!).isInitialized()).toBe(true);
     expect(books[0].publisher!.unwrap().tests.isInitialized(true)).toBe(true);
     expect(books[0].publisher!.unwrap().tests.count()).toBe(2);
     expect(books[0].publisher!.unwrap().tests[0].name).toBe('t11');
@@ -1809,7 +1809,7 @@ describe('EntityManagerMySql', () => {
     const res1 = await orm.em.find(Book2, { author: { name: 'Jon Snow' } }, { populate: ['perex'] });
     expect(res1).toHaveLength(3);
     expect(res1[0].test).toBeInstanceOf(Test2);
-    expect(wrap(res1[0].test).isInitialized()).toBe(false);
+    expect(wrap(res1[0].test!).isInitialized()).toBe(false);
     expect(mock.mock.calls).toHaveLength(1);
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `test_id` ' +
       'from `book2` as `b0` ' +
@@ -1822,7 +1822,7 @@ describe('EntityManagerMySql', () => {
     const res2 = await orm.em.find(Book2, { author: { favouriteBook: { author: { name: 'Jon Snow' } } } }, { populate: ['perex'] });
     expect(res2).toHaveLength(3);
     expect(res2[0].test).toBeInstanceOf(Test2);
-    expect(wrap(res2[0].test).isInitialized()).toBe(false);
+    expect(wrap(res2[0].test!).isInitialized()).toBe(false);
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t4`.`id` as `test_id` ' +
       'from `book2` as `b0` ' +
@@ -1837,7 +1837,7 @@ describe('EntityManagerMySql', () => {
     const res3 = await orm.em.find(Book2, { author: { favouriteBook: book3 } }, { populate: ['perex'] });
     expect(res3).toHaveLength(3);
     expect(res3[0].test).toBeInstanceOf(Test2);
-    expect(wrap(res3[0].test).isInitialized()).toBe(false);
+    expect(wrap(res3[0].test!).isInitialized()).toBe(false);
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `test_id` ' +
       'from `book2` as `b0` ' +
@@ -1850,7 +1850,7 @@ describe('EntityManagerMySql', () => {
     const res4 = await orm.em.find(Book2, { author: { favouriteBook: { $or: [{ author: { name: 'Jon Snow' } }] } } }, { populate: ['perex'] });
     expect(res4).toHaveLength(3);
     expect(res4[0].test).toBeInstanceOf(Test2);
-    expect(wrap(res4[0].test).isInitialized()).toBe(false);
+    expect(wrap(res4[0].test!).isInitialized()).toBe(false);
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t4`.`id` as `test_id` ' +
       'from `book2` as `b0` ' +

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -932,17 +932,17 @@ describe('EntityManagerPostgre', () => {
     expect(jon.name).toBe('Jon Snow');
     expect(jon.born).toEqual(new Date('1990-03-23'));
     expect(jon.favouriteBook).toBeInstanceOf(Book2);
-    expect(wrap(jon.favouriteBook).isInitialized()).toBe(false);
+    expect(wrap(jon.favouriteBook!).isInitialized()).toBe(false);
 
-    await wrap(jon.favouriteBook).init();
+    await wrap(jon.favouriteBook!).init();
     expect(jon.favouriteBook).toBeInstanceOf(Book2);
-    expect(wrap(jon.favouriteBook).isInitialized()).toBe(true);
+    expect(wrap(jon.favouriteBook!).isInitialized()).toBe(true);
     expect(jon.favouriteBook!.title).toBe('Bible');
 
     const em2 = orm.em.fork();
     const bible2 = await em2.findOneOrFail(Book2, { uuid: bible.uuid });
     expect(wrap(bible2, true).__em!.id).toBe(em2.id);
-    expect(wrap(bible2.publisher, true).__em!.id).toBe(em2.id);
+    expect(wrap(bible2.publisher!, true).__em!.id).toBe(em2.id);
     const publisher2 = await bible2.publisher!.load();
     expect(wrap(publisher2, true).__em!.id).toBe(em2.id);
   });
@@ -1292,7 +1292,7 @@ describe('EntityManagerPostgre', () => {
     expect(tags[0].books[0].author.name).toBe('Jon Snow');
     expect(tags[0].books[0].publisher).toBeInstanceOf(Reference);
     expect(tags[0].books[0].publisher!.unwrap()).toBeInstanceOf(Publisher2);
-    expect(wrap(tags[0].books[0].publisher).isInitialized()).toBe(true);
+    expect(wrap(tags[0].books[0].publisher!).isInitialized()).toBe(true);
     expect(tags[0].books[0].publisher!.unwrap().tests.isInitialized(true)).toBe(true);
     expect(tags[0].books[0].publisher!.unwrap().tests.count()).toBe(2);
     expect(tags[0].books[0].publisher!.unwrap().tests[0].name).toBe('t11');

--- a/tests/EntityManager.sqlite2.test.ts
+++ b/tests/EntityManager.sqlite2.test.ts
@@ -200,7 +200,7 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
     const authorRepository = orm.em.getRepository(Author4);
     const booksRepository = orm.em.getRepository(Book4);
     const books = await booksRepository.findAll({ populate: ['author'] });
-    expect(wrap(books[0].author).isInitialized()).toBe(true);
+    expect(wrap(books[0].author!).isInitialized()).toBe(true);
     expect(await authorRepository.findOne({ favouriteBook: bible.id })).not.toBe(null);
     orm.em.clear();
 
@@ -250,9 +250,9 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
         expect(book.title).toMatch(/My Life on The Wall, part \d/);
 
         expect(book.author!.constructor.name).toBe('Author4');
-        expect(wrap(book.author).isInitialized()).toBe(true);
+        expect(wrap(book.author!).isInitialized()).toBe(true);
         expect(book.publisher!.unwrap().constructor.name).toBe('Publisher4');
-        expect(wrap(book.publisher).isInitialized()).toBe(false);
+        expect(wrap(book.publisher!).isInitialized()).toBe(false);
       }
     }
 
@@ -280,7 +280,7 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
     expect(lastBook.length).toBe(1);
     expect(lastBook[0].title).toBe('My Life on The Wall, part 1');
     expect(lastBook[0].author!.constructor.name).toBe('Author4');
-    expect(wrap(lastBook[0].author).isInitialized()).toBe(true);
+    expect(wrap(lastBook[0].author!).isInitialized()).toBe(true);
     await orm.em.getRepository(Book4).remove(lastBook[0]).flush();
   });
 
@@ -576,11 +576,11 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
     expect(jon2).not.toBeNull();
     expect(jon2.name).toBe('Jon Snow');
     expect(jon2.favouriteBook!.constructor.name).toBe('Book4');
-    expect(wrap(jon2.favouriteBook).isInitialized()).toBe(false);
+    expect(wrap(jon2.favouriteBook!).isInitialized()).toBe(false);
 
-    await wrap(jon2.favouriteBook).init();
+    await wrap(jon2.favouriteBook!).init();
     expect(jon2.favouriteBook!.constructor.name).toBe('Book4');
-    expect(wrap(jon2.favouriteBook).isInitialized()).toBe(true);
+    expect(wrap(jon2.favouriteBook!).isInitialized()).toBe(true);
     expect(jon2.favouriteBook!.title).toBe('Bible');
   });
 

--- a/tests/RequestContext.test.ts
+++ b/tests/RequestContext.test.ts
@@ -54,7 +54,7 @@ describe('RequestContext', () => {
         const em = RequestContext.getEntityManager()!;
         const jon = await em.findOne(Author, author.id, { populate: ['favouriteBook'] });
         expect(jon!.favouriteBook).toBeInstanceOf(Book);
-        expect(wrap(jon!.favouriteBook).isInitialized()).toBe(true);
+        expect(wrap(jon!.favouriteBook!).isInitialized()).toBe(true);
         expect(jon!.favouriteBook!.title).toBe('Bible');
         resolve();
       });

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -5,7 +5,7 @@ import {
   Entity,
   Filter,
   Formula,
-  IdentifiedReference,
+  Ref,
   Index,
   ManyToMany,
   ManyToOne,
@@ -61,7 +61,7 @@ export class Book2 {
   author: Author2;
 
   @ManyToOne(() => Publisher2, { cascade: [Cascade.PERSIST, Cascade.REMOVE], nullable: true, wrappedReference: true })
-  publisher?: IdentifiedReference<Publisher2>;
+  publisher?: Ref<Publisher2>;
 
   @OneToOne({ cascade: [], mappedBy: 'book', nullable: true })
   test?: Test2;

--- a/tests/entities-sql/Car2.ts
+++ b/tests/entities-sql/Car2.ts
@@ -1,6 +1,14 @@
-import { Collection, Entity, Index, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyType, Property, t } from '@mikro-orm/core';
+import {
+  Collection,
+  Entity,
+  Index,
+  ManyToMany,
+  PrimaryKey,
+  PrimaryKeyProp,
+  Property,
+  t,
+} from '@mikro-orm/core';
 import { User2 } from './User2';
-import { Test2 } from './Test2';
 
 @Entity()
 export class Car2 {
@@ -19,7 +27,7 @@ export class Car2 {
   @ManyToMany(() => User2, u => u.cars)
   users = new Collection<User2>(this);
 
-  [PrimaryKeyType]?: [string, number];
+  [PrimaryKeyProp]?: ['name', 'year'];
 
   constructor(name: string, year: number, price: number) {
     this.name = name;

--- a/tests/entities-sql/FooParam2.ts
+++ b/tests/entities-sql/FooParam2.ts
@@ -1,4 +1,4 @@
-import { Entity, ManyToOne, PrimaryKeyProp, PrimaryKeyType, Property } from '@mikro-orm/core';
+import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -17,8 +17,7 @@ export class FooParam2 {
   @Property({ version: true })
   version!: Date;
 
-  [PrimaryKeyType]?: [number, number];
-  [PrimaryKeyProp]?: 'bar' | 'baz';
+  [PrimaryKeyProp]?: ['bar', 'baz'];
 
   constructor(bar: FooBar2, baz: FooBaz2, value: string) {
     this.bar = bar;

--- a/tests/entities-sql/User2.ts
+++ b/tests/entities-sql/User2.ts
@@ -1,4 +1,12 @@
-import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyType, Property } from '@mikro-orm/core';
+import {
+  Collection,
+  Entity,
+  ManyToMany,
+  OneToOne,
+  PrimaryKey,
+  PrimaryKeyProp,
+  Property,
+} from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './sandwich';
 
@@ -23,7 +31,7 @@ export class User2 {
   @OneToOne({ entity: () => Car2, nullable: true })
   favouriteCar?: Car2;
 
-  [PrimaryKeyType]?: [string, string];
+  [PrimaryKeyProp]?: ['firstName', 'lastName'];
 
   constructor(firstName: string, lastName: string) {
     this.firstName = firstName;

--- a/tests/entities/Author.ts
+++ b/tests/entities/Author.ts
@@ -123,8 +123,8 @@ export class Author extends BaseEntity<Author, 'termsAccepted' | 'code2' | 'vers
     Author.afterDestroyCalled += 1;
   }
 
-  assign(data: any): Author {
-    return EntityAssigner.assign<Author>(this, data);
+  assign(data: any): this {
+    return EntityAssigner.assign(this, data);
   }
 
   toJSON(strict = true, strip = ['id', 'email'], ...args: any[]): EntityDTO<this> {

--- a/tests/entities/BaseEntity.ts
+++ b/tests/entities/BaseEntity.ts
@@ -1,11 +1,20 @@
 import { ObjectId } from 'bson';
-import { BeforeCreate, PrimaryKey, Property, SerializedPrimaryKey, BaseEntity as MikroBaseEntity, OptionalProps } from '@mikro-orm/core';
+import {
+  BeforeCreate,
+  PrimaryKey,
+  Property,
+  SerializedPrimaryKey,
+  BaseEntity as MikroBaseEntity,
+  OptionalProps,
+  PrimaryKeyProp,
+} from '@mikro-orm/core';
 
 export type BaseEntityOptional = 'updatedAt' | 'hookTest';
 
 export abstract class BaseEntity<T extends object, Optional extends keyof T = never> extends MikroBaseEntity {
 
   [OptionalProps]?: BaseEntityOptional | Optional;
+  [PrimaryKeyProp]?: 'id' | '_id';
 
   @PrimaryKey()
   _id!: ObjectId;

--- a/tests/entities/BaseEntity.ts
+++ b/tests/entities/BaseEntity.ts
@@ -3,7 +3,7 @@ import { BeforeCreate, PrimaryKey, Property, SerializedPrimaryKey, BaseEntity as
 
 export type BaseEntityOptional = 'updatedAt' | 'hookTest';
 
-export abstract class BaseEntity<T extends { id: unknown; _id: unknown }, Optional extends keyof T = never> extends MikroBaseEntity<T, 'id' | '_id'> {
+export abstract class BaseEntity<T extends object, Optional extends keyof T = never> extends MikroBaseEntity {
 
   [OptionalProps]?: BaseEntityOptional | Optional;
 

--- a/tests/entities/BaseEntity3.ts
+++ b/tests/entities/BaseEntity3.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from '@mikro-orm/mongodb';
 import { BaseEntity, PrimaryKey, SerializedPrimaryKey } from '@mikro-orm/core';
 
-export abstract class BaseEntity3<T extends object> extends BaseEntity<T, keyof T> {
+export abstract class BaseEntity3 extends BaseEntity {
 
   @PrimaryKey()
   _id!: ObjectId;

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -1,5 +1,5 @@
 import { ObjectId } from 'bson';
-import { EntityDTO, IdentifiedReference, Dictionary, Collection, Cascade, Entity, Index, ManyToMany, ManyToOne, PrimaryKey, Property, Unique, wrap, Filter, OptionalProps } from '@mikro-orm/core';
+import { EntityDTO, Ref, Dictionary, Collection, Cascade, Entity, Index, ManyToMany, ManyToOne, PrimaryKey, Property, Unique, wrap, Filter, OptionalProps } from '@mikro-orm/core';
 import { Publisher } from './Publisher';
 import { Author } from './Author';
 import { BookTag } from './book-tag';
@@ -32,7 +32,7 @@ export class Book extends BaseEntity3 {
 
   @ManyToOne(() => Publisher, { wrappedReference: true, cascade: [Cascade.PERSIST, Cascade.REMOVE], nullable: true })
   @Index({ name: 'publisher_idx' })
-  publisher!: IdentifiedReference<Publisher, '_id' | 'id'> | null;
+  publisher!: Ref<Publisher, '_id' | 'id'> | null;
 
   @ManyToMany(() => BookTag)
   tags = new Collection<BookTag>(this);

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -32,7 +32,7 @@ export class Book extends BaseEntity3 {
 
   @ManyToOne(() => Publisher, { wrappedReference: true, cascade: [Cascade.PERSIST, Cascade.REMOVE], nullable: true })
   @Index({ name: 'publisher_idx' })
-  publisher!: Ref<Publisher, '_id' | 'id'> | null;
+  publisher!: Ref<Publisher> | null;
 
   @ManyToMany(() => BookTag)
   tags = new Collection<BookTag>(this);

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -11,7 +11,7 @@ import { BookRepository } from '../repositories/BookRepository';
 @Index({ properties: 'title', type: 'fulltext' })
 @Index({ options: { point: '2dsphere', title: -1 } })
 @Filter({ name: 'writtenBy', cond: args => ({ author: args.author }) })
-export class Book extends BaseEntity3<Book> {
+export class Book extends BaseEntity3 {
 
   [OptionalProps]?: 'createdAt';
 

--- a/tests/entities/Publisher.ts
+++ b/tests/entities/Publisher.ts
@@ -1,5 +1,17 @@
 import { ObjectId } from 'bson';
-import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, Property, BeforeCreate, Enum, SerializedPrimaryKey, OptionalProps } from '@mikro-orm/core';
+import {
+  Collection,
+  Entity,
+  ManyToMany,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  BeforeCreate,
+  Enum,
+  SerializedPrimaryKey,
+  OptionalProps,
+  PrimaryKeyProp,
+} from '@mikro-orm/core';
 import { Book } from './Book';
 import { Test } from './test.model';
 import { PublisherType } from './PublisherType';
@@ -8,6 +20,7 @@ import { PublisherType } from './PublisherType';
 export class Publisher {
 
   [OptionalProps]?: 'type';
+  [PrimaryKeyProp]?: 'id' | '_id';
 
   @PrimaryKey()
   _id!: ObjectId;

--- a/tests/features/composite-keys/GH1079.test.ts
+++ b/tests/features/composite-keys/GH1079.test.ts
@@ -1,4 +1,15 @@
-import { Entity, PrimaryKey, MikroORM, ManyToOne, Enum, PrimaryKeyType, Property, BigIntType, wrap, OptionalProps } from '@mikro-orm/core';
+import {
+  Entity,
+  PrimaryKey,
+  MikroORM,
+  ManyToOne,
+  Enum,
+  Property,
+  BigIntType,
+  wrap,
+  OptionalProps,
+  PrimaryKeyProp,
+} from '@mikro-orm/core';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 import { v4 } from 'uuid';
 import { mockLogger } from '../../helpers';
@@ -14,7 +25,7 @@ class User {
 @Entity()
 class Wallet {
 
-  [PrimaryKeyType]?: [string, string];
+  [PrimaryKeyProp]?: ['currencyRef', 'owner'];
 
   @PrimaryKey()
   currencyRef!: string;
@@ -56,7 +67,7 @@ enum DepositStatus {
 @Entity()
 export class Deposit extends AbstractDeposit<'status'> {
 
-  [PrimaryKeyType]?: [string, string, string];
+  [PrimaryKeyProp]?: ['txRef', 'wallet'];
 
   @PrimaryKey()
   txRef!: string;

--- a/tests/features/composite-keys/GH1624.test.ts
+++ b/tests/features/composite-keys/GH1624.test.ts
@@ -1,4 +1,18 @@
-import { Collection, Entity, Ref, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyType, Property, Reference, Unique, wrap } from '@mikro-orm/core';
+import {
+  Collection,
+  Entity,
+  Ref,
+  LoadStrategy,
+  ManyToOne,
+  MikroORM,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  Reference,
+  Unique,
+  wrap,
+  PrimaryKeyProp,
+} from '@mikro-orm/core';
 import { v4 } from 'uuid';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
@@ -53,7 +67,7 @@ export class User {
   @OneToMany({ entity: 'UserRole', mappedBy: 'user' })
   userRoles = new Collection<UserRole>(this);
 
-  [PrimaryKeyType]?: [string, string];
+  [PrimaryKeyProp]?: ['id', 'organization'];
 
   constructor(value: Partial<User> = {}) {
     Object.assign(this, value);
@@ -102,7 +116,7 @@ export class UserRole {
   })
   role!: Ref<Role>;
 
-  [PrimaryKeyType]?: [string, string, string];
+  [PrimaryKeyProp]?: ['user', 'role'];
 
   constructor(value: Partial<UserRole> = {}) {
     Object.assign(this, value);
@@ -156,7 +170,7 @@ export class Site {
   @Property({ columnType: 'varchar' })
   name!: string;
 
-  [PrimaryKeyType]?: [string, string, string];
+  [PrimaryKeyProp]?: ['id', 'program'];
 
   constructor(value: Partial<Site> = {}) {
     Object.assign(this, value);

--- a/tests/features/composite-keys/GH1624.test.ts
+++ b/tests/features/composite-keys/GH1624.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, IdentifiedReference, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyType, Property, Reference, Unique, wrap } from '@mikro-orm/core';
+import { Collection, Entity, Ref, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyType, Property, Reference, Unique, wrap } from '@mikro-orm/core';
 import { v4 } from 'uuid';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
@@ -39,7 +39,7 @@ export class User {
     cascade: [],
     onDelete: 'no action',
   })
-  organization!: IdentifiedReference<Organization>;
+  organization!: Ref<Organization>;
 
   @Property({ columnType: 'varchar' })
   firstName!: string;
@@ -90,7 +90,7 @@ export class UserRole {
     cascade: [],
     onDelete: 'cascade',
   })
-  user!: IdentifiedReference<User>;
+  user!: Ref<User>;
 
   @ManyToOne({
     entity: () => Role,
@@ -100,7 +100,7 @@ export class UserRole {
     cascade: [],
     onDelete: 'no action',
   })
-  role!: IdentifiedReference<Role>;
+  role!: Ref<Role>;
 
   [PrimaryKeyType]?: [string, string, string];
 
@@ -122,7 +122,7 @@ export class Program {
     primary: true,
     wrappedReference: true,
   })
-  organization!: IdentifiedReference<Organization>;
+  organization!: Ref<Organization>;
 
   @OneToMany({ entity: 'Site', mappedBy: 'program', cascade: [] })
   sites = new Collection<Site, Program>(this);

--- a/tests/features/composite-keys/GH1914.test.ts
+++ b/tests/features/composite-keys/GH1914.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyType } from '@mikro-orm/core';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import type { AbstractSqlDriver } from '@mikro-orm/sqlite';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
@@ -43,7 +43,7 @@ export class SiteCategory {
   @ManyToOne({ entity: () => Category, primary: true })
   category!: Category;
 
-  [PrimaryKeyType]?: [number, number];
+  [PrimaryKeyProp]?: ['site', 'category'];
 
 }
 

--- a/tests/features/composite-keys/GH3860.test.ts
+++ b/tests/features/composite-keys/GH3860.test.ts
@@ -1,4 +1,13 @@
-import { Entity, PrimaryKey, MikroORM, ManyToOne, PrimaryKeyType, Property, Collection, ManyToMany } from '@mikro-orm/core';
+import {
+  Entity,
+  PrimaryKey,
+  MikroORM,
+  ManyToOne,
+  Property,
+  Collection,
+  ManyToMany,
+  PrimaryKeyProp,
+} from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
 @Entity()
@@ -35,7 +44,7 @@ export class OrderItem {
   @Property({ default: 1 })
   amount!: number;
 
-  [PrimaryKeyType]?: [number, number];
+  [PrimaryKeyProp]?: ['order', 'product'];
 
   constructor(order: Order, product: Product) {
     this.order = order;

--- a/tests/features/composite-keys/composite-keys.sqlite.test.ts
+++ b/tests/features/composite-keys/composite-keys.sqlite.test.ts
@@ -1,6 +1,6 @@
 import {
   Cascade, Collection, Entity, ManyToMany, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey,
-  PrimaryKeyType, Property, ValidationError, wrap, LoadStrategy,
+  Property, ValidationError, wrap, LoadStrategy, PrimaryKeyProp,
 } from '@mikro-orm/core';
 import { AbstractSqlConnection, SqliteDriver } from '@mikro-orm/sqlite';
 import { mockLogger } from '../../helpers';
@@ -50,7 +50,7 @@ export class FooParam2 {
   @Property({ version: true })
   version!: Date;
 
-  [PrimaryKeyType]?: [number, number];
+  [PrimaryKeyProp]?: ['bar', 'baz'];
 
   constructor(bar: FooBar2, baz: FooBaz2, value: string) {
     this.bar = bar;
@@ -154,7 +154,7 @@ export class Car2 {
   @ManyToMany('User2', 'cars')
   users = new Collection<User2>(this);
 
-  [PrimaryKeyType]?: [string, number];
+  [PrimaryKeyProp]?: ['name', 'year'];
 
   constructor(name: string, year: number, price: number) {
     this.name = name;
@@ -185,7 +185,7 @@ export class User2 {
   @OneToOne({ entity: () => Car2, nullable: true })
   favouriteCar?: Car2;
 
-  [PrimaryKeyType]?: [string, string];
+  [PrimaryKeyProp]?: ['firstName', 'lastName'];
 
   constructor(firstName: string, lastName: string) {
     this.firstName = firstName;
@@ -290,7 +290,7 @@ describe('composite keys in sqlite', () => {
     orm.em.clear();
 
     // test populating a PK
-    const p1 = await orm.em.findOneOrFail(FooParam2, [param.bar.id, param.baz.id], { populate: ['bar'] });
+    const p1 = await orm.em.findOneOrFail(FooParam2, [param.bar.id, param.baz.id] as const, { populate: ['bar'] });
     expect(wrap(p1).toJSON().bar).toMatchObject(wrap(p1.bar).toJSON());
     expect(wrap(p1).toJSON().baz).toBe(p1.baz.id);
 

--- a/tests/features/composite-keys/custom-pivot-entity-uni.sqlite.test.ts
+++ b/tests/features/composite-keys/custom-pivot-entity-uni.sqlite.test.ts
@@ -1,4 +1,15 @@
-import { Entity, PrimaryKey, MikroORM, ManyToOne, PrimaryKeyType, Property, wrap, OneToMany, Collection, ManyToMany } from '@mikro-orm/core';
+import {
+  Entity,
+  PrimaryKey,
+  MikroORM,
+  ManyToOne,
+  Property,
+  wrap,
+  OneToMany,
+  Collection,
+  ManyToMany,
+  PrimaryKeyProp,
+} from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
 @Entity()
@@ -58,7 +69,7 @@ export class OrderItem {
   @Property({ default: 0 })
   offeredPrice: number;
 
-  [PrimaryKeyType]?: [number, number];
+  [PrimaryKeyProp]?: ['order', 'product'];
 
   constructor(order: Order, product: Product) {
     this.order = order;

--- a/tests/features/composite-keys/custom-pivot-entity-wrong-order.sqlite.test.ts
+++ b/tests/features/composite-keys/custom-pivot-entity-wrong-order.sqlite.test.ts
@@ -1,4 +1,15 @@
-import { Entity, PrimaryKey, MikroORM, ManyToOne, PrimaryKeyType, Property, wrap, OneToMany, Collection, ManyToMany } from '@mikro-orm/core';
+import {
+  Entity,
+  PrimaryKey,
+  MikroORM,
+  ManyToOne,
+  Property,
+  wrap,
+  OneToMany,
+  Collection,
+  ManyToMany,
+  PrimaryKeyProp,
+} from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
 @Entity()
@@ -61,7 +72,7 @@ export class OrderItem {
   @Property({ default: 0 })
   offeredPrice: number;
 
-  [PrimaryKeyType]?: [number, number];
+  [PrimaryKeyProp]?: ['product', 'order'];
 
   constructor(order: Order, product: Product) {
     this.order = order;

--- a/tests/features/composite-keys/custom-pivot-entity.sqlite.test.ts
+++ b/tests/features/composite-keys/custom-pivot-entity.sqlite.test.ts
@@ -1,4 +1,15 @@
-import { Entity, PrimaryKey, MikroORM, ManyToOne, PrimaryKeyType, Property, wrap, OneToMany, Collection, ManyToMany } from '@mikro-orm/core';
+import {
+  Entity,
+  PrimaryKey,
+  MikroORM,
+  ManyToOne,
+  Property,
+  wrap,
+  OneToMany,
+  Collection,
+  ManyToMany,
+  PrimaryKeyProp,
+} from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
 @Entity()
@@ -61,7 +72,7 @@ export class OrderItem {
   @Property({ default: 0 })
   offeredPrice: number;
 
-  [PrimaryKeyType]?: [number, number];
+  [PrimaryKeyProp]?: ['order', 'product'];
 
   constructor(order: Order, product: Product) {
     this.order = order;

--- a/tests/features/custom-types/GH446.test.ts
+++ b/tests/features/custom-types/GH446.test.ts
@@ -1,5 +1,16 @@
 import { v4, parse, stringify } from 'uuid';
-import { Entity, LoadStrategy, ManyToOne, MikroORM, OneToOne, PrimaryKey, PrimaryKeyType, Property, Type, wrap } from '@mikro-orm/core';
+import {
+  Entity,
+  LoadStrategy,
+  ManyToOne,
+  MikroORM,
+  OneToOne,
+  PrimaryKey,
+  PrimaryKeyProp,
+  Property,
+  Type,
+  wrap,
+} from '@mikro-orm/core';
 import { MySqlDriver } from '@mikro-orm/mysql';
 
 export class UuidBinaryType extends Type<string, Buffer> {
@@ -35,6 +46,8 @@ class B {
   @OneToOne({ primary: true })
   a!: A;
 
+  [PrimaryKeyProp]?: 'a';
+
 }
 
 @Entity()
@@ -43,7 +56,7 @@ class C {
   @OneToOne({ primary: true })
   b!: B;
 
-  [PrimaryKeyType]?: B | A | string;
+  [PrimaryKeyProp]?: 'b';
 
 }
 

--- a/tests/features/embeddables/GH2717.test.ts
+++ b/tests/features/embeddables/GH2717.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Embeddable, Embedded, Entity, IdentifiedReference, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
+import { Collection, Embeddable, Embedded, Entity, Ref, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
 @Entity()
@@ -8,7 +8,7 @@ export class Cat {
   name!: string;
 
   @ManyToOne(() => User, { wrappedReference: true })
-  user!: IdentifiedReference<User>;
+  user!: Ref<User>;
 
 }
 

--- a/tests/features/embeddables/entities-in-embeddables.mongo.test.ts
+++ b/tests/features/embeddables/entities-in-embeddables.mongo.test.ts
@@ -243,7 +243,7 @@ describe('embedded entities in mongo', () => {
     expect(u1.profile1.identity.meta).toBeInstanceOf(IdentityMeta);
     expect(u1.profile1.source).toBeInstanceOf(Source);
     expect(u1.profile1.identity.source).toBeInstanceOf(Source);
-    expect(wrap(u1.profile1.identity.source).isInitialized()).toBe(false);
+    expect(wrap(u1.profile1.identity.source!).isInitialized()).toBe(false);
     expect(u1.profile1).toMatchObject({
       username: 'u1',
       identity: {
@@ -404,11 +404,11 @@ describe('embedded entities in mongo', () => {
     expect(mock.mock.calls[3][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000002') ] } }, {}).sort([ [ '_id', 1 ] ]).toArray();`);
     expect(mock.mock.calls[4][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000014'), ObjectId('600000000000000000000015') ] } }, {}).sort([ [ '_id', 1 ] ]).toArray();`);
     expect(mock.mock.calls[5][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000016'), ObjectId('600000000000000000000017'), ObjectId('600000000000000000000018'), ObjectId('600000000000000000000019'), ObjectId('60000000000000000000001a'), ObjectId('60000000000000000000001b') ] } }, {}).sort([ [ '_id', 1 ] ]).toArray();`);
-    expect(wrap(users[0].profile1.source).isInitialized()).toBe(true);
+    expect(wrap(users[0].profile1.source!).isInitialized()).toBe(true);
     expect(users[0].profile1.source!.name).toBe('s1');
-    expect(wrap(users[1].profile1.identity.links[1].source).isInitialized()).toBe(true);
+    expect(wrap(users[1].profile1.identity.links[1].source!).isInitialized()).toBe(true);
     expect(users[1].profile1.identity.links[1].source!.name).toBe('ils32');
-    expect(wrap(users[1].profile1.identity.links[1].metas[2].source).isInitialized()).toBe(true);
+    expect(wrap(users[1].profile1.identity.links[1].metas[2].source!).isInitialized()).toBe(true);
     expect(users[1].profile1.identity.links[1].metas[2].source!.name).toBe('ilms323');
 
     // test serialization context

--- a/tests/features/embeddables/entities-in-embeddables.postgres.test.ts
+++ b/tests/features/embeddables/entities-in-embeddables.postgres.test.ts
@@ -219,7 +219,7 @@ describe('embedded entities in postgres', () => {
     expect(u1.profile1.identity.meta).toBeInstanceOf(IdentityMeta);
     expect(u1.profile1.source).toBeInstanceOf(Source);
     expect(u1.profile1.identity.source).toBeInstanceOf(Source);
-    expect(wrap(u1.profile1.identity.source).isInitialized()).toBe(false);
+    expect(wrap(u1.profile1.identity.source!).isInitialized()).toBe(false);
     expect(u1.profile1).toMatchObject({
       username: 'u1',
       identity: {
@@ -374,7 +374,7 @@ describe('embedded entities in postgres', () => {
     expect(mock.mock.calls[2][0]).toMatch(`select "s0".* from "source" as "s0" where "s0"."id" in (2, 8) order by "s0"."id" asc`);
     expect(mock.mock.calls[3][0]).toMatch(`select "s0".* from "source" as "s0" where "s0"."id" in (3) order by "s0"."id" asc`);
     expect(mock.mock.calls[4][0]).toMatch(`select "s0".* from "source" as "s0" where "s0"."id" in (11, 12, 13, 14, 15, 16) order by "s0"."id" asc`);
-    expect(wrap(users[1].profile1.identity.links[1].metas[2].source).isInitialized()).toBe(true);
+    expect(wrap(users[1].profile1.identity.links[1].metas[2].source!).isInitialized()).toBe(true);
     expect(users[1].profile1.identity.links[1].metas[2].source!.name).toBe('ilms323');
 
     // test serialization context

--- a/tests/features/entity-assigner/EntityAssigner.mongo.test.ts
+++ b/tests/features/entity-assigner/EntityAssigner.mongo.test.ts
@@ -66,9 +66,9 @@ describe('EntityAssignerMongo', () => {
   test('#assign() should merge references', async () => {
     const jon = new Author('Jon Snow', 'snow@wall.st');
     orm.em.assign(jon, { favouriteBook: { _id: ObjectId.createFromTime(1), title: 'b1' } }, { merge: false });
-    expect(wrap(jon.favouriteBook, true).__em).toBeUndefined();
+    expect(wrap(jon.favouriteBook!, true).__em).toBeUndefined();
     orm.em.assign(jon, { favouriteBook: { _id: ObjectId.createFromTime(1), title: 'b1' } }, { merge: true });
-    expect(wrap(jon.favouriteBook, true).__em).not.toBeUndefined();
+    expect(wrap(jon.favouriteBook!, true).__em).not.toBeUndefined();
   });
 
   test('#assign() should merge collection items', async () => {

--- a/tests/features/entity-assigner/EntityAssigner.mysql.test.ts
+++ b/tests/features/entity-assigner/EntityAssigner.mysql.test.ts
@@ -118,7 +118,7 @@ describe('EntityAssignerMySql', () => {
     expect(Reference.isReference(book2.author)).toEqual(false);
     expect(wrap(book2.author).isInitialized()).toEqual(false);
 
-    expect(wrap(book2.publisher).isInitialized()).toEqual(false);
+    expect(wrap(book2.publisher!).isInitialized()).toEqual(false);
     expect(Reference.isReference(book2.publisher)).toEqual(true);
 
     const value = Reference.unwrapReference(book2.publisher!);
@@ -142,12 +142,12 @@ describe('EntityAssignerMySql', () => {
 
     const book2 = (await orm.em.getRepository(Book2).findOne(id))!;
 
-    expect(wrap(book2.publisher).isInitialized()).toEqual(false);
+    expect(wrap(book2.publisher!).isInitialized()).toEqual(false);
     expect(Reference.isReference(book2.publisher)).toEqual(true);
 
     await book2.publisher?.load();
 
-    expect(wrap(book2.publisher).isInitialized()).toEqual(true);
+    expect(wrap(book2.publisher!).isInitialized()).toEqual(true);
 
     const originalValue = Reference.unwrapReference(book2.publisher!);
     const originalRef = book2.publisher!;

--- a/tests/features/entity-assigner/GH3571.test.ts
+++ b/tests/features/entity-assigner/GH3571.test.ts
@@ -2,7 +2,7 @@ import { MikroORM, SqliteDriver } from '@mikro-orm/sqlite';
 import { BaseEntity, Entity, PrimaryKey, ManyToOne, ManyToMany, Collection } from '@mikro-orm/core';
 
 @Entity()
-export class Car extends BaseEntity<User, 'id'> {
+export class Car extends BaseEntity {
 
   @PrimaryKey()
   id!: number;
@@ -10,7 +10,7 @@ export class Car extends BaseEntity<User, 'id'> {
 }
 
 @Entity()
-export class User extends BaseEntity<User, 'id'> {
+export class User extends BaseEntity {
 
   @PrimaryKey()
   id!: number;

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
@@ -74,11 +74,11 @@ export enum Publisher2Type2 {
 
 exports[`EntityGenerator generate EntitySchema with bidirectional relations and reference wrappers [mysql]: mysql-entity-schema-bidirectional-dump 1`] = `
 [
-  "import { EntitySchema, IdentifiedReference } from '@mikro-orm/core';
+  "import { EntitySchema, Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
 export class Address2 {
-  author!: IdentifiedReference<Author2>;
+  author!: Ref<Author2>;
   value!: string;
 }
 
@@ -97,7 +97,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, IdentifiedReference } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 export class Author2 {
@@ -112,8 +112,8 @@ export class Author2 {
   identities?: string;
   born?: string;
   bornTime?: string;
-  favouriteBook?: IdentifiedReference<Book2>;
-  favouriteAuthor?: IdentifiedReference<Author2>;
+  favouriteBook?: Ref<Book2>;
+  favouriteAuthor?: Ref<Author2>;
   authorToFriend = new Collection<Author2>(this);
   following = new Collection<Author2>(this);
   authorInverse = new Collection<Book2>(this);
@@ -187,7 +187,7 @@ export const Author2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, IdentifiedReference } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Ref } from '@mikro-orm/core';
 
 export class BaseUser2 {
   id!: number;
@@ -195,12 +195,12 @@ export class BaseUser2 {
   lastName!: string;
   type!: BaseUser2Type;
   ownerProp?: string;
-  favouriteEmployee?: IdentifiedReference<BaseUser2>;
-  favouriteManager?: IdentifiedReference<BaseUser2>;
+  favouriteEmployee?: Ref<BaseUser2>;
+  favouriteManager?: Ref<BaseUser2>;
   employeeProp?: number;
   managerProp?: string;
   favouriteEmployeeInverse = new Collection<BaseUser2>(this);
-  favouriteManagerInverse?: IdentifiedReference<BaseUser2>;
+  favouriteManagerInverse?: Ref<BaseUser2>;
 }
 
 export enum BaseUser2Type {
@@ -266,7 +266,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, IdentifiedReference } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
@@ -281,13 +281,13 @@ export class Book2 {
   price?: string;
   double?: string;
   meta?: any;
-  author!: IdentifiedReference<Author2>;
-  publisher?: IdentifiedReference<Publisher2>;
+  author!: Ref<Author2>;
+  publisher?: Ref<Publisher2>;
   foo?: string;
   bookToTagUnordered = new Collection<BookTag2>(this);
   favouriteBookInverse = new Collection<Author2>(this);
   book2Inverse = new Collection<Book2Tags>(this);
-  bookInverse?: IdentifiedReference<Test2>;
+  bookInverse?: Ref<Test2>;
 }
 
 export const Book2Schema = new EntitySchema({
@@ -328,14 +328,14 @@ export const Book2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, IdentifiedReference } from '@mikro-orm/core';
+  "import { EntitySchema, Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { BookTag2 } from './BookTag2';
 
 export class Book2Tags {
   order!: number;
-  book2!: IdentifiedReference<Book2>;
-  bookTag2!: IdentifiedReference<BookTag2>;
+  book2!: Ref<Book2>;
+  bookTag2!: Ref<BookTag2>;
 }
 
 export const Book2TagsSchema = new EntitySchema({
@@ -360,13 +360,13 @@ export const Book2TagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, IdentifiedReference } from '@mikro-orm/core';
+  "import { EntitySchema, Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 
 export class CarOwner2 {
   id!: number;
   name!: string;
-  car!: IdentifiedReference<Car2>;
+  car!: Ref<Car2>;
 }
 
 export const CarOwner2Schema = new EntitySchema({
@@ -383,7 +383,7 @@ export const CarOwner2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, IdentifiedReference } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Ref } from '@mikro-orm/core';
 import { CarOwner2 } from './CarOwner2';
 import { User2 } from './User2';
 
@@ -392,7 +392,7 @@ export class Car2 {
   year!: number;
   price!: number;
   carInverse = new Collection<CarOwner2>(this);
-  favouriteCarInverse?: IdentifiedReference<User2>;
+  favouriteCarInverse?: Ref<User2>;
   carsInverse = new Collection<User2>(this);
 }
 
@@ -413,12 +413,12 @@ export const Car2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, IdentifiedReference } from '@mikro-orm/core';
+  "import { EntitySchema, Ref } from '@mikro-orm/core';
 import { Test2 } from './Test2';
 
 export class Configuration2 {
   property!: string;
-  test!: IdentifiedReference<Test2>;
+  test!: Ref<Test2>;
   value!: string;
 }
 
@@ -450,7 +450,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, IdentifiedReference } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Ref } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
 import { Test2 } from './Test2';
@@ -459,13 +459,13 @@ export class FooBar2 {
   id!: number;
   name!: string;
   nameWithSpace?: string;
-  baz?: IdentifiedReference<FooBaz2>;
-  fooBar?: IdentifiedReference<FooBar2>;
+  baz?: Ref<FooBaz2>;
+  fooBar?: Ref<FooBar2>;
   version!: Date;
   blob?: Buffer;
   array?: string;
   objectProperty?: any;
-  fooBarInverse?: IdentifiedReference<Test2>;
+  fooBarInverse?: Ref<Test2>;
   barInverse = new Collection<FooParam2>(this);
   barsInverse = new Collection<Test2>(this);
 }
@@ -527,13 +527,13 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, IdentifiedReference } from '@mikro-orm/core';
+  "import { EntitySchema, Ref } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 {
-  bar!: IdentifiedReference<FooBar2>;
-  baz!: IdentifiedReference<FooBaz2>;
+  bar!: Ref<FooBar2>;
+  baz!: Ref<FooBaz2>;
   value!: string;
   version!: Date;
 }
@@ -615,14 +615,14 @@ export const Publisher2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, IdentifiedReference } from '@mikro-orm/core';
+  "import { EntitySchema, Ref } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
 
 export class Publisher2Tests {
   id!: number;
-  publisher2!: IdentifiedReference<Publisher2>;
-  test2!: IdentifiedReference<Test2>;
+  publisher2!: Ref<Publisher2>;
+  test2!: Ref<Test2>;
 }
 
 export const Publisher2TestsSchema = new EntitySchema({
@@ -667,7 +667,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, IdentifiedReference } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
@@ -676,10 +676,10 @@ import { Publisher2Tests } from './Publisher2Tests';
 export class Test2 {
   id!: number;
   name?: string;
-  book?: IdentifiedReference<Book2>;
-  parent?: IdentifiedReference<Test2>;
+  book?: Ref<Book2>;
+  parent?: Ref<Test2>;
   version: number = 1;
-  fooBar?: IdentifiedReference<FooBar2>;
+  fooBar?: Ref<FooBar2>;
   fooBaz?: number;
   bars = new Collection<FooBar2>(this);
   testInverse = new Collection<Configuration2>(this);
@@ -730,7 +730,7 @@ export const Test2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, IdentifiedReference } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './Sandwich';
 
@@ -738,7 +738,7 @@ export class User2 {
   firstName!: string;
   lastName!: string;
   foo?: number;
-  favouriteCar?: IdentifiedReference<Car2>;
+  favouriteCar?: Ref<Car2>;
   cars = new Collection<Car2>(this);
   sandwiches = new Collection<Sandwich>(this);
 }
@@ -2421,21 +2421,21 @@ export class User2 {
 
 exports[`EntityGenerator generate entities with bidirectional relations and reference wrappers [mysql]: mysql-entity-bidirectional-dump 1`] = `
 [
-  "import { Entity, IdentifiedReference, OneToOne, Property } from '@mikro-orm/core';
+  "import { Entity, Ref, OneToOne, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
 @Entity()
 export class Address2 {
 
   @OneToOne({ entity: () => Author2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade', primary: true })
-  author!: IdentifiedReference<Author2>;
+  author!: Ref<Author2>;
 
   @Property({ length: 255 })
   value!: string;
 
 }
 ",
-  "import { Collection, Entity, IdentifiedReference, Index, ManyToMany, ManyToOne, OneToMany, OptionalProps, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Ref, Index, ManyToMany, ManyToOne, OneToMany, OptionalProps, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -2485,10 +2485,10 @@ export class Author2 {
   bornTime?: string;
 
   @ManyToOne({ entity: () => Book2, wrappedReference: true, onDelete: 'cascade', nullable: true })
-  favouriteBook?: IdentifiedReference<Book2>;
+  favouriteBook?: Ref<Book2>;
 
   @ManyToOne({ entity: () => Author2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
-  favouriteAuthor?: IdentifiedReference<Author2>;
+  favouriteAuthor?: Ref<Author2>;
 
   @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
   authorToFriend = new Collection<Author2>(this);
@@ -2510,7 +2510,7 @@ export class Author2 {
 
 }
 ",
-  "import { Collection, Entity, Enum, IdentifiedReference, Index, ManyToOne, OneToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Enum, Ref, Index, ManyToOne, OneToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class BaseUser2 {
@@ -2532,10 +2532,10 @@ export class BaseUser2 {
   ownerProp?: string;
 
   @ManyToOne({ entity: () => BaseUser2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
-  favouriteEmployee?: IdentifiedReference<BaseUser2>;
+  favouriteEmployee?: Ref<BaseUser2>;
 
   @OneToOne({ entity: () => BaseUser2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
-  favouriteManager?: IdentifiedReference<BaseUser2>;
+  favouriteManager?: Ref<BaseUser2>;
 
   @Property({ nullable: true })
   employeeProp?: number;
@@ -2547,7 +2547,7 @@ export class BaseUser2 {
   favouriteEmployeeInverse = new Collection<BaseUser2>(this);
 
   @OneToOne({ entity: () => BaseUser2, wrappedReference: true, mappedBy: 'favouriteManager' })
-  favouriteManagerInverse?: IdentifiedReference<BaseUser2>;
+  favouriteManagerInverse?: Ref<BaseUser2>;
 
 }
 
@@ -2578,7 +2578,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, IdentifiedReference, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Ref, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
@@ -2613,10 +2613,10 @@ export class Book2 {
   meta?: any;
 
   @ManyToOne({ entity: () => Author2, wrappedReference: true })
-  author!: IdentifiedReference<Author2>;
+  author!: Ref<Author2>;
 
   @ManyToOne({ entity: () => Publisher2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade', nullable: true })
-  publisher?: IdentifiedReference<Publisher2>;
+  publisher?: Ref<Publisher2>;
 
   @Property({ length: 255, nullable: true, default: 'lol' })
   foo?: string;
@@ -2631,11 +2631,11 @@ export class Book2 {
   book2Inverse = new Collection<Book2Tags>(this);
 
   @OneToOne({ entity: () => Test2, wrappedReference: true, mappedBy: 'book' })
-  bookInverse?: IdentifiedReference<Test2>;
+  bookInverse?: Ref<Test2>;
 
 }
 ",
-  "import { Entity, IdentifiedReference, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { Entity, Ref, ManyToOne, PrimaryKey } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { BookTag2 } from './BookTag2';
 
@@ -2646,14 +2646,14 @@ export class Book2Tags {
   order!: number;
 
   @ManyToOne({ entity: () => Book2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
-  book2!: IdentifiedReference<Book2>;
+  book2!: Ref<Book2>;
 
   @ManyToOne({ entity: () => BookTag2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
-  bookTag2!: IdentifiedReference<BookTag2>;
+  bookTag2!: Ref<BookTag2>;
 
 }
 ",
-  "import { Entity, IdentifiedReference, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Ref, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 
 @Entity()
@@ -2666,11 +2666,11 @@ export class CarOwner2 {
   name!: string;
 
   @ManyToOne({ entity: () => Car2, wrappedReference: true, onUpdateIntegrity: 'cascade' })
-  car!: IdentifiedReference<Car2>;
+  car!: Ref<Car2>;
 
 }
 ",
-  "import { Collection, Entity, IdentifiedReference, Index, ManyToMany, OneToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Ref, Index, ManyToMany, OneToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { CarOwner2 } from './CarOwner2';
 import { User2 } from './User2';
 
@@ -2692,14 +2692,14 @@ export class Car2 {
   carInverse = new Collection<CarOwner2>(this);
 
   @OneToOne({ entity: () => User2, wrappedReference: true, mappedBy: 'favouriteCar' })
-  favouriteCarInverse?: IdentifiedReference<User2>;
+  favouriteCarInverse?: Ref<User2>;
 
   @ManyToMany({ entity: () => User2, mappedBy: 'cars' })
   carsInverse = new Collection<User2>(this);
 
 }
 ",
-  "import { Entity, IdentifiedReference, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Ref, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { Test2 } from './Test2';
 
 @Entity()
@@ -2709,7 +2709,7 @@ export class Configuration2 {
   property!: string;
 
   @ManyToOne({ entity: () => Test2, wrappedReference: true, onUpdateIntegrity: 'cascade', primary: true })
-  test!: IdentifiedReference<Test2>;
+  test!: Ref<Test2>;
 
   @Property({ length: 255 })
   value!: string;
@@ -2726,7 +2726,7 @@ export class Dummy2 {
 
 }
 ",
-  "import { Collection, Entity, IdentifiedReference, ManyToMany, OneToMany, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Ref, ManyToMany, OneToMany, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
 import { Test2 } from './Test2';
@@ -2746,10 +2746,10 @@ export class FooBar2 {
   nameWithSpace?: string;
 
   @OneToOne({ entity: () => FooBaz2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
-  baz?: IdentifiedReference<FooBaz2>;
+  baz?: Ref<FooBaz2>;
 
   @OneToOne({ entity: () => FooBar2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
-  fooBar?: IdentifiedReference<FooBar2>;
+  fooBar?: Ref<FooBar2>;
 
   @Property({ defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date;
@@ -2764,7 +2764,7 @@ export class FooBar2 {
   objectProperty?: any;
 
   @OneToOne({ entity: () => Test2, wrappedReference: true, mappedBy: 'fooBar' })
-  fooBarInverse?: IdentifiedReference<Test2>;
+  fooBarInverse?: Ref<Test2>;
 
   @OneToMany({ entity: () => FooParam2, mappedBy: 'bar' })
   barInverse = new Collection<FooParam2>(this);
@@ -2796,7 +2796,7 @@ export class FooBaz2 {
 
 }
 ",
-  "import { Entity, IdentifiedReference, ManyToOne, OptionalProps, Property } from '@mikro-orm/core';
+  "import { Entity, Ref, ManyToOne, OptionalProps, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -2806,10 +2806,10 @@ export class FooParam2 {
   [OptionalProps]?: 'version';
 
   @ManyToOne({ entity: () => FooBar2, wrappedReference: true, onUpdateIntegrity: 'cascade', primary: true })
-  bar!: IdentifiedReference<FooBar2>;
+  bar!: Ref<FooBar2>;
 
   @ManyToOne({ entity: () => FooBaz2, wrappedReference: true, onUpdateIntegrity: 'cascade', primary: true })
-  baz!: IdentifiedReference<FooBaz2>;
+  baz!: Ref<FooBaz2>;
 
   @Property({ length: 255 })
   value!: string;
@@ -2881,7 +2881,7 @@ export enum Publisher2Enum5 {
   A = 'a',
 }
 ",
-  "import { Entity, IdentifiedReference, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { Entity, Ref, ManyToOne, PrimaryKey } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
 
@@ -2892,10 +2892,10 @@ export class Publisher2Tests {
   id!: number;
 
   @ManyToOne({ entity: () => Publisher2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
-  publisher2!: IdentifiedReference<Publisher2>;
+  publisher2!: Ref<Publisher2>;
 
   @ManyToOne({ entity: () => Test2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
-  test2!: IdentifiedReference<Test2>;
+  test2!: Ref<Test2>;
 
 }
 ",
@@ -2919,7 +2919,7 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, IdentifiedReference, ManyToMany, ManyToOne, OneToMany, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Ref, ManyToMany, ManyToOne, OneToMany, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
@@ -2937,16 +2937,16 @@ export class Test2 {
   name?: string;
 
   @OneToOne({ entity: () => Book2, wrappedReference: true, onDelete: 'set null', nullable: true })
-  book?: IdentifiedReference<Book2>;
+  book?: Ref<Book2>;
 
   @ManyToOne({ entity: () => Test2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
-  parent?: IdentifiedReference<Test2>;
+  parent?: Ref<Test2>;
 
   @Property({ default: 1 })
   version: number = 1;
 
   @OneToOne({ entity: () => FooBar2, wrappedReference: true, fieldName: 'foo___bar', onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
-  fooBar?: IdentifiedReference<FooBar2>;
+  fooBar?: Ref<FooBar2>;
 
   @Property({ fieldName: 'foo___baz', nullable: true })
   fooBaz?: number;
@@ -2965,7 +2965,7 @@ export class Test2 {
 
 }
 ",
-  "import { Collection, Entity, IdentifiedReference, ManyToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Ref, ManyToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './Sandwich';
 
@@ -2982,7 +2982,7 @@ export class User2 {
   foo?: number;
 
   @OneToOne({ entity: () => Car2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
-  favouriteCar?: IdentifiedReference<Car2>;
+  favouriteCar?: Ref<Car2>;
 
   @ManyToMany({ entity: () => Car2, joinColumns: ['user2_first_name', 'user2_last_name'], inverseJoinColumns: ['car2_name', 'car2_year'] })
   cars = new Collection<Car2>(this);
@@ -2997,21 +2997,21 @@ export class User2 {
 
 exports[`EntityGenerator generate entities with reference wrappers and named import [mysql]: mysql-entity-named-dump 1`] = `
 [
-  "import { Entity, IdentifiedReference, OneToOne, Property } from '@mikro-orm/core';
+  "import { Entity, Ref, OneToOne, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2.js';
 
 @Entity()
 export class Address2 {
 
   @OneToOne({ entity: () => Author2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade', primary: true })
-  author!: IdentifiedReference<Author2>;
+  author!: Ref<Author2>;
 
   @Property({ length: 255 })
   value!: string;
 
 }
 ",
-  "import { Collection, Entity, IdentifiedReference, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Ref, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2.js';
 
 @Entity()
@@ -3061,10 +3061,10 @@ export class Author2 {
   bornTime?: string;
 
   @ManyToOne({ entity: () => Book2, wrappedReference: true, onDelete: 'cascade', nullable: true })
-  favouriteBook?: IdentifiedReference<Book2>;
+  favouriteBook?: Ref<Book2>;
 
   @ManyToOne({ entity: () => Author2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
-  favouriteAuthor?: IdentifiedReference<Author2>;
+  favouriteAuthor?: Ref<Author2>;
 
   @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
   authorToFriend = new Collection<Author2>(this);
@@ -3074,7 +3074,7 @@ export class Author2 {
 
 }
 ",
-  "import { Entity, Enum, IdentifiedReference, Index, ManyToOne, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, Ref, Index, ManyToOne, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class BaseUser2 {
@@ -3096,10 +3096,10 @@ export class BaseUser2 {
   ownerProp?: string;
 
   @ManyToOne({ entity: () => BaseUser2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
-  favouriteEmployee?: IdentifiedReference<BaseUser2>;
+  favouriteEmployee?: Ref<BaseUser2>;
 
   @OneToOne({ entity: () => BaseUser2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
-  favouriteManager?: IdentifiedReference<BaseUser2>;
+  favouriteManager?: Ref<BaseUser2>;
 
   @Property({ nullable: true })
   employeeProp?: number;
@@ -3128,7 +3128,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, IdentifiedReference, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Ref, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2.js';
 import { BookTag2 } from './BookTag2.js';
 import { Publisher2 } from './Publisher2.js';
@@ -3161,10 +3161,10 @@ export class Book2 {
   meta?: any;
 
   @ManyToOne({ entity: () => Author2, wrappedReference: true })
-  author!: IdentifiedReference<Author2>;
+  author!: Ref<Author2>;
 
   @ManyToOne({ entity: () => Publisher2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade', nullable: true })
-  publisher?: IdentifiedReference<Publisher2>;
+  publisher?: Ref<Publisher2>;
 
   @Property({ length: 255, nullable: true, default: 'lol' })
   foo?: string;
@@ -3174,7 +3174,7 @@ export class Book2 {
 
 }
 ",
-  "import { Entity, IdentifiedReference, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { Entity, Ref, ManyToOne, PrimaryKey } from '@mikro-orm/core';
 import { Book2 } from './Book2.js';
 import { BookTag2 } from './BookTag2.js';
 
@@ -3185,14 +3185,14 @@ export class Book2Tags {
   order!: number;
 
   @ManyToOne({ entity: () => Book2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
-  book2!: IdentifiedReference<Book2>;
+  book2!: Ref<Book2>;
 
   @ManyToOne({ entity: () => BookTag2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
-  bookTag2!: IdentifiedReference<BookTag2>;
+  bookTag2!: Ref<BookTag2>;
 
 }
 ",
-  "import { Entity, IdentifiedReference, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Ref, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { Car2 } from './Car2.js';
 
 @Entity()
@@ -3205,7 +3205,7 @@ export class CarOwner2 {
   name!: string;
 
   @ManyToOne({ entity: () => Car2, wrappedReference: true, onUpdateIntegrity: 'cascade' })
-  car!: IdentifiedReference<Car2>;
+  car!: Ref<Car2>;
 
 }
 ",
@@ -3227,7 +3227,7 @@ export class Car2 {
 
 }
 ",
-  "import { Entity, IdentifiedReference, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Ref, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { Test2 } from './Test2.js';
 
 @Entity()
@@ -3237,7 +3237,7 @@ export class Configuration2 {
   property!: string;
 
   @ManyToOne({ entity: () => Test2, wrappedReference: true, onUpdateIntegrity: 'cascade', primary: true })
-  test!: IdentifiedReference<Test2>;
+  test!: Ref<Test2>;
 
   @Property({ length: 255 })
   value!: string;
@@ -3254,7 +3254,7 @@ export class Dummy2 {
 
 }
 ",
-  "import { Entity, IdentifiedReference, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Ref, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2.js';
 
 @Entity()
@@ -3272,10 +3272,10 @@ export class FooBar2 {
   nameWithSpace?: string;
 
   @OneToOne({ entity: () => FooBaz2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
-  baz?: IdentifiedReference<FooBaz2>;
+  baz?: Ref<FooBaz2>;
 
   @OneToOne({ entity: () => FooBar2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
-  fooBar?: IdentifiedReference<FooBar2>;
+  fooBar?: Ref<FooBar2>;
 
   @Property({ defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date;
@@ -3309,7 +3309,7 @@ export class FooBaz2 {
 
 }
 ",
-  "import { Entity, IdentifiedReference, ManyToOne, OptionalProps, Property } from '@mikro-orm/core';
+  "import { Entity, Ref, ManyToOne, OptionalProps, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2.js';
 import { FooBaz2 } from './FooBaz2.js';
 
@@ -3319,10 +3319,10 @@ export class FooParam2 {
   [OptionalProps]?: 'version';
 
   @ManyToOne({ entity: () => FooBar2, wrappedReference: true, onUpdateIntegrity: 'cascade', primary: true })
-  bar!: IdentifiedReference<FooBar2>;
+  bar!: Ref<FooBar2>;
 
   @ManyToOne({ entity: () => FooBaz2, wrappedReference: true, onUpdateIntegrity: 'cascade', primary: true })
-  baz!: IdentifiedReference<FooBaz2>;
+  baz!: Ref<FooBaz2>;
 
   @Property({ length: 255 })
   value!: string;
@@ -3386,7 +3386,7 @@ export enum Publisher2Enum5 {
   A = 'a',
 }
 ",
-  "import { Entity, IdentifiedReference, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { Entity, Ref, ManyToOne, PrimaryKey } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2.js';
 import { Test2 } from './Test2.js';
 
@@ -3397,10 +3397,10 @@ export class Publisher2Tests {
   id!: number;
 
   @ManyToOne({ entity: () => Publisher2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
-  publisher2!: IdentifiedReference<Publisher2>;
+  publisher2!: Ref<Publisher2>;
 
   @ManyToOne({ entity: () => Test2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
-  test2!: IdentifiedReference<Test2>;
+  test2!: Ref<Test2>;
 
 }
 ",
@@ -3420,7 +3420,7 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, IdentifiedReference, ManyToMany, ManyToOne, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Ref, ManyToMany, ManyToOne, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2.js';
 import { FooBar2 } from './FooBar2.js';
 
@@ -3436,16 +3436,16 @@ export class Test2 {
   name?: string;
 
   @OneToOne({ entity: () => Book2, wrappedReference: true, onDelete: 'set null', nullable: true })
-  book?: IdentifiedReference<Book2>;
+  book?: Ref<Book2>;
 
   @ManyToOne({ entity: () => Test2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
-  parent?: IdentifiedReference<Test2>;
+  parent?: Ref<Test2>;
 
   @Property({ default: 1 })
   version: number = 1;
 
   @OneToOne({ entity: () => FooBar2, wrappedReference: true, fieldName: 'foo___bar', onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
-  fooBar?: IdentifiedReference<FooBar2>;
+  fooBar?: Ref<FooBar2>;
 
   @Property({ fieldName: 'foo___baz', nullable: true })
   fooBaz?: number;
@@ -3455,7 +3455,7 @@ export class Test2 {
 
 }
 ",
-  "import { Collection, Entity, IdentifiedReference, ManyToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Ref, ManyToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { Car2 } from './Car2.js';
 import { Sandwich } from './Sandwich.js';
 
@@ -3472,7 +3472,7 @@ export class User2 {
   foo?: number;
 
   @OneToOne({ entity: () => Car2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
-  favouriteCar?: IdentifiedReference<Car2>;
+  favouriteCar?: Ref<Car2>;
 
   @ManyToMany({ entity: () => Car2, joinColumns: ['user2_first_name', 'user2_last_name'], inverseJoinColumns: ['car2_name', 'car2_year'] })
   cars = new Collection<Car2>(this);

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
@@ -89,7 +89,7 @@ export const Address2Schema = new EntitySchema({
       primary: true,
       reference: '1:1',
       entity: () => Author2,
-      wrappedReference: true,
+      ref: true,
       onUpdateIntegrity: 'cascade',
       onDelete: 'cascade',
     },
@@ -155,14 +155,14 @@ export const Author2Schema = new EntitySchema({
     favouriteBook: {
       reference: 'm:1',
       entity: () => Book2,
-      wrappedReference: true,
+      ref: true,
       onDelete: 'cascade',
       nullable: true,
     },
     favouriteAuthor: {
       reference: 'm:1',
       entity: () => Author2,
-      wrappedReference: true,
+      ref: true,
       onUpdateIntegrity: 'cascade',
       onDelete: 'set null',
       nullable: true,
@@ -220,7 +220,7 @@ export const BaseUser2Schema = new EntitySchema({
     favouriteEmployee: {
       reference: 'm:1',
       entity: () => BaseUser2,
-      wrappedReference: true,
+      ref: true,
       onUpdateIntegrity: 'cascade',
       onDelete: 'set null',
       nullable: true,
@@ -228,7 +228,7 @@ export const BaseUser2Schema = new EntitySchema({
     favouriteManager: {
       reference: '1:1',
       entity: () => BaseUser2,
-      wrappedReference: true,
+      ref: true,
       onUpdateIntegrity: 'cascade',
       onDelete: 'set null',
       nullable: true,
@@ -239,7 +239,7 @@ export const BaseUser2Schema = new EntitySchema({
     favouriteManagerInverse: {
       reference: '1:1',
       entity: () => BaseUser2,
-      wrappedReference: true,
+      ref: true,
       mappedBy: 'favouriteManager',
     },
   },
@@ -300,11 +300,11 @@ export const Book2Schema = new EntitySchema({
     price: { type: 'string', columnType: 'decimal(8,2)', nullable: true },
     double: { type: 'string', columnType: 'double', nullable: true },
     meta: { type: 'any', columnType: 'json', nullable: true },
-    author: { reference: 'm:1', entity: () => Author2, wrappedReference: true },
+    author: { reference: 'm:1', entity: () => Author2, ref: true },
     publisher: {
       reference: 'm:1',
       entity: () => Publisher2,
-      wrappedReference: true,
+      ref: true,
       onUpdateIntegrity: 'cascade',
       onDelete: 'cascade',
       nullable: true,
@@ -319,12 +319,7 @@ export const Book2Schema = new EntitySchema({
     },
     favouriteBookInverse: { reference: '1:m', entity: () => Author2, mappedBy: 'favouriteBook' },
     book2Inverse: { reference: '1:m', entity: () => Book2Tags, mappedBy: 'book2' },
-    bookInverse: {
-      reference: '1:1',
-      entity: () => Test2,
-      wrappedReference: true,
-      mappedBy: 'book',
-    },
+    bookInverse: { reference: '1:1', entity: () => Test2, ref: true, mappedBy: 'book' },
   },
 });
 ",
@@ -346,14 +341,14 @@ export const Book2TagsSchema = new EntitySchema({
     book2: {
       reference: 'm:1',
       entity: () => Book2,
-      wrappedReference: true,
+      ref: true,
       onUpdateIntegrity: 'cascade',
       onDelete: 'cascade',
     },
     bookTag2: {
       reference: 'm:1',
       entity: () => BookTag2,
-      wrappedReference: true,
+      ref: true,
       onUpdateIntegrity: 'cascade',
       onDelete: 'cascade',
     },
@@ -377,7 +372,7 @@ export const CarOwner2Schema = new EntitySchema({
     car: {
       reference: 'm:1',
       entity: () => Car2,
-      wrappedReference: true,
+      ref: true,
       onUpdateIntegrity: 'cascade',
     },
   },
@@ -403,12 +398,7 @@ export const Car2Schema = new EntitySchema({
     year: { primary: true, type: 'number', index: 'car2_year_index' },
     price: { type: 'number' },
     carInverse: { reference: '1:m', entity: () => CarOwner2, mappedBy: 'car' },
-    favouriteCarInverse: {
-      reference: '1:1',
-      entity: () => User2,
-      wrappedReference: true,
-      mappedBy: 'favouriteCar',
-    },
+    favouriteCarInverse: { reference: '1:1', entity: () => User2, ref: true, mappedBy: 'favouriteCar' },
     carsInverse: { reference: 'm:n', entity: () => User2, mappedBy: 'cars' },
   },
 });
@@ -430,7 +420,7 @@ export const Configuration2Schema = new EntitySchema({
       primary: true,
       reference: 'm:1',
       entity: () => Test2,
-      wrappedReference: true,
+      ref: true,
       onUpdateIntegrity: 'cascade',
     },
     value: { type: 'string', length: 255 },
@@ -479,7 +469,7 @@ export const FooBar2Schema = new EntitySchema({
     baz: {
       reference: '1:1',
       entity: () => FooBaz2,
-      wrappedReference: true,
+      ref: true,
       onUpdateIntegrity: 'cascade',
       onDelete: 'set null',
       nullable: true,
@@ -487,7 +477,7 @@ export const FooBar2Schema = new EntitySchema({
     fooBar: {
       reference: '1:1',
       entity: () => FooBar2,
-      wrappedReference: true,
+      ref: true,
       onUpdateIntegrity: 'cascade',
       onDelete: 'set null',
       nullable: true,
@@ -496,12 +486,7 @@ export const FooBar2Schema = new EntitySchema({
     blob: { type: 'Buffer', length: 65535, nullable: true },
     array: { type: 'string', columnType: 'text', length: 65535, nullable: true },
     objectProperty: { type: 'any', columnType: 'json', nullable: true },
-    fooBarInverse: {
-      reference: '1:1',
-      entity: () => Test2,
-      wrappedReference: true,
-      mappedBy: 'fooBar',
-    },
+    fooBarInverse: { reference: '1:1', entity: () => Test2, ref: true, mappedBy: 'fooBar' },
     barInverse: { reference: '1:m', entity: () => FooParam2, mappedBy: 'bar' },
     barsInverse: { reference: 'm:n', entity: () => Test2, mappedBy: 'bars' },
   },
@@ -545,14 +530,14 @@ export const FooParam2Schema = new EntitySchema({
       primary: true,
       reference: 'm:1',
       entity: () => FooBar2,
-      wrappedReference: true,
+      ref: true,
       onUpdateIntegrity: 'cascade',
     },
     baz: {
       primary: true,
       reference: 'm:1',
       entity: () => FooBaz2,
-      wrappedReference: true,
+      ref: true,
       onUpdateIntegrity: 'cascade',
     },
     value: { type: 'string', length: 255 },
@@ -633,14 +618,14 @@ export const Publisher2TestsSchema = new EntitySchema({
     publisher2: {
       reference: 'm:1',
       entity: () => Publisher2,
-      wrappedReference: true,
+      ref: true,
       onUpdateIntegrity: 'cascade',
       onDelete: 'cascade',
     },
     test2: {
       reference: 'm:1',
       entity: () => Test2,
-      wrappedReference: true,
+      ref: true,
       onUpdateIntegrity: 'cascade',
       onDelete: 'cascade',
     },
@@ -695,14 +680,14 @@ export const Test2Schema = new EntitySchema({
     book: {
       reference: '1:1',
       entity: () => Book2,
-      wrappedReference: true,
+      ref: true,
       onDelete: 'set null',
       nullable: true,
     },
     parent: {
       reference: 'm:1',
       entity: () => Test2,
-      wrappedReference: true,
+      ref: true,
       onUpdateIntegrity: 'cascade',
       onDelete: 'set null',
       nullable: true,
@@ -711,7 +696,7 @@ export const Test2Schema = new EntitySchema({
     fooBar: {
       reference: '1:1',
       entity: () => FooBar2,
-      wrappedReference: true,
+      ref: true,
       fieldName: 'foo___bar',
       onUpdateIntegrity: 'cascade',
       onDelete: 'set null',
@@ -752,7 +737,7 @@ export const User2Schema = new EntitySchema({
     favouriteCar: {
       reference: '1:1',
       entity: () => Car2,
-      wrappedReference: true,
+      ref: true,
       onUpdateIntegrity: 'cascade',
       onDelete: 'set null',
       nullable: true,
@@ -2421,13 +2406,13 @@ export class User2 {
 
 exports[`EntityGenerator generate entities with bidirectional relations and reference wrappers [mysql]: mysql-entity-bidirectional-dump 1`] = `
 [
-  "import { Entity, Ref, OneToOne, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, Property, Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
 @Entity()
 export class Address2 {
 
-  @OneToOne({ entity: () => Author2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade', primary: true })
+  @OneToOne({ entity: () => Author2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade', primary: true })
   author!: Ref<Author2>;
 
   @Property({ length: 255 })
@@ -2435,7 +2420,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Ref, Index, ManyToMany, ManyToOne, OneToMany, OptionalProps, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OptionalProps, PrimaryKey, Property, Ref, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -2484,10 +2469,10 @@ export class Author2 {
   @Property({ columnType: 'time', nullable: true })
   bornTime?: string;
 
-  @ManyToOne({ entity: () => Book2, wrappedReference: true, onDelete: 'cascade', nullable: true })
+  @ManyToOne({ entity: () => Book2, ref: true, onDelete: 'cascade', nullable: true })
   favouriteBook?: Ref<Book2>;
 
-  @ManyToOne({ entity: () => Author2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  @ManyToOne({ entity: () => Author2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
   favouriteAuthor?: Ref<Author2>;
 
   @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
@@ -2510,7 +2495,7 @@ export class Author2 {
 
 }
 ",
-  "import { Collection, Entity, Enum, Ref, Index, ManyToOne, OneToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Enum, Index, ManyToOne, OneToMany, OneToOne, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 
 @Entity()
 export class BaseUser2 {
@@ -2531,10 +2516,10 @@ export class BaseUser2 {
   @Property({ length: 255, nullable: true })
   ownerProp?: string;
 
-  @ManyToOne({ entity: () => BaseUser2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  @ManyToOne({ entity: () => BaseUser2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
   favouriteEmployee?: Ref<BaseUser2>;
 
-  @OneToOne({ entity: () => BaseUser2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  @OneToOne({ entity: () => BaseUser2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
   favouriteManager?: Ref<BaseUser2>;
 
   @Property({ nullable: true })
@@ -2546,7 +2531,7 @@ export class BaseUser2 {
   @OneToMany({ entity: () => BaseUser2, mappedBy: 'favouriteEmployee' })
   favouriteEmployeeInverse = new Collection<BaseUser2>(this);
 
-  @OneToOne({ entity: () => BaseUser2, wrappedReference: true, mappedBy: 'favouriteManager' })
+  @OneToOne({ entity: () => BaseUser2, ref: true, mappedBy: 'favouriteManager' })
   favouriteManagerInverse?: Ref<BaseUser2>;
 
 }
@@ -2578,7 +2563,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Ref, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, OptionalProps, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
@@ -2612,10 +2597,10 @@ export class Book2 {
   @Property({ columnType: 'json', nullable: true })
   meta?: any;
 
-  @ManyToOne({ entity: () => Author2, wrappedReference: true })
+  @ManyToOne({ entity: () => Author2, ref: true })
   author!: Ref<Author2>;
 
-  @ManyToOne({ entity: () => Publisher2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade', nullable: true })
+  @ManyToOne({ entity: () => Publisher2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade', nullable: true })
   publisher?: Ref<Publisher2>;
 
   @Property({ length: 255, nullable: true, default: 'lol' })
@@ -2630,12 +2615,12 @@ export class Book2 {
   @OneToMany({ entity: () => Book2Tags, mappedBy: 'book2' })
   book2Inverse = new Collection<Book2Tags>(this);
 
-  @OneToOne({ entity: () => Test2, wrappedReference: true, mappedBy: 'book' })
+  @OneToOne({ entity: () => Test2, ref: true, mappedBy: 'book' })
   bookInverse?: Ref<Test2>;
 
 }
 ",
-  "import { Entity, Ref, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { BookTag2 } from './BookTag2';
 
@@ -2645,15 +2630,15 @@ export class Book2Tags {
   @PrimaryKey()
   order!: number;
 
-  @ManyToOne({ entity: () => Book2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
+  @ManyToOne({ entity: () => Book2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
   book2!: Ref<Book2>;
 
-  @ManyToOne({ entity: () => BookTag2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
+  @ManyToOne({ entity: () => BookTag2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
   bookTag2!: Ref<BookTag2>;
 
 }
 ",
-  "import { Entity, Ref, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 
 @Entity()
@@ -2665,12 +2650,12 @@ export class CarOwner2 {
   @Property({ length: 255 })
   name!: string;
 
-  @ManyToOne({ entity: () => Car2, wrappedReference: true, onUpdateIntegrity: 'cascade' })
+  @ManyToOne({ entity: () => Car2, ref: true, onUpdateIntegrity: 'cascade' })
   car!: Ref<Car2>;
 
 }
 ",
-  "import { Collection, Entity, Ref, Index, ManyToMany, OneToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, OneToMany, OneToOne, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 import { CarOwner2 } from './CarOwner2';
 import { User2 } from './User2';
 
@@ -2691,7 +2676,7 @@ export class Car2 {
   @OneToMany({ entity: () => CarOwner2, mappedBy: 'car' })
   carInverse = new Collection<CarOwner2>(this);
 
-  @OneToOne({ entity: () => User2, wrappedReference: true, mappedBy: 'favouriteCar' })
+  @OneToOne({ entity: () => User2, ref: true, mappedBy: 'favouriteCar' })
   favouriteCarInverse?: Ref<User2>;
 
   @ManyToMany({ entity: () => User2, mappedBy: 'cars' })
@@ -2699,7 +2684,7 @@ export class Car2 {
 
 }
 ",
-  "import { Entity, Ref, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 import { Test2 } from './Test2';
 
 @Entity()
@@ -2708,7 +2693,7 @@ export class Configuration2 {
   @PrimaryKey({ length: 255 })
   property!: string;
 
-  @ManyToOne({ entity: () => Test2, wrappedReference: true, onUpdateIntegrity: 'cascade', primary: true })
+  @ManyToOne({ entity: () => Test2, ref: true, onUpdateIntegrity: 'cascade', primary: true })
   test!: Ref<Test2>;
 
   @Property({ length: 255 })
@@ -2726,7 +2711,7 @@ export class Dummy2 {
 
 }
 ",
-  "import { Collection, Entity, Ref, ManyToMany, OneToMany, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, OptionalProps, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
 import { Test2 } from './Test2';
@@ -2745,10 +2730,10 @@ export class FooBar2 {
   @Property({ fieldName: 'name with space', length: 255, nullable: true })
   nameWithSpace?: string;
 
-  @OneToOne({ entity: () => FooBaz2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  @OneToOne({ entity: () => FooBaz2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
   baz?: Ref<FooBaz2>;
 
-  @OneToOne({ entity: () => FooBar2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  @OneToOne({ entity: () => FooBar2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
   fooBar?: Ref<FooBar2>;
 
   @Property({ defaultRaw: \`CURRENT_TIMESTAMP\` })
@@ -2763,7 +2748,7 @@ export class FooBar2 {
   @Property({ columnType: 'json', nullable: true })
   objectProperty?: any;
 
-  @OneToOne({ entity: () => Test2, wrappedReference: true, mappedBy: 'fooBar' })
+  @OneToOne({ entity: () => Test2, ref: true, mappedBy: 'fooBar' })
   fooBarInverse?: Ref<Test2>;
 
   @OneToMany({ entity: () => FooParam2, mappedBy: 'bar' })
@@ -2796,7 +2781,7 @@ export class FooBaz2 {
 
 }
 ",
-  "import { Entity, Ref, ManyToOne, OptionalProps, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OptionalProps, Property, Ref } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -2805,10 +2790,10 @@ export class FooParam2 {
 
   [OptionalProps]?: 'version';
 
-  @ManyToOne({ entity: () => FooBar2, wrappedReference: true, onUpdateIntegrity: 'cascade', primary: true })
+  @ManyToOne({ entity: () => FooBar2, ref: true, onUpdateIntegrity: 'cascade', primary: true })
   bar!: Ref<FooBar2>;
 
-  @ManyToOne({ entity: () => FooBaz2, wrappedReference: true, onUpdateIntegrity: 'cascade', primary: true })
+  @ManyToOne({ entity: () => FooBaz2, ref: true, onUpdateIntegrity: 'cascade', primary: true })
   baz!: Ref<FooBaz2>;
 
   @Property({ length: 255 })
@@ -2881,7 +2866,7 @@ export enum Publisher2Enum5 {
   A = 'a',
 }
 ",
-  "import { Entity, Ref, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, Ref } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
 
@@ -2891,10 +2876,10 @@ export class Publisher2Tests {
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne({ entity: () => Publisher2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
+  @ManyToOne({ entity: () => Publisher2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
   publisher2!: Ref<Publisher2>;
 
-  @ManyToOne({ entity: () => Test2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
+  @ManyToOne({ entity: () => Test2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
   test2!: Ref<Test2>;
 
 }
@@ -2919,7 +2904,7 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, Ref, ManyToMany, ManyToOne, OneToMany, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToMany, OneToOne, OptionalProps, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
@@ -2936,16 +2921,16 @@ export class Test2 {
   @Property({ length: 255, nullable: true })
   name?: string;
 
-  @OneToOne({ entity: () => Book2, wrappedReference: true, onDelete: 'set null', nullable: true })
+  @OneToOne({ entity: () => Book2, ref: true, onDelete: 'set null', nullable: true })
   book?: Ref<Book2>;
 
-  @ManyToOne({ entity: () => Test2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  @ManyToOne({ entity: () => Test2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
   parent?: Ref<Test2>;
 
   @Property({ default: 1 })
   version: number = 1;
 
-  @OneToOne({ entity: () => FooBar2, wrappedReference: true, fieldName: 'foo___bar', onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  @OneToOne({ entity: () => FooBar2, ref: true, fieldName: 'foo___bar', onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
   fooBar?: Ref<FooBar2>;
 
   @Property({ fieldName: 'foo___baz', nullable: true })
@@ -2965,7 +2950,7 @@ export class Test2 {
 
 }
 ",
-  "import { Collection, Entity, Ref, ManyToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './Sandwich';
 
@@ -2981,7 +2966,7 @@ export class User2 {
   @Property({ nullable: true })
   foo?: number;
 
-  @OneToOne({ entity: () => Car2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  @OneToOne({ entity: () => Car2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
   favouriteCar?: Ref<Car2>;
 
   @ManyToMany({ entity: () => Car2, joinColumns: ['user2_first_name', 'user2_last_name'], inverseJoinColumns: ['car2_name', 'car2_year'] })
@@ -2997,13 +2982,13 @@ export class User2 {
 
 exports[`EntityGenerator generate entities with reference wrappers and named import [mysql]: mysql-entity-named-dump 1`] = `
 [
-  "import { Entity, Ref, OneToOne, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, Property, Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2.js';
 
 @Entity()
 export class Address2 {
 
-  @OneToOne({ entity: () => Author2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade', primary: true })
+  @OneToOne({ entity: () => Author2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade', primary: true })
   author!: Ref<Author2>;
 
   @Property({ length: 255 })
@@ -3011,7 +2996,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Ref, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, Property, Ref, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2.js';
 
 @Entity()
@@ -3060,10 +3045,10 @@ export class Author2 {
   @Property({ columnType: 'time', nullable: true })
   bornTime?: string;
 
-  @ManyToOne({ entity: () => Book2, wrappedReference: true, onDelete: 'cascade', nullable: true })
+  @ManyToOne({ entity: () => Book2, ref: true, onDelete: 'cascade', nullable: true })
   favouriteBook?: Ref<Book2>;
 
-  @ManyToOne({ entity: () => Author2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  @ManyToOne({ entity: () => Author2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
   favouriteAuthor?: Ref<Author2>;
 
   @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
@@ -3074,7 +3059,7 @@ export class Author2 {
 
 }
 ",
-  "import { Entity, Enum, Ref, Index, ManyToOne, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, Index, ManyToOne, OneToOne, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 
 @Entity()
 export class BaseUser2 {
@@ -3095,10 +3080,10 @@ export class BaseUser2 {
   @Property({ length: 255, nullable: true })
   ownerProp?: string;
 
-  @ManyToOne({ entity: () => BaseUser2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  @ManyToOne({ entity: () => BaseUser2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
   favouriteEmployee?: Ref<BaseUser2>;
 
-  @OneToOne({ entity: () => BaseUser2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  @OneToOne({ entity: () => BaseUser2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
   favouriteManager?: Ref<BaseUser2>;
 
   @Property({ nullable: true })
@@ -3128,7 +3113,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Ref, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2.js';
 import { BookTag2 } from './BookTag2.js';
 import { Publisher2 } from './Publisher2.js';
@@ -3160,10 +3145,10 @@ export class Book2 {
   @Property({ columnType: 'json', nullable: true })
   meta?: any;
 
-  @ManyToOne({ entity: () => Author2, wrappedReference: true })
+  @ManyToOne({ entity: () => Author2, ref: true })
   author!: Ref<Author2>;
 
-  @ManyToOne({ entity: () => Publisher2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade', nullable: true })
+  @ManyToOne({ entity: () => Publisher2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade', nullable: true })
   publisher?: Ref<Publisher2>;
 
   @Property({ length: 255, nullable: true, default: 'lol' })
@@ -3174,7 +3159,7 @@ export class Book2 {
 
 }
 ",
-  "import { Entity, Ref, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2.js';
 import { BookTag2 } from './BookTag2.js';
 
@@ -3184,15 +3169,15 @@ export class Book2Tags {
   @PrimaryKey()
   order!: number;
 
-  @ManyToOne({ entity: () => Book2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
+  @ManyToOne({ entity: () => Book2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
   book2!: Ref<Book2>;
 
-  @ManyToOne({ entity: () => BookTag2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
+  @ManyToOne({ entity: () => BookTag2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
   bookTag2!: Ref<BookTag2>;
 
 }
 ",
-  "import { Entity, Ref, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2.js';
 
 @Entity()
@@ -3204,7 +3189,7 @@ export class CarOwner2 {
   @Property({ length: 255 })
   name!: string;
 
-  @ManyToOne({ entity: () => Car2, wrappedReference: true, onUpdateIntegrity: 'cascade' })
+  @ManyToOne({ entity: () => Car2, ref: true, onUpdateIntegrity: 'cascade' })
   car!: Ref<Car2>;
 
 }
@@ -3227,7 +3212,7 @@ export class Car2 {
 
 }
 ",
-  "import { Entity, Ref, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 import { Test2 } from './Test2.js';
 
 @Entity()
@@ -3236,7 +3221,7 @@ export class Configuration2 {
   @PrimaryKey({ length: 255 })
   property!: string;
 
-  @ManyToOne({ entity: () => Test2, wrappedReference: true, onUpdateIntegrity: 'cascade', primary: true })
+  @ManyToOne({ entity: () => Test2, ref: true, onUpdateIntegrity: 'cascade', primary: true })
   test!: Ref<Test2>;
 
   @Property({ length: 255 })
@@ -3254,7 +3239,7 @@ export class Dummy2 {
 
 }
 ",
-  "import { Entity, Ref, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, OptionalProps, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2.js';
 
 @Entity()
@@ -3271,10 +3256,10 @@ export class FooBar2 {
   @Property({ fieldName: 'name with space', length: 255, nullable: true })
   nameWithSpace?: string;
 
-  @OneToOne({ entity: () => FooBaz2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  @OneToOne({ entity: () => FooBaz2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
   baz?: Ref<FooBaz2>;
 
-  @OneToOne({ entity: () => FooBar2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  @OneToOne({ entity: () => FooBar2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
   fooBar?: Ref<FooBar2>;
 
   @Property({ defaultRaw: \`CURRENT_TIMESTAMP\` })
@@ -3309,7 +3294,7 @@ export class FooBaz2 {
 
 }
 ",
-  "import { Entity, Ref, ManyToOne, OptionalProps, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OptionalProps, Property, Ref } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2.js';
 import { FooBaz2 } from './FooBaz2.js';
 
@@ -3318,10 +3303,10 @@ export class FooParam2 {
 
   [OptionalProps]?: 'version';
 
-  @ManyToOne({ entity: () => FooBar2, wrappedReference: true, onUpdateIntegrity: 'cascade', primary: true })
+  @ManyToOne({ entity: () => FooBar2, ref: true, onUpdateIntegrity: 'cascade', primary: true })
   bar!: Ref<FooBar2>;
 
-  @ManyToOne({ entity: () => FooBaz2, wrappedReference: true, onUpdateIntegrity: 'cascade', primary: true })
+  @ManyToOne({ entity: () => FooBaz2, ref: true, onUpdateIntegrity: 'cascade', primary: true })
   baz!: Ref<FooBaz2>;
 
   @Property({ length: 255 })
@@ -3386,7 +3371,7 @@ export enum Publisher2Enum5 {
   A = 'a',
 }
 ",
-  "import { Entity, Ref, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, Ref } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2.js';
 import { Test2 } from './Test2.js';
 
@@ -3396,10 +3381,10 @@ export class Publisher2Tests {
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne({ entity: () => Publisher2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
+  @ManyToOne({ entity: () => Publisher2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
   publisher2!: Ref<Publisher2>;
 
-  @ManyToOne({ entity: () => Test2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
+  @ManyToOne({ entity: () => Test2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'cascade' })
   test2!: Ref<Test2>;
 
 }
@@ -3420,7 +3405,7 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, Ref, ManyToMany, ManyToOne, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, OptionalProps, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2.js';
 import { FooBar2 } from './FooBar2.js';
 
@@ -3435,16 +3420,16 @@ export class Test2 {
   @Property({ length: 255, nullable: true })
   name?: string;
 
-  @OneToOne({ entity: () => Book2, wrappedReference: true, onDelete: 'set null', nullable: true })
+  @OneToOne({ entity: () => Book2, ref: true, onDelete: 'set null', nullable: true })
   book?: Ref<Book2>;
 
-  @ManyToOne({ entity: () => Test2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  @ManyToOne({ entity: () => Test2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
   parent?: Ref<Test2>;
 
   @Property({ default: 1 })
   version: number = 1;
 
-  @OneToOne({ entity: () => FooBar2, wrappedReference: true, fieldName: 'foo___bar', onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  @OneToOne({ entity: () => FooBar2, ref: true, fieldName: 'foo___bar', onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
   fooBar?: Ref<FooBar2>;
 
   @Property({ fieldName: 'foo___baz', nullable: true })
@@ -3455,7 +3440,7 @@ export class Test2 {
 
 }
 ",
-  "import { Collection, Entity, Ref, ManyToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2.js';
 import { Sandwich } from './Sandwich.js';
 
@@ -3471,7 +3456,7 @@ export class User2 {
   @Property({ nullable: true })
   foo?: number;
 
-  @OneToOne({ entity: () => Car2, wrappedReference: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
+  @OneToOne({ entity: () => Car2, ref: true, onUpdateIntegrity: 'cascade', onDelete: 'set null', nullable: true })
   favouriteCar?: Ref<Car2>;
 
   @ManyToMany({ entity: () => Car2, joinColumns: ['user2_first_name', 'user2_last_name'], inverseJoinColumns: ['car2_name', 'car2_year'] })

--- a/tests/features/joined-strategy.postgre.test.ts
+++ b/tests/features/joined-strategy.postgre.test.ts
@@ -425,7 +425,7 @@ describe('Joined loading strategy', () => {
     expect(tags[0].books[0].author.name).toBe('Jon Snow');
     expect(tags[0].books[0].publisher).toBeInstanceOf(Reference);
     expect(tags[0].books[0].publisher!.unwrap()).toBeInstanceOf(Publisher2);
-    expect(wrap(tags[0].books[0].publisher).isInitialized()).toBe(true);
+    expect(wrap(tags[0].books[0].publisher!).isInitialized()).toBe(true);
     expect(tags[0].books[0].publisher!.unwrap().tests.isInitialized(true)).toBe(true);
     expect(tags[0].books[0].publisher!.unwrap().tests.count()).toBe(2);
     expect(tags[0].books[0].publisher!.unwrap().tests[0].name).toBe('t21');

--- a/tests/features/multiple-schemas/different-schema-from-config.postgres.test.ts
+++ b/tests/features/multiple-schemas/different-schema-from-config.postgres.test.ts
@@ -68,7 +68,7 @@ describe('different schema from config', () => {
 
     const e = await orm.em.findOne(Book, entity);
     expect(e).not.toBeNull();
-    expect(wrap(e).getSchema()).toBe('privateschema');
+    expect(wrap(e!).getSchema()).toBe('privateschema');
     e!.tags.set([new BookTag('t2')]);
     await orm.em.flush();
   });

--- a/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
+++ b/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
@@ -21,7 +21,7 @@ export class Author {
 }
 
 @Entity({ schema: '*' })
-export class BookTag extends BaseEntity<BookTag, 'id'> {
+export class BookTag extends BaseEntity {
 
   @PrimaryKey()
   id!: number;
@@ -32,7 +32,7 @@ export class BookTag extends BaseEntity<BookTag, 'id'> {
 }
 
 @Entity({ schema: '*' })
-export class Book extends BaseEntity<Book, 'id'> {
+export class Book extends BaseEntity {
 
   @PrimaryKey()
   id!: number;

--- a/tests/features/multiple-schemas/reloading-entity.postgres.test.ts
+++ b/tests/features/multiple-schemas/reloading-entity.postgres.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, PrimaryKey, Reference } from '@mikro-orm/core';
+import { Collection, Entity, Ref, ManyToOne, MikroORM, OneToMany, PrimaryKey, Reference } from '@mikro-orm/core';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 
 @Entity()
@@ -19,9 +19,9 @@ export class License {
   id!: number;
 
   @ManyToOne({ entity: () => Customer, wrappedReference: true })
-  customer: IdentifiedReference<Customer>;
+  customer: Ref<Customer>;
 
-  constructor(customer: Customer | IdentifiedReference<Customer>) {
+  constructor(customer: Customer | Ref<Customer>) {
     this.customer = Reference.create(customer);
   }
 

--- a/tests/features/optimistic-lock/GH3209.test.ts
+++ b/tests/features/optimistic-lock/GH3209.test.ts
@@ -1,6 +1,17 @@
 /* eslint-disable eqeqeq */
 import type { Platform } from '@mikro-orm/core';
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, OptionalProps, PrimaryKey, PrimaryKeyType, Property, Type } from '@mikro-orm/core';
+import {
+  Collection,
+  Entity,
+  ManyToOne,
+  MikroORM,
+  OneToMany,
+  OptionalProps,
+  PrimaryKey,
+  PrimaryKeyProp,
+  Property,
+  Type,
+} from '@mikro-orm/core';
 import { mockLogger } from '../../helpers';
 import { BetterSqliteDriver } from '@mikro-orm/better-sqlite';
 
@@ -41,7 +52,7 @@ export class Author {
   @PrimaryKey({ type: TransformType })
   deletedDate: Date | 0 = 0;
 
-  [PrimaryKeyType]?: [string, number];
+  [PrimaryKeyProp]?: ['id', 'deletedDate'];
 
   [OptionalProps]?: 'deletedDate' | 'version';
 

--- a/tests/features/reflection/TsMorphMetadataProvider.test.ts
+++ b/tests/features/reflection/TsMorphMetadataProvider.test.ts
@@ -1,5 +1,5 @@
 import { MikroORM } from '@mikro-orm/mongodb';
-import type { Options, PrimaryProperty, Cast, IsUnknown, EntityMetadata } from '@mikro-orm/core';
+import type { Options, PrimaryProperty, EntityMetadata } from '@mikro-orm/core';
 import { Collection as Collection_, Reference as Reference_, ReferenceType, EnumArrayType } from '@mikro-orm/core';
 import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
 import { Author, Book, Publisher, BaseEntity, BaseEntity3, BookTagSchema, Test, FooBaz } from './entities';
@@ -8,7 +8,7 @@ import FooBar from './entities/FooBar';
 // we need to define those to get around typescript issues with reflection (ts-morph would return `any` for the type otherwise)
 export class Collection<T extends object> extends Collection_<T> { }
 export class Reference<T extends object> extends Reference_<T> { }
-export type Ref<T extends object, PK extends keyof T | unknown = PrimaryProperty<T>> = true extends IsUnknown<PK> ? Reference<T> : ({ [K in Cast<PK, keyof T>]?: T[K] } & Reference<T>);
+export type Ref<T extends object> = ({ [K in PrimaryProperty<T> & keyof T]?: T[K] } & Reference<T>);
 
 describe('TsMorphMetadataProvider', () => {
 

--- a/tests/features/reflection/TsMorphMetadataProvider.test.ts
+++ b/tests/features/reflection/TsMorphMetadataProvider.test.ts
@@ -8,7 +8,7 @@ import FooBar from './entities/FooBar';
 // we need to define those to get around typescript issues with reflection (ts-morph would return `any` for the type otherwise)
 export class Collection<T extends object> extends Collection_<T> { }
 export class Reference<T extends object> extends Reference_<T> { }
-export type IdentifiedReference<T extends object, PK extends keyof T | unknown = PrimaryProperty<T>> = true extends IsUnknown<PK> ? Reference<T> : ({ [K in Cast<PK, keyof T>]?: T[K] } & Reference<T>);
+export type Ref<T extends object, PK extends keyof T | unknown = PrimaryProperty<T>> = true extends IsUnknown<PK> ? Reference<T> : ({ [K in Cast<PK, keyof T>]?: T[K] } & Reference<T>);
 
 describe('TsMorphMetadataProvider', () => {
 

--- a/tests/features/reflection/entities-compiled/Book.d.ts
+++ b/tests/features/reflection/entities-compiled/Book.d.ts
@@ -6,7 +6,7 @@ import { BaseEntity3 } from './BaseEntity3';
 export declare class Book extends BaseEntity3 {
     title: string;
     author: Author;
-    publisher: Ref<Publisher, '_id' | 'id'>;
+    publisher: Ref<Publisher>;
     tags: Collection<BookTag>;
     metaObject?: object;
     metaArray?: any[];

--- a/tests/features/reflection/entities-compiled/Book.d.ts
+++ b/tests/features/reflection/entities-compiled/Book.d.ts
@@ -1,12 +1,12 @@
 import { Publisher } from './Publisher';
 import { Author } from './Author';
 import { BookTag } from './BookTag';
-import { Collection, IdentifiedReference } from '../TsMorphMetadataProvider.test';
+import { Collection, Ref } from '../TsMorphMetadataProvider.test';
 import { BaseEntity3 } from './BaseEntity3';
 export declare class Book extends BaseEntity3 {
     title: string;
     author: Author;
-    publisher: IdentifiedReference<Publisher, '_id' | 'id'>;
+    publisher: Ref<Publisher, '_id' | 'id'>;
     tags: Collection<BookTag>;
     metaObject?: object;
     metaArray?: any[];

--- a/tests/features/reflection/entities/Book.ts
+++ b/tests/features/reflection/entities/Book.ts
@@ -15,7 +15,7 @@ export class Book extends BaseEntity3 {
   author: Author;
 
   @ManyToOne({ cascade: [Cascade.PERSIST, Cascade.REMOVE] })
-  publisher!: Ref<Publisher, '_id' | 'id'>;
+  publisher!: Ref<Publisher>;
 
   @ManyToMany()
   tags = new Collection<BookTag>(this);

--- a/tests/features/reflection/entities/Book.ts
+++ b/tests/features/reflection/entities/Book.ts
@@ -2,7 +2,7 @@ import { Cascade, Entity, ManyToMany, ManyToOne, Property } from '@mikro-orm/cor
 import type { Publisher } from './Publisher';
 import { Author } from './Author';
 import type { BookTag } from './BookTag';
-import { Collection, IdentifiedReference } from '../TsMorphMetadataProvider.test';
+import { Collection, Ref } from '../TsMorphMetadataProvider.test';
 import { BaseEntity3 } from './BaseEntity3';
 
 @Entity()
@@ -15,7 +15,7 @@ export class Book extends BaseEntity3 {
   author: Author;
 
   @ManyToOne({ cascade: [Cascade.PERSIST, Cascade.REMOVE] })
-  publisher!: IdentifiedReference<Publisher, '_id' | 'id'>;
+  publisher!: Ref<Publisher, '_id' | 'id'>;
 
   @ManyToMany()
   tags = new Collection<BookTag>(this);

--- a/tests/features/schema-generator/index-diffing.mysql.test.ts
+++ b/tests/features/schema-generator/index-diffing.mysql.test.ts
@@ -1,4 +1,4 @@
-import { Entity, IdentifiedReference, Index, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
+import { Entity, Ref, Index, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
 import { MySqlDriver } from '@mikro-orm/mysql';
 
 @Entity()
@@ -19,10 +19,10 @@ export class Book1 {
   id!: number;
 
   @ManyToOne(() => Author, { wrappedReference: true })
-  author1!: IdentifiedReference<Author>;
+  author1!: Ref<Author>;
 
   @ManyToOne(() => Author, { wrappedReference: true })
-  author2!: IdentifiedReference<Author>;
+  author2!: Ref<Author>;
 
   @ManyToOne(() => Author)
   author3!: Author;
@@ -47,11 +47,11 @@ export class Book2 {
   id!: number;
 
   @ManyToOne(() => Author, { wrappedReference: true })
-  author1!: IdentifiedReference<Author>;
+  author1!: Ref<Author>;
 
   @ManyToOne(() => Author, { wrappedReference: true })
   @Index()
-  author2!: IdentifiedReference<Author>;
+  author2!: Ref<Author>;
 
   @ManyToOne(() => Author)
   author3!: Author;
@@ -79,11 +79,11 @@ export class Book3 {
   id!: number;
 
   @ManyToOne(() => Author, { wrappedReference: true })
-  author1!: IdentifiedReference<Author>;
+  author1!: Ref<Author>;
 
   @ManyToOne(() => Author, { wrappedReference: true })
   @Index()
-  author2!: IdentifiedReference<Author>;
+  author2!: Ref<Author>;
 
   @ManyToOne(() => Author)
   author3!: Author;
@@ -111,11 +111,11 @@ export class Book4 {
   id!: number;
 
   @ManyToOne(() => Author, { wrappedReference: true })
-  author1!: IdentifiedReference<Author>;
+  author1!: Ref<Author>;
 
   @ManyToOne(() => Author, { wrappedReference: true })
   @Index()
-  author2!: IdentifiedReference<Author>;
+  author2!: Ref<Author>;
 
   @ManyToOne(() => Author)
   author3!: Author;

--- a/tests/features/schema-generator/index-diffing.postgres.test.ts
+++ b/tests/features/schema-generator/index-diffing.postgres.test.ts
@@ -1,4 +1,4 @@
-import { Entity, IdentifiedReference, Index, ManyToOne, MikroORM, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+import { Entity, Ref, Index, ManyToOne, MikroORM, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 
 @Entity()
@@ -19,10 +19,10 @@ export class Book1 {
   id!: number;
 
   @ManyToOne(() => Author, { wrappedReference: true })
-  author1!: IdentifiedReference<Author>;
+  author1!: Ref<Author>;
 
   @ManyToOne(() => Author, { wrappedReference: true })
-  author2!: IdentifiedReference<Author>;
+  author2!: Ref<Author>;
 
   @ManyToOne(() => Author)
   author3!: Author;
@@ -51,11 +51,11 @@ export class Book2 {
   id!: number;
 
   @ManyToOne(() => Author, { wrappedReference: true })
-  author1!: IdentifiedReference<Author>;
+  author1!: Ref<Author>;
 
   @ManyToOne(() => Author, { wrappedReference: true })
   @Index()
-  author2!: IdentifiedReference<Author>;
+  author2!: Ref<Author>;
 
   @ManyToOne(() => Author)
   author3!: Author;
@@ -87,11 +87,11 @@ export class Book3 {
   id!: number;
 
   @ManyToOne(() => Author, { wrappedReference: true })
-  author1!: IdentifiedReference<Author>;
+  author1!: Ref<Author>;
 
   @ManyToOne(() => Author, { wrappedReference: true })
   @Index()
-  author2!: IdentifiedReference<Author>;
+  author2!: Ref<Author>;
 
   @ManyToOne(() => Author)
   author3!: Author;
@@ -123,11 +123,11 @@ export class Book4 {
   id!: number;
 
   @ManyToOne(() => Author, { wrappedReference: true })
-  author1!: IdentifiedReference<Author>;
+  author1!: Ref<Author>;
 
   @ManyToOne(() => Author, { wrappedReference: true })
   @Index()
-  author2!: IdentifiedReference<Author>;
+  author2!: Ref<Author>;
 
   @ManyToOne(() => Author)
   author3!: Author;

--- a/tests/features/schema-generator/index-diffing.sqlite.test.ts
+++ b/tests/features/schema-generator/index-diffing.sqlite.test.ts
@@ -1,4 +1,4 @@
-import { Entity, IdentifiedReference, Index, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
+import { Entity, Ref, Index, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
@@ -20,10 +20,10 @@ export class Book1 {
   id!: number;
 
   @ManyToOne(() => Author, { wrappedReference: true })
-  author1!: IdentifiedReference<Author>;
+  author1!: Ref<Author>;
 
   @ManyToOne(() => Author, { wrappedReference: true })
-  author2!: IdentifiedReference<Author>;
+  author2!: Ref<Author>;
 
   @ManyToOne(() => Author)
   author3!: Author;
@@ -45,11 +45,11 @@ export class Book2 {
   id!: number;
 
   @ManyToOne(() => Author, { wrappedReference: true })
-  author1!: IdentifiedReference<Author>;
+  author1!: Ref<Author>;
 
   @ManyToOne(() => Author, { wrappedReference: true })
   @Index()
-  author2!: IdentifiedReference<Author>;
+  author2!: Ref<Author>;
 
   @ManyToOne(() => Author)
   author3!: Author;
@@ -73,11 +73,11 @@ export class Book3 {
   id!: number;
 
   @ManyToOne(() => Author, { wrappedReference: true })
-  author1!: IdentifiedReference<Author>;
+  author1!: Ref<Author>;
 
   @ManyToOne(() => Author, { wrappedReference: true })
   @Index()
-  author2!: IdentifiedReference<Author>;
+  author2!: Ref<Author>;
 
   @ManyToOne(() => Author)
   author3!: Author;
@@ -101,11 +101,11 @@ export class Book4 {
   id!: number;
 
   @ManyToOne(() => Author, { wrappedReference: true })
-  author1!: IdentifiedReference<Author>;
+  author1!: Ref<Author>;
 
   @ManyToOne(() => Author, { wrappedReference: true })
   @Index()
-  author2!: IdentifiedReference<Author>;
+  author2!: Ref<Author>;
 
   @ManyToOne(() => Author)
   author3!: Author;

--- a/tests/features/seeder/entities/project.entity.ts
+++ b/tests/features/seeder/entities/project.entity.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, IdentifiedReference, ManyToOne, OneToMany, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+import { Collection, Entity, Ref, ManyToOne, OneToMany, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
 import { House } from './house.entity';
 import { User } from './user.entity';
 
@@ -14,7 +14,7 @@ export class Project {
   name!: string;
 
   @ManyToOne({ entity: () => User, wrappedReference: true })
-  owner!: IdentifiedReference<User>;
+  owner!: Ref<User>;
 
   @Property()
   worth!: number;

--- a/tests/features/single-table-inheritance/GH2364.test.ts
+++ b/tests/features/single-table-inheritance/GH2364.test.ts
@@ -1,4 +1,4 @@
-import { BigIntType, Entity, Enum, IdentifiedReference, ManyToOne, MikroORM, PrimaryKey, QueryOrder } from '@mikro-orm/core';
+import { BigIntType, Entity, Enum, Ref, ManyToOne, MikroORM, PrimaryKey, QueryOrder } from '@mikro-orm/core';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 
 export enum EntityType {
@@ -13,7 +13,7 @@ abstract class BaseEntity {
   id!: string;
 
   @ManyToOne(() => BaseEntity, { wrappedReference: true, nullable: true })
-  parent?: IdentifiedReference<BaseEntity>;
+  parent?: Ref<BaseEntity>;
 
   @Enum({ type: () => EntityType })
   type!: EntityType;

--- a/tests/features/single-table-inheritance/GH2723.test.ts
+++ b/tests/features/single-table-inheritance/GH2723.test.ts
@@ -1,10 +1,10 @@
-import { Collection, Entity, Ref, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyType } from '@mikro-orm/core';
+import { Collection, Entity, Ref, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Cat {
 
-  [PrimaryKeyType]?: [string, string];
+  [PrimaryKeyProp]?: ['name', 'user'];
 
   @PrimaryKey()
   name!: string;

--- a/tests/features/single-table-inheritance/GH2723.test.ts
+++ b/tests/features/single-table-inheritance/GH2723.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyType } from '@mikro-orm/core';
+import { Collection, Entity, Ref, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyType } from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
 @Entity()
@@ -10,7 +10,7 @@ export class Cat {
   name!: string;
 
   @ManyToOne(() => User, { primary: true, onDelete: 'CASCADE', wrappedReference: true })
-  user!: IdentifiedReference<User>;
+  user!: Ref<User>;
 
 }
 

--- a/tests/features/single-table-inheritance/single-table-inheritance.mysql.test.ts
+++ b/tests/features/single-table-inheritance/single-table-inheritance.mysql.test.ts
@@ -158,13 +158,13 @@ describe('single table inheritance in mysql', () => {
     const owner = await orm.em.findOneOrFail(CompanyOwner2, { firstName: 'Bruce' });
     expect(owner).toBeInstanceOf(CompanyOwner2);
     expect(owner.favouriteEmployee).toBeInstanceOf(Employee2);
-    expect(wrap(owner.favouriteEmployee).isInitialized()).toBe(false);
-    await wrap(owner.favouriteEmployee).init();
-    expect(wrap(owner.favouriteEmployee).isInitialized()).toBe(true);
+    expect(wrap(owner.favouriteEmployee!).isInitialized()).toBe(false);
+    await wrap(owner.favouriteEmployee!).init();
+    expect(wrap(owner.favouriteEmployee!).isInitialized()).toBe(true);
     expect(owner.favouriteManager).toBeInstanceOf(Manager2);
-    expect(wrap(owner.favouriteManager).isInitialized()).toBe(false);
-    await wrap(owner.favouriteManager).init();
-    expect(wrap(owner.favouriteManager).isInitialized()).toBe(true);
+    expect(wrap(owner.favouriteManager!).isInitialized()).toBe(false);
+    await wrap(owner.favouriteManager!).init();
+    expect(wrap(owner.favouriteManager!).isInitialized()).toBe(true);
   });
 
   test('loading base type with discriminator condition', async () => {

--- a/tests/features/unit-of-work/EntityComparator.test.ts
+++ b/tests/features/unit-of-work/EntityComparator.test.ts
@@ -138,7 +138,7 @@ export class ObjectHydratorOld {
     const meta = this.metadata.find(prop.type)!;
 
     if (Utils.isPrimaryKey(value, meta.compositePK)) {
-      return factory.createReference<T>(prop.type, value, { merge: true });
+      return factory.createReference<T>(prop.type, value as any, { merge: true });
     }
 
     if (Utils.isEntity<T>(value)) {

--- a/tests/issues/GH1003.test.ts
+++ b/tests/issues/GH1003.test.ts
@@ -2,7 +2,7 @@ import { BaseEntity, Collection, MikroORM, Entity, ManyToOne, OneToMany, Primary
 import type { IdentifiedReference } from '@mikro-orm/sqlite';
 
 @Entity()
-export class Parent extends BaseEntity<Parent, 'id'> {
+export class Parent extends BaseEntity {
 
   @PrimaryKey()
   id!: string;
@@ -13,7 +13,7 @@ export class Parent extends BaseEntity<Parent, 'id'> {
 }
 
 @Entity()
-export class Child extends BaseEntity<Parent, 'id'> {
+export class Child extends BaseEntity {
 
   @PrimaryKey()
   id!: string;

--- a/tests/issues/GH1003.test.ts
+++ b/tests/issues/GH1003.test.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Collection, MikroORM, Entity, ManyToOne, OneToMany, PrimaryKey } from '@mikro-orm/sqlite';
-import type { IdentifiedReference } from '@mikro-orm/sqlite';
+import type { Ref } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Parent extends BaseEntity {
@@ -24,7 +24,7 @@ export class Child extends BaseEntity {
     index: true,
     onDelete: 'cascade',
   })
-  parent!: IdentifiedReference<Parent>;
+  parent!: Ref<Parent>;
 
 }
 

--- a/tests/issues/GH1111.test.ts
+++ b/tests/issues/GH1111.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, Ref, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, PrimaryKeyType, Property, Reference } from '@mikro-orm/postgresql';
+import { Collection, Entity, Ref, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Reference } from '@mikro-orm/postgresql';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -12,7 +12,6 @@ class Node {
 @Entity()
 class A {
 
-  [PrimaryKeyType]?: number;
   [PrimaryKeyProp]?: 'node';
   @OneToOne({ entity: () => Node, wrappedReference: true, primary: true, onDelete: 'cascade', onUpdateIntegrity: 'cascade' })
   node!: Ref<Node>;

--- a/tests/issues/GH1111.test.ts
+++ b/tests/issues/GH1111.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, PrimaryKeyType, Property, Reference } from '@mikro-orm/postgresql';
+import { Collection, Entity, Ref, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, PrimaryKeyType, Property, Reference } from '@mikro-orm/postgresql';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -15,7 +15,7 @@ class A {
   [PrimaryKeyType]?: number;
   [PrimaryKeyProp]?: 'node';
   @OneToOne({ entity: () => Node, wrappedReference: true, primary: true, onDelete: 'cascade', onUpdateIntegrity: 'cascade' })
-  node!: IdentifiedReference<Node>;
+  node!: Ref<Node>;
 
   @OneToMany('B', 'a', { eager: true, orphanRemoval: true })
   bs = new Collection<B>(this);
@@ -63,7 +63,7 @@ describe('GH issue 1111', () => {
 
   afterAll(() => orm.close(true));
 
-  test('FK as PK with IdentifiedReference - single insert', async () => {
+  test('FK as PK with Ref - single insert', async () => {
     const a1 = new A();
     a1.name = 'test';
     a1.node = Reference.create(new Node());
@@ -83,7 +83,7 @@ describe('GH issue 1111', () => {
     expect(a2.bs.count()).toBe(1);
   });
 
-  test('FK as PK with IdentifiedReference - multiple inserts', async () => {
+  test('FK as PK with Ref - multiple inserts', async () => {
     const a1 = new A();
     a1.name = 'test';
     a1.node = Reference.create(new Node());

--- a/tests/issues/GH1224.test.ts
+++ b/tests/issues/GH1224.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, PrimaryKeyType, Property, Reference } from '@mikro-orm/postgresql';
+import { Collection, Entity, Ref, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, PrimaryKeyType, Property, Reference } from '@mikro-orm/postgresql';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -27,7 +27,7 @@ class A {
   [PrimaryKeyType]?: number;
   [PrimaryKeyProp]?: 'node';
   @OneToOne({ entity: 'Node', wrappedReference: true, primary: true, onDelete: 'cascade', onUpdateIntegrity: 'cascade' })
-  node!: IdentifiedReference<Node>;
+  node!: Ref<Node>;
 
   @Property()
   name!: string;

--- a/tests/issues/GH1224.test.ts
+++ b/tests/issues/GH1224.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, Ref, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, PrimaryKeyType, Property, Reference } from '@mikro-orm/postgresql';
+import { Collection, Entity, Ref, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Reference } from '@mikro-orm/postgresql';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -24,7 +24,6 @@ class B {
 @Entity()
 class A {
 
-  [PrimaryKeyType]?: number;
   [PrimaryKeyProp]?: 'node';
   @OneToOne({ entity: 'Node', wrappedReference: true, primary: true, onDelete: 'cascade', onUpdateIntegrity: 'cascade' })
   node!: Ref<Node>;

--- a/tests/issues/GH1326.test.ts
+++ b/tests/issues/GH1326.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, IdentifiedReference, MikroORM, ManyToOne, OneToMany, PrimaryKey, Property } from '@mikro-orm/mysql';
+import { Collection, Entity, Ref, MikroORM, ManyToOne, OneToMany, PrimaryKey, Property } from '@mikro-orm/mysql';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -39,10 +39,10 @@ export class License {
   expiresAt!: Date;
 
   @ManyToOne(() => Driver, { inversedBy: 'licenses', wrappedReference: true })
-  driver!: IdentifiedReference<Driver>;
+  driver!: Ref<Driver>;
 
   @ManyToOne('LicenseType', { inversedBy: 'licenses', wrappedReference: true })
-  licenseType!: IdentifiedReference<LicenseType>;
+  licenseType!: Ref<LicenseType>;
 
 }
 

--- a/tests/issues/GH1331.test.ts
+++ b/tests/issues/GH1331.test.ts
@@ -1,7 +1,7 @@
 import {
   Collection,
   Entity,
-  IdentifiedReference,
+  Ref,
   LoadStrategy,
   ManyToOne,
   MikroORM,
@@ -27,7 +27,7 @@ export class D {
     wrappedReference: true,
     nullable: true,
   })
-  c?: IdentifiedReference<C>;
+  c?: Ref<C>;
 
 }
 
@@ -45,7 +45,7 @@ export class C {
     wrappedReference: true,
     nullable: true,
   })
-  b?: IdentifiedReference<B>;
+  b?: Ref<B>;
 
   @OneToMany(
     () => D,
@@ -73,7 +73,7 @@ export class B {
     wrappedReference: true,
     nullable: true,
   })
-  a?: IdentifiedReference<A>;
+  a?: Ref<A>;
 
   @OneToMany(
     () => C,

--- a/tests/issues/GH1334.test.ts
+++ b/tests/issues/GH1334.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, IdentifiedReference, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, QueryOrder } from '@mikro-orm/sqlite';
+import { Collection, Entity, Ref, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, QueryOrder } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -14,7 +14,7 @@ export class RadioOption {
   order!: number;
 
   @ManyToOne('Radio', { wrappedReference: true })
-  radio!: IdentifiedReference<Radio>;
+  radio!: Ref<Radio>;
 
 }
 
@@ -31,7 +31,7 @@ export class Radio {
   question: string = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 10);
 
   @ManyToOne('Project', { wrappedReference: true })
-  project!: IdentifiedReference<Project>;
+  project!: Ref<Project>;
 
   @OneToMany(
     () => RadioOption,

--- a/tests/issues/GH1352.test.ts
+++ b/tests/issues/GH1352.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, IdentifiedReference, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
+import { Collection, Entity, Ref, LoadStrategy, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Manager {
@@ -10,7 +10,7 @@ export class Manager {
   name!: string;
 
   @ManyToOne('Project', { wrappedReference: true })
-  project!: IdentifiedReference<Project>;
+  project!: Ref<Project>;
 
   constructor(name: string) {
     this.name = name;
@@ -28,7 +28,7 @@ export class Owner {
   name!: string;
 
   @ManyToOne('Risk', { wrappedReference: true })
-  risk!: IdentifiedReference<Risk>;
+  risk!: Ref<Risk>;
 
   constructor(name: string) {
     this.name = name;
@@ -49,7 +49,7 @@ export class Risk {
   owners = new Collection<Owner>(this);
 
   @ManyToOne('Project', { wrappedReference: true })
-  project!: IdentifiedReference<Project>;
+  project!: Ref<Project>;
 
   constructor(value: string) {
     this.value = value;

--- a/tests/issues/GH1553.test.ts
+++ b/tests/issues/GH1553.test.ts
@@ -4,7 +4,7 @@ import {
   PrimaryKey,
   Property,
   ManyToOne,
-  IdentifiedReference,
+  Ref,
   OneToMany,
   Collection,
   LoadStrategy,
@@ -20,7 +20,7 @@ export class Owner {
   name!: string;
 
   @ManyToOne('Radio', { wrappedReference: true })
-  radio!: IdentifiedReference<Radio>;
+  radio!: Ref<Radio>;
 
   constructor(name: string) {
     this.name = name;
@@ -38,7 +38,7 @@ export class RadioOption {
   enabled!: boolean;
 
   @ManyToOne('Radio', { wrappedReference: true })
-  radio!: IdentifiedReference<Radio>;
+  radio!: Ref<Radio>;
 
 
   constructor(enabled: boolean) {

--- a/tests/issues/GH1592.test.ts
+++ b/tests/issues/GH1592.test.ts
@@ -1,4 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, Property, IdentifiedReference, LoadStrategy, OneToOne } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, PrimaryKey, Property, Ref, LoadStrategy, OneToOne } from '@mikro-orm/sqlite';
 
 @Entity()
 export class RadioOption {
@@ -13,7 +13,7 @@ export class RadioOption {
   createdAt: Date = new Date();
 
   @OneToOne({ entity: 'Radio', wrappedReference: true, mappedBy: 'option' })
-  radio!: IdentifiedReference<Radio>;
+  radio!: Ref<Radio>;
 
   constructor(enabled: boolean) {
     this.enabled = enabled;
@@ -31,7 +31,7 @@ export class Radio {
   question: string = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 10);
 
   @OneToOne({ entity: () => RadioOption, wrappedReference: true, eager: true })
-  option!: IdentifiedReference<RadioOption>;
+  option!: Ref<RadioOption>;
 
 }
 

--- a/tests/issues/GH1657.test.ts
+++ b/tests/issues/GH1657.test.ts
@@ -73,8 +73,8 @@ describe('GH issue 1657', () => {
     const mock = mockLogger(orm, ['query', 'query-params']);
     const res1 = await orm.em.find(OrderItem, { id: { $lte: 100 } });
     expect(res1).toHaveLength(2);
-    expect(wrap(res1[0].order1).isInitialized()).toBe(true);
-    expect(wrap(res1[1].order2).isInitialized()).toBe(true);
+    expect(wrap(res1[0].order1!).isInitialized()).toBe(true);
+    expect(wrap(res1[1].order2!).isInitialized()).toBe(true);
 
     // first query loads item and joins the order2 relation (eager + joined strategy)
     expect(mock.mock.calls[0][0]).toMatch('select `o0`.`id`, `o0`.`order1_id`, `o0`.`order2_id`, `o1`.`id` as `o1__id` from `order_item` as `o0` left join `order` as `o1` on `o0`.`order2_id` = `o1`.`id` where `o0`.`id` <= 100');

--- a/tests/issues/GH1831.test.ts
+++ b/tests/issues/GH1831.test.ts
@@ -1,7 +1,7 @@
 import {
   Collection,
   Entity,
-  IdentifiedReference,
+  Ref,
   ManyToOne,
   MikroORM,
   OneToMany,
@@ -20,7 +20,7 @@ export class FilterValue {
   name!: string;
 
   @ManyToOne('Filter', { wrappedReference: true })
-  filter!: IdentifiedReference<Filter>;
+  filter!: Ref<Filter>;
 
 }
 
@@ -34,7 +34,7 @@ export class Filter {
   name!: string;
 
   @ManyToOne('Project', { wrappedReference: true })
-  project!: IdentifiedReference<Project>;
+  project!: Ref<Project>;
 
   @OneToMany('FilterValue', 'filter')
   values = new Collection<FilterValue>(this);

--- a/tests/issues/GH1902.test.ts
+++ b/tests/issues/GH1902.test.ts
@@ -1,4 +1,17 @@
-import { MikroORM, Entity, PrimaryKey, PrimaryKeyType, Unique, Collection, ManyToOne, OneToMany, Property, Filter, LoadStrategy, OptionalProps } from '@mikro-orm/sqlite';
+import {
+  MikroORM,
+  Entity,
+  PrimaryKey,
+  Unique,
+  Collection,
+  ManyToOne,
+  OneToMany,
+  Property,
+  Filter,
+  LoadStrategy,
+  OptionalProps,
+  PrimaryKeyProp,
+} from '@mikro-orm/sqlite';
 
 @Entity({ tableName: 'users' })
 export class UserEntity {
@@ -52,7 +65,7 @@ class UserTenantEntity {
   @ManyToOne({ primary: true, entity: () => TenantEntity, fieldName: 'tenantId', cascade: [] })
   tenant!: TenantEntity;
 
-  [PrimaryKeyType]?: [number, number];
+  [PrimaryKeyProp]?: ['user', 'tenant'];
   [OptionalProps]?: 'isActive';
 
   @Property({ type: 'boolean', fieldName: 'isActive' })

--- a/tests/issues/GH2148.test.ts
+++ b/tests/issues/GH2148.test.ts
@@ -1,4 +1,4 @@
-import { Entity, IdentifiedReference, ManyToOne, MikroORM, PrimaryKey, Reference } from '@mikro-orm/postgresql';
+import { Entity, Ref, ManyToOne, MikroORM, PrimaryKey, Reference } from '@mikro-orm/postgresql';
 
 @Entity()
 export class First {
@@ -20,10 +20,10 @@ export class Second {
 export class Third {
 
   @ManyToOne({ primary: true, entity: () => First, wrappedReference: true })
-  first: IdentifiedReference<First>;
+  first: Ref<First>;
 
   @ManyToOne({ primary: true, entity: () => Second, wrappedReference: true })
-  second: IdentifiedReference<Second>;
+  second: Ref<Second>;
 
   constructor(first: First, second: Second) {
     this.first = Reference.create(first);

--- a/tests/issues/GH2371.test.ts
+++ b/tests/issues/GH2371.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/sqlite';
+import { Collection, Entity, Ref, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/sqlite';
 
 @Entity({ tableName: 'vehicle', discriminatorColumn: 'type', abstract: true })
 class Vehicle {
@@ -7,7 +7,7 @@ class Vehicle {
   id!: number;
 
   @ManyToOne(() => Garage, { wrappedReference: true })
-  garage!: IdentifiedReference<Garage>;
+  garage!: Ref<Garage>;
 
 }
 

--- a/tests/issues/GH2379.test.ts
+++ b/tests/issues/GH2379.test.ts
@@ -1,4 +1,4 @@
-import { BigIntType, Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, OptionalProps, PrimaryKey, Property } from '@mikro-orm/sqlite';
+import { BigIntType, Collection, Entity, Ref, ManyToOne, MikroORM, OneToMany, OptionalProps, PrimaryKey, Property } from '@mikro-orm/sqlite';
 import { performance } from 'perf_hooks';
 
 @Entity()
@@ -13,10 +13,10 @@ export class VendorBuyerRelationship {
   created!: Date;
 
   @ManyToOne(() => Member, { wrappedReference: true })
-  buyer!: IdentifiedReference<Member>;
+  buyer!: Ref<Member>;
 
   @ManyToOne(() => Member, { wrappedReference: true })
-  vendor!: IdentifiedReference<Member>;
+  vendor!: Ref<Member>;
 
   @OneToMany(() => Order, o => o.buyerRel)
   orders = new Collection<Order>(this);
@@ -44,7 +44,7 @@ export class Member {
   orders = new Collection<Order>(this);
 
   @ManyToOne(() => Member, { wrappedReference: true, nullable: true })
-  parent?: IdentifiedReference<Member>;
+  parent?: Ref<Member>;
 
 }
 
@@ -57,28 +57,28 @@ export class Job {
   id!: string;
 
   @ManyToOne(() => Member, { wrappedReference: true, nullable: true })
-  member?: IdentifiedReference<Member>;
+  member?: Ref<Member>;
 
   @ManyToOne(() => Order, { wrappedReference: true, nullable: true })
-  order?: IdentifiedReference<Order>;
+  order?: Ref<Order>;
 
   @OneToMany(() => Job, job => job.parent)
   children = new Collection<Job>(this);
 
   @ManyToOne(() => Job, { wrappedReference: true, nullable: true })
-  parent?: IdentifiedReference<Job>;
+  parent?: Ref<Job>;
 
   @Property()
   rejected: boolean = false;
 
   @ManyToOne(() => VendorBuyerRelationship, { wrappedReference: true, nullable: true })
-  buyer?: IdentifiedReference<VendorBuyerRelationship>;
+  buyer?: Ref<VendorBuyerRelationship>;
 
   @ManyToOne(() => Job, { wrappedReference: true, nullable: true })
-  delegate?: IdentifiedReference<Job>;
+  delegate?: Ref<Job>;
 
   @ManyToOne(() => Member, { wrappedReference: true, nullable: true })
-  assignee?: IdentifiedReference<Member>;
+  assignee?: Ref<Member>;
 
 }
 
@@ -94,13 +94,13 @@ export class Order {
   created!: Date;
 
   @ManyToOne(() => VendorBuyerRelationship, { wrappedReference: true, nullable: true })
-  buyerRel?: IdentifiedReference<VendorBuyerRelationship>;
+  buyerRel?: Ref<VendorBuyerRelationship>;
 
   @OneToMany(() => Job, job => job.order)
   jobs = new Collection<Job>(this);
 
   @ManyToOne(() => Member, { wrappedReference: true, nullable: true })
-  vendor?: IdentifiedReference<Member>;
+  vendor?: Ref<Member>;
 
 }
 

--- a/tests/issues/GH2395.test.ts
+++ b/tests/issues/GH2395.test.ts
@@ -1,4 +1,4 @@
-import { Cascade, Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/sqlite';
+import { Cascade, Collection, Entity, Ref, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Parent {
@@ -24,7 +24,7 @@ export class Child {
   id!: number;
 
   @ManyToOne(() => Parent, { wrappedReference: true })
-  parent!: IdentifiedReference<Parent>;
+  parent!: Ref<Parent>;
 
 }
 
@@ -35,7 +35,7 @@ export class Child2 {
   id!: number;
 
   @ManyToOne(() => Parent, { wrappedReference: true, cascade: [Cascade.ALL] })
-  parent!: IdentifiedReference<Parent>;
+  parent!: Ref<Parent>;
 
 }
 
@@ -46,7 +46,7 @@ export class Child3 {
   id!: number;
 
   @ManyToOne(() => Parent, { wrappedReference: true })
-  parent!: IdentifiedReference<Parent>;
+  parent!: Ref<Parent>;
 
 }
 

--- a/tests/issues/GH2406.test.ts
+++ b/tests/issues/GH2406.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/sqlite';
+import { Collection, Entity, Ref, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/sqlite';
 
 @Entity({ forceConstructor: true })
 export class Parent {
@@ -18,7 +18,7 @@ export class Child {
   id!: number;
 
   @ManyToOne({ entity: () => Parent, wrappedReference: true })
-  parent!: IdentifiedReference<Parent>;
+  parent!: Ref<Parent>;
 
 }
 

--- a/tests/issues/GH2410.test.ts
+++ b/tests/issues/GH2410.test.ts
@@ -1,4 +1,4 @@
-import { BigIntType, Cascade, Collection, Entity, IdentifiedReference, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/sqlite';
+import { BigIntType, Cascade, Collection, Entity, Ref, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/sqlite';
 
 @Entity({ tableName: 'user' })
 class User {
@@ -7,7 +7,7 @@ class User {
   id!: number;
 
   @ManyToOne('Member', { fieldName: 'ownerMemberId', nullable: true, wrappedReference: true })
-  ownerMember?: IdentifiedReference<Member>;
+  ownerMember?: Ref<Member>;
 
 }
 
@@ -32,10 +32,10 @@ class MemberUser {
   id!: number;
 
   @ManyToOne(() => Member, { fieldName: 'memberId', wrappedReference: true })
-  member!: IdentifiedReference<Member>;
+  member!: Ref<Member>;
 
   @ManyToOne(() => User, { fieldName: 'userId', wrappedReference: true })
-  user?: IdentifiedReference<User>;
+  user?: Ref<User>;
 
 }
 

--- a/tests/issues/GH2648.test.ts
+++ b/tests/issues/GH2648.test.ts
@@ -1,4 +1,4 @@
-import { Entity, Ref, JsonType, ManyToOne, MikroORM, OneToOne, PrimaryKey, PrimaryKeyType, Property } from '@mikro-orm/sqlite';
+import { Entity, Ref, JsonType, ManyToOne, MikroORM, OneToOne, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 export class A {
@@ -14,7 +14,6 @@ export class A {
 @Entity()
 export class B1 {
 
-  [PrimaryKeyType]?: number;
   @ManyToOne({ entity: () => A, primary: true, wrappedReference: true })
   a!: Ref<A>;
 
@@ -26,7 +25,6 @@ export class B2 {
   @PrimaryKey()
   id!: number;
 
-  [PrimaryKeyType]?: number;
   @OneToOne({ entity: () => A, primary: true, wrappedReference: true })
   a!: Ref<A>;
 
@@ -35,7 +33,6 @@ export class B2 {
 @Entity()
 export class B3 {
 
-  [PrimaryKeyType]?: number;
   @OneToOne({ entity: () => A, primary: true, wrappedReference: true })
   a!: Ref<A>;
 
@@ -47,7 +44,6 @@ export class B4 {
   @PrimaryKey()
   id!: number;
 
-  [PrimaryKeyType]?: number;
   @OneToOne({ entity: () => A, primary: true, wrappedReference: true })
   a!: Ref<A>;
 

--- a/tests/issues/GH2648.test.ts
+++ b/tests/issues/GH2648.test.ts
@@ -1,4 +1,4 @@
-import { Entity, IdentifiedReference, JsonType, ManyToOne, MikroORM, OneToOne, PrimaryKey, PrimaryKeyType, Property } from '@mikro-orm/sqlite';
+import { Entity, Ref, JsonType, ManyToOne, MikroORM, OneToOne, PrimaryKey, PrimaryKeyType, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 export class A {
@@ -16,7 +16,7 @@ export class B1 {
 
   [PrimaryKeyType]?: number;
   @ManyToOne({ entity: () => A, primary: true, wrappedReference: true })
-  a!: IdentifiedReference<A>;
+  a!: Ref<A>;
 
 }
 
@@ -28,7 +28,7 @@ export class B2 {
 
   [PrimaryKeyType]?: number;
   @OneToOne({ entity: () => A, primary: true, wrappedReference: true })
-  a!: IdentifiedReference<A>;
+  a!: Ref<A>;
 
 }
 
@@ -37,7 +37,7 @@ export class B3 {
 
   [PrimaryKeyType]?: number;
   @OneToOne({ entity: () => A, primary: true, wrappedReference: true })
-  a!: IdentifiedReference<A>;
+  a!: Ref<A>;
 
 }
 
@@ -49,7 +49,7 @@ export class B4 {
 
   [PrimaryKeyType]?: number;
   @OneToOne({ entity: () => A, primary: true, wrappedReference: true })
-  a!: IdentifiedReference<A>;
+  a!: Ref<A>;
 
 }
 
@@ -60,16 +60,16 @@ export class C {
   id!: number;
 
   @ManyToOne({ entity: () => B1, wrappedReference: true })
-  b1!: IdentifiedReference<B1>;
+  b1!: Ref<B1>;
 
   @ManyToOne({ entity: () => B2, wrappedReference: true })
-  b2!: IdentifiedReference<B2>;
+  b2!: Ref<B2>;
 
   @ManyToOne({ entity: () => B3, wrappedReference: true })
-  b3!: IdentifiedReference<B3>;
+  b3!: Ref<B3>;
 
   @ManyToOne({ entity: () => B4, wrappedReference: true })
-  b4!: IdentifiedReference<B4>;
+  b4!: Ref<B4>;
 
 }
 

--- a/tests/issues/GH269.test.ts
+++ b/tests/issues/GH269.test.ts
@@ -1,4 +1,4 @@
-import { Entity, IdentifiedReference, MikroORM, OneToOne, PrimaryKey, Property, wrap, Reference } from '@mikro-orm/sqlite';
+import { Entity, Ref, MikroORM, OneToOne, PrimaryKey, Property, wrap, Reference } from '@mikro-orm/sqlite';
 
 @Entity()
 export class A {
@@ -7,7 +7,7 @@ export class A {
   id!: number;
 
   @OneToOne({ entity: () => B, inversedBy: 'a', wrappedReference: true, nullable: true })
-  b?: IdentifiedReference<B>;
+  b?: Ref<B>;
 
   @Property()
   name!: string;
@@ -21,7 +21,7 @@ export class B {
   id!: number;
 
   @OneToOne({ entity: () => A, mappedBy: 'b', wrappedReference: true, nullable: true })
-  a?: IdentifiedReference<A>;
+  a?: Ref<A>;
 
   @Property()
   name!: string;

--- a/tests/issues/GH2777.test.ts
+++ b/tests/issues/GH2777.test.ts
@@ -92,7 +92,7 @@ describe('GH issue 2777', () => {
     const ret = await orm.em.find(Customer, {});
     expect(ret[0]).toBe(ret[0].product.image!.customer);
     expect(wrap(ret[0].product).isInitialized()).toBe(true);
-    expect(wrap(ret[0].product.image).isInitialized()).toBe(true);
+    expect(wrap(ret[0].product.image!).isInitialized()).toBe(true);
     expect(wrap(ret[0].product.image!.customer).isInitialized()).toBe(true);
   });
 

--- a/tests/issues/GH2810.test.ts
+++ b/tests/issues/GH2810.test.ts
@@ -1,4 +1,4 @@
-import { Cascade, Collection, Entity, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, PrimaryKeyType } from '@mikro-orm/sqlite';
+import { Cascade, Collection, Entity, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/sqlite';
 
 @Entity()
 export class NodeEntity {
@@ -14,7 +14,6 @@ export class NodeEntity {
 @Entity()
 export class ElementEntity {
 
-  [PrimaryKeyType]?: number;
   [PrimaryKeyProp]?: 'node';
 
   @OneToOne({ entity: () => NodeEntity, primary: true, onDelete: 'cascade', onUpdateIntegrity: 'cascade' })

--- a/tests/issues/GH3269.test.ts
+++ b/tests/issues/GH3269.test.ts
@@ -1,4 +1,4 @@
-import { Entity, MikroORM, PrimaryKey, Property, ManyToOne, PrimaryKeyType } from '@mikro-orm/better-sqlite';
+import { Entity, MikroORM, PrimaryKey, Property, ManyToOne } from '@mikro-orm/better-sqlite';
 
 @Entity()
 class Main {
@@ -8,8 +8,6 @@ class Main {
 
   @Property({ primary: true })
   pk_two!: string;
-
-  [PrimaryKeyType]?: [string, string];
 
   @Property()
   type!: string;
@@ -24,8 +22,6 @@ class Dependent {
 
   @PrimaryKey()
   id!: string;
-
-  [PrimaryKeyType]?: [string, string, string];
 
   @Property()
   bar!: string;

--- a/tests/issues/GH3354.test.ts
+++ b/tests/issues/GH3354.test.ts
@@ -1,7 +1,7 @@
 import { BaseEntity, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
-export class Group extends BaseEntity<Group, 'id'> {
+export class Group extends BaseEntity {
 
   @PrimaryKey()
   id!: number;

--- a/tests/issues/GH3564.test.ts
+++ b/tests/issues/GH3564.test.ts
@@ -1,4 +1,4 @@
-import { MikroORM, Collection, Entity, IdentifiedReference, ManyToOne, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
+import { MikroORM, Collection, Entity, Ref, ManyToOne, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 class Part {
@@ -14,13 +14,13 @@ class Part {
     nullable: true,
     onDelete: 'cascade',
   })
-  car?: IdentifiedReference<Car>;
+  car?: Ref<Car>;
 
   @ManyToOne(() => Part, {
     wrappedReference: true,
     nullable: true,
   })
-  part?: IdentifiedReference<Part>;
+  part?: Ref<Part>;
 
   @OneToMany(() => Part, fV => fV.part, {
     orphanRemoval: true,

--- a/tests/issues/GH3669.test.ts
+++ b/tests/issues/GH3669.test.ts
@@ -1,4 +1,14 @@
-import { Entity, MikroORM, ManyToOne, OneToOne, PrimaryKey, PrimaryKeyType, Property, Rel, SimpleLogger } from '@mikro-orm/postgresql';
+import {
+  Entity,
+  MikroORM,
+  ManyToOne,
+  OneToOne,
+  PrimaryKey,
+  Property,
+  Rel,
+  SimpleLogger,
+  PrimaryKeyProp,
+} from '@mikro-orm/postgresql';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -15,7 +25,7 @@ class Vendor {
 @Entity()
 class TechnicianManager {
 
-  [PrimaryKeyType]?: [number, number];
+  [PrimaryKeyProp]?: ['vendor', 'user'];
 
   @ManyToOne({ entity: () => Vendor, primary: true })
   vendor!: Vendor;

--- a/tests/issues/GH3737.test.ts
+++ b/tests/issues/GH3737.test.ts
@@ -75,7 +75,7 @@ class ProjectUsersSubscriber implements EventSubscriber<ProjectUser> {
       .getChangeSets()
       .filter(cs => cs.entity instanceof ProjectUser);
     for (const cs of changeSets) {
-      const pk = cs.getPrimaryKey(true) as Record<string, unknown>;
+      const pk = cs.getPrimaryKey(true)! as Record<string, unknown>;
       expect(pk).toBeInstanceOf(Object);
       expect(Array.isArray(pk)).toBe(false);
       expect(Object.keys(pk)).toMatchObject(['project', 'user']);

--- a/tests/issues/GH3965.test.ts
+++ b/tests/issues/GH3965.test.ts
@@ -1,4 +1,14 @@
-import { Collection, Entity, Property, ManyToOne, OneToMany, PrimaryKey, PrimaryKeyType, Cascade, Ref } from '@mikro-orm/core';
+import {
+  Collection,
+  Entity,
+  Property,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Cascade,
+  Ref,
+  PrimaryKeyProp, Primary,
+} from '@mikro-orm/core';
 import { MikroORM } from '@mikro-orm/mysql';
 import { randomUUID } from 'crypto';
 
@@ -41,7 +51,7 @@ export class Article {
   })
   category!: Ref<Category>;
 
-  [PrimaryKeyType]?: [string, string];
+  [PrimaryKeyProp]?: ['id', 'category'];
 
   @OneToMany(() => ArticleAttribute, attr => attr.article, {
     cascade: [Cascade.ALL],
@@ -67,9 +77,11 @@ export class ArticleAttribute {
   })
   article!: Ref<Article>;
 
-  [PrimaryKeyType]?: [string, [string, string]];
+  [PrimaryKeyProp]?: ['id', 'article'];
 
 }
+
+type T = Primary<ArticleAttribute>;
 
 let orm: MikroORM;
 
@@ -101,4 +113,7 @@ test('3965', async () => {
   await orm.em.persistAndFlush(category);
   expect(category.createdAt).toBeDefined();
   expect(category.createdAt).toBeInstanceOf(Date);
+
+  const miss = await orm.em.findOne(ArticleAttribute, ['a', ['1', '1']]);
+  expect(miss).toBeNull();
 });

--- a/tests/issues/GH450.test.ts
+++ b/tests/issues/GH450.test.ts
@@ -82,7 +82,7 @@ describe('GH issue 450', () => {
 
     const t2 = await orm.em.findOneOrFail(Task, t.id, { populate: ['assignee'] });
     expect(t2.assignee).toBeInstanceOf(TaskAssignee);
-    expect(wrap(t2.assignee).isInitialized()).toBe(true);
+    expect(wrap(t2.assignee!).isInitialized()).toBe(true);
   });
 
 });

--- a/tests/issues/GH467.test.ts
+++ b/tests/issues/GH467.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, PrimaryKey, ManyToOne, OneToMany, MikroORM, IdentifiedReference } from '@mikro-orm/sqlite';
+import { Collection, Entity, PrimaryKey, ManyToOne, OneToMany, MikroORM, Ref } from '@mikro-orm/sqlite';
 
 @Entity()
 class A {
@@ -7,7 +7,7 @@ class A {
   id!: string;
 
   @ManyToOne({ entity: 'B', wrappedReference: true, nullable: true })
-  b?: IdentifiedReference<B>;
+  b?: Ref<B>;
 
 }
 

--- a/tests/issues/GH529.test.ts
+++ b/tests/issues/GH529.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyType, Property } from '@mikro-orm/postgresql';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/postgresql';
 
 @Entity()
 export class Customer {
@@ -68,8 +68,6 @@ export class OrderItem {
 
   @Property()
   offeredPrice: number;
-
-  [PrimaryKeyType]?: [number, number]; // this is needed for proper type checks in `FilterQuery`
 
   constructor(order: Order, product: Product, amount = 1) {
     this.order = order;

--- a/tests/issues/GH535.test.ts
+++ b/tests/issues/GH535.test.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryKey, Property, MikroORM, wrap, IdentifiedReference, OneToOne } from '@mikro-orm/postgresql';
+import { Entity, PrimaryKey, Property, MikroORM, wrap, Ref, OneToOne } from '@mikro-orm/postgresql';
 
 @Entity()
 class A {
@@ -12,7 +12,7 @@ class A {
     wrappedReference: true,
     nullable: true,
   })
-  b!: IdentifiedReference<B>;
+  b!: Ref<B>;
 
   @Property({ persist: false })
   get calcProp() {
@@ -28,7 +28,7 @@ class B {
   id!: number;
 
   @OneToOne({ entity: () => A, wrappedReference: true })
-  a!: IdentifiedReference<A>;
+  a!: Ref<A>;
 
   @Property()
   prop: string = 'foo';

--- a/tests/issues/GH572.test.ts
+++ b/tests/issues/GH572.test.ts
@@ -1,4 +1,4 @@
-import { Entity, IdentifiedReference, MikroORM, OneToOne, PrimaryKey, Property, QueryOrder } from '@mikro-orm/sqlite';
+import { Entity, Ref, MikroORM, OneToOne, PrimaryKey, Property, QueryOrder } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -8,7 +8,7 @@ export class A {
   id!: number;
 
   @OneToOne('B', 'a', { wrappedReference: true })
-  b!: IdentifiedReference<B>;
+  b!: Ref<B>;
 
 }
 
@@ -22,7 +22,7 @@ export class B {
   camelCaseField?: string;
 
   @OneToOne('A', 'b', { owner: true, wrappedReference: true })
-  a!: IdentifiedReference<A>;
+  a!: Ref<A>;
 
 }
 

--- a/tests/issues/GH589.test.ts
+++ b/tests/issues/GH589.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyType, Reference, IdentifiedReference } from '@mikro-orm/postgresql';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyType, Reference, Ref } from '@mikro-orm/postgresql';
 
 @Entity()
 export class User {
@@ -15,10 +15,10 @@ export class User {
 export class Chat {
 
   @ManyToOne(() => User, { primary: true, wrappedReference: true })
-  owner: IdentifiedReference<User>;
+  owner: Ref<User>;
 
   @ManyToOne(() => User, { primary: true, wrappedReference: true })
-  recipient: IdentifiedReference<User>;
+  recipient: Ref<User>;
 
   @ManyToOne(() => User, { nullable: true })
   User?: User;

--- a/tests/issues/GH589.test.ts
+++ b/tests/issues/GH589.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyType, Reference, Ref } from '@mikro-orm/postgresql';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Reference, Ref } from '@mikro-orm/postgresql';
 
 @Entity()
 export class User {
@@ -22,8 +22,6 @@ export class Chat {
 
   @ManyToOne(() => User, { nullable: true })
   User?: User;
-
-  [PrimaryKeyType]?: [number, number];
 
   constructor(owner: User, recipient: User) {
     this.owner = Reference.create(owner);

--- a/tests/issues/GH610.test.ts
+++ b/tests/issues/GH610.test.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryKey, ManyToOne, IdentifiedReference, Property, MikroORM, wrap, ObjectBindingPattern } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, ManyToOne, Ref, Property, MikroORM, wrap, ObjectBindingPattern } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -11,7 +11,7 @@ export class Test {
   name!: string;
 
   @ManyToOne(() => Test, { nullable: true, wrappedReference: true })
-  rootNode?: IdentifiedReference<Test>;
+  rootNode?: Ref<Test>;
 
   constructor({ name }: Partial<Test> = {}) {
     this.name = name!;

--- a/tests/issues/GH910.test.ts
+++ b/tests/issues/GH910.test.ts
@@ -1,5 +1,5 @@
 import type { Platform } from '@mikro-orm/sqlite';
-import { Cascade, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, PrimaryKeyType, Property, Type } from '@mikro-orm/sqlite';
+import { Cascade, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, Type } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 export class Sku {
@@ -64,8 +64,6 @@ export class CartItem {
 
   @PrimaryKey({ type: SkuType })
   readonly sku: Sku;
-
-  [PrimaryKeyType]?: [string, string];
 
   @Property()
   quantity: number;

--- a/tests/issues/GH915.test.ts
+++ b/tests/issues/GH915.test.ts
@@ -1,4 +1,4 @@
-import { Entity, MikroORM, OneToOne, PrimaryKey, PrimaryKeyType } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, OneToOne, PrimaryKey } from '@mikro-orm/sqlite';
 
 @Entity()
 export class A {
@@ -10,8 +10,6 @@ export class A {
 
 @Entity()
 export class B {
-
-  [PrimaryKeyType]?: number;
 
   @OneToOne({ primary: true, cascade: [] })
   object!: A;

--- a/tests/perf/serializing-nested-entities/entities.ts
+++ b/tests/perf/serializing-nested-entities/entities.ts
@@ -1,7 +1,7 @@
 import {
   Collection,
   Entity,
-  IdentifiedReference,
+  Ref,
   ManyToMany,
   ManyToOne,
   OneToMany,
@@ -36,7 +36,7 @@ export class Risk {
   title!: string;
 
   @ManyToOne(() => Project, { serializer: p => p.id, wrappedReference: true })
-  project!: IdentifiedReference<Project>;
+  project!: Ref<Project>;
 
   @ManyToMany({
       entity: () => FilterValue,
@@ -65,7 +65,7 @@ export class Filter {
     wrappedReference: true,
     onDelete: 'cascade',
   })
-  project!: IdentifiedReference<Project>;
+  project!: Ref<Project>;
 
 }
 
@@ -83,7 +83,7 @@ export class FilterValue {
     wrappedReference: true,
     onDelete: 'cascade',
   })
-  filter!: IdentifiedReference<Filter>;
+  filter!: Ref<Filter>;
 
   @ManyToMany(() => Risk, risk => risk.filterValues, {
     hidden: true,

--- a/tests/repositories/AuthorRepository.ts
+++ b/tests/repositories/AuthorRepository.ts
@@ -1,5 +1,5 @@
 import type { FilterQuery, FindOptions, Loaded } from '@mikro-orm/core';
-import { EntityRepository } from '@mikro-orm/core';
+import { EntityRepository } from '@mikro-orm/mongodb';
 import type { Author } from '../entities';
 
 export class AuthorRepository extends EntityRepository<Author> {

--- a/tests/sqlite-constraints.test.ts
+++ b/tests/sqlite-constraints.test.ts
@@ -1,4 +1,4 @@
-import { Entity, type EntityManager, ManyToOne, MikroORM, PrimaryKey, Property, IdentifiedReference, Reference, ForeignKeyConstraintViolationException } from '@mikro-orm/core';
+import { Entity, type EntityManager, ManyToOne, MikroORM, PrimaryKey, Property, Ref, Reference, ForeignKeyConstraintViolationException } from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 import { BetterSqliteDriver } from '@mikro-orm/better-sqlite';
 
@@ -25,7 +25,7 @@ export class Book {
   name!: string;
 
   @ManyToOne(() => Author, { wrappedReference: true })
-  author!: IdentifiedReference<Author>;
+  author!: Ref<Author>;
 
 }
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -260,7 +260,7 @@ describe('check typings', () => {
       name: string;
       publisher?: Publisher;
       publisherRef?: Reference<Publisher>;
-      publisherIdRef?: Ref<Publisher, 'id'>;
+      publisherIdRef?: Ref<Publisher>;
     }
 
     // simulate usage of ORM base entity so `wrap` will return its parameter
@@ -270,20 +270,16 @@ describe('check typings', () => {
     book.publisher = publisher;
     // @ts-expect-error
     book.publisher = wrap(publisher).toReference();
-    // @ts-expect-error
-    book.publisher = wrap(publisher).toReference<'id'>();
 
     const id = book.publisherIdRef?.id;
 
     // @ts-expect-error
     book.publisherRef = publisher;
     book.publisherRef = wrap(publisher).toReference();
-    book.publisherRef = wrap(publisher).toReference<'id'>();
 
     // @ts-expect-error
     book.publisherIdRef = publisher;
     book.publisherIdRef = wrap(publisher).toReference();
-    book.publisherIdRef = wrap(publisher).toReference<'id'>();
 
     // composite keys
     const compositePks: Primary<FooParam2> = [1, 2];
@@ -304,7 +300,7 @@ describe('check typings', () => {
       readonly born?: Date;
       readonly rel?: Publisher;
       readonly relRef?: Reference<Publisher>;
-      readonly relIdRef?: Ref<Publisher, 'id'>;
+      readonly relIdRef?: Ref<Publisher>;
       readonly rels?: Collection<Publisher>;
     }
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -518,12 +518,12 @@ describe('check typings', () => {
   });
 
   test('Loaded type and assignability with extending the ORM BaseEntity (#3865)', async () => {
-    interface MemberNotification extends BaseEntity<MemberNotification, 'id'> {
+    interface MemberNotification extends BaseEntity {
       id: string;
       notification?: Ref<Notification>;
     }
 
-    interface Notification extends BaseEntity<Notification, 'id'> {
+    interface Notification extends BaseEntity {
       id: string;
     }
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,5 +1,5 @@
-import { OptionalProps, Ref, wrap } from '@mikro-orm/core';
-import type { BaseEntity, IdentifiedReference, Reference, Collection, EntityManager, EntityName, RequiredEntityData } from '@mikro-orm/core';
+import { OptionalProps, wrap } from '@mikro-orm/core';
+import type { BaseEntity, Ref, Reference, Collection, EntityManager, EntityName, RequiredEntityData } from '@mikro-orm/core';
 import type { Has, IsExact } from 'conditional-type-checks';
 import { assert } from 'conditional-type-checks';
 import type { ObjectId } from 'bson';
@@ -44,7 +44,7 @@ describe('check typings', () => {
     b = { publisher: null };
     b = { publisher: { name: 'p' } };
     b = { publisher: {} as Publisher2 };
-    b = { publisher: {} as IdentifiedReference<Publisher2> };
+    b = { publisher: {} as Ref<Publisher2> };
 
     // @ts-expect-error
     b = { name: 'a' };
@@ -260,7 +260,7 @@ describe('check typings', () => {
       name: string;
       publisher?: Publisher;
       publisherRef?: Reference<Publisher>;
-      publisherIdRef?: IdentifiedReference<Publisher, 'id'>;
+      publisherIdRef?: Ref<Publisher, 'id'>;
     }
 
     // simulate usage of ORM base entity so `wrap` will return its parameter
@@ -287,7 +287,7 @@ describe('check typings', () => {
 
     // composite keys
     const compositePks: Primary<FooParam2> = [1, 2];
-    const compositeRef = {} as IdentifiedReference<FooParam2>;
+    const compositeRef = {} as Ref<FooParam2>;
     const bar = compositeRef.bar;
     const baz = compositeRef.baz;
   });
@@ -304,7 +304,7 @@ describe('check typings', () => {
       readonly born?: Date;
       readonly rel?: Publisher;
       readonly relRef?: Reference<Publisher>;
-      readonly relIdRef?: IdentifiedReference<Publisher, 'id'>;
+      readonly relIdRef?: Ref<Publisher, 'id'>;
       readonly rels?: Collection<Publisher>;
     }
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -3,7 +3,7 @@ import type { BaseEntity, Ref, Reference, Collection, EntityManager, EntityName,
 import type { Has, IsExact } from 'conditional-type-checks';
 import { assert } from 'conditional-type-checks';
 import type { ObjectId } from 'bson';
-import type { EntityData, EntityDTO, FilterQuery, FilterValue, Loaded, OperatorMap, Primary, PrimaryKeyType, Query } from '../packages/core/src/typings';
+import type { EntityData, EntityDTO, FilterQuery, FilterValue, Loaded, OperatorMap, Primary, PrimaryKeyProp, Query } from '../packages/core/src/typings';
 import type { Author2, Book2, BookTag2, Car2, FooBar2, FooParam2, Publisher2, User2 } from './entities-sql';
 import type { Author, Book } from './entities';
 
@@ -18,8 +18,8 @@ describe('check typings', () => {
     assert<IsExact<Primary<{ id?: number }>, number>>(true);
     assert<IsExact<Primary<Author2>, string>>(false);
 
-    // PrimaryKeyType symbol has priority
-    type Test = { _id: ObjectId; id: string; uuid: number; [PrimaryKeyType]?: Date };
+    // PrimaryKeyProp symbol has priority
+    type Test = { _id: ObjectId; id: string; uuid: number; foo: Date; [PrimaryKeyProp]?: 'foo' };
     assert<IsExact<Primary<Test>, Date>>(true);
     assert<IsExact<Primary<Test>, ObjectId>>(false);
     assert<IsExact<Primary<Test>, string>>(false);
@@ -63,6 +63,7 @@ describe('check typings', () => {
     c = { name: 'n', price: 123, year: 2021, users: [{ firstName: 'f', lastName: 'l' }] };
     c = { name: 'n', price: 123, year: 2021, users: [{} as User2] };
     c = { name: 'n', price: 123, year: 2021, users: [['f', 'l']] };
+    type T = Primary<User2>;
 
     // @ts-expect-error
     c = { name: 'n', price: 123, year: '2021' };


### PR DESCRIPTION
## `BaseEntity` no longer has generic type arguments

Instead, the `this` type is used.

```diff
-class User extends BaseEntity<User> { ... }
+class User extends BaseEntity { ... }
```

## `wrap` helper no longer accepts `undefined` on type level

The runtime implementation still checks for this case and returns the argument, but on type level this will fail to compile. It was never correct to pass in nullable values inside as it were not allowed in the return type.

Note that if you used it for converting entity instance to reference wrapper, the new `ref()` helper does a better job at that (and accepts nullable values).

## Primary key inference

Some methods allowed you to pass in the primary key property via second generic type argument, this is now removed in favour of the automatic inference. To set the PK type explicitly, use the `PrimaryKeyProp` symbol.

`PrimaryKeyType` symbol has been removed, use `PrimaryKeyProp` instead if needed. Moreover, the value for composite PKs now has to be a tuple instead of a union to ensure we preserve the order of keys:

```diff
@Entity()
export class Foo {

  @ManyToOne(() => Bar, { primary: true })
  bar!: Bar;

  @ManyToOne(() => Baz, { primary: true })
  baz!: Baz;

-  [PrimaryKeyType]?: [number, number];
-  [PrimaryKeyProp]?: 'bar' | 'baz';
+  [PrimaryKeyProp]?: ['bar', 'baz'];

}
```

BREAKING CHANGE