### PR TITLE
feat(core): strict partial loading

### DIFF
--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -12,6 +12,25 @@ Support for older node versions was dropped.
 
 Support for older TypeScript versions was dropped. 
 
+## Strict partial loading
+
+The `Loaded` type is now improved to support the partial loading hints (`fields` option). When used, the returned type will only allow accessing selected properties. Primary keys are automatically selected.
+
+```ts
+// book is typed to `Selected<Book, 'author', 'title' | 'author.email'>`
+const book = await em.findOneOrFail(Book, 1, { 
+  fields: ['title', 'author.email'], 
+  populate: ['author'],
+});
+
+const id = book.id; // ok, PK is selected automatically
+const title = book.title; // ok, title is selected
+const publisher = book.publisher; // fail, not selected
+const author = book.author.id; // ok, PK is selected automatically
+const email = book.author.email; // ok, selected
+const name = book.author.name; // fail, not selected
+```
+
 ## Removal of static require calls
 
 There were some places where we did a static `require()` call, e.g. when loading the driver implementation based on the `type` option. Those places were problematic for bundlers like webpack, as well as new school build systems like vite.

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -144,11 +144,12 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   async find<
     Entity extends object,
     Hint extends string = never,
-  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint>[]> {
+    Fields extends string = '*',
+  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint, Fields> = {}): Promise<Loaded<Entity, Hint, Fields>[]> {
     if (options.disableIdentityMap) {
       const em = this.getContext(false);
       const fork = em.fork();
-      const ret = await fork.find<Entity, Hint>(entityName, where, { ...options, disableIdentityMap: false });
+      const ret = await fork.find<Entity, Hint, Fields>(entityName, where, { ...options, disableIdentityMap: false });
       fork.clear();
 
       return ret;
@@ -160,9 +161,9 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     where = await em.processWhere(entityName, where, options, 'read') as FilterQuery<Entity>;
     em.validator.validateParams(where);
     options.orderBy = options.orderBy || {};
-    options.populate = em.preparePopulate<Entity, Hint>(entityName, options) as unknown as Populate<Entity, Hint>;
+    options.populate = em.preparePopulate<Entity, Hint, Fields>(entityName, options) as unknown as Populate<Entity, Hint>;
     const populate = options.populate as unknown as PopulateOptions<Entity>[];
-    const cached = await em.tryCache<Entity, Loaded<Entity, Hint>[]>(entityName, options.cache, [entityName, 'em.find', options, where], options.refresh, true);
+    const cached = await em.tryCache<Entity, Loaded<Entity, Hint, Fields>[]>(entityName, options.cache, [entityName, 'em.find', options, where], options.refresh, true);
 
     if (cached?.data) {
       await em.entityLoader.populate<Entity, Hint>(entityName, cached.data as Entity[], populate, {
@@ -176,7 +177,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       return cached.data;
     }
 
-    const results = await em.driver.find<Entity, Hint>(entityName, where, { ctx: em.transactionContext, ...options });
+    const results = await em.driver.find<Entity, Hint, Fields>(entityName, where, { ctx: em.transactionContext, ...options });
 
     if (results.length === 0) {
       await em.storeCache(options.cache, cached!, []);
@@ -184,7 +185,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     const meta = this.metadata.get(entityName);
-    const ret: Entity[] = [];
+    const ret: Loaded<Entity, Hint, Fields>[] = [];
 
     for (const data of results) {
       const entity = em.entityFactory.create(entityName, data as EntityData<Entity>, {
@@ -192,10 +193,10 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
         refresh: options.refresh,
         schema: options.schema,
         convertCustomTypes: true,
-      }) as Entity;
+      }) as Loaded<Entity, Hint, Fields>;
 
       if (!meta.virtual) {
-        em.unitOfWork.registerManaged(entity, data, { refresh: options.refresh, loaded: true });
+        em.unitOfWork.registerManaged(entity as Entity, data, { refresh: options.refresh, loaded: true });
       }
 
       ret.push(entity);
@@ -205,11 +206,11 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       await em.unitOfWork.dispatchOnLoadEvent();
       await em.storeCache(options.cache, cached!, () => ret);
 
-      return ret as Loaded<Entity, Hint>[];
+      return ret;
     }
 
     const unique = Utils.unique(ret);
-    await em.entityLoader.populate<Entity, Hint>(entityName, unique, populate, {
+    await em.entityLoader.populate<Entity, Hint>(entityName, unique as Entity[], populate, {
       ...options as Dictionary,
       ...em.getPopulateWhere(where as FilterQuery<Entity>, options),
       convertCustomTypes: false,
@@ -219,7 +220,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     await em.unitOfWork.dispatchOnLoadEvent();
     await em.storeCache(options.cache, cached!, () => unique.map(e => helper(e).toPOJO()));
 
-    return unique as Loaded<Entity, Hint>[];
+    return unique;
   }
 
   private getPopulateWhere<
@@ -291,7 +292,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   protected async processWhere<
     Entity extends object,
     Hint extends string = never,
-  >(entityName: string, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint> | FindOneOptions<Entity, Hint>, type: 'read' | 'update' | 'delete'): Promise<FilterQuery<Entity>> {
+    Fields extends string = '*',
+  >(entityName: string, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint, Fields> | FindOneOptions<Entity, Hint, Fields>, type: 'read' | 'update' | 'delete'): Promise<FilterQuery<Entity>> {
     where = QueryHelper.processWhere({
       where: where as FilterQuery<Entity>,
       entityName,
@@ -393,10 +395,11 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   async findAndCount<
     Entity extends object,
     Hint extends string = never,
-  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint> = {}): Promise<[Loaded<Entity, Hint>[], number]> {
+    Fields extends string = '*',
+  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint, Fields> = {}): Promise<[Loaded<Entity, Hint, Fields>[], number]> {
     const em = this.getContext(false);
     const [entities, count] = await Promise.all([
-      em.find<Entity, Hint>(entityName, where, options),
+      em.find<Entity, Hint, Fields>(entityName, where, options),
       em.count(entityName, where, options),
     ]);
 
@@ -458,7 +461,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   async findByCursor<
     Entity extends object,
     Hint extends string = never,
-  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindByCursorOptions<Entity, Hint> = {}): Promise<Cursor<Entity, Hint>> {
+    Fields extends string = '*',
+  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindByCursorOptions<Entity, Hint, Fields> = {}): Promise<Cursor<Entity, Hint, Fields>> {
     const em = this.getContext(false);
     entityName = Utils.className(entityName);
     options.overfetch ??= true;
@@ -469,7 +473,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
 
     const [entities, count] = await em.findAndCount(entityName, where, options);
 
-    return new Cursor<Entity, Hint>(entities, count, options, this.metadata.get(entityName));
+    return new Cursor<Entity, Hint, Fields>(entities, count, options, this.metadata.get(entityName));
   }
 
   /**
@@ -478,7 +482,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   async refresh<
     Entity extends object,
     Hint extends string = never,
-  >(entity: Entity, options: FindOneOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint> | null> {
+    Fields extends string = '*',
+  >(entity: Entity, options: FindOneOptions<Entity, Hint, Fields> = {}): Promise<Loaded<Entity, Hint, Fields> | null> {
     const fork = this.fork();
     const entityName = entity.constructor.name;
     const reloaded = await fork.findOne(entityName, entity, {
@@ -502,11 +507,12 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   async findOne<
     Entity extends object,
     Hint extends string = never,
-  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOneOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint> | null> {
+    Fields extends string = '*',
+  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOneOptions<Entity, Hint, Fields> = {}): Promise<Loaded<Entity, Hint, Fields> | null> {
     if (options.disableIdentityMap) {
       const em = this.getContext(false);
       const fork = em.fork();
-      const ret = await fork.findOne<Entity, Hint>(entityName, where, { ...options, disableIdentityMap: false });
+      const ret = await fork.findOne<Entity, Hint, Fields>(entityName, where, { ...options, disableIdentityMap: false });
       fork.clear();
 
       return ret;
@@ -527,8 +533,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     em.validator.validateParams(where);
-    options.populate = em.preparePopulate<Entity, Hint>(entityName, options) as unknown as Populate<Entity, Hint>;
-    const cached = await em.tryCache<Entity, Loaded<Entity, Hint>>(entityName, options.cache, [entityName, 'em.findOne', options, where], options.refresh, true);
+    options.populate = em.preparePopulate<Entity, Hint, Fields>(entityName, options) as unknown as Populate<Entity, Hint>;
+    const cached = await em.tryCache<Entity, Loaded<Entity, Hint, Fields>>(entityName, options.cache, [entityName, 'em.findOne', options, where], options.refresh, true);
 
     if (cached?.data) {
       await em.entityLoader.populate<Entity, Hint>(entityName, [cached.data as Entity], options.populate as unknown as PopulateOptions<Entity>[], {
@@ -542,7 +548,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       return cached.data;
     }
 
-    const data = await em.driver.findOne<Entity, Hint>(entityName, where, { ctx: em.transactionContext, ...options });
+    const data = await em.driver.findOne<Entity, Hint, Fields>(entityName, where, { ctx: em.transactionContext, ...options });
 
     if (!data) {
       await em.storeCache(options.cache, cached!, null);
@@ -564,7 +570,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     await em.unitOfWork.dispatchOnLoadEvent();
     await em.storeCache(options.cache, cached!, () => helper(entity!).toPOJO());
 
-    return entity as Loaded<Entity, Hint>;
+    return entity as Loaded<Entity, Hint, Fields>;
   }
 
   /**
@@ -576,12 +582,13 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   async findOneOrFail<
     Entity extends object,
     Hint extends string = never,
-  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOneOrFailOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint>> {
-    let entity: Loaded<Entity, Hint> | null;
+    Fields extends string = '*',
+  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOneOrFailOptions<Entity, Hint, Fields> = {}): Promise<Loaded<Entity, Hint, Fields>> {
+    let entity: Loaded<Entity, Hint, Fields> | null;
     let isStrictViolation = false;
 
     if (options.strict) {
-      const ret = await this.find(entityName, where, { ...options as FindOptions<Entity, Hint>, limit: 2 });
+      const ret = await this.find(entityName, where, { ...options as FindOptions<Entity, Hint, Fields>, limit: 2 });
       isStrictViolation = ret.length !== 1;
       entity = ret[0];
     } else {
@@ -1515,7 +1522,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }
   }
 
-  private async lockAndPopulate<T extends object, P extends string = never>(entityName: string, entity: T, where: FilterQuery<T>, options: FindOneOptions<T, P>): Promise<Loaded<T, P>> {
+  private async lockAndPopulate<T extends object, P extends string = never, F extends string = '*'>(entityName: string, entity: T, where: FilterQuery<T>, options: FindOneOptions<T, P, F>): Promise<Loaded<T, P, F>> {
     if (options.lockMode === LockMode.OPTIMISTIC) {
       await this.lock(entity, options.lockMode, {
         lockVersion: options.lockVersion,
@@ -1523,7 +1530,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       });
     }
 
-    const preparedPopulate = this.preparePopulate<T, P>(entityName, options);
+    const preparedPopulate = this.preparePopulate<T, P, F>(entityName, options);
     await this.entityLoader.populate(entityName, [entity], preparedPopulate, {
       ...options as Dictionary,
       ...this.getPopulateWhere(where, options),
@@ -1532,7 +1539,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       lookup: false,
     });
 
-    return entity as Loaded<T, P>;
+    return entity as Loaded<T, P, F>;
   }
 
   private buildFields<T extends object, P extends string>(fields: readonly EntityField<T, P>[]): readonly AutoPath<T, P>[] {
@@ -1547,14 +1554,18 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }, [] as AutoPath<T, P>[]);
   }
 
-  private preparePopulate<T extends object, P extends string = never>(entityName: string, options: Pick<FindOptions<T, P>, 'populate' | 'strategy' | 'fields'>): PopulateOptions<T>[] {
+  private preparePopulate<
+    Entity extends object,
+    Hint extends string = never,
+    Fields extends string = '*',
+  >(entityName: string, options: Pick<FindOptions<Entity, Hint, Fields>, 'populate' | 'strategy' | 'fields'>): PopulateOptions<Entity>[] {
     // infer populate hint if only `fields` are available
     if (!options.populate && options.fields) {
-      options.populate = this.buildFields(options.fields);
+      options.populate = this.buildFields(options.fields) as any;
     }
 
     if (!options.populate) {
-      return this.entityLoader.normalizePopulate<T>(entityName, [], options.strategy);
+      return this.entityLoader.normalizePopulate<Entity>(entityName, [], options.strategy);
     }
 
     if (Array.isArray(options.populate)) {
@@ -1564,10 +1575,10 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
         }
 
         return field;
-      }) as unknown as Populate<T>;
+      }) as unknown as Populate<Entity>;
     }
 
-    const ret: PopulateOptions<T>[] = this.entityLoader.normalizePopulate<T>(entityName, options.populate as true, options.strategy);
+    const ret: PopulateOptions<Entity>[] = this.entityLoader.normalizePopulate<Entity>(entityName, options.populate as true, options.strategy);
     const invalid = ret.find(({ field }) => !this.canPopulate(entityName, field));
 
     if (invalid) {
@@ -1585,7 +1596,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * when the entity is found in identity map, we check if it was partially loaded or we are trying to populate
    * some additional lazy properties, if so, we reload and merge the data from database
    */
-  protected shouldRefresh<T extends object, P extends string = never>(meta: EntityMetadata<T>, entity: T, options: FindOneOptions<T, P>) {
+  protected shouldRefresh<T extends object, P extends string = never, F extends string = '*'>(meta: EntityMetadata<T>, entity: T, options: FindOneOptions<T, P, F>) {
     if (!helper(entity).__initialized || options.refresh) {
       return true;
     }

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -55,9 +55,9 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     // do nothing on this level
   }
 
-  abstract find<T extends object, P extends string = never>(entityName: string, where: FilterQuery<T>, options?: FindOptions<T, P>): Promise<EntityData<T>[]>;
+  abstract find<T extends object, P extends string = never, F extends string = '*'>(entityName: string, where: FilterQuery<T>, options?: FindOptions<T, P, F>): Promise<EntityData<T>[]>;
 
-  abstract findOne<T extends object, P extends string = never>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T, P>): Promise<EntityData<T> | null>;
+  abstract findOne<T extends object, P extends string = never, F extends string = '*'>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T, P, F>): Promise<EntityData<T> | null>;
 
   abstract nativeInsert<T extends object>(entityName: string, data: EntityDictionary<T>, options?: NativeInsertUpdateOptions<T>): Promise<QueryResult<T>>;
 
@@ -162,7 +162,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     return this.dependencies;
   }
 
-  protected processCursorOptions<T extends object, P extends string>(meta: EntityMetadata<T>, options: FindOptions<T, P>, orderBy: OrderDefinition<T>): { orderBy: OrderDefinition<T>[]; where: FilterQuery<T> } {
+  protected processCursorOptions<T extends object, P extends string>(meta: EntityMetadata<T>, options: FindOptions<T, P, any>, orderBy: OrderDefinition<T>): { orderBy: OrderDefinition<T>[]; where: FilterQuery<T> } {
     const { first, last, before, after, overfetch } = options;
     const limit = first || last;
     const isLast = !first && !!last;

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -1,6 +1,6 @@
 import type {
   ConnectionType, EntityData, EntityMetadata, EntityProperty, FilterQuery, Primary, Dictionary, QBFilterQuery,
-  IPrimaryKey, PopulateOptions, EntityDictionary, ExpandProperty, AutoPath, ObjectQuery, FilterObject,
+  IPrimaryKey, PopulateOptions, EntityDictionary, AutoPath, ObjectQuery, FilterObject,
 } from '../typings';
 import type { Connection, QueryResult, Transaction } from '../connections';
 import type { FlushMode, LockMode, QueryOrderMap, QueryFlag, LoadStrategy, PopulateHint } from '../enums';
@@ -33,12 +33,12 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   /**
    * Finds selection of entities
    */
-  find<T extends object, P extends string = never>(entityName: string, where: FilterQuery<T>, options?: FindOptions<T, P>): Promise<EntityData<T>[]>;
+  find<T extends object, P extends string = never, F extends string = '*'>(entityName: string, where: FilterQuery<T>, options?: FindOptions<T, P, F>): Promise<EntityData<T>[]>;
 
   /**
    * Finds single entity (table row, document)
    */
-  findOne<T extends object, P extends string = never>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T, P>): Promise<EntityData<T> | null>;
+  findOne<T extends object, P extends string = never, F extends string = '*'>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T, P, F>): Promise<EntityData<T> | null>;
 
   findVirtual<T extends object>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, any>): Promise<EntityData<T>[]>;
 
@@ -91,12 +91,11 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
 
 }
 
-type FieldsMap<T, P extends string = never> = { [K in keyof T]?: EntityField<ExpandProperty<T[K]>>[] };
-export type EntityField<T, P extends string = never> = keyof T | '*' | AutoPath<T, P, '*'> | FieldsMap<T, P>;
+export type EntityField<T, P extends string = never> = keyof T | '*' | AutoPath<T, P, '*'>;
 
 export type OrderDefinition<T> = (QueryOrderMap<T> & { 0?: never }) | QueryOrderMap<T>[];
 
-export interface FindOptions<T, P extends string = never> {
+export interface FindOptions<T, P extends string = never, F extends string = '*'> {
   where?: FilterQuery<T>;
   populate?: readonly AutoPath<T, P>[] | boolean;
   populateWhere?: ObjectQuery<T> | PopulateHint;
@@ -117,7 +116,7 @@ export interface FindOptions<T, P extends string = never> {
   refresh?: boolean;
   convertCustomTypes?: boolean;
   disableIdentityMap?: boolean;
-  fields?: readonly EntityField<T, P>[];
+  fields?: readonly EntityField<T, F>[];
   schema?: string;
   flags?: QueryFlag[];
   groupBy?: string | string[];
@@ -131,15 +130,15 @@ export interface FindOptions<T, P extends string = never> {
   connectionType?: ConnectionType;
 }
 
-export interface FindByCursorOptions<T extends object, P extends string = never> extends Omit<FindOptions<T, P>, 'limit' | 'offset'> {
+export interface FindByCursorOptions<T extends object, P extends string = never, F extends string = never> extends Omit<FindOptions<T, P, F>, 'limit' | 'offset'> {
 }
 
-export interface FindOneOptions<T extends object, P extends string = never> extends Omit<FindOptions<T, P>, 'limit' | 'lockMode'> {
+export interface FindOneOptions<T extends object, P extends string = never, F extends string = never> extends Omit<FindOptions<T, P, F>, 'limit' | 'lockMode'> {
   lockMode?: LockMode;
   lockVersion?: number | Date;
 }
 
-export interface FindOneOrFailOptions<T extends object, P extends string = never> extends FindOneOptions<T, P> {
+export interface FindOneOrFailOptions<T extends object, P extends string = never, F extends string = never> extends FindOneOptions<T, P, F> {
   failHandler?: (entityName: string, where: Dictionary | IPrimaryKey | any) => Error;
   strict?: boolean;
 }

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -312,7 +312,7 @@ export class EntityFactory {
   /**
    * returns parameters for entity constructor, creating references from plain ids
    */
-  private extractConstructorParams<T>(meta: EntityMetadata<T>, data: EntityData<T>, options: FactoryOptions): EntityValue<T>[] {
+  private extractConstructorParams<T extends object>(meta: EntityMetadata<T>, data: EntityData<T>, options: FactoryOptions): EntityValue<T>[] {
     return meta.constructorParams.map(k => {
       if (meta.properties[k] && [ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(meta.properties[k].kind) && data[k]) {
         const entity = this.unitOfWork.getById(meta.properties[k].type, data[k] as any, options.schema) as T[keyof T];

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -19,7 +19,7 @@ export type EntityKey<T = unknown> = string & keyof { [K in keyof T as ExcludeFu
 export type EntityValue<T> = T[EntityKey<T>];
 export type FilterKey<T> = keyof FilterQuery<T>;
 export type AsyncFunction<R = any, T = Dictionary> = (args: T) => Promise<T>;
-type Compute<T> = {[K in keyof T]: T[K]} & {};
+type Compute<T> = { [K in keyof T]: T[K] } & {};
 export type ExcludeFunctions<T, K extends keyof T> = T[K] extends Function ? never : (K extends symbol ? never : K);
 export type Cast<T, R> = T extends R ? T : R;
 export type IsUnknown<T> = T extends unknown ? unknown extends T ? true : never : never;
@@ -55,7 +55,7 @@ export type Primary<T> = T extends { [PrimaryKeyProp]?: infer PK }
   ? ReadonlyPrimary<PK> : T;
 export type PrimaryProperty<T> = T extends { [PrimaryKeyProp]?: infer PK }
   ? (PK extends keyof T ? PK : (PK extends any[] ? PK[number] : never)) : T extends { _id?: any }
-  ? '_id' : T extends { uuid?: any }
+  ? (T extends { id?: any } ? 'id' | '_id' : '_id') : T extends { uuid?: any }
   ? 'uuid' : T extends { id?: any }
   ? 'id' : never;
 export type IPrimaryKeyValue = number | string | bigint | Date | { toHexString(): string };
@@ -696,21 +696,37 @@ export type ExpandProperty<T> = T extends Reference<infer U>
       : NonNullable<T>;
 
 type LoadedLoadable<T, E extends object> = T extends Collection<any, any>
-  ? T & LoadedCollection<E>
-  : (T extends Reference<any> ? T & LoadedReference<E> : T & E);
+  ? LoadedCollection<E>
+  : (T extends Reference<any> ? LoadedReference<E> : E);
 
-type Prefix<K> = K extends `${infer S}.${string}` ? S : K;
-type IsPrefixed<K, L extends string> = K extends Prefix<L> ? K : never;
-type Suffix<K> = K extends `${string}.${infer S}` ? S : never;
-type Defined<T> = Exclude<T, null | undefined> & {};
+type Prefix<T, K> = K extends `${infer S}.${string}` ? S : (K extends '*' ? keyof T : K);
+type IsPrefixed<T, K, L extends string> = K extends Prefix<T, L> ? K : never;
+type IsPrefixedOnly1<T, K, L extends string, F extends string> = K extends Prefix<T, F> ? never : (K extends Prefix<T, L> ? K : never);
+type IsPrefixedOnly2<T, K, L extends string, F extends string> = K extends Prefix<T, L> ? never : (K extends Prefix<T, F> ? K : (K extends PrimaryProperty<T> ? K : never));
+type IsPrefixed1and2<T, K, L extends string, F extends string> = K extends Prefix<T, F> ? (K extends Prefix<T, L> ? K : never) : never;
+
+type Suffix<K> = K extends `${string}.${infer S}` ? S : (K extends '*' ? '*' : never);
+type Defined<T> = T & {};
+
+type AddOptional<T, K extends keyof T> = undefined | null extends T[K] ? null | undefined : null extends T[K] ? null : undefined extends T[K] ? undefined : never;
+
+export type Selected<T, L extends string = never, F extends string = '*'> = {
+  // only populate hint
+  [K in keyof T as IsPrefixedOnly1<T, K, L, F>]: LoadedLoadable<Defined<T[K]>, Loaded<ExtractType<Defined<T[K]>>, Suffix<L>>>;
+} & {
+  // both populate and selected hints
+  [K in keyof T as IsPrefixed1and2<T, K, L, F>]: LoadedLoadable<Defined<T[K]>, Loaded<ExtractType<Defined<T[K]>>, Suffix<L>, Suffix<F>>> | AddOptional<T, K>;
+} & {
+  // only selected hint
+  [K in keyof T as IsPrefixedOnly2<T, K, L, F>]: LoadedLoadable<Defined<T[K]>, Loaded<ExtractType<Defined<T[K]>>, never, Suffix<F>>>;
+};
 
 // For each property on T check if it is included in prefix of keys to load L:
 //   1. It yes, mark the collection or reference loaded and resolve its inner type recursively (passing suffix).
 //   2. If no, just return it as-is (scalars will be included, loadables too but not loaded).
-export type Loaded<T, L extends string = never> = T & {
-  // this feels more correct, but breaks serialization methods on base entity, see #3865
-  [K in keyof T as IsPrefixed<K, L>]: LoadedLoadable<T[K], Loaded<ExtractType<T[K]>, Suffix<L>>>;
-};
+export type Loaded<T, L extends string = never, F extends string = '*'> = [F] extends ['*'] ? (T & {
+  [K in keyof T as IsPrefixed<T, K, L>]: LoadedLoadable<Defined<T[K]>, Loaded<ExtractType<Defined<T[K]>>, Suffix<L>>> | AddOptional<T, K>;
+}) : Selected<T, L, F>;
 
 export interface LoadedReference<T> extends Reference<Defined<T>> {
   $: Defined<T>;

--- a/packages/core/src/utils/Cursor.ts
+++ b/packages/core/src/utils/Cursor.ts
@@ -53,7 +53,7 @@ import { Reference } from '../entity/Reference';
  * }
  * ```
  */
-export class Cursor<Entity extends object, Hint extends string = never> {
+export class Cursor<Entity extends object, Hint extends string = never, Fields extends string = '*'> {
 
   readonly hasPrevPage: boolean;
   readonly hasNextPage: boolean;
@@ -61,9 +61,9 @@ export class Cursor<Entity extends object, Hint extends string = never> {
   private readonly definition: (readonly [EntityKey<Entity>, QueryOrder])[];
 
   constructor(
-    readonly items: Loaded<Entity, Hint>[],
+    readonly items: Loaded<Entity, Hint, Fields>[],
     readonly totalCount: number,
-    options: FindByCursorOptions<Entity, Hint>,
+    options: FindByCursorOptions<Entity, Hint, Fields>,
     meta: EntityMetadata<Entity>,
   ) {
     const { first, last, before, after, orderBy, overfetch } = options;
@@ -103,7 +103,7 @@ export class Cursor<Entity extends object, Hint extends string = never> {
   /**
    * Computes the cursor value for given entity.
    */
-  from(entity: Entity) {
+  from(entity: Entity | Loaded<Entity, Hint, Fields>) {
     const processEntity = <T extends object> (entity: T, prop: EntityKey<T>, direction: QueryOrderKeys<T>, object = false) => {
       if (Utils.isPlainObject(direction)) {
         const value = Utils.keys(direction).reduce((o, key) => {
@@ -119,11 +119,11 @@ export class Cursor<Entity extends object, Hint extends string = never> {
 
       return entity[prop];
     };
-    const value = this.definition.map(([key, direction]) => processEntity(entity, key, direction));
+    const value = this.definition.map(([key, direction]) => processEntity(entity as Entity, key, direction));
     return Cursor.encode(value);
   }
 
-  * [Symbol.iterator](): IterableIterator<Loaded<Entity, Hint>> {
+  * [Symbol.iterator](): IterableIterator<Loaded<Entity, Hint, Fields>> {
     for (const item of this.items) {
       yield item;
     }

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -433,7 +433,7 @@ export class Utils {
   /**
    * Extracts primary key from `data`. Accepts objects or primary keys directly.
    */
-  static extractPK<T>(data: any, meta?: EntityMetadata<T>, strict = false): Primary<T> | string | null {
+  static extractPK<T extends object>(data: any, meta?: EntityMetadata<T>, strict = false): Primary<T> | string | null {
     if (Utils.isPrimaryKey(data)) {
       return data as Primary<T>;
     }
@@ -543,7 +543,7 @@ export class Utils {
     return cond;
   }
 
-  static getPrimaryKeyCondFromArray<T>(pks: Primary<T>[], meta: EntityMetadata<T>): Record<string, Primary<T>> {
+  static getPrimaryKeyCondFromArray<T extends object>(pks: Primary<T>[], meta: EntityMetadata<T>): Record<string, Primary<T>> {
     return meta.getPrimaryProps().reduce((o, pk, idx) => {
       if (Array.isArray(pks[idx]) && pk.targetMeta) {
         o[pk.name] = pks[idx];

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -73,7 +73,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
     return new SqlEntityManager(this.config, this, this.metadata, useContext) as unknown as EntityManager<D>;
   }
 
-  async find<T extends object, P extends string = never>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, P> = {}): Promise<EntityData<T>[]> {
+  async find<T extends object, P extends string = never, F extends string = '*'>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, P, F> = {}): Promise<EntityData<T>[]> {
     options = { populate: [], orderBy: [], ...options };
     const meta = this.metadata.find<T>(entityName)!;
 
@@ -131,7 +131,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
     return result;
   }
 
-  async findOne<T extends object, P extends string = never>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T, P>): Promise<EntityData<T> | null> {
+  async findOne<T extends object, P extends string = never, F extends string = '*'>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T, P, F>): Promise<EntityData<T> | null> {
     const opts = { populate: [], ...(options || {}) } as FindOptions<T>;
     const meta = this.metadata.find(entityName)!;
     const populate = this.autoJoinOneToOneOwner(meta, opts.populate as unknown as PopulateOptions<T>[], opts.fields);
@@ -151,7 +151,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
     return res[0] || null;
   }
 
-  override async findVirtual<T extends object>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, any>): Promise<EntityData<T>[]> {
+  override async findVirtual<T extends object>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, any, any>): Promise<EntityData<T>[]> {
     const meta = this.metadata.get<T>(entityName);
 
     /* istanbul ignore next */
@@ -757,7 +757,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
         return !fields?.includes('*');
       }
 
-      return fields.includes(prop.name);
+      return fields.some(f => f === prop.name || f.toString().startsWith(prop.name + '.'));
     };
 
     // alias all fields in the primary table

--- a/tests/DatabaseDriver.test.ts
+++ b/tests/DatabaseDriver.test.ts
@@ -38,11 +38,11 @@ class Driver extends DatabaseDriver<Connection> implements IDatabaseDriver {
     return 0;
   }
 
-  async find<T extends object, P extends string = never>(entityName: string, where: ObjectQuery<T>, options: FindOptions<T, P> | undefined): Promise<EntityData<T>[]> {
+  async find<T extends object, P extends string = never, F extends string = '*'>(entityName: string, where: ObjectQuery<T>, options: FindOptions<T, P, F> | undefined): Promise<EntityData<T>[]> {
     return [];
   }
 
-  async findOne<T extends object, P extends string = never>(entityName: string, where: ObjectQuery<T>, options: FindOneOptions<T, P> | undefined): Promise<EntityData<T> | null> {
+  async findOne<T extends object, P extends string = never, F extends string = '*'>(entityName: string, where: ObjectQuery<T>, options: FindOneOptions<T, P, F> | undefined): Promise<EntityData<T> | null> {
     return null;
   }
 

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -778,19 +778,21 @@ describe('EntityManagerMongo', () => {
 
     // test inverse side
     const tagRepository = orm.em.getRepository(BookTag);
-    let tags = await tagRepository.findAll({ populate: ['books'] });
-    expect(tags).toBeInstanceOf(Array);
-    expect(tags.length).toBe(5);
-    expect(tags[0]).toBeInstanceOf(BookTag);
-    expect(tags[0].name).toBe('silly');
-    expect(tags[0].books).toBeInstanceOf(Collection);
-    expect(tags[0].books.isInitialized()).toBe(true);
-    expect(tags[0].books.isDirty()).toBe(false);
-    expect(tags[0].books.count()).toBe(2);
-    expect(tags[0].books.length).toBe(2);
+    {
+      const tags = await tagRepository.findAll({ populate: ['books'] });
+      expect(tags).toBeInstanceOf(Array);
+      expect(tags.length).toBe(5);
+      expect(tags[0]).toBeInstanceOf(BookTag);
+      expect(tags[0].name).toBe('silly');
+      expect(tags[0].books).toBeInstanceOf(Collection);
+      expect(tags[0].books.isInitialized()).toBe(true);
+      expect(tags[0].books.isDirty()).toBe(false);
+      expect(tags[0].books.count()).toBe(2);
+      expect(tags[0].books.length).toBe(2);
+    }
 
     orm.em.clear();
-    tags = await orm.em.find(BookTag, {});
+    const tags = await orm.em.find(BookTag, {});
     expect(tags[0].books.isInitialized()).toBe(false);
     expect(tags[0].books.isDirty()).toBe(false);
     expect(() => tags[0].books.getItems()).toThrowError(/Collection<Book> of entity BookTag\[\w{24}] not initialized/);
@@ -1908,6 +1910,7 @@ describe('EntityManagerMongo', () => {
 
     const [authors2, count2] = await orm.em.findAndCount(Author, {}, { limit: 10, offset: 25, fields: ['name'] });
     expect(authors2).toHaveLength(5);
+    // @ts-expect-error
     expect(authors2[0].email).toBeUndefined();
     expect(count2).toBe(30);
     expect(authors2[0].name).toBe('God 26');

--- a/tests/EntityManager.mongo2.test.ts
+++ b/tests/EntityManager.mongo2.test.ts
@@ -36,7 +36,9 @@ describe('EntityManagerMongo2', () => {
       fields: ['*', 'publisher.name'],
     });
     expect(books[0].publisher!.get().books.get()[0].publisher!.$.name).toBe('Publisher 123');
-    expect(books[0].publisher!.$.type).toBeUndefined();
+    expect(books[0].publisher!.$
+      // @ts-expect-error
+      .type).toBeUndefined();
 
     const book5 = await orm.em.findOneOrFail(Book, bible, { populate: ['publisher', 'tags', 'perex'] });
     expect(book5.publisher!.$.name).toBe('Publisher 123');

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -310,6 +310,7 @@ describe('EntityManagerMySql', () => {
     });
     expect(a1.name).toBe('fz');
     expect(a1.bar).toBeInstanceOf(FooBar2);
+    // @ts-expect-error
     expect(a1.version).toBeUndefined();
     expect(wrap(a1.bar!).isInitialized()).toBe(false);
   });
@@ -1905,6 +1906,7 @@ describe('EntityManagerMySql', () => {
 
     const [authors2, count2] = await orm.em.findAndCount(Author2, {}, { limit: 10, offset: 25, fields: ['name'], orderBy: { id: QueryOrder.ASC } });
     expect(authors2).toHaveLength(5);
+    // @ts-expect-error
     expect(authors2[0].email).toBeUndefined();
     expect(count2).toBe(30);
     expect(authors2[0].name).toBe('God 26');
@@ -2254,6 +2256,7 @@ describe('EntityManagerMySql', () => {
     const r1 = await orm.em.find(Author2, god, { fields: ['id'], populate: ['books'] });
     expect(r1).toHaveLength(1);
     expect(r1[0].id).toBe(god.id);
+    // @ts-expect-error
     expect(r1[0].name).toBeUndefined();
     const r2 = await orm.em.find(Author2, god, { refresh: true, populate: ['books'] });
     expect(r2).toHaveLength(1);

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -889,11 +889,13 @@ describe('EntityManagerPostgre', () => {
     god.books.add(new Book2('Bible', god));
     await orm.em.fork().persistAndFlush(god);
 
+    // when populating collections, the owner is selected automatically (here book.author)
     const newGod = await orm.em.findOneOrFail(Author2, god.id, {
       populate: ['books'],
-      fields: [{ books: ['title'] }],
+      fields: ['books.title'],
     });
     const json = wrap(newGod).toJSON();
+    // @ts-expect-error
     expect(json.books[0].author).toBe(newGod.id);
   });
 

--- a/tests/features/auto-refreshing.postgre.test.ts
+++ b/tests/features/auto-refreshing.postgre.test.ts
@@ -36,7 +36,7 @@ describe('automatic refreshing of already loaded entities', () => {
   test('em.find()', async () => {
     const { god } = await createEntities();
 
-    const r1 = await orm.em.find(Author2, god, { fields: ['id'], populate: ['books'] });
+    const r1 = await orm.em.find(Author2, god, { fields: ['id'] as never, populate: ['books'] });
     r1[0].email = 'lol';
     expect(r1).toHaveLength(1);
     expect(r1[0].id).toBe(god.id);
@@ -61,7 +61,7 @@ describe('automatic refreshing of already loaded entities', () => {
   test('em.find() with relations and joined strategy 1', async () => {
     const { god } = await createEntities();
 
-    const r1 = await orm.em.find(Author2, god, { fields: ['id'] });
+    const r1 = await orm.em.find(Author2, god, { fields: ['id' as '*'] });
     r1[0].email = 'lol@lol.lol';
     expect(r1).toHaveLength(1);
     expect(r1[0].id).toBe(god.id);
@@ -90,16 +90,21 @@ describe('automatic refreshing of already loaded entities', () => {
     const { god } = await createEntities();
 
     const r1 = await orm.em.find(Author2, god, { fields: ['id', 'books.title', 'books.author'], populate: ['books'], strategy: LoadStrategy.JOINED });
+    // @ts-expect-error
     r1[0].email = 'lol@lol.lol';
     r1[0].books[0].title = 'lol';
     expect(r1).toHaveLength(1);
     expect(r1[0].id).toBe(god.id);
+    // @ts-expect-error
     expect(r1[0].name).toBeUndefined();
+    // @ts-expect-error
     expect(r1[0].termsAccepted).toBeUndefined();
     expect(r1[0].books[0].uuid).toBeDefined();
     expect(r1[0].books[0].title).toBeDefined();
     expect(r1[0].books[0].author).toBeDefined();
+    // @ts-expect-error
     expect(r1[0].books[0].price).toBeUndefined();
+    // @ts-expect-error
     expect(r1[0].books[0].perex).toBeUndefined();
     // with auto-flush mode, this would trigger flushing as we have dirty author and we query for authors
     const r2 = await orm.em.find(Author2, god, { populate: ['books', 'books.perex'], strategy: LoadStrategy.JOINED, flushMode: FlushMode.COMMIT });
@@ -125,13 +130,17 @@ describe('automatic refreshing of already loaded entities', () => {
     const { god } = await createEntities();
 
     const r1 = await orm.em.find(Author2, god, { fields: ['id', 'favouriteAuthor.name'], populate: ['favouriteAuthor'], strategy: LoadStrategy.JOINED });
+    // @ts-expect-error
     r1[0].email = 'lol@lol.lol';
     expect(r1).toHaveLength(1);
     expect(r1[0].id).toBe(god.id);
+    // @ts-expect-error
     expect(r1[0].name).toBeUndefined();
+    // @ts-expect-error
     expect(r1[0].termsAccepted).toBeUndefined();
     expect(r1[0].favouriteAuthor!.id).toBeDefined();
     expect(r1[0].favouriteAuthor!.name).toBeDefined();
+    // @ts-expect-error
     expect(r1[0].favouriteAuthor!.age).toBeUndefined();
     r1[0].favouriteAuthor!.name = 'lol';
     // with auto-flush mode, this would trigger flushing as we have dirty author and we query for authors
@@ -161,9 +170,13 @@ describe('automatic refreshing of already loaded entities', () => {
     expect(a1.id).toBe(god.id);
     expect(a1.email).toBe(god.email);
     a1.email = 'lol';
+    // @ts-expect-error
     expect(a1.name).toBeUndefined();
+    // @ts-expect-error
     expect(a1.termsAccepted).toBeUndefined();
+    // @ts-expect-error
     expect(a1.age).toBeUndefined();
+    // @ts-expect-error
     expect(a1.identities).toBeUndefined();
 
     // reloading with same fields won't fire the query
@@ -176,7 +189,9 @@ describe('automatic refreshing of already loaded entities', () => {
     // with auto-flush mode, this would trigger flushing as we have dirty author and we query for authors
     const a12 = await orm.em.findOneOrFail(Author2, god, { fields: ['id', 'age'], flushMode: FlushMode.COMMIT });
     expect(a12).toBe(a1);
+    // @ts-expect-error
     expect(a1.age).toBe(999);
+    // @ts-expect-error
     a1.age = 1000;
     expect(mock).toBeCalledTimes(3);
 
@@ -216,9 +231,13 @@ describe('automatic refreshing of already loaded entities', () => {
     expect(a1.id).toBe(god.id);
     expect(a1.email).toBe(god.email);
     a1.email = 'lol';
+    // @ts-expect-error
     expect(a1.name).toBeUndefined();
+    // @ts-expect-error
     expect(a1.termsAccepted).toBeUndefined();
+    // @ts-expect-error
     expect(a1.age).toBeUndefined();
+    // @ts-expect-error
     expect(a1.identities).toBeUndefined();
 
     // reloading with same fields won't fire the query
@@ -231,7 +250,9 @@ describe('automatic refreshing of already loaded entities', () => {
     // with auto-flush mode, this would trigger flushing as we have dirty author and we query for authors
     const a12 = await orm.em.findOneOrFail(Author2, god, { fields: ['id', 'age'], flushMode: FlushMode.COMMIT });
     expect(a12).toBe(a1);
+    // @ts-expect-error
     expect(a1.age).toBe(999);
+    // @ts-expect-error
     a1.age = 1000;
     expect(mock).toBeCalledTimes(2);
 

--- a/tests/features/embeddables/embedded-entities.postgres.test.ts
+++ b/tests/features/embeddables/embedded-entities.postgres.test.ts
@@ -274,6 +274,7 @@ describe('embedded entities in postgresql', () => {
 
     const mock = mockLogger(orm, ['query']);
     await orm.em.fork().find(User, {}, { fields: ['address2'] });
+    // @ts-expect-error old syntax is still technically supported, but not on type level
     await orm.em.fork().find(User, {}, { fields: [{ address2: ['street', 'city'] }] });
     await orm.em.fork().find(User, {}, { fields: ['address2.street', 'address2.city'] });
     expect(mock.mock.calls[0][0]).toMatch('select "u0"."id", "u0"."addr_street", "u0"."addr_postal_code", "u0"."addr_city", "u0"."addr_country" from "user" as "u0"');

--- a/tests/features/embeddables/nested-embeddables.postgres.test.ts
+++ b/tests/features/embeddables/nested-embeddables.postgres.test.ts
@@ -299,7 +299,9 @@ describe('embedded entities in postgres', () => {
     await orm.em.fork().find(User, {}, { fields: ['profile1.identity.meta.foo'] });
     await orm.em.fork().find(User, {}, { fields: ['profile2.identity.meta.foo'] });
 
+    // @ts-expect-error old syntax is still technically supported, but not on type level
     await orm.em.fork().find(User, {}, { fields: [{ profile1: ['identity'] }] });
+    // @ts-expect-error old syntax is still technically supported, but not on type level
     await orm.em.fork().find(User, {}, { fields: [{ profile2: ['identity'] }] });
 
     expect(mock.mock.calls[0][0]).toMatch('select "u0"."id", "u0"."profile1_username", "u0"."profile1_identity_email", "u0"."profile1_identity_meta_foo", "u0"."profile1_identity_meta_bar", "u0"."profile1_identity_links" from "user" as "u0"');

--- a/tests/features/partial-loading/partial-loading.mysql.test.ts
+++ b/tests/features/partial-loading/partial-loading.mysql.test.ts
@@ -37,7 +37,9 @@ describe('partial loading (mysql)', () => {
 
     const a = (await orm.em.findOne(Author2, author, { fields: ['name'] }))!;
     expect(a.name).toBe('Jon Snow');
+    // @ts-expect-error
     expect(a.email).toBeUndefined();
+    // @ts-expect-error
     expect(a.born).toBeUndefined();
     orm.em.clear();
 
@@ -54,9 +56,11 @@ describe('partial loading (mysql)', () => {
     const r1 = await orm.em.find(Author2, god, { fields: ['id', 'books.author', 'books.title'] });
     expect(r1).toHaveLength(1);
     expect(r1[0].id).toBe(god.id);
+    // @ts-expect-error
     expect(r1[0].name).toBeUndefined();
     expect(r1[0].books[0].uuid).toBe(god.books[0].uuid);
     expect(r1[0].books[0].title).toBe('Bible 1');
+    // @ts-expect-error
     expect(r1[0].books[0].price).toBeUndefined();
     expect(r1[0].books[0].author).toBeDefined();
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id` from `author2` as `a0` where `a0`.`id` = ?');
@@ -64,12 +68,15 @@ describe('partial loading (mysql)', () => {
     orm.em.clear();
     mock.mock.calls.length = 0;
 
-    const r2 = await orm.em.find(Author2, god, { fields: ['id', { books: ['uuid', 'author', 'title'] }] });
+    // old syntax is still supported
+    const r2 = await orm.em.find(Author2, god, { fields: ['id', 'books.uuid', 'books.author', 'books.title'] });
     expect(r2).toHaveLength(1);
     expect(r2[0].id).toBe(god.id);
+    // @ts-expect-error
     expect(r2[0].name).toBeUndefined();
     expect(r2[0].books[0].uuid).toBe(god.books[0].uuid);
     expect(r2[0].books[0].title).toBe('Bible 1');
+    // @ts-expect-error
     expect(r2[0].books[0].price).toBeUndefined();
     expect(r2[0].books[0].author).toBeDefined();
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id` from `author2` as `a0` where `a0`.`id` = ?');
@@ -81,9 +88,11 @@ describe('partial loading (mysql)', () => {
     const r0 = await orm.em.find(Author2, god, { fields: ['id', 'books', 'books.author', 'books.title'] });
     expect(r0).toHaveLength(1);
     expect(r0[0].id).toBe(god.id);
+    // @ts-expect-error
     expect(r0[0].name).toBeUndefined();
     expect(r0[0].books[0].uuid).toBe(god.books[0].uuid);
     expect(r0[0].books[0].title).toBe('Bible 1');
+    // @ts-expect-error
     expect(r0[0].books[0].price).toBeUndefined();
     expect(r0[0].books[0].author).toBeDefined();
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id` from `author2` as `a0` where `a0`.`id` = ?');
@@ -95,10 +104,13 @@ describe('partial loading (mysql)', () => {
     const r00 = await orm.em.find(Author2, god, { fields: ['id', 'books.title'] });
     expect(r00).toHaveLength(1);
     expect(r00[0].id).toBe(god.id);
+    // @ts-expect-error
     expect(r00[0].name).toBeUndefined();
     expect(r00[0].books[0].uuid).toBe(god.books[0].uuid);
     expect(r00[0].books[0].title).toBe('Bible 1');
+    // @ts-expect-error
     expect(r00[0].books[0].price).toBeUndefined();
+    // @ts-expect-error
     expect(r00[0].books[0].author).toBeDefined();
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id` from `author2` as `a0` where `a0`.`id` = ?');
     expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`title`, `b0`.`author_id` from `book2` as `b0` where `b0`.`author_id` is not null and `b0`.`author_id` in (?) order by `b0`.`title` asc');
@@ -109,13 +121,19 @@ describe('partial loading (mysql)', () => {
     const b1 = god.books[0];
     const mock = mockLogger(orm, ['query']);
 
-    const r1 = await orm.em.find(Book2, b1, { fields: ['uuid', 'title', 'author', 'author.email'], populate: ['author'], filters: false });
+    const r1 = await orm.em.find(Book2, b1, {
+      fields: ['uuid', 'title', 'author', 'author.email'],
+      populate: ['author'],
+      filters: false,
+    });
     expect(r1).toHaveLength(1);
     expect(r1[0].uuid).toBe(b1.uuid);
     expect(r1[0].title).toBe('Bible 1');
+    // @ts-expect-error
     expect(r1[0].price).toBeUndefined();
     expect(r1[0].author).toBeDefined();
     expect(r1[0].author.id).toBe(god.id);
+    // @ts-expect-error
     expect(r1[0].author.name).toBeUndefined();
     expect(r1[0].author.email).toBeDefined();
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`title`, `b0`.`author_id` from `book2` as `b0` where `b0`.`uuid_pk` = ?');
@@ -123,13 +141,19 @@ describe('partial loading (mysql)', () => {
     orm.em.clear();
     mock.mock.calls.length = 0;
 
-    const r2 = await orm.em.find(Book2, b1, { fields: ['uuid', 'title', 'author', { author: ['email'] }], populate: ['author'], filters: false });
+    const r2 = await orm.em.find(Book2, b1, {
+      fields: ['uuid', 'title', 'author.email'],
+      populate: ['author'],
+      filters: false,
+    });
     expect(r2).toHaveLength(1);
     expect(r2[0].uuid).toBe(b1.uuid);
     expect(r2[0].title).toBe('Bible 1');
+    // @ts-expect-error
     expect(r2[0].price).toBeUndefined();
     expect(r2[0].author).toBeDefined();
     expect(r2[0].author.id).toBe(god.id);
+    // @ts-expect-error
     expect(r2[0].author.name).toBeUndefined();
     expect(r2[0].author.email).toBeDefined();
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`title`, `b0`.`author_id` from `book2` as `b0` where `b0`.`uuid_pk` = ?');
@@ -144,18 +168,22 @@ describe('partial loading (mysql)', () => {
     expect(r1).toHaveLength(6);
     expect(r1[0].name).toBe('t1');
     expect(r1[0].books[0].title).toBe('Bible 1');
+    // @ts-expect-error
     expect(r1[0].books[0].price).toBeUndefined();
+    // @ts-expect-error
     expect(r1[0].books[0].author).toBeUndefined();
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name` from `book_tag2` as `b0`');
     expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`title`, `b1`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `b1`.`book_tag2_id` as `fk__book_tag2_id`, `t2`.`id` as `test_id` from `book2` as `b0` left join `book2_tags` as `b1` on `b0`.`uuid_pk` = `b1`.`book2_uuid_pk` left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` where `b1`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) order by `b1`.`order` asc');
     orm.em.clear();
     mock.mock.calls.length = 0;
 
-    const r2 = await orm.em.find(BookTag2, { name: 't1' }, { fields: ['name', { books: ['title'] }], filters: false });
+    const r2 = await orm.em.find(BookTag2, { name: 't1' }, { fields: ['name', 'books.title'], filters: false });
     expect(r2).toHaveLength(1);
     expect(r2[0].name).toBe('t1');
     expect(r2[0].books[0].title).toBe('Bible 1');
+    // @ts-expect-error
     expect(r2[0].books[0].price).toBeUndefined();
+    // @ts-expect-error
     expect(r2[0].books[0].author).toBeUndefined();
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name` from `book_tag2` as `b0` where `b0`.`name` = ?');
     expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`title`, `b1`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `b1`.`book_tag2_id` as `fk__book_tag2_id`, `t2`.`id` as `test_id` from `book2` as `b0` left join `book2_tags` as `b1` on `b0`.`uuid_pk` = `b1`.`book2_uuid_pk` left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` where `b1`.`book_tag2_id` in (?) order by `b1`.`order` asc');
@@ -165,13 +193,19 @@ describe('partial loading (mysql)', () => {
     const god = await createEntities();
     const mock = mockLogger(orm, ['query']);
 
-    const r1 = await orm.em.find(BookTag2, {}, { fields: ['name', 'books.title', 'books.author', 'books.author.email'], populate: ['books.author'], filters: false });
+    const r1 = await orm.em.find(BookTag2, {}, {
+      fields: ['name', 'books.title', 'books.author', 'books.author.email'],
+      populate: ['books.author'],
+      filters: false,
+    });
     expect(r1).toHaveLength(6);
     expect(r1[0].name).toBe('t1');
     expect(r1[0].books[0].title).toBe('Bible 1');
+    // @ts-expect-error
     expect(r1[0].books[0].price).toBeUndefined();
     expect(r1[0].books[0].author).toBeDefined();
     expect(r1[0].books[0].author.id).toBeDefined();
+    // @ts-expect-error
     expect(r1[0].books[0].author.name).toBeUndefined();
     expect(r1[0].books[0].author.email).toBe(god.email);
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name` from `book_tag2` as `b0`');
@@ -192,9 +226,11 @@ describe('partial loading (mysql)', () => {
     expect(r3).toHaveLength(6);
     expect(r3[0].name).toBe('t1');
     expect(r3[0].books[0].title).toBe('Bible 1');
+    // @ts-expect-error
     expect(r3[0].books[0].price).toBeUndefined();
     expect(r3[0].books[0].author).toBeDefined();
     expect(r3[0].books[0].author.id).toBeDefined();
+    // @ts-expect-error
     expect(r3[0].books[0].author.name).toBeUndefined();
     expect(r3[0].books[0].author.email).toBe(god.email);
     expect(mock.mock.calls).toHaveLength(1);
@@ -229,13 +265,19 @@ describe('partial loading (mysql)', () => {
     const god = await createEntities();
     const mock = mockLogger(orm, ['query']);
 
-    const r2 = await orm.em.find(BookTag2, {}, { fields: ['name', { books: ['title', 'author', { author: ['email'] }] } ], populate: ['books.author'], filters: false });
+    const r2 = await orm.em.find(BookTag2, {}, {
+      fields: ['name', 'books.title', 'books.author', 'books.author.email'],
+      populate: ['books.author'],
+      filters: false,
+    });
     expect(r2).toHaveLength(6);
     expect(r2[0].name).toBe('t1');
     expect(r2[0].books[0].title).toBe('Bible 1');
+    // @ts-expect-error
     expect(r2[0].books[0].price).toBeUndefined();
     expect(r2[0].books[0].author).toBeDefined();
     expect(r2[0].books[0].author.id).toBeDefined();
+    // @ts-expect-error
     expect(r2[0].books[0].author.name).toBeUndefined();
     expect(r2[0].books[0].author.email).toBe(god.email);
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name` from `book_tag2` as `b0`');
@@ -248,7 +290,7 @@ describe('partial loading (mysql)', () => {
     const mock = mockLogger(orm, ['query']);
 
     const r3 = await orm.em.find(BookTag2, {}, {
-      fields: ['name', { books: ['title', 'author', { author: ['email'] }] } ],
+      fields: ['name', 'books.title', 'books.author.email'],
       populate: ['books.author'],
       filters: false,
       strategy: LoadStrategy.JOINED,
@@ -256,9 +298,11 @@ describe('partial loading (mysql)', () => {
     expect(r3).toHaveLength(6);
     expect(r3[0].name).toBe('t1');
     expect(r3[0].books[0].title).toBe('Bible 1');
+    // @ts-expect-error
     expect(r3[0].books[0].price).toBeUndefined();
     expect(r3[0].books[0].author).toBeDefined();
     expect(r3[0].books[0].author.id).toBeDefined();
+    // @ts-expect-error
     expect(r3[0].books[0].author.name).toBeUndefined();
     expect(r3[0].books[0].author.email).toBe(god.email);
     expect(mock.mock.calls).toHaveLength(1);
@@ -269,6 +313,11 @@ describe('partial loading (mysql)', () => {
       'left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` ' +
       'left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` ' +
       'left join `author2` as `a3` on `b1`.`author_id` = `a3`.`id`');
+
+    // Expected substring: "
+    // select `b0`.`id`, `b0`.`name`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`title` as `b1__title`, `b1`.`author_id` as `b1__author_id`, `a3`.`id` as `a3__id`, `a3`.`email` as `a3__email` from `book_tag2` as `b0` left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` left join `author2` as `a3` on `b1`.`author_id` = `a3`.`id`"
+    // Received string:    "
+    // select `b0`.`id`, `b0`.`name`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`title` as `b1__title`, `a3`.`id` as `a3__id`, `a3`.`email` as `a3__email` from `book_tag2` as `b0` left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` left join `author2` as `a3` on `b1`.`author_id` = `a3`.`id` [took 7 ms] (via read connection 'read-1')"
   });
 
 });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -566,15 +566,14 @@ describe('check typings', () => {
     // @ts-expect-error Loaded<Parent, never> is not assignable
     foo(e);
     // populated1 = await parent.load();
+    const populated22 = await parent.load({ populate: [] });
     // @ts-expect-error Loaded<Parent, never> is not assignable
-    const populated2: Loaded<Parent, 'children'> = await parent.load({ populate: [] });
+    const populated2: Loaded<Parent, 'children'> = populated22;
 
     // only this should pass
     const populated3: Loaded<Parent, 'children'> = await parent.load({ populate: ['children'] });
     const populated4: Loaded<Parent, 'children'> = await parent.load({ populate: ['children', 'id'] });
-
-    // this fails because of https://github.com/mikro-orm/mikro-orm/issues/3277
-    // const populated5: Loaded<Parent, 'children'> = await parent.load({ populate: ['children.parent'] });
+    const populated5: Loaded<Parent, 'children'> = await parent.load({ populate: ['children.parent'] });
   });
 
   test('exclusion', async () => {


### PR DESCRIPTION
The `Loaded` type is now improved to support the partial loading hints (`fields` option). When used, the returned type will only allow accessing selected properties. Primary keys are automatically selected.

```ts
// book is typed to `Selected<Book, 'author', 'title' | 'author.email'>`
const book = await em.findOneOrFail(Book, 1, {
  fields: ['title', 'author.email'],
  populate: ['author'],
});

const id = book.id; // ok, PK is selected automatically
const title = book.title; // ok, title is selected
const publisher = book.publisher; // fail, not selected
const author = book.author.id; // ok, PK is selected automatically
const email = book.author.email; // ok, selected
const name = book.author.name; // fail, not selected
```

BREAKING CHANGE:
`FindOptions.fields` now accepts only array of strings, like `populate`.

Closes #3443