### PR TITLE
V6: Broken loaded use-case #3277

### DIFF
--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -595,7 +595,7 @@ describe('check typings', () => {
     q = { [OptionalProps]: 'bar' };
   });
 
-  test('GH #3277', async () => {
+  test('GH #3277 (1)', async () => {
     interface Owner {
       id: number;
       vehicles: Collection<Vehicle>;
@@ -646,6 +646,48 @@ describe('check typings', () => {
 
     // const foo = await owner1.vehicles.$.loadItems({ populate: ['owner'] });
     // const v1 = foo[0].owner.$.vehicles;
+  });
+
+  test('GH #3277 (2)', async () => {
+    interface Person {
+      foobar: Collection<{}>;
+    }
+
+    interface Calendar {
+      events: Collection<CalendarEvent>;
+      owner: Ref<Person>;
+    }
+
+    interface CalendarEvent {
+      order: Ref<Order>;
+      calendar: Ref<Calendar>;
+    }
+
+    interface Order {
+      customer: Ref<Customer>;
+      foobar: Collection<{}>;
+    }
+
+    interface Customer {
+      foobar: Collection<{}>;
+    }
+
+
+    function preloaded(event: Loaded<CalendarEvent, 'calendar.owner'>) {
+      // no-op
+    }
+
+    const event1 = {} as Loaded<CalendarEvent, 'calendar.owner' | 'order.customer.foobar'>;
+    const event2 = {} as Loaded<CalendarEvent, 'calendar.owner.foobar' | 'order.customer'>;
+    const event3 = {} as Loaded<CalendarEvent, 'calendar.owner' | 'order.customer'>;
+    const event4 = {} as Loaded<CalendarEvent, 'calendar.owner' | 'order'>;
+    const event5 = {} as Loaded<CalendarEvent, 'calendar.owner' | 'order.foobar'>;
+
+    preloaded(event1);
+    preloaded(event2);
+    preloaded(event3);
+    preloaded(event4);
+    preloaded(event5);
   });
 
 });


### PR DESCRIPTION
The fixes in V6 for #3277 solve a portion of my population conflicts but I've run into this particular problem in most of my instances. When a property with the same name exists at the same "dot level", the compiler cannot handle it. As you can see in my PR reproduction, `event5` compiles just fine as `calendar.foobar` is not defined, but because both `calendar.owner.foobar` and `order.customer.foobar` both exist, `event1` / `event2` does not work.