### PR TITLE
fix(postgres): use quoted schema+table name when dropping constraints

### DIFF
--- a/packages/postgresql/src/PostgreSqlSchemaHelper.ts
+++ b/packages/postgresql/src/PostgreSqlSchemaHelper.ts
@@ -266,14 +266,13 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
 
   getPreAlterTable(tableDiff: TableDifference, safe: boolean): string {
     const ret: string[] = [];
-    const quoted = (val: string) => this.platform.quoteIdentifier(val);
 
     const parts = tableDiff.name.split('.');
     const tableName = parts.pop()!;
     const schemaName = parts.pop();
     /* istanbul ignore next */
     const name = (schemaName && schemaName !== this.platform.getDefaultSchemaName() ? schemaName + '.' : '') + tableName;
-    const quotedName = quoted(name);
+    const quotedName = this.platform.quoteIdentifier(name);
 
     // detect that the column was an enum before and remove the check constraint in such case here
     const changedEnums = Object.values(tableDiff.changedColumns).filter(col => col.fromColumn.mappedType instanceof EnumType);

--- a/tests/SchemaHelper.test.ts
+++ b/tests/SchemaHelper.test.ts
@@ -1,6 +1,8 @@
 import type { Column } from '@mikro-orm/sqlite';
 import { SchemaHelper, SqlitePlatform } from '@mikro-orm/sqlite';
 import { MySqlPlatform } from '@mikro-orm/mysql';
+import { ColumnDifference, PostgreSqlPlatform, TableDifference } from '@mikro-orm/postgresql';
+import { Dictionary, Type, EnumType, StringType } from '@mikro-orm/core';
 
 class SchemaHelperTest extends SchemaHelper { }
 
@@ -41,4 +43,41 @@ describe('SchemaHelper', () => {
     expect(helper.getRenameColumnSQL('table', 'test1', { name: 'test_123' } as Column)).toBe('alter table `table` rename column `test1` to `test_123`');
   });
 
+  describe('postgresql schema helper', () => {
+    test('helper quotes schema name when dropping contraints', () => {
+      const helper = new PostgreSqlPlatform().getSchemaHelper()!;
+      const fromEnum = { name: 'test_enum', nullable: false, mappedType: Type.getType(EnumType) } as Column;
+      const toEnum = { name: 'test_enum', nullable: false, mappedType: Type.getType(StringType) } as Column;
+      const fromUuid = { name: 'test_uuid', nullable: false, type: 'uuid' } as Column;
+      const toUuid = { name: 'test_uuid', nullable: false, type: 'uuid' } as Column;
+      const changedColumns = {
+        test_enum: {
+          oldColumnName: 'test_column',
+          column: toEnum,
+          fromColumn: fromEnum,
+          changedProperties: new Set(),
+        },
+        test_uuid: {
+          oldColumnName: 'test_uuid',
+          column: toUuid,
+          fromColumn: fromUuid,
+          changedProperties: new Set(['type']),
+        },
+      } as Dictionary<ColumnDifference>;
+
+      const tableDifference: TableDifference = {
+        name: 'test',
+        changedColumns,
+      } as TableDifference;
+
+      expect(helper.getPreAlterTable(tableDifference, true)).toEqual(`alter table "test" drop constraint if exists "test_test_enum_check";\nalter table "test" alter column "test_uuid" type text using ("test_uuid"::text)`);
+
+      const schemaTableDifference: TableDifference = {
+        name: 'my_schema.test',
+        changedColumns,
+      } as TableDifference;
+
+      expect(helper.getPreAlterTable(schemaTableDifference, true)).toEqual(`alter table "my_schema"."test" drop constraint if exists "test_test_enum_check";\nalter table "my_schema"."test" alter column "test_uuid" type text using ("test_uuid"::text)`);
+    });
+  });
 });


### PR DESCRIPTION
I noticed that when I was updating a column with an Enum type using an entity with a schema defined, the migration generated attempted to drop the existing constraint but failed due to a quoting issue. The migration was generated with a line like:

```sql
alter table "my_schema.test" drop constraint if exists "test_column_check";
```

instead of 

```sql
alter table "my_schema"."test" drop constraint if exists "test_column_check";
```

I've added a test that I believe exercises the functionality.