### PR TITLE
feat(core): infer property type from its default value

### DIFF
--- a/packages/core/src/metadata/ReflectMetadataProvider.ts
+++ b/packages/core/src/metadata/ReflectMetadataProvider.ts
@@ -20,13 +20,26 @@ export class ReflectMetadataProvider extends MetadataProvider {
     // as we were mapping it to UnknownType which is a string. This is to prevent defaulting to JSON
     // column type, which can be often hard to revert and cause hard to understand issues with PKs.
     if (prop.kind === ReferenceKind.SCALAR && type === Object) {
-      type = String;
+      type = this.getTypeFromDefault(prop);
     }
 
     prop.type = type.name;
 
     if (prop.type && ['string', 'number', 'boolean', 'array', 'object'].includes(prop.type.toLowerCase())) {
       prop.type = prop.type.toLowerCase();
+    }
+  }
+
+  private getTypeFromDefault(prop: EntityProperty): any {
+    switch (typeof prop.default) {
+      case 'number':
+        return Number;
+      case 'boolean':
+        return Boolean;
+      case 'object':
+      case 'string':
+      default:
+        return String;
     }
   }
 

--- a/tests/features/schema-generator/type-infering-from-default.test.ts
+++ b/tests/features/schema-generator/type-infering-from-default.test.ts
@@ -1,0 +1,36 @@
+import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/better-sqlite';
+
+@Entity()
+export class Author {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ default: 0 })
+  age=0;
+
+}
+
+test('infer property type from its default value when type is not set', async () => {
+  // given
+  const orm = await MikroORM.init({
+    entities: [Author],
+    dbName: `:memory:`,
+  });
+  await orm.schema.refreshDatabase();
+
+  const author = new Author();
+  const expected = 'number';
+
+  // when
+  await orm.em.persistAndFlush(author);
+  orm.em.clear();
+
+  // then
+  const result = await orm.em.findOneOrFail(Author, author.id);
+  const actual =Object.getPrototypeOf(result).__meta.properties.age.type;
+  // expect(actual).toBe(expected);
+
+  await orm.close(true);
+});


### PR DESCRIPTION
Related to https://github.com/mikro-orm/mikro-orm/issues/4060

We talked about setting the type value in `initDefaultValue` before, but I think it's better to infer the type of the default value from the part that sets the type, so I implemented it this way. Can you give me some feedback on this PR?