### PR TITLE
docs: add information to deployment guide for esbuild bundling

### DIFF
--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -277,10 +277,9 @@ To run Webpack execute `webpack` (or `npx webpack` if not installed globally) in
 of the project. It will probably throw a few warnings but you can ignore the errors regarding 
 MikroORM: the mentioned pieces of code won't be executed if properly bundled with Webpack.
 
-## Deploy a bundle of entities and dependencies with [esbuild](https://esbuild.github.io/)
+## Deploy a bundle of entities and dependencies with `esbuild`
 
-esbuild can be used to bundle MikroORM entities and dependencies: you get a single file that contains 
-every required module/file.
+[`esbuild`](https://esbuild.github.io/) can be used to bundle MikroORM entities and dependencies: you get a single file that contains every required module/file. Due to how the bundling works, there are few issues that needs to be properly addressed to make `esbuild` work with MikroORM.
 
 ### Required shim for Knex with esbuild
 


### PR DESCRIPTION
As discussed on [MikroORM Slack](https://mikroorm.slack.com/archives/CFTFEK39D/p1676393290381249?thread_ts=1676045567.606219&cid=CFTFEK39D), adding docs around `esbuild` bundling