### PR TITLE
feat(core): support atomic updates via `raw()` helper

### DIFF
--- a/docs/docs/filters.md
+++ b/docs/docs/filters.md
@@ -60,7 +60,7 @@ import type { EntityManager } from '@mikro-orm/mysql';
 
   return { 
     author: { name: args.name }, 
-    publishedAt: { $lte: em.raw('now()') },
+    publishedAt: { $lte: raw('now()') },
   };
 } })
 export class Book {

--- a/docs/docs/query-builder.md
+++ b/docs/docs/query-builder.md
@@ -408,11 +408,11 @@ console.log(qb4.getQuery());
 
 ## Referring to column in update queries
 
-You can use `qb.raw()` to insert raw SQL snippets like this:
+You can use static `raw()` helper to insert raw SQL snippets like this:
 
 ```ts
 const qb = em.createQueryBuilder(Book);
-qb.update({ price: qb.raw('price + 1') }).where({ uuid: '123' });
+qb.update({ price: raw('price + 1') }).where({ uuid: '123' });
 
 console.log(qb.getQuery());
 // update `book` set `price` = price + 1 where `uuid_pk` = ?

--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -220,3 +220,13 @@ Use `RequestContext.create` instead, it can be awaited now.
 
 The decorator was renamed to `@CreateRequestContext()` to make it clear it always creates new context, and a new `@EnsureRequestContext()` decorator was added that will reuse existing contexts if available. 
 
+## Removed `em.raw()` and `qb.raw()`
+
+Both removed in favour of new static `raw()` helper, which can be also used to do atomic updates via `flush`:
+
+```ts
+const ref = em.getReference(User, 1);
+ref.age = raw(`age * 2`);
+await em.flush();
+console.log(ref.age); // real value is available after flush
+```

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     ]
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": ">= 16.0.0",
     "yarn": ">=3.2.0"
   },
   "devDependencies": {

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -419,9 +419,13 @@ export class EntityMetadata<T = any> {
 
       o[prop.name] = {
         get() {
-          return this.__helper?.__data[prop.name];
+          return this.__helper.__data[prop.name];
         },
         set(val: unknown) {
+          if (typeof val === 'object' && !!val && '__raw' in val) {
+            (val as Dictionary).use();
+          }
+
           this.__helper.__data[prop.name] = val;
           this.__helper.__touched = true;
         },

--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -2,12 +2,13 @@ import { Reference } from '../entity/Reference';
 import { Utils } from './Utils';
 import type {
   Dictionary,
+  EntityKey,
   EntityMetadata,
   EntityProperty,
-  FilterDef,
-  EntityKey,
   EntityValue,
-  FilterQuery, FilterKey,
+  FilterDef,
+  FilterKey,
+  FilterQuery,
 } from '../typings';
 import { ARRAY_OPERATORS, GroupOperator, ReferenceKind } from '../enums';
 import type { Platform } from '../platforms';
@@ -299,4 +300,60 @@ export function expr<T = unknown>(sql: (keyof T & string) | (keyof T & string)[]
   }
 
   return sql;
+}
+
+export class RawQueryFragment {
+
+  readonly sql: string;
+  readonly params?: unknown[];
+
+  #used = 0;
+
+  constructor(sql: string, params?: unknown[]) {
+    this.sql = sql;
+
+    if (params) {
+      this.params = params;
+    }
+  }
+
+  valueOf() {
+    throw new Error(`Trying to modify raw SQL fragment: '${this.sql}'`);
+  }
+
+  toJSON() {
+    throw new Error(`Trying to serialize raw SQL fragment: '${this.sql}'`);
+  }
+
+  /** @internal */
+  use() {
+    if (this.#used > 0) {
+      throw new Error(`Cannot reassign already used RawQueryFragment: '${this.sql}'`);
+    }
+
+    this.#used++;
+  }
+
+}
+
+Object.defineProperties(RawQueryFragment.prototype, {
+  __raw: { value: true, enumerable: false },
+  // toString: { value() { throw new Error(`Trying to serialize raw SQL fragment: '${this.sql}'`); }, enumerable: false },
+  // toJSON: { value() { throw new Error(`Trying to serialize raw SQL fragment: '${this.sql}'`); }, enumerable: false },
+});
+
+/**
+ * Creates raw SQL query fragment that can be assigned to a property or part of a filter.
+ */
+export function raw<R = any>(sql: string, params?: unknown[] | Dictionary<unknown>): R {
+  if (typeof params === 'object' && !Array.isArray(params)) {
+    const pairs = Object.entries(params);
+    params = [];
+    for (const [key, value] of pairs) {
+      sql = sql.replace(':' + key, '?');
+      params.push(value);
+    }
+  }
+
+  return new RawQueryFragment(sql, params) as R;
 }

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -1145,4 +1145,8 @@ export class Utils {
     return Object.entries(obj) as [keyof T, T[keyof T]][];
   }
 
+  static isRawSql(value: unknown): value is { sql: string; params?: unknown[]; use: () => void } {
+    return typeof value === 'object' && !!value && '__raw' in value;
+  }
+
 }

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -215,7 +215,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
     const kqb = qb.getKnexQuery().clear('select');
 
     if (type === QueryType.COUNT) {
-      kqb.select(qb.raw('count(*) as count'));
+      kqb.select(this.connection.getKnex().raw('count(*) as count'));
     } else { // select
       kqb.select('*');
     }
@@ -415,9 +415,11 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
       }).join(', ');
     }
 
-    if (this.platform.usesReturningStatement()) {
-      /* istanbul ignore next */
-      const returningProps = meta!.hydrateProps.filter(prop => prop.persist !== false && (prop.primary || prop.defaultRaw));
+    if (meta && this.platform.usesReturningStatement()) {
+      const returningProps = meta.hydrateProps
+        .filter(prop => prop.persist !== false && ((prop.primary && prop.autoincrement) || prop.defaultRaw))
+        .filter(prop => !(prop.name in data[0]) || Utils.isRawSql(data[0][prop.name]));
+
       const returningFields = Utils.flatten(returningProps.map(prop => prop.fieldNames));
       /* istanbul ignore next */
       sql += returningFields.length > 0 ? ` returning ${returningFields.map(field => this.platform.quoteIdentifier(field)).join(', ')}` : '';
@@ -496,7 +498,16 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
 
     const collections = options.processCollections ? data.map(d => this.extractManyToMany(entityName, d)) : [];
     const keys = new Set<EntityKey<T>>();
-    data.forEach(row => Utils.keys(row).forEach(k => keys.add(k as EntityKey<T>)));
+    const returning = new Set<EntityKey<T>>();
+    data.forEach(row => {
+      Utils.keys(row).forEach(k => {
+        keys.add(k as EntityKey<T>);
+
+        if (Utils.isRawSql(row[k])) {
+          returning.add(k);
+        }
+      });
+    });
     const pkCond = Utils.flatten(meta.primaryKeys.map(pk => meta.properties[pk].fieldNames)).map(pk => `${this.platform.quoteIdentifier(pk)} = ?`).join(' and ');
     const params: any[] = [];
     let sql = `update ${this.getTableName(meta, options)} set `;
@@ -565,6 +576,13 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
       return '?';
     });
     sql += ` in (${conds.join(', ')})`;
+
+    if (this.platform.usesReturningStatement() && returning.size > 0) {
+      const returningFields = Utils.flatten([...returning].map(prop => meta.properties[prop].fieldNames));
+      /* istanbul ignore next */
+      sql += returningFields.length > 0 ? ` returning ${returningFields.map(field => this.platform.quoteIdentifier(field)).join(', ')}` : '';
+    }
+
     const res = await this.rethrow(this.execute<QueryResult<T>>(sql, params, 'run', options.ctx));
 
     for (let i = 0; i < collections.length; i++) {
@@ -794,7 +812,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
 
     if (prop.customType?.convertToJSValueSQL && tableAlias) {
       const prefixed = qb.ref(prop.fieldNames[0]).withSchema(tableAlias).toString();
-      return [qb.raw(prop.customType.convertToJSValueSQL(prefixed, this.platform) + ' as ' + aliased).toString()];
+      return [prop.customType.convertToJSValueSQL(prefixed, this.platform) + ' as ' + aliased];
     }
 
     if (prop.formula) {

--- a/packages/knex/src/AbstractSqlPlatform.ts
+++ b/packages/knex/src/AbstractSqlPlatform.ts
@@ -36,6 +36,10 @@ export abstract class AbstractSqlPlatform extends Platform {
   }
 
   override quoteValue(value: any): string {
+    if (Utils.isRawSql(value)) {
+      return this.formatQuery(value.sql, value.params ?? []);
+    }
+
     if (this.isRaw(value)) {
       return value;
     }

--- a/packages/knex/src/SqlEntityManager.ts
+++ b/packages/knex/src/SqlEntityManager.ts
@@ -27,16 +27,6 @@ export class SqlEntityManager<D extends AbstractSqlDriver = AbstractSqlDriver> e
   }
 
   /**
-   * Creates raw SQL query that won't be escaped when used as a parameter.
-   */
-  raw<R = Knex.Raw>(sql: string, bindings: Knex.RawBinding[] | Knex.ValueDict = []): R {
-    const raw = this.getKnex().raw(sql, bindings);
-    (raw as Dictionary).__raw = true; // tag it as there is now way to check via `instanceof`
-
-    return raw as unknown as R;
-  }
-
-  /**
    * Returns configured knex instance.
    */
   getKnex(type?: ConnectionType) {

--- a/packages/knex/src/query/CriteriaNodeFactory.ts
+++ b/packages/knex/src/query/CriteriaNodeFactory.ts
@@ -13,7 +13,7 @@ export class CriteriaNodeFactory {
 
   static createNode<T extends object>(metadata: MetadataStorage, entityName: string, payload: any, parent?: ICriteriaNode<T>, key?: EntityKey<T>): ICriteriaNode<T> {
     const customExpression = CriteriaNode.isCustomExpression(key || '');
-    const scalar = Utils.isPrimaryKey(payload) || payload as unknown instanceof RegExp || payload as unknown instanceof Date || customExpression;
+    const scalar = Utils.isPrimaryKey(payload) || Utils.isRawSql(payload) || payload as unknown instanceof RegExp || payload as unknown instanceof Date || customExpression;
 
     if (Array.isArray(payload) && !scalar) {
       return this.createArrayNode(metadata, entityName, payload, parent, key);

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -23,6 +23,7 @@ import type {
   RequiredEntityData,
 } from '@mikro-orm/core';
 import {
+  raw,
   helper,
   LoadStrategy,
   LockMode,
@@ -190,7 +191,7 @@ export class QueryBuilder<T extends object = AnyEntity> {
     } else if (this.hasToManyJoins()) {
       this._fields = this.mainAlias.metadata!.primaryKeys;
     } else {
-      this._fields = [this.raw('*')];
+      this._fields = [raw('*')];
     }
 
     if (distinct) {
@@ -392,13 +393,6 @@ export class QueryBuilder<T extends object = AnyEntity> {
     return this.knex.ref(field);
   }
 
-  raw<R = Knex.Raw>(sql: string, bindings: Knex.RawBinding[] | Knex.ValueDict = []): R {
-    const raw = this.knex.raw(sql, bindings);
-    (raw as Dictionary).__raw = true; // tag it as there is now way to check via `instanceof`
-
-    return raw as unknown as R;
-  }
-
   limit(limit?: number, offset = 0): this {
     this.ensureNotFinalized();
     this._limit = limit;
@@ -520,7 +514,7 @@ export class QueryBuilder<T extends object = AnyEntity> {
       this.helper.getLockSQL(qb, this.lockMode, this.lockTables);
     }
 
-    this.helper.finalize(this.type ?? QueryType.SELECT, qb, this.mainAlias.metadata);
+    this.helper.finalize(this.type ?? QueryType.SELECT, qb, this.mainAlias.metadata, this._data);
 
     return qb;
   }

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -1,9 +1,29 @@
 import { v4 } from 'uuid';
 import { inspect } from 'util';
 import { SqlHighlighter } from '@mikro-orm/sql-highlighter';
-import { Collection, Configuration, EntityManager, LockMode, MikroORM, QueryFlag, QueryOrder, Reference, ValidationError, wrap,
-  UniqueConstraintViolationException, TableNotFoundException, TableExistsException, SyntaxErrorException, NonUniqueFieldNameException,
-  InvalidFieldNameException, expr, IsolationLevel, NullHighlighter, PopulateHint } from '@mikro-orm/core';
+import {
+  Collection,
+  Configuration,
+  EntityManager,
+  LockMode,
+  MikroORM,
+  QueryFlag,
+  QueryOrder,
+  Reference,
+  ValidationError,
+  wrap,
+  UniqueConstraintViolationException,
+  TableNotFoundException,
+  TableExistsException,
+  SyntaxErrorException,
+  NonUniqueFieldNameException,
+  InvalidFieldNameException,
+  expr,
+  IsolationLevel,
+  NullHighlighter,
+  PopulateHint,
+  raw,
+} from '@mikro-orm/core';
 import { MySqlDriver, MySqlConnection } from '@mikro-orm/mysql';
 import { Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, PublisherType, Test2 } from './entities-sql';
 import { initORMMySql, mockLogger } from './bootstrap';
@@ -1787,6 +1807,59 @@ describe('EntityManagerMySql', () => {
     await expect(orm.em.count(Book2, [book1, book2, book3])).resolves.toBe(3);
     const a = await orm.em.find(Book2, [book1, book2, book3]) as Book2[];
     await expect(orm.em.getRepository(Book2).count([book1, book2, book3])).resolves.toBe(3);
+  });
+
+  test('insert with raw sql fragment', async () => {
+    const author = orm.em.create(Author2, { id: 1, name: 'name', email: 'email', age: raw('100 + 20 + 3') });
+    const mock = mockLogger(orm, ['query', 'query-params']);
+    expect(() => author.age!++).toThrow();
+    expect(() => JSON.stringify(author)).toThrow();
+    await orm.em.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch(/insert into `author2` \(`id`, `created_at`, `updated_at`, `name`, `email`, `age`, `terms_accepted`\) values \(1, '.*', '.*', 'name', 'email', 100 \+ 20 \+ 3, false\)/);
+    expect(mock.mock.calls[2][0]).toMatch('select `a0`.`id`, `a0`.`age` from `author2` as `a0` where `a0`.`id` in (1)');
+    expect(mock.mock.calls[3][0]).toMatch('commit');
+
+    expect(author.age).toBe(123);
+  });
+
+  test('update with raw sql fragment', async () => {
+    await orm.em.insert(Author2, { id: 1, name: 'name', email: 'email', age: 123 });
+    const mock = mockLogger(orm, ['query', 'query-params']);
+
+    const ref = orm.em.getReference(Author2, 1);
+    ref.age = raw(`age * 2`);
+    await orm.em.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch(/update `author2` set `age` = age \* 2, `updated_at` = '.*' where `id` = 1/);
+    expect(mock.mock.calls[2][0]).toMatch('select `a0`.`id`, `a0`.`age` from `author2` as `a0` where `a0`.`id` in (1)');
+    expect(mock.mock.calls[3][0]).toMatch('commit');
+
+    expect(ref.age).toBe(246);
+  });
+
+  test('update with raw sql fragment (batch)', async () => {
+    await orm.em.insertMany(Author2, [
+      { id: 1, name: 'name 1', email: 'email 1', age: 123 },
+      { id: 2, name: 'name 2', email: 'email 2', age: 222 },
+    ]);
+    const mock = mockLogger(orm, ['query', 'query-params']);
+
+    const ref1 = orm.em.getReference(Author2, 1);
+    const ref2 = orm.em.getReference(Author2, 2);
+    ref1.age = raw(`age * 2`);
+    ref2.age = raw(`age / 2`);
+    await orm.em.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch(/update `author2` set `age` = case when \(`id` = 1\) then age \* 2 when \(`id` = 2\) then age \/ 2 else `age` end, `updated_at` = case when \(`id` = 1\) then '.*' when \(`id` = 2\) then '.*' else `updated_at` end where `id` in \(1, 2\)/);
+    expect(mock.mock.calls[2][0]).toMatch('select `a0`.`id`, `a0`.`age` from `author2` as `a0` where `a0`.`id` in (1, 2)');
+    expect(mock.mock.calls[3][0]).toMatch('commit');
+
+    expect(ref1.age).toBe(246);
+    expect(ref2.age).toBe(111);
   });
 
   test('find by joined property', async () => {

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -1,9 +1,30 @@
 import { v4 } from 'uuid';
 import type { EventSubscriber, ChangeSet, AnyEntity, FlushEventArgs, FilterQuery } from '@mikro-orm/core';
 import {
-  Collection, Configuration, EntityManager, LockMode, MikroORM, QueryFlag, QueryOrder, Reference, ValidationError, ChangeSetType, wrap, expr,
-  UniqueConstraintViolationException, TableNotFoundException, NotNullConstraintViolationException, TableExistsException, SyntaxErrorException,
-  NonUniqueFieldNameException, InvalidFieldNameException, LoadStrategy, IsolationLevel, PopulateHint, ref,
+  Collection,
+  Configuration,
+  EntityManager,
+  LockMode,
+  MikroORM,
+  QueryFlag,
+  QueryOrder,
+  Reference,
+  ValidationError,
+  ChangeSetType,
+  wrap,
+  expr,
+  UniqueConstraintViolationException,
+  TableNotFoundException,
+  NotNullConstraintViolationException,
+  TableExistsException,
+  SyntaxErrorException,
+  NonUniqueFieldNameException,
+  InvalidFieldNameException,
+  LoadStrategy,
+  IsolationLevel,
+  PopulateHint,
+  ref,
+  raw,
 } from '@mikro-orm/core';
 import { PostgreSqlDriver, PostgreSqlConnection } from '@mikro-orm/postgresql';
 import { Address2, Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, PublisherType, PublisherType2, Test2, Label2 } from './entities-sql';
@@ -234,7 +255,7 @@ describe('EntityManagerPostgre', () => {
     } catch { }
 
     expect(mock.mock.calls[0][0]).toMatch('begin isolation level read uncommitted');
-    expect(mock.mock.calls[1][0]).toMatch('insert into "author2" ("created_at", "updated_at", "name", "email", "terms_accepted") values ($1, $2, $3, $4, $5) returning "id", "created_at", "updated_at", "age", "terms_accepted"');
+    expect(mock.mock.calls[1][0]).toMatch('insert into "author2" ("created_at", "updated_at", "name", "email", "terms_accepted") values ($1, $2, $3, $4, $5) returning "id", "age"');
     expect(mock.mock.calls[2][0]).toMatch('rollback');
   });
 
@@ -1256,7 +1277,7 @@ describe('EntityManagerPostgre', () => {
 
     expect(mock.mock.calls[0][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."author_id" = $1 order by "b0"."title" asc`);
     expect(mock.mock.calls[1][0]).toMatch(`begin`);
-    expect(mock.mock.calls[2][0]).toMatch(`insert into "book2" ("uuid_pk", "created_at", "title", "price", "author_id") values ($1, $2, $3, $4, $5) returning "uuid_pk", "created_at", "title"`);
+    expect(mock.mock.calls[2][0]).toMatch(`insert into "book2" ("uuid_pk", "created_at", "title", "price", "author_id") values ($1, $2, $3, $4, $5)`);
     expect(mock.mock.calls[3][0]).toMatch(`commit`);
   });
 
@@ -1521,10 +1542,68 @@ describe('EntityManagerPostgre', () => {
     orm.em.clear();
 
     const books2 = await orm.em.find(Book2, {
-      [expr('upper(title)')]: orm.em.getKnex().raw('upper(?)', ['b2']),
+      [expr('upper(title)')]: raw('upper(?)', ['b2']),
     }, { populate: ['perex'] });
     expect(books2).toHaveLength(1);
     expect(mock.mock.calls[1][0]).toMatch(`select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and upper(title) = upper('b2')`);
+  });
+
+  test('insert with raw sql fragment', async () => {
+    const author = orm.em.create(Author2, { id: 1, name: 'name', email: 'email', age: raw('100 + 20 + 3') });
+    const mock = mockLogger(orm, ['query', 'query-params']);
+    expect(() => author.age!++).toThrow();
+    expect(() => JSON.stringify(author)).toThrow();
+    await orm.em.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch(/insert into "author2" \("id", "created_at", "updated_at", "name", "email", "age", "terms_accepted"\) values \(1, '.*', '.*', 'name', 'email', 100 \+ 20 \+ 3, false\) returning "age"/);
+    expect(mock.mock.calls[2][0]).toMatch('commit');
+
+    expect(author.age).toBe(123);
+  });
+
+  test('update with raw sql fragment', async () => {
+    await orm.em.insertMany(Author2, [
+      { id: 1, name: 'name', email: 'email1', age: 123 },
+      { id: 2, name: 'name', email: 'email2', age: 1 },
+    ]);
+    const ref1 = await orm.em.findOneOrFail(Author2, 1);
+    const ref2 = await orm.em.findOneOrFail(Author2, 2);
+
+    const mock = mockLogger(orm, ['query', 'query-params']);
+    ref1.age = raw(`age * 2`);
+    expect(() => ref1.age!++).toThrow();
+    expect(() => ref2.age = ref1.age).toThrow();
+    expect(() => JSON.stringify(ref1)).toThrow();
+    await orm.em.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch(/update "author2" set "age" = age \* 2, "updated_at" = '.*' where "id" = 1 returning "age"/);
+    expect(mock.mock.calls[2][0]).toMatch('commit');
+
+    expect(ref1.age).toBe(246);
+  });
+
+  test('update with raw sql fragment (batch)', async () => {
+    await orm.em.insertMany(Author2, [
+      { id: 1, name: 'name 1', email: 'email 1', age: 123 },
+      { id: 2, name: 'name 2', email: 'email 2', age: 222 },
+    ]);
+    const mock = mockLogger(orm, ['query', 'query-params']);
+
+    const ref1 = orm.em.getReference(Author2, 1);
+    const ref2 = orm.em.getReference(Author2, 2);
+    ref1.age = raw(`age * 2`);
+    ref2.age = raw(`age / 2`);
+
+    await orm.em.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch('begin');
+    expect(mock.mock.calls[1][0]).toMatch(/update "author2" set "age" = case when \("id" = 1\) then age \* 2 when \("id" = 2\) then age \/ 2 else "age" end, "updated_at" = case when \("id" = 1\) then '.*' when \("id" = 2\) then '.*' else "updated_at" end where "id" in \(1, 2\) returning "age"/);
+    expect(mock.mock.calls[2][0]).toMatch('commit');
+
+    expect(ref1.age).toBe(246);
+    expect(ref2.age).toBe(111);
   });
 
   test('find by joined property', async () => {
@@ -1996,8 +2075,8 @@ describe('EntityManagerPostgre', () => {
     expect(b.publisher.unwrap()).toBe(ref2);
 
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('insert into "author2" ("created_at", "updated_at", "name", "email", "terms_accepted") values ($1, $2, $3, $4, $5) returning "id", "created_at", "updated_at", "age", "terms_accepted"');
-    expect(mock.mock.calls[2][0]).toMatch('insert into "book2" ("uuid_pk", "created_at", "title", "price", "author_id", "publisher_id") values ($1, $2, $3, $4, $5, $6) returning "uuid_pk", "created_at", "title"');
+    expect(mock.mock.calls[1][0]).toMatch('insert into "author2" ("created_at", "updated_at", "name", "email", "terms_accepted") values ($1, $2, $3, $4, $5) returning "id", "age"');
+    expect(mock.mock.calls[2][0]).toMatch('insert into "book2" ("uuid_pk", "created_at", "title", "price", "author_id", "publisher_id") values ($1, $2, $3, $4, $5, $6)');
     expect(mock.mock.calls[3][0]).toMatch('commit');
     expect(mock.mock.calls[4][0]).toMatch('begin');
     expect(mock.mock.calls[5][0]).toMatch('update "book2" set "publisher_id" = $1 where "uuid_pk" = $2');
@@ -2035,8 +2114,8 @@ describe('EntityManagerPostgre', () => {
 
     // flushing things at the same tick will even batch the queries
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('insert into "author2" ("created_at", "updated_at", "name", "email", "terms_accepted") values ($1, $2, $3, $4, $5), ($6, $7, $8, $9, $10), ($11, $12, $13, $14, $15) returning "id", "created_at", "updated_at", "age", "terms_accepted"');
-    expect(mock.mock.calls[2][0]).toMatch('insert into "book2" ("uuid_pk", "created_at", "title", "price", "author_id") values ($1, $2, $3, $4, $5), ($6, $7, $8, $9, $10), ($11, $12, $13, $14, $15) returning "uuid_pk", "created_at", "title"');
+    expect(mock.mock.calls[1][0]).toMatch('insert into "author2" ("created_at", "updated_at", "name", "email", "terms_accepted") values ($1, $2, $3, $4, $5), ($6, $7, $8, $9, $10), ($11, $12, $13, $14, $15) returning "id", "age"');
+    expect(mock.mock.calls[2][0]).toMatch('insert into "book2" ("uuid_pk", "created_at", "title", "price", "author_id") values ($1, $2, $3, $4, $5), ($6, $7, $8, $9, $10), ($11, $12, $13, $14, $15)');
     expect(mock.mock.calls[3][0]).toMatch('commit');
 
     expect(ret.map(b => b.author.id)).toEqual([1, 2, 3]);
@@ -2073,16 +2152,16 @@ describe('EntityManagerPostgre', () => {
 
     // flushing things at different time will create multiple transactions
     expect(mock.mock.calls[0][0]).toMatch(`begin`);
-    expect(mock.mock.calls[1][0]).toMatch(`insert into "author2" ("created_at", "updated_at", "name", "email", "terms_accepted") values ($1, $2, $3, $4, $5) returning "id", "created_at", "updated_at", "age", "terms_accepted"`);
-    expect(mock.mock.calls[2][0]).toMatch(`insert into "book2" ("uuid_pk", "created_at", "title", "price", "author_id") values ($1, $2, $3, $4, $5) returning "uuid_pk", "created_at", "title"`);
+    expect(mock.mock.calls[1][0]).toMatch(`insert into "author2" ("created_at", "updated_at", "name", "email", "terms_accepted") values ($1, $2, $3, $4, $5) returning "id", "age"`);
+    expect(mock.mock.calls[2][0]).toMatch(`insert into "book2" ("uuid_pk", "created_at", "title", "price", "author_id") values ($1, $2, $3, $4, $5)`);
     expect(mock.mock.calls[3][0]).toMatch(`commit`);
     expect(mock.mock.calls[4][0]).toMatch(`begin`);
-    expect(mock.mock.calls[5][0]).toMatch(`insert into "author2" ("created_at", "updated_at", "name", "email", "terms_accepted") values ($1, $2, $3, $4, $5) returning "id", "created_at", "updated_at", "age", "terms_accepted"`);
-    expect(mock.mock.calls[6][0]).toMatch(`insert into "book2" ("uuid_pk", "created_at", "title", "price", "author_id") values ($1, $2, $3, $4, $5) returning "uuid_pk", "created_at", "title"`);
+    expect(mock.mock.calls[5][0]).toMatch(`insert into "author2" ("created_at", "updated_at", "name", "email", "terms_accepted") values ($1, $2, $3, $4, $5) returning "id", "age"`);
+    expect(mock.mock.calls[6][0]).toMatch(`insert into "book2" ("uuid_pk", "created_at", "title", "price", "author_id") values ($1, $2, $3, $4, $5)`);
     expect(mock.mock.calls[7][0]).toMatch(`commit`);
     expect(mock.mock.calls[8][0]).toMatch(`begin`);
-    expect(mock.mock.calls[9][0]).toMatch(`insert into "author2" ("created_at", "updated_at", "name", "email", "terms_accepted") values ($1, $2, $3, $4, $5) returning "id", "created_at", "updated_at", "age", "terms_accepted"`);
-    expect(mock.mock.calls[10][0]).toMatch(`insert into "book2" ("uuid_pk", "created_at", "title", "price", "author_id") values ($1, $2, $3, $4, $5) returning "uuid_pk", "created_at", "title"`);
+    expect(mock.mock.calls[9][0]).toMatch(`insert into "author2" ("created_at", "updated_at", "name", "email", "terms_accepted") values ($1, $2, $3, $4, $5) returning "id", "age"`);
+    expect(mock.mock.calls[10][0]).toMatch(`insert into "book2" ("uuid_pk", "created_at", "title", "price", "author_id") values ($1, $2, $3, $4, $5)`);
     expect(mock.mock.calls[11][0]).toMatch(`commit`);
 
     mock.mockRestore();

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -1,5 +1,5 @@
 import { inspect } from 'util';
-import { expr, LockMode, MikroORM, QueryFlag, QueryOrder, UnderscoreNamingStrategy } from '@mikro-orm/core';
+import { expr, LockMode, MikroORM, QueryFlag, QueryOrder, raw, UnderscoreNamingStrategy } from '@mikro-orm/core';
 import { CriteriaNode, QueryBuilder, PostgreSqlDriver } from '@mikro-orm/postgresql';
 import { MySqlDriver } from '@mikro-orm/mysql';
 import { Address2, Author2, Book2, BookTag2, Car2, CarOwner2, Configuration2, FooBar2, FooBaz2, FooParam2, Publisher2, PublisherType, Test2, User2 } from './entities-sql';
@@ -1460,21 +1460,13 @@ describe('QueryBuilder', () => {
 
   test('update query with column reference', async () => {
     const qb = orm.em.createQueryBuilder(Book2);
-    qb.update({ price: qb.raw('price + 1') }).where({ uuid: '123' });
-    expect(qb.getQuery()).toEqual('update `book2` set `price` = price + 1 where `uuid_pk` = ?');
-    expect(qb.getParams()).toEqual(['123']);
+    qb.update({ price: raw('price + 1') }).where({ uuid: '123' });
+    expect(qb.getFormattedQuery()).toEqual('update `book2` set `price` = price + 1 where `uuid_pk` = \'123\'');
   });
 
-  test('update query with column reference via static raw helper', async () => {
+  test('count query with column reference', async () => {
     const qb = orm.em.createQueryBuilder(Book2);
-    qb.update({ price: orm.em.raw('price + 1') }).where({ uuid: '123' });
-    expect(qb.getQuery()).toEqual('update `book2` set `price` = price + 1 where `uuid_pk` = ?');
-    expect(qb.getParams()).toEqual(['123']);
-  });
-
-  test('count query with column reference via static raw helper', async () => {
-    const qb = orm.em.createQueryBuilder(Book2);
-    await qb.where({ price: orm.em.raw('price + 1') }).getCount();
+    await qb.where({ price: raw('price + 1') }).getCount();
   });
 
   test('gh issue 3182', async () => {
@@ -1484,15 +1476,15 @@ describe('QueryBuilder', () => {
 
   test('update query with JSON type and raw value', async () => {
     const qb = orm.em.createQueryBuilder(Book2);
-    const raw = qb.raw<any>(`jsonb_set(payload, '$.{consumed}', ?)`, [123]);
-    qb.update({ meta: raw }).where({ uuid: '456' });
+    const meta = raw(`jsonb_set(payload, '$.{consumed}', ?)`, [123]);
+    qb.update({ meta }).where({ uuid: '456' });
     expect(qb.getFormattedQuery()).toEqual('update `book2` set `meta` = jsonb_set(payload, \'$.{consumed}\', 123) where `uuid_pk` = \'456\'');
   });
 
-  test('qb.raw() with named bindings', async () => {
+  test('raw() with named bindings', async () => {
     const qb = orm.em.createQueryBuilder(Book2);
-    const raw = qb.raw<any>(`jsonb_set(payload, '$.{consumed}', :val)`, { val: 123 });
-    qb.update({ meta: raw }).where({ uuid: '456' });
+    const meta = raw(`jsonb_set(payload, '$.{consumed}', :val)`, { val: 123 });
+    qb.update({ meta }).where({ uuid: '456' });
     expect(qb.getFormattedQuery()).toEqual('update `book2` set `meta` = jsonb_set(payload, \'$.{consumed}\', 123) where `uuid_pk` = \'456\'');
   });
 

--- a/tests/features/composite-keys/GH1079.test.ts
+++ b/tests/features/composite-keys/GH1079.test.ts
@@ -132,7 +132,7 @@ describe('GH issue 1079', () => {
 
     const queries: string[] = mock.mock.calls.map(c => c[0]);
     expect(queries[0]).toMatch(`begin`);
-    expect(queries[1]).toMatch(`insert into "user" ("_id") values ($1) returning "_id"`);
+    expect(queries[1]).toMatch(`insert into "user" ("_id") values ($1)`);
     expect(queries[2]).toMatch(`insert into "wallet" ("currency_ref", "owner__id", "main_balance") values ($1, $2, $3)`);
     expect(queries[3]).toMatch(`insert into "deposit" ("tx_ref", "wallet_currency_ref", "wallet_owner__id", "amount", "gateway_key", "created_at", "updated_at", "status") values ($1, $2, $3, $4, $5, $6, $7, $8)`);
     expect(queries[4]).toMatch(`commit`);

--- a/tests/features/filters/filters.postgres.test.ts
+++ b/tests/features/filters/filters.postgres.test.ts
@@ -1,4 +1,14 @@
-import { Collection, Entity, ManyToMany, MikroORM, PrimaryKey, Property, Filter, ManyToOne } from '@mikro-orm/core';
+import {
+  Collection,
+  Entity,
+  ManyToMany,
+  MikroORM,
+  PrimaryKey,
+  Property,
+  Filter,
+  ManyToOne,
+  raw,
+} from '@mikro-orm/core';
 import type { AbstractSqlDriver, EntityManager } from '@mikro-orm/knex';
 import { mockLogger } from '../../helpers';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
@@ -62,7 +72,7 @@ class User {
 @Entity()
 @Filter({
   name: 'user',
-  cond: (_args, _type, em: EntityManager) => ({ user: { $or: [{ firstName: 'name' }, { lastName: 'name' }, { age: em.raw('(select 1 + 1)') }] } }),
+  cond: () => ({ user: { $or: [{ firstName: 'name' }, { lastName: 'name' }, { age: raw('(select 1 + 1)') }] } }),
   default: true,
   args: false,
 })
@@ -145,7 +155,7 @@ describe('filters [postgres]', () => {
     }, { filters: false });
 
     expect(mock.mock.calls[0][0]).toMatch(`select "u0".* from "user" as "u0" where ("u0"."age" = $1 or "u0"."age" = $2) and ("u0"."first_name" = $3 or "u0"."last_name" = $4)`);
-    expect(mock.mock.calls[1][0]).toMatch(`select "m0".* from "membership" as "m0" left join "user" as "u1" on "m0"."user_id" = "u1"."id" where ("u1"."first_name" = $1 or "u1"."last_name" = $2 or "u1"."age" = (select 1 + 1)) and ("m0"."role" = $3 or "m0"."role" = $4)`);
+    expect(mock.mock.calls[1][0]).toMatch(`select "m0".* from "membership" as "m0" left join "user" as "u1" on "m0"."user_id" = "u1"."id" where ("u1"."first_name" = $1 or "u1"."last_name" = $2 or "u1"."age" = $3) and ("m0"."role" = $4 or "m0"."role" = $5)`);
     expect(mock.mock.calls[2][0]).toMatch(`select "m0".* from "membership" as "m0" left join "user" as "u1" on "m0"."user_id" = "u1"."id" where ("m0"."role" = $1 or "m0"."role" = $2) and ("u1"."first_name" = $3 or "u1"."last_name" = $4)`);
   });
 

--- a/tests/features/multiple-schemas/GH3177.test.ts
+++ b/tests/features/multiple-schemas/GH3177.test.ts
@@ -89,9 +89,9 @@ test(`GH issue 3177`, async () => {
 
   expect(mock.mock.calls[0][0]).toMatch(`begin`);
   expect(mock.mock.calls[1][0]).toMatch(`insert into "tenant_01"."user_access_profile" ("id") values (default) returning "id"`);
-  expect(mock.mock.calls[2][0]).toMatch(`insert into "tenant_01"."user" ("id", "access_profile_id") values (1, 1) returning "id"`);
+  expect(mock.mock.calls[2][0]).toMatch(`insert into "tenant_01"."user" ("id", "access_profile_id") values (1, 1)`);
   expect(mock.mock.calls[3][0]).toMatch(`insert into "public"."permission" ("id") values (default), (default), (default) returning "id"`);
-  expect(mock.mock.calls[4][0]).toMatch(`insert into "tenant_01"."user_access_profile_permissions" ("user_access_profile_id", "permission_id") values (1, 1), (1, 2), (1, 3) returning "user_access_profile_id", "permission_id"`);
+  expect(mock.mock.calls[4][0]).toMatch(`insert into "tenant_01"."user_access_profile_permissions" ("user_access_profile_id", "permission_id") values (1, 1), (1, 2), (1, 3)`);
   expect(mock.mock.calls[5][0]).toMatch(`commit`);
   expect(mock.mock.calls[6][0]).toMatch(`select "u0".* from "tenant_01"."user" as "u0" where "u0"."id" = 1 limit 1`);
   expect(mock.mock.calls[7][0]).toMatch(`select "p0".* from "public"."permission" as "p0" where "p0"."id" in (1, 2, 3)`);

--- a/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
+++ b/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
@@ -252,10 +252,10 @@ describe('multiple connected schemas in postgres', () => {
     expect(mock.mock.calls[7][0]).toMatch(`insert into "n4"."book" ("author_id") values (1) returning "id"`);
     expect(mock.mock.calls[8][0]).toMatch(`update "n5"."book" set "based_on_id" = 1 where "id" = 1`);
     expect(mock.mock.calls[9][0]).toMatch(`update "n4"."book" set "based_on_id" = 1 where "id" = 1`);
-    expect(mock.mock.calls[10][0]).toMatch(`insert into "n3"."book_tags" ("book_id", "book_tag_id") values (1, 1), (1, 2), (1, 3) returning "book_id", "book_tag_id"`);
-    expect(mock.mock.calls[11][0]).toMatch(`insert into "n5"."book_tags" ("book_id", "book_tag_id") values (1, 1), (1, 2), (1, 3) returning "book_id", "book_tag_id"`);
-    expect(mock.mock.calls[12][0]).toMatch(`insert into "n5"."book_tags" ("book_id", "book_tag_id") values (2, 4), (2, 5), (2, 6) returning "book_id", "book_tag_id"`);
-    expect(mock.mock.calls[13][0]).toMatch(`insert into "n4"."book_tags" ("book_id", "book_tag_id") values (1, 1), (1, 2), (1, 3) returning "book_id", "book_tag_id"`);
+    expect(mock.mock.calls[10][0]).toMatch(`insert into "n3"."book_tags" ("book_id", "book_tag_id") values (1, 1), (1, 2), (1, 3)`);
+    expect(mock.mock.calls[11][0]).toMatch(`insert into "n5"."book_tags" ("book_id", "book_tag_id") values (1, 1), (1, 2), (1, 3)`);
+    expect(mock.mock.calls[12][0]).toMatch(`insert into "n5"."book_tags" ("book_id", "book_tag_id") values (2, 4), (2, 5), (2, 6)`);
+    expect(mock.mock.calls[13][0]).toMatch(`insert into "n4"."book_tags" ("book_id", "book_tag_id") values (1, 1), (1, 2), (1, 3)`);
     expect(mock.mock.calls[14][0]).toMatch(`commit`);
     mock.mockReset();
 

--- a/tests/features/upsert/GH3787-2.test.ts
+++ b/tests/features/upsert/GH3787-2.test.ts
@@ -57,8 +57,8 @@ test('JSON serialization with upsert', async () => {
   });
   await orm.em.upsert(entity2);
   expect(mock.mock.calls).toEqual([
-    ['[query] insert into `my_entity1` (`field`, `id`) values (\'{"firstName":"John","lastName":"Doe"}\', 1) on conflict (`id`) do update set `field` = excluded.`field` returning `id`'],
-    ['[query] insert into `my_entity2` (`field`, `id`) values (\'{"firstName":"Albert","lastName":"Doe"}\', 1) on conflict (`id`) do update set `field` = excluded.`field` returning `id`'],
+    ['[query] insert into `my_entity1` (`field`, `id`) values (\'{"firstName":"John","lastName":"Doe"}\', 1) on conflict (`id`) do update set `field` = excluded.`field`'],
+    ['[query] insert into `my_entity2` (`field`, `id`) values (\'{"firstName":"Albert","lastName":"Doe"}\', 1) on conflict (`id`) do update set `field` = excluded.`field`'],
   ]);
 });
 

--- a/tests/features/upsert/GH4020.test.ts
+++ b/tests/features/upsert/GH4020.test.ts
@@ -40,6 +40,6 @@ test('GH issue 4020', async () => {
 
   expect(e.created_at).toBeInstanceOf(Date);
   expect(mock.mock.calls).toEqual([
-    ["[query] insert into `guild_entity` (`id`, `name`) values ('1', 'name') on conflict (`id`) do update set `name` = excluded.`name` returning `id`, `created_at`"],
+    ["[query] insert into `guild_entity` (`id`, `name`) values ('1', 'name') on conflict (`id`) do update set `name` = excluded.`name` returning `created_at`"],
   ]);
 });

--- a/tests/issues/GH3810.test.ts
+++ b/tests/issues/GH3810.test.ts
@@ -45,7 +45,7 @@ test('3810', async () => {
 
   expect(mock.mock.calls).toEqual([
     ['[query] begin'],
-    ["[query] insert into \"user\" (\"options\") values ('{\"foo,\"}') returning \"id\", \"options\""],
+    ["[query] insert into \"user\" (\"options\") values ('{\"foo,\"}') returning \"id\""],
     ['[query] commit'],
     ['[query] begin'],
     ["[query] update \"user\" set \"options\" = '{\"foo,\",\"asd,\",bar,\",baz\"}' where \"id\" = 1"],

--- a/tests/issues/GH3988.test.ts
+++ b/tests/issues/GH3988.test.ts
@@ -107,8 +107,8 @@ it('should create and persist entity along with child entity', async () => {
   await parentRepository.persistAndFlush(parent);
   expect(mock.mock.calls).toEqual([
     ['[query] begin'],
-    ['[query] insert into `parent_entity` (`id`, `id2`) values (1, 2) returning `id`, `id2`'],
-    ['[query] insert into `child_entity` (`id`, `parent_id`, `parent_id2`) values (1, 1, 2) returning `id`'],
+    ['[query] insert into `parent_entity` (`id`, `id2`) values (1, 2)'],
+    ['[query] insert into `child_entity` (`id`, `parent_id`, `parent_id2`) values (1, 1, 2)'],
     ['[query] commit'],
   ]);
 });

--- a/tests/issues/GH4027.test.ts
+++ b/tests/issues/GH4027.test.ts
@@ -66,11 +66,11 @@ test('GH 4027', async () => {
 
   expect(mock.mock.calls).toEqual([
     ['[query] begin'],
-    ["[query] insert into `child` (`id`, `created_at`) values ('e80ccf60-5cb2-4972-9227-7a4b9138c845', 1676050010440) returning `id`"],
+    ["[query] insert into `child` (`id`, `created_at`) values ('e80ccf60-5cb2-4972-9227-7a4b9138c845', 1676050010440)"],
     ['[query] commit'],
     ['[query] begin'],
-    ["[query] insert into `parent` (`id`, `created_at`) values ('9a061473-4a98-477d-ad03-fd7bcba3ec4f', 1676050010441) returning `id`"],
-    ["[query] insert into `parent_refs` (`parent_id`, `child_id`) values ('9a061473-4a98-477d-ad03-fd7bcba3ec4f', 'e80ccf60-5cb2-4972-9227-7a4b9138c845') returning `parent_id`, `child_id`"],
+    ["[query] insert into `parent` (`id`, `created_at`) values ('9a061473-4a98-477d-ad03-fd7bcba3ec4f', 1676050010441)"],
+    ["[query] insert into `parent_refs` (`parent_id`, `child_id`) values ('9a061473-4a98-477d-ad03-fd7bcba3ec4f', 'e80ccf60-5cb2-4972-9227-7a4b9138c845')"],
     ['[query] commit'],
   ]);
 });

--- a/tests/issues/GH482.test.ts
+++ b/tests/issues/GH482.test.ts
@@ -99,7 +99,7 @@ describe('GH issue 482', () => {
     expect(j.optional).toBeNull();
 
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch(`insert into "job" ("id", "optional") values ('2', '1') returning "id"`);
+    expect(mock.mock.calls[1][0]).toMatch(`insert into "job" ("id", "optional") values ('2', '1')`);
     expect(mock.mock.calls[2][0]).toMatch('commit');
     expect(mock.mock.calls[3][0]).toMatch('begin');
     expect(mock.mock.calls[4][0]).toMatch(`update "job" set "optional" = NULL where "id" = '2'`);


### PR DESCRIPTION
When you want to issue an atomic update query via flush, you can use the static `raw()` helper:

```ts
const ref = em.getReference(Author, 123);
ref.age = raw(`age * 2`);

await em.flush();
console.log(ref.age); // real value is available after flush
```

The `raw()` helper returns special raw query fragment object. It disallows serialization (via `toJSON`) as well as working with the value (via [`valueOf()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf)). Only single use of this value is allowed, if you try to reassign it to another entity, an error will be thrown to protect you from mistakes like this:

```ts
order.number = raw(`(select max(num) + 1 from orders)`);
user.lastOrderNumber = order.number; // throws, it could resolve to a different value
JSON.stringify(order); // throws, raw value cannot be serialized
```

Closes #3657