### PR TITLE
docs: format markdown with prettier

### DIFF
--- a/docs/.prettierrc
+++ b/docs/.prettierrc
@@ -1,0 +1,11 @@
+printWidth: 160
+tabWidth: 2
+semi: true
+singleQuote: true
+quoteProps: consistent
+trailingComma: 'all'
+bracketSpacing: true
+arrowParens: avoid
+proseWrap: never
+bracketSameLine: true
+embeddedLanguageFormatting: off

--- a/docs/blog/2019-04-08-introducing-mikroorm-typescript-data-mapper-orm-with-identity-map.md
+++ b/docs/blog/2019-04-08-introducing-mikroorm-typescript-data-mapper-orm-with-identity-map.md
@@ -188,7 +188,7 @@ To fetch entities from database you can use `find()` and `findOne()` methods of 
 
 ```typescript
 // find all authors with name matching 'Jon', and populate all of their books
-const authors = await orm.em.find(Author, { name: /Jon/ }, ['books']); 
+const authors = await orm.em.find(Author, { name: /Jon/ }, ['books']);
 
 for (const author of authors) {
   console.log(author.name); // Jon Snow
@@ -217,7 +217,7 @@ const booksRepository = orm.em.getRepository(Book);
 const books = await booksRepository.find({ author: '...' }, ['author'], { title: QueryOrder.DESC }, 2, 1);
 
 // or with options object
-const books = await booksRepository.find({ author: '...' }, { 
+const books = await booksRepository.find({ author: '...' }, {
   populate: ['author'],
   limit: 1,
   offset: 2,
@@ -245,7 +245,7 @@ console.log(author.name); // undefined
 console.log(author === book.author); // true
 
 // this will trigger db call, we could also use `orm.em.findOne(Author, author.id)` to do the same
-await author.init(); 
+await author.init();
 console.log(author.isInitialized()); // true
 console.log(author.name); // defined
 ```
@@ -305,14 +305,14 @@ More information about collections can be found [in the docs](https://b4nan.gith
 
 So you read through the whole article, got here and still not satisfied? There are more articles to come (beginning with integration manual for popular frameworks like [Express](https://expressjs.com/) or [NestJS](https://nestjs.com/)), but you can take a look at some advanced features covered in docs right now:
 
-*   [Smart nested populate](https://b4nan.github.io/mikro-orm/nested-populate/)
-*   [Smart query conditions](https://b4nan.github.io/mikro-orm/query-conditions/)
-*   [Updating entity values with `IEntity.assign()`](https://b4nan.github.io/mikro-orm/entity-helper/) 
-*   [Property validation](https://b4nan.github.io/mikro-orm/property-validation/)
-*   [Lifecycle hooks](https://b4nan.github.io/mikro-orm/lifecycle-hooks/)
-*   [Naming strategy](https://b4nan.github.io/mikro-orm/naming-strategy/)
-*   [Usage with NestJS](https://b4nan.github.io/mikro-orm/usage-with-nestjs/)
-*   [Usage with JavaScript](https://b4nan.github.io/mikro-orm/usage-with-js/)
+- [Smart nested populate](https://b4nan.github.io/mikro-orm/nested-populate/)
+- [Smart query conditions](https://b4nan.github.io/mikro-orm/query-conditions/)
+- [Updating entity values with `IEntity.assign()`](https://b4nan.github.io/mikro-orm/entity-helper/)
+- [Property validation](https://b4nan.github.io/mikro-orm/property-validation/)
+- [Lifecycle hooks](https://b4nan.github.io/mikro-orm/lifecycle-hooks/)
+- [Naming strategy](https://b4nan.github.io/mikro-orm/naming-strategy/)
+- [Usage with NestJS](https://b4nan.github.io/mikro-orm/usage-with-nestjs/)
+- [Usage with JavaScript](https://b4nan.github.io/mikro-orm/usage-with-js/)
 
 ![](https://cdn-images-1.medium.com/max/800/1*4877k4Hq9dPdtmvg9hnGFA.jpeg)
 

--- a/docs/blog/2019-06-18-handling-transactions-and-concurrency-in-mikroorm.md
+++ b/docs/blog/2019-06-18-handling-transactions-and-concurrency-in-mikroorm.md
@@ -237,12 +237,12 @@ MikroORM supports Pessimistic Locking at the database level. Every Entity can be
 
 MikroORM currently supports two pessimistic lock modes:
 
-*   Pessimistic Write (`LockMode.PESSIMISTIC_WRITE`), locks the underlying database rows for concurrent Read and Write Operations.
-*   Pessimistic Read (`LockMode.PESSIMISTIC_READ`), locks other concurrent requests that attempt to update or lock rows in write mode.
+- Pessimistic Write (`LockMode.PESSIMISTIC_WRITE`), locks the underlying database rows for concurrent Read and Write Operations.
+- Pessimistic Read (`LockMode.PESSIMISTIC_READ`), locks other concurrent requests that attempt to update or lock rows in write mode.
 
 You can use pessimistic locks in three different scenarios:
 
-1.  Using `em.findOne(className, id, { lockMode  })`
+1.  Using `em.findOne(className, id, { lockMode })`
 2.  Using `em.lock(entity, lockMode)`
 3.  Using `QueryBuilder.setLockMode(lockMode)`
 

--- a/docs/blog/2020-01-16-mikro-orm-3-released.md
+++ b/docs/blog/2020-01-16-mikro-orm-3-released.md
@@ -289,10 +289,10 @@ export class DateType extends Type {
 ```typescript
 @Entity()
 export class FooBar implements IdEntity<FooBar> {
-  
+
   @PrimaryKey()
   id!: number;
-  
+
   @Property({ type: DateType })
   born?: Date;
 
@@ -369,5 +369,3 @@ There are also some interesting suggestion in the Github issues, like [Dataloade
 So that is MikroORM 3, what do you think about it? What features or changes would you like to see next? Or what part of the documentation should be improved and how?
 
 > _Like_ [_MikroORM_](https://mikro-orm.io)_? ⭐️_ [_Star it_](https://github.com/mikro-orm/mikro-orm) _on GitHub and share this article with your friends._
-
-* * *

--- a/docs/blog/2020-09-08-mikro-orm-4-released.md
+++ b/docs/blog/2020-09-08-mikro-orm-4-released.md
@@ -122,7 +122,7 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
   }
 
   async afterUpdate(args: EventArgs<Author>): Promise<void> {
-    // ... 
+    // ...
   }
 
 }
@@ -166,7 +166,7 @@ await em.persistAndFlush(bar);
 
 ### Joined loading strategy
 
-Loading of complex relations now support so called [JOINED strategy](https://mikro-orm.io/docs/loading-strategies/). Its name is quite self-explanatory — instead of the default (SELECT\_IN) strategy, it uses single SQL query and maps the result to multiple entities.
+Loading of complex relations now support so called [JOINED strategy](https://mikro-orm.io/docs/loading-strategies/). Its name is quite self-explanatory — instead of the default (SELECT_IN) strategy, it uses single SQL query and maps the result to multiple entities.
 
 ```ts
 // with the default SELECT_IN strategy, following will issue 2 queries
@@ -228,7 +228,7 @@ export class User {
 
 @Embeddable()
 export class Address {
-  
+
   @Property()
   street!: string;
 
@@ -300,7 +300,7 @@ export class Book {
 
   @ManyToMany(() => BookTag)
   tags = new Collection<BookTag>(this);
-    
+
 }
 ```
 
@@ -346,8 +346,8 @@ qb1.count('b.uuid', true).where({ author: qb1.ref('a.id') });
 const qb2 = em.createQueryBuilder(Author, 'a');
 qb2.select(['*', qb1.as('Author.booksTotal')]).orderBy({ booksTotal: 'desc' });
 
-// select `a`.*, (select count(distinct `b`.`uuid_pk`) as `count` from `book` as `b` where `b`.`author_id` = `a`.`id`) as `books_total` 
-// from `author` as `a` 
+// select `a`.*, (select count(distinct `b`.`uuid_pk`) as `count` from `book` as `b` where `b`.`author_id` = `a`.`id`) as `books_total`
+// from `author` as `a`
 // order by `books_total` desc
 ```
 
@@ -360,7 +360,7 @@ const qb1 = em.createQueryBuilder(Book, 'b').count('b.uuid', true).where({ autho
 const qb2 = em.createQueryBuilder(Author, 'a');
 qb2.select('*').withSubQuery(qb1, 'a.booksTotal').where({ 'a.booksTotal': { $in: [1, 2, 3] } });
 
-// select `a`.* 
+// select `a`.*
 // from `author` as `a`
 // where (select count(distinct `b`.`uuid_pk`) as `count` from `book` as `b` where `b`.`author_id` = `a`.`id`) in (?, ?, ?)
 ```
@@ -369,7 +369,7 @@ qb2.select('*').withSubQuery(qb1, 'a.booksTotal').where({ 'a.booksTotal': { $in:
 const qb = em.createQueryBuilder(Publisher);
 qb.update({ name: 'test 123' }).where({ $or: [{ books: { author: 123 } }, { books: { title: 'book' } }] });
 
-// update `publisher` set `name` = ? 
+// update `publisher` set `name` = ?
 // where `id` in (select `e0`.`id` from (
 //   select distinct `e0`.`id` from `publisher` as `e0` left join `book` as `e1` on `e0`.`id` = `e1`.`publisher_id` where (`e1`.`author_id` = ? or `e1`.`title` = ?)
 // ) as `e0`)
@@ -402,8 +402,8 @@ For smooth upgrading, read the full [upgrading guide](https://mikro-orm.io/docs/
 - @mikro-orm/core package is not dependent on knex, and therefore cannot provide methods like createQueryBuilder() — instead, those methods exist on SqlEntityManager. You can import it from the driver package, e.g. import { EntityManager } from '@mikro-orm/mysql;.
 - To use CLI, you need to install @mikro-orm/cli package.
 - When using folder based discovery, the options entitiesDirs and entitiesDirsTs are now removed in favour of entities and entitiesTs. You can now mix entity references with folders and file globs, negative globs are also supported.
-- For Nest.js users, there is a new [@mikro-orm/nestjs](https://github.com/mikro-orm/nestjs) package, which is a fork of the [nestjs-mikro-orm](https://github.com/dario1985/nestjs-mikro-orm) module with changes needed for   
-MikroORM 4.
+- For Nest.js users, there is a new [@mikro-orm/nestjs](https://github.com/mikro-orm/nestjs) package, which is a fork of the [nestjs-mikro-orm](https://github.com/dario1985/nestjs-mikro-orm) module with changes needed for  
+  MikroORM 4.
 
 ### What’s next?
 

--- a/docs/blog/2020-10-13-mikro-orm-4-1-lets-talk-about-performance.md
+++ b/docs/blog/2020-10-13-mikro-orm-4-1-lets-talk-about-performance.md
@@ -9,9 +9,7 @@ authorTwitter: B4nan
 tags: [typescript, javascript, node, sql]
 ---
 
-I just shipped version 4.1 of [MikroORM](https://github.com/mikro-orm/mikro-orm), 
-the TypeScript ORM for Node.js, and I feel like this particular release deserves 
-a bit more attention than a regular feature release.
+I just shipped version 4.1 of [MikroORM](https://github.com/mikro-orm/mikro-orm), the TypeScript ORM for Node.js, and I feel like this particular release deserves a bit more attention than a regular feature release.
 
 <!--truncate-->
 
@@ -63,13 +61,13 @@ for (const user of users) {
 await em.flush();
 
 // update `user` set
-//   `name` = case 
-//     when (`id` = 1) then 'Peter 1 changed!' 
-//     when (`id` = 2) then 'Peter 2 changed!' 
-//     when (`id` = 3) then 'Peter 3 changed!' 
-//     when (`id` = 4) then 'Peter 4 changed!' 
-//     when (`id` = 5) then 'Peter 5 changed!' 
-//     else `priority` end 
+//   `name` = case
+//     when (`id` = 1) then 'Peter 1 changed!'
+//     when (`id` = 2) then 'Peter 2 changed!'
+//     when (`id` = 3) then 'Peter 3 changed!'
+//     when (`id` = 4) then 'Peter 4 changed!'
+//     when (`id` = 5) then 'Peter 5 changed!'
+//     else `priority` end
 //   where `id` in (1, 2, 3, 4, 5)
 ```
 

--- a/docs/blog/2022-02-06-mikro-orm-5-released.md
+++ b/docs/blog/2022-02-06-mikro-orm-5-released.md
@@ -426,7 +426,7 @@ While MikroORM v5 is still compiled and published as CommonJS, we added several 
 ### Other notable changes
 
 - Partial loading support (`fields`) for joined loading strategy
-- `AsyncLocalStorage` used by default in the ``RequestContext`` helper
+- `AsyncLocalStorage` used by default in the `RequestContext` helper
 - `onLoad` event (like `onInit`, but allows async and fires only for loaded entities, not references)
 - Exporting async functions from CLI config
 - Configurable aliasing strategy for SQL

--- a/docs/docs/async-local-storage.md
+++ b/docs/docs/async-local-storage.md
@@ -3,12 +3,12 @@ title: Using AsyncLocalStorage
 ---
 
 :::info
-Since v5 `AsyncLocalStorage` is used inside `RequestContext` helper so this section
-is no longer valid.
+
+Since v5 `AsyncLocalStorage` is used inside `RequestContext` helper so this section is no longer valid.
+
 :::
 
-In v4 and older versions, the `domain` api was used in the `RequestContext` helper. Since v4.0.3,
-we can use the new `AsyncLocalStorage` too, if we are on up-to-date node version:
+In v4 and older versions, the `domain` api was used in the `RequestContext` helper. Since v4.0.3, we can use the new `AsyncLocalStorage` too, if we are on up-to-date node version:
 
 ```ts
 const storage = new AsyncLocalStorage<EntityManager>();

--- a/docs/docs/caching.md
+++ b/docs/docs/caching.md
@@ -2,12 +2,9 @@
 title: Result cache
 ---
 
-MikroORM has simple result caching mechanism. It works with those methods of
-`EntityManager`: `find()`, `findOne()`, `findAndCount()`, `findOneOrFail()`,
-`count()`, as well as with `QueryBuilder` result methods (including `execute`).
+MikroORM has simple result caching mechanism. It works with those methods of `EntityManager`: `find()`, `findOne()`, `findAndCount()`, `findOneOrFail()`, `count()`, as well as with `QueryBuilder` result methods (including `execute`).
 
-By default, in memory cache is used, that is shared for the whole `MikroORM`
-instance. Default expiration is 1 second.
+By default, in memory cache is used, that is shared for the whole `MikroORM` instance. Default expiration is 1 second.
 
 ```ts
 const res = await em.find(Book, { author: { name: 'Jon Snow' } }, {
@@ -27,8 +24,7 @@ const res = await em.createQueryBuilder(Book)
   .getResultList();
 ```
 
-We can change the default expiration as well as provide custom cache adapter in
-the ORM configuration:
+We can change the default expiration as well as provide custom cache adapter in the ORM configuration:
 
 ```ts
 const orm = await MikroORM.init({
@@ -42,8 +38,7 @@ const orm = await MikroORM.init({
 });
 ```
 
-To clear the cached result, we need to load it with explicit cache key, and later
-on we can use `em.clearCache(cacheKey)` method.
+To clear the cached result, we need to load it with explicit cache key, and later on we can use `em.clearCache(cacheKey)` method.
 
 ```ts
 // set the cache key to 'book-cache-key', with expiration of 60s

--- a/docs/docs/cascading.md
+++ b/docs/docs/cascading.md
@@ -5,17 +5,13 @@ sidebar_label: Cascading
 
 > From v4.2, cascade merging is no longer configurable (and is kept enabled for all relations).
 
-> This section is about application level cascading. For that to work, we need
-> to have relations populated. 
+> This section is about application level cascading. For that to work, we need to have relations populated.
 
-When persisting or removing entity, all your references are by default cascade persisted. 
-This means that by persisting any entity, ORM will automatically persist all of its 
-associations. 
+When persisting or removing entity, all your references are by default cascade persisted. This means that by persisting any entity, ORM will automatically persist all of its associations.
 
-You can control this behaviour via `cascade` attribute of `@ManyToOne`, `@ManyToMany`, 
-`@OneToMany` and `@OneToOne` fields.
+You can control this behaviour via `cascade` attribute of `@ManyToOne`, `@ManyToMany`, `@OneToMany` and `@OneToOne` fields.
 
-> New entities without primary key will be always persisted, regardless of `cascade` value. 
+> New entities without primary key will be always persisted, regardless of `cascade` value.
 
 ```ts
 // cascade persist is default value
@@ -55,23 +51,19 @@ book.tags[1].name = 'new name 2';
 await orm.em.persistAndFlush(book); // all book tags and author will be persisted too
 ```
 
-> When cascade persisting collections, keep in mind only fully initialized collections 
-> will be cascade persisted.
+> When cascade persisting collections, keep in mind only fully initialized collections will be cascade persisted.
 
 ## Cascade remove
 
-Cascade remove works same way as cascade persist, just for removing entities. Following 
-example assumes that `Book.publisher` is set to `Cascade.REMOVE`:
+Cascade remove works same way as cascade persist, just for removing entities. Following example assumes that `Book.publisher` is set to `Cascade.REMOVE`:
 
-> Note that cascade remove for collections can be inefficient as it will fire 1 query
-> for each entity in collection.
+> Note that cascade remove for collections can be inefficient as it will fire 1 query for each entity in collection.
 
 ```ts
 await orm.em.remove(book).flush(); // this will also remove book.publisher
 ```
 
-Keep in mind that cascade remove **can be dangerous** when used on `@ManyToOne` fields, 
-as cascade removed entity can stay referenced in another entities that were not removed.
+Keep in mind that cascade remove **can be dangerous** when used on `@ManyToOne` fields, as cascade removed entity can stay referenced in another entities that were not removed.
 
 ```ts
 const publisher = new Publisher(...);
@@ -85,9 +77,7 @@ console.log(book2.publisher, book3.publisher);
 
 ## Orphan removal
 
-In addition to `Cascade.REMOVE`, there is also additional and more aggressive remove 
-cascading mode which can be specified using the `orphanRemoval` flag of the `@OneToOne`
-and `@OneToMany` properties:
+In addition to `Cascade.REMOVE`, there is also additional and more aggressive remove cascading mode which can be specified using the `orphanRemoval` flag of the `@OneToOne` and `@OneToMany` properties:
 
 ```ts
 @Entity()
@@ -99,13 +89,9 @@ export class Author {
 }
 ```
 
-> `orphanRemoval` flag behaves just like `Cascade.REMOVE` for remove operation, so specifying 
-> both is redundant.
+> `orphanRemoval` flag behaves just like `Cascade.REMOVE` for remove operation, so specifying both is redundant.
 
-With simple `Cascade.REMOVE`, you would need to remove the `Author` entity to cascade 
-the operation down to all loaded `Book`s. By enabling orphan removal on the collection, 
-`Book`s will be also removed when they get disconnected from the collection (either via 
-`remove()`, or by replacing collection items via `set()`):
+With simple `Cascade.REMOVE`, you would need to remove the `Author` entity to cascade the operation down to all loaded `Book`s. By enabling orphan removal on the collection, `Book`s will be also removed when they get disconnected from the collection (either via `remove()`, or by replacing collection items via `set()`):
 
 ```ts
 await author.books.set([book1, book2]); // replace whole collection
@@ -113,18 +99,15 @@ await author.books.remove(book1); // remove book from collection
 await orm.em.persistAndFlush(author); // book1 will be removed, as well as all original items (before we called `set()`)
 ```
 
-In this example, no `Book` would be removed with simple `Cascade.REMOVE` as no remove operation
-was executed. 
+In this example, no `Book` would be removed with simple `Cascade.REMOVE` as no remove operation was executed.
 
 ## Declarative Referential Integrity
 
 > This is only supported in SQL drivers.
 
-As opposed to the application level cascading controlled by the `cascade` option, we can
-also define database level referential integrity actions: `on update` and `on delete`.
+As opposed to the application level cascading controlled by the `cascade` option, we can also define database level referential integrity actions: `on update` and `on delete`.
 
-Their values are automatically inferred from the `cascade` option value. You can also 
-control the value manually via `onUpdateIntegrity` and `onDelete` options. 
+Their values are automatically inferred from the `cascade` option value. You can also control the value manually via `onUpdateIntegrity` and `onDelete` options.
 
 ```ts
 @Entity()

--- a/docs/docs/collections.md
+++ b/docs/docs/collections.md
@@ -66,9 +66,7 @@ console.log(await author.books.loadItems()); // Book[]
 
 ### Removing items from collection
 
-Removing items from a collection does not necessarily imply deleting the target entity, it means we are disconnecting the relation - removing items from collection, not removing entities from database - `Collection.remove()` is not the same as `em.remove()`. When you use `em.assign()` to update entities you can also remove/disconnect entities from a collection, they do not get automatically removed from the database.  If we want to delete the entity by removing it from collection, we need to enable `orphanRemoval: true`, which tells the ORM we don't want orphaned entities to exist, so we know those should be removed. Also check the documentation on [Orphan Removal](cascading.md#orphan-removal)
-
-
+Removing items from a collection does not necessarily imply deleting the target entity, it means we are disconnecting the relation - removing items from collection, not removing entities from database - `Collection.remove()` is not the same as `em.remove()`. When you use `em.assign()` to update entities you can also remove/disconnect entities from a collection, they do not get automatically removed from the database. If we want to delete the entity by removing it from collection, we need to enable `orphanRemoval: true`, which tells the ORM we don't want orphaned entities to exist, so we know those should be removed. Also check the documentation on [Orphan Removal](cascading.md#orphan-removal)
 
 ## OneToMany Collections
 
@@ -195,7 +193,7 @@ Alternatively, we can work with the pivot entity directly:
 
 ```ts
 // create new item
-const item = em.create(OrderItem, { 
+const item = em.create(OrderItem, {
   order: 123,
   product: 321,
   amount: 999,
@@ -210,8 +208,7 @@ We can as well define the 1:m properties targeting the pivot entity as in the pr
 
 ### Forcing fixed order of collection items
 
-> Since v3 many to many collections does not require having auto increment primary key, that
-> was used to ensure fixed order of collection items.
+> Since v3 many to many collections does not require having auto increment primary key, that was used to ensure fixed order of collection items.
 
 To preserve fixed order of collections, we can use `fixedOrder: true` attribute, which will start ordering by `id` column. Schema generator will convert the pivot table to have auto increment primary key `id`. We can also change the order column name via `fixedOrderColumn: 'order'`.
 
@@ -242,9 +239,9 @@ console.log(tag.books.contains(book)); // true
 
 tag.books.add(book);
 console.log(book.tags.contains(tag)); // true
-``` 
+```
 
->  Since v5.2.2 propagation of adding new items to inverse side M:N relation also works if the owning collection is not initialized. For propagation of remove operation, both sides still have to be initialized.
+> Since v5.2.2 propagation of adding new items to inverse side M:N relation also works if the owning collection is not initialized. For propagation of remove operation, both sides still have to be initialized.
 
 > Although this propagation works also for M:N inverse side, we should always use owning side to manipulate the collection.
 

--- a/docs/docs/composite-keys.md
+++ b/docs/docs/composite-keys.md
@@ -5,14 +5,9 @@ sidebar_label: Composite Primary Keys
 
 > Support for composite keys was added in version 3.5
 
-MikroORM supports composite primary keys natively. Composite keys are a very powerful
-relational database concept and we took good care to make sure MikroORM supports as
-many of the composite primary key use-cases. MikroORM supports composite keys of primitive
-data-types as well as foreign keys as primary keys. You can also use your composite key
-entities in relationships.
+MikroORM supports composite primary keys natively. Composite keys are a very powerful relational database concept and we took good care to make sure MikroORM supports as many of the composite primary key use-cases. MikroORM supports composite keys of primitive data-types as well as foreign keys as primary keys. You can also use your composite key entities in relationships.
 
-This section shows how the semantics of composite primary keys work and how they map
-to the database.
+This section shows how the semantics of composite primary keys work and how they map to the database.
 
 ## General Considerations
 
@@ -20,8 +15,7 @@ ID fields have to have their values set before you call `em.persist(entity)`.
 
 ## Primitive Types only
 
-Suppose you want to create a database of cars and use the model-name and year of
-production as primary keys:
+Suppose you want to create a database of cars and use the model-name and year of production as primary keys:
 
 ```ts
 @Entity()
@@ -50,39 +44,28 @@ const car = new Car('Audi A8', 2010);
 await em.persistAndFlush(car);
 ```
 
-And for querying you need to provide all primary keys in the condition or an array of
-primary keys in the same order as the keys were defined:
+And for querying you need to provide all primary keys in the condition or an array of primary keys in the same order as the keys were defined:
 
 ```ts
 const audi1 = await em.findOneOrFail(Car, { name: 'Audi A8', year: 2010 });
 const audi2 = await em.findOneOrFail(Car, ['Audi A8', 2010]);
 ```
 
-> If we want to use the second approach with primary key tuple, we will need to specify
-> the type of entity's primary key via `PrimaryKeyType` symbol as shown in the `Car` entity.
+> If we want to use the second approach with primary key tuple, we will need to specify the type of entity's primary key via `PrimaryKeyType` symbol as shown in the `Car` entity.
 
-> `PrimaryKeyType` is not needed when your entity has single scalar primary key under
-> one of following property names: `id: number | string | bigint`, `_id: any` or
-> `uuid: string`.
+> `PrimaryKeyType` is not needed when your entity has single scalar primary key under one of following property names: `id: number | string | bigint`, `_id: any` or `uuid: string`.
 
-You can also use this entity in associations. MikroORM will then generate two foreign
-keys one for name and to year to the related entities.
+You can also use this entity in associations. MikroORM will then generate two foreign keys one for name and to year to the related entities.
 
-This example shows how you can nicely solve the requirement for existing values before
-`em.persist()`: By adding them as mandatory values for the constructor.
+This example shows how you can nicely solve the requirement for existing values before `em.persist()`: By adding them as mandatory values for the constructor.
 
 ## Identity through foreign Entities
 
-There are tons of use-cases where the identity of an Entity should be determined by
-the entity of one or many parent entities.
+There are tons of use-cases where the identity of an Entity should be determined by the entity of one or many parent entities.
 
-- Dynamic Attributes of an Entity (for example `Article`). Each Article has many
-  attributes with primary key `article_id` and `attribute_name`.
-- `Address` object of a `Person`, the primary key of the address is `user_id`. This
-  is not a case of a composite primary key, but the identity is derived through a
-  foreign entity and a foreign key.
-- Pivot Tables with metadata can be modelled as Entity, for example connections between
-  two articles with a little description and a score.
+- Dynamic Attributes of an Entity (for example `Article`). Each Article has many attributes with primary key `article_id` and `attribute_name`.
+- `Address` object of a `Person`, the primary key of the address is `user_id`. This is not a case of a composite primary key, but the identity is derived through a foreign entity and a foreign key.
+- Pivot Tables with metadata can be modelled as Entity, for example connections between two articles with a little description and a score.
 
 The semantics of mapping identity through foreign entities are easy:
 
@@ -133,9 +116,7 @@ export class ArticleAttribute {
 
 ## Use-Case 2: Simple Derived Identity
 
-Sometimes you have the requirement that two objects are related by a `@OneToOne`
-association and that the dependent class should re-use the primary key of the class
-it depends on. One good example for this is a user-address relationship:
+Sometimes you have the requirement that two objects are related by a `@OneToOne` association and that the dependent class should re-use the primary key of the class it depends on. One good example for this is a user-address relationship:
 
 ```ts
 @Entity()
@@ -162,9 +143,7 @@ export class Address {
 
 ## Use-Case 3: Join-Table with Metadata
 
-In the classic order product shop example there is the concept of the order item which
-contains references to order and product and additional data such as the amount of products
-purchased and maybe even the current price.
+In the classic order product shop example there is the concept of the order item which contains references to order and product and additional data such as the amount of products purchased and maybe even the current price.
 
 ```ts
 @Entity()
@@ -235,6 +214,7 @@ export class OrderItem {
 ```
 
 :::info
+
 By default, a generated pivot table entity is used under the hood to represent the pivot table. Since v5.1 we can provide our own implementation via `pivotEntity` option.
 
 The pivot table entity needs to have exactly two many-to-one properties, where first one needs to point to the owning entity and the second to the target entity of the many-to-many relation.
@@ -295,12 +275,12 @@ const em.nativeDelete(OrderItem, { order: 123, product: 321 });
 ```
 
 We can as well define the 1:m properties targeting the pivot entity as in the previous example, and use that for modifying the collection, while using the M:N property for easier reading and filtering purposes.
+
 :::
 
 ## Using QueryBuilder with composite keys
 
-Internally composite keys are represented as tuples, containing all the values in the
-same order as the primary keys were defined.
+Internally composite keys are represented as tuples, containing all the values in the same order as the primary keys were defined.
 
 ```ts
 const qb1 = em.createQueryBuilder(CarOwner);
@@ -321,7 +301,6 @@ This also applies when you want to get a reference to entity with composite key:
 ```ts
 const ref = em.getReference(Car, ['Audi A8', 2010]);
 console.log(ref instanceof Car); // true
-``` 
+```
 
-> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/composite-primary-keys.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/composite-primary-keys.html) as the behaviour here is pretty much the same.

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -4,8 +4,7 @@ title: Configuration
 
 ## Entity Discovery
 
-You can either provide array of entity instances via `entities`, or let the ORM look up your 
-entities in selected folders. 
+You can either provide array of entity instances via `entities`, or let the ORM look up your entities in selected folders.
 
 ```ts
 MikroORM.init({
@@ -13,14 +12,9 @@ MikroORM.init({
 });
 ```
 
-We can also use folder based discovery by providing list of paths to the entities
-we want to discover (globs are supported as well). This way we also need to specify
-`entitiesTs`, where we point the paths to the TS source files instead of the JS 
-compiled files (see more at [Metadata Providers](metadata-providers.md)).
+We can also use folder based discovery by providing list of paths to the entities we want to discover (globs are supported as well). This way we also need to specify `entitiesTs`, where we point the paths to the TS source files instead of the JS compiled files (see more at [Metadata Providers](metadata-providers.md)).
 
-> The `entitiesTs` option is used when running the app via `ts-node`, as the ORM 
-> needs to discover the TS files. Always specify this option if you use folder/file
-> based discovery. 
+> The `entitiesTs` option is used when running the app via `ts-node`, as the ORM needs to discover the TS files. Always specify this option if you use folder/file based discovery.
 
 ```ts
 MikroORM.init({
@@ -31,19 +25,11 @@ MikroORM.init({
 });
 ```
 
-> Be careful when overriding the `baseDir` with dynamic values like `__dirname`, 
-> as you can end up with valid paths from `ts-node`, but invalid paths from `node`.
-> Ideally you should keep the default of `process.cwd()` there to always have the 
-> same base path regardless of how you run the app.
+> Be careful when overriding the `baseDir` with dynamic values like `__dirname`, as you can end up with valid paths from `ts-node`, but invalid paths from `node`. Ideally you should keep the default of `process.cwd()` there to always have the same base path regardless of how you run the app.
 
-By default, `ReflectMetadataProvider` is used that leverages the `reflect-metadata`. 
-You can also use `TsMorphMetadataProvider` by installing `@mikro-orm/reflection`. 
-This provider will analyse your entity source files (or `.d.ts` type definition files). 
-If you aim to use plain JavaScript instead of TypeScript, use `EntitySchema` or 
-the `JavaScriptMetadataProvider`.
+By default, `ReflectMetadataProvider` is used that leverages the `reflect-metadata`. You can also use `TsMorphMetadataProvider` by installing `@mikro-orm/reflection`. This provider will analyse your entity source files (or `.d.ts` type definition files). If you aim to use plain JavaScript instead of TypeScript, use `EntitySchema` or the `JavaScriptMetadataProvider`.
 
-> You can also implement your own metadata provider and use it instead. To do so, extend the 
-> `MetadataProvider` class.
+> You can also implement your own metadata provider and use it instead. To do so, extend the `MetadataProvider` class.
 
 ```ts
 import { MikroORM } from '@mikro-orm/core';
@@ -113,19 +99,17 @@ const orm = await MikroORM.init({
 
 To select driver, you can either use `type` option, or provide the driver class reference.
 
-| type | driver name | dependency | note |
-|------|-------------|------------|------|
-| `mongo` | `MongoDriver` | `mongodb^3.3.4` | - |
-| `mysql` | `MySqlDriver` | `mysql2^2.0.0` | compatible with MariaDB |
-| `mariadb` | `MariaDbDriver` | `mariadb^2.0.0` | compatible with MySQL |
-| `postgresql` | `PostgreSqlDriver` | `pg^7.0.0` | - |
-| `sqlite` | `SqliteDriver` | `sqlite3^4.0.0` | - |
+| type         | driver name        | dependency      | note                    |
+| ------------ | ------------------ | --------------- | ----------------------- |
+| `mongo`      | `MongoDriver`      | `mongodb^3.3.4` | -                       |
+| `mysql`      | `MySqlDriver`      | `mysql2^2.0.0`  | compatible with MariaDB |
+| `mariadb`    | `MariaDbDriver`    | `mariadb^2.0.0` | compatible with MySQL   |
+| `postgresql` | `PostgreSqlDriver` | `pg^7.0.0`      | -                       |
+| `sqlite`     | `SqliteDriver`     | `sqlite3^4.0.0` | -                       |
 
-> Driver and connection implementations are not directly exported from `@mikro-orm/core` module. 
-> You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
+> Driver and connection implementations are not directly exported from `@mikro-orm/core` module. You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
 
-> You can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. 
-> The object will be deeply merged, overriding all internally used options.
+> You can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. The object will be deeply merged, overriding all internally used options.
 
 ```ts
 import { MySqlDriver } from '@mikro-orm/mysql';
@@ -147,8 +131,7 @@ MikroORM.init({
 
 ## Connection
 
-Each platform (driver) provides default connection string, you can override it as a whole
-through `clientUrl`, or partially through one of following options:
+Each platform (driver) provides default connection string, you can override it as a whole through `clientUrl`, or partially through one of following options:
 
 ```ts
 export interface DynamicPassword {
@@ -172,17 +155,16 @@ export interface ConnectionOptions {
 
 Following table shows default client connection strings:
 
-| type | default connection url |
-|------|------------------------|
-| `mongo` | `mongodb://127.0.0.1:27017` |
-| `mysql` | `mysql://root@127.0.0.1:3306` |
-| `mariadb` | `mysql://root@127.0.0.1:3306` |
+| type         | default connection url                 |
+| ------------ | -------------------------------------- |
+| `mongo`      | `mongodb://127.0.0.1:27017`            |
+| `mysql`      | `mysql://root@127.0.0.1:3306`          |
+| `mariadb`    | `mysql://root@127.0.0.1:3306`          |
 | `postgresql` | `postgresql://postgres@127.0.0.1:5432` |
 
 ### Read Replicas
 
-To set up read replicas, you can use `replicas` option. You can provide only those parts of the 
-`ConnectionOptions` interface, they will be used to override the `master` connection options.
+To set up read replicas, you can use `replicas` option. You can provide only those parts of the `ConnectionOptions` interface, they will be used to override the `master` connection options.
 
 ```ts
 MikroORM.init({
@@ -203,10 +185,7 @@ Read more about this in [Installation](installation.md) and [Read Connections](r
 
 ### Using short-lived tokens
 
-Many cloud providers include alternative methods for connecting to database instances 
-using short-lived authentication tokens. MikroORM supports dynamic passwords via 
-a callback function, either synchronous or asynchronous. The callback function must 
-resolve to a string.
+Many cloud providers include alternative methods for connecting to database instances using short-lived authentication tokens. MikroORM supports dynamic passwords via a callback function, either synchronous or asynchronous. The callback function must resolve to a string.
 
 ```ts
 MikroORM.init({
@@ -216,8 +195,7 @@ MikroORM.init({
 });
 ```
 
-The password callback value will be cached, to invalidate this cache we can specify
-`expirationChecker` callback:
+The password callback value will be cached, to invalidate this cache we can specify `expirationChecker` callback:
 
 ```ts
 MikroORM.init({
@@ -232,8 +210,7 @@ MikroORM.init({
 
 ## Naming Strategy
 
-When mapping your entities to database tables and columns, their names will be defined by naming 
-strategy. There are 3 basic naming strategies you can choose from:
+When mapping your entities to database tables and columns, their names will be defined by naming strategy. There are 3 basic naming strategies you can choose from:
 
 - `UnderscoreNamingStrategy` - default of all SQL drivers
 - `MongoNamingStrategy` - default of `MongoDriver`
@@ -251,9 +228,7 @@ Read more about this in [Naming Strategy](naming-strategy.md) section.
 
 ## Auto-join of 1:1 owners
 
-By default, owning side of 1:1 relation will be auto-joined when you select the inverse side 
-so we can have the reference to it. You can disable this behaviour via `autoJoinOneToOneOwner` 
-configuration toggle.
+By default, owning side of 1:1 relation will be auto-joined when you select the inverse side so we can have the reference to it. You can disable this behaviour via `autoJoinOneToOneOwner` configuration toggle.
 
 ```ts
 MikroORM.init({
@@ -263,8 +238,7 @@ MikroORM.init({
 
 ## Propagation of 1:1 and m:1 owners
 
-MikroORM defines getter and setter for every owning side of m:1 and 1:1 relation. This is 
-then used for propagation of changes to the inverse side of bi-directional relations.
+MikroORM defines getter and setter for every owning side of m:1 and 1:1 relation. This is then used for propagation of changes to the inverse side of bi-directional relations.
 
 ```ts
 const author = new Author('n', 'e');
@@ -283,9 +257,7 @@ MikroORM.init({
 
 ## Forcing UTC Timezone
 
-Use `forceUtcTimezone` option to force the `Date`s to be saved in UTC in datetime columns 
-without timezone. It works for MySQL (`datetime` type) and PostgreSQL (`timestamp` type). 
-SQLite does this by default. 
+Use `forceUtcTimezone` option to force the `Date`s to be saved in UTC in datetime columns without timezone. It works for MySQL (`datetime` type) and PostgreSQL (`timestamp` type). SQLite does this by default.
 
 ```ts
 MikroORM.init({
@@ -295,9 +267,7 @@ MikroORM.init({
 
 ## Mapping `null` values to `undefined`
 
-By default `null` values from nullable database columns are hydrated as `null`. 
-Using `forceUndefined` we can tell the ORM to convert those `null` values to
-`undefined` instead. 
+By default `null` values from nullable database columns are hydrated as `null`. Using `forceUndefined` we can tell the ORM to convert those `null` values to `undefined` instead.
 
 ```ts
 MikroORM.init({
@@ -307,13 +277,9 @@ MikroORM.init({
 
 ## Serialization of new entities
 
-After flushing a new entity, all relations are marked as populated,
-just like if the entity was loaded from the db. This aligns the serialized
-output of `e.toJSON()` of a loaded entity and just-inserted one.
+After flushing a new entity, all relations are marked as populated, just like if the entity was loaded from the db. This aligns the serialized output of `e.toJSON()` of a loaded entity and just-inserted one.
 
-In v4 this behaviour was disabled by default, so even after the new entity was 
-flushed, the serialized form contained only FKs for its relations. We can opt in 
-to this old behaviour via `populateAfterFlush: false`.
+In v4 this behaviour was disabled by default, so even after the new entity was flushed, the serialized form contained only FKs for its relations. We can opt in to this old behaviour via `populateAfterFlush: false`.
 
 ```ts
 MikroORM.init({
@@ -325,30 +291,21 @@ MikroORM.init({
 
 > This applies only to SELECT_IN strategy, as JOINED strategy implies the inference.
 
-In v4, when we used populate hints in `em.find()` and similar methods, the
-query for our entity would be analysed and parts of it extracted and used for
-the population. Following example would find all authors that have books with
-given IDs, and populate their books collection, again using this PK condition,
-resulting in only such books being in those collections.
+In v4, when we used populate hints in `em.find()` and similar methods, the query for our entity would be analysed and parts of it extracted and used for the population. Following example would find all authors that have books with given IDs, and populate their books collection, again using this PK condition, resulting in only such books being in those collections.
 
 ```ts
 // this would end up with `Author.books` collections having only books of PK 1, 2, 3
 const a = await em.find(Author, { books: [1, 2, 3] }, { populate: ['books'] });
 ```
 
-Following this example, if we wanted to load all books, we would need a separate
-`em.populate()` call:
+Following this example, if we wanted to load all books, we would need a separate `em.populate()` call:
 
 ```ts
 const a = await em.find(Author, { books: [1, 2, 3] });
 await em.populate(a, ['books']);
 ```
 
-This behaviour changed and is now configurable both globally and locally, via
-`populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and
-`PopulateHint.INFER`, the former being the default in v5, the latter being the
-default behaviour in v4. Locally (via `FindOptions`) we can also specify custom
-where condition that will be passed to `em.populate()` call.
+This behaviour changed and is now configurable both globally and locally, via `populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and `PopulateHint.INFER`, the former being the default in v5, the latter being the default behaviour in v4. Locally (via `FindOptions`) we can also specify custom where condition that will be passed to `em.populate()` call.
 
 ```ts
 MikroORM.init({
@@ -359,8 +316,7 @@ MikroORM.init({
 
 ## Custom Hydrator
 
-Hydrator is responsible for assigning values from the database to entities. 
-You can implement your custom `Hydrator` (by extending the abstract `Hydrator` class):
+Hydrator is responsible for assigning values from the database to entities. You can implement your custom `Hydrator` (by extending the abstract `Hydrator` class):
 
 ```ts
 MikroORM.init({
@@ -370,8 +326,7 @@ MikroORM.init({
 
 ## Custom Repository
 
-You can also register custom base repository (for all entities where you do not specify 
-`customRepository`) globally:
+You can also register custom base repository (for all entities where you do not specify `customRepository`) globally:
 
 > You can still use entity specific repositories in combination with global base repository.
 
@@ -385,14 +340,9 @@ Read more about this in [Repositories](repositories.md) section.
 
 ## Strict Mode and property validation
 
-> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`.
-> It has performance implications and usually should not be needed, as long as
-> you don't modify your entities via `Object.assign()`.
+> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`. It has performance implications and usually should not be needed, as long as you don't modify your entities via `Object.assign()`.
 
-`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong 
-data types for you automatically. If automatic conversion fails, it will throw an error. You can 
-enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered 
-when persisting the entity. 
+`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong data types for you automatically. If automatic conversion fails, it will throw an error. You can enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered when persisting the entity.
 
 ```ts
 MikroORM.init({
@@ -405,12 +355,9 @@ Read more about this in [Property Validation](property-validation.md) section.
 
 ## Required properties validation
 
-Since v5, new entities are validated on runtime (just before executing insert
-queries), based on the entity metadata. This means that mongo users now need 
-to use `nullable: true` on their optional properties too).
+Since v5, new entities are validated on runtime (just before executing insert queries), based on the entity metadata. This means that mongo users now need to use `nullable: true` on their optional properties too).
 
-This behaviour can be disabled globally via `validateRequired: false` in the 
-ORM config.
+This behaviour can be disabled globally via `validateRequired: false` in the ORM config.
 
 ```ts
 MikroORM.init({
@@ -420,8 +367,7 @@ MikroORM.init({
 
 ## Debugging & Logging
 
-You can enable logging with `debug` option. Either set it to `true` to log everything, or 
-provide array of `'query' | 'query-params' | 'discovery' | 'info'` namespaces.
+You can enable logging with `debug` option. Either set it to `true` to log everything, or provide array of `'query' | 'query-params' | 'discovery' | 'info'` namespaces.
 
 ```ts
 MikroORM.init({
@@ -436,8 +382,7 @@ Read more about this in [Debugging](logging.md) section.
 
 ## Custom Fail Handler
 
-When no entity is found during `em.findOneOrFail()` call, a `NotFoundError` will be thrown. 
-You can customize how the `Error` instance is created via `findOneOrFailHandler` (or `findExactlyOneOrFailHandler` if [strict mode](#strict-mode-and-property-validation) is enabled):
+When no entity is found during `em.findOneOrFail()` call, a `NotFoundError` will be thrown. You can customize how the `Error` instance is created via `findOneOrFailHandler` (or `findExactlyOneOrFailHandler` if [strict mode](#strict-mode-and-property-validation) is enabled):
 
 ```ts
 MikroORM.init({
@@ -464,8 +409,7 @@ MikroORM.init({
 
 ## Migrations
 
-Under the `migrations` namespace, you can adjust how the integrated migrations support works.
-Following example shows all possible options and their defaults:
+Under the `migrations` namespace, you can adjust how the integrated migrations support works. Following example shows all possible options and their defaults:
 
 ```ts
 MikroORM.init({
@@ -500,8 +444,7 @@ Read more about this in [seeding docs](seeding.md).
 
 ## Caching
 
-By default, metadata discovery results are cached. You can either disable caching, or adjust 
-how it works. Following example shows all possible options and their defaults:
+By default, metadata discovery results are cached. You can either disable caching, or adjust how it works. Following example shows all possible options and their defaults:
 
 ```ts
 MikroORM.init({
@@ -527,22 +470,20 @@ MikroORM.init({
   ...
 });
 ```
- > This should be disabled in production environments for added security.
+
+> This should be disabled in production environments for added security.
 
 ## Using native private properties
 
-If we want to use native private properties inside entities, the default approach of 
-how MikroORM creates entity instances via `Object.create()` is not viable (more about this
-in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity
-constructors, we can use `forceEntityConstructor` toggle:
+If we want to use native private properties inside entities, the default approach of how MikroORM creates entity instances via `Object.create()` is not viable (more about this in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity constructors, we can use `forceEntityConstructor` toggle:
 
 ```ts
 MikroORM.init({
-  forceEntityConstructor: true, // or specify just some entities via `[Author, 'Book', ...]` 
+  forceEntityConstructor: true, // or specify just some entities via `[Author, 'Book', ...]`
 });
 ```
 
-## Persist created entities automatically 
+## Persist created entities automatically
 
 > Since v5.5 `persistOnCreate` defaults to `true`.
 
@@ -558,26 +499,19 @@ MikroORM.init({
 
 ## Using global Identity Map
 
-In v5, it is no longer possible to use the global identity map. This was a
-common issue that led to weird bugs, as using the global EM without request
-context is almost always wrong, we always need to have a dedicated context for
-each request, so they do not interfere.
+In v5, it is no longer possible to use the global identity map. This was a common issue that led to weird bugs, as using the global EM without request context is almost always wrong, we always need to have a dedicated context for each request, so they do not interfere.
 
-We still can disable this check via `allowGlobalContext` configuration, or
-a connected environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can
-be handy especially in unit tests.
+We still can disable this check via `allowGlobalContext` configuration, or a connected environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can be handy especially in unit tests.
 
 ```ts
 MikroORM.init({
-  allowGlobalContext: true, 
+  allowGlobalContext: true,
 });
 ```
 
 ## Using environment variables
 
-Since v4.5 it is possible to set most of the ORM options via environment variables.
-By default `.env` file from the root directory is loaded - it is also possible to
-set full path to the env file you want to use via `MIKRO_ORM_ENV` environment variable.
+Since v4.5 it is possible to set most of the ORM options via environment variables. By default `.env` file from the root directory is loaded - it is also possible to set full path to the env file you want to use via `MIKRO_ORM_ENV` environment variable.
 
 > Environment variables always have precedence.
 
@@ -597,54 +531,54 @@ MIKRO_ORM_FORCE_UNDEFINED = true
 
 Full list of supported options:
 
-| env variable | config key |
-|--------------|------------|
-| `MIKRO_ORM_BASE_DIR` | `baseDir` |
-| `MIKRO_ORM_TYPE` | `type` |
-| `MIKRO_ORM_ENTITIES` | `entities` |
-| `MIKRO_ORM_ENTITIES_TS` | `entitiesTs` |
-| `MIKRO_ORM_CLIENT_URL` | `clientUrl` |
-| `MIKRO_ORM_HOST` | `host` |
-| `MIKRO_ORM_PORT` | `port` |
-| `MIKRO_ORM_USER` | `user` |
-| `MIKRO_ORM_PASSWORD` | `password` |
-| `MIKRO_ORM_DB_NAME` | `dbName` |
-| `MIKRO_ORM_SCHEMA`  | `schema` |
-| `MIKRO_ORM_LOAD_STRATEGY` | `loadStrategy` |
-| `MIKRO_ORM_BATCH_SIZE` | `batchSize` |
-| `MIKRO_ORM_USE_BATCH_INSERTS` | `useBatchInserts` |
-| `MIKRO_ORM_USE_BATCH_UPDATES` | `useBatchUpdates` |
-| `MIKRO_ORM_STRICT` | `strict` |
-| `MIKRO_ORM_VALIDATE` | `validate` |
-| `MIKRO_ORM_AUTO_JOIN_ONE_TO_ONE_OWNER` | `autoJoinOneToOneOwner` |
-| `MIKRO_ORM_PROPAGATE_TO_ONE_OWNER` | `propagateToOneOwner` |
-| `MIKRO_ORM_POPULATE_AFTER_FLUSH` | `populateAfterFlush` |
-| `MIKRO_ORM_FORCE_ENTITY_CONSTRUCTOR` | `forceEntityConstructor` |
-| `MIKRO_ORM_FORCE_UNDEFINED` | `forceUndefined` |
-| `MIKRO_ORM_FORCE_UTC_TIMEZONE` | `forceUtcTimezone` |
-| `MIKRO_ORM_TIMEZONE` | `timezone` |
-| `MIKRO_ORM_ENSURE_INDEXES` | `ensureIndexes` |
-| `MIKRO_ORM_IMPLICIT_TRANSACTIONS` | `implicitTransactions` |
-| `MIKRO_ORM_DEBUG` | `debug` |
-| `MIKRO_ORM_VERBOSE` | `verbose` |
-| `MIKRO_ORM_DISCOVERY_WARN_WHEN_NO_ENTITIES` | `discovery.warnWhenNoEntities` |
-| `MIKRO_ORM_DISCOVERY_REQUIRE_ENTITIES_ARRAY` | `discovery.requireEntitiesArray` |
-| `MIKRO_ORM_DISCOVERY_ALWAYS_ANALYSE_PROPERTIES` | `discovery.alwaysAnalyseProperties` |
-| `MIKRO_ORM_DISCOVERY_DISABLE_DYNAMIC_FILE_ACCESS` | `discovery.disableDynamicFileAccess` |
-| `MIKRO_ORM_MIGRATIONS_TABLE_NAME` | `migrations.tableName` |
-| `MIKRO_ORM_MIGRATIONS_PATH` | `migrations.path` |
-| `MIKRO_ORM_MIGRATIONS_PATH_TS` | `migrations.pathTs` |
-| `MIKRO_ORM_MIGRATIONS_GLOB` | `migrations.glob` |
-| `MIKRO_ORM_MIGRATIONS_TRANSACTIONAL` | `migrations.transactional` |
-| `MIKRO_ORM_MIGRATIONS_DISABLE_FOREIGN_KEYS` | `migrations.disableForeignKeys` |
-| `MIKRO_ORM_MIGRATIONS_ALL_OR_NOTHING` | `migrations.allOrNothing` |
-| `MIKRO_ORM_MIGRATIONS_DROP_TABLES` | `migrations.dropTables` |
-| `MIKRO_ORM_MIGRATIONS_SAFE` | `migrations.safe` |
-| `MIKRO_ORM_MIGRATIONS_EMIT` | `migrations.emit` |
-| `MIKRO_ORM_SCHEMA_GENERATOR_DISABLE_FOREIGN_KEYS` | `migrations.disableForeignKeys` |
+| env variable                                                | config key                               |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `MIKRO_ORM_BASE_DIR`                                        | `baseDir`                                |
+| `MIKRO_ORM_TYPE`                                            | `type`                                   |
+| `MIKRO_ORM_ENTITIES`                                        | `entities`                               |
+| `MIKRO_ORM_ENTITIES_TS`                                     | `entitiesTs`                             |
+| `MIKRO_ORM_CLIENT_URL`                                      | `clientUrl`                              |
+| `MIKRO_ORM_HOST`                                            | `host`                                   |
+| `MIKRO_ORM_PORT`                                            | `port`                                   |
+| `MIKRO_ORM_USER`                                            | `user`                                   |
+| `MIKRO_ORM_PASSWORD`                                        | `password`                               |
+| `MIKRO_ORM_DB_NAME`                                         | `dbName`                                 |
+| `MIKRO_ORM_SCHEMA`                                          | `schema`                                 |
+| `MIKRO_ORM_LOAD_STRATEGY`                                   | `loadStrategy`                           |
+| `MIKRO_ORM_BATCH_SIZE`                                      | `batchSize`                              |
+| `MIKRO_ORM_USE_BATCH_INSERTS`                               | `useBatchInserts`                        |
+| `MIKRO_ORM_USE_BATCH_UPDATES`                               | `useBatchUpdates`                        |
+| `MIKRO_ORM_STRICT`                                          | `strict`                                 |
+| `MIKRO_ORM_VALIDATE`                                        | `validate`                               |
+| `MIKRO_ORM_AUTO_JOIN_ONE_TO_ONE_OWNER`                      | `autoJoinOneToOneOwner`                  |
+| `MIKRO_ORM_PROPAGATE_TO_ONE_OWNER`                          | `propagateToOneOwner`                    |
+| `MIKRO_ORM_POPULATE_AFTER_FLUSH`                            | `populateAfterFlush`                     |
+| `MIKRO_ORM_FORCE_ENTITY_CONSTRUCTOR`                        | `forceEntityConstructor`                 |
+| `MIKRO_ORM_FORCE_UNDEFINED`                                 | `forceUndefined`                         |
+| `MIKRO_ORM_FORCE_UTC_TIMEZONE`                              | `forceUtcTimezone`                       |
+| `MIKRO_ORM_TIMEZONE`                                        | `timezone`                               |
+| `MIKRO_ORM_ENSURE_INDEXES`                                  | `ensureIndexes`                          |
+| `MIKRO_ORM_IMPLICIT_TRANSACTIONS`                           | `implicitTransactions`                   |
+| `MIKRO_ORM_DEBUG`                                           | `debug`                                  |
+| `MIKRO_ORM_VERBOSE`                                         | `verbose`                                |
+| `MIKRO_ORM_DISCOVERY_WARN_WHEN_NO_ENTITIES`                 | `discovery.warnWhenNoEntities`           |
+| `MIKRO_ORM_DISCOVERY_REQUIRE_ENTITIES_ARRAY`                | `discovery.requireEntitiesArray`         |
+| `MIKRO_ORM_DISCOVERY_ALWAYS_ANALYSE_PROPERTIES`             | `discovery.alwaysAnalyseProperties`      |
+| `MIKRO_ORM_DISCOVERY_DISABLE_DYNAMIC_FILE_ACCESS`           | `discovery.disableDynamicFileAccess`     |
+| `MIKRO_ORM_MIGRATIONS_TABLE_NAME`                           | `migrations.tableName`                   |
+| `MIKRO_ORM_MIGRATIONS_PATH`                                 | `migrations.path`                        |
+| `MIKRO_ORM_MIGRATIONS_PATH_TS`                              | `migrations.pathTs`                      |
+| `MIKRO_ORM_MIGRATIONS_GLOB`                                 | `migrations.glob`                        |
+| `MIKRO_ORM_MIGRATIONS_TRANSACTIONAL`                        | `migrations.transactional`               |
+| `MIKRO_ORM_MIGRATIONS_DISABLE_FOREIGN_KEYS`                 | `migrations.disableForeignKeys`          |
+| `MIKRO_ORM_MIGRATIONS_ALL_OR_NOTHING`                       | `migrations.allOrNothing`                |
+| `MIKRO_ORM_MIGRATIONS_DROP_TABLES`                          | `migrations.dropTables`                  |
+| `MIKRO_ORM_MIGRATIONS_SAFE`                                 | `migrations.safe`                        |
+| `MIKRO_ORM_MIGRATIONS_EMIT`                                 | `migrations.emit`                        |
+| `MIKRO_ORM_SCHEMA_GENERATOR_DISABLE_FOREIGN_KEYS`           | `migrations.disableForeignKeys`          |
 | `MIKRO_ORM_SCHEMA_GENERATOR_CREATE_FOREIGN_KEY_CONSTRAINTS` | `migrations.createForeignKeyConstraints` |
-| `MIKRO_ORM_SEEDER_PATH` | `seeder.path` |
-| `MIKRO_ORM_SEEDER_PATH_TS` | `seeder.pathTs` |
-| `MIKRO_ORM_SEEDER_GLOB` | `seeder.glob` |
-| `MIKRO_ORM_SEEDER_EMIT` | `seeder.emit` |
-| `MIKRO_ORM_SEEDER_DEFAULT_SEEDER` | `seeder.defaultSeeder` |
+| `MIKRO_ORM_SEEDER_PATH`                                     | `seeder.path`                            |
+| `MIKRO_ORM_SEEDER_PATH_TS`                                  | `seeder.pathTs`                          |
+| `MIKRO_ORM_SEEDER_GLOB`                                     | `seeder.glob`                            |
+| `MIKRO_ORM_SEEDER_EMIT`                                     | `seeder.emit`                            |
+| `MIKRO_ORM_SEEDER_DEFAULT_SEEDER`                           | `seeder.defaultSeeder`                   |

--- a/docs/docs/custom-driver.md
+++ b/docs/docs/custom-driver.md
@@ -2,18 +2,17 @@
 title: Creating Custom Driver
 ---
 
-If you want to use database that is not currently supported, you can implement your own driver.
-To do so, you will need to design 4 classes:
+If you want to use database that is not currently supported, you can implement your own driver. To do so, you will need to design 4 classes:
 
 ## Platform
 
-Platform is a class that provides information about available features of given driver: 
+Platform is a class that provides information about available features of given driver:
 
 ```ts
 import { Platform } from '@mikro-orm/core';
 
 export class MyCustomPlatform extends Platform {
-  
+
   protected abstract schemaHelper: MyCustomSchemaHelper;
 
   // here you can override default settings
@@ -39,7 +38,7 @@ Part of platform is a `SchemaHelper`, that provides information about how to bui
 import { SchemaHelper } from '@mikro-orm/core';
 
 export class MyCustomSchemaHelper extends SchemaHelper {
-  
+
   // here you can override default settings
   getIdentifierQuoteCharacter(): string;
   getSchemaBeginning(): string;
@@ -67,7 +66,7 @@ Next part is connection wrapper, that will be responsible for querying the datab
 import { Connection } from '@mikro-orm/core';
 
 export class MyCustomConnection extends Connection {
-  
+
   // implement abstract methods
   connect(): Promise<void>;
   isConnected(): Promise<boolean>;
@@ -80,12 +79,9 @@ export class MyCustomConnection extends Connection {
 
 ## Driver
 
-Last part is driver, that is responsible for using the connection to persist changes to 
-database. If you are building SQL driver, it might be handy to extend `AbstractSqlDriver`, 
-if not, extend `DatabaseDriver` abstract class. 
+Last part is driver, that is responsible for using the connection to persist changes to database. If you are building SQL driver, it might be handy to extend `AbstractSqlDriver`, if not, extend `DatabaseDriver` abstract class.
 
-If you want to have absolute control, you can implement the whole driver yourself via
-`IDatabaseDriver` interface. 
+If you want to have absolute control, you can implement the whole driver yourself via `IDatabaseDriver` interface.
 
 ```ts
 import { DatabaseDriver } from '@mikro-orm/core';

--- a/docs/docs/custom-types.md
+++ b/docs/docs/custom-types.md
@@ -22,13 +22,11 @@ You can define custom types by extending `Type` abstract class. It has several o
 
 - `convertToDatabaseValueSQL(key: string, platform: Platform): string`
 
-  Converts a value from its JS representation to its database representation of this type.
-  _(added in v4.4.2)_
+  Converts a value from its JS representation to its database representation of this type. _(added in v4.4.2)_
 
 - `convertToJSValueSQL(key: string, platform: Platform): string`
 
-  Modifies the SQL expression (identifier, parameter) to convert to a JS value.
-  _(added in v4.4.2)_
+  Modifies the SQL expression (identifier, parameter) to convert to a JS value. _(added in v4.4.2)_
 
 - `compareAsType(): string`
 
@@ -101,9 +99,7 @@ born?: string;
 
 In this example we will combine mapping values via database as well as during runtime.
 
-> The Point type is part of the Spatial extension of MySQL and enables you to store
-> a single location in a coordinate space by using x and y coordinates. You can use
-> the Point type to store a longitude/latitude pair to represent a geographic location.
+> The Point type is part of the Spatial extension of MySQL and enables you to store a single location in a coordinate space by using x and y coordinates. You can use the Point type to store a longitude/latitude pair to represent a geographic location.
 
 First let's define the `Point` class that will be used to represent the value during runtime:
 
@@ -201,8 +197,7 @@ update `location` set `point` = ST_PointFromText('point(2.34 9.87)') where `id` 
 commit
 ```
 
-We do a 2-step conversion here. In the first step, we convert the Point object into a string representation before saving to the database (in the convertToDatabaseValue method) and back into an object
-after fetching the value from the database (in the convertToJSValue method).
+We do a 2-step conversion here. In the first step, we convert the Point object into a string representation before saving to the database (in the convertToDatabaseValue method) and back into an object after fetching the value from the database (in the convertToJSValue method).
 
 The format of the string representation format is called Well-known text (WKT). The advantage of this format is, that it is both human readable and parsable by MySQL.
 
@@ -212,9 +207,7 @@ This is where the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods 
 
 This methods wrap a sql expression (the WKT representation of the Point) into MySQL functions ST_PointFromText and ST_AsText which convert WKT strings to and from the internal format of MySQL.
 
-> When using DQL queries, the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods
-> only apply to identification variables and path expressions in SELECT clauses. Expressions
-> in WHERE clauses are not wrapped!
+> When using DQL queries, the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods only apply to identification variables and path expressions in SELECT clauses. Expressions in WHERE clauses are not wrapped!
 
 ## Types provided by MikroORM
 
@@ -260,18 +253,11 @@ export const types = {
 
 ### ArrayType
 
-In PostgreSQL and MongoDB, it uses native arrays, otherwise it concatenates the values into string separated by commas. This means that you can't use values that contain comma with the `ArrayType` (
-but you can create custom array type that will handle this case, e.g. by using different separator).
+In PostgreSQL and MongoDB, it uses native arrays, otherwise it concatenates the values into string separated by commas. This means that you can't use values that contain comma with the `ArrayType` ( but you can create custom array type that will handle this case, e.g. by using different separator).
 
-By default, array of strings is returned from the type. You can also have arrays of numbers or other data types - to do so, you will need to implement custom
-`hydrate` method that is used for converting the array values to the right type.
+By default, array of strings is returned from the type. You can also have arrays of numbers or other data types - to do so, you will need to implement custom `hydrate` method that is used for converting the array values to the right type.
 
-> `ArrayType` will be used automatically if `type` is set to `array` (default behaviour
-> of reflect-metadata) or `string[]` or `number[]` (either manually or via ts-morph).
-> In case of `number[]` it will automatically handle the conversion to numbers.
-> This means that the following examples would both have the `ArrayType` used
-> automatically (but with reflect-metadata we would have a string array for both
-> unless we specify the type manually as `type: 'number[]')
+> `ArrayType` will be used automatically if `type` is set to `array` (default behaviour of reflect-metadata) or `string[]` or `number[]` (either manually or via ts-morph). In case of `number[]` it will automatically handle the conversion to numbers. This means that the following examples would both have the `ArrayType` used automatically (but with reflect-metadata we would have a string array for both unless we specify the type manually as `type: 'number[]')
 
 ```ts
 @Property({ type: ArrayType, nullable: true })
@@ -294,9 +280,7 @@ id: string;
 
 Blob type can be used to store binary data in the database.
 
-> `BlobType` will be used automatically if you specify the type hint as `Buffer`.
-> This means that the following example should work even without the explicit
-> `type: BlobType` option (with both reflect-metadata and ts-morph providers).
+> `BlobType` will be used automatically if you specify the type hint as `Buffer`. This means that the following example should work even without the explicit `type: BlobType` option (with both reflect-metadata and ts-morph providers).
 
 ```ts
 @Property({ type: BlobType, nullable: true })
@@ -305,8 +289,7 @@ blob?: Buffer;
 
 ### JsonType
 
-To store objects we can use `JsonType`. As some drivers are handling objects automatically and some don't, this type will handle the serialization in a driver independent way (calling `parse`
-and `stringify` only when needed).
+To store objects we can use `JsonType`. As some drivers are handling objects automatically and some don't, this type will handle the serialization in a driver independent way (calling `parse` and `stringify` only when needed).
 
 ```ts
 @Property({ type: JsonType, nullable: true })
@@ -315,8 +298,7 @@ object?: { foo: string; bar: number };
 
 ### DateType
 
-To store dates without time information, we can use `DateType`. It does use `date`
-column type and maps it to the `Date` object.
+To store dates without time information, we can use `DateType`. It does use `date` column type and maps it to the `Date` object.
 
 ```ts
 @Property({ type: DateType, nullable: true })
@@ -325,8 +307,7 @@ born?: Date;
 
 ### TimeType
 
-As opposed to the `DateType`, to store only the time information, we can use
-`TimeType`. It will use the `time` column type, the runtime type is string.
+As opposed to the `DateType`, to store only the time information, we can use `TimeType`. It will use the `time` column type, the runtime type is string.
 
 ```ts
 @Property({ type: TimeType, nullable: true })

--- a/docs/docs/decorators.md
+++ b/docs/docs/decorators.md
@@ -4,28 +4,25 @@ title: Decorators
 
 ## Entity Definition
 
-> Some options affect how the [Schema Generator](schema-generator.md) works, and those are SQL only,
-> meaning they affect only SQL drivers - whereas, mongo has no schema.
+> Some options affect how the [Schema Generator](schema-generator.md) works, and those are SQL only, meaning they affect only SQL drivers - whereas, mongo has no schema.
 
 ### @Entity()
 
-`@Entity` decorator is used to mark your model classes as entities. Do not use it for 
-abstract base classes.
+`@Entity` decorator is used to mark your model classes as entities. Do not use it for abstract base classes.
 
 | Parameter             | Type                     | Optional | Description                                                                      |
-|-----------------------|--------------------------|----------|----------------------------------------------------------------------------------|
+| --------------------- | ------------------------ | -------- | -------------------------------------------------------------------------------- |
 | `tableName`           | `string`                 | yes      | Override default collection/table name.                                          |
 | `schema`              | `string`                 | yes      | Sets the schema name.                                                            |
 | `collection`          | `string`                 | yes      | Alias for `tableName`.                                                           |
 | `comment`             | `string`                 | yes      | Specify comment to table. **(SQL only)**                                         |
 | `customRepository`    | `() => EntityRepository` | yes      | Set [custom repository class](repositories.md#custom-repository).                |
-| `discriminatorColumn` | `string`                 | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance). |                 
-| `discriminatorMap`    | `Dictionary<string>`     | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance). |     
+| `discriminatorColumn` | `string`                 | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance). |
+| `discriminatorMap`    | `Dictionary<string>`     | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance). |
 | `discriminatorValue`  | `number` &#124; `string` | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance). |
 | `forceConstructor`    | `boolean`                | yes      | Enforce use of constructor when creating managed entity instances                |
-| `abstract`              | `boolean`                | yes      | Marks entity as abstract, such entities are inlined during discovery.            |
-| `readonly`              | `boolean`                | yes      | Disables change tracking - such entities are ignored during flush.               |
-
+| `abstract`            | `boolean`                | yes      | Marks entity as abstract, such entities are inlined during discovery.            |
+| `readonly`            | `boolean`                | yes      | Disables change tracking - such entities are ignored during flush.               |
 
 ```ts
 @Entity({ tableName: 'authors' })
@@ -36,28 +33,27 @@ export class Author { ... }
 
 ### @Property()
 
-`@Property()` decorator is used to define regular entity property. All following decorators
-extend the `@Property()` decorator, so you can also use its parameters there.
+`@Property()` decorator is used to define regular entity property. All following decorators extend the `@Property()` decorator, so you can also use its parameters there.
 
-| Parameter          | Type | Optional | Description                                                                                                                                         |
-|--------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `fieldName`        | `string` | yes | Override default property name (see [Naming Strategy](naming-strategy.md)).                                                                         |
-| `type`             | `string` &#124; `Constructor<Type>` &#124; `Type` | yes | Explicitly specify the runtime type (see [Metadata Providers](metadata-providers.md) and [Custom Types](custom-types.md)).                          |
-| `customType`       | `Type` | yes | Explicitly specify the mapped type instance for this property (see [Custom Types](custom-types.md)).                                                |
-| `onUpdate`         | `() => any` | yes | Automatically update the property value every time entity gets updated.                                                                             |
-| `persist`          | `boolean` | yes | Set to `false` to define [Shadow Property](serializing.md#shadow-properties).                                                                       |
-| `hydrate`          | `boolean` | yes | Set to `false` to disable hydration of this property. Useful for persisted getters.                                                                 |
-| `hidden`           | `boolean` | yes | Set to `true` to omit the property when [Serializing](serializing.md).                                                                              |
-| `columnType`       | `string` | yes | Specify exact database column type for [Schema Generator](schema-generator.md). **(SQL only)**                                                      |
-| `length`           | `number` | yes | Length/precision of database column, used for `datetime/timestamp/varchar` column types for [Schema Generator](schema-generator.md). **(SQL only)** |
-| `default`          | `any` | yes | Specify default column value for [Schema Generator](schema-generator.md). **(SQL only)**                                                            |
-| `unique`           | `boolean` | yes | Set column as unique for [Schema Generator](schema-generator.md). **(SQL only)**                                                                    |
-| `nullable`         | `boolean` | yes | Set column as nullable for [Schema Generator](schema-generator.md). **(SQL only)**                                                                  |
-| `unsigned`         | `boolean` | yes | Set column as unsigned for [Schema Generator](schema-generator.md). **(SQL only)**                                                                  |
-| `comment`          | `string` | yes | Specify comment of column for [Schema Generator](schema-generator.md). **(SQL only)**                                                               |
-| `version`          | `boolean` | yes | Set to true to enable [Optimistic Locking](transactions.md#optimistic-locking) via version field. **(SQL only)**                                    |
-| `concurrencyCheck` | `boolean` | yes | Set to true to enable [Concurrency Check](transactions.md#concurrency-checks) via concurrency fields.                                               |
-| `customOrder`      | `string[]` &#124; `number[]` &#124; `boolean[]` | yes | Specify a custom order for the column. **(SQL only)**                                                                                               |
+| Parameter | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `fieldName` | `string` | yes | Override default property name (see [Naming Strategy](naming-strategy.md)). |
+| `type` | `string` &#124; `Constructor<Type>` &#124; `Type` | yes | Explicitly specify the runtime type (see [Metadata Providers](metadata-providers.md) and [Custom Types](custom-types.md)). |
+| `customType` | `Type` | yes | Explicitly specify the mapped type instance for this property (see [Custom Types](custom-types.md)). |
+| `onUpdate` | `() => any` | yes | Automatically update the property value every time entity gets updated. |
+| `persist` | `boolean` | yes | Set to `false` to define [Shadow Property](serializing.md#shadow-properties). |
+| `hydrate` | `boolean` | yes | Set to `false` to disable hydration of this property. Useful for persisted getters. |
+| `hidden` | `boolean` | yes | Set to `true` to omit the property when [Serializing](serializing.md). |
+| `columnType` | `string` | yes | Specify exact database column type for [Schema Generator](schema-generator.md). **(SQL only)** |
+| `length` | `number` | yes | Length/precision of database column, used for `datetime/timestamp/varchar` column types for [Schema Generator](schema-generator.md). **(SQL only)** |
+| `default` | `any` | yes | Specify default column value for [Schema Generator](schema-generator.md). **(SQL only)** |
+| `unique` | `boolean` | yes | Set column as unique for [Schema Generator](schema-generator.md). **(SQL only)** |
+| `nullable` | `boolean` | yes | Set column as nullable for [Schema Generator](schema-generator.md). **(SQL only)** |
+| `unsigned` | `boolean` | yes | Set column as unsigned for [Schema Generator](schema-generator.md). **(SQL only)** |
+| `comment` | `string` | yes | Specify comment of column for [Schema Generator](schema-generator.md). **(SQL only)** |
+| `version` | `boolean` | yes | Set to true to enable [Optimistic Locking](transactions.md#optimistic-locking) via version field. **(SQL only)** |
+| `concurrencyCheck` | `boolean` | yes | Set to true to enable [Concurrency Check](transactions.md#concurrency-checks) via concurrency fields. |
+| `customOrder` | `string[]` &#124; `number[]` &#124; `boolean[]` | yes | Specify a custom order for the column. **(SQL only)** |
 
 > You can use property initializers as usual.
 
@@ -80,14 +76,13 @@ registered = false;
 
 ### @PrimaryKey()
 
-`@PrimaryKey()` decorator is used to define entity's unique primary key identifier. 
+`@PrimaryKey()` decorator is used to define entity's unique primary key identifier.
 
-> `@PrimaryKey()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@PrimaryKey()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 > Every entity needs to have at least one primary key (see composite primary keys).
 
-> Note that if only one PrimaryKey is set and it's type is number it will be set to auto incremented automatically in all SQL drivers. 
+> Note that if only one PrimaryKey is set and it's type is number it will be set to auto incremented automatically in all SQL drivers.
 
 ```ts
 @PrimaryKey()
@@ -105,13 +100,10 @@ _id!: ObjectId; // ObjectId PK in mongodb driver
 
 ### @SerializedPrimaryKey()
 
-> Property marked with `@SerializedPrimaryKey()` is virtual, it will not be persisted 
-> into the database.
+> Property marked with `@SerializedPrimaryKey()` is virtual, it will not be persisted into the database.
 
-For MongoDB you can define serialized primary key, which will be then used in entity 
-serialization via `JSON.stringify()` (through method `entity.toJSON()`).
-You will be able to use it to manipulate with the primary key as string. 
- 
+For MongoDB you can define serialized primary key, which will be then used in entity serialization via `JSON.stringify()` (through method `entity.toJSON()`). You will be able to use it to manipulate with the primary key as string.
+
 See [Usage with MongoDB](usage-with-mongo.md) and [Serializing](serializing.md).
 
 ```ts
@@ -124,19 +116,15 @@ id!: string;
 
 ### @Enum()
 
-> `@Enum()` decorator extend the `@Property()` decorator, so you can use all its 
-> parameters.
+> `@Enum()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
-`@Enum()` decorator can be used for both numeric and string enums. By default enums are 
-considered numeric, and will be represented in the database schema as `tinyint/smallint`. 
-For string enums, if you define the enum in same file, its values will be automatically 
-sniffed. 
+`@Enum()` decorator can be used for both numeric and string enums. By default enums are considered numeric, and will be represented in the database schema as `tinyint/smallint`. For string enums, if you define the enum in same file, its values will be automatically sniffed.
 
 See [Defining Entities](defining-entities.md#enums).
 
-| Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
-| `items` | `number[]` &#124; `string[]` &#124; `() => Dictionary` | yes | Specify enum items explicitly. |
+| Parameter | Type                                                   | Optional | Description                    |
+| --------- | ------------------------------------------------------ | -------- | ------------------------------ |
+| `items`   | `number[]` &#124; `string[]` &#124; `() => Dictionary` | yes      | Specify enum items explicitly. |
 
 ```ts
 @Enum() // with ts-morph metadata provider we do not need to specify anything
@@ -157,14 +145,13 @@ enum4 = 'a';
 
 ### @Formula()
 
-`@Formula()` decorator can be used to map some SQL snippet to your entity. 
-The SQL fragment can be as complex as you want and even include subselects.
+`@Formula()` decorator can be used to map some SQL snippet to your entity. The SQL fragment can be as complex as you want and even include subselects.
 
 See [Defining Entities](defining-entities.md#formulas).
 
-| Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
-| `formula` | `string` &#124; `() => string` | no | SQL fragment that will be part of the select clause.  |
+| Parameter | Type                           | Optional | Description                                          |
+| --------- | ------------------------------ | -------- | ---------------------------------------------------- |
+| `formula` | `string` &#124; `() => string` | no       | SQL fragment that will be part of the select clause. |
 
 ```ts
 @Formula('obj_length * obj_height * obj_width')
@@ -173,18 +160,15 @@ objectVolume?: number;
 
 ### @Index() and @Unique()
 
-Use `@Index()` to create an index, or `@Unique()` to create unique constraint. You can 
-use those decorators both on the entity level and on property level. To create compound
-index, use the decorator on the entity level and provide list of property names via the
-`properties` option.
+Use `@Index()` to create an index, or `@Unique()` to create unique constraint. You can use those decorators both on the entity level and on property level. To create compound index, use the decorator on the entity level and provide list of property names via the `properties` option.
 
 See [Defining Entities](defining-entities.md#indexes).
 
-| Parameter    | Type     | Optional | Description |
-|--------------|----------|----------|-------------|
-| `name`       | `string` | yes      | index name  |
+| Parameter | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `name` | `string` | yes | index name |
 | `properties` | `string` &#124; `string[]` | yes | list of properties, required when using on entity level |
-| `type`       | `string` | yes      | index type, not available for `@Unique()`. Use `fulltext` to enable support for the `$fulltext` operator |
+| `type` | `string` | yes | index type, not available for `@Unique()`. Use `fulltext` to enable support for the `$fulltext` operator |
 
 ```ts
 @Entity()
@@ -210,29 +194,25 @@ export class Author {
 
 ### @Check()
 
-We can define check constraints via `@Check()` decorator. We can use it
-either on entity class, or on entity property. It has a required `expression`
-property, that can be either a string or a callback, that receives map of
-property names to column names. Note that we need to use the generic type
-argument if we want TypeScript suggestions for the property names.
+We can define check constraints via `@Check()` decorator. We can use it either on entity class, or on entity property. It has a required `expression` property, that can be either a string or a callback, that receives map of property names to column names. Note that we need to use the generic type argument if we want TypeScript suggestions for the property names.
 
 > Check constraints are currently supported only in postgres driver.
 
 See [Defining Entities](defining-entities.md#check-constraints).
 
-| Parameter    | Type     | Optional | Description       |
-|--------------|----------|----------|-------------------|
-| `name`       | `string` | yes      | constraint name   |
-| `property`   | `string` | yes      | property name, only used when generating the constraint name |
+| Parameter    | Type                            | Optional | Description                                                                          |
+| ------------ | ------------------------------- | -------- | ------------------------------------------------------------------------------------ |
+| `name`       | `string`                        | yes      | constraint name                                                                      |
+| `property`   | `string`                        | yes      | property name, only used when generating the constraint name                         |
 | `expression` | `string` &#124; `CheckCallback` | no       | constraint definition, can be a callback that gets a map of property to column names |
 
 ```ts
 @Entity()
-// with generated name based on the table name 
+// with generated name based on the table name
 @Check({ expression: 'price1 >= 0' })
-// with explicit name 
+// with explicit name
 @Check({ name: 'foo', expression: columns => `${columns.price1} >= 0` })
-// with explicit type argument we get autocomplete on `columns` 
+// with explicit type argument we get autocomplete on `columns`
 @Check<FooEntity>({ expression: columns => `${columns.price1} >= 0` })
 export class Book {
 
@@ -254,39 +234,31 @@ export class Book {
 
 ## Entity Relationships
 
-All relationship decorators have `entity`, `cascade` and `eager` optional parameters. 
-If you use the default `ReflectMetadataProvider`, then `entity` parameter might be required 
-You will be warned about it being not defined while required during discovery process if you 
-use `ReflectMetadataProvider`. 
+All relationship decorators have `entity`, `cascade` and `eager` optional parameters. If you use the default `ReflectMetadataProvider`, then `entity` parameter might be required You will be warned about it being not defined while required during discovery process if you use `ReflectMetadataProvider`.
 
-You can also use `type` parameter instead of it - the difference being that `type` parameter
-needs to be string, while in `entity` parameter you can provide a reference (wrapped in 
-a callback to overcome issues with circular dependencies) to the entity, which plays nice 
-with refactoring features in IDEs like WebStorm. 
+You can also use `type` parameter instead of it - the difference being that `type` parameter needs to be string, while in `entity` parameter you can provide a reference (wrapped in a callback to overcome issues with circular dependencies) to the entity, which plays nice with refactoring features in IDEs like WebStorm.
 
-> If you explicitly provide `entity` as a reference, it will enable type checks for other
-> reference parameters like `inversedBy` or `mappedBy`.
+> If you explicitly provide `entity` as a reference, it will enable type checks for other reference parameters like `inversedBy` or `mappedBy`.
 
 ### @ManyToOne()
 
-> `@ManyToOne()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@ManyToOne()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 Many instances of the current Entity refer to One instance of the referred Entity.
 
 See [Defining Entities](relationships.md#manytoone) for more examples.
 
-| Parameter           | Type | Optional | Description                                                                                                                                               |
-|---------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `entity`            | `string` &#124; `() => EntityName` | yes | Set target entity type.                                                                                                                                   |
-| `cascade`           | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
-| `eager`             | `boolean` | yes | Always load the relationship.                                                                                                                             |
-| `inversedBy`        | `(string & keyof T) ` &#124; ` (e: T) => any` | yes | Point to the inverse side property name.                                                                                                                  |
-| `wrappedReference`  | `boolean` | yes | Wrap the entity in [`Reference` wrapper](type-safe-relations.md).                                                                                         |
-| `ref`               | `boolean` | yes | Alias for `wrappedReference`.                                                                                                                             |
-| `primary`           | `boolean` | yes | Use this relation as primary key.                                                                                                                         |
-| `onDelete`          | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity).                                                                                  |
-| `onUpdateIntegrity` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity).                                                                                  |
+| Parameter | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
+| `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
+| `eager` | `boolean` | yes | Always load the relationship. |
+| `inversedBy` | `(string & keyof T) ` &#124; ` (e: T) => any` | yes | Point to the inverse side property name. |
+| `wrappedReference` | `boolean` | yes | Wrap the entity in [`Reference` wrapper](type-safe-relations.md). |
+| `ref` | `boolean` | yes | Alias for `wrappedReference`. |
+| `primary` | `boolean` | yes | Use this relation as primary key. |
+| `onDelete` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity). |
+| `onUpdateIntegrity` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity). |
 
 ```ts
 @ManyToOne()
@@ -301,28 +273,27 @@ author3?: Author;
 
 ### @OneToOne()
 
-> `@OneToOne()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@OneToOne()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 One instance of the current Entity refers to One instance of the referred Entity.
 
 See [Defining Entities](relationships.md#onetoone) for more examples, including bi-directional 1:1.
 
-| Parameter           | Type | Optional | Description                                                                                                                                               |
-|---------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `entity`            | `string` &#124; `() => EntityName` | yes | Set target entity type.                                                                                                                                   |
-| `cascade`           | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
-| `eager`             | `boolean` | yes | Always load the relationship.                                                                                                                             |
-| `owner`             | `boolean` | yes | Explicitly set as owning side (same as providing `inversedBy`).                                                                                           |
-| `inversedBy`        | `(string & keyof T) ` &#124; ` (e: T) => any` | yes | Point to the inverse side property name.                                                                                                                  |
-| `mappedBy`          | `(string & keyof T)` &#124; `(e: T) => any` | yes | Point to the owning side property name.                                                                                                                   |
-| `wrappedReference`  | `boolean` | yes | Wrap the entity in [`Reference` wrapper](type-safe-relations.md).                                                                                         |
-| `ref`               | `boolean` | yes | Alias for `wrappedReference`.                                                                                                                             |
-| `orphanRemoval`     | `boolean` | yes | Remove the entity when it gets disconnected from the relationship (see [Cascading](cascading.md#orphan-removal)).                                         |
-| `joinColumn`        | `string` | yes | Override default database column name on the owning side (see [Naming Strategy](naming-strategy.md)).                                                     |
-| `primary`           | `boolean` | yes | Use this relation as primary key.                                                                                                                         |
-| `onDelete`          | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity).                                                                                  |
-| `onUpdateIntegrity` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity).                                                                                  |
+| Parameter | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
+| `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
+| `eager` | `boolean` | yes | Always load the relationship. |
+| `owner` | `boolean` | yes | Explicitly set as owning side (same as providing `inversedBy`). |
+| `inversedBy` | `(string & keyof T) ` &#124; ` (e: T) => any` | yes | Point to the inverse side property name. |
+| `mappedBy` | `(string & keyof T)` &#124; `(e: T) => any` | yes | Point to the owning side property name. |
+| `wrappedReference` | `boolean` | yes | Wrap the entity in [`Reference` wrapper](type-safe-relations.md). |
+| `ref` | `boolean` | yes | Alias for `wrappedReference`. |
+| `orphanRemoval` | `boolean` | yes | Remove the entity when it gets disconnected from the relationship (see [Cascading](cascading.md#orphan-removal)). |
+| `joinColumn` | `string` | yes | Override default database column name on the owning side (see [Naming Strategy](naming-strategy.md)). |
+| `primary` | `boolean` | yes | Use this relation as primary key. |
+| `onDelete` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity). |
+| `onUpdateIntegrity` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity). |
 
 ```ts
 // when none of `owner/inverseBy/mappedBy` is provided, it will be considered owning side
@@ -340,8 +311,7 @@ bestFriend3!: User;
 
 ### @OneToMany()
 
-> `@OneToMany()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@OneToMany()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 One instance of the current Entity has Many instances (references) to the referred Entity.
 
@@ -350,7 +320,7 @@ See [Defining Entities](relationships.md#onetomany) for more examples, including
 > You need to initialize the value with `Collection<T>` instance.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `mappedBy` | `(string & keyof T)` &#124; `(e: T) => any` | no | Point to the owning side property name. |
 | `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
 | `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
@@ -370,8 +340,7 @@ books2 = new Collection<Book>(this); // target entity type can be read via `TsMo
 
 ### @ManyToMany()
 
-> `@ManyToMany()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@ManyToMany()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 Many instances of the current Entity refers to Many instances of the referred Entity.
 
@@ -380,7 +349,7 @@ See [Defining Entities](relationships.md#manytomany) for more examples, includin
 > You need to initialize the value with `Collection<T>` instance.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
 | `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
 | `eager` | `boolean` | yes | Always load the relationship. |
@@ -404,15 +373,13 @@ tagsUnordered = new Collection<BookTag>(this); // m:n with composite PK
 
 ## Lifecycle Hooks
 
-You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of
-entity methods with them, you can also mark multiple methods with same hook.
+You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of entity methods with them, you can also mark multiple methods with same hook.
 
 > All hooks support async methods with one exception - `@OnInit`.
 
 ### @OnInit()
 
-Fired when new instance of entity is created, either manually `em.create()`, or 
-automatically when new entities are loaded from database
+Fired when new instance of entity is created, either manually `em.create()`, or automatically when new entities are loaded from database
 
 > `@OnInit` is not fired when you create the entity manually via its constructor (`new MyEntity()`)
 
@@ -425,9 +392,7 @@ doStuffOnInit() {
 
 ### @OnLoad()
 
-Fired when new entities are loaded from database. Unlike `@InInit()`, 
-this will be fired only for fully loaded entities (not references). The method
-can be `async`.
+Fired when new entities are loaded from database. Unlike `@InInit()`, this will be fired only for fully loaded entities (not references). The method can be `async`.
 
 ```ts
 @OnLoad()
@@ -449,9 +414,7 @@ async doStuffBeforeCreate() {
 
 ### @AfterCreate()
 
-Fired right after the new entity is created in the database and merged to identity map. 
-Since this event entity will have reference to `EntityManager` and will be 
-enabled to call `wrap(entity).init()` method (including all entity references and collections).
+Fired right after the new entity is created in the database and merged to identity map. Since this event entity will have reference to `EntityManager` and will be enabled to call `wrap(entity).init()` method (including all entity references and collections).
 
 ```ts
 @AfterCreate()
@@ -473,7 +436,7 @@ async doStuffBeforeUpdate() {
 
 ### @AfterUpdate()
 
-Fired right after the entity is updated in the database. 
+Fired right after the entity is updated in the database.
 
 ```ts
 @AfterUpdate()
@@ -484,8 +447,7 @@ async doStuffAfterUpdate() {
 
 ### @BeforeDelete()
 
-Fired right before we delete the record from database. It is fired only when
-removing entity or entity reference, not when deleting records by query. 
+Fired right before we delete the record from database. It is fired only when removing entity or entity reference, not when deleting records by query.
 
 ```ts
 @BeforeDelete()
@@ -509,9 +471,7 @@ async doStuffAfterDelete() {
 
 ### @Subscriber()
 
-Used to register an event subscriber. Keep in mind that you need to make sure the file 
-gets loaded in order to make this decorator registration work (e.g. you import that file 
-explicitly somewhere).
+Used to register an event subscriber. Keep in mind that you need to make sure the file gets loaded in order to make this decorator registration work (e.g. you import that file explicitly somewhere).
 
 ```ts
 @Subscriber()

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -5,43 +5,27 @@ title: Defining Entities
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Entities are simple javascript objects (so called POJO) without restrictions and without the need to extend base classes. Using [entity constructors](entity-constructors.md) works as well - they are never executed for managed entities (loaded from database). 
-Every entity is required to have a primary key.
+Entities are simple javascript objects (so called POJO) without restrictions and without the need to extend base classes. Using [entity constructors](entity-constructors.md) works as well - they are never executed for managed entities (loaded from database). Every entity is required to have a primary key.
 
 Entities can be defined in two ways:
 
-- Decorated classes - the attributes of the entity, as well as each property are provided
-  via decorators. We use `@Entity()` decorator on the class. Entity properties are decorated 
-  either with `@Property` decorator, or with one of reference decorators: 
-  `@ManyToOne`, `@OneToMany`, `@OneToOne` and `@ManyToMany`.
-  Check out the full [decorator reference](decorators.md).
-- `EntitySchema` helper - With `EntitySchema` helper we define the schema programmatically.
-  We can use regular classes as well as interfaces. This approach also allows to re-use 
-  partial entity definitions (e.g. traits/mixins). Read more about this 
-  in [Defining Entities via EntitySchema section](entity-schema.md).
+- Decorated classes - the attributes of the entity, as well as each property are provided via decorators. We use `@Entity()` decorator on the class. Entity properties are decorated either with `@Property` decorator, or with one of reference decorators: `@ManyToOne`, `@OneToMany`, `@OneToOne` and `@ManyToMany`. Check out the full [decorator reference](decorators.md).
+- `EntitySchema` helper - With `EntitySchema` helper we define the schema programmatically. We can use regular classes as well as interfaces. This approach also allows to re-use partial entity definitions (e.g. traits/mixins). Read more about this in [Defining Entities via EntitySchema section](entity-schema.md).
 
-Moreover, how the metadata extraction from decorators happens is controlled 
-via `MetadataProvider`. Two main metadata providers are:
+Moreover, how the metadata extraction from decorators happens is controlled via `MetadataProvider`. Two main metadata providers are:
 
-- `ReflectMetadataProvider` - uses `reflect-metadata` to read the property types. Faster
-  but simpler and more verbose. 
-- `TsMorphMetadataProvider` - uses `ts-morph` to read the type information from the
-  TypeScript compiled API. Heavier (requires full TS as a dependency), but allows DRY 
-  entity definition. With `ts-morph` we are able to extract the type as it is defined in
-  the code, including interface names, as well as optionality of properties. 
+- `ReflectMetadataProvider` - uses `reflect-metadata` to read the property types. Faster but simpler and more verbose.
+- `TsMorphMetadataProvider` - uses `ts-morph` to read the type information from the TypeScript compiled API. Heavier (requires full TS as a dependency), but allows DRY entity definition. With `ts-morph` we are able to extract the type as it is defined in the code, including interface names, as well as optionality of properties.
 
 Read more about them in the [Metadata Providers section](metadata-providers.md).
 
-> Current set of decorators in MikroORM is designed to work with the `tsc`. 
-> Using `babel` is also possible, but requires some additional setup. Read more about it
-> [here](usage-with-babel.md). For notes about `webpack`, read the [deployment section](deployment.md).
+> Current set of decorators in MikroORM is designed to work with the `tsc`. Using `babel` is also possible, but requires some additional setup. Read more about it [here](usage-with-babel.md). For notes about `webpack`, read the [deployment section](deployment.md).
 >
 > `ts-morph` is compatible only with the `tsc` approach.
 
 > From v3 we can also use default exports when defining your entity.
 
-Example definition of a `Book` entity follows. We can switch the tabs to see the difference
-for various ways:
+Example definition of a `Book` entity follows. We can switch the tabs to see the difference for various ways:
 
 <Tabs
   groupId="entity-def"
@@ -123,8 +107,7 @@ export const Book = new EntitySchema<IBook, CustomBaseEntity>({
 
 > Including `{ wrappedEntity: true }` in your `Ref` property definitions will wrap the reference, providing access to helper methods like `.load` and `.unwrap`, which can be helpful for loading data and changing the type of your references where you plan to use them.
 
-Here is another example of `Author` entity, that was referenced from the `Book` one, this
-time defined for mongo:
+Here is another example of `Author` entity, that was referenced from the `Book` one, this time defined for mongo:
 
 <Tabs
   groupId="entity-def"
@@ -306,9 +289,7 @@ For an example of Vanilla JavaScript usage, take a look [here](usage-with-js.md)
 
 ## Optional Properties
 
-With the default `reflect-metadata` provider, we need to mark each optional property as `nullable: true`.
-When using `ts-morph`, if you define the property as optional (marked with `?`), this will be automatically considered
-as nullable property (mainly for SQL schema generator).
+With the default `reflect-metadata` provider, we need to mark each optional property as `nullable: true`. When using `ts-morph`, if you define the property as optional (marked with `?`), this will be automatically considered as nullable property (mainly for SQL schema generator).
 
 <Tabs
   groupId="entity-def"
@@ -350,10 +331,7 @@ properties: {
 
 We can set default value of a property in 2 ways:
 
-1. Use runtime default value of the property. This approach should be preferred as long
-as we are not using any native database function like `now()`. With this approach our
-entities will have the default value set even before it is actually persisted into the
-database (e.g. when we instantiate new entity via `new Author()` or `em.create(Author, { ... })`.
+1. Use runtime default value of the property. This approach should be preferred as long as we are not using any native database function like `now()`. With this approach our entities will have the default value set even before it is actually persisted into the database (e.g. when we instantiate new entity via `new Author()` or `em.create(Author, { ... })`.
 
 <Tabs
 groupId="entity-def"
@@ -405,12 +383,9 @@ properties: {
   </TabItem>
 </Tabs>
 
-2. Use `default` parameter of `@Property` decorator. This way the actual default value
-will be provided by the database, and automatically mapped to the entity property after
-it is being persisted (after flush). To use SQL functions like `now()`, use `defaultRaw`.
+2. Use `default` parameter of `@Property` decorator. This way the actual default value will be provided by the database, and automatically mapped to the entity property after it is being persisted (after flush). To use SQL functions like `now()`, use `defaultRaw`.
 
-  > Since v4 you should use `defaultRaw` for SQL functions, as `default` with string values
-  > will be automatically quoted.
+> Since v4 you should use `defaultRaw` for SQL functions, as `default` with string values will be automatically quoted.
 
 <Tabs
 groupId="entity-def"
@@ -466,12 +441,9 @@ properties: {
 
 To define an enum property, use `@Enum()` decorator. Enums can be either numeric or string values.
 
-For schema generator to work properly in case of string enums, we need to define the enum
-in the same file as where it is used, so its values can be automatically discovered. If we want
-to define the enum in another file, we should re-export it also in place where we use it.
+For schema generator to work properly in case of string enums, we need to define the enum in the same file as where it is used, so its values can be automatically discovered. If we want to define the enum in another file, we should re-export it also in place where we use it.
 
-Another possibility is to provide the reference to the enum implementation in the decorator
-via `@Enum(() => UserRole)`.
+Another possibility is to provide the reference to the enum implementation in the decorator via `@Enum(() => UserRole)`.
 
 > We can also set enum items manually via `items: string[]` attribute.
 
@@ -580,8 +552,7 @@ properties: {
 
 ## Enum arrays
 
-We can also use array of values for enum, in that case, `EnumArrayType` type
-will be used automatically, that will validate items on flush.
+We can also use array of values for enum, in that case, `EnumArrayType` type will be used automatically, that will validate items on flush.
 
 <Tabs
 groupId="entity-def"
@@ -636,8 +607,7 @@ properties: {
 
 ## Mapping directly to primary keys
 
-Sometimes we might want to work only with the primary key of a relation.
-To do that, we can use `mapToPk` option on M:1 and 1:1 relations:
+Sometimes we might want to work only with the primary key of a relation. To do that, we can use `mapToPk` option on M:1 and 1:1 relations:
 
 <Tabs
 groupId="entity-def"
@@ -675,8 +645,7 @@ properties: {
   </TabItem>
 </Tabs>
 
-For composite keys, this will give us ordered tuple representing the raw PKs,
-which is the internal format of composite PK:
+For composite keys, this will give us ordered tuple representing the raw PKs, which is the internal format of composite PK:
 
 <Tabs
 groupId="entity-def"
@@ -717,8 +686,7 @@ properties: {
 
 ## Formulas
 
-`@Formula()` decorator can be used to map some SQL snippet to your entity.
-The SQL fragment can be as complex as you want and even include subselects.
+`@Formula()` decorator can be used to map some SQL snippet to your entity. The SQL fragment can be as complex as you want and even include subselects.
 
 <Tabs
 groupId="entity-def"
@@ -757,9 +725,7 @@ properties: {
 </Tabs>
 ```
 
-Formulas will be added to the select clause automatically. In case you are facing
-problems with `NonUniqueFieldNameException`, you can define the formula as a
-callback that will receive the entity alias in the parameter:
+Formulas will be added to the select clause automatically. In case you are facing problems with `NonUniqueFieldNameException`, you can define the formula as a callback that will receive the entity alias in the parameter:
 
 <Tabs
 groupId="entity-def"
@@ -799,8 +765,7 @@ properties: {
 
 ## Indexes
 
-We can define indexes via `@Index()` decorator, for unique indexes, we can 
-use `@Unique()` decorator. We can use it either on entity class, or on entity property. 
+We can define indexes via `@Index()` decorator, for unique indexes, we can use `@Unique()` decorator. We can use it either on entity class, or on entity property.
 
 To define complex indexes, we can use index expressions. They allow us to specify the final `create index` query and an index name - this name is then used for index diffing, so the schema generator will only try to create it if it's not there yet, or remove it, if it's no longer defined in the entity. Index expressions are not bound to any property, rather to the entity itself (we can still define them on both entity and property level).
 
@@ -899,11 +864,7 @@ export const AuthorSchema = new EntitySchema<Author, CustomBaseEntity>({
 
 ## Check constraints
 
-We can define check constraints via `@Check()` decorator. We can use it 
-either on entity class, or on entity property. It has a required `expression`
-property, that can be either a string or a callback, that receives map of
-property names to column names. Note that we need to use the generic type 
-argument if we want TypeScript suggestions for the property names.
+We can define check constraints via `@Check()` decorator. We can use it either on entity class, or on entity property. It has a required `expression` property, that can be either a string or a callback, that receives map of property names to column names. Note that we need to use the generic type argument if we want TypeScript suggestions for the property names.
 
 > Check constraints are currently supported only in postgres driver.
 
@@ -920,11 +881,11 @@ values={[
 
 ```ts title="./entities/Book.ts"
 @Entity()
-// with generated name based on the table name 
+// with generated name based on the table name
 @Check({ expression: 'price1 >= 0' })
-// with explicit name 
+// with explicit name
 @Check({ name: 'foo', expression: columns => `${columns.price1} >= 0` })
-// with explicit type argument we get autocomplete on `columns` 
+// with explicit type argument we get autocomplete on `columns`
 @Check<FooEntity>({ expression: columns => `${columns.price1} >= 0` })
 export class Book {
 
@@ -949,11 +910,11 @@ export class Book {
 
 ```ts title="./entities/Book.ts"
 @Entity()
-// with generated name based on the table name 
+// with generated name based on the table name
 @Check({ expression: 'price1 >= 0' })
-// with explicit name 
+// with explicit name
 @Check({ name: 'foo', expression: columns => `${columns.price1} >= 0` })
-// with explicit type argument we get autocomplete on `columns` 
+// with explicit type argument we get autocomplete on `columns`
 @Check<FooEntity>({ expression: columns => `${columns.price1} >= 0` })
 export class Book {
 
@@ -1012,8 +973,7 @@ We can define custom types by extending `Type` abstract class. It has 4 optional
 
 - `toJSON(value: any, platform: Platform): any`
 
-  Converts a value from its JS representation to its serialized JSON form of this type.
-  By default converts to the database value.
+  Converts a value from its JS representation to its serialized JSON form of this type. By default converts to the database value.
 
 - `getColumnType(prop: EntityProperty, platform: Platform): string`
 
@@ -1023,9 +983,7 @@ More information can be found in [Custom Types](custom-types.md) section.
 
 ## Lazy scalar properties
 
-We can mark any property as `lazy: true` to omit it from the select clause.
-This can be handy for properties that are too large, and you want to have them
-available only sometimes, like a full text of an article.
+We can mark any property as `lazy: true` to omit it from the select clause. This can be handy for properties that are too large, and you want to have them available only sometimes, like a full text of an article.
 
 <Tabs
 groupId="entity-def"
@@ -1070,19 +1028,15 @@ const b1 = await em.find(Book, 1); // this will omit the `text` property
 const b2 = await em.find(Book, 1, { populate: ['text'] }); // this will load the `text` property
 ```
 
-> If the entity is already loaded and you need to populate a lazy scalar property,
-> you might need to pass `refresh: true` in the `FindOptions`.
+> If the entity is already loaded and you need to populate a lazy scalar property, you might need to pass `refresh: true` in the `FindOptions`.
 
 ## Virtual Properties
 
 We can define our properties as virtual, either as a method, or via JavaScript `get/set`.
 
-Following example defines User entity with `firstName` and `lastName` database fields, that
-are both hidden from the serialized response, replaced with virtual properties `fullName`
-(defined as a classic method) and `fullName2` (defined as a JavaScript getter).
+Following example defines User entity with `firstName` and `lastName` database fields, that are both hidden from the serialized response, replaced with virtual properties `fullName` (defined as a classic method) and `fullName2` (defined as a JavaScript getter).
 
-> For JavaScript getter you need to provide `{ persist: false }` option otherwise the value
-> would be stored in the database.
+> For JavaScript getter you need to provide `{ persist: false }` option otherwise the value would be stored in the database.
 
 <Tabs
 groupId="entity-def"
@@ -1183,18 +1137,15 @@ console.log(wrap(author).toJSON()); // { fullName: 'Jon Snow', fullName2: 'Jon S
 
 ## Entity file names
 
-Starting with MikroORM 4.2, there is no limitation for entity file names. It is now
-also possible to define multiple entities in a single file using folder based discovery.
+Starting with MikroORM 4.2, there is no limitation for entity file names. It is now also possible to define multiple entities in a single file using folder based discovery.
 
 ## Using custom base entity
 
-We can define our own base entity with properties that are required on all entities, like
-primary key and created/updated time. Single table inheritance is also supported.
+We can define our own base entity with properties that are required on all entities, like primary key and created/updated time. Single table inheritance is also supported.
 
 Read more about this topic in [Inheritance Mapping](inheritance-mapping.md) section.
 
-> If you are initializing the ORM via `entities` option, you need to specify all your
-> base entities as well.
+> If you are initializing the ORM via `entities` option, you need to specify all your base entities as well.
 
 <Tabs
 groupId="entity-def"
@@ -1270,9 +1221,7 @@ export const schema = new EntitySchema<CustomBaseEntity>({
   </TabItem>
 </Tabs>
 
-There is a special case, when we need to annotate the base entity - if we are using
-folder based discovery, and the base entity is not using any decorators (e.g. it does
-not define any decorated property). In that case, we need to mark it as abstract:
+There is a special case, when we need to annotate the base entity - if we are using folder based discovery, and the base entity is not using any decorators (e.g. it does not define any decorated property). In that case, we need to mark it as abstract:
 
 ```ts
 @Entity({ abstract: true })
@@ -1283,9 +1232,7 @@ export abstract class CustomBaseEntity {
 
 ## SQL Generated columns
 
-Knex currently does not support generated columns, so the schema generator
-cannot properly diff them. To work around this, we can set `ignoreSchemaChanges`
-on a property to avoid a perpetual diff from the schema generator
+Knex currently does not support generated columns, so the schema generator cannot properly diff them. To work around this, we can set `ignoreSchemaChanges` on a property to avoid a perpetual diff from the schema generator
 
 <Tabs
 groupId="entity-def"
@@ -1584,8 +1531,7 @@ export const BookSchema = new EntitySchema<Book>({
 
 ### Using BigInt as primary key (MySQL and PostgreSQL)
 
-We can use `BigIntType` to support `bigint`s. By default, it will represent the value as
-a `string`.
+We can use `BigIntType` to support `bigint`s. By default, it will represent the value as a `string`.
 
 <Tabs
 groupId="entity-def"
@@ -1715,8 +1661,7 @@ export const Book = new EntitySchema<IBook>({
 
 ### Using MikroORM's BaseEntity (previously WrappedEntity)
 
-From v4 `BaseEntity` class is provided with `init`, `isInitialized`, `assign`
-and other methods that are otherwise available via the `wrap()` helper.
+From v4 `BaseEntity` class is provided with `init`, `isInitialized`, `assign` and other methods that are otherwise available via the `wrap()` helper.
 
 > Usage of the `BaseEntity` is optional.
 
@@ -1741,5 +1686,4 @@ const book = new Book();
 console.log(book.isInitialized()); // true
 ```
 
-Having the entities set up, we can now start [using entity manager](entity-manager.md) and
-[repositories](repositories.md) as described in following sections.
+Having the entities set up, we can now start [using entity manager](entity-manager.md) and [repositories](repositories.md) as described in following sections.

--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -2,29 +2,19 @@
 title: Deployment
 ---
 
-Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. Thanks to this, 
-defining the type is enough for runtime validation.
+Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. Thanks to this, defining the type is enough for runtime validation.
 
-This has some consequences for deployment of your application. Sometimes you will want to 
-deploy only your compiled output, without TS source files at all. In that case, discovery 
-process will probably fail. You have several options:
+This has some consequences for deployment of your application. Sometimes you will want to deploy only your compiled output, without TS source files at all. In that case, discovery process will probably fail. You have several options:
 
 ## Deploy pre-built cache
 
-By default, output of metadata discovery will be cached in `temp` folder. You can reuse this 
-cache in your deployed application. Currently the cache is saved in files named like the entity
-source file, e.g. `Author.ts` entity will store cache in `temp/Author.ts.json` file.
+By default, output of metadata discovery will be cached in `temp` folder. You can reuse this cache in your deployed application. Currently the cache is saved in files named like the entity source file, e.g. `Author.ts` entity will store cache in `temp/Author.ts.json` file.
 
-When running compiled code, JS entities will be taken into account instead, so you will need to 
-generate the cache by running the compiled code locally. That will generate `temp/Author.js.json`, 
-which is the file you will need to deploy alongside your application. 
+When running compiled code, JS entities will be taken into account instead, so you will need to generate the cache by running the compiled code locally. That will generate `temp/Author.js.json`, which is the file you will need to deploy alongside your application.
 
 ## Fill type or entity attributes everywhere
 
-What discovery process does is to sniff TS types and save their value to string, so it can be 
-used later for validation. You can skip the whole process by simply providing those values 
-manually:
+What discovery process does is to sniff TS types and save their value to string, so it can be used later for validation. You can skip the whole process by simply providing those values manually:
 
 ```ts
 @Entity()
@@ -63,36 +53,28 @@ export enum BookStatus {
 
 ## Deploy your entity source files
 
-Usually it does not matter much that you deploy more files than needed, so the easiest way
-is to just deploy your TS source files next to the compiled output, just like during development.
+Usually it does not matter much that you deploy more files than needed, so the easiest way is to just deploy your TS source files next to the compiled output, just like during development.
 
 ## Deploy a bundle of entities and dependencies with [Webpack](https://webpack.js.org/)
 
-Webpack can be used to bundle every entity and dependency: you get a single file that contains 
-every required module/file and has no external dependencies.
+Webpack can be used to bundle every entity and dependency: you get a single file that contains every required module/file and has no external dependencies.
 
 ### Prepare your project for Webpack
 
-Webpack requires every required file to be hardcoded in your code. Code like this won't work 
-(it will throw an error because Webpack doesn't know which file to include in the bundle):
+Webpack requires every required file to be hardcoded in your code. Code like this won't work (it will throw an error because Webpack doesn't know which file to include in the bundle):
 
 ```ts
 let dependencyNameInVariable = 'dependency';
 const dependency = import(dependencyNameInVariable);
 ```
 
-As Webpack creates a file bundle, it isn't desired that it scans directories for entities 
-or metadata. Therefore you need to provide list of entities in the `entities` option in 
-the initialization function, folder/file based discovery is not supported (see dynamically 
-including entities as an alternative solution). Also you need to fill `type` or `entity` 
-attributes everywhere (see above) and disable caching (it will decrease start-time slightly).
+As Webpack creates a file bundle, it isn't desired that it scans directories for entities or metadata. Therefore you need to provide list of entities in the `entities` option in the initialization function, folder/file based discovery is not supported (see dynamically including entities as an alternative solution). Also you need to fill `type` or `entity` attributes everywhere (see above) and disable caching (it will decrease start-time slightly).
 
 > In v4 caching is disabled by default when using `ReflectMetadataProvider`.
 
 #### Disabling dynamic file access
 
-First thing you should do is to disable dynamic file access in the discovery process via the
-`discovery.disableDynamicFileAccess` toggle. This will effectively do:
+First thing you should do is to disable dynamic file access in the discovery process via the `discovery.disableDynamicFileAccess` toggle. This will effectively do:
 
 - set metadata provider to `ReflectMetadataProvider`
 - disable caching
@@ -113,15 +95,11 @@ await MikroORM.init({
 
 #### Dynamically loading dependencies
 
-This will make use of a Webpack feature called [dynamic imports](https://webpack.js.org/guides/code-splitting/#dynamic-imports). 
-This way you can import dependencies as long as part of the path is known.
+This will make use of a Webpack feature called [dynamic imports](https://webpack.js.org/guides/code-splitting/#dynamic-imports). This way you can import dependencies as long as part of the path is known.
 
-In following example [`require.context`](https://webpack.js.org/guides/dependency-management/#requirecontext) 
-is used. This 'function' is only usable during the building process from Webpack so therefore 
-there is an alternative solution provided that will as long as the environment variable 
-WEBPACK is not set (e.g. during development with `ts-node`).
+In following example [`require.context`](https://webpack.js.org/guides/dependency-management/#requirecontext) is used. This 'function' is only usable during the building process from Webpack so therefore there is an alternative solution provided that will as long as the environment variable WEBPACK is not set (e.g. during development with `ts-node`).
 
-Here, all files with the extension `.ts` will be imported from the directory `../entities`. 
+Here, all files with the extension `.ts` will be imported from the directory `../entities`.
 
 > [`flatMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap) is a method from ECMAScript 2019 and requires [Node.js](https://nodejs.org/) 11 or higher.
 
@@ -152,10 +130,7 @@ async function getEntities(): Promise<any[]> {
 
 ### Webpack configuration
 
-Webpack can be run without [configuration file](https://webpack.js.org/configuration/) but 
-for building MikroORM and [Node.js](https://nodejs.org/) bundles it requires additional 
-configuration. Configuration for Webpack is stored in the root of the project as 
-`webpack.config.js`. For all the options please refer to the following [page](https://webpack.js.org/configuration/).
+Webpack can be run without [configuration file](https://webpack.js.org/configuration/) but for building MikroORM and [Node.js](https://nodejs.org/) bundles it requires additional configuration. Configuration for Webpack is stored in the root of the project as `webpack.config.js`. For all the options please refer to the following [page](https://webpack.js.org/configuration/).
 
 For bundling MikroORM the following configuration is required:
 
@@ -199,7 +174,7 @@ module.exports = {
           mangle: false,
           // Similarly, Terser's compression may at its own discretion change function and class names.
           // While it only rarely does so, it's safest to also disable changing their names here.
-          // This can be controlled in a more granular way if needed (see 
+          // This can be controlled in a more granular way if needed (see
           // https://terser.org/docs/api-reference.html#compress-options).
           compress: {
             keep_classnames: true,
@@ -273,9 +248,7 @@ module.exports = {
 
 ### Running Webpack
 
-To run Webpack execute `webpack` (or `npx webpack` if not installed globally) in the root 
-of the project. It will probably throw a few warnings but you can ignore the errors regarding 
-MikroORM: the mentioned pieces of code won't be executed if properly bundled with Webpack.
+To run Webpack execute `webpack` (or `npx webpack` if not installed globally) in the root of the project. It will probably throw a few warnings but you can ignore the errors regarding MikroORM: the mentioned pieces of code won't be executed if properly bundled with Webpack.
 
 ## Deploy a bundle of entities and dependencies with `esbuild`
 

--- a/docs/docs/embeddables.md
+++ b/docs/docs/embeddables.md
@@ -8,22 +8,13 @@ import TabItem from '@theme/TabItem';
 
 > Support for embeddables was added in version 4.0
 
-Embeddables are classes which are not entities themselves, but are embedded in 
-entities and can also be queried. You'll mostly want to use them to reduce 
-duplication or separating concerns. Value objects such as date range or address 
-are the primary use case for this feature.
+Embeddables are classes which are not entities themselves, but are embedded in entities and can also be queried. You'll mostly want to use them to reduce duplication or separating concerns. Value objects such as date range or address are the primary use case for this feature.
 
-> Embeddables needs to be discovered just like regular entities, don't forget to 
-> add them to the list of entities when initializing the ORM.
+> Embeddables needs to be discovered just like regular entities, don't forget to add them to the list of entities when initializing the ORM.
 
-Embeddables can contain properties with basic `@Property()` mapping, nested 
-`@Embedded()` properties or arrays of `@Embedded()` properties. From version
-5.0 we can also use `@ManyToOne()` properties.
+Embeddables can contain properties with basic `@Property()` mapping, nested `@Embedded()` properties or arrays of `@Embedded()` properties. From version 5.0 we can also use `@ManyToOne()` properties.
 
-For the purposes of this tutorial, we will assume that you have a `User` class in 
-your application and you would like to store an address in the `User` class. We will 
-model the `Address` class as an embeddable instead of simply adding the respective 
-columns to the `User` class.
+For the purposes of this tutorial, we will assume that you have a `User` class in your application and you would like to store an address in the `User` class. We will model the `Address` class as an embeddable instead of simply adding the respective columns to the `User` class.
 
 <Tabs
   groupId="entity-def"
@@ -144,17 +135,13 @@ export const AddressSchema = new EntitySchema({
   </TabItem>
 </Tabs>
 
-> When using ReflectMetadataProvider, you might need to provide the class in decorator options:
-> `@Embedded(() => Address)` or `@Embedded({ entity: () => Address })`.
+> When using ReflectMetadataProvider, you might need to provide the class in decorator options: `@Embedded(() => Address)` or `@Embedded({ entity: () => Address })`.
 
-In terms of your database schema, MikroORM will automatically inline all columns from 
-the `Address` class into the table of the `User` class, just as if you had declared 
-them directly there.
+In terms of your database schema, MikroORM will automatically inline all columns from the `Address` class into the table of the `User` class, just as if you had declared them directly there.
 
 ## Initializing embeddables
 
-In case all fields in the embeddable are nullable, you might want to initialize the 
-embeddable, to avoid getting a null value instead of the embedded object.
+In case all fields in the embeddable are nullable, you might want to initialize the embeddable, to avoid getting a null value instead of the embedded object.
 
 <Tabs
   groupId="entity-def"
@@ -194,11 +181,9 @@ address: { reference: 'embedded', entity: 'Address', onCreate: () => new Address
 
 By default, MikroORM names your columns by prefixing them, using the value object name.
 
-Following the example above, your columns would be named as `address_street`, 
-`address_postal_code`...
+Following the example above, your columns would be named as `address_street`, `address_postal_code`...
 
-You can change this behaviour to meet your needs by changing the `prefix` attribute 
-in the `@Embedded()` notation.
+You can change this behaviour to meet your needs by changing the `prefix` attribute in the `@Embedded()` notation.
 
 The following example shows you how to set your prefix to `myPrefix_`:
 
@@ -246,8 +231,7 @@ address: { reference: 'embedded', entity: 'Address', prefix: 'myPrefix_' },
   </TabItem>
 </Tabs>
 
-To have MikroORM drop the prefix and use the value object's property name directly, 
-set `prefix: false`:
+To have MikroORM drop the prefix and use the value object's property name directly, set `prefix: false`:
 
 <Tabs
   groupId="entity-def"
@@ -285,8 +269,7 @@ address: { reference: 'embedded', entity: 'Address', prefix: false },
 
 ## Storing embeddables as objects
 
-From MikroORM v4.2 we can also store the embeddable as an object instead of
-inlining its properties to the owing entity.
+From MikroORM v4.2 we can also store the embeddable as an object instead of inlining its properties to the owing entity.
 
 <Tabs
   groupId="entity-def"
@@ -322,17 +305,15 @@ address: { reference: 'embedded', entity: 'Address', object: true },
   </TabItem>
 </Tabs>
 
-In SQL drivers, this will use a JSON column to store the value. 
+In SQL drivers, this will use a JSON column to store the value.
 
 > Only MySQL and PostgreSQL drivers support searching by JSON properties currently.
 
-> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/embeddables.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/embeddables.html) as the behaviour here is pretty much the same.
 
 ## Array of embeddables
 
-Embedded arrays are always stored as JSON. It is possible to use them inside
-nested embeddables. 
+Embedded arrays are always stored as JSON. It is possible to use them inside nested embeddables.
 
 <Tabs
   groupId="entity-def"
@@ -533,10 +514,7 @@ export const IdentitySchema = new EntitySchema({
 
 ## Polymorphic embeddables
 
-Since v5, it is also possible to use polymorphic embeddables. This means we
-can define multiple classes for a single embedded property and the right one
-will be used based on the discriminator column, similar to how single table 
-inheritance work.
+Since v5, it is also possible to use polymorphic embeddables. This means we can define multiple classes for a single embedded property and the right one will be used based on the discriminator column, similar to how single table inheritance work.
 
 <Tabs
   groupId="entity-def"

--- a/docs/docs/entity-constructors.md
+++ b/docs/docs/entity-constructors.md
@@ -84,7 +84,7 @@ The `rel()` helper will create entity instance that is not yet managed (as we do
 
 > `rel()` is a shortcut for `Reference.createNakedFromPK()`.
 
-And if you want to be safer and use the `Reference` wrapper, the `ref()` helper also accepts this new signature: 
+And if you want to be safer and use the `Reference` wrapper, the `ref()` helper also accepts this new signature:
 
 ```ts
 @ManyToOne({ entity: () => Author, ref: true })

--- a/docs/docs/entity-generator.md
+++ b/docs/docs/entity-generator.md
@@ -2,12 +2,11 @@
 title: Entity Generator
 ---
 
-To generate entities from existing database schema, you can use `EntityGenerator` helper. 
+To generate entities from existing database schema, you can use `EntityGenerator` helper.
 
-You can use it via CLI: 
+You can use it via CLI:
 
-> To work with the CLI, first install `@mikro-orm/cli` package locally.
-> The version needs to be aligned with the `@mikro-orm/core` package.
+> To work with the CLI, first install `@mikro-orm/cli` package locally. The version needs to be aligned with the `@mikro-orm/core` package.
 
 ```sh
 npx mikro-orm generate-entities --dump  # Dumps all generated entities
@@ -22,14 +21,14 @@ import { MikroORM } from '@mikro-orm/core';
 (async () => {
   const orm = await MikroORM.init({
     discovery: {
-      // we need to disable validation for no entities 
+      // we need to disable validation for no entities
       warnWhenNoEntities: false,
     },
     dbName: 'your-db-name',
     // ...
   });
   const generator = orm.getEntityGenerator();
-  const dump = await generator.generate({ 
+  const dump = await generator.generate({
     save: true,
     baseDir: process.cwd() + '/my-entities',
   });
@@ -46,7 +45,7 @@ $ ts-node generate-entities
 
 ## Advanced configuration
 
-By default, the `EntityGenerator` generates only owning sides of relations (e.g. M:1) and uses decorators for the entity definition. We can adjust its behaviour via `entityGenerator` section in the ORM config. Available options: 
+By default, the `EntityGenerator` generates only owning sides of relations (e.g. M:1) and uses decorators for the entity definition. We can adjust its behaviour via `entityGenerator` section in the ORM config. Available options:
 
 - `bidirectionalRelations` to generate also the inverse sides for them
 - `identifiedReferences` to generate M:1 and 1:1 relations as wrapped references

--- a/docs/docs/entity-helper.md
+++ b/docs/docs/entity-helper.md
@@ -18,8 +18,8 @@ Same result can be easily achieved with `assign()`:
 ```ts
 import { wrap } from '@mikro-orm/core';
 
-wrap(book).assign({ 
-  title: 'Better Book 1', 
+wrap(book).assign({
+  title: 'Better Book 1',
   author: '...id...',
 });
 console.log(book.title); // 'Better Book 1'
@@ -27,14 +27,14 @@ console.log(book.author); // instance of Author with id: '...id...'
 console.log(book.author.id); // '...id...'
 ```
 
-To use `assign()` on not managed entities, you need to provide `EntityManager` instance explicitly: 
+To use `assign()` on not managed entities, you need to provide `EntityManager` instance explicitly:
 
 ```ts
 import { wrap } from '@mikro-orm/core';
 
 const book = new Book();
-wrap(book).assign({ 
-  title: 'Better Book 1', 
+wrap(book).assign({
+  title: 'Better Book 1',
   author: '...id...',
 }, { em });
 ```
@@ -55,9 +55,7 @@ console.log(book.meta); // { foo: 4 }
 
 ### Updating deep entity graph
 
-Since v5, `assign` allows updating deep entity graph by default. To update existing
-entity, we need to provide its PK in the `data`, as well as to **load that entity first
-into current context**.
+Since v5, `assign` allows updating deep entity graph by default. To update existing entity, we need to provide its PK in the `data`, as well as to **load that entity first into current context**.
 
 ```ts
 const book = await em.findOneOrFail(Book, 1, { populate: ['author'] });
@@ -71,8 +69,7 @@ wrap(book).assign({
 });
 ```
 
-If we want to always update the entity, even without the entity PK being present 
-in `data`, we can use `updateByPrimaryKey: false`:
+If we want to always update the entity, even without the entity PK being present in `data`, we can use `updateByPrimaryKey: false`:
 
 ```ts
 const book = await em.findOneOrFail(Book, 1, { populate: ['author'] });
@@ -85,8 +82,7 @@ wrap(book).assign({
 }, { updateByPrimaryKey: false });
 ```
 
-Otherwise the entity data without PK are considered as new entity, and will trigger
-insert query:
+Otherwise the entity data without PK are considered as new entity, and will trigger insert query:
 
 ```ts
 const book = await em.findOneOrFail(Book, 1, { populate: ['author'] });
@@ -99,9 +95,7 @@ wrap(book).assign({
 });
 ```
 
-Same applies to the case when we do not load the child entity first into the context,
-e.g. when we try to assign to a relation that was not populated. Even if we provide
-its PK, it will be considered as new object and trigger an insert query.
+Same applies to the case when we do not load the child entity first into the context, e.g. when we try to assign to a relation that was not populated. Even if we provide its PK, it will be considered as new object and trigger an insert query.
 
 ```ts
 const book = await em.findOneOrFail(Book, 1); // author is not populated
@@ -115,12 +109,7 @@ wrap(book).assign({
 });
 ```
 
-When updating collections, we can either pass complete array of all items, or just
-a single item - in such case, the new item will be appended to the existing items.
-Passing a completely new array of items will replace the existing items. Previously
-existing items will be disconnected/removed from the collection. Also check the 
-[Collection page](collections.md#removing-items-from-collection) on the effects of 
-removing entities from collections.
+When updating collections, we can either pass complete array of all items, or just a single item - in such case, the new item will be appended to the existing items. Passing a completely new array of items will replace the existing items. Previously existing items will be disconnected/removed from the collection. Also check the [Collection page](collections.md#removing-items-from-collection) on the effects of removing entities from collections.
 
 ```ts
 // resets the addresses collection to a single item
@@ -173,9 +162,9 @@ interface IWrappedEntity<T, PK extends keyof T> {
 
 There are two ways to access those methods. You can either extend `BaseEntity` (exported from `@mikro-orm/core`), that defines those methods, or use the `wrap()` helper to access `WrappedEntity` instance, where those methods exist.
 
-Users can choose whether they are fine with polluting the entity interface with those additional methods, or they want to keep the interface clean and use the `wrap(entity)` helper method instead to access them. 
+Users can choose whether they are fine with polluting the entity interface with those additional methods, or they want to keep the interface clean and use the `wrap(entity)` helper method instead to access them.
 
-> Since v4, `wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is  being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...), if you want to access internal properties like `__meta` or `__em`, you need to explicitly ask for the helper via `wrap(entity, true)`.
+> Since v4, `wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...), if you want to access internal properties like `__meta` or `__em`, you need to explicitly ask for the helper via `wrap(entity, true)`.
 
 ```ts
 import { BaseEntity } from '@mikro-orm/core';
@@ -194,9 +183,7 @@ console.log(book.meta); // { foo: 3, bar: 2 }
 
 ### Accessing internal prefixed properties
 
-Previously it was possible to access internal properties like `__meta` or `__em` 
-from the `wrap()` helper. Now to access them, you need to use second parameter of
-wrap:
+Previously it was possible to access internal properties like `__meta` or `__em` from the `wrap()` helper. Now to access them, you need to use second parameter of wrap:
 
 ```ts
 @Entity()

--- a/docs/docs/entity-manager.md
+++ b/docs/docs/entity-manager.md
@@ -58,12 +58,12 @@ const userRef = em.getReference(User, 1);
 console.log(userRef);
 ```
 
-This will log something like `(User) { id: 1 }`, note the class name being wrapped in parens - this tells you the entity is not-initialized state and represents just the primary key. 
+This will log something like `(User) { id: 1 }`, note the class name being wrapped in parens - this tells you the entity is not-initialized state and represents just the primary key.
 
 Here is an example of common actions you can do with a reference instead of a fully loaded entity:
 
 ```ts
-// setting relation properties 
+// setting relation properties
 author.favouriteBook = em.getReference(Book, 1);
 
 // removing entity by reference
@@ -144,7 +144,7 @@ You can also use `em.populate()` helper to populate relations (or to ensure they
 const authors = await em.createQueryBuilder(Author).select('*').getResult();
 await em.populate(authors, { populate: ['books.tags'] });
 
-// now our Author entities will have `books` collections populated, 
+// now our Author entities will have `books` collections populated,
 // as well as they will have their `tags` collections populated.
 console.log(authors[0].books[0].tags[0]); // initialized BookTag
 ```
@@ -327,7 +327,7 @@ const users = await em.find(User, { [expr('lower(email)')]: 'foo@bar.baz' }, {
 This will produce following query:
 
 ```sql
-select `e0`.* 
+select `e0`.*
 from `user` as `e0`
 where lower(email) = 'foo@bar.baz'
 order by (point(loc_latitude, loc_longitude) <@> point(0, 0)) asc
@@ -430,13 +430,13 @@ for (const user of users) {
 await em.flush();
 
 // update `user` set
-//   `name` = case 
-//     when (`id` = 1) then 'Peter 1 changed!' 
-//     when (`id` = 2) then 'Peter 2 changed!' 
-//     when (`id` = 3) then 'Peter 3 changed!' 
-//     when (`id` = 4) then 'Peter 4 changed!' 
-//     when (`id` = 5) then 'Peter 5 changed!' 
-//     else `priority` end 
+//   `name` = case
+//     when (`id` = 1) then 'Peter 1 changed!'
+//     when (`id` = 2) then 'Peter 2 changed!'
+//     when (`id` = 3) then 'Peter 3 changed!'
+//     when (`id` = 4) then 'Peter 4 changed!'
+//     when (`id` = 5) then 'Peter 5 changed!'
+//     else `priority` end
 //   where `id` in (1, 2, 3, 4, 5)
 ```
 
@@ -459,7 +459,7 @@ const users = await em.find(User, { email: 'foo@bar.baz' }, {
   populate: ['cars.brand'],
 });
 users[0].name = 'changed';
-await em.flush(); // calling flush have no effect, as the entity is not managed  
+await em.flush(); // calling flush have no effect, as the entity is not managed
 ```
 
 > Keep in mind that this can also have [negative effect on the performance](https://stackoverflow.com/questions/9259480/entity-framework-mergeoption-notracking-bad-performance).

--- a/docs/docs/entity-schema.md
+++ b/docs/docs/entity-schema.md
@@ -2,7 +2,7 @@
 title: Defining Entities via EntitySchema
 ---
 
-With `EntitySchema` helper we define the schema programmatically. 
+With `EntitySchema` helper we define the schema programmatically.
 
 ```ts title="./entities/Book.ts"
 export interface Book extends CustomBaseEntity {
@@ -13,7 +13,7 @@ export interface Book extends CustomBaseEntity {
 }
 
 // The second type argument is optional, and should be used only with custom
-// base entities, not with the `BaseEntity` class exported from `@mikro-orm/core`. 
+// base entities, not with the `BaseEntity` class exported from `@mikro-orm/core`.
 export const schema = new EntitySchema<Book, CustomBaseEntity>({
   // name should be used only with interfaces
   name: 'Book',
@@ -29,8 +29,7 @@ export const schema = new EntitySchema<Book, CustomBaseEntity>({
 });
 ```
 
-When creating new entity instances, you will need to use `em.create()` method that will
-create instance of internally created class. 
+When creating new entity instances, you will need to use `em.create()` method that will create instance of internally created class.
 
 ```ts
 const repo = em.getRepository<Author>('Author');
@@ -42,7 +41,7 @@ await repo.persistAndFlush(author);
 
 ## Using custom entity classes
 
-You can optionally use custom class for entity instances.  
+You can optionally use custom class for entity instances.
 
 ```ts title="./entities/Author.ts"
 export class Author extends CustomBaseEntity {
@@ -55,7 +54,7 @@ export class Author extends CustomBaseEntity {
   books = new Collection<Book>(this);
   favouriteBook?: Book;
   version?: number;
-  
+
   constructor(name: string, email: string) {
     super();
     this.name = name;
@@ -90,7 +89,7 @@ await repo.persistAndFlush(author);
 
 ## Using custom base entity
 
-Do not forget that base entities needs to be discovered just like normal entities. 
+Do not forget that base entities needs to be discovered just like normal entities.
 
 ```ts title="./entities/BaseEntity.ts"
 export interface CustomBaseEntity {
@@ -112,9 +111,7 @@ export const schema = new EntitySchema<CustomBaseEntity>({
 
 ## Configuration Reference
 
-The parameter of `EntitySchema` requires to provide either `name` or `class` parameters. 
-When using `class`, `extends` will be automatically inferred. You can optionally pass 
-these additional parameters:
+The parameter of `EntitySchema` requires to provide either `name` or `class` parameters. When using `class`, `extends` will be automatically inferred. You can optionally pass these additional parameters:
 
 ```ts
 name: string;
@@ -129,8 +126,7 @@ hooks: Partial<Record<keyof typeof EventType, ((string & keyof T) | NonNullable<
 abstract: boolean;
 ```
 
-Every property then needs to contain a type specification - one of `type`/`customType`/`entity`.
-Here are some examples of various property types:
+Every property then needs to contain a type specification - one of `type`/`customType`/`entity`. Here are some examples of various property types:
 
 ```ts
 export enum MyEnum {
@@ -187,10 +183,7 @@ export const schema = new EntitySchema<BookTag>({
 
 ## Hooks example
 
-Entity hooks can be defined either as a property name, or as a function.
-When defined as a function, the `this` argument will be the entity instance.
-Arrow functions can be used if desired, and the entity will be available at args.entity.
-See [Events and Lifecycle Hooks](events.md) section for more details on `EventArgs`.
+Entity hooks can be defined either as a property name, or as a function. When defined as a function, the `this` argument will be the entity instance. Arrow functions can be used if desired, and the entity will be available at args.entity. See [Events and Lifecycle Hooks](events.md) section for more details on `EventArgs`.
 
 ```ts
 export class BookTag {

--- a/docs/docs/events.md
+++ b/docs/docs/events.md
@@ -3,11 +3,10 @@ title: Events and Lifecycle Hooks
 sidebar_label: Events and Hooks
 ---
 
-There are two ways to hook to the lifecycle of an entity: 
+There are two ways to hook to the lifecycle of an entity:
 
 - **Lifecycle hooks** are methods defined on the entity prototype.
-- **EventSubscriber**s are classes that can be used to hook to multiple entities
-  or when we do not want to have the method present on the entity prototype.
+- **EventSubscriber**s are classes that can be used to hook to multiple entities or when we do not want to have the method present on the entity prototype.
 
 > Hooks are internally executed the same way as subscribers.
 
@@ -15,53 +14,37 @@ There are two ways to hook to the lifecycle of an entity:
 
 ## Hooks
 
-We can use lifecycle hooks to run some code when entity gets persisted. We can mark any of
-entity methods with them, we can also mark multiple methods with same hook.
+We can use lifecycle hooks to run some code when entity gets persisted. We can mark any of entity methods with them, we can also mark multiple methods with same hook.
 
 All hooks support async methods with one exception - `@OnInit`.
 
-- `@OnInit` is fired when new instance of entity is created, either manually `em.create()`, or 
-automatically when new entities are loaded from database
+- `@OnInit` is fired when new instance of entity is created, either manually `em.create()`, or automatically when new entities are loaded from database
 
-- `@OnLoad` is fired when new entity is loaded into context (e.g. via `em.find()` or `em.populate()`). As opposed to `@OnInit` this will be fired only for fully loaded entities, not references, and this hook can be async. 
+- `@OnLoad` is fired when new entity is loaded into context (e.g. via `em.find()` or `em.populate()`). As opposed to `@OnInit` this will be fired only for fully loaded entities, not references, and this hook can be async.
 
 - `@BeforeCreate()` and `@BeforeUpdate()` is fired right before we persist the entity in database
 
-- `@AfterCreate()` and `@AfterUpdate()` is fired right after the entity is updated in database and 
-merged to identity map. Since this event entity will have reference to `EntityManager` and will be 
-enabled to call `wrap(entity).init()` method (including all entity references and collections).
+- `@AfterCreate()` and `@AfterUpdate()` is fired right after the entity is updated in database and merged to identity map. Since this event entity will have reference to `EntityManager` and will be enabled to call `wrap(entity).init()` method (including all entity references and collections).
 
-- `@BeforeDelete()` is fired right before we delete the record from database. It is fired only when
-removing entity or entity reference, not when deleting records by query. 
+- `@BeforeDelete()` is fired right before we delete the record from database. It is fired only when removing entity or entity reference, not when deleting records by query.
 
-- `@AfterDelete()` is fired right after the record gets deleted from database and it is unset from 
-the identity map.
+- `@AfterDelete()` is fired right after the record gets deleted from database and it is unset from the identity map.
 
 > `@OnInit` is not fired when we create the entity manually via its constructor (`new MyEntity()`)
 
-> `@OnInit` can be sometimes fired twice, once when the entity reference is
-> created, and once after its populated. To distinguish between those we can
-> use `wrap(this).isInitialized()`.
+> `@OnInit` can be sometimes fired twice, once when the entity reference is created, and once after its populated. To distinguish between those we can use `wrap(this).isInitialized()`.
 
 ## Limitations of lifecycle hooks
 
-Hooks are executed inside the commit action of unit of work, after all change 
-sets are computed. This means that it is not possible to create new entities as
-usual from inside the hook. Calling `em.flush()` from hooks will result in 
-validation error. Calling `em.persist()` can result in undefined behaviour like
-locking errors. 
+Hooks are executed inside the commit action of unit of work, after all change sets are computed. This means that it is not possible to create new entities as usual from inside the hook. Calling `em.flush()` from hooks will result in validation error. Calling `em.persist()` can result in undefined behaviour like locking errors.
 
-> The **internal** instance of `EntityManager` accessible under `wrap(this, true).__em` is 
-> not meant for public usage. 
+> The **internal** instance of `EntityManager` accessible under `wrap(this, true).__em` is not meant for public usage.
 
 ## EventSubscriber
 
-Use `EventSubscriber` to hook to multiple entities or if we do not want to pollute
-the entity prototype. All methods are optional, if we omit the `getSubscribedEntities()`
-method, it means we are subscribing to all entities.
+Use `EventSubscriber` to hook to multiple entities or if we do not want to pollute the entity prototype. All methods are optional, if we omit the `getSubscribedEntities()` method, it means we are subscribing to all entities.
 
-We can either register the subscribers manually in the ORM configuration (via 
-`subscribers` array where we put the instance):
+We can either register the subscribers manually in the ORM configuration (via `subscribers` array where we put the instance):
 
 ```ts
 MikroORM.init({
@@ -69,9 +52,7 @@ MikroORM.init({
 });
 ```
 
-Or use `@Subscriber()` decorator - keep in mind that we need to make sure the file gets 
-loaded in order to make this decorator registration work (e.g. we import that file 
-explicitly somewhere).
+Or use `@Subscriber()` decorator - keep in mind that we need to make sure the file gets loaded in order to make this decorator registration work (e.g. we import that file explicitly somewhere).
 
 ```ts
 import { EntityName, EventArgs, EventSubscriber, Subscriber } from '@mikro-orm/core';
@@ -88,13 +69,13 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
   }
 
   async afterUpdate(args: EventArgs<Author>): Promise<void> {
-    // ... 
+    // ...
   }
 
 }
 ```
 
-Another example, where we register to all the events and all entities: 
+Another example, where we register to all the events and all entities:
 
 ```ts
 import { EventArgs, EventSubscriber, Subscriber } from '@mikro-orm/core';
@@ -111,7 +92,7 @@ export class EverythingSubscriber implements EventSubscriber {
   async afterUpdate<T>(args: EventArgs<T>): Promise<void> { ... }
   async beforeDelete<T>(args: EventArgs<T>): Promise<void> { ... }
   async afterDelete<T>(args: EventArgs<T>): Promise<void> { ... }
-  
+
   // flush events
   async beforeFlush<T>(args: EventArgs<T>): Promise<void> { ... }
   async onFlush<T>(args: EventArgs<T>): Promise<void> { ... }
@@ -130,9 +111,7 @@ export class EverythingSubscriber implements EventSubscriber {
 
 ## EventArgs
 
-As a parameter to the hook method we get `EventArgs` instance. It will always contain
-reference to the current `EntityManager` and the particular entity. Events fired
-from `UnitOfWork` during flush operation also contain the `ChangeSet` object.
+As a parameter to the hook method we get `EventArgs` instance. It will always contain reference to the current `EntityManager` and the particular entity. Events fired from `UnitOfWork` during flush operation also contain the `ChangeSet` object.
 
 ```ts
 interface EventArgs<T> {
@@ -161,28 +140,21 @@ enum ChangeSetType {
 
 ## Flush events
 
-There is a special kind of events executed during the commit phase (flush operation).
-They are executed before, during and after the flush, and they are not bound to any
-entity in particular. 
+There is a special kind of events executed during the commit phase (flush operation). They are executed before, during and after the flush, and they are not bound to any entity in particular.
 
-- `beforeFlush` is executed before change sets are computed, this is the only
-  event where it is safe to persist new entities. 
+- `beforeFlush` is executed before change sets are computed, this is the only event where it is safe to persist new entities.
 - `onFlush` is executed after the change sets are computed.
-- `afterFlush` is executed as the last step just before the `flush` call resolves.
-  it will be executed even if there are no changes to be flushed. 
+- `afterFlush` is executed as the last step just before the `flush` call resolves. it will be executed even if there are no changes to be flushed.
 
-Flush event args will not contain any entity instance, as they are entity agnostic.
-They do contain additional reference to the `UnitOfWork` instance.
+Flush event args will not contain any entity instance, as they are entity agnostic. They do contain additional reference to the `UnitOfWork` instance.
 
 ```ts
 interface FlushEventArgs extends Omit<EventArgs<unknown>, 'entity'> {
   uow?: UnitOfWork;
 }
-``` 
+```
 
-> Flush events are entity agnostic, specifying `getSubscribedEntities()` method
-> will not have any effect for those. They are fired only once per the `flush` 
-> operation.
+> Flush events are entity agnostic, specifying `getSubscribedEntities()` method will not have any effect for those. They are fired only once per the `flush` operation.
 
 ## Transaction events
 
@@ -219,18 +191,12 @@ UnitOfWork.getExtraUpdates(): Set<[AnyEntity, string, (AnyEntity | Reference<Any
 
 ### Using onFlush event
 
-In following example we have 2 entities: `FooBar` and `FooBaz`, connected via 
-M:1 relation. Our subscriber will automatically create new `FooBaz` entity and 
-connect it to the `FooBar` when we detect it in the change sets.
+In following example we have 2 entities: `FooBar` and `FooBaz`, connected via M:1 relation. Our subscriber will automatically create new `FooBaz` entity and connect it to the `FooBar` when we detect it in the change sets.
 
-We first use `uow.getChangeSets()` method to look up the change set of entity
-we are interested in. After we create the `FooBaz` instance and link it with 
-`FooBar`, we need to do two things:
+We first use `uow.getChangeSets()` method to look up the change set of entity we are interested in. After we create the `FooBaz` instance and link it with `FooBar`, we need to do two things:
 
-1. Call `uow.computeChangeSet(baz)` to compute the change set of newly created 
-  `FooBaz` entity
-2. Call `uow.recomputeSingleChangeSet(cs.entity)` to recalculate the existing 
-  change set of the `FooBar` entity.
+1. Call `uow.computeChangeSet(baz)` to compute the change set of newly created `FooBaz` entity
+2. Call `uow.recomputeSingleChangeSet(cs.entity)` to recalculate the existing change set of the `FooBar` entity.
 
 ```ts
 @Subscriber()
@@ -258,7 +224,7 @@ await em.persistAndFlush(bar);
 
 ## Transaction events
 
-Transaction events happen at the beginning and end of a transaction. 
+Transaction events happen at the beginning and end of a transaction.
 
 - `beforeTransactionStart` is executed before a transaction starts.
 - `afterTransactionStart` is executed after a transaction starts.
@@ -267,5 +233,4 @@ Transaction events happen at the beginning and end of a transaction.
 - `beforeTransactionRollback` is executed before a transaction is rolled back.
 - `afterTransactionRollback` is executed after a transaction is rolled back.
 
-They are also entity agnostic and will only reference the transaction, `UnitOfWork` instance
-and `EntityManager` instance.
+They are also entity agnostic and will only reference the transaction, `UnitOfWork` instance and `EntityManager` instance.

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -5,6 +5,7 @@ title: Frequently Asked Questions
 ### How can I synchronize my database schema with the entities?
 
 There are two ways:
+
 - [Schema Generator](./schema-generator.md)
 - [Migrations](./migrations.md)
 
@@ -14,21 +15,15 @@ npx mikro-orm schema:update --run
 
 ### I cannot run the CLI
 
-Make sure you install `@mikro-orm/cli` package locally. If you want to have
-global installation, you will need to install driver packages globally too.
+Make sure you install `@mikro-orm/cli` package locally. If you want to have global installation, you will need to install driver packages globally too.
 
 ### EntityManager does not have `createQueryBuilder()` method
 
 The method is there, the issue is in the TS type.
 
-In v4 the `core` package, where `EntityManager` and `EntityRepository` are
-defined, is not dependent on knex, and therefore it cannot have a method
-returning a `QueryBuilder`. You need to import the SQL flavour of the EM
-from the driver package to access the `createQueryBuilder()` method.
+In v4 the `core` package, where `EntityManager` and `EntityRepository` are defined, is not dependent on knex, and therefore it cannot have a method returning a `QueryBuilder`. You need to import the SQL flavour of the EM from the driver package to access the `createQueryBuilder()` method.
 
-> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under
-> this name and under `EntityManager` alias, so you can just change the
-> location from where you import.
+> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ```ts
 import { EntityManager } from '@mikro-orm/mysql'; // or any other SQL driver package
@@ -37,8 +32,7 @@ const em = orm.em as EntityManager;
 const qb = await em.createQueryBuilder(...);
 ```
 
-To have the `orm.em` variable properly typed, we can use generic type parameter of
-`MikroORM.init()`:
+To have the `orm.em` variable properly typed, we can use generic type parameter of `MikroORM.init()`:
 
 ```ts
 import { MySqlDriver } from '@mikro-orm/mysql'; // or any other SQL driver package
@@ -58,25 +52,19 @@ const em = orm.em as EntityManager;
 const ret = await em.aggregate(...);
 ```
 
-> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under
-> this name and under `EntityManager` alias, so you can just change the
-> location from where you import.
+> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ### How can I add columns to pivot table (M:N relation)
 
-You should model your M:N relation transparently, via 1:m and m:1 properties.
-More about this can be found in [Composite Keys section](./composite-keys.md/#use-case-3-join-table-with-metadata).
+You should model your M:N relation transparently, via 1:m and m:1 properties. More about this can be found in [Composite Keys section](./composite-keys.md/#use-case-3-join-table-with-metadata).
 
 ### You cannot call `em.flush()` from inside lifecycle hook handlers
 
-You might see this validation error even if you do not use hooks. If that happens,
-the reason is usually because you do not have [request context](identity-map.md) set up properly, and
-you are reusing one `EntityManager` instance.
+You might see this validation error even if you do not use hooks. If that happens, the reason is usually because you do not have [request context](identity-map.md) set up properly, and you are reusing one `EntityManager` instance.
 
 ### Column is being created with JSON type while the TS type is `string/Date/number/...`
 
-You are probably using the default `ReflectMetadataProvider`, which does not
-support inferring property type when there is a property initializer.
+You are probably using the default `ReflectMetadataProvider`, which does not support inferring property type when there is a property initializer.
 
 ```ts
 @Property()
@@ -84,6 +72,7 @@ foo = 'abc';
 ```
 
 There are two ways around this:
+
 - Use [TsMorphMetadataProvider](./metadata-providers.md/#tsmorphmetadataprovider)
 - Specify the type explicitly:
 
@@ -124,8 +113,7 @@ When creating new entity instances, either with `new Book()` or `em.create(Book,
 Book {}
 ```
 
-But some users might find that this returns an object with properties that are explicitly
-set to `undefined`:
+But some users might find that this returns an object with properties that are explicitly set to `undefined`:
 
 ```ts
 Book {
@@ -135,8 +123,7 @@ Book {
 }
 ```
 
-This can cause unexpected behavior, particularly if you're expecting the database to set a
-default value for a column.
+This can cause unexpected behavior, particularly if you're expecting the database to set a default value for a column.
 
 To fix this, disable the [`useDefineForClassFields`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#the-usedefineforclassfields-flag-and-the-declare-property-modifier) option in your tsconfig:
 
@@ -147,5 +134,3 @@ To fix this, disable the [`useDefineForClassFields`](https://www.typescriptlang.
   }
 }
 ```
-
-

--- a/docs/docs/filters.md
+++ b/docs/docs/filters.md
@@ -2,16 +2,11 @@
 title: Filters
 ---
 
-MikroORM has the ability to pre-define filter criteria and attach those filters 
-to given entities. The application can then decide at runtime whether certain 
-filters should be enabled and what their parameter values should be. Filters 
-can be used like database views, but they are parameterized inside the application.
+MikroORM has the ability to pre-define filter criteria and attach those filters to given entities. The application can then decide at runtime whether certain filters should be enabled and what their parameter values should be. Filters can be used like database views, but they are parameterized inside the application.
 
-> Filter can be defined at the entity level, dynamically via EM (global filters) 
-> or in the ORM configuration.
+> Filter can be defined at the entity level, dynamically via EM (global filters) or in the ORM configuration.
 
-Filters are applied to those methods of `EntityManager`: `find()`, `findOne()`, 
-`findAndCount()`, `findOneOrFail()`, `count()`, `nativeUpdate()` and `nativeDelete()`. 
+Filters are applied to those methods of `EntityManager`: `find()`, `findOne()`, `findAndCount()`, `findOneOrFail()`, `count()`, `nativeUpdate()` and `nativeDelete()`.
 
 > The `cond` parameter can be a callback, possibly asynchronous.
 
@@ -36,14 +31,14 @@ const books2 = await orm.em.find(Book, {}, {
 ## Properties of filter
 
 There are three parameters you can use:
+
 - `name` - can be used to enable a filter on the query can also used to pass a parameter
 - `cond` - is the condition that should be added to the query when the filter is enabled. This can be a callback, even async
 - `default` - indicates if the filter is enabled by default on the query
 
 ## Parameters
 
-You can define the `cond` dynamically as a callback. This callback can be also 
-asynchronous. It will get three arguments:
+You can define the `cond` dynamically as a callback. This callback can be also asynchronous. It will get three arguments:
 
 - `args` - dictionary of parameters provided by user
 - `type` - type of operation that is being filtered, one of `'read'`, `'update'`, `'delete'`
@@ -58,8 +53,8 @@ import type { EntityManager } from '@mikro-orm/mysql';
     return {}; // do not apply when updating
   }
 
-  return { 
-    author: { name: args.name }, 
+  return {
+    author: { name: args.name },
     publishedAt: { $lte: em.raw('now()') },
   };
 } })
@@ -74,9 +69,7 @@ const books = await orm.em.find(Book, {}, {
 
 ### Filters without parameters
 
-If we want to have a filter condition that do not need arguments, but we want
-to access the `type` parameter, we will need to explicitly set `args: false`, 
-otherwise error will be raised due to missing parameters:
+If we want to have a filter condition that do not need arguments, but we want to access the `type` parameter, we will need to explicitly set `args: false`, otherwise error will be raised due to missing parameters:
 
 ```ts
 @Filter({
@@ -91,10 +84,7 @@ otherwise error will be raised due to missing parameters:
 
 ## Global filters
 
-We can also register filters dynamically via `EntityManager` API. We call such filters 
-global. They are enabled by default (unless disabled via last parameter in `addFilter()`
-method), and applied to all entities. You can limit the global filter to only specified
-entities. 
+We can also register filters dynamically via `EntityManager` API. We call such filters global. They are enabled by default (unless disabled via last parameter in `addFilter()` method), and applied to all entities. You can limit the global filter to only specified entities.
 
 > Filters as well as filter params set on the EM will be copied to all its forks.
 
@@ -125,12 +115,9 @@ MikroORM.init({
 
 ## Using filters
 
-We can control what filters will be applied via `filter` parameter in `FindOptions`.
-We can either provide an array of names of filters you want to enable, or options 
-object, where we can also disable a filter (that was enabled by default), or pass some
-parameters to those that are expecting them.
+We can control what filters will be applied via `filter` parameter in `FindOptions`. We can either provide an array of names of filters you want to enable, or options object, where we can also disable a filter (that was enabled by default), or pass some parameters to those that are expecting them.
 
-> By passing `filters: false` we can also disable all the filters for given call. 
+> By passing `filters: false` we can also disable all the filters for given call.
 
 ```ts
 em.find(Book, {}); // same as `{ tenantId: 123 }`
@@ -141,17 +128,11 @@ em.find(Book, {}, { filters: false }); // disabled all filters, so truly `{}`
 
 ## Filters and populating of relationships
 
-When populating relationships, filters will be applied only to the root entity of 
-given query, but not to those that are auto-joined. On the other hand, this means that
-when you use the default loading strategy - `LoadStrategy.SELECT_IN` - filters will
-be applied to every entity populated this way, as the child entities will become
-root entities in their respective load calls.
+When populating relationships, filters will be applied only to the root entity of given query, but not to those that are auto-joined. On the other hand, this means that when you use the default loading strategy - `LoadStrategy.SELECT_IN` - filters will be applied to every entity populated this way, as the child entities will become root entities in their respective load calls.
 
 ## Naming of filters
 
-When toggling filters via `FindOptions`, we do not care about the entity name. This
-means that when you have multiple filters defined on different entities, but with 
-the same name, they will be controlled via single toggle in the `FindOptions`. 
+When toggling filters via `FindOptions`, we do not care about the entity name. This means that when you have multiple filters defined on different entities, but with the same name, they will be controlled via single toggle in the `FindOptions`.
 
 ```ts
 @Entity()

--- a/docs/docs/inheritance-mapping.md
+++ b/docs/docs/inheritance-mapping.md
@@ -4,18 +4,13 @@ title: Inheritance Mapping
 
 ## Mapped Superclasses
 
-A mapped superclass is an abstract or concrete class that provides persistent entity state and mapping information for its subclasses, but which is not itself an entity. Typically, the purpose of such
-a mapped superclass is to define state and mapping information that is common to multiple entity classes.
+A mapped superclass is an abstract or concrete class that provides persistent entity state and mapping information for its subclasses, but which is not itself an entity. Typically, the purpose of such a mapped superclass is to define state and mapping information that is common to multiple entity classes.
 
 Mapped superclasses, just as regular, non-mapped classes, can appear in the middle of an otherwise mapped inheritance hierarchy (through Single Table Inheritance).
 
-> A mapped superclass cannot be an entity, it is not query-able and persistent relationships defined
-> by a mapped superclass must be unidirectional (with an owning side only). This means that One-To-Many
-> associations are not possible on a mapped superclass at all. Furthermore Many-To-Many associations
-> are only possible if the mapped superclass is only used in exactly one entity at the moment. For
-> further support of inheritance, the single table inheritance features have to be used.
+> A mapped superclass cannot be an entity, it is not query-able and persistent relationships defined by a mapped superclass must be unidirectional (with an owning side only). This means that One-To-Many associations are not possible on a mapped superclass at all. Furthermore Many-To-Many associations are only possible if the mapped superclass is only used in exactly one entity at the moment. For further support of inheritance, the single table inheritance features have to be used.
 
-> Also note that we can't use generics to define any relations. This means that we cannot have a generic type argument in the base entity that would be used as a target of some relation. 
+> Also note that we can't use generics to define any relations. This means that we cannot have a generic type argument in the base entity that would be used as a target of some relation.
 
 ```ts
 // do not use @Entity decorator on base classes (mapped superclasses)
@@ -69,16 +64,13 @@ create table `employee` (
 );
 ```
 
-As we can see from this DDL snippet, there is only a single table for the entity subclass. All the mappings from the mapped superclass were inherited to the subclass as if they had been defined on
-that class directly.
+As we can see from this DDL snippet, there is only a single table for the entity subclass. All the mappings from the mapped superclass were inherited to the subclass as if they had been defined on that class directly.
 
 ## Single Table Inheritance
 
 > Support for STI was added in version 4.0
 
-[Single Table Inheritance](https://martinfowler.com/eaaCatalog/singleTableInheritance.html)
-is an inheritance mapping strategy where all classes of a hierarchy are mapped to a single database table. In order to distinguish which row represents which type in the hierarchy a so-called
-discriminator column is used.
+[Single Table Inheritance](https://martinfowler.com/eaaCatalog/singleTableInheritance.html) is an inheritance mapping strategy where all classes of a hierarchy are mapped to a single database table. In order to distinguish which row represents which type in the hierarchy a so-called discriminator column is used.
 
 ```ts
 @Entity({
@@ -98,18 +90,14 @@ export class Employee extends Person {
 Things to note:
 
 - The `discriminatorColumn` option must be specified on the topmost class that is part of the mapped entity hierarchy.
-- The `discriminatorMap` specifies which values of the discriminator column identify a row as being of a certain type. In the case above a value of `person` identifies a row as being of type `Person`
-  and `employee` identifies a row as being of type
-  `Employee`.
+- The `discriminatorMap` specifies which values of the discriminator column identify a row as being of a certain type. In the case above a value of `person` identifies a row as being of type `Person` and `employee` identifies a row as being of type `Employee`.
 - All entity classes that are part of the mapped entity hierarchy (including the topmost class) should be specified in the `discriminatorMap`. In the case above `Person` class included.
 - We can use abstract class as the root entity - then the root class should not be part of the discriminator map
-- If no discriminator map is provided, then the map is generated automatically. The automatically generated discriminator map contains the table names that would be otherwise used in case of regular
-  entities.
+- If no discriminator map is provided, then the map is generated automatically. The automatically generated discriminator map contains the table names that would be otherwise used in case of regular entities.
 
 ### Using `discriminatorValue` instead of `discriminatorMap`
 
-As noted above, the discriminator map can be auto-generated. In that case, we might want to control the tokens that will be used in the map. To do so, we can use
-`discriminatorValue` on the child entities:
+As noted above, the discriminator map can be auto-generated. In that case, we might want to control the tokens that will be used in the map. To do so, we can use `discriminatorValue` on the child entities:
 
 ```ts
 @Entity({
@@ -130,8 +118,7 @@ export class Employee extends Person {
 
 ### Explicit discriminator column
 
-The `discriminatorColumn` specifies the name of special column that will be used to define what type of class should given row be represented with. It will be defined automatically for us and it will
-stay hidden (it won't be hydrated as a regular property).
+The `discriminatorColumn` specifies the name of special column that will be used to define what type of class should given row be represented with. It will be defined automatically for us and it will stay hidden (it won't be hydrated as a regular property).
 
 On the other hand, it is perfectly fine to define the column explicitly. Doing so, we will be able to:
 
@@ -190,18 +177,14 @@ export class Employee extends Person {
 
 ### Design-time considerations
 
-This mapping approach works well when the type hierarchy is fairly simple and stable. Adding a new type to the hierarchy and adding fields to existing supertypes simply involves adding new columns to
-the table, though in large deployments this may have an adverse impact on the index and column layout inside the database.
+This mapping approach works well when the type hierarchy is fairly simple and stable. Adding a new type to the hierarchy and adding fields to existing supertypes simply involves adding new columns to the table, though in large deployments this may have an adverse impact on the index and column layout inside the database.
 
 ### Performance impact
 
-This strategy is very efficient for querying across all types in the hierarchy or for specific types. No table joins are required, only a WHERE clause listing the type identifiers. In particular,
-relationships involving types that employ this mapping strategy are very performant.
+This strategy is very efficient for querying across all types in the hierarchy or for specific types. No table joins are required, only a WHERE clause listing the type identifiers. In particular, relationships involving types that employ this mapping strategy are very performant.
 
 ### SQL Schema considerations
 
-For Single-Table-Inheritance to work in scenarios where we are using either a legacy database schema or a self-written database schema we have to make sure that all columns that are not in the root
-entity but in any of the different sub-entities has to allow null values. Columns that have NOT NULL constraints have to be on the root entity of the single-table inheritance hierarchy.
+For Single-Table-Inheritance to work in scenarios where we are using either a legacy database schema or a self-written database schema we have to make sure that all columns that are not in the root entity but in any of the different sub-entities has to allow null values. Columns that have NOT NULL constraints have to be on the root entity of the single-table inheritance hierarchy.
 
-> This part of documentation is highly inspired by [doctrine docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/inheritance-mapping.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/inheritance-mapping.html) as the behaviour here is pretty much the same.

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -2,12 +2,9 @@
 title: Installation & Usage
 ---
 
-First install the module via `yarn` or `npm` and do not forget to install the 
-driver package as well:
+First install the module via `yarn` or `npm` and do not forget to install the driver package as well:
 
-> Since v4, we should install the driver package, but not the db connector itself,
-> e.g. install `@mikro-orm/sqlite`, but not `sqlite3` as that is already included
-> in the driver package.
+> Since v4, we should install the driver package, but not the db connector itself, e.g. install `@mikro-orm/sqlite`, but not `sqlite3` as that is already included in the driver package.
 
 ```sh
 yarn add @mikro-orm/core @mikro-orm/mongodb     # for mongo
@@ -27,8 +24,7 @@ npm i -s @mikro-orm/core @mikro-orm/postgresql  # for postgresql
 npm i -s @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 ```
 
-Next we will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html)
-as well as `esModuleInterop` in `tsconfig.json` via:
+Next we will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html) as well as `esModuleInterop` in `tsconfig.json` via:
 
 ```json
 "experimentalDecorators": true,
@@ -38,9 +34,7 @@ as well as `esModuleInterop` in `tsconfig.json` via:
 
 Then call `MikroORM.init` as part of bootstrapping our app:
 
-> To access driver specific methods like `em.createQueryBuilder()` we need to specify
-> the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the
-> `orm.em` to `EntityManager` exported from the driver package:
+> To access driver specific methods like `em.createQueryBuilder()` we need to specify the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the `orm.em` to `EntityManager` exported from the driver package:
 >
 > ```ts
 > import { EntityManager } from '@mikro-orm/postgresql';
@@ -62,10 +56,7 @@ console.log(orm.em); // access EntityManager via `em` property
 
 > Read more about all the possible configuration options in [Advanced Configuration](configuration.md) section.
 
-We can also provide paths where we store our entities via `entities` array. Internally
-it uses [`globby`](https://github.com/sindresorhus/globby) so we can use 
-[globbing patterns](https://github.com/sindresorhus/globby#globbing-patterns), 
-including negative globs. 
+We can also provide paths where we store our entities via `entities` array. Internally it uses [`globby`](https://github.com/sindresorhus/globby) so we can use [globbing patterns](https://github.com/sindresorhus/globby#globbing-patterns), including negative globs.
 
 ```ts
 const orm = await MikroORM.init<PostgreSqlDriver>({
@@ -75,21 +66,17 @@ const orm = await MikroORM.init<PostgreSqlDriver>({
 });
 ```
 
-If we are experiencing problems with folder based discovery, try using `mikro-orm debug`
-CLI command to check what paths are actually being used.
+If we are experiencing problems with folder based discovery, try using `mikro-orm debug` CLI command to check what paths are actually being used.
 
 > Since v4, we can also use file globs, like `./dist/app/**/entities/*.entity.js`.
 
 We can also set the configuration via [environment variables](configuration.md#using-environment-variables).
 
-> We can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. 
-> The object will be deeply merged, overriding all internally used options.
+> We can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. The object will be deeply merged, overriding all internally used options.
 
 ## Possible issues with circular dependencies
 
-Our entities will most probably contain circular dependencies (e.g. if we use bi-directional 
-relationship). While this is fine, there might be issues caused by wrong order of entities 
-during discovery, especially when we are using the folder based way.
+Our entities will most probably contain circular dependencies (e.g. if we use bi-directional relationship). While this is fine, there might be issues caused by wrong order of entities during discovery, especially when we are using the folder based way.
 
 The errors caused by circular dependencies are usually similar to this one:
 
@@ -110,17 +97,12 @@ TypeError: Cannot read property 'name' of undefined
 
 If we encounter this, we have basically two options:
 
-- Use entity references in `entities` array to have control over the order of discovery. 
-  We might need to play with the actual order we provide here, or possibly with the 
-  order of import statements.
-- Use strings instead of references (e.g. `@OneToMany('Book', 'author')`). The downside 
-  here is that we will lose the typechecking capabilities of the decorators. 
+- Use entity references in `entities` array to have control over the order of discovery. We might need to play with the actual order we provide here, or possibly with the order of import statements.
+- Use strings instead of references (e.g. `@OneToMany('Book', 'author')`). The downside here is that we will lose the typechecking capabilities of the decorators.
 
 ## Entity Discovery in TypeScript
 
-In v4 the default metadata provider is `ReflectMetadataProvider`. If we want to use
-`ts-morph` based discovery (that reads actual TS types via the compiler API), we 
-need to install `@mikro-orm/reflection`.
+In v4 the default metadata provider is `ReflectMetadataProvider`. If we want to use `ts-morph` based discovery (that reads actual TS types via the compiler API), we need to install `@mikro-orm/reflection`.
 
 ```ts
 import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
@@ -141,19 +123,16 @@ const orm = await MikroORM.init<PostgreSqlDriver>({
 });
 ```
 
-> It is important that `entities` will point to the compiled JS files, and `entitiesTs`
-> will point to the TS source files. We should not mix those. 
+> It is important that `entities` will point to the compiled JS files, and `entitiesTs` will point to the TS source files. We should not mix those.
 
-> For `ts-morph` discovery to work in production, we need to deploy `.d.ts` declaration
-> files. Be sure to enable `compilerOptions.declaration` in our `tsconfig.json`.
+> For `ts-morph` discovery to work in production, we need to deploy `.d.ts` declaration files. Be sure to enable `compilerOptions.declaration` in our `tsconfig.json`.
 
 We can also use different [metadata provider](metadata-providers.md) or even write custom one:
 
 - `ReflectMetadataProvider` that uses `reflect-metadata` instead of `ts-morph`
 - `JavaScriptMetadataProvider` that allows us to manually provide the entity schema (mainly for Vanilla JS)
 
-> Using [`EntitySchema`](entity-schema.md) is another way to define our entities, which is better
-> suited than using `JavaScriptMetadataProvider`.
+> Using [`EntitySchema`](entity-schema.md) is another way to define our entities, which is better suited than using `JavaScriptMetadataProvider`.
 
 ```ts
 const orm = await MikroORM.init<PostgreSqlDriver>({
@@ -175,8 +154,7 @@ app.use((req, res, next) => {
 });
 ```
 
-> If the `next` handler needs to be awaited (like in Koa), 
-> use `RequestContext.createAsync()` instead.
+> If the `next` handler needs to be awaited (like in Koa), use `RequestContext.createAsync()` instead.
 >
 > ```ts
 > app.use((ctx, next) => RequestContext.createAsync(orm.em, next));
@@ -186,12 +164,9 @@ More info about `RequestContext` is described [here](identity-map.md#request-con
 
 ## Setting up the Commandline Tool
 
-MikroORM ships with a number of command line tools that are very helpful during development, 
-like `SchemaGenerator` and `EntityGenerator`. We can call this command from the NPM binary 
-directory or use `npx`:
+MikroORM ships with a number of command line tools that are very helpful during development, like `SchemaGenerator` and `EntityGenerator`. We can call this command from the NPM binary directory or use `npx`:
 
-> To work with the CLI, first install `@mikro-orm/cli` package locally.
-> The version needs to be aligned with the `@mikro-orm/core` package.
+> To work with the CLI, first install `@mikro-orm/cli` package locally. The version needs to be aligned with the `@mikro-orm/core` package.
 
 ```sh
 # install the CLI package first!
@@ -207,15 +182,11 @@ $ npx mikro-orm
 $ yarn mikro-orm
 ```
 
-For CLI to be able to access our database, we will need to create `mikro-orm.config.js` file that exports our ORM configuration. 
+For CLI to be able to access our database, we will need to create `mikro-orm.config.js` file that exports our ORM configuration.
 
-> ORM configuration file can export the Promise, like:
-> `export default Promise.resolve({...});`.
+> ORM configuration file can export the Promise, like: `export default Promise.resolve({...});`.
 
-TypeScript is also supported, just enable `useTsNode` flag in our
-`package.json` file. There we can also set up array of possible paths to `mikro-orm.config` file,
-as well as use different file name. The `package.json` file can be located in 
-the current working directory, or in one of its parent folders.
+TypeScript is also supported, just enable `useTsNode` flag in our `package.json` file. There we can also set up array of possible paths to `mikro-orm.config` file, as well as use different file name. The `package.json` file can be located in the current working directory, or in one of its parent folders.
 
 We can use these environment variables to override CLI settings:
 
@@ -225,13 +196,9 @@ We can use these environment variables to override CLI settings:
 
 > Do not forget to install `ts-node` when enabling `useTsNode` flag.
 
-> The `useTsNode` is used only when executing the CLI, it is not respected when 
-> running our app.
+> The `useTsNode` is used only when executing the CLI, it is not respected when running our app.
 
-MikroORM will always try to load the first available config file, based on the 
-order in `configPaths`. This means that if we specify the first item as the TS 
-config, but we do not have `ts-node` enabled and installed, it will fail to 
-load it.
+MikroORM will always try to load the first available config file, based on the order in `configPaths`. This means that if we specify the first item as the TS config, but we do not have `ts-node` enabled and installed, it will fail to load it.
 
 ```json title="./package.json"
 {
@@ -277,23 +244,16 @@ export default defineConfig({
 });
 ```
 
-When we have `useTsNode` disabled and `ts-node` is not already registered and detected,
-TS config files will be ignored.
+When we have `useTsNode` disabled and `ts-node` is not already registered and detected, TS config files will be ignored.
 
-Once we have the CLI config properly set up, we can omit the `MikroORM.init()` options
-parameter, and the CLI config will be automatically used. This process may fail if we
-use bundlers that use tree shaking. As the config file is not referenced anywhere 
-statically, it would not be compiled - for that the best approach is to provide the config
-explicitly:
+Once we have the CLI config properly set up, we can omit the `MikroORM.init()` options parameter, and the CLI config will be automatically used. This process may fail if we use bundlers that use tree shaking. As the config file is not referenced anywhere statically, it would not be compiled - for that the best approach is to provide the config explicitly:
 
 ```ts
 import config from './mikro-orm.config';
 const orm = await MikroORM.init(config);
 ```
 
-> We can also use different names for this file, simply rename it in the `configPaths` array
-> our in `package.json`. We can also use `MIKRO_ORM_CLI` environment variable with the path
-> to override `configPaths` value.
+> We can also use different names for this file, simply rename it in the `configPaths` array our in `package.json`. We can also use `MIKRO_ORM_CLI` environment variable with the path to override `configPaths` value.
 
 Now we should be able to start using the CLI. All available commands are listed in the CLI help:
 
@@ -330,10 +290,8 @@ Examples:
 
 To verify our setup, we can use `mikro-orm debug` command.
 
-> When we have CLI config properly set up, we can omit the `options` parameter
-> when calling `MikroORM.init()`.
+> When we have CLI config properly set up, we can omit the `options` parameter when calling `MikroORM.init()`.
 
-> Note: When importing a dump file we need `multipleStatements: true` in our
-> configuration. Please check the configuration documentation for more information.
+> Note: When importing a dump file we need `multipleStatements: true` in our configuration. Please check the configuration documentation for more information.
 
 Now we can start [defining our entities](defining-entities.md).

--- a/docs/docs/json-properties.md
+++ b/docs/docs/json-properties.md
@@ -4,8 +4,7 @@ title: Using JSON properties
 
 ## Defining JSON properties
 
-Each database driver behaves a bit differently when it comes to JSON properties. MikroORM tries to unify the experience via [JsonType](custom-types.md#jsontype). This type will be also used if we
-specify `type: 'json'`.
+Each database driver behaves a bit differently when it comes to JSON properties. MikroORM tries to unify the experience via [JsonType](custom-types.md#jsontype). This type will be also used if we specify `type: 'json'`.
 
 ```ts
 @Entity()
@@ -42,15 +41,14 @@ const b = await em.findOne(Book, {
 Will produce following query (in postgres):
 
 ```sql
-select "e0".* 
-from "book" as "e0" 
-where ("meta"->>'valid')::bool = true 
-  and "meta"->'nested'->>'foo' = '123' 
-  and ("meta"->'nested'->>'bar')::float8 = 321 
-  and ("meta"->'nested'->'deep'->>'baz')::float8 = 59 
-  and ("meta"->'nested'->'deep'->>'qux')::bool = false 
+select "e0".*
+from "book" as "e0"
+where ("meta"->>'valid')::bool = true
+  and "meta"->'nested'->>'foo' = '123'
+  and ("meta"->'nested'->>'bar')::float8 = 321
+  and ("meta"->'nested'->'deep'->>'baz')::float8 = 59
+  and ("meta"->'nested'->'deep'->>'qux')::bool = false
 limit 1
 ```
 
-> All drivers are currently supported (including sqlite and mongo). In postgres we
-> also try to cast the value if we detect number or boolean on the right-hand side.
+> All drivers are currently supported (including sqlite and mongo). In postgres we also try to cast the value if we detect number or boolean on the right-hand side.

--- a/docs/docs/loading-strategies.md
+++ b/docs/docs/loading-strategies.md
@@ -5,9 +5,7 @@ sidebar_label: Loading Strategies
 
 > `JOINED` loading strategy is SQL only feature.
 
-Controls how relationships get loaded when querying. By default, populated relationships
-are loaded via the `select-in` strategy. This strategy issues one additional `SELECT`
-statement per relation being loaded.
+Controls how relationships get loaded when querying. By default, populated relationships are loaded via the `select-in` strategy. This strategy issues one additional `SELECT` statement per relation being loaded.
 
 The loading strategy can be specified both at mapping time and when loading entities.
 
@@ -29,8 +27,7 @@ export class Book {
 }
 ```
 
-The following will issue two SQL statements.
-One to load the author and another to load all the books belonging to that author:
+The following will issue two SQL statements. One to load the author and another to load all the books belonging to that author:
 
 ```ts
 const author = await orm.em.findOne(Author, 1, { populate: ['books'] });
@@ -58,8 +55,7 @@ The following will issue **one** SQL statement:
 const author = await orm.em.findOne(Author, 1, { populate: ['books'] });
 ```
 
-You can also specify the load strategy as needed. This will override whatever strategy is declared in the mapping.
-This also works for nested populates:
+You can also specify the load strategy as needed. This will override whatever strategy is declared in the mapping. This also works for nested populates:
 
 ```ts
 const author = await orm.em.findOne(Author, 1, {
@@ -78,37 +74,27 @@ MikroORM.init({
 });
 ```
 
-This value will be used as the default, specifying the loading strategy on 
-property level has precedence, as well as specifying it in the `FindOptions`.
+This value will be used as the default, specifying the loading strategy on property level has precedence, as well as specifying it in the `FindOptions`.
 
 ## Population where condition
 
 > This applies only to SELECT_IN strategy, as JOINED strategy implies the inference.
 
-In v4, when we used populate hints in `em.find()` and similar methods, the
-query for our entity would be analysed and parts of it extracted and used for
-the population. Following example would find all authors that have books with
-given IDs, and populate their books collection, again using this PK condition,
-resulting in only such books being in those collections.
+In v4, when we used populate hints in `em.find()` and similar methods, the query for our entity would be analysed and parts of it extracted and used for the population. Following example would find all authors that have books with given IDs, and populate their books collection, again using this PK condition, resulting in only such books being in those collections.
 
 ```ts
 // this would end up with `Author.books` collections having only books of PK 1, 2, 3
 const a = await em.find(Author, { books: [1, 2, 3] }, { populate: ['books'] });
 ```
 
-Following this example, if we wanted to load all books, we would need a separate
-`em.populate()` call:
+Following this example, if we wanted to load all books, we would need a separate `em.populate()` call:
 
 ```ts
 const a = await em.find(Author, { books: [1, 2, 3] });
 await em.populate(a, ['books']);
 ```
 
-This behaviour changed and is now configurable both globally and locally, via
-`populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and
-`PopulateHint.INFER`, the former being the default in v5, the latter being the
-default behaviour in v4. Locally (via `FindOptions`) we can also specify custom
-where condition that will be passed to `em.populate()` call.
+This behaviour changed and is now configurable both globally and locally, via `populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and `PopulateHint.INFER`, the former being the default in v5, the latter being the default behaviour in v4. Locally (via `FindOptions`) we can also specify custom where condition that will be passed to `em.populate()` call.
 
 ```ts
 await em.find(Author, { ... }, {

--- a/docs/docs/logging.md
+++ b/docs/docs/logging.md
@@ -41,8 +41,7 @@ return MikroORM.init({
 });
 ```
 
-If we want to have more control over logging, we can use `loggerFactory`
-and use our own implementation of the `Logger` interface:
+If we want to have more control over logging, we can use `loggerFactory` and use our own implementation of the `Logger` interface:
 
 ```ts
 import { Logger, LoggerOptions, MikroORM, Configuration } from '@mikro-orm/core';
@@ -109,8 +108,7 @@ If you provide `query-params` then you must also provide `query` in order for it
 
 ## Highlighters
 
-Previously Highlight.js was used to highlight various things in the CLI, like SQL and mongo queries, or migrations or entities generated via CLI. While the library worked fine, it was causing
-performance issues mainly for those bundling via webpack and using lambdas, as the library was huge.
+Previously Highlight.js was used to highlight various things in the CLI, like SQL and mongo queries, or migrations or entities generated via CLI. While the library worked fine, it was causing performance issues mainly for those bundling via webpack and using lambdas, as the library was huge.
 
 Since v4, highlighting is disabled by default, and there are 2 highlighters you can optionally use (you need to install them first).
 
@@ -123,5 +121,4 @@ MikroORM.init({
 });
 ```
 
-For MongoDB you can use `MongoHighlighter` from `@mikro-orm/mongo-highlighter`
-package.
+For MongoDB you can use `MongoHighlighter` from `@mikro-orm/mongo-highlighter` package.

--- a/docs/docs/metadata-cache.md
+++ b/docs/docs/metadata-cache.md
@@ -2,32 +2,19 @@
 title: Metadata Cache
 ---
 
-> In v4 and later versions, we need to explicitly install `@mikro-orm/reflection`
-> to use `TsMorphMetadataProvider`.
+> In v4 and later versions, we need to explicitly install `@mikro-orm/reflection` to use `TsMorphMetadataProvider`.
 
-MikroORM allows different ways to [obtain entity metadata](metadata-providers.md).
-One way is to use [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. This 
-process can be performance heavy and time-consuming. For this reason, metadata
-cache is automatically enabled for `TsMorphMetadataProvider`. It can be optionally
-enabled for the other metadata providers, but it should not be needed.
+MikroORM allows different ways to [obtain entity metadata](metadata-providers.md). One way is to use [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. This process can be performance heavy and time-consuming. For this reason, metadata cache is automatically enabled for `TsMorphMetadataProvider`. It can be optionally enabled for the other metadata providers, but it should not be needed.
 
-After the discovery process ends, all metadata will be cached. By default, 
-`FileCacheAdapter` will be used to store the cache inside `./temp` folder to JSON
-files.
+After the discovery process ends, all metadata will be cached. By default, `FileCacheAdapter` will be used to store the cache inside `./temp` folder to JSON files.
 
-If we use folder based discovery, cache will be dependent on environment - if we 
-run via ts-node, the cache will be generated for TS files. To generate production
-cache, we can use the CLI command `mikro-orm cache:generate`.
+If we use folder based discovery, cache will be dependent on environment - if we run via ts-node, the cache will be generated for TS files. To generate production cache, we can use the CLI command `mikro-orm cache:generate`.
 
 ## Automatic Invalidation
 
-Entity metadata are cached together with modified time of the source file, and every time
-the cache is requested, it first checks if the cache is not invalid. This way we can forget 
-about the caching mechanism most of the time.
+Entity metadata are cached together with modified time of the source file, and every time the cache is requested, it first checks if the cache is not invalid. This way we can forget about the caching mechanism most of the time.
 
-One case where we can end up needing to wipe the cache manually is when we work withing a 
-git branch where contents of entities folder differs. 
+One case where we can end up needing to wipe the cache manually is when we work withing a git branch where contents of entities folder differs.
 
 ## Disabling Metadata Cache
 
@@ -65,8 +52,7 @@ await MikroORM.init({
 
 ## Providing Custom Cache Adapter
 
-You can also implement your own cache adapter, for example to store the cache in redis. 
-To do so, just implement simple `CacheAdapter` interface:
+You can also implement your own cache adapter, for example to store the cache in redis. To do so, just implement simple `CacheAdapter` interface:
 
 ```ts
 export interface CacheAdapter {

--- a/docs/docs/metadata-providers.md
+++ b/docs/docs/metadata-providers.md
@@ -2,8 +2,7 @@
 title: Metadata Providers
 ---
 
-As part of entity discovery process, MikroORM uses so called `MetadataProvider` to get necessary
-type information about our entities' properties.
+As part of entity discovery process, MikroORM uses so called `MetadataProvider` to get necessary type information about our entities' properties.
 
 > We can also implement custom metadata provider by extending abstract `MetadataProvider` class.
 
@@ -11,9 +10,7 @@ There are 3 built-in metadata providers we can use:
 
 ## TsMorphMetadataProvider
 
-With `TsMorphMetadataProvider` MikroORM will use [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. Thanks to this, 
-defining the type is enough for runtime validation.
+With `TsMorphMetadataProvider` MikroORM will use [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. Thanks to this, defining the type is enough for runtime validation.
 
 To use it, first install the `@mikro-orm/reflection` package.
 
@@ -26,18 +23,11 @@ await MikroORM.init({
 });
 ```
 
-If we use folder-based discovery, we should specify paths to
-the compiled entities via `entities` as well as paths to the TS source files of
-those entities via `entitiesTs`. When we run the ORM via `ts-node`, the latter
-will be used automatically, or if we explicitly pass `tsNode: true` in the config. Note that `tsNode: true` should not be part of production config.
+If we use folder-based discovery, we should specify paths to the compiled entities via `entities` as well as paths to the TS source files of those entities via `entitiesTs`. When we run the ORM via `ts-node`, the latter will be used automatically, or if we explicitly pass `tsNode: true` in the config. Note that `tsNode: true` should not be part of production config.
 
-> When running via `node`, `.d.ts` files are used to obtain the type, so we 
-> need to ship them in the production build. TS source files are no longer 
-> needed (since v4). Be sure to enable `compilerOptions.declaration` in our
-> `tsconfig.json`.
+> When running via `node`, `.d.ts` files are used to obtain the type, so we need to ship them in the production build. TS source files are no longer needed (since v4). Be sure to enable `compilerOptions.declaration` in our `tsconfig.json`.
 
-After the discovery process ends, all [metadata will be cached](metadata-cache.md). By default, 
-`FileCacheAdapter` will be used to store the cache inside `./temp` folder in JSON files. 
+After the discovery process ends, all [metadata will be cached](metadata-cache.md). By default, `FileCacheAdapter` will be used to store the cache inside `./temp` folder in JSON files.
 
 > We can generate production cache via CLI command `mikro-orm cache:generate`.
 
@@ -45,11 +35,9 @@ After the discovery process ends, all [metadata will be cached](metadata-cache.m
 
 ## ReflectMetadataProvider
 
-`ReflectMetadataProvider` uses `reflect-metadata` module to read the type from decorator 
-metadata exported by TypeScript compiler. 
+`ReflectMetadataProvider` uses `reflect-metadata` module to read the type from decorator metadata exported by TypeScript compiler.
 
-We will need to install `reflect-metadata` module and import at the top of our app's 
-bootstrap script (e.g. `main.ts` or `app.ts`). 
+We will need to install `reflect-metadata` module and import at the top of our app's bootstrap script (e.g. `main.ts` or `app.ts`).
 
 ```ts
 import 'reflect-metadata';
@@ -57,7 +45,7 @@ import 'reflect-metadata';
 
 Next step is to enable `emitDecoratorMetadata` flag in our `tsconfig.json`.
 
-> As this approach does not have performance impact, metadata caching is not really necessary. 
+> As this approach does not have performance impact, metadata caching is not really necessary.
 
 ```ts
 await MikroORM.init({
@@ -102,8 +90,7 @@ prop?: string;
 
 #### Enums
 
-By default, enum is considered as numeric type. For string enums, we need to explicitly 
-provide one of:
+By default, enum is considered as numeric type. For string enums, we need to explicitly provide one of:
 
 - reference to the enum (which will force us to define the enum before defining the entity)
   ```ts
@@ -123,31 +110,24 @@ provide one of:
 
 #### Circular dependencies
 
-Reading type of referenced entity in `@ManyToOne` and `@OneToOne` properties fails if there is 
-circular dependency. We will need to explicitly define the type in the decorator (preferably 
-via `entity: () => ...` callback).
+Reading type of referenced entity in `@ManyToOne` and `@OneToOne` properties fails if there is circular dependency. We will need to explicitly define the type in the decorator (preferably via `entity: () => ...` callback).
 
 ```ts
 @ManyToOne({ entity: () => Author })
 author: Author;
-``` 
+```
 
-> There can be recursion issues when we define multiple entities (with circular dependencies 
-> between each other) in single file. In that case, we might want to provide the type via decorator's
-> `type` or `entity` attributes and set the TS property type to something else (like `any` or `object`).
+> There can be recursion issues when we define multiple entities (with circular dependencies between each other) in single file. In that case, we might want to provide the type via decorator's `type` or `entity` attributes and set the TS property type to something else (like `any` or `object`).
 
 #### Additional typings might be required
 
-We might have to install additional typings, one example is use of `ObjectId` in MongoDB, 
-which requires `@types/mongodb` to be installed. 
+We might have to install additional typings, one example is use of `ObjectId` in MongoDB, which requires `@types/mongodb` to be installed.
 
 ## JavaScriptMetadataProvider
 
 > `JavaScriptMetadataProvider` is deprecated, [use `EntitySchema` instead](entity-schema.md).
 
-This provider should be used only if we are not using TypeScript at all and therefore we do 
-not use decorators to annotate our properties. It will require us to specify the whole schema 
-manually. 
+This provider should be used only if we are not using TypeScript at all and therefore we do not use decorators to annotate our properties. It will require us to specify the whole schema manually.
 
 ```ts
 await MikroORM.init({

--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -8,8 +8,7 @@ MikroORM has integrated support for migrations via [umzug](https://github.com/se
 
 > Since v5, migrations are stored without extension.
 
-By default, each migration will be all executed inside a transaction, and all of them will 
-be wrapped in one master transaction, so if one of them fails, everything will be rolled back. 
+By default, each migration will be all executed inside a transaction, and all of them will be wrapped in one master transaction, so if one of them fails, everything will be rolled back.
 
 ## Migration class
 
@@ -27,41 +26,31 @@ export class Migration20191019195930 extends Migration {
 }
 ```
 
-To support undoing those changed, we can implement the `down` method, which throws an error by default. 
+To support undoing those changed, we can implement the `down` method, which throws an error by default.
 
-Migrations are by default wrapped in a transaction. You can override this behaviour on 
-per migration basis by implementing the `isTransactional(): boolean` method.
+Migrations are by default wrapped in a transaction. You can override this behaviour on per migration basis by implementing the `isTransactional(): boolean` method.
 
 `Configuration` object and driver instance are available in the `Migration` class context.
 
-You can execute queries in the migration via `Migration.execute()` method, which 
-will run queries in the same transaction as the rest of the migration. The 
-`Migration.addSql()` method also accepts instances of knex. Knex instance can be 
-accessed via `Migration.getKnex()`; 
+You can execute queries in the migration via `Migration.execute()` method, which will run queries in the same transaction as the rest of the migration. The `Migration.addSql()` method also accepts instances of knex. Knex instance can be accessed via `Migration.getKnex()`;
 
 ## Initial migration
 
 > This is optional and only needed for the specific use case, when both entities and schema already exist.
 
-If we want to start using migrations, and we already have the schema generated, 
-we can do so by creating so called initial migration:
+If we want to start using migrations, and we already have the schema generated, we can do so by creating so called initial migration:
 
-> Initial migration can be created only if there are no migrations previously
-> generated or executed. 
+> Initial migration can be created only if there are no migrations previously generated or executed.
 
 ```sh
 npx mikro-orm migration:create --initial
 ```
 
-This will create the initial migration, containing the schema dump from 
-`schema:create` command. The migration will be automatically marked as executed. 
+This will create the initial migration, containing the schema dump from `schema:create` command. The migration will be automatically marked as executed.
 
 ## Snapshots
 
-Creating new migration will automatically save the target schema snapshot into 
-migrations folder. This snapshot will be then used if we try to create new migration,
-instead of using current database schema. This means that if we try to create new 
-migration before we run the pending ones, we still get the right schema diff.
+Creating new migration will automatically save the target schema snapshot into migrations folder. This snapshot will be then used if we try to create new migration, instead of using current database schema. This means that if we try to create new migration before we run the pending ones, we still get the right schema diff.
 
 > Snapshots should be versioned just like the regular migration files.
 
@@ -71,8 +60,7 @@ Snapshotting can be disabled via `migrations.snapshot: false` in the ORM config.
 
 > Since v5, `umzug` 3.0 is used, and `pattern` option has been replaced with `glob`.
 
-> `migrations.path` and `migrations.pathTs` works the same way as `entities` and 
-> `entitiesTs` in entity discovery.
+> `migrations.path` and `migrations.pathTs` works the same way as `entities` and `entitiesTs` in entity discovery.
 
 ```ts
 await MikroORM.init({
@@ -96,9 +84,7 @@ await MikroORM.init({
 
 ## Running migrations in production
 
-In production environment we might want to use compiled migration files. Since v5,
-this should work almost out of box, all we need to do is to configure the migration
-path accordingly:
+In production environment we might want to use compiled migration files. Since v5, this should work almost out of box, all we need to do is to configure the migration path accordingly:
 
 ```ts
 import { MikroORM, Utils } from '@mikro-orm/core';
@@ -116,15 +102,11 @@ await MikroORM.init({
 });
 ```
 
-This should allow using CLI to generate TS migration files (as in CLI we probably
-have TS support enabled), while using compiled JS files in production, where ts-node
-is not registered.
+This should allow using CLI to generate TS migration files (as in CLI we probably have TS support enabled), while using compiled JS files in production, where ts-node is not registered.
 
 ## Using custom `MigrationGenerator`
 
-When we generate new migrations, `MigrationGenerator` class is responsible for 
-generating the file contents. We can provide our own implementation to do things 
-like formatting the SQL statement. 
+When we generate new migrations, `MigrationGenerator` class is responsible for generating the file contents. We can provide our own implementation to do things like formatting the SQL statement.
 
 ```ts
 import { TSMigrationGenerator } from '@mikro-orm/migrations';
@@ -157,7 +139,7 @@ await MikroORM.init({
 
 ## Using via CLI
 
-You can use it via CLI: 
+You can use it via CLI:
 
 ```sh
 npx mikro-orm migration:create   # Create new migration with current schema diff
@@ -169,11 +151,9 @@ npx mikro-orm migration:pending  # List all pending migrations
 npx mikro-orm migration:fresh    # Drop the database and migrate up to the latest version
 ```
 
-> To create blank migration file, we can use 
-> `npx mikro-orm migration:create --blank`.
+> To create blank migration file, we can use `npx mikro-orm migration:create --blank`.
 
-For `migration:up` and `migration:down` commands we can specify `--from` (`-f`), `--to` (`-t`) 
-and `--only` (`-o`) options to run only a subset of migrations:
+For `migration:up` and `migration:down` commands we can specify `--from` (`-f`), `--to` (`-t`) and `--only` (`-o`) options to run only a subset of migrations:
 
 ```sh
 npx mikro-orm migration:up --from 2019101911 --to 2019102117  # the same as above
@@ -181,14 +161,15 @@ npx mikro-orm migration:up --only 2019101923                  # apply a single m
 npx mikro-orm migration:down --to 0                           # migrate down all migrations
 ```
 
-> To run TS migration files, we will need to [enable `useTsNode` flag](installation.md#setting-up-the-commandline-tool)
-> in our `package.json`.
+> To run TS migration files, we will need to [enable `useTsNode` flag](installation.md#setting-up-the-commandline-tool) in our `package.json`.
 
 For the `migration:fresh` command we can specify `--seed` to seed the database after migrating.
+
 ```shell
 npx mikro-orm migration:fresh --seed              # seed the database with the default database seeder
 npx mikro-orm migration:fresh --seed=UsersSeeder  # seed the database with the UsersSeeder
 ```
+
 > You can specify the default database seeder in the orm config with the key `config.seeder.defaultSeeder`
 
 ## Using the Migrator programmatically
@@ -236,8 +217,7 @@ await orm.em.transactional(async em => {
 
 ## Importing migrations statically
 
-If we do not want to dynamically import a folder (e.g. when bundling our code with webpack) we can import migrations
-directly.
+If we do not want to dynamically import a folder (e.g. when bundling our code with webpack) we can import migrations directly.
 
 ```ts
 import { MikroORM } from '@mikro-orm/core';
@@ -255,8 +235,7 @@ await MikroORM.init({
 });
 ```
 
-With the help of [webpack's context module api](https://webpack.js.org/guides/dependency-management/#context-module-api)
-we can dynamically import the migrations making it possible to import all files in a folder.
+With the help of [webpack's context module api](https://webpack.js.org/guides/dependency-management/#context-module-api) we can dynamically import the migrations making it possible to import all files in a folder.
 
 ```ts
 import { MikroORM } from '@mikro-orm/core';
@@ -312,9 +291,9 @@ import { Migration } from '@mikro-orm/migrations-mongodb';
 export class MigrationTest1 extends Migration {
 
   async up(): Promise<void> {
-    // use `this.getCollection()` to work with the mongodb collection directly 
+    // use `this.getCollection()` to work with the mongodb collection directly
     await this.getCollection('Book').updateMany({}, { $set: { updatedAt: new Date() } }, { session: this.ctx });
-    
+
     // or use `this.driver` to work with the `MongoDriver` API instead
     await this.driver.nativeDelete('Book', { foo: true }, { ctx: this.ctx });
   }
@@ -326,8 +305,7 @@ export class MigrationTest1 extends Migration {
 
 ### MySQL
 
-There is no way to rollback DDL changes in MySQL. An implicit commit is forced for those 
-queries automatically, so transactions are not working as expected. 
+There is no way to rollback DDL changes in MySQL. An implicit commit is forced for those queries automatically, so transactions are not working as expected.
 
 - https://github.com/mikro-orm/mikro-orm/issues/217
 - https://dev.mysql.com/doc/refman/5.7/en/implicit-commit.html

--- a/docs/docs/multiple-schemas.md
+++ b/docs/docs/multiple-schemas.md
@@ -2,14 +2,11 @@
 title: Using Multiple Schemas
 ---
 
-In MySQL and PostgreSQL it is possible to define your entities in multiple schemas. In MySQL 
-terminology, it is called database, but from an implementation point of view, it is a schema. 
+In MySQL and PostgreSQL it is possible to define your entities in multiple schemas. In MySQL terminology, it is called database, but from an implementation point of view, it is a schema.
 
-> To use multiple schemas, your connection needs to have access to all of them (multiple 
-> connections are not supported in a single MikroORM instance).
+> To use multiple schemas, your connection needs to have access to all of them (multiple connections are not supported in a single MikroORM instance).
 
-All you need to do is simply define the schema name via `schema` options, or 
-table name including schema name in `tableName` option:
+All you need to do is simply define the schema name via `schema` options, or table name including schema name in `tableName` option:
 
 ```ts
 @Entity({ schema: 'first_schema' })
@@ -20,12 +17,9 @@ export class Foo { ... }
 export class Bar { ... }
 ```
 
-Then use those entities as usual. Resulting SQL queries will use this `tableName` value as a 
-table name so as long as your connection has access to given schema, everything should work 
-as expected.
+Then use those entities as usual. Resulting SQL queries will use this `tableName` value as a table name so as long as your connection has access to given schema, everything should work as expected.
 
-You can also query for entity in specific schema via `EntityManager`, `EntityRepository` or 
-`QueryBuilder`:
+You can also query for entity in specific schema via `EntityManager`, `EntityRepository` or `QueryBuilder`:
 
 ```ts
 const user = await em.findOne(User, { ... }, { schema: 'client-123' });
@@ -40,8 +34,7 @@ await qb.insert({ email: 'foo@bar.com' }).withSchema('client-123');
 
 ## Wildcard Schema
 
-Since v5, MikroORM also supports defining entities that can exist in multiple
-schemas. To do that, we just specify wildcard schema:
+Since v5, MikroORM also supports defining entities that can exist in multiple schemas. To do that, we just specify wildcard schema:
 
 ```ts
 @Entity({ schema: '*' })
@@ -62,19 +55,10 @@ export class Book {
 }
 ```
 
-Entities like this will be by default ignored when using `SchemaGenerator`, 
-as we need to specify which schema to use. For that we need to use the `schema`
-option of the `createSchema/updateSchema/dropSchema` methods or the `--schema` 
-CLI parameter.
+Entities like this will be by default ignored when using `SchemaGenerator`, as we need to specify which schema to use. For that we need to use the `schema` option of the `createSchema/updateSchema/dropSchema` methods or the `--schema` CLI parameter.
 
-On runtime, the wildcard schema will be replaced with either `FindOptions.schema`,
-or with the `schema` option from the ORM config.
+On runtime, the wildcard schema will be replaced with either `FindOptions.schema`, or with the `schema` option from the ORM config.
 
 ### Note about migrations
 
-Currently, this is not supported via migrations, they will always ignore
-wildcard schema entities, and `SchemaGenerator` needs to be used explicitly.
-Given the dynamic nature of such entities, it makes sense to only sync the 
-schema dynamically, e.g. in an API endpoint. We could still use the ORM 
-migrations, but we need to add the dynamic schema queries manually to migration
-files. It makes sense to use the `safe` mode for such queries.
+Currently, this is not supported via migrations, they will always ignore wildcard schema entities, and `SchemaGenerator` needs to be used explicitly. Given the dynamic nature of such entities, it makes sense to only sync the schema dynamically, e.g. in an API endpoint. We could still use the ORM migrations, but we need to add the dynamic schema queries manually to migration files. It makes sense to use the `safe` mode for such queries.

--- a/docs/docs/naming-strategy.md
+++ b/docs/docs/naming-strategy.md
@@ -2,15 +2,13 @@
 title: Naming Strategy
 ---
 
-When mapping our entities to database tables and columns, their names will be defined by naming 
-strategy. There are 3 basic naming strategies we can choose from:
+When mapping our entities to database tables and columns, their names will be defined by naming strategy. There are 3 basic naming strategies we can choose from:
 
 - `UnderscoreNamingStrategy` - default of all SQL drivers
 - `MongoNamingStrategy` - default of `MongoDriver`
 - `EntityCaseNamingStrategy` - uses unchanged entity and property names
 
-You can override this when initializing ORM. You can also provide our own naming strategy, just 
-implement `NamingStrategy` interface and provide our implementation when bootstrapping ORM:
+You can override this when initializing ORM. You can also provide our own naming strategy, just implement `NamingStrategy` interface and provide our implementation when bootstrapping ORM:
 
 ```ts
 class MyCustomNamingStrategy implements NamingStrategy {
@@ -24,20 +22,17 @@ const orm = await MikroORM.init({
 });
 ```
 
-> You can also extend `AbstractNamingStrategy` which implements one method for we - `getClassName()`
-> that is used to map entity file name to class name.
+> You can also extend `AbstractNamingStrategy` which implements one method for we - `getClassName()` that is used to map entity file name to class name.
 
 ## Naming Strategy in mongo driver
 
-`MongoNamingStrategy` will simply use all field names as they are defined. Collection names will
-be translated into lower-cased dashed form:
+`MongoNamingStrategy` will simply use all field names as they are defined. Collection names will be translated into lower-cased dashed form:
 
 `MyCoolEntity` will be translated into `my-cool-entity` collection name.
 
 ## Naming Strategy in SQL drivers
 
-`MySqlDriver` defaults to `UnderscoreNamingStrategy`, which means our all our database tables and
-columns will be lower-cased and words divided by underscored:
+`MySqlDriver` defaults to `UnderscoreNamingStrategy`, which means our all our database tables and columns will be lower-cased and words divided by underscored:
 
 ```sql
 CREATE TABLE `author` (
@@ -87,7 +82,7 @@ Return a join column name for a property.
 
 #### `NamingStrategy.joinTableName(sourceEntity: string, targetEntity: string, propertyName: string): string`
 
-Return a join table name. This is used as default value for `pivotTable`. 
+Return a join table name. This is used as default value for `pivotTable`.
 
 ---
 
@@ -99,15 +94,12 @@ Return the foreign key column name for the given parameters.
 
 #### `NamingStrategy.indexName(tableName: string, columns: string[], type: 'primary' | 'foreign' | 'unique' | 'index' | 'sequence'): string`
 
-Returns key/constraint name for given type. Some drivers might not support all 
-the types (e.g. mysql and sqlite enforce the PK name).
+Returns key/constraint name for given type. Some drivers might not support all the types (e.g. mysql and sqlite enforce the PK name).
 
 ---
 
 #### `NamingStrategy.aliasName(entityName: string, index: number): string`
 
-Returns alias name for given entity. The alias needs to be unique across the 
-query, which is by default ensured via appended index parameter. It is optional 
-to use it as long as we ensure it will be unique.
+Returns alias name for given entity. The alias needs to be unique across the query, which is by default ensured via appended index parameter. It is optional to use it as long as we ensure it will be unique.
 
 ---

--- a/docs/docs/nested-populate.md
+++ b/docs/docs/nested-populate.md
@@ -2,15 +2,12 @@
 title: Smart Nested Populate
 ---
 
-`MikroORM` is capable of loading large nested structures while maintaining good 
-performance, querying each database table only once. Imagine you have this nested 
-structure:
+`MikroORM` is capable of loading large nested structures while maintaining good performance, querying each database table only once. Imagine you have this nested structure:
 
 - `Book` has one `Publisher` (M:1), one `Author` (M:1) and many `BookTag`s (M:N)
 - `Publisher` has many `Test`s (M:N)
 
-When you use nested populate while querying all `BookTag`s, this is what happens in
-the background:
+When you use nested populate while querying all `BookTag`s, this is what happens in the background:
 
 ```ts
 const tags = await em.findAll(BookTag, { populate: ['books.publisher.tests', 'books.author'] });
@@ -61,6 +58,7 @@ db.getCollection("author").find({"_id":{"$in":[...]}}).toArray();
 The request to populate can be ambiguous. For example, let's say as a hypothetical that there's a `Book` called `'One'` with tags `'Fiction'` and `'Hard Cover'`.
 
 Then you run the following:
+
 ```ts
 const books = await em.find(Book, { tags: { name: 'Fiction' } }, {
   populate: ['tags'],
@@ -71,8 +69,8 @@ You're requesting books that have the tag of `'Fiction'` then asking to populate
 
 Both behaviors are useful in different cases, so MikroORM provides an option that allows you to control this called `populateWhere`. There are two options, `INFER` and `ALL`. The default is `ALL` which will ensure that all possible members of the collection are fetched in the populate (e.g. the the first interpretation above).
 
-
 You can specify this globally:
+
 ```ts
 const orm = await MikroORM.init({
     // We want our populate fetches to respect the outer filter passed in a where condition.
@@ -81,6 +79,7 @@ const orm = await MikroORM.init({
 ```
 
 Or you can override this on a query by query basis:
+
 ```ts
 const books = await em.find(Book, { tags: { name: 'Fiction' } }, {
   populate: ['tags'],
@@ -106,7 +105,7 @@ To populate existing entities, you can use `em.populate()`.
 const authors = await em.createQueryBuilder(Author).select('*').getResult();
 await em.populate(authors, ['books.tags']);
 
-// now your Author entities will have `books` collections populated, 
+// now your Author entities will have `books` collections populated,
 // as well as they will have their `tags` collections populated.
 console.log(authors[0].books[0].tags[0]); // initialized BookTag
 ```

--- a/docs/docs/propagation.md
+++ b/docs/docs/propagation.md
@@ -2,8 +2,7 @@
 title: Propagation
 ---
 
-By default, MikroORM will propagate all changes made to one side of bi-directional relations to the other side, keeping them in sync. This works for all relations, including M:1 and 1:1. As part of
-the discovery process, all M:1 and 1:1 properties are re-defined as getter/setter.
+By default, MikroORM will propagate all changes made to one side of bi-directional relations to the other side, keeping them in sync. This works for all relations, including M:1 and 1:1. As part of the discovery process, all M:1 and 1:1 properties are re-defined as getter/setter.
 
 ```ts
 const author = new Author(...);
@@ -39,11 +38,10 @@ console.log(tag.books.contains(book)); // true
 
 tag.books.add(book);
 console.log(book.tags.contains(tag)); // true
-``` 
+```
 
 > Collections on both sides have to be initialized, otherwise propagation won't work.
 
-> Although this propagation works also for M:N inverse side, you should always use owning
-> side to manipulate the collection.
+> Although this propagation works also for M:N inverse side, you should always use owning side to manipulate the collection.
 
 Same applies for `Collection.remove()`.

--- a/docs/docs/property-validation.md
+++ b/docs/docs/property-validation.md
@@ -63,14 +63,9 @@ When we define our entities, we need to be careful about optional properties. Wi
 
 ## Strict property type validation
 
-> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`.
-> It has performance implications and usually should not be needed, as long as
-> you don't modify your entities via `Object.assign()`.
+> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`. It has performance implications and usually should not be needed, as long as you don't modify your entities via `Object.assign()`.
 
-`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong 
-data types for you automatically. If automatic conversion fails, it will throw an error. You can 
-enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered 
-when persisting the entity. 
+`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong data types for you automatically. If automatic conversion fails, it will throw an error. You can enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered when persisting the entity.
 
 ```ts
 // number instead of string will throw

--- a/docs/docs/query-builder.md
+++ b/docs/docs/query-builder.md
@@ -2,12 +2,14 @@
 title: Using Query Builder
 ---
 
-:::info Since v4, we need to make sure we are working with correctly typed `EntityManager`
-or `EntityRepository` to have access to `createQueryBuilder()` method.
+:::info
+
+Since v4, we need to make sure we are working with correctly typed `EntityManager` or `EntityRepository` to have access to `createQueryBuilder()` method.
 
 ```ts
 import { EntityManager, EntityRepository } from '@mikro-orm/mysql'; // or any other driver package
 ```
+
 :::
 
 When you need to execute some SQL query without all the ORM stuff involved, you can either compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
@@ -39,8 +41,7 @@ const res2 = await qb.execute('get'); // returns single object
 const res3 = await qb.execute('run'); // returns object like `{ affectedRows: number, insertId: number, row: any }`
 ```
 
-Second argument can be used to disable mapping of database columns to property names (which is enabled by default). In following example, `Book` entity has `createdAt` property defined with implicit
-underscored field name `created_at`:
+Second argument can be used to disable mapping of database columns to property names (which is enabled by default). In following example, `Book` entity has `createdAt` property defined with implicit underscored field name `created_at`:
 
 ```ts
 const res4 = await em.createQueryBuilder(Book).select('*').execute('get', true);
@@ -49,8 +50,7 @@ const res5 = await em.createQueryBuilder(Book).select('*').execute('get', false)
 console.log(res5); // `created_at` will be defined, while `createdAt` will be missing
 ```
 
-To get entity instances from the QueryBuilder result, you can use `getResult()` and `getSingleResult()`
-methods:
+To get entity instances from the QueryBuilder result, you can use `getResult()` and `getSingleResult()` methods:
 
 ```ts
 const book = await em.createQueryBuilder(Book).select('*').where({ id: 1 }).getSingleResult();
@@ -63,21 +63,20 @@ console.log(books[0] instanceof Book); // true
 
 ## Awaiting the QueryBuilder
 
-Since v5 we can await the `QueryBuilder` instance, which will automatically execute the QB and return appropriate response. The QB instance is now typed based on usage
-of `select/insert/update/delete/truncate` methods to one of:
+Since v5 we can await the `QueryBuilder` instance, which will automatically execute the QB and return appropriate response. The QB instance is now typed based on usage of `select/insert/update/delete/truncate` methods to one of:
 
 - `SelectQueryBuilder`
-    - awaiting yields array of entities (as `qb.getResultList()`)
+  - awaiting yields array of entities (as `qb.getResultList()`)
 - `CountQueryBuilder`
-    - awaiting yields number (as `qb.getCount()`)
+  - awaiting yields number (as `qb.getCount()`)
 - `InsertQueryBuilder` (extends `RunQueryBuilder`)
-    - awaiting yields `QueryResult`
+  - awaiting yields `QueryResult`
 - `UpdateQueryBuilder` (extends `RunQueryBuilder`)
-    - awaiting yields `QueryResult`
+  - awaiting yields `QueryResult`
 - `DeleteQueryBuilder` (extends `RunQueryBuilder`)
-    - awaiting yields `QueryResult`
+  - awaiting yields `QueryResult`
 - `TruncateQueryBuilder` (extends `RunQueryBuilder`)
-    - awaiting yields `QueryResult`
+  - awaiting yields `QueryResult`
 
 ```ts
 const res1 = await em.qb(Publisher).insert({
@@ -112,9 +111,7 @@ expect(res5.affectedRows > 0).toBe(true); // test the type
 
 ## Mapping Raw Results to Entities
 
-Another way to create entity from raw results (that are not necessarily mapped to entity properties)
-is to use `map()` method of `EntityManager`, that is basically a shortcut for mapping results via `IDatabaseDriver.mapResult()` (which converts field names to property names - e.g. `created_at`
-to `createdAt`) and `merge()` which converts the data to entity instance and makes it managed.
+Another way to create entity from raw results (that are not necessarily mapped to entity properties) is to use `map()` method of `EntityManager`, that is basically a shortcut for mapping results via `IDatabaseDriver.mapResult()` (which converts field names to property names - e.g. `created_at` to `createdAt`) and `merge()` which converts the data to entity instance and makes it managed.
 
 This method comes handy when you want to use 3rd party query builders, where the result is not mapped to entity properties automatically:
 
@@ -151,12 +148,12 @@ qb.select('*')
   .orderBy({ books: { tags: { createdBy: QueryOrder.DESC } } });
 
 console.log(qb.getQuery());
-// select `e0`.* 
-// from `author` as `e0` 
-// left join `book2` as `e1` on `e0`.`id` = `e1`.`author_id` 
-// left join `book2_to_book_tag2` as `e3` on `e1`.`uuid_pk` = `e3`.`book2_uuid_pk` 
-// left join `book_tag2` as `e2` on `e3`.`book_tag2_id` = `e2`.`id` 
-// where `e2`.`name` = ? 
+// select `e0`.*
+// from `author` as `e0`
+// left join `book2` as `e1` on `e0`.`id` = `e1`.`author_id`
+// left join `book2_to_book_tag2` as `e3` on `e1`.`uuid_pk` = `e3`.`book2_uuid_pk`
+// left join `book_tag2` as `e2` on `e3`.`book_tag2_id` = `e2`.`id`
+// where `e2`.`name` = ?
 // order by `e1`.`tags` asc
 ```
 
@@ -183,8 +180,7 @@ console.log(qb.getQuery());
 
 ## Mapping joined results
 
-To select multiple entities and map them from `QueryBuilder`, we can use
-`joinAndSelect` or `leftJoinAndSelect` method:
+To select multiple entities and map them from `QueryBuilder`, we can use `joinAndSelect` or `leftJoinAndSelect` method:
 
 ```ts
 // `res` will contain array of authors, with books and their tags populated
@@ -215,7 +211,7 @@ const users = em.createQueryBuilder(User)
 This will produce following query:
 
 ```sql
-select `e0`.* 
+select `e0`.*
 from `user` as `e0`
 where lower(email) = 'foo@bar.baz'
 order by (point(loc_latitude, loc_longitude) <@> point(0, 0)) asc
@@ -313,7 +309,7 @@ console.log(count); // total count regardless limit and offset, e.g. 1327
 
 ## Overriding FROM clause
 
-You can specify the table used in the `FROM` clause, replacing the current table name if one has already been specified. This is typically used to specify a sub-query expression in SQL. 
+You can specify the table used in the `FROM` clause, replacing the current table name if one has already been specified. This is typically used to specify a sub-query expression in SQL.
 
 ```ts
 const qb = em.createQueryBuilder(Book2);
@@ -383,8 +379,7 @@ console.log(qb4.getQuery());
 
 When you want to filter by sub-query on the left-hand side of a predicate, you will need to register it first via `qb.withSubquery()`:
 
-> The dynamic property (`booksTotal`) needs to be defined at the entity level (as `persist: false`).
-> You always need to use prefix in the `qb.withSchema()` (so `a.booksTotal`).
+> The dynamic property (`booksTotal`) needs to be defined at the entity level (as `persist: false`). You always need to use prefix in the `qb.withSchema()` (so `a.booksTotal`).
 
 ```ts
 const knex = em.getKnex();
@@ -432,14 +427,14 @@ console.log(qb.getQuery()); // for MySQL
 
 Available lock modes:
 
-| Mode | Postgres | MySQL |
-|------|----------|-------|
-| `LockMode.PESSIMISTIC_READ` | `for share` | `lock in share mode` |
-| `LockMode.PESSIMISTIC_WRITE` | `for update` | `for update` |
-| `LockMode.PESSIMISTIC_PARTIAL_WRITE` | `for update skip locked` | `for update skip locked` |
-| `LockMode.PESSIMISTIC_WRITE_OR_FAIL` | `for update nowait` | `for update nowait` |
-| `LockMode.PESSIMISTIC_PARTIAL_READ` | `for share skip locked` | `lock in share mode skip locked` |
-| `LockMode.PESSIMISTIC_READ_OR_FAIL` | `for share nowait` | `lock in share mode nowait` |
+| Mode                                 | Postgres                 | MySQL                            |
+| ------------------------------------ | ------------------------ | -------------------------------- |
+| `LockMode.PESSIMISTIC_READ`          | `for share`              | `lock in share mode`             |
+| `LockMode.PESSIMISTIC_WRITE`         | `for update`             | `for update`                     |
+| `LockMode.PESSIMISTIC_PARTIAL_WRITE` | `for update skip locked` | `for update skip locked`         |
+| `LockMode.PESSIMISTIC_WRITE_OR_FAIL` | `for update nowait`      | `for update nowait`              |
+| `LockMode.PESSIMISTIC_PARTIAL_READ`  | `for share skip locked`  | `lock in share mode skip locked` |
+| `LockMode.PESSIMISTIC_READ_OR_FAIL`  | `for share nowait`       | `lock in share mode nowait`      |
 
 Optionally we can also pass list of table aliases we want to lock via second parameter:
 
@@ -451,10 +446,10 @@ qb.select('*')
   .setLockMode(LockMode.PESSIMISTIC_READ, ['u']);
 
 console.log(qb.getQuery()); // for Postgres
-// select ... 
+// select ...
 //   from "user" as "u"
-//   left join "identity" as "i" on "u"."id" = "i"."user_id" 
-//   where "u"."name" = 'Jon' 
+//   left join "identity" as "i" on "u"."id" = "i"."user_id"
+//   where "u"."name" = 'Jon'
 //   for update of "u" skip locked
 ```
 
@@ -474,12 +469,9 @@ const entities = res.map(a => em.map(Author, a));
 console.log(entities); // Author[]
 ```
 
-You can also get clear and configured knex instance from the connection via `getKnex()` method. As this method is not available on the base `Connection` class, you will need to either manually type
-cast the connection to `AbstractSqlConnection` (or the actual implementation you are using, e.g. `MySqlConnection`), or provide correct driver type hint to your `EntityManager` instance, which will be
-then automatically inferred in `em.getConnection()` method.
+You can also get clear and configured knex instance from the connection via `getKnex()` method. As this method is not available on the base `Connection` class, you will need to either manually type cast the connection to `AbstractSqlConnection` (or the actual implementation you are using, e.g. `MySqlConnection`), or provide correct driver type hint to your `EntityManager` instance, which will be then automatically inferred in `em.getConnection()` method.
 
-> Driver and connection implementations are not directly exported from `@mikro-orm/core` module.
-> You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
+> Driver and connection implementations are not directly exported from `@mikro-orm/core` module. You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
 
 ```ts
 const conn = em.getConnection() as AbstractSqlConnection;

--- a/docs/docs/query-conditions.md
+++ b/docs/docs/query-conditions.md
@@ -2,8 +2,7 @@
 title: Smart Query Conditions
 ---
 
-When you want to make complex queries, we can easily end up with a lot of boilerplate code
-full of curly brackets:
+When you want to make complex queries, we can easily end up with a lot of boilerplate code full of curly brackets:
 
 ```ts
 const res = await orm.em.find(Author, { $and: [
@@ -20,8 +19,8 @@ const res = await orm.em.find(Author, { $and: [
 For AND condition with single field, we can also do this:
 
 ```ts
-const res = await orm.em.find(Author, { 
-  id: { 
+const res = await orm.em.find(Author, {
+  id: {
     $in: [1, 2, 7],
     $nin: [3, 4],
     $gt: 5,
@@ -33,8 +32,7 @@ const res = await orm.em.find(Author, {
 });
 ```
 
-There is also shortcut for `$in` - simply provide array as value and it 
-will be converted automatically:
+There is also shortcut for `$in` - simply provide array as value and it will be converted automatically:
 
 ```ts
 const res = await orm.em.find(Author, { favouriteBook: [1, 2, 7] });
@@ -50,30 +48,30 @@ const res = await orm.em.find(Author, [1, 2, 7]);
 
 ### Comparison
 
-| operator | name               | description |
-|----------|--------------------|-------------|
-| `$eq`	   | equals             | Matches values that are equal to a specified value. |
-| `$gt`	   | greater            | Matches values that are greater than a specified value. |
-| `$gte`   | greater or equal   | Matches values that are greater than or equal to a specified value. |
-| `$in`	   | contains           | Matches any of the values specified in an array. |
-| `$lt`	   | lower              | Matches values that are less than a specified value. |
-| `$lte`   | lower or equal     | Matches values that are less than or equal to a specified value. |
-| `$ne`	   | not equal          | Matches all values that are not equal to a specified value. |
-| `$nin`   | not contains       | Matches none of the values specified in an array. |
-| `$like`  | like               | Uses LIKE operator |
-| `$re`    | regexp             | Uses REGEXP operator |
-| `$fulltext` | full text       | A driver specific full text search function. See requirements [below](#full-text-searching) |
-| `$ilike` | ilike              | (postgres only) |
-| `$overlap` | &&               | (postgres only) |
-| `$contains` | @>              | (postgres only) |
-| `$contained` | <@             | (postgres only) |
+| operator     | name             | description                                                                                 |
+| ------------ | ---------------- | ------------------------------------------------------------------------------------------- |
+| `$eq`        | equals           | Matches values that are equal to a specified value.                                         |
+| `$gt`        | greater          | Matches values that are greater than a specified value.                                     |
+| `$gte`       | greater or equal | Matches values that are greater than or equal to a specified value.                         |
+| `$in`        | contains         | Matches any of the values specified in an array.                                            |
+| `$lt`        | lower            | Matches values that are less than a specified value.                                        |
+| `$lte`       | lower or equal   | Matches values that are less than or equal to a specified value.                            |
+| `$ne`        | not equal        | Matches all values that are not equal to a specified value.                                 |
+| `$nin`       | not contains     | Matches none of the values specified in an array.                                           |
+| `$like`      | like             | Uses LIKE operator                                                                          |
+| `$re`        | regexp           | Uses REGEXP operator                                                                        |
+| `$fulltext`  | full text        | A driver specific full text search function. See requirements [below](#full-text-searching) |
+| `$ilike`     | ilike            | (postgres only)                                                                             |
+| `$overlap`   | &&               | (postgres only)                                                                             |
+| `$contains`  | @>               | (postgres only)                                                                             |
+| `$contained` | <@               | (postgres only)                                                                             |
 
 ### Logical
 
-| operator | description |
-|----------|-------------|
+| operator | description                                                                                             |
+| -------- | ------------------------------------------------------------------------------------------------------- |
 | `$and`   | Joins query clauses with a logical AND returns all documents that match the conditions of both clauses. |
-| `$not`   | Inverts the effect of a query expression and returns documents that do not match the query expression. |
+| `$not`   | Inverts the effect of a query expression and returns documents that do not match the query expression.  |
 | `$or`    | Joins query clauses with a logical OR returns all documents that match the conditions of either clause. |
 
 ## Full text searching
@@ -136,6 +134,7 @@ And to find results: `repository.findOne({ title: { $fulltext: 'query' } })`
 </Tabs>
 
 ### MySQL, MariaDB
+
 MySQL and MariaDB allow full text searches on all columns with a fulltext index.
 
 Refer to the [MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/fulltext-boolean.html) or [MariaDB documentation](https://mariadb.com/kb/en/full-text-index-overview/#in-boolean-mode) for possible queries.
@@ -158,7 +157,6 @@ And to find results: `repository.findOne({ title: { $fulltext: 'query' } })`
 MongoDB allows full text searches on all columns with a text index. However, when executing a full text search, it selects matches based on all fields with a text index: it's only possible to add one query and only on the top-level of the query object. Refer to the [MongoDB documentation](https://www.mongodb.com/docs/manual/reference/operator/query/text/#behavior) for more information on this behavior.
 
 Refer to the [MongoDB documentation](https://www.mongodb.com/docs/manual/reference/operator/query/text/#definition) for possible queries.
-
 
 ```ts title="./entities/Book.ts"
 @Entity()

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -2,8 +2,7 @@
 title: Quick Start
 ---
 
-First install the module via `yarn` or `npm` and do not forget to install the 
-database driver as well:
+First install the module via `yarn` or `npm` and do not forget to install the database driver as well:
 
 ```sh
 yarn add @mikro-orm/core @mikro-orm/mongodb     # for mongo
@@ -23,8 +22,7 @@ npm i -s @mikro-orm/core @mikro-orm/postgresql  # for postgresql
 npm i -s @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 ```
 
-Next you will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html)
-as well as `esModuleInterop` in `tsconfig.json` via:
+Next you will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html) as well as `esModuleInterop` in `tsconfig.json` via:
 
 ```json
 "experimentalDecorators": true,
@@ -34,9 +32,7 @@ as well as `esModuleInterop` in `tsconfig.json` via:
 
 Then call `MikroORM.init` as part of bootstrapping your app:
 
-> To access driver specific methods like `em.createQueryBuilder()` we need to specify
-> the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the
-> `orm.em` to `EntityManager` exported from the driver package:
+> To access driver specific methods like `em.createQueryBuilder()` we need to specify the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the `orm.em` to `EntityManager` exported from the driver package:
 >
 > ```ts
 > import { EntityManager } from '@mikro-orm/postgresql';
@@ -55,14 +51,11 @@ const orm = await MikroORM.init<PostgreSqlDriver>({
 console.log(orm.em); // access EntityManager via `em` property
 ```
 
-There are more ways to configure your entities, take a look at 
-[installation page](https://mikro-orm.io/installation/).
+There are more ways to configure your entities, take a look at [installation page](https://mikro-orm.io/installation/).
 
 > Read more about all the possible configuration options in [Advanced Configuration](https://mikro-orm.io/docs/configuration) section.
 
-Then you will need to fork entity manager for each request so their 
-[identity maps](https://mikro-orm.io/identity-map/) will not collide. 
-To do so, use the `RequestContext` helper:
+Then you will need to fork entity manager for each request so their [identity maps](https://mikro-orm.io/identity-map/) will not collide. To do so, use the `RequestContext` helper:
 
 ```ts
 const app = express();
@@ -72,15 +65,11 @@ app.use((req, res, next) => {
 });
 ```
 
-> You should register this middleware as the last one just before request handlers and before
-> any of your custom middleware that is using the ORM. There might be issues when you register 
-> it before request processing middleware like `queryParser` or `bodyParser`, so definitely 
-> register the context after them. 
+> You should register this middleware as the last one just before request handlers and before any of your custom middleware that is using the ORM. There might be issues when you register it before request processing middleware like `queryParser` or `bodyParser`, so definitely register the context after them.
 
 More info about `RequestContext` is described [here](https://mikro-orm.io/identity-map/#request-context).
 
-Now you can start defining your entities (in one of the `entities` folders). This is how
-simple entity can look like in mongo driver:
+Now you can start defining your entities (in one of the `entities` folders). This is how simple entity can look like in mongo driver:
 
 ```ts title="./entities/MongoBook.ts"
 @Entity()
@@ -135,15 +124,11 @@ export class UuidBook {
 }
 ```
 
-More information can be found in
-[defining entities section](https://mikro-orm.io/defining-entities/) in docs.
+More information can be found in [defining entities section](https://mikro-orm.io/defining-entities/) in docs.
 
-When you have your entities defined, you can start using ORM either via `EntityManager`
-or via `EntityRepository`s.
+When you have your entities defined, you can start using ORM either via `EntityManager` or via `EntityRepository`s.
 
-To save entity state to database, you need to persist it. Persist determines 
-whether to use `insert` or `update` and computes appropriate change-set. Entity references
-that are not persisted yet (does not have identifier) will be cascade persisted automatically. 
+To save entity state to database, you need to persist it. Persist determines whether to use `insert` or `update` and computes appropriate change-set. Entity references that are not persisted yet (does not have identifier) will be cascade persisted automatically.
 
 ```ts
 // use constructors in your entities for required parameters
@@ -163,7 +148,7 @@ book3.publisher = publisher;
 await em.persistAndFlush([book1, book2, book3]);
 ```
 
-To fetch entities from database you can use `find()` and `findOne()` of `EntityManager`: 
+To fetch entities from database you can use `find()` and `findOne()` of `EntityManager`:
 
 ```ts
 const authors = em.find(Author, {});
@@ -179,13 +164,12 @@ for (const author of authors) {
 }
 ```
 
-More convenient way of fetching entities from database is by using `EntityRepository`, that
-carries the entity name so you do not have to pass it to every `find` and `findOne` calls:
+More convenient way of fetching entities from database is by using `EntityRepository`, that carries the entity name so you do not have to pass it to every `find` and `findOne` calls:
 
 ```ts
 const booksRepository = em.getRepository(Book);
 
-const books = await booksRepository.find({ author: '...' }, { 
+const books = await booksRepository.find({ author: '...' }, {
   populate: ['author'],
   limit: 1,
   offset: 2,
@@ -195,5 +179,4 @@ const books = await booksRepository.find({ author: '...' }, {
 console.log(books); // Book[]
 ```
 
-Take a look at docs about [working with `EntityManager`](https://mikro-orm.io/entity-manager/)
-or [using `EntityRepository` instead](https://mikro-orm.io/repositories/).
+Take a look at docs about [working with `EntityManager`](https://mikro-orm.io/entity-manager/) or [using `EntityRepository` instead](https://mikro-orm.io/repositories/).

--- a/docs/docs/read-connections.md
+++ b/docs/docs/read-connections.md
@@ -2,19 +2,13 @@
 title: Read Replica Connections
 ---
 
-Users can specify multiple read connections via `replicas` option. You can provide only fields
-that differ from master connection, rest will be taken from it.
+Users can specify multiple read connections via `replicas` option. You can provide only fields that differ from master connection, rest will be taken from it.
 
-When resolving read connections, the default strategy is to assign random read replicas for all
-read operations (SELECT, COUNT) that are not running inside a transaction.
+When resolving read connections, the default strategy is to assign random read replicas for all read operations (SELECT, COUNT) that are not running inside a transaction.
 
-You can specify an explicit connection type for find and count operations by using the `connectionType`
-property on the corresponding Options argument (i.e. `FindOptions`, `CountOptions`).
+You can specify an explicit connection type for find and count operations by using the `connectionType` property on the corresponding Options argument (i.e. `FindOptions`, `CountOptions`).
 
-The connection resolution strategy can be also inverted by setting the `preferReadReplicas` configuration property
-to `false` so that the default connection will always be a write connection, unless explicitly requested to be read
-(can be useful in applications where read-replicas are available but should only be used for specific use-cases).
-
+The connection resolution strategy can be also inverted by setting the `preferReadReplicas` configuration property to `false` so that the default connection will always be a write connection, unless explicitly requested to be read (can be useful in applications where read-replicas are available but should only be used for specific use-cases).
 
 ```ts
 const orm = await MikroORM.init({
@@ -31,9 +25,7 @@ const orm = await MikroORM.init({
 });
 ```
 
-By default, select queries will use random read connection if not inside transaction. You can
-specify the connection type explicitly in `em.getConnection(type: 'read' | 'write')`.
-
+By default, select queries will use random read connection if not inside transaction. You can specify the connection type explicitly in `em.getConnection(type: 'read' | 'write')`.
 
 ```ts
 const connection = em.getConnection(); // write connection

--- a/docs/docs/relationships.md
+++ b/docs/docs/relationships.md
@@ -3,20 +3,16 @@ title: Modeling Entity Relationships
 sidebar_label: Modeling Entity Relationships
 ---
 
-There are 4 types of entity relationships in MikroORM: 
+There are 4 types of entity relationships in MikroORM:
 
 - ManyToOne
 - OneToMany
 - OneToOne
 - ManyToMany
 
-Relations can be unidirectional and bidirectional. Unidirectional are defined only on one 
-side (the owning side). Bidirectional are defined on both sides, while one is owning side 
-(where references are store), marked by `inversedBy` attribute pointing to the inverse side.
-On the inversed side we define it with `mappedBy` attribute pointing back to the owner:
+Relations can be unidirectional and bidirectional. Unidirectional are defined only on one side (the owning side). Bidirectional are defined on both sides, while one is owning side (where references are store), marked by `inversedBy` attribute pointing to the inverse side. On the inversed side we define it with `mappedBy` attribute pointing back to the owner:
 
-> When modeling bidirectional relationship, you can also omit the `inversedBy` attribute, 
-> defining `mappedBy` on the inverse side is enough as it will be auto-wired. 
+> When modeling bidirectional relationship, you can also omit the `inversedBy` attribute, defining `mappedBy` on the inverse side is enough as it will be auto-wired.
 
 ## ManyToOne
 
@@ -43,8 +39,7 @@ export class Book {
 }
 ```
 
-You can also specify how operations on given entity should [cascade](cascading.md) 
-to the referred entity.
+You can also specify how operations on given entity should [cascade](cascading.md) to the referred entity.
 
 ## OneToMany
 
@@ -71,19 +66,15 @@ export class Author {
 }
 ```
 
-As you can see, OneToMany is the inverse side of ManyToOne (which is the owning side).
-More about how collections work can be found on [collections page](collections.md). 
+As you can see, OneToMany is the inverse side of ManyToOne (which is the owning side). More about how collections work can be found on [collections page](collections.md).
 
-You can also specify how operations on given entity should [cascade](cascading.md) to the referred
-entities. There is also more aggressive remove mode called [Orphan Removal](cascading.md#orphan-removal) 
-(`books4` example).
+You can also specify how operations on given entity should [cascade](cascading.md) to the referred entities. There is also more aggressive remove mode called [Orphan Removal](cascading.md#orphan-removal) (`books4` example).
 
 ## OneToOne
 
 > One instance of the current Entity refers to One instance of the referred Entity.
 
-This is a variant of ManyToOne, where there is always just one entity on both sides. This means
-that the foreign key column is also unique.
+This is a variant of ManyToOne, where there is always just one entity on both sides. This means that the foreign key column is also unique.
 
 ### Owning Side
 
@@ -121,8 +112,7 @@ export class User {
 }
 ```
 
-As you can see, relationships can be also self-referencing (all of them. OneToOne also supports 
-[Orphan Removal](cascading.md#orphan-removal). 
+As you can see, relationships can be also self-referencing (all of them. OneToOne also supports [Orphan Removal](cascading.md#orphan-removal).
 
 ## ManyToMany
 
@@ -149,7 +139,7 @@ export class Book {
   @ManyToMany(() => BookTag, 'books', { owner: true })
   tags4 = new Collection<BookTag>(this);
 
-  // to define uni-directional many to many, simply provide only 
+  // to define uni-directional many to many, simply provide only
   @ManyToMany(() => Author)
   friends: Collection<Author> = new Collection<Author>(this);
 
@@ -169,7 +159,7 @@ export class BookTag {
 }
 ```
 
-Again, more information about how collections work can be found on [collections page](collections.md). 
+Again, more information about how collections work can be found on [collections page](collections.md).
 
 ## Relations in ESM projects
 

--- a/docs/docs/repositories.md
+++ b/docs/docs/repositories.md
@@ -3,18 +3,14 @@ title: Using EntityRepository instead of EntityManager
 sidebar_label: Entity Repository
 ---
 
-Entity Repositories are thin layers on top of `EntityManager`. They act as an 
-extension point, so we can add custom methods, or even alter the existing ones. 
-The default, `EntityRepository` implementation just forwards the calls to 
-underlying `EntityManager` instance.
+Entity Repositories are thin layers on top of `EntityManager`. They act as an extension point, so we can add custom methods, or even alter the existing ones. The default, `EntityRepository` implementation just forwards the calls to underlying `EntityManager` instance.
 
-> `EntityRepository` class carries the entity type, so we do not have to pass 
-> it to every `find` or `findOne` calls.
+> `EntityRepository` class carries the entity type, so we do not have to pass it to every `find` or `findOne` calls.
 
 ```ts
 const booksRepository = em.getRepository(Book);
 
-const books = await booksRepository.find({ author: '...' }, { 
+const books = await booksRepository.find({ author: '...' }, {
   populate: ['author'],
   limit: 1,
   offset: 2,
@@ -24,16 +20,14 @@ const books = await booksRepository.find({ author: '...' }, {
 console.log(books); // Book[]
 ```
 
-Note that there is no such thing as "flushing repository" - it is just a shortcut
-to `em.flush()`. In other words, we always flush the whole Unit of Work, not just
-a single entity that this repository represents.
+Note that there is no such thing as "flushing repository" - it is just a shortcut to `em.flush()`. In other words, we always flush the whole Unit of Work, not just a single entity that this repository represents.
 
 ## Custom Repository
 
 :::info
-Since v4, we need to make sure we are working with correctly typed `EntityRepository` 
-to have access to driver specific methods (like `createQueryBuilder()`). Use the one
-exported from your driver package.
+
+Since v4, we need to make sure we are working with correctly typed `EntityRepository` to have access to driver specific methods (like `createQueryBuilder()`). Use the one exported from your driver package.
+
 :::
 
 To use custom repository, just extend `EntityRepository<T>` class:
@@ -60,19 +54,15 @@ export class Author {
 }
 ```
 
-> `@Repository()` decorator has been removed in v5, use
-> `@Entity({ customRepository: () => MyRepository })` instead.
+> `@Repository()` decorator has been removed in v5, use `@Entity({ customRepository: () => MyRepository })` instead.
 
-Note that we need to pass that repository reference inside a callback so we will not run
-into circular dependency issues when using entity references inside that repository.
+Note that we need to pass that repository reference inside a callback so we will not run into circular dependency issues when using entity references inside that repository.
 
 Now we can access our custom repository via `em.getRepository()` method.
 
 ### Inferring custom repository type
 
-To have the `em.getRepository()` method return correctly typed custom repository
-instead of the generic `EntityRepository<T>`, we can use `EntityRepositoryType`
-symbol:
+To have the `em.getRepository()` method return correctly typed custom repository instead of the generic `EntityRepository<T>`, we can use `EntityRepositoryType` symbol:
 
 ```ts
 @Entity({ customRepository: () => AuthorRepository })
@@ -85,9 +75,6 @@ export class Author {
 const repo = em.getRepository(Author); // repo has type AuthorRepository
 ```
 
-> We can also register custom base repository (for all entities where we do not specify 
-> `customRepository`) globally, via `MikroORM.init({ entityRepository: CustomBaseRepository })`.
+> We can also register custom base repository (for all entities where we do not specify `customRepository`) globally, via `MikroORM.init({ entityRepository: CustomBaseRepository })`.
 
-For more examples, take a look at
-[`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts)
-or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).
+For more examples, take a look at [`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts) or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).

--- a/docs/docs/schema-generator.md
+++ b/docs/docs/schema-generator.md
@@ -2,51 +2,41 @@
 title: Schema Generator
 ---
 
-> SchemaGenerator can do harm to your database. It will drop or alter tables, indexes, 
-> sequences and such. Please use this tool with caution in development and not on a 
-> production server. It is meant for helping you develop your Database Schema, but NOT 
-> with migrating schema from A to B in production. A safe approach would be generating 
-> the SQL on development server and saving it into SQL Migration files that are executed 
-> manually on the production server.
+> SchemaGenerator can do harm to your database. It will drop or alter tables, indexes, sequences and such. Please use this tool with caution in development and not on a production server. It is meant for helping you develop your Database Schema, but NOT with migrating schema from A to B in production. A safe approach would be generating the SQL on development server and saving it into SQL Migration files that are executed manually on the production server.
 
-> SchemaGenerator assumes your project uses the given database on its own. Update and Drop 
-> commands will mess with other tables if they are not related to the current project 
-> that is using MikroORM. Please be careful!
+> SchemaGenerator assumes your project uses the given database on its own. Update and Drop commands will mess with other tables if they are not related to the current project that is using MikroORM. Please be careful!
 
-To generate schema from your entity metadata, you can use `SchemaGenerator` helper. 
+To generate schema from your entity metadata, you can use `SchemaGenerator` helper.
 
-You can use it via CLI: 
+You can use it via CLI:
 
-> To work with the CLI, first install `@mikro-orm/cli` package locally.
-> The version needs to be aligned with the `@mikro-orm/core` package.
+> To work with the CLI, first install `@mikro-orm/cli` package locally. The version needs to be aligned with the `@mikro-orm/core` package.
 
 ```sh
 npx mikro-orm schema:create --dump   # Dumps create schema SQL
 npx mikro-orm schema:update --dump   # Dumps update schema SQL
-npx mikro-orm schema:drop --dump     # Dumps drop schema SQL 
+npx mikro-orm schema:drop --dump     # Dumps drop schema SQL
 ```
 
-> You can also use `--run` flag to fire all queries, but be careful as it might break your
-> database. Be sure to always check the generated SQL first before executing. Do not use
-> `--run` flag in production! 
+> You can also use `--run` flag to fire all queries, but be careful as it might break your database. Be sure to always check the generated SQL first before executing. Do not use `--run` flag in production!
 
-`schema:create` will automatically create the database if it does not exist. 
+`schema:create` will automatically create the database if it does not exist.
 
-`schema:update` drops all unknown tables by default, you can use `--no-drop-tables` 
-to get around it. There is also `--safe` flag that will disable both table dropping as 
-well as column dropping. 
+`schema:update` drops all unknown tables by default, you can use `--no-drop-tables` to get around it. There is also `--safe` flag that will disable both table dropping as well as column dropping.
 
-`schema:drop` will by default drop all database tables. You can use `--drop-db` flag to drop
-the whole database instead. 
+`schema:drop` will by default drop all database tables. You can use `--drop-db` flag to drop the whole database instead.
 
 ```shell
 npx mikro-orm schema:fresh --run     # !WARNING! Drops the database schema and recreates it
 ```
+
 This command can be run with the `--seed` option to seed the database after it has been created again.
+
 ```shell
 npx mikro-orm schema:fresh --run --seed              # seed the database with the default database seeder
 npx mikro-orm schema:fresh --run --seed=UsersSeeder  # seed the database with the UsersSeeder
 ```
+
 > You can specify the default database seeder in the orm config with the key `config.seeder.defaultSeeder`
 
 ## Configuration
@@ -64,8 +54,7 @@ const orm = await MikroORM.init({
 });
 ```
 
-> Note that if we disable FK constraints and current schema is using them, the 
-> schema diffing will try to remove those that already exist.
+> Note that if we disable FK constraints and current schema is using them, the schema diffing will try to remove those that already exist.
 
 ## Using SchemaGenerator programmatically
 
@@ -99,7 +88,7 @@ import { MikroORM } from '@mikro-orm/core';
   await generator.dropSchema();
   await generator.createSchema();
   await generator.updateSchema();
-  
+
   // in tests it can be handy to use those:
   await generator.refreshDatabase(); // ensure db exists and is fresh
   await generator.clearDatabase(); // removes all data
@@ -122,12 +111,10 @@ See the [SQL Generated columns](defining-entities.md#SQL Generated columns) sect
 
 ## Limitations of SQLite
 
-There are limitations of SQLite database because of which it behaves differently 
-than other SQL drivers. Namely, it is not possible to:
+There are limitations of SQLite database because of which it behaves differently than other SQL drivers. Namely, it is not possible to:
 
 - create foreign key constraints when altering columns
 - create empty tables without columns
 - alter column requires nullability
 
-Because of this, you can end up with different schema with SQLite, so it is not
-suggested to use SQLite for integration tests of your application.
+Because of this, you can end up with different schema with SQLite, so it is not suggested to use SQLite for integration tests of your application.

--- a/docs/docs/seeding.md
+++ b/docs/docs/seeding.md
@@ -2,13 +2,11 @@
 title: Seeding
 ---
 
-When initializing your application or testing it can be exhausting to create sample data for your database. The solution is to use seeding. Create factories for your entities and use them in the seed
-script or combine multiple seed scripts.
+When initializing your application or testing it can be exhausting to create sample data for your database. The solution is to use seeding. Create factories for your entities and use them in the seed script or combine multiple seed scripts.
 
 ## Configuration
 
-> `seeder.path` and `seeder.pathTs` works the same way as `entities` and
-> `entitiesTs` in entity discovery.
+> `seeder.path` and `seeder.pathTs` works the same way as `entities` and `entitiesTs` in entity discovery.
 
 The seeder has a few default settings that can be changed easily through the MikroORM config. Underneath you find the configuration options with their defaults.
 
@@ -35,8 +33,7 @@ We can also override these default using the [environment variables](configurati
 
 ## Seeders
 
-A seeder class contains one method `run`. This method is called when you use the command `npx mikro-orm seeder:run`. In the `run` method you define how and what data you want to insert into the
-database. You can create entities using the [EntityManager](http://mikro-orm.io/docs/entity-manager) or you can use [Factories](#using-entity-factories).
+A seeder class contains one method `run`. This method is called when you use the command `npx mikro-orm seeder:run`. In the `run` method you define how and what data you want to insert into the database. You can create entities using the [EntityManager](http://mikro-orm.io/docs/entity-manager) or you can use [Factories](#using-entity-factories).
 
 You can create your own seeder classes using the following CLI command:
 
@@ -46,15 +43,11 @@ npx mikro-orm seeder:create test            # generates the class TestSeeder
 npx mikro-orm seeder:create project-names   # generates the class ProjectNamesSeeder
 ```
 
-This creates a new seeder class. By default, it will be generated in the `./seeders/` directory. You can configure the directory in the config with the key `seeder.path` or using
-the [environment variable](configuration.md#using-environment-variables) `MIKRO_ORM_SEEDER_PATH`. You are allowed to call the `seeder:create` command with a name, class name or hyphenated name.
+This creates a new seeder class. By default, it will be generated in the `./seeders/` directory. You can configure the directory in the config with the key `seeder.path` or using the [environment variable](configuration.md#using-environment-variables) `MIKRO_ORM_SEEDER_PATH`. You are allowed to call the `seeder:create` command with a name, class name or hyphenated name.
 
 As an example we will look at a very basic seeder.
 
-> Note that the `EntityManager` available in seeders will have `persistOnCreate`
-> enabled, hence calling `em.create()` will automatically call `em.persist()`
-> on the created entity. If we use entity constructor instead, we need to call
-> `em.persist()` explicitly.
+> Note that the `EntityManager` available in seeders will have `persistOnCreate` enabled, hence calling `em.create()` will automatically call `em.persist()` on the created entity. If we use entity constructor instead, we need to call `em.persist()` explicitly.
 
 ```ts title="./database/seeder/database.seeder.ts"
 import { EntityManager } from '@mikro-orm/core';
@@ -80,8 +73,7 @@ export class DatabaseSeeder extends Seeder {
 
 ### Using entity factories
 
-Instead of specifying all the attributes for every entity, you can also use [entity factories](#entity-factories). These can be used to generate large amounts of database records. Please read
-the [documentation on how to define factories](#entity-factories) to learn how to define your factories.
+Instead of specifying all the attributes for every entity, you can also use [entity factories](#entity-factories). These can be used to generate large amounts of database records. Please read the [documentation on how to define factories](#entity-factories) to learn how to define your factories.
 
 As an example we will generate 10 authors.
 
@@ -100,8 +92,7 @@ export class DatabaseSeeder extends Seeder {
 
 ### Calling additional seeders
 
-Inside the `run` method you can specify other seeder classes. You can use the `call` method to break up the database seeder into multiple files to prevent a seeder file from becoming too large.
-The `call` method requires an `em` and an array of seeder classes.
+Inside the `run` method you can specify other seeder classes. You can use the `call` method to break up the database seeder into multiple files to prevent a seeder file from becoming too large. The `call` method requires an `em` and an array of seeder classes.
 
 ```ts
 import { EntityManager } from '@mikro-orm/core';
@@ -148,8 +139,7 @@ export class BookSeeder extends Seeder {
 
 ## Entity factories
 
-When testing you may insert entities in the database before starting a test. Instead of specifying every attribute of every entity by hand, you could also use a `Factory` to define a set of default
-attributes for an entity using entity factories.
+When testing you may insert entities in the database before starting a test. Instead of specifying every attribute of every entity by hand, you could also use a `Factory` to define a set of default attributes for an entity using entity factories.
 
 Lets have a look at an example factory for an [Author entity](http://mikro-orm.io/docs/defining-entities).
 
@@ -168,10 +158,9 @@ export class AuthorFactory extends Factory<Author> {
     };
   }
 }
-``` 
+```
 
-Basically you extend the base `Factory` class, define a `model` property and a `definition` method. The `model` defines for which entity the factory generates entity instances. The `definition` method
-returns the default set of attribute values that should be applied when creating an entity using the factory.
+Basically you extend the base `Factory` class, define a `model` property and a `definition` method. The `model` defines for which entity the factory generates entity instances. The `definition` method returns the default set of attribute values that should be applied when creating an entity using the factory.
 
 Via the faker property, factories have access to the [Faker library](https://github.com/faker-js/faker), which allows you to conveniently generate various kinds of random data for testing.
 
@@ -190,18 +179,17 @@ Generate multiple entities by calling the `make` method. The parameter of the `m
 ```ts
 // Generate 5 authors
 const authors = new AuthorFactory(orm.em).make(5);
-``` 
+```
 
 #### Overriding attributes
 
-If you would like to override some of the default values of your factories, you may pass an object to the make method. Only the specified attributes will be replaced while the rest of the attributes
-remain set to their default values as specified by the factory.
+If you would like to override some of the default values of your factories, you may pass an object to the make method. Only the specified attributes will be replaced while the rest of the attributes remain set to their default values as specified by the factory.
 
 ```ts
 const author = new AuthorFactory(orm.em).make({
   name: 'John Snow',
 });
-``` 
+```
 
 ### Persisting entities
 
@@ -231,9 +219,7 @@ const authors = await new AuthorFactory(orm.em).create(5, {
 
 ### Factory relationships
 
-It is nice to create large quantities of data for one entity, but most of the time we want to create data for multiple entities and also have relations between these. For this we can use the `each`
-method which can be chained on a factory. The `each` method can be called with a function that transforms output entity from the factory before returning it. Lets look at some examples for the
-different relations.
+It is nice to create large quantities of data for one entity, but most of the time we want to create data for multiple entities and also have relations between these. For this we can use the `each` method which can be chained on a factory. The `each` method can be called with a function that transforms output entity from the factory before returning it. Lets look at some examples for the different relations.
 
 #### ManyToOne and OneToOne relations
 
@@ -241,7 +227,7 @@ different relations.
 const books: Book[] = new BookFactory(orm.em).each(book => {
   book.author = new AuthorFactory(orm.em).makeOne();
 }).make(5);
-``` 
+```
 
 #### OneToMany and ManyToMany
 
@@ -249,13 +235,11 @@ const books: Book[] = new BookFactory(orm.em).each(book => {
 const books: Book[] = new BookFactory(orm.em).each(book => {
   book.owners.set(new OwnerFactory(orm.em).make(5));
 }).make(5);
-``` 
+```
 
 ## Use with CLI
 
-You may execute the `seeder:run` MikroORM CLI command to seed your database. By default, the `seeder:run` command runs the `DatabaseSeeder` class, which may in turn invoke other seed classes. You can
-configure the default seeder using the key `seeder.defaultSeeder` or using the [environment variable](configuration.md#using-environment-variables) `MIKRO_ORM_SEEDER_DEFAULT_SEEDER`. You can also use
-the `--class` option to specify a seeder class:
+You may execute the `seeder:run` MikroORM CLI command to seed your database. By default, the `seeder:run` command runs the `DatabaseSeeder` class, which may in turn invoke other seed classes. You can configure the default seeder using the key `seeder.defaultSeeder` or using the [environment variable](configuration.md#using-environment-variables) `MIKRO_ORM_SEEDER_DEFAULT_SEEDER`. You can also use the `--class` option to specify a seeder class:
 
 ```shell script
 npx mikro-orm seeder:run
@@ -263,8 +247,7 @@ npx mikro-orm seeder:run
 npx mikro-orm seeder:run --class=BookSeeder
 ```
 
-You may also seed your database using the [`migrate:fresh`](migrations.md#using-via-cli) or [`schema:fresh`](schema-generator.md) command in combination with the `--seed` option, which will drop all
-tables and re-run all of your migrations or generate the database based on the current entities. This command is useful for completely re-building your database:
+You may also seed your database using the [`migrate:fresh`](migrations.md#using-via-cli) or [`schema:fresh`](schema-generator.md) command in combination with the `--seed` option, which will drop all tables and re-run all of your migrations or generate the database based on the current entities. This command is useful for completely re-building your database:
 
 ```shell script
 npx mikro-orm migration:fresh --seed    # will drop the database, run all migrations and the DatabaseSeeder class
@@ -272,8 +255,7 @@ npx mikro-orm migration:fresh --seed    # will drop the database, run all migrat
 npx mikro-orm schema:fresh --seed       # will recreate the database and run the DatabaseSeeder class
 ```
 
-If you do not want to run the `DatabaseSeeder` class you can either specify what the default seeder class should be. This can be done by changing the [default settings](#default-settings). Another
-option is to explicitly define the seeder class you want to run.
+If you do not want to run the `DatabaseSeeder` class you can either specify what the default seeder class should be. This can be done by changing the [default settings](#default-settings). Another option is to explicitly define the seeder class you want to run.
 
 ```shell script
 npx mikro-orm migration:fresh --seed TestSeeder       # will drop the database, run all migrations and the TestSeeder class
@@ -327,6 +309,4 @@ await MikroORM.init({
 });
 ```
 
-This should allow using CLI to generate TS seeder files (as in CLI we probably
-have TS support enabled), while using compiled JS files in production, where ts-node
-is not registered.
+This should allow using CLI to generate TS seeder files (as in CLI we probably have TS support enabled), while using compiled JS files in production, where ts-node is not registered.

--- a/docs/docs/serializing.md
+++ b/docs/docs/serializing.md
@@ -12,9 +12,7 @@ export interface AnyEntity<K = number | string> {
 }
 ```
 
-When you serialize your entity via `JSON.stringify(entity)`, its `toJSON` method will be 
-called automatically. You can provide custom implementation for `toJSON`, while using 
-`toObject` for initial serialization:
+When you serialize your entity via `JSON.stringify(entity)`, its `toJSON` method will be called automatically. You can provide custom implementation for `toJSON`, while using `toObject` for initial serialization:
 
 ```ts
 @Entity()
@@ -35,13 +33,11 @@ export class Book {
 }
 ```
 
-> Do not forget to pass rest params when calling `toObject(...args)`, otherwise the results
-> might not be stable.
+> Do not forget to pass rest params when calling `toObject(...args)`, otherwise the results might not be stable.
 
 ## Hidden Properties
 
-If you want to omit some properties from serialized result, you can mark them with `hidden`
-flag on `@Property()` decorator:
+If you want to omit some properties from serialized result, you can mark them with `hidden` flag on `@Property()` decorator:
 
 ```ts
 @Entity()
@@ -59,13 +55,9 @@ console.log(wrap(book).toJSON().hiddenField); // undefined
 
 ## Shadow Properties
 
-The opposite situation where you want to define a property that lives only in memory (is 
-not persisted into database) can be solved by defining your property as `persist: false`. 
-Such property can be assigned via one of `Entity.assign()`, `em.create()` and 
-`em.merge()`. It will be also part of serialized result. 
+The opposite situation where you want to define a property that lives only in memory (is not persisted into database) can be solved by defining your property as `persist: false`. Such property can be assigned via one of `Entity.assign()`, `em.create()` and `em.merge()`. It will be also part of serialized result.
 
-This can be handled when dealing with additional values selected via `QueryBuilder` or 
-MongoDB's aggregations.
+This can be handled when dealing with additional values selected via `QueryBuilder` or MongoDB's aggregations.
 
 ```ts
 @Entity()
@@ -84,8 +76,7 @@ console.log(wrap(book).toJSON().count); // 123
 
 ## Property Serializers
 
-As an alternative to custom `toJSON()` method, we can also use property serializers.
-They allow to specify a callback that will be used when serializing a property:
+As an alternative to custom `toJSON()` method, we can also use property serializers. They allow to specify a callback that will be used when serializing a property:
 
 ```ts
 @Entity()
@@ -144,7 +135,7 @@ import { serialize } from '@mikro-orm/core';
 const dto = serialize(author, {
   populate: ['books.author', 'books.publisher', 'favouriteBook'], // populate some relations
   exclude: ['books.author.email'], // skip property of some relation
-  forceObject: true, // not populated or not initialized relations will result in object, e.g. `{ author: { id: 1 } }` 
+  forceObject: true, // not populated or not initialized relations will result in object, e.g. `{ author: { id: 1 } }`
   skipNull: true, // properties with `null` value won't be part of the result
 });
 ```

--- a/docs/docs/transactions.md
+++ b/docs/docs/transactions.md
@@ -6,28 +6,17 @@ title: Transactions and Concurrency
 
 ## Transaction Demarcation
 
-Transaction demarcation is the task of defining your transaction boundaries. Proper 
-transaction demarcation is very important because if not done properly it can negatively 
-affect the performance of your application. Many databases and database abstraction 
-layers by default operate in auto-commit mode, which means that every single SQL statement 
-is wrapped in a small transaction. Without any explicit transaction demarcation from your 
-side, this quickly results in poor performance because transactions are not cheap. 
+Transaction demarcation is the task of defining your transaction boundaries. Proper transaction demarcation is very important because if not done properly it can negatively affect the performance of your application. Many databases and database abstraction layers by default operate in auto-commit mode, which means that every single SQL statement is wrapped in a small transaction. Without any explicit transaction demarcation from your side, this quickly results in poor performance because transactions are not cheap.
 
-For the most part, MikroORM already takes care of proper transaction demarcation for you: 
-All the write operations (INSERT/UPDATE/DELETE) are queued until `em.flush()` 
-is invoked which wraps all of these changes in a single transaction.
+For the most part, MikroORM already takes care of proper transaction demarcation for you: All the write operations (INSERT/UPDATE/DELETE) are queued until `em.flush()` is invoked which wraps all of these changes in a single transaction.
 
-However, MikroORM also allows (and encourages) you to take over and control transaction 
-demarcation yourself.
+However, MikroORM also allows (and encourages) you to take over and control transaction demarcation yourself.
 
-These are two ways to deal with transactions when using the MikroORM and are now described 
-in more detail.
+These are two ways to deal with transactions when using the MikroORM and are now described in more detail.
 
 ### Approach 1: Implicitly
 
-The first approach is to use the implicit transaction handling provided by the MikroORM 
-`EntityManager`. Given the following code snippet, without any explicit transaction 
-demarcation:
+The first approach is to use the implicit transaction handling provided by the MikroORM `EntityManager`. Given the following code snippet, without any explicit transaction demarcation:
 
 ```ts
 const user = new User(...);
@@ -35,16 +24,11 @@ user.name = 'George';
 await orm.em.persistAndFlush(user);
 ```
 
-Since we do not do any custom transaction demarcation in the above code, `em.flush()` 
-will begin and commit/rollback a transaction. This behavior is made possible by the 
-aggregation of the DML operations by the MikroORM and is sufficient if all the data 
-manipulation that is part of a unit of work happens through the domain model and thus 
-the ORM.
+Since we do not do any custom transaction demarcation in the above code, `em.flush()` will begin and commit/rollback a transaction. This behavior is made possible by the aggregation of the DML operations by the MikroORM and is sufficient if all the data manipulation that is part of a unit of work happens through the domain model and thus the ORM.
 
 ### Approach 2: Explicitly
 
-The explicit alternative is to use the transactions API directly to control the boundaries. 
-The code then looks like this:
+The explicit alternative is to use the transactions API directly to control the boundaries. The code then looks like this:
 
 ```ts
 await orm.em.transactional(em => {
@@ -55,8 +39,7 @@ await orm.em.transactional(em => {
 });
 ```
 
-Or you can use `begin/commit/rollback` methods explicitly. Following example is
-equivalent to the previous one:
+Or you can use `begin/commit/rollback` methods explicitly. Following example is equivalent to the previous one:
 
 ```ts
 const em = orm.em.fork();
@@ -74,68 +57,37 @@ try {
 }
 ```
 
-Explicit transaction demarcation is required when you want to include custom DBAL operations 
-in a unit of work or when you want to make use of some methods of the EntityManager API 
-that require an active transaction. Such methods will throw a `ValidationError` to inform 
-you of that requirement.
+Explicit transaction demarcation is required when you want to include custom DBAL operations in a unit of work or when you want to make use of some methods of the EntityManager API that require an active transaction. Such methods will throw a `ValidationError` to inform you of that requirement.
 
 `em.transactional(cb)` will flush the inner `EntityManager` prior to transaction commit.
 
 ### Exception Handling
 
-When using implicit transaction demarcation and an exception occurs during 
-`em.flush()`, the transaction is automatically rolled back.
+When using implicit transaction demarcation and an exception occurs during `em.flush()`, the transaction is automatically rolled back.
 
-When using explicit transaction demarcation and an exception occurs, the transaction should 
-be rolled back immediately as demonstrated in the example above. This can be handled elegantly 
-by the control abstractions shown earlier. Note that when catching Exception you should 
-generally re-throw the exception. If you intend to recover from some exceptions, catch them 
-explicitly in earlier catch blocks (but do not forget to rollback the transaction). All 
-other best practices of exception handling apply similarly (i.e. either log or re-throw, 
-not both, etc.).
+When using explicit transaction demarcation and an exception occurs, the transaction should be rolled back immediately as demonstrated in the example above. This can be handled elegantly by the control abstractions shown earlier. Note that when catching Exception you should generally re-throw the exception. If you intend to recover from some exceptions, catch them explicitly in earlier catch blocks (but do not forget to rollback the transaction). All other best practices of exception handling apply similarly (i.e. either log or re-throw, not both, etc.).
 
-As a result of this procedure, all previously managed or removed instances of the `EntityManager` 
-become detached. The state of the detached objects will be the state at the point at which the 
-transaction was rolled back. The state of the objects is in no way rolled back and thus the 
-objects are now out of sync with the database. The application can continue to use the detached 
-objects, knowing that their state is potentially no longer accurate.
+As a result of this procedure, all previously managed or removed instances of the `EntityManager` become detached. The state of the detached objects will be the state at the point at which the transaction was rolled back. The state of the objects is in no way rolled back and thus the objects are now out of sync with the database. The application can continue to use the detached objects, knowing that their state is potentially no longer accurate.
 
-If you intend to start another unit of work after an exception has occurred you should do 
-that with a new `EntityManager`. Simply use `em.fork()` to obtain fresh copy 
-with cleared identity map. 
+If you intend to start another unit of work after an exception has occurred you should do that with a new `EntityManager`. Simply use `em.fork()` to obtain fresh copy with cleared identity map.
 
 ## Locking Support
 
 ### Why we need concurrency control?
 
-If transactions are executed serially (one at a time), no transaction concurrency exists. 
-However, if concurrent transactions with interleaving operations are allowed, you may easily 
-run into one of those problems:
+If transactions are executed serially (one at a time), no transaction concurrency exists. However, if concurrent transactions with interleaving operations are allowed, you may easily run into one of those problems:
 
 1. The lost update problem
 2. The dirty read problem
 3. The incorrect summary problem
 
-To mitigate those problems, MikroORM offers support for Pessimistic and Optimistic locking 
-strategies natively. This allows you to take very fine-grained control over what kind of 
-locking is required for your entities in your application.
+To mitigate those problems, MikroORM offers support for Pessimistic and Optimistic locking strategies natively. This allows you to take very fine-grained control over what kind of locking is required for your entities in your application.
 
 ### Optimistic Locking
 
-Database transactions are fine for concurrency control during a single request. However, a 
-database transaction should not span across requests, the so-called "user think time". Therefore 
-a long-running "business transaction" that spans multiple requests needs to involve several 
-database transactions. Thus, database transactions alone can no longer control concurrency 
-during such a long-running business transaction. Concurrency control becomes the partial 
-responsibility of the application itself.
+Database transactions are fine for concurrency control during a single request. However, a database transaction should not span across requests, the so-called "user think time". Therefore a long-running "business transaction" that spans multiple requests needs to involve several database transactions. Thus, database transactions alone can no longer control concurrency during such a long-running business transaction. Concurrency control becomes the partial responsibility of the application itself.
 
-MikroORM has integrated support for automatic optimistic locking via a version field. In 
-this approach any entity that should be protected against concurrent modifications during 
-long-running business transactions gets a version field that is either a simple number 
-(mapping type: integer) or a timestamp (mapping type: datetime). When changes to such an 
-entity are persisted at the end of a long-running conversation the version of the entity 
-is compared to the version in the database and if they don't match, a `OptimisticLockError` 
-is thrown, indicating that the entity has been modified by someone else already.
+MikroORM has integrated support for automatic optimistic locking via a version field. In this approach any entity that should be protected against concurrent modifications during long-running business transactions gets a version field that is either a simple number (mapping type: integer) or a timestamp (mapping type: datetime). When changes to such an entity are persisted at the end of a long-running conversation the version of the entity is compared to the version in the database and if they don't match, a `OptimisticLockError` is thrown, indicating that the entity has been modified by someone else already.
 
 You designate a version field in an entity as follows. In this example we'll use an integer.
 
@@ -159,23 +111,13 @@ export class User {
 }
 ```
 
-Version numbers (not timestamps) should however be preferred as they can not potentially 
-conflict in a highly concurrent environment, unlike timestamps where this is a possibility, 
-depending on the resolution of the timestamp on the particular database platform.
+Version numbers (not timestamps) should however be preferred as they can not potentially conflict in a highly concurrent environment, unlike timestamps where this is a possibility, depending on the resolution of the timestamp on the particular database platform.
 
-When a version conflict is encountered during `em.flush()`, a `OptimisticLockError` 
-is thrown and the active transaction rolled back (or marked for rollback). This exception 
-can be caught and handled. Potential responses to a `OptimisticLockError` are to present the 
-conflict to the user or to refresh or reload objects in a new transaction and then retrying 
-the transaction.
+When a version conflict is encountered during `em.flush()`, a `OptimisticLockError` is thrown and the active transaction rolled back (or marked for rollback). This exception can be caught and handled. Potential responses to a `OptimisticLockError` are to present the conflict to the user or to refresh or reload objects in a new transaction and then retrying the transaction.
 
-The time between showing an update form and actually modifying the entity can in the worst 
-scenario be as long as your application's session timeout. If changes happen to the entity 
-in that time frame you want to know directly when retrieving the entity that you will hit 
-an optimistic locking exception:
+The time between showing an update form and actually modifying the entity can in the worst scenario be as long as your application's session timeout. If changes happen to the entity in that time frame you want to know directly when retrieving the entity that you will hit an optimistic locking exception:
 
-You can always verify the version of an entity during a request either when calling 
-`em.findOne()`:
+You can always verify the version of an entity during a request either when calling `em.findOne()`:
 
 ```ts
 const theEntityId = 1;
@@ -209,14 +151,9 @@ try {
 
 ### Concurrency Checks
 
-As opposed to version fields that are handled automatically, we can use 
-concurrency checks. They allow us to mark specific properties to be included
-in the concurrency check, just like the version field was. But this time, we
-will be responsible for updating the fields explicitly.
+As opposed to version fields that are handled automatically, we can use concurrency checks. They allow us to mark specific properties to be included in the concurrency check, just like the version field was. But this time, we will be responsible for updating the fields explicitly.
 
-When we try to update such entity without changing one of the concurrency fields,
-`OptimisticLockError` will be thrown. Same mechanism is then used to check whether
-the update succeeded, and throw the same type of error when not.
+When we try to update such entity without changing one of the concurrency fields, `OptimisticLockError` will be thrown. Same mechanism is then used to check whether the update succeeded, and throw the same type of error when not.
 
 ```ts
 @Entity()
@@ -241,23 +178,16 @@ export class ConcurrencyCheckUser {
 
 #### Important Implementation Notes
 
-You can easily get the optimistic locking workflow wrong if you compare the wrong versions. 
-Say you have Alice and Bob editing a hypothetical blog post:
+You can easily get the optimistic locking workflow wrong if you compare the wrong versions. Say you have Alice and Bob editing a hypothetical blog post:
 
 - Alice reads the headline of the blog post being "Foo", at optimistic lock version 1 (GET Request)
 - Bob reads the headline of the blog post being "Foo", at optimistic lock version 1 (GET Request)
 - Bob updates the headline to "Bar", upgrading the optimistic lock version to 2 (POST Request of a Form)
 - Alice updates the headline to "Baz", ... (POST Request of a Form)
 
-Now at the last stage of this scenario the blog post has to be read again from the database 
-before Alice's headline can be applied. At this point you will want to check if the blog 
-post is still at version 1 (which it is not in this scenario).
+Now at the last stage of this scenario the blog post has to be read again from the database before Alice's headline can be applied. At this point you will want to check if the blog post is still at version 1 (which it is not in this scenario).
 
-Using optimistic locking correctly, you **have** to add the version as an additional hidden 
-field (or into the session for more safety). Otherwise you cannot verify the version is still 
-the one being originally read from the database when Alice performed her GET request for the 
-blog post. If this happens you might see lost updates you wanted to prevent with Optimistic 
-Locking.
+Using optimistic locking correctly, you **have** to add the version as an additional hidden field (or into the session for more safety). Otherwise you cannot verify the version is still the one being originally read from the database when Alice performed her GET request for the blog post. If this happens you might see lost updates you wanted to prevent with Optimistic Locking.
 
 See the example code (frontend):
 
@@ -296,33 +226,24 @@ async update(req, res) {
 }
 ```
 
-Your frontend app loads an entity from API, the response includes the version property. 
-User makes some changes and fires PUT request back to the API, with version field included 
-in the payload. The PUT handler of the API then reads the version and passes it to the 
-`em.findOne()` call.
+Your frontend app loads an entity from API, the response includes the version property. User makes some changes and fires PUT request back to the API, with version field included in the payload. The PUT handler of the API then reads the version and passes it to the `em.findOne()` call.
 
 ### Pessimistic Locking
 
-MikroORM supports Pessimistic Locking at the database level. No attempt is being made to implement 
-pessimistic locking inside MikroORM, rather vendor-specific and ANSI-SQL commands are used to 
-acquire row-level locks. Every Entity can be part of a pessimistic lock, there is no special 
-metadata required to use this feature.
+MikroORM supports Pessimistic Locking at the database level. No attempt is being made to implement pessimistic locking inside MikroORM, rather vendor-specific and ANSI-SQL commands are used to acquire row-level locks. Every Entity can be part of a pessimistic lock, there is no special metadata required to use this feature.
 
-However, for Pessimistic Locking to work you have to disable the Auto-Commit Mode of your Database 
-and start a transaction around your pessimistic lock use-case using the "Approach 2: Explicit 
-Transaction Demarcation" described above. MikroORM will throw an Exception if you attempt to 
-acquire a pessimistic lock and no transaction is running.
+However, for Pessimistic Locking to work you have to disable the Auto-Commit Mode of your Database and start a transaction around your pessimistic lock use-case using the "Approach 2: Explicit Transaction Demarcation" described above. MikroORM will throw an Exception if you attempt to acquire a pessimistic lock and no transaction is running.
 
 MikroORM currently supports 6 pessimistic lock modes:
 
-| Mode | Postgres | MySQL |
-|------|----------|-------|
-| `LockMode.PESSIMISTIC_READ` | `for share` | `lock in share mode` |
-| `LockMode.PESSIMISTIC_WRITE` | `for update` | `for update` |
-| `LockMode.PESSIMISTIC_PARTIAL_WRITE` | `for update skip locked` | `for update skip locked` |
-| `LockMode.PESSIMISTIC_WRITE_OR_FAIL` | `for update nowait` | `for update nowait` |
-| `LockMode.PESSIMISTIC_PARTIAL_READ` | `for share skip locked` | `lock in share mode skip locked` |
-| `LockMode.PESSIMISTIC_READ_OR_FAIL` | `for share nowait` | `lock in share mode nowait` |
+| Mode                                 | Postgres                 | MySQL                            |
+| ------------------------------------ | ------------------------ | -------------------------------- |
+| `LockMode.PESSIMISTIC_READ`          | `for share`              | `lock in share mode`             |
+| `LockMode.PESSIMISTIC_WRITE`         | `for update`             | `for update`                     |
+| `LockMode.PESSIMISTIC_PARTIAL_WRITE` | `for update skip locked` | `for update skip locked`         |
+| `LockMode.PESSIMISTIC_WRITE_OR_FAIL` | `for update nowait`      | `for update nowait`              |
+| `LockMode.PESSIMISTIC_PARTIAL_READ`  | `for share skip locked`  | `lock in share mode skip locked` |
+| `LockMode.PESSIMISTIC_READ_OR_FAIL`  | `for share nowait`       | `lock in share mode nowait`      |
 
 You can use pessimistic locks in three different scenarios:
 
@@ -342,10 +263,10 @@ const res = await em.find(User, { name: 'Jon' }, {
   lockTableAliases: ['e0'],
 });
 
-// select ... 
+// select ...
 //   from "user" as "e0"
-//   left join "identity" as "i1" on "e0"."id" = "i1"."user_id" 
-//   where "e0"."name" = 'Jon' 
+//   left join "identity" as "i1" on "e0"."id" = "i1"."user_id"
+//   where "e0"."name" = 'Jon'
 //   for update of "e0" skip locked
 ```
 
@@ -367,5 +288,4 @@ Available isolation levels:
 - `IsolationLevel.REPEATABLE_READ`
 - `IsolationLevel.SERIALIZABLE`
 
-> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html) as the behaviour here is pretty much the same.

--- a/docs/docs/type-safe-relations.md
+++ b/docs/docs/type-safe-relations.md
@@ -308,7 +308,7 @@ book.author.set(new Author(...));
 
 `Ref` is an intersection type that adds primary key property to the `Reference` interface. It allows to get the primary key from `Reference` instance directly.
 
-By default, we try to detect the PK by checking if a property with a known name exists. We check for those in order: `_id`, `uuid`, `id` - with a way to manually set the property name via `PrimaryKeyProp` symbol (`[PrimaryKeyProp]?: 'foo';`). 
+By default, we try to detect the PK by checking if a property with a known name exists. We check for those in order: `_id`, `uuid`, `id` - with a way to manually set the property name via `PrimaryKeyProp` symbol (`[PrimaryKeyProp]?: 'foo';`).
 
 We can also override this via second generic type argument.
 
@@ -403,4 +403,4 @@ console.log(book.author.id); // ok, returns string PK
 console.log(book.author._id); // ok, returns ObjectId PK
 ```
 
-> As opposed to `wrap(e).init()` which always refreshes the entity, `Reference.load()` method will query the database only if the entity is not already loaded in Identity Map. 
+> As opposed to `wrap(e).init()` which always refreshes the entity, `Reference.load()` method will query the database only if the entity is not already loaded in Identity Map.

--- a/docs/docs/upgrading-v2-to-v3.md
+++ b/docs/docs/upgrading-v2-to-v3.md
@@ -2,19 +2,13 @@
 title: Upgrading from v2 to v3
 ---
 
-Following sections describe (hopefully) all breaking changes, most of them might be not valid 
-for you, like if you do not use custom `NamingStrategy` implementation, you do not care about
-the interface being changed.
+Following sections describe (hopefully) all breaking changes, most of them might be not valid for you, like if you do not use custom `NamingStrategy` implementation, you do not care about the interface being changed.
 
 ## Default value of autoFlush has changed to false
 
-> If you had `autoFlush: false` in your ORM configuration before, you can now remove 
-> this line, no changes are needed in your app. 
+> If you had `autoFlush: false` in your ORM configuration before, you can now remove this line, no changes are needed in your app.
 
-Default value for `autoFlush` is now `false`. That means you need to call 
-`em.flush()` yourself to persist changes into database. You can still change this via ORM's
-options to ease the transition but generally it is not recommended as it can cause unwanted
-small transactions being created around each `persist`. 
+Default value for `autoFlush` is now `false`. That means you need to call `em.flush()` yourself to persist changes into database. You can still change this via ORM's options to ease the transition but generally it is not recommended as it can cause unwanted small transactions being created around each `persist`.
 
 ```ts
 orm.em.persist(new Entity()); // no auto-flushing by default
@@ -24,29 +18,20 @@ await orm.em.persist(new Entity(), true); // you can still use second parameter 
 
 ## Reworked entity definition
 
-> Implementing those interfaces is optional.  
+> Implementing those interfaces is optional.
 
-Now it is no longer needed to merge entities with `IEntity` interface, that was polluting entity's 
-interface with internal methods. New interfaces `IdentifiedEntity<T>`, `UuidEntity<T>` and `MongoEntity<T>` 
-are introduced, that can be implemented by entities. They are not adding any new properties or methods, 
-keeping the entity's interface clean. This is also the reason why they can be omitted.
+Now it is no longer needed to merge entities with `IEntity` interface, that was polluting entity's interface with internal methods. New interfaces `IdentifiedEntity<T>`, `UuidEntity<T>` and `MongoEntity<T>` are introduced, that can be implemented by entities. They are not adding any new properties or methods, keeping the entity's interface clean. This is also the reason why they can be omitted.
 
-`IEntity` interface has been renamed to `AnyEntity<T, PK>` and it no longer has public methods 
-like `toJSON()`, `toObject()` or `init()`. One can use `wrap()` method provided by ORM that
-will enhance property type when needed with those methods (`await wrap(book.author).init()`). 
-To keep all methods available on the entity, you can still use interface merging with 
-`WrappedEntity<T, PK>` that both extends `AnyEntity<T, PK>` and defines all those methods.
+`IEntity` interface has been renamed to `AnyEntity<T, PK>` and it no longer has public methods like `toJSON()`, `toObject()` or `init()`. One can use `wrap()` method provided by ORM that will enhance property type when needed with those methods (`await wrap(book.author).init()`). To keep all methods available on the entity, you can still use interface merging with `WrappedEntity<T, PK>` that both extends `AnyEntity<T, PK>` and defines all those methods.
 
 You can mark the entity by implementing one of `*Entity` interfaces:
 
 - `IdEntity<T>` for numeric/string PK on `id` property (`id: number`)
 - `UuidEntity<T>` for string PK on `uuid` property (`uuid: string`)
 - `MongoEntity<T>` for mongo, where `id: string` and `_id: ObjectId` are required
-- `AnyEntity<T, PK>` for other possible properties (fill the PK property name to `PK` 
-parameter, e.g.: `AnyEntity<Book, 'myPrimaryProperty'>'`)
+- `AnyEntity<T, PK>` for other possible properties (fill the PK property name to `PK` parameter, e.g.: `AnyEntity<Book, 'myPrimaryProperty'>'`)
 
-To keep all public methods that were part of `IEntity` interface in v2, you can use 
-`WrappedEntity<T, PK>` via interface merging:
+To keep all public methods that were part of `IEntity` interface in v2, you can use `WrappedEntity<T, PK>` via interface merging:
 
 ```ts
 @Entity()
@@ -58,37 +43,25 @@ For more examples, take a look at [defining entities section](defining-entities.
 
 ## Integrated Knex.js as query builder and runner
 
-`QueryBuilder` now internally uses knex to run all queries. As knex already supports connection 
-pooling, this feature comes without any effort. New configuration for pooling is now available
+`QueryBuilder` now internally uses knex to run all queries. As knex already supports connection pooling, this feature comes without any effort. New configuration for pooling is now available
 
-Transactions now require using `em.transactional()` method, previous helpers 
-`beginTransaction`/`commit`/`rollback` are now removed.
+Transactions now require using `em.transactional()` method, previous helpers `beginTransaction`/`commit`/`rollback` are now removed.
 
-All transaction management has been removed from `IDatabaseDriver` interface, now EM handles 
-this, passing the transaction context (carried by EM, and created by `Connection`) to all 
-driver methods. New methods on EM exists: `isInTransaction()` and `getTransactionContext()`.
+All transaction management has been removed from `IDatabaseDriver` interface, now EM handles this, passing the transaction context (carried by EM, and created by `Connection`) to all driver methods. New methods on EM exists: `isInTransaction()` and `getTransactionContext()`.
 
-In postgres driver, it used to be required to pass parameters as indexed dollar sign 
-($1, $2, ...), while now knex requires the placeholder to be simple question mark (`?`), 
-like in other dialects, so this is now unified with other drivers.
+In postgres driver, it used to be required to pass parameters as indexed dollar sign ($1, $2, ...), while now knex requires the placeholder to be simple question mark (`?`), like in other dialects, so this is now unified with other drivers.
 
 ## ManyToMany now uses composite primary key
 
-Previously it was required to have autoincrement primary key for m:n pivot tables. Now this 
-has changed. By default, only foreign columns are required and composite key over both of them
-is used as primary key.
+Previously it was required to have autoincrement primary key for m:n pivot tables. Now this has changed. By default, only foreign columns are required and composite key over both of them is used as primary key.
 
-To preserve stable order of collections, you can force previous behaviour by defining the 
-m:n property as `fixedOrder: true`, which will start ordering by `id` column. You can also 
-override the order column name via `fixedOrderColumn: 'order'`. 
+To preserve stable order of collections, you can force previous behaviour by defining the m:n property as `fixedOrder: true`, which will start ordering by `id` column. You can also override the order column name via `fixedOrderColumn: 'order'`.
 
 You can also specify default ordering via `orderBy: { ... }` attribute.
 
 ## Entity references now don't have instantiated collections
 
-Previously all entity instances, including entity references (not fully loaded entities where
-we know only the primary key), had instantiated collection classes. Now only initialized entities
-have them.
+Previously all entity instances, including entity references (not fully loaded entities where we know only the primary key), had instantiated collection classes. Now only initialized entities have them.
 
 ```ts
 const book = em.getReference(Book, 1);
@@ -99,12 +72,9 @@ console.log(book.tags); // instance of Collection (not initialized)
 
 ## EntityAssigner.assign() requires EM for new entities
 
-Previously all entities had internal reference to the root EM - the one created when 
-initializing the ORM. Now only managed entities (those merged to the EM, e.g. loaded 
-from the database) have this internal reference. 
+Previously all entities had internal reference to the root EM - the one created when initializing the ORM. Now only managed entities (those merged to the EM, e.g. loaded from the database) have this internal reference.
 
-To use `assign()` method on new (not managed) entities, you need to provide the `em`
-parameter:
+To use `assign()` method on new (not managed) entities, you need to provide the `em` parameter:
 
 ```ts
 const book = new Book();
@@ -113,46 +83,36 @@ wrap(book).assign(data, { em: orm.em });
 
 ## Strict FilterQuery and smart query conditions
 
-`FilterQuery` now does not allow using smart query operators. You can either cast your condition 
-as any or use object syntax instead (instead of `{ 'age:gte': 18 }` use `{ age: { $gte: 18 } }`).
+`FilterQuery` now does not allow using smart query operators. You can either cast your condition as any or use object syntax instead (instead of `{ 'age:gte': 18 }` use `{ age: { $gte: 18 } }`).
 
 ## Logging configuration
 
-Previously to start logging it was required to provide your custom logger. Logger now defaults 
-to `console.log()`, and users can specify what namespaces are they interested in via `debug` 
-option. `true`/`false` will enable/disable all namespaces.
+Previously to start logging it was required to provide your custom logger. Logger now defaults to `console.log()`, and users can specify what namespaces are they interested in via `debug` option. `true`/`false` will enable/disable all namespaces.
 
 Available logger namespaces: `'query' | 'query-params' | 'discovery' | 'info'`.
 
-## Removed deprecated fk option from 1:m and m:1 decorators 
+## Removed deprecated fk option from 1:m and m:1 decorators
 
 Use `mappedBy`/`inversedBy` instead.
 
 ## SchemaGenerator.generate() is now async
 
-If you used `SchemaGenerator`, now there is CLI tool you can use instead. Learn more 
-in [SchemaGenerator docs](schema-generator.md). To setup CLI, take a look at 
-[installation section](installation.md).
+If you used `SchemaGenerator`, now there is CLI tool you can use instead. Learn more in [SchemaGenerator docs](schema-generator.md). To setup CLI, take a look at [installation section](installation.md).
 
 ## New method on NamingStrategy interface
 
-`getClassName()` is used to find entity class name based on its file name. Now users can 
-override the default implementation to accommodate their specific needs.
+`getClassName()` is used to find entity class name based on its file name. Now users can override the default implementation to accommodate their specific needs.
 
-If you used custom naming strategy, you will either need to implement this method yourself, 
-or extend `AbstractNamingStrategy`.
+If you used custom naming strategy, you will either need to implement this method yourself, or extend `AbstractNamingStrategy`.
 
 ## TypescriptMetadataProvider has been renamed
 
-The name is now `TsMorphMetadataProvider`, there is also newly added `ReflectMetadataProvider`
-that uses `reflect-metadata` instead. As `TypescriptMetadataProvider` was the default, no 
-changes should be required. 
+The name is now `TsMorphMetadataProvider`, there is also newly added `ReflectMetadataProvider` that uses `reflect-metadata` instead. As `TypescriptMetadataProvider` was the default, no changes should be required.
 
 ## Updated mongodb driver
 
 MongoDB driver version 3.3.4 or higher is now required.
 
 ## EntityManager.find() now requires where parameter
-`EntityManager` has now same `find` method interface aligned with `EntityRepository`, 
-`where` parameter is now required. To select all entities, use `em.find(Entity, {})` 
-as value.
+
+`EntityManager` has now same `find` method interface aligned with `EntityRepository`, `where` parameter is now required. To select all entities, use `em.find(Entity, {})` as value.

--- a/docs/docs/upgrading-v3-to-v4.md
+++ b/docs/docs/upgrading-v3-to-v4.md
@@ -2,24 +2,19 @@
 title: Upgrading from v3 to v4
 ---
 
-> Following sections describe (hopefully) all breaking changes, most of them might be not valid 
-> for you, like if you do not use custom `NamingStrategy` implementation, you do not care about
-> the interface being changed.
+> Following sections describe (hopefully) all breaking changes, most of them might be not valid for you, like if you do not use custom `NamingStrategy` implementation, you do not care about the interface being changed.
 
 ## Node 10.13.0+ required
 
-Support for older node versions was dropped. 
+Support for older node versions was dropped.
 
 ## TypeScript 3.7+ required
 
-Support for older TypeScript versions was dropped. 
+Support for older TypeScript versions was dropped.
 
 ## Monorepo
 
-The ORM has been split into several packages. In v4 one needs to require
-`@mikro-orm/core` and a driver package, e.g. `@mikro-orm/mysql`. This driver
-package already contains the `mysql2` dependency, so you can remove that from
-your `package.json`. 
+The ORM has been split into several packages. In v4 one needs to require `@mikro-orm/core` and a driver package, e.g. `@mikro-orm/mysql`. This driver package already contains the `mysql2` dependency, so you can remove that from your `package.json`.
 
 - `@mikro-orm/core`
 - `@mikro-orm/reflection` - `TsMorphMetadataProvider`
@@ -34,17 +29,13 @@ your `package.json`.
 - `@mikro-orm/postgresql`
 - `@mikro-orm/mongodb`
 
-> For easier transition, meta package mikro-orm is still present, reexporting 
-> core, reflection, migrations, entity-generator and cli packages. You should 
-> **not** install both `mikro-orm` and `@mikro-orm/core` packages together. 
+> For easier transition, meta package mikro-orm is still present, reexporting core, reflection, migrations, entity-generator and cli packages. You should **not** install both `mikro-orm` and `@mikro-orm/core` packages together.
 
-> You should prefer the `@mikro-orm/core` over `mikro-orm` package, there were
-> weird dependency issues reported with the `mikro-orm` meta-package. 
+> You should prefer the `@mikro-orm/core` over `mikro-orm` package, there were weird dependency issues reported with the `mikro-orm` meta-package.
 
 ## Default metadata provider is now `ReflectMetadataProvider`
 
-If you want to use ts-morph, you need to install `@mikro-orm/reflection` package
-and enable the provider explicitly in the ORM config, as described [here](./metadata-providers.md#tsmorphmetadataprovider).
+If you want to use ts-morph, you need to install `@mikro-orm/reflection` package and enable the provider explicitly in the ORM config, as described [here](./metadata-providers.md#tsmorphmetadataprovider).
 
 ```ts
 import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
@@ -55,30 +46,22 @@ await MikroORM.init({
 });
 ```
 
-Using `ReflectMetadataProvider` has some limitations, so be sure to read 
-about them [here](./metadata-providers.md#limitations-and-requirements).
+Using `ReflectMetadataProvider` has some limitations, so be sure to read about them [here](./metadata-providers.md#limitations-and-requirements).
 
-One common gotcha with `reflect-metadata` is that you need to explicitly
-state the property type when using property initializer:
+One common gotcha with `reflect-metadata` is that you need to explicitly state the property type when using property initializer:
 
 ```ts
 @Property()
 createdAt: Date = new Date();
 ```
 
-Without the explicit type, we would infer `Object` instead of `Date`, 
-which would be most probably mapped to JSON column type (depends on driver).
+Without the explicit type, we would infer `Object` instead of `Date`, which would be most probably mapped to JSON column type (depends on driver).
 
 ## SqlEntityManager and MongoEntityManager
 
-In v4 the `core` package, where `EntityManager` and `EntityRepository` are 
-defined, is not dependent on knex, and therefore it cannot have a method 
-returning a `QueryBuilder`. You need to import the SQL flavour of the EM 
-from the driver package to access the `createQueryBuilder()` method.
+In v4 the `core` package, where `EntityManager` and `EntityRepository` are defined, is not dependent on knex, and therefore it cannot have a method returning a `QueryBuilder`. You need to import the SQL flavour of the EM from the driver package to access the `createQueryBuilder()` method.
 
-> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under 
-> this name and under `EntityManager` alias, so you can just change the 
-> location from where you import.
+> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ```ts
 import { EntityManager } from '@mikro-orm/mysql'; // or any other SQL driver package
@@ -96,32 +79,21 @@ const em: EntityManager;
 const ret = await em.aggregate(...);
 ```
 
-> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under 
-> this name and under `EntityManager` alias, so you can just change the 
-> location from where you import.
+> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ## Different default `pivotTable`
 
-Implementation of `UnderscoreNamingStrategy` and `EntityCaseNamingStrategy` 
-`joinTableName()` method has changed. You can use `pivotTable` on the owning side
-of M:N relation to specify the table name manually. 
+Implementation of `UnderscoreNamingStrategy` and `EntityCaseNamingStrategy` `joinTableName()` method has changed. You can use `pivotTable` on the owning side of M:N relation to specify the table name manually.
 
-Previously the table name did not respect property name, if one defined multiple
-M:N relations between same entities, there were conflicts and one would have to 
-specify `pivotTable` name manually at least on one of them. With the new way, 
-we can be sure that the table name won't conflict with other pivot tables. 
+Previously the table name did not respect property name, if one defined multiple M:N relations between same entities, there were conflicts and one would have to specify `pivotTable` name manually at least on one of them. With the new way, we can be sure that the table name won't conflict with other pivot tables.
 
-Previously the name was constructed from 2 entity names as `entity_a_to_entity_b`,
-ignoring the actual property name. In v4 the name will be `entity_a_coll_name` in 
-case of the collection property on the owning side being named `collName`. 
+Previously the name was constructed from 2 entity names as `entity_a_to_entity_b`, ignoring the actual property name. In v4 the name will be `entity_a_coll_name` in case of the collection property on the owning side being named `collName`.
 
 ## Changes in folder-based discovery (`entitiesDirs` removed)
 
-`entitiesDirs` and `entitiesDirsTs` were removed in favour of `entities` and `entitiesTs`,
-`entities` will be used as a default for `entitiesTs` (that is used when we detect `ts-node`).
+`entitiesDirs` and `entitiesDirsTs` were removed in favour of `entities` and `entitiesTs`, `entities` will be used as a default for `entitiesTs` (that is used when we detect `ts-node`).
 
-`entities` can now contain mixture of paths to directories, globs pointing to entities,
-or references to the entities or instances of `EntitySchema`. 
+`entities` can now contain mixture of paths to directories, globs pointing to entities, or references to the entities or instances of `EntitySchema`.
 
 This basically means that all you need to change is renaming `entitiesDirs` to `entities`.
 
@@ -134,26 +106,17 @@ MikroORM.init({
 
 ## Changes in `wrap()` helper, `WrappedEntity` interface and `Reference` wrapper
 
-Previously all the methods and properties of `WrappedEntity` interface were
-added to the entity prototype during discovery. In v4 there is only one property
-added: `__helper: WrappedEntity`. `WrappedEntity` has been converted to actual class.
+Previously all the methods and properties of `WrappedEntity` interface were added to the entity prototype during discovery. In v4 there is only one property added: `__helper: WrappedEntity`. `WrappedEntity` has been converted to actual class.
 
-`wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is 
-being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...),
-if you want to access internal properties like `__meta` or `__em`, you need to explicitly
-ask for the helper via `wrap(entity, true)`.
+`wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...), if you want to access internal properties like `__meta` or `__em`, you need to explicitly ask for the helper via `wrap(entity, true)`.
 
-Internal methods (with `__` prefix) were also removed from the `Reference` class, 
-use `wrap(ref, true)` to access them. 
+Internal methods (with `__` prefix) were also removed from the `Reference` class, use `wrap(ref, true)` to access them.
 
-Instead of interface merging with `WrappedEntity`, one can now use classic inheritance,
-by extending `BaseEntity` exported from `@mikro-orm/core`. If you do so, `wrap(entity)` 
-will return your entity. 
+Instead of interface merging with `WrappedEntity`, one can now use classic inheritance, by extending `BaseEntity` exported from `@mikro-orm/core`. If you do so, `wrap(entity)` will return your entity.
 
 ## Removed `flush` parameter from `persist()` and `remove()` methods
 
-`flush` param is removed, both `persist` and `remove` methods are synchronous and
-require explicit flushing, possibly via fluent interface call.
+`flush` param is removed, both `persist` and `remove` methods are synchronous and require explicit flushing, possibly via fluent interface call.
 
 ```ts
 // before
@@ -167,19 +130,15 @@ await em.remove(jon).flush();
 
 ## `remove()` method requires entity instances
 
-The `em.remove()` method originally allowed to pass either entity instance, or 
-a condition. When one passed a condition, it was firing a native delete query, 
-without handling transactions or hooks. 
+The `em.remove()` method originally allowed to pass either entity instance, or a condition. When one passed a condition, it was firing a native delete query, without handling transactions or hooks.
 
-In v4, the method is now simplified and works only with entity instances. Use 
-`em.nativeDelete()` explicitly if you want to fire a delete query instead of 
-letting the `UnitOfWork` doing its job.
+In v4, the method is now simplified and works only with entity instances. Use `em.nativeDelete()` explicitly if you want to fire a delete query instead of letting the `UnitOfWork` doing its job.
 
 ```ts
 // before
 await em.remove(Author, 1); // fires query directly
 
-// after 
+// after
 await em.nativeDelete(Author, 1);
 ```
 
@@ -187,20 +146,11 @@ await em.nativeDelete(Author, 1);
 
 ## Type safe references
 
-EM now returns `Loaded<T, P>` instead of the entity (`T`). This type automatically
-adds synchronous method `get()` that returns the entity (for references) or array
-of entities (for collections).
+EM now returns `Loaded<T, P>` instead of the entity (`T`). This type automatically adds synchronous method `get()` that returns the entity (for references) or array of entities (for collections).
 
-`Reference.get()` is now available only with correct `Loaded` type hint and is used 
-as a sync getter for the entity, just like `unwrap()`. You can use `Reference.load(prop)` 
-for the original `get()` method functionality. 
+`Reference.get()` is now available only with correct `Loaded` type hint and is used as a sync getter for the entity, just like `unwrap()`. You can use `Reference.load(prop)` for the original `get()` method functionality.
 
-`em.find()` and similar methods now have two type arguments, due to TypeScript not supporting partial
-type inference, when you specify the `T` explicitly (without also explicitly 
-specifying the load hint), the inference will not work. This use case was mainly
-for usage without classes (interfaces + `EntitySchema`) - in that case it is now 
-supported to pass actual instance of `EntitySchema` as the first parameter to these
-methods, that will allow correct type inference:
+`em.find()` and similar methods now have two type arguments, due to TypeScript not supporting partial type inference, when you specify the `T` explicitly (without also explicitly specifying the load hint), the inference will not work. This use case was mainly for usage without classes (interfaces + `EntitySchema`) - in that case it is now supported to pass actual instance of `EntitySchema` as the first parameter to these methods, that will allow correct type inference:
 
 ```ts
 const author = await em.findOne(AuthorSchema, { ... }, ['books']);
@@ -209,59 +159,45 @@ console.log(author.books.get()); // `get()` is now inferred correctly
 
 ## Custom types are now type safe
 
-Generic `Type` class has now two type arguments - the input and output types. 
-Input type defaults to `string`, output type defaults to the input type. 
+Generic `Type` class has now two type arguments - the input and output types. Input type defaults to `string`, output type defaults to the input type.
 
 You might need to explicitly provide the types if your methods are strictly typed.
 
 ## Custom type serialization
 
-Custom types used to be serialized to the database value. In v4, the runtime 
-value is used by default. Implement custom `toJSON()` method if you need to 
-customize this.
+Custom types used to be serialized to the database value. In v4, the runtime value is used by default. Implement custom `toJSON()` method if you need to customize this.
 
 ## Property `default` and `defaultRaw`
 
-Previously the `default` option of properties was used as is, so we had to wrap 
-strings in quotes (e.g. `@Property({ default: "'foo bar'" })`). 
+Previously the `default` option of properties was used as is, so we had to wrap strings in quotes (e.g. `@Property({ default: "'foo bar'" })`).
 
-In v4 the `default` is typed as `string | number | boolean | null` and when used
-with string value, it will be automatically quoted. 
+In v4 the `default` is typed as `string | number | boolean | null` and when used with string value, it will be automatically quoted.
 
 To use SQL functions we now need to use `defaultRaw`: `@Property({ defaultRaw: 'now()' })`.
 
 ## `autoFlush` option has been removed
 
-Also `persistLater()` and `removeLater()` methods are deprecated. Use `persist()` or
-`remove` respectively.
+Also `persistLater()` and `removeLater()` methods are deprecated. Use `persist()` or `remove` respectively.
 
 ## `IdEntity`, `UuidEntity` and `MongoEntity` interfaces are removed
 
-They were actually never needed. 
+They were actually never needed.
 
 ## MongoDB driver is no longer the default
 
-You need to specify the platform type either via `type` option or provide the driver
-implementation via `driver` option. 
+You need to specify the platform type either via `type` option or provide the driver implementation via `driver` option.
 
 Available platforms types: `[ 'mongo', 'mysql', 'mariadb', 'postgresql', 'sqlite' ]`
 
 ## Removed configuration `discovery.tsConfigPath`
 
-Removed as it is no longer needed, it was used only for `TsMorphMetadataProvider`,
-when the `entitiesDirsTs` were not explicitly provided. In v4, this is no longer
-needed, as ts-morph discovery will use `d.ts` files instead, that should be located
-next to the compiled entities. 
+Removed as it is no longer needed, it was used only for `TsMorphMetadataProvider`, when the `entitiesDirsTs` were not explicitly provided. In v4, this is no longer needed, as ts-morph discovery will use `d.ts` files instead, that should be located next to the compiled entities.
 
 ## Changes in query highlighting
 
-Previously Highlight.js was used to highlight various things in the CLI, 
-like SQL and mongo queries, or migrations or entities generated via CLI.
-While the library worked fine, it was causing performance issues mainly 
-for those bundling via webpack and using lambdas, as the library was huge.
+Previously Highlight.js was used to highlight various things in the CLI, like SQL and mongo queries, or migrations or entities generated via CLI. While the library worked fine, it was causing performance issues mainly for those bundling via webpack and using lambdas, as the library was huge.
 
-In v4 highlighting is disabled by default, and there are 2 highlighters 
-you can optionally use (you need to install them first).
+In v4 highlighting is disabled by default, and there are 2 highlighters you can optionally use (you need to install them first).
 
 ```ts
 import { SqlHighlighter } from '@mikro-orm/sql-highlighter';

--- a/docs/docs/upgrading-v4-to-v5.md
+++ b/docs/docs/upgrading-v4-to-v5.md
@@ -2,23 +2,19 @@
 title: Upgrading from v4 to v5
 ---
 
-> Following sections describe (hopefully) all breaking changes, most of them might be not valid 
-> for you, like if you do not use custom `NamingStrategy` implementation, you do not care about
-> the interface being changed.
+> Following sections describe (hopefully) all breaking changes, most of them might be not valid for you, like if you do not use custom `NamingStrategy` implementation, you do not care about the interface being changed.
 
 ## Node 14+ required
 
-Support for older node versions was dropped. 
+Support for older node versions was dropped.
 
 ## TypeScript 4.1+ required
 
-Support for older TypeScript versions was dropped. 
+Support for older TypeScript versions was dropped.
 
 ## Options parameters
 
-Previously many methods had many (often boolean) parameters, in v5 such methods are
-refactored to use options object instead to improve readability. Some methods offered
-both signatures - the multi parameter signatures are now removed.
+Previously many methods had many (often boolean) parameters, in v5 such methods are refactored to use options object instead to improve readability. Some methods offered both signatures - the multi parameter signatures are now removed.
 
 List of such methods:
 
@@ -47,10 +43,7 @@ This also applies to the methods on `IDatabaseDriver` interface.
 
 ## Type-safe populate parameter with dot notation
 
-`FindOptions.populate` parameter is now strictly typed and supports only array of 
-strings or a boolean.
-Object way is no longer supported. To set loading strategy, use `FindOptions.strategy`.
-The return type of all such methods now returns properly typed `Loaded` response. 
+`FindOptions.populate` parameter is now strictly typed and supports only array of strings or a boolean. Object way is no longer supported. To set loading strategy, use `FindOptions.strategy`. The return type of all such methods now returns properly typed `Loaded` response.
 
 ## Type-safe fields parameter
 
@@ -58,8 +51,7 @@ The return type of all such methods now returns properly typed `Loaded` response
 
 ## Type-safe orderBy parameter
 
-`FindOptions.orderBy` parameter is now strictly typed. It also allows passing an 
-array of objects instead of just a single object.
+`FindOptions.orderBy` parameter is now strictly typed. It also allows passing an array of objects instead of just a single object.
 
 ```ts
 const books = await em.find(Book, {}, {
@@ -72,41 +64,25 @@ const books = await em.find(Book, {}, {
 
 ## Removed `@Repository()` decorator
 
-The decorator was problematic as it could only work properly it the file was required
-soon enough - before the ORM initialization, otherwise the repository would not be 
-registered at all.
+The decorator was problematic as it could only work properly it the file was required soon enough - before the ORM initialization, otherwise the repository would not be registered at all.
 
-Use `@Entity({ customRepository: () => CustomRepository })` in the entity definition
-instead.
+Use `@Entity({ customRepository: () => CustomRepository })` in the entity definition instead.
 
 ## Disallowed global identity map
 
-In v5, it is no longer possible to use the global identity map. This was a 
-common issue that led to weird bugs, as using the global EM without request
-context is wrong, we always need to have a dedicated context for each request,
-so they do not interfere.
+In v5, it is no longer possible to use the global identity map. This was a common issue that led to weird bugs, as using the global EM without request context is wrong, we always need to have a dedicated context for each request, so they do not interfere.
 
-Now we get a validation error if we try to use the global context. We still can
-disable this check via `allowGlobalContext` configuration, or a connected 
-environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can be handy 
-especially in unit tests.
+Now we get a validation error if we try to use the global context. We still can disable this check via `allowGlobalContext` configuration, or a connected environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can be handy especially in unit tests.
 
 ## `LoadedCollection.get()` and `$` now return the `Collection` instance
 
-Previously those dynamically added getters returned the array copy of collection
-items. In v5, we return the collection instance, which is also iterable and has
-a `length` getter and indexed access support, so it mimics the array. To get the
-array copy as before, call `getItems()` as with a regular collection.
+Previously those dynamically added getters returned the array copy of collection items. In v5, we return the collection instance, which is also iterable and has a `length` getter and indexed access support, so it mimics the array. To get the array copy as before, call `getItems()` as with a regular collection.
 
 ## Different table aliasing for select-in loading strategy and for QueryBuilder
 
-Previously with select-in strategy as well as with QueryBuilder, table aliases
-were always the letter `e` followed by unique index. In v5, we use the same 
-method as with joined strategy - the letter is inferred from the entity name.
+Previously with select-in strategy as well as with QueryBuilder, table aliases were always the letter `e` followed by unique index. In v5, we use the same method as with joined strategy - the letter is inferred from the entity name.
 
-This can be breaking if you used the aliases somewhere, e.g. in custom SQL 
-fragments. We can restore to the old behaviour by implementing custom naming
-strategy, overriding the `aliasName` method:
+This can be breaking if you used the aliases somewhere, e.g. in custom SQL fragments. We can restore to the old behaviour by implementing custom naming strategy, overriding the `aliasName` method:
 
 ```ts
 import { AbstractNamingStrategy } from '@mikro-orm/core';
@@ -118,37 +94,27 @@ class CustomNamingStrategy extends AbstractNamingStrategy {
 }
 ```
 
-Note that in v5 it is possible to use `expr()` helper to access the alias name
-dynamically, e.g. ``expr(alias => `lower('${alias}.name')`)``, which should be 
-now preferred way instead of hardcoding the aliases.
+Note that in v5 it is possible to use `expr()` helper to access the alias name dynamically, e.g. `` expr(alias => `lower('${alias}.name')`) ``, which should be now preferred way instead of hardcoding the aliases.
 
 ## Migrations are now stored without extensions
 
-Running migrations in production via node and ts-node is now handled the same.
-This should actually not be breaking, as old format with extension is still 
-supported (e.g. they still can be rolled back), but newly logged migrations
-will not contain the extension.
+Running migrations in production via node and ts-node is now handled the same. This should actually not be breaking, as old format with extension is still supported (e.g. they still can be rolled back), but newly logged migrations will not contain the extension.
 
 ## Changes in `assign()` helper
 
-Embeddable instances are now created via `EntityFactory` and they respect the
-`forceEntityConstructor` configuration. Due to this we need to have EM instance
-when assigning to embedded properties. 
+Embeddable instances are now created via `EntityFactory` and they respect the `forceEntityConstructor` configuration. Due to this we need to have EM instance when assigning to embedded properties.
 
 Using `em.assign()` should be preferred to get around this.
 
-Deep assigning of child entities now works by default based on the presence of PKs in the payload.
-This behaviour can be disable via updateByPrimaryKey: false in the assign options.
+Deep assigning of child entities now works by default based on the presence of PKs in the payload. This behaviour can be disable via updateByPrimaryKey: false in the assign options.
 
 `mergeObjects` option is now enabled by default.
 
 ## `em.populate()` always return array of entities
 
-Previously it was possible to call `em.populate()` with a single entity input,
-and the output would be again just a single entity.
+Previously it was possible to call `em.populate()` with a single entity input, and the output would be again just a single entity.
 
-Due to issues with TS 4.5, this method now always return array of entities.
-You can use destructing if you want to have a single entity return type:
+Due to issues with TS 4.5, this method now always return array of entities. You can use destructing if you want to have a single entity return type:
 
 ```ts
 const [loadedAuthor] = await em.populate(author, ...);
@@ -156,66 +122,45 @@ const [loadedAuthor] = await em.populate(author, ...);
 
 ## QueryBuilder is awaitable
 
-Previously awaiting of QB instance was a no-op. In v5, QB is promise-like interface,
-so we can await it. More about this in [Awaiting the QueryBuilder](./query-builder.md#awaiting-the-querybuilder) section.
+Previously awaiting of QB instance was a no-op. In v5, QB is promise-like interface, so we can await it. More about this in [Awaiting the QueryBuilder](./query-builder.md#awaiting-the-querybuilder) section.
 
 ## `UnitOfWork.getScheduledCollectionDeletions()` has been removed
 
-Previously scheduled collection deletions were used for a hack when removing 
-1:m collection via orphan removal might require early deletes - in case we were 
-adding the same entity (but different instance), so with same PK - inserting it 
-in the same unit would cause unique constraint failures.
+Previously scheduled collection deletions were used for a hack when removing 1:m collection via orphan removal might require early deletes - in case we were adding the same entity (but different instance), so with same PK - inserting it in the same unit would cause unique constraint failures.
 
 Also `IDatabaseDriver.clearCollection()` method is no longer present in the driver API.
 
 ## `populateAfterFlush` is enabled by default
 
-After flushing a new entity, all relations are marked as populated,
-just like if the entity was loaded from the db. This aligns the serialized
-output of `e.toJSON()` of a loaded entity and just-inserted one.
+After flushing a new entity, all relations are marked as populated, just like if the entity was loaded from the db. This aligns the serialized output of `e.toJSON()` of a loaded entity and just-inserted one.
 
-In v4 this behaviour was disabled by default, so even after the new entity was
-flushed, the serialized form contained only FKs for its relations. We can opt in
-to this old behaviour via `populateAfterFlush: false`.
+In v4 this behaviour was disabled by default, so even after the new entity was flushed, the serialized form contained only FKs for its relations. We can opt in to this old behaviour via `populateAfterFlush: false`.
 
 ## `migrations.pattern` is removed in favour of `migrations.glob`
 
-Migrations are using `umzug` under the hood, which is now upgraded to v3.0.
-With this version, the `pattern` configuration options is no longer available, 
-and has been replaced with `glob`. This change is also reflected in MikroORM.
+Migrations are using `umzug` under the hood, which is now upgraded to v3.0. With this version, the `pattern` configuration options is no longer available, and has been replaced with `glob`. This change is also reflected in MikroORM.
 
-The default value for `glob` is `!(*.d).{js,ts}`, so both JS and TS files are matched
-(but not .d.ts files). You should usually not need to change this option as this default
-suits both development and production environments.
+The default value for `glob` is `!(*.d).{js,ts}`, so both JS and TS files are matched (but not .d.ts files). You should usually not need to change this option as this default suits both development and production environments.
 
 ## Population no longer infers the where condition by default
 
 > This applies only to SELECT_IN strategy, as JOINED strategy implies the inference.
 
-Previously when we used populate hints in `em.find()` and similar methods, the
-query for our entity would be analysed and parts of it extracted and used for 
-the population. Following example would find all authors that have books with 
-given IDs, and populate their books collection, again using this PK condition,
-resulting in only such books being in those collections. 
+Previously when we used populate hints in `em.find()` and similar methods, the query for our entity would be analysed and parts of it extracted and used for the population. Following example would find all authors that have books with given IDs, and populate their books collection, again using this PK condition, resulting in only such books being in those collections.
 
 ```ts
 // this would end up with `Author.books` collections having only books of PK 1, 2, 3
 const a = await em.find(Author, { books: [1, 2, 3] }, { populate: ['books'] });
 ```
 
-Following this example, if we wanted to load all books, we would need a separate 
-`em.populate()` call:
+Following this example, if we wanted to load all books, we would need a separate `em.populate()` call:
 
 ```ts
 const a = await em.find(Author, { books: [1, 2, 3] });
 await em.populate(a, ['books']);
 ```
 
-This behaviour changed and is now configurable both globally and locally, via 
-`populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and 
-`PopulateHint.INFER`, the former being the default in v5, the latter being the
-default behaviour in v4. Locally (via `FindOptions`) we can also specify custom
-where condition that will be passed to `em.populate()` call.
+This behaviour changed and is now configurable both globally and locally, via `populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and `PopulateHint.INFER`, the former being the default in v5, the latter being the default behaviour in v4. Locally (via `FindOptions`) we can also specify custom where condition that will be passed to `em.populate()` call.
 
 ```ts
 // revert back to the old behaviour locally
@@ -227,20 +172,12 @@ const a = await em.find(Author, { books: [1, 2, 3] }, {
 
 ## `em.create()` respects required properties
 
-`em.create()` will now require you to pass all non-optional properties. Some 
-properties might be defined as required for TS, but we have a default value for 
-them (either runtime, or database one) - for such we can use `OptionalProps` 
-symbol to specify which properties should be considered as optional.
+`em.create()` will now require you to pass all non-optional properties. Some properties might be defined as required for TS, but we have a default value for them (either runtime, or database one) - for such we can use `OptionalProps` symbol to specify which properties should be considered as optional.
 
 ## Required properties are validated before insert
 
-Previously the validation took place in the database, so it worked only for SQL
-drivers. Now we have runtime validation based on the entity metadata. This means
-mongo users now need to use `nullable: true` on their optional properties, or
-disable the validation globally via `validateRequired: false` in the ORM config.
+Previously the validation took place in the database, so it worked only for SQL drivers. Now we have runtime validation based on the entity metadata. This means mongo users now need to use `nullable: true` on their optional properties, or disable the validation globally via `validateRequired: false` in the ORM config.
 
 ## `PrimaryKeyType` symbol should be defined as optional
 
-Previously when we had nonstandard PK types, we could use `PrimaryKeyType` symbol
-to let the type system know it. It was required to define this property as 
-required, now it can be defined as optional too.
+Previously when we had nonstandard PK types, we could use `PrimaryKeyType` symbol to let the type system know it. It was required to define this property as required, now it can be defined as optional too.

--- a/docs/docs/usage-with-adminjs.md
+++ b/docs/docs/usage-with-adminjs.md
@@ -6,12 +6,15 @@ sidebar_label: Usage with AdminJS
 ## Installation
 
 To use MikroORM with AdminJS you need to install:
+
 1. [`AdminJS Core`](https://github.com/SoftwareBrothers/adminjs):
+
 ```bash
 $ yarn add adminjs
 ```
 
 2. [`MikroORM Adapter`](https://github.com/SoftwareBrothers/adminjs-mikroorm):
+
 ```bash
 $ yarn add @adminjs/mikroorm
 # A MikroORM driver and core package, choose the one which suits you:
@@ -23,7 +26,9 @@ $ yarn add @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 ```
 
 3. A plugin specific to your server's framework:
+
 - [`Express Plugin`](https://github.com/SoftwareBrothers/adminjs-expressjs):
+
 ```bash
 $ yarn add @adminjs/express
 # Peer dependencies
@@ -31,6 +36,7 @@ $ yarn add express express-formidable express-session
 ```
 
 - [`Hapi Plugin`](https://github.com/SoftwareBrothers/adminjs-hapijs):
+
 ```bash
 $ yarn add @adminjs/hapi
 # Peer dependencies
@@ -41,8 +47,7 @@ $ yarn add @hapi/boom @hapi/cookie @hapi/hapi @hapi/inert
 
 ## Setup
 
-Once the installation process is completed, we need to set up AdminJS endpoints and database connection.
-The process is straightforward but differs based on which `plugin` you are using. Below you can find examples specific to supported frameworks:
+Once the installation process is completed, we need to set up AdminJS endpoints and database connection. The process is straightforward but differs based on which `plugin` you are using. Below you can find examples specific to supported frameworks:
 
 ### MikroORM + Express Plugin
 
@@ -133,7 +138,6 @@ const run = async () => {
 run();
 ```
 
-
 You can start your server afterwards and the admin panel will be available at `http://localhost:{PORT}/admin`. If you followed the example setup thoroughly, you should be able to see all of your entities in the sidebar and you should be able to perform basic **CRUD** operations on them.
 
 To further customize your AdminJS panel, please refer to the [`official documentation`](https://adminjs.co/docs.html).
@@ -149,11 +153,13 @@ The examples above set up AdminJS with unauthenticated access. To require your u
 You need to use `AdminJSExpress.buildAuthenticatedRouter` instead of `AdminJS.buildRouter`:
 
 **Before**:
+
 ```ts
   const router = AdminJSExpress.buildRouter(admin);
 ```
 
 **After**:
+
 ```ts
 const ADMIN_EMAIL = 'example@test.com';
 const ADMIN_PASSWORD = 'password';
@@ -174,6 +180,7 @@ const router = AdminJSExpress.buildAuthenticatedRouter(admin, {
 You need to simply add `auth` property to AdminJS options.
 
 **Before**:
+
 ```ts
 const adminOptions = {
   databases: [orm],
@@ -181,6 +188,7 @@ const adminOptions = {
 ```
 
 **After**:
+
 ```ts
 const ADMIN_EMAIL = 'example@test.com';
 const ADMIN_PASSWORD = 'password';

--- a/docs/docs/usage-with-babel.md
+++ b/docs/docs/usage-with-babel.md
@@ -2,9 +2,7 @@
 title: Usage with Babel
 ---
 
-When compiling TS via babel, decorators are by default handled different implementation
-than what `tsc` uses. To make the metadata extraction from decorators via Babel work, 
-we need to do use following plugins:
+When compiling TS via babel, decorators are by default handled different implementation than what `tsc` uses. To make the metadata extraction from decorators via Babel work, we need to do use following plugins:
 
 ```json
 {
@@ -18,9 +16,9 @@ we need to do use following plugins:
 
 > Make sure to install the plugins first: `yarn add -D babel-plugin-transform-typescript-metadata @babel/plugin-proposal-decorators @babel/plugin-proposal-class-properties`
 
-Lastly we need to set the `BABEL_DECORATORS_COMPAT` environment variable to `true` to 
-adjust the return value of decorators. 
+Lastly we need to set the `BABEL_DECORATORS_COMPAT` environment variable to `true` to adjust the return value of decorators.
 
 More information about this topic can be found here:
+
 - https://github.com/mikro-orm/mikro-orm/issues/840
 - https://jonahallibonetech.medium.com/next-js-9-mikroorm-eb6f6e08e1a1

--- a/docs/docs/usage-with-js.md
+++ b/docs/docs/usage-with-js.md
@@ -67,8 +67,7 @@ module.exports.entity = Author;
 module.exports.schema = schema;
 ```
 
-> Do not forget to provide `name` and `path` schema parameters as well as `entity`
-> and `schema` exports.
+> Do not forget to provide `name` and `path` schema parameters as well as `entity` and `schema` exports.
 
 Reference parameter can be one of (where `SCALAR` is the default one):
 
@@ -95,5 +94,4 @@ const orm = await MikroORM.init({
 
 > We can also pass the `EntitySchema` instance to the `entities` array.
 
-For more examples of plain JavaScript entity definitions take a look
-[Express JavaScript example](https://github.com/mikro-orm/express-js-example-app). 
+For more examples of plain JavaScript entity definitions take a look [Express JavaScript example](https://github.com/mikro-orm/express-js-example-app).

--- a/docs/docs/usage-with-mongo.md
+++ b/docs/docs/usage-with-mongo.md
@@ -2,12 +2,9 @@
 title: Usage with MongoDB
 ---
 
-To use MikroORM with mongo database, do not forget to install `@mikro-orm/mongodb`
-dependency. Then call `MikroORM.init()` as part of bootstrapping your app:
+To use MikroORM with mongo database, do not forget to install `@mikro-orm/mongodb` dependency. Then call `MikroORM.init()` as part of bootstrapping your app:
 
-> To access driver specific methods like `em.aggregate()` we need to specify
-> the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the
-> `orm.em` to `EntityManager` exported from the driver package:
+> To access driver specific methods like `em.aggregate()` we need to specify the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the `orm.em` to `EntityManager` exported from the driver package:
 >
 > ```ts
 > import { EntityManager } from '@mikro-orm/mongodb';
@@ -41,13 +38,11 @@ _id: ObjectId;
 id!: string; // won't be saved in the database
 ```
 
-> Only `_id: ObjectId` will be saved in the database. `id: string` is virtual and is 
-> also optional. 
+> Only `_id: ObjectId` will be saved in the database. `id: string` is virtual and is also optional.
 
 ## ObjectId and string id duality
 
-Every entity has both `ObjectId` and `string` id available, also all methods of `EntityManager` 
-and `EntityRepository` supports querying by both of them. 
+Every entity has both `ObjectId` and `string` id available, also all methods of `EntityManager` and `EntityRepository` supports querying by both of them.
 
 ```ts
 const author = orm.em.getReference('...id...');
@@ -66,24 +61,21 @@ const bar2 = await repo.find({ _id: { $in: [new ObjectId(article)] }, favouriteB
 
 ## ManyToMany collections with inlined pivot array
 
-As opposed to SQL drivers that use pivot tables, in mongo we can leverage available array type
-to store array of collection items (identifiers). This approach has two main benefits:
+As opposed to SQL drivers that use pivot tables, in mongo we can leverage available array type to store array of collection items (identifiers). This approach has two main benefits:
 
-1. Collection is stored on owning side entity, so we know how many items are there even before
-initializing the collection.
+1. Collection is stored on owning side entity, so we know how many items are there even before initializing the collection.
 2. As there are no pivot tables, resulting database queries are much simpler.
 
 ## Transactions
 
-Starting with v3.4, MongoDB driver supports transactions. To use transactions, there
-are several things you need to respect:
+Starting with v3.4, MongoDB driver supports transactions. To use transactions, there are several things you need to respect:
 
 - you need to use replica set (see [run-rs](https://github.com/vkarpov15/run-rs))
 - implicit transactions are disabled by default
-    - use `implicitTransactions: true` to enable them globally
-    - or use explicit transaction demarcation via `em.transactional()`
+  - use `implicitTransactions: true` to enable them globally
+  - or use explicit transaction demarcation via `em.transactional()`
 - you need to explicitly create all collections before working with them
-    - use `orm.getSchemaGenerator().createSchema()` method to do so
+  - use `orm.getSchemaGenerator().createSchema()` method to do so
 
 ```sh
 # first create replica set
@@ -105,15 +97,11 @@ const orm = await MikroORM.init<MongoDriver>({
 await orm.getSchemaGenerator().createSchema();
 ```
 
-> The `createCollections` method is present on the `MongoDriver` class only. You need 
-> to have the entity manager correctly typed (as `EntityManager<MongoDriver>`).
+> The `createCollections` method is present on the `MongoDriver` class only. You need to have the entity manager correctly typed (as `EntityManager<MongoDriver>`).
 
 ## Indexes
 
-Starting with v3.4, MongoDB driver supports indexes and unique constraints. You can 
-use `@Index()` and `@Unique()` as described in [Defining Entities section](defining-entities.md#indexes).
-To automatically create new indexes when initializing the ORM, you need to enable
-`ensureIndexes` option. 
+Starting with v3.4, MongoDB driver supports indexes and unique constraints. You can use `@Index()` and `@Unique()` as described in [Defining Entities section](defining-entities.md#indexes). To automatically create new indexes when initializing the ORM, you need to enable `ensureIndexes` option.
 
 ```ts
 const orm = await MikroORM.init<MongoDriver>({
@@ -122,7 +110,7 @@ const orm = await MikroORM.init<MongoDriver>({
   type: 'mongo',
   ensureIndexes: true, // defaults to false
 });
-``` 
+```
 
 Alternatively you can call `ensureIndexes()` method on the `SchemaGenerator`:
 
@@ -133,24 +121,20 @@ await orm.getSchemaGenerator().ensureIndexes();
 ```
 
 > You can pass additional index/unique options via `options` parameter:
-> 
+>
 > `@Unique({ options: { partialFilterExpression: { name: { $exists: true } } }})`
 
 > You can also create text indexes by passing `type` parameter:
-> 
+>
 > `@Index({ properties: ['name', 'caption'], type: 'text' })`
 
-> If you provide only `options` in the index definition, it will be used as is, 
-> this allows to define any kind of index:
+> If you provide only `options` in the index definition, it will be used as is, this allows to define any kind of index:
 >
-> `@Index({ options: { point: '2dsphere', title: -1 } })` 
+> `@Index({ options: { point: '2dsphere', title: -1 } })`
 
 ## Native collection methods
 
-Sometimes you need to perform some bulk operation, or you just want to populate your
-database with initial fixtures. Using ORM for such operations can bring unnecessary
-boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete`
-methods:
+Sometimes you need to perform some bulk operation, or you just want to populate your database with initial fixtures. Using ORM for such operations can bring unnecessary boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete` methods:
 
 ```ts
 em.nativeInsert<T extends AnyEntity>(entityName: string, data: any): Promise<IPrimaryKey>;
@@ -158,9 +142,7 @@ em.nativeUpdate<T extends AnyEntity>(entityName: string, where: FilterQuery<T>, 
 em.nativeDelete<T extends AnyEntity>(entityName: string, where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Those methods execute native driver methods like Mongo's `insertOne/updateMany/deleteMany` collection methods respectively. 
-This is common interface for all drivers, so for MySQL driver, it will fire native SQL queries. 
-Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks. 
+Those methods execute native driver methods like Mongo's `insertOne/updateMany/deleteMany` collection methods respectively. This is common interface for all drivers, so for MySQL driver, it will fire native SQL queries. Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks.
 
 They are also available as `EntityRepository` shortcuts:
 

--- a/docs/docs/usage-with-nestjs.md
+++ b/docs/docs/usage-with-nestjs.md
@@ -167,7 +167,7 @@ export class MyService {
 
 > `autoLoadEntities` option was added in v4.1.0
 
-Manually adding entities to the entities array of the connection options can be tedious. In addition, referencing entities from the root module breaks application domain boundaries and causes leaking implementation details to other parts of the  application. To solve this issue, static glob paths can be used.
+Manually adding entities to the entities array of the connection options can be tedious. In addition, referencing entities from the root module breaks application domain boundaries and causes leaking implementation details to other parts of the application. To solve this issue, static glob paths can be used.
 
 Note, however, that glob paths are not supported by webpack, so if you are building your application within a monorepo, you won't be able to use them. To address this issue, an alternative solution is provided. To automatically load entities, set the `autoLoadEntities` property of the configuration object (passed into the `forRoot()` method) to `true`, as shown below:
 
@@ -183,35 +183,23 @@ Note, however, that glob paths are not supported by webpack, so if you are build
 export class AppModule {}
 ```
 
-With that option specified, every entity registered through the `forFeature()`
-method will be automatically added to the entities array of the configuration
-object.
+With that option specified, every entity registered through the `forFeature()` method will be automatically added to the entities array of the configuration object.
 
-> Note that entities that aren't registered through the `forFeature()` method, but
-> are only referenced from the entity (via a relationship), won't be included by
-> way of the `autoLoadEntities` setting.
+> Note that entities that aren't registered through the `forFeature()` method, but are only referenced from the entity (via a relationship), won't be included by way of the `autoLoadEntities` setting.
 
-> Using `autoLoadEntities` also has no effect on the MikroORM CLI - for that we
-> still need CLI config with the full list of entities. On the other hand, we can
-> use globs there, as the CLI won't go through webpack.
+> Using `autoLoadEntities` also has no effect on the MikroORM CLI - for that we still need CLI config with the full list of entities. On the other hand, we can use globs there, as the CLI won't go through webpack.
 
 ## Request scoped handlers in queues
 
 > `@UseRequestContext()` decorator was added in v4.1.0
 
-> Since v5, `@UseRequestContext()` decorator is available in the `@mikro-orm/core`
-> package. It is valid approach not just for nestjs projects.
+> Since v5, `@UseRequestContext()` decorator is available in the `@mikro-orm/core` package. It is valid approach not just for nestjs projects.
 
 As mentioned in the [docs](identity-map.md), we need a clean state for each request. That is handled automatically thanks to the `RequestContext` helper registered via middleware.
 
-But middlewares are executed only for regular HTTP request handles, what if we need
-a request scoped method outside of that? One example of that is queue handlers or
-scheduled tasks.
+But middlewares are executed only for regular HTTP request handles, what if we need a request scoped method outside of that? One example of that is queue handlers or scheduled tasks.
 
-We can use the `@UseRequestContext()` decorator. It requires you to first inject the
-`MikroORM` instance to current context, it will be then used to create the context
-for you. Under the hood, the decorator will register new request context for your
-method and execute it inside the context.
+We can use the `@UseRequestContext()` decorator. It requires you to first inject the `MikroORM` instance to current context, it will be then used to create the context for you. Under the hood, the decorator will register new request context for your method and execute it inside the context.
 
 Keep in mind, that all handlers that are decorated with @UseRequestContext(), should NOT return anything.
 
@@ -244,9 +232,7 @@ export class MyService {
 }
 ```
 
-Another thing to look out for how you combine them with other decorators.
-For example if you use it in combination with NestJS's "[BullJS queues module](https://docs.nestjs.com/techniques/queues)", a safe bet is to extract the part of the code that needs a clean [docs](identity-map.md),
-either in a new method or inject a separate service.
+Another thing to look out for how you combine them with other decorators. For example if you use it in combination with NestJS's "[BullJS queues module](https://docs.nestjs.com/techniques/queues)", a safe bet is to extract the part of the code that needs a clean [docs](identity-map.md), either in a new method or inject a separate service.
 
 ```ts
 @Processor({
@@ -275,27 +261,27 @@ The GraphQL module in NestJS uses `apollo-server-express` which enables `bodypar
 
 This can be done by adding bodyparser to your main.ts file
 
- ```ts
+```ts
 import { NestFactory } from '@nestjs/core';
 import express from 'express';
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule,{ bodyParser: false });
-  app.use(express.json());
-  await app.listen(5555);
+ const app = await NestFactory.create(AppModule,{ bodyParser: false });
+ app.use(express.json());
+ await app.listen(5555);
 }
- ```
+```
 
 And at the same time disabling the bodyparser in the GraphQL Module
 
- ```ts
- @Module({
-  imports: [
-    GraphQLModule.forRoot({
-      bodyParserConfig: false,
-    }),
-  ],
+```ts
+@Module({
+ imports: [
+   GraphQLModule.forRoot({
+     bodyParserConfig: false,
+   }),
+ ],
 })
- ```
+```
 
 ## App shutdown and cleanup
 
@@ -430,8 +416,9 @@ export class PhotoModule {}
 ## Using `AsyncLocalStorage` for request context
 
 :::info
-Since v5 `AsyncLocalStorage` is used inside `RequestContext` helper so this section
-is no longer valid.
+
+Since v5 `AsyncLocalStorage` is used inside `RequestContext` helper so this section is no longer valid.
+
 :::
 
 In older versions, the `domain` api was used in the `RequestContext` helper. Since `@mikro-orm/core@4.0.3`, we can use the new `AsyncLocalStorage` too, if you are on up to date node version:
@@ -486,7 +473,7 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
   }
 
   async afterUpdate(args: EventArgs<Author>): Promise<void> {
-    // ... 
+    // ...
   }
 
 }

--- a/docs/docs/usage-with-sql.md
+++ b/docs/docs/usage-with-sql.md
@@ -3,8 +3,7 @@ title: Usage with MySQL, MariaDB, PostgreSQL or SQLite
 sidebar_label: Usage with SQL Drivers
 ---
 
-To use `mikro-orm` with MySQL database, simply install the `@mikro-orm/mysql` dependency and set 
-the type option to `mysql` when initializing ORM. Since v4 it is no longer needed to install the `mysql2` package manually.
+To use `mikro-orm` with MySQL database, simply install the `@mikro-orm/mysql` dependency and set the type option to `mysql` when initializing ORM. Since v4 it is no longer needed to install the `mysql2` package manually.
 
 ```sh
 yarn add @mikro-orm/core @mikro-orm/mongodb     # for mongo
@@ -26,9 +25,7 @@ npm i -s @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 
 Then call `MikroORM.init` as part of bootstrapping your app:
 
-> To access driver specific methods like `em.createQueryBuilder()` we need to specify
-> the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the
-> `orm.em` to `EntityManager` exported from the driver package:
+> To access driver specific methods like `em.createQueryBuilder()` we need to specify the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the `orm.em` to `EntityManager` exported from the driver package:
 >
 > ```ts
 > import { EntityManager } from '@mikro-orm/postgresql';
@@ -49,9 +46,7 @@ console.log(orm.em); // access EntityManager via `em` property
 
 ## Custom driver
 
-If you want to use database that is not currently supported, you can implement your own driver.
-More information about how to create one can be [found here](custom-driver.md). Then provide the 
-driver class via `driver` configuration option: 
+If you want to use database that is not currently supported, you can implement your own driver. More information about how to create one can be [found here](custom-driver.md). Then provide the driver class via `driver` configuration option:
 
 ```ts
 import { MyCustomDriver } from './MyCustomDriver.ts';
@@ -65,8 +60,7 @@ const orm = await MikroORM.init<MyCustomDriver>({
 
 ## Schema
 
-Currently you will need to maintain the database schema yourself. For initial dump, you can 
-use [`SchemaGenerator` helper](schema-generator.md).  
+Currently you will need to maintain the database schema yourself. For initial dump, you can use [`SchemaGenerator` helper](schema-generator.md).
 
 ## ManyToMany collections with pivot tables
 
@@ -81,8 +75,7 @@ CREATE TABLE `publisher_to_test` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 ```
 
-You can adjust the name of pivot table via `pivotTable` option in `@ManyToMany` decorator
-defined on owning side: 
+You can adjust the name of pivot table via `pivotTable` option in `@ManyToMany` decorator defined on owning side:
 
 ```ts
 // for unidirectional
@@ -96,8 +89,7 @@ tags = new Collection<BookTag>(this);
 
 ## Using QueryBuilder to execute native SQL queries
 
-When you need to execute some SQL query without all the ORM stuff involved, you can either
-compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
+When you need to execute some SQL query without all the ORM stuff involved, you can either compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
 
 ```ts
 const qb = orm.em.createQueryBuilder(Author);
@@ -140,17 +132,13 @@ QueryBuilder.getParams(): any;
 QueryBuilder.clone(): QueryBuilder;
 ```
 
-For more examples of how to work with `QueryBuilder`, take a look at `QueryBuilder` tests in 
-[`tests/QueryBuilder.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/QueryBuilder.test.ts).
+For more examples of how to work with `QueryBuilder`, take a look at `QueryBuilder` tests in [`tests/QueryBuilder.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/QueryBuilder.test.ts).
 
 ## Transactions
 
-When you call `em.flush()`, all computed changes are queried [inside a database
-transaction](unit-of-work.md) by default, so you do not have to handle transactions manually. 
+When you call `em.flush()`, all computed changes are queried [inside a database transaction](unit-of-work.md) by default, so you do not have to handle transactions manually.
 
-When you need to explicitly handle the transaction, you can use `em.transactional(cb)` 
-to run callback in transaction. It will provide forked `EntityManager` as a parameter 
-with clear isolated identity map - please use that to make changes. 
+When you need to explicitly handle the transaction, you can use `em.transactional(cb)` to run callback in transaction. It will provide forked `EntityManager` as a parameter with clear isolated identity map - please use that to make changes.
 
 ```ts
 // if an error occurs inside the callback, all db queries from inside the callback will be rolled back
@@ -171,16 +159,13 @@ const author3 = new Author2('Author 3', 'a3@example.com');
 await orm.em.persistAndFlush([author1, author2, author3]);
 
 // finds authors with email like '%exa%le.c_m'
-const authors = await orm.em.find(Author2, { email: /exa.*le\.c.m$/ }); 
+const authors = await orm.em.find(Author2, { email: /exa.*le\.c.m$/ });
 console.log(authors); // all 3 authors found
 ```
 
 ## Native Collection Methods
 
-Sometimes you need to perform some bulk operation, or you just want to populate your
-database with initial fixtures. Using ORM for such operations can bring unnecessary
-boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete`
-methods:
+Sometimes you need to perform some bulk operation, or you just want to populate your database with initial fixtures. Using ORM for such operations can bring unnecessary boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete` methods:
 
 ```ts
 em.nativeInsert<T extends AnyEntity>(entityName: string, data: any): Promise<IPrimaryKey>;
@@ -188,9 +173,7 @@ em.nativeUpdate<T extends AnyEntity>(entityName: string, where: FilterQuery<T>, 
 em.nativeDelete<T extends AnyEntity>(entityName: string, where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Those methods execute native SQL queries generated via `QueryBuilder` based on entity 
-metadata. Keep in mind that they do not hydrate results to entities, and they do not 
-trigger lifecycle hooks. 
+Those methods execute native SQL queries generated via `QueryBuilder` based on entity metadata. Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks.
 
 They are also available as `EntityRepository` shortcuts:
 
@@ -200,9 +183,7 @@ EntityRepository.nativeUpdate(where: FilterQuery<T>, data: any): Promise<number>
 EntityRepository.nativeDelete(where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Additionally there is `execute()` method that supports executing raw SQL queries or `QueryBuilder`
-instances. To create `QueryBuilder`, you can use `createQueryBuilder()` factory method on both 
-`EntityManager` and `EntityRepository` classes: 
+Additionally there is `execute()` method that supports executing raw SQL queries or `QueryBuilder` instances. To create `QueryBuilder`, you can use `createQueryBuilder()` factory method on both `EntityManager` and `EntityRepository` classes:
 
 ```ts
 const qb = em.createQueryBuilder('Author');

--- a/docs/docs/using-bigint-pks.md
+++ b/docs/docs/using-bigint-pks.md
@@ -2,8 +2,7 @@
 title: Using native BigInt PKs (MySQL and PostgreSQL)
 ---
 
-We can use `BigIntType` to support `bigint`s. By default, it will represent the value as
-a `string`.
+We can use `BigIntType` to support `bigint`s. By default, it will represent the value as a `string`.
 
 ```ts
 import { Entity, PrimaryKey, t } from '@mikro-orm/core';
@@ -17,10 +16,7 @@ export class Book {
 }
 ```
 
-`bigint` can fit larger numbers than JavaScript number, for this reason it
-is mapped to a string. If we want to map it to a number anyway, we can implement
-[custom type](custom-types.md) that will do so. Similarly, we can define one to 
-use the native `bigint` type:
+`bigint` can fit larger numbers than JavaScript number, for this reason it is mapped to a string. If we want to map it to a number anyway, we can implement [custom type](custom-types.md) that will do so. Similarly, we can define one to use the native `bigint` type:
 
 ```ts
 export class NativeBigIntType extends BigIntType {

--- a/docs/docs/virtual-entities.md
+++ b/docs/docs/virtual-entities.md
@@ -5,7 +5,7 @@ title: Virtual Entities
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Virtual entities don't represent any database table. Instead, they dynamically resolve to an SQL query (or an aggregation in mongo), allowing to map any kind of results onto an entity. Such entities are mean for read purposes, they don't have a primary key and therefore cannot be tracked for changes. In a sense they are similar to (currently unsupported) database views. 
+Virtual entities don't represent any database table. Instead, they dynamically resolve to an SQL query (or an aggregation in mongo), allowing to map any kind of results onto an entity. Such entities are mean for read purposes, they don't have a primary key and therefore cannot be tracked for changes. In a sense they are similar to (currently unsupported) database views.
 
 To define a virtual entity, provide an `expression`, either as a string (SQL query):
 
@@ -85,7 +85,7 @@ export interface IBookWithAuthor{
   tags: string[];
 }
 
-export const BookWithAuthor = new EntitySchema<IBookWithAuthor>({ 
+export const BookWithAuthor = new EntitySchema<IBookWithAuthor>({
   name: 'BookWithAuthor',
   expression: 'select name, age, ' +
     '(select count(*) from book b where b.author_id = a.id) as total_books, ' +

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,8 @@
     "start": "docusaurus start",
     "build": "node --max_old_space_size=16000 node_modules/@docusaurus/core/bin/docusaurus.mjs build",
     "swizzle": "docusaurus swizzle",
-    "deploy": "node --max_old_space_size=16000 node_modules/@docusaurus/core/bin/docusaurus.mjs deploy"
+    "deploy": "node --max_old_space_size=16000 node_modules/@docusaurus/core/bin/docusaurus.mjs deploy",
+    "prettier": "prettier --write 'docs/**/*.md' 'blog/**/*.md' 'versioned_docs/**/*.md'"
   },
   "dependencies": {
     "@docusaurus/core": "2.3.1",
@@ -29,5 +30,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "prettier": "^2.8.4"
   }
 }

--- a/docs/versioned_docs/version-2.7/cascading.md
+++ b/docs/versioned_docs/version-2.7/cascading.md
@@ -3,14 +3,11 @@ title: Cascading persist, merge and remove
 sidebar_label: Cascading
 ---
 
-When persisting or removing entity, all your references are by default cascade persisted. 
-This means that by persisting any entity, ORM will automatically persist all of its 
-associations. 
+When persisting or removing entity, all your references are by default cascade persisted. This means that by persisting any entity, ORM will automatically persist all of its associations.
 
-You can control this behaviour via `cascade` attribute of `@ManyToOne`, `@ManyToMany`, 
-`@OneToMany` and `@OneToOne` fields.
+You can control this behaviour via `cascade` attribute of `@ManyToOne`, `@ManyToMany`, `@OneToMany` and `@OneToOne` fields.
 
-> New entities without primary key will be always persisted, regardless of `cascade` value. 
+> New entities without primary key will be always persisted, regardless of `cascade` value.
 
 ```typescript
 // cascade persist & merge is default value
@@ -54,18 +51,13 @@ book.tags[1].name = 'new name 2';
 await orm.em.persistAndFlush(book); // all book tags and author will be persisted too
 ```
 
-> When cascade persisting collections, keep in mind only fully initialized collections 
-> will be cascade persisted.
+> When cascade persisting collections, keep in mind only fully initialized collections will be cascade persisted.
 
 ## Cascade merge
 
-When you want to merge entity and all its associations, you can use `Cascade.MERGE`. This
-comes handy when you want to clear identity map (e.g. when importing large number of entities), 
-but you also have to keep your parent entities managed (because otherwise they would be considered
-as new entities and insert-persisted, which would fail with non-unique identifier).
+When you want to merge entity and all its associations, you can use `Cascade.MERGE`. This comes handy when you want to clear identity map (e.g. when importing large number of entities), but you also have to keep your parent entities managed (because otherwise they would be considered as new entities and insert-persisted, which would fail with non-unique identifier).
 
-In following example, without having `Author.favouriteBook` set to cascade merge, you would 
-get an error because it would be cascade-inserted with already taken ID. 
+In following example, without having `Author.favouriteBook` set to cascade merge, you would get an error because it would be cascade-inserted with already taken ID.
 
 ```typescript
 const a1 = new Author(...);
@@ -75,13 +67,13 @@ await orm.em.persistAndFlush(a1); // cascade persists favourite book as well
 for (let i = 1; i < 1000; i++) {
   const book = new Book('...', a1);
   orm.em.persistLater(book);
-  
+
   // persist every 100 records
   if (i % 100 === 0) {
     await orm.em.flush();
     orm.em.clear(); // this makes both a1 and his favourite book detached
     orm.em.merge(a1); // so we need to merge them to prevent cascade-inserts
-    
+
     // without cascade merge, you would need to manually merge all his associations
     orm.em.merge(a1.favouriteBook); // not needed with Cascade.MERGE
   }
@@ -92,18 +84,15 @@ await orm.em.flush();
 
 ## Cascade remove
 
-Cascade remove works same way as cascade persist, just for removing entities. Following 
-example assumes that `Book.publisher` is set to `Cascade.REMOVE`:
+Cascade remove works same way as cascade persist, just for removing entities. Following example assumes that `Book.publisher` is set to `Cascade.REMOVE`:
 
-> Note that cascade remove for collections can be inefficient as it will fire 1 query
-> for each entity in collection.
+> Note that cascade remove for collections can be inefficient as it will fire 1 query for each entity in collection.
 
 ```typescript
 await orm.em.removeEntity(book); // this will also remove book.publisher
 ```
 
-Keep in mind that cascade remove **can be dangerous** when used on `@ManyToOne` fields, 
-as cascade removed entity can stay referenced in another entities that were not removed.
+Keep in mind that cascade remove **can be dangerous** when used on `@ManyToOne` fields, as cascade removed entity can stay referenced in another entities that were not removed.
 
 ```typescript
 const publisher = new Publisher(...);
@@ -117,9 +106,7 @@ console.log(book2.publisher, book3.publisher);
 
 ## Orphan removal
 
-In addition to `Cascade.REMOVE`, there is also additional and more aggressive remove 
-cascading mode which can be specified using the `orphanRemoval` flag of the `@OneToOne`
-and `@OneToMany` properties:
+In addition to `Cascade.REMOVE`, there is also additional and more aggressive remove cascading mode which can be specified using the `orphanRemoval` flag of the `@OneToOne` and `@OneToMany` properties:
 
 ```typescript
 export class Author {
@@ -128,13 +115,9 @@ export class Author {
 }
 ```
 
-> `orphanRemoval` flag behaves just like `Cascade.REMOVE` for remove operation, so specifying 
-> both is redundant.
+> `orphanRemoval` flag behaves just like `Cascade.REMOVE` for remove operation, so specifying both is redundant.
 
-With simple `Cascade.REMOVE`, you wound need to remove the `Author` entity to cascade 
-the operation down to all loaded `Book`s. By enabling orphan removal on the collection, 
-`Book`s will be also removed when they get disconnected from the collection (either via 
-`remove()`, or by replacing collection items via `set()`):
+With simple `Cascade.REMOVE`, you wound need to remove the `Author` entity to cascade the operation down to all loaded `Book`s. By enabling orphan removal on the collection, `Book`s will be also removed when they get disconnected from the collection (either via `remove()`, or by replacing collection items via `set()`):
 
 ```typescript
 await author.books.set([book1, book2]); // replace whole collection
@@ -142,5 +125,4 @@ await author.books.remove(book1); // remove book from collection
 await orm.em.persistAndFlush(author); // book1 will be removed, as well as all original items (before we called `set()`)
 ```
 
-In this example, no `Book` would be removed with simple `Cascade.REMOVE` as no remove operation
-was executed. 
+In this example, no `Book` would be removed with simple `Cascade.REMOVE` as no remove operation was executed.

--- a/docs/versioned_docs/version-2.7/collections.md
+++ b/docs/versioned_docs/version-2.7/collections.md
@@ -2,15 +2,11 @@
 title: Collections
 ---
 
-`OneToMany` and `ManyToMany` collections are stored in a `Collection` wrapper. It implements
-iterator so you can use `for of` loop to iterate through it. 
+`OneToMany` and `ManyToMany` collections are stored in a `Collection` wrapper. It implements iterator so you can use `for of` loop to iterate through it.
 
-Another way to access collection items is to use bracket syntax like when you access array items.
-Keep in mind that this approach will not check if the collection is initialed, while using `get`
-method will throw error in this case.
+Another way to access collection items is to use bracket syntax like when you access array items. Keep in mind that this approach will not check if the collection is initialed, while using `get` method will throw error in this case.
 
-> Note that array access in `Collection` is available only for reading already loaded items, you 
-> cannot add new items to `Collection` this way. 
+> Note that array access in `Collection` is available only for reading already loaded items, you cannot add new items to `Collection` this way.
 
 ```typescript
 const author = orm.em.findOne(Author, '...', ['books']); // populating books collection
@@ -51,7 +47,7 @@ console.log(author.books[12345]); // undefined, even if the collection is not in
 ## OneToMany collections
 
 `OneToMany` collections are inverse side of `ManyToOne` references, to which they need to point via `fk` attribute:
- 
+
 ```typescript
 @Entity()
 export class Book {
@@ -78,8 +74,7 @@ export class Author {
 
 ## ManyToMany collections
 
-As opposed to SQL databases, with MongoDB we do not need to have join tables for `ManyToMany` relations. 
-All references are stored as an array of `ObjectID`s on owning entity. 
+As opposed to SQL databases, with MongoDB we do not need to have join tables for `ManyToMany` relations. All references are stored as an array of `ObjectID`s on owning entity.
 
 ### Unidirectional
 
@@ -92,8 +87,7 @@ books = new Collection<Book>(this);
 
 ### Bidirectional
 
-Bidirectional `ManyToMany` relations are defined on both sides, while one is owning side (where references are store), 
-marked by `inversedBy` attribute pointing to the inverse side:
+Bidirectional `ManyToMany` relations are defined on both sides, while one is owning side (where references are store), marked by `inversedBy` attribute pointing to the inverse side:
 
 ```typescript
 @ManyToMany({ entity: () => BookTag, inversedBy: 'books' })
@@ -109,8 +103,7 @@ books = new Collection<Book>(this);
 
 ## Propagation of Collection's add() and remove() operations
 
-When you use one of `Collection.add()` method, the item is added to given collection, 
-and this action is also propagated to its counterpart. 
+When you use one of `Collection.add()` method, the item is added to given collection, and this action is also propagated to its counterpart.
 
 ```typescript
 // one to many
@@ -121,7 +114,7 @@ author.books.add(book);
 console.log(book.author); // author will be set thanks to the propagation
 ```
 
-For M:N this works in both ways, either from owning side, or from inverse side. 
+For M:N this works in both ways, either from owning side, or from inverse side.
 
 ```typescript
 // many to many works both from owning side and from inverse side
@@ -133,12 +126,10 @@ console.log(tag.books.contains(book)); // true
 
 tag.books.add(book);
 console.log(book.tags.contains(tag)); // true
-``` 
+```
 
 > Collections on both sides have to be initialized, otherwise propagation won't work.
 
-> Although this propagation works also for M:N inverse side, you should always use owning
-> side to manipulate the collection.
+> Although this propagation works also for M:N inverse side, you should always use owning side to manipulate the collection.
 
 Same applies for `Collection.remove()`.
-

--- a/docs/versioned_docs/version-2.7/custom-driver.md
+++ b/docs/versioned_docs/version-2.7/custom-driver.md
@@ -2,18 +2,17 @@
 title: Creating Custom Driver
 ---
 
-If you want to use database that is not currently supported, you can implement your own driver.
-To do so, you will need to design 4 classes:
+If you want to use database that is not currently supported, you can implement your own driver. To do so, you will need to design 4 classes:
 
 ## Platform
 
-Platform is a class that provides information about available features of given driver: 
+Platform is a class that provides information about available features of given driver:
 
 ```typescript
 import { Platform } from 'mikro-orm';
 
 export class MyCustomPlatform extends Platform {
-  
+
   protected abstract schemaHelper: MyCustomSchemaHelper;
 
   // here you can override default settings
@@ -39,7 +38,7 @@ Part of platform is a `SchemaHelper`, that provides information about how to bui
 import { SchemaHelper } from 'mikro-orm';
 
 export class MyCustomSchemaHelper extends SchemaHelper {
-  
+
   // here you can override default settings
   getIdentifierQuoteCharacter(): string;
   getSchemaBeginning(): string;
@@ -67,7 +66,7 @@ Next part is connection wrapper, that will be responsible for querying the datab
 import { Connection } from 'mikro-orm';
 
 export class MyCustomConnection extends Connection {
-  
+
   // implement abstract methods
   connect(): Promise<void>;
   isConnected(): Promise<boolean>;
@@ -80,12 +79,9 @@ export class MyCustomConnection extends Connection {
 
 ## Driver
 
-Last part is driver, that is responsible for using the connection to persist changes to 
-database. If you are building SQL driver, it might be handy to extend `AbstractSqlDriver`, 
-if not, extend `DatabaseDriver` abstract class. 
+Last part is driver, that is responsible for using the connection to persist changes to database. If you are building SQL driver, it might be handy to extend `AbstractSqlDriver`, if not, extend `DatabaseDriver` abstract class.
 
-If you want to have absolute control, you can implement the whole driver yourself via
-`IDatabaseDriver` interface. 
+If you want to have absolute control, you can implement the whole driver yourself via `IDatabaseDriver` interface.
 
 ```typescript
 import { DatabaseDriver } from 'mikro-orm';

--- a/docs/versioned_docs/version-2.7/debugging.md
+++ b/docs/versioned_docs/version-2.7/debugging.md
@@ -20,8 +20,7 @@ By doing this `MikroORM` will start using provided logger function to dump all q
 [query-logger] COMMIT [took 2 ms]
 ```
 
-It is also useful for debugging problems with entity discovery, as you will see information
-about every processed entity:
+It is also useful for debugging problems with entity discovery, as you will see information about every processed entity:
 
 ```
 ORM entity discovery started

--- a/docs/versioned_docs/version-2.7/defining-entities.md
+++ b/docs/versioned_docs/version-2.7/defining-entities.md
@@ -2,10 +2,7 @@
 title: Defining entities
 ---
 
-Entities are simple javascript objects (so called POJO), decorated with `@Entity` decorator.
-No real restrictions are made, you do not have to extend any base class, you are more than welcome
-to [use entity constructors](entity-constructors.md), just do not forget to specify primary key with
-`@PrimaryKey` decorator.
+Entities are simple javascript objects (so called POJO), decorated with `@Entity` decorator. No real restrictions are made, you do not have to extend any base class, you are more than welcome to [use entity constructors](entity-constructors.md), just do not forget to specify primary key with `@PrimaryKey` decorator.
 
 ```typescript title="./entities/Book.ts"
 @Entity()
@@ -42,16 +39,11 @@ export class Book {
 export interface Book extends IEntity<string> { }
 ```
 
-You will need to extend Book's interface with `IEntity`. The interface represents internal 
-methods added to your entity's prototype via `@Entity` decorator.
+You will need to extend Book's interface with `IEntity`. The interface represents internal methods added to your entity's prototype via `@Entity` decorator.
 
-> `IEntity` is generic interface, its type parameter depends on data type of normalized primary
-> key produced by used driver. SQL drivers usually use `number` and Mongo driver uses `string`.
-> This type default to union type `number | string`. Keep in mind that you have to worry about 
-> this only when you define your primary key as `_id` instead of `id`.
+> `IEntity` is generic interface, its type parameter depends on data type of normalized primary key produced by used driver. SQL drivers usually use `number` and Mongo driver uses `string`. This type default to union type `number | string`. Keep in mind that you have to worry about this only when you define your primary key as `_id` instead of `id`.
 
-As you can see, entity properties are decorated either with `@Property` decorator, or with one
-of reference decorators: `@ManyToOne`, `@OneToMany`, `@OneToOne` and `@ManyToMany`. 
+As you can see, entity properties are decorated either with `@Property` decorator, or with one of reference decorators: `@ManyToOne`, `@OneToMany`, `@OneToOne` and `@ManyToMany`.
 
 Here is another example of `Author` entity, that was referenced from the `Book` one:
 
@@ -119,16 +111,13 @@ You are free to choose one of those formats for entity filename (for a `BookTag`
 - `book-tag.model.ts`
 - `book-tag.entity.ts`
 
-Entity name is inferred from the first part of file name before first dot occurs, so you can 
-add any suffix behind the dot, not just `.model.ts` or `.entity.ts`. 
+Entity name is inferred from the first part of file name before first dot occurs, so you can add any suffix behind the dot, not just `.model.ts` or `.entity.ts`.
 
 ## Using BaseEntity
 
-You can define your own base entity with properties that you require on all entities, like
-primary key and created/updated time. 
+You can define your own base entity with properties that you require on all entities, like primary key and created/updated time.
 
-> If you are initializing the ORM via `entities` option, you need to specify all your
-> base entities as well.
+> If you are initializing the ORM via `entities` option, you need to specify all your base entities as well.
 
 ```typescript title="./entities/BaseEntity.ts"
 export abstract class BaseEntity {
@@ -147,8 +136,7 @@ export abstract class BaseEntity {
 
 ## Note about SQL drivers and @PrimaryKey
 
-All entities described above were defined with `_id: ObjectID` primary key - those were Mongo
-entities. 
+All entities described above were defined with `_id: ObjectID` primary key - those were Mongo entities.
 
 For SQL drivers, you will want to define your primary key as `id: number` instead:
 
@@ -157,6 +145,4 @@ For SQL drivers, you will want to define your primary key as `id: number` instea
 id: number;
 ```
 
-With your entities set up, you can start [using entity manager](entity-manager.md) and 
-[repositories](repositories.md) as described in following sections. 
-
+With your entities set up, you can start [using entity manager](entity-manager.md) and [repositories](repositories.md) as described in following sections.

--- a/docs/versioned_docs/version-2.7/entity-constructors.md
+++ b/docs/versioned_docs/version-2.7/entity-constructors.md
@@ -2,12 +2,9 @@
 title: Using entity constructors
 ---
 
-Internally, `MikroORM` never calls entity constructor, so you are free to use it as you wish.
-The constructor will be called only when you instantiate the class yourself via `new` operator,
-so it is a handy place to require your data when creating new entity.
+Internally, `MikroORM` never calls entity constructor, so you are free to use it as you wish. The constructor will be called only when you instantiate the class yourself via `new` operator, so it is a handy place to require your data when creating new entity.
 
-For example following `Book` entity definition will always require to set `title` and `author`, 
-but `publisher` will be optional:
+For example following `Book` entity definition will always require to set `title` and `author`, but `publisher` will be optional:
 
 ```typescript
 @Entity()
@@ -37,4 +34,3 @@ export class Book {
 
 export interface Book extends IEntity { }
 ```
-

--- a/docs/versioned_docs/version-2.7/entity-helper.md
+++ b/docs/versioned_docs/version-2.7/entity-helper.md
@@ -5,10 +5,7 @@ sidebar_label: Updating Entity Values
 
 ## Updating entity values with IEntity.assign()
 
-When you want to update entity based on user input, you will usually have just plain
-string ids of entity relations as user input. Normally you would need to use 
-`EntityManager.getReference()` to create references from each id first, and then
-use those references to update entity relations:
+When you want to update entity based on user input, you will usually have just plain string ids of entity relations as user input. Normally you would need to use `EntityManager.getReference()` to create references from each id first, and then use those references to update entity relations:
 
 ```typescript
 const jon = new Author('Jon Snow', 'snow@wall.st');
@@ -19,8 +16,8 @@ book.author = orm.em.getReference<Author>(Author, '...id...');
 Same result can be easily achieved with `IEntity.assign()`:
 
 ```typescript
-book.assign({ 
-  title: 'Better Book 1', 
+book.assign({
+  title: 'Better Book 1',
   author: '...id...',
 });
 console.log(book.title); // 'Better Book 1'
@@ -28,9 +25,7 @@ console.log(book.author); // instance of Author with id: '...id...'
 console.log(book.author.id); // '...id...'
 ```
 
-By default, `IEntity.assign(data)` behaves same way as `Object.assign(entity, data)`, 
-e.g. it does not merge things recursively. To enable deep merging of object properties, 
-use second parameter to enable `mergeObjects` flag:
+By default, `IEntity.assign(data)` behaves same way as `Object.assign(entity, data)`, e.g. it does not merge things recursively. To enable deep merging of object properties, use second parameter to enable `mergeObjects` flag:
 
 ```typescript
 book.meta = { foo: 1, bar: 2 };
@@ -41,4 +36,3 @@ console.log(book.meta); // { foo: 3, bar: 2 }
 book.assign({ meta: { foo: 4 } });
 console.log(book.meta); // { foo: 4 }
 ```
-

--- a/docs/versioned_docs/version-2.7/entity-manager.md
+++ b/docs/versioned_docs/version-2.7/entity-manager.md
@@ -5,28 +5,17 @@ sidebar_label: Entity Manager
 
 ## Persist and flush
 
-There are 2 methods we should first describe to understand how persisting works in MikroORM: 
-`em.persist()` and `em.flush()`.
+There are 2 methods we should first describe to understand how persisting works in MikroORM: `em.persist()` and `em.flush()`.
 
-`em.persist(entity, flush?: boolean)` is used to mark new entities for future persisting. 
-It will make the entity managed by given `EntityManager` and once `flush` will be called, it 
-will be written to the database. Second boolean parameter can be used to invoke `flush` 
-immediately. Its default value is configurable via `autoFlush` option.
+`em.persist(entity, flush?: boolean)` is used to mark new entities for future persisting. It will make the entity managed by given `EntityManager` and once `flush` will be called, it will be written to the database. Second boolean parameter can be used to invoke `flush` immediately. Its default value is configurable via `autoFlush` option.
 
-To understand `flush`, lets first define what managed entity is: An entity is managed if 
-it’s fetched from the database (via `em.find()`, `em.findOne()` or via other managed entity) 
-or registered as new through `em.persist()`.
+To understand `flush`, lets first define what managed entity is: An entity is managed if it’s fetched from the database (via `em.find()`, `em.findOne()` or via other managed entity) or registered as new through `em.persist()`.
 
-`em.flush()` will go through all managed entities, compute appropriate change sets and 
-perform according database queries. As an entity loaded from database becomes managed 
-automatically, you do not have to call persist on those, and flush is enough to update 
-them.
+`em.flush()` will go through all managed entities, compute appropriate change sets and perform according database queries. As an entity loaded from database becomes managed automatically, you do not have to call persist on those, and flush is enough to update them.
 
 ## Persisting and cascading
 
-To save entity state to database, you need to persist it. Persist determines 
-whether to use `insert` or `update` and computes appropriate change-set. Entity references
-that are not persisted yet (does not have identifier) will be cascade persisted automatically. 
+To save entity state to database, you need to persist it. Persist determines whether to use `insert` or `update` and computes appropriate change-set. Entity references that are not persisted yet (does not have identifier) will be cascade persisted automatically.
 
 ```typescript
 // use constructors in your entities for required parameters
@@ -48,14 +37,13 @@ await orm.em.persistAndFlush([book1, book2, book3]);
 // or one by one
 orm.em.persistLater(book1);
 orm.em.persistLater(book2);
-orm.em.persistLater(book3); 
+orm.em.persistLater(book3);
 await orm.em.flush(); // flush everything to database at once
 ```
 
 ### Auto flushing
 
-By default, `EntityManager.persist()` will **flush your changes automatically**. You can use
-its second parameter to disable auto-flushing, and use `EntityManager.flush()` manually. 
+By default, `EntityManager.persist()` will **flush your changes automatically**. You can use its second parameter to disable auto-flushing, and use `EntityManager.flush()` manually.
 
 You can also disable this feature globally via `autoFlush` option when initializing the ORM:
 
@@ -69,13 +57,11 @@ await orm.em.flush();
 await orm.em.persist(new Entity(), true); // you can still use second parameter to auto-flush
 ```
 
-> Default value of `autoFlush` is currently set to `true`, which will change in upcoming major 
-> release. Users are encouraged to either set `autoFlush` to `false` or use `em.persistLater()` 
-> (equal to `em.persist(entity, false)`) and `em.persistAndFlush()` methods instead. 
+> Default value of `autoFlush` is currently set to `true`, which will change in upcoming major release. Users are encouraged to either set `autoFlush` to `false` or use `em.persistLater()` (equal to `em.persist(entity, false)`) and `em.persistAndFlush()` methods instead.
 
 ## Fetching entities with EntityManager
 
-To fetch entities from database you can use `find()` and `findOne()` of `EntityManager`: 
+To fetch entities from database you can use `find()` and `findOne()` of `EntityManager`:
 
 Example:
 
@@ -112,8 +98,7 @@ console.log(author.email); // undefined
 
 ## Type of fetched entities
 
-Both `EntityManager.find` and `EntityManager.findOne()` methods have generic return types.
-All of following examples are equal and will let typescript correctly infer the entity type:
+Both `EntityManager.find` and `EntityManager.findOne()` methods have generic return types. All of following examples are equal and will let typescript correctly infer the entity type:
 
 ```typescript
 const author1 = await orm.em.findOne<Author>(Author.name, '...id...');
@@ -121,30 +106,23 @@ const author2 = await orm.em.findOne<Author>('Author', '...id...');
 const author3 = await orm.em.findOne(Author, '...id...');
 ```
 
-As the last one is the least verbose, it should be preferred. 
+As the last one is the least verbose, it should be preferred.
 
 ## Entity repositories
 
-Although you can use `EntityManager` directly, much more convenient way is to use 
-[`EntityRepository` instead](https://mikro-orm.io/repositories/). You can register
-your repositories in dependency injection container like [InversifyJS](http://inversify.io/)
-so you do not need to get them from `EntityManager` each time.
+Although you can use `EntityManager` directly, much more convenient way is to use [`EntityRepository` instead](https://mikro-orm.io/repositories/). You can register your repositories in dependency injection container like [InversifyJS](http://inversify.io/) so you do not need to get them from `EntityManager` each time.
 
-For more examples, take a look at
-[`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts)
-or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).
+For more examples, take a look at [`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts) or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).
 
 ## EntityManager API
 
 #### `getRepository<T extends IEntity>(entityName: string | EntityClass<T>): EntityRepository<T>`
 
-Returns `EntityRepository` for given entity, respects `customRepository` option of `@Entity`
-and `entityRepository` option of `MikroORM.init()`.
+Returns `EntityRepository` for given entity, respects `customRepository` option of `@Entity` and `entityRepository` option of `MikroORM.init()`.
 
 #### `find<T extends IEntity>(entityName: string | EntityClass<T>, where?: FilterQuery<T>, options?: FindOptions): Promise<T[]>`
 
-Returns array of entities found for given condition. You can specify `FindOptions` to request
-population of referenced entities or control the pagination:
+Returns array of entities found for given condition. You can specify `FindOptions` to request population of referenced entities or control the pagination:
 
 ```typescript
 export interface FindOptions {
@@ -159,51 +137,43 @@ export interface FindOptions {
 
 #### `find<T extends IEntity>(entityName: string | EntityClass<T>, where?: FilterQuery<T>, populate?: string[], orderBy?: { [k: string]: QueryOrder }, limit?: number, offset?: number): Promise<T[]>`
 
-Same as previous `find` method, just with dedicated parameters for `populate`, `orderBy`, `limit`
-and `offset`.
+Same as previous `find` method, just with dedicated parameters for `populate`, `orderBy`, `limit` and `offset`.
 
 ---
 
 #### `findOne<T extends IEntity>(entityName: string | EntityClass<T>, where: FilterQuery<T> | string, populate?: string[]): Promise<T | null>`
 
-Finds an entity by given `where` condition. You can use primary key as `where` value, then
-if the entity is already managed, no database call will be made. 
+Finds an entity by given `where` condition. You can use primary key as `where` value, then if the entity is already managed, no database call will be made.
 
 ---
 
 #### `merge<T extends IEntity>(entityName: string | EntityClass<T>, data: EntityData<T>): T`
 
-Adds given entity to current Identity Map. After merging, entity becomes managed. 
-This is useful when you want to work with cached entities. 
+Adds given entity to current Identity Map. After merging, entity becomes managed. This is useful when you want to work with cached entities.
 
 ---
 
 #### `map<T extends IEntity>(entityName: string | EntityClass<T>, data: EntityData<T>): T`
 
-Maps raw DB result to entity, adding it to current Identity Map. Equivalent to 
-`IDatabaseDriver.mapResult()` followed by `EntityManager.merge()`.
+Maps raw DB result to entity, adding it to current Identity Map. Equivalent to `IDatabaseDriver.mapResult()` followed by `EntityManager.merge()`.
 
 ---
 
 #### `getReference<T extends IEntity>(entityName: string | EntityClass<T>, id: string): T`
 
-Gets a reference to the entity identified by the given type and identifier without actually 
-loading it, if the entity is not yet loaded.
+Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded.
 
 ---
 
 #### `count(entityName: string | EntityClass<T>, where: any): Promise<number>`
 
-Gets count of entities matching the `where` condition. 
+Gets count of entities matching the `where` condition.
 
 ---
 
 #### `persist(entity: IEntity | IEntity[], flush?: boolean): Promise<void>`
 
-Tells the EntityManager to make an instance managed and persistent. The entity will be 
-entered into the database at or before transaction commit or as a result of the flush 
-operation. You can control immediate flushing via `flush` parameter and via `autoFlush`
-configuration option. 
+Tells the EntityManager to make an instance managed and persistent. The entity will be entered into the database at or before transaction commit or as a result of the flush operation. You can control immediate flushing via `flush` parameter and via `autoFlush` configuration option.
 
 ---
 
@@ -215,7 +185,7 @@ Shortcut for `persist` & `flush`.
 
 #### `persistLater(entity: IEntity | IEntity[]): void`
 
-Shortcut for just `persist`, without flushing. 
+Shortcut for just `persist`, without flushing.
 
 ---
 
@@ -227,20 +197,17 @@ Flushes all changes to objects that have been queued up to now to the database.
 
 #### `remove(entityName: string | EntityClass<T>, where: IEntity | any, flush?: boolean): Promise<number>`
 
-When provided entity instance as `where` value, then it calls `removeEntity(entity, flush)`, 
-otherwise it fires delete query with given `where` condition. 
+When provided entity instance as `where` value, then it calls `removeEntity(entity, flush)`, otherwise it fires delete query with given `where` condition.
 
-This method fires `beforeDelete` and `afterDelete` hooks only if you provide entity instance.  
+This method fires `beforeDelete` and `afterDelete` hooks only if you provide entity instance.
 
 ---
 
 #### `removeEntity(entity: IEntity, flush?: boolean): Promise<number>`
 
-Removes an entity instance. A removed entity will be removed from the database at or before 
-transaction commit or as a result of the flush operation. You can control immediate flushing 
-via `flush` parameter and via `autoFlush` configuration option.
+Removes an entity instance. A removed entity will be removed from the database at or before transaction commit or as a result of the flush operation. You can control immediate flushing via `flush` parameter and via `autoFlush` configuration option.
 
-This method fires `beforeDelete` and `afterDelete` hooks.  
+This method fires `beforeDelete` and `afterDelete` hooks.
 
 ---
 
@@ -252,21 +219,18 @@ Shortcut for `removeEntity` & `flush`.
 
 #### `removeLater(entity: IEntity): void`
 
-Shortcut for `removeEntity` without flushing. 
+Shortcut for `removeEntity` without flushing.
 
 ---
 
 #### `clear(): void`
 
-Clears the EntityManager. All entities that are currently managed by this EntityManager 
-become detached.
+Clears the EntityManager. All entities that are currently managed by this EntityManager become detached.
 
 ---
 
 #### `canPopulate(entityName: string | EntityClass<T>, property: string): boolean`
 
-Returns whether given entity has given property which can be populated (is reference or
-collection).
+Returns whether given entity has given property which can be populated (is reference or collection).
 
 ---
-

--- a/docs/versioned_docs/version-2.7/entity-references.md
+++ b/docs/versioned_docs/version-2.7/entity-references.md
@@ -2,12 +2,9 @@
 title: Entity References
 ---
 
-Every single entity relation is mapped to an entity reference. Reference is an entity that has
-only its identifier. This reference is stored in identity map so you will get the same object 
-reference when fetching the same document from database.
+Every single entity relation is mapped to an entity reference. Reference is an entity that has only its identifier. This reference is stored in identity map so you will get the same object reference when fetching the same document from database.
 
-You can call `await entity.init()` to initialize the entity. This will trigger database call 
-and populate itself, keeping the same reference in identity map. 
+You can call `await entity.init()` to initialize the entity. This will trigger database call and populate itself, keeping the same reference in identity map.
 
 ```typescript
 const author = orm.em.getReference('...id...');
@@ -19,4 +16,3 @@ await author.init(); // this will trigger db call
 console.log(author.isInitialized()); // true
 console.log(author.name); // defined
 ```
-

--- a/docs/versioned_docs/version-2.7/identity-map.md
+++ b/docs/versioned_docs/version-2.7/identity-map.md
@@ -2,8 +2,7 @@
 title: Identity Map and Request Context
 ---
 
-`MikroORM` uses identity map in background so you will always get the same instance of 
-one entity.
+`MikroORM` uses identity map in background so you will always get the same instance of one entity.
 
 ```typescript
 const authorRepository = orm.em.getRepository(Author);
@@ -20,8 +19,7 @@ If you want to clear this identity map cache, you can do so via `EntityManager.c
 orm.em.clear();
 ```
 
-You should always keep unique identity map per each request. This basically means that you need 
-to clone entity manager and use the clone in request context. There are two ways to achieve this:
+You should always keep unique identity map per each request. This basically means that you need to clone entity manager and use the clone in request context. There are two ways to achieve this:
 
 ## Forking Entity Manager
 
@@ -33,23 +31,14 @@ const em = orm.em.fork();
 
 ## <a name="request-context"></a> RequestContext helper for DI containers
 
-If you use dependency injection container like `inversify` or the one in `nestjs` framework, it 
-can be hard to achieve this, because you usually want to access your repositories via DI container,
-but it will always provide you with the same instance, rather than new one for each request. 
+If you use dependency injection container like `inversify` or the one in `nestjs` framework, it can be hard to achieve this, because you usually want to access your repositories via DI container, but it will always provide you with the same instance, rather than new one for each request.
 
-To solve this, you can use `RequestContext` helper, that will use `node`'s Domain API in the 
-background to isolate the request context. MikroORM will always use request specific (forked) 
-entity manager if available, so all you need to do is to create new request context preferably 
-in middle:
+To solve this, you can use `RequestContext` helper, that will use `node`'s Domain API in the background to isolate the request context. MikroORM will always use request specific (forked) entity manager if available, so all you need to do is to create new request context preferably in middle:
 
 ```typescript
 app.use((req, res, next) => {
   RequestContext.create(orm.em, next);
 });
-``` 
+```
 
-You should register this middleware as the last one just before request handlers and before
-any of your custom middleware that is using the ORM. There might be issues when you register 
-it before request processing middleware like `queryParser` or `bodyParser`, so definitely 
-register the context after them. 
-
+You should register this middleware as the last one just before request handlers and before any of your custom middleware that is using the ORM. There might be issues when you register it before request processing middleware like `queryParser` or `bodyParser`, so definitely register the context after them.

--- a/docs/versioned_docs/version-2.7/index.md
+++ b/docs/versioned_docs/version-2.7/index.md
@@ -4,13 +4,7 @@ title: MikroORM v2.7
 hide_title: true
 ---
 
-[![NPM version](https://img.shields.io/npm/v/mikro-orm.svg)](https://www.npmjs.com/package/mikro-orm)
-[![Chat on slack](https://img.shields.io/badge/chat-on%20slack-blue.svg)](https://join.slack.com/t/mikroorm/shared_invite/enQtNTM1ODYzMzM4MDk3LTBmZDNlODBhYjcxNGZlMTkyYzJmODAwMDhjODc0ZTM2MzQ2Y2VkOGM0ODYzYTJjMDRiZDdjMmIxYjI2OTY0Y2U)
-[![Downloads](https://img.shields.io/npm/dm/mikro-orm.svg)](https://www.npmjs.com/package/mikro-orm)
-[![Coverage Status](https://img.shields.io/coveralls/mikro-orm/mikro-orm.svg)](https://coveralls.io/r/mikro-orm/mikro-orm?branch=master)
-[![Maintainability](https://api.codeclimate.com/v1/badges/27999651d3adc47cfa40/maintainability)](https://codeclimate.com/github/mikro-orm/mikro-orm/maintainability)
-[![Dependency Status](https://david-dm.org/mikro-orm/mikro-orm.svg)](https://david-dm.org/mikro-orm/mikro-orm)
-[![Build Status](https://github.com/mikro-orm/mikro-orm/workflows/tests/badge.svg?branch=master)](https://github.com/mikro-orm/mikro-orm/actions?workflow=tests)
+[![NPM version](https://img.shields.io/npm/v/mikro-orm.svg)](https://www.npmjs.com/package/mikro-orm) [![Chat on slack](https://img.shields.io/badge/chat-on%20slack-blue.svg)](https://join.slack.com/t/mikroorm/shared_invite/enQtNTM1ODYzMzM4MDk3LTBmZDNlODBhYjcxNGZlMTkyYzJmODAwMDhjODc0ZTM2MzQ2Y2VkOGM0ODYzYTJjMDRiZDdjMmIxYjI2OTY0Y2U) [![Downloads](https://img.shields.io/npm/dm/mikro-orm.svg)](https://www.npmjs.com/package/mikro-orm) [![Coverage Status](https://img.shields.io/coveralls/mikro-orm/mikro-orm.svg)](https://coveralls.io/r/mikro-orm/mikro-orm?branch=master) [![Maintainability](https://api.codeclimate.com/v1/badges/27999651d3adc47cfa40/maintainability)](https://codeclimate.com/github/mikro-orm/mikro-orm/maintainability) [![Dependency Status](https://david-dm.org/mikro-orm/mikro-orm.svg)](https://david-dm.org/mikro-orm/mikro-orm) [![Build Status](https://github.com/mikro-orm/mikro-orm/workflows/tests/badge.svg?branch=master)](https://github.com/mikro-orm/mikro-orm/actions?workflow=tests)
 
 MikroORM is TypeScript ORM for Node.js based on Data Mapper, Unit of Work and Identity Map patterns.
 

--- a/docs/versioned_docs/version-2.7/installation.md
+++ b/docs/versioned_docs/version-2.7/installation.md
@@ -20,8 +20,7 @@ $ npm i -s mikro-orm pg      # for postgresql
 $ npm i -s mikro-orm sqlite  # for sqlite
 ```
 
-Next you will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html)
-in `tsconfig.json` via:
+Next you will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html) in `tsconfig.json` via:
 
 ```json
 "experimentalDecorators": true
@@ -39,9 +38,7 @@ const orm = await MikroORM.init({
 console.log(orm.em); // access EntityManager via `em` property
 ```
 
-You can also provide paths where you store your entities via `entitiesDirs` array. Internally
-it uses [`globby`](https://github.com/sindresorhus/globby) so you can use 
-[globbing patterns](https://github.com/sindresorhus/globby#globbing-patterns). 
+You can also provide paths where you store your entities via `entitiesDirs` array. Internally it uses [`globby`](https://github.com/sindresorhus/globby) so you can use [globbing patterns](https://github.com/sindresorhus/globby#globbing-patterns).
 
 ```typescript
 const orm = await MikroORM.init({
@@ -50,8 +47,7 @@ const orm = await MikroORM.init({
 });
 ```
 
-You should provide list of directories, not paths to entities directly. If you want to do that
-instead, you should use `entities` array and use `globby` manually:
+You should provide list of directories, not paths to entities directly. If you want to do that instead, you should use `entities` array and use `globby` manually:
 
 ```typescript
 import { sync } from 'globby';
@@ -64,10 +60,7 @@ const orm = await MikroORM.init({
 
 ## Entity discovery in TypeScript
 
-Internally, `MikroORM` uses [performs analysis](metadata-cache.md) of source files of entities 
-to sniff types of all properties. This process can be slow if your project contains lots of 
-files. To speed up the discovery process a bit, you can provide more accurate paths where your
-entity source files are: 
+Internally, `MikroORM` uses [performs analysis](metadata-cache.md) of source files of entities to sniff types of all properties. This process can be slow if your project contains lots of files. To speed up the discovery process a bit, you can provide more accurate paths where your entity source files are:
 
 ```typescript
 const orm = await MikroORM.init({
@@ -79,8 +72,7 @@ const orm = await MikroORM.init({
 
 ## Request context
 
-Then you will need to fork entity manager for each request so their identity maps will not 
-collide. To do so, use the `RequestContext` helper:
+Then you will need to fork entity manager for each request so their identity maps will not collide. To do so, use the `RequestContext` helper:
 
 ```typescript
 const app = express();
@@ -93,4 +85,3 @@ app.use((req, res, next) => {
 More info about `RequestContext` is described [here](identity-map.md#request-context).
 
 Now you can start [defining your entities](defining-entities.md) (in one of the `entitiesDirs` folders).
-

--- a/docs/versioned_docs/version-2.7/lifecycle-hooks.md
+++ b/docs/versioned_docs/version-2.7/lifecycle-hooks.md
@@ -2,20 +2,14 @@
 title: Lifecycle hooks
 ---
 
-You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of
-entity methods with them, you can also mark multiple methods with same hook.
+You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of entity methods with them, you can also mark multiple methods with same hook.
 
 All hooks support async methods.
 
 - `@BeforeCreate()` and `@BeforeUpdate()` is fired right before we persist the entity in database
 
-- `@AfterCreate()` and `@AfterUpdate()` is fired right after the entity is updated in database and 
-merged to identity map. Since this event entity will have reference to `EntityManager` and will be 
-enabled to call `entity.init()` method (including all entity references and collections).
+- `@AfterCreate()` and `@AfterUpdate()` is fired right after the entity is updated in database and merged to identity map. Since this event entity will have reference to `EntityManager` and will be enabled to call `entity.init()` method (including all entity references and collections).
 
-- `@BeforeDelete()` is fired right before we delete the record from database. It is fired only when
-removing entity or entity reference, not when deleting records by query. 
+- `@BeforeDelete()` is fired right before we delete the record from database. It is fired only when removing entity or entity reference, not when deleting records by query.
 
-- `@AfterDelete()` is fired right after the record gets deleted from database and it is unset from 
-the identity map.
-
+- `@AfterDelete()` is fired right after the record gets deleted from database and it is unset from the identity map.

--- a/docs/versioned_docs/version-2.7/metadata-cache.md
+++ b/docs/versioned_docs/version-2.7/metadata-cache.md
@@ -2,25 +2,17 @@
 title: Metadata cache
 ---
 
-Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. Thanks to this, 
-defining the type is enough for runtime validation.
+Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. Thanks to this, defining the type is enough for runtime validation.
 
-This process can be a bit slow, mainly because `ts-morph` will scan all your source files
-based on your `tsconfig.json`. You can speed up this process by whitelisting only the folders
-where your entities are via `entitiesDirsTs` option. 
+This process can be a bit slow, mainly because `ts-morph` will scan all your source files based on your `tsconfig.json`. You can speed up this process by whitelisting only the folders where your entities are via `entitiesDirsTs` option.
 
-After the discovery process ends, all metadata will be cached. By default, `FileCacheAdapter`
-will be used to store the cache inside `./temp` folder to JSON files. 
+After the discovery process ends, all metadata will be cached. By default, `FileCacheAdapter` will be used to store the cache inside `./temp` folder to JSON files.
 
 ## Automatic invalidation
 
-Entity metadata are cached together with modified time of the source file, and every time
-the cache is requested, it first checks if the cache is not invalid. This way you can forgot 
-about the caching mechanism most of the time.
+Entity metadata are cached together with modified time of the source file, and every time the cache is requested, it first checks if the cache is not invalid. This way you can forgot about the caching mechanism most of the time.
 
-One case where you can end up needing to wipe the cache manually is when you work withing a 
-git branch where contents of entities folder differs. 
+One case where you can end up needing to wipe the cache manually is when you work withing a git branch where contents of entities folder differs.
 
 ## Disabling metadata cache
 
@@ -46,8 +38,7 @@ await MikroORM.init({
 
 ## Providing custom cache adapter
 
-You can also implement your own cache adapter, for example to store the cache in redis. 
-To do so, just implement simple `CacheAdapter` interface:
+You can also implement your own cache adapter, for example to store the cache in redis. To do so, just implement simple `CacheAdapter` interface:
 
 ```typescript
 export interface CacheAdapter {

--- a/docs/versioned_docs/version-2.7/naming-strategy.md
+++ b/docs/versioned_docs/version-2.7/naming-strategy.md
@@ -2,14 +2,12 @@
 title: Naming strategy
 ---
 
-When mapping your entities to database tables and columns, their names will be defined by naming 
-strategy. There are 2 basic naming strategies you can choose from:
+When mapping your entities to database tables and columns, their names will be defined by naming strategy. There are 2 basic naming strategies you can choose from:
 
 - `UnderscoreNamingStrategy` - default of `MySqlDriver` and `SqliteDriver`
 - `MongoNamingStrategy` - default of `MongoDriver`
 
-You can override this when initializing ORM. You can also provide your own naming strategy, just 
-implement `NamingStrategy` interface and provide your implementation when bootstrapping ORM:
+You can override this when initializing ORM. You can also provide your own naming strategy, just implement `NamingStrategy` interface and provide your implementation when bootstrapping ORM:
 
 ```typescript
 class YourCustomNamingStrategy implements NamingStrategy {
@@ -25,15 +23,13 @@ const orm = await MikroORM.init({
 
 ## Naming strategy in mongo driver
 
-`MongoNamingStrategy` will simply use all field names as they are defined. Collection names will
-be translated into lower-cased dashed form:
+`MongoNamingStrategy` will simply use all field names as they are defined. Collection names will be translated into lower-cased dashed form:
 
 `MyCoolEntity` will be translated into `my-cool-entity` collection name.
 
 ## Naming strategy in SQL drivers
 
-`MySqlDriver` defaults to `UnderscoreNamingStrategy`, which means your all your database tables and
-columns will be lower-cased and words divided by underscored:
+`MySqlDriver` defaults to `UnderscoreNamingStrategy`, which means your all your database tables and columns will be lower-cased and words divided by underscored:
 
 ```sql
 CREATE TABLE `author` (
@@ -48,4 +44,3 @@ CREATE TABLE `author` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 ```
-

--- a/docs/versioned_docs/version-2.7/nested-populate.md
+++ b/docs/versioned_docs/version-2.7/nested-populate.md
@@ -2,15 +2,12 @@
 title: Smart Nested Populate
 ---
 
-`MikroORM` is capable of loading large nested structures while maintaining good 
-performance, querying each database table only once. Imagine you have this nested 
-structure:
+`MikroORM` is capable of loading large nested structures while maintaining good performance, querying each database table only once. Imagine you have this nested structure:
 
 - `Book` has one `Publisher` (M:1), one `Author` (M:1) and many `BookTag`s (M:N)
 - `Publisher` has many `Test`s (M:N)
 
-When you use nested populate while querying all `BookTag`s, this is what happens in
-the background:
+When you use nested populate while querying all `BookTag`s, this is what happens in the background:
 
 ```typescript
 const tags = await orm.em.findAll(BookTag, ['books.publisher.tests', 'books.author']);
@@ -56,8 +53,7 @@ db.getCollection("author").find({"_id":{"$in":[...]}}).toArray();
 
 ## Using EntityLoader manually
 
-Under the hood, EntityManager uses EntityLoader to populate other entities. You can use it
-manually if you already have list of entities (e.g. queried via QueryBuilder):
+Under the hood, EntityManager uses EntityLoader to populate other entities. You can use it manually if you already have list of entities (e.g. queried via QueryBuilder):
 
 ```typescript
 import { EntityLoader } from 'mikro-orm';
@@ -67,8 +63,7 @@ const res = await orm.em.createQueryBuilder(Author).select('*').execute();
 const authors = res.map(data => orm.em.merge(Author, data));
 await loader.populate(Author, authors, ['books.tags']);
 
-// now your Author entities will have `books` collections populated, 
+// now your Author entities will have `books` collections populated,
 // as well as they will have their `tags` collections populated.
 console.log(authors[0].books[0].tags[0]); // initialized BookTag
 ```
-

--- a/docs/versioned_docs/version-2.7/property-validation.md
+++ b/docs/versioned_docs/version-2.7/property-validation.md
@@ -2,10 +2,7 @@
 title: Property validation
 ---
 
-`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong 
-data types for you automatically. If automatic conversion fails, it will throw an error. You can 
-enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered 
-when persisting the entity. 
+`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong data types for you automatically. If automatic conversion fails, it will throw an error. You can enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered when persisting the entity.
 
 ```typescript
 // number instead of string will throw
@@ -45,4 +42,3 @@ await orm.em.persistAndFlush(author); // throws "Validation error: trying to set
 author.assign({ age: false });
 await orm.em.persistAndFlush(author); // throws "Validation error: trying to set Author.age of type 'number' to 'false' of type 'boolean'"
 ```
-

--- a/docs/versioned_docs/version-2.7/query-builder.md
+++ b/docs/versioned_docs/version-2.7/query-builder.md
@@ -2,8 +2,7 @@
 title: Using QueryBuilder
 ---
 
-When you need to execute some SQL query without all the ORM stuff involved, you can either
-compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
+When you need to execute some SQL query without all the ORM stuff involved, you can either compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
 
 ```typescript
 const qb = orm.em.createQueryBuilder(Author);
@@ -41,9 +40,7 @@ const res2 = await qb.execute('get'); // returns single object
 const res3 = await qb.execute('run'); // returns object like `{ affectedRows: number, insertId: number, row: any }`
 ```
 
-Second argument can be used to disable mapping of database columns to property names (which 
-is enabled by default). In following example, `Book` entity has `createdAt` property defined 
-with implicit underscored field name `created_at`:
+Second argument can be used to disable mapping of database columns to property names (which is enabled by default). In following example, `Book` entity has `createdAt` property defined with implicit underscored field name `created_at`:
 
 ```typescript
 const res4 = await orm.em.createQueryBuilder(Book).select('*').execute('get', true);
@@ -62,13 +59,9 @@ console.log(entities); // array of Book entities
 
 ## Mapping raw results to entities
 
-Another way to create entity from raw results (that are not necessarily mapped to entity properties)
-is to use `map()` method of `EntityManager`, that is basically a shortcut for mapping results
-via `IDatabaseDriver.mapResult()` (which converts field names to property names - e.g. `created_at`
-to `createdAt`) and `merge()` which converts the data to entity instance and makes it managed. 
+Another way to create entity from raw results (that are not necessarily mapped to entity properties) is to use `map()` method of `EntityManager`, that is basically a shortcut for mapping results via `IDatabaseDriver.mapResult()` (which converts field names to property names - e.g. `created_at` to `createdAt`) and `merge()` which converts the data to entity instance and makes it managed.
 
-This method comes handy when you want to use 3rd party query builder like [Knex.js](https://knexjs.org/), 
-where the result is not mapped to entity properties automatically:
+This method comes handy when you want to use 3rd party query builder like [Knex.js](https://knexjs.org/), where the result is not mapped to entity properties automatically:
 
 ```typescript
 const results = await knex.select('*').from('users').where(knex.raw('id = ?', [id]));
@@ -115,8 +108,7 @@ console.log(qb.getQuery());
 
 ## Complex where conditions
 
-There are multiple ways to construct complex query conditions. You can either write parts of SQL
-manually, use `andWhere()`/`orWhere()`, or provide condition object:
+There are multiple ways to construct complex query conditions. You can either write parts of SQL manually, use `andWhere()`/`orWhere()`, or provide condition object:
 
 ### Custom SQL in where
 
@@ -201,4 +193,3 @@ QueryBuilder.getQuery(): string;
 QueryBuilder.getParams(): any;
 QueryBuilder.clone(): QueryBuilder;
 ```
-

--- a/docs/versioned_docs/version-2.7/query-conditions.md
+++ b/docs/versioned_docs/version-2.7/query-conditions.md
@@ -2,8 +2,7 @@
 title: Smart query conditions
 ---
 
-When you want to make complex queries, you can easily end up with a lot of boilerplate code
-full of curly brackets:
+When you want to make complex queries, you can easily end up with a lot of boilerplate code full of curly brackets:
 
 ```typescript
 const res = await orm.em.find(Author, { $and: [
@@ -20,8 +19,8 @@ const res = await orm.em.find(Author, { $and: [
 For AND condition with single field, you can also do this:
 
 ```typescript
-const res = await orm.em.find(Author, { 
-  id: { 
+const res = await orm.em.find(Author, {
+  id: {
     $in: [1, 2, 7],
     $nin: [3, 4],
     $gt: 5,
@@ -59,8 +58,7 @@ const res = await orm.em.find(Author, { $and: [
 ] });
 ```
 
-There is also shortcut for `$in` - simply provide array as value and it 
-will be converted automatically:
+There is also shortcut for `$in` - simply provide array as value and it will be converted automatically:
 
 ```typescript
 const res = await orm.em.find(Author, { favouriteBook: [1, 2, 7] });

--- a/docs/versioned_docs/version-2.7/repositories.md
+++ b/docs/versioned_docs/version-2.7/repositories.md
@@ -3,8 +3,7 @@ title: Using EntityRepository instead of EntityManager
 sidebar_label: Entity Repository
 ---
 
-More convenient way of fetching entities from database is by using `EntityRepository`, that
-carries the entity name so you do not have to pass it to every `find` and `findOne` calls:
+More convenient way of fetching entities from database is by using `EntityRepository`, that carries the entity name so you do not have to pass it to every `find` and `findOne` calls:
 
 Example:
 
@@ -15,7 +14,7 @@ const booksRepository = orm.em.getRepository(Book);
 const books = await booksRepository.find({ author: '...' }, ['author'], { title: QueryOrder.DESC }, 2, 1);
 
 // or with options object
-const books = await booksRepository.find({ author: '...' }, { 
+const books = await booksRepository.find({ author: '...' }, {
   populate: ['author'],
   limit: 1,
   offset: 2,
@@ -49,24 +48,19 @@ export class Publisher {
 }
 ```
 
-Note that we need to pass that repository reference inside a callback so we will not run
-into circular dependency issues when using entity references inside that repository.
+Note that we need to pass that repository reference inside a callback so we will not run into circular dependency issues when using entity references inside that repository.
 
 Now you can access your custom repository via `EntityManager.getRepository()` method.
 
-> You can also register custom base repository (for all entities where you do not specify 
-`customRepository`) globally, via `MikroORM.init({ entityRepository: CustomBaseRepository })`
+> You can also register custom base repository (for all entities where you do not specify `customRepository`) globally, via `MikroORM.init({ entityRepository: CustomBaseRepository })`
 
-For more examples, take a look at
-[`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts)
-or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).
+For more examples, take a look at [`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts) or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).
 
 ## EntityRepository\<T\> API
 
 #### `find(where?: FilterQuery<T>, options?: FindOptions): Promise<T[]>`
 
-Returns array of entities found for given condition. You can specify `FindOptions` to request
-population of referenced entities or control the pagination:
+Returns array of entities found for given condition. You can specify `FindOptions` to request population of referenced entities or control the pagination:
 
 ```typescript
 export interface FindOptions {
@@ -81,57 +75,49 @@ export interface FindOptions {
 
 #### `find(where?: FilterQuery<T>, populate?: string[], orderBy?: { [k: string]: QueryOrder }, limit?: number, offset?: number): Promise<T[]>`
 
-Same as previous `find` method, just with dedicated parameters for `populate`, `orderBy`, `limit`
-and `offset`.
+Same as previous `find` method, just with dedicated parameters for `populate`, `orderBy`, `limit` and `offset`.
 
 ---
 
 #### `findAll(options?: FindOptions): Promise<T[]>`
 
-Returns all entities for given type. 
+Returns all entities for given type.
 
 ---
 
 #### `findAll(populate?: string[], orderBy?: { [k: string]: QueryOrder }, limit?: number, offset?: number): Promise<T[]>`
 
-Same as previous `findAll` method, just with dedicated parameters for `populate`, `orderBy`, `limit`
-and `offset`.
+Same as previous `findAll` method, just with dedicated parameters for `populate`, `orderBy`, `limit` and `offset`.
 
 ---
 
 #### `findOne(where: FilterQuery<T> | string, populate?: string[]): Promise<T | null>`
 
-Finds an entity by given `where` condition. You can use primary key as `where` value, then
-if the entity is already managed, no database call will be made. 
+Finds an entity by given `where` condition. You can use primary key as `where` value, then if the entity is already managed, no database call will be made.
 
 ---
 
 #### `merge(data: EntityData<T>): T`
 
-Adds given entity to current Identity Map. After merging, entity becomes managed. 
-This is useful when you want to work with cached entities. 
+Adds given entity to current Identity Map. After merging, entity becomes managed. This is useful when you want to work with cached entities.
 
 ---
 
 #### `getReference(id: string): T`
 
-Gets a reference to the entity identified by the given type and identifier without actually 
-loading it, if the entity is not yet loaded.
+Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded.
 
 ---
 
 #### `count(where: any): Promise<number>`
 
-Gets count of entities matching the `where` condition. 
+Gets count of entities matching the `where` condition.
 
 ---
 
 #### `persist(entity: IEntity | IEntity[], flush?: boolean): Promise<void>`
 
-Tells the EntityManager to make an instance managed and persistent. The entity will be 
-entered into the database at or before transaction commit or as a result of the flush 
-operation. You can control immediate flushing via `flush` parameter and via `autoFlush`
-configuration option. 
+Tells the EntityManager to make an instance managed and persistent. The entity will be entered into the database at or before transaction commit or as a result of the flush operation. You can control immediate flushing via `flush` parameter and via `autoFlush` configuration option.
 
 ---
 
@@ -143,7 +129,7 @@ Shortcut for `persist` & `flush`.
 
 #### `persistLater(entity: IEntity | IEntity[]): void`
 
-Shortcut for just `persist`, without flushing. 
+Shortcut for just `persist`, without flushing.
 
 ---
 
@@ -155,10 +141,9 @@ Flushes all changes to objects that have been queued up to now to the database.
 
 #### `remove(where: IEntity | any, flush?: boolean): Promise<number>`
 
-When provided entity instance as `where` value, then it calls `removeEntity(entity, flush)`, 
-otherwise it fires delete query with given `where` condition. 
+When provided entity instance as `where` value, then it calls `removeEntity(entity, flush)`, otherwise it fires delete query with given `where` condition.
 
-This method fires `beforeDelete` and `afterDelete` hooks only if you provide entity instance.  
+This method fires `beforeDelete` and `afterDelete` hooks only if you provide entity instance.
 
 ---
 
@@ -166,22 +151,20 @@ This method fires `beforeDelete` and `afterDelete` hooks only if you provide ent
 
 Shortcut for `removeEntity` & `flush`.
 
-This method fires `beforeDelete` and `afterDelete` hooks. 
+This method fires `beforeDelete` and `afterDelete` hooks.
 
 ---
 
 #### `removeLater(entity: IEntity): void`
 
-Shortcut for `removeEntity` without flushing. 
+Shortcut for `removeEntity` without flushing.
 
-This method fires `beforeDelete` and `afterDelete` hooks. 
+This method fires `beforeDelete` and `afterDelete` hooks.
 
 ---
 
 #### `canPopulate(property: string): boolean`
 
-Returns whether given entity has given property which can be populated (is reference or
-collection).
+Returns whether given entity has given property which can be populated (is reference or collection).
 
 ---
-

--- a/docs/versioned_docs/version-2.7/schema-generator.md
+++ b/docs/versioned_docs/version-2.7/schema-generator.md
@@ -2,9 +2,7 @@
 title: Schema generator
 ---
 
-To generate schema from your entity metadata, you can use `SchemaGenerator`
-helper. You will need to create simple script where you initialize MikroORM
-like this:
+To generate schema from your entity metadata, you can use `SchemaGenerator` helper. You will need to create simple script where you initialize MikroORM like this:
 
 ```typescript title="./create-schema.ts"
 import { MikroORM, SchemaGenerator } from 'mikro-orm';

--- a/docs/versioned_docs/version-2.7/serializing.md
+++ b/docs/versioned_docs/version-2.7/serializing.md
@@ -12,9 +12,7 @@ export interface IEntity<K = number | string> {
 }
 ```
 
-When you serialize your entity via `JSON.stringify(entity)`, its `toJSON` method will be 
-called automatically. You can provide custom implementation for `toJSON`, while using 
-`toObject` for initial serialization:
+When you serialize your entity via `JSON.stringify(entity)`, its `toJSON` method will be called automatically. You can provide custom implementation for `toJSON`, while using `toObject` for initial serialization:
 
 ```typescript
 @Entity()
@@ -35,13 +33,11 @@ export class Book {
 }
 ```
 
-> Do not forget to pass rest params when calling `toObject(...args)`, otherwise the results
-> might not be stable.
+> Do not forget to pass rest params when calling `toObject(...args)`, otherwise the results might not be stable.
 
 ## Hidden properties
 
-If you want to omit some properties from serialized result, you can mark them with `hidden`
-flag on `@Property()` decorator:
+If you want to omit some properties from serialized result, you can mark them with `hidden` flag on `@Property()` decorator:
 
 ```typescript
 @Entity()
@@ -59,13 +55,9 @@ console.log(book.toJSON().hiddenField); // undefined
 
 ## Shadow properties
 
-The opposite situation where you want to define a property that lives only in memory (is 
-not persisted into database) can be solved by defining your property as `persist: false`. 
-Such property can be assigned via one of `IEntity.assign()`, `EntityManager.create()` and 
-`EntityManager.merge()`. It will be also part of serialized result. 
+The opposite situation where you want to define a property that lives only in memory (is not persisted into database) can be solved by defining your property as `persist: false`. Such property can be assigned via one of `IEntity.assign()`, `EntityManager.create()` and `EntityManager.merge()`. It will be also part of serialized result.
 
-This can be handle when dealing with additional values selected via `QueryBuilder` or 
-MongoDB's aggregations.
+This can be handle when dealing with additional values selected via `QueryBuilder` or MongoDB's aggregations.
 
 ```typescript
 @Entity()

--- a/docs/versioned_docs/version-2.7/transactions.md
+++ b/docs/versioned_docs/version-2.7/transactions.md
@@ -4,28 +4,17 @@ title: Transactions and concurrency
 
 ## Transaction demarcation
 
-Transaction demarcation is the task of defining your transaction boundaries. Proper 
-transaction demarcation is very important because if not done properly it can negatively 
-affect the performance of your application. Many databases and database abstraction 
-layers by default operate in auto-commit mode, which means that every single SQL statement 
-is wrapped in a small transaction. Without any explicit transaction demarcation from your 
-side, this quickly results in poor performance because transactions are not cheap. 
+Transaction demarcation is the task of defining your transaction boundaries. Proper transaction demarcation is very important because if not done properly it can negatively affect the performance of your application. Many databases and database abstraction layers by default operate in auto-commit mode, which means that every single SQL statement is wrapped in a small transaction. Without any explicit transaction demarcation from your side, this quickly results in poor performance because transactions are not cheap.
 
-For the most part, MikroORM already takes care of proper transaction demarcation for you: 
-All the write operations (INSERT/UPDATE/DELETE) are queued until `em.flush()` 
-is invoked which wraps all of these changes in a single transaction.
+For the most part, MikroORM already takes care of proper transaction demarcation for you: All the write operations (INSERT/UPDATE/DELETE) are queued until `em.flush()` is invoked which wraps all of these changes in a single transaction.
 
-However, MikroORM also allows (and encourages) you to take over and control transaction 
-demarcation yourself.
+However, MikroORM also allows (and encourages) you to take over and control transaction demarcation yourself.
 
-These are two ways to deal with transactions when using the MikroORM and are now described 
-in more detail.
+These are two ways to deal with transactions when using the MikroORM and are now described in more detail.
 
 ### Approach 1: Implicitly
 
-The first approach is to use the implicit transaction handling provided by the MikroORM 
-`EntityManager`. Given the following code snippet, without any explicit transaction 
-demarcation:
+The first approach is to use the implicit transaction handling provided by the MikroORM `EntityManager`. Given the following code snippet, without any explicit transaction demarcation:
 
 ```typescript
 const user = new User(...);
@@ -33,16 +22,11 @@ user.name = 'George';
 await orm.em.persistAndFlush(user);
 ```
 
-Since we do not do any custom transaction demarcation in the above code, `em.flush()` 
-will begin and commit/rollback a transaction. This behavior is made possible by the 
-aggregation of the DML operations by the MikroORM and is sufficient if all the data 
-manipulation that is part of a unit of work happens through the domain model and thus 
-the ORM.
+Since we do not do any custom transaction demarcation in the above code, `em.flush()` will begin and commit/rollback a transaction. This behavior is made possible by the aggregation of the DML operations by the MikroORM and is sufficient if all the data manipulation that is part of a unit of work happens through the domain model and thus the ORM.
 
 ### Approach 2: Explicitly
 
-The explicit alternative is to use the transactions API directly to control the boundaries. 
-The code then looks like this:
+The explicit alternative is to use the transactions API directly to control the boundaries. The code then looks like this:
 
 ```typescript
 await orm.em.beginTransaction(); // suspend auto-commit
@@ -59,16 +43,9 @@ try {
 }
 ```
 
-Explicit transaction demarcation is required when you want to include custom DBAL operations 
-in a unit of work or when you want to make use of some methods of the EntityManager API 
-that require an active transaction. Such methods will throw a `ValidationError` to inform 
-you of that requirement.
+Explicit transaction demarcation is required when you want to include custom DBAL operations in a unit of work or when you want to make use of some methods of the EntityManager API that require an active transaction. Such methods will throw a `ValidationError` to inform you of that requirement.
 
-A more convenient alternative for explicit transaction demarcation is the use of provided 
-control abstractions in the form of `em.transactional(cb)`. When used, these 
-control abstractions ensure that you never forget to rollback the transaction, in addition 
-to the obvious code reduction. An example that is functionally equivalent to the previously 
-shown code looks as follows:
+A more convenient alternative for explicit transaction demarcation is the use of provided control abstractions in the form of `em.transactional(cb)`. When used, these control abstractions ensure that you never forget to rollback the transaction, in addition to the obvious code reduction. An example that is functionally equivalent to the previously shown code looks as follows:
 
 ```typescript
 orm.em.transactional(_em => {
@@ -79,64 +56,35 @@ orm.em.transactional(_em => {
 });
 ```
 
-`em.transactional(cb)` will flush the inner `EntityManager` prior to transaction 
-commit.
+`em.transactional(cb)` will flush the inner `EntityManager` prior to transaction commit.
 
 ### Exception Handling
 
-When using implicit transaction demarcation and an exception occurs during 
-`em.flush()`, the transaction is automatically rolled back.
+When using implicit transaction demarcation and an exception occurs during `em.flush()`, the transaction is automatically rolled back.
 
-When using explicit transaction demarcation and an exception occurs, the transaction should 
-be rolled back immediately as demonstrated in the example above. This can be handled elegantly 
-by the control abstractions shown earlier. Note that when catching Exception you should 
-generally re-throw the exception. If you intend to recover from some exceptions, catch them 
-explicitly in earlier catch blocks (but do not forget to rollback the transaction). All 
-other best practices of exception handling apply similarly (i.e. either log or re-throw, 
-not both, etc.).
+When using explicit transaction demarcation and an exception occurs, the transaction should be rolled back immediately as demonstrated in the example above. This can be handled elegantly by the control abstractions shown earlier. Note that when catching Exception you should generally re-throw the exception. If you intend to recover from some exceptions, catch them explicitly in earlier catch blocks (but do not forget to rollback the transaction). All other best practices of exception handling apply similarly (i.e. either log or re-throw, not both, etc.).
 
-As a result of this procedure, all previously managed or removed instances of the `EntityManager` 
-become detached. The state of the detached objects will be the state at the point at which the 
-transaction was rolled back. The state of the objects is in no way rolled back and thus the 
-objects are now out of sync with the database. The application can continue to use the detached 
-objects, knowing that their state is potentially no longer accurate.
+As a result of this procedure, all previously managed or removed instances of the `EntityManager` become detached. The state of the detached objects will be the state at the point at which the transaction was rolled back. The state of the objects is in no way rolled back and thus the objects are now out of sync with the database. The application can continue to use the detached objects, knowing that their state is potentially no longer accurate.
 
-If you intend to start another unit of work after an exception has occurred you should do 
-that with a new `EntityManager`. Simply use `em.fork()` to obtain fresh copy 
-with cleared identity map. 
+If you intend to start another unit of work after an exception has occurred you should do that with a new `EntityManager`. Simply use `em.fork()` to obtain fresh copy with cleared identity map.
 
 ## Locking Support
 
 ### Why we need concurrency control?
 
-If transactions are executed serially (one at a time), no transaction concurrency exists. 
-However, if concurrent transactions with interleaving operations are allowed, you may easily 
-run into one of those problems:
+If transactions are executed serially (one at a time), no transaction concurrency exists. However, if concurrent transactions with interleaving operations are allowed, you may easily run into one of those problems:
 
 1. The lost update problem
 2. The dirty read problem
 3. The incorrect summary problem
 
-To mitigate those problems, MikroORM offers support for Pessimistic and Optimistic locking 
-strategies natively. This allows you to take very fine-grained control over what kind of 
-locking is required for your entities in your application.
+To mitigate those problems, MikroORM offers support for Pessimistic and Optimistic locking strategies natively. This allows you to take very fine-grained control over what kind of locking is required for your entities in your application.
 
 ### Optimistic Locking
 
-Database transactions are fine for concurrency control during a single request. However, a 
-database transaction should not span across requests, the so-called "user think time". Therefore 
-a long-running "business transaction" that spans multiple requests needs to involve several 
-database transactions. Thus, database transactions alone can no longer control concurrency 
-during such a long-running business transaction. Concurrency control becomes the partial 
-responsibility of the application itself.
+Database transactions are fine for concurrency control during a single request. However, a database transaction should not span across requests, the so-called "user think time". Therefore a long-running "business transaction" that spans multiple requests needs to involve several database transactions. Thus, database transactions alone can no longer control concurrency during such a long-running business transaction. Concurrency control becomes the partial responsibility of the application itself.
 
-MikroORM has integrated support for automatic optimistic locking via a version field. In 
-this approach any entity that should be protected against concurrent modifications during 
-long-running business transactions gets a version field that is either a simple number 
-(mapping type: integer) or a timestamp (mapping type: datetime). When changes to such an 
-entity are persisted at the end of a long-running conversation the version of the entity 
-is compared to the version in the database and if they don't match, a `ValidationError` 
-is thrown, indicating that the entity has been modified by someone else already.
+MikroORM has integrated support for automatic optimistic locking via a version field. In this approach any entity that should be protected against concurrent modifications during long-running business transactions gets a version field that is either a simple number (mapping type: integer) or a timestamp (mapping type: datetime). When changes to such an entity are persisted at the end of a long-running conversation the version of the entity is compared to the version in the database and if they don't match, a `ValidationError` is thrown, indicating that the entity has been modified by someone else already.
 
 You designate a version field in an entity as follows. In this example we'll use an integer.
 
@@ -160,23 +108,13 @@ export class User {
 }
 ```
 
-Version numbers (not timestamps) should however be preferred as they can not potentially 
-conflict in a highly concurrent environment, unlike timestamps where this is a possibility, 
-depending on the resolution of the timestamp on the particular database platform.
+Version numbers (not timestamps) should however be preferred as they can not potentially conflict in a highly concurrent environment, unlike timestamps where this is a possibility, depending on the resolution of the timestamp on the particular database platform.
 
-When a version conflict is encountered during `em.flush()`, a `ValidationError` 
-is thrown and the active transaction rolled back (or marked for rollback). This exception 
-can be caught and handled. Potential responses to a `ValidationError` are to present the 
-conflict to the user or to refresh or reload objects in a new transaction and then retrying 
-the transaction.
+When a version conflict is encountered during `em.flush()`, a `ValidationError` is thrown and the active transaction rolled back (or marked for rollback). This exception can be caught and handled. Potential responses to a `ValidationError` are to present the conflict to the user or to refresh or reload objects in a new transaction and then retrying the transaction.
 
-The time between showing an update form and actually modifying the entity can in the worst 
-scenario be as long as your applications session timeout. If changes happen to the entity 
-in that time frame you want to know directly when retrieving the entity that you will hit 
-an optimistic locking exception:
+The time between showing an update form and actually modifying the entity can in the worst scenario be as long as your applications session timeout. If changes happen to the entity in that time frame you want to know directly when retrieving the entity that you will hit an optimistic locking exception:
 
-You can always verify the version of an entity during a request either when calling 
-`em.findOne()`:
+You can always verify the version of an entity during a request either when calling `em.findOne()`:
 
 ```typescript
 const theEntityId = 1;
@@ -210,23 +148,16 @@ try {
 
 #### Important Implementation Notes
 
-You can easily get the optimistic locking workflow wrong if you compare the wrong versions. 
-Say you have Alice and Bob editing a hypothetical blog post:
+You can easily get the optimistic locking workflow wrong if you compare the wrong versions. Say you have Alice and Bob editing a hypothetical blog post:
 
 - Alice reads the headline of the blog post being "Foo", at optimistic lock version 1 (GET Request)
 - Bob reads the headline of the blog post being "Foo", at optimistic lock version 1 (GET Request)
 - Bob updates the headline to "Bar", upgrading the optimistic lock version to 2 (POST Request of a Form)
 - Alice updates the headline to "Baz", ... (POST Request of a Form)
 
-Now at the last stage of this scenario the blog post has to be read again from the database 
-before Alice's headline can be applied. At this point you will want to check if the blog 
-post is still at version 1 (which it is not in this scenario).
+Now at the last stage of this scenario the blog post has to be read again from the database before Alice's headline can be applied. At this point you will want to check if the blog post is still at version 1 (which it is not in this scenario).
 
-Using optimistic locking correctly, you **have** to add the version as an additional hidden 
-field (or into the session for more safety). Otherwise you cannot verify the version is still 
-the one being originally read from the database when Alice performed her GET request for the 
-blog post. If this happens you might see lost updates you wanted to prevent with Optimistic 
-Locking.
+Using optimistic locking correctly, you **have** to add the version as an additional hidden field (or into the session for more safety). Otherwise you cannot verify the version is still the one being originally read from the database when Alice performed her GET request for the blog post. If this happens you might see lost updates you wanted to prevent with Optimistic Locking.
 
 See the example code (frontend):
 
@@ -265,22 +196,13 @@ async update(req, res) {
 }
 ```
 
-Your frontend app loads an entity from API, the response includes the version property. 
-User makes some changes and fires PUT request back to the API, with version field included 
-in the payload. The PUT handler of the API then reads the version and passes it to the 
-`em.findOne()` call.
+Your frontend app loads an entity from API, the response includes the version property. User makes some changes and fires PUT request back to the API, with version field included in the payload. The PUT handler of the API then reads the version and passes it to the `em.findOne()` call.
 
 ### Pessimistic Locking
 
-MikroORM supports Pessimistic Locking at the database level. No attempt is being made to implement 
-pessimistic locking inside MikroORM, rather vendor-specific and ANSI-SQL commands are used to 
-acquire row-level locks. Every Entity can be part of a pessimistic lock, there is no special 
-metadata required to use this feature.
+MikroORM supports Pessimistic Locking at the database level. No attempt is being made to implement pessimistic locking inside MikroORM, rather vendor-specific and ANSI-SQL commands are used to acquire row-level locks. Every Entity can be part of a pessimistic lock, there is no special metadata required to use this feature.
 
-However for Pessimistic Locking to work you have to disable the Auto-Commit Mode of your Database 
-and start a transaction around your pessimistic lock use-case using the "Approach 2: Explicit 
-Transaction Demarcation" described above. MikroORM will throw an Exception if you attempt to 
-acquire an pessimistic lock and no transaction is running.
+However for Pessimistic Locking to work you have to disable the Auto-Commit Mode of your Database and start a transaction around your pessimistic lock use-case using the "Approach 2: Explicit Transaction Demarcation" described above. MikroORM will throw an Exception if you attempt to acquire an pessimistic lock and no transaction is running.
 
 MikroORM currently supports two pessimistic lock modes:
 
@@ -293,5 +215,4 @@ You can use pessimistic locks in three different scenarios:
 2. Using `em.lock(entity, LockMode.PESSIMISTIC_WRITE)` or `em.lock(entity, LockMode.PESSIMISTIC_READ)`
 3. Using `QueryBuilder.setLockMode(LockMode.PESSIMISTIC_WRITE)` or `QueryBuilder.setLockMode(LockMode.PESSIMISTIC_READ)`
 
-> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html) as the behaviour here is pretty much the same.

--- a/docs/versioned_docs/version-2.7/unit-of-work.md
+++ b/docs/versioned_docs/version-2.7/unit-of-work.md
@@ -3,11 +3,9 @@ title: Unit of Work and transactions
 sidebar_label: Unit of Work
 ---
 
-MikroORM uses the Identity Map pattern to track objects. Whenever you fetch an object from 
-the database, MikroORM will keep a reference to this object inside its `UnitOfWork`. 
+MikroORM uses the Identity Map pattern to track objects. Whenever you fetch an object from the database, MikroORM will keep a reference to this object inside its `UnitOfWork`.
 
-This allows MikroORM room for optimizations. If you call the EntityManager and ask for an 
-entity with a specific ID twice, it will return the same instance:
+This allows MikroORM room for optimizations. If you call the EntityManager and ask for an entity with a specific ID twice, it will return the same instance:
 
 ```typescript
 const authorRepository = orm.em.getRepository(Author);
@@ -18,13 +16,9 @@ const jon2 = await authorRepository.findOne(1);
 console.log(jon1 === jon2); // true
 ```
 
-Only one SELECT query will be fired against the database here. In the second `findOne()` 
-call MikroORM will check the identity map first and will skip the database round trip as
-it will find the entity already loaded.
+Only one SELECT query will be fired against the database here. In the second `findOne()` call MikroORM will check the identity map first and will skip the database round trip as it will find the entity already loaded.
 
-The identity map being indexed by primary keys only allows shortcuts when you ask for objects 
-by primary key. When you query by other properties, you will still get the same reference, 
-but two separate database calls will be made:
+The identity map being indexed by primary keys only allows shortcuts when you ask for objects by primary key. When you query by other properties, you will still get the same reference, but two separate database calls will be made:
 
 ```typescript
 const authorRepository = orm.em.getRepository(Author);
@@ -35,21 +29,13 @@ const jon2 = await authorRepository.findOne({ name: 'Jon Snow' });
 console.log(jon1 === jon2); // true
 ```
 
-MikroORM only knows objects by id, so a query for different criteria has to go to the database, 
-even if it was executed just before. But instead of creating a second `Author` object MikroORM 
-first gets the primary key from the row and checks if it already has an object inside the 
-`UnitOfWork` with that primary key. 
+MikroORM only knows objects by id, so a query for different criteria has to go to the database, even if it was executed just before. But instead of creating a second `Author` object MikroORM first gets the primary key from the row and checks if it already has an object inside the `UnitOfWork` with that primary key.
 
 ## Persisting managed entities
 
-The identity map has a second use-case. When you call `EntityManager#flush()`, MikroORM will 
-ask the identity map for all objects that are currently managed. This means you don't have to 
-call `EntityManager#persistLater()` over and over again to pass known objects to the 
-`EntityManager`. This is a NO-OP for known entities, but leads to much code written that is 
-confusing to other developers.
+The identity map has a second use-case. When you call `EntityManager#flush()`, MikroORM will ask the identity map for all objects that are currently managed. This means you don't have to call `EntityManager#persistLater()` over and over again to pass known objects to the `EntityManager`. This is a NO-OP for known entities, but leads to much code written that is confusing to other developers.
 
-The following code WILL update your database with the changes made to the `Author` object, 
-even if you did not call `EntityManager#persistLater()`:
+The following code WILL update your database with the changes made to the `Author` object, even if you did not call `EntityManager#persistLater()`:
 
 ```typescript
 const authorRepository = orm.em.getRepository(Author);
@@ -60,29 +46,17 @@ await authorRepository.flush(); // calling orm.em.flush() has same effect
 
 ## How MikroORM detects changes
 
-MikroORM is a data-mapper that tries to achieve persistence-ignorance (PI). This means you 
-map JS objects into a relational database that do not necessarily know about the database at 
-all. A natural question would now be, "how does MikroORM even detect objects have changed?".
+MikroORM is a data-mapper that tries to achieve persistence-ignorance (PI). This means you map JS objects into a relational database that do not necessarily know about the database at all. A natural question would now be, "how does MikroORM even detect objects have changed?".
 
-For this MikroORM keeps a second map inside the `UnitOfWork`. Whenever you fetch an object 
-from the database MikroORM will keep a copy of all the properties and associations inside 
-the `UnitOfWork`. 
+For this MikroORM keeps a second map inside the `UnitOfWork`. Whenever you fetch an object from the database MikroORM will keep a copy of all the properties and associations inside the `UnitOfWork`.
 
-Now whenever you call `EntityManager#flush()` MikroORM will iterate over all entities you 
-previously marked for persisting via `EntityManager#persistLater()`. For each object it will
-compare the original property and association values with the values that are currently set 
-on the object. If changes are detected then the object is queued for a UPDATE operation. 
-Only the fields that actually changed are updated.
+Now whenever you call `EntityManager#flush()` MikroORM will iterate over all entities you previously marked for persisting via `EntityManager#persistLater()`. For each object it will compare the original property and association values with the values that are currently set on the object. If changes are detected then the object is queued for a UPDATE operation. Only the fields that actually changed are updated.
 
 ## Implicit Transactions
 
-First and most important implication of having Unit of Work is that it allows handling
-transactions automatically. 
+First and most important implication of having Unit of Work is that it allows handling transactions automatically.
 
-When you call `EntityManager#flush()`, all computed changes are queried inside a database
-transaction (if supported by given driver). This means that you can control the boundaries 
-of transactions simply by calling `EntityManager#persistLater()` and once all your changes 
-are ready, simply calling `flush()` will run them inside a transaction. 
+When you call `EntityManager#flush()`, all computed changes are queried inside a database transaction (if supported by given driver). This means that you can control the boundaries of transactions simply by calling `EntityManager#persistLater()` and once all your changes are ready, simply calling `flush()` will run them inside a transaction.
 
 > You can also control the transaction boundaries manually via `em.transactional(cb)`.
 
@@ -97,14 +71,11 @@ user.cars.add(car);
 await em.persistAndFlush(user);
 ```
 
-You can find more information about transactions in [Transactions and concurrency](transactions.md) 
-page.
+You can find more information about transactions in [Transactions and concurrency](transactions.md) page.
 
 ### Beware: Auto-flushing and transactions
 
-Originally there was only `EntityManager#persist(entity, flush = true)` method, that was
-automatically flushing changes to database, if not given second `false` parameter. This 
-behaviour can be now changed via `autoFlush` option when initializing the ORM:
+Originally there was only `EntityManager#persist(entity, flush = true)` method, that was automatically flushing changes to database, if not given second `false` parameter. This behaviour can be now changed via `autoFlush` option when initializing the ORM:
 
 ```typescript
 const orm = await MikroORM.init({
@@ -116,13 +87,8 @@ await orm.em.flush();
 await orm.em.persist(new Entity(), true); // you can still use second parameter to auto-flush
 ```
 
-When using driver that supports transactions (all SQL drivers), you should either disable 
-auto-flushing, or use `persistLater()` method instead, as otherwise each `persist()` call 
-will immediately create new transaction to run the query.
+When using driver that supports transactions (all SQL drivers), you should either disable auto-flushing, or use `persistLater()` method instead, as otherwise each `persist()` call will immediately create new transaction to run the query.
 
-This behaviour will be changed in v3, `autoFlush` will stay configurable but the default 
-value will be `false`. Users are encouraged to use `persistAndFlush()` instead if they need
-the immediate persist. 
+This behaviour will be changed in v3, `autoFlush` will stay configurable but the default value will be `false`. Users are encouraged to use `persistAndFlush()` instead if they need the immediate persist.
 
-> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/unitofwork.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/unitofwork.html) as the behaviour here is pretty much the same.

--- a/docs/versioned_docs/version-2.7/usage-with-js.md
+++ b/docs/versioned_docs/version-2.7/usage-with-js.md
@@ -75,8 +75,7 @@ module.exports.entity = Author;
 module.exports.schema = schema;
 ```
 
-> Do not forget to provide `name` and `path` schema parameters as well as `entity` 
-> and `schema` exports.
+> Do not forget to provide `name` and `path` schema parameters as well as `entity` and `schema` exports.
 
 Reference parameter can be one of (where `SCALAR` is the default one):
 
@@ -99,7 +98,4 @@ const orm = await MikroORM.init({
 });
 ```
 
-For more examples of plain JavaScript entity definitions take a look
-[at the tests](https://github.com/mikro-orm/mikro-orm/blob/master/tests/entities-js) or at
-[Express JavaScript example](https://github.com/mikro-orm/mikro-orm-examples/tree/master/express-js). 
-
+For more examples of plain JavaScript entity definitions take a look [at the tests](https://github.com/mikro-orm/mikro-orm/blob/master/tests/entities-js) or at [Express JavaScript example](https://github.com/mikro-orm/mikro-orm-examples/tree/master/express-js).

--- a/docs/versioned_docs/version-2.7/usage-with-mongo.md
+++ b/docs/versioned_docs/version-2.7/usage-with-mongo.md
@@ -2,8 +2,7 @@
 title: Usage with MongoDB
 ---
 
-To use `mikro-orm` with mongo database, do not forget to install `mongodb` dependency. As `MongoDriver`
-is the default one, you do not need to provide it.
+To use `mikro-orm` with mongo database, do not forget to install `mongodb` dependency. As `MongoDriver` is the default one, you do not need to provide it.
 
 Then call `MikroORM.init` as part of bootstrapping your app:
 
@@ -26,8 +25,7 @@ _id: ObjectID;
 
 ## ObjectID and string id duality
 
-Every entity has both `ObjectID` and `string` id available, also all methods of `EntityManager` 
-and `EntityRepository` supports querying by both of them. 
+Every entity has both `ObjectID` and `string` id available, also all methods of `EntityManager` and `EntityRepository` supports querying by both of them.
 
 ```typescript
 const author = orm.em.getReference('...id...');
@@ -46,19 +44,14 @@ const bar2 = await repo.find({ _id: { $in: [new ObjectID(article)] }, favouriteB
 
 ## ManyToMany collections with inlined pivot array
 
-As opposed to SQL drivers that use pivot tables, in mongo we can leverage available array type
-to store array of collection items (identifiers). This approach has two main benefits:
+As opposed to SQL drivers that use pivot tables, in mongo we can leverage available array type to store array of collection items (identifiers). This approach has two main benefits:
 
-1. Collection is stored on owning side entity, so we know how many items are there even before
-initializing the collection.
+1. Collection is stored on owning side entity, so we know how many items are there even before initializing the collection.
 2. As there are no pivot tables, resulting database queries are much simpler.
 
 ## Native collection methods
 
-Sometimes you need to perform some bulk operation, or you just want to populate your
-database with initial fixtures. Using ORM for such operations can bring unnecessary
-boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete`
-methods:
+Sometimes you need to perform some bulk operation, or you just want to populate your database with initial fixtures. Using ORM for such operations can bring unnecessary boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete` methods:
 
 ```typescript
 EntityManager.nativeInsert<T extends IEntity>(entityName: string, data: any): Promise<IPrimaryKey>;
@@ -66,9 +59,7 @@ EntityManager.nativeUpdate<T extends IEntity>(entityName: string, where: FilterQ
 EntityManager.nativeDelete<T extends IEntity>(entityName: string, where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Those methods execute native driver methods like Mongo's `insertOne/updateMany/deleteMany` collection methods respectively. 
-This is common interface for all drivers, so for MySQL driver, it will fire native SQL queries. 
-Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks. 
+Those methods execute native driver methods like Mongo's `insertOne/updateMany/deleteMany` collection methods respectively. This is common interface for all drivers, so for MySQL driver, it will fire native SQL queries. Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks.
 
 They are also available as `EntityRepository` shortcuts:
 
@@ -84,4 +75,3 @@ There is also shortcut for calling `aggregate` method:
 EntityManager.aggregate(entityName: string, pipeline: any[]): Promise<any[]>;
 EntityRepository.aggregate(pipeline: any[]): Promise<any[]>;
 ```
-

--- a/docs/versioned_docs/version-2.7/usage-with-nestjs.md
+++ b/docs/versioned_docs/version-2.7/usage-with-nestjs.md
@@ -5,8 +5,7 @@ sidebar_label: Usage with NestJS
 
 ## Installation
 
-Easiest way to integrate MikroORM to Nest is via [`nestjs-mikro-orm` module](https://github.com/dario1985/nestjs-mikro-orm).
-Simply install it next to Nest, MikroORM and underlying driver: 
+Easiest way to integrate MikroORM to Nest is via [`nestjs-mikro-orm` module](https://github.com/dario1985/nestjs-mikro-orm). Simply install it next to Nest, MikroORM and underlying driver:
 
 ```
 $ yarn add mikro-orm nestjs-mikro-orm mongodb # for mongo
@@ -24,9 +23,7 @@ $ npm i -s mikro-orm nestjs-mikro-orm pg      # for postgre
 $ npm i -s mikro-orm nestjs-mikro-orm sqlite  # for sqlite
 ```
 
-Then import the `MikroOrmModule` in your top level module (usually called `AppModule`) via 
-`forRoot()`, which will register `MikroORM` and `EntityManager` services. It will also 
-create the request context for you automatically.
+Then import the `MikroOrmModule` in your top level module (usually called `AppModule`) via `forRoot()`, which will register `MikroORM` and `EntityManager` services. It will also create the request context for you automatically.
 
 ```typescript
 @Module({
@@ -56,4 +53,3 @@ export class PhotoModule {}
 ```
 
 > Don't forget to import the feature module in your top level module.
-

--- a/docs/versioned_docs/version-2.7/usage-with-sql.md
+++ b/docs/versioned_docs/version-2.7/usage-with-sql.md
@@ -3,11 +3,9 @@ title: Usage with MySQL, MariaDB, PostgreSQL or SQLite
 sidebar_label: Usage with SQL Drivers
 ---
 
-To use `mikro-orm` with MySQL database, do not forget to install `mysql2` dependency and set 
-the type option to `mysql` when initializing ORM.
+To use `mikro-orm` with MySQL database, do not forget to install `mysql2` dependency and set the type option to `mysql` when initializing ORM.
 
-Similarly for SQLite install `sqlite` dependency and provide `sqlite` database type. For 
-PostgreSQL install `pg` and provide `postgresql` type.
+Similarly for SQLite install `sqlite` dependency and provide `sqlite` database type. For PostgreSQL install `pg` and provide `postgresql` type.
 
 Then call `MikroORM.init` as part of bootstrapping your app:
 
@@ -21,9 +19,7 @@ const orm = await MikroORM.init({
 
 ## Custom driver
 
-If you want to use database that is not currently supported, you can implement your own driver.
-More information about how to create one can be [found here](custom-driver.md). Then provide the 
-driver class via `driver` configuration option: 
+If you want to use database that is not currently supported, you can implement your own driver. More information about how to create one can be [found here](custom-driver.md). Then provide the driver class via `driver` configuration option:
 
 ```typescript
 import { MyCustomDriver } from './MyCustomDriver.ts';
@@ -37,8 +33,7 @@ const orm = await MikroORM.init({
 
 ## Schema
 
-Currently you will need to maintain the database schema yourself. For initial dump, you can 
-use [`SchemaGenerator` helper](schema-generator.md).  
+Currently you will need to maintain the database schema yourself. For initial dump, you can use [`SchemaGenerator` helper](schema-generator.md).
 
 ## ManyToMany collections with pivot tables
 
@@ -53,8 +48,7 @@ CREATE TABLE `publisher_to_test` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 ```
 
-You can adjust the name of pivot table via `pivotTable` option in `@ManyToMany` decorator
-defined on owning side: 
+You can adjust the name of pivot table via `pivotTable` option in `@ManyToMany` decorator defined on owning side:
 
 ```typescript
 // for unidirectional
@@ -68,8 +62,7 @@ tags = new Collection<BookTag>(this);
 
 ## Using QueryBuilder to execute native SQL queries
 
-When you need to execute some SQL query without all the ORM stuff involved, you can either
-compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
+When you need to execute some SQL query without all the ORM stuff involved, you can either compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
 
 ```typescript
 const qb = orm.em.createQueryBuilder(Author);
@@ -112,20 +105,15 @@ QueryBuilder.getParams(): any;
 QueryBuilder.clone(): QueryBuilder;
 ```
 
-For more examples of how to work with `QueryBuilder`, take a look at `QueryBuilder` tests in 
-[`tests/QueryBuilder.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/QueryBuilder.test.ts).
+For more examples of how to work with `QueryBuilder`, take a look at `QueryBuilder` tests in [`tests/QueryBuilder.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/QueryBuilder.test.ts).
 
 ## Transactions
 
-When you call `EntityManager#flush()`, all computed changes are queried [inside a database
-transaction](unit-of-work.md) by default, so you do not have to handle transactions manually. 
+When you call `EntityManager#flush()`, all computed changes are queried [inside a database transaction](unit-of-work.md) by default, so you do not have to handle transactions manually.
 
-When you need to explicitly handle the transaction, you can use `beginTransaction/commit/rollback` 
-methods on both `MySqlDriver` and their shortcuts on `EntityManager`. 
+When you need to explicitly handle the transaction, you can use `beginTransaction/commit/rollback` methods on both `MySqlDriver` and their shortcuts on `EntityManager`.
 
-You can also use `EntityManager.transactional(cb)` helper to run callback in transaction. It will
-provide forked `EntityManager` as a parameter with clear clear isolated identity map - please use that
-to make changes. 
+You can also use `EntityManager.transactional(cb)` helper to run callback in transaction. It will provide forked `EntityManager` as a parameter with clear clear isolated identity map - please use that to make changes.
 
 ```typescript
 // if an error occurs inside the callback, all db queries from inside the callback will be rolled back
@@ -153,16 +141,13 @@ const author3 = new Author2('Author 3', 'a3@example.com');
 await orm.em.persistAndFlush([author1, author2, author3]);
 
 // finds authors with email like '%exa%le.c_m'
-const authors = await orm.em.find(Author2, { email: /exa.*le\.c.m$/ }); 
+const authors = await orm.em.find(Author2, { email: /exa.*le\.c.m$/ });
 console.log(authors); // all 3 authors found
 ```
 
 ## Native collection methods
 
-Sometimes you need to perform some bulk operation, or you just want to populate your
-database with initial fixtures. Using ORM for such operations can bring unnecessary
-boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete`
-methods:
+Sometimes you need to perform some bulk operation, or you just want to populate your database with initial fixtures. Using ORM for such operations can bring unnecessary boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete` methods:
 
 ```typescript
 EntityManager.nativeInsert<T extends IEntity>(entityName: string, data: any): Promise<IPrimaryKey>;
@@ -170,9 +155,7 @@ EntityManager.nativeUpdate<T extends IEntity>(entityName: string, where: FilterQ
 EntityManager.nativeDelete<T extends IEntity>(entityName: string, where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Those methods execute native SQL queries generated via `QueryBuilder` based on entity 
-metadata. Keep in mind that they do not hydrate results to entities, and they do not 
-trigger lifecycle hooks. 
+Those methods execute native SQL queries generated via `QueryBuilder` based on entity metadata. Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks.
 
 They are also available as `EntityRepository` shortcuts:
 
@@ -182,9 +165,7 @@ EntityRepository.nativeUpdate(where: FilterQuery<T>, data: any): Promise<number>
 EntityRepository.nativeDelete(where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Additionally there is `execute()` method that supports executing raw SQL queries or `QueryBuilder`
-instances. To create `QueryBuilder`, you can use `createQueryBuilder()` factory method on both 
-`EntityManager` and `EntityRepository` classes: 
+Additionally there is `execute()` method that supports executing raw SQL queries or `QueryBuilder` instances. To create `QueryBuilder`, you can use `createQueryBuilder()` factory method on both `EntityManager` and `EntityRepository` classes:
 
 ```typescript
 const qb = em.createQueryBuilder('Author');
@@ -192,4 +173,3 @@ qb.select('*').where({ id: { $in: [...] } });
 const res = await em.getDriver<MySqlDriver>().execute(qb);
 console.log(res); // unprocessed result of underlying database driver
 ```
-

--- a/docs/versioned_docs/version-3.6/cascading.md
+++ b/docs/versioned_docs/version-3.6/cascading.md
@@ -3,14 +3,11 @@ title: Cascading persist, merge and remove
 sidebar_label: Cascading
 ---
 
-When persisting or removing entity, all your references are by default cascade persisted. 
-This means that by persisting any entity, ORM will automatically persist all of its 
-associations. 
+When persisting or removing entity, all your references are by default cascade persisted. This means that by persisting any entity, ORM will automatically persist all of its associations.
 
-You can control this behaviour via `cascade` attribute of `@ManyToOne`, `@ManyToMany`, 
-`@OneToMany` and `@OneToOne` fields.
+You can control this behaviour via `cascade` attribute of `@ManyToOne`, `@ManyToMany`, `@OneToMany` and `@OneToOne` fields.
 
-> New entities without primary key will be always persisted, regardless of `cascade` value. 
+> New entities without primary key will be always persisted, regardless of `cascade` value.
 
 ```typescript
 // cascade persist & merge is default value
@@ -54,18 +51,13 @@ book.tags[1].name = 'new name 2';
 await orm.em.persistAndFlush(book); // all book tags and author will be persisted too
 ```
 
-> When cascade persisting collections, keep in mind only fully initialized collections 
-> will be cascade persisted.
+> When cascade persisting collections, keep in mind only fully initialized collections will be cascade persisted.
 
 ## Cascade merge
 
-When you want to merge entity and all its associations, you can use `Cascade.MERGE`. This
-comes handy when you want to clear identity map (e.g. when importing large number of entities), 
-but you also have to keep your parent entities managed (because otherwise they would be considered
-as new entities and insert-persisted, which would fail with non-unique identifier).
+When you want to merge entity and all its associations, you can use `Cascade.MERGE`. This comes handy when you want to clear identity map (e.g. when importing large number of entities), but you also have to keep your parent entities managed (because otherwise they would be considered as new entities and insert-persisted, which would fail with non-unique identifier).
 
-In following example, without having `Author.favouriteBook` set to cascade merge, you would 
-get an error because it would be cascade-inserted with already taken ID. 
+In following example, without having `Author.favouriteBook` set to cascade merge, you would get an error because it would be cascade-inserted with already taken ID.
 
 ```typescript
 const a1 = new Author(...);
@@ -75,13 +67,13 @@ await orm.em.persistAndFlush(a1); // cascade persists favourite book as well
 for (let i = 1; i < 1000; i++) {
   const book = new Book('...', a1);
   orm.em.persistLater(book);
-  
+
   // persist every 100 records
   if (i % 100 === 0) {
     await orm.em.flush();
     orm.em.clear(); // this makes both a1 and his favourite book detached
     orm.em.merge(a1); // so we need to merge them to prevent cascade-inserts
-    
+
     // without cascade merge, you would need to manually merge all his associations
     orm.em.merge(a1.favouriteBook); // not needed with Cascade.MERGE
   }
@@ -92,18 +84,15 @@ await orm.em.flush();
 
 ## Cascade remove
 
-Cascade remove works same way as cascade persist, just for removing entities. Following 
-example assumes that `Book.publisher` is set to `Cascade.REMOVE`:
+Cascade remove works same way as cascade persist, just for removing entities. Following example assumes that `Book.publisher` is set to `Cascade.REMOVE`:
 
-> Note that cascade remove for collections can be inefficient as it will fire 1 query
-> for each entity in collection.
+> Note that cascade remove for collections can be inefficient as it will fire 1 query for each entity in collection.
 
 ```typescript
 await orm.em.removeEntity(book); // this will also remove book.publisher
 ```
 
-Keep in mind that cascade remove **can be dangerous** when used on `@ManyToOne` fields, 
-as cascade removed entity can stay referenced in another entities that were not removed.
+Keep in mind that cascade remove **can be dangerous** when used on `@ManyToOne` fields, as cascade removed entity can stay referenced in another entities that were not removed.
 
 ```typescript
 const publisher = new Publisher(...);
@@ -117,9 +106,7 @@ console.log(book2.publisher, book3.publisher);
 
 ## Orphan removal
 
-In addition to `Cascade.REMOVE`, there is also additional and more aggressive remove 
-cascading mode which can be specified using the `orphanRemoval` flag of the `@OneToOne`
-and `@OneToMany` properties:
+In addition to `Cascade.REMOVE`, there is also additional and more aggressive remove cascading mode which can be specified using the `orphanRemoval` flag of the `@OneToOne` and `@OneToMany` properties:
 
 ```typescript
 @Entity()
@@ -131,13 +118,9 @@ export class Author {
 }
 ```
 
-> `orphanRemoval` flag behaves just like `Cascade.REMOVE` for remove operation, so specifying 
-> both is redundant.
+> `orphanRemoval` flag behaves just like `Cascade.REMOVE` for remove operation, so specifying both is redundant.
 
-With simple `Cascade.REMOVE`, you wound need to remove the `Author` entity to cascade 
-the operation down to all loaded `Book`s. By enabling orphan removal on the collection, 
-`Book`s will be also removed when they get disconnected from the collection (either via 
-`remove()`, or by replacing collection items via `set()`):
+With simple `Cascade.REMOVE`, you wound need to remove the `Author` entity to cascade the operation down to all loaded `Book`s. By enabling orphan removal on the collection, `Book`s will be also removed when they get disconnected from the collection (either via `remove()`, or by replacing collection items via `set()`):
 
 ```typescript
 await author.books.set([book1, book2]); // replace whole collection
@@ -145,18 +128,15 @@ await author.books.remove(book1); // remove book from collection
 await orm.em.persistAndFlush(author); // book1 will be removed, as well as all original items (before we called `set()`)
 ```
 
-In this example, no `Book` would be removed with simple `Cascade.REMOVE` as no remove operation
-was executed. 
+In this example, no `Book` would be removed with simple `Cascade.REMOVE` as no remove operation was executed.
 
 ## Declarative Referential Integrity
 
 > This is only supported in SQL drivers.
 
-As opposed to the application level cascading controlled by the `cascade` option, we can
-also define database level referential integrity actions: `on update` and `on delete`.
+As opposed to the application level cascading controlled by the `cascade` option, we can also define database level referential integrity actions: `on update` and `on delete`.
 
-Their values are automatically inferred from the `cascade` option value. You can also 
-control the value manually via `onUpdateIntegrity` and `onDelete` options. 
+Their values are automatically inferred from the `cascade` option value. You can also control the value manually via `onUpdateIntegrity` and `onDelete` options.
 
 ```typescript
 @Entity()

--- a/docs/versioned_docs/version-3.6/collections.md
+++ b/docs/versioned_docs/version-3.6/collections.md
@@ -2,15 +2,11 @@
 title: Collections
 ---
 
-`OneToMany` and `ManyToMany` collections are stored in a `Collection` wrapper. It implements
-iterator so you can use `for of` loop to iterate through it. 
+`OneToMany` and `ManyToMany` collections are stored in a `Collection` wrapper. It implements iterator so you can use `for of` loop to iterate through it.
 
-Another way to access collection items is to use bracket syntax like when you access array items.
-Keep in mind that this approach will not check if the collection is initialed, while using `get`
-method will throw error in this case.
+Another way to access collection items is to use bracket syntax like when you access array items. Keep in mind that this approach will not check if the collection is initialed, while using `get` method will throw error in this case.
 
-> Note that array access in `Collection` is available only for reading already loaded items, you 
-> cannot add new items to `Collection` this way. 
+> Note that array access in `Collection` is available only for reading already loaded items, you cannot add new items to `Collection` this way.
 
 ```typescript
 const author = orm.em.findOne(Author, '...', ['books']); // populating books collection
@@ -56,7 +52,7 @@ console.log(await author.books.loadItems()); // Book[]
 ## OneToMany Collections
 
 `OneToMany` collections are inverse side of `ManyToOne` references, to which they need to point via `fk` attribute:
- 
+
 ```typescript
 @Entity()
 export class Book {
@@ -87,15 +83,13 @@ export class Author {
 
 ## ManyToMany Collections
 
-For ManyToMany, SQL drivers use pivot table that holds reference to both entities. 
+For ManyToMany, SQL drivers use pivot table that holds reference to both entities.
 
-As opposed to them, with MongoDB we do not need to have join tables for `ManyToMany` 
-relations. All references are stored as an array of `ObjectId`s on owning entity. 
+As opposed to them, with MongoDB we do not need to have join tables for `ManyToMany` relations. All references are stored as an array of `ObjectId`s on owning entity.
 
 ### Unidirectional
 
-Unidirectional `ManyToMany` relations are defined only on one side, if you define only `entity`
-attribute, then it will be considered the owning side:
+Unidirectional `ManyToMany` relations are defined only on one side, if you define only `entity` attribute, then it will be considered the owning side:
 
 ```typescript
 @ManyToMany(() => Book)
@@ -108,8 +102,7 @@ books2 = new Collection<Book>(this);
 
 ### Bidirectional
 
-Bidirectional `ManyToMany` relations are defined on both sides, while one is owning side (where references are store), 
-marked by `inversedBy` attribute pointing to the inverse side:
+Bidirectional `ManyToMany` relations are defined on both sides, while one is owning side (where references are store), marked by `inversedBy` attribute pointing to the inverse side:
 
 ```typescript
 @ManyToMany(() => BookTag, tag => tag.books, { owner: true })
@@ -133,22 +126,15 @@ books = new Collection<Book>(this);
 
 ### Forcing fixed order of collection items
 
-> Since v3 many to many collections does not require having auto increment primary key, that 
-> was used to ensure fixed order of collection items.
+> Since v3 many to many collections does not require having auto increment primary key, that was used to ensure fixed order of collection items.
 
-To preserve fixed order of collections, you can use `fixedOrder: true` attribute, which will 
-start ordering by `id` column. Schema generator will convert the pivot table to have auto increment
-primary key `id`. You can also change the order column name via `fixedOrderColumn: 'order'`. 
+To preserve fixed order of collections, you can use `fixedOrder: true` attribute, which will start ordering by `id` column. Schema generator will convert the pivot table to have auto increment primary key `id`. You can also change the order column name via `fixedOrderColumn: 'order'`.
 
-You can also specify default ordering via `orderBy: { ... }` attribute. This will be used when
-you fully populate the collection including its items, as it orders by the referenced entity 
-properties instead of pivot table columns (which `fixedOrderColumn` is). On the other hand, 
-`fixedOrder` is used to maintain the insert order of items instead of ordering by some property. 
+You can also specify default ordering via `orderBy: { ... }` attribute. This will be used when you fully populate the collection including its items, as it orders by the referenced entity properties instead of pivot table columns (which `fixedOrderColumn` is). On the other hand, `fixedOrder` is used to maintain the insert order of items instead of ordering by some property.
 
 ## Propagation of Collection's add() and remove() operations
 
-When you use one of `Collection.add()` method, the item is added to given collection, 
-and this action is also propagated to its counterpart. 
+When you use one of `Collection.add()` method, the item is added to given collection, and this action is also propagated to its counterpart.
 
 ```typescript
 // one to many
@@ -159,7 +145,7 @@ author.books.add(book);
 console.log(book.author); // author will be set thanks to the propagation
 ```
 
-For M:N this works in both ways, either from owning side, or from inverse side. 
+For M:N this works in both ways, either from owning side, or from inverse side.
 
 ```typescript
 // many to many works both from owning side and from inverse side
@@ -171,19 +157,17 @@ console.log(tag.books.contains(book)); // true
 
 tag.books.add(book);
 console.log(book.tags.contains(tag)); // true
-``` 
+```
 
 > Collections on both sides have to be initialized, otherwise propagation won't work.
 
-> Although this propagation works also for M:N inverse side, you should always use owning
-> side to manipulate the collection.
+> Although this propagation works also for M:N inverse side, you should always use owning side to manipulate the collection.
 
 Same applies for `Collection.remove()`.
 
 ## Filtering and ordering of collection items
 
-When initializing collection items via `collection.init()`, you can filter the collection
-as well as order its items:
+When initializing collection items via `collection.init()`, you can filter the collection as well as order its items:
 
 ```typescript
 await book.tags.init({ where: { active: true }, orderBy: { name: QueryOrder.DESC } });

--- a/docs/versioned_docs/version-3.6/composite-keys.md
+++ b/docs/versioned_docs/version-3.6/composite-keys.md
@@ -5,14 +5,9 @@ sidebar_label: Composite Primary Keys
 
 > Support for composite keys was added in version 3.5
 
-MikroORM supports composite primary keys natively. Composite keys are a very powerful 
-relational database concept and we took good care to make sure MikroORM supports as 
-many of the composite primary key use-cases. MikroORM supports composite keys of primitive 
-data-types as well as foreign keys as primary keys. You can also use your composite key 
-entities in relationships. 
+MikroORM supports composite primary keys natively. Composite keys are a very powerful relational database concept and we took good care to make sure MikroORM supports as many of the composite primary key use-cases. MikroORM supports composite keys of primitive data-types as well as foreign keys as primary keys. You can also use your composite key entities in relationships.
 
-This section shows how the semantics of composite primary keys work and how they map 
-to the database.
+This section shows how the semantics of composite primary keys work and how they map to the database.
 
 ## General Considerations
 
@@ -20,8 +15,7 @@ ID fields have to have their values set before you call `em.persist(entity)`.
 
 ## Primitive Types only
 
-Suppose you want to create a database of cars and use the model-name and year of 
-production as primary keys:
+Suppose you want to create a database of cars and use the model-name and year of production as primary keys:
 
 ```typescript
 @Entity()
@@ -50,39 +44,28 @@ const car = new Car('Audi A8', 2010);
 await em.persistAndFlush(car);
 ```
 
-And for querying you need to provide all primary keys in the condition or an array of
-primary keys in the same order as the keys were defined:
+And for querying you need to provide all primary keys in the condition or an array of primary keys in the same order as the keys were defined:
 
 ```typescript
 const audi1 = await em.findOneOrFail(Car, { name: 'Audi A8', year: 2010 });
 const audi2 = await em.findOneOrFail(Car, ['Audi A8', 2010]);
 ```
 
-> If we want to use the second approach with primary key tuple, we will need to specify 
-> the type of entity's primary key via `PrimaryKeyType` symbol as shown in the `Car` entity.
+> If we want to use the second approach with primary key tuple, we will need to specify the type of entity's primary key via `PrimaryKeyType` symbol as shown in the `Car` entity.
 
-> `PrimaryKeyType` is not needed when your entity has single scalar primary key under 
-> one of following property names: `id: number | string | bigint`, `_id: any` or 
-> `uuid: string`.
+> `PrimaryKeyType` is not needed when your entity has single scalar primary key under one of following property names: `id: number | string | bigint`, `_id: any` or `uuid: string`.
 
-You can also use this entity in associations. MikroORM will then generate two foreign 
-keys one for name and to year to the related entities.
+You can also use this entity in associations. MikroORM will then generate two foreign keys one for name and to year to the related entities.
 
-This example shows how you can nicely solve the requirement for existing values before 
-`em.persist()`: By adding them as mandatory values for the constructor.
+This example shows how you can nicely solve the requirement for existing values before `em.persist()`: By adding them as mandatory values for the constructor.
 
 ## Identity through foreign Entities
 
-There are tons of use-cases where the identity of an Entity should be determined by 
-the entity of one or many parent entities.
+There are tons of use-cases where the identity of an Entity should be determined by the entity of one or many parent entities.
 
-- Dynamic Attributes of an Entity (for example `Article`). Each Article has many 
-  attributes with primary key `article_id` and `attribute_name`.
-- `Address` object of a `Person`, the primary key of the address is `user_id`. This 
-  is not a case of a composite primary key, but the identity is derived through a 
-  foreign entity and a foreign key.
-- Pivot Tables with metadata can be modelled as Entity, for example connections between 
-  two articles with a little description and a score.
+- Dynamic Attributes of an Entity (for example `Article`). Each Article has many attributes with primary key `article_id` and `attribute_name`.
+- `Address` object of a `Person`, the primary key of the address is `user_id`. This is not a case of a composite primary key, but the identity is derived through a foreign entity and a foreign key.
+- Pivot Tables with metadata can be modelled as Entity, for example connections between two articles with a little description and a score.
 
 The semantics of mapping identity through foreign entities are easy:
 
@@ -133,9 +116,7 @@ export class ArticleAttribute {
 
 ## Use-Case 2: Simple Derived Identity
 
-Sometimes you have the requirement that two objects are related by a `@OneToOne` 
-association and that the dependent class should re-use the primary key of the class 
-it depends on. One good example for this is a user-address relationship:
+Sometimes you have the requirement that two objects are related by a `@OneToOne` association and that the dependent class should re-use the primary key of the class it depends on. One good example for this is a user-address relationship:
 
 ```typescript
 @Entity()
@@ -162,9 +143,7 @@ export class Address {
 
 ## Use-Case 3: Join-Table with Metadata
 
-In the classic order product shop example there is the concept of the order item which 
-contains references to order and product and additional data such as the amount of products 
-purchased and maybe even the current price.
+In the classic order product shop example there is the concept of the order item which contains references to order and product and additional data such as the amount of products purchased and maybe even the current price.
 
 ```typescript
 @Entity()
@@ -236,8 +215,7 @@ export class OrderItem {
 
 ## Using QueryBuilder with composite keys
 
-Internally composite keys are represented as tuples, containing all the values in the
-same order as the primary keys were defined. 
+Internally composite keys are represented as tuples, containing all the values in the same order as the primary keys were defined.
 
 ```typescript
 const qb1 = em.createQueryBuilder(CarOwner);
@@ -258,7 +236,6 @@ This also applies when you want to get a reference to entity with composite key:
 ```typescript
 const ref = em.getReference(Car, ['Audi A8', 2010]);
 console.log(ref instanceof Car); // true
-``` 
+```
 
-> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/composite-primary-keys.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/composite-primary-keys.html) as the behaviour here is pretty much the same.

--- a/docs/versioned_docs/version-3.6/configuration.md
+++ b/docs/versioned_docs/version-3.6/configuration.md
@@ -4,8 +4,7 @@ title: Advanced Configuration
 
 ## Entity Discovery
 
-You can either provide array of entity instances via `entities`, or let the ORM look up your 
-entities in selected folders. 
+You can either provide array of entity instances via `entities`, or let the ORM look up your entities in selected folders.
 
 ```typescript
 MikroORM.init({
@@ -13,11 +12,9 @@ MikroORM.init({
 });
 ```
 
-When using `entitiesDirs`, you can optionally provide also set of directories with TS source files, 
-that will be used to look up missing types (see more at [Metadata Providers](metadata-providers.md)).
+When using `entitiesDirs`, you can optionally provide also set of directories with TS source files, that will be used to look up missing types (see more at [Metadata Providers](metadata-providers.md)).
 
-> The `entitiesDirsTs` option is used only with the default `TsMorphMetadataProvider`. By default, all your 
-> source files will be scanned, based on your `tsconfig.json`. 
+> The `entitiesDirsTs` option is used only with the default `TsMorphMetadataProvider`. By default, all your source files will be scanned, based on your `tsconfig.json`.
 
 ```typescript
 MikroORM.init({
@@ -29,12 +26,9 @@ MikroORM.init({
 });
 ```
 
-By default, `TsMorphMetadataProvider` is used that analyses your entity source files. You can
-use `ReflectMetadataProvider` if you do not want the source file analyses to happen. 
-If you aim to use plain JavaScript instead of TypeScript, use the `JavaScriptMetadataProvider`.
+By default, `TsMorphMetadataProvider` is used that analyses your entity source files. You can use `ReflectMetadataProvider` if you do not want the source file analyses to happen. If you aim to use plain JavaScript instead of TypeScript, use the `JavaScriptMetadataProvider`.
 
-> You can also implement your own metadata provider and use it instead. To do so, extend the 
-> `MetadataProvider` class.
+> You can also implement your own metadata provider and use it instead. To do so, extend the `MetadataProvider` class.
 
 ```typescript
 MikroORM.init({
@@ -57,8 +51,7 @@ MikroORM.init({
 });
 ```
 
-> If you disable `discovery.alwaysAnalyseProperties` option, you will need to explicitly 
-> provide `nullable` and `wrappedReference` parameters (where applicable).
+> If you disable `discovery.alwaysAnalyseProperties` option, you will need to explicitly provide `nullable` and `wrappedReference` parameters (where applicable).
 
 Read more about this in [Metadata Providers](metadata-providers.md) sections.
 
@@ -66,19 +59,17 @@ Read more about this in [Metadata Providers](metadata-providers.md) sections.
 
 To select driver, you can either use `type` option, or provide the driver class reference.
 
-| type | driver name | dependency | note |
-|------|-------------|------------|------|
-| `mongo` | `MongoDriver` | `mongodb^3.3.4` | default driver |
-| `mysql` | `MySqlDriver` | `mysql2^2.0.0` | compatible with MariaDB |
-| `mariadb` | `MariaDbDriver` | `mariadb^2.0.0` | compatible with MySQL |
-| `postgresql` | `PostgreSqlDriver` | `pg^7.0.0` | - |
-| `sqlite` | `SqliteDriver` | `sqlite3^4.0.0` | - |
+| type         | driver name        | dependency      | note                    |
+| ------------ | ------------------ | --------------- | ----------------------- |
+| `mongo`      | `MongoDriver`      | `mongodb^3.3.4` | default driver          |
+| `mysql`      | `MySqlDriver`      | `mysql2^2.0.0`  | compatible with MariaDB |
+| `mariadb`    | `MariaDbDriver`    | `mariadb^2.0.0` | compatible with MySQL   |
+| `postgresql` | `PostgreSqlDriver` | `pg^7.0.0`      | -                       |
+| `sqlite`     | `SqliteDriver`     | `sqlite3^4.0.0` | -                       |
 
-> Driver and connection implementations are not directly exported from `mikro-orm` module. 
-> You can import them from `mikro-orm/dist/drivers`.
+> Driver and connection implementations are not directly exported from `mikro-orm` module. You can import them from `mikro-orm/dist/drivers`.
 
-> You can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. 
-> The object will be deeply merged, overriding all internally used options.
+> You can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. The object will be deeply merged, overriding all internally used options.
 
 ```typescript
 import { MySqlDriver } from 'mikro-orm/dist/drivers/MySqlDriver';
@@ -100,8 +91,7 @@ MikroORM.init({
 
 ## Connection
 
-Each platform (driver) provides default connection string, you can override it as a whole
-through `clientUrl`, or partially through one of following options:
+Each platform (driver) provides default connection string, you can override it as a whole through `clientUrl`, or partially through one of following options:
 
 ```typescript
 export interface ConnectionOptions {
@@ -119,15 +109,14 @@ export interface ConnectionOptions {
 
 Following table shows default client connection strings:
 
-| type | default connection url |
-|------|------------------------|
-| `mongo` | `mongodb://127.0.0.1:27017` |
-| `mysql` | `mysql://root@127.0.0.1:3306` |
-| `mariadb` | `mysql://root@127.0.0.1:3306` |
+| type         | default connection url                 |
+| ------------ | -------------------------------------- |
+| `mongo`      | `mongodb://127.0.0.1:27017`            |
+| `mysql`      | `mysql://root@127.0.0.1:3306`          |
+| `mariadb`    | `mysql://root@127.0.0.1:3306`          |
 | `postgresql` | `postgresql://postgres@127.0.0.1:5432` |
 
-To set up read replicas, you can use `replicas` option. You can provide only those parts of the 
-`ConnectionOptions` interface, they will be used to override the `master` connection options.
+To set up read replicas, you can use `replicas` option. You can provide only those parts of the `ConnectionOptions` interface, they will be used to override the `master` connection options.
 
 ```typescript
 MikroORM.init({
@@ -148,10 +137,7 @@ Read more about this in [Installation](installation.md) and [Read Connections](r
 
 ## Auto-flush
 
-Since MikroORM v3, default value for `autoFlush` is `false`. That means you need to call 
-`em.flush()` yourself to persist changes into database. You can still change this via ORM's 
-options to ease the transition but generally it is not recommended as it can cause unwanted 
-small transactions being created around each `persist`. 
+Since MikroORM v3, default value for `autoFlush` is `false`. That means you need to call `em.flush()` yourself to persist changes into database. You can still change this via ORM's options to ease the transition but generally it is not recommended as it can cause unwanted small transactions being created around each `persist`.
 
 ```typescript
 MikroORM.init({
@@ -166,8 +152,7 @@ Read more about this in [Entity Manager](entity-manager.md#auto-flushing) docs.
 
 ## Naming Strategy
 
-When mapping your entities to database tables and columns, their names will be defined by naming 
-strategy. There are 3 basic naming strategies you can choose from:
+When mapping your entities to database tables and columns, their names will be defined by naming strategy. There are 3 basic naming strategies you can choose from:
 
 - `UnderscoreNamingStrategy` - default of all SQL drivers
 - `MongoNamingStrategy` - default of `MongoDriver`
@@ -185,9 +170,7 @@ Read more about this in [Naming Strategy](naming-strategy.md) section.
 
 ## Auto-join of 1:1 owners
 
-By default, owning side of 1:1 relation will be auto-joined when you select the inverse side 
-so we can have the reference to it. You can disable this behaviour via `autoJoinOneToOneOwner` 
-configuration toggle.
+By default, owning side of 1:1 relation will be auto-joined when you select the inverse side so we can have the reference to it. You can disable this behaviour via `autoJoinOneToOneOwner` configuration toggle.
 
 ```typescript
 MikroORM.init({
@@ -197,8 +180,7 @@ MikroORM.init({
 
 ## Propagation of 1:1 and m:1 owners
 
-MikroORM defines getter and setter for every owning side of m:1 and 1:1 relation. This is 
-then used for propagation of changes to the inverse side of bi-directional relations.
+MikroORM defines getter and setter for every owning side of m:1 and 1:1 relation. This is then used for propagation of changes to the inverse side of bi-directional relations.
 
 ```typescript
 const author = new Author('n', 'e');
@@ -217,9 +199,7 @@ MikroORM.init({
 
 ## Forcing UTC Timezone
 
-Use `forceUtcTimezone` option to force the `Date`s to be saved in UTC in datetime columns 
-without timezone. It works for MySQL (`datetime` type) and PostgreSQL (`timestamp` type). 
-SQLite does this by default. 
+Use `forceUtcTimezone` option to force the `Date`s to be saved in UTC in datetime columns without timezone. It works for MySQL (`datetime` type) and PostgreSQL (`timestamp` type). SQLite does this by default.
 
 ```typescript
 MikroORM.init({
@@ -229,8 +209,7 @@ MikroORM.init({
 
 ## Custom Hydrator
 
-Hydrator is responsible for assigning values from the database to entities. 
-You can implement your custom `Hydrator` (by extending the abstract `Hydrator` class):
+Hydrator is responsible for assigning values from the database to entities. You can implement your custom `Hydrator` (by extending the abstract `Hydrator` class):
 
 ```typescript
 MikroORM.init({
@@ -240,8 +219,7 @@ MikroORM.init({
 
 ## Custom Repository
 
-You can also register custom base repository (for all entities where you do not specify 
-`customRepository`) globally:
+You can also register custom base repository (for all entities where you do not specify `customRepository`) globally:
 
 > You can still use entity specific repositories in combination with global base repository.
 
@@ -255,10 +233,7 @@ Read more about this in [Repositories](repositories.md) section.
 
 ## Strict Mode
 
-`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong 
-data types for you automatically. If automatic conversion fails, it will throw an error. You can 
-enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered 
-when persisting the entity. 
+`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong data types for you automatically. If automatic conversion fails, it will throw an error. You can enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered when persisting the entity.
 
 ```typescript
 MikroORM.init({
@@ -270,8 +245,7 @@ Read more about this in [Property Validation](property-validation.md) section.
 
 ## Debugging & Logging
 
-You can enable logging with `debug` option. Either set it to `true` to log everything, or 
-provide array of `'query' | 'query-params' | 'discovery' | 'info'` namespaces.
+You can enable logging with `debug` option. Either set it to `true` to log everything, or provide array of `'query' | 'query-params' | 'discovery' | 'info'` namespaces.
 
 ```typescript
 MikroORM.init({
@@ -286,8 +260,7 @@ Read more about this in [Debugging](debugging.md) section.
 
 ## Custom Fail Handler
 
-When no entity is found during `em.findOneOrFail()` call, `new Error()` will be thrown. 
-You can customize how the `Error` instance is created via `findOneOrFailHandler`:
+When no entity is found during `em.findOneOrFail()` call, `new Error()` will be thrown. You can customize how the `Error` instance is created via `findOneOrFailHandler`:
 
 ```typescript
 MikroORM.init({
@@ -301,8 +274,7 @@ Read more about this in [Entity Manager](entity-manager.md#handling-not-found-en
 
 ## Migrations
 
-Under the `migrations` namespace, you can adjust how the integrated migrations support works.
-Following example shows all possible options and their defaults:
+Under the `migrations` namespace, you can adjust how the integrated migrations support works. Following example shows all possible options and their defaults:
 
 ```typescript
 MikroORM.init({
@@ -322,8 +294,7 @@ Read more about this in [Migrations](migrations.md) section.
 
 ## Caching
 
-By default, metadata discovery results are cached. You can either disable caching, or adjust 
-how it works. Following example shows all possible options and their defaults:
+By default, metadata discovery results are cached. You can either disable caching, or adjust how it works. Following example shows all possible options and their defaults:
 
 ```typescript
 MikroORM.init({

--- a/docs/versioned_docs/version-3.6/custom-driver.md
+++ b/docs/versioned_docs/version-3.6/custom-driver.md
@@ -2,18 +2,17 @@
 title: Creating Custom Driver
 ---
 
-If you want to use database that is not currently supported, you can implement your own driver.
-To do so, you will need to design 4 classes:
+If you want to use database that is not currently supported, you can implement your own driver. To do so, you will need to design 4 classes:
 
 ## Platform
 
-Platform is a class that provides information about available features of given driver: 
+Platform is a class that provides information about available features of given driver:
 
 ```typescript
 import { Platform } from 'mikro-orm';
 
 export class MyCustomPlatform extends Platform {
-  
+
   protected readonly schemaHelper: MyCustomSchemaHelper;
 
   // here you can override default settings
@@ -39,7 +38,7 @@ Part of platform is a `SchemaHelper`, that provides information about how to bui
 import { SchemaHelper } from 'mikro-orm';
 
 export class MyCustomSchemaHelper extends SchemaHelper {
-  
+
   // here you can override default settings
   getIdentifierQuoteCharacter(): string;
   getSchemaBeginning(): string;
@@ -67,7 +66,7 @@ Next part is connection wrapper, that will be responsible for querying the datab
 import { Connection } from 'mikro-orm';
 
 export class MyCustomConnection extends Connection {
-  
+
   // implement abstract methods
   connect(): Promise<void>;
   isConnected(): Promise<boolean>;
@@ -80,12 +79,9 @@ export class MyCustomConnection extends Connection {
 
 ## Driver
 
-Last part is driver, that is responsible for using the connection to persist changes to 
-database. If you are building SQL driver, it might be handy to extend `AbstractSqlDriver`, 
-if not, extend `DatabaseDriver` abstract class. 
+Last part is driver, that is responsible for using the connection to persist changes to database. If you are building SQL driver, it might be handy to extend `AbstractSqlDriver`, if not, extend `DatabaseDriver` abstract class.
 
-If you want to have absolute control, you can implement the whole driver yourself via
-`IDatabaseDriver` interface. 
+If you want to have absolute control, you can implement the whole driver yourself via `IDatabaseDriver` interface.
 
 ```typescript
 import { DatabaseDriver } from 'mikro-orm';

--- a/docs/versioned_docs/version-3.6/custom-types.md
+++ b/docs/versioned_docs/version-3.6/custom-types.md
@@ -6,23 +6,19 @@ You can define custom types by extending `Type` abstract class. It has 4 optiona
 
 - `convertToDatabaseValue(value: any, platform: Platform): any`
 
-  Converts a value from its JS representation to its database representation of this type.
-  By default returns unchanged `value`.
+  Converts a value from its JS representation to its database representation of this type. By default returns unchanged `value`.
 
 - `convertToJSValue(value: any, platform: Platform): any`
 
-  Converts a value from its database representation to its JS representation of this type.
-  By default returns unchanged `value`.
+  Converts a value from its database representation to its JS representation of this type. By default returns unchanged `value`.
 
 - `toJSON(value: any, platform: Platform): any`
 
-  Converts a value from its JS representation to its serialized JSON form of this type.
-  By default converts to the database value.
-  
+  Converts a value from its JS representation to its serialized JSON form of this type. By default converts to the database value.
+
 - `getColumnType(prop: EntityProperty, platform: Platform): string`
 
-  Gets the SQL declaration snippet for a field of this type.
-  By default returns `columnType` of given property.
+  Gets the SQL declaration snippet for a field of this type. By default returns `columnType` of given property.
 
 > `DateType` and `TimeType` types are already implemented in the ORM.
 

--- a/docs/versioned_docs/version-3.6/debugging.md
+++ b/docs/versioned_docs/version-3.6/debugging.md
@@ -19,8 +19,7 @@ By doing this `MikroORM` will start using `console.log()` function to dump all q
 [query] commit [took 2 ms]
 ```
 
-It is also useful for debugging problems with entity discovery, as you will see information
-about every processed entity:
+It is also useful for debugging problems with entity discovery, as you will see information about every processed entity:
 
 ```
 [discovery] ORM entity discovery started
@@ -33,7 +32,7 @@ about every processed entity:
 
 ## Custom Logger
 
-You can also provide your own logger via `logger` option. 
+You can also provide your own logger via `logger` option.
 
 ```typescript
 return MikroORM.init({
@@ -44,8 +43,7 @@ return MikroORM.init({
 
 ## Logger Namespaces
 
-There are multiple Logger Namespaces that you can specifically request, while omitting the rest.
-Just specify array of them via the `debug` option:
+There are multiple Logger Namespaces that you can specifically request, while omitting the rest. Just specify array of them via the `debug` option:
 
 ```typescript
 return MikroORM.init({

--- a/docs/versioned_docs/version-3.6/decorators.md
+++ b/docs/versioned_docs/version-3.6/decorators.md
@@ -6,14 +6,13 @@ title: Decorators Reference
 
 ### @Entity()
 
-`@Entity` decorator is used to mark your model classes as entities. Do not use it for 
-abstract base classes.
+`@Entity` decorator is used to mark your model classes as entities. Do not use it for abstract base classes.
 
-| Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
-| `tableName` | `string` | yes | Override default collection/table name. |
-| `collection` | `string` | yes | Alias for `tableName`. |
-| `customRepository` | `() => EntityRepository` | yes | Set custom repository class. |
+| Parameter          | Type                     | Optional | Description                             |
+| ------------------ | ------------------------ | -------- | --------------------------------------- |
+| `tableName`        | `string`                 | yes      | Override default collection/table name. |
+| `collection`       | `string`                 | yes      | Alias for `tableName`.                  |
+| `customRepository` | `() => EntityRepository` | yes      | Set custom repository class.            |
 
 > You can also use `@Repository()` decorator instead of `customRepository` parameter.
 
@@ -26,11 +25,10 @@ export class Author { ... }
 
 ### @Property()
 
-`@Property()` decorator is used to define regular entity property. All following decorators
-extend the `@Property()` decorator, so you can also use its parameters there. 
+`@Property()` decorator is used to define regular entity property. All following decorators extend the `@Property()` decorator, so you can also use its parameters there.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `fieldName` | `string` | yes | Override default property name (see [Naming Strategy](naming-strategy.md)). |
 | `type` | `string` &#124; `Type` | yes | Explicitly specify the runtime type (see [Metadata Providers](metadata-providers.md) and [Custom Types](custom-types.md)). |
 | `onUpdate` | `() => any` | yes | Automatically update the property value every time entity gets updated. |
@@ -65,14 +63,13 @@ registered = false;
 
 ### @PrimaryKey()
 
-`@PrimaryKey()` decorator is used to define entity's unique primary key identifier. 
+`@PrimaryKey()` decorator is used to define entity's unique primary key identifier.
 
-> `@PrimaryKey()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@PrimaryKey()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 > Every entity needs to have at least one primary key (see composite primary keys).
 
-> Note that if only one PrimaryKey is set and it's type is number it will be set to auto incremented automatically in all SQL drivers. 
+> Note that if only one PrimaryKey is set and it's type is number it will be set to auto incremented automatically in all SQL drivers.
 
 ```typescript
 @PrimaryKey()
@@ -87,13 +84,10 @@ _id!: ObjectId; // ObjectId PK in mongodb driver
 
 ### @SerializedPrimaryKey()
 
-> Property marked with `@SerializedPrimaryKey()` is virtual, it will not be persisted 
-> into the database.
+> Property marked with `@SerializedPrimaryKey()` is virtual, it will not be persisted into the database.
 
-For MongoDB you can define serialized primary key, which will be then used in entity 
-serialization via `JSON.stringify()` (through method `entity.toJSON()`).
-You will be able to use it to manipulate with the primary key as string. 
- 
+For MongoDB you can define serialized primary key, which will be then used in entity serialization via `JSON.stringify()` (through method `entity.toJSON()`). You will be able to use it to manipulate with the primary key as string.
+
 See [Usage with MongoDB](usage-with-mongo.md) and [Serializing](serializing.md).
 
 ```typescript
@@ -106,19 +100,15 @@ id!: string;
 
 ### @Enum()
 
-> `@Enum()` decorator extend the `@Property()` decorator, so you can use all its 
-> parameters.
+> `@Enum()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
-`@Enum()` decorator can be used for both numeric and string enums. By default enums are 
-considered numeric, and will be represented in the database schema as `tinyint/smallint`. 
-For string enums, if you define the enum in same file, its values will be automatically 
-sniffed. 
+`@Enum()` decorator can be used for both numeric and string enums. By default enums are considered numeric, and will be represented in the database schema as `tinyint/smallint`. For string enums, if you define the enum in same file, its values will be automatically sniffed.
 
 See [Defining Entities](defining-entities.md#enums).
 
-| Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
-| `items` | `number[]` &#124; `string[]` &#124; `() => Dictionary` | yes | Specify enum items explicitly. |
+| Parameter | Type                                                   | Optional | Description                    |
+| --------- | ------------------------------------------------------ | -------- | ------------------------------ |
+| `items`   | `number[]` &#124; `string[]` &#124; `() => Dictionary` | yes      | Specify enum items explicitly. |
 
 ```typescript
 @Enum() // with ts-morph metadata provider we do not need to specify anything
@@ -139,18 +129,15 @@ enum4 = 'a';
 
 ### @Index() and @Unique()
 
-Use `@Index()` to create an index, or `@Unique()` to create unique constraint. You can 
-use those decorators both on the entity level and on property level. To create compound
-index, use the decorator on the entity level and provide list of property names via the
-`properties` option.
+Use `@Index()` to create an index, or `@Unique()` to create unique constraint. You can use those decorators both on the entity level and on property level. To create compound index, use the decorator on the entity level and provide list of property names via the `properties` option.
 
 See [Defining Entities](defining-entities.md#indexes).
 
-| Parameter    | Type     | Optional | Description |
-|--------------|----------|----------|-------------|
-| `name`       | `string` | yes      | index name  |
-| `properties` | `string` &#124; `string[]` | yes | list of properties, required when using on entity level |
-| `type`       | `string` | yes      | index type, not available for `@Unique()` |
+| Parameter    | Type                       | Optional | Description                                             |
+| ------------ | -------------------------- | -------- | ------------------------------------------------------- |
+| `name`       | `string`                   | yes      | index name                                              |
+| `properties` | `string` &#124; `string[]` | yes      | list of properties, required when using on entity level |
+| `type`       | `string`                   | yes      | index type, not available for `@Unique()`               |
 
 ```typescript
 @Entity()
@@ -176,30 +163,22 @@ export class Author {
 
 ## Entity Relationships
 
-All relationship decorators have `entity`, `cascade` and `eager` optional parameters. 
-If you use the default `ReflectMetadataProvider`, then `entity` parameter might be required 
-You will be warned about it being not defined while required during discovery process if you 
-use `ReflectMetadataProvider`. 
+All relationship decorators have `entity`, `cascade` and `eager` optional parameters. If you use the default `ReflectMetadataProvider`, then `entity` parameter might be required You will be warned about it being not defined while required during discovery process if you use `ReflectMetadataProvider`.
 
-You can also use `type` parameter instead of it - the difference being that `type` parameter
-needs to be string, while in `entity` parameter you can provide a reference (wrapped in 
-a callback to overcome issues with circular dependencies) to the entity, which plays nice 
-with refactoring features in IDEs like WebStorm. 
+You can also use `type` parameter instead of it - the difference being that `type` parameter needs to be string, while in `entity` parameter you can provide a reference (wrapped in a callback to overcome issues with circular dependencies) to the entity, which plays nice with refactoring features in IDEs like WebStorm.
 
-> If you explicitly provide `entity` as a reference, it will enable type checks for other
-> reference parameters like `inversedBy` or `mappedBy`.
+> If you explicitly provide `entity` as a reference, it will enable type checks for other reference parameters like `inversedBy` or `mappedBy`.
 
 ### @ManyToOne()
 
-> `@ManyToOne()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@ManyToOne()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 Many instances of the current Entity refer to One instance of the referred Entity.
 
 See [Defining Entities](relationships.md#manytoone) for more examples.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
 | `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
 | `eager` | `boolean` | yes | Always load the relationship. |
@@ -221,15 +200,14 @@ author3?: Author;
 
 ### @OneToOne()
 
-> `@OneToOne()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@OneToOne()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 One instance of the current Entity refers to One instance of the referred Entity.
 
 See [Defining Entities](relationships.md#onetoone) for more examples, including bi-directional 1:1.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
 | `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
 | `eager` | `boolean` | yes | Always load the relationship. |
@@ -258,8 +236,7 @@ bestFriend3!: User;
 
 ### @OneToMany()
 
-> `@OneToMany()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@OneToMany()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 One instance of the current Entity has Many instances (references) to the referred Entity.
 
@@ -268,7 +245,7 @@ See [Defining Entities](relationships.md#onetomany) for more examples, including
 > You need to initialize the value with `Collection<T>` instance.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `mappedBy` | `(string & keyof T)` &#124; `(e: T) => any` | no | Point to the owning side property name. |
 | `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
 | `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
@@ -288,8 +265,7 @@ books2 = new Collection<Book>(this); // target entity type can be read via `TsMo
 
 ### @ManyToMany()
 
-> `@ManyToMany()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@ManyToMany()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 Many instances of the current Entity refers to Many instances of the referred Entity.
 
@@ -298,7 +274,7 @@ See [Defining Entities](relationships.md#manytomany) for more examples, includin
 > You need to initialize the value with `Collection<T>` instance.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
 | `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
 | `eager` | `boolean` | yes | Always load the relationship. |
@@ -322,15 +298,13 @@ tagsUnordered = new Collection<BookTag>(this); // m:n with composite PK
 
 ## Lifecycle Hooks
 
-You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of
-entity methods with them, you can also mark multiple methods with same hook.
+You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of entity methods with them, you can also mark multiple methods with same hook.
 
 > All hooks support async methods with one exception - `@OnInit`.
 
 ### @OnInit()
 
-Fired when new instance of entity is created, either manually `em.create()`, or 
-automatically when new entities are loaded from database
+Fired when new instance of entity is created, either manually `em.create()`, or automatically when new entities are loaded from database
 
 > `@OnInit` is not fired when you create the entity manually via its constructor (`new MyEntity()`)
 
@@ -354,9 +328,7 @@ async doStuffBeforeCreate() {
 
 ### @AfterCreate()
 
-Fired right after the new entity is created in the database and merged to identity map. 
-Since this event entity will have reference to `EntityManager` and will be 
-enabled to call `entity.init()` method (including all entity references and collections).
+Fired right after the new entity is created in the database and merged to identity map. Since this event entity will have reference to `EntityManager` and will be enabled to call `entity.init()` method (including all entity references and collections).
 
 ```typescript
 @AfterCreate()
@@ -378,7 +350,7 @@ async doStuffBeforeUpdate() {
 
 ### @AfterUpdate()
 
-Fired right after the entity is updated in the database. 
+Fired right after the entity is updated in the database.
 
 ```typescript
 @AfterUpdate()
@@ -389,8 +361,7 @@ async doStuffAfterUpdate() {
 
 ### @BeforeDelete()
 
-Fired right before we delete the record from database. It is fired only when
-removing entity or entity reference, not when deleting records by query. 
+Fired right before we delete the record from database. It is fired only when removing entity or entity reference, not when deleting records by query.
 
 ```typescript
 @BeforeDelete()
@@ -414,7 +385,7 @@ async doStuffAfterDelete() {
 
 ### @Repository()
 
-Used to register custom entity repository. 
+Used to register custom entity repository.
 
 > `em.getRepository()` will automatically return custom repository if it is registered.
 

--- a/docs/versioned_docs/version-3.6/defining-entities.md
+++ b/docs/versioned_docs/version-3.6/defining-entities.md
@@ -9,7 +9,7 @@ There are two ways how you can define your entities:
 
 # EntitySchema helper
 
-With `EntitySchema` helper you define the schema programmatically. 
+With `EntitySchema` helper you define the schema programmatically.
 
 ```typescript title="./entities/Book.ts"
 export interface Book extends BaseEntity {
@@ -31,8 +31,7 @@ export const schema = new EntitySchema<Book, BaseEntity>({
 });
 ```
 
-When creating new entity instances, you will need to use `em.create()` method that will
-create instance of internally created class. 
+When creating new entity instances, you will need to use `em.create()` method that will create instance of internally created class.
 
 ```typescript
 const repo = em.getRepository<Author>('Author');
@@ -40,15 +39,11 @@ const author = repo.create('Author', { name: 'name', email: 'email' }); // insta
 await repo.persistAndFlush(author);
 ```
 
-You can optionally use custom class for entity instances. Read more about this approach 
-in [Defining Entities via EntitySchema section](entity-schema.md).
+You can optionally use custom class for entity instances. Read more about this approach in [Defining Entities via EntitySchema section](entity-schema.md).
 
 # Classes and Decorators
 
-Entities are simple javascript objects (so called POJO), decorated with `@Entity` decorator.
-No real restrictions are made, you do not have to extend any base class, you are more than welcome
-to [use entity constructors](entity-constructors.md), just do not forget to specify primary key with
-`@PrimaryKey` decorator.
+Entities are simple javascript objects (so called POJO), decorated with `@Entity` decorator. No real restrictions are made, you do not have to extend any base class, you are more than welcome to [use entity constructors](entity-constructors.md), just do not forget to specify primary key with `@PrimaryKey` decorator.
 
 ```typescript title="./entities/Book.ts"
 @Entity()
@@ -83,13 +78,11 @@ export class Book {
 }
 ```
 
-As you can see, entity properties are decorated either with `@Property` decorator, or with one
-of reference decorators: `@ManyToOne`, `@OneToMany`, `@OneToOne` and `@ManyToMany`. 
+As you can see, entity properties are decorated either with `@Property` decorator, or with one of reference decorators: `@ManyToOne`, `@OneToMany`, `@OneToOne` and `@ManyToMany`.
 
 > From v3 you can also use default exports when defining your entity.
 
-Here is another example of `Author` entity, that was referenced from the `Book` one, this 
-time defined for mongo:
+Here is another example of `Author` entity, that was referenced from the `Book` one, this time defined for mongo:
 
 ```typescript title="./entities/Author.ts"
 @Entity()
@@ -151,8 +144,7 @@ If you want to define your entity in Vanilla JavaScript, take a look [here](usag
 
 ### Optional Properties
 
-When you define the property as optional (marked with `?`), this will be automatically considered
-as nullable property (mainly for SQL schema generator). 
+When you define the property as optional (marked with `?`), this will be automatically considered as nullable property (mainly for SQL schema generator).
 
 > This auto-detection works only when you omit the `type`/`entity` attribute.
 
@@ -171,10 +163,7 @@ favouriteBook?: Book; // wrong, not marked as `nullable`
 
 You can set default value of a property in 2 ways:
 
-1. Use runtime default value of the property. This approach should be preferred as long 
-as you are not using any native database function like `now()`. With this approach your
-entities will have the default value set even before it is actually persisted into the 
-database (e.g. when you instantiate new entity via `new Author()` or `em.create(Author, { ... })`.
+1. Use runtime default value of the property. This approach should be preferred as long as you are not using any native database function like `now()`. With this approach your entities will have the default value set even before it is actually persisted into the database (e.g. when you instantiate new entity via `new Author()` or `em.create(Author, { ... })`.
 
 ```typescript
 @Property()
@@ -185,12 +174,9 @@ bar!: string = 'abc';
 
 @Property()
 baz!: Date = new Date();
-``` 
+```
 
-2. Use `default` parameter of `@Property` decorator. This way the actual default value 
-will be provided by the database, and automatically mapped to the entity property after
-it is being persisted (after flush). Also note that with this approach, you need to wrap
-string default values in quotes as without quoting the value is considered a function.
+2. Use `default` parameter of `@Property` decorator. This way the actual default value will be provided by the database, and automatically mapped to the entity property after it is being persisted (after flush). Also note that with this approach, you need to wrap string default values in quotes as without quoting the value is considered a function.
 
 ```typescript
 @Property({ default: 1 })
@@ -201,20 +187,17 @@ bar!: string;
 
 @Property({ default: 'now' })
 baz!: Date;
-``` 
+```
 
 ### Enums
 
-To define enum property, use `@Enum()` decorator. Enums can be either numeric or string valued. 
+To define enum property, use `@Enum()` decorator. Enums can be either numeric or string valued.
 
-For schema generator to work properly in case of string enums, you need to define the enum 
-is same file as where it is used, so its values can be automatically discovered. If you want 
-to define the enum in another file, you should reexport it also in place where you use it. 
+For schema generator to work properly in case of string enums, you need to define the enum is same file as where it is used, so its values can be automatically discovered. If you want to define the enum in another file, you should reexport it also in place where you use it.
 
-Another possibility is to provide the reference to the enum implementation in the decorator
-via `@Enum(() => UserRole)`. 
+Another possibility is to provide the reference to the enum implementation in the decorator via `@Enum(() => UserRole)`.
 
-> You can also set enum items manually via `items: string[]` attribute.  
+> You can also set enum items manually via `items: string[]` attribute.
 
 ```typescript
 import { OutsideEnum } from './OutsideEnum.ts';
@@ -246,12 +229,11 @@ export const enum UserStatus {
 
 // or we could reexport OutsideEnum
 // export { OutsideEnum } from './OutsideEnum.ts';
-``` 
+```
 
 ## Indexes
 
-You can define indexes via `@Index()` decorator, for unique indexes, use `@Unique()` decorator. 
-You can use it either on entity class, or on entity property:
+You can define indexes via `@Index()` decorator, for unique indexes, use `@Unique()` decorator. You can use it either on entity class, or on entity property:
 
 ```typescript
 @Entity()
@@ -289,9 +271,8 @@ You can define custom types by extending `Type` abstract class. It has 4 optiona
 
 - `toJSON(value: any, platform: Platform): any`
 
-  Converts a value from its JS representation to its serialized JSON form of this type.
-  By default converts to the database value.
-  
+  Converts a value from its JS representation to its serialized JSON form of this type. By default converts to the database value.
+
 - `getColumnType(prop: EntityProperty, platform: Platform): string`
 
   Gets the SQL declaration snippet for a field of this type.
@@ -302,12 +283,9 @@ More information can be found in [Custom Types](custom-types.md) section.
 
 You can define your properties as virtual, either as a method, or via JavaScript `get/set`.
 
-Following example defines User entity with `firstName` and `lastName` database fields, that 
-are both hidden from the serialized response, replaced with virtual properties `fullName` 
-(defined as a classic method) and `fullName2` (defined as a JavaScript getter).
+Following example defines User entity with `firstName` and `lastName` database fields, that are both hidden from the serialized response, replaced with virtual properties `fullName` (defined as a classic method) and `fullName2` (defined as a JavaScript getter).
 
-> For JavaScript getter you need to provide `{ persist: false }` option otherwise the value
-> would be stored in the database. 
+> For JavaScript getter you need to provide `{ persist: false }` option otherwise the value would be stored in the database.
 
 ```typescript
 @Entity()
@@ -349,18 +327,15 @@ You are free to choose one of those formats for entity filename (for a `BookTag`
 - `book-tag.model.ts`
 - `book-tag.entity.ts`
 
-Entity name is inferred from the first part of file name before first dot occurs, so you can 
-add any suffix behind the dot, not just `.model.ts` or `.entity.ts`. 
+Entity name is inferred from the first part of file name before first dot occurs, so you can add any suffix behind the dot, not just `.model.ts` or `.entity.ts`.
 
 > You can change this behaviour by defining custom `NamingStrategy.getClassName()` method.
 
 ## Using BaseEntity
 
-You can define your own base entity with properties that you require on all entities, like
-primary key and created/updated time. 
+You can define your own base entity with properties that you require on all entities, like primary key and created/updated time.
 
-> If you are initializing the ORM via `entities` option, you need to specify all your
-> base entities as well.
+> If you are initializing the ORM via `entities` option, you need to specify all your base entities as well.
 
 ```typescript title="./entities/BaseEntity.ts"
 import { v4 } from 'uuid';
@@ -421,8 +396,7 @@ export class Book {
 
 ### Using BigInt as primary key (MySQL and PostgreSQL)
 
-You can use `BigIntType` to support `bigint`s. By default it will represent the value as
-a `string`.  
+You can use `BigIntType` to support `bigint`s. By default it will represent the value as a `string`.
 
 ```typescript
 @Entity()
@@ -436,7 +410,6 @@ export class Book {
 
 If you want to use native `bigint`s, read the following guide: [Using native BigInt PKs](using-bigint-pks.md).
 
-
 ### Example of Mongo entity
 
 ```typescript
@@ -446,7 +419,7 @@ export class Book {
   @PrimaryKey()
   _id!: ObjectId;
 
-  @SerializedPrimaryKey() 
+  @SerializedPrimaryKey()
   id!: string; // string variant of PK, will be handled automatically
 
   @Property()
@@ -478,5 +451,4 @@ export class Book {
 export interface Book extends WrappedEntity<Book, 'id'> { };
 ```
 
-With your entities set up, you can start [using entity manager](entity-manager.md) and 
-[repositories](repositories.md) as described in following sections. 
+With your entities set up, you can start [using entity manager](entity-manager.md) and [repositories](repositories.md) as described in following sections.

--- a/docs/versioned_docs/version-3.6/deployment.md
+++ b/docs/versioned_docs/version-3.6/deployment.md
@@ -2,29 +2,19 @@
 title: Deployment
 ---
 
-Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. Thanks to this, 
-defining the type is enough for runtime validation.
+Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. Thanks to this, defining the type is enough for runtime validation.
 
-This has some consequences for deployment of your application. Sometimes you will want to 
-deploy only your compiled output, without TS source files at all. In that case, discovery 
-process will probably fail. You have several options:
+This has some consequences for deployment of your application. Sometimes you will want to deploy only your compiled output, without TS source files at all. In that case, discovery process will probably fail. You have several options:
 
 ## Deploy pre-built cache
 
-By default, output of metadata discovery will be cached in `temp` folder. You can reuse this 
-cache in your deployed application. Currently the cache is saved in files named like the entity
-source file, e.g. `Author.ts` entity will store cache in `temp/Author.ts.json` file.
+By default, output of metadata discovery will be cached in `temp` folder. You can reuse this cache in your deployed application. Currently the cache is saved in files named like the entity source file, e.g. `Author.ts` entity will store cache in `temp/Author.ts.json` file.
 
-When running compiled code, JS entities will be taken into account instead, so you will need to 
-generate the cache by running the compiled code locally. That will generate `temp/Author.js.json`, 
-which is the file you will need to deploy alongside your application. 
+When running compiled code, JS entities will be taken into account instead, so you will need to generate the cache by running the compiled code locally. That will generate `temp/Author.js.json`, which is the file you will need to deploy alongside your application.
 
 ## Fill type or entity attributes everywhere
 
-What discovery process does is to sniff TS types and save their value to string, so it can be 
-used later for validation. You can skip the whole process by simply providing those values 
-manually:
+What discovery process does is to sniff TS types and save their value to string, so it can be used later for validation. You can skip the whole process by simply providing those values manually:
 
 ```typescript
 @Entity()
@@ -63,34 +53,26 @@ export enum BookStatus {
 
 ## Deploy your entity source files
 
-Usually it does not matter much that you deploy more files than needed, so the easiest way
-is to just deploy your TS source files next to the compiled output, just like during development.
+Usually it does not matter much that you deploy more files than needed, so the easiest way is to just deploy your TS source files next to the compiled output, just like during development.
 
 ## Deploy a bundle of entities and dependencies with [Webpack](https://webpack.js.org/)
 
-Webpack can be used to bundle every entity and dependency: you get a single file that contains 
-every required module/file and has no external dependencies.
+Webpack can be used to bundle every entity and dependency: you get a single file that contains every required module/file and has no external dependencies.
 
 ### Prepare your project for Webpack
 
-Webpack requires every required file to be hardcoded in your code. Code like this won't work 
-(it will throw an error because Webpack doesn't know which file to include in the bundle):
+Webpack requires every required file to be hardcoded in your code. Code like this won't work (it will throw an error because Webpack doesn't know which file to include in the bundle):
 
 ```typescript
 let dependencyNameInVariable = 'dependency';
 const dependency = import(dependencyNameInVariable);
 ```
 
-As Webpack creates a file bundle, it isn't desired that it scans directories for entities 
-or metadata. Therefore you need to use the `entities` option in the initialization function 
-and `entitiesDirs`/`entitiesDirsTs` will be ignored (see dynamically including entities as 
-an alternative solution). Also you need to fill `type` or `entity` attributes everywhere 
-(see above) and disable caching (it will decrease start-time slightly).
+As Webpack creates a file bundle, it isn't desired that it scans directories for entities or metadata. Therefore you need to use the `entities` option in the initialization function and `entitiesDirs`/`entitiesDirsTs` will be ignored (see dynamically including entities as an alternative solution). Also you need to fill `type` or `entity` attributes everywhere (see above) and disable caching (it will decrease start-time slightly).
 
 #### Disabling dynamic file access
 
-First thing you should do is to disable dynamic file access in the discovery process via the
-`discovery.disableDynamicFileAccess` toggle. This will effectively do:
+First thing you should do is to disable dynamic file access in the discovery process via the `discovery.disableDynamicFileAccess` toggle. This will effectively do:
 
 - set metadata provider to `ReflectMetadataProvider`
 - disable caching
@@ -111,15 +93,11 @@ await MikroORM.init({
 
 #### Dynamically loading dependencies
 
-This will make use of a Webpack feature called [dynamic imports](https://webpack.js.org/guides/code-splitting/#dynamic-imports). 
-This way you can import dependencies as long as part of the path is known.
+This will make use of a Webpack feature called [dynamic imports](https://webpack.js.org/guides/code-splitting/#dynamic-imports). This way you can import dependencies as long as part of the path is known.
 
-In following example [`require.context`](https://webpack.js.org/guides/dependency-management/#requirecontext) 
-is used. This 'function' is only usable during the building process from Webpack so therefore 
-there is an alternative solution provided that will as long as the environment variable 
-WEBPACK is not set (e.g. during development with `ts-node`).
+In following example [`require.context`](https://webpack.js.org/guides/dependency-management/#requirecontext) is used. This 'function' is only usable during the building process from Webpack so therefore there is an alternative solution provided that will as long as the environment variable WEBPACK is not set (e.g. during development with `ts-node`).
 
-Here, all files with the extension `.ts` will be imported from the directory `../entities`. 
+Here, all files with the extension `.ts` will be imported from the directory `../entities`.
 
 > [`flatMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap) is a method from ECMAScript 2019 and requires [Node.js](https://nodejs.org/) 11 or higher.
 
@@ -150,10 +128,7 @@ async function getEntities(): Promise<any[]> {
 
 ### Webpack configuration
 
-Webpack can be run without [configuration file](https://webpack.js.org/configuration/) but 
-for building MikroORM and [Node.js](https://nodejs.org/) bundles it requires additional 
-configuration. Configuration for Webpack is stored in the root of the project as 
-`webpack.config.js`. For all the options please refer to the following [page](https://webpack.js.org/configuration/).
+Webpack can be run without [configuration file](https://webpack.js.org/configuration/) but for building MikroORM and [Node.js](https://nodejs.org/) bundles it requires additional configuration. Configuration for Webpack is stored in the root of the project as `webpack.config.js`. For all the options please refer to the following [page](https://webpack.js.org/configuration/).
 
 For bundling MikroORM the following configuration is required:
 
@@ -273,6 +248,4 @@ module.exports = {
 
 ### Running Webpack
 
-To run Webpack execute `webpack` (or `npx webpack` if not installed globally) in the root 
-of the project. It will probably throw a few warnings but you can ignore the errors regarding 
-MikroORM: the mentioned pieces of code won't be executed if properly bundled with Webpack.
+To run Webpack execute `webpack` (or `npx webpack` if not installed globally) in the root of the project. It will probably throw a few warnings but you can ignore the errors regarding MikroORM: the mentioned pieces of code won't be executed if properly bundled with Webpack.

--- a/docs/versioned_docs/version-3.6/entity-constructors.md
+++ b/docs/versioned_docs/version-3.6/entity-constructors.md
@@ -2,12 +2,9 @@
 title: Using Entity Constructors
 ---
 
-Internally, `MikroORM` never calls entity constructor, so you are free to use it as you wish.
-The constructor will be called only when you instantiate the class yourself via `new` operator,
-so it is a handy place to require your data when creating new entity.
+Internally, `MikroORM` never calls entity constructor, so you are free to use it as you wish. The constructor will be called only when you instantiate the class yourself via `new` operator, so it is a handy place to require your data when creating new entity.
 
-For example following `Book` entity definition will always require to set `title` and `author`, 
-but `publisher` will be optional:
+For example following `Book` entity definition will always require to set `title` and `author`, but `publisher` will be optional:
 
 ```typescript
 @Entity()

--- a/docs/versioned_docs/version-3.6/entity-generator.md
+++ b/docs/versioned_docs/version-3.6/entity-generator.md
@@ -2,9 +2,9 @@
 title: Entity Generator
 ---
 
-To generate entities from existing database schema, you can use `EntityGenerator` helper. 
+To generate entities from existing database schema, you can use `EntityGenerator` helper.
 
-You can use it via CLI: 
+You can use it via CLI:
 
 ```sh
 npx mikro-orm generate-entities --dump  # Dumps all generated entities
@@ -22,7 +22,7 @@ import { MikroORM } from 'mikro-orm';
     // ...
   });
   const generator = orm.getEntityGenerator();
-  const dump = await generator.generate({ 
+  const dump = await generator.generate({
     save: true,
     baseDir: process.cwd() + '/my-entities',
   });

--- a/docs/versioned_docs/version-3.6/entity-helper.md
+++ b/docs/versioned_docs/version-3.6/entity-helper.md
@@ -5,10 +5,7 @@ sidebar_label: Updating Entity Values
 
 ## Updating Entity Values with `entity.assign()`
 
-When you want to update entity based on user input, you will usually have just plain
-string ids of entity relations as user input. Normally you would need to use 
-`em.getReference()` to create references from each id first, and then
-use those references to update entity relations:
+When you want to update entity based on user input, you will usually have just plain string ids of entity relations as user input. Normally you would need to use `em.getReference()` to create references from each id first, and then use those references to update entity relations:
 
 ```typescript
 const jon = new Author('Jon Snow', 'snow@wall.st');
@@ -21,8 +18,8 @@ Same result can be easily achieved with `entity.assign()`:
 ```typescript
 import { wrap } from 'mikro-orm';
 
-wrap(book).assign({ 
-  title: 'Better Book 1', 
+wrap(book).assign({
+  title: 'Better Book 1',
   author: '...id...',
 });
 console.log(book.title); // 'Better Book 1'
@@ -30,22 +27,19 @@ console.log(book.author); // instance of Author with id: '...id...'
 console.log(book.author.id); // '...id...'
 ```
 
-To use `entity.assign()` on not managed entities, you need to provide `EntityManager` 
-instance explicitly: 
+To use `entity.assign()` on not managed entities, you need to provide `EntityManager` instance explicitly:
 
 ```typescript
 import { wrap } from 'mikro-orm';
 
 const book = new Book();
-wrap(book).assign({ 
-  title: 'Better Book 1', 
+wrap(book).assign({
+  title: 'Better Book 1',
   author: '...id...',
 }, { em: orm.em });
 ```
 
-By default, `entity.assign(data)` behaves same way as `Object.assign(entity, data)`, 
-e.g. it does not merge things recursively. To enable deep merging of object properties, 
-use second parameter to enable `mergeObjects` flag:
+By default, `entity.assign(data)` behaves same way as `Object.assign(entity, data)`, e.g. it does not merge things recursively. To enable deep merging of object properties, use second parameter to enable `mergeObjects` flag:
 
 ```typescript
 import { wrap } from 'mikro-orm';
@@ -61,8 +55,7 @@ console.log(book.meta); // { foo: 4 }
 
 ## `WrappedEntity` and `wrap()` helper
 
-`IWrappedEntity` is interface that defines helper methods as well as some internal 
-properties provided by the ORM:
+`IWrappedEntity` is interface that defines helper methods as well as some internal properties provided by the ORM:
 
 ```typescript
 interface IWrappedEntity<T, PK extends keyof T> {
@@ -84,12 +77,9 @@ interface IWrappedEntity<T, PK extends keyof T> {
 }
 ```
 
-Users can choose whether they are fine with polluting the entity interface with 
-those additional methods and properties, or they want to keep the interface clean 
-and use the `wrap(entity)` helper method instead to access them. 
+Users can choose whether they are fine with polluting the entity interface with those additional methods and properties, or they want to keep the interface clean and use the `wrap(entity)` helper method instead to access them.
 
-To keep all methods available on the entity, you can use interface merging with 
-`WrappedEntity<T, PK>` that both extends `AnyEntity<T, PK>` and defines all those methods.
+To keep all methods available on the entity, you can use interface merging with `WrappedEntity<T, PK>` that both extends `AnyEntity<T, PK>` and defines all those methods.
 
 ```typescript
 @Entity()

--- a/docs/versioned_docs/version-3.6/entity-manager.md
+++ b/docs/versioned_docs/version-3.6/entity-manager.md
@@ -5,22 +5,13 @@ sidebar_label: Entity Manager
 
 ## Persist and Flush
 
-There are 2 methods we should first describe to understand how persisting works in MikroORM: 
-`em.persist()` and `em.flush()`.
+There are 2 methods we should first describe to understand how persisting works in MikroORM: `em.persist()` and `em.flush()`.
 
-`em.persist(entity, flush?: boolean)` is used to mark new entities for future persisting. 
-It will make the entity managed by given `EntityManager` and once `flush` will be called, it 
-will be written to the database. Second boolean parameter can be used to invoke `flush` 
-immediately. Its default value is configurable via `autoFlush` option.
+`em.persist(entity, flush?: boolean)` is used to mark new entities for future persisting. It will make the entity managed by given `EntityManager` and once `flush` will be called, it will be written to the database. Second boolean parameter can be used to invoke `flush` immediately. Its default value is configurable via `autoFlush` option.
 
-To understand `flush`, lets first define what managed entity is: An entity is managed if 
-it’s fetched from the database (via `em.find()`, `em.findOne()` or via other managed entity) 
-or registered as new through `em.persist()`.
+To understand `flush`, lets first define what managed entity is: An entity is managed if it’s fetched from the database (via `em.find()`, `em.findOne()` or via other managed entity) or registered as new through `em.persist()`.
 
-`em.flush()` will go through all managed entities, compute appropriate change sets and 
-perform according database queries. As an entity loaded from database becomes managed 
-automatically, you do not have to call persist on those, and flush is enough to update 
-them.
+`em.flush()` will go through all managed entities, compute appropriate change sets and perform according database queries. As an entity loaded from database becomes managed automatically, you do not have to call persist on those, and flush is enough to update them.
 
 ```typescript
 const book = await orm.em.findOne(Book, 1);
@@ -32,9 +23,7 @@ await orm.em.flush();
 
 ## Persisting and Cascading
 
-To save entity state to database, you need to persist it. Persist determines 
-whether to use `insert` or `update` and computes appropriate change-set. Entity references
-that are not persisted yet (does not have identifier) will be cascade persisted automatically. 
+To save entity state to database, you need to persist it. Persist determines whether to use `insert` or `update` and computes appropriate change-set. Entity references that are not persisted yet (does not have identifier) will be cascade persisted automatically.
 
 ```typescript
 // use constructors in your entities for required parameters
@@ -56,16 +45,13 @@ await orm.em.persistAndFlush([book1, book2, book3]);
 // or one by one
 orm.em.persistLater(book1);
 orm.em.persistLater(book2);
-orm.em.persistLater(book3); 
+orm.em.persistLater(book3);
 await orm.em.flush(); // flush everything to database at once
 ```
 
 ### Auto-flushing
 
-Since MikroORM v3, default value for `autoFlush` is `false`. That means you need to call 
-`em.flush()` yourself to persist changes into database. You can still change this via ORM's
-options to ease the transition but generally it is not recommended as it can cause unwanted
-small transactions being created around each `persist`. 
+Since MikroORM v3, default value for `autoFlush` is `false`. That means you need to call `em.flush()` yourself to persist changes into database. You can still change this via ORM's options to ease the transition but generally it is not recommended as it can cause unwanted small transactions being created around each `persist`.
 
 ```typescript
 orm.em.persist(new Entity()); // no auto-flushing by default
@@ -75,7 +61,7 @@ await orm.em.persist(new Entity(), true); // you can still use second parameter 
 
 ## Fetching Entities with EntityManager
 
-To fetch entities from database you can use `find()` and `findOne()` of `EntityManager`: 
+To fetch entities from database you can use `find()` and `findOne()` of `EntityManager`:
 
 Example:
 
@@ -105,23 +91,20 @@ To populate entity relations, you can use `populate` parameter.
 const books = await orm.em.find(Book, { foo: 1 }, ['author.friends']);
 ```
 
-You can also use `em.populate()` helper to populate relations (or to ensure they 
-are fully populated) on already loaded entities. This is also handy when loading 
-entities via `QueryBuilder`:
+You can also use `em.populate()` helper to populate relations (or to ensure they are fully populated) on already loaded entities. This is also handy when loading entities via `QueryBuilder`:
 
 ```typescript
 const authors = await orm.em.createQueryBuilder(Author).select('*').getResult();
 await em.populate(authors, ['books.tags']);
 
-// now your Author entities will have `books` collections populated, 
+// now your Author entities will have `books` collections populated,
 // as well as they will have their `tags` collections populated.
 console.log(authors[0].books[0].tags[0]); // initialized BookTag
 ```
 
 ### Conditions Object (`FilterQuery<T>`)
 
-Querying entities via conditions object (`where` in `em.find(Entity, where: FilterQuery<T>)`) 
-supports many different ways:
+Querying entities via conditions object (`where` in `em.find(Entity, where: FilterQuery<T>)`) supports many different ways:
 
 ```typescript
 // search by entity properties
@@ -149,18 +132,13 @@ const users = await orm.em.find(User, [1, 2, 3, 4, 5]);
 const user1 = await orm.em.findOne(User, 1);
 ```
 
-As you can see in the fifth example, one can also use operators like `$and`, `$or`, `$gte`, 
-`$gt`, `$lte`, `$lt`, `$in`, `$nin`, `$eq`, `$ne`, `$like`, `$re`. More about that can be found in 
-[Query Conditions](query-conditions.md) section. 
+As you can see in the fifth example, one can also use operators like `$and`, `$or`, `$gte`, `$gt`, `$lte`, `$lt`, `$in`, `$nin`, `$eq`, `$ne`, `$like`, `$re`. More about that can be found in [Query Conditions](query-conditions.md) section.
 
 #### Mitigating `Type instantiation is excessively deep and possibly infinite.ts(2589)` error
 
-Sometimes you might be facing TypeScript errors caused by too complex query for it to 
-properly infer all types. Usually it can be solved by providing the type argument 
-explicitly.
+Sometimes you might be facing TypeScript errors caused by too complex query for it to properly infer all types. Usually it can be solved by providing the type argument explicitly.
 
-You can also opt in to use repository instead, as there the type inference should not be
-problematic. 
+You can also opt in to use repository instead, as there the type inference should not be problematic.
 
 > As a last resort, you can always type cast the query to `any`.
 
@@ -172,16 +150,11 @@ const books = await orm.em.getRepository(Book).find({ ... your complex query ...
 const books = await orm.em.find<any>(Book, { ... your complex query ... }) as Book[];
 ```
 
-Another problem you might be facing is `RangeError: Maximum call stack size exceeded` error 
-thrown during TypeScript compilation (usually from file `node_modules/typescript/lib/typescript.js`).
-The solution to this is the same, just provide the type argument explicitly.
+Another problem you might be facing is `RangeError: Maximum call stack size exceeded` error thrown during TypeScript compilation (usually from file `node_modules/typescript/lib/typescript.js`). The solution to this is the same, just provide the type argument explicitly.
 
 ### Searching by referenced entity fields
 
-You can also search by referenced entity properties. Simply pass nested where condition like 
-this and all requested relationships will be automatically joined. Currently it will only join 
-them so you can search and sort by those. To populate entities, do not forget to pass the populate 
-parameter as well. 
+You can also search by referenced entity properties. Simply pass nested where condition like this and all requested relationships will be automatically joined. Currently it will only join them so you can search and sort by those. To populate entities, do not forget to pass the populate parameter as well.
 
 ```typescript
 // find author of a book that has tag specified by name
@@ -194,9 +167,7 @@ console.log(author.books[0].tags.isInitialized()); // true, because it was popul
 console.log(author.books[0].tags[0].isInitialized()); // true, because it was populated
 ```
 
-> This feature is fully available only for SQL drivers. In MongoDB always you need to 
-> query from the owning side - so in the example above, first load book tag by name,
-> then associated book, then the author. Another option is to denormalize the schema.  
+> This feature is fully available only for SQL drivers. In MongoDB always you need to query from the owning side - so in the example above, first load book tag by name, then associated book, then the author. Another option is to denormalize the schema.
 
 ### Fetching Partial Entities
 
@@ -211,8 +182,7 @@ console.log(author.email); // undefined
 
 ### Fetching Paginated Results
 
-If you are going to paginate your results, you can use `em.findAndCount()` that will return
-total count of entities before applying limit and offset.
+If you are going to paginate your results, you can use `em.findAndCount()` that will return total count of entities before applying limit and offset.
 
 ```typescript
 const [authors, count] = await orm.em.findAndCount(Author, { ... }, { limit: 10, offset: 50 });
@@ -222,8 +192,7 @@ console.log(count); // total count, e.g. 1327
 
 ### Handling Not Found Entities
 
-When you call `em.findOne()` and no entity is found based on your criteria, `null` will be 
-returned. If you rather have an `Error` instance thrown, you can use `em.findOneOrFail()`:
+When you call `em.findOne()` and no entity is found based on your criteria, `null` will be returned. If you rather have an `Error` instance thrown, you can use `em.findOneOrFail()`:
 
 ```typescript
 const author = await orm.em.findOne(Author, { name: 'does-not-exist' });
@@ -237,8 +206,7 @@ try {
 }
 ```
 
-You can customize the error either globally via `findOneOrFailHandler` option, or locally via 
-`failHandler` option in `findOneOrFail` call.
+You can customize the error either globally via `findOneOrFailHandler` option, or locally via `failHandler` option in `findOneOrFail` call.
 
 ```typescript
 try {
@@ -252,8 +220,7 @@ try {
 
 ## Type of Fetched Entities
 
-Both `em.find` and `em.findOne()` methods have generic return types.
-All of following examples are equal and will let typescript correctly infer the entity type:
+Both `em.find` and `em.findOne()` methods have generic return types. All of following examples are equal and will let typescript correctly infer the entity type:
 
 ```typescript
 const author1 = await orm.em.findOne<Author>(Author.name, '...id...');
@@ -261,30 +228,23 @@ const author2 = await orm.em.findOne<Author>('Author', '...id...');
 const author3 = await orm.em.findOne(Author, '...id...');
 ```
 
-As the last one is the least verbose, it should be preferred. 
+As the last one is the least verbose, it should be preferred.
 
 ## Entity Repositories
 
-Although you can use `EntityManager` directly, much more convenient way is to use 
-[`EntityRepository` instead](https://mikro-orm.io/repositories/). You can register
-your repositories in dependency injection container like [InversifyJS](http://inversify.io/)
-so you do not need to get them from `EntityManager` each time.
+Although you can use `EntityManager` directly, much more convenient way is to use [`EntityRepository` instead](https://mikro-orm.io/repositories/). You can register your repositories in dependency injection container like [InversifyJS](http://inversify.io/) so you do not need to get them from `EntityManager` each time.
 
-For more examples, take a look at
-[`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts)
-or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).
+For more examples, take a look at [`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts) or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).
 
 ## EntityManager API
 
 #### `getRepository<T extends AnyEntity>(entityName: string | EntityClass<T>): EntityRepository<T>`
 
-Returns `EntityRepository` for given entity, respects `customRepository` option of `@Entity`
-and `entityRepository` option of `MikroORM.init()`.
+Returns `EntityRepository` for given entity, respects `customRepository` option of `@Entity` and `entityRepository` option of `MikroORM.init()`.
 
 #### `find<T extends AnyEntity>(entityName: string | EntityClass<T>, where: FilterQuery<T>, options?: FindOptions): Promise<T[]>`
 
-Returns array of entities found for given condition. You can specify `FindOptions` to request
-population of referenced entities or control the pagination:
+Returns array of entities found for given condition. You can specify `FindOptions` to request population of referenced entities or control the pagination:
 
 ```typescript
 export interface FindOptions {
@@ -300,65 +260,55 @@ export interface FindOptions {
 
 #### `find<T extends AnyEntity>(entityName: string | EntityClass<T>, where: FilterQuery<T>, populate?: string[], orderBy?: { [k: string]: QueryOrder }, limit?: number, offset?: number): Promise<T[]>`
 
-Same as previous `find` method, just with dedicated parameters for `populate`, `orderBy`, `limit`
-and `offset`.
+Same as previous `find` method, just with dedicated parameters for `populate`, `orderBy`, `limit` and `offset`.
 
 ---
 
 #### `findAndCount<T extends AnyEntity>(entityName: string | EntityClass<T>, where: FilterQuery<T>, populate?: string[], orderBy?: { [k: string]: QueryOrder }, limit?: number, offset?: number): Promise<[T[], number]>`
 
-Combination of `find` and `count` methods. 
+Combination of `find` and `count` methods.
 
 ---
 
 #### `findOne<T extends AnyEntity>(entityName: string | EntityClass<T>, where: FilterQuery<T> | IPrimaryKey, populate?: string[]): Promise<T | null>`
 
-Finds an entity by given `where` condition. You can use primary key as `where` value, then
-if the entity is already managed, no database call will be made. 
+Finds an entity by given `where` condition. You can use primary key as `where` value, then if the entity is already managed, no database call will be made.
 
 ---
 
 #### `findOneOrFail<T extends AnyEntity>(entityName: string | EntityClass<T>, where: FilterQuery<T> | IPrimaryKey, populate?: string[]): Promise<T>`
 
-Just like `findOne`, but throws when entity not found, so it always resolves to given entity. 
-You can customize the error either globally via `findOneOrFailHandler` option, or locally via 
-`failHandler` option in `findOneOrFail` call.
+Just like `findOne`, but throws when entity not found, so it always resolves to given entity. You can customize the error either globally via `findOneOrFailHandler` option, or locally via `failHandler` option in `findOneOrFail` call.
 
 ---
 
 #### `merge<T extends AnyEntity>(entityName: string | EntityClass<T>, data: EntityData<T>): T`
 
-Adds given entity to current Identity Map. After merging, entity becomes managed. 
-This is useful when you want to work with cached entities. 
+Adds given entity to current Identity Map. After merging, entity becomes managed. This is useful when you want to work with cached entities.
 
 ---
 
 #### `map<T extends AnyEntity>(entityName: string | EntityClass<T>, data: EntityData<T>): T`
 
-Maps raw DB result to entity, adding it to current Identity Map. Equivalent to 
-`IDatabaseDriver.mapResult()` followed by `em.merge()`.
+Maps raw DB result to entity, adding it to current Identity Map. Equivalent to `IDatabaseDriver.mapResult()` followed by `em.merge()`.
 
 ---
 
 #### `getReference<T extends AnyEntity>(entityName: string | EntityClass<T>, id: string): T`
 
-Gets a reference to the entity identified by the given type and identifier without actually 
-loading it, if the entity is not yet loaded.
+Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded.
 
 ---
 
 #### `count(entityName: string | EntityClass<T>, where?: FilterQuery<T>): Promise<number>`
 
-Gets count of entities matching the `where` condition. 
+Gets count of entities matching the `where` condition.
 
 ---
 
 #### `persist(entity: AnyEntity | AnyEntity[], flush?: boolean): void | Promise<void>`
 
-Tells the EntityManager to make an instance managed and persistent. The entity will be 
-entered into the database at or before transaction commit or as a result of the flush 
-operation. You can control immediate flushing via `flush` parameter and via `autoFlush`
-configuration option. 
+Tells the EntityManager to make an instance managed and persistent. The entity will be entered into the database at or before transaction commit or as a result of the flush operation. You can control immediate flushing via `flush` parameter and via `autoFlush` configuration option.
 
 ---
 
@@ -370,7 +320,7 @@ Shortcut for `persist` & `flush`.
 
 #### `persistLater(entity: AnyEntity | AnyEntity[]): void`
 
-Shortcut for just `persist`, without flushing. 
+Shortcut for just `persist`, without flushing.
 
 ---
 
@@ -382,20 +332,17 @@ Flushes all changes to objects that have been queued up to now to the database.
 
 #### `remove(entityName: string | EntityClass<T>, where: AnyEntity | FilterQuery<T> | IPrimaryKey, flush?: boolean): Promise<number>`
 
-When provided entity instance as `where` value, then it calls `removeEntity(entity, flush)`, 
-otherwise it fires delete query with given `where` condition. 
+When provided entity instance as `where` value, then it calls `removeEntity(entity, flush)`, otherwise it fires delete query with given `where` condition.
 
-This method fires `beforeDelete` and `afterDelete` hooks only if you provide entity instance.  
+This method fires `beforeDelete` and `afterDelete` hooks only if you provide entity instance.
 
 ---
 
 #### `removeEntity(entity: AnyEntity, flush?: boolean): Promise<number>`
 
-Removes an entity instance. A removed entity will be removed from the database at or before 
-transaction commit or as a result of the flush operation. You can control immediate flushing 
-via `flush` parameter and via `autoFlush` configuration option.
+Removes an entity instance. A removed entity will be removed from the database at or before transaction commit or as a result of the flush operation. You can control immediate flushing via `flush` parameter and via `autoFlush` configuration option.
 
-This method fires `beforeDelete` and `afterDelete` hooks.  
+This method fires `beforeDelete` and `afterDelete` hooks.
 
 ---
 
@@ -407,20 +354,18 @@ Shortcut for `removeEntity` & `flush`.
 
 #### `removeLater(entity: AnyEntity): void`
 
-Shortcut for `removeEntity` without flushing. 
+Shortcut for `removeEntity` without flushing.
 
 ---
 
 #### `clear(): void`
 
-Clears the EntityManager. All entities that are currently managed by this EntityManager 
-become detached.
+Clears the EntityManager. All entities that are currently managed by this EntityManager become detached.
 
 ---
 
 #### `canPopulate(entityName: string | EntityClass<T>, property: string): boolean`
 
-Returns whether given entity has given property which can be populated (is reference or
-collection).
+Returns whether given entity has given property which can be populated (is reference or collection).
 
 ---

--- a/docs/versioned_docs/version-3.6/entity-references.md
+++ b/docs/versioned_docs/version-3.6/entity-references.md
@@ -3,12 +3,9 @@ title: Entity References
 sidebar_label: Entity References and Reference<T> Wrapper
 ---
 
-Every single entity relation is mapped to an entity reference. Reference is an entity that has
-only its identifier. This reference is stored in identity map so you will get the same object 
-reference when fetching the same document from database.
+Every single entity relation is mapped to an entity reference. Reference is an entity that has only its identifier. This reference is stored in identity map so you will get the same object reference when fetching the same document from database.
 
-You can call `await entity.init()` to initialize the entity. This will trigger database call 
-and populate itself, keeping the same reference in identity map. 
+You can call `await entity.init()` to initialize the entity. This will trigger database call and populate itself, keeping the same reference in identity map.
 
 ```typescript
 const author = orm.em.getReference('...id...');
@@ -23,8 +20,7 @@ console.log(author.name); // defined
 
 # Better Type-safety with `Reference<T>` Wrapper
 
-When you define `@ManyToOne` and `@OneToOne` properties on your entity, TypeScript compiler
-will think that desired entities are always loaded:
+When you define `@ManyToOne` and `@OneToOne` properties on your entity, TypeScript compiler will think that desired entities are always loaded:
 
 ```typescript
 @Entity()
@@ -48,13 +44,9 @@ console.log(book.author.isInitialized()); // false
 console.log(book.author.name); // undefined as `Author` is not loaded yet
 ```
 
-You can overcome this issue by using the `Reference<T>` wrapper. It simply wraps the entity, 
-defining `load(): Promise<T>` method that will first lazy load the association if not already
-available. You can also use `unwrap(): T` method to access the underlying entity without loading
-it.
+You can overcome this issue by using the `Reference<T>` wrapper. It simply wraps the entity, defining `load(): Promise<T>` method that will first lazy load the association if not already available. You can also use `unwrap(): T` method to access the underlying entity without loading it.
 
-You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>`, which works like `load()`
-but returns the specified property.
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>`, which works like `load()` but returns the specified property.
 
 ```typescript
 import { Entity, IdentifiedReference, ManyToOne, PrimaryKey, Reference } from 'mikro-orm';
@@ -84,9 +76,7 @@ console.log((await book.author.load()).name); // ok, author already loaded
 console.log(book.author.unwrap().name); // ok, author already loaded
 ```
 
-There are also `getEntity()` and `getProperty()` methods that are synchronous getters, 
-that will first check if the wrapped entity is initialized, and if not, it will throw 
-and error.
+There are also `getEntity()` and `getProperty()` methods that are synchronous getters, that will first check if the wrapped entity is initialized, and if not, it will throw and error.
 
 ```typescript
 const book = await orm.em.findOne(Book, 1);
@@ -98,9 +88,7 @@ console.log((await book.author.get('name'))); // ok, loading the author first
 console.log(book.author.getProperty('name')); // ok, author already loaded
 ```
 
-If you use different metadata provider than `TsMorphMetadataProvider` 
-(e.g. `ReflectMetadataProvider`), you will also need to explicitly set `wrappedReference` 
-parameter:
+If you use different metadata provider than `TsMorphMetadataProvider` (e.g. `ReflectMetadataProvider`), you will also need to explicitly set `wrappedReference` parameter:
 
 ```typescript
 @ManyToOne(() => Author, { wrappedReference: true })
@@ -109,9 +97,7 @@ author!: IdentifiedReference<Author>;
 
 ## Assigning to Reference Properties
 
-When you define the property as `Reference` wrapper, you will need to assign the `Reference`
-to it instead of the entity. You can create it via `Reference.create()` factory, or use `wrapped`
-parameter of `em.getReference()`:
+When you define the property as `Reference` wrapper, you will need to assign the `Reference` to it instead of the entity. You can create it via `Reference.create()` factory, or use `wrapped` parameter of `em.getReference()`:
 
 ```typescript
 const book = await orm.em.findOne(Book, 1);
@@ -124,8 +110,7 @@ book.author = Reference.create(repo.getReference(2));
 await orm.em.flush();
 ```
 
-Another way is to use `toReference()` method available as part of 
-[`WrappedEntity` interface](entity-helper.md#wrappedentity-and-wrap-helper):
+Another way is to use `toReference()` method available as part of [`WrappedEntity` interface](entity-helper.md#wrappedentity-and-wrap-helper):
 
 ```typescript
 const author = new Author(...)
@@ -140,11 +125,9 @@ book.author.set(new Author(...));
 
 ## What is IdentifiedReference?
 
-`IdentifiedReference` is an intersection type that adds primary key property to the `Reference` 
-interface. It allows to get the primary key from `Reference` instance directly.
+`IdentifiedReference` is an intersection type that adds primary key property to the `Reference` interface. It allows to get the primary key from `Reference` instance directly.
 
-By default it defines the PK property as `id`, you can override this via second generic type
-argument.
+By default it defines the PK property as `id`, you can override this via second generic type argument.
 
 ```typescript
 const book = await orm.em.findOne(Book, 1);
@@ -169,8 +152,7 @@ const book = await orm.em.findOne(Book, 1);
 console.log(book.author.uuid); // ok, returns the PK
 ```
 
-For MongoDB, define the PK generic type argument as `'id' | '_id'` to access both `string` 
-and `ObjectId` PK values:
+For MongoDB, define the PK generic type argument as `'id' | '_id'` to access both `string` and `ObjectId` PK values:
 
 ```typescript
 @Entity()
@@ -192,5 +174,4 @@ console.log(book.author.id); // ok, returns string PK
 console.log(book.author._id); // ok, returns ObjectId PK
 ```
 
-> As opposed to `Entity.init()` which always refreshes the entity, `Reference.load()` 
-> method will query the database only if the entity is not already loaded in Identity Map. 
+> As opposed to `Entity.init()` which always refreshes the entity, `Reference.load()` method will query the database only if the entity is not already loaded in Identity Map.

--- a/docs/versioned_docs/version-3.6/entity-schema.md
+++ b/docs/versioned_docs/version-3.6/entity-schema.md
@@ -2,7 +2,7 @@
 title: Defining Entities via EntitySchema
 ---
 
-With `EntitySchema` helper you define the schema programmatically. 
+With `EntitySchema` helper you define the schema programmatically.
 
 ```typescript title="./entities/Book.ts"
 export interface Book extends BaseEntity {
@@ -24,8 +24,7 @@ export const schema = new EntitySchema<Book, BaseEntity>({
 });
 ```
 
-When creating new entity instances, you will need to use `em.create()` method that will
-create instance of internally created class. 
+When creating new entity instances, you will need to use `em.create()` method that will create instance of internally created class.
 
 ```typescript
 const repo = em.getRepository<Author>('Author');
@@ -37,7 +36,7 @@ await repo.persistAndFlush(author);
 
 ## Using custom entity classes
 
-You can optionally use custom class for entity instances.  
+You can optionally use custom class for entity instances.
 
 ```typescript title="./entities/Author.ts"
 export class Author extends BaseEntity {
@@ -50,7 +49,7 @@ export class Author extends BaseEntity {
   books = new Collection<Book>(this);
   favouriteBook?: Book;
   version?: number;
-  
+
   constructor(name: string, email: string) {
     this.name = name;
     this.email = email;
@@ -83,7 +82,7 @@ await repo.persistAndFlush(author);
 
 ## Using BaseEntity
 
-Do not forget that base entities needs to be discovered just like normal entities. 
+Do not forget that base entities needs to be discovered just like normal entities.
 
 ```typescript title="./entities/BaseEntity.ts"
 export interface BaseEntity {
@@ -105,9 +104,7 @@ export const schema = new EntitySchema<BaseEntity>({
 
 ## Configuration Reference
 
-The parameter of `EntitySchema` requires to provide either `name` or `class` parameters. 
-When using `class`, `extends` will be automatically inferred. You can optionally pass 
-these additional parameters:
+The parameter of `EntitySchema` requires to provide either `name` or `class` parameters. When using `class`, `extends` will be automatically inferred. You can optionally pass these additional parameters:
 
 ```typescript
 name: string;
@@ -122,8 +119,7 @@ hooks: Partial<Record<HookType, (string & keyof T)[]>>;
 abstract: boolean;
 ```
 
-Every property then needs to contain a type specification - one of `type`/`customType`/`entity`.
-Here are some examples of various property types:
+Every property then needs to contain a type specification - one of `type`/`customType`/`entity`. Here are some examples of various property types:
 
 ```typescript
 export enum MyEnum {

--- a/docs/versioned_docs/version-3.6/identity-map.md
+++ b/docs/versioned_docs/version-3.6/identity-map.md
@@ -2,8 +2,7 @@
 title: Identity Map and Request Context
 ---
 
-`MikroORM` uses identity map in background so you will always get the same instance of 
-one entity.
+`MikroORM` uses identity map in background so you will always get the same instance of one entity.
 
 ```typescript
 const authorRepository = orm.em.getRepository(Author);
@@ -20,8 +19,7 @@ If you want to clear this identity map cache, you can do so via `em.clear()` met
 orm.em.clear();
 ```
 
-You should always keep unique identity map per each request. This basically means that you need 
-to clone entity manager and use the clone in request context. There are two ways to achieve this:
+You should always keep unique identity map per each request. This basically means that you need to clone entity manager and use the clone in request context. There are two ways to achieve this:
 
 ## Forking Entity Manager
 
@@ -33,54 +31,39 @@ const em = orm.em.fork();
 
 ## <a name="request-context"></a> RequestContext helper for DI containers
 
-If you use dependency injection container like `inversify` or the one in `nestjs` framework, it 
-can be hard to achieve this, because you usually want to access your repositories via DI container,
-but it will always provide you with the same instance, rather than new one for each request. 
+If you use dependency injection container like `inversify` or the one in `nestjs` framework, it can be hard to achieve this, because you usually want to access your repositories via DI container, but it will always provide you with the same instance, rather than new one for each request.
 
-To solve this, you can use `RequestContext` helper, that will use `node`'s Domain API in the 
-background to isolate the request context. MikroORM will always use request specific (forked) 
-entity manager if available, so all you need to do is to create new request context preferably 
-as a middleware:
+To solve this, you can use `RequestContext` helper, that will use `node`'s Domain API in the background to isolate the request context. MikroORM will always use request specific (forked) entity manager if available, so all you need to do is to create new request context preferably as a middleware:
 
 ```typescript
 app.use((req, res, next) => {
   RequestContext.create(orm.em, next);
 });
-``` 
+```
 
-You should register this middleware as the last one just before request handlers and before
-any of your custom middleware that is using the ORM. There might be issues when you register 
-it before request processing middleware like `queryParser` or `bodyParser`, so definitely 
-register the context after them. 
+You should register this middleware as the last one just before request handlers and before any of your custom middleware that is using the ORM. There might be issues when you register it before request processing middleware like `queryParser` or `bodyParser`, so definitely register the context after them.
 
 ## Why is Request Context needed?
 
-Imagine you will use single Identity Map throughout your application. It will be shared across 
-all request handlers, that can possibly run in parallel. 
+Imagine you will use single Identity Map throughout your application. It will be shared across all request handlers, that can possibly run in parallel.
 
 ### Problem 1 - growing memory footprint
 
-As there would be only one shared Identity Map, you can't just clear it after your request ends.
-There can be another request working with it so clearing the Identity Map from one request could 
-break other requests running in parallel. This will result in growing memory footprint, as every 
-entity that became managed at some point in time would be kept in the Identity Map. 
+As there would be only one shared Identity Map, you can't just clear it after your request ends. There can be another request working with it so clearing the Identity Map from one request could break other requests running in parallel. This will result in growing memory footprint, as every entity that became managed at some point in time would be kept in the Identity Map.
 
 ### Problem 2 - unstable response of API endpoints
 
-Every entity has `toJSON()` method, that automatically converts it to serialized form. If you 
-have only one shared Identity Map, following situation may occur:
+Every entity has `toJSON()` method, that automatically converts it to serialized form. If you have only one shared Identity Map, following situation may occur:
 
 Let's say there are 2 endpoints
 
 1. `GET /book/:id` that returns just the book, without populating anything
 2. `GET /book-with-author/:id` that returns the book and its author populated
 
-Now when someone requests same book via both of those endpoints, you could end up with both 
-returning the same output:
- 
+Now when someone requests same book via both of those endpoints, you could end up with both returning the same output:
+
 1. `GET /book/1` returns `Book` without populating its property `author` property
 2. `GET /book-with-author/1` returns `Book`, this time with `author` populated
 3. `GET /book/1` returns `Book`, but this time also with `author` populated
 
-This happens because the information about entity association being populated is stored in
-the Identity Map. 
+This happens because the information about entity association being populated is stored in the Identity Map.

--- a/docs/versioned_docs/version-3.6/installation.md
+++ b/docs/versioned_docs/version-3.6/installation.md
@@ -22,8 +22,7 @@ $ npm i -s mikro-orm pg      # for postgresql
 $ npm i -s mikro-orm sqlite3 # for sqlite
 ```
 
-Next you will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html)
-as well as `esModuleInterop` in `tsconfig.json` via:
+Next you will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html) as well as `esModuleInterop` in `tsconfig.json` via:
 
 ```json
 "experimentalDecorators": true,
@@ -44,9 +43,7 @@ console.log(orm.em); // access EntityManager via `em` property
 
 > Read more about all the possible configuration options in [Advanced Configuration](configuration.md) section.
 
-You can also provide paths where you store your entities via `entitiesDirs` array. Internally
-it uses [`globby`](https://github.com/sindresorhus/globby) so you can use 
-[globbing patterns](https://github.com/sindresorhus/globby#globbing-patterns). 
+You can also provide paths where you store your entities via `entitiesDirs` array. Internally it uses [`globby`](https://github.com/sindresorhus/globby) so you can use [globbing patterns](https://github.com/sindresorhus/globby#globbing-patterns).
 
 ```typescript
 const orm = await MikroORM.init({
@@ -55,8 +52,7 @@ const orm = await MikroORM.init({
 });
 ```
 
-You should provide list of directories, not paths to entities directly. If you want to do that
-instead, you should use `entities` array and use `globby` manually:
+You should provide list of directories, not paths to entities directly. If you want to do that instead, you should use `entities` array and use `globby` manually:
 
 ```typescript
 import globby from 'globby';
@@ -67,14 +63,11 @@ const orm = await MikroORM.init({
 });
 ```
 
-> You can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. 
-> The object will be deeply merged, overriding all internally used options.
+> You can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. The object will be deeply merged, overriding all internally used options.
 
 ## Possible issues with circular dependencies
 
-Your entities will most probably contain circular dependencies (e.g. if you use bi-directional 
-relationship). While this is fine, there might be issues caused by wrong order of entities 
-during discovery, especially when you are using the folder based way (via `entitiesDirs`).
+Your entities will most probably contain circular dependencies (e.g. if you use bi-directional relationship). While this is fine, there might be issues caused by wrong order of entities during discovery, especially when you are using the folder based way (via `entitiesDirs`).
 
 The errors caused by circular dependencies are usually similar to this one:
 
@@ -95,17 +88,12 @@ TypeError: Cannot read property 'name' of undefined
 
 If you encounter this, you have basically two options:
 
-- Use `entities` array to have control over the order of discovery. You might need to play with the actual 
-  order you provide here, or possibly with the order of import statements.
-- Use strings instead of references (e.g. `@OneToMany('Book', 'author')`). The downside here is that you 
-  will loose the typechecking capabilities of the decorators. 
+- Use `entities` array to have control over the order of discovery. You might need to play with the actual order you provide here, or possibly with the order of import statements.
+- Use strings instead of references (e.g. `@OneToMany('Book', 'author')`). The downside here is that you will loose the typechecking capabilities of the decorators.
 
 ## Entity Discovery in TypeScript
 
-Internally, `MikroORM` uses [`ts-morph` to perform analysis](metadata-providers.md) of source files 
-of entities to sniff types of all properties. This process can be slow if your project contains lots 
-of files. To speed up the discovery process a bit, you can provide more accurate paths where your
-entity source files are: 
+Internally, `MikroORM` uses [`ts-morph` to perform analysis](metadata-providers.md) of source files of entities to sniff types of all properties. This process can be slow if your project contains lots of files. To speed up the discovery process a bit, you can provide more accurate paths where your entity source files are:
 
 ```typescript
 const orm = await MikroORM.init({
@@ -129,9 +117,7 @@ const orm = await MikroORM.init({
 
 ## Setting up the Commandline Tool
 
-MikroORM ships with a number of command line tools that are very helpful during development, 
-like Schema Generator and Entity Generator. You can call this command from the NPM binary 
-directory or use `npx`:
+MikroORM ships with a number of command line tools that are very helpful during development, like Schema Generator and Entity Generator. You can call this command from the NPM binary directory or use `npx`:
 
 ```sh
 $ node node_modules/.bin/mikro-orm
@@ -141,10 +127,7 @@ $ npx mikro-orm
 $ mikro-orm
 ```
 
-For CLI to be able to access your database, you will need to create `mikro-orm.config.js` file that 
-exports your ORM configuration. TypeScript is also supported, just enable `useTsNode` flag in your
-`package.json` file. There you can also set up array of possible paths to `mikro-orm.config` file,
-as well as use different file name:
+For CLI to be able to access your database, you will need to create `mikro-orm.config.js` file that exports your ORM configuration. TypeScript is also supported, just enable `useTsNode` flag in your `package.json` file. There you can also set up array of possible paths to `mikro-orm.config` file, as well as use different file name:
 
 > Do not forget to install `ts-node` when enabling `useTsNode` flag.
 
@@ -170,12 +153,9 @@ export default {
 };
 ```
 
-Once you have the CLI config properly set up, you can omit the `MikroORM.init()` options
-parameter and the CLI config will be automatically used. 
+Once you have the CLI config properly set up, you can omit the `MikroORM.init()` options parameter and the CLI config will be automatically used.
 
-> You can also use different names for this file, simply rename it in the `configPaths` array
-> your in `package.json`. You can also use `MIKRO_ORM_CLI` environment variable with the path
-> to override `configPaths` value.
+> You can also use different names for this file, simply rename it in the `configPaths` array your in `package.json`. You can also use `MIKRO_ORM_CLI` environment variable with the path to override `configPaths` value.
 
 Now you should be able to start using the CLI. All available commands are listed in the CLI help:
 
@@ -199,13 +179,11 @@ Examples:
 
 To verify your setup, you can use `mikro-orm debug` command.
 
-> When you have CLI config properly set up, you can omit the `options` parameter
-> when calling `MikroORM.init()`.
+> When you have CLI config properly set up, you can omit the `options` parameter when calling `MikroORM.init()`.
 
 ## Request Context
 
-Then you will need to fork Entity Manager for each request so their identity maps will not 
-collide. To do so, use the `RequestContext` helper:
+Then you will need to fork Entity Manager for each request so their identity maps will not collide. To do so, use the `RequestContext` helper:
 
 ```typescript
 const app = express();

--- a/docs/versioned_docs/version-3.6/lifecycle-hooks.md
+++ b/docs/versioned_docs/version-3.6/lifecycle-hooks.md
@@ -2,35 +2,24 @@
 title: Lifecycle Hooks
 ---
 
-You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of
-entity methods with them, you can also mark multiple methods with same hook.
+You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of entity methods with them, you can also mark multiple methods with same hook.
 
 All hooks support async methods with one exception - `@OnInit`.
 
-- `@OnInit` is fired when new instance of entity is created, either manually `em.create()`, or 
-automatically when new entities are loaded from database
+- `@OnInit` is fired when new instance of entity is created, either manually `em.create()`, or automatically when new entities are loaded from database
 
 - `@BeforeCreate()` and `@BeforeUpdate()` is fired right before we persist the entity in database
 
-- `@AfterCreate()` and `@AfterUpdate()` is fired right after the entity is updated in database and 
-merged to identity map. Since this event entity will have reference to `EntityManager` and will be 
-enabled to call `entity.init()` method (including all entity references and collections).
+- `@AfterCreate()` and `@AfterUpdate()` is fired right after the entity is updated in database and merged to identity map. Since this event entity will have reference to `EntityManager` and will be enabled to call `entity.init()` method (including all entity references and collections).
 
-- `@BeforeDelete()` is fired right before we delete the record from database. It is fired only when
-removing entity or entity reference, not when deleting records by query. 
+- `@BeforeDelete()` is fired right before we delete the record from database. It is fired only when removing entity or entity reference, not when deleting records by query.
 
-- `@AfterDelete()` is fired right after the record gets deleted from database and it is unset from 
-the identity map.
+- `@AfterDelete()` is fired right after the record gets deleted from database and it is unset from the identity map.
 
 > `@OnInit` is not fired when you create the entity manually via its constructor (`new MyEntity()`)
 
 ## Limitations of lifecycle hooks
 
-Hooks are executed inside the commit action of unit of work, after all change 
-sets are computed. This means that it is not possible to create new entities as
-usual from inside the hook. Calling `em.flush()` from hooks will result in 
-validation error. Calling `em.persist()` can result in undefined behaviour like
-locking errors. 
+Hooks are executed inside the commit action of unit of work, after all change sets are computed. This means that it is not possible to create new entities as usual from inside the hook. Calling `em.flush()` from hooks will result in validation error. Calling `em.persist()` can result in undefined behaviour like locking errors.
 
-> The **internal** instance of `EntityManager` accessible under `wrap(this).__em` is 
-> not meant for public usage. 
+> The **internal** instance of `EntityManager` accessible under `wrap(this).__em` is not meant for public usage.

--- a/docs/versioned_docs/version-3.6/metadata-cache.md
+++ b/docs/versioned_docs/version-3.6/metadata-cache.md
@@ -2,25 +2,17 @@
 title: Metadata Cache
 ---
 
-Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. Thanks to this, 
-defining the type is enough for runtime validation.
+Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. Thanks to this, defining the type is enough for runtime validation.
 
-This process can be a bit slow, mainly because `ts-morph` will scan all your source files
-based on your `tsconfig.json`. You can speed up this process by whitelisting only the folders
-where your entities are via `entitiesDirsTs` option. 
+This process can be a bit slow, mainly because `ts-morph` will scan all your source files based on your `tsconfig.json`. You can speed up this process by whitelisting only the folders where your entities are via `entitiesDirsTs` option.
 
-After the discovery process ends, all metadata will be cached. By default, `FileCacheAdapter`
-will be used to store the cache inside `./temp` folder to JSON files. 
+After the discovery process ends, all metadata will be cached. By default, `FileCacheAdapter` will be used to store the cache inside `./temp` folder to JSON files.
 
 ## Automatic Invalidation
 
-Entity metadata are cached together with modified time of the source file, and every time
-the cache is requested, it first checks if the cache is not invalid. This way you can forgot 
-about the caching mechanism most of the time.
+Entity metadata are cached together with modified time of the source file, and every time the cache is requested, it first checks if the cache is not invalid. This way you can forgot about the caching mechanism most of the time.
 
-One case where you can end up needing to wipe the cache manually is when you work withing a 
-git branch where contents of entities folder differs. 
+One case where you can end up needing to wipe the cache manually is when you work withing a git branch where contents of entities folder differs.
 
 ## Disabling Metadata Cache
 
@@ -57,8 +49,7 @@ await MikroORM.init({
 
 ## Providing Custom Cache Adapter
 
-You can also implement your own cache adapter, for example to store the cache in redis. 
-To do so, just implement simple `CacheAdapter` interface:
+You can also implement your own cache adapter, for example to store the cache in redis. To do so, just implement simple `CacheAdapter` interface:
 
 ```typescript
 export interface CacheAdapter {

--- a/docs/versioned_docs/version-3.6/metadata-providers.md
+++ b/docs/versioned_docs/version-3.6/metadata-providers.md
@@ -2,26 +2,19 @@
 title: Metadata Providers
 ---
 
-As part of entity discovery process, MikroORM uses so called `MetadataProvider` to get necessary
-type information about your entities' properties. There are 3 built in metadata providers you can 
-use:
+As part of entity discovery process, MikroORM uses so called `MetadataProvider` to get necessary type information about your entities' properties. There are 3 built in metadata providers you can use:
 
 > You can also implement custom metadata provider by extending abstract `MetadataProvider` class.
 
 ## TsMorphMetadataProvider
 
-By default, MikroORM uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. Thanks to this, 
-defining the type is enough for runtime validation.
+By default, MikroORM uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. Thanks to this, defining the type is enough for runtime validation.
 
-This process can be a bit slow as well as memory consuming, mainly because `ts-morph` will
-scan all your source files based on your `tsconfig.json`. You can speed up this process by 
-whitelisting only the folders where your entities are via `entitiesDirsTs` option. 
+This process can be a bit slow as well as memory consuming, mainly because `ts-morph` will scan all your source files based on your `tsconfig.json`. You can speed up this process by whitelisting only the folders where your entities are via `entitiesDirsTs` option.
 
 > You can specify the path to `tsconfig.json` manually via `discovery: { tsConfigPath: '...' }`.
 
-After the discovery process ends, all [metadata will be cached](metadata-cache.md). By default, 
-`FileCacheAdapter` will be used to store the cache inside `./temp` folder in JSON files. 
+After the discovery process ends, all [metadata will be cached](metadata-cache.md). By default, `FileCacheAdapter` will be used to store the cache inside `./temp` folder in JSON files.
 
 > You can generate production cache via CLI command `mikro-orm cache:generate`.
 
@@ -29,11 +22,9 @@ After the discovery process ends, all [metadata will be cached](metadata-cache.m
 
 ## ReflectMetadataProvider
 
-`ReflectMetadataProvider` uses `reflect-metadata` module to read the type from decorator 
-metadata exported by TypeScript compiler. 
+`ReflectMetadataProvider` uses `reflect-metadata` module to read the type from decorator metadata exported by TypeScript compiler.
 
-You will need to install `reflect-metadata` module and import at the top of your app's 
-bootstrap script (e.g. `main.ts` or `app.ts`). 
+You will need to install `reflect-metadata` module and import at the top of your app's bootstrap script (e.g. `main.ts` or `app.ts`).
 
 ```typescript
 import 'reflect-metadata';
@@ -41,7 +32,7 @@ import 'reflect-metadata';
 
 Next step is to enable `emitDecoratorMetadata` flag in your `tsconfig.json`.
 
-> As this approach does not have performance impact, metadata caching is not really necessary. 
+> As this approach does not have performance impact, metadata caching is not really necessary.
 
 ```typescript
 await MikroORM.init({
@@ -85,8 +76,7 @@ prop?: string;
 
 #### Enums
 
-By default, enum is considered as numeric type. For string enums, you need to explicitly 
-provide one of:
+By default, enum is considered as numeric type. For string enums, you need to explicitly provide one of:
 
 - reference to the enum (which will force you to define the enum before defining the entity)
   ```typescript
@@ -106,29 +96,22 @@ provide one of:
 
 #### Circular dependencies
 
-Reading type of referenced entity in `@ManyToOne` and `@OneToOne` properties fails if there is 
-circular dependency. You will need to explicitly define the type in the decorator (preferably 
-via `entity: () => ...` callback).
+Reading type of referenced entity in `@ManyToOne` and `@OneToOne` properties fails if there is circular dependency. You will need to explicitly define the type in the decorator (preferably via `entity: () => ...` callback).
 
 ```typescript
 @ManyToOne({ entity: () => Author })
 author: Author;
-``` 
+```
 
-> There can be recursion issues when you define multiple entities (with circular dependencies 
-> between each other) in single file. In that case, you might want to provide the type via decorator's
-> `type` or `entity` attributes and set the TS property type to something else (like `any` or `object`).
+> There can be recursion issues when you define multiple entities (with circular dependencies between each other) in single file. In that case, you might want to provide the type via decorator's `type` or `entity` attributes and set the TS property type to something else (like `any` or `object`).
 
 #### Additional typings might be required
 
-You might have to install additional typings, one example is use of `ObjectId` in MongoDB, 
-which requires `@types/mongodb` to be installed. 
+You might have to install additional typings, one example is use of `ObjectId` in MongoDB, which requires `@types/mongodb` to be installed.
 
 ## JavaScriptMetadataProvider
 
-This provider should be used only if you are not using TypeScript at all and therefore you do 
-not use decorators to annotate your properties. It will require you to specify the whole schema 
-manually. 
+This provider should be used only if you are not using TypeScript at all and therefore you do not use decorators to annotate your properties. It will require you to specify the whole schema manually.
 
 ```typescript
 await MikroORM.init({

--- a/docs/versioned_docs/version-3.6/migrations.md
+++ b/docs/versioned_docs/version-3.6/migrations.md
@@ -2,11 +2,9 @@
 title: Migrations
 ---
 
-MikroORM has integrated support for migrations via [umzug](https://github.com/sequelize/umzug).
-It allows you to generate migrations with current schema differences.
+MikroORM has integrated support for migrations via [umzug](https://github.com/sequelize/umzug). It allows you to generate migrations with current schema differences.
 
-By default, each migration will be all executed inside a transaction, and all of them will 
-be wrapped in one master transaction, so if one of them fails, everything will be rolled back. 
+By default, each migration will be all executed inside a transaction, and all of them will be wrapped in one master transaction, so if one of them fails, everything will be rolled back.
 
 ## Migration class
 
@@ -22,10 +20,9 @@ export class Migration20191019195930 extends Migration {
 }
 ```
 
-To support undoing those changed, you can implement the `down` method, which throws an error by default. 
+To support undoing those changed, you can implement the `down` method, which throws an error by default.
 
-Migrations are by default wrapped in a transaction. You can override this behaviour on 
-per migration basis by implementing the `isTransactional(): boolean` method.
+Migrations are by default wrapped in a transaction. You can override this behaviour on per migration basis by implementing the `isTransactional(): boolean` method.
 
 `Configuration` object and driver instance are available in the `Migration` class context.
 
@@ -50,7 +47,7 @@ await MikroORM.init({
 
 ## Using via CLI
 
-You can use it via CLI: 
+You can use it via CLI:
 
 ```sh
 npx mikro-orm migration:create   # Create new migration with current schema diff
@@ -60,8 +57,7 @@ npx mikro-orm migration:list     # List all executed migrations
 npx mikro-orm migration:pending  # List all pending migrations
 ```
 
-For `migration:up` and `migration:down` commands you can specify `--from` (`-f`), `--to` (`-t`) 
-and `--only` (`-o`) options to run only a subset of migrations:
+For `migration:up` and `migration:down` commands you can specify `--from` (`-f`), `--to` (`-t`) and `--only` (`-o`) options to run only a subset of migrations:
 
 ```sh
 npx mikro-orm migration:up --from 2019101911 --to 2019102117  # the same as above
@@ -69,8 +65,7 @@ npx mikro-orm migration:up --only 2019101923                  # apply a single m
 npx mikro-orm migration:down --to 0                           # migrate down all migrations
 ```
 
-> To run TS migration files, you will need to [enable `useTsNode` flag](installation.md) 
-> in your `package.json`.
+> To run TS migration files, you will need to [enable `useTsNode` flag](installation.md) in your `package.json`.
 
 ## Using the Migrator programmatically
 
@@ -109,9 +104,7 @@ $ ts-node migrate
 
 ### MySQL
 
-There is no way to rollback DDL changes in MySQL. An implicit commit is forced for those 
-queries automatically, so transactions are not working as expected. 
+There is no way to rollback DDL changes in MySQL. An implicit commit is forced for those queries automatically, so transactions are not working as expected.
 
 - https://github.com/mikro-orm/mikro-orm/issues/217
 - https://dev.mysql.com/doc/refman/5.7/en/implicit-commit.html
-

--- a/docs/versioned_docs/version-3.6/multiple-schemas.md
+++ b/docs/versioned_docs/version-3.6/multiple-schemas.md
@@ -2,11 +2,9 @@
 title: Using Multiple Schemas
 ---
 
-In MySQL and PostgreSQL it is possible to define your entities in multiple schemas. In MySQL 
-terminology, it is called database, but from an implementation point of view, it is a schema. 
+In MySQL and PostgreSQL it is possible to define your entities in multiple schemas. In MySQL terminology, it is called database, but from an implementation point of view, it is a schema.
 
-> To use multiple schemas, your connection needs to have access to all of them (multiple 
-> connections are not supported).
+> To use multiple schemas, your connection needs to have access to all of them (multiple connections are not supported).
 
 All you need to do is simply define the table name including schema name in `collection` option:
 
@@ -18,12 +16,9 @@ export class Foo { ... }
 export class Bar { ... }
 ```
 
-Then use those entities as usual. Resulting SQL queries will use this `tableName` value as a 
-table name so as long as your connection has access to given schema, everything should work 
-as expected.
+Then use those entities as usual. Resulting SQL queries will use this `tableName` value as a table name so as long as your connection has access to given schema, everything should work as expected.
 
-You can also query for entity in specific schema via `EntityManager`, `EntityRepository` or 
-`QueryBuilder`:
+You can also query for entity in specific schema via `EntityManager`, `EntityRepository` or `QueryBuilder`:
 
 ```typescript
 const user = await em.findOne(User, { ... }, { schema: 'client-123' });

--- a/docs/versioned_docs/version-3.6/naming-strategy.md
+++ b/docs/versioned_docs/version-3.6/naming-strategy.md
@@ -2,15 +2,13 @@
 title: Naming Strategy
 ---
 
-When mapping your entities to database tables and columns, their names will be defined by naming 
-strategy. There are 3 basic naming strategies you can choose from:
+When mapping your entities to database tables and columns, their names will be defined by naming strategy. There are 3 basic naming strategies you can choose from:
 
 - `UnderscoreNamingStrategy` - default of all SQL drivers
 - `MongoNamingStrategy` - default of `MongoDriver`
 - `EntityCaseNamingStrategy` - uses unchanged entity and property names
 
-You can override this when initializing ORM. You can also provide your own naming strategy, just 
-implement `NamingStrategy` interface and provide your implementation when bootstrapping ORM:
+You can override this when initializing ORM. You can also provide your own naming strategy, just implement `NamingStrategy` interface and provide your implementation when bootstrapping ORM:
 
 ```typescript
 class YourCustomNamingStrategy implements NamingStrategy {
@@ -24,20 +22,17 @@ const orm = await MikroORM.init({
 });
 ```
 
-> You can also extend `AbstractNamingStrategy` which implements one method for you - `getClassName()`
-> that is used to map entity file name to class name.
+> You can also extend `AbstractNamingStrategy` which implements one method for you - `getClassName()` that is used to map entity file name to class name.
 
 ## Naming Strategy in mongo driver
 
-`MongoNamingStrategy` will simply use all field names as they are defined. Collection names will
-be translated into lower-cased dashed form:
+`MongoNamingStrategy` will simply use all field names as they are defined. Collection names will be translated into lower-cased dashed form:
 
 `MyCoolEntity` will be translated into `my-cool-entity` collection name.
 
 ## Naming Strategy in SQL drivers
 
-`MySqlDriver` defaults to `UnderscoreNamingStrategy`, which means your all your database tables and
-columns will be lower-cased and words divided by underscored:
+`MySqlDriver` defaults to `UnderscoreNamingStrategy`, which means your all your database tables and columns will be lower-cased and words divided by underscored:
 
 ```sql
 CREATE TABLE `author` (

--- a/docs/versioned_docs/version-3.6/nested-populate.md
+++ b/docs/versioned_docs/version-3.6/nested-populate.md
@@ -2,15 +2,12 @@
 title: Smart Nested Populate
 ---
 
-`MikroORM` is capable of loading large nested structures while maintaining good 
-performance, querying each database table only once. Imagine you have this nested 
-structure:
+`MikroORM` is capable of loading large nested structures while maintaining good performance, querying each database table only once. Imagine you have this nested structure:
 
 - `Book` has one `Publisher` (M:1), one `Author` (M:1) and many `BookTag`s (M:N)
 - `Publisher` has many `Test`s (M:N)
 
-When you use nested populate while querying all `BookTag`s, this is what happens in
-the background:
+When you use nested populate while querying all `BookTag`s, this is what happens in the background:
 
 ```typescript
 const tags = await orm.em.findAll(BookTag, ['books.publisher.tests', 'books.author']);
@@ -64,7 +61,7 @@ To populate existing entities, you can use `em.populate()`.
 const authors = await orm.em.createQueryBuilder(Author).select('*').getResult();
 await em.populate(authors, ['books.tags']);
 
-// now your Author entities will have `books` collections populated, 
+// now your Author entities will have `books` collections populated,
 // as well as they will have their `tags` collections populated.
 console.log(authors[0].books[0].tags[0]); // initialized BookTag
 ```

--- a/docs/versioned_docs/version-3.6/propagation.md
+++ b/docs/versioned_docs/version-3.6/propagation.md
@@ -2,9 +2,7 @@
 title: Propagation
 ---
 
-By default MikroORM will propagate all changes made to one side of bi-directional relations
-to the other side, keeping them in sync. This works for all relations, including M:1 and 1:1.
-As part of the discovery process, all M:1 and 1:1 properties are re-defined as getter/setter.
+By default MikroORM will propagate all changes made to one side of bi-directional relations to the other side, keeping them in sync. This works for all relations, including M:1 and 1:1. As part of the discovery process, all M:1 and 1:1 properties are re-defined as getter/setter.
 
 ```typescript
 const author = new Author(...);
@@ -17,8 +15,7 @@ console.log(author.books.contains(book)); // true
 
 ## Propagation of Collection's add() and remove() operations
 
-When you use one of `Collection.add()` method, the item is added to given collection, 
-and this action is also propagated to its counterpart. 
+When you use one of `Collection.add()` method, the item is added to given collection, and this action is also propagated to its counterpart.
 
 ```typescript
 // one to many
@@ -29,7 +26,7 @@ author.books.add(book);
 console.log(book.author); // author will be set thanks to the propagation
 ```
 
-For M:N this works in both ways, either from owning side, or from inverse side. 
+For M:N this works in both ways, either from owning side, or from inverse side.
 
 ```typescript
 // many to many works both from owning side and from inverse side
@@ -41,11 +38,10 @@ console.log(tag.books.contains(book)); // true
 
 tag.books.add(book);
 console.log(book.tags.contains(tag)); // true
-``` 
+```
 
 > Collections on both sides have to be initialized, otherwise propagation won't work.
 
-> Although this propagation works also for M:N inverse side, you should always use owning
-> side to manipulate the collection.
+> Although this propagation works also for M:N inverse side, you should always use owning side to manipulate the collection.
 
 Same applies for `Collection.remove()`.

--- a/docs/versioned_docs/version-3.6/property-validation.md
+++ b/docs/versioned_docs/version-3.6/property-validation.md
@@ -2,10 +2,7 @@
 title: Property Validation
 ---
 
-`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong 
-data types for you automatically. If automatic conversion fails, it will throw an error. You can 
-enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered 
-when persisting the entity. 
+`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong data types for you automatically. If automatic conversion fails, it will throw an error. You can enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered when persisting the entity.
 
 ```typescript
 // number instead of string will throw

--- a/docs/versioned_docs/version-3.6/query-builder.md
+++ b/docs/versioned_docs/version-3.6/query-builder.md
@@ -2,8 +2,7 @@
 title: Using Query Builder
 ---
 
-When you need to execute some SQL query without all the ORM stuff involved, you can either
-compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
+When you need to execute some SQL query without all the ORM stuff involved, you can either compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
 
 ```typescript
 const qb = orm.em.createQueryBuilder(Author);
@@ -23,8 +22,7 @@ const res1 = await qb.execute();
 
 ## Using Knex.js
 
-Under the hood, `QueryBuilder` uses [`Knex.js`](https://knexjs.org) to compose and run queries.
-You can access configured `knex` instance via `qb.getKnexQuery()` method:
+Under the hood, `QueryBuilder` uses [`Knex.js`](https://knexjs.org) to compose and run queries. You can access configured `knex` instance via `qb.getKnexQuery()` method:
 
 ```typescript
 const qb = orm.em.createQueryBuilder(Author);
@@ -38,14 +36,9 @@ const entities = res.map(a => orm.em.map(Author, a));
 console.log(entities); // Author[]
 ```
 
-You can also get clear and configured knex instance from the connection via `getKnex()` method.
-As this method is not available on the base `Connection` class, you will need to either manually
-type cast the connection to `AbstractSqlConnection` (or the actual implementation you are using, 
-e.g. `MySqlConnection`), or provide correct driver type hint to your `EntityManager` instance, 
-which will be then automatically inferred in `em.getConnection()` method.
+You can also get clear and configured knex instance from the connection via `getKnex()` method. As this method is not available on the base `Connection` class, you will need to either manually type cast the connection to `AbstractSqlConnection` (or the actual implementation you are using, e.g. `MySqlConnection`), or provide correct driver type hint to your `EntityManager` instance, which will be then automatically inferred in `em.getConnection()` method.
 
-> Driver and connection implementations are not directly exported from `mikro-orm` module. 
-> You can import them from `mikro-orm/dist` (e.g. `import { PostgreSqlDriver } from 'mikro-orm/dist/drivers/PostgreSqlDriver'`).
+> Driver and connection implementations are not directly exported from `mikro-orm` module. You can import them from `mikro-orm/dist` (e.g. `import { PostgreSqlDriver } from 'mikro-orm/dist/drivers/PostgreSqlDriver'`).
 
 ```typescript
 const conn = orm.em.getConnection() as AbstractSqlConnection;
@@ -80,9 +73,7 @@ const res2 = await qb.execute('get'); // returns single object
 const res3 = await qb.execute('run'); // returns object like `{ affectedRows: number, insertId: number, row: any }`
 ```
 
-Second argument can be used to disable mapping of database columns to property names (which 
-is enabled by default). In following example, `Book` entity has `createdAt` property defined 
-with implicit underscored field name `created_at`:
+Second argument can be used to disable mapping of database columns to property names (which is enabled by default). In following example, `Book` entity has `createdAt` property defined with implicit underscored field name `created_at`:
 
 ```typescript
 const res4 = await orm.em.createQueryBuilder(Book).select('*').execute('get', true);
@@ -91,8 +82,7 @@ const res5 = await orm.em.createQueryBuilder(Book).select('*').execute('get', fa
 console.log(res5); // `created_at` will be defined, while `createdAt` will be missing
 ```
 
-To get entity instances from the QueryBuilder result, you can use `getResult()` and `getSingleResult()`
-methods:
+To get entity instances from the QueryBuilder result, you can use `getResult()` and `getSingleResult()` methods:
 
 ```typescript
 const book = await orm.em.createQueryBuilder(Book).select('*').where({ id: 1 }).getSingleResult();
@@ -103,13 +93,9 @@ console.log(books[0] instanceof Book); // true
 
 ## Mapping Raw Results to Entities
 
-Another way to create entity from raw results (that are not necessarily mapped to entity properties)
-is to use `map()` method of `EntityManager`, that is basically a shortcut for mapping results
-via `IDatabaseDriver.mapResult()` (which converts field names to property names - e.g. `created_at`
-to `createdAt`) and `merge()` which converts the data to entity instance and makes it managed. 
+Another way to create entity from raw results (that are not necessarily mapped to entity properties) is to use `map()` method of `EntityManager`, that is basically a shortcut for mapping results via `IDatabaseDriver.mapResult()` (which converts field names to property names - e.g. `created_at` to `createdAt`) and `merge()` which converts the data to entity instance and makes it managed.
 
-This method comes handy when you want to use 3rd party query builders, where the result is not 
-mapped to entity properties automatically:
+This method comes handy when you want to use 3rd party query builders, where the result is not mapped to entity properties automatically:
 
 ```typescript
 const results = await knex.select('*').from('users').where(knex.raw('id = ?', [id]));
@@ -144,17 +130,16 @@ qb.select('*')
   .orderBy({ books: { tags: { createdBy: QueryOrder.DESC } } });
 
 console.log(qb.getQuery());
-// select `e0`.* 
-// from `author` as `e0` 
-// left join `book2` as `e1` on `e0`.`id` = `e1`.`author_id` 
-// left join `book2_to_book_tag2` as `e3` on `e1`.`uuid_pk` = `e3`.`book2_uuid_pk` 
-// left join `book_tag2` as `e2` on `e3`.`book_tag2_id` = `e2`.`id` 
-// where `e2`.`name` = ? 
+// select `e0`.*
+// from `author` as `e0`
+// left join `book2` as `e1` on `e0`.`id` = `e1`.`author_id`
+// left join `book2_to_book_tag2` as `e3` on `e1`.`uuid_pk` = `e3`.`book2_uuid_pk`
+// left join `book_tag2` as `e2` on `e3`.`book_tag2_id` = `e2`.`id`
+// where `e2`.`name` = ?
 // order by `e1`.`tags` asc
 ```
 
-This is currently available only for filtering (`where`) and sorting (`orderBy`), only 
-the root entity will be selected. To populate its relationships, you can use [EntityLoader](nested-populate.md).
+This is currently available only for filtering (`where`) and sorting (`orderBy`), only the root entity will be selected. To populate its relationships, you can use [EntityLoader](nested-populate.md).
 
 ## Explicit Joining
 
@@ -177,8 +162,7 @@ console.log(qb.getQuery());
 
 ## Complex Where Conditions
 
-There are multiple ways to construct complex query conditions. You can either write parts of SQL
-manually, use `andWhere()`/`orWhere()`, or provide condition object:
+There are multiple ways to construct complex query conditions. You can either write parts of SQL manually, use `andWhere()`/`orWhere()`, or provide condition object:
 
 ### Custom SQL in where
 

--- a/docs/versioned_docs/version-3.6/query-conditions.md
+++ b/docs/versioned_docs/version-3.6/query-conditions.md
@@ -2,8 +2,7 @@
 title: Smart Query Conditions
 ---
 
-When you want to make complex queries, you can easily end up with a lot of boilerplate code
-full of curly brackets:
+When you want to make complex queries, you can easily end up with a lot of boilerplate code full of curly brackets:
 
 ```typescript
 const res = await orm.em.find(Author, { $and: [
@@ -20,8 +19,8 @@ const res = await orm.em.find(Author, { $and: [
 For AND condition with single field, you can also do this:
 
 ```typescript
-const res = await orm.em.find(Author, { 
-  id: { 
+const res = await orm.em.find(Author, {
+  id: {
     $in: [1, 2, 7],
     $nin: [3, 4],
     $gt: 5,
@@ -59,12 +58,9 @@ const res = await orm.em.find(Author, { $and: [
 ] });
 ```
 
-> Keys with operators like this will cause TypeScript errors as there is no way to support 
-> them on the typings side. They are still supported, but you will need to cast the condition
-> to `any` to use them. 
+> Keys with operators like this will cause TypeScript errors as there is no way to support them on the typings side. They are still supported, but you will need to cast the condition to `any` to use them.
 
-There is also shortcut for `$in` - simply provide array as value and it 
-will be converted automatically:
+There is also shortcut for `$in` - simply provide array as value and it will be converted automatically:
 
 ```typescript
 const res = await orm.em.find(Author, { favouriteBook: [1, 2, 7] });
@@ -80,23 +76,23 @@ const res = await orm.em.find(Author, [1, 2, 7]);
 
 ### Comparison
 
-| operator | name               | description |
-|----------|--------------------|-------------|
-| `$eq`	   | equals             | Matches values that are equal to a specified value. |
-| `$gt`	   | greater            | Matches values that are greater than a specified value. |
-| `$gte`   | greater or equal   | Matches values that are greater than or equal to a specified value. |
-| `$in`	   | contains           | Matches any of the values specified in an array. |
-| `$lt`	   | lower              | Matches values that are less than a specified value. |
-| `$lte`   | lower or equal     | Matches values that are less than or equal to a specified value. |
-| `$ne`	   | not equal          | Matches all values that are not equal to a specified value. |
-| `$nin`   | not contains       | Matches none of the values specified in an array. |
-| `$like`  | like               | Uses LIKE operator |
-| `$re`    | regexp             | Uses REGEXP operator |
+| operator | name             | description                                                         |
+| -------- | ---------------- | ------------------------------------------------------------------- |
+| `$eq`    | equals           | Matches values that are equal to a specified value.                 |
+| `$gt`    | greater          | Matches values that are greater than a specified value.             |
+| `$gte`   | greater or equal | Matches values that are greater than or equal to a specified value. |
+| `$in`    | contains         | Matches any of the values specified in an array.                    |
+| `$lt`    | lower            | Matches values that are less than a specified value.                |
+| `$lte`   | lower or equal   | Matches values that are less than or equal to a specified value.    |
+| `$ne`    | not equal        | Matches all values that are not equal to a specified value.         |
+| `$nin`   | not contains     | Matches none of the values specified in an array.                   |
+| `$like`  | like             | Uses LIKE operator                                                  |
+| `$re`    | regexp           | Uses REGEXP operator                                                |
 
 ### Logical
 
-| operator | description |
-|----------|-------------|
+| operator | description                                                                                             |
+| -------- | ------------------------------------------------------------------------------------------------------- |
 | `$and`   | Joins query clauses with a logical AND returns all documents that match the conditions of both clauses. |
-| `$not`   | Inverts the effect of a query expression and returns documents that do not match the query expression. |
+| `$not`   | Inverts the effect of a query expression and returns documents that do not match the query expression.  |
 | `$or`    | Joins query clauses with a logical OR returns all documents that match the conditions of either clause. |

--- a/docs/versioned_docs/version-3.6/read-connections.md
+++ b/docs/versioned_docs/version-3.6/read-connections.md
@@ -2,8 +2,7 @@
 title: Read Replica Connections
 ---
 
-Users can specify multiple read connections via `replicas` option. You can provide only fields 
-that differ from master connection, rest will be taken from it.
+Users can specify multiple read connections via `replicas` option. You can provide only fields that differ from master connection, rest will be taken from it.
 
 ```typescript
 const orm = await MikroORM.init({
@@ -19,8 +18,7 @@ const orm = await MikroORM.init({
 });
 ```
 
-By default select queries will use random read connection if not inside transaction. You can 
-specify connection type manually in `em.getConnection(type: 'read' | 'write')`.
+By default select queries will use random read connection if not inside transaction. You can specify connection type manually in `em.getConnection(type: 'read' | 'write')`.
 
 ```typescript
 const connection = orm.em.getConnection(); // write connection

--- a/docs/versioned_docs/version-3.6/relationships.md
+++ b/docs/versioned_docs/version-3.6/relationships.md
@@ -3,20 +3,16 @@ title: Modeling Entity Relationships
 sidebar_label: Modeling Entity Relationships
 ---
 
-There are 4 types of entity relationships in MikroORM: 
+There are 4 types of entity relationships in MikroORM:
 
 - ManyToOne
 - OneToMany
 - OneToOne
 - ManyToMany
 
-Relations can be unidirectional and bidirectional. Unidirectional are defined only on one 
-side (the owning side). Bidirectional are defined on both sides, while one is owning side 
-(where references are store), marked by `inversedBy` attribute pointing to the inverse side.
-On the inversed side we define it with `mappedBy` attribute pointing back to the owner:
+Relations can be unidirectional and bidirectional. Unidirectional are defined only on one side (the owning side). Bidirectional are defined on both sides, while one is owning side (where references are store), marked by `inversedBy` attribute pointing to the inverse side. On the inversed side we define it with `mappedBy` attribute pointing back to the owner:
 
-> When modeling bidirectional relationship, you can also omit the `inversedBy` attribute, 
-> defining `mappedBy` on the inverse side is enough as it will be auto-wired. 
+> When modeling bidirectional relationship, you can also omit the `inversedBy` attribute, defining `mappedBy` on the inverse side is enough as it will be auto-wired.
 
 ## ManyToOne
 
@@ -43,8 +39,7 @@ export class Book {
 }
 ```
 
-You can also specify how operations on given entity should [cascade](cascading.md) 
-to the referred entity.
+You can also specify how operations on given entity should [cascade](cascading.md) to the referred entity.
 
 ## OneToMany
 
@@ -71,19 +66,15 @@ export class Author {
 }
 ```
 
-As you can see, OneToMany is the inverse side of ManyToOne (which is the owning side).
-More about how collections work can be found on [collections page](collections.md). 
+As you can see, OneToMany is the inverse side of ManyToOne (which is the owning side). More about how collections work can be found on [collections page](collections.md).
 
-You can also specify how operations on given entity should [cascade](cascading.md) to the referred
-entities. There is also more aggressive remove mode called [Orphan Removal](cascading.md#orphan-removal) 
-(`books4` example).
+You can also specify how operations on given entity should [cascade](cascading.md) to the referred entities. There is also more aggressive remove mode called [Orphan Removal](cascading.md#orphan-removal) (`books4` example).
 
 ## OneToOne
 
 > One instance of the current Entity refers to One instance of the referred Entity.
 
-This is a variant of ManyToOne, where there is always just one entity on both sides. This means
-that the foreign key column is also unique.
+This is a variant of ManyToOne, where there is always just one entity on both sides. This means that the foreign key column is also unique.
 
 ### Owning Side
 
@@ -121,8 +112,7 @@ export class User {
 }
 ```
 
-As you can see, relationships can be also self-referencing (all of them. OneToOne also supports 
-[Orphan Removal](cascading.md#orphan-removal). 
+As you can see, relationships can be also self-referencing (all of them. OneToOne also supports [Orphan Removal](cascading.md#orphan-removal).
 
 ## ManyToMany
 
@@ -149,7 +139,7 @@ export class Book {
   @ManyToMany(() => BookTag, 'books', { owner: true })
   tags4 = new Collection<BookTag>(this);
 
-  // to define uni-directional many to many, simply provide only 
+  // to define uni-directional many to many, simply provide only
   @ManyToMany(() => Author)
   friends: Collection<Author> = new Collection<Author>(this);
 
@@ -169,7 +159,7 @@ export class BookTag {
 }
 ```
 
-Again, more information about how collections work can be found on [collections page](collections.md). 
+Again, more information about how collections work can be found on [collections page](collections.md).
 
 > Note: if you are using multiple M:N relations between the same entities, you will need to manually specify the pivot table's name just on the **owning** sides. Here is an example:
 

--- a/docs/versioned_docs/version-3.6/repositories.md
+++ b/docs/versioned_docs/version-3.6/repositories.md
@@ -3,8 +3,7 @@ title: Using EntityRepository instead of EntityManager
 sidebar_label: Entity Repository
 ---
 
-More convenient way of fetching entities from database is by using `EntityRepository`, that
-carries the entity name so you do not have to pass it to every `find` and `findOne` calls:
+More convenient way of fetching entities from database is by using `EntityRepository`, that carries the entity name so you do not have to pass it to every `find` and `findOne` calls:
 
 Example:
 
@@ -15,7 +14,7 @@ const booksRepository = orm.em.getRepository(Book);
 const books = await booksRepository.find({ author: '...' }, ['author'], { title: QueryOrder.DESC }, 2, 1);
 
 // or with options object
-const books = await booksRepository.find({ author: '...' }, { 
+const books = await booksRepository.find({ author: '...' }, {
   populate: ['author'],
   limit: 1,
   offset: 2,
@@ -41,8 +40,7 @@ export class CustomAuthorRepository extends EntityRepository<Author> {
 }
 ```
 
-You can also omit the `@Repository` decorator and register your repository in `@Entity` 
-decorator instead:
+You can also omit the `@Repository` decorator and register your repository in `@Entity` decorator instead:
 
 ```typescript
 @Entity({ customRepository: () => CustomAuthorRepository })
@@ -51,24 +49,19 @@ export class Author {
 }
 ```
 
-Note that we need to pass that repository reference inside a callback so we will not run
-into circular dependency issues when using entity references inside that repository.
+Note that we need to pass that repository reference inside a callback so we will not run into circular dependency issues when using entity references inside that repository.
 
 Now you can access your custom repository via `em.getRepository()` method.
 
-> You can also register custom base repository (for all entities where you do not specify 
-> `customRepository`) globally, via `MikroORM.init({ entityRepository: CustomBaseRepository })`.
+> You can also register custom base repository (for all entities where you do not specify `customRepository`) globally, via `MikroORM.init({ entityRepository: CustomBaseRepository })`.
 
-For more examples, take a look at
-[`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts)
-or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).
+For more examples, take a look at [`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts) or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).
 
 ## EntityRepository\<T\> API
 
 #### `find(where: FilterQuery<T>, options?: FindOptions): Promise<T[]>`
 
-Returns array of entities found for given condition. You can specify `FindOptions` to request
-population of referenced entities or control the pagination:
+Returns array of entities found for given condition. You can specify `FindOptions` to request population of referenced entities or control the pagination:
 
 ```typescript
 export interface FindOptions {
@@ -84,71 +77,61 @@ export interface FindOptions {
 
 #### `find(where: FilterQuery<T>, populate?: string[], orderBy?: { [k: string]: QueryOrder }, limit?: number, offset?: number): Promise<T[]>`
 
-Same as previous `find` method, just with dedicated parameters for `populate`, `orderBy`, `limit`
-and `offset`.
+Same as previous `find` method, just with dedicated parameters for `populate`, `orderBy`, `limit` and `offset`.
 
 ---
 
 #### `findAndCount(where: FilterQuery<T>, populate?: string[], orderBy?: { [k: string]: QueryOrder }, limit?: number, offset?: number): Promise<T[]>`
 
-Combination of `find` and `count` methods. 
+Combination of `find` and `count` methods.
 
 ---
 
 #### `findAll(options?: FindOptions): Promise<T[]>`
 
-Returns all entities for given type. 
+Returns all entities for given type.
 
 ---
 
 #### `findAll(populate?: string[], orderBy?: { [k: string]: QueryOrder }, limit?: number, offset?: number): Promise<T[]>`
 
-Same as previous `findAll` method, just with dedicated parameters for `populate`, `orderBy`, `limit`
-and `offset`.
+Same as previous `findAll` method, just with dedicated parameters for `populate`, `orderBy`, `limit` and `offset`.
 
 ---
 
 #### `findOne(where: FilterQuery<T> | string, populate?: string[]): Promise<T | null>`
 
-Finds an entity by given `where` condition. You can use primary key as `where` value, then
-if the entity is already managed, no database call will be made. 
+Finds an entity by given `where` condition. You can use primary key as `where` value, then if the entity is already managed, no database call will be made.
 
 ---
 
 #### `findOneOrFail(where: FilterQuery<T> | string, populate?: string[]): Promise<T>`
 
-Just like `findOne`, but throws when entity not found, so it always resolves to given entity. 
-You can customize the error either globally via `findOneOrFailHandler` option, or locally via 
-`failHandler` option in `findOneOrFail` call.
+Just like `findOne`, but throws when entity not found, so it always resolves to given entity. You can customize the error either globally via `findOneOrFailHandler` option, or locally via `failHandler` option in `findOneOrFail` call.
 
 ---
 
 #### `merge(data: EntityData<T>): T`
 
-Adds given entity to current Identity Map. After merging, entity becomes managed. 
-This is useful when you want to work with cached entities. 
+Adds given entity to current Identity Map. After merging, entity becomes managed. This is useful when you want to work with cached entities.
 
 ---
 
 #### `getReference(id: string): T`
 
-Gets a reference to the entity identified by the given type and identifier without actually 
-loading it, if the entity is not yet loaded.
+Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded.
 
 ---
 
 #### `count(where?: FilterQuery<T>): Promise<number>`
 
-Gets count of entities matching the `where` condition. 
+Gets count of entities matching the `where` condition.
 
 ---
 
 #### `persist(entity: AnyEntity | AnyEntity[], flush?: boolean): Promise<void>`
 
-Tells the EntityManager to make an instance managed and persistent. The entity will be 
-entered into the database at or before transaction commit or as a result of the flush 
-operation. You can control immediate flushing via `flush` parameter and via `autoFlush`
-configuration option. 
+Tells the EntityManager to make an instance managed and persistent. The entity will be entered into the database at or before transaction commit or as a result of the flush operation. You can control immediate flushing via `flush` parameter and via `autoFlush` configuration option.
 
 ---
 
@@ -160,7 +143,7 @@ Shortcut for `persist` & `flush`.
 
 #### `persistLater(entity: AnyEntity | AnyEntity[]): void`
 
-Shortcut for just `persist`, without flushing. 
+Shortcut for just `persist`, without flushing.
 
 ---
 
@@ -172,10 +155,9 @@ Flushes all changes to objects that have been queued up to now to the database.
 
 #### `remove(where: AnyEntity | FilterQuery<T>, flush?: boolean): Promise<number>`
 
-When provided entity instance as `where` value, then it calls `removeEntity(entity, flush)`, 
-otherwise it fires delete query with given `where` condition. 
+When provided entity instance as `where` value, then it calls `removeEntity(entity, flush)`, otherwise it fires delete query with given `where` condition.
 
-This method fires `beforeDelete` and `afterDelete` hooks only if you provide entity instance.  
+This method fires `beforeDelete` and `afterDelete` hooks only if you provide entity instance.
 
 ---
 
@@ -183,21 +165,20 @@ This method fires `beforeDelete` and `afterDelete` hooks only if you provide ent
 
 Shortcut for `removeEntity` & `flush`.
 
-This method fires `beforeDelete` and `afterDelete` hooks. 
+This method fires `beforeDelete` and `afterDelete` hooks.
 
 ---
 
 #### `removeLater(entity: AnyEntity): void`
 
-Shortcut for `removeEntity` without flushing. 
+Shortcut for `removeEntity` without flushing.
 
-This method fires `beforeDelete` and `afterDelete` hooks. 
+This method fires `beforeDelete` and `afterDelete` hooks.
 
 ---
 
 #### `canPopulate(property: string): boolean`
 
-Returns whether given entity has given property which can be populated (is reference or
-collection).
+Returns whether given entity has given property which can be populated (is reference or collection).
 
 ---

--- a/docs/versioned_docs/version-3.6/schema-generator.md
+++ b/docs/versioned_docs/version-3.6/schema-generator.md
@@ -2,20 +2,13 @@
 title: Schema Generator
 ---
 
-> SchemaGenerator can do harm to your database. It will drop or alter tables, indexes, 
-> sequences and such. Please use this tool with caution in development and not on a 
-> production server. It is meant for helping you develop your Database Schema, but NOT 
-> with migrating schema from A to B in production. A safe approach would be generating 
-> the SQL on development server and saving it into SQL Migration files that are executed 
-> manually on the production server.
+> SchemaGenerator can do harm to your database. It will drop or alter tables, indexes, sequences and such. Please use this tool with caution in development and not on a production server. It is meant for helping you develop your Database Schema, but NOT with migrating schema from A to B in production. A safe approach would be generating the SQL on development server and saving it into SQL Migration files that are executed manually on the production server.
 
-> SchemaTool assumes your project uses the given database on its own. Update and Drop 
-> commands will mess with other tables if they are not related to the current project 
-> that is using MikroORM. Please be careful!
+> SchemaTool assumes your project uses the given database on its own. Update and Drop commands will mess with other tables if they are not related to the current project that is using MikroORM. Please be careful!
 
-To generate schema from your entity metadata, you can use `SchemaGenerator` helper. 
+To generate schema from your entity metadata, you can use `SchemaGenerator` helper.
 
-You can use it via CLI: 
+You can use it via CLI:
 
 ```sh
 npx mikro-orm schema:create --dump   # Dumps create schema SQL
@@ -23,18 +16,13 @@ npx mikro-orm schema:update --dump   # Dumps update schema SQL
 npx mikro-orm schema:drop --dump     # Dumps drop schema SQL
 ```
 
-> You can also use `--run` flag to fire all queries, but be careful as it might break your
-> database. Be sure to always check the generated SQL first before executing. Do not use
-> `--run` flag in production! 
+> You can also use `--run` flag to fire all queries, but be careful as it might break your database. Be sure to always check the generated SQL first before executing. Do not use `--run` flag in production!
 
-`schema:create` will automatically create the database if it does not exist. 
+`schema:create` will automatically create the database if it does not exist.
 
-`schema:update` drops all unknown tables by default, you can use `--no-drop-tables` 
-to get around it. There is also `--safe` flag that will disable both table dropping as 
-well as column dropping. 
+`schema:update` drops all unknown tables by default, you can use `--no-drop-tables` to get around it. There is also `--safe` flag that will disable both table dropping as well as column dropping.
 
-`schema:drop` will by default drop all database tables. You can use `--drop-db` flag to drop
-the whole database instead. 
+`schema:drop` will by default drop all database tables. You can use `--drop-db` flag to drop the whole database instead.
 
 ## Using SchemaGenerator programmatically
 
@@ -81,12 +69,10 @@ $ ts-node create-schema
 
 ## Limitations of SQLite
 
-There are limitations of SQLite database because of which it behaves differently 
-than other SQL drivers. Namely, it is not possible to:
+There are limitations of SQLite database because of which it behaves differently than other SQL drivers. Namely, it is not possible to:
 
 - create foreign key constraints when altering columns
 - create empty tables without columns
 - alter column requires nullability
 
-Because of this, you can end up with different schema with SQLite, so it is not
-suggested to use SQLite for integration tests of your application.
+Because of this, you can end up with different schema with SQLite, so it is not suggested to use SQLite for integration tests of your application.

--- a/docs/versioned_docs/version-3.6/serializing.md
+++ b/docs/versioned_docs/version-3.6/serializing.md
@@ -12,9 +12,7 @@ export interface AnyEntity<K = number | string> {
 }
 ```
 
-When you serialize your entity via `JSON.stringify(entity)`, its `toJSON` method will be 
-called automatically. You can provide custom implementation for `toJSON`, while using 
-`toObject` for initial serialization:
+When you serialize your entity via `JSON.stringify(entity)`, its `toJSON` method will be called automatically. You can provide custom implementation for `toJSON`, while using `toObject` for initial serialization:
 
 ```typescript
 @Entity()
@@ -35,13 +33,11 @@ export class Book {
 }
 ```
 
-> Do not forget to pass rest params when calling `toObject(...args)`, otherwise the results
-> might not be stable.
+> Do not forget to pass rest params when calling `toObject(...args)`, otherwise the results might not be stable.
 
 ## Hidden Properties
 
-If you want to omit some properties from serialized result, you can mark them with `hidden`
-flag on `@Property()` decorator:
+If you want to omit some properties from serialized result, you can mark them with `hidden` flag on `@Property()` decorator:
 
 ```typescript
 @Entity()
@@ -59,13 +55,9 @@ console.log(book.toJSON().hiddenField); // undefined
 
 ## Shadow Properties
 
-The opposite situation where you want to define a property that lives only in memory (is 
-not persisted into database) can be solved by defining your property as `persist: false`. 
-Such property can be assigned via one of `Entity.assign()`, `em.create()` and 
-`em.merge()`. It will be also part of serialized result. 
+The opposite situation where you want to define a property that lives only in memory (is not persisted into database) can be solved by defining your property as `persist: false`. Such property can be assigned via one of `Entity.assign()`, `em.create()` and `em.merge()`. It will be also part of serialized result.
 
-This can be handle when dealing with additional values selected via `QueryBuilder` or 
-MongoDB's aggregations.
+This can be handle when dealing with additional values selected via `QueryBuilder` or MongoDB's aggregations.
 
 ```typescript
 @Entity()

--- a/docs/versioned_docs/version-3.6/transactions.md
+++ b/docs/versioned_docs/version-3.6/transactions.md
@@ -6,28 +6,17 @@ title: Transactions and Concurrency
 
 ## Transaction Demarcation
 
-Transaction demarcation is the task of defining your transaction boundaries. Proper 
-transaction demarcation is very important because if not done properly it can negatively 
-affect the performance of your application. Many databases and database abstraction 
-layers by default operate in auto-commit mode, which means that every single SQL statement 
-is wrapped in a small transaction. Without any explicit transaction demarcation from your 
-side, this quickly results in poor performance because transactions are not cheap. 
+Transaction demarcation is the task of defining your transaction boundaries. Proper transaction demarcation is very important because if not done properly it can negatively affect the performance of your application. Many databases and database abstraction layers by default operate in auto-commit mode, which means that every single SQL statement is wrapped in a small transaction. Without any explicit transaction demarcation from your side, this quickly results in poor performance because transactions are not cheap.
 
-For the most part, MikroORM already takes care of proper transaction demarcation for you: 
-All the write operations (INSERT/UPDATE/DELETE) are queued until `em.flush()` 
-is invoked which wraps all of these changes in a single transaction.
+For the most part, MikroORM already takes care of proper transaction demarcation for you: All the write operations (INSERT/UPDATE/DELETE) are queued until `em.flush()` is invoked which wraps all of these changes in a single transaction.
 
-However, MikroORM also allows (and encourages) you to take over and control transaction 
-demarcation yourself.
+However, MikroORM also allows (and encourages) you to take over and control transaction demarcation yourself.
 
-These are two ways to deal with transactions when using the MikroORM and are now described 
-in more detail.
+These are two ways to deal with transactions when using the MikroORM and are now described in more detail.
 
 ### Approach 1: Implicitly
 
-The first approach is to use the implicit transaction handling provided by the MikroORM 
-`EntityManager`. Given the following code snippet, without any explicit transaction 
-demarcation:
+The first approach is to use the implicit transaction handling provided by the MikroORM `EntityManager`. Given the following code snippet, without any explicit transaction demarcation:
 
 ```typescript
 const user = new User(...);
@@ -35,16 +24,11 @@ user.name = 'George';
 await orm.em.persistAndFlush(user);
 ```
 
-Since we do not do any custom transaction demarcation in the above code, `em.flush()` 
-will begin and commit/rollback a transaction. This behavior is made possible by the 
-aggregation of the DML operations by the MikroORM and is sufficient if all the data 
-manipulation that is part of a unit of work happens through the domain model and thus 
-the ORM.
+Since we do not do any custom transaction demarcation in the above code, `em.flush()` will begin and commit/rollback a transaction. This behavior is made possible by the aggregation of the DML operations by the MikroORM and is sufficient if all the data manipulation that is part of a unit of work happens through the domain model and thus the ORM.
 
 ### Approach 2: Explicitly
 
-The explicit alternative is to use the transactions API directly to control the boundaries. 
-The code then looks like this:
+The explicit alternative is to use the transactions API directly to control the boundaries. The code then looks like this:
 
 ```typescript
 await orm.em.transactional(_em => {
@@ -55,68 +39,37 @@ await orm.em.transactional(_em => {
 });
 ```
 
-Explicit transaction demarcation is required when you want to include custom DBAL operations 
-in a unit of work or when you want to make use of some methods of the EntityManager API 
-that require an active transaction. Such methods will throw a `ValidationError` to inform 
-you of that requirement.
+Explicit transaction demarcation is required when you want to include custom DBAL operations in a unit of work or when you want to make use of some methods of the EntityManager API that require an active transaction. Such methods will throw a `ValidationError` to inform you of that requirement.
 
 `em.transactional(cb)` will flush the inner `EntityManager` prior to transaction commit.
 
 ### Exception Handling
 
-When using implicit transaction demarcation and an exception occurs during 
-`em.flush()`, the transaction is automatically rolled back.
+When using implicit transaction demarcation and an exception occurs during `em.flush()`, the transaction is automatically rolled back.
 
-When using explicit transaction demarcation and an exception occurs, the transaction should 
-be rolled back immediately as demonstrated in the example above. This can be handled elegantly 
-by the control abstractions shown earlier. Note that when catching Exception you should 
-generally re-throw the exception. If you intend to recover from some exceptions, catch them 
-explicitly in earlier catch blocks (but do not forget to rollback the transaction). All 
-other best practices of exception handling apply similarly (i.e. either log or re-throw, 
-not both, etc.).
+When using explicit transaction demarcation and an exception occurs, the transaction should be rolled back immediately as demonstrated in the example above. This can be handled elegantly by the control abstractions shown earlier. Note that when catching Exception you should generally re-throw the exception. If you intend to recover from some exceptions, catch them explicitly in earlier catch blocks (but do not forget to rollback the transaction). All other best practices of exception handling apply similarly (i.e. either log or re-throw, not both, etc.).
 
-As a result of this procedure, all previously managed or removed instances of the `EntityManager` 
-become detached. The state of the detached objects will be the state at the point at which the 
-transaction was rolled back. The state of the objects is in no way rolled back and thus the 
-objects are now out of sync with the database. The application can continue to use the detached 
-objects, knowing that their state is potentially no longer accurate.
+As a result of this procedure, all previously managed or removed instances of the `EntityManager` become detached. The state of the detached objects will be the state at the point at which the transaction was rolled back. The state of the objects is in no way rolled back and thus the objects are now out of sync with the database. The application can continue to use the detached objects, knowing that their state is potentially no longer accurate.
 
-If you intend to start another unit of work after an exception has occurred you should do 
-that with a new `EntityManager`. Simply use `em.fork()` to obtain fresh copy 
-with cleared identity map. 
+If you intend to start another unit of work after an exception has occurred you should do that with a new `EntityManager`. Simply use `em.fork()` to obtain fresh copy with cleared identity map.
 
 ## Locking Support
 
 ### Why we need concurrency control?
 
-If transactions are executed serially (one at a time), no transaction concurrency exists. 
-However, if concurrent transactions with interleaving operations are allowed, you may easily 
-run into one of those problems:
+If transactions are executed serially (one at a time), no transaction concurrency exists. However, if concurrent transactions with interleaving operations are allowed, you may easily run into one of those problems:
 
 1. The lost update problem
 2. The dirty read problem
 3. The incorrect summary problem
 
-To mitigate those problems, MikroORM offers support for Pessimistic and Optimistic locking 
-strategies natively. This allows you to take very fine-grained control over what kind of 
-locking is required for your entities in your application.
+To mitigate those problems, MikroORM offers support for Pessimistic and Optimistic locking strategies natively. This allows you to take very fine-grained control over what kind of locking is required for your entities in your application.
 
 ### Optimistic Locking
 
-Database transactions are fine for concurrency control during a single request. However, a 
-database transaction should not span across requests, the so-called "user think time". Therefore 
-a long-running "business transaction" that spans multiple requests needs to involve several 
-database transactions. Thus, database transactions alone can no longer control concurrency 
-during such a long-running business transaction. Concurrency control becomes the partial 
-responsibility of the application itself.
+Database transactions are fine for concurrency control during a single request. However, a database transaction should not span across requests, the so-called "user think time". Therefore a long-running "business transaction" that spans multiple requests needs to involve several database transactions. Thus, database transactions alone can no longer control concurrency during such a long-running business transaction. Concurrency control becomes the partial responsibility of the application itself.
 
-MikroORM has integrated support for automatic optimistic locking via a version field. In 
-this approach any entity that should be protected against concurrent modifications during 
-long-running business transactions gets a version field that is either a simple number 
-(mapping type: integer) or a timestamp (mapping type: datetime). When changes to such an 
-entity are persisted at the end of a long-running conversation the version of the entity 
-is compared to the version in the database and if they don't match, a `ValidationError` 
-is thrown, indicating that the entity has been modified by someone else already.
+MikroORM has integrated support for automatic optimistic locking via a version field. In this approach any entity that should be protected against concurrent modifications during long-running business transactions gets a version field that is either a simple number (mapping type: integer) or a timestamp (mapping type: datetime). When changes to such an entity are persisted at the end of a long-running conversation the version of the entity is compared to the version in the database and if they don't match, a `ValidationError` is thrown, indicating that the entity has been modified by someone else already.
 
 You designate a version field in an entity as follows. In this example we'll use an integer.
 
@@ -140,23 +93,13 @@ export class User {
 }
 ```
 
-Version numbers (not timestamps) should however be preferred as they can not potentially 
-conflict in a highly concurrent environment, unlike timestamps where this is a possibility, 
-depending on the resolution of the timestamp on the particular database platform.
+Version numbers (not timestamps) should however be preferred as they can not potentially conflict in a highly concurrent environment, unlike timestamps where this is a possibility, depending on the resolution of the timestamp on the particular database platform.
 
-When a version conflict is encountered during `em.flush()`, a `ValidationError` 
-is thrown and the active transaction rolled back (or marked for rollback). This exception 
-can be caught and handled. Potential responses to a `ValidationError` are to present the 
-conflict to the user or to refresh or reload objects in a new transaction and then retrying 
-the transaction.
+When a version conflict is encountered during `em.flush()`, a `ValidationError` is thrown and the active transaction rolled back (or marked for rollback). This exception can be caught and handled. Potential responses to a `ValidationError` are to present the conflict to the user or to refresh or reload objects in a new transaction and then retrying the transaction.
 
-The time between showing an update form and actually modifying the entity can in the worst 
-scenario be as long as your applications session timeout. If changes happen to the entity 
-in that time frame you want to know directly when retrieving the entity that you will hit 
-an optimistic locking exception:
+The time between showing an update form and actually modifying the entity can in the worst scenario be as long as your applications session timeout. If changes happen to the entity in that time frame you want to know directly when retrieving the entity that you will hit an optimistic locking exception:
 
-You can always verify the version of an entity during a request either when calling 
-`em.findOne()`:
+You can always verify the version of an entity during a request either when calling `em.findOne()`:
 
 ```typescript
 const theEntityId = 1;
@@ -190,23 +133,16 @@ try {
 
 #### Important Implementation Notes
 
-You can easily get the optimistic locking workflow wrong if you compare the wrong versions. 
-Say you have Alice and Bob editing a hypothetical blog post:
+You can easily get the optimistic locking workflow wrong if you compare the wrong versions. Say you have Alice and Bob editing a hypothetical blog post:
 
 - Alice reads the headline of the blog post being "Foo", at optimistic lock version 1 (GET Request)
 - Bob reads the headline of the blog post being "Foo", at optimistic lock version 1 (GET Request)
 - Bob updates the headline to "Bar", upgrading the optimistic lock version to 2 (POST Request of a Form)
 - Alice updates the headline to "Baz", ... (POST Request of a Form)
 
-Now at the last stage of this scenario the blog post has to be read again from the database 
-before Alice's headline can be applied. At this point you will want to check if the blog 
-post is still at version 1 (which it is not in this scenario).
+Now at the last stage of this scenario the blog post has to be read again from the database before Alice's headline can be applied. At this point you will want to check if the blog post is still at version 1 (which it is not in this scenario).
 
-Using optimistic locking correctly, you **have** to add the version as an additional hidden 
-field (or into the session for more safety). Otherwise you cannot verify the version is still 
-the one being originally read from the database when Alice performed her GET request for the 
-blog post. If this happens you might see lost updates you wanted to prevent with Optimistic 
-Locking.
+Using optimistic locking correctly, you **have** to add the version as an additional hidden field (or into the session for more safety). Otherwise you cannot verify the version is still the one being originally read from the database when Alice performed her GET request for the blog post. If this happens you might see lost updates you wanted to prevent with Optimistic Locking.
 
 See the example code (frontend):
 
@@ -245,22 +181,13 @@ async update(req, res) {
 }
 ```
 
-Your frontend app loads an entity from API, the response includes the version property. 
-User makes some changes and fires PUT request back to the API, with version field included 
-in the payload. The PUT handler of the API then reads the version and passes it to the 
-`em.findOne()` call.
+Your frontend app loads an entity from API, the response includes the version property. User makes some changes and fires PUT request back to the API, with version field included in the payload. The PUT handler of the API then reads the version and passes it to the `em.findOne()` call.
 
 ### Pessimistic Locking
 
-MikroORM supports Pessimistic Locking at the database level. No attempt is being made to implement 
-pessimistic locking inside MikroORM, rather vendor-specific and ANSI-SQL commands are used to 
-acquire row-level locks. Every Entity can be part of a pessimistic lock, there is no special 
-metadata required to use this feature.
+MikroORM supports Pessimistic Locking at the database level. No attempt is being made to implement pessimistic locking inside MikroORM, rather vendor-specific and ANSI-SQL commands are used to acquire row-level locks. Every Entity can be part of a pessimistic lock, there is no special metadata required to use this feature.
 
-However for Pessimistic Locking to work you have to disable the Auto-Commit Mode of your Database 
-and start a transaction around your pessimistic lock use-case using the "Approach 2: Explicit 
-Transaction Demarcation" described above. MikroORM will throw an Exception if you attempt to 
-acquire an pessimistic lock and no transaction is running.
+However for Pessimistic Locking to work you have to disable the Auto-Commit Mode of your Database and start a transaction around your pessimistic lock use-case using the "Approach 2: Explicit Transaction Demarcation" described above. MikroORM will throw an Exception if you attempt to acquire an pessimistic lock and no transaction is running.
 
 MikroORM currently supports two pessimistic lock modes:
 
@@ -273,5 +200,4 @@ You can use pessimistic locks in three different scenarios:
 2. Using `em.lock(entity, LockMode.PESSIMISTIC_WRITE)` or `em.lock(entity, LockMode.PESSIMISTIC_READ)`
 3. Using `QueryBuilder.setLockMode(LockMode.PESSIMISTIC_WRITE)` or `QueryBuilder.setLockMode(LockMode.PESSIMISTIC_READ)`
 
-> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html) as the behaviour here is pretty much the same.

--- a/docs/versioned_docs/version-3.6/unit-of-work.md
+++ b/docs/versioned_docs/version-3.6/unit-of-work.md
@@ -3,11 +3,9 @@ title: Unit of Work and Transactions
 sidebar_label: Unit of Work
 ---
 
-MikroORM uses the Identity Map pattern to track objects. Whenever you fetch an object from 
-the database, MikroORM will keep a reference to this object inside its `UnitOfWork`. 
+MikroORM uses the Identity Map pattern to track objects. Whenever you fetch an object from the database, MikroORM will keep a reference to this object inside its `UnitOfWork`.
 
-This allows MikroORM room for optimizations. If you call the EntityManager and ask for an 
-entity with a specific ID twice, it will return the same instance:
+This allows MikroORM room for optimizations. If you call the EntityManager and ask for an entity with a specific ID twice, it will return the same instance:
 
 ```typescript
 const authorRepository = orm.em.getRepository(Author);
@@ -18,13 +16,9 @@ const jon2 = await authorRepository.findOne(1);
 console.log(jon1 === jon2); // true
 ```
 
-Only one SELECT query will be fired against the database here. In the second `findOne()` 
-call MikroORM will check the identity map first and will skip the database round trip as
-it will find the entity already loaded.
+Only one SELECT query will be fired against the database here. In the second `findOne()` call MikroORM will check the identity map first and will skip the database round trip as it will find the entity already loaded.
 
-The identity map being indexed by primary keys only allows shortcuts when you ask for objects 
-by primary key. When you query by other properties, you will still get the same reference, 
-but two separate database calls will be made:
+The identity map being indexed by primary keys only allows shortcuts when you ask for objects by primary key. When you query by other properties, you will still get the same reference, but two separate database calls will be made:
 
 ```typescript
 const authorRepository = orm.em.getRepository(Author);
@@ -35,21 +29,13 @@ const jon2 = await authorRepository.findOne({ name: 'Jon Snow' });
 console.log(jon1 === jon2); // true
 ```
 
-MikroORM only knows objects by id, so a query for different criteria has to go to the database, 
-even if it was executed just before. But instead of creating a second `Author` object MikroORM 
-first gets the primary key from the row and checks if it already has an object inside the 
-`UnitOfWork` with that primary key. 
+MikroORM only knows objects by id, so a query for different criteria has to go to the database, even if it was executed just before. But instead of creating a second `Author` object MikroORM first gets the primary key from the row and checks if it already has an object inside the `UnitOfWork` with that primary key.
 
 ## Persisting Managed Entities
 
-The identity map has a second use-case. When you call `em.flush()`, MikroORM will 
-ask the identity map for all objects that are currently managed. This means you don't have to 
-call `em.persistLater()` over and over again to pass known objects to the 
-`EntityManager`. This is a NO-OP for known entities, but leads to much code written that is 
-confusing to other developers.
+The identity map has a second use-case. When you call `em.flush()`, MikroORM will ask the identity map for all objects that are currently managed. This means you don't have to call `em.persistLater()` over and over again to pass known objects to the `EntityManager`. This is a NO-OP for known entities, but leads to much code written that is confusing to other developers.
 
-The following code WILL update your database with the changes made to the `Author` object, 
-even if you did not call `em.persistLater()`:
+The following code WILL update your database with the changes made to the `Author` object, even if you did not call `em.persistLater()`:
 
 ```typescript
 const authorRepository = orm.em.getRepository(Author);
@@ -60,29 +46,17 @@ await authorRepository.flush(); // calling orm.em.flush() has same effect
 
 ## How MikroORM Detects Changes
 
-MikroORM is a data-mapper that tries to achieve persistence-ignorance (PI). This means you 
-map JS objects into a relational database that do not necessarily know about the database at 
-all. A natural question would now be, "how does MikroORM even detect objects have changed?".
+MikroORM is a data-mapper that tries to achieve persistence-ignorance (PI). This means you map JS objects into a relational database that do not necessarily know about the database at all. A natural question would now be, "how does MikroORM even detect objects have changed?".
 
-For this MikroORM keeps a second map inside the `UnitOfWork`. Whenever you fetch an object 
-from the database MikroORM will keep a copy of all the properties and associations inside 
-the `UnitOfWork`. 
+For this MikroORM keeps a second map inside the `UnitOfWork`. Whenever you fetch an object from the database MikroORM will keep a copy of all the properties and associations inside the `UnitOfWork`.
 
-Now whenever you call `em.flush()` MikroORM will iterate over all entities you 
-previously marked for persisting via `em.persistLater()`. For each object it will
-compare the original property and association values with the values that are currently set 
-on the object. If changes are detected then the object is queued for a UPDATE operation. 
-Only the fields that actually changed are updated.
+Now whenever you call `em.flush()` MikroORM will iterate over all entities you previously marked for persisting via `em.persistLater()`. For each object it will compare the original property and association values with the values that are currently set on the object. If changes are detected then the object is queued for a UPDATE operation. Only the fields that actually changed are updated.
 
 ## Implicit Transactions
 
-First and most important implication of having Unit of Work is that it allows handling
-transactions automatically. 
+First and most important implication of having Unit of Work is that it allows handling transactions automatically.
 
-When you call `em.flush()`, all computed changes are queried inside a database
-transaction (if supported by given driver). This means that you can control the boundaries 
-of transactions simply by calling `em.persistLater()` and once all your changes 
-are ready, simply calling `flush()` will run them inside a transaction. 
+When you call `em.flush()`, all computed changes are queried inside a database transaction (if supported by given driver). This means that you can control the boundaries of transactions simply by calling `em.persistLater()` and once all your changes are ready, simply calling `flush()` will run them inside a transaction.
 
 > You can also control the transaction boundaries manually via `em.transactional(cb)`.
 
@@ -97,18 +71,13 @@ user.cars.add(car);
 await em.persistAndFlush(user);
 ```
 
-You can find more information about transactions in [Transactions and concurrency](transactions.md) 
-page.
+You can find more information about transactions in [Transactions and concurrency](transactions.md) page.
 
 ### Beware: Auto-flushing and Transactions
 
-> Since MikroORM v3, default value for `autoFlush` is `false`. That means you need to call 
-> `em.flush()` yourself to persist changes into database. You can still change this via ORM's
-> options to ease the transition but generally it is not recommended. 
+> Since MikroORM v3, default value for `autoFlush` is `false`. That means you need to call `em.flush()` yourself to persist changes into database. You can still change this via ORM's options to ease the transition but generally it is not recommended.
 
-Originally there was only `em.persist(entity, flush = true)` method, that was
-automatically flushing changes to database, if not given second `false` parameter. This 
-behaviour can be now changed via `autoFlush` option when initializing the ORM:
+Originally there was only `em.persist(entity, flush = true)` method, that was automatically flushing changes to database, if not given second `false` parameter. This behaviour can be now changed via `autoFlush` option when initializing the ORM:
 
 ```typescript
 const orm = await MikroORM.init({
@@ -120,9 +89,6 @@ await orm.em.flush();
 await orm.em.persist(new Entity(), true); // you can still use second parameter to auto-flush
 ```
 
-When using driver that supports transactions (all SQL drivers), you should either keep auto-flushing 
-disabled, or use `persistLater()` method instead, as otherwise each `persist()` call will immediately 
-create new transaction to run the query.
+When using driver that supports transactions (all SQL drivers), you should either keep auto-flushing disabled, or use `persistLater()` method instead, as otherwise each `persist()` call will immediately create new transaction to run the query.
 
-> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/unitofwork.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/unitofwork.html) as the behaviour here is pretty much the same.

--- a/docs/versioned_docs/version-3.6/upgrading-v2-to-v3.md
+++ b/docs/versioned_docs/version-3.6/upgrading-v2-to-v3.md
@@ -2,19 +2,13 @@
 title: Upgrading from v2 to v3
 ---
 
-Following sections describe (hopefully) all breaking changes, most of them might be not valid 
-for you, like if you do not use custom `NamingStrategy` implementation, you do not care about
-the interface being changed.
+Following sections describe (hopefully) all breaking changes, most of them might be not valid for you, like if you do not use custom `NamingStrategy` implementation, you do not care about the interface being changed.
 
 ## Default value of autoFlush has changed to false
 
-> If you had `autoFlush: false` in your ORM configuration before, you can now remove 
-> this line, no changes are needed in your app. 
+> If you had `autoFlush: false` in your ORM configuration before, you can now remove this line, no changes are needed in your app.
 
-Default value for `autoFlush` is now `false`. That means you need to call 
-`em.flush()` yourself to persist changes into database. You can still change this via ORM's
-options to ease the transition but generally it is not recommended as it can cause unwanted
-small transactions being created around each `persist`. 
+Default value for `autoFlush` is now `false`. That means you need to call `em.flush()` yourself to persist changes into database. You can still change this via ORM's options to ease the transition but generally it is not recommended as it can cause unwanted small transactions being created around each `persist`.
 
 ```typescript
 orm.em.persist(new Entity()); // no auto-flushing by default
@@ -24,29 +18,20 @@ await orm.em.persist(new Entity(), true); // you can still use second parameter 
 
 ## Reworked entity definition
 
-> Implementing those interfaces is optional.  
+> Implementing those interfaces is optional.
 
-Now it is no longer needed to merge entities with `IEntity` interface, that was polluting entity's 
-interface with internal methods. New interfaces `IdentifiedEntity<T>`, `UuidEntity<T>` and `MongoEntity<T>` 
-are introduced, that can be implemented by entities. They are not adding any new properties or methods, 
-keeping the entity's interface clean. This is also the reason why they can be omitted.
+Now it is no longer needed to merge entities with `IEntity` interface, that was polluting entity's interface with internal methods. New interfaces `IdentifiedEntity<T>`, `UuidEntity<T>` and `MongoEntity<T>` are introduced, that can be implemented by entities. They are not adding any new properties or methods, keeping the entity's interface clean. This is also the reason why they can be omitted.
 
-`IEntity` interface has been renamed to `AnyEntity<T, PK>` and it no longer has public methods 
-like `toJSON()`, `toObject()` or `init()`. One can use `wrap()` method provided by ORM that
-will enhance property type when needed with those methods (`await wrap(book.author).init()`). 
-To keep all methods available on the entity, you can still use interface merging with 
-`WrappedEntity<T, PK>` that both extends `AnyEntity<T, PK>` and defines all those methods.
+`IEntity` interface has been renamed to `AnyEntity<T, PK>` and it no longer has public methods like `toJSON()`, `toObject()` or `init()`. One can use `wrap()` method provided by ORM that will enhance property type when needed with those methods (`await wrap(book.author).init()`). To keep all methods available on the entity, you can still use interface merging with `WrappedEntity<T, PK>` that both extends `AnyEntity<T, PK>` and defines all those methods.
 
 You can mark the entity by implementing one of `*Entity` interfaces:
 
 - `IdEntity<T>` for numeric/string PK on `id` property (`id: number`)
 - `UuidEntity<T>` for string PK on `uuid` property (`uuid: string`)
 - `MongoEntity<T>` for mongo, where `id: string` and `_id: ObjectId` are required
-- `AnyEntity<T, PK>` for other possible properties (fill the PK property name to `PK` 
-parameter, e.g.: `AnyEntity<Book, 'myPrimaryProperty'>'`)
+- `AnyEntity<T, PK>` for other possible properties (fill the PK property name to `PK` parameter, e.g.: `AnyEntity<Book, 'myPrimaryProperty'>'`)
 
-To keep all public methods that were part of `IEntity` interface in v2, you can use 
-`WrappedEntity<T, PK>` via interface merging:
+To keep all public methods that were part of `IEntity` interface in v2, you can use `WrappedEntity<T, PK>` via interface merging:
 
 ```typescript
 @Entity()
@@ -58,37 +43,25 @@ For more examples, take a look at [defining entities section](defining-entities.
 
 ## Integrated Knex.js as query builder and runner
 
-`QueryBuilder` now internally uses knex to run all queries. As knex already supports connection 
-pooling, this feature comes without any effort. New configuration for pooling is now available
+`QueryBuilder` now internally uses knex to run all queries. As knex already supports connection pooling, this feature comes without any effort. New configuration for pooling is now available
 
-Transactions now require using `em.transactional()` method, previous helpers 
-`beginTransaction`/`commit`/`rollback` are now removed.
+Transactions now require using `em.transactional()` method, previous helpers `beginTransaction`/`commit`/`rollback` are now removed.
 
-All transaction management has been removed from `IDatabaseDriver` interface, now EM handles 
-this, passing the transaction context (carried by EM, and created by `Connection`) to all 
-driver methods. New methods on EM exists: `isInTransaction()` and `getTransactionContext()`.
+All transaction management has been removed from `IDatabaseDriver` interface, now EM handles this, passing the transaction context (carried by EM, and created by `Connection`) to all driver methods. New methods on EM exists: `isInTransaction()` and `getTransactionContext()`.
 
-In postgres driver, it used to be required to pass parameters as indexed dollar sign 
-($1, $2, ...), while now knex requires the placeholder to be simple question mark (`?`), 
-like in other dialects, so this is now unified with other drivers.
+In postgres driver, it used to be required to pass parameters as indexed dollar sign ($1, $2, ...), while now knex requires the placeholder to be simple question mark (`?`), like in other dialects, so this is now unified with other drivers.
 
 ## ManyToMany now uses composite primary key
 
-Previously it was required to have autoincrement primary key for m:n pivot tables. Now this 
-has changed. By default, only foreign columns are required and composite key over both of them
-is used as primary key.
+Previously it was required to have autoincrement primary key for m:n pivot tables. Now this has changed. By default, only foreign columns are required and composite key over both of them is used as primary key.
 
-To preserve stable order of collections, you can force previous behaviour by defining the 
-m:n property as `fixedOrder: true`, which will start ordering by `id` column. You can also 
-override the order column name via `fixedOrderColumn: 'order'`. 
+To preserve stable order of collections, you can force previous behaviour by defining the m:n property as `fixedOrder: true`, which will start ordering by `id` column. You can also override the order column name via `fixedOrderColumn: 'order'`.
 
 You can also specify default ordering via `orderBy: { ... }` attribute.
 
 ## Entity references now don't have instantiated collections
 
-Previously all entity instances, including entity references (not fully loaded entities where
-we know only the primary key), had instantiated collection classes. Now only initialized entities
-have them.
+Previously all entity instances, including entity references (not fully loaded entities where we know only the primary key), had instantiated collection classes. Now only initialized entities have them.
 
 ```typescript
 const book = em.getReference(Book, 1);
@@ -99,12 +72,9 @@ console.log(book.tags); // instance of Collection (not initialized)
 
 ## EntityAssigner.assign() requires EM for new entities
 
-Previously all entities had internal reference to the root EM - the one created when 
-initializing the ORM. Now only managed entities (those merged to the EM, e.g. loaded 
-from the database) have this internal reference. 
+Previously all entities had internal reference to the root EM - the one created when initializing the ORM. Now only managed entities (those merged to the EM, e.g. loaded from the database) have this internal reference.
 
-To use `assign()` method on new (not managed) entities, you need to provide the `em`
-parameter:
+To use `assign()` method on new (not managed) entities, you need to provide the `em` parameter:
 
 ```typescript
 const book = new Book();
@@ -113,46 +83,36 @@ wrap(book).assign(data, { em: orm.em });
 
 ## Strict FilterQuery and smart query conditions
 
-`FilterQuery` now does not allow using smart query operators. You can either cast your condition 
-as any or use object syntax instead (instead of `{ 'age:gte': 18 }` use `{ age: { $gte: 18 } }`).
+`FilterQuery` now does not allow using smart query operators. You can either cast your condition as any or use object syntax instead (instead of `{ 'age:gte': 18 }` use `{ age: { $gte: 18 } }`).
 
 ## Logging configuration
 
-Previously to start logging it was required to provide your custom logger. Logger now defaults 
-to `console.log()`, and users can specify what namespaces are they interested in via `debug` 
-option. `true`/`false` will enable/disable all namespaces.
+Previously to start logging it was required to provide your custom logger. Logger now defaults to `console.log()`, and users can specify what namespaces are they interested in via `debug` option. `true`/`false` will enable/disable all namespaces.
 
 Available logger namespaces: `'query' | 'query-params' | 'discovery' | 'info'`.
 
-## Removed deprecated fk option from 1:m and m:1 decorators 
+## Removed deprecated fk option from 1:m and m:1 decorators
 
 Use `mappedBy`/`inversedBy` instead.
 
 ## SchemaGenerator.generate() is now async
 
-If you used `SchemaGenerator`, now there is CLI tool you can use instead. Learn more 
-in [SchemaGenerator docs](schema-generator.md). To setup CLI, take a look at 
-[installation section](installation.md).
+If you used `SchemaGenerator`, now there is CLI tool you can use instead. Learn more in [SchemaGenerator docs](schema-generator.md). To setup CLI, take a look at [installation section](installation.md).
 
 ## New method on NamingStrategy interface
 
-`getClassName()` is used to find entity class name based on its file name. Now users can 
-override the default implementation to accommodate their specific needs.
+`getClassName()` is used to find entity class name based on its file name. Now users can override the default implementation to accommodate their specific needs.
 
-If you used custom naming strategy, you will either need to implement this method yourself, 
-or extend `AbstractNamingStrategy`.
+If you used custom naming strategy, you will either need to implement this method yourself, or extend `AbstractNamingStrategy`.
 
 ## TypescriptMetadataProvider has been renamed
 
-The name is now `TsMorphMetadataProvider`, there is also newly added `ReflectMetadataProvider`
-that uses `reflect-metadata` instead. As `TypescriptMetadataProvider` was the default, no 
-changes should be required. 
+The name is now `TsMorphMetadataProvider`, there is also newly added `ReflectMetadataProvider` that uses `reflect-metadata` instead. As `TypescriptMetadataProvider` was the default, no changes should be required.
 
 ## Updated mongodb driver
 
 MongoDB driver version 3.3.4 or higher is now required.
 
 ## EntityManager.find() now requires where parameter
-`EntityManager` has now same `find` method interface aligned with `EntityRepository`, 
-`where` parameter is now required. To select all entities, use `em.find(Entity, {})` 
-as value.
+
+`EntityManager` has now same `find` method interface aligned with `EntityRepository`, `where` parameter is now required. To select all entities, use `em.find(Entity, {})` as value.

--- a/docs/versioned_docs/version-3.6/upgrading-v3-to-v4.md
+++ b/docs/versioned_docs/version-3.6/upgrading-v3-to-v4.md
@@ -2,24 +2,19 @@
 title: Upgrading from v3 to v4
 ---
 
-> Following sections describe (hopefully) all breaking changes, most of them might be not valid 
-> for you, like if you do not use custom `NamingStrategy` implementation, you do not care about
-> the interface being changed.
+> Following sections describe (hopefully) all breaking changes, most of them might be not valid for you, like if you do not use custom `NamingStrategy` implementation, you do not care about the interface being changed.
 
 ## Node 10.13.0+ required
 
-Support for older node versions was dropped. 
+Support for older node versions was dropped.
 
 ## TypeScript 3.7+ required
 
-Support for older TypeScript versions was dropped. 
+Support for older TypeScript versions was dropped.
 
 ## Monorepo
 
-The ORM has been split into several packages. In v4 one needs to require
-`@mikro-orm/core` and a driver package, e.g. `@mikro-orm/mysql`. This driver
-package already contains the `mysql2` dependency, so you can remove that from
-your `package.json`. 
+The ORM has been split into several packages. In v4 one needs to require `@mikro-orm/core` and a driver package, e.g. `@mikro-orm/mysql`. This driver package already contains the `mysql2` dependency, so you can remove that from your `package.json`.
 
 - `@mikro-orm/core`
 - `@mikro-orm/reflection` - `TsMorphMetadataProvider`
@@ -34,17 +29,13 @@ your `package.json`.
 - `@mikro-orm/postgresql`
 - `@mikro-orm/mongodb`
 
-> For easier transition, meta package mikro-orm is still present, reexporting 
-> core, reflection, migrations, entity-generator and cli packages. You should 
-> **not** install both `mikro-orm` and `@mikro-orm/core` packages together. 
+> For easier transition, meta package mikro-orm is still present, reexporting core, reflection, migrations, entity-generator and cli packages. You should **not** install both `mikro-orm` and `@mikro-orm/core` packages together.
 
-> You should prefer the `@mikro-orm/core` over `mikro-orm` package, there were
-> weird dependency issues reported with the `mikro-orm` meta-package. 
+> You should prefer the `@mikro-orm/core` over `mikro-orm` package, there were weird dependency issues reported with the `mikro-orm` meta-package.
 
 ## Default metadata provider is now `ReflectMetadataProvider`
 
-If you want to use ts-morph, you need to install `@mikro-orm/reflection` package
-and enable the provider explicitly in the ORM config, as described [here](./metadata-providers.md#tsmorphmetadataprovider).
+If you want to use ts-morph, you need to install `@mikro-orm/reflection` package and enable the provider explicitly in the ORM config, as described [here](./metadata-providers.md#tsmorphmetadataprovider).
 
 ```typescript
 import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
@@ -55,30 +46,22 @@ await MikroORM.init({
 });
 ```
 
-Using `ReflectMetadataProvider` has some limitations, so be sure to read
-about them [here](./metadata-providers.md#limitations-and-requirements).
+Using `ReflectMetadataProvider` has some limitations, so be sure to read about them [here](./metadata-providers.md#limitations-and-requirements).
 
-One common gotcha with `reflect-metadata` is that you need to explicitly
-state the property type when using property initializer:
+One common gotcha with `reflect-metadata` is that you need to explicitly state the property type when using property initializer:
 
 ```ts
 @Property()
 createdAt: Date = new Date();
 ```
 
-Without the explicit type, we would infer `Object` instead of `Date`,
-which would be most probably mapped to JSON column type (depends on driver).
+Without the explicit type, we would infer `Object` instead of `Date`, which would be most probably mapped to JSON column type (depends on driver).
 
 ## SqlEntityManager and MongoEntityManager
 
-In v4 the `core` package, where `EntityManager` and `EntityRepository` are 
-defined, is not dependent on knex, and therefore it cannot have a method 
-returning a `QueryBuilder`. You need to import the SQL flavour of the EM 
-from the driver package to access the `createQueryBuilder()` method.
+In v4 the `core` package, where `EntityManager` and `EntityRepository` are defined, is not dependent on knex, and therefore it cannot have a method returning a `QueryBuilder`. You need to import the SQL flavour of the EM from the driver package to access the `createQueryBuilder()` method.
 
-> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under 
-> this name and under `EntityManager` alias, so you can just change the 
-> location from where you import.
+> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ```typescript
 import { EntityManager } from '@mikro-orm/mysql'; // or any other SQL driver package
@@ -96,32 +79,21 @@ const em: EntityManager;
 const ret = await em.aggregate(...);
 ```
 
-> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under 
-> this name and under `EntityManager` alias, so you can just change the 
-> location from where you import.
+> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ## Different default `pivotTable`
 
-Implementation of `UnderscoreNamingStrategy` and `EntityCaseNamingStrategy` 
-`joinTableName()` method has changed. You can use `pivotTable` on the owning side
-of M:N relation to specify the table name manually. 
+Implementation of `UnderscoreNamingStrategy` and `EntityCaseNamingStrategy` `joinTableName()` method has changed. You can use `pivotTable` on the owning side of M:N relation to specify the table name manually.
 
-Previously the table name did not respect property name, if one defined multiple
-M:N relations between same entities, there were conflicts and one would have to 
-specify `pivotTable` name manually at least on one of them. With the new way, 
-we can be sure that the table name won't conflict with other pivot tables. 
+Previously the table name did not respect property name, if one defined multiple M:N relations between same entities, there were conflicts and one would have to specify `pivotTable` name manually at least on one of them. With the new way, we can be sure that the table name won't conflict with other pivot tables.
 
-Previously the name was constructed from 2 entity names as `entity_a_to_entity_b`,
-ignoring the actual property name. In v4 the name will be `entity_a_coll_name` in 
-case of the collection property on the owning side being named `collName`. 
+Previously the name was constructed from 2 entity names as `entity_a_to_entity_b`, ignoring the actual property name. In v4 the name will be `entity_a_coll_name` in case of the collection property on the owning side being named `collName`.
 
 ## Changes in folder-based discovery (`entitiesDirs` removed)
 
-`entitiesDirs` and `entitiesDirsTs` were removed in favour of `entities` and `entitiesTs`,
-`entities` will be used as a default for `entitiesTs` (that is used when we detect `ts-node`).
+`entitiesDirs` and `entitiesDirsTs` were removed in favour of `entities` and `entitiesTs`, `entities` will be used as a default for `entitiesTs` (that is used when we detect `ts-node`).
 
-`entities` can now contain mixture of paths to directories, globs pointing to entities,
-or references to the entities or instances of `EntitySchema`. 
+`entities` can now contain mixture of paths to directories, globs pointing to entities, or references to the entities or instances of `EntitySchema`.
 
 This basically means that all you need to change is renaming `entitiesDirs` to `entities`.
 
@@ -134,26 +106,17 @@ MikroORM.init({
 
 ## Changes in `wrap()` helper, `WrappedEntity` interface and `Reference` wrapper
 
-Previously all the methods and properties of `WrappedEntity` interface were
-added to the entity prototype during discovery. In v4 there is only one property
-added: `__helper: WrappedEntity`. `WrappedEntity` has been converted to actual class.
+Previously all the methods and properties of `WrappedEntity` interface were added to the entity prototype during discovery. In v4 there is only one property added: `__helper: WrappedEntity`. `WrappedEntity` has been converted to actual class.
 
-`wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is 
-being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...),
-if you want to access internal properties like `__meta` or `__em`, you need to explicitly
-ask for the helper via `wrap(entity, true)`.
+`wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...), if you want to access internal properties like `__meta` or `__em`, you need to explicitly ask for the helper via `wrap(entity, true)`.
 
-Internal methods (with `__` prefix) were also removed from the `Reference` class, 
-use `wrap(ref, true)` to access them. 
+Internal methods (with `__` prefix) were also removed from the `Reference` class, use `wrap(ref, true)` to access them.
 
-Instead of interface merging with `WrappedEntity`, one can now use classic inheritance,
-by extending `BaseEntity` exported from `@mikro-orm/core`. If you do so, `wrap(entity)` 
-will return your entity. 
+Instead of interface merging with `WrappedEntity`, one can now use classic inheritance, by extending `BaseEntity` exported from `@mikro-orm/core`. If you do so, `wrap(entity)` will return your entity.
 
 ## Removed `flush` parameter from `persist()` and `remove()` methods
 
-`flush` param is removed, both `persist` and `remove` methods are synchronous and
-require explicit flushing, possibly via fluent interface call.
+`flush` param is removed, both `persist` and `remove` methods are synchronous and require explicit flushing, possibly via fluent interface call.
 
 ```typescript
 // before
@@ -167,19 +130,15 @@ await em.remove(jon).flush();
 
 ## `remove()` method requires entity instances
 
-The `em.remove()` method originally allowed to pass either entity instance, or 
-a condition. When one passed a condition, it was firing a native delete query, 
-without handling transactions or hooks. 
+The `em.remove()` method originally allowed to pass either entity instance, or a condition. When one passed a condition, it was firing a native delete query, without handling transactions or hooks.
 
-In v4, the method is now simplified and works only with entity instances. Use 
-`em.nativeDelete()` explicitly if you want to fire a delete query instead of 
-letting the `UnitOfWork` doing its job.
+In v4, the method is now simplified and works only with entity instances. Use `em.nativeDelete()` explicitly if you want to fire a delete query instead of letting the `UnitOfWork` doing its job.
 
 ```typescript
 // before
 await em.remove(Author, 1); // fires query directly
 
-// after 
+// after
 await em.nativeDelete(Author, 1);
 ```
 
@@ -187,20 +146,11 @@ await em.nativeDelete(Author, 1);
 
 ## Type safe references
 
-EM now returns `Loaded<T, P>` instead of the entity (`T`). This type automatically
-adds synchronous method `get()` that returns the entity (for references) or array
-of entities (for collections).
+EM now returns `Loaded<T, P>` instead of the entity (`T`). This type automatically adds synchronous method `get()` that returns the entity (for references) or array of entities (for collections).
 
-`Reference.get()` is now available only with correct `Loaded` type hint and is used 
-as a sync getter for the entity, just like `unwrap()`. You can use `Reference.load(prop)` 
-for the original `get()` method functionality. 
+`Reference.get()` is now available only with correct `Loaded` type hint and is used as a sync getter for the entity, just like `unwrap()`. You can use `Reference.load(prop)` for the original `get()` method functionality.
 
-`em.find()` and similar methods now have two type arguments, due to TypeScript not supporting partial
-type inference, when you specify the `T` explicitly (without also explicitly 
-specifying the load hint), the inference will not work. This use case was mainly
-for usage without classes (interfaces + `EntitySchema`) - in that case it is now 
-supported to pass actual instance of `EntitySchema` as the first parameter to these
-methods, that will allow correct type inference:
+`em.find()` and similar methods now have two type arguments, due to TypeScript not supporting partial type inference, when you specify the `T` explicitly (without also explicitly specifying the load hint), the inference will not work. This use case was mainly for usage without classes (interfaces + `EntitySchema`) - in that case it is now supported to pass actual instance of `EntitySchema` as the first parameter to these methods, that will allow correct type inference:
 
 ```typescript
 const author = await em.findOne(AuthorSchema, { ... }, ['books']);
@@ -209,59 +159,45 @@ console.log(author.books.get()); // `get()` is now inferred correctly
 
 ## Custom types are now type safe
 
-Generic `Type` class has now two type arguments - the input and output types. 
-Input type defaults to `string`, output type defaults to the input type. 
+Generic `Type` class has now two type arguments - the input and output types. Input type defaults to `string`, output type defaults to the input type.
 
 You might need to explicitly provide the types if your methods are strictly typed.
 
 ## Custom type serialization
 
-Custom types used to be serialized to the database value. In v4, the runtime 
-value is used by default. Implement custom `toJSON()` method if you need to 
-customize this.
+Custom types used to be serialized to the database value. In v4, the runtime value is used by default. Implement custom `toJSON()` method if you need to customize this.
 
 ## Property `default` and `defaultRaw`
 
-Previously the `default` option of properties was used as is, so we had to wrap 
-strings in quotes (e.g. `@Property({ default: "'foo bar'" })`). 
+Previously the `default` option of properties was used as is, so we had to wrap strings in quotes (e.g. `@Property({ default: "'foo bar'" })`).
 
-In v4 the `default` is typed as `string | number | boolean | null` and when used
-with string value, it will be automatically quoted. 
+In v4 the `default` is typed as `string | number | boolean | null` and when used with string value, it will be automatically quoted.
 
 To use SQL functions we now need to use `defaultRaw`: `@Property({ defaultRaw: 'now()' })`.
 
 ## `autoFlush` option has been removed
 
-Also `persistLater()` and `removeLater()` methods are deprecated. Use `persist()` or
-`remove` respectively.
+Also `persistLater()` and `removeLater()` methods are deprecated. Use `persist()` or `remove` respectively.
 
 ## `IdEntity`, `UuidEntity` and `MongoEntity` interfaces are removed
 
-They were actually never needed. 
+They were actually never needed.
 
 ## MongoDB driver is no longer the default
 
-You need to specify the platform type either via `type` option or provide the driver
-implementation via `driver` option. 
+You need to specify the platform type either via `type` option or provide the driver implementation via `driver` option.
 
 Available platforms types: `[ 'mongo', 'mysql', 'mariadb', 'postgresql', 'sqlite' ]`
 
 ## Removed configuration `discovery.tsConfigPath`
 
-Removed as it is no longer needed, it was used only for `TsMorphMetadataProvider`,
-when the `entitiesDirsTs` were not explicitly provided. In v4, this is no longer
-needed, as ts-morph discovery will use `d.ts` files instead, that should be located
-next to the compiled entities. 
+Removed as it is no longer needed, it was used only for `TsMorphMetadataProvider`, when the `entitiesDirsTs` were not explicitly provided. In v4, this is no longer needed, as ts-morph discovery will use `d.ts` files instead, that should be located next to the compiled entities.
 
 ## Changes in query highlighting
 
-Previously Highlight.js was used to highlight various things in the CLI, 
-like SQL and mongo queries, or migrations or entities generated via CLI.
-While the library worked fine, it was causing performance issues mainly 
-for those bundling via webpack and using lambdas, as the library was huge.
+Previously Highlight.js was used to highlight various things in the CLI, like SQL and mongo queries, or migrations or entities generated via CLI. While the library worked fine, it was causing performance issues mainly for those bundling via webpack and using lambdas, as the library was huge.
 
-In v4 highlighting is disabled by default, and there are 2 highlighters 
-you can optionally use (you need to install them first).
+In v4 highlighting is disabled by default, and there are 2 highlighters you can optionally use (you need to install them first).
 
 ```typescript
 import { SqlHighlighter } from '@mikro-orm/sql-highlighter';

--- a/docs/versioned_docs/version-3.6/usage-with-js.md
+++ b/docs/versioned_docs/version-3.6/usage-with-js.md
@@ -3,8 +3,7 @@ title: Usage with JavaScript
 sidebar_label: Usage with Vanilla JS
 ---
 
-Since MikroORM 3.2, we can use `EntitySchema` helper to define own entities without 
-decorators, which works also for Vanilla JavaScript.
+Since MikroORM 3.2, we can use `EntitySchema` helper to define own entities without decorators, which works also for Vanilla JavaScript.
 
 > Read more about `EntitySchema` in [this section](entity-schema.md).
 
@@ -68,8 +67,7 @@ module.exports.entity = Author;
 module.exports.schema = schema;
 ```
 
-> Do not forget to provide `name` and `path` schema parameters as well as `entity` 
-> and `schema` exports.
+> Do not forget to provide `name` and `path` schema parameters as well as `entity` and `schema` exports.
 
 Reference parameter can be one of (where `SCALAR` is the default one):
 
@@ -92,5 +90,4 @@ const orm = await MikroORM.init({
 });
 ```
 
-For more examples of plain JavaScript entity definitions take a look
-[Express JavaScript example](https://github.com/mikro-orm/mikro-orm-examples/tree/master/express-js). 
+For more examples of plain JavaScript entity definitions take a look [Express JavaScript example](https://github.com/mikro-orm/mikro-orm-examples/tree/master/express-js).

--- a/docs/versioned_docs/version-3.6/usage-with-mongo.md
+++ b/docs/versioned_docs/version-3.6/usage-with-mongo.md
@@ -2,8 +2,7 @@
 title: Usage with MongoDB
 ---
 
-To use `mikro-orm` with mongo database, do not forget to install `mongodb` dependency. As `MongoDriver`
-is the default one, you do not need to provide it.
+To use `mikro-orm` with mongo database, do not forget to install `mongodb` dependency. As `MongoDriver` is the default one, you do not need to provide it.
 
 Then call `MikroORM.init` as part of bootstrapping your app:
 
@@ -28,13 +27,11 @@ _id: ObjectId;
 id!: string; // won't be saved in the database
 ```
 
-> Only `_id: ObjectId` will be saved in the database. `id: string` is virtual and is 
-> also optional. 
+> Only `_id: ObjectId` will be saved in the database. `id: string` is virtual and is also optional.
 
 ## ObjectId and string id duality
 
-Every entity has both `ObjectId` and `string` id available, also all methods of `EntityManager` 
-and `EntityRepository` supports querying by both of them. 
+Every entity has both `ObjectId` and `string` id available, also all methods of `EntityManager` and `EntityRepository` supports querying by both of them.
 
 ```typescript
 const author = orm.em.getReference('...id...');
@@ -53,24 +50,21 @@ const bar2 = await repo.find({ _id: { $in: [new ObjectId(article)] }, favouriteB
 
 ## ManyToMany collections with inlined pivot array
 
-As opposed to SQL drivers that use pivot tables, in mongo we can leverage available array type
-to store array of collection items (identifiers). This approach has two main benefits:
+As opposed to SQL drivers that use pivot tables, in mongo we can leverage available array type to store array of collection items (identifiers). This approach has two main benefits:
 
-1. Collection is stored on owning side entity, so we know how many items are there even before
-initializing the collection.
+1. Collection is stored on owning side entity, so we know how many items are there even before initializing the collection.
 2. As there are no pivot tables, resulting database queries are much simpler.
 
 ## Transactions
 
-Starting with v3.4, MongoDB driver supports transactions. To use transactions, there
-are several things you need to respect:
+Starting with v3.4, MongoDB driver supports transactions. To use transactions, there are several things you need to respect:
 
 - you need to use replica set (see [run-rs](https://github.com/vkarpov15/run-rs))
 - implicit transactions are disabled by default
-    - use `implicitTransactions: true` to enable them globally
-    - or use explicit transaction demarcation via `em.transactional()`
+  - use `implicitTransactions: true` to enable them globally
+  - or use explicit transaction demarcation via `em.transactional()`
 - you need to explicitly create all collections before working with them
-    - use `em.getDriver().createCollections()` method to do so
+  - use `em.getDriver().createCollections()` method to do so
 
 ```sh
 # first create replica set
@@ -92,15 +86,11 @@ const orm = await MikroORM.init<MongoDriver>({
 await orm.em.getDriver().createCollections();
 ```
 
-> The `createCollections` method is present on the `MongoDriver` class only. You need 
-> to have the entity manager correctly typed (as `EntityManager<MongoDriver>`).
+> The `createCollections` method is present on the `MongoDriver` class only. You need to have the entity manager correctly typed (as `EntityManager<MongoDriver>`).
 
 ## Indexes
 
-Starting with v3.4, MongoDB driver supports indexes and unique constraints. You can 
-use `@Index()` and `@Unique()` as described in [Defining Entities section](defining-entities.md#indexes).
-To automatically create new indexes when initializing the ORM, you need to enable
-`ensureIndexes` option. 
+Starting with v3.4, MongoDB driver supports indexes and unique constraints. You can use `@Index()` and `@Unique()` as described in [Defining Entities section](defining-entities.md#indexes). To automatically create new indexes when initializing the ORM, you need to enable `ensureIndexes` option.
 
 ```typescript
 const orm = await MikroORM.init({
@@ -109,7 +99,7 @@ const orm = await MikroORM.init({
   type: 'mongo',
   ensureIndexes: true, // defaults to false
 });
-``` 
+```
 
 Alternatively you can call `ensureIndexes()` method on the `MongoDriver`:
 
@@ -118,15 +108,12 @@ await orm.em.getDriver().ensureIndexes();
 ```
 
 > You can pass additional index/unique options via `options` parameter:
-> 
+>
 > `@Unique({ options: { partialFilterExpression: { name: { $exists: true } } }})`
 
 ## Native collection methods
 
-Sometimes you need to perform some bulk operation, or you just want to populate your
-database with initial fixtures. Using ORM for such operations can bring unnecessary
-boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete`
-methods:
+Sometimes you need to perform some bulk operation, or you just want to populate your database with initial fixtures. Using ORM for such operations can bring unnecessary boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete` methods:
 
 ```typescript
 em.nativeInsert<T extends AnyEntity>(entityName: string, data: any): Promise<IPrimaryKey>;
@@ -134,9 +121,7 @@ em.nativeUpdate<T extends AnyEntity>(entityName: string, where: FilterQuery<T>, 
 em.nativeDelete<T extends AnyEntity>(entityName: string, where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Those methods execute native driver methods like Mongo's `insertOne/updateMany/deleteMany` collection methods respectively. 
-This is common interface for all drivers, so for MySQL driver, it will fire native SQL queries. 
-Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks. 
+Those methods execute native driver methods like Mongo's `insertOne/updateMany/deleteMany` collection methods respectively. This is common interface for all drivers, so for MySQL driver, it will fire native SQL queries. Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks.
 
 They are also available as `EntityRepository` shortcuts:
 

--- a/docs/versioned_docs/version-3.6/usage-with-nestjs.md
+++ b/docs/versioned_docs/version-3.6/usage-with-nestjs.md
@@ -5,8 +5,7 @@ sidebar_label: Usage with NestJS
 
 ## Installation
 
-Easiest way to integrate MikroORM to Nest is via [`nestjs-mikro-orm` module](https://github.com/dario1985/nestjs-mikro-orm).
-Simply install it next to Nest, MikroORM and underlying driver: 
+Easiest way to integrate MikroORM to Nest is via [`nestjs-mikro-orm` module](https://github.com/dario1985/nestjs-mikro-orm). Simply install it next to Nest, MikroORM and underlying driver:
 
 ```
 $ yarn add mikro-orm nestjs-mikro-orm mongodb # for mongo
@@ -24,9 +23,7 @@ $ npm i -s mikro-orm nestjs-mikro-orm pg      # for postgre
 $ npm i -s mikro-orm nestjs-mikro-orm sqlite3 # for sqlite
 ```
 
-Then import the `MikroOrmModule` in your top level module (usually called `AppModule`) via 
-`forRoot()`, which will register `MikroORM` and `EntityManager` services. It will also 
-create the request context for you automatically.
+Then import the `MikroOrmModule` in your top level module (usually called `AppModule`) via `forRoot()`, which will register `MikroORM` and `EntityManager` services. It will also create the request context for you automatically.
 
 ```typescript
 @Module({

--- a/docs/versioned_docs/version-3.6/usage-with-sql.md
+++ b/docs/versioned_docs/version-3.6/usage-with-sql.md
@@ -3,11 +3,9 @@ title: Usage with MySQL, MariaDB, PostgreSQL or SQLite
 sidebar_label: Usage with SQL Drivers
 ---
 
-To use `mikro-orm` with MySQL database, do not forget to install `mysql2` dependency and set 
-the type option to `mysql` when initializing ORM.
+To use `mikro-orm` with MySQL database, do not forget to install `mysql2` dependency and set the type option to `mysql` when initializing ORM.
 
-Similarly for SQLite install `sqlite` dependency and provide `sqlite` database type. For 
-PostgreSQL install `pg` and provide `postgresql` type.
+Similarly for SQLite install `sqlite` dependency and provide `sqlite` database type. For PostgreSQL install `pg` and provide `postgresql` type.
 
 Then call `MikroORM.init` as part of bootstrapping your app:
 
@@ -21,9 +19,7 @@ const orm = await MikroORM.init({
 
 ## Custom driver
 
-If you want to use database that is not currently supported, you can implement your own driver.
-More information about how to create one can be [found here](custom-driver.md). Then provide the 
-driver class via `driver` configuration option: 
+If you want to use database that is not currently supported, you can implement your own driver. More information about how to create one can be [found here](custom-driver.md). Then provide the driver class via `driver` configuration option:
 
 ```typescript
 import { MyCustomDriver } from './MyCustomDriver.ts';
@@ -37,8 +33,7 @@ const orm = await MikroORM.init({
 
 ## Schema
 
-Currently you will need to maintain the database schema yourself. For initial dump, you can 
-use [`SchemaGenerator` helper](schema-generator.md).  
+Currently you will need to maintain the database schema yourself. For initial dump, you can use [`SchemaGenerator` helper](schema-generator.md).
 
 ## ManyToMany collections with pivot tables
 
@@ -53,8 +48,7 @@ CREATE TABLE `publisher_to_test` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 ```
 
-You can adjust the name of pivot table via `pivotTable` option in `@ManyToMany` decorator
-defined on owning side: 
+You can adjust the name of pivot table via `pivotTable` option in `@ManyToMany` decorator defined on owning side:
 
 ```typescript
 // for unidirectional
@@ -68,8 +62,7 @@ tags = new Collection<BookTag>(this);
 
 ## Using QueryBuilder to execute native SQL queries
 
-When you need to execute some SQL query without all the ORM stuff involved, you can either
-compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
+When you need to execute some SQL query without all the ORM stuff involved, you can either compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
 
 ```typescript
 const qb = orm.em.createQueryBuilder(Author);
@@ -112,17 +105,13 @@ QueryBuilder.getParams(): any;
 QueryBuilder.clone(): QueryBuilder;
 ```
 
-For more examples of how to work with `QueryBuilder`, take a look at `QueryBuilder` tests in 
-[`tests/QueryBuilder.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/QueryBuilder.test.ts).
+For more examples of how to work with `QueryBuilder`, take a look at `QueryBuilder` tests in [`tests/QueryBuilder.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/QueryBuilder.test.ts).
 
 ## Transactions
 
-When you call `em.flush()`, all computed changes are queried [inside a database
-transaction](unit-of-work.md) by default, so you do not have to handle transactions manually. 
+When you call `em.flush()`, all computed changes are queried [inside a database transaction](unit-of-work.md) by default, so you do not have to handle transactions manually.
 
-When you need to explicitly handle the transaction, you can use `em.transactional(cb)` 
-to run callback in transaction. It will provide forked `EntityManager` as a parameter 
-with clear isolated identity map - please use that to make changes. 
+When you need to explicitly handle the transaction, you can use `em.transactional(cb)` to run callback in transaction. It will provide forked `EntityManager` as a parameter with clear isolated identity map - please use that to make changes.
 
 ```typescript
 // if an error occurs inside the callback, all db queries from inside the callback will be rolled back
@@ -143,16 +132,13 @@ const author3 = new Author2('Author 3', 'a3@example.com');
 await orm.em.persistAndFlush([author1, author2, author3]);
 
 // finds authors with email like '%exa%le.c_m'
-const authors = await orm.em.find(Author2, { email: /exa.*le\.c.m$/ }); 
+const authors = await orm.em.find(Author2, { email: /exa.*le\.c.m$/ });
 console.log(authors); // all 3 authors found
 ```
 
 ## Native Collection Methods
 
-Sometimes you need to perform some bulk operation, or you just want to populate your
-database with initial fixtures. Using ORM for such operations can bring unnecessary
-boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete`
-methods:
+Sometimes you need to perform some bulk operation, or you just want to populate your database with initial fixtures. Using ORM for such operations can bring unnecessary boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete` methods:
 
 ```typescript
 em.nativeInsert<T extends AnyEntity>(entityName: string, data: any): Promise<IPrimaryKey>;
@@ -160,9 +146,7 @@ em.nativeUpdate<T extends AnyEntity>(entityName: string, where: FilterQuery<T>, 
 em.nativeDelete<T extends AnyEntity>(entityName: string, where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Those methods execute native SQL queries generated via `QueryBuilder` based on entity 
-metadata. Keep in mind that they do not hydrate results to entities, and they do not 
-trigger lifecycle hooks. 
+Those methods execute native SQL queries generated via `QueryBuilder` based on entity metadata. Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks.
 
 They are also available as `EntityRepository` shortcuts:
 
@@ -172,9 +156,7 @@ EntityRepository.nativeUpdate(where: FilterQuery<T>, data: any): Promise<number>
 EntityRepository.nativeDelete(where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Additionally there is `execute()` method that supports executing raw SQL queries or `QueryBuilder`
-instances. To create `QueryBuilder`, you can use `createQueryBuilder()` factory method on both 
-`EntityManager` and `EntityRepository` classes: 
+Additionally there is `execute()` method that supports executing raw SQL queries or `QueryBuilder` instances. To create `QueryBuilder`, you can use `createQueryBuilder()` factory method on both `EntityManager` and `EntityRepository` classes:
 
 ```typescript
 const qb = em.createQueryBuilder('Author');

--- a/docs/versioned_docs/version-3.6/using-bigint-pks.md
+++ b/docs/versioned_docs/version-3.6/using-bigint-pks.md
@@ -2,8 +2,7 @@
 title: Using native BigInt PKs (MySQL and PostgreSQL)
 ---
 
-You can use `BigIntType` to support `bigint`s. By default it will represent the value as
-a `string`.  
+You can use `BigIntType` to support `bigint`s. By default it will represent the value as a `string`.
 
 ```typescript
 @Entity()
@@ -15,8 +14,7 @@ export class Book {
 }
 ```
 
-If you want to use native `bigint` type, you will need to create new type based on the
-`BigIntType`:
+If you want to use native `bigint` type, you will need to create new type based on the `BigIntType`:
 
 ```typescript
 export class NativeBigIntType extends BigIntType {

--- a/docs/versioned_docs/version-4.5/async-local-storage.md
+++ b/docs/versioned_docs/version-4.5/async-local-storage.md
@@ -2,8 +2,7 @@
 title: Using AsyncLocalStorage
 ---
 
-By default, the `domain` api is used in the `RequestContext` helper. Since v4.0.3,
-you can use the new `AsyncLocalStorage` too, if you are on up to date node version:
+By default, the `domain` api is used in the `RequestContext` helper. Since v4.0.3, you can use the new `AsyncLocalStorage` too, if you are on up to date node version:
 
 ```typescript
 const storage = new AsyncLocalStorage<EntityManager>();

--- a/docs/versioned_docs/version-4.5/caching.md
+++ b/docs/versioned_docs/version-4.5/caching.md
@@ -2,12 +2,9 @@
 title: Result cache
 ---
 
-MikroORM has simple result caching mechanism. It works with those methods of
-`EntityManager`: `find()`, `findOne()`, `findAndCount()`, `findOneOrFail()`,
-`count()`, as well as with `QueryBuilder` result methods (including `execute`).
+MikroORM has simple result caching mechanism. It works with those methods of `EntityManager`: `find()`, `findOne()`, `findAndCount()`, `findOneOrFail()`, `count()`, as well as with `QueryBuilder` result methods (including `execute`).
 
-By default, in memory cache is used, that is shared for the whole `MikroORM`
-instance. Default expiration is 1 second.
+By default, in memory cache is used, that is shared for the whole `MikroORM` instance. Default expiration is 1 second.
 
 ```ts
 const res = await em.find(Book, { author: { name: 'Jon Snow' } }, {
@@ -27,8 +24,7 @@ const res = await em.createQueryBuilder(Book)
   .getResultList();
 ```
 
-We can change the default expiration as well as provide custom cache adapter in
-the ORM configuration:
+We can change the default expiration as well as provide custom cache adapter in the ORM configuration:
 
 ```ts
 const orm = await MikroORM.init({

--- a/docs/versioned_docs/version-4.5/cascading.md
+++ b/docs/versioned_docs/version-4.5/cascading.md
@@ -5,17 +5,13 @@ sidebar_label: Cascading
 
 > From v4.2, cascade merging is no longer configurable (and is kept enabled for all relations).
 
-> This section is about application level cascading. For that to work, we need
-> to have relations populated. 
+> This section is about application level cascading. For that to work, we need to have relations populated.
 
-When persisting or removing entity, all your references are by default cascade persisted. 
-This means that by persisting any entity, ORM will automatically persist all of its 
-associations. 
+When persisting or removing entity, all your references are by default cascade persisted. This means that by persisting any entity, ORM will automatically persist all of its associations.
 
-You can control this behaviour via `cascade` attribute of `@ManyToOne`, `@ManyToMany`, 
-`@OneToMany` and `@OneToOne` fields.
+You can control this behaviour via `cascade` attribute of `@ManyToOne`, `@ManyToMany`, `@OneToMany` and `@OneToOne` fields.
 
-> New entities without primary key will be always persisted, regardless of `cascade` value. 
+> New entities without primary key will be always persisted, regardless of `cascade` value.
 
 ```typescript
 // cascade persist is default value
@@ -55,23 +51,19 @@ book.tags[1].name = 'new name 2';
 await orm.em.persistAndFlush(book); // all book tags and author will be persisted too
 ```
 
-> When cascade persisting collections, keep in mind only fully initialized collections 
-> will be cascade persisted.
+> When cascade persisting collections, keep in mind only fully initialized collections will be cascade persisted.
 
 ## Cascade remove
 
-Cascade remove works same way as cascade persist, just for removing entities. Following 
-example assumes that `Book.publisher` is set to `Cascade.REMOVE`:
+Cascade remove works same way as cascade persist, just for removing entities. Following example assumes that `Book.publisher` is set to `Cascade.REMOVE`:
 
-> Note that cascade remove for collections can be inefficient as it will fire 1 query
-> for each entity in collection.
+> Note that cascade remove for collections can be inefficient as it will fire 1 query for each entity in collection.
 
 ```typescript
 await orm.em.remove(book).flush(); // this will also remove book.publisher
 ```
 
-Keep in mind that cascade remove **can be dangerous** when used on `@ManyToOne` fields, 
-as cascade removed entity can stay referenced in another entities that were not removed.
+Keep in mind that cascade remove **can be dangerous** when used on `@ManyToOne` fields, as cascade removed entity can stay referenced in another entities that were not removed.
 
 ```typescript
 const publisher = new Publisher(...);
@@ -85,9 +77,7 @@ console.log(book2.publisher, book3.publisher);
 
 ## Orphan removal
 
-In addition to `Cascade.REMOVE`, there is also additional and more aggressive remove 
-cascading mode which can be specified using the `orphanRemoval` flag of the `@OneToOne`
-and `@OneToMany` properties:
+In addition to `Cascade.REMOVE`, there is also additional and more aggressive remove cascading mode which can be specified using the `orphanRemoval` flag of the `@OneToOne` and `@OneToMany` properties:
 
 ```typescript
 @Entity()
@@ -99,13 +89,9 @@ export class Author {
 }
 ```
 
-> `orphanRemoval` flag behaves just like `Cascade.REMOVE` for remove operation, so specifying 
-> both is redundant.
+> `orphanRemoval` flag behaves just like `Cascade.REMOVE` for remove operation, so specifying both is redundant.
 
-With simple `Cascade.REMOVE`, you would need to remove the `Author` entity to cascade 
-the operation down to all loaded `Book`s. By enabling orphan removal on the collection, 
-`Book`s will be also removed when they get disconnected from the collection (either via 
-`remove()`, or by replacing collection items via `set()`):
+With simple `Cascade.REMOVE`, you would need to remove the `Author` entity to cascade the operation down to all loaded `Book`s. By enabling orphan removal on the collection, `Book`s will be also removed when they get disconnected from the collection (either via `remove()`, or by replacing collection items via `set()`):
 
 ```typescript
 await author.books.set([book1, book2]); // replace whole collection
@@ -113,18 +99,15 @@ await author.books.remove(book1); // remove book from collection
 await orm.em.persistAndFlush(author); // book1 will be removed, as well as all original items (before we called `set()`)
 ```
 
-In this example, no `Book` would be removed with simple `Cascade.REMOVE` as no remove operation
-was executed. 
+In this example, no `Book` would be removed with simple `Cascade.REMOVE` as no remove operation was executed.
 
 ## Declarative Referential Integrity
 
 > This is only supported in SQL drivers.
 
-As opposed to the application level cascading controlled by the `cascade` option, we can
-also define database level referential integrity actions: `on update` and `on delete`.
+As opposed to the application level cascading controlled by the `cascade` option, we can also define database level referential integrity actions: `on update` and `on delete`.
 
-Their values are automatically inferred from the `cascade` option value. You can also 
-control the value manually via `onUpdateIntegrity` and `onDelete` options. 
+Their values are automatically inferred from the `cascade` option value. You can also control the value manually via `onUpdateIntegrity` and `onDelete` options.
 
 ```typescript
 @Entity()

--- a/docs/versioned_docs/version-4.5/collections.md
+++ b/docs/versioned_docs/version-4.5/collections.md
@@ -2,15 +2,11 @@
 title: Collections
 ---
 
-`OneToMany` and `ManyToMany` collections are stored in a `Collection` wrapper. It implements
-iterator so you can use `for of` loop to iterate through it. 
+`OneToMany` and `ManyToMany` collections are stored in a `Collection` wrapper. It implements iterator so you can use `for of` loop to iterate through it.
 
-Another way to access collection items is to use bracket syntax like when you access array items.
-Keep in mind that this approach will not check if the collection is initialed, while using `get`
-method will throw error in this case.
+Another way to access collection items is to use bracket syntax like when you access array items. Keep in mind that this approach will not check if the collection is initialed, while using `get` method will throw error in this case.
 
-> Note that array access in `Collection` is available only for reading already loaded items, you 
-> cannot add new items to `Collection` this way. 
+> Note that array access in `Collection` is available only for reading already loaded items, you cannot add new items to `Collection` this way.
 
 ```typescript
 const author = em.findOne(Author, '...', ['books']); // populating books collection
@@ -57,7 +53,7 @@ console.log(await author.books.loadItems()); // Book[]
 ## OneToMany Collections
 
 `OneToMany` collections are inverse side of `ManyToOne` references, to which they need to point via `fk` attribute:
- 
+
 ```typescript
 @Entity()
 export class Book {
@@ -88,15 +84,13 @@ export class Author {
 
 ## ManyToMany Collections
 
-For ManyToMany, SQL drivers use pivot table that holds reference to both entities. 
+For ManyToMany, SQL drivers use pivot table that holds reference to both entities.
 
-As opposed to them, with MongoDB we do not need to have join tables for `ManyToMany` 
-relations. All references are stored as an array of `ObjectId`s on owning entity. 
+As opposed to them, with MongoDB we do not need to have join tables for `ManyToMany` relations. All references are stored as an array of `ObjectId`s on owning entity.
 
 ### Unidirectional
 
-Unidirectional `ManyToMany` relations are defined only on one side, if you define only `entity`
-attribute, then it will be considered the owning side:
+Unidirectional `ManyToMany` relations are defined only on one side, if you define only `entity` attribute, then it will be considered the owning side:
 
 ```typescript
 @ManyToMany(() => Book)
@@ -109,8 +103,7 @@ books2 = new Collection<Book>(this);
 
 ### Bidirectional
 
-Bidirectional `ManyToMany` relations are defined on both sides, while one is owning side (where references are store), 
-marked by `inversedBy` attribute pointing to the inverse side:
+Bidirectional `ManyToMany` relations are defined on both sides, while one is owning side (where references are store), marked by `inversedBy` attribute pointing to the inverse side:
 
 ```typescript
 @ManyToMany(() => BookTag, tag => tag.books, { owner: true })
@@ -134,22 +127,15 @@ books = new Collection<Book>(this);
 
 ### Forcing fixed order of collection items
 
-> Since v3 many to many collections does not require having auto increment primary key, that 
-> was used to ensure fixed order of collection items.
+> Since v3 many to many collections does not require having auto increment primary key, that was used to ensure fixed order of collection items.
 
-To preserve fixed order of collections, you can use `fixedOrder: true` attribute, which will 
-start ordering by `id` column. Schema generator will convert the pivot table to have auto increment
-primary key `id`. You can also change the order column name via `fixedOrderColumn: 'order'`. 
+To preserve fixed order of collections, you can use `fixedOrder: true` attribute, which will start ordering by `id` column. Schema generator will convert the pivot table to have auto increment primary key `id`. You can also change the order column name via `fixedOrderColumn: 'order'`.
 
-You can also specify default ordering via `orderBy: { ... }` attribute. This will be used when
-you fully populate the collection including its items, as it orders by the referenced entity 
-properties instead of pivot table columns (which `fixedOrderColumn` is). On the other hand, 
-`fixedOrder` is used to maintain the insert order of items instead of ordering by some property. 
+You can also specify default ordering via `orderBy: { ... }` attribute. This will be used when you fully populate the collection including its items, as it orders by the referenced entity properties instead of pivot table columns (which `fixedOrderColumn` is). On the other hand, `fixedOrder` is used to maintain the insert order of items instead of ordering by some property.
 
 ## Propagation of Collection's add() and remove() operations
 
-When you use one of `Collection.add()` method, the item is added to given collection, 
-and this action is also propagated to its counterpart. 
+When you use one of `Collection.add()` method, the item is added to given collection, and this action is also propagated to its counterpart.
 
 ```typescript
 // one to many
@@ -160,7 +146,7 @@ author.books.add(book);
 console.log(book.author); // author will be set thanks to the propagation
 ```
 
-For M:N this works in both ways, either from owning side, or from inverse side. 
+For M:N this works in both ways, either from owning side, or from inverse side.
 
 ```typescript
 // many to many works both from owning side and from inverse side
@@ -172,19 +158,17 @@ console.log(tag.books.contains(book)); // true
 
 tag.books.add(book);
 console.log(book.tags.contains(tag)); // true
-``` 
+```
 
 > Collections on both sides have to be initialized, otherwise propagation won't work.
 
-> Although this propagation works also for M:N inverse side, you should always use owning
-> side to manipulate the collection.
+> Although this propagation works also for M:N inverse side, you should always use owning side to manipulate the collection.
 
 Same applies for `Collection.remove()`.
 
 ## Filtering and ordering of collection items
 
-When initializing collection items via `collection.init()`, you can filter the collection
-as well as order its items:
+When initializing collection items via `collection.init()`, you can filter the collection as well as order its items:
 
 ```typescript
 await book.tags.init({ where: { active: true }, orderBy: { name: QueryOrder.DESC } });
@@ -194,10 +178,7 @@ await book.tags.init({ where: { active: true }, orderBy: { name: QueryOrder.DESC
 
 ## Filtering Collections
 
-Collections have a `matching` method that allows to slice parts of data from a collection.
-By default, it will return the list of entities based on the query. We can use the `store`
-boolean parameter to save this list into the collection items - this will mark the 
-collection as `readonly`, methods like `add` or `remove` will throw. 
+Collections have a `matching` method that allows to slice parts of data from a collection. By default, it will return the list of entities based on the query. We can use the `store` boolean parameter to save this list into the collection items - this will mark the collection as `readonly`, methods like `add` or `remove` will throw.
 
 ```ts
 const a = await em.findOneOrFail(Author, 1);

--- a/docs/versioned_docs/version-4.5/composite-keys.md
+++ b/docs/versioned_docs/version-4.5/composite-keys.md
@@ -5,14 +5,9 @@ sidebar_label: Composite Primary Keys
 
 > Support for composite keys was added in version 3.5
 
-MikroORM supports composite primary keys natively. Composite keys are a very powerful 
-relational database concept and we took good care to make sure MikroORM supports as 
-many of the composite primary key use-cases. MikroORM supports composite keys of primitive 
-data-types as well as foreign keys as primary keys. You can also use your composite key 
-entities in relationships. 
+MikroORM supports composite primary keys natively. Composite keys are a very powerful relational database concept and we took good care to make sure MikroORM supports as many of the composite primary key use-cases. MikroORM supports composite keys of primitive data-types as well as foreign keys as primary keys. You can also use your composite key entities in relationships.
 
-This section shows how the semantics of composite primary keys work and how they map 
-to the database.
+This section shows how the semantics of composite primary keys work and how they map to the database.
 
 ## General Considerations
 
@@ -20,8 +15,7 @@ ID fields have to have their values set before you call `em.persist(entity)`.
 
 ## Primitive Types only
 
-Suppose you want to create a database of cars and use the model-name and year of 
-production as primary keys:
+Suppose you want to create a database of cars and use the model-name and year of production as primary keys:
 
 ```typescript
 @Entity()
@@ -50,39 +44,28 @@ const car = new Car('Audi A8', 2010);
 await em.persistAndFlush(car);
 ```
 
-And for querying you need to provide all primary keys in the condition or an array of
-primary keys in the same order as the keys were defined:
+And for querying you need to provide all primary keys in the condition or an array of primary keys in the same order as the keys were defined:
 
 ```typescript
 const audi1 = await em.findOneOrFail(Car, { name: 'Audi A8', year: 2010 });
 const audi2 = await em.findOneOrFail(Car, ['Audi A8', 2010]);
 ```
 
-> If we want to use the second approach with primary key tuple, we will need to specify 
-> the type of entity's primary key via `PrimaryKeyType` symbol as shown in the `Car` entity.
+> If we want to use the second approach with primary key tuple, we will need to specify the type of entity's primary key via `PrimaryKeyType` symbol as shown in the `Car` entity.
 
-> `PrimaryKeyType` is not needed when your entity has single scalar primary key under 
-> one of following property names: `id: number | string | bigint`, `_id: any` or 
-> `uuid: string`.
+> `PrimaryKeyType` is not needed when your entity has single scalar primary key under one of following property names: `id: number | string | bigint`, `_id: any` or `uuid: string`.
 
-You can also use this entity in associations. MikroORM will then generate two foreign 
-keys one for name and to year to the related entities.
+You can also use this entity in associations. MikroORM will then generate two foreign keys one for name and to year to the related entities.
 
-This example shows how you can nicely solve the requirement for existing values before 
-`em.persist()`: By adding them as mandatory values for the constructor.
+This example shows how you can nicely solve the requirement for existing values before `em.persist()`: By adding them as mandatory values for the constructor.
 
 ## Identity through foreign Entities
 
-There are tons of use-cases where the identity of an Entity should be determined by 
-the entity of one or many parent entities.
+There are tons of use-cases where the identity of an Entity should be determined by the entity of one or many parent entities.
 
-- Dynamic Attributes of an Entity (for example `Article`). Each Article has many 
-  attributes with primary key `article_id` and `attribute_name`.
-- `Address` object of a `Person`, the primary key of the address is `user_id`. This 
-  is not a case of a composite primary key, but the identity is derived through a 
-  foreign entity and a foreign key.
-- Pivot Tables with metadata can be modelled as Entity, for example connections between 
-  two articles with a little description and a score.
+- Dynamic Attributes of an Entity (for example `Article`). Each Article has many attributes with primary key `article_id` and `attribute_name`.
+- `Address` object of a `Person`, the primary key of the address is `user_id`. This is not a case of a composite primary key, but the identity is derived through a foreign entity and a foreign key.
+- Pivot Tables with metadata can be modelled as Entity, for example connections between two articles with a little description and a score.
 
 The semantics of mapping identity through foreign entities are easy:
 
@@ -133,9 +116,7 @@ export class ArticleAttribute {
 
 ## Use-Case 2: Simple Derived Identity
 
-Sometimes you have the requirement that two objects are related by a `@OneToOne` 
-association and that the dependent class should re-use the primary key of the class 
-it depends on. One good example for this is a user-address relationship:
+Sometimes you have the requirement that two objects are related by a `@OneToOne` association and that the dependent class should re-use the primary key of the class it depends on. One good example for this is a user-address relationship:
 
 ```typescript
 @Entity()
@@ -162,9 +143,7 @@ export class Address {
 
 ## Use-Case 3: Join-Table with Metadata
 
-In the classic order product shop example there is the concept of the order item which 
-contains references to order and product and additional data such as the amount of products 
-purchased and maybe even the current price.
+In the classic order product shop example there is the concept of the order item which contains references to order and product and additional data such as the amount of products purchased and maybe even the current price.
 
 ```typescript
 @Entity()
@@ -236,8 +215,7 @@ export class OrderItem {
 
 ## Using QueryBuilder with composite keys
 
-Internally composite keys are represented as tuples, containing all the values in the
-same order as the primary keys were defined. 
+Internally composite keys are represented as tuples, containing all the values in the same order as the primary keys were defined.
 
 ```typescript
 const qb1 = em.createQueryBuilder(CarOwner);
@@ -258,7 +236,6 @@ This also applies when you want to get a reference to entity with composite key:
 ```typescript
 const ref = em.getReference(Car, ['Audi A8', 2010]);
 console.log(ref instanceof Car); // true
-``` 
+```
 
-> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/composite-primary-keys.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/composite-primary-keys.html) as the behaviour here is pretty much the same.

--- a/docs/versioned_docs/version-4.5/configuration.md
+++ b/docs/versioned_docs/version-4.5/configuration.md
@@ -4,8 +4,7 @@ title: Configuration
 
 ## Entity Discovery
 
-You can either provide array of entity instances via `entities`, or let the ORM look up your 
-entities in selected folders. 
+You can either provide array of entity instances via `entities`, or let the ORM look up your entities in selected folders.
 
 ```typescript
 MikroORM.init({
@@ -13,14 +12,9 @@ MikroORM.init({
 });
 ```
 
-We can also use folder based discovery by providing list of paths to the entities
-we want to discover (globs are supported as well). This way we also need to specify
-`entitiesTs`, where we point the paths to the TS source files instead of the JS 
-compiled files (see more at [Metadata Providers](metadata-providers.md)).
+We can also use folder based discovery by providing list of paths to the entities we want to discover (globs are supported as well). This way we also need to specify `entitiesTs`, where we point the paths to the TS source files instead of the JS compiled files (see more at [Metadata Providers](metadata-providers.md)).
 
-> The `entitiesTs` option is used when running the app via `ts-node`, as the ORM 
-> needs to discover the TS files. Always specify this option if you use folder/file
-> based discovery. 
+> The `entitiesTs` option is used when running the app via `ts-node`, as the ORM needs to discover the TS files. Always specify this option if you use folder/file based discovery.
 
 ```typescript
 MikroORM.init({
@@ -31,19 +25,11 @@ MikroORM.init({
 });
 ```
 
-> Be careful when overriding the `baseDir` with dynamic values like `__dirname`, 
-> as you can end up with valid paths from `ts-node`, but invalid paths from `node`.
-> Ideally you should keep the default of `process.cwd()` there to always have the 
-> same base path regardless of how you run the app.
+> Be careful when overriding the `baseDir` with dynamic values like `__dirname`, as you can end up with valid paths from `ts-node`, but invalid paths from `node`. Ideally you should keep the default of `process.cwd()` there to always have the same base path regardless of how you run the app.
 
-By default, `ReflectMetadataProvider` is used that leverages the `reflect-metadata`. 
-You can also use `TsMorphMetadataProvider` by installing `@mikro-orm/reflection`. 
-This provider will analyse your entity source files (or `.d.ts` type definition files). 
-If you aim to use plain JavaScript instead of TypeScript, use `EntitySchema` or 
-the `JavaScriptMetadataProvider`.
+By default, `ReflectMetadataProvider` is used that leverages the `reflect-metadata`. You can also use `TsMorphMetadataProvider` by installing `@mikro-orm/reflection`. This provider will analyse your entity source files (or `.d.ts` type definition files). If you aim to use plain JavaScript instead of TypeScript, use `EntitySchema` or the `JavaScriptMetadataProvider`.
 
-> You can also implement your own metadata provider and use it instead. To do so, extend the 
-> `MetadataProvider` class.
+> You can also implement your own metadata provider and use it instead. To do so, extend the `MetadataProvider` class.
 
 ```typescript
 import { MikroORM } from '@mikro-orm/core';
@@ -66,8 +52,7 @@ MikroORM.init({
 });
 ```
 
-> If you disable `discovery.alwaysAnalyseProperties` option, you will need to explicitly 
-> provide `nullable` and `wrappedReference` parameters (where applicable).
+> If you disable `discovery.alwaysAnalyseProperties` option, you will need to explicitly provide `nullable` and `wrappedReference` parameters (where applicable).
 
 Read more about this in [Metadata Providers](metadata-providers.md) sections.
 
@@ -75,19 +60,17 @@ Read more about this in [Metadata Providers](metadata-providers.md) sections.
 
 To select driver, you can either use `type` option, or provide the driver class reference.
 
-| type | driver name | dependency | note |
-|------|-------------|------------|------|
-| `mongo` | `MongoDriver` | `mongodb^3.3.4` | - |
-| `mysql` | `MySqlDriver` | `mysql2^2.0.0` | compatible with MariaDB |
-| `mariadb` | `MariaDbDriver` | `mariadb^2.0.0` | compatible with MySQL |
-| `postgresql` | `PostgreSqlDriver` | `pg^7.0.0` | - |
-| `sqlite` | `SqliteDriver` | `sqlite3^4.0.0` | - |
+| type         | driver name        | dependency      | note                    |
+| ------------ | ------------------ | --------------- | ----------------------- |
+| `mongo`      | `MongoDriver`      | `mongodb^3.3.4` | -                       |
+| `mysql`      | `MySqlDriver`      | `mysql2^2.0.0`  | compatible with MariaDB |
+| `mariadb`    | `MariaDbDriver`    | `mariadb^2.0.0` | compatible with MySQL   |
+| `postgresql` | `PostgreSqlDriver` | `pg^7.0.0`      | -                       |
+| `sqlite`     | `SqliteDriver`     | `sqlite3^4.0.0` | -                       |
 
-> Driver and connection implementations are not directly exported from `@mikro-orm/core` module. 
-> You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
+> Driver and connection implementations are not directly exported from `@mikro-orm/core` module. You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
 
-> You can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. 
-> The object will be deeply merged, overriding all internally used options.
+> You can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. The object will be deeply merged, overriding all internally used options.
 
 ```typescript
 import { MySqlDriver } from '@mikro-orm/mysql';
@@ -109,8 +92,7 @@ MikroORM.init({
 
 ## Connection
 
-Each platform (driver) provides default connection string, you can override it as a whole
-through `clientUrl`, or partially through one of following options:
+Each platform (driver) provides default connection string, you can override it as a whole through `clientUrl`, or partially through one of following options:
 
 ```typescript
 export interface ConnectionOptions {
@@ -129,15 +111,14 @@ export interface ConnectionOptions {
 
 Following table shows default client connection strings:
 
-| type | default connection url |
-|------|------------------------|
-| `mongo` | `mongodb://127.0.0.1:27017` |
-| `mysql` | `mysql://root@127.0.0.1:3306` |
-| `mariadb` | `mysql://root@127.0.0.1:3306` |
+| type         | default connection url                 |
+| ------------ | -------------------------------------- |
+| `mongo`      | `mongodb://127.0.0.1:27017`            |
+| `mysql`      | `mysql://root@127.0.0.1:3306`          |
+| `mariadb`    | `mysql://root@127.0.0.1:3306`          |
 | `postgresql` | `postgresql://postgres@127.0.0.1:5432` |
 
-To set up read replicas, you can use `replicas` option. You can provide only those parts of the 
-`ConnectionOptions` interface, they will be used to override the `master` connection options.
+To set up read replicas, you can use `replicas` option. You can provide only those parts of the `ConnectionOptions` interface, they will be used to override the `master` connection options.
 
 ```typescript
 MikroORM.init({
@@ -158,8 +139,7 @@ Read more about this in [Installation](installation.md) and [Read Connections](r
 
 ## Naming Strategy
 
-When mapping your entities to database tables and columns, their names will be defined by naming 
-strategy. There are 3 basic naming strategies you can choose from:
+When mapping your entities to database tables and columns, their names will be defined by naming strategy. There are 3 basic naming strategies you can choose from:
 
 - `UnderscoreNamingStrategy` - default of all SQL drivers
 - `MongoNamingStrategy` - default of `MongoDriver`
@@ -177,9 +157,7 @@ Read more about this in [Naming Strategy](naming-strategy.md) section.
 
 ## Auto-join of 1:1 owners
 
-By default, owning side of 1:1 relation will be auto-joined when you select the inverse side 
-so we can have the reference to it. You can disable this behaviour via `autoJoinOneToOneOwner` 
-configuration toggle.
+By default, owning side of 1:1 relation will be auto-joined when you select the inverse side so we can have the reference to it. You can disable this behaviour via `autoJoinOneToOneOwner` configuration toggle.
 
 ```typescript
 MikroORM.init({
@@ -189,8 +167,7 @@ MikroORM.init({
 
 ## Propagation of 1:1 and m:1 owners
 
-MikroORM defines getter and setter for every owning side of m:1 and 1:1 relation. This is 
-then used for propagation of changes to the inverse side of bi-directional relations.
+MikroORM defines getter and setter for every owning side of m:1 and 1:1 relation. This is then used for propagation of changes to the inverse side of bi-directional relations.
 
 ```typescript
 const author = new Author('n', 'e');
@@ -209,9 +186,7 @@ MikroORM.init({
 
 ## Forcing UTC Timezone
 
-Use `forceUtcTimezone` option to force the `Date`s to be saved in UTC in datetime columns 
-without timezone. It works for MySQL (`datetime` type) and PostgreSQL (`timestamp` type). 
-SQLite does this by default. 
+Use `forceUtcTimezone` option to force the `Date`s to be saved in UTC in datetime columns without timezone. It works for MySQL (`datetime` type) and PostgreSQL (`timestamp` type). SQLite does this by default.
 
 ```typescript
 MikroORM.init({
@@ -221,9 +196,7 @@ MikroORM.init({
 
 ## Mapping `null` values to `undefined`
 
-By default `null` values from nullable database columns are hydrated as `null`. 
-Using `forceUndefined` we can tell the ORM to convert those `null` values to
-`undefined` instead. 
+By default `null` values from nullable database columns are hydrated as `null`. Using `forceUndefined` we can tell the ORM to convert those `null` values to `undefined` instead.
 
 ```typescript
 MikroORM.init({
@@ -233,8 +206,7 @@ MikroORM.init({
 
 ## Custom Hydrator
 
-Hydrator is responsible for assigning values from the database to entities. 
-You can implement your custom `Hydrator` (by extending the abstract `Hydrator` class):
+Hydrator is responsible for assigning values from the database to entities. You can implement your custom `Hydrator` (by extending the abstract `Hydrator` class):
 
 ```typescript
 MikroORM.init({
@@ -244,8 +216,7 @@ MikroORM.init({
 
 ## Custom Repository
 
-You can also register custom base repository (for all entities where you do not specify 
-`customRepository`) globally:
+You can also register custom base repository (for all entities where you do not specify `customRepository`) globally:
 
 > You can still use entity specific repositories in combination with global base repository.
 
@@ -259,14 +230,9 @@ Read more about this in [Repositories](repositories.md) section.
 
 ## Strict Mode and property validation
 
-> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`.
-> It has performance implications and usually should not be needed, as long as
-> you don't modify your entities via `Object.assign()`.
+> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`. It has performance implications and usually should not be needed, as long as you don't modify your entities via `Object.assign()`.
 
-`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong 
-data types for you automatically. If automatic conversion fails, it will throw an error. You can 
-enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered 
-when persisting the entity. 
+`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong data types for you automatically. If automatic conversion fails, it will throw an error. You can enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered when persisting the entity.
 
 ```typescript
 MikroORM.init({
@@ -279,8 +245,7 @@ Read more about this in [Property Validation](property-validation.md) section.
 
 ## Debugging & Logging
 
-You can enable logging with `debug` option. Either set it to `true` to log everything, or 
-provide array of `'query' | 'query-params' | 'discovery' | 'info'` namespaces.
+You can enable logging with `debug` option. Either set it to `true` to log everything, or provide array of `'query' | 'query-params' | 'discovery' | 'info'` namespaces.
 
 ```typescript
 MikroORM.init({
@@ -295,8 +260,7 @@ Read more about this in [Debugging](debugging.md) section.
 
 ## Custom Fail Handler
 
-When no entity is found during `em.findOneOrFail()` call, `new Error()` will be thrown. 
-You can customize how the `Error` instance is created via `findOneOrFailHandler`:
+When no entity is found during `em.findOneOrFail()` call, `new Error()` will be thrown. You can customize how the `Error` instance is created via `findOneOrFailHandler`:
 
 ```typescript
 MikroORM.init({
@@ -310,8 +274,7 @@ Read more about this in [Entity Manager](entity-manager.md#handling-not-found-en
 
 ## Migrations
 
-Under the `migrations` namespace, you can adjust how the integrated migrations support works.
-Following example shows all possible options and their defaults:
+Under the `migrations` namespace, you can adjust how the integrated migrations support works. Following example shows all possible options and their defaults:
 
 ```typescript
 MikroORM.init({
@@ -331,8 +294,7 @@ Read more about this in [Migrations](migrations.md) section.
 
 ## Caching
 
-By default, metadata discovery results are cached. You can either disable caching, or adjust 
-how it works. Following example shows all possible options and their defaults:
+By default, metadata discovery results are cached. You can either disable caching, or adjust how it works. Following example shows all possible options and their defaults:
 
 ```typescript
 MikroORM.init({
@@ -358,28 +320,24 @@ MikroORM.init({
   ...
 });
 ```
- > This should be disabled in production environments for added security.
+
+> This should be disabled in production environments for added security.
 
 ## Using native private properties
 
-If we want to use native private properties inside entities, the default approach of 
-how MikroORM creates entity instances via `Object.create()` is not viable (more about this
-in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity
-constructors, we can use `forceEntityConstructor` toggle:
+If we want to use native private properties inside entities, the default approach of how MikroORM creates entity instances via `Object.create()` is not viable (more about this in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity constructors, we can use `forceEntityConstructor` toggle:
 
 ```ts
 MikroORM.init({
   ...
-  forceEntityConstructor: true, // or specify just some entities via `[Author, 'Book', ...]` 
+  forceEntityConstructor: true, // or specify just some entities via `[Author, 'Book', ...]`
   ...
 });
 ```
 
 ## Using environment variables
 
-Since v4.5 it is possible to set most of the ORM options via environment variables.
-By default `.env` file from the root directory is loaded - it is also possible to
-set full path to the env file you want to use via `MIKRO_ORM_ENV` environment variable.
+Since v4.5 it is possible to set most of the ORM options via environment variables. By default `.env` file from the root directory is loaded - it is also possible to set full path to the env file you want to use via `MIKRO_ORM_ENV` environment variable.
 
 > Environment variables always have precedence.
 
@@ -399,45 +357,45 @@ MIKRO_ORM_FORCE_UNDEFINED = true
 
 Full list of supported options:
 
-| env variable | config key |
-|--------------|------------|
-| `MIKRO_ORM_BASE_DIR` | `baseDir` |
-| `MIKRO_ORM_TYPE` | `type` |
-| `MIKRO_ORM_ENTITIES` | `entities` |
-| `MIKRO_ORM_ENTITIES_TS` | `entitiesTs` |
-| `MIKRO_ORM_CLIENT_URL` | `clientUrl` |
-| `MIKRO_ORM_HOST` | `host` |
-| `MIKRO_ORM_PORT` | `port` |
-| `MIKRO_ORM_USER` | `user` |
-| `MIKRO_ORM_PASSWORD` | `password` |
-| `MIKRO_ORM_DB_NAME` | `dbName` |
-| `MIKRO_ORM_LOAD_STRATEGY` | `loadStrategy` |
-| `MIKRO_ORM_BATCH_SIZE` | `batchSize` |
-| `MIKRO_ORM_USE_BATCH_INSERTS` | `useBatchInserts` |
-| `MIKRO_ORM_USE_BATCH_UPDATES` | `useBatchUpdates` |
-| `MIKRO_ORM_STRICT` | `strict` |
-| `MIKRO_ORM_VALIDATE` | `validate` |
-| `MIKRO_ORM_AUTO_JOIN_ONE_TO_ONE_OWNER` | `autoJoinOneToOneOwner` |
-| `MIKRO_ORM_PROPAGATE_TO_ONE_OWNER` | `propagateToOneOwner` |
-| `MIKRO_ORM_POPULATE_AFTER_FLUSH` | `populateAfterFlush` |
-| `MIKRO_ORM_FORCE_ENTITY_CONSTRUCTOR` | `forceEntityConstructor` |
-| `MIKRO_ORM_FORCE_UNDEFINED` | `forceUndefined` |
-| `MIKRO_ORM_FORCE_UTC_TIMEZONE` | `forceUtcTimezone` |
-| `MIKRO_ORM_TIMEZONE` | `timezone` |
-| `MIKRO_ORM_ENSURE_INDEXES` | `ensureIndexes` |
-| `MIKRO_ORM_IMPLICIT_TRANSACTIONS` | `implicitTransactions` |
-| `MIKRO_ORM_DEBUG` | `debug` |
-| `MIKRO_ORM_VERBOSE` | `verbose` |
-| `MIKRO_ORM_DISCOVERY_WARN_WHEN_NO_ENTITIES` | `discovery.warnWhenNoEntities` |
-| `MIKRO_ORM_DISCOVERY_REQUIRE_ENTITIES_ARRAY` | `discovery.requireEntitiesArray` |
-| `MIKRO_ORM_DISCOVERY_ALWAYS_ANALYSE_PROPERTIES` | `discovery.alwaysAnalyseProperties` |
+| env variable                                      | config key                           |
+| ------------------------------------------------- | ------------------------------------ |
+| `MIKRO_ORM_BASE_DIR`                              | `baseDir`                            |
+| `MIKRO_ORM_TYPE`                                  | `type`                               |
+| `MIKRO_ORM_ENTITIES`                              | `entities`                           |
+| `MIKRO_ORM_ENTITIES_TS`                           | `entitiesTs`                         |
+| `MIKRO_ORM_CLIENT_URL`                            | `clientUrl`                          |
+| `MIKRO_ORM_HOST`                                  | `host`                               |
+| `MIKRO_ORM_PORT`                                  | `port`                               |
+| `MIKRO_ORM_USER`                                  | `user`                               |
+| `MIKRO_ORM_PASSWORD`                              | `password`                           |
+| `MIKRO_ORM_DB_NAME`                               | `dbName`                             |
+| `MIKRO_ORM_LOAD_STRATEGY`                         | `loadStrategy`                       |
+| `MIKRO_ORM_BATCH_SIZE`                            | `batchSize`                          |
+| `MIKRO_ORM_USE_BATCH_INSERTS`                     | `useBatchInserts`                    |
+| `MIKRO_ORM_USE_BATCH_UPDATES`                     | `useBatchUpdates`                    |
+| `MIKRO_ORM_STRICT`                                | `strict`                             |
+| `MIKRO_ORM_VALIDATE`                              | `validate`                           |
+| `MIKRO_ORM_AUTO_JOIN_ONE_TO_ONE_OWNER`            | `autoJoinOneToOneOwner`              |
+| `MIKRO_ORM_PROPAGATE_TO_ONE_OWNER`                | `propagateToOneOwner`                |
+| `MIKRO_ORM_POPULATE_AFTER_FLUSH`                  | `populateAfterFlush`                 |
+| `MIKRO_ORM_FORCE_ENTITY_CONSTRUCTOR`              | `forceEntityConstructor`             |
+| `MIKRO_ORM_FORCE_UNDEFINED`                       | `forceUndefined`                     |
+| `MIKRO_ORM_FORCE_UTC_TIMEZONE`                    | `forceUtcTimezone`                   |
+| `MIKRO_ORM_TIMEZONE`                              | `timezone`                           |
+| `MIKRO_ORM_ENSURE_INDEXES`                        | `ensureIndexes`                      |
+| `MIKRO_ORM_IMPLICIT_TRANSACTIONS`                 | `implicitTransactions`               |
+| `MIKRO_ORM_DEBUG`                                 | `debug`                              |
+| `MIKRO_ORM_VERBOSE`                               | `verbose`                            |
+| `MIKRO_ORM_DISCOVERY_WARN_WHEN_NO_ENTITIES`       | `discovery.warnWhenNoEntities`       |
+| `MIKRO_ORM_DISCOVERY_REQUIRE_ENTITIES_ARRAY`      | `discovery.requireEntitiesArray`     |
+| `MIKRO_ORM_DISCOVERY_ALWAYS_ANALYSE_PROPERTIES`   | `discovery.alwaysAnalyseProperties`  |
 | `MIKRO_ORM_DISCOVERY_DISABLE_DYNAMIC_FILE_ACCESS` | `discovery.disableDynamicFileAccess` |
-| `MIKRO_ORM_MIGRATIONS_TABLE_NAME` | `migrations.tableName` |
-| `MIKRO_ORM_MIGRATIONS_PATH` | `migrations.path` |
-| `MIKRO_ORM_MIGRATIONS_PATTERN` | `migrations.pattern` |
-| `MIKRO_ORM_MIGRATIONS_TRANSACTIONAL` | `migrations.transactional` |
-| `MIKRO_ORM_MIGRATIONS_DISABLE_FOREIGN_KEYS` | `migrations.disableForeignKeys` |
-| `MIKRO_ORM_MIGRATIONS_ALL_OR_NOTHING` | `migrations.allOrNothing` |
-| `MIKRO_ORM_MIGRATIONS_DROP_TABLES` | `migrations.dropTables` |
-| `MIKRO_ORM_MIGRATIONS_SAFE` | `migrations.safe` |
-| `MIKRO_ORM_MIGRATIONS_EMIT` | `migrations.emit` |
+| `MIKRO_ORM_MIGRATIONS_TABLE_NAME`                 | `migrations.tableName`               |
+| `MIKRO_ORM_MIGRATIONS_PATH`                       | `migrations.path`                    |
+| `MIKRO_ORM_MIGRATIONS_PATTERN`                    | `migrations.pattern`                 |
+| `MIKRO_ORM_MIGRATIONS_TRANSACTIONAL`              | `migrations.transactional`           |
+| `MIKRO_ORM_MIGRATIONS_DISABLE_FOREIGN_KEYS`       | `migrations.disableForeignKeys`      |
+| `MIKRO_ORM_MIGRATIONS_ALL_OR_NOTHING`             | `migrations.allOrNothing`            |
+| `MIKRO_ORM_MIGRATIONS_DROP_TABLES`                | `migrations.dropTables`              |
+| `MIKRO_ORM_MIGRATIONS_SAFE`                       | `migrations.safe`                    |
+| `MIKRO_ORM_MIGRATIONS_EMIT`                       | `migrations.emit`                    |

--- a/docs/versioned_docs/version-4.5/custom-driver.md
+++ b/docs/versioned_docs/version-4.5/custom-driver.md
@@ -2,18 +2,17 @@
 title: Creating Custom Driver
 ---
 
-If you want to use database that is not currently supported, you can implement your own driver.
-To do so, you will need to design 4 classes:
+If you want to use database that is not currently supported, you can implement your own driver. To do so, you will need to design 4 classes:
 
 ## Platform
 
-Platform is a class that provides information about available features of given driver: 
+Platform is a class that provides information about available features of given driver:
 
 ```typescript
 import { Platform } from '@mikro-orm/core';
 
 export class MyCustomPlatform extends Platform {
-  
+
   protected abstract schemaHelper: MyCustomSchemaHelper;
 
   // here you can override default settings
@@ -39,7 +38,7 @@ Part of platform is a `SchemaHelper`, that provides information about how to bui
 import { SchemaHelper } from '@mikro-orm/core';
 
 export class MyCustomSchemaHelper extends SchemaHelper {
-  
+
   // here you can override default settings
   getIdentifierQuoteCharacter(): string;
   getSchemaBeginning(): string;
@@ -67,7 +66,7 @@ Next part is connection wrapper, that will be responsible for querying the datab
 import { Connection } from '@mikro-orm/core';
 
 export class MyCustomConnection extends Connection {
-  
+
   // implement abstract methods
   connect(): Promise<void>;
   isConnected(): Promise<boolean>;
@@ -80,12 +79,9 @@ export class MyCustomConnection extends Connection {
 
 ## Driver
 
-Last part is driver, that is responsible for using the connection to persist changes to 
-database. If you are building SQL driver, it might be handy to extend `AbstractSqlDriver`, 
-if not, extend `DatabaseDriver` abstract class. 
+Last part is driver, that is responsible for using the connection to persist changes to database. If you are building SQL driver, it might be handy to extend `AbstractSqlDriver`, if not, extend `DatabaseDriver` abstract class.
 
-If you want to have absolute control, you can implement the whole driver yourself via
-`IDatabaseDriver` interface. 
+If you want to have absolute control, you can implement the whole driver yourself via `IDatabaseDriver` interface.
 
 ```typescript
 import { DatabaseDriver } from '@mikro-orm/core';

--- a/docs/versioned_docs/version-4.5/custom-types.md
+++ b/docs/versioned_docs/version-4.5/custom-types.md
@@ -6,33 +6,27 @@ You can define custom types by extending `Type` abstract class. It has several o
 
 - `convertToDatabaseValue(value: any, platform: Platform): any`
 
-  Converts a value from its JS representation to its database representation of this type.
-  By default returns unchanged `value`.
+  Converts a value from its JS representation to its database representation of this type. By default returns unchanged `value`.
 
 - `convertToJSValue(value: any, platform: Platform): any`
 
-  Converts a value from its database representation to its JS representation of this type.
-  By default returns unchanged `value`.
+  Converts a value from its database representation to its JS representation of this type. By default returns unchanged `value`.
 
 - `toJSON(value: any, platform: Platform): any`
 
-  Converts a value from its JS representation to its serialized JSON form of this type.
-  By default uses the runtime value.
+  Converts a value from its JS representation to its serialized JSON form of this type. By default uses the runtime value.
 
 - `getColumnType(prop: EntityProperty, platform: Platform): string`
 
-  Gets the SQL declaration snippet for a field of this type.
-  By default returns `columnType` of given property.
+  Gets the SQL declaration snippet for a field of this type. By default returns `columnType` of given property.
 
 - `convertToDatabaseValueSQL(key: string, platform: Platform): string`
 
-  Converts a value from its JS representation to its database representation of this type.
-  _(added in v4.4.2)_
+  Converts a value from its JS representation to its database representation of this type. _(added in v4.4.2)_
 
 - `convertToJSValueSQL?(key: string, platform: Platform): string`
 
-  Modifies the SQL expression (identifier, parameter) to convert to a JS value.
-  _(added in v4.4.2)_
+  Modifies the SQL expression (identifier, parameter) to convert to a JS value. _(added in v4.4.2)_
 
 ```typescript
 import { Type, Platform, EntityProperty, ValidationError } from '@mikro-orm/core';
@@ -90,9 +84,7 @@ export class FooBar {
 }
 ```
 
-If our type implementation is stateful, e.g. if we want the type to behave
-differently for each property, we can use `customType` option and provide an
-instance of the type:
+If our type implementation is stateful, e.g. if we want the type to behave differently for each property, we can use `customType` option and provide an instance of the type:
 
 ```ts
 @Property({ customType: new MyDateType('DD-MM-YYYY') })
@@ -103,9 +95,7 @@ born?: string;
 
 In this example we will combine mapping values via database as well as during runtime.
 
-> The Point type is part of the Spatial extension of MySQL and enables you to store
-> a single location in a coordinate space by using x and y coordinates. You can use
-> the Point type to store a longitude/latitude pair to represent a geographic location.
+> The Point type is part of the Spatial extension of MySQL and enables you to store a single location in a coordinate space by using x and y coordinates. You can use the Point type to store a longitude/latitude pair to represent a geographic location.
 
 First let's define the `Point` class that will be used to represent the value during runtime:
 
@@ -200,52 +190,29 @@ update `location` set `point` = ST_PointFromText('point(2.34 9.87)') where `id` 
 commit
 ```
 
-We do a 2-step conversion here. In the first step, we convert the Point object into
-a string representation before saving to the database (in the convertToDatabaseValue
-method) and back into an object after fetching the value from the database (in the
-convertToJSValue method).
+We do a 2-step conversion here. In the first step, we convert the Point object into a string representation before saving to the database (in the convertToDatabaseValue method) and back into an object after fetching the value from the database (in the convertToJSValue method).
 
-The format of the string representation format is called Well-known text (WKT). The
-advantage of this format is, that it is both human readable and parsable by MySQL.
+The format of the string representation format is called Well-known text (WKT). The advantage of this format is, that it is both human readable and parsable by MySQL.
 
-Internally, MySQL stores geometry values in a binary format that is not identical to
-the WKT format. So, we need to let MySQL transform the WKT representation into its
-internal format.
+Internally, MySQL stores geometry values in a binary format that is not identical to the WKT format. So, we need to let MySQL transform the WKT representation into its internal format.
 
-This is where the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods come
-into play.
+This is where the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods come into play.
 
-This methods wrap a sql expression (the WKT representation of the Point) into MySQL
-functions ST_PointFromText and ST_AsText which convert WKT strings to and from the
-internal format of MySQL.
+This methods wrap a sql expression (the WKT representation of the Point) into MySQL functions ST_PointFromText and ST_AsText which convert WKT strings to and from the internal format of MySQL.
 
-> When using DQL queries, the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods
-> only apply to identification variables and path expressions in SELECT clauses. Expressions
-> in WHERE clauses are not wrapped!
+> When using DQL queries, the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods only apply to identification variables and path expressions in SELECT clauses. Expressions in WHERE clauses are not wrapped!
 
 ## Types provided by MikroORM
 
-There are few types provided by MikroORM. All of them aim to provide similar
-experience among all the drivers, even if the particular feature is not supported
-out of box by the driver.
+There are few types provided by MikroORM. All of them aim to provide similar experience among all the drivers, even if the particular feature is not supported out of box by the driver.
 
 ### ArrayType
 
-In PostgreSQL and MongoDB, it uses native arrays, otherwise it concatenates the
-values into string separated by commas. This means that you can't use values that
-contain comma with the `ArrayType` (but you can create custom array type that will
-handle this case, e.g. by using different separator).
+In PostgreSQL and MongoDB, it uses native arrays, otherwise it concatenates the values into string separated by commas. This means that you can't use values that contain comma with the `ArrayType` (but you can create custom array type that will handle this case, e.g. by using different separator).
 
-By default array of strings is returned from the type. You can also have arrays
-of numbers or other data types - to do so, you will need to implement custom
-`hydrate` method that is used for converting the array values to the right type.
+By default array of strings is returned from the type. You can also have arrays of numbers or other data types - to do so, you will need to implement custom `hydrate` method that is used for converting the array values to the right type.
 
-> `ArrayType` will be used automatically if `type` is set to `array` (default behaviour
-> of reflect-metadata) or `string[]` or `number[]` (either manually or via ts-morph).
-> In case of `number[]` it will automatically handle the conversion to numbers.
-> This means that the following examples would both have the `ArrayType` used
-> automatically (but with reflect-metadata we would have a string array for both
-> unless we specify the type manually as `type: 'number[]')
+> `ArrayType` will be used automatically if `type` is set to `array` (default behaviour of reflect-metadata) or `string[]` or `number[]` (either manually or via ts-morph). In case of `number[]` it will automatically handle the conversion to numbers. This means that the following examples would both have the `ArrayType` used automatically (but with reflect-metadata we would have a string array for both unless we specify the type manually as `type: 'number[]')
 
 ```typescript
 @Property({ type: ArrayType, nullable: true })
@@ -257,8 +224,7 @@ numericArray?: number[];
 
 ### BigIntType
 
-You can use `BigIntType` to support `bigint`s. By default, it will represent the
-value as a `string`.
+You can use `BigIntType` to support `bigint`s. By default, it will represent the value as a `string`.
 
 ```typescript
 @PrimaryKey({ type: BigIntType })
@@ -269,9 +235,7 @@ id: string;
 
 Blob type can be used to store binary data in the database.
 
-> `BlobType` will be used automatically if you specify the type hint as `Buffer`.
-> This means that the following example should work even without the explicit
-> `type: BlobType` option (with both reflect-metadata and ts-morph providers).
+> `BlobType` will be used automatically if you specify the type hint as `Buffer`. This means that the following example should work even without the explicit `type: BlobType` option (with both reflect-metadata and ts-morph providers).
 
 ```typescript
 @Property({ type: BlobType, nullable: true })
@@ -280,9 +244,7 @@ blob?: Buffer;
 
 ### JsonType
 
-To store objects we can use `JsonType`. As some drivers are handling objects
-automatically and some don't, this type will handle the serialization in a driver
-independent way (calling `parse` and `stringify` only when needed).
+To store objects we can use `JsonType`. As some drivers are handling objects automatically and some don't, this type will handle the serialization in a driver independent way (calling `parse` and `stringify` only when needed).
 
 ```typescript
 @Property({ type: JsonType, nullable: true })
@@ -291,8 +253,7 @@ object?: { foo: string; bar: number };
 
 ### DateType
 
-To store dates without time information, we can use `DateType`. It does use `date`
-column type and maps it to the `Date` object.
+To store dates without time information, we can use `DateType`. It does use `date` column type and maps it to the `Date` object.
 
 ```typescript
 @Property({ type: DateType, nullable: true })
@@ -301,8 +262,7 @@ born?: Date;
 
 ### TimeType
 
-As opposed to the `DateType`, to store only the time information, we can use
-`TimeType`. It will use the `time` column type, the runtime type is string.
+As opposed to the `DateType`, to store only the time information, we can use `TimeType`. It will use the `time` column type, the runtime type is string.
 
 ```typescript
 @Property({ type: TimeType, nullable: true })

--- a/docs/versioned_docs/version-4.5/debugging.md
+++ b/docs/versioned_docs/version-4.5/debugging.md
@@ -19,8 +19,7 @@ By doing this `MikroORM` will start using `console.log()` function to dump all q
 [query] commit [took 2 ms]
 ```
 
-It is also useful for debugging problems with entity discovery, as you will see information
-about every processed entity:
+It is also useful for debugging problems with entity discovery, as you will see information about every processed entity:
 
 ```
 [discovery] ORM entity discovery started
@@ -33,7 +32,7 @@ about every processed entity:
 
 ## Custom Logger
 
-You can also provide your own logger via `logger` option. 
+You can also provide your own logger via `logger` option.
 
 ```typescript
 return MikroORM.init({
@@ -44,8 +43,7 @@ return MikroORM.init({
 
 ## Logger Namespaces
 
-There are multiple Logger Namespaces that you can specifically request, while omitting the rest.
-Just specify array of them via the `debug` option:
+There are multiple Logger Namespaces that you can specifically request, while omitting the rest. Just specify array of them via the `debug` option:
 
 ```typescript
 return MikroORM.init({
@@ -59,13 +57,9 @@ If you provide `query-params` then you must also provide `query` in order for it
 
 ## Highlighters
 
-Previously Highlight.js was used to highlight various things in the CLI, 
-like SQL and mongo queries, or migrations or entities generated via CLI.
-While the library worked fine, it was causing performance issues mainly 
-for those bundling via webpack and using lambdas, as the library was huge.
+Previously Highlight.js was used to highlight various things in the CLI, like SQL and mongo queries, or migrations or entities generated via CLI. While the library worked fine, it was causing performance issues mainly for those bundling via webpack and using lambdas, as the library was huge.
 
-In v4 highlighting is disabled by default, and there are 2 highlighters 
-you can optionally use (you need to install them first).
+In v4 highlighting is disabled by default, and there are 2 highlighters you can optionally use (you need to install them first).
 
 ```typescript
 import { SqlHighlighter } from '@mikro-orm/sql-highlighter';
@@ -76,5 +70,4 @@ MikroORM.init({
 });
 ```
 
-For MongoDB you can use `MongoHighlighter` from `@mikro-orm/mongo-highlighter` 
-package.
+For MongoDB you can use `MongoHighlighter` from `@mikro-orm/mongo-highlighter` package.

--- a/docs/versioned_docs/version-4.5/decorators.md
+++ b/docs/versioned_docs/version-4.5/decorators.md
@@ -6,15 +6,14 @@ title: Decorators
 
 ### @Entity()
 
-`@Entity` decorator is used to mark your model classes as entities. Do not use it for 
-abstract base classes.
+`@Entity` decorator is used to mark your model classes as entities. Do not use it for abstract base classes.
 
-| Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
-| `tableName` | `string` | yes | Override default collection/table name. |
-| `collection` | `string` | yes | Alias for `tableName`. |
-| `comment` | `string` | yes | Specify comment to table **(SQL only)** |
-| `customRepository` | `() => EntityRepository` | yes | Set custom repository class. |
+| Parameter          | Type                     | Optional | Description                             |
+| ------------------ | ------------------------ | -------- | --------------------------------------- |
+| `tableName`        | `string`                 | yes      | Override default collection/table name. |
+| `collection`       | `string`                 | yes      | Alias for `tableName`.                  |
+| `comment`          | `string`                 | yes      | Specify comment to table **(SQL only)** |
+| `customRepository` | `() => EntityRepository` | yes      | Set custom repository class.            |
 
 > You can also use `@Repository()` decorator instead of `customRepository` parameter.
 
@@ -27,11 +26,10 @@ export class Author { ... }
 
 ### @Property()
 
-`@Property()` decorator is used to define regular entity property. All following decorators
-extend the `@Property()` decorator, so you can also use its parameters there. 
+`@Property()` decorator is used to define regular entity property. All following decorators extend the `@Property()` decorator, so you can also use its parameters there.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `fieldName` | `string` | yes | Override default property name (see [Naming Strategy](naming-strategy.md)). |
 | `type` | `string` &#124; `Constructor<Type>` &#124; `Type` | yes | Explicitly specify the runtime type (see [Metadata Providers](metadata-providers.md) and [Custom Types](custom-types.md)). |
 | `customType` | `Type` | yes | Explicitly specify the mapped type instance for this property (see [Custom Types](custom-types.md)). |
@@ -68,14 +66,13 @@ registered = false;
 
 ### @PrimaryKey()
 
-`@PrimaryKey()` decorator is used to define entity's unique primary key identifier. 
+`@PrimaryKey()` decorator is used to define entity's unique primary key identifier.
 
-> `@PrimaryKey()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@PrimaryKey()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 > Every entity needs to have at least one primary key (see composite primary keys).
 
-> Note that if only one PrimaryKey is set and it's type is number it will be set to auto incremented automatically in all SQL drivers. 
+> Note that if only one PrimaryKey is set and it's type is number it will be set to auto incremented automatically in all SQL drivers.
 
 ```typescript
 @PrimaryKey()
@@ -90,13 +87,10 @@ _id!: ObjectId; // ObjectId PK in mongodb driver
 
 ### @SerializedPrimaryKey()
 
-> Property marked with `@SerializedPrimaryKey()` is virtual, it will not be persisted 
-> into the database.
+> Property marked with `@SerializedPrimaryKey()` is virtual, it will not be persisted into the database.
 
-For MongoDB you can define serialized primary key, which will be then used in entity 
-serialization via `JSON.stringify()` (through method `entity.toJSON()`).
-You will be able to use it to manipulate with the primary key as string. 
- 
+For MongoDB you can define serialized primary key, which will be then used in entity serialization via `JSON.stringify()` (through method `entity.toJSON()`). You will be able to use it to manipulate with the primary key as string.
+
 See [Usage with MongoDB](usage-with-mongo.md) and [Serializing](serializing.md).
 
 ```typescript
@@ -109,19 +103,15 @@ id!: string;
 
 ### @Enum()
 
-> `@Enum()` decorator extend the `@Property()` decorator, so you can use all its 
-> parameters.
+> `@Enum()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
-`@Enum()` decorator can be used for both numeric and string enums. By default enums are 
-considered numeric, and will be represented in the database schema as `tinyint/smallint`. 
-For string enums, if you define the enum in same file, its values will be automatically 
-sniffed. 
+`@Enum()` decorator can be used for both numeric and string enums. By default enums are considered numeric, and will be represented in the database schema as `tinyint/smallint`. For string enums, if you define the enum in same file, its values will be automatically sniffed.
 
 See [Defining Entities](defining-entities.md#enums).
 
-| Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
-| `items` | `number[]` &#124; `string[]` &#124; `() => Dictionary` | yes | Specify enum items explicitly. |
+| Parameter | Type                                                   | Optional | Description                    |
+| --------- | ------------------------------------------------------ | -------- | ------------------------------ |
+| `items`   | `number[]` &#124; `string[]` &#124; `() => Dictionary` | yes      | Specify enum items explicitly. |
 
 ```typescript
 @Enum() // with ts-morph metadata provider we do not need to specify anything
@@ -142,14 +132,13 @@ enum4 = 'a';
 
 ### @Formula()
 
-`@Formula()` decorator can be used to map some SQL snippet to your entity. 
-The SQL fragment can be as complex as you want and even include subselects.
+`@Formula()` decorator can be used to map some SQL snippet to your entity. The SQL fragment can be as complex as you want and even include subselects.
 
 See [Defining Entities](defining-entities.md#formulas).
 
-| Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
-| `formula` | `string` &#124; `() => string` | no | SQL fragment that will be part of the select clause.  |
+| Parameter | Type                           | Optional | Description                                          |
+| --------- | ------------------------------ | -------- | ---------------------------------------------------- |
+| `formula` | `string` &#124; `() => string` | no       | SQL fragment that will be part of the select clause. |
 
 ```typescript
 @Formula('obj_length * obj_height * obj_width')
@@ -158,18 +147,15 @@ objectVolume?: number;
 
 ### @Index() and @Unique()
 
-Use `@Index()` to create an index, or `@Unique()` to create unique constraint. You can 
-use those decorators both on the entity level and on property level. To create compound
-index, use the decorator on the entity level and provide list of property names via the
-`properties` option.
+Use `@Index()` to create an index, or `@Unique()` to create unique constraint. You can use those decorators both on the entity level and on property level. To create compound index, use the decorator on the entity level and provide list of property names via the `properties` option.
 
 See [Defining Entities](defining-entities.md#indexes).
 
-| Parameter    | Type     | Optional | Description |
-|--------------|----------|----------|-------------|
-| `name`       | `string` | yes      | index name  |
-| `properties` | `string` &#124; `string[]` | yes | list of properties, required when using on entity level |
-| `type`       | `string` | yes      | index type, not available for `@Unique()` |
+| Parameter    | Type                       | Optional | Description                                             |
+| ------------ | -------------------------- | -------- | ------------------------------------------------------- |
+| `name`       | `string`                   | yes      | index name                                              |
+| `properties` | `string` &#124; `string[]` | yes      | list of properties, required when using on entity level |
+| `type`       | `string`                   | yes      | index type, not available for `@Unique()`               |
 
 ```typescript
 @Entity()
@@ -195,30 +181,22 @@ export class Author {
 
 ## Entity Relationships
 
-All relationship decorators have `entity`, `cascade` and `eager` optional parameters. 
-If you use the default `ReflectMetadataProvider`, then `entity` parameter might be required 
-You will be warned about it being not defined while required during discovery process if you 
-use `ReflectMetadataProvider`. 
+All relationship decorators have `entity`, `cascade` and `eager` optional parameters. If you use the default `ReflectMetadataProvider`, then `entity` parameter might be required You will be warned about it being not defined while required during discovery process if you use `ReflectMetadataProvider`.
 
-You can also use `type` parameter instead of it - the difference being that `type` parameter
-needs to be string, while in `entity` parameter you can provide a reference (wrapped in 
-a callback to overcome issues with circular dependencies) to the entity, which plays nice 
-with refactoring features in IDEs like WebStorm. 
+You can also use `type` parameter instead of it - the difference being that `type` parameter needs to be string, while in `entity` parameter you can provide a reference (wrapped in a callback to overcome issues with circular dependencies) to the entity, which plays nice with refactoring features in IDEs like WebStorm.
 
-> If you explicitly provide `entity` as a reference, it will enable type checks for other
-> reference parameters like `inversedBy` or `mappedBy`.
+> If you explicitly provide `entity` as a reference, it will enable type checks for other reference parameters like `inversedBy` or `mappedBy`.
 
 ### @ManyToOne()
 
-> `@ManyToOne()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@ManyToOne()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 Many instances of the current Entity refer to One instance of the referred Entity.
 
 See [Defining Entities](relationships.md#manytoone) for more examples.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
 | `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
 | `eager` | `boolean` | yes | Always load the relationship. |
@@ -241,15 +219,14 @@ author3?: Author;
 
 ### @OneToOne()
 
-> `@OneToOne()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@OneToOne()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 One instance of the current Entity refers to One instance of the referred Entity.
 
 See [Defining Entities](relationships.md#onetoone) for more examples, including bi-directional 1:1.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
 | `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
 | `eager` | `boolean` | yes | Always load the relationship. |
@@ -279,8 +256,7 @@ bestFriend3!: User;
 
 ### @OneToMany()
 
-> `@OneToMany()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@OneToMany()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 One instance of the current Entity has Many instances (references) to the referred Entity.
 
@@ -289,7 +265,7 @@ See [Defining Entities](relationships.md#onetomany) for more examples, including
 > You need to initialize the value with `Collection<T>` instance.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `mappedBy` | `(string & keyof T)` &#124; `(e: T) => any` | no | Point to the owning side property name. |
 | `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
 | `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
@@ -309,8 +285,7 @@ books2 = new Collection<Book>(this); // target entity type can be read via `TsMo
 
 ### @ManyToMany()
 
-> `@ManyToMany()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@ManyToMany()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 Many instances of the current Entity refers to Many instances of the referred Entity.
 
@@ -319,7 +294,7 @@ See [Defining Entities](relationships.md#manytomany) for more examples, includin
 > You need to initialize the value with `Collection<T>` instance.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
 | `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
 | `eager` | `boolean` | yes | Always load the relationship. |
@@ -343,15 +318,13 @@ tagsUnordered = new Collection<BookTag>(this); // m:n with composite PK
 
 ## Lifecycle Hooks
 
-You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of
-entity methods with them, you can also mark multiple methods with same hook.
+You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of entity methods with them, you can also mark multiple methods with same hook.
 
 > All hooks support async methods with one exception - `@OnInit`.
 
 ### @OnInit()
 
-Fired when new instance of entity is created, either manually `em.create()`, or 
-automatically when new entities are loaded from database
+Fired when new instance of entity is created, either manually `em.create()`, or automatically when new entities are loaded from database
 
 > `@OnInit` is not fired when you create the entity manually via its constructor (`new MyEntity()`)
 
@@ -375,9 +348,7 @@ async doStuffBeforeCreate() {
 
 ### @AfterCreate()
 
-Fired right after the new entity is created in the database and merged to identity map. 
-Since this event entity will have reference to `EntityManager` and will be 
-enabled to call `wrap(entity).init()` method (including all entity references and collections).
+Fired right after the new entity is created in the database and merged to identity map. Since this event entity will have reference to `EntityManager` and will be enabled to call `wrap(entity).init()` method (including all entity references and collections).
 
 ```typescript
 @AfterCreate()
@@ -399,7 +370,7 @@ async doStuffBeforeUpdate() {
 
 ### @AfterUpdate()
 
-Fired right after the entity is updated in the database. 
+Fired right after the entity is updated in the database.
 
 ```typescript
 @AfterUpdate()
@@ -410,8 +381,7 @@ async doStuffAfterUpdate() {
 
 ### @BeforeDelete()
 
-Fired right before we delete the record from database. It is fired only when
-removing entity or entity reference, not when deleting records by query. 
+Fired right before we delete the record from database. It is fired only when removing entity or entity reference, not when deleting records by query.
 
 ```typescript
 @BeforeDelete()
@@ -435,7 +405,7 @@ async doStuffAfterDelete() {
 
 ### @Repository()
 
-Used to register custom entity repository. 
+Used to register custom entity repository.
 
 > `em.getRepository()` will automatically return custom repository if it is registered.
 
@@ -450,9 +420,7 @@ export class CustomAuthorRepository extends EntityRepository<Author> {
 
 ### @Subscriber()
 
-Used to register an event subscriber. Keep in mind that you need to make sure the file 
-gets loaded in order to make this decorator registration work (e.g. you import that file 
-explicitly somewhere).
+Used to register an event subscriber. Keep in mind that you need to make sure the file gets loaded in order to make this decorator registration work (e.g. you import that file explicitly somewhere).
 
 ```typescript
 @Subscriber()

--- a/docs/versioned_docs/version-4.5/defining-entities.md
+++ b/docs/versioned_docs/version-4.5/defining-entities.md
@@ -5,43 +5,27 @@ title: Defining Entities
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Entities are simple javascript objects (so called POJO) without restrictions and without the need to extend base classes. Using [entity constructors](entity-constructors.md) works as well - they are never executed for managed entities (loaded from database). 
-Every entity is required to have a primary key.
+Entities are simple javascript objects (so called POJO) without restrictions and without the need to extend base classes. Using [entity constructors](entity-constructors.md) works as well - they are never executed for managed entities (loaded from database). Every entity is required to have a primary key.
 
 Entities can be defined in two ways:
 
-- Decorated classes - the attributes of the entity, as well as each property are provided
-  via decorators. We use `@Entity()` decorator on the class. Entity properties are decorated 
-  either with `@Property` decorator, or with one of reference decorators: 
-  `@ManyToOne`, `@OneToMany`, `@OneToOne` and `@ManyToMany`.
-  Check out the full [decorator reference](decorators.md).
-- `EntitySchema` helper - With `EntitySchema` helper we define the schema programmatically.
-  We can use regular classes as well as interfaces. This approach also allows to re-use 
-  partial entity definitions (e.g. traits/mixins). Read more about this 
-  in [Defining Entities via EntitySchema section](entity-schema.md).
+- Decorated classes - the attributes of the entity, as well as each property are provided via decorators. We use `@Entity()` decorator on the class. Entity properties are decorated either with `@Property` decorator, or with one of reference decorators: `@ManyToOne`, `@OneToMany`, `@OneToOne` and `@ManyToMany`. Check out the full [decorator reference](decorators.md).
+- `EntitySchema` helper - With `EntitySchema` helper we define the schema programmatically. We can use regular classes as well as interfaces. This approach also allows to re-use partial entity definitions (e.g. traits/mixins). Read more about this in [Defining Entities via EntitySchema section](entity-schema.md).
 
-Moreover, how the metadata extraction from decorators happens is controlled 
-via `MetadataProvider`. Two main metadata providers are:
+Moreover, how the metadata extraction from decorators happens is controlled via `MetadataProvider`. Two main metadata providers are:
 
-- `ReflectMetadataProvider` - uses `reflect-metadata` to read the property types. Faster
-  but simpler and more verbose. 
-- `TsMorphMetadataProvider` - uses `ts-morph` to read the type information from the
-  TypeScript compiled API. Heavier (requires full TS as a dependency), but allows DRY 
-  entity definition. With `ts-morph` we are able to extract the type as it is defined in
-  the code, including interface names, as well as optionality of properties. 
+- `ReflectMetadataProvider` - uses `reflect-metadata` to read the property types. Faster but simpler and more verbose.
+- `TsMorphMetadataProvider` - uses `ts-morph` to read the type information from the TypeScript compiled API. Heavier (requires full TS as a dependency), but allows DRY entity definition. With `ts-morph` we are able to extract the type as it is defined in the code, including interface names, as well as optionality of properties.
 
 Read more about them in the [Metadata Providers section](metadata-providers.md).
 
-> Current set of decorators in MikroORM is designed to work with the `tsc`. 
-> Using `babel` is also possible, but requires some additional setup. Read more about it
-> [here](usage-with-babel.md). For notes about `webpack`, read the [deployment section](deployment.md).
+> Current set of decorators in MikroORM is designed to work with the `tsc`. Using `babel` is also possible, but requires some additional setup. Read more about it [here](usage-with-babel.md). For notes about `webpack`, read the [deployment section](deployment.md).
 >
 > `ts-morph` is compatible only with the `tsc` approach.
 
 > From v3 you can also use default exports when defining your entity.
 
-Example definition of a `Book` entity follows. We can switch the tabs to see the difference
-for various ways:
+Example definition of a `Book` entity follows. We can switch the tabs to see the difference for various ways:
 
 <Tabs
   groupId="entity-def"
@@ -121,8 +105,7 @@ export const Book = new EntitySchema<IBook, BaseEntity>({
   </TabItem>
 </Tabs>
 
-Here is another example of `Author` entity, that was referenced from the `Book` one, this
-time defined for mongo:
+Here is another example of `Author` entity, that was referenced from the `Book` one, this time defined for mongo:
 
 <Tabs
   groupId="entity-def"
@@ -304,9 +287,7 @@ For an example of Vanilla JavaScript usage, take a look [here](usage-with-js.md)
 
 ## Optional Properties
 
-With the default `reflect-metadata` provider, we need to mark each optional property as `nullable: true`.
-When using `ts-morph`, if you define the property as optional (marked with `?`), this will be automatically considered
-as nullable property (mainly for SQL schema generator).
+With the default `reflect-metadata` provider, we need to mark each optional property as `nullable: true`. When using `ts-morph`, if you define the property as optional (marked with `?`), this will be automatically considered as nullable property (mainly for SQL schema generator).
 
 <Tabs
   groupId="entity-def"
@@ -348,21 +329,18 @@ properties: {
 
 We can set default value of a property in 2 ways:
 
-1. Use runtime default value of the property. This approach should be preferred as long
-as we are not using any native database function like `now()`. With this approach our
-entities will have the default value set even before it is actually persisted into the
-database (e.g. when we instantiate new entity via `new Author()` or `em.create(Author, { ... })`.
+1. Use runtime default value of the property. This approach should be preferred as long as we are not using any native database function like `now()`. With this approach our entities will have the default value set even before it is actually persisted into the database (e.g. when we instantiate new entity via `new Author()` or `em.create(Author, { ... })`.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
 @Property()
@@ -403,23 +381,20 @@ properties: {
   </TabItem>
 </Tabs>
 
-2. Use `default` parameter of `@Property` decorator. This way the actual default value
-will be provided by the database, and automatically mapped to the entity property after
-it is being persisted (after flush). To use SQL functions like `now()`, use `defaultRaw`.
+2. Use `default` parameter of `@Property` decorator. This way the actual default value will be provided by the database, and automatically mapped to the entity property after it is being persisted (after flush). To use SQL functions like `now()`, use `defaultRaw`.
 
-  > Since v4 you should use `defaultRaw` for SQL functions, as `default` with string values
-  > will be automatically quoted.
+> Since v4 you should use `defaultRaw` for SQL functions, as `default` with string values will be automatically quoted.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
 @Property({ default: 1 })
@@ -464,25 +439,22 @@ properties: {
 
 To define enum property, use `@Enum()` decorator. Enums can be either numeric or string valued.
 
-For schema generator to work properly in case of string enums, we need to define the enum
-is same file as where it is used, so its values can be automatically discovered. If we want
-to define the enum in another file, we should reexport it also in place where we use it.
+For schema generator to work properly in case of string enums, we need to define the enum is same file as where it is used, so its values can be automatically discovered. If we want to define the enum in another file, we should reexport it also in place where we use it.
 
-Another possibility is to provide the reference to the enum implementation in the decorator
-via `@Enum(() => UserRole)`.
+Another possibility is to provide the reference to the enum implementation in the decorator via `@Enum(() => UserRole)`.
 
 > You can also set enum items manually via `items: string[]` attribute.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
 import { OutsideEnum } from './OutsideEnum.ts';
@@ -578,19 +550,18 @@ properties: {
 
 ## Enum arrays
 
-We can also use array of values for enum, in that case, `EnumArrayType` type
-will be used automatically, that will validate items on flush.
+We can also use array of values for enum, in that case, `EnumArrayType` type will be used automatically, that will validate items on flush.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
 enum Role {
@@ -634,19 +605,18 @@ properties: {
 
 ## Mapping directly to primary keys
 
-Sometimes we might want to work only with the primary key of a relation.
-To do that, we can use `mapToPk` option on M:1 and 1:1 relations:
+Sometimes we might want to work only with the primary key of a relation. To do that, we can use `mapToPk` option on M:1 and 1:1 relations:
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
 @ManyToOne(() => User, { mapToPk: true })
@@ -673,19 +643,18 @@ properties: {
   </TabItem>
 </Tabs>
 
-For composite keys, this will give us ordered tuple representing the raw PKs,
-which is the internal format of composite PK:
+For composite keys, this will give us ordered tuple representing the raw PKs, which is the internal format of composite PK:
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
 @ManyToOne(() => User, { mapToPk: true })
@@ -715,19 +684,18 @@ properties: {
 
 ## Formulas
 
-`@Formula()` decorator can be used to map some SQL snippet to your entity.
-The SQL fragment can be as complex as you want and even include subselects.
+`@Formula()` decorator can be used to map some SQL snippet to your entity. The SQL fragment can be as complex as you want and even include subselects.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Box.ts"
 @Formula('obj_length * obj_height * obj_width')
@@ -755,20 +723,18 @@ properties: {
 </Tabs>
 ```
 
-Formulas will be added to the select clause automatically. In case you are facing
-problems with `NonUniqueFieldNameException`, you can define the formula as a
-callback that will receive the entity alias in the parameter:
+Formulas will be added to the select clause automatically. In case you are facing problems with `NonUniqueFieldNameException`, you can define the formula as a callback that will receive the entity alias in the parameter:
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Box.ts"
 @Formula(alias => `${alias}.obj_length * ${alias}.obj_height * ${alias}.obj_width`)
@@ -797,19 +763,18 @@ properties: {
 
 ## Indexes
 
-You can define indexes via `@Index()` decorator, for unique indexes, use `@Unique()` decorator.
-You can use it either on entity class, or on entity property:
+You can define indexes via `@Index()` decorator, for unique indexes, use `@Unique()` decorator. You can use it either on entity class, or on entity property:
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
 @Entity()
@@ -897,8 +862,7 @@ You can define custom types by extending `Type` abstract class. It has 4 optiona
 
 - `toJSON(value: any, platform: Platform): any`
 
-  Converts a value from its JS representation to its serialized JSON form of this type.
-  By default converts to the database value.
+  Converts a value from its JS representation to its serialized JSON form of this type. By default converts to the database value.
 
 - `getColumnType(prop: EntityProperty, platform: Platform): string`
 
@@ -908,20 +872,18 @@ More information can be found in [Custom Types](custom-types.md) section.
 
 ## Lazy scalar properties
 
-You can mark any property as `lazy: true` to omit it from the select clause.
-This can be handy for properties that are too large and you want to have them
-available only some times, like a full text of an article.
+You can mark any property as `lazy: true` to omit it from the select clause. This can be handy for properties that are too large and you want to have them available only some times, like a full text of an article.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Property({ columnType: 'text', lazy: true })
@@ -955,30 +917,26 @@ const b1 = await em.find(Book, 1); // this will omit the `text` property
 const b2 = await em.find(Book, 1, { populate: ['text'] }); // this will load the `text` property
 ```
 
-> If the entity is already loaded and you need to populate a lazy scalar property,
-> you might need to pass `refresh: true` in the `FindOptions`.
+> If the entity is already loaded and you need to populate a lazy scalar property, you might need to pass `refresh: true` in the `FindOptions`.
 
 ## Virtual Properties
 
 You can define your properties as virtual, either as a method, or via JavaScript `get/set`.
 
-Following example defines User entity with `firstName` and `lastName` database fields, that
-are both hidden from the serialized response, replaced with virtual properties `fullName`
-(defined as a classic method) and `fullName2` (defined as a JavaScript getter).
+Following example defines User entity with `firstName` and `lastName` database fields, that are both hidden from the serialized response, replaced with virtual properties `fullName` (defined as a classic method) and `fullName2` (defined as a JavaScript getter).
 
-> For JavaScript getter you need to provide `{ persist: false }` option otherwise the value
-> would be stored in the database.
+> For JavaScript getter you need to provide `{ persist: false }` option otherwise the value would be stored in the database.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
 @Entity()
@@ -1068,29 +1026,26 @@ console.log(wrap(author).toJSON()); // { fullName: 'Jon Snow', fullName2: 'Jon S
 
 ## Entity file names
 
-Starting with MikroORM 4.2, there is no limitation for entity file names. It is now
-also possible to define multiple entities in a single file using folder based discovery.
+Starting with MikroORM 4.2, there is no limitation for entity file names. It is now also possible to define multiple entities in a single file using folder based discovery.
 
 ## Using BaseEntity
 
-You can define your own base entity with properties that you require on all entities, like
-primary key and created/updated time. Single table inheritance is also supported.
+You can define your own base entity with properties that you require on all entities, like primary key and created/updated time. Single table inheritance is also supported.
 
 Read more about this topic in [Inheritance Mapping](inheritance-mapping.md) section.
 
-> If you are initializing the ORM via `entities` option, you need to specify all your
-> base entities as well.
+> If you are initializing the ORM via `entities` option, you need to specify all your base entities as well.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/BaseEntity.ts"
 import { v4 } from 'uuid';
@@ -1153,9 +1108,7 @@ export const schema = new EntitySchema<BaseEntity>({
   </TabItem>
 </Tabs>
 
-There is a special case, when we need to annotate the base entity - if we are using
-folder based discovery, and the base entity is not using any decorators (e.g. it does
-not define any decorated property). In that case, we need to mark it as abstract:
+There is a special case, when we need to annotate the base entity - if we are using folder based discovery, and the base entity is not using any decorators (e.g. it does not define any decorated property). In that case, we need to mark it as abstract:
 
 ```ts
 @Entity({ abstract: true })
@@ -1169,15 +1122,15 @@ export abstract class BaseEntity {
 ### Using id as primary key (SQL drivers)
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
@@ -1247,15 +1200,15 @@ export const BookSchema = new EntitySchema<Book>({
 ### Using UUID as primary key (SQL drivers)
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 import { v4 } from 'uuid';
@@ -1324,15 +1277,15 @@ export const Book = new EntitySchema<IBook>({
 Requires enabling the module via: `create extension "uuid-ossp";`
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
@@ -1394,19 +1347,18 @@ export const BookSchema = new EntitySchema<Book>({
 
 ### Using BigInt as primary key (MySQL and PostgreSQL)
 
-You can use `BigIntType` to support `bigint`s. By default, it will represent the value as
-a `string`.
+You can use `BigIntType` to support `bigint`s. By default, it will represent the value as a `string`.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/BaseEntity.ts"
 @Entity()
@@ -1448,15 +1400,15 @@ If you want to use native `bigint`s, read the following guide: [Using native Big
 ### Example of Mongo entity
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
@@ -1525,8 +1477,7 @@ export const Book = new EntitySchema<IBook>({
 
 ### Using MikroORM's BaseEntity (previously WrappedEntity)
 
-From v4 `BaseEntity` class is provided with `init`, `isInitialized`, `assign`
-and other methods that are otherwise available via the `wrap()` helper.
+From v4 `BaseEntity` class is provided with `init`, `isInitialized`, `assign` and other methods that are otherwise available via the `wrap()` helper.
 
 > Usage of the `BaseEntity` is optional.
 
@@ -1551,5 +1502,4 @@ const book = new Book();
 console.log(book.isInitialized()); // true
 ```
 
-With your entities set up, you can start [using entity manager](entity-manager.md) and
-[repositories](repositories.md) as described in following sections.
+With your entities set up, you can start [using entity manager](entity-manager.md) and [repositories](repositories.md) as described in following sections.

--- a/docs/versioned_docs/version-4.5/deployment.md
+++ b/docs/versioned_docs/version-4.5/deployment.md
@@ -2,29 +2,19 @@
 title: Deployment
 ---
 
-Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. Thanks to this, 
-defining the type is enough for runtime validation.
+Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. Thanks to this, defining the type is enough for runtime validation.
 
-This has some consequences for deployment of your application. Sometimes you will want to 
-deploy only your compiled output, without TS source files at all. In that case, discovery 
-process will probably fail. You have several options:
+This has some consequences for deployment of your application. Sometimes you will want to deploy only your compiled output, without TS source files at all. In that case, discovery process will probably fail. You have several options:
 
 ## Deploy pre-built cache
 
-By default, output of metadata discovery will be cached in `temp` folder. You can reuse this 
-cache in your deployed application. Currently the cache is saved in files named like the entity
-source file, e.g. `Author.ts` entity will store cache in `temp/Author.ts.json` file.
+By default, output of metadata discovery will be cached in `temp` folder. You can reuse this cache in your deployed application. Currently the cache is saved in files named like the entity source file, e.g. `Author.ts` entity will store cache in `temp/Author.ts.json` file.
 
-When running compiled code, JS entities will be taken into account instead, so you will need to 
-generate the cache by running the compiled code locally. That will generate `temp/Author.js.json`, 
-which is the file you will need to deploy alongside your application. 
+When running compiled code, JS entities will be taken into account instead, so you will need to generate the cache by running the compiled code locally. That will generate `temp/Author.js.json`, which is the file you will need to deploy alongside your application.
 
 ## Fill type or entity attributes everywhere
 
-What discovery process does is to sniff TS types and save their value to string, so it can be 
-used later for validation. You can skip the whole process by simply providing those values 
-manually:
+What discovery process does is to sniff TS types and save their value to string, so it can be used later for validation. You can skip the whole process by simply providing those values manually:
 
 ```typescript
 @Entity()
@@ -63,36 +53,28 @@ export enum BookStatus {
 
 ## Deploy your entity source files
 
-Usually it does not matter much that you deploy more files than needed, so the easiest way
-is to just deploy your TS source files next to the compiled output, just like during development.
+Usually it does not matter much that you deploy more files than needed, so the easiest way is to just deploy your TS source files next to the compiled output, just like during development.
 
 ## Deploy a bundle of entities and dependencies with [Webpack](https://webpack.js.org/)
 
-Webpack can be used to bundle every entity and dependency: you get a single file that contains 
-every required module/file and has no external dependencies.
+Webpack can be used to bundle every entity and dependency: you get a single file that contains every required module/file and has no external dependencies.
 
 ### Prepare your project for Webpack
 
-Webpack requires every required file to be hardcoded in your code. Code like this won't work 
-(it will throw an error because Webpack doesn't know which file to include in the bundle):
+Webpack requires every required file to be hardcoded in your code. Code like this won't work (it will throw an error because Webpack doesn't know which file to include in the bundle):
 
 ```typescript
 let dependencyNameInVariable = 'dependency';
 const dependency = import(dependencyNameInVariable);
 ```
 
-As Webpack creates a file bundle, it isn't desired that it scans directories for entities 
-or metadata. Therefore you need to provide list of entities in the `entities` option in 
-the initialization function, folder/file based discovery is not supported (see dynamically 
-including entities as an alternative solution). Also you need to fill `type` or `entity` 
-attributes everywhere (see above) and disable caching (it will decrease start-time slightly).
+As Webpack creates a file bundle, it isn't desired that it scans directories for entities or metadata. Therefore you need to provide list of entities in the `entities` option in the initialization function, folder/file based discovery is not supported (see dynamically including entities as an alternative solution). Also you need to fill `type` or `entity` attributes everywhere (see above) and disable caching (it will decrease start-time slightly).
 
 > In v4 caching is disabled by default when using `ReflectMetadataProvider`.
 
 #### Disabling dynamic file access
 
-First thing you should do is to disable dynamic file access in the discovery process via the
-`discovery.disableDynamicFileAccess` toggle. This will effectively do:
+First thing you should do is to disable dynamic file access in the discovery process via the `discovery.disableDynamicFileAccess` toggle. This will effectively do:
 
 - set metadata provider to `ReflectMetadataProvider`
 - disable caching
@@ -113,15 +95,11 @@ await MikroORM.init({
 
 #### Dynamically loading dependencies
 
-This will make use of a Webpack feature called [dynamic imports](https://webpack.js.org/guides/code-splitting/#dynamic-imports). 
-This way you can import dependencies as long as part of the path is known.
+This will make use of a Webpack feature called [dynamic imports](https://webpack.js.org/guides/code-splitting/#dynamic-imports). This way you can import dependencies as long as part of the path is known.
 
-In following example [`require.context`](https://webpack.js.org/guides/dependency-management/#requirecontext) 
-is used. This 'function' is only usable during the building process from Webpack so therefore 
-there is an alternative solution provided that will as long as the environment variable 
-WEBPACK is not set (e.g. during development with `ts-node`).
+In following example [`require.context`](https://webpack.js.org/guides/dependency-management/#requirecontext) is used. This 'function' is only usable during the building process from Webpack so therefore there is an alternative solution provided that will as long as the environment variable WEBPACK is not set (e.g. during development with `ts-node`).
 
-Here, all files with the extension `.ts` will be imported from the directory `../entities`. 
+Here, all files with the extension `.ts` will be imported from the directory `../entities`.
 
 > [`flatMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap) is a method from ECMAScript 2019 and requires [Node.js](https://nodejs.org/) 11 or higher.
 
@@ -152,10 +130,7 @@ async function getEntities(): Promise<any[]> {
 
 ### Webpack configuration
 
-Webpack can be run without [configuration file](https://webpack.js.org/configuration/) but 
-for building MikroORM and [Node.js](https://nodejs.org/) bundles it requires additional 
-configuration. Configuration for Webpack is stored in the root of the project as 
-`webpack.config.js`. For all the options please refer to the following [page](https://webpack.js.org/configuration/).
+Webpack can be run without [configuration file](https://webpack.js.org/configuration/) but for building MikroORM and [Node.js](https://nodejs.org/) bundles it requires additional configuration. Configuration for Webpack is stored in the root of the project as `webpack.config.js`. For all the options please refer to the following [page](https://webpack.js.org/configuration/).
 
 For bundling MikroORM the following configuration is required:
 
@@ -199,7 +174,7 @@ module.exports = {
           mangle: false,
           // Similarly, Terser's compression may at its own discretion change function and class names.
           // While it only rarely does so, it's safest to also disable changing their names here.
-          // This can be controlled in a more granular way if needed (see 
+          // This can be controlled in a more granular way if needed (see
           // https://terser.org/docs/api-reference.html#compress-options).
           compress: {
             keep_classnames: true,
@@ -273,6 +248,4 @@ module.exports = {
 
 ### Running Webpack
 
-To run Webpack execute `webpack` (or `npx webpack` if not installed globally) in the root 
-of the project. It will probably throw a few warnings but you can ignore the errors regarding 
-MikroORM: the mentioned pieces of code won't be executed if properly bundled with Webpack.
+To run Webpack execute `webpack` (or `npx webpack` if not installed globally) in the root of the project. It will probably throw a few warnings but you can ignore the errors regarding MikroORM: the mentioned pieces of code won't be executed if properly bundled with Webpack.

--- a/docs/versioned_docs/version-4.5/embeddables.md
+++ b/docs/versioned_docs/version-4.5/embeddables.md
@@ -5,20 +5,13 @@ sidebar_label: Embeddables
 
 > Support for embeddables was added in version 4.0
 
-Embeddables are classes which are not entities themselves, but are embedded in 
-entities and can also be queried. You'll mostly want to use them to reduce 
-duplication or separating concerns. Value objects such as date range or address 
-are the primary use case for this feature.
+Embeddables are classes which are not entities themselves, but are embedded in entities and can also be queried. You'll mostly want to use them to reduce duplication or separating concerns. Value objects such as date range or address are the primary use case for this feature.
 
-> Embeddables needs to be discovered just like regular entities, don't forget to 
-> add them to the list of entities when initializing the ORM.
+> Embeddables needs to be discovered just like regular entities, don't forget to add them to the list of entities when initializing the ORM.
 
 Embeddables can only contain properties with basic `@Property()` mapping.
 
-For the purposes of this tutorial, we will assume that you have a `User` class in 
-your application and you would like to store an address in the `User` class. We will 
-model the `Address` class as an embeddable instead of simply adding the respective 
-columns to the `User` class.
+For the purposes of this tutorial, we will assume that you have a `User` class in your application and you would like to store an address in the `User` class. We will model the `Address` class as an embeddable instead of simply adding the respective columns to the `User` class.
 
 ```typescript
 @Entity()
@@ -31,7 +24,7 @@ export class User {
 
 @Embeddable()
 export class Address {
-  
+
   @Property()
   street!: string;
 
@@ -47,17 +40,13 @@ export class Address {
 }
 ```
 
-> When using ReflectMetadataProvider, you might need to provide the class in decorator options:
-> `@Embedded(() => Address)` or `@Embedded({ entity: () => Address })`.
+> When using ReflectMetadataProvider, you might need to provide the class in decorator options: `@Embedded(() => Address)` or `@Embedded({ entity: () => Address })`.
 
-In terms of your database schema, MikroORM will automatically inline all columns from 
-the `Address` class into the table of the `User` class, just as if you had declared 
-them directly there.
+In terms of your database schema, MikroORM will automatically inline all columns from the `Address` class into the table of the `User` class, just as if you had declared them directly there.
 
 ## Initializing embeddables
 
-In case all fields in the embeddable are nullable, you might want to initialize the 
-embeddable, to avoid getting a null value instead of the embedded object.
+In case all fields in the embeddable are nullable, you might want to initialize the embeddable, to avoid getting a null value instead of the embedded object.
 
 ```typescript
 @Embedded()
@@ -68,11 +57,9 @@ address = new Address();
 
 By default, MikroORM names your columns by prefixing them, using the value object name.
 
-Following the example above, your columns would be named as `address_street`, 
-`address_postal_code`...
+Following the example above, your columns would be named as `address_street`, `address_postal_code`...
 
-You can change this behaviour to meet your needs by changing the `prefix` attribute 
-in the `@Embedded()` notation.
+You can change this behaviour to meet your needs by changing the `prefix` attribute in the `@Embedded()` notation.
 
 The following example shows you how to set your prefix to `myPrefix_`:
 
@@ -86,8 +73,7 @@ export class User {
 }
 ```
 
-To have MikroORM drop the prefix and use the value object's property name directly, 
-set `prefix: false`:
+To have MikroORM drop the prefix and use the value object's property name directly, set `prefix: false`:
 
 ```typescript
 @Entity()
@@ -101,8 +87,7 @@ export class User {
 
 ## Storing embeddables as objects
 
-From MikroORM v4.2 we can also store the embeddable as an object instead of
-inlining its properties to the owing entity.
+From MikroORM v4.2 we can also store the embeddable as an object instead of inlining its properties to the owing entity.
 
 ```ts
 @Entity()
@@ -114,17 +99,15 @@ export class User {
 }
 ```
 
-In SQL drivers, this will use a JSON column to store the value. 
+In SQL drivers, this will use a JSON column to store the value.
 
 > Only MySQL and PostgreSQL drivers support searching by JSON properties currently.
 
-> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/embeddables.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/embeddables.html) as the behaviour here is pretty much the same.
 
 ## Array of embeddables
 
-Embedded arrays are always stored as JSON. It is possible to use them inside
-nested embeddables. 
+Embedded arrays are always stored as JSON. It is possible to use them inside nested embeddables.
 
 ```ts
   @Embedded(() => Address, { array: true })

--- a/docs/versioned_docs/version-4.5/entity-constructors.md
+++ b/docs/versioned_docs/version-4.5/entity-constructors.md
@@ -2,12 +2,9 @@
 title: Using Entity Constructors
 ---
 
-Internally, `MikroORM` never calls entity constructor, so you are free to use it as you wish.
-The constructor will be called only when you instantiate the class yourself via `new` operator,
-so it is a handy place to require your data when creating new entity.
+Internally, `MikroORM` never calls entity constructor, so you are free to use it as you wish. The constructor will be called only when you instantiate the class yourself via `new` operator, so it is a handy place to require your data when creating new entity.
 
-For example following `Book` entity definition will always require to set `title` and `author`, 
-but `publisher` will be optional:
+For example following `Book` entity definition will always require to set `title` and `author`, but `publisher` will be optional:
 
 ```typescript
 @Entity()
@@ -38,7 +35,4 @@ export class Book {
 
 ## Using native private properties
 
-If we want to use native private properties inside entities, the default approach of
-how MikroORM creates entity instances via `Object.create()` is not viable (more about this
-in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity
-constructors, we can use [`forceEntityConstructor`](./configuration.md#using-native-private-properties) toggle.
+If we want to use native private properties inside entities, the default approach of how MikroORM creates entity instances via `Object.create()` is not viable (more about this in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity constructors, we can use [`forceEntityConstructor`](./configuration.md#using-native-private-properties) toggle.

--- a/docs/versioned_docs/version-4.5/entity-generator.md
+++ b/docs/versioned_docs/version-4.5/entity-generator.md
@@ -2,9 +2,9 @@
 title: Entity Generator
 ---
 
-To generate entities from existing database schema, you can use `EntityGenerator` helper. 
+To generate entities from existing database schema, you can use `EntityGenerator` helper.
 
-You can use it via CLI: 
+You can use it via CLI:
 
 ```sh
 npx mikro-orm generate-entities --dump  # Dumps all generated entities
@@ -19,14 +19,14 @@ import { MikroORM } from '@mikro-orm/core';
 (async () => {
   const orm = await MikroORM.init({
     discovery: {
-      // we need to disable validation for no entities 
+      // we need to disable validation for no entities
       warnWhenNoEntities: false,
     },
     dbName: 'your-db-name',
     // ...
   });
   const generator = orm.getEntityGenerator();
-  const dump = await generator.generate({ 
+  const dump = await generator.generate({
     save: true,
     baseDir: process.cwd() + '/my-entities',
   });

--- a/docs/versioned_docs/version-4.5/entity-helper.md
+++ b/docs/versioned_docs/version-4.5/entity-helper.md
@@ -5,10 +5,7 @@ sidebar_label: Updating Entity Values
 
 ## Updating Entity Values with `entity.assign()`
 
-When you want to update entity based on user input, you will usually have just plain
-string ids of entity relations as user input. Normally you would need to use 
-`em.getReference()` to create references from each id first, and then
-use those references to update entity relations:
+When you want to update entity based on user input, you will usually have just plain string ids of entity relations as user input. Normally you would need to use `em.getReference()` to create references from each id first, and then use those references to update entity relations:
 
 ```typescript
 const jon = new Author('Jon Snow', 'snow@wall.st');
@@ -21,8 +18,8 @@ Same result can be easily achieved with `entity.assign()`:
 ```typescript
 import { wrap } from '@mikro-orm/core';
 
-wrap(book).assign({ 
-  title: 'Better Book 1', 
+wrap(book).assign({
+  title: 'Better Book 1',
   author: '...id...',
 });
 console.log(book.title); // 'Better Book 1'
@@ -30,22 +27,19 @@ console.log(book.author); // instance of Author with id: '...id...'
 console.log(book.author.id); // '...id...'
 ```
 
-To use `entity.assign()` on not managed entities, you need to provide `EntityManager` 
-instance explicitly: 
+To use `entity.assign()` on not managed entities, you need to provide `EntityManager` instance explicitly:
 
 ```typescript
 import { wrap } from '@mikro-orm/core';
 
 const book = new Book();
-wrap(book).assign({ 
-  title: 'Better Book 1', 
+wrap(book).assign({
+  title: 'Better Book 1',
   author: '...id...',
 }, { em: orm.em });
 ```
 
-By default, `entity.assign(data)` behaves same way as `Object.assign(entity, data)`, 
-e.g. it does not merge things recursively. To enable deep merging of object properties (not referenced entities), 
-use second parameter to enable `mergeObjects` flag:
+By default, `entity.assign(data)` behaves same way as `Object.assign(entity, data)`, e.g. it does not merge things recursively. To enable deep merging of object properties (not referenced entities), use second parameter to enable `mergeObjects` flag:
 
 ```typescript
 import { wrap } from '@mikro-orm/core';
@@ -79,8 +73,7 @@ console.log(book.author === authorEntity) // false
 
 ## `WrappedEntity` and `wrap()` helper
 
-`IWrappedEntity` is an interface that defines public helper methods provided 
-by the ORM:
+`IWrappedEntity` is an interface that defines public helper methods provided by the ORM:
 
 ```typescript
 interface IWrappedEntity<T, PK extends keyof T> {
@@ -94,19 +87,11 @@ interface IWrappedEntity<T, PK extends keyof T> {
 }
 ```
 
-There are two ways to access those methods. You can either extend `BaseEntity` 
-(exported from `@mikro-orm/core`), that defines those methods, or use the 
-`wrap()` helper to access `WrappedEntity` instance, where those methods
-exist.
+There are two ways to access those methods. You can either extend `BaseEntity` (exported from `@mikro-orm/core`), that defines those methods, or use the `wrap()` helper to access `WrappedEntity` instance, where those methods exist.
 
-Users can choose whether they are fine with polluting the entity interface with 
-those additional methods, or they want to keep the interface clean 
-and use the `wrap(entity)` helper method instead to access them. 
+Users can choose whether they are fine with polluting the entity interface with those additional methods, or they want to keep the interface clean and use the `wrap(entity)` helper method instead to access them.
 
-> Since v4 `wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is 
-> being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...),
-> if you want to access internal properties like `__meta` or `__em`, you need to explicitly
-> ask for the helper via `wrap(entity, true)`.
+> Since v4 `wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...), if you want to access internal properties like `__meta` or `__em`, you need to explicitly ask for the helper via `wrap(entity, true)`.
 
 ```typescript
 import { BaseEntity } from '@mikro-orm/core';
@@ -125,9 +110,7 @@ console.log(book.meta); // { foo: 3, bar: 2 }
 
 ### Accessing internal prefixed properties
 
-Previously it was possible to access internal properties like `__meta` or `__em` 
-from the `wrap()` helper. Now to access them, you need to use second parameter of
-wrap:
+Previously it was possible to access internal properties like `__meta` or `__em` from the `wrap()` helper. Now to access them, you need to use second parameter of wrap:
 
 ```typescript
 @Entity()

--- a/docs/versioned_docs/version-4.5/entity-manager-api.md
+++ b/docs/versioned_docs/version-4.5/entity-manager-api.md
@@ -6,26 +6,25 @@ title: EntityManager API
 
 Gets the Driver instance used by this EntityManager
 
-----
+---
 
 #### `getConnection(type?: 'read' | 'write'): ReturnType<D['getConnection']>`
 
 Gets the Connection instance, by default returns write connection
 
-----
+---
 
 #### `getRepository(entityName: EntityName<T>): GetRepository<T, U>`
 
-Returns `EntityRepository` for given entity, respects `customRepository` option of `@Entity`
-and `entityRepository` option of `MikroORM.init()`.
+Returns `EntityRepository` for given entity, respects `customRepository` option of `@Entity` and `entityRepository` option of `MikroORM.init()`.
 
-----
+---
 
 #### `getValidator(): EntityValidator`
 
 Gets EntityValidator instance
 
-----
+---
 
 #### `find(entityName: EntityName<T>, where: FilterQuery<T>, options?: FindOptions<T, P>): Promise<Loaded<T, P>[]>`
 
@@ -49,248 +48,231 @@ export interface FindOptions<T, P extends Populate<T> = Populate<T>> {
 }
 ```
 
-----
+---
 
 #### `find(entityName: EntityName<T>, where: FilterQuery<T>, populate?: P, orderBy?: QueryOrderMap, limit?: number, offset?: number): Promise<Loaded<T, P>[]>`
 
-Finds all entities matching your `where` query.
-Same as previous `find` method, just with dedicated parameters for `populate`, `orderBy`, `limit`
-and `offset`.
+Finds all entities matching your `where` query. Same as previous `find` method, just with dedicated parameters for `populate`, `orderBy`, `limit` and `offset`.
 
-----
+---
 
 #### `addFilter(name: string, cond: FilterQuery<T> | ((args: Dictionary) => FilterQuery<T>), entityName?: EntityName<T>[], enabled?: boolean): void`
 
-----
+---
 
 #### `setFilterParams(name: string, args: Dictionary): void`
 
-----
+---
 
 #### `getFilterParams<T extends Dictionary = Dictionary>(name: string): T`
 
-----
+---
 
 #### `findAndCount(entityName: EntityName<T>, where: FilterQuery<T>, options?: FindOptions<T, P>): Promise<[Loaded<T, P>[], number]>`
 
-Calls `em.find()` and `em.count()` with the same arguments (where applicable) and returns the results as tuple
-where first element is the array of entities and the second is the count.
+Calls `em.find()` and `em.count()` with the same arguments (where applicable) and returns the results as tuple where first element is the array of entities and the second is the count.
 
-----
+---
 
 #### `findAndCount(entityName: EntityName<T>, where: FilterQuery<T>, populate?: P, orderBy?: QueryOrderMap, limit?: number, offset?: number): Promise<[Loaded<T, P>[], number]>`
 
-Calls `em.find()` and `em.count()` with the same arguments (where applicable) and returns the results as tuple
-where first element is the array of entities and the second is the count.
+Calls `em.find()` and `em.count()` with the same arguments (where applicable) and returns the results as tuple where first element is the array of entities and the second is the count.
 
-----
+---
 
 #### `findOne(entityName: EntityName<T>, where: FilterQuery<T>, options?: FindOneOptions<T, P>): Promise<Loaded<T, P> | null>`
 
 Finds first entity matching your `where` query.
 
-----
+---
 
 #### `findOne(entityName: EntityName<T>, where: FilterQuery<T>, populate?: P, orderBy?: QueryOrderMap): Promise<Loaded<T, P> | null>`
 
 Finds first entity matching your `where` query.
 
-----
+---
 
 #### `findOneOrFail(entityName: EntityName<T>, where: FilterQuery<T>, options?: FindOneOrFailOptions<T, P>): Promise<Loaded<T, P>>`
 
-Finds first entity matching your `where` query. If nothing found, it will throw an error.
-You can override the factory for creating this method via `options.failHandler` locally
-or via `Configuration.findOneOrFailHandler` globally.
+Finds first entity matching your `where` query. If nothing found, it will throw an error. You can override the factory for creating this method via `options.failHandler` locally or via `Configuration.findOneOrFailHandler` globally.
 
 Finds first entity matching your `where` query. If nothing found, it will throw an error.
 
-----
+---
 
 #### `findOneOrFail(entityName: EntityName<T>, where: FilterQuery<T>, populate?: P, orderBy?: QueryOrderMap): Promise<Loaded<T, P>>`
 
-You can override the factory for creating this method via `options.failHandler` locally
-or via `Configuration.findOneOrFailHandler` globally.
+You can override the factory for creating this method via `options.failHandler` locally or via `Configuration.findOneOrFailHandler` globally.
 
-----
+---
 
 #### `transactional(cb: (em: D[typeof EntityManagerType]) => Promise<T>, ctx?: any): Promise<T>`
 
 Runs your callback wrapped inside a database transaction.
 
-----
+---
 
 #### `begin(ctx?: Transaction): Promise<void>`
 
 Starts new transaction bound to this EntityManager. Use `ctx` parameter to provide the parent when nesting transactions.
 
-----
+---
 
 #### `commit(): Promise<void>`
 
 Commits the transaction bound to this EntityManager. Flushes before doing the actual commit query.
 
-----
+---
 
 #### `rollback(): Promise<void>`
 
 Rollbacks the transaction bound to this EntityManager.
 
-----
+---
 
 #### `lock(entity: AnyEntity, lockMode: LockMode, lockVersion?: number | Date): Promise<void>`
 
 Runs your callback wrapped inside a database transaction.
 
-----
+---
 
 #### `nativeInsert(entity: T): Promise<Primary<T>>`
 
 Fires native insert query. Calling this has no side effects on the context (identity map).
 
-----
+---
 
 #### `nativeInsert(entityName: EntityName<T>, data: EntityData<T>): Promise<Primary<T>>`
 
 Fires native insert query. Calling this has no side effects on the context (identity map).
 
-----
+---
 
 #### `nativeUpdate(entityName: EntityName<T>, where: FilterQuery<T>, data: EntityData<T>, options?: UpdateOptions<T>): Promise<number>`
 
 Fires native update query. Calling this has no side effects on the context (identity map).
 
-----
+---
 
 #### `nativeDelete(entityName: EntityName<T>, where: FilterQuery<T>, options?: DeleteOptions<T>): Promise<number>`
 
 Fires native delete query. Calling this has no side effects on the context (identity map).
 
-----
+---
 
 #### `map(entityName: EntityName<T>, result: EntityData<T>): T`
 
-Maps raw DB result to entity, adding it to current Identity Map. Equivalent to 
-`driver.mapResult()` followed by `em.merge()`.
+Maps raw DB result to entity, adding it to current Identity Map. Equivalent to `driver.mapResult()` followed by `em.merge()`.
 
-----
+---
 
 #### `merge(entity: T, refresh?: boolean): T`
 
-Merges given entity to this EntityManager so it becomes managed. You can force refreshing of existing entities
-via second parameter. By default it will return already loaded entities without modifying them.
+Merges given entity to this EntityManager so it becomes managed. You can force refreshing of existing entities via second parameter. By default it will return already loaded entities without modifying them.
 
-This is useful when you want to work with cached entities. 
+This is useful when you want to work with cached entities.
 
-----
+---
 
 #### `merge(entityName: EntityName<T>, data: EntityData<T>, refresh?: boolean, convertCustomTypes?: boolean): T`
 
-Merges given entity to this EntityManager so it becomes managed. You can force refreshing of existing entities
-via second parameter. By default it will return already loaded entities without modifying them.
+Merges given entity to this EntityManager so it becomes managed. You can force refreshing of existing entities via second parameter. By default it will return already loaded entities without modifying them.
 
-----
+---
 
 #### `create(entityName: EntityName<T>, data: EntityData<T>): New<T, P>`
 
 Creates new instance of given entity and populates it with given data
 
-----
+---
 
 #### `assign(entity: T, data: EntityData<T>, options?: AssignOptions): T`
 
 Shortcut for `wrap(entity).assign(data, { em })`
 
-----
+---
 
 #### `getReference(entityName: EntityName<T>, id: Primary<T>, wrapped?: boolean, convertCustomTypes?: boolean): T | Reference<T>`
 
 Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
 
-----
+---
 
 #### `count(entityName: EntityName<T>, where?: FilterQuery<T>, options?: CountOptions<T>): Promise<number>`
 
 Returns total number of entities matching your `where` query.
 
-----
+---
 
 #### `persist(entity: AnyEntity | Reference<AnyEntity> | (AnyEntity | Reference<AnyEntity>)[]): this`
 
-Tells the EntityManager to make an instance managed and persistent.
-The entity will be entered into the database at or before transaction commit or as a result of the flush operation.
+Tells the EntityManager to make an instance managed and persistent. The entity will be entered into the database at or before transaction commit or as a result of the flush operation.
 
-----
+---
 
 #### `persistAndFlush(entity: AnyEntity | Reference<AnyEntity> | (AnyEntity | Reference<AnyEntity>)[]): Promise<void>`
 
-Persists your entity immediately, flushing all not yet persisted changes to the database too.
-Equivalent to `em.persist(e).flush()`.
+Persists your entity immediately, flushing all not yet persisted changes to the database too. Equivalent to `em.persist(e).flush()`.
 
-----
+---
 
 #### `persistLater(entity: AnyEntity | AnyEntity[]): void`
 
 > deprecated, use `persist()`
 
-Tells the EntityManager to make an instance managed and persistent.
-The entity will be entered into the database at or before transaction commit or as a result of the flush operation.
+Tells the EntityManager to make an instance managed and persistent. The entity will be entered into the database at or before transaction commit or as a result of the flush operation.
 
-----
+---
 
 #### `remove(entity: T | Reference<T> | (T | Reference<T>)[]): this`
 
-Marks entity for removal.
-A removed entity will be removed from the database at or before transaction commit or as a result of the flush operation.
+Marks entity for removal. A removed entity will be removed from the database at or before transaction commit or as a result of the flush operation.
 
-This method fires `beforeDelete` and `afterDelete` hooks.  
+This method fires `beforeDelete` and `afterDelete` hooks.
 
 To remove entities by condition, use `em.nativeDelete()`.
 
-----
+---
 
 #### `removeAndFlush(entity: AnyEntity | Reference<AnyEntity>): Promise<void>`
 
-Removes an entity instance immediately, flushing all not yet persisted changes to the database too.
-Equivalent to `em.remove(e).flush()`
+Removes an entity instance immediately, flushing all not yet persisted changes to the database too. Equivalent to `em.remove(e).flush()`
 
-This method fires `beforeDelete` and `afterDelete` hooks.  
+This method fires `beforeDelete` and `afterDelete` hooks.
 
-----
+---
 
 #### `removeLater(entity: AnyEntity): void`
 
 > deprecated use `remove()`
 
-Marks entity for removal.
-A removed entity will be removed from the database at or before transaction commit or as a result of the flush operation.
+Marks entity for removal. A removed entity will be removed from the database at or before transaction commit or as a result of the flush operation.
 
-----
+---
 
 #### `flush(): Promise<void>`
 
-Flushes all changes to objects that have been queued up to now to the database.
-This effectively synchronizes the in-memory state of managed objects with the database.
+Flushes all changes to objects that have been queued up to now to the database. This effectively synchronizes the in-memory state of managed objects with the database.
 
-----
+---
 
 #### `clear(): void`
 
 Clears the EntityManager. All entities that are currently managed by this EntityManager become detached.
 
-----
+---
 
 #### `canPopulate(entityName: EntityName<T>, property: string): boolean`
 
 Checks whether given property can be populated on the entity.
 
-----
+---
 
 #### `populate(entities: T | T[], populate: P, where?: FilterQuery<T>, orderBy?: QueryOrderMap, refresh?: boolean, validate?: boolean): Promise<Loaded<T, P> | Loaded<T, P>[]>`
 
 Populate existing entities. Supports nested (conditional) populating.
 
-----
+---
 
 #### `fork(clear?: boolean, useContext?: boolean): D[typeof EntityManagerType]`
 
@@ -301,42 +283,42 @@ Returns new EntityManager instance with its own identity map
 @param useContext use request context? should be used only for top level request scope EM, defaults to false
 ```
 
-----
+---
 
 #### `getUnitOfWork(): UnitOfWork`
 
 Gets the UnitOfWork used by the EntityManager to coordinate operations.
 
-----
+---
 
 #### `getEntityFactory(): EntityFactory`
 
 Gets the EntityFactory used by the EntityManager.
 
-----
+---
 
 #### `getEventManager(): EventManager`
 
-----
+---
 
 #### `isInTransaction(): boolean`
 
 Checks whether this EntityManager is currently operating inside a database transaction.
 
-----
+---
 
 #### `getTransactionContext<T extends Transaction = Transaction>(): T | undefined`
 
 Gets the transaction context (driver dependent object used to make sure queries are executed on same connection).
 
-----
+---
 
 #### `getMetadata(): MetadataStorage`
 
 Gets the MetadataStorage.
 
-----
+---
 
 #### `getComparator(): EntityComparator`
 
-----
+---

--- a/docs/versioned_docs/version-4.5/entity-manager.md
+++ b/docs/versioned_docs/version-4.5/entity-manager.md
@@ -5,21 +5,13 @@ sidebar_label: Entity Manager
 
 ## Persist and Flush
 
-There are 2 methods we should first describe to understand how persisting works in MikroORM: 
-`em.persist()` and `em.flush()`.
+There are 2 methods we should first describe to understand how persisting works in MikroORM: `em.persist()` and `em.flush()`.
 
-`em.persist(entity)` is used to mark new entities for future persisting. 
-It will make the entity managed by given `EntityManager` and once `flush` will be called, it 
-will be written to the database. 
+`em.persist(entity)` is used to mark new entities for future persisting. It will make the entity managed by given `EntityManager` and once `flush` will be called, it will be written to the database.
 
-To understand `flush`, lets first define what managed entity is: An entity is managed if 
-it’s fetched from the database (via `em.find()`, `em.findOne()` or via other managed entity) 
-or registered as new through `em.persist()`.
+To understand `flush`, lets first define what managed entity is: An entity is managed if it’s fetched from the database (via `em.find()`, `em.findOne()` or via other managed entity) or registered as new through `em.persist()`.
 
-`em.flush()` will go through all managed entities, compute appropriate change sets and 
-perform according database queries. As an entity loaded from database becomes managed 
-automatically, you do not have to call persist on those, and flush is enough to update 
-them.
+`em.flush()` will go through all managed entities, compute appropriate change sets and perform according database queries. As an entity loaded from database becomes managed automatically, you do not have to call persist on those, and flush is enough to update them.
 
 ```typescript
 const book = await orm.em.findOne(Book, 1);
@@ -31,9 +23,7 @@ await orm.em.flush();
 
 ## Persisting and Cascading
 
-To save entity state to database, you need to persist it. Persist determines 
-whether to use `insert` or `update` and computes appropriate change-set. Entity references
-that are not persisted yet (does not have identifier) will be cascade persisted automatically. 
+To save entity state to database, you need to persist it. Persist determines whether to use `insert` or `update` and computes appropriate change-set. Entity references that are not persisted yet (does not have identifier) will be cascade persisted automatically.
 
 ```typescript
 // use constructors in your entities for required parameters
@@ -55,13 +45,13 @@ await orm.em.persistAndFlush([book1, book2, book3]);
 // or one by one
 orm.em.persist(book1);
 orm.em.persist(book2);
-orm.em.persist(book3); 
+orm.em.persist(book3);
 await orm.em.flush(); // flush everything to database at once
 ```
 
 ## Fetching Entities with EntityManager
 
-To fetch entities from database you can use `find()` and `findOne()` of `EntityManager`: 
+To fetch entities from database you can use `find()` and `findOne()` of `EntityManager`:
 
 Example:
 
@@ -91,23 +81,20 @@ To populate entity relations, you can use `populate` parameter.
 const books = await orm.em.find(Book, { foo: 1 }, ['author.friends']);
 ```
 
-You can also use `em.populate()` helper to populate relations (or to ensure they 
-are fully populated) on already loaded entities. This is also handy when loading 
-entities via `QueryBuilder`:
+You can also use `em.populate()` helper to populate relations (or to ensure they are fully populated) on already loaded entities. This is also handy when loading entities via `QueryBuilder`:
 
 ```typescript
 const authors = await orm.em.createQueryBuilder(Author).select('*').getResult();
 await em.populate(authors, ['books.tags']);
 
-// now your Author entities will have `books` collections populated, 
+// now your Author entities will have `books` collections populated,
 // as well as they will have their `tags` collections populated.
 console.log(authors[0].books[0].tags[0]); // initialized BookTag
 ```
 
 ### Conditions Object (`FilterQuery<T>`)
 
-Querying entities via conditions object (`where` in `em.find(Entity, where: FilterQuery<T>)`) 
-supports many different ways:
+Querying entities via conditions object (`where` in `em.find(Entity, where: FilterQuery<T>)`) supports many different ways:
 
 ```typescript
 // search by entity properties
@@ -135,23 +122,19 @@ const users = await orm.em.find(User, [1, 2, 3, 4, 5]);
 const user1 = await orm.em.findOne(User, 1);
 ```
 
-As you can see in the fifth example, one can also use operators like `$and`, `$or`, `$gte`, 
-`$gt`, `$lte`, `$lt`, `$in`, `$nin`, `$eq`, `$ne`, `$like`, `$re`. More about that can be found in 
-[Query Conditions](query-conditions.md) section.
+As you can see in the fifth example, one can also use operators like `$and`, `$or`, `$gte`, `$gt`, `$lte`, `$lt`, `$in`, `$nin`, `$eq`, `$ne`, `$like`, `$re`. More about that can be found in [Query Conditions](query-conditions.md) section.
 
 #### Using custom FilterQuery DTO
+
 If you decide to abstract the filter options in your own object then you might run into the problem that the find option does not return the results you'd expect. This is due to the fact that the FilterQuery should be provided as a POJO (Plain Old JS Object `{}`).
 
 If you want to provide your own FilterQuery DTO, then your DTO class should extend the `PlainObject` class. This way MikroORM knows it should be treated as such.
 
 #### Mitigating `Type instantiation is excessively deep and possibly infinite.ts(2589)` error
 
-Sometimes you might be facing TypeScript errors caused by too complex query for it to 
-properly infer all types. Usually it can be solved by providing the type argument 
-explicitly.
+Sometimes you might be facing TypeScript errors caused by too complex query for it to properly infer all types. Usually it can be solved by providing the type argument explicitly.
 
-You can also opt in to use repository instead, as there the type inference should not be
-problematic. 
+You can also opt in to use repository instead, as there the type inference should not be problematic.
 
 > As a last resort, you can always type cast the query to `any`.
 
@@ -163,16 +146,11 @@ const books = await orm.em.getRepository(Book).find({ ... your complex query ...
 const books = await orm.em.find<any>(Book, { ... your complex query ... }) as Book[];
 ```
 
-Another problem you might be facing is `RangeError: Maximum call stack size exceeded` error 
-thrown during TypeScript compilation (usually from file `node_modules/typescript/lib/typescript.js`).
-The solution to this is the same, just provide the type argument explicitly.
+Another problem you might be facing is `RangeError: Maximum call stack size exceeded` error thrown during TypeScript compilation (usually from file `node_modules/typescript/lib/typescript.js`). The solution to this is the same, just provide the type argument explicitly.
 
 ### Searching by referenced entity fields
 
-You can also search by referenced entity properties. Simply pass nested where condition like 
-this and all requested relationships will be automatically joined. Currently it will only join 
-them so you can search and sort by those. To populate entities, do not forget to pass the populate 
-parameter as well. 
+You can also search by referenced entity properties. Simply pass nested where condition like this and all requested relationships will be automatically joined. Currently it will only join them so you can search and sort by those. To populate entities, do not forget to pass the populate parameter as well.
 
 ```typescript
 // find author of a book that has tag specified by name
@@ -185,9 +163,7 @@ console.log(author.books[0].tags.isInitialized()); // true, because it was popul
 console.log(author.books[0].tags[0].isInitialized()); // true, because it was populated
 ```
 
-> This feature is fully available only for SQL drivers. In MongoDB always you need to 
-> query from the owning side - so in the example above, first load book tag by name,
-> then associated book, then the author. Another option is to denormalize the schema.  
+> This feature is fully available only for SQL drivers. In MongoDB always you need to query from the owning side - so in the example above, first load book tag by name, then associated book, then the author. Another option is to denormalize the schema.
 
 ### Fetching Partial Entities
 
@@ -220,23 +196,18 @@ It is also possible to use multiple levels:
 const author = await orm.em.findOne(Author, '...', { fields: ['name', { books: ['title', 'price', 'author', { author: ['email'] }] }] });
 ```
 
-Primary keys are always selected even if you omit them. On the other hand, you are responsible 
-for selecting the FKs - if you omit such property, the relation might not be loaded properly.
-In the following example the books would not be linked the author, because we did not specify 
-the `books.author` field to be loaded.
+Primary keys are always selected even if you omit them. On the other hand, you are responsible for selecting the FKs - if you omit such property, the relation might not be loaded properly. In the following example the books would not be linked the author, because we did not specify the `books.author` field to be loaded.
 
 ```ts
 // this will load both author and book entities, but they won't be connected due to the missing FK in select
 const author = await orm.em.findOne(Author, '...', { fields: ['name', { books: ['title', 'price'] });
 ```
 
-> Same problem can occur in mongo with M:N collections - those are stored as array property 
-> on the owning entity, so you need to make sure to mark such properties too.
+> Same problem can occur in mongo with M:N collections - those are stored as array property on the owning entity, so you need to make sure to mark such properties too.
 
 ### Fetching Paginated Results
 
-If you are going to paginate your results, you can use `em.findAndCount()` that will return
-total count of entities before applying limit and offset.
+If you are going to paginate your results, you can use `em.findAndCount()` that will return total count of entities before applying limit and offset.
 
 ```typescript
 const [authors, count] = await orm.em.findAndCount(Author, { ... }, { limit: 10, offset: 50 });
@@ -246,8 +217,7 @@ console.log(count); // total count, e.g. 1327
 
 ### Handling Not Found Entities
 
-When you call `em.findOne()` and no entity is found based on your criteria, `null` will be 
-returned. If you rather have an `Error` instance thrown, you can use `em.findOneOrFail()`:
+When you call `em.findOne()` and no entity is found based on your criteria, `null` will be returned. If you rather have an `Error` instance thrown, you can use `em.findOneOrFail()`:
 
 ```typescript
 const author = await orm.em.findOne(Author, { name: 'does-not-exist' });
@@ -261,8 +231,7 @@ try {
 }
 ```
 
-You can customize the error either globally via `findOneOrFailHandler` option, or locally via 
-`failHandler` option in `findOneOrFail` call.
+You can customize the error either globally via `findOneOrFailHandler` option, or locally via `failHandler` option in `findOneOrFail` call.
 
 ```typescript
 try {
@@ -278,8 +247,7 @@ try {
 
 It is possible to use any SQL fragment in your `WHERE` query or `ORDER BY` clause:
 
-> The `expr()` helper is an identity function - all it does is to return its parameter.
-> We can use it to bypass the strict type checks in `FilterQuery`.
+> The `expr()` helper is an identity function - all it does is to return its parameter. We can use it to bypass the strict type checks in `FilterQuery`.
 
 ```ts
 const users = await orm.em.find(User, { [expr('lower(email)')]: 'foo@bar.baz' }, {
@@ -290,7 +258,7 @@ const users = await orm.em.find(User, { [expr('lower(email)')]: 'foo@bar.baz' },
 This will produce following query:
 
 ```sql
-select `e0`.* 
+select `e0`.*
 from `user` as `e0`
 where lower(email) = 'foo@bar.baz'
 order by (point(loc_latitude, loc_longitude) <@> point(0, 0)) asc
@@ -298,13 +266,9 @@ order by (point(loc_latitude, loc_longitude) <@> point(0, 0)) asc
 
 ## Disabling identity map and change set tracking
 
-Sometimes we might want to disable identity map and change set tracking for some query.
-This is possible via `disableIdentityMap` option. Behind the scenes, it will create new 
-context, load the entities inside that, and clear it afterwards, so the main identity map
-will stay clean.
+Sometimes we might want to disable identity map and change set tracking for some query. This is possible via `disableIdentityMap` option. Behind the scenes, it will create new context, load the entities inside that, and clear it afterwards, so the main identity map will stay clean.
 
-> As opposed to _managed_ entities, such entities are called _detached_. 
-> To be able to work with them, you first need to merge them via `em.registerManaged()`. 
+> As opposed to _managed_ entities, such entities are called _detached_. To be able to work with them, you first need to merge them via `em.registerManaged()`.
 
 ```ts
 const users = await orm.em.find(User, { email: 'foo@bar.baz' }, {
@@ -312,16 +276,14 @@ const users = await orm.em.find(User, { email: 'foo@bar.baz' }, {
   populate: { cars: { brand: true } },
 });
 users[0].name = 'changed';
-await orm.em.flush(); // calling flush have no effect, as the entity is not managed  
+await orm.em.flush(); // calling flush have no effect, as the entity is not managed
 ```
 
-> Keep in mind that this can also have 
-> [negative effect on the performance](https://stackoverflow.com/questions/9259480/entity-framework-mergeoption-notracking-bad-performance).
+> Keep in mind that this can also have [negative effect on the performance](https://stackoverflow.com/questions/9259480/entity-framework-mergeoption-notracking-bad-performance).
 
 ## Type of Fetched Entities
 
-Both `em.find` and `em.findOne()` methods have generic return types.
-All of following examples are equal and will let typescript correctly infer the entity type:
+Both `em.find` and `em.findOne()` methods have generic return types. All of following examples are equal and will let typescript correctly infer the entity type:
 
 ```typescript
 const author1 = await orm.em.findOne<Author>(Author.name, '...id...');
@@ -329,15 +291,10 @@ const author2 = await orm.em.findOne<Author>('Author', '...id...');
 const author3 = await orm.em.findOne(Author, '...id...');
 ```
 
-As the last one is the least verbose, it should be preferred. 
+As the last one is the least verbose, it should be preferred.
 
 ## Entity Repositories
 
-Although you can use `EntityManager` directly, much more convenient way is to use 
-[`EntityRepository` instead](https://mikro-orm.io/repositories/). You can register
-your repositories in dependency injection container like [InversifyJS](http://inversify.io/)
-so you do not need to get them from `EntityManager` each time.
+Although you can use `EntityManager` directly, much more convenient way is to use [`EntityRepository` instead](https://mikro-orm.io/repositories/). You can register your repositories in dependency injection container like [InversifyJS](http://inversify.io/) so you do not need to get them from `EntityManager` each time.
 
-For more examples, take a look at
-[`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts)
-or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).
+For more examples, take a look at [`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts) or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).

--- a/docs/versioned_docs/version-4.5/entity-references.md
+++ b/docs/versioned_docs/version-4.5/entity-references.md
@@ -6,12 +6,9 @@ sidebar_label: Entity References and Reference<T> Wrapper
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Every single entity relation is mapped to an entity reference. Reference is an entity that has
-only its identifier. This reference is stored in identity map so you will get the same object 
-reference when fetching the same document from database.
+Every single entity relation is mapped to an entity reference. Reference is an entity that has only its identifier. This reference is stored in identity map so you will get the same object reference when fetching the same document from database.
 
-You can call `await wrap(entity).init()` to initialize the entity. This will trigger database call 
-and populate itself, keeping the same reference in identity map. 
+You can call `await wrap(entity).init()` to initialize the entity. This will trigger database call and populate itself, keeping the same reference in identity map.
 
 ```typescript
 const author = orm.em.getReference('...id...');
@@ -26,8 +23,7 @@ console.log(author.name); // defined
 
 ## Better Type-safety with `Reference<T>` Wrapper
 
-When you define `@ManyToOne` and `@OneToOne` properties on your entity, TypeScript compiler
-will think that desired entities are always loaded:
+When you define `@ManyToOne` and `@OneToOne` properties on your entity, TypeScript compiler will think that desired entities are always loaded:
 
 ```typescript
 @Entity()
@@ -51,24 +47,20 @@ console.log(book.author.isInitialized()); // false
 console.log(book.author.name); // undefined as `Author` is not loaded yet
 ```
 
-You can overcome this issue by using the `Reference<T>` wrapper. It simply wraps the entity, 
-defining `load(): Promise<T>` method that will first lazy load the association if not already
-available. You can also use `unwrap(): T` method to access the underlying entity without loading
-it.
+You can overcome this issue by using the `Reference<T>` wrapper. It simply wraps the entity, defining `load(): Promise<T>` method that will first lazy load the association if not already available. You can also use `unwrap(): T` method to access the underlying entity without loading it.
 
-You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>`, which works like `load()`
-but returns the specified property.
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>`, which works like `load()` but returns the specified property.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 import { Entity, IdentifiedReference, ManyToOne, PrimaryKey, Reference } from '@mikro-orm/core';
@@ -143,9 +135,7 @@ console.log((await book.author.load()).name); // ok, author already loaded
 console.log(book.author.unwrap().name); // ok, author already loaded
 ```
 
-There are also `getEntity()` and `getProperty()` methods that are synchronous getters, 
-that will first check if the wrapped entity is initialized, and if not, it will throw 
-and error.
+There are also `getEntity()` and `getProperty()` methods that are synchronous getters, that will first check if the wrapped entity is initialized, and if not, it will throw and error.
 
 ```typescript
 const book = await orm.em.findOne(Book, 1);
@@ -157,9 +147,7 @@ console.log((await book.author.load('name'))); // ok, loading the author first
 console.log(book.author.getProperty('name')); // ok, author already loaded
 ```
 
-If you use different metadata provider than `TsMorphMetadataProvider` 
-(e.g. `ReflectMetadataProvider`), you will also need to explicitly set `wrappedReference` 
-parameter:
+If you use different metadata provider than `TsMorphMetadataProvider` (e.g. `ReflectMetadataProvider`), you will also need to explicitly set `wrappedReference` parameter:
 
 ```typescript
 @ManyToOne(() => Author, { wrappedReference: true })
@@ -168,9 +156,7 @@ author!: IdentifiedReference<Author>;
 
 ### Assigning to Reference Properties
 
-When you define the property as `Reference` wrapper, you will need to assign the `Reference`
-to it instead of the entity. You can create it via `Reference.create()` factory, or use `wrapped`
-parameter of `em.getReference()`:
+When you define the property as `Reference` wrapper, you will need to assign the `Reference` to it instead of the entity. You can create it via `Reference.create()` factory, or use `wrapped` parameter of `em.getReference()`:
 
 ```typescript
 const book = await orm.em.findOne(Book, 1);
@@ -183,8 +169,7 @@ book.author = Reference.create(repo.getReference(2));
 await orm.em.flush();
 ```
 
-Another way is to use `toReference()` method available as part of 
-[`WrappedEntity` interface](entity-helper.md#wrappedentity-and-wrap-helper):
+Another way is to use `toReference()` method available as part of [`WrappedEntity` interface](entity-helper.md#wrappedentity-and-wrap-helper):
 
 ```typescript
 const author = new Author(...)
@@ -199,12 +184,9 @@ book.author.set(new Author(...));
 
 ### What is IdentifiedReference?
 
-`IdentifiedReference` is an intersection type that adds primary key property to the `Reference` 
-interface. It allows to get the primary key from `Reference` instance directly.
+`IdentifiedReference` is an intersection type that adds primary key property to the `Reference` interface. It allows to get the primary key from `Reference` instance directly.
 
-By default, we try to detect the PK by checking if a property with a known name exists.
-We check for those in order: `_id`, `uuid`, `id` - with a way to manually set the property
-name via `PrimaryKeyProp` symbol (`[PrimaryKeyProp]?: 'foo';`). 
+By default, we try to detect the PK by checking if a property with a known name exists. We check for those in order: `_id`, `uuid`, `id` - with a way to manually set the property name via `PrimaryKeyProp` symbol (`[PrimaryKeyProp]?: 'foo';`).
 
 We can also override this via second generic type argument.
 
@@ -222,19 +204,18 @@ const book = await orm.em.findOne(Book, 1);
 console.log(book.author.myPrimaryKey); // ok, returns the PK
 ```
 
-For MongoDB, define the PK generic type argument as `'id' | '_id'` to access both `string` 
-and `ObjectId` PK values:
+For MongoDB, define the PK generic type argument as `'id' | '_id'` to access both `string` and `ObjectId` PK values:
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
@@ -300,5 +281,4 @@ console.log(book.author.id); // ok, returns string PK
 console.log(book.author._id); // ok, returns ObjectId PK
 ```
 
-> As opposed to `EntityHelper.init()` which always refreshes the entity, `Reference.load()` 
-> method will query the database only if the entity is not already loaded in Identity Map. 
+> As opposed to `EntityHelper.init()` which always refreshes the entity, `Reference.load()` method will query the database only if the entity is not already loaded in Identity Map.

--- a/docs/versioned_docs/version-4.5/entity-schema.md
+++ b/docs/versioned_docs/version-4.5/entity-schema.md
@@ -2,7 +2,7 @@
 title: Defining Entities via EntitySchema
 ---
 
-With `EntitySchema` helper you define the schema programmatically. 
+With `EntitySchema` helper you define the schema programmatically.
 
 ```typescript title="./entities/Book.ts"
 export interface Book extends BaseEntity {
@@ -24,8 +24,7 @@ export const schema = new EntitySchema<Book, BaseEntity>({
 });
 ```
 
-When creating new entity instances, you will need to use `em.create()` method that will
-create instance of internally created class. 
+When creating new entity instances, you will need to use `em.create()` method that will create instance of internally created class.
 
 ```typescript
 const repo = em.getRepository<Author>('Author');
@@ -36,13 +35,14 @@ await repo.persistAndFlush(author);
 > Using this approach, metadata caching is automatically disabled as it is not needed.
 
 #### Using DTO class
+
 It is very common to define a DTO (Data Transfer Object) to validate incoming request bodies and pass the request body data on to the other parts of your application. If you pass the DTO directly to the `create` method it could lead to unexpected results. The data for the `create` method should be provided as a POJO (Plain Old JS Object `{}`).
 
 You can achieve this by letting your DTO class extend the `PlainObject` class. This way MikroORM knows it should be treated as such.
 
 ## Using custom entity classes
 
-You can optionally use custom class for entity instances.  
+You can optionally use custom class for entity instances.
 
 ```typescript title="./entities/Author.ts"
 export class Author extends BaseEntity {
@@ -55,7 +55,7 @@ export class Author extends BaseEntity {
   books = new Collection<Book>(this);
   favouriteBook?: Book;
   version?: number;
-  
+
   constructor(name: string, email: string) {
     this.name = name;
     this.email = email;
@@ -88,7 +88,7 @@ await repo.persistAndFlush(author);
 
 ## Using BaseEntity
 
-Do not forget that base entities needs to be discovered just like normal entities. 
+Do not forget that base entities needs to be discovered just like normal entities.
 
 ```typescript title="./entities/BaseEntity.ts"
 export interface BaseEntity {
@@ -110,9 +110,7 @@ export const schema = new EntitySchema<BaseEntity>({
 
 ## Configuration Reference
 
-The parameter of `EntitySchema` requires to provide either `name` or `class` parameters. 
-When using `class`, `extends` will be automatically inferred. You can optionally pass 
-these additional parameters:
+The parameter of `EntitySchema` requires to provide either `name` or `class` parameters. When using `class`, `extends` will be automatically inferred. You can optionally pass these additional parameters:
 
 ```typescript
 name: string;
@@ -127,8 +125,7 @@ hooks: Partial<Record<HookType, (string & keyof T)[]>>;
 abstract: boolean;
 ```
 
-Every property then needs to contain a type specification - one of `type`/`customType`/`entity`.
-Here are some examples of various property types:
+Every property then needs to contain a type specification - one of `type`/`customType`/`entity`. Here are some examples of various property types:
 
 ```typescript
 export enum MyEnum {

--- a/docs/versioned_docs/version-4.5/faq.md
+++ b/docs/versioned_docs/version-4.5/faq.md
@@ -5,6 +5,7 @@ title: Frequently Asked Questions
 ### How can I synchronize my database schema with the entities?
 
 There are two ways:
+
 - [Schema Generator](./schema-generator.md)
 - [Migrations](./migrations.md)
 
@@ -14,21 +15,15 @@ npx mikro-orm schema:update --run
 
 ### I cannot run the CLI
 
-Make sure you install `@mikro-orm/cli` package locally. If you want to have
-global installation, you will need to install driver packages globally too.
+Make sure you install `@mikro-orm/cli` package locally. If you want to have global installation, you will need to install driver packages globally too.
 
 ### EntityManager does not have `createQueryBuilder()` method
 
 The method is there, the issue is in the TS type.
 
-In v4 the `core` package, where `EntityManager` and `EntityRepository` are
-defined, is not dependent on knex, and therefore it cannot have a method
-returning a `QueryBuilder`. You need to import the SQL flavour of the EM
-from the driver package to access the `createQueryBuilder()` method.
+In v4 the `core` package, where `EntityManager` and `EntityRepository` are defined, is not dependent on knex, and therefore it cannot have a method returning a `QueryBuilder`. You need to import the SQL flavour of the EM from the driver package to access the `createQueryBuilder()` method.
 
-> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under
-> this name and under `EntityManager` alias, so you can just change the
-> location from where you import.
+> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ```typescript
 import { EntityManager } from '@mikro-orm/mysql'; // or any other SQL driver package
@@ -46,25 +41,19 @@ const em: EntityManager;
 const ret = await em.aggregate(...);
 ```
 
-> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under
-> this name and under `EntityManager` alias, so you can just change the
-> location from where you import.
+> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ### How can I add columns to pivot table (M:N relation)
 
-You should model your M:N relation transparently, via 1:m and m:1 properties.
-More about this can be found in [Composite Keys section](./composite-keys.md/#use-case-3-join-table-with-metadata).
+You should model your M:N relation transparently, via 1:m and m:1 properties. More about this can be found in [Composite Keys section](./composite-keys.md/#use-case-3-join-table-with-metadata).
 
 ### You cannot call `em.flush()` from inside lifecycle hook handlers
 
-You might see this validation error even if you do not use hooks. If that happens,
-the reason is usually because you do not have [request context](identity-map.md) set up properly, and
-you are reusing one `EntityManager` instance.
+You might see this validation error even if you do not use hooks. If that happens, the reason is usually because you do not have [request context](identity-map.md) set up properly, and you are reusing one `EntityManager` instance.
 
 ### Column is being created with JSON type while the TS type is `string/Date/number/...`
 
-You are probably using the default `ReflectMetadataProvider`, which does not
-support inferring property type when there is a property initializer.
+You are probably using the default `ReflectMetadataProvider`, which does not support inferring property type when there is a property initializer.
 
 ```ts
 @Property()
@@ -72,6 +61,7 @@ foo = 'abc';
 ```
 
 There are two ways around this:
+
 - Use [TsMorphMetadataProvider](./metadata-providers.md/#tsmorphmetadataprovider)
 - Specify the type explicitly:
 
@@ -112,8 +102,7 @@ When creating new entity instances, either with `new Book()` or `em.create(Book,
 Book {}
 ```
 
-But some users might find that this returns an object with properties that are explicitly
-set to `undefined`:
+But some users might find that this returns an object with properties that are explicitly set to `undefined`:
 
 ```ts
 Book {
@@ -123,8 +112,7 @@ Book {
 }
 ```
 
-This can cause unexpected behavior, particularly if you're expecting the database to set a
-default value for a column.
+This can cause unexpected behavior, particularly if you're expecting the database to set a default value for a column.
 
 To fix this, disable the [`useDefineForClassFields`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#the-usedefineforclassfields-flag-and-the-declare-property-modifier) option in your tsconfig:
 

--- a/docs/versioned_docs/version-4.5/filters.md
+++ b/docs/versioned_docs/version-4.5/filters.md
@@ -2,16 +2,11 @@
 title: Filters
 ---
 
-MikroORM has the ability to pre-define filter criteria and attach those filters 
-to given entities. The application can then decide at runtime whether certain 
-filters should be enabled and what their parameter values should be. Filters 
-can be used like database views, but they are parameterized inside the application.
+MikroORM has the ability to pre-define filter criteria and attach those filters to given entities. The application can then decide at runtime whether certain filters should be enabled and what their parameter values should be. Filters can be used like database views, but they are parameterized inside the application.
 
-> Filter can be defined at the entity level, dynamically via EM (global filters) 
-> or in the ORM configuration.
+> Filter can be defined at the entity level, dynamically via EM (global filters) or in the ORM configuration.
 
-Filters are applied to those methods of `EntityManager`: `find()`, `findOne()`, 
-`findAndCount()`, `findOneOrFail()`, `count()`, `nativeUpdate()` and `nativeDelete()`. 
+Filters are applied to those methods of `EntityManager`: `find()`, `findOne()`, `findAndCount()`, `findOneOrFail()`, `count()`, `nativeUpdate()` and `nativeDelete()`.
 
 > The `cond` parameter can be a callback, possibly asynchronous.
 
@@ -36,14 +31,14 @@ const books2 = await orm.em.find(Book, {}, {
 ## Properties of filter
 
 There are three parameters you can use:
+
 - `name` - can be used to enable a filter on the query can also used to pass a parameter
 - `cond` - is the condition that should be added to the query when the filter is enabled. This can be a callback, even async
 - `default` - indicates if the filter is enabled by default on the query
 
 ## Parameters
 
-You can define the `cond` dynamically as a callback. This callback can be also 
-asynchronous. It will get two arguments:
+You can define the `cond` dynamically as a callback. This callback can be also asynchronous. It will get two arguments:
 
 - `args` - dictionary of parameters provided by user
 - `type` - type of operation that is being filtered, one of `'read'`, `'update'`, `'delete'`
@@ -68,9 +63,7 @@ const books = await orm.em.find(Book, {}, {
 
 ### Filters without parameters
 
-If we want to have a filter condition that do not need arguments, but we want
-to access the `type` parameter, we will need to explicitly set `args: false`, 
-otherwise error will be raised due to missing parameters:
+If we want to have a filter condition that do not need arguments, but we want to access the `type` parameter, we will need to explicitly set `args: false`, otherwise error will be raised due to missing parameters:
 
 ```ts
 @Filter({
@@ -85,10 +78,7 @@ otherwise error will be raised due to missing parameters:
 
 ## Global filters
 
-We can also register filters dynamically via `EntityManager` API. We call such filters 
-global. They are enabled by default (unless disabled via last parameter in `addFilter()`
-method), and applied to all entities. You can limit the global filter to only specified
-entities. 
+We can also register filters dynamically via `EntityManager` API. We call such filters global. They are enabled by default (unless disabled via last parameter in `addFilter()` method), and applied to all entities. You can limit the global filter to only specified entities.
 
 > Filters as well as filter params set on the EM will be copied to all its forks.
 
@@ -119,12 +109,9 @@ MikroORM.init({
 
 ## Using filters
 
-We can control what filters will be applied via `filter` parameter in `FindOptions`.
-We can either provide an array of names of filters you want to enable, or options 
-object, where we can also disable a filter (that was enabled by default), or pass some
-parameters to those that are expecting them.
+We can control what filters will be applied via `filter` parameter in `FindOptions`. We can either provide an array of names of filters you want to enable, or options object, where we can also disable a filter (that was enabled by default), or pass some parameters to those that are expecting them.
 
-> By passing `filters: false` we can also disable all the filters for given call. 
+> By passing `filters: false` we can also disable all the filters for given call.
 
 ```typescript
 em.find(Book, {}); // same as `{ tenantId: 123 }`
@@ -135,17 +122,11 @@ em.find(Book, {}, { filters: false }); // disabled all filters, so truly `{}`
 
 ## Filters and populating of relationships
 
-When populating relationships, filters will be applied only to the root entity of 
-given query, but not to those that are auto-joined. On the other hand, this means that
-when you use the default loading strategy - `LoadStrategy.SELECT_IN` - filters will
-be applied to every entity populated this way, as the child entities will become
-root entities in their respective load calls.
+When populating relationships, filters will be applied only to the root entity of given query, but not to those that are auto-joined. On the other hand, this means that when you use the default loading strategy - `LoadStrategy.SELECT_IN` - filters will be applied to every entity populated this way, as the child entities will become root entities in their respective load calls.
 
 ## Naming of filters
 
-When toggling filters via `FindOptions`, we do not care about the entity name. This
-means that when you have multiple filters defined on different entities, but with 
-the same name, they will be controlled via single toggle in the `FindOptions`. 
+When toggling filters via `FindOptions`, we do not care about the entity name. This means that when you have multiple filters defined on different entities, but with the same name, they will be controlled via single toggle in the `FindOptions`.
 
 ```typescript
 @Entity()

--- a/docs/versioned_docs/version-4.5/identity-map.md
+++ b/docs/versioned_docs/version-4.5/identity-map.md
@@ -2,8 +2,7 @@
 title: Identity Map and Request Context
 ---
 
-`MikroORM` uses identity map in background so you will always get the same instance of 
-one entity.
+`MikroORM` uses identity map in background so you will always get the same instance of one entity.
 
 ```typescript
 const authorRepository = orm.em.getRepository(Author);
@@ -20,8 +19,7 @@ If you want to clear this identity map cache, you can do so via `em.clear()` met
 orm.em.clear();
 ```
 
-You should always keep unique identity map per each request. This basically means that you need 
-to clone entity manager and use the clone in request context. There are two ways to achieve this:
+You should always keep unique identity map per each request. This basically means that you need to clone entity manager and use the clone in request context. There are two ways to achieve this:
 
 ## Forking Entity Manager
 
@@ -33,60 +31,43 @@ const em = orm.em.fork();
 
 ## <a name="request-context"></a> RequestContext helper for DI containers
 
-If you use dependency injection container like `inversify` or the one in `nestjs` framework, it 
-can be hard to achieve this, because you usually want to access your repositories via DI container,
-but it will always provide you with the same instance, rather than new one for each request. 
+If you use dependency injection container like `inversify` or the one in `nestjs` framework, it can be hard to achieve this, because you usually want to access your repositories via DI container, but it will always provide you with the same instance, rather than new one for each request.
 
-To solve this, you can use `RequestContext` helper, that will use `node`'s Domain API in the 
-background to isolate the request context. MikroORM will always use request specific (forked) 
-entity manager if available, so all you need to do is to create new request context preferably 
-as a middleware:
+To solve this, you can use `RequestContext` helper, that will use `node`'s Domain API in the background to isolate the request context. MikroORM will always use request specific (forked) entity manager if available, so all you need to do is to create new request context preferably as a middleware:
 
 ```typescript
 app.use((req, res, next) => {
   RequestContext.create(orm.em, next);
 });
-``` 
+```
 
-You should register this middleware as the last one just before request handlers and before
-any of your custom middleware that is using the ORM. There might be issues when you register 
-it before request processing middleware like `queryParser` or `bodyParser`, so definitely 
-register the context after them. 
+You should register this middleware as the last one just before request handlers and before any of your custom middleware that is using the ORM. There might be issues when you register it before request processing middleware like `queryParser` or `bodyParser`, so definitely register the context after them.
 
-Later on you can then access the request scoped `EntityManager` via `RequestContext.getEntityManager()`.
-This method is used under the hood automatically, so you should not need it. 
+Later on you can then access the request scoped `EntityManager` via `RequestContext.getEntityManager()`. This method is used under the hood automatically, so you should not need it.
 
-> `RequestContext.getEntityManager()` will return `undefined` if the context was
-> not started yet.
+> `RequestContext.getEntityManager()` will return `undefined` if the context was not started yet.
 
 ## Why is Request Context needed?
 
-Imagine you will use single Identity Map throughout your application. It will be shared across 
-all request handlers, that can possibly run in parallel. 
+Imagine you will use single Identity Map throughout your application. It will be shared across all request handlers, that can possibly run in parallel.
 
 ### Problem 1 - growing memory footprint
 
-As there would be only one shared Identity Map, you can't just clear it after your request ends.
-There can be another request working with it so clearing the Identity Map from one request could 
-break other requests running in parallel. This will result in growing memory footprint, as every 
-entity that became managed at some point in time would be kept in the Identity Map. 
+As there would be only one shared Identity Map, you can't just clear it after your request ends. There can be another request working with it so clearing the Identity Map from one request could break other requests running in parallel. This will result in growing memory footprint, as every entity that became managed at some point in time would be kept in the Identity Map.
 
 ### Problem 2 - unstable response of API endpoints
 
-Every entity has `toJSON()` method, that automatically converts it to serialized form. If you 
-have only one shared Identity Map, following situation may occur:
+Every entity has `toJSON()` method, that automatically converts it to serialized form. If you have only one shared Identity Map, following situation may occur:
 
 Let's say there are 2 endpoints
 
 1. `GET /book/:id` that returns just the book, without populating anything
 2. `GET /book-with-author/:id` that returns the book and its author populated
 
-Now when someone requests same book via both of those endpoints, you could end up with both 
-returning the same output:
- 
+Now when someone requests same book via both of those endpoints, you could end up with both returning the same output:
+
 1. `GET /book/1` returns `Book` without populating its property `author` property
 2. `GET /book-with-author/1` returns `Book`, this time with `author` populated
 3. `GET /book/1` returns `Book`, but this time also with `author` populated
 
-This happens because the information about entity association being populated is stored in
-the Identity Map. 
+This happens because the information about entity association being populated is stored in the Identity Map.

--- a/docs/versioned_docs/version-4.5/inheritance-mapping.md
+++ b/docs/versioned_docs/version-4.5/inheritance-mapping.md
@@ -4,19 +4,11 @@ title: Inheritance Mapping
 
 ## Mapped Superclasses
 
-A mapped superclass is an abstract or concrete class that provides persistent entity state and 
-mapping information for its subclasses, but which is not itself an entity. Typically, the purpose 
-of such a mapped superclass is to define state and mapping information that is common to multiple 
-entity classes.
+A mapped superclass is an abstract or concrete class that provides persistent entity state and mapping information for its subclasses, but which is not itself an entity. Typically, the purpose of such a mapped superclass is to define state and mapping information that is common to multiple entity classes.
 
-Mapped superclasses, just as regular, non-mapped classes, can appear in the middle of an otherwise 
-mapped inheritance hierarchy (through Single Table Inheritance).
+Mapped superclasses, just as regular, non-mapped classes, can appear in the middle of an otherwise mapped inheritance hierarchy (through Single Table Inheritance).
 
-> A mapped superclass cannot be an entity, it is not query-able and persistent relationships defined 
-> by a mapped superclass must be unidirectional (with an owning side only). This means that One-To-Many 
-> associations are not possible on a mapped superclass at all. Furthermore Many-To-Many associations 
-> are only possible if the mapped superclass is only used in exactly one entity at the moment. For 
-> further support of inheritance, the single table inheritance features have to be used.
+> A mapped superclass cannot be an entity, it is not query-able and persistent relationships defined by a mapped superclass must be unidirectional (with an owning side only). This means that One-To-Many associations are not possible on a mapped superclass at all. Furthermore Many-To-Many associations are only possible if the mapped superclass is only used in exactly one entity at the moment. For further support of inheritance, the single table inheritance features have to be used.
 
 ```typescript
 // do not use @Entity decorator on base classes (mapped superclasses)
@@ -28,7 +20,7 @@ export abstract class Person {
 
   @Property()
   mapped2!: string;
- 
+
   @OneToOne()
   toothbrush!: Toothbrush;
 
@@ -50,7 +42,7 @@ export class Employee extends Person {
 
 @Entity()
 export class Toothbrush {
-  
+
   @PrimaryKey()
   id!: number;
 
@@ -70,18 +62,13 @@ create table `employee` (
 );
 ```
 
-As you can see from this DDL snippet, there is only a single table for the entity 
-subclass. All the mappings from the mapped superclass were inherited to the subclass 
-as if they had been defined on that class directly.
+As you can see from this DDL snippet, there is only a single table for the entity subclass. All the mappings from the mapped superclass were inherited to the subclass as if they had been defined on that class directly.
 
 ## Single Table Inheritance
 
 > Support for STI was added in version 4.0
 
-[Single Table Inheritance](https://martinfowler.com/eaaCatalog/singleTableInheritance.html) 
-is an inheritance mapping strategy where all classes of a hierarchy are mapped to a single 
-database table. In order to distinguish which row represents which type in the hierarchy 
-a so-called discriminator column is used.
+[Single Table Inheritance](https://martinfowler.com/eaaCatalog/singleTableInheritance.html) is an inheritance mapping strategy where all classes of a hierarchy are mapped to a single database table. In order to distinguish which row represents which type in the hierarchy a so-called discriminator column is used.
 
 ```typescript
 @Entity({
@@ -100,26 +87,15 @@ export class Employee extends Person {
 
 Things to note:
 
-- The `discriminatorColumn` option must be specified on the topmost class that is 
-  part of the mapped entity hierarchy.
-- The `discriminatorMap` specifies which values of the discriminator column identify 
-  a row as being of a certain type. In the case above a value of `person` identifies
-  a row as being of type `Person` and `employee` identifies a row as being of type 
-  `Employee`.
-- All entity classes that are part of the mapped entity hierarchy (including the topmost 
-  class) should be specified in the `discriminatorMap`. In the case above `Person` class
-  included.
-- We can use abstract class as the root entity - then the root class should not be part
-  of the discriminator map
-- If no discriminator map is provided, then the map is generated automatically. 
-  The automatically generated discriminator map contains the table names that would be
-  otherwise used in case of regular entities. 
+- The `discriminatorColumn` option must be specified on the topmost class that is part of the mapped entity hierarchy.
+- The `discriminatorMap` specifies which values of the discriminator column identify a row as being of a certain type. In the case above a value of `person` identifies a row as being of type `Person` and `employee` identifies a row as being of type `Employee`.
+- All entity classes that are part of the mapped entity hierarchy (including the topmost class) should be specified in the `discriminatorMap`. In the case above `Person` class included.
+- We can use abstract class as the root entity - then the root class should not be part of the discriminator map
+- If no discriminator map is provided, then the map is generated automatically. The automatically generated discriminator map contains the table names that would be otherwise used in case of regular entities.
 
 ### Using `discriminatorValue` instead of `discriminatorMap`
 
-As noted above, the discriminator map can be auto-generated. In that case, we might
-want to control the tokens that will be used in the map. To do so, we can use 
-`discriminatorValue` on the child entities:
+As noted above, the discriminator map can be auto-generated. In that case, we might want to control the tokens that will be used in the map. To do so, we can use `discriminatorValue` on the child entities:
 
 ```ts
 @Entity({
@@ -140,18 +116,14 @@ export class Employee extends Person {
 
 ### Explicit discriminator column
 
-The `discriminatorColumn` specifies the name of special column that will be used to
-define what type of class should given row be represented with. It will be defined 
-automatically for you and it will stay hidden (it won't by hydrated as regular property). 
+The `discriminatorColumn` specifies the name of special column that will be used to define what type of class should given row be represented with. It will be defined automatically for you and it will stay hidden (it won't by hydrated as regular property).
 
-On the other hand, it is perfectly fine to define the column explicitly. Doing so, 
-you will be able to:
+On the other hand, it is perfectly fine to define the column explicitly. Doing so, you will be able to:
 
 - querying by the type, e.g. `em.find(Person, { type: { $ne: 'employee' } }`
 - the column will be part of the serialized response
 
-Following example shows how we can define the discriminator explicitly, as well
-as a version where root entity is abstract class.
+Following example shows how we can define the discriminator explicitly, as well as a version where root entity is abstract class.
 
 ```ts
 @Entity({
@@ -176,8 +148,7 @@ export class Employee extends Person {
 }
 ```
 
-If we wanted to use `discriminatorValue` with abstract entities, we need to mark
-the entity as `abstract: true` so it can be skipped from the discriminator map:
+If we wanted to use `discriminatorValue` with abstract entities, we need to mark the entity as `abstract: true` so it can be skipped from the discriminator map:
 
 ```ts
 @Entity({
@@ -204,25 +175,14 @@ export class Employee extends Person {
 
 ### Design-time considerations
 
-This mapping approach works well when the type hierarchy is fairly simple and stable. 
-Adding a new type to the hierarchy and adding fields to existing supertypes simply 
-involves adding new columns to the table, though in large deployments this may have 
-an adverse impact on the index and column layout inside the database.
+This mapping approach works well when the type hierarchy is fairly simple and stable. Adding a new type to the hierarchy and adding fields to existing supertypes simply involves adding new columns to the table, though in large deployments this may have an adverse impact on the index and column layout inside the database.
 
 ### Performance impact
 
-This strategy is very efficient for querying across all types in the hierarchy or 
-for specific types. No table joins are required, only a WHERE clause listing the 
-type identifiers. In particular, relationships involving types that employ this 
-mapping strategy are very performant.
+This strategy is very efficient for querying across all types in the hierarchy or for specific types. No table joins are required, only a WHERE clause listing the type identifiers. In particular, relationships involving types that employ this mapping strategy are very performant.
 
 ### SQL Schema considerations
 
-For Single-Table-Inheritance to work in scenarios where you are using either a legacy 
-database schema or a self-written database schema you have to make sure that all 
-columns that are not in the root entity but in any of the different sub-entities 
-has to allow null values. Columns that have NOT NULL constraints have to be on the 
-root entity of the single-table inheritance hierarchy.
+For Single-Table-Inheritance to work in scenarios where you are using either a legacy database schema or a self-written database schema you have to make sure that all columns that are not in the root entity but in any of the different sub-entities has to allow null values. Columns that have NOT NULL constraints have to be on the root entity of the single-table inheritance hierarchy.
 
-> This part of documentation is highly inspired by [doctrine docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/inheritance-mapping.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/inheritance-mapping.html) as the behaviour here is pretty much the same.

--- a/docs/versioned_docs/version-4.5/installation.md
+++ b/docs/versioned_docs/version-4.5/installation.md
@@ -2,12 +2,9 @@
 title: Installation & Usage
 ---
 
-First install the module via `yarn` or `npm` and do not forget to install the 
-driver package as well:
+First install the module via `yarn` or `npm` and do not forget to install the driver package as well:
 
-> Since v4, you should install the driver package, but not the db connector itself,
-> e.g. install `@mikro-orm/sqlite`, but not `sqlite3` as that is already included
-> in the driver package.
+> Since v4, you should install the driver package, but not the db connector itself, e.g. install `@mikro-orm/sqlite`, but not `sqlite3` as that is already included in the driver package.
 
 ```sh
 yarn add @mikro-orm/core @mikro-orm/mongodb     # for mongo
@@ -27,8 +24,7 @@ npm i -s @mikro-orm/core @mikro-orm/postgresql  # for postgresql
 npm i -s @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 ```
 
-Next you will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html)
-as well as `esModuleInterop` in `tsconfig.json` via:
+Next you will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html) as well as `esModuleInterop` in `tsconfig.json` via:
 
 ```json
 "experimentalDecorators": true,
@@ -50,10 +46,7 @@ console.log(orm.em); // access EntityManager via `em` property
 
 > Read more about all the possible configuration options in [Advanced Configuration](configuration.md) section.
 
-We can also provide paths where you store your entities via `entities` array. Internally
-it uses [`globby`](https://github.com/sindresorhus/globby) so we can use 
-[globbing patterns](https://github.com/sindresorhus/globby#globbing-patterns), 
-including negative globs. 
+We can also provide paths where you store your entities via `entities` array. Internally it uses [`globby`](https://github.com/sindresorhus/globby) so we can use [globbing patterns](https://github.com/sindresorhus/globby#globbing-patterns), including negative globs.
 
 ```typescript
 const orm = await MikroORM.init({
@@ -62,21 +55,17 @@ const orm = await MikroORM.init({
 });
 ```
 
-If you are experiencing problems with folder based discovery, try using `mikro-orm debug`
-CLI command to check what paths are actually being used.
+If you are experiencing problems with folder based discovery, try using `mikro-orm debug` CLI command to check what paths are actually being used.
 
 > Since v4, you can also use file globs, like `./dist/app/**/entities/*.entity.js`.
 
 We can also set the configuration via [environment variables](configuration.md#using-environment-variables).
 
-> You can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. 
-> The object will be deeply merged, overriding all internally used options.
+> You can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. The object will be deeply merged, overriding all internally used options.
 
 ## Possible issues with circular dependencies
 
-Your entities will most probably contain circular dependencies (e.g. if you use bi-directional 
-relationship). While this is fine, there might be issues caused by wrong order of entities 
-during discovery, especially when you are using the folder based way.
+Your entities will most probably contain circular dependencies (e.g. if you use bi-directional relationship). While this is fine, there might be issues caused by wrong order of entities during discovery, especially when you are using the folder based way.
 
 The errors caused by circular dependencies are usually similar to this one:
 
@@ -97,17 +86,12 @@ TypeError: Cannot read property 'name' of undefined
 
 If you encounter this, you have basically two options:
 
-- Use entity references in `entities` array to have control over the order of discovery. 
-  You might need to play with the actual order you provide here, or possibly with the 
-  order of import statements.
-- Use strings instead of references (e.g. `@OneToMany('Book', 'author')`). The downside 
-  here is that you will lose the typechecking capabilities of the decorators. 
+- Use entity references in `entities` array to have control over the order of discovery. You might need to play with the actual order you provide here, or possibly with the order of import statements.
+- Use strings instead of references (e.g. `@OneToMany('Book', 'author')`). The downside here is that you will lose the typechecking capabilities of the decorators.
 
 ## Entity Discovery in TypeScript
 
-In v4 the default metadata provider is `ReflectMetadataProvider`. If you want to use
-`ts-morph` based discovery (that reads actual TS types via the compiler API), you 
-need to install `@mikro-orm/reflection`.
+In v4 the default metadata provider is `ReflectMetadataProvider`. If you want to use `ts-morph` based discovery (that reads actual TS types via the compiler API), you need to install `@mikro-orm/reflection`.
 
 ```typescript
 import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
@@ -128,19 +112,16 @@ const orm = await MikroORM.init({
 });
 ```
 
-> It is important that `entities` will point to the compiled JS files, and `entitiesTs`
-> will point to the TS source files. You should not mix those. 
+> It is important that `entities` will point to the compiled JS files, and `entitiesTs` will point to the TS source files. You should not mix those.
 
-> For `ts-morph` discovery to work in production, we need to deploy `.d.ts` declaration
-> files. Be sure to enable `compilerOptions.declaration` in your `tsconfig.json`.
+> For `ts-morph` discovery to work in production, we need to deploy `.d.ts` declaration files. Be sure to enable `compilerOptions.declaration` in your `tsconfig.json`.
 
 You can also use different [metadata provider](metadata-providers.md) or even write custom one:
 
 - `ReflectMetadataProvider` that uses `reflect-metadata` instead of `ts-morph`
 - `JavaScriptMetadataProvider` that allows you to manually provide the entity schema (mainly for Vanilla JS)
 
-> Using [`EntitySchema`](entity-schema.md) is another way to define your entities, which is better
-> suited than using `JavaScriptMetadataProvider`.
+> Using [`EntitySchema`](entity-schema.md) is another way to define your entities, which is better suited than using `JavaScriptMetadataProvider`.
 
 ```typescript
 const orm = await MikroORM.init({
@@ -152,8 +133,7 @@ const orm = await MikroORM.init({
 
 ## Request Context
 
-Then you will need to fork Entity Manager for each request so their identity maps will not 
-collide. To do so, use the `RequestContext` helper:
+Then you will need to fork Entity Manager for each request so their identity maps will not collide. To do so, use the `RequestContext` helper:
 
 ```typescript
 const app = express();
@@ -163,8 +143,7 @@ app.use((req, res, next) => {
 });
 ```
 
-> If the `next` handler needs to be awaited (like in Koa), 
-> use `RequestContext.createAsync()` instead.
+> If the `next` handler needs to be awaited (like in Koa), use `RequestContext.createAsync()` instead.
 >
 > ```typescript
 > app.use((ctx, next) => RequestContext.createAsync(orm.em, next));
@@ -174,12 +153,9 @@ More info about `RequestContext` is described [here](identity-map.md#request-con
 
 ## Setting up the Commandline Tool
 
-MikroORM ships with a number of command line tools that are very helpful during development, 
-like `SchemaGenerator` and `EntityGenerator`. You can call this command from the NPM binary 
-directory or use `npx`:
+MikroORM ships with a number of command line tools that are very helpful during development, like `SchemaGenerator` and `EntityGenerator`. You can call this command from the NPM binary directory or use `npx`:
 
-> To work with the CLI, first install `@mikro-orm/cli` package locally.
-> The version needs to be aligned with the `@mikro-orm/core` package.
+> To work with the CLI, first install `@mikro-orm/cli` package locally. The version needs to be aligned with the `@mikro-orm/core` package.
 
 ```sh
 # install the CLI package first!
@@ -195,25 +171,17 @@ $ npx mikro-orm
 $ yarn mikro-orm
 ```
 
-For CLI to be able to access your database, you will need to create `mikro-orm.config.js` file that 
-exports your ORM configuration. 
+For CLI to be able to access your database, you will need to create `mikro-orm.config.js` file that exports your ORM configuration.
 
-> Your ORM configuration file can export the Promise, like:
-> `export default Promise.resolve({...});`.
+> Your ORM configuration file can export the Promise, like: `export default Promise.resolve({...});`.
 
-TypeScript is also supported, just enable `useTsNode` flag in your
-`package.json` file. There you can also set up array of possible paths to `mikro-orm.config` file,
-as well as use different file name:
+TypeScript is also supported, just enable `useTsNode` flag in your `package.json` file. There you can also set up array of possible paths to `mikro-orm.config` file, as well as use different file name:
 
 > Do not forget to install `ts-node` when enabling `useTsNode` flag.
 
-> The `useTsNode` is used only when executing the CLI, it is not respected when 
-> running your app.
+> The `useTsNode` is used only when executing the CLI, it is not respected when running your app.
 
-MikroORM will always try to load the first available config file, based on the 
-order in `configPaths`. This means that if you specify the first item as the TS 
-config, but you do not have `ts-node` enabled and installed, it will fail to 
-load it.
+MikroORM will always try to load the first available config file, based on the order in `configPaths`. This means that if you specify the first item as the TS config, but you do not have `ts-node` enabled and installed, it will fail to load it.
 
 ```json title="./package.json"
 {
@@ -237,23 +205,16 @@ export default {
 };
 ```
 
-When we have `useTsNode` disabled and `ts-node` is not already registered and detected,
-TS config files will be ignored.
+When we have `useTsNode` disabled and `ts-node` is not already registered and detected, TS config files will be ignored.
 
-Once you have the CLI config properly set up, you can omit the `MikroORM.init()` options
-parameter, and the CLI config will be automatically used. This process may fail if you
-use bundlers that use tree shaking. As the config file is not referenced anywhere 
-statically, it would not be compiled - for that the best approach is to provide the config
-explicitly:
+Once you have the CLI config properly set up, you can omit the `MikroORM.init()` options parameter, and the CLI config will be automatically used. This process may fail if you use bundlers that use tree shaking. As the config file is not referenced anywhere statically, it would not be compiled - for that the best approach is to provide the config explicitly:
 
 ```ts
 import config from './mikro-orm.config';
 const orm = await MikroORM.init(config);
 ```
 
-> You can also use different names for this file, simply rename it in the `configPaths` array
-> your in `package.json`. You can also use `MIKRO_ORM_CLI` environment variable with the path
-> to override `configPaths` value.
+> You can also use different names for this file, simply rename it in the `configPaths` array your in `package.json`. You can also use `MIKRO_ORM_CLI` environment variable with the path to override `configPaths` value.
 
 Now you should be able to start using the CLI. All available commands are listed in the CLI help:
 
@@ -290,10 +251,8 @@ Examples:
 
 To verify your setup, you can use `mikro-orm debug` command.
 
-> When you have CLI config properly set up, you can omit the `options` parameter
-> when calling `MikroORM.init()`.
+> When you have CLI config properly set up, you can omit the `options` parameter when calling `MikroORM.init()`.
 
-> Note: When importing a dump file you need `multipleStatements: true` in your
-> configuration. Please check the configuration documentation for more information.
+> Note: When importing a dump file you need `multipleStatements: true` in your configuration. Please check the configuration documentation for more information.
 
 Now you can start [defining your entities](defining-entities.md).

--- a/docs/versioned_docs/version-4.5/json-properties.md
+++ b/docs/versioned_docs/version-4.5/json-properties.md
@@ -4,9 +4,7 @@ title: Using JSON properties
 
 ## Defining JSON properties
 
-Each database driver behaves a bit differently when it comes to JSON properties.
-MikroORM tries to unify the experience via [JsonType](custom-types.md#jsontype).
-This type will be also used if you specify `type: 'json'`.
+Each database driver behaves a bit differently when it comes to JSON properties. MikroORM tries to unify the experience via [JsonType](custom-types.md#jsontype). This type will be also used if you specify `type: 'json'`.
 
 ```ts
 @Entity()
@@ -28,10 +26,10 @@ We can query by JSON object properties easily:
 const b = await em.findOne(Book, {
   meta: {
     valid: true,
-    nested: { 
-      foo: '123', 
-      bar: 321, 
-      deep: { 
+    nested: {
+      foo: '123',
+      bar: 321,
+      deep: {
         baz: 59,
         qux: false,
       },
@@ -43,15 +41,14 @@ const b = await em.findOne(Book, {
 Will produce following query (in postgres):
 
 ```sql
-select "e0".* 
-from "book" as "e0" 
-where ("meta"->>'valid')::bool = true 
-  and "meta"->'nested'->>'foo' = '123' 
-  and ("meta"->'nested'->>'bar')::float8 = 321 
-  and ("meta"->'nested'->'deep'->>'baz')::float8 = 59 
-  and ("meta"->'nested'->'deep'->>'qux')::bool = false 
+select "e0".*
+from "book" as "e0"
+where ("meta"->>'valid')::bool = true
+  and "meta"->'nested'->>'foo' = '123'
+  and ("meta"->'nested'->>'bar')::float8 = 321
+  and ("meta"->'nested'->'deep'->>'baz')::float8 = 59
+  and ("meta"->'nested'->'deep'->>'qux')::bool = false
 limit 1
 ```
 
-> All drivers are currently supported (including sqlite and mongo). In postgres we
-> also try to cast the value if we detect number or boolean on the right-hand side.
+> All drivers are currently supported (including sqlite and mongo). In postgres we also try to cast the value if we detect number or boolean on the right-hand side.

--- a/docs/versioned_docs/version-4.5/lifecycle-hooks.md
+++ b/docs/versioned_docs/version-4.5/lifecycle-hooks.md
@@ -3,11 +3,10 @@ title: Lifecycle Hooks and EventSubscriber
 sidebar_label: Hooks and Events
 ---
 
-There are two ways to hook to the lifecycle of an entity: 
+There are two ways to hook to the lifecycle of an entity:
 
 - **Lifecycle hooks** are methods defined on the entity prototype.
-- **EventSubscriber**s are classes that can be used to hook to multiple entities
-  or when you do not want to have the method present on the entity prototype.
+- **EventSubscriber**s are classes that can be used to hook to multiple entities or when you do not want to have the method present on the entity prototype.
 
 > Hooks are internally executed the same way as subscribers.
 
@@ -15,51 +14,35 @@ There are two ways to hook to the lifecycle of an entity:
 
 ## Hooks
 
-You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of
-entity methods with them, you can also mark multiple methods with same hook.
+You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of entity methods with them, you can also mark multiple methods with same hook.
 
 All hooks support async methods with one exception - `@OnInit`.
 
-- `@OnInit` is fired when new instance of entity is created, either manually `em.create()`, or 
-automatically when new entities are loaded from database
+- `@OnInit` is fired when new instance of entity is created, either manually `em.create()`, or automatically when new entities are loaded from database
 
 - `@BeforeCreate()` and `@BeforeUpdate()` is fired right before we persist the entity in database
 
-- `@AfterCreate()` and `@AfterUpdate()` is fired right after the entity is updated in database and 
-merged to identity map. Since this event entity will have reference to `EntityManager` and will be 
-enabled to call `wrap(entity).init()` method (including all entity references and collections).
+- `@AfterCreate()` and `@AfterUpdate()` is fired right after the entity is updated in database and merged to identity map. Since this event entity will have reference to `EntityManager` and will be enabled to call `wrap(entity).init()` method (including all entity references and collections).
 
-- `@BeforeDelete()` is fired right before we delete the record from database. It is fired only when
-removing entity or entity reference, not when deleting records by query. 
+- `@BeforeDelete()` is fired right before we delete the record from database. It is fired only when removing entity or entity reference, not when deleting records by query.
 
-- `@AfterDelete()` is fired right after the record gets deleted from database and it is unset from 
-the identity map.
+- `@AfterDelete()` is fired right after the record gets deleted from database and it is unset from the identity map.
 
 > `@OnInit` is not fired when you create the entity manually via its constructor (`new MyEntity()`)
 
-> `@OnInit` can be sometimes fired twice, once when the entity reference is
-> created, and once after its populated. To distinguish between those we can
-> use `wrap(this).isInitialized()`.
+> `@OnInit` can be sometimes fired twice, once when the entity reference is created, and once after its populated. To distinguish between those we can use `wrap(this).isInitialized()`.
 
 ## Limitations of lifecycle hooks
 
-Hooks are executed inside the commit action of unit of work, after all change 
-sets are computed. This means that it is not possible to create new entities as
-usual from inside the hook. Calling `em.flush()` from hooks will result in 
-validation error. Calling `em.persist()` can result in undefined behaviour like
-locking errors. 
+Hooks are executed inside the commit action of unit of work, after all change sets are computed. This means that it is not possible to create new entities as usual from inside the hook. Calling `em.flush()` from hooks will result in validation error. Calling `em.persist()` can result in undefined behaviour like locking errors.
 
-> The **internal** instance of `EntityManager` accessible under `wrap(this, true).__em` is 
-> not meant for public usage. 
+> The **internal** instance of `EntityManager` accessible under `wrap(this, true).__em` is not meant for public usage.
 
 ## EventSubscriber
 
-Use `EventSubscriber` to hook to multiple entities or if you do not want to pollute
-the entity prototype. All methods are optional, if you omit the `getSubscribedEntities()`
-method, it means you are subscribing to all entities.
+Use `EventSubscriber` to hook to multiple entities or if you do not want to pollute the entity prototype. All methods are optional, if you omit the `getSubscribedEntities()` method, it means you are subscribing to all entities.
 
-You can either register the subscribers manually in the ORM configuration (via 
-`subscribers` array where you put the instance):
+You can either register the subscribers manually in the ORM configuration (via `subscribers` array where you put the instance):
 
 ```typescript
 MikroORM.init({
@@ -67,9 +50,7 @@ MikroORM.init({
 });
 ```
 
-Or use `@Subscriber()` decorator - keep in mind that you need to make sure the file gets 
-loaded in order to make this decorator registration work (e.g. you import that file 
-explicitly somewhere).
+Or use `@Subscriber()` decorator - keep in mind that you need to make sure the file gets loaded in order to make this decorator registration work (e.g. you import that file explicitly somewhere).
 
 ```typescript
 import { EntityName, EventArgs, EventSubscriber, Subscriber } from '@mikro-orm/core';
@@ -86,13 +67,13 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
   }
 
   async afterUpdate(args: EventArgs<Author>): Promise<void> {
-    // ... 
+    // ...
   }
 
 }
 ```
 
-Another example, where we register to all the events and all entities: 
+Another example, where we register to all the events and all entities:
 
 ```typescript
 import { EventArgs, EventSubscriber, Subscriber } from '@mikro-orm/core';
@@ -116,9 +97,7 @@ export class EverythingSubscriber implements EventSubscriber {
 
 ## EventArgs
 
-As a parameter to the hook method we get `EventArgs` instance. It will always contain
-reference to the current `EntityManager` and the particular entity. Events fired
-from `UnitOfWork` during flush operation also contain the `ChangeSet` object.
+As a parameter to the hook method we get `EventArgs` instance. It will always contain reference to the current `EntityManager` and the particular entity. Events fired from `UnitOfWork` during flush operation also contain the `ChangeSet` object.
 
 ```typescript
 interface EventArgs<T> {
@@ -146,28 +125,21 @@ enum ChangeSetType {
 
 ## Flush events
 
-There is a special kind of events executed during the commit phase (flush operation).
-They are executed before, during and after the flush, and they are not bound to any
-entity in particular. 
+There is a special kind of events executed during the commit phase (flush operation). They are executed before, during and after the flush, and they are not bound to any entity in particular.
 
-- `beforeFlush` is executed before change sets are computed, this is the only
-  event where it is safe to persist new entities. 
+- `beforeFlush` is executed before change sets are computed, this is the only event where it is safe to persist new entities.
 - `onFlush` is executed after the change sets are computed.
-- `afterFlush` is executed as the last step just before the `flush` call resolves.
-  it will be executed even if there are no changes to be flushed. 
+- `afterFlush` is executed as the last step just before the `flush` call resolves. it will be executed even if there are no changes to be flushed.
 
-Flush event args will not contain any entity instance, as they are entity agnostic.
-They do contain additional reference to the `UnitOfWork` instance.
+Flush event args will not contain any entity instance, as they are entity agnostic. They do contain additional reference to the `UnitOfWork` instance.
 
 ```typescript
 interface FlushEventArgs extends Omit<EventArgs<unknown>, 'entity'> {
   uow?: UnitOfWork;
 }
-``` 
+```
 
-> Flush events are entity agnostic, specifying `getSubscribedEntities()` method
-> will not have any effect for those. They are fired only once per the `flush` 
-> operation.
+> Flush events are entity agnostic, specifying `getSubscribedEntities()` method will not have any effect for those. They are fired only once per the `flush` operation.
 
 ### Getting the changes from UnitOfWork
 
@@ -184,18 +156,12 @@ UnitOfWork.getExtraUpdates(): Set<[AnyEntity, string, (AnyEntity | Reference<Any
 
 ### Using onFlush event
 
-In following example we have 2 entities: `FooBar` and `FooBaz`, connected via 
-M:1 relation. Our subscriber will automatically create new `FooBaz` entity and 
-connect it to the `FooBar` when we detect it in the change sets.
+In following example we have 2 entities: `FooBar` and `FooBaz`, connected via M:1 relation. Our subscriber will automatically create new `FooBaz` entity and connect it to the `FooBar` when we detect it in the change sets.
 
-We first use `uow.getChangeSets()` method to look up the change set of entity
-we are interested in. After we create the `FooBaz` instance and link it with 
-`FooBar`, we need to do two things:
+We first use `uow.getChangeSets()` method to look up the change set of entity we are interested in. After we create the `FooBaz` instance and link it with `FooBar`, we need to do two things:
 
-1. Call `uow.computeChangeSet(baz)` to compute the change set of newly created 
-  `FooBaz` entity
-2. Call `uow.recomputeSingleChangeSet(cs.entity)` to recalculate the existing 
-  change set of the `FooBar` entity.
+1. Call `uow.computeChangeSet(baz)` to compute the change set of newly created `FooBaz` entity
+2. Call `uow.recomputeSingleChangeSet(cs.entity)` to recalculate the existing change set of the `FooBar` entity.
 
 ```typescript
 @Subscriber()

--- a/docs/versioned_docs/version-4.5/loading-strategies.md
+++ b/docs/versioned_docs/version-4.5/loading-strategies.md
@@ -5,9 +5,7 @@ sidebar_label: Loading Strategies
 
 > `JOINED` loading strategy is SQL only feature.
 
-Controls how relationships get loaded when querying. By default, populated relationships
-are loaded via the `select-in` strategy. This strategy issues one additional `SELECT`
-statement per relation being loaded.
+Controls how relationships get loaded when querying. By default, populated relationships are loaded via the `select-in` strategy. This strategy issues one additional `SELECT` statement per relation being loaded.
 
 The loading strategy can be specified both at mapping time and when loading entities.
 
@@ -29,8 +27,7 @@ export class Book {
 }
 ```
 
-The following will issue two SQL statements.
-One to load the author and another to load all the books belonging to that author:
+The following will issue two SQL statements. One to load the author and another to load all the books belonging to that author:
 
 ```typescript
 const author = await orm.em.findOne(Author, 1, ['books']);
@@ -58,12 +55,11 @@ The following will issue **one** SQL statement:
 const author = await orm.em.findOne(Author, 1, ['books']);
 ```
 
-You can also specify the load strategy as needed. This will override whatever strategy is declared in the mapping.
-This also works for nested populates:
+You can also specify the load strategy as needed. This will override whatever strategy is declared in the mapping. This also works for nested populates:
 
 ```typescript
 // one level
-const author = await orm.em.findOne(Author, 1, { 
+const author = await orm.em.findOne(Author, 1, {
   populate: {
     books: LoadStrategy.JOINED,
   },
@@ -88,5 +84,4 @@ MikroORM.init({
 });
 ```
 
-This value will be used as the default, specifying the loading strategy on
-property level has precedence, as well as specifying it in the `FindOptions`.
+This value will be used as the default, specifying the loading strategy on property level has precedence, as well as specifying it in the `FindOptions`.

--- a/docs/versioned_docs/version-4.5/metadata-cache.md
+++ b/docs/versioned_docs/version-4.5/metadata-cache.md
@@ -4,26 +4,17 @@ title: Metadata Cache
 
 > In v4 you need to explicitly install `@mikro-orm/reflection` to use `TsMorphMetadataProvider`.
 
-Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. Thanks to this, 
-defining the type is enough for runtime validation.
+Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. Thanks to this, defining the type is enough for runtime validation.
 
-If you use folder-based discovery, you should specify paths to
-the compiled entities via `entities` as well as paths to the TS source files of
-those entities via `entitiesTs`. When you run the ORM via `ts-node`, the latter
-will be used automatically, or if you explicitly pass `tsNode: true` in the config.
+If you use folder-based discovery, you should specify paths to the compiled entities via `entities` as well as paths to the TS source files of those entities via `entitiesTs`. When you run the ORM via `ts-node`, the latter will be used automatically, or if you explicitly pass `tsNode: true` in the config.
 
-After the discovery process ends, all metadata will be cached. By default, `FileCacheAdapter`
-will be used to store the cache inside `./temp` folder to JSON files. 
+After the discovery process ends, all metadata will be cached. By default, `FileCacheAdapter` will be used to store the cache inside `./temp` folder to JSON files.
 
 ## Automatic Invalidation
 
-Entity metadata are cached together with modified time of the source file, and every time
-the cache is requested, it first checks if the cache is not invalid. This way you can forgot 
-about the caching mechanism most of the time.
+Entity metadata are cached together with modified time of the source file, and every time the cache is requested, it first checks if the cache is not invalid. This way you can forgot about the caching mechanism most of the time.
 
-One case where you can end up needing to wipe the cache manually is when you work withing a 
-git branch where contents of entities folder differs. 
+One case where you can end up needing to wipe the cache manually is when you work withing a git branch where contents of entities folder differs.
 
 ## Disabling Metadata Cache
 
@@ -60,8 +51,7 @@ await MikroORM.init({
 
 ## Providing Custom Cache Adapter
 
-You can also implement your own cache adapter, for example to store the cache in redis. 
-To do so, just implement simple `CacheAdapter` interface:
+You can also implement your own cache adapter, for example to store the cache in redis. To do so, just implement simple `CacheAdapter` interface:
 
 ```typescript
 export interface CacheAdapter {

--- a/docs/versioned_docs/version-4.5/metadata-providers.md
+++ b/docs/versioned_docs/version-4.5/metadata-providers.md
@@ -2,17 +2,13 @@
 title: Metadata Providers
 ---
 
-As part of entity discovery process, MikroORM uses so called `MetadataProvider` to get necessary
-type information about your entities' properties. There are 3 built-in metadata providers you can 
-use:
+As part of entity discovery process, MikroORM uses so called `MetadataProvider` to get necessary type information about your entities' properties. There are 3 built-in metadata providers you can use:
 
 > You can also implement custom metadata provider by extending abstract `MetadataProvider` class.
 
 ## TsMorphMetadataProvider
 
-With `TsMorphMetadataProvider` MikroORM will use [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. Thanks to this, 
-defining the type is enough for runtime validation.
+With `TsMorphMetadataProvider` MikroORM will use [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. Thanks to this, defining the type is enough for runtime validation.
 
 To use it, first install the `@mikro-orm/reflection` package.
 
@@ -25,18 +21,11 @@ await MikroORM.init({
 });
 ```
 
-If you use folder-based discovery, you should specify paths to
-the compiled entities via `entities` as well as paths to the TS source files of
-those entities via `entitiesTs`. When you run the ORM via `ts-node`, the latter
-will be used automatically, or if you explicitly pass `tsNode: true` in the config.
+If you use folder-based discovery, you should specify paths to the compiled entities via `entities` as well as paths to the TS source files of those entities via `entitiesTs`. When you run the ORM via `ts-node`, the latter will be used automatically, or if you explicitly pass `tsNode: true` in the config.
 
-> When running via `node`, `.d.ts` files are used to obtain the type, so we 
-> need to ship them in the production build. TS source files are no longer 
-> needed (since v4). Be sure to enable `compilerOptions.declaration` in your
-> `tsconfig.json`.
+> When running via `node`, `.d.ts` files are used to obtain the type, so we need to ship them in the production build. TS source files are no longer needed (since v4). Be sure to enable `compilerOptions.declaration` in your `tsconfig.json`.
 
-After the discovery process ends, all [metadata will be cached](metadata-cache.md). By default, 
-`FileCacheAdapter` will be used to store the cache inside `./temp` folder in JSON files. 
+After the discovery process ends, all [metadata will be cached](metadata-cache.md). By default, `FileCacheAdapter` will be used to store the cache inside `./temp` folder in JSON files.
 
 > You can generate production cache via CLI command `mikro-orm cache:generate`.
 
@@ -44,11 +33,9 @@ After the discovery process ends, all [metadata will be cached](metadata-cache.m
 
 ## ReflectMetadataProvider
 
-`ReflectMetadataProvider` uses `reflect-metadata` module to read the type from decorator 
-metadata exported by TypeScript compiler. 
+`ReflectMetadataProvider` uses `reflect-metadata` module to read the type from decorator metadata exported by TypeScript compiler.
 
-You will need to install `reflect-metadata` module and import at the top of your app's 
-bootstrap script (e.g. `main.ts` or `app.ts`). 
+You will need to install `reflect-metadata` module and import at the top of your app's bootstrap script (e.g. `main.ts` or `app.ts`).
 
 ```typescript
 import 'reflect-metadata';
@@ -56,7 +43,7 @@ import 'reflect-metadata';
 
 Next step is to enable `emitDecoratorMetadata` flag in your `tsconfig.json`.
 
-> As this approach does not have performance impact, metadata caching is not really necessary. 
+> As this approach does not have performance impact, metadata caching is not really necessary.
 
 ```typescript
 await MikroORM.init({
@@ -99,8 +86,7 @@ prop?: string;
 
 #### Enums
 
-By default, enum is considered as numeric type. For string enums, you need to explicitly 
-provide one of:
+By default, enum is considered as numeric type. For string enums, you need to explicitly provide one of:
 
 - reference to the enum (which will force you to define the enum before defining the entity)
   ```typescript
@@ -120,31 +106,24 @@ provide one of:
 
 #### Circular dependencies
 
-Reading type of referenced entity in `@ManyToOne` and `@OneToOne` properties fails if there is 
-circular dependency. You will need to explicitly define the type in the decorator (preferably 
-via `entity: () => ...` callback).
+Reading type of referenced entity in `@ManyToOne` and `@OneToOne` properties fails if there is circular dependency. You will need to explicitly define the type in the decorator (preferably via `entity: () => ...` callback).
 
 ```typescript
 @ManyToOne({ entity: () => Author })
 author: Author;
-``` 
+```
 
-> There can be recursion issues when you define multiple entities (with circular dependencies 
-> between each other) in single file. In that case, you might want to provide the type via decorator's
-> `type` or `entity` attributes and set the TS property type to something else (like `any` or `object`).
+> There can be recursion issues when you define multiple entities (with circular dependencies between each other) in single file. In that case, you might want to provide the type via decorator's `type` or `entity` attributes and set the TS property type to something else (like `any` or `object`).
 
 #### Additional typings might be required
 
-You might have to install additional typings, one example is use of `ObjectId` in MongoDB, 
-which requires `@types/mongodb` to be installed. 
+You might have to install additional typings, one example is use of `ObjectId` in MongoDB, which requires `@types/mongodb` to be installed.
 
 ## JavaScriptMetadataProvider
 
 > `JavaScriptMetadataProvider` is deprecated, [use `EntitySchema` instead](entity-schema.md).
 
-This provider should be used only if you are not using TypeScript at all and therefore you do 
-not use decorators to annotate your properties. It will require you to specify the whole schema 
-manually. 
+This provider should be used only if you are not using TypeScript at all and therefore you do not use decorators to annotate your properties. It will require you to specify the whole schema manually.
 
 ```typescript
 await MikroORM.init({

--- a/docs/versioned_docs/version-4.5/migrations.md
+++ b/docs/versioned_docs/version-4.5/migrations.md
@@ -4,11 +4,9 @@ title: Migrations
 
 > To use migrations we need to first install `@mikro-orm/migrations` package.
 
-MikroORM has integrated support for migrations via [umzug](https://github.com/sequelize/umzug).
-It allows you to generate migrations with current schema differences.
+MikroORM has integrated support for migrations via [umzug](https://github.com/sequelize/umzug). It allows you to generate migrations with current schema differences.
 
-By default, each migration will be all executed inside a transaction, and all of them will 
-be wrapped in one master transaction, so if one of them fails, everything will be rolled back. 
+By default, each migration will be all executed inside a transaction, and all of them will be wrapped in one master transaction, so if one of them fails, everything will be rolled back.
 
 ## Migration class
 
@@ -26,32 +24,25 @@ export class Migration20191019195930 extends Migration {
 }
 ```
 
-To support undoing those changed, you can implement the `down` method, which throws an error by default. 
+To support undoing those changed, you can implement the `down` method, which throws an error by default.
 
-Migrations are by default wrapped in a transaction. You can override this behaviour on 
-per migration basis by implementing the `isTransactional(): boolean` method.
+Migrations are by default wrapped in a transaction. You can override this behaviour on per migration basis by implementing the `isTransactional(): boolean` method.
 
 `Configuration` object and driver instance are available in the `Migration` class context.
 
-You can execute queries in the migration via `Migration.execute()` method, which 
-will run queries in the same transaction as the rest of the migration. The 
-`Migration.addSql()` method also accepts instances of knex. Knex instance can be 
-accessed via `Migration.getKnex()`; 
+You can execute queries in the migration via `Migration.execute()` method, which will run queries in the same transaction as the rest of the migration. The `Migration.addSql()` method also accepts instances of knex. Knex instance can be accessed via `Migration.getKnex()`;
 
 ## Initial migration
 
-If you want to start using migrations, and you already have the schema generated, 
-you can do so by creating so called initial migration:
+If you want to start using migrations, and you already have the schema generated, you can do so by creating so called initial migration:
 
-> Initial migration can be created only if there are no migrations previously
-> generated or executed. 
+> Initial migration can be created only if there are no migrations previously generated or executed.
 
 ```sh
 npx mikro-orm migration:create --initial
 ```
 
-This will create the initial migration, containing the schema dump from 
-`schema:create` command. The migration will be automatically marked as executed. 
+This will create the initial migration, containing the schema dump from `schema:create` command. The migration will be automatically marked as executed.
 
 ## Configuration
 
@@ -74,7 +65,7 @@ await MikroORM.init({
 
 ## Using via CLI
 
-You can use it via CLI: 
+You can use it via CLI:
 
 ```sh
 npx mikro-orm migration:create   # Create new migration with current schema diff
@@ -84,11 +75,9 @@ npx mikro-orm migration:list     # List all executed migrations
 npx mikro-orm migration:pending  # List all pending migrations
 ```
 
-> To create blank migration file, we can use
-> `npx mikro-orm migration:create --blank`.
+> To create blank migration file, we can use `npx mikro-orm migration:create --blank`.
 
-For `migration:up` and `migration:down` commands you can specify `--from` (`-f`), `--to` (`-t`) 
-and `--only` (`-o`) options to run only a subset of migrations:
+For `migration:up` and `migration:down` commands you can specify `--from` (`-f`), `--to` (`-t`) and `--only` (`-o`) options to run only a subset of migrations:
 
 ```sh
 npx mikro-orm migration:up --from 2019101911 --to 2019102117  # the same as above
@@ -96,8 +85,7 @@ npx mikro-orm migration:up --only 2019101923                  # apply a single m
 npx mikro-orm migration:down --to 0                           # migrate down all migrations
 ```
 
-> To run TS migration files, you will need to [enable `useTsNode` flag](installation.md) 
-> in your `package.json`.
+> To run TS migration files, you will need to [enable `useTsNode` flag](installation.md) in your `package.json`.
 
 ## Using the Migrator programmatically
 
@@ -144,8 +132,7 @@ await orm.em.transactional(async em => {
 
 ## Importing migrations statically
 
-If you do not want to dynamically import a folder (e.g. when bundling your code with webpack) you can import migrations
-directly.
+If you do not want to dynamically import a folder (e.g. when bundling your code with webpack) you can import migrations directly.
 
 ```typescript
 import { MikroORM } from '@mikro-orm/core';
@@ -163,8 +150,7 @@ await MikroORM.init({
 });
 ```
 
-With the help of [webpack's context module api](https://webpack.js.org/guides/dependency-management/#context-module-api)
-we can dynamically import the migrations making it possible to import all files in a folder.
+With the help of [webpack's context module api](https://webpack.js.org/guides/dependency-management/#context-module-api) we can dynamically import the migrations making it possible to import all files in a folder.
 
 ```typescript
 import { MikroORM } from '@mikro-orm/core';
@@ -196,9 +182,7 @@ await MikroORM.init({
 
 ### MySQL
 
-There is no way to rollback DDL changes in MySQL. An implicit commit is forced for those 
-queries automatically, so transactions are not working as expected. 
+There is no way to rollback DDL changes in MySQL. An implicit commit is forced for those queries automatically, so transactions are not working as expected.
 
 - https://github.com/mikro-orm/mikro-orm/issues/217
 - https://dev.mysql.com/doc/refman/5.7/en/implicit-commit.html
-

--- a/docs/versioned_docs/version-4.5/multiple-schemas.md
+++ b/docs/versioned_docs/version-4.5/multiple-schemas.md
@@ -2,11 +2,9 @@
 title: Using Multiple Schemas
 ---
 
-In MySQL and PostgreSQL it is possible to define your entities in multiple schemas. In MySQL 
-terminology, it is called database, but from an implementation point of view, it is a schema. 
+In MySQL and PostgreSQL it is possible to define your entities in multiple schemas. In MySQL terminology, it is called database, but from an implementation point of view, it is a schema.
 
-> To use multiple schemas, your connection needs to have access to all of them (multiple 
-> connections are not supported).
+> To use multiple schemas, your connection needs to have access to all of them (multiple connections are not supported).
 
 All you need to do is simply define the table name including schema name in `collection` option:
 
@@ -18,12 +16,9 @@ export class Foo { ... }
 export class Bar { ... }
 ```
 
-Then use those entities as usual. Resulting SQL queries will use this `tableName` value as a 
-table name so as long as your connection has access to given schema, everything should work 
-as expected.
+Then use those entities as usual. Resulting SQL queries will use this `tableName` value as a table name so as long as your connection has access to given schema, everything should work as expected.
 
-You can also query for entity in specific schema via `EntityManager`, `EntityRepository` or 
-`QueryBuilder`:
+You can also query for entity in specific schema via `EntityManager`, `EntityRepository` or `QueryBuilder`:
 
 ```typescript
 const user = await em.findOne(User, { ... }, { schema: 'client-123' });

--- a/docs/versioned_docs/version-4.5/naming-strategy.md
+++ b/docs/versioned_docs/version-4.5/naming-strategy.md
@@ -2,15 +2,13 @@
 title: Naming Strategy
 ---
 
-When mapping your entities to database tables and columns, their names will be defined by naming 
-strategy. There are 3 basic naming strategies you can choose from:
+When mapping your entities to database tables and columns, their names will be defined by naming strategy. There are 3 basic naming strategies you can choose from:
 
 - `UnderscoreNamingStrategy` - default of all SQL drivers
 - `MongoNamingStrategy` - default of `MongoDriver`
 - `EntityCaseNamingStrategy` - uses unchanged entity and property names
 
-You can override this when initializing ORM. You can also provide your own naming strategy, just 
-implement `NamingStrategy` interface and provide your implementation when bootstrapping ORM:
+You can override this when initializing ORM. You can also provide your own naming strategy, just implement `NamingStrategy` interface and provide your implementation when bootstrapping ORM:
 
 ```typescript
 class YourCustomNamingStrategy implements NamingStrategy {
@@ -24,20 +22,17 @@ const orm = await MikroORM.init({
 });
 ```
 
-> You can also extend `AbstractNamingStrategy` which implements one method for you - `getClassName()`
-> that is used to map entity file name to class name.
+> You can also extend `AbstractNamingStrategy` which implements one method for you - `getClassName()` that is used to map entity file name to class name.
 
 ## Naming Strategy in mongo driver
 
-`MongoNamingStrategy` will simply use all field names as they are defined. Collection names will
-be translated into lower-cased dashed form:
+`MongoNamingStrategy` will simply use all field names as they are defined. Collection names will be translated into lower-cased dashed form:
 
 `MyCoolEntity` will be translated into `my-cool-entity` collection name.
 
 ## Naming Strategy in SQL drivers
 
-`MySqlDriver` defaults to `UnderscoreNamingStrategy`, which means your all your database tables and
-columns will be lower-cased and words divided by underscored:
+`MySqlDriver` defaults to `UnderscoreNamingStrategy`, which means your all your database tables and columns will be lower-cased and words divided by underscored:
 
 ```sql
 CREATE TABLE `author` (
@@ -87,7 +82,7 @@ Return a join column name for a property.
 
 #### `NamingStrategy.joinTableName(sourceEntity: string, targetEntity: string, propertyName: string): string`
 
-Return a join table name. This is used as default value for `pivotTable`. 
+Return a join table name. This is used as default value for `pivotTable`.
 
 ---
 

--- a/docs/versioned_docs/version-4.5/nested-populate.md
+++ b/docs/versioned_docs/version-4.5/nested-populate.md
@@ -2,15 +2,12 @@
 title: Smart Nested Populate
 ---
 
-`MikroORM` is capable of loading large nested structures while maintaining good 
-performance, querying each database table only once. Imagine you have this nested 
-structure:
+`MikroORM` is capable of loading large nested structures while maintaining good performance, querying each database table only once. Imagine you have this nested structure:
 
 - `Book` has one `Publisher` (M:1), one `Author` (M:1) and many `BookTag`s (M:N)
 - `Publisher` has many `Test`s (M:N)
 
-When you use nested populate while querying all `BookTag`s, this is what happens in
-the background:
+When you use nested populate while querying all `BookTag`s, this is what happens in the background:
 
 ```typescript
 const tags = await orm.em.findAll(BookTag, ['books.publisher.tests', 'books.author']);
@@ -64,7 +61,7 @@ To populate existing entities, you can use `em.populate()`.
 const authors = await orm.em.createQueryBuilder(Author).select('*').getResult();
 await em.populate(authors, ['books.tags']);
 
-// now your Author entities will have `books` collections populated, 
+// now your Author entities will have `books` collections populated,
 // as well as they will have their `tags` collections populated.
 console.log(authors[0].books[0].tags[0]); // initialized BookTag
 ```

--- a/docs/versioned_docs/version-4.5/propagation.md
+++ b/docs/versioned_docs/version-4.5/propagation.md
@@ -2,9 +2,7 @@
 title: Propagation
 ---
 
-By default MikroORM will propagate all changes made to one side of bi-directional relations
-to the other side, keeping them in sync. This works for all relations, including M:1 and 1:1.
-As part of the discovery process, all M:1 and 1:1 properties are re-defined as getter/setter.
+By default MikroORM will propagate all changes made to one side of bi-directional relations to the other side, keeping them in sync. This works for all relations, including M:1 and 1:1. As part of the discovery process, all M:1 and 1:1 properties are re-defined as getter/setter.
 
 ```typescript
 const author = new Author(...);
@@ -17,8 +15,7 @@ console.log(author.books.contains(book)); // true
 
 ## Propagation of Collection's add() and remove() operations
 
-When you use one of `Collection.add()` method, the item is added to given collection, 
-and this action is also propagated to its counterpart. 
+When you use one of `Collection.add()` method, the item is added to given collection, and this action is also propagated to its counterpart.
 
 ```typescript
 // one to many
@@ -29,7 +26,7 @@ author.books.add(book);
 console.log(book.author); // author will be set thanks to the propagation
 ```
 
-For M:N this works in both ways, either from owning side, or from inverse side. 
+For M:N this works in both ways, either from owning side, or from inverse side.
 
 ```typescript
 // many to many works both from owning side and from inverse side
@@ -41,11 +38,10 @@ console.log(tag.books.contains(book)); // true
 
 tag.books.add(book);
 console.log(book.tags.contains(tag)); // true
-``` 
+```
 
 > Collections on both sides have to be initialized, otherwise propagation won't work.
 
-> Although this propagation works also for M:N inverse side, you should always use owning
-> side to manipulate the collection.
+> Although this propagation works also for M:N inverse side, you should always use owning side to manipulate the collection.
 
 Same applies for `Collection.remove()`.

--- a/docs/versioned_docs/version-4.5/property-validation.md
+++ b/docs/versioned_docs/version-4.5/property-validation.md
@@ -2,14 +2,9 @@
 title: Property Validation
 ---
 
-> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`.
-> It has performance implications and usually should not be needed, as long as
-> you don't modify your entities via `Object.assign()`.
+> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`. It has performance implications and usually should not be needed, as long as you don't modify your entities via `Object.assign()`.
 
-`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong 
-data types for you automatically. If automatic conversion fails, it will throw an error. You can 
-enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered 
-when persisting the entity. 
+`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong data types for you automatically. If automatic conversion fails, it will throw an error. You can enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered when persisting the entity.
 
 ```typescript
 // number instead of string will throw

--- a/docs/versioned_docs/version-4.5/query-builder.md
+++ b/docs/versioned_docs/version-4.5/query-builder.md
@@ -2,17 +2,15 @@
 title: Using Query Builder
 ---
 
-:::info
-Since v4, we need to make sure we are working with correctly typed `EntityManager`
-or `EntityRepository` to have access to `createQueryBuilder()` method.
+:::info Since v4, we need to make sure we are working with correctly typed `EntityManager` or `EntityRepository` to have access to `createQueryBuilder()` method.
 
 ```ts
 import { EntityManager, EntityRepository } from '@mikro-orm/mysql'; // or any other driver package
 ```
+
 :::
 
-When you need to execute some SQL query without all the ORM stuff involved, you can either
-compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
+When you need to execute some SQL query without all the ORM stuff involved, you can either compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
 
 ```typescript
 const qb = orm.em.createQueryBuilder(Author);
@@ -32,8 +30,7 @@ const res1 = await qb.execute();
 
 ## Using Knex.js
 
-Under the hood, `QueryBuilder` uses [`Knex.js`](https://knexjs.org) to compose and run queries.
-You can access configured `knex` instance via `qb.getKnexQuery()` method:
+Under the hood, `QueryBuilder` uses [`Knex.js`](https://knexjs.org) to compose and run queries. You can access configured `knex` instance via `qb.getKnexQuery()` method:
 
 ```typescript
 const qb = orm.em.createQueryBuilder(Author);
@@ -47,14 +44,9 @@ const entities = res.map(a => orm.em.map(Author, a));
 console.log(entities); // Author[]
 ```
 
-You can also get clear and configured knex instance from the connection via `getKnex()` method.
-As this method is not available on the base `Connection` class, you will need to either manually
-type cast the connection to `AbstractSqlConnection` (or the actual implementation you are using, 
-e.g. `MySqlConnection`), or provide correct driver type hint to your `EntityManager` instance, 
-which will be then automatically inferred in `em.getConnection()` method.
+You can also get clear and configured knex instance from the connection via `getKnex()` method. As this method is not available on the base `Connection` class, you will need to either manually type cast the connection to `AbstractSqlConnection` (or the actual implementation you are using, e.g. `MySqlConnection`), or provide correct driver type hint to your `EntityManager` instance, which will be then automatically inferred in `em.getConnection()` method.
 
-> Driver and connection implementations are not directly exported from `@mikro-orm/core` module. 
-> You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
+> Driver and connection implementations are not directly exported from `@mikro-orm/core` module. You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
 
 ```typescript
 const conn = orm.em.getConnection() as AbstractSqlConnection;
@@ -89,9 +81,7 @@ const res2 = await qb.execute('get'); // returns single object
 const res3 = await qb.execute('run'); // returns object like `{ affectedRows: number, insertId: number, row: any }`
 ```
 
-Second argument can be used to disable mapping of database columns to property names (which 
-is enabled by default). In following example, `Book` entity has `createdAt` property defined 
-with implicit underscored field name `created_at`:
+Second argument can be used to disable mapping of database columns to property names (which is enabled by default). In following example, `Book` entity has `createdAt` property defined with implicit underscored field name `created_at`:
 
 ```typescript
 const res4 = await orm.em.createQueryBuilder(Book).select('*').execute('get', true);
@@ -100,8 +90,7 @@ const res5 = await orm.em.createQueryBuilder(Book).select('*').execute('get', fa
 console.log(res5); // `created_at` will be defined, while `createdAt` will be missing
 ```
 
-To get entity instances from the QueryBuilder result, you can use `getResult()` and `getSingleResult()`
-methods:
+To get entity instances from the QueryBuilder result, you can use `getResult()` and `getSingleResult()` methods:
 
 ```typescript
 const book = await orm.em.createQueryBuilder(Book).select('*').where({ id: 1 }).getSingleResult();
@@ -114,13 +103,9 @@ console.log(books[0] instanceof Book); // true
 
 ## Mapping Raw Results to Entities
 
-Another way to create entity from raw results (that are not necessarily mapped to entity properties)
-is to use `map()` method of `EntityManager`, that is basically a shortcut for mapping results
-via `IDatabaseDriver.mapResult()` (which converts field names to property names - e.g. `created_at`
-to `createdAt`) and `merge()` which converts the data to entity instance and makes it managed. 
+Another way to create entity from raw results (that are not necessarily mapped to entity properties) is to use `map()` method of `EntityManager`, that is basically a shortcut for mapping results via `IDatabaseDriver.mapResult()` (which converts field names to property names - e.g. `created_at` to `createdAt`) and `merge()` which converts the data to entity instance and makes it managed.
 
-This method comes handy when you want to use 3rd party query builders, where the result is not 
-mapped to entity properties automatically:
+This method comes handy when you want to use 3rd party query builders, where the result is not mapped to entity properties automatically:
 
 ```typescript
 const results = await knex.select('*').from('users').where(knex.raw('id = ?', [id]));
@@ -155,17 +140,16 @@ qb.select('*')
   .orderBy({ books: { tags: { createdBy: QueryOrder.DESC } } });
 
 console.log(qb.getQuery());
-// select `e0`.* 
-// from `author` as `e0` 
-// left join `book2` as `e1` on `e0`.`id` = `e1`.`author_id` 
-// left join `book2_to_book_tag2` as `e3` on `e1`.`uuid_pk` = `e3`.`book2_uuid_pk` 
-// left join `book_tag2` as `e2` on `e3`.`book_tag2_id` = `e2`.`id` 
-// where `e2`.`name` = ? 
+// select `e0`.*
+// from `author` as `e0`
+// left join `book2` as `e1` on `e0`.`id` = `e1`.`author_id`
+// left join `book2_to_book_tag2` as `e3` on `e1`.`uuid_pk` = `e3`.`book2_uuid_pk`
+// left join `book_tag2` as `e2` on `e3`.`book_tag2_id` = `e2`.`id`
+// where `e2`.`name` = ?
 // order by `e1`.`tags` asc
 ```
 
-This is currently available only for filtering (`where`) and sorting (`orderBy`), only 
-the root entity will be selected. To populate its relationships, you can use [`em.populate()`](nested-populate.md).
+This is currently available only for filtering (`where`) and sorting (`orderBy`), only the root entity will be selected. To populate its relationships, you can use [`em.populate()`](nested-populate.md).
 
 ## Explicit Joining
 
@@ -188,8 +172,7 @@ console.log(qb.getQuery());
 
 ## Mapping joined results
 
-To select multiple entities and map them from `QueryBuilder`, we can use
-`joinAndSelect` or `leftJoinAndSelect` method:
+To select multiple entities and map them from `QueryBuilder`, we can use `joinAndSelect` or `leftJoinAndSelect` method:
 
 ```ts
 // `res` will contain array of authors, with books and their tags populated
@@ -203,8 +186,7 @@ const res = await orm.em.createQueryBuilder(Author, 'a')
 
 ## Complex Where Conditions
 
-There are multiple ways to construct complex query conditions. You can either write parts of SQL
-manually, use `andWhere()`/`orWhere()`, or provide condition object:
+There are multiple ways to construct complex query conditions. You can either write parts of SQL manually, use `andWhere()`/`orWhere()`, or provide condition object:
 
 ### Using custom SQL fragments
 
@@ -221,7 +203,7 @@ const users = orm.em.createQueryBuilder(User)
 This will produce following query:
 
 ```sql
-select `e0`.* 
+select `e0`.*
 from `user` as `e0`
 where lower(email) = 'foo@bar.baz'
 order by (point(loc_latitude, loc_longitude) <@> point(0, 0)) asc
@@ -287,7 +269,7 @@ console.log(qb2.getQuery());
 // select `a`.* from `author2` as `a` where `a`.`id` in (select `b`.`author_id` from `book2` as `b` where `b`.`price` > ?)
 ```
 
-For sub-queries in selects, use the `qb.as(alias)` method: 
+For sub-queries in selects, use the `qb.as(alias)` method:
 
 > The dynamic property (`booksTotal`) needs to be defined at the entity level (as `persist: false`).
 
@@ -313,8 +295,7 @@ console.log(qb4.getQuery());
 
 When you want to filter by sub-query on the left-hand side of a predicate, you will need to register it first via `qb.withSubquery()`:
 
-> The dynamic property (`booksTotal`) needs to be defined at the entity level (as `persist: false`).
-> You always need to use prefix in the `qb.withSchema()` (so `a.booksTotal`). 
+> The dynamic property (`booksTotal`) needs to be defined at the entity level (as `persist: false`). You always need to use prefix in the `qb.withSchema()` (so `a.booksTotal`).
 
 ```typescript
 const knex = orm.em.getKnex();

--- a/docs/versioned_docs/version-4.5/query-conditions.md
+++ b/docs/versioned_docs/version-4.5/query-conditions.md
@@ -2,8 +2,7 @@
 title: Smart Query Conditions
 ---
 
-When you want to make complex queries, you can easily end up with a lot of boilerplate code
-full of curly brackets:
+When you want to make complex queries, you can easily end up with a lot of boilerplate code full of curly brackets:
 
 ```typescript
 const res = await orm.em.find(Author, { $and: [
@@ -20,8 +19,8 @@ const res = await orm.em.find(Author, { $and: [
 For AND condition with single field, you can also do this:
 
 ```typescript
-const res = await orm.em.find(Author, { 
-  id: { 
+const res = await orm.em.find(Author, {
+  id: {
     $in: [1, 2, 7],
     $nin: [3, 4],
     $gt: 5,
@@ -61,12 +60,9 @@ const res = await orm.em.find(Author, { $and: [
 ] });
 ```
 
-> Keys with operators like this will cause TypeScript errors as there is no way to support 
-> them on the typings side. They are still supported, but you will need to cast the condition
-> to `any` to use them. 
+> Keys with operators like this will cause TypeScript errors as there is no way to support them on the typings side. They are still supported, but you will need to cast the condition to `any` to use them.
 
-There is also shortcut for `$in` - simply provide array as value and it 
-will be converted automatically:
+There is also shortcut for `$in` - simply provide array as value and it will be converted automatically:
 
 ```typescript
 const res = await orm.em.find(Author, { favouriteBook: [1, 2, 7] });
@@ -82,27 +78,27 @@ const res = await orm.em.find(Author, [1, 2, 7]);
 
 ### Comparison
 
-| operator | name               | description |
-|----------|--------------------|-------------|
-| `$eq`	   | equals             | Matches values that are equal to a specified value. |
-| `$gt`	   | greater            | Matches values that are greater than a specified value. |
-| `$gte`   | greater or equal   | Matches values that are greater than or equal to a specified value. |
-| `$in`	   | contains           | Matches any of the values specified in an array. |
-| `$lt`	   | lower              | Matches values that are less than a specified value. |
-| `$lte`   | lower or equal     | Matches values that are less than or equal to a specified value. |
-| `$ne`	   | not equal          | Matches all values that are not equal to a specified value. |
-| `$nin`   | not contains       | Matches none of the values specified in an array. |
-| `$like`  | like               | Uses LIKE operator |
-| `$re`    | regexp             | Uses REGEXP operator |
-| `$ilike` | ilike              | (postgres only) |
-| `$overlap` | &&               | (postgres only) |
-| `$contains` | @>              | (postgres only) |
-| `$contained` | <@             | (postgres only) |
+| operator     | name             | description                                                         |
+| ------------ | ---------------- | ------------------------------------------------------------------- |
+| `$eq`        | equals           | Matches values that are equal to a specified value.                 |
+| `$gt`        | greater          | Matches values that are greater than a specified value.             |
+| `$gte`       | greater or equal | Matches values that are greater than or equal to a specified value. |
+| `$in`        | contains         | Matches any of the values specified in an array.                    |
+| `$lt`        | lower            | Matches values that are less than a specified value.                |
+| `$lte`       | lower or equal   | Matches values that are less than or equal to a specified value.    |
+| `$ne`        | not equal        | Matches all values that are not equal to a specified value.         |
+| `$nin`       | not contains     | Matches none of the values specified in an array.                   |
+| `$like`      | like             | Uses LIKE operator                                                  |
+| `$re`        | regexp           | Uses REGEXP operator                                                |
+| `$ilike`     | ilike            | (postgres only)                                                     |
+| `$overlap`   | &&               | (postgres only)                                                     |
+| `$contains`  | @>               | (postgres only)                                                     |
+| `$contained` | <@               | (postgres only)                                                     |
 
 ### Logical
 
-| operator | description |
-|----------|-------------|
+| operator | description                                                                                             |
+| -------- | ------------------------------------------------------------------------------------------------------- |
 | `$and`   | Joins query clauses with a logical AND returns all documents that match the conditions of both clauses. |
-| `$not`   | Inverts the effect of a query expression and returns documents that do not match the query expression. |
+| `$not`   | Inverts the effect of a query expression and returns documents that do not match the query expression.  |
 | `$or`    | Joins query clauses with a logical OR returns all documents that match the conditions of either clause. |

--- a/docs/versioned_docs/version-4.5/quick-start.md
+++ b/docs/versioned_docs/version-4.5/quick-start.md
@@ -2,8 +2,7 @@
 title: Quick Start
 ---
 
-First install the module via `yarn` or `npm` and do not forget to install the 
-database driver as well:
+First install the module via `yarn` or `npm` and do not forget to install the database driver as well:
 
 ```sh
 yarn add @mikro-orm/core @mikro-orm/mongodb     # for mongo
@@ -23,8 +22,7 @@ npm i -s @mikro-orm/core @mikro-orm/postgresql  # for postgresql
 npm i -s @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 ```
 
-Next you will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html)
-as well as `esModuleInterop` in `tsconfig.json` via:
+Next you will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html) as well as `esModuleInterop` in `tsconfig.json` via:
 
 ```json
 "experimentalDecorators": true,
@@ -44,14 +42,11 @@ const orm = await MikroORM.init({
 console.log(orm.em); // access EntityManager via `em` property
 ```
 
-There are more ways to configure your entities, take a look at 
-[installation page](https://mikro-orm.io/installation/).
+There are more ways to configure your entities, take a look at [installation page](https://mikro-orm.io/installation/).
 
 > Read more about all the possible configuration options in [Advanced Configuration](https://mikro-orm.io/docs/configuration) section.
 
-Then you will need to fork entity manager for each request so their 
-[identity maps](https://mikro-orm.io/identity-map/) will not collide. 
-To do so, use the `RequestContext` helper:
+Then you will need to fork entity manager for each request so their [identity maps](https://mikro-orm.io/identity-map/) will not collide. To do so, use the `RequestContext` helper:
 
 ```typescript
 const app = express();
@@ -61,15 +56,11 @@ app.use((req, res, next) => {
 });
 ```
 
-> You should register this middleware as the last one just before request handlers and before
-> any of your custom middleware that is using the ORM. There might be issues when you register 
-> it before request processing middleware like `queryParser` or `bodyParser`, so definitely 
-> register the context after them. 
+> You should register this middleware as the last one just before request handlers and before any of your custom middleware that is using the ORM. There might be issues when you register it before request processing middleware like `queryParser` or `bodyParser`, so definitely register the context after them.
 
 More info about `RequestContext` is described [here](https://mikro-orm.io/identity-map/#request-context).
 
-Now you can start defining your entities (in one of the `entities` folders). This is how
-simple entity can look like in mongo driver:
+Now you can start defining your entities (in one of the `entities` folders). This is how simple entity can look like in mongo driver:
 
 ```typescript title="./entities/MongoBook.ts"
 @Entity()
@@ -124,15 +115,11 @@ export class UuidBook {
 }
 ```
 
-More information can be found in
-[defining entities section](https://mikro-orm.io/defining-entities/) in docs.
+More information can be found in [defining entities section](https://mikro-orm.io/defining-entities/) in docs.
 
-When you have your entities defined, you can start using ORM either via `EntityManager`
-or via `EntityRepository`s.
+When you have your entities defined, you can start using ORM either via `EntityManager` or via `EntityRepository`s.
 
-To save entity state to database, you need to persist it. Persist determines 
-whether to use `insert` or `update` and computes appropriate change-set. Entity references
-that are not persisted yet (does not have identifier) will be cascade persisted automatically. 
+To save entity state to database, you need to persist it. Persist determines whether to use `insert` or `update` and computes appropriate change-set. Entity references that are not persisted yet (does not have identifier) will be cascade persisted automatically.
 
 ```typescript
 // use constructors in your entities for required parameters
@@ -152,7 +139,7 @@ book3.publisher = publisher;
 await orm.em.persistAndFlush([book1, book2, book3]);
 ```
 
-To fetch entities from database you can use `find()` and `findOne()` of `EntityManager`: 
+To fetch entities from database you can use `find()` and `findOne()` of `EntityManager`:
 
 ```typescript
 const authors = orm.em.find(Author, {});
@@ -168,8 +155,7 @@ for (const author of authors) {
 }
 ```
 
-More convenient way of fetching entities from database is by using `EntityRepository`, that
-carries the entity name so you do not have to pass it to every `find` and `findOne` calls:
+More convenient way of fetching entities from database is by using `EntityRepository`, that carries the entity name so you do not have to pass it to every `find` and `findOne` calls:
 
 ```typescript
 const booksRepository = orm.em.getRepository(Book);
@@ -178,7 +164,7 @@ const booksRepository = orm.em.getRepository(Book);
 const books = await booksRepository.find({ author: '...' }, ['author'], { title: QueryOrder.DESC }, 2, 1);
 
 // or with options object
-const books = await booksRepository.find({ author: '...' }, { 
+const books = await booksRepository.find({ author: '...' }, {
   populate: ['author'],
   limit: 1,
   offset: 2,
@@ -188,5 +174,4 @@ const books = await booksRepository.find({ author: '...' }, {
 console.log(books); // Book[]
 ```
 
-Take a look at docs about [working with `EntityManager`](https://mikro-orm.io/entity-manager/)
-or [using `EntityRepository` instead](https://mikro-orm.io/repositories/).
+Take a look at docs about [working with `EntityManager`](https://mikro-orm.io/entity-manager/) or [using `EntityRepository` instead](https://mikro-orm.io/repositories/).

--- a/docs/versioned_docs/version-4.5/read-connections.md
+++ b/docs/versioned_docs/version-4.5/read-connections.md
@@ -2,8 +2,7 @@
 title: Read Replica Connections
 ---
 
-Users can specify multiple read connections via `replicas` option. You can provide only fields 
-that differ from master connection, rest will be taken from it.
+Users can specify multiple read connections via `replicas` option. You can provide only fields that differ from master connection, rest will be taken from it.
 
 ```typescript
 const orm = await MikroORM.init({
@@ -19,8 +18,7 @@ const orm = await MikroORM.init({
 });
 ```
 
-By default select queries will use random read connection if not inside transaction. You can 
-specify connection type manually in `em.getConnection(type: 'read' | 'write')`.
+By default select queries will use random read connection if not inside transaction. You can specify connection type manually in `em.getConnection(type: 'read' | 'write')`.
 
 ```typescript
 const connection = orm.em.getConnection(); // write connection

--- a/docs/versioned_docs/version-4.5/relationships.md
+++ b/docs/versioned_docs/version-4.5/relationships.md
@@ -3,20 +3,16 @@ title: Modeling Entity Relationships
 sidebar_label: Modeling Entity Relationships
 ---
 
-There are 4 types of entity relationships in MikroORM: 
+There are 4 types of entity relationships in MikroORM:
 
 - ManyToOne
 - OneToMany
 - OneToOne
 - ManyToMany
 
-Relations can be unidirectional and bidirectional. Unidirectional are defined only on one 
-side (the owning side). Bidirectional are defined on both sides, while one is owning side 
-(where references are store), marked by `inversedBy` attribute pointing to the inverse side.
-On the inversed side we define it with `mappedBy` attribute pointing back to the owner:
+Relations can be unidirectional and bidirectional. Unidirectional are defined only on one side (the owning side). Bidirectional are defined on both sides, while one is owning side (where references are store), marked by `inversedBy` attribute pointing to the inverse side. On the inversed side we define it with `mappedBy` attribute pointing back to the owner:
 
-> When modeling bidirectional relationship, you can also omit the `inversedBy` attribute, 
-> defining `mappedBy` on the inverse side is enough as it will be auto-wired. 
+> When modeling bidirectional relationship, you can also omit the `inversedBy` attribute, defining `mappedBy` on the inverse side is enough as it will be auto-wired.
 
 ## ManyToOne
 
@@ -43,8 +39,7 @@ export class Book {
 }
 ```
 
-You can also specify how operations on given entity should [cascade](cascading.md) 
-to the referred entity.
+You can also specify how operations on given entity should [cascade](cascading.md) to the referred entity.
 
 ## OneToMany
 
@@ -71,19 +66,15 @@ export class Author {
 }
 ```
 
-As you can see, OneToMany is the inverse side of ManyToOne (which is the owning side).
-More about how collections work can be found on [collections page](collections.md). 
+As you can see, OneToMany is the inverse side of ManyToOne (which is the owning side). More about how collections work can be found on [collections page](collections.md).
 
-You can also specify how operations on given entity should [cascade](cascading.md) to the referred
-entities. There is also more aggressive remove mode called [Orphan Removal](cascading.md#orphan-removal) 
-(`books4` example).
+You can also specify how operations on given entity should [cascade](cascading.md) to the referred entities. There is also more aggressive remove mode called [Orphan Removal](cascading.md#orphan-removal) (`books4` example).
 
 ## OneToOne
 
 > One instance of the current Entity refers to One instance of the referred Entity.
 
-This is a variant of ManyToOne, where there is always just one entity on both sides. This means
-that the foreign key column is also unique.
+This is a variant of ManyToOne, where there is always just one entity on both sides. This means that the foreign key column is also unique.
 
 ### Owning Side
 
@@ -121,8 +112,7 @@ export class User {
 }
 ```
 
-As you can see, relationships can be also self-referencing (all of them. OneToOne also supports 
-[Orphan Removal](cascading.md#orphan-removal). 
+As you can see, relationships can be also self-referencing (all of them. OneToOne also supports [Orphan Removal](cascading.md#orphan-removal).
 
 ## ManyToMany
 
@@ -149,7 +139,7 @@ export class Book {
   @ManyToMany(() => BookTag, 'books', { owner: true })
   tags4 = new Collection<BookTag>(this);
 
-  // to define uni-directional many to many, simply provide only 
+  // to define uni-directional many to many, simply provide only
   @ManyToMany(() => Author)
   friends: Collection<Author> = new Collection<Author>(this);
 
@@ -169,4 +159,4 @@ export class BookTag {
 }
 ```
 
-Again, more information about how collections work can be found on [collections page](collections.md). 
+Again, more information about how collections work can be found on [collections page](collections.md).

--- a/docs/versioned_docs/version-4.5/repositories-api.md
+++ b/docs/versioned_docs/version-4.5/repositories-api.md
@@ -4,8 +4,7 @@ title: EntityRepository API
 
 #### `find(where: FilterQuery<T>, options?: FindOptions): Promise<T[]>`
 
-Returns array of entities found for given condition. You can specify `FindOptions` to request
-population of referenced entities or control the pagination:
+Returns array of entities found for given condition. You can specify `FindOptions` to request population of referenced entities or control the pagination:
 
 ```typescript
 export interface FindOptions {
@@ -21,70 +20,61 @@ export interface FindOptions {
 
 #### `find(where: FilterQuery<T>, populate?: string[], orderBy?: { [k: string]: QueryOrder }, limit?: number, offset?: number): Promise<T[]>`
 
-Same as previous `find` method, just with dedicated parameters for `populate`, `orderBy`, `limit`
-and `offset`.
+Same as previous `find` method, just with dedicated parameters for `populate`, `orderBy`, `limit` and `offset`.
 
 ---
 
 #### `findAndCount(where: FilterQuery<T>, populate?: string[], orderBy?: { [k: string]: QueryOrder }, limit?: number, offset?: number): Promise<T[]>`
 
-Combination of `find` and `count` methods. 
+Combination of `find` and `count` methods.
 
 ---
 
 #### `findAll(options?: FindOptions): Promise<T[]>`
 
-Returns all entities for given type. 
+Returns all entities for given type.
 
 ---
 
 #### `findAll(populate?: string[], orderBy?: { [k: string]: QueryOrder }, limit?: number, offset?: number): Promise<T[]>`
 
-Same as previous `findAll` method, just with dedicated parameters for `populate`, `orderBy`, `limit`
-and `offset`.
+Same as previous `findAll` method, just with dedicated parameters for `populate`, `orderBy`, `limit` and `offset`.
 
 ---
 
 #### `findOne(where: FilterQuery<T> | string, populate?: string[]): Promise<T | null>`
 
-Finds an entity by given `where` condition. You can use primary key as `where` value, then
-if the entity is already managed, no database call will be made. 
+Finds an entity by given `where` condition. You can use primary key as `where` value, then if the entity is already managed, no database call will be made.
 
 ---
 
 #### `findOneOrFail(where: FilterQuery<T> | string, populate?: string[]): Promise<T>`
 
-Just like `findOne`, but throws when entity not found, so it always resolves to given entity. 
-You can customize the error either globally via `findOneOrFailHandler` option, or locally via 
-`failHandler` option in `findOneOrFail` call.
+Just like `findOne`, but throws when entity not found, so it always resolves to given entity. You can customize the error either globally via `findOneOrFailHandler` option, or locally via `failHandler` option in `findOneOrFail` call.
 
 ---
 
 #### `merge(data: EntityData<T>): T`
 
-Adds given entity to current Identity Map. After merging, entity becomes managed. 
-This is useful when you want to work with cached entities. 
+Adds given entity to current Identity Map. After merging, entity becomes managed. This is useful when you want to work with cached entities.
 
 ---
 
 #### `getReference(id: string): T`
 
-Gets a reference to the entity identified by the given type and identifier without actually 
-loading it, if the entity is not yet loaded.
+Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded.
 
 ---
 
 #### `count(where?: FilterQuery<T>): Promise<number>`
 
-Gets count of entities matching the `where` condition. 
+Gets count of entities matching the `where` condition.
 
 ---
 
 #### `persist(entity: AnyEntity | AnyEntity[]): Promise<void>`
 
-Tells the EntityManager to make an instance managed and persistent. The entity will be 
-entered into the database at or before transaction commit or as a result of the flush 
-operation. 
+Tells the EntityManager to make an instance managed and persistent. The entity will be entered into the database at or before transaction commit or as a result of the flush operation.
 
 ---
 
@@ -118,7 +108,7 @@ This method fires `beforeDelete` and `afterDelete` hooks.
 
 Shortcut for `remove` & `flush`.
 
-This method fires `beforeDelete` and `afterDelete` hooks. 
+This method fires `beforeDelete` and `afterDelete` hooks.
 
 ---
 
@@ -126,13 +116,12 @@ This method fires `beforeDelete` and `afterDelete` hooks.
 
 Shortcut for `remove` without flushing. Deprecated, use `em.remove()`.
 
-This method fires `beforeDelete` and `afterDelete` hooks. 
+This method fires `beforeDelete` and `afterDelete` hooks.
 
 ---
 
 #### `canPopulate(property: string): boolean`
 
-Returns whether given entity has given property which can be populated (is reference or
-collection).
+Returns whether given entity has given property which can be populated (is reference or collection).
 
 ---

--- a/docs/versioned_docs/version-4.5/repositories.md
+++ b/docs/versioned_docs/version-4.5/repositories.md
@@ -3,8 +3,7 @@ title: Using EntityRepository instead of EntityManager
 sidebar_label: Entity Repository
 ---
 
-More convenient way of fetching entities from database is by using `EntityRepository`, that
-carries the entity name so you do not have to pass it to every `find` and `findOne` calls:
+More convenient way of fetching entities from database is by using `EntityRepository`, that carries the entity name so you do not have to pass it to every `find` and `findOne` calls:
 
 Example:
 
@@ -15,7 +14,7 @@ const booksRepository = orm.em.getRepository(Book);
 const books = await booksRepository.find({ author: '...' }, ['author'], { title: QueryOrder.DESC }, 2, 1);
 
 // or with options object
-const books = await booksRepository.find({ author: '...' }, { 
+const books = await booksRepository.find({ author: '...' }, {
   populate: ['author'],
   limit: 1,
   offset: 2,
@@ -27,11 +26,7 @@ console.log(books); // Book[]
 
 ## Custom Repository
 
-:::info
-Since v4, we need to make sure we are working with correctly typed `EntityRepository` 
-to have access to driver specific methods (like `createQueryBuilder()`). Use the one
-exported from your driver package.
-:::
+:::info Since v4, we need to make sure we are working with correctly typed `EntityRepository` to have access to driver specific methods (like `createQueryBuilder()`). Use the one exported from your driver package. :::
 
 To use custom repository, just extend `EntityRepository<T>` class:
 
@@ -49,8 +44,7 @@ export class CustomAuthorRepository extends EntityRepository<Author> {
 }
 ```
 
-You can also omit the `@Repository` decorator and register your repository in `@Entity` 
-decorator instead:
+You can also omit the `@Repository` decorator and register your repository in `@Entity` decorator instead:
 
 ```typescript
 @Entity({ customRepository: () => CustomAuthorRepository })
@@ -59,16 +53,13 @@ export class Author {
 }
 ```
 
-Note that we need to pass that repository reference inside a callback so we will not run
-into circular dependency issues when using entity references inside that repository.
+Note that we need to pass that repository reference inside a callback so we will not run into circular dependency issues when using entity references inside that repository.
 
 Now you can access your custom repository via `em.getRepository()` method.
 
 ### Inferring custom repository type
 
-To have the `em.getRepository()` method return correctly typed custom repository
-instead of the generic `EntityRepository<T>`, we can use `EntityRepositoryType`
-symbol:
+To have the `em.getRepository()` method return correctly typed custom repository instead of the generic `EntityRepository<T>`, we can use `EntityRepositoryType` symbol:
 
 ```ts
 @Entity({ customRepository: () => AuthorRepository })
@@ -81,11 +72,8 @@ export class Author {
 const repo = em.getRepository(Author); // repo has type AuthorRepository
 ```
 
-> You can also register custom base repository (for all entities where you do not specify 
-> `customRepository`) globally, via `MikroORM.init({ entityRepository: CustomBaseRepository })`.
+> You can also register custom base repository (for all entities where you do not specify `customRepository`) globally, via `MikroORM.init({ entityRepository: CustomBaseRepository })`.
 
 > Note that you cannot use both `@Repository(Author)` on the repository and `{ customRepository: () => AuthorRepository }` on the entity at the same time. This will cause a circular dependency and throws an error. Either one of options achieves the same goal.
 
-For more examples, take a look at
-[`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts)
-or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).
+For more examples, take a look at [`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts) or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).

--- a/docs/versioned_docs/version-4.5/schema-generator.md
+++ b/docs/versioned_docs/version-4.5/schema-generator.md
@@ -2,20 +2,13 @@
 title: Schema Generator
 ---
 
-> SchemaGenerator can do harm to your database. It will drop or alter tables, indexes, 
-> sequences and such. Please use this tool with caution in development and not on a 
-> production server. It is meant for helping you develop your Database Schema, but NOT 
-> with migrating schema from A to B in production. A safe approach would be generating 
-> the SQL on development server and saving it into SQL Migration files that are executed 
-> manually on the production server.
+> SchemaGenerator can do harm to your database. It will drop or alter tables, indexes, sequences and such. Please use this tool with caution in development and not on a production server. It is meant for helping you develop your Database Schema, but NOT with migrating schema from A to B in production. A safe approach would be generating the SQL on development server and saving it into SQL Migration files that are executed manually on the production server.
 
-> SchemaTool assumes your project uses the given database on its own. Update and Drop 
-> commands will mess with other tables if they are not related to the current project 
-> that is using MikroORM. Please be careful!
+> SchemaTool assumes your project uses the given database on its own. Update and Drop commands will mess with other tables if they are not related to the current project that is using MikroORM. Please be careful!
 
-To generate schema from your entity metadata, you can use `SchemaGenerator` helper. 
+To generate schema from your entity metadata, you can use `SchemaGenerator` helper.
 
-You can use it via CLI: 
+You can use it via CLI:
 
 ```sh
 npx mikro-orm schema:create --dump   # Dumps create schema SQL
@@ -23,18 +16,13 @@ npx mikro-orm schema:update --dump   # Dumps update schema SQL
 npx mikro-orm schema:drop --dump     # Dumps drop schema SQL
 ```
 
-> You can also use `--run` flag to fire all queries, but be careful as it might break your
-> database. Be sure to always check the generated SQL first before executing. Do not use
-> `--run` flag in production! 
+> You can also use `--run` flag to fire all queries, but be careful as it might break your database. Be sure to always check the generated SQL first before executing. Do not use `--run` flag in production!
 
-`schema:create` will automatically create the database if it does not exist. 
+`schema:create` will automatically create the database if it does not exist.
 
-`schema:update` drops all unknown tables by default, you can use `--no-drop-tables` 
-to get around it. There is also `--safe` flag that will disable both table dropping as 
-well as column dropping. 
+`schema:update` drops all unknown tables by default, you can use `--no-drop-tables` to get around it. There is also `--safe` flag that will disable both table dropping as well as column dropping.
 
-`schema:drop` will by default drop all database tables. You can use `--drop-db` flag to drop
-the whole database instead. 
+`schema:drop` will by default drop all database tables. You can use `--drop-db` flag to drop the whole database instead.
 
 ## Using SchemaGenerator programmatically
 
@@ -81,12 +69,10 @@ $ ts-node create-schema
 
 ## Limitations of SQLite
 
-There are limitations of SQLite database because of which it behaves differently 
-than other SQL drivers. Namely, it is not possible to:
+There are limitations of SQLite database because of which it behaves differently than other SQL drivers. Namely, it is not possible to:
 
 - create foreign key constraints when altering columns
 - create empty tables without columns
 - alter column requires nullability
 
-Because of this, you can end up with different schema with SQLite, so it is not
-suggested to use SQLite for integration tests of your application.
+Because of this, you can end up with different schema with SQLite, so it is not suggested to use SQLite for integration tests of your application.

--- a/docs/versioned_docs/version-4.5/serializing.md
+++ b/docs/versioned_docs/version-4.5/serializing.md
@@ -12,9 +12,7 @@ export interface AnyEntity<K = number | string> {
 }
 ```
 
-When you serialize your entity via `JSON.stringify(entity)`, its `toJSON` method will be 
-called automatically. You can provide custom implementation for `toJSON`, while using 
-`toObject` for initial serialization:
+When you serialize your entity via `JSON.stringify(entity)`, its `toJSON` method will be called automatically. You can provide custom implementation for `toJSON`, while using `toObject` for initial serialization:
 
 ```typescript
 @Entity()
@@ -35,13 +33,11 @@ export class Book {
 }
 ```
 
-> Do not forget to pass rest params when calling `toObject(...args)`, otherwise the results
-> might not be stable.
+> Do not forget to pass rest params when calling `toObject(...args)`, otherwise the results might not be stable.
 
 ## Hidden Properties
 
-If you want to omit some properties from serialized result, you can mark them with `hidden`
-flag on `@Property()` decorator:
+If you want to omit some properties from serialized result, you can mark them with `hidden` flag on `@Property()` decorator:
 
 ```typescript
 @Entity()
@@ -59,13 +55,9 @@ console.log(wrap(book).toJSON().hiddenField); // undefined
 
 ## Shadow Properties
 
-The opposite situation where you want to define a property that lives only in memory (is 
-not persisted into database) can be solved by defining your property as `persist: false`. 
-Such property can be assigned via one of `Entity.assign()`, `em.create()` and 
-`em.merge()`. It will be also part of serialized result. 
+The opposite situation where you want to define a property that lives only in memory (is not persisted into database) can be solved by defining your property as `persist: false`. Such property can be assigned via one of `Entity.assign()`, `em.create()` and `em.merge()`. It will be also part of serialized result.
 
-This can be handle when dealing with additional values selected via `QueryBuilder` or 
-MongoDB's aggregations.
+This can be handle when dealing with additional values selected via `QueryBuilder` or MongoDB's aggregations.
 
 ```typescript
 @Entity()
@@ -84,8 +76,7 @@ console.log(wrap(book).toJSON().count); // 123
 
 ## Property Serializers
 
-As an alternative to custom `toJSON()` method, we can also use property serializers.
-They allow to specify a callback that will be used when serializing a property:
+As an alternative to custom `toJSON()` method, we can also use property serializers. They allow to specify a callback that will be used when serializing a property:
 
 ```typescript
 @Entity()

--- a/docs/versioned_docs/version-4.5/transactions.md
+++ b/docs/versioned_docs/version-4.5/transactions.md
@@ -6,28 +6,17 @@ title: Transactions and Concurrency
 
 ## Transaction Demarcation
 
-Transaction demarcation is the task of defining your transaction boundaries. Proper 
-transaction demarcation is very important because if not done properly it can negatively 
-affect the performance of your application. Many databases and database abstraction 
-layers by default operate in auto-commit mode, which means that every single SQL statement 
-is wrapped in a small transaction. Without any explicit transaction demarcation from your 
-side, this quickly results in poor performance because transactions are not cheap. 
+Transaction demarcation is the task of defining your transaction boundaries. Proper transaction demarcation is very important because if not done properly it can negatively affect the performance of your application. Many databases and database abstraction layers by default operate in auto-commit mode, which means that every single SQL statement is wrapped in a small transaction. Without any explicit transaction demarcation from your side, this quickly results in poor performance because transactions are not cheap.
 
-For the most part, MikroORM already takes care of proper transaction demarcation for you: 
-All the write operations (INSERT/UPDATE/DELETE) are queued until `em.flush()` 
-is invoked which wraps all of these changes in a single transaction.
+For the most part, MikroORM already takes care of proper transaction demarcation for you: All the write operations (INSERT/UPDATE/DELETE) are queued until `em.flush()` is invoked which wraps all of these changes in a single transaction.
 
-However, MikroORM also allows (and encourages) you to take over and control transaction 
-demarcation yourself.
+However, MikroORM also allows (and encourages) you to take over and control transaction demarcation yourself.
 
-These are two ways to deal with transactions when using the MikroORM and are now described 
-in more detail.
+These are two ways to deal with transactions when using the MikroORM and are now described in more detail.
 
 ### Approach 1: Implicitly
 
-The first approach is to use the implicit transaction handling provided by the MikroORM 
-`EntityManager`. Given the following code snippet, without any explicit transaction 
-demarcation:
+The first approach is to use the implicit transaction handling provided by the MikroORM `EntityManager`. Given the following code snippet, without any explicit transaction demarcation:
 
 ```typescript
 const user = new User(...);
@@ -35,16 +24,11 @@ user.name = 'George';
 await orm.em.persistAndFlush(user);
 ```
 
-Since we do not do any custom transaction demarcation in the above code, `em.flush()` 
-will begin and commit/rollback a transaction. This behavior is made possible by the 
-aggregation of the DML operations by the MikroORM and is sufficient if all the data 
-manipulation that is part of a unit of work happens through the domain model and thus 
-the ORM.
+Since we do not do any custom transaction demarcation in the above code, `em.flush()` will begin and commit/rollback a transaction. This behavior is made possible by the aggregation of the DML operations by the MikroORM and is sufficient if all the data manipulation that is part of a unit of work happens through the domain model and thus the ORM.
 
 ### Approach 2: Explicitly
 
-The explicit alternative is to use the transactions API directly to control the boundaries. 
-The code then looks like this:
+The explicit alternative is to use the transactions API directly to control the boundaries. The code then looks like this:
 
 ```typescript
 await orm.em.transactional(em => {
@@ -55,8 +39,7 @@ await orm.em.transactional(em => {
 });
 ```
 
-Or you can use `begin/commit/rollback` methods explicitly. Following example is
-equivalent to the previous one:
+Or you can use `begin/commit/rollback` methods explicitly. Following example is equivalent to the previous one:
 
 ```typescript
 const em = orm.em.fork(false);
@@ -74,68 +57,37 @@ try {
 }
 ```
 
-Explicit transaction demarcation is required when you want to include custom DBAL operations 
-in a unit of work or when you want to make use of some methods of the EntityManager API 
-that require an active transaction. Such methods will throw a `ValidationError` to inform 
-you of that requirement.
+Explicit transaction demarcation is required when you want to include custom DBAL operations in a unit of work or when you want to make use of some methods of the EntityManager API that require an active transaction. Such methods will throw a `ValidationError` to inform you of that requirement.
 
 `em.transactional(cb)` will flush the inner `EntityManager` prior to transaction commit.
 
 ### Exception Handling
 
-When using implicit transaction demarcation and an exception occurs during 
-`em.flush()`, the transaction is automatically rolled back.
+When using implicit transaction demarcation and an exception occurs during `em.flush()`, the transaction is automatically rolled back.
 
-When using explicit transaction demarcation and an exception occurs, the transaction should 
-be rolled back immediately as demonstrated in the example above. This can be handled elegantly 
-by the control abstractions shown earlier. Note that when catching Exception you should 
-generally re-throw the exception. If you intend to recover from some exceptions, catch them 
-explicitly in earlier catch blocks (but do not forget to rollback the transaction). All 
-other best practices of exception handling apply similarly (i.e. either log or re-throw, 
-not both, etc.).
+When using explicit transaction demarcation and an exception occurs, the transaction should be rolled back immediately as demonstrated in the example above. This can be handled elegantly by the control abstractions shown earlier. Note that when catching Exception you should generally re-throw the exception. If you intend to recover from some exceptions, catch them explicitly in earlier catch blocks (but do not forget to rollback the transaction). All other best practices of exception handling apply similarly (i.e. either log or re-throw, not both, etc.).
 
-As a result of this procedure, all previously managed or removed instances of the `EntityManager` 
-become detached. The state of the detached objects will be the state at the point at which the 
-transaction was rolled back. The state of the objects is in no way rolled back and thus the 
-objects are now out of sync with the database. The application can continue to use the detached 
-objects, knowing that their state is potentially no longer accurate.
+As a result of this procedure, all previously managed or removed instances of the `EntityManager` become detached. The state of the detached objects will be the state at the point at which the transaction was rolled back. The state of the objects is in no way rolled back and thus the objects are now out of sync with the database. The application can continue to use the detached objects, knowing that their state is potentially no longer accurate.
 
-If you intend to start another unit of work after an exception has occurred you should do 
-that with a new `EntityManager`. Simply use `em.fork()` to obtain fresh copy 
-with cleared identity map. 
+If you intend to start another unit of work after an exception has occurred you should do that with a new `EntityManager`. Simply use `em.fork()` to obtain fresh copy with cleared identity map.
 
 ## Locking Support
 
 ### Why we need concurrency control?
 
-If transactions are executed serially (one at a time), no transaction concurrency exists. 
-However, if concurrent transactions with interleaving operations are allowed, you may easily 
-run into one of those problems:
+If transactions are executed serially (one at a time), no transaction concurrency exists. However, if concurrent transactions with interleaving operations are allowed, you may easily run into one of those problems:
 
 1. The lost update problem
 2. The dirty read problem
 3. The incorrect summary problem
 
-To mitigate those problems, MikroORM offers support for Pessimistic and Optimistic locking 
-strategies natively. This allows you to take very fine-grained control over what kind of 
-locking is required for your entities in your application.
+To mitigate those problems, MikroORM offers support for Pessimistic and Optimistic locking strategies natively. This allows you to take very fine-grained control over what kind of locking is required for your entities in your application.
 
 ### Optimistic Locking
 
-Database transactions are fine for concurrency control during a single request. However, a 
-database transaction should not span across requests, the so-called "user think time". Therefore 
-a long-running "business transaction" that spans multiple requests needs to involve several 
-database transactions. Thus, database transactions alone can no longer control concurrency 
-during such a long-running business transaction. Concurrency control becomes the partial 
-responsibility of the application itself.
+Database transactions are fine for concurrency control during a single request. However, a database transaction should not span across requests, the so-called "user think time". Therefore a long-running "business transaction" that spans multiple requests needs to involve several database transactions. Thus, database transactions alone can no longer control concurrency during such a long-running business transaction. Concurrency control becomes the partial responsibility of the application itself.
 
-MikroORM has integrated support for automatic optimistic locking via a version field. In 
-this approach any entity that should be protected against concurrent modifications during 
-long-running business transactions gets a version field that is either a simple number 
-(mapping type: integer) or a timestamp (mapping type: datetime). When changes to such an 
-entity are persisted at the end of a long-running conversation the version of the entity 
-is compared to the version in the database and if they don't match, a `ValidationError` 
-is thrown, indicating that the entity has been modified by someone else already.
+MikroORM has integrated support for automatic optimistic locking via a version field. In this approach any entity that should be protected against concurrent modifications during long-running business transactions gets a version field that is either a simple number (mapping type: integer) or a timestamp (mapping type: datetime). When changes to such an entity are persisted at the end of a long-running conversation the version of the entity is compared to the version in the database and if they don't match, a `ValidationError` is thrown, indicating that the entity has been modified by someone else already.
 
 You designate a version field in an entity as follows. In this example we'll use an integer.
 
@@ -159,23 +111,13 @@ export class User {
 }
 ```
 
-Version numbers (not timestamps) should however be preferred as they can not potentially 
-conflict in a highly concurrent environment, unlike timestamps where this is a possibility, 
-depending on the resolution of the timestamp on the particular database platform.
+Version numbers (not timestamps) should however be preferred as they can not potentially conflict in a highly concurrent environment, unlike timestamps where this is a possibility, depending on the resolution of the timestamp on the particular database platform.
 
-When a version conflict is encountered during `em.flush()`, a `ValidationError` 
-is thrown and the active transaction rolled back (or marked for rollback). This exception 
-can be caught and handled. Potential responses to a `ValidationError` are to present the 
-conflict to the user or to refresh or reload objects in a new transaction and then retrying 
-the transaction.
+When a version conflict is encountered during `em.flush()`, a `ValidationError` is thrown and the active transaction rolled back (or marked for rollback). This exception can be caught and handled. Potential responses to a `ValidationError` are to present the conflict to the user or to refresh or reload objects in a new transaction and then retrying the transaction.
 
-The time between showing an update form and actually modifying the entity can in the worst 
-scenario be as long as your applications session timeout. If changes happen to the entity 
-in that time frame you want to know directly when retrieving the entity that you will hit 
-an optimistic locking exception:
+The time between showing an update form and actually modifying the entity can in the worst scenario be as long as your applications session timeout. If changes happen to the entity in that time frame you want to know directly when retrieving the entity that you will hit an optimistic locking exception:
 
-You can always verify the version of an entity during a request either when calling 
-`em.findOne()`:
+You can always verify the version of an entity during a request either when calling `em.findOne()`:
 
 ```typescript
 const theEntityId = 1;
@@ -209,23 +151,16 @@ try {
 
 #### Important Implementation Notes
 
-You can easily get the optimistic locking workflow wrong if you compare the wrong versions. 
-Say you have Alice and Bob editing a hypothetical blog post:
+You can easily get the optimistic locking workflow wrong if you compare the wrong versions. Say you have Alice and Bob editing a hypothetical blog post:
 
 - Alice reads the headline of the blog post being "Foo", at optimistic lock version 1 (GET Request)
 - Bob reads the headline of the blog post being "Foo", at optimistic lock version 1 (GET Request)
 - Bob updates the headline to "Bar", upgrading the optimistic lock version to 2 (POST Request of a Form)
 - Alice updates the headline to "Baz", ... (POST Request of a Form)
 
-Now at the last stage of this scenario the blog post has to be read again from the database 
-before Alice's headline can be applied. At this point you will want to check if the blog 
-post is still at version 1 (which it is not in this scenario).
+Now at the last stage of this scenario the blog post has to be read again from the database before Alice's headline can be applied. At this point you will want to check if the blog post is still at version 1 (which it is not in this scenario).
 
-Using optimistic locking correctly, you **have** to add the version as an additional hidden 
-field (or into the session for more safety). Otherwise you cannot verify the version is still 
-the one being originally read from the database when Alice performed her GET request for the 
-blog post. If this happens you might see lost updates you wanted to prevent with Optimistic 
-Locking.
+Using optimistic locking correctly, you **have** to add the version as an additional hidden field (or into the session for more safety). Otherwise you cannot verify the version is still the one being originally read from the database when Alice performed her GET request for the blog post. If this happens you might see lost updates you wanted to prevent with Optimistic Locking.
 
 See the example code (frontend):
 
@@ -264,22 +199,13 @@ async update(req, res) {
 }
 ```
 
-Your frontend app loads an entity from API, the response includes the version property. 
-User makes some changes and fires PUT request back to the API, with version field included 
-in the payload. The PUT handler of the API then reads the version and passes it to the 
-`em.findOne()` call.
+Your frontend app loads an entity from API, the response includes the version property. User makes some changes and fires PUT request back to the API, with version field included in the payload. The PUT handler of the API then reads the version and passes it to the `em.findOne()` call.
 
 ### Pessimistic Locking
 
-MikroORM supports Pessimistic Locking at the database level. No attempt is being made to implement 
-pessimistic locking inside MikroORM, rather vendor-specific and ANSI-SQL commands are used to 
-acquire row-level locks. Every Entity can be part of a pessimistic lock, there is no special 
-metadata required to use this feature.
+MikroORM supports Pessimistic Locking at the database level. No attempt is being made to implement pessimistic locking inside MikroORM, rather vendor-specific and ANSI-SQL commands are used to acquire row-level locks. Every Entity can be part of a pessimistic lock, there is no special metadata required to use this feature.
 
-However for Pessimistic Locking to work you have to disable the Auto-Commit Mode of your Database 
-and start a transaction around your pessimistic lock use-case using the "Approach 2: Explicit 
-Transaction Demarcation" described above. MikroORM will throw an Exception if you attempt to 
-acquire an pessimistic lock and no transaction is running.
+However for Pessimistic Locking to work you have to disable the Auto-Commit Mode of your Database and start a transaction around your pessimistic lock use-case using the "Approach 2: Explicit Transaction Demarcation" described above. MikroORM will throw an Exception if you attempt to acquire an pessimistic lock and no transaction is running.
 
 MikroORM currently supports two pessimistic lock modes:
 
@@ -292,5 +218,4 @@ You can use pessimistic locks in three different scenarios:
 2. Using `em.lock(entity, LockMode.PESSIMISTIC_WRITE)` or `em.lock(entity, LockMode.PESSIMISTIC_READ)`
 3. Using `QueryBuilder.setLockMode(LockMode.PESSIMISTIC_WRITE)` or `QueryBuilder.setLockMode(LockMode.PESSIMISTIC_READ)`
 
-> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html) as the behaviour here is pretty much the same.

--- a/docs/versioned_docs/version-4.5/unit-of-work.md
+++ b/docs/versioned_docs/version-4.5/unit-of-work.md
@@ -3,11 +3,9 @@ title: Unit of Work and Transactions
 sidebar_label: Unit of Work
 ---
 
-MikroORM uses the Identity Map pattern to track objects. Whenever you fetch an object from 
-the database, MikroORM will keep a reference to this object inside its `UnitOfWork`. 
+MikroORM uses the Identity Map pattern to track objects. Whenever you fetch an object from the database, MikroORM will keep a reference to this object inside its `UnitOfWork`.
 
-This allows MikroORM room for optimizations. If you call the EntityManager and ask for an 
-entity with a specific ID twice, it will return the same instance:
+This allows MikroORM room for optimizations. If you call the EntityManager and ask for an entity with a specific ID twice, it will return the same instance:
 
 ```typescript
 const authorRepository = orm.em.getRepository(Author);
@@ -18,13 +16,9 @@ const jon2 = await authorRepository.findOne(1);
 console.log(jon1 === jon2); // true
 ```
 
-Only one SELECT query will be fired against the database here. In the second `findOne()` 
-call MikroORM will check the identity map first and will skip the database round trip as
-it will find the entity already loaded.
+Only one SELECT query will be fired against the database here. In the second `findOne()` call MikroORM will check the identity map first and will skip the database round trip as it will find the entity already loaded.
 
-The identity map being indexed by primary keys only allows shortcuts when you ask for objects 
-by primary key. When you query by other properties, you will still get the same reference, 
-but two separate database calls will be made:
+The identity map being indexed by primary keys only allows shortcuts when you ask for objects by primary key. When you query by other properties, you will still get the same reference, but two separate database calls will be made:
 
 ```typescript
 const authorRepository = orm.em.getRepository(Author);
@@ -35,21 +29,13 @@ const jon2 = await authorRepository.findOne({ name: 'Jon Snow' });
 console.log(jon1 === jon2); // true
 ```
 
-MikroORM only knows objects by id, so a query for different criteria has to go to the database, 
-even if it was executed just before. But instead of creating a second `Author` object MikroORM 
-first gets the primary key from the row and checks if it already has an object inside the 
-`UnitOfWork` with that primary key. 
+MikroORM only knows objects by id, so a query for different criteria has to go to the database, even if it was executed just before. But instead of creating a second `Author` object MikroORM first gets the primary key from the row and checks if it already has an object inside the `UnitOfWork` with that primary key.
 
 ## Persisting Managed Entities
 
-The identity map has a second use-case. When you call `em.flush()`, MikroORM will 
-ask the identity map for all objects that are currently managed. This means you don't have to 
-call `em.persist()` over and over again to pass known objects to the 
-`EntityManager`. This is a NO-OP for known entities, but leads to much code written that is 
-confusing to other developers.
+The identity map has a second use-case. When you call `em.flush()`, MikroORM will ask the identity map for all objects that are currently managed. This means you don't have to call `em.persist()` over and over again to pass known objects to the `EntityManager`. This is a NO-OP for known entities, but leads to much code written that is confusing to other developers.
 
-The following code WILL update your database with the changes made to the `Author` object, 
-even if you did not call `em.persist()`:
+The following code WILL update your database with the changes made to the `Author` object, even if you did not call `em.persist()`:
 
 ```typescript
 const authorRepository = orm.em.getRepository(Author);
@@ -60,29 +46,17 @@ await authorRepository.flush(); // calling orm.em.flush() has same effect
 
 ## How MikroORM Detects Changes
 
-MikroORM is a data-mapper that tries to achieve persistence-ignorance (PI). This means you 
-map JS objects into a relational database that do not necessarily know about the database at 
-all. A natural question would now be, "how does MikroORM even detect objects have changed?".
+MikroORM is a data-mapper that tries to achieve persistence-ignorance (PI). This means you map JS objects into a relational database that do not necessarily know about the database at all. A natural question would now be, "how does MikroORM even detect objects have changed?".
 
-For this MikroORM keeps a second map inside the `UnitOfWork`. Whenever you fetch an object 
-from the database MikroORM will keep a copy of all the properties and associations inside 
-the `UnitOfWork`. 
+For this MikroORM keeps a second map inside the `UnitOfWork`. Whenever you fetch an object from the database MikroORM will keep a copy of all the properties and associations inside the `UnitOfWork`.
 
-Now whenever you call `em.flush()` MikroORM will iterate over all entities you 
-previously marked for persisting via `em.persist()`. For each object it will
-compare the original property and association values with the values that are currently set 
-on the object. If changes are detected then the object is queued for a UPDATE operation. 
-Only the fields that actually changed are updated.
+Now whenever you call `em.flush()` MikroORM will iterate over all entities you previously marked for persisting via `em.persist()`. For each object it will compare the original property and association values with the values that are currently set on the object. If changes are detected then the object is queued for a UPDATE operation. Only the fields that actually changed are updated.
 
 ## Implicit Transactions
 
-First and most important implication of having Unit of Work is that it allows handling
-transactions automatically. 
+First and most important implication of having Unit of Work is that it allows handling transactions automatically.
 
-When you call `em.flush()`, all computed changes are queried inside a database
-transaction (if supported by given driver). This means that you can control the boundaries 
-of transactions simply by calling `em.persist()` and once all your changes 
-are ready, simply calling `flush()` will run them inside a transaction. 
+When you call `em.flush()`, all computed changes are queried inside a database transaction (if supported by given driver). This means that you can control the boundaries of transactions simply by calling `em.persist()` and once all your changes are ready, simply calling `flush()` will run them inside a transaction.
 
 > You can also control the transaction boundaries manually via `em.transactional(cb)`.
 
@@ -97,8 +71,6 @@ user.cars.add(car);
 await em.persistAndFlush(user);
 ```
 
-You can find more information about transactions in [Transactions and concurrency](transactions.md) 
-page.
+You can find more information about transactions in [Transactions and concurrency](transactions.md) page.
 
-> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/unitofwork.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/unitofwork.html) as the behaviour here is pretty much the same.

--- a/docs/versioned_docs/version-4.5/upgrading-v2-to-v3.md
+++ b/docs/versioned_docs/version-4.5/upgrading-v2-to-v3.md
@@ -2,19 +2,13 @@
 title: Upgrading from v2 to v3
 ---
 
-Following sections describe (hopefully) all breaking changes, most of them might be not valid 
-for you, like if you do not use custom `NamingStrategy` implementation, you do not care about
-the interface being changed.
+Following sections describe (hopefully) all breaking changes, most of them might be not valid for you, like if you do not use custom `NamingStrategy` implementation, you do not care about the interface being changed.
 
 ## Default value of autoFlush has changed to false
 
-> If you had `autoFlush: false` in your ORM configuration before, you can now remove 
-> this line, no changes are needed in your app. 
+> If you had `autoFlush: false` in your ORM configuration before, you can now remove this line, no changes are needed in your app.
 
-Default value for `autoFlush` is now `false`. That means you need to call 
-`em.flush()` yourself to persist changes into database. You can still change this via ORM's
-options to ease the transition but generally it is not recommended as it can cause unwanted
-small transactions being created around each `persist`. 
+Default value for `autoFlush` is now `false`. That means you need to call `em.flush()` yourself to persist changes into database. You can still change this via ORM's options to ease the transition but generally it is not recommended as it can cause unwanted small transactions being created around each `persist`.
 
 ```typescript
 orm.em.persist(new Entity()); // no auto-flushing by default
@@ -24,29 +18,20 @@ await orm.em.persist(new Entity(), true); // you can still use second parameter 
 
 ## Reworked entity definition
 
-> Implementing those interfaces is optional.  
+> Implementing those interfaces is optional.
 
-Now it is no longer needed to merge entities with `IEntity` interface, that was polluting entity's 
-interface with internal methods. New interfaces `IdentifiedEntity<T>`, `UuidEntity<T>` and `MongoEntity<T>` 
-are introduced, that can be implemented by entities. They are not adding any new properties or methods, 
-keeping the entity's interface clean. This is also the reason why they can be omitted.
+Now it is no longer needed to merge entities with `IEntity` interface, that was polluting entity's interface with internal methods. New interfaces `IdentifiedEntity<T>`, `UuidEntity<T>` and `MongoEntity<T>` are introduced, that can be implemented by entities. They are not adding any new properties or methods, keeping the entity's interface clean. This is also the reason why they can be omitted.
 
-`IEntity` interface has been renamed to `AnyEntity<T, PK>` and it no longer has public methods 
-like `toJSON()`, `toObject()` or `init()`. One can use `wrap()` method provided by ORM that
-will enhance property type when needed with those methods (`await wrap(book.author).init()`). 
-To keep all methods available on the entity, you can still use interface merging with 
-`WrappedEntity<T, PK>` that both extends `AnyEntity<T, PK>` and defines all those methods.
+`IEntity` interface has been renamed to `AnyEntity<T, PK>` and it no longer has public methods like `toJSON()`, `toObject()` or `init()`. One can use `wrap()` method provided by ORM that will enhance property type when needed with those methods (`await wrap(book.author).init()`). To keep all methods available on the entity, you can still use interface merging with `WrappedEntity<T, PK>` that both extends `AnyEntity<T, PK>` and defines all those methods.
 
 You can mark the entity by implementing one of `*Entity` interfaces:
 
 - `IdEntity<T>` for numeric/string PK on `id` property (`id: number`)
 - `UuidEntity<T>` for string PK on `uuid` property (`uuid: string`)
 - `MongoEntity<T>` for mongo, where `id: string` and `_id: ObjectId` are required
-- `AnyEntity<T, PK>` for other possible properties (fill the PK property name to `PK` 
-parameter, e.g.: `AnyEntity<Book, 'myPrimaryProperty'>'`)
+- `AnyEntity<T, PK>` for other possible properties (fill the PK property name to `PK` parameter, e.g.: `AnyEntity<Book, 'myPrimaryProperty'>'`)
 
-To keep all public methods that were part of `IEntity` interface in v2, you can use 
-`WrappedEntity<T, PK>` via interface merging:
+To keep all public methods that were part of `IEntity` interface in v2, you can use `WrappedEntity<T, PK>` via interface merging:
 
 ```typescript
 @Entity()
@@ -58,37 +43,25 @@ For more examples, take a look at [defining entities section](defining-entities.
 
 ## Integrated Knex.js as query builder and runner
 
-`QueryBuilder` now internally uses knex to run all queries. As knex already supports connection 
-pooling, this feature comes without any effort. New configuration for pooling is now available
+`QueryBuilder` now internally uses knex to run all queries. As knex already supports connection pooling, this feature comes without any effort. New configuration for pooling is now available
 
-Transactions now require using `em.transactional()` method, previous helpers 
-`beginTransaction`/`commit`/`rollback` are now removed.
+Transactions now require using `em.transactional()` method, previous helpers `beginTransaction`/`commit`/`rollback` are now removed.
 
-All transaction management has been removed from `IDatabaseDriver` interface, now EM handles 
-this, passing the transaction context (carried by EM, and created by `Connection`) to all 
-driver methods. New methods on EM exists: `isInTransaction()` and `getTransactionContext()`.
+All transaction management has been removed from `IDatabaseDriver` interface, now EM handles this, passing the transaction context (carried by EM, and created by `Connection`) to all driver methods. New methods on EM exists: `isInTransaction()` and `getTransactionContext()`.
 
-In postgres driver, it used to be required to pass parameters as indexed dollar sign 
-($1, $2, ...), while now knex requires the placeholder to be simple question mark (`?`), 
-like in other dialects, so this is now unified with other drivers.
+In postgres driver, it used to be required to pass parameters as indexed dollar sign ($1, $2, ...), while now knex requires the placeholder to be simple question mark (`?`), like in other dialects, so this is now unified with other drivers.
 
 ## ManyToMany now uses composite primary key
 
-Previously it was required to have autoincrement primary key for m:n pivot tables. Now this 
-has changed. By default, only foreign columns are required and composite key over both of them
-is used as primary key.
+Previously it was required to have autoincrement primary key for m:n pivot tables. Now this has changed. By default, only foreign columns are required and composite key over both of them is used as primary key.
 
-To preserve stable order of collections, you can force previous behaviour by defining the 
-m:n property as `fixedOrder: true`, which will start ordering by `id` column. You can also 
-override the order column name via `fixedOrderColumn: 'order'`. 
+To preserve stable order of collections, you can force previous behaviour by defining the m:n property as `fixedOrder: true`, which will start ordering by `id` column. You can also override the order column name via `fixedOrderColumn: 'order'`.
 
 You can also specify default ordering via `orderBy: { ... }` attribute.
 
 ## Entity references now don't have instantiated collections
 
-Previously all entity instances, including entity references (not fully loaded entities where
-we know only the primary key), had instantiated collection classes. Now only initialized entities
-have them.
+Previously all entity instances, including entity references (not fully loaded entities where we know only the primary key), had instantiated collection classes. Now only initialized entities have them.
 
 ```typescript
 const book = em.getReference(Book, 1);
@@ -99,12 +72,9 @@ console.log(book.tags); // instance of Collection (not initialized)
 
 ## EntityAssigner.assign() requires EM for new entities
 
-Previously all entities had internal reference to the root EM - the one created when 
-initializing the ORM. Now only managed entities (those merged to the EM, e.g. loaded 
-from the database) have this internal reference. 
+Previously all entities had internal reference to the root EM - the one created when initializing the ORM. Now only managed entities (those merged to the EM, e.g. loaded from the database) have this internal reference.
 
-To use `assign()` method on new (not managed) entities, you need to provide the `em`
-parameter:
+To use `assign()` method on new (not managed) entities, you need to provide the `em` parameter:
 
 ```typescript
 const book = new Book();
@@ -113,46 +83,36 @@ wrap(book).assign(data, { em: orm.em });
 
 ## Strict FilterQuery and smart query conditions
 
-`FilterQuery` now does not allow using smart query operators. You can either cast your condition 
-as any or use object syntax instead (instead of `{ 'age:gte': 18 }` use `{ age: { $gte: 18 } }`).
+`FilterQuery` now does not allow using smart query operators. You can either cast your condition as any or use object syntax instead (instead of `{ 'age:gte': 18 }` use `{ age: { $gte: 18 } }`).
 
 ## Logging configuration
 
-Previously to start logging it was required to provide your custom logger. Logger now defaults 
-to `console.log()`, and users can specify what namespaces are they interested in via `debug` 
-option. `true`/`false` will enable/disable all namespaces.
+Previously to start logging it was required to provide your custom logger. Logger now defaults to `console.log()`, and users can specify what namespaces are they interested in via `debug` option. `true`/`false` will enable/disable all namespaces.
 
 Available logger namespaces: `'query' | 'query-params' | 'discovery' | 'info'`.
 
-## Removed deprecated fk option from 1:m and m:1 decorators 
+## Removed deprecated fk option from 1:m and m:1 decorators
 
 Use `mappedBy`/`inversedBy` instead.
 
 ## SchemaGenerator.generate() is now async
 
-If you used `SchemaGenerator`, now there is CLI tool you can use instead. Learn more 
-in [SchemaGenerator docs](schema-generator.md). To setup CLI, take a look at 
-[installation section](installation.md).
+If you used `SchemaGenerator`, now there is CLI tool you can use instead. Learn more in [SchemaGenerator docs](schema-generator.md). To setup CLI, take a look at [installation section](installation.md).
 
 ## New method on NamingStrategy interface
 
-`getClassName()` is used to find entity class name based on its file name. Now users can 
-override the default implementation to accommodate their specific needs.
+`getClassName()` is used to find entity class name based on its file name. Now users can override the default implementation to accommodate their specific needs.
 
-If you used custom naming strategy, you will either need to implement this method yourself, 
-or extend `AbstractNamingStrategy`.
+If you used custom naming strategy, you will either need to implement this method yourself, or extend `AbstractNamingStrategy`.
 
 ## TypescriptMetadataProvider has been renamed
 
-The name is now `TsMorphMetadataProvider`, there is also newly added `ReflectMetadataProvider`
-that uses `reflect-metadata` instead. As `TypescriptMetadataProvider` was the default, no 
-changes should be required. 
+The name is now `TsMorphMetadataProvider`, there is also newly added `ReflectMetadataProvider` that uses `reflect-metadata` instead. As `TypescriptMetadataProvider` was the default, no changes should be required.
 
 ## Updated mongodb driver
 
 MongoDB driver version 3.3.4 or higher is now required.
 
 ## EntityManager.find() now requires where parameter
-`EntityManager` has now same `find` method interface aligned with `EntityRepository`, 
-`where` parameter is now required. To select all entities, use `em.find(Entity, {})` 
-as value.
+
+`EntityManager` has now same `find` method interface aligned with `EntityRepository`, `where` parameter is now required. To select all entities, use `em.find(Entity, {})` as value.

--- a/docs/versioned_docs/version-4.5/upgrading-v3-to-v4.md
+++ b/docs/versioned_docs/version-4.5/upgrading-v3-to-v4.md
@@ -2,24 +2,19 @@
 title: Upgrading from v3 to v4
 ---
 
-> Following sections describe (hopefully) all breaking changes, most of them might be not valid 
-> for you, like if you do not use custom `NamingStrategy` implementation, you do not care about
-> the interface being changed.
+> Following sections describe (hopefully) all breaking changes, most of them might be not valid for you, like if you do not use custom `NamingStrategy` implementation, you do not care about the interface being changed.
 
 ## Node 10.13.0+ required
 
-Support for older node versions was dropped. 
+Support for older node versions was dropped.
 
 ## TypeScript 3.7+ required
 
-Support for older TypeScript versions was dropped. 
+Support for older TypeScript versions was dropped.
 
 ## Monorepo
 
-The ORM has been split into several packages. In v4 one needs to require
-`@mikro-orm/core` and a driver package, e.g. `@mikro-orm/mysql`. This driver
-package already contains the `mysql2` dependency, so you can remove that from
-your `package.json`. 
+The ORM has been split into several packages. In v4 one needs to require `@mikro-orm/core` and a driver package, e.g. `@mikro-orm/mysql`. This driver package already contains the `mysql2` dependency, so you can remove that from your `package.json`.
 
 - `@mikro-orm/core`
 - `@mikro-orm/reflection` - `TsMorphMetadataProvider`
@@ -34,17 +29,13 @@ your `package.json`.
 - `@mikro-orm/postgresql`
 - `@mikro-orm/mongodb`
 
-> For easier transition, meta package mikro-orm is still present, reexporting 
-> core, reflection, migrations, entity-generator and cli packages. You should 
-> **not** install both `mikro-orm` and `@mikro-orm/core` packages together. 
+> For easier transition, meta package mikro-orm is still present, reexporting core, reflection, migrations, entity-generator and cli packages. You should **not** install both `mikro-orm` and `@mikro-orm/core` packages together.
 
-> You should prefer the `@mikro-orm/core` over `mikro-orm` package, there were
-> weird dependency issues reported with the `mikro-orm` meta-package. 
+> You should prefer the `@mikro-orm/core` over `mikro-orm` package, there were weird dependency issues reported with the `mikro-orm` meta-package.
 
 ## Default metadata provider is now `ReflectMetadataProvider`
 
-If you want to use ts-morph, you need to install `@mikro-orm/reflection` package
-and enable the provider explicitly in the ORM config, as described [here](./metadata-providers.md#tsmorphmetadataprovider).
+If you want to use ts-morph, you need to install `@mikro-orm/reflection` package and enable the provider explicitly in the ORM config, as described [here](./metadata-providers.md#tsmorphmetadataprovider).
 
 ```typescript
 import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
@@ -55,30 +46,22 @@ await MikroORM.init({
 });
 ```
 
-Using `ReflectMetadataProvider` has some limitations, so be sure to read 
-about them [here](./metadata-providers.md#limitations-and-requirements).
+Using `ReflectMetadataProvider` has some limitations, so be sure to read about them [here](./metadata-providers.md#limitations-and-requirements).
 
-One common gotcha with `reflect-metadata` is that you need to explicitly
-state the property type when using property initializer:
+One common gotcha with `reflect-metadata` is that you need to explicitly state the property type when using property initializer:
 
 ```ts
 @Property()
 createdAt: Date = new Date();
 ```
 
-Without the explicit type, we would infer `Object` instead of `Date`, 
-which would be most probably mapped to JSON column type (depends on driver).
+Without the explicit type, we would infer `Object` instead of `Date`, which would be most probably mapped to JSON column type (depends on driver).
 
 ## SqlEntityManager and MongoEntityManager
 
-In v4 the `core` package, where `EntityManager` and `EntityRepository` are 
-defined, is not dependent on knex, and therefore it cannot have a method 
-returning a `QueryBuilder`. You need to import the SQL flavour of the EM 
-from the driver package to access the `createQueryBuilder()` method.
+In v4 the `core` package, where `EntityManager` and `EntityRepository` are defined, is not dependent on knex, and therefore it cannot have a method returning a `QueryBuilder`. You need to import the SQL flavour of the EM from the driver package to access the `createQueryBuilder()` method.
 
-> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under 
-> this name and under `EntityManager` alias, so you can just change the 
-> location from where you import.
+> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ```typescript
 import { EntityManager } from '@mikro-orm/mysql'; // or any other SQL driver package
@@ -96,32 +79,21 @@ const em: EntityManager;
 const ret = await em.aggregate(...);
 ```
 
-> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under 
-> this name and under `EntityManager` alias, so you can just change the 
-> location from where you import.
+> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ## Different default `pivotTable`
 
-Implementation of `UnderscoreNamingStrategy` and `EntityCaseNamingStrategy` 
-`joinTableName()` method has changed. You can use `pivotTable` on the owning side
-of M:N relation to specify the table name manually. 
+Implementation of `UnderscoreNamingStrategy` and `EntityCaseNamingStrategy` `joinTableName()` method has changed. You can use `pivotTable` on the owning side of M:N relation to specify the table name manually.
 
-Previously the table name did not respect property name, if one defined multiple
-M:N relations between same entities, there were conflicts and one would have to 
-specify `pivotTable` name manually at least on one of them. With the new way, 
-we can be sure that the table name won't conflict with other pivot tables. 
+Previously the table name did not respect property name, if one defined multiple M:N relations between same entities, there were conflicts and one would have to specify `pivotTable` name manually at least on one of them. With the new way, we can be sure that the table name won't conflict with other pivot tables.
 
-Previously the name was constructed from 2 entity names as `entity_a_to_entity_b`,
-ignoring the actual property name. In v4 the name will be `entity_a_coll_name` in 
-case of the collection property on the owning side being named `collName`. 
+Previously the name was constructed from 2 entity names as `entity_a_to_entity_b`, ignoring the actual property name. In v4 the name will be `entity_a_coll_name` in case of the collection property on the owning side being named `collName`.
 
 ## Changes in folder-based discovery (`entitiesDirs` removed)
 
-`entitiesDirs` and `entitiesDirsTs` were removed in favour of `entities` and `entitiesTs`,
-`entities` will be used as a default for `entitiesTs` (that is used when we detect `ts-node`).
+`entitiesDirs` and `entitiesDirsTs` were removed in favour of `entities` and `entitiesTs`, `entities` will be used as a default for `entitiesTs` (that is used when we detect `ts-node`).
 
-`entities` can now contain mixture of paths to directories, globs pointing to entities,
-or references to the entities or instances of `EntitySchema`. 
+`entities` can now contain mixture of paths to directories, globs pointing to entities, or references to the entities or instances of `EntitySchema`.
 
 This basically means that all you need to change is renaming `entitiesDirs` to `entities`.
 
@@ -134,26 +106,17 @@ MikroORM.init({
 
 ## Changes in `wrap()` helper, `WrappedEntity` interface and `Reference` wrapper
 
-Previously all the methods and properties of `WrappedEntity` interface were
-added to the entity prototype during discovery. In v4 there is only one property
-added: `__helper: WrappedEntity`. `WrappedEntity` has been converted to actual class.
+Previously all the methods and properties of `WrappedEntity` interface were added to the entity prototype during discovery. In v4 there is only one property added: `__helper: WrappedEntity`. `WrappedEntity` has been converted to actual class.
 
-`wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is 
-being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...),
-if you want to access internal properties like `__meta` or `__em`, you need to explicitly
-ask for the helper via `wrap(entity, true)`.
+`wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...), if you want to access internal properties like `__meta` or `__em`, you need to explicitly ask for the helper via `wrap(entity, true)`.
 
-Internal methods (with `__` prefix) were also removed from the `Reference` class, 
-use `wrap(ref, true)` to access them. 
+Internal methods (with `__` prefix) were also removed from the `Reference` class, use `wrap(ref, true)` to access them.
 
-Instead of interface merging with `WrappedEntity`, one can now use classic inheritance,
-by extending `BaseEntity` exported from `@mikro-orm/core`. If you do so, `wrap(entity)` 
-will return your entity. 
+Instead of interface merging with `WrappedEntity`, one can now use classic inheritance, by extending `BaseEntity` exported from `@mikro-orm/core`. If you do so, `wrap(entity)` will return your entity.
 
 ## Removed `flush` parameter from `persist()` and `remove()` methods
 
-`flush` param is removed, both `persist` and `remove` methods are synchronous and
-require explicit flushing, possibly via fluent interface call.
+`flush` param is removed, both `persist` and `remove` methods are synchronous and require explicit flushing, possibly via fluent interface call.
 
 ```typescript
 // before
@@ -167,19 +130,15 @@ await em.remove(jon).flush();
 
 ## `remove()` method requires entity instances
 
-The `em.remove()` method originally allowed to pass either entity instance, or 
-a condition. When one passed a condition, it was firing a native delete query, 
-without handling transactions or hooks. 
+The `em.remove()` method originally allowed to pass either entity instance, or a condition. When one passed a condition, it was firing a native delete query, without handling transactions or hooks.
 
-In v4, the method is now simplified and works only with entity instances. Use 
-`em.nativeDelete()` explicitly if you want to fire a delete query instead of 
-letting the `UnitOfWork` doing its job.
+In v4, the method is now simplified and works only with entity instances. Use `em.nativeDelete()` explicitly if you want to fire a delete query instead of letting the `UnitOfWork` doing its job.
 
 ```typescript
 // before
 await em.remove(Author, 1); // fires query directly
 
-// after 
+// after
 await em.nativeDelete(Author, 1);
 ```
 
@@ -187,20 +146,11 @@ await em.nativeDelete(Author, 1);
 
 ## Type safe references
 
-EM now returns `Loaded<T, P>` instead of the entity (`T`). This type automatically
-adds synchronous method `get()` that returns the entity (for references) or array
-of entities (for collections).
+EM now returns `Loaded<T, P>` instead of the entity (`T`). This type automatically adds synchronous method `get()` that returns the entity (for references) or array of entities (for collections).
 
-`Reference.get()` is now available only with correct `Loaded` type hint and is used 
-as a sync getter for the entity, just like `unwrap()`. You can use `Reference.load(prop)` 
-for the original `get()` method functionality. 
+`Reference.get()` is now available only with correct `Loaded` type hint and is used as a sync getter for the entity, just like `unwrap()`. You can use `Reference.load(prop)` for the original `get()` method functionality.
 
-`em.find()` and similar methods now have two type arguments, due to TypeScript not supporting partial
-type inference, when you specify the `T` explicitly (without also explicitly 
-specifying the load hint), the inference will not work. This use case was mainly
-for usage without classes (interfaces + `EntitySchema`) - in that case it is now 
-supported to pass actual instance of `EntitySchema` as the first parameter to these
-methods, that will allow correct type inference:
+`em.find()` and similar methods now have two type arguments, due to TypeScript not supporting partial type inference, when you specify the `T` explicitly (without also explicitly specifying the load hint), the inference will not work. This use case was mainly for usage without classes (interfaces + `EntitySchema`) - in that case it is now supported to pass actual instance of `EntitySchema` as the first parameter to these methods, that will allow correct type inference:
 
 ```typescript
 const author = await em.findOne(AuthorSchema, { ... }, ['books']);
@@ -209,59 +159,45 @@ console.log(author.books.get()); // `get()` is now inferred correctly
 
 ## Custom types are now type safe
 
-Generic `Type` class has now two type arguments - the input and output types. 
-Input type defaults to `string`, output type defaults to the input type. 
+Generic `Type` class has now two type arguments - the input and output types. Input type defaults to `string`, output type defaults to the input type.
 
 You might need to explicitly provide the types if your methods are strictly typed.
 
 ## Custom type serialization
 
-Custom types used to be serialized to the database value. In v4, the runtime 
-value is used by default. Implement custom `toJSON()` method if you need to 
-customize this.
+Custom types used to be serialized to the database value. In v4, the runtime value is used by default. Implement custom `toJSON()` method if you need to customize this.
 
 ## Property `default` and `defaultRaw`
 
-Previously the `default` option of properties was used as is, so we had to wrap 
-strings in quotes (e.g. `@Property({ default: "'foo bar'" })`). 
+Previously the `default` option of properties was used as is, so we had to wrap strings in quotes (e.g. `@Property({ default: "'foo bar'" })`).
 
-In v4 the `default` is typed as `string | number | boolean | null` and when used
-with string value, it will be automatically quoted. 
+In v4 the `default` is typed as `string | number | boolean | null` and when used with string value, it will be automatically quoted.
 
 To use SQL functions we now need to use `defaultRaw`: `@Property({ defaultRaw: 'now()' })`.
 
 ## `autoFlush` option has been removed
 
-Also `persistLater()` and `removeLater()` methods are deprecated. Use `persist()` or
-`remove` respectively.
+Also `persistLater()` and `removeLater()` methods are deprecated. Use `persist()` or `remove` respectively.
 
 ## `IdEntity`, `UuidEntity` and `MongoEntity` interfaces are removed
 
-They were actually never needed. 
+They were actually never needed.
 
 ## MongoDB driver is no longer the default
 
-You need to specify the platform type either via `type` option or provide the driver
-implementation via `driver` option. 
+You need to specify the platform type either via `type` option or provide the driver implementation via `driver` option.
 
 Available platforms types: `[ 'mongo', 'mysql', 'mariadb', 'postgresql', 'sqlite' ]`
 
 ## Removed configuration `discovery.tsConfigPath`
 
-Removed as it is no longer needed, it was used only for `TsMorphMetadataProvider`,
-when the `entitiesDirsTs` were not explicitly provided. In v4, this is no longer
-needed, as ts-morph discovery will use `d.ts` files instead, that should be located
-next to the compiled entities. 
+Removed as it is no longer needed, it was used only for `TsMorphMetadataProvider`, when the `entitiesDirsTs` were not explicitly provided. In v4, this is no longer needed, as ts-morph discovery will use `d.ts` files instead, that should be located next to the compiled entities.
 
 ## Changes in query highlighting
 
-Previously Highlight.js was used to highlight various things in the CLI, 
-like SQL and mongo queries, or migrations or entities generated via CLI.
-While the library worked fine, it was causing performance issues mainly 
-for those bundling via webpack and using lambdas, as the library was huge.
+Previously Highlight.js was used to highlight various things in the CLI, like SQL and mongo queries, or migrations or entities generated via CLI. While the library worked fine, it was causing performance issues mainly for those bundling via webpack and using lambdas, as the library was huge.
 
-In v4 highlighting is disabled by default, and there are 2 highlighters 
-you can optionally use (you need to install them first).
+In v4 highlighting is disabled by default, and there are 2 highlighters you can optionally use (you need to install them first).
 
 ```typescript
 import { SqlHighlighter } from '@mikro-orm/sql-highlighter';

--- a/docs/versioned_docs/version-4.5/upgrading-v4-to-v5.md
+++ b/docs/versioned_docs/version-4.5/upgrading-v4-to-v5.md
@@ -2,23 +2,19 @@
 title: Upgrading from v4 to v5
 ---
 
-> Following sections describe (hopefully) all breaking changes, most of them might be not valid 
-> for you, like if you do not use custom `NamingStrategy` implementation, you do not care about
-> the interface being changed.
+> Following sections describe (hopefully) all breaking changes, most of them might be not valid for you, like if you do not use custom `NamingStrategy` implementation, you do not care about the interface being changed.
 
 ## Node 14+ required
 
-Support for older node versions was dropped. 
+Support for older node versions was dropped.
 
 ## TypeScript 4.1+ required
 
-Support for older TypeScript versions was dropped. 
+Support for older TypeScript versions was dropped.
 
 ## Options parameters
 
-Previously many methods had many (often boolean) parameters, in v5 such methods are
-refactored to use options object instead to improve readability. Some methods offered
-both signatures - the multi parameter signatures are now removed.
+Previously many methods had many (often boolean) parameters, in v5 such methods are refactored to use options object instead to improve readability. Some methods offered both signatures - the multi parameter signatures are now removed.
 
 List of such methods:
 
@@ -47,10 +43,7 @@ This also applies to the methods on `IDatabaseDriver` interface.
 
 ## Type-safe populate parameter with dot notation
 
-`FindOptions.populate` parameter is now strictly typed and supports only array of 
-strings or a boolean.
-Object way is no longer supported. To set loading strategy, use `FindOptions.strategy`.
-The return type of all such methods now returns properly typed `Loaded` response. 
+`FindOptions.populate` parameter is now strictly typed and supports only array of strings or a boolean. Object way is no longer supported. To set loading strategy, use `FindOptions.strategy`. The return type of all such methods now returns properly typed `Loaded` response.
 
 ## Type-safe fields parameter
 
@@ -58,8 +51,7 @@ The return type of all such methods now returns properly typed `Loaded` response
 
 ## Type-safe orderBy parameter
 
-`FindOptions.orderBy` parameter is now strictly typed. It also allows passing an 
-array of objects instead of just a single object.
+`FindOptions.orderBy` parameter is now strictly typed. It also allows passing an array of objects instead of just a single object.
 
 ```ts
 const books = await em.find(Book, {}, {
@@ -72,41 +64,25 @@ const books = await em.find(Book, {}, {
 
 ## Removed `@Repository()` decorator
 
-The decorator was problematic as it could only work properly it the file was required
-soon enough - before the ORM initialization, otherwise the repository would not be 
-registered at all.
+The decorator was problematic as it could only work properly it the file was required soon enough - before the ORM initialization, otherwise the repository would not be registered at all.
 
-Use `@Entity({ customRepository: () => CustomRepository })` in the entity definition
-instead.
+Use `@Entity({ customRepository: () => CustomRepository })` in the entity definition instead.
 
 ## Disallowed global identity map
 
-In v5, it is no longer possible to use the global identity map. This was a 
-common issue that led to weird bugs, as using the global EM without request
-context is wrong, we always need to have a dedicated context for each request,
-so they do not interfere.
+In v5, it is no longer possible to use the global identity map. This was a common issue that led to weird bugs, as using the global EM without request context is wrong, we always need to have a dedicated context for each request, so they do not interfere.
 
-Now we get a validation error if we try to use the global context. We still can
-disable this check via `allowGlobalContext` configuration, or a connected 
-environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can be handy 
-especially in unit tests.
+Now we get a validation error if we try to use the global context. We still can disable this check via `allowGlobalContext` configuration, or a connected environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can be handy especially in unit tests.
 
 ## `LoadedCollection.get()` and `$` now return the `Collection` instance
 
-Previously those dynamically added getters returned the array copy of collection
-items. In v5, we return the collection instance, which is also iterable and has
-a `length` getter and indexed access support, so it mimics the array. To get the
-array copy as before, call `getItems()` as with a regular collection.
+Previously those dynamically added getters returned the array copy of collection items. In v5, we return the collection instance, which is also iterable and has a `length` getter and indexed access support, so it mimics the array. To get the array copy as before, call `getItems()` as with a regular collection.
 
 ## Different table aliasing for select-in loading strategy and for QueryBuilder
 
-Previously with select-in strategy as well as with QueryBuilder, table aliases
-were always the letter `e` followed by unique index. In v5, we use the same 
-method as with joined strategy - the letter is inferred from the entity name.
+Previously with select-in strategy as well as with QueryBuilder, table aliases were always the letter `e` followed by unique index. In v5, we use the same method as with joined strategy - the letter is inferred from the entity name.
 
-This can be breaking if you used the aliases somewhere, e.g. in custom SQL 
-fragments. We can restore to the old behaviour by implementing custom naming
-strategy, overriding the `aliasName` method:
+This can be breaking if you used the aliases somewhere, e.g. in custom SQL fragments. We can restore to the old behaviour by implementing custom naming strategy, overriding the `aliasName` method:
 
 ```ts
 import { AbstractNamingStrategy } from '@mikro-orm/core';
@@ -118,37 +94,27 @@ class CustomNamingStrategy extends AbstractNamingStrategy {
 }
 ```
 
-Note that in v5 it is possible to use `expr()` helper to access the alias name
-dynamically, e.g. ``expr(alias => `lower('${alias}.name')`)``, which should be 
-now preferred way instead of hardcoding the aliases.
+Note that in v5 it is possible to use `expr()` helper to access the alias name dynamically, e.g. `` expr(alias => `lower('${alias}.name')`) ``, which should be now preferred way instead of hardcoding the aliases.
 
 ## Migrations are now stored without extensions
 
-Running migrations in production via node and ts-node is now handled the same.
-This should actually not be breaking, as old format with extension is still 
-supported (e.g. they still can be rolled back), but newly logged migrations
-will not contain the extension.
+Running migrations in production via node and ts-node is now handled the same. This should actually not be breaking, as old format with extension is still supported (e.g. they still can be rolled back), but newly logged migrations will not contain the extension.
 
 ## Changes in `assign()` helper
 
-Embeddable instances are now created via `EntityFactory` and they respect the
-`forceEntityConstructor` configuration. Due to this we need to have EM instance
-when assigning to embedded properties. 
+Embeddable instances are now created via `EntityFactory` and they respect the `forceEntityConstructor` configuration. Due to this we need to have EM instance when assigning to embedded properties.
 
 Using `em.assign()` should be preferred to get around this.
 
-Deep assigning of child entities now works by default based on the presence of PKs in the payload.
-This behaviour can be disable via updateByPrimaryKey: false in the assign options.
+Deep assigning of child entities now works by default based on the presence of PKs in the payload. This behaviour can be disable via updateByPrimaryKey: false in the assign options.
 
 `mergeObjects` option is now enabled by default.
 
 ## `em.populate()` always return array of entities
 
-Previously it was possible to call `em.populate()` with a single entity input,
-and the output would be again just a single entity.
+Previously it was possible to call `em.populate()` with a single entity input, and the output would be again just a single entity.
 
-Due to issues with TS 4.5, this method now always return array of entities.
-You can use destructing if you want to have a single entity return type:
+Due to issues with TS 4.5, this method now always return array of entities. You can use destructing if you want to have a single entity return type:
 
 ```ts
 const [loadedAuthor] = await em.populate(author, ...);
@@ -156,66 +122,45 @@ const [loadedAuthor] = await em.populate(author, ...);
 
 ## QueryBuilder is awaitable
 
-Previously awaiting of QB instance was a no-op. In v5, QB is promise-like interface,
-so we can await it. More about this in [Awaiting the QueryBuilder](./query-builder.md#awaiting-the-querybuilder) section.
+Previously awaiting of QB instance was a no-op. In v5, QB is promise-like interface, so we can await it. More about this in [Awaiting the QueryBuilder](./query-builder.md#awaiting-the-querybuilder) section.
 
 ## `UnitOfWork.getScheduledCollectionDeletions()` has been removed
 
-Previously scheduled collection deletions were used for a hack when removing 
-1:m collection via orphan removal might require early deletes - in case we were 
-adding the same entity (but different instance), so with same PK - inserting it 
-in the same unit would cause unique constraint failures.
+Previously scheduled collection deletions were used for a hack when removing 1:m collection via orphan removal might require early deletes - in case we were adding the same entity (but different instance), so with same PK - inserting it in the same unit would cause unique constraint failures.
 
 Also `IDatabaseDriver.clearCollection()` method is no longer present in the driver API.
 
 ## `populateAfterFlush` is enabled by default
 
-After flushing a new entity, all relations are marked as populated,
-just like if the entity was loaded from the db. This aligns the serialized
-output of `e.toJSON()` of a loaded entity and just-inserted one.
+After flushing a new entity, all relations are marked as populated, just like if the entity was loaded from the db. This aligns the serialized output of `e.toJSON()` of a loaded entity and just-inserted one.
 
-In v4 this behaviour was disabled by default, so even after the new entity was
-flushed, the serialized form contained only FKs for its relations. We can opt in
-to this old behaviour via `populateAfterFlush: false`.
+In v4 this behaviour was disabled by default, so even after the new entity was flushed, the serialized form contained only FKs for its relations. We can opt in to this old behaviour via `populateAfterFlush: false`.
 
 ## `migrations.pattern` is removed in favour of `migrations.glob`
 
-Migrations are using `umzug` under the hood, which is now upgraded to v3.0.
-With this version, the `pattern` configuration options is no longer available, 
-and has been replaced with `glob`. This change is also reflected in MikroORM.
+Migrations are using `umzug` under the hood, which is now upgraded to v3.0. With this version, the `pattern` configuration options is no longer available, and has been replaced with `glob`. This change is also reflected in MikroORM.
 
-The default value for `glob` is `!(*.d).{js,ts}`, so both JS and TS files are matched
-(but not .d.ts files). You should usually not need to change this option as this default
-suits both development and production environments.
+The default value for `glob` is `!(*.d).{js,ts}`, so both JS and TS files are matched (but not .d.ts files). You should usually not need to change this option as this default suits both development and production environments.
 
 ## Population no longer infers the where condition by default
 
 > This applies only to SELECT_IN strategy, as JOINED strategy implies the inference.
 
-Previously when we used populate hints in `em.find()` and similar methods, the
-query for our entity would be analysed and parts of it extracted and used for 
-the population. Following example would find all authors that have books with 
-given IDs, and populate their books collection, again using this PK condition,
-resulting in only such books being in those collections. 
+Previously when we used populate hints in `em.find()` and similar methods, the query for our entity would be analysed and parts of it extracted and used for the population. Following example would find all authors that have books with given IDs, and populate their books collection, again using this PK condition, resulting in only such books being in those collections.
 
 ```ts
 // this would end up with `Author.books` collections having only books of PK 1, 2, 3
 const a = await em.find(Author, { books: [1, 2, 3] }, { populate: ['books'] });
 ```
 
-Following this example, if we wanted to load all books, we would need a separate 
-`em.populate()` call:
+Following this example, if we wanted to load all books, we would need a separate `em.populate()` call:
 
 ```ts
 const a = await em.find(Author, { books: [1, 2, 3] });
 await em.populate(a, ['books']);
 ```
 
-This behaviour changed and is now configurable both globally and locally, via 
-`populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and 
-`PopulateHint.INFER`, the former being the default in v5, the latter being the
-default behaviour in v4. Locally (via `FindOptions`) we can also specify custom
-where condition that will be passed to `em.populate()` call.
+This behaviour changed and is now configurable both globally and locally, via `populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and `PopulateHint.INFER`, the former being the default in v5, the latter being the default behaviour in v4. Locally (via `FindOptions`) we can also specify custom where condition that will be passed to `em.populate()` call.
 
 ```ts
 // revert back to the old behaviour locally
@@ -227,20 +172,12 @@ const a = await em.find(Author, { books: [1, 2, 3] }, {
 
 ## `em.create()` respects required properties
 
-`em.create()` will now require you to pass all non-optional properties. Some 
-properties might be defined as required for TS, but we have a default value for 
-them (either runtime, or database one) - for such we can use `OptionalProps` 
-symbol to specify which properties should be considered as optional.
+`em.create()` will now require you to pass all non-optional properties. Some properties might be defined as required for TS, but we have a default value for them (either runtime, or database one) - for such we can use `OptionalProps` symbol to specify which properties should be considered as optional.
 
 ## Required properties are validated before insert
 
-Previously the validation took place in the database, so it worked only for SQL
-drivers. Now we have runtime validation based on the entity metadata. This means
-mongo users now need to use `nullable: true` on their optional properties, or
-disable the validation globally via `validateRequired: false` in the ORM config.
+Previously the validation took place in the database, so it worked only for SQL drivers. Now we have runtime validation based on the entity metadata. This means mongo users now need to use `nullable: true` on their optional properties, or disable the validation globally via `validateRequired: false` in the ORM config.
 
 ## `PrimaryKeyType` symbol should be defined as optional
 
-Previously when we had nonstandard PK types, we could use `PrimaryKeyType` symbol
-to let the type system know it. It was required to define this property as 
-required, now it can be defined as optional too.
+Previously when we had nonstandard PK types, we could use `PrimaryKeyType` symbol to let the type system know it. It was required to define this property as required, now it can be defined as optional too.

--- a/docs/versioned_docs/version-4.5/usage-with-adminjs.md
+++ b/docs/versioned_docs/version-4.5/usage-with-adminjs.md
@@ -6,12 +6,15 @@ sidebar_label: Usage with AdminJS
 ## Installation
 
 To use MikroORM with AdminJS you need to install:
+
 1. [`AdminJS Core`](https://github.com/SoftwareBrothers/adminjs):
+
 ```bash
 $ yarn add adminjs
 ```
 
 2. [`MikroORM Adapter`](https://github.com/SoftwareBrothers/adminjs-mikroorm):
+
 ```bash
 $ yarn add @adminjs/mikroorm
 # A MikroORM driver and core package, choose the one which suits you:
@@ -23,7 +26,9 @@ $ yarn add @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 ```
 
 3. A plugin specific to your server's framework:
+
 - [`Express Plugin`](https://github.com/SoftwareBrothers/adminjs-expressjs):
+
 ```bash
 $ yarn add @adminjs/express
 # Peer dependencies
@@ -31,6 +36,7 @@ $ yarn add express express-formidable express-session
 ```
 
 - [`Hapi Plugin`](https://github.com/SoftwareBrothers/adminjs-hapijs):
+
 ```bash
 $ yarn add @adminjs/hapi
 # Peer dependencies
@@ -41,8 +47,7 @@ $ yarn add @hapi/boom @hapi/cookie @hapi/hapi @hapi/inert
 
 ## Setup
 
-Once the installation process is completed, we need to set up AdminJS endpoints and database connection.
-The process is straightforward but differs based on which `plugin` you are using. Below you can find examples specific to supported frameworks:
+Once the installation process is completed, we need to set up AdminJS endpoints and database connection. The process is straightforward but differs based on which `plugin` you are using. Below you can find examples specific to supported frameworks:
 
 ### MikroORM + Express Plugin
 
@@ -133,7 +138,6 @@ const run = async () => {
 run();
 ```
 
-
 You can start your server afterwards and the admin panel will be available at `http://localhost:{PORT}/admin`. If you followed the example setup thoroughly, you should be able to see all of your entities in the sidebar and you should be able to perform basic **CRUD** operations on them.
 
 To further customize your AdminJS panel, please refer to the [`official documentation`](https://adminjs.co/docs.html).
@@ -149,11 +153,13 @@ The examples above set up AdminJS with unauthenticated access. To require your u
 You need to use `AdminJSExpress.buildAuthenticatedRouter` instead of `AdminJS.buildRouter`:
 
 **Before**:
+
 ```typescript
   const router = AdminJSExpress.buildRouter(admin);
 ```
 
 **After**:
+
 ```typescript
 const ADMIN_EMAIL = 'example@test.com';
 const ADMIN_PASSWORD = 'password';
@@ -174,6 +180,7 @@ const router = AdminJSExpress.buildAuthenticatedRouter(admin, {
 You need to simply add `auth` property to AdminJS options.
 
 **Before**:
+
 ```typescript
 const adminOptions = {
   databases: [orm],
@@ -181,6 +188,7 @@ const adminOptions = {
 ```
 
 **After**:
+
 ```typescript
 const ADMIN_EMAIL = 'example@test.com';
 const ADMIN_PASSWORD = 'password';

--- a/docs/versioned_docs/version-4.5/usage-with-babel.md
+++ b/docs/versioned_docs/version-4.5/usage-with-babel.md
@@ -2,9 +2,7 @@
 title: Usage with Babel
 ---
 
-When compiling TS via babel, decorators are by default handled different implementation
-than what `tsc` uses. To make the metadata extraction from decorators via Babel work, 
-we need to do use following plugins:
+When compiling TS via babel, decorators are by default handled different implementation than what `tsc` uses. To make the metadata extraction from decorators via Babel work, we need to do use following plugins:
 
 ```json
 {
@@ -18,9 +16,9 @@ we need to do use following plugins:
 
 > Make sure to install the plugins first: `yarn add -D babel-plugin-transform-typescript-metadata @babel/plugin-proposal-decorators @babel/plugin-proposal-class-properties`
 
-Lastly we need to set the `BABEL_DECORATORS_COMPAT` environment variable to `true` to 
-adjust the return value of decorators. 
+Lastly we need to set the `BABEL_DECORATORS_COMPAT` environment variable to `true` to adjust the return value of decorators.
 
 More information about this topic can be found here:
+
 - https://github.com/mikro-orm/mikro-orm/issues/840
 - https://jonahallibonetech.medium.com/next-js-9-mikroorm-eb6f6e08e1a1

--- a/docs/versioned_docs/version-4.5/usage-with-js.md
+++ b/docs/versioned_docs/version-4.5/usage-with-js.md
@@ -3,8 +3,7 @@ title: Usage with JavaScript
 sidebar_label: Usage with Vanilla JS
 ---
 
-Since MikroORM 3.2, we can use `EntitySchema` helper to define own entities without 
-decorators, which works also for Vanilla JavaScript.
+Since MikroORM 3.2, we can use `EntitySchema` helper to define own entities without decorators, which works also for Vanilla JavaScript.
 
 > Read more about `EntitySchema` in [this section](entity-schema.md).
 
@@ -68,8 +67,7 @@ module.exports.entity = Author;
 module.exports.schema = schema;
 ```
 
-> Do not forget to provide `name` and `path` schema parameters as well as `entity` 
-> and `schema` exports.
+> Do not forget to provide `name` and `path` schema parameters as well as `entity` and `schema` exports.
 
 Reference parameter can be one of (where `SCALAR` is the default one):
 
@@ -94,5 +92,4 @@ const orm = await MikroORM.init({
 });
 ```
 
-For more examples of plain JavaScript entity definitions take a look
-[Express JavaScript example](https://github.com/mikro-orm/express-js-example-app). 
+For more examples of plain JavaScript entity definitions take a look [Express JavaScript example](https://github.com/mikro-orm/express-js-example-app).

--- a/docs/versioned_docs/version-4.5/usage-with-mongo.md
+++ b/docs/versioned_docs/version-4.5/usage-with-mongo.md
@@ -2,8 +2,7 @@
 title: Usage with MongoDB
 ---
 
-To use MikroORM with mongo database, do not forget to install `@mikro-orm/mongodb`
-dependency. Then call `MikroORM.init()` as part of bootstrapping your app:
+To use MikroORM with mongo database, do not forget to install `@mikro-orm/mongodb` dependency. Then call `MikroORM.init()` as part of bootstrapping your app:
 
 > We need to use `clientUrl` to setup hosts, using `host` or `port` is not supported.
 
@@ -28,13 +27,11 @@ _id: ObjectId;
 id!: string; // won't be saved in the database
 ```
 
-> Only `_id: ObjectId` will be saved in the database. `id: string` is virtual and is 
-> also optional. 
+> Only `_id: ObjectId` will be saved in the database. `id: string` is virtual and is also optional.
 
 ## ObjectId and string id duality
 
-Every entity has both `ObjectId` and `string` id available, also all methods of `EntityManager` 
-and `EntityRepository` supports querying by both of them. 
+Every entity has both `ObjectId` and `string` id available, also all methods of `EntityManager` and `EntityRepository` supports querying by both of them.
 
 ```typescript
 const author = orm.em.getReference('...id...');
@@ -53,24 +50,21 @@ const bar2 = await repo.find({ _id: { $in: [new ObjectId(article)] }, favouriteB
 
 ## ManyToMany collections with inlined pivot array
 
-As opposed to SQL drivers that use pivot tables, in mongo we can leverage available array type
-to store array of collection items (identifiers). This approach has two main benefits:
+As opposed to SQL drivers that use pivot tables, in mongo we can leverage available array type to store array of collection items (identifiers). This approach has two main benefits:
 
-1. Collection is stored on owning side entity, so we know how many items are there even before
-initializing the collection.
+1. Collection is stored on owning side entity, so we know how many items are there even before initializing the collection.
 2. As there are no pivot tables, resulting database queries are much simpler.
 
 ## Transactions
 
-Starting with v3.4, MongoDB driver supports transactions. To use transactions, there
-are several things you need to respect:
+Starting with v3.4, MongoDB driver supports transactions. To use transactions, there are several things you need to respect:
 
 - you need to use replica set (see [run-rs](https://github.com/vkarpov15/run-rs))
 - implicit transactions are disabled by default
-    - use `implicitTransactions: true` to enable them globally
-    - or use explicit transaction demarcation via `em.transactional()`
+  - use `implicitTransactions: true` to enable them globally
+  - or use explicit transaction demarcation via `em.transactional()`
 - you need to explicitly create all collections before working with them
-    - use `em.getDriver().createCollections()` method to do so
+  - use `em.getDriver().createCollections()` method to do so
 
 ```sh
 # first create replica set
@@ -92,15 +86,11 @@ const orm = await MikroORM.init<MongoDriver>({
 await orm.em.getDriver().createCollections();
 ```
 
-> The `createCollections` method is present on the `MongoDriver` class only. You need 
-> to have the entity manager correctly typed (as `EntityManager<MongoDriver>`).
+> The `createCollections` method is present on the `MongoDriver` class only. You need to have the entity manager correctly typed (as `EntityManager<MongoDriver>`).
 
 ## Indexes
 
-Starting with v3.4, MongoDB driver supports indexes and unique constraints. You can 
-use `@Index()` and `@Unique()` as described in [Defining Entities section](defining-entities.md#indexes).
-To automatically create new indexes when initializing the ORM, you need to enable
-`ensureIndexes` option. 
+Starting with v3.4, MongoDB driver supports indexes and unique constraints. You can use `@Index()` and `@Unique()` as described in [Defining Entities section](defining-entities.md#indexes). To automatically create new indexes when initializing the ORM, you need to enable `ensureIndexes` option.
 
 ```typescript
 const orm = await MikroORM.init({
@@ -109,7 +99,7 @@ const orm = await MikroORM.init({
   type: 'mongo',
   ensureIndexes: true, // defaults to false
 });
-``` 
+```
 
 Alternatively you can call `ensureIndexes()` method on the `MongoDriver`:
 
@@ -118,24 +108,20 @@ await orm.em.getDriver().ensureIndexes();
 ```
 
 > You can pass additional index/unique options via `options` parameter:
-> 
+>
 > `@Unique({ options: { partialFilterExpression: { name: { $exists: true } } }})`
 
 > You can also create text indexes by passing `type` parameter:
-> 
+>
 > `@Index({ properties: ['name', 'caption'], type: 'text' })`
 
-> If you provide only `options` in the index definition, it will be used as is, 
-> this allows to define any kind of index:
+> If you provide only `options` in the index definition, it will be used as is, this allows to define any kind of index:
 >
-> `@Index({ options: { point: '2dsphere', title: -1 } })` 
+> `@Index({ options: { point: '2dsphere', title: -1 } })`
 
 ## Native collection methods
 
-Sometimes you need to perform some bulk operation, or you just want to populate your
-database with initial fixtures. Using ORM for such operations can bring unnecessary
-boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete`
-methods:
+Sometimes you need to perform some bulk operation, or you just want to populate your database with initial fixtures. Using ORM for such operations can bring unnecessary boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete` methods:
 
 ```typescript
 em.nativeInsert<T extends AnyEntity>(entityName: string, data: any): Promise<IPrimaryKey>;
@@ -143,9 +129,7 @@ em.nativeUpdate<T extends AnyEntity>(entityName: string, where: FilterQuery<T>, 
 em.nativeDelete<T extends AnyEntity>(entityName: string, where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Those methods execute native driver methods like Mongo's `insertOne/updateMany/deleteMany` collection methods respectively. 
-This is common interface for all drivers, so for MySQL driver, it will fire native SQL queries. 
-Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks. 
+Those methods execute native driver methods like Mongo's `insertOne/updateMany/deleteMany` collection methods respectively. This is common interface for all drivers, so for MySQL driver, it will fire native SQL queries. Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks.
 
 They are also available as `EntityRepository` shortcuts:
 

--- a/docs/versioned_docs/version-4.5/usage-with-nestjs.md
+++ b/docs/versioned_docs/version-4.5/usage-with-nestjs.md
@@ -5,8 +5,7 @@ sidebar_label: Usage with NestJS
 
 ## Installation
 
-Easiest way to integrate MikroORM to Nest is via [`@mikro-orm/nestjs` module](https://github.com/mikro-orm/nestjs).
-Simply install it next to Nest, MikroORM and underlying driver: 
+Easiest way to integrate MikroORM to Nest is via [`@mikro-orm/nestjs` module](https://github.com/mikro-orm/nestjs). Simply install it next to Nest, MikroORM and underlying driver:
 
 ```bash
 $ yarn add @mikro-orm/core @mikro-orm/nestjs @mikro-orm/mongodb     # for mongo
@@ -46,7 +45,7 @@ export class AppModule {}
 
 The `forRoot()` method accepts the same configuration object as `init()` from the MikroORM package. Check [this page](configuration.md) for the complete configuration documentation.
 
-Alternatively we can [configure the CLI](installation.md#setting-up-the-commandline-tool) by creating a configuration file `mikro-orm.config.ts` and then call the `forRoot()` without any arguments. This won't work when you use a build tools that use tree shaking. 
+Alternatively we can [configure the CLI](installation.md#setting-up-the-commandline-tool) by creating a configuration file `mikro-orm.config.ts` and then call the `forRoot()` without any arguments. This won't work when you use a build tools that use tree shaking.
 
 ```typescript
 @Module({
@@ -75,15 +74,14 @@ export class MyService {
 ```
 
 > Notice that the `EntityManager` is imported from the `@mikro-orm/driver` package, where driver is `mysql`, `sqlite`, `postgres` or whatever driver you are using.
-> 
+>
 > In case you have `@mikro-orm/knex` installed as a dependency, you can also import the `EntityManager` from there.
 
 ## Repositories
+
 MikroORM supports the repository design pattern. For every entity we can create a repository. Read the complete [documentation on repositories here](repositories.md). To define which repositories shall be registered in the current scope you can use the `forFeature()` method. For example, in this way:
 
-> You should **not** register your base entities via `forFeature()`, as there are no
-> repositories for those. On the other hand, base entities need to be part of the list
-> in `forRoot()` (or in the ORM config in general).
+> You should **not** register your base entities via `forFeature()`, as there are no repositories for those. On the other hand, base entities need to be part of the list in `forRoot()` (or in the ORM config in general).
 
 ```typescript
 // photo.module.ts
@@ -122,16 +120,13 @@ export class PhotoService {
 
 ## Using custom repositories
 
-When using custom repositories, we can get around the need for `@InjectRepository()`
-decorator by naming our repositories the same way as `getRepositoryToken()` method do:
+When using custom repositories, we can get around the need for `@InjectRepository()` decorator by naming our repositories the same way as `getRepositoryToken()` method do:
 
 ```ts
 export const getRepositoryToken = <T> (entity: EntityName<T>) => `${Utils.className(entity)}Repository`;
 ```
 
-In other words, as long as we name the repository same was as the entity is called,
-appending `Repository` suffix, the repository will be registered automatically in
-the Nest.js DI container.
+In other words, as long as we name the repository same was as the entity is called, appending `Repository` suffix, the repository will be registered automatically in the Nest.js DI container.
 
 `**./author.entity.ts**`
 
@@ -156,8 +151,7 @@ export class AuthorRepository extends EntityRepository<Author> {
 }
 ```
 
-As the custom repository name is the same as what `getRepositoryToken()` would
-return, we do not need the `@InjectRepository()` decorator anymore:
+As the custom repository name is the same as what `getRepositoryToken()` would return, we do not need the `@InjectRepository()` decorator anymore:
 
 ```ts
 @Injectable()
@@ -170,18 +164,11 @@ export class MyService {
 
 ## Load entities automatically
 
-> `autoLoadEntities` option was added in v4.1.0 
+> `autoLoadEntities` option was added in v4.1.0
 
-Manually adding entities to the entities array of the connection options can be 
-tedious. In addition, referencing entities from the root module breaks application 
-domain boundaries and causes leaking implementation details to other parts of the 
-application. To solve this issue, static glob paths can be used.
+Manually adding entities to the entities array of the connection options can be tedious. In addition, referencing entities from the root module breaks application domain boundaries and causes leaking implementation details to other parts of the application. To solve this issue, static glob paths can be used.
 
-Note, however, that glob paths are not supported by webpack, so if you are building 
-your application within a monorepo, you won't be able to use them. To address this 
-issue, an alternative solution is provided. To automatically load entities, set the 
-`autoLoadEntities` property of the configuration object (passed into the `forRoot()` 
-method) to `true`, as shown below: 
+Note, however, that glob paths are not supported by webpack, so if you are building your application within a monorepo, you won't be able to use them. To address this issue, an alternative solution is provided. To automatically load entities, set the `autoLoadEntities` property of the configuration object (passed into the `forRoot()` method) to `true`, as shown below:
 
 ```ts
 @Module({
@@ -195,32 +182,21 @@ method) to `true`, as shown below:
 export class AppModule {}
 ```
 
-With that option specified, every entity registered through the `forFeature()` 
-method will be automatically added to the entities array of the configuration 
-object.
+With that option specified, every entity registered through the `forFeature()` method will be automatically added to the entities array of the configuration object.
 
-> Note that entities that aren't registered through the `forFeature()` method, but 
-> are only referenced from the entity (via a relationship), won't be included by 
-> way of the `autoLoadEntities` setting.
+> Note that entities that aren't registered through the `forFeature()` method, but are only referenced from the entity (via a relationship), won't be included by way of the `autoLoadEntities` setting.
 
-> Using `autoLoadEntities` also has no effect on the MikroORM CLI - for that we 
-> still need CLI config with the full list of entities. On the other hand, we can
-> use globs there, as the CLI won't go thru webpack.
+> Using `autoLoadEntities` also has no effect on the MikroORM CLI - for that we still need CLI config with the full list of entities. On the other hand, we can use globs there, as the CLI won't go thru webpack.
 
 ## Request scoped handlers in queues
 
-> `@UseRequestContext()` decorator was added in v4.1.0 
+> `@UseRequestContext()` decorator was added in v4.1.0
 
-As mentioned in the [docs](identity-map.md), we need a clean state for each request. That is handled automatically thanks to the `RequestContext` helper registered via middleware. 
+As mentioned in the [docs](identity-map.md), we need a clean state for each request. That is handled automatically thanks to the `RequestContext` helper registered via middleware.
 
-But middlewares are executed only for regular HTTP request handles, what if we need
-a request scoped method outside of that? One example of that is queue handlers or 
-scheduled tasks. 
+But middlewares are executed only for regular HTTP request handles, what if we need a request scoped method outside of that? One example of that is queue handlers or scheduled tasks.
 
-We can use the `@UseRequestContext()` decorator. It requires you to first inject the
-`MikroORM` instance to current context, it will be then used to create the context 
-for you. Under the hood, the decorator will register new request context for your 
-method and execute it inside the context. 
+We can use the `@UseRequestContext()` decorator. It requires you to first inject the `MikroORM` instance to current context, it will be then used to create the context for you. Under the hood, the decorator will register new request context for your method and execute it inside the context.
 
 Keep in mind, that all handlers that are decorated with @UseRequestContext(), should NOT return anything.
 
@@ -238,9 +214,7 @@ export class MyService {
 }
 ```
 
-Another thing to look out for how you combine them with other decorators.
-For example if you use it in combination with NestJS's "[BullJS queues module](https://docs.nestjs.com/techniques/queues)", a safe bet is to extract the part of the code that needs a clean [docs](identity-map.md),
-either in a new method or inject a separate service.
+Another thing to look out for how you combine them with other decorators. For example if you use it in combination with NestJS's "[BullJS queues module](https://docs.nestjs.com/techniques/queues)", a safe bet is to extract the part of the code that needs a clean [docs](identity-map.md), either in a new method or inject a separate service.
 
 ```ts
 @Processor({
@@ -262,7 +236,6 @@ export class MyConsumer {
 ```
 
 As in this case, the `@Process()` decorator expects to receive an executable function, but if we add `@UseRequestContext()` to the handler as well, if `@UseRequestContext()` is executed before `@Process()`, the later will receive `void`.
-
 
 ## Request scoping when using GraphQL
 
@@ -295,8 +268,7 @@ And at the same time disabling the bodyparser in the GraphQL Module
 
 ## Using `AsyncLocalStorage` for request context
 
-By default, the `domain` api is used in the `RequestContext` helper. Since `@mikro-orm/core@4.0.3`,
-you can use the new `AsyncLocalStorage` too, if you are on up to date node version:
+By default, the `domain` api is used in the `RequestContext` helper. Since `@mikro-orm/core@4.0.3`, you can use the new `AsyncLocalStorage` too, if you are on up to date node version:
 
 ```typescript
 // create new (global) storage instance
@@ -347,7 +319,7 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
   }
 
   async afterUpdate(args: EventArgs<Author>): Promise<void> {
-    // ... 
+    // ...
   }
 
 }
@@ -371,4 +343,5 @@ export class PhotoModule {}
 ```
 
 ## Example
+
 A real world example of NestJS with MikroORM can be found [here](https://github.com/mikro-orm/nestjs-realworld-example-app)

--- a/docs/versioned_docs/version-4.5/usage-with-sql.md
+++ b/docs/versioned_docs/version-4.5/usage-with-sql.md
@@ -3,8 +3,7 @@ title: Usage with MySQL, MariaDB, PostgreSQL or SQLite
 sidebar_label: Usage with SQL Drivers
 ---
 
-To use `mikro-orm` with MySQL database, simply install the `@mikro-orm/mysql` dependency and set 
-the type option to `mysql` when initializing ORM. Since v4 it is no longer needed to install the `mysql2` package manually.
+To use `mikro-orm` with MySQL database, simply install the `@mikro-orm/mysql` dependency and set the type option to `mysql` when initializing ORM. Since v4 it is no longer needed to install the `mysql2` package manually.
 
 ```sh
 yarn add @mikro-orm/core @mikro-orm/mongodb     # for mongo
@@ -36,9 +35,7 @@ const orm = await MikroORM.init({
 
 ## Custom driver
 
-If you want to use database that is not currently supported, you can implement your own driver.
-More information about how to create one can be [found here](custom-driver.md). Then provide the 
-driver class via `driver` configuration option: 
+If you want to use database that is not currently supported, you can implement your own driver. More information about how to create one can be [found here](custom-driver.md). Then provide the driver class via `driver` configuration option:
 
 ```typescript
 import { MyCustomDriver } from './MyCustomDriver.ts';
@@ -52,8 +49,7 @@ const orm = await MikroORM.init({
 
 ## Schema
 
-Currently you will need to maintain the database schema yourself. For initial dump, you can 
-use [`SchemaGenerator` helper](schema-generator.md).  
+Currently you will need to maintain the database schema yourself. For initial dump, you can use [`SchemaGenerator` helper](schema-generator.md).
 
 ## ManyToMany collections with pivot tables
 
@@ -68,8 +64,7 @@ CREATE TABLE `publisher_to_test` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 ```
 
-You can adjust the name of pivot table via `pivotTable` option in `@ManyToMany` decorator
-defined on owning side: 
+You can adjust the name of pivot table via `pivotTable` option in `@ManyToMany` decorator defined on owning side:
 
 ```typescript
 // for unidirectional
@@ -83,8 +78,7 @@ tags = new Collection<BookTag>(this);
 
 ## Using QueryBuilder to execute native SQL queries
 
-When you need to execute some SQL query without all the ORM stuff involved, you can either
-compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
+When you need to execute some SQL query without all the ORM stuff involved, you can either compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
 
 ```typescript
 const qb = orm.em.createQueryBuilder(Author);
@@ -127,17 +121,13 @@ QueryBuilder.getParams(): any;
 QueryBuilder.clone(): QueryBuilder;
 ```
 
-For more examples of how to work with `QueryBuilder`, take a look at `QueryBuilder` tests in 
-[`tests/QueryBuilder.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/QueryBuilder.test.ts).
+For more examples of how to work with `QueryBuilder`, take a look at `QueryBuilder` tests in [`tests/QueryBuilder.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/QueryBuilder.test.ts).
 
 ## Transactions
 
-When you call `em.flush()`, all computed changes are queried [inside a database
-transaction](unit-of-work.md) by default, so you do not have to handle transactions manually. 
+When you call `em.flush()`, all computed changes are queried [inside a database transaction](unit-of-work.md) by default, so you do not have to handle transactions manually.
 
-When you need to explicitly handle the transaction, you can use `em.transactional(cb)` 
-to run callback in transaction. It will provide forked `EntityManager` as a parameter 
-with clear isolated identity map - please use that to make changes. 
+When you need to explicitly handle the transaction, you can use `em.transactional(cb)` to run callback in transaction. It will provide forked `EntityManager` as a parameter with clear isolated identity map - please use that to make changes.
 
 ```typescript
 // if an error occurs inside the callback, all db queries from inside the callback will be rolled back
@@ -158,16 +148,13 @@ const author3 = new Author2('Author 3', 'a3@example.com');
 await orm.em.persistAndFlush([author1, author2, author3]);
 
 // finds authors with email like '%exa%le.c_m'
-const authors = await orm.em.find(Author2, { email: /exa.*le\.c.m$/ }); 
+const authors = await orm.em.find(Author2, { email: /exa.*le\.c.m$/ });
 console.log(authors); // all 3 authors found
 ```
 
 ## Native Collection Methods
 
-Sometimes you need to perform some bulk operation, or you just want to populate your
-database with initial fixtures. Using ORM for such operations can bring unnecessary
-boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete`
-methods:
+Sometimes you need to perform some bulk operation, or you just want to populate your database with initial fixtures. Using ORM for such operations can bring unnecessary boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete` methods:
 
 ```typescript
 em.nativeInsert<T extends AnyEntity>(entityName: string, data: any): Promise<IPrimaryKey>;
@@ -175,9 +162,7 @@ em.nativeUpdate<T extends AnyEntity>(entityName: string, where: FilterQuery<T>, 
 em.nativeDelete<T extends AnyEntity>(entityName: string, where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Those methods execute native SQL queries generated via `QueryBuilder` based on entity 
-metadata. Keep in mind that they do not hydrate results to entities, and they do not 
-trigger lifecycle hooks. 
+Those methods execute native SQL queries generated via `QueryBuilder` based on entity metadata. Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks.
 
 They are also available as `EntityRepository` shortcuts:
 
@@ -187,9 +172,7 @@ EntityRepository.nativeUpdate(where: FilterQuery<T>, data: any): Promise<number>
 EntityRepository.nativeDelete(where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Additionally there is `execute()` method that supports executing raw SQL queries or `QueryBuilder`
-instances. To create `QueryBuilder`, you can use `createQueryBuilder()` factory method on both 
-`EntityManager` and `EntityRepository` classes: 
+Additionally there is `execute()` method that supports executing raw SQL queries or `QueryBuilder` instances. To create `QueryBuilder`, you can use `createQueryBuilder()` factory method on both `EntityManager` and `EntityRepository` classes:
 
 ```typescript
 const qb = em.createQueryBuilder('Author');

--- a/docs/versioned_docs/version-4.5/using-bigint-pks.md
+++ b/docs/versioned_docs/version-4.5/using-bigint-pks.md
@@ -2,8 +2,7 @@
 title: Using native BigInt PKs (MySQL and PostgreSQL)
 ---
 
-You can use `BigIntType` to support `bigint`s. By default it will represent the value as
-a `string`.  
+You can use `BigIntType` to support `bigint`s. By default it will represent the value as a `string`.
 
 ```typescript
 @Entity()
@@ -15,8 +14,7 @@ export class Book {
 }
 ```
 
-If you want to use native `bigint` type, you will need to create new type based on the
-`BigIntType`:
+If you want to use native `bigint` type, you will need to create new type based on the `BigIntType`:
 
 ```typescript
 export class NativeBigIntType extends BigIntType {

--- a/docs/versioned_docs/version-5.4/async-local-storage.md
+++ b/docs/versioned_docs/version-5.4/async-local-storage.md
@@ -2,13 +2,9 @@
 title: Using AsyncLocalStorage
 ---
 
-:::info
-Since v5 `AsyncLocalStorage` is used inside `RequestContext` helper so this section
-is no longer valid.
-:::
+:::info Since v5 `AsyncLocalStorage` is used inside `RequestContext` helper so this section is no longer valid. :::
 
-In v4 and older versions, the `domain` api was used in the `RequestContext` helper. Since v4.0.3,
-we can use the new `AsyncLocalStorage` too, if we are on up-to-date node version:
+In v4 and older versions, the `domain` api was used in the `RequestContext` helper. Since v4.0.3, we can use the new `AsyncLocalStorage` too, if we are on up-to-date node version:
 
 ```ts
 const storage = new AsyncLocalStorage<EntityManager>();

--- a/docs/versioned_docs/version-5.4/caching.md
+++ b/docs/versioned_docs/version-5.4/caching.md
@@ -2,12 +2,9 @@
 title: Result cache
 ---
 
-MikroORM has simple result caching mechanism. It works with those methods of
-`EntityManager`: `find()`, `findOne()`, `findAndCount()`, `findOneOrFail()`,
-`count()`, as well as with `QueryBuilder` result methods (including `execute`).
+MikroORM has simple result caching mechanism. It works with those methods of `EntityManager`: `find()`, `findOne()`, `findAndCount()`, `findOneOrFail()`, `count()`, as well as with `QueryBuilder` result methods (including `execute`).
 
-By default, in memory cache is used, that is shared for the whole `MikroORM`
-instance. Default expiration is 1 second.
+By default, in memory cache is used, that is shared for the whole `MikroORM` instance. Default expiration is 1 second.
 
 ```ts
 const res = await em.find(Book, { author: { name: 'Jon Snow' } }, {
@@ -27,8 +24,7 @@ const res = await em.createQueryBuilder(Book)
   .getResultList();
 ```
 
-We can change the default expiration as well as provide custom cache adapter in
-the ORM configuration:
+We can change the default expiration as well as provide custom cache adapter in the ORM configuration:
 
 ```ts
 const orm = await MikroORM.init({
@@ -42,8 +38,7 @@ const orm = await MikroORM.init({
 });
 ```
 
-To clear the cached result, we need to load it with explicit cache key, and later
-on we can use `em.clearCache(cacheKey)` method.
+To clear the cached result, we need to load it with explicit cache key, and later on we can use `em.clearCache(cacheKey)` method.
 
 ```ts
 // set the cache key to 'book-cache-key', with expiration of 60s

--- a/docs/versioned_docs/version-5.4/cascading.md
+++ b/docs/versioned_docs/version-5.4/cascading.md
@@ -5,17 +5,13 @@ sidebar_label: Cascading
 
 > From v4.2, cascade merging is no longer configurable (and is kept enabled for all relations).
 
-> This section is about application level cascading. For that to work, we need
-> to have relations populated. 
+> This section is about application level cascading. For that to work, we need to have relations populated.
 
-When persisting or removing entity, all your references are by default cascade persisted. 
-This means that by persisting any entity, ORM will automatically persist all of its 
-associations. 
+When persisting or removing entity, all your references are by default cascade persisted. This means that by persisting any entity, ORM will automatically persist all of its associations.
 
-You can control this behaviour via `cascade` attribute of `@ManyToOne`, `@ManyToMany`, 
-`@OneToMany` and `@OneToOne` fields.
+You can control this behaviour via `cascade` attribute of `@ManyToOne`, `@ManyToMany`, `@OneToMany` and `@OneToOne` fields.
 
-> New entities without primary key will be always persisted, regardless of `cascade` value. 
+> New entities without primary key will be always persisted, regardless of `cascade` value.
 
 ```ts
 // cascade persist is default value
@@ -55,23 +51,19 @@ book.tags[1].name = 'new name 2';
 await orm.em.persistAndFlush(book); // all book tags and author will be persisted too
 ```
 
-> When cascade persisting collections, keep in mind only fully initialized collections 
-> will be cascade persisted.
+> When cascade persisting collections, keep in mind only fully initialized collections will be cascade persisted.
 
 ## Cascade remove
 
-Cascade remove works same way as cascade persist, just for removing entities. Following 
-example assumes that `Book.publisher` is set to `Cascade.REMOVE`:
+Cascade remove works same way as cascade persist, just for removing entities. Following example assumes that `Book.publisher` is set to `Cascade.REMOVE`:
 
-> Note that cascade remove for collections can be inefficient as it will fire 1 query
-> for each entity in collection.
+> Note that cascade remove for collections can be inefficient as it will fire 1 query for each entity in collection.
 
 ```ts
 await orm.em.remove(book).flush(); // this will also remove book.publisher
 ```
 
-Keep in mind that cascade remove **can be dangerous** when used on `@ManyToOne` fields, 
-as cascade removed entity can stay referenced in another entities that were not removed.
+Keep in mind that cascade remove **can be dangerous** when used on `@ManyToOne` fields, as cascade removed entity can stay referenced in another entities that were not removed.
 
 ```ts
 const publisher = new Publisher(...);
@@ -85,9 +77,7 @@ console.log(book2.publisher, book3.publisher);
 
 ## Orphan removal
 
-In addition to `Cascade.REMOVE`, there is also additional and more aggressive remove 
-cascading mode which can be specified using the `orphanRemoval` flag of the `@OneToOne`
-and `@OneToMany` properties:
+In addition to `Cascade.REMOVE`, there is also additional and more aggressive remove cascading mode which can be specified using the `orphanRemoval` flag of the `@OneToOne` and `@OneToMany` properties:
 
 ```ts
 @Entity()
@@ -99,13 +89,9 @@ export class Author {
 }
 ```
 
-> `orphanRemoval` flag behaves just like `Cascade.REMOVE` for remove operation, so specifying 
-> both is redundant.
+> `orphanRemoval` flag behaves just like `Cascade.REMOVE` for remove operation, so specifying both is redundant.
 
-With simple `Cascade.REMOVE`, you would need to remove the `Author` entity to cascade 
-the operation down to all loaded `Book`s. By enabling orphan removal on the collection, 
-`Book`s will be also removed when they get disconnected from the collection (either via 
-`remove()`, or by replacing collection items via `set()`):
+With simple `Cascade.REMOVE`, you would need to remove the `Author` entity to cascade the operation down to all loaded `Book`s. By enabling orphan removal on the collection, `Book`s will be also removed when they get disconnected from the collection (either via `remove()`, or by replacing collection items via `set()`):
 
 ```ts
 await author.books.set([book1, book2]); // replace whole collection
@@ -113,18 +99,15 @@ await author.books.remove(book1); // remove book from collection
 await orm.em.persistAndFlush(author); // book1 will be removed, as well as all original items (before we called `set()`)
 ```
 
-In this example, no `Book` would be removed with simple `Cascade.REMOVE` as no remove operation
-was executed. 
+In this example, no `Book` would be removed with simple `Cascade.REMOVE` as no remove operation was executed.
 
 ## Declarative Referential Integrity
 
 > This is only supported in SQL drivers.
 
-As opposed to the application level cascading controlled by the `cascade` option, we can
-also define database level referential integrity actions: `on update` and `on delete`.
+As opposed to the application level cascading controlled by the `cascade` option, we can also define database level referential integrity actions: `on update` and `on delete`.
 
-Their values are automatically inferred from the `cascade` option value. You can also 
-control the value manually via `onUpdateIntegrity` and `onDelete` options. 
+Their values are automatically inferred from the `cascade` option value. You can also control the value manually via `onUpdateIntegrity` and `onDelete` options.
 
 ```ts
 @Entity()

--- a/docs/versioned_docs/version-5.4/collections.md
+++ b/docs/versioned_docs/version-5.4/collections.md
@@ -179,8 +179,7 @@ export class OrderItem {
 
 ### Forcing fixed order of collection items
 
-> Since v3 many to many collections does not require having auto increment primary key, that
-> was used to ensure fixed order of collection items.
+> Since v3 many to many collections does not require having auto increment primary key, that was used to ensure fixed order of collection items.
 
 To preserve fixed order of collections, we can use `fixedOrder: true` attribute, which will start ordering by `id` column. Schema generator will convert the pivot table to have auto increment primary key `id`. We can also change the order column name via `fixedOrderColumn: 'order'`.
 
@@ -211,9 +210,9 @@ console.log(tag.books.contains(book)); // true
 
 tag.books.add(book);
 console.log(book.tags.contains(tag)); // true
-``` 
+```
 
->  Since v5.2.2 propagation of adding new items to inverse side M:N relation also works if the owning collection is not initialized. For propagation of remove operation, both sides still have to be initialized.
+> Since v5.2.2 propagation of adding new items to inverse side M:N relation also works if the owning collection is not initialized. For propagation of remove operation, both sides still have to be initialized.
 
 > Although this propagation works also for M:N inverse side, we should always use owning side to manipulate the collection.
 

--- a/docs/versioned_docs/version-5.4/composite-keys.md
+++ b/docs/versioned_docs/version-5.4/composite-keys.md
@@ -5,14 +5,9 @@ sidebar_label: Composite Primary Keys
 
 > Support for composite keys was added in version 3.5
 
-MikroORM supports composite primary keys natively. Composite keys are a very powerful 
-relational database concept and we took good care to make sure MikroORM supports as 
-many of the composite primary key use-cases. MikroORM supports composite keys of primitive 
-data-types as well as foreign keys as primary keys. You can also use your composite key 
-entities in relationships. 
+MikroORM supports composite primary keys natively. Composite keys are a very powerful relational database concept and we took good care to make sure MikroORM supports as many of the composite primary key use-cases. MikroORM supports composite keys of primitive data-types as well as foreign keys as primary keys. You can also use your composite key entities in relationships.
 
-This section shows how the semantics of composite primary keys work and how they map 
-to the database.
+This section shows how the semantics of composite primary keys work and how they map to the database.
 
 ## General Considerations
 
@@ -20,8 +15,7 @@ ID fields have to have their values set before you call `em.persist(entity)`.
 
 ## Primitive Types only
 
-Suppose you want to create a database of cars and use the model-name and year of 
-production as primary keys:
+Suppose you want to create a database of cars and use the model-name and year of production as primary keys:
 
 ```ts
 @Entity()
@@ -50,39 +44,28 @@ const car = new Car('Audi A8', 2010);
 await em.persistAndFlush(car);
 ```
 
-And for querying you need to provide all primary keys in the condition or an array of
-primary keys in the same order as the keys were defined:
+And for querying you need to provide all primary keys in the condition or an array of primary keys in the same order as the keys were defined:
 
 ```ts
 const audi1 = await em.findOneOrFail(Car, { name: 'Audi A8', year: 2010 });
 const audi2 = await em.findOneOrFail(Car, ['Audi A8', 2010]);
 ```
 
-> If we want to use the second approach with primary key tuple, we will need to specify 
-> the type of entity's primary key via `PrimaryKeyType` symbol as shown in the `Car` entity.
+> If we want to use the second approach with primary key tuple, we will need to specify the type of entity's primary key via `PrimaryKeyType` symbol as shown in the `Car` entity.
 
-> `PrimaryKeyType` is not needed when your entity has single scalar primary key under 
-> one of following property names: `id: number | string | bigint`, `_id: any` or 
-> `uuid: string`.
+> `PrimaryKeyType` is not needed when your entity has single scalar primary key under one of following property names: `id: number | string | bigint`, `_id: any` or `uuid: string`.
 
-You can also use this entity in associations. MikroORM will then generate two foreign 
-keys one for name and to year to the related entities.
+You can also use this entity in associations. MikroORM will then generate two foreign keys one for name and to year to the related entities.
 
-This example shows how you can nicely solve the requirement for existing values before 
-`em.persist()`: By adding them as mandatory values for the constructor.
+This example shows how you can nicely solve the requirement for existing values before `em.persist()`: By adding them as mandatory values for the constructor.
 
 ## Identity through foreign Entities
 
-There are tons of use-cases where the identity of an Entity should be determined by 
-the entity of one or many parent entities.
+There are tons of use-cases where the identity of an Entity should be determined by the entity of one or many parent entities.
 
-- Dynamic Attributes of an Entity (for example `Article`). Each Article has many 
-  attributes with primary key `article_id` and `attribute_name`.
-- `Address` object of a `Person`, the primary key of the address is `user_id`. This 
-  is not a case of a composite primary key, but the identity is derived through a 
-  foreign entity and a foreign key.
-- Pivot Tables with metadata can be modelled as Entity, for example connections between 
-  two articles with a little description and a score.
+- Dynamic Attributes of an Entity (for example `Article`). Each Article has many attributes with primary key `article_id` and `attribute_name`.
+- `Address` object of a `Person`, the primary key of the address is `user_id`. This is not a case of a composite primary key, but the identity is derived through a foreign entity and a foreign key.
+- Pivot Tables with metadata can be modelled as Entity, for example connections between two articles with a little description and a score.
 
 The semantics of mapping identity through foreign entities are easy:
 
@@ -133,9 +116,7 @@ export class ArticleAttribute {
 
 ## Use-Case 2: Simple Derived Identity
 
-Sometimes you have the requirement that two objects are related by a `@OneToOne` 
-association and that the dependent class should re-use the primary key of the class 
-it depends on. One good example for this is a user-address relationship:
+Sometimes you have the requirement that two objects are related by a `@OneToOne` association and that the dependent class should re-use the primary key of the class it depends on. One good example for this is a user-address relationship:
 
 ```ts
 @Entity()
@@ -162,9 +143,7 @@ export class Address {
 
 ## Use-Case 3: Join-Table with Metadata
 
-In the classic order product shop example there is the concept of the order item which 
-contains references to order and product and additional data such as the amount of products 
-purchased and maybe even the current price.
+In the classic order product shop example there is the concept of the order item which contains references to order and product and additional data such as the amount of products purchased and maybe even the current price.
 
 ```ts
 @Entity()
@@ -234,8 +213,7 @@ export class OrderItem {
 }
 ```
 
-:::info
-By default, a generated pivot table entity is used under the hood to represent the pivot table. Since v5.1 we can provide our own implementation via `pivotEntity` option.
+:::info By default, a generated pivot table entity is used under the hood to represent the pivot table. Since v5.1 we can provide our own implementation via `pivotEntity` option.
 
 The pivot table entity needs to have exactly two many-to-one properties, where first one needs to point to the owning entity and the second to the target entity of the many-to-many relation.
 
@@ -266,12 +244,12 @@ export class OrderItem {
 
 }
 ```
+
 :::
 
 ## Using QueryBuilder with composite keys
 
-Internally composite keys are represented as tuples, containing all the values in the
-same order as the primary keys were defined. 
+Internally composite keys are represented as tuples, containing all the values in the same order as the primary keys were defined.
 
 ```ts
 const qb1 = em.createQueryBuilder(CarOwner);
@@ -292,7 +270,6 @@ This also applies when you want to get a reference to entity with composite key:
 ```ts
 const ref = em.getReference(Car, ['Audi A8', 2010]);
 console.log(ref instanceof Car); // true
-``` 
+```
 
-> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/composite-primary-keys.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/composite-primary-keys.html) as the behaviour here is pretty much the same.

--- a/docs/versioned_docs/version-5.4/configuration.md
+++ b/docs/versioned_docs/version-5.4/configuration.md
@@ -4,8 +4,7 @@ title: Configuration
 
 ## Entity Discovery
 
-You can either provide array of entity instances via `entities`, or let the ORM look up your 
-entities in selected folders. 
+You can either provide array of entity instances via `entities`, or let the ORM look up your entities in selected folders.
 
 ```ts
 MikroORM.init({
@@ -13,14 +12,9 @@ MikroORM.init({
 });
 ```
 
-We can also use folder based discovery by providing list of paths to the entities
-we want to discover (globs are supported as well). This way we also need to specify
-`entitiesTs`, where we point the paths to the TS source files instead of the JS 
-compiled files (see more at [Metadata Providers](metadata-providers.md)).
+We can also use folder based discovery by providing list of paths to the entities we want to discover (globs are supported as well). This way we also need to specify `entitiesTs`, where we point the paths to the TS source files instead of the JS compiled files (see more at [Metadata Providers](metadata-providers.md)).
 
-> The `entitiesTs` option is used when running the app via `ts-node`, as the ORM 
-> needs to discover the TS files. Always specify this option if you use folder/file
-> based discovery. 
+> The `entitiesTs` option is used when running the app via `ts-node`, as the ORM needs to discover the TS files. Always specify this option if you use folder/file based discovery.
 
 ```ts
 MikroORM.init({
@@ -31,19 +25,11 @@ MikroORM.init({
 });
 ```
 
-> Be careful when overriding the `baseDir` with dynamic values like `__dirname`, 
-> as you can end up with valid paths from `ts-node`, but invalid paths from `node`.
-> Ideally you should keep the default of `process.cwd()` there to always have the 
-> same base path regardless of how you run the app.
+> Be careful when overriding the `baseDir` with dynamic values like `__dirname`, as you can end up with valid paths from `ts-node`, but invalid paths from `node`. Ideally you should keep the default of `process.cwd()` there to always have the same base path regardless of how you run the app.
 
-By default, `ReflectMetadataProvider` is used that leverages the `reflect-metadata`. 
-You can also use `TsMorphMetadataProvider` by installing `@mikro-orm/reflection`. 
-This provider will analyse your entity source files (or `.d.ts` type definition files). 
-If you aim to use plain JavaScript instead of TypeScript, use `EntitySchema` or 
-the `JavaScriptMetadataProvider`.
+By default, `ReflectMetadataProvider` is used that leverages the `reflect-metadata`. You can also use `TsMorphMetadataProvider` by installing `@mikro-orm/reflection`. This provider will analyse your entity source files (or `.d.ts` type definition files). If you aim to use plain JavaScript instead of TypeScript, use `EntitySchema` or the `JavaScriptMetadataProvider`.
 
-> You can also implement your own metadata provider and use it instead. To do so, extend the 
-> `MetadataProvider` class.
+> You can also implement your own metadata provider and use it instead. To do so, extend the `MetadataProvider` class.
 
 ```ts
 import { MikroORM } from '@mikro-orm/core';
@@ -66,8 +52,7 @@ MikroORM.init({
 });
 ```
 
-> If you disable `discovery.alwaysAnalyseProperties` option, you will need to explicitly 
-> provide `nullable` and `wrappedReference` parameters (where applicable).
+> If you disable `discovery.alwaysAnalyseProperties` option, you will need to explicitly provide `nullable` and `wrappedReference` parameters (where applicable).
 
 Read more about this in [Metadata Providers](metadata-providers.md) sections.
 
@@ -96,19 +81,17 @@ const orm = await MikroORM.init({
 
 To select driver, you can either use `type` option, or provide the driver class reference.
 
-| type | driver name | dependency | note |
-|------|-------------|------------|------|
-| `mongo` | `MongoDriver` | `mongodb^3.3.4` | - |
-| `mysql` | `MySqlDriver` | `mysql2^2.0.0` | compatible with MariaDB |
-| `mariadb` | `MariaDbDriver` | `mariadb^2.0.0` | compatible with MySQL |
-| `postgresql` | `PostgreSqlDriver` | `pg^7.0.0` | - |
-| `sqlite` | `SqliteDriver` | `sqlite3^4.0.0` | - |
+| type         | driver name        | dependency      | note                    |
+| ------------ | ------------------ | --------------- | ----------------------- |
+| `mongo`      | `MongoDriver`      | `mongodb^3.3.4` | -                       |
+| `mysql`      | `MySqlDriver`      | `mysql2^2.0.0`  | compatible with MariaDB |
+| `mariadb`    | `MariaDbDriver`    | `mariadb^2.0.0` | compatible with MySQL   |
+| `postgresql` | `PostgreSqlDriver` | `pg^7.0.0`      | -                       |
+| `sqlite`     | `SqliteDriver`     | `sqlite3^4.0.0` | -                       |
 
-> Driver and connection implementations are not directly exported from `@mikro-orm/core` module. 
-> You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
+> Driver and connection implementations are not directly exported from `@mikro-orm/core` module. You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
 
-> You can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. 
-> The object will be deeply merged, overriding all internally used options.
+> You can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. The object will be deeply merged, overriding all internally used options.
 
 ```ts
 import { MySqlDriver } from '@mikro-orm/mysql';
@@ -130,8 +113,7 @@ MikroORM.init({
 
 ## Connection
 
-Each platform (driver) provides default connection string, you can override it as a whole
-through `clientUrl`, or partially through one of following options:
+Each platform (driver) provides default connection string, you can override it as a whole through `clientUrl`, or partially through one of following options:
 
 ```ts
 export interface DynamicPassword {
@@ -155,17 +137,16 @@ export interface ConnectionOptions {
 
 Following table shows default client connection strings:
 
-| type | default connection url |
-|------|------------------------|
-| `mongo` | `mongodb://127.0.0.1:27017` |
-| `mysql` | `mysql://root@127.0.0.1:3306` |
-| `mariadb` | `mysql://root@127.0.0.1:3306` |
+| type         | default connection url                 |
+| ------------ | -------------------------------------- |
+| `mongo`      | `mongodb://127.0.0.1:27017`            |
+| `mysql`      | `mysql://root@127.0.0.1:3306`          |
+| `mariadb`    | `mysql://root@127.0.0.1:3306`          |
 | `postgresql` | `postgresql://postgres@127.0.0.1:5432` |
 
 ### Read Replicas
 
-To set up read replicas, you can use `replicas` option. You can provide only those parts of the 
-`ConnectionOptions` interface, they will be used to override the `master` connection options.
+To set up read replicas, you can use `replicas` option. You can provide only those parts of the `ConnectionOptions` interface, they will be used to override the `master` connection options.
 
 ```ts
 MikroORM.init({
@@ -186,10 +167,7 @@ Read more about this in [Installation](installation.md) and [Read Connections](r
 
 ### Using short-lived tokens
 
-Many cloud providers include alternative methods for connecting to database instances 
-using short-lived authentication tokens. MikroORM supports dynamic passwords via 
-a callback function, either synchronous or asynchronous. The callback function must 
-resolve to a string.
+Many cloud providers include alternative methods for connecting to database instances using short-lived authentication tokens. MikroORM supports dynamic passwords via a callback function, either synchronous or asynchronous. The callback function must resolve to a string.
 
 ```ts
 MikroORM.init({
@@ -199,8 +177,7 @@ MikroORM.init({
 });
 ```
 
-The password callback value will be cached, to invalidate this cache we can specify
-`expirationChecker` callback:
+The password callback value will be cached, to invalidate this cache we can specify `expirationChecker` callback:
 
 ```ts
 MikroORM.init({
@@ -215,8 +192,7 @@ MikroORM.init({
 
 ## Naming Strategy
 
-When mapping your entities to database tables and columns, their names will be defined by naming 
-strategy. There are 3 basic naming strategies you can choose from:
+When mapping your entities to database tables and columns, their names will be defined by naming strategy. There are 3 basic naming strategies you can choose from:
 
 - `UnderscoreNamingStrategy` - default of all SQL drivers
 - `MongoNamingStrategy` - default of `MongoDriver`
@@ -234,9 +210,7 @@ Read more about this in [Naming Strategy](naming-strategy.md) section.
 
 ## Auto-join of 1:1 owners
 
-By default, owning side of 1:1 relation will be auto-joined when you select the inverse side 
-so we can have the reference to it. You can disable this behaviour via `autoJoinOneToOneOwner` 
-configuration toggle.
+By default, owning side of 1:1 relation will be auto-joined when you select the inverse side so we can have the reference to it. You can disable this behaviour via `autoJoinOneToOneOwner` configuration toggle.
 
 ```ts
 MikroORM.init({
@@ -246,8 +220,7 @@ MikroORM.init({
 
 ## Propagation of 1:1 and m:1 owners
 
-MikroORM defines getter and setter for every owning side of m:1 and 1:1 relation. This is 
-then used for propagation of changes to the inverse side of bi-directional relations.
+MikroORM defines getter and setter for every owning side of m:1 and 1:1 relation. This is then used for propagation of changes to the inverse side of bi-directional relations.
 
 ```ts
 const author = new Author('n', 'e');
@@ -266,9 +239,7 @@ MikroORM.init({
 
 ## Forcing UTC Timezone
 
-Use `forceUtcTimezone` option to force the `Date`s to be saved in UTC in datetime columns 
-without timezone. It works for MySQL (`datetime` type) and PostgreSQL (`timestamp` type). 
-SQLite does this by default. 
+Use `forceUtcTimezone` option to force the `Date`s to be saved in UTC in datetime columns without timezone. It works for MySQL (`datetime` type) and PostgreSQL (`timestamp` type). SQLite does this by default.
 
 ```ts
 MikroORM.init({
@@ -278,9 +249,7 @@ MikroORM.init({
 
 ## Mapping `null` values to `undefined`
 
-By default `null` values from nullable database columns are hydrated as `null`. 
-Using `forceUndefined` we can tell the ORM to convert those `null` values to
-`undefined` instead. 
+By default `null` values from nullable database columns are hydrated as `null`. Using `forceUndefined` we can tell the ORM to convert those `null` values to `undefined` instead.
 
 ```ts
 MikroORM.init({
@@ -290,13 +259,9 @@ MikroORM.init({
 
 ## Serialization of new entities
 
-After flushing a new entity, all relations are marked as populated,
-just like if the entity was loaded from the db. This aligns the serialized
-output of `e.toJSON()` of a loaded entity and just-inserted one.
+After flushing a new entity, all relations are marked as populated, just like if the entity was loaded from the db. This aligns the serialized output of `e.toJSON()` of a loaded entity and just-inserted one.
 
-In v4 this behaviour was disabled by default, so even after the new entity was 
-flushed, the serialized form contained only FKs for its relations. We can opt in 
-to this old behaviour via `populateAfterFlush: false`.
+In v4 this behaviour was disabled by default, so even after the new entity was flushed, the serialized form contained only FKs for its relations. We can opt in to this old behaviour via `populateAfterFlush: false`.
 
 ```ts
 MikroORM.init({
@@ -308,30 +273,21 @@ MikroORM.init({
 
 > This applies only to SELECT_IN strategy, as JOINED strategy implies the inference.
 
-In v4, when we used populate hints in `em.find()` and similar methods, the
-query for our entity would be analysed and parts of it extracted and used for
-the population. Following example would find all authors that have books with
-given IDs, and populate their books collection, again using this PK condition,
-resulting in only such books being in those collections.
+In v4, when we used populate hints in `em.find()` and similar methods, the query for our entity would be analysed and parts of it extracted and used for the population. Following example would find all authors that have books with given IDs, and populate their books collection, again using this PK condition, resulting in only such books being in those collections.
 
 ```ts
 // this would end up with `Author.books` collections having only books of PK 1, 2, 3
 const a = await em.find(Author, { books: [1, 2, 3] }, { populate: ['books'] });
 ```
 
-Following this example, if we wanted to load all books, we would need a separate
-`em.populate()` call:
+Following this example, if we wanted to load all books, we would need a separate `em.populate()` call:
 
 ```ts
 const a = await em.find(Author, { books: [1, 2, 3] });
 await em.populate(a, ['books']);
 ```
 
-This behaviour changed and is now configurable both globally and locally, via
-`populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and
-`PopulateHint.INFER`, the former being the default in v5, the latter being the
-default behaviour in v4. Locally (via `FindOptions`) we can also specify custom
-where condition that will be passed to `em.populate()` call.
+This behaviour changed and is now configurable both globally and locally, via `populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and `PopulateHint.INFER`, the former being the default in v5, the latter being the default behaviour in v4. Locally (via `FindOptions`) we can also specify custom where condition that will be passed to `em.populate()` call.
 
 ```ts
 MikroORM.init({
@@ -342,8 +298,7 @@ MikroORM.init({
 
 ## Custom Hydrator
 
-Hydrator is responsible for assigning values from the database to entities. 
-You can implement your custom `Hydrator` (by extending the abstract `Hydrator` class):
+Hydrator is responsible for assigning values from the database to entities. You can implement your custom `Hydrator` (by extending the abstract `Hydrator` class):
 
 ```ts
 MikroORM.init({
@@ -353,8 +308,7 @@ MikroORM.init({
 
 ## Custom Repository
 
-You can also register custom base repository (for all entities where you do not specify 
-`customRepository`) globally:
+You can also register custom base repository (for all entities where you do not specify `customRepository`) globally:
 
 > You can still use entity specific repositories in combination with global base repository.
 
@@ -368,14 +322,9 @@ Read more about this in [Repositories](repositories.md) section.
 
 ## Strict Mode and property validation
 
-> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`.
-> It has performance implications and usually should not be needed, as long as
-> you don't modify your entities via `Object.assign()`.
+> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`. It has performance implications and usually should not be needed, as long as you don't modify your entities via `Object.assign()`.
 
-`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong 
-data types for you automatically. If automatic conversion fails, it will throw an error. You can 
-enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered 
-when persisting the entity. 
+`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong data types for you automatically. If automatic conversion fails, it will throw an error. You can enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered when persisting the entity.
 
 ```ts
 MikroORM.init({
@@ -388,12 +337,9 @@ Read more about this in [Property Validation](property-validation.md) section.
 
 ## Required properties validation
 
-Since v5, new entities are validated on runtime (just before executing insert
-queries), based on the entity metadata. This means that mongo users now need 
-to use `nullable: true` on their optional properties too).
+Since v5, new entities are validated on runtime (just before executing insert queries), based on the entity metadata. This means that mongo users now need to use `nullable: true` on their optional properties too).
 
-This behaviour can be disabled globally via `validateRequired: false` in the 
-ORM config.
+This behaviour can be disabled globally via `validateRequired: false` in the ORM config.
 
 ```ts
 MikroORM.init({
@@ -403,8 +349,7 @@ MikroORM.init({
 
 ## Debugging & Logging
 
-You can enable logging with `debug` option. Either set it to `true` to log everything, or 
-provide array of `'query' | 'query-params' | 'discovery' | 'info'` namespaces.
+You can enable logging with `debug` option. Either set it to `true` to log everything, or provide array of `'query' | 'query-params' | 'discovery' | 'info'` namespaces.
 
 ```ts
 MikroORM.init({
@@ -419,8 +364,7 @@ Read more about this in [Debugging](logging.md) section.
 
 ## Custom Fail Handler
 
-When no entity is found during `em.findOneOrFail()` call, `new Error()` will be thrown. 
-You can customize how the `Error` instance is created via `findOneOrFailHandler`:
+When no entity is found during `em.findOneOrFail()` call, `new Error()` will be thrown. You can customize how the `Error` instance is created via `findOneOrFailHandler`:
 
 ```ts
 MikroORM.init({
@@ -447,8 +391,7 @@ MikroORM.init({
 
 ## Migrations
 
-Under the `migrations` namespace, you can adjust how the integrated migrations support works.
-Following example shows all possible options and their defaults:
+Under the `migrations` namespace, you can adjust how the integrated migrations support works. Following example shows all possible options and their defaults:
 
 ```ts
 MikroORM.init({
@@ -483,8 +426,7 @@ Read more about this in [seeding docs](seeding.md).
 
 ## Caching
 
-By default, metadata discovery results are cached. You can either disable caching, or adjust 
-how it works. Following example shows all possible options and their defaults:
+By default, metadata discovery results are cached. You can either disable caching, or adjust how it works. Following example shows all possible options and their defaults:
 
 ```ts
 MikroORM.init({
@@ -510,30 +452,24 @@ MikroORM.init({
   ...
 });
 ```
- > This should be disabled in production environments for added security.
+
+> This should be disabled in production environments for added security.
 
 ## Using native private properties
 
-If we want to use native private properties inside entities, the default approach of 
-how MikroORM creates entity instances via `Object.create()` is not viable (more about this
-in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity
-constructors, we can use `forceEntityConstructor` toggle:
+If we want to use native private properties inside entities, the default approach of how MikroORM creates entity instances via `Object.create()` is not viable (more about this in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity constructors, we can use `forceEntityConstructor` toggle:
 
 ```ts
 MikroORM.init({
-  forceEntityConstructor: true, // or specify just some entities via `[Author, 'Book', ...]` 
+  forceEntityConstructor: true, // or specify just some entities via `[Author, 'Book', ...]`
 });
 ```
 
-## Persist created entities automatically 
+## Persist created entities automatically
 
-If we create new entity via `em.create()`, we still need to mark it via 
-`em.persist()` to make the `EntityManager` aware of it. Alternatively we
-can enable `persistOnCreate` flag, which will make this work automatically.
+If we create new entity via `em.create()`, we still need to mark it via `em.persist()` to make the `EntityManager` aware of it. Alternatively we can enable `persistOnCreate` flag, which will make this work automatically.
 
-> This flag affects only `em.create()`, entities created via constructors
-> still need explicit `em.persist()` call or they need to be part of entity 
-> graph of some already managed entity.
+> This flag affects only `em.create()`, entities created via constructors still need explicit `em.persist()` call or they need to be part of entity graph of some already managed entity.
 
 ```ts
 MikroORM.init({
@@ -543,26 +479,19 @@ MikroORM.init({
 
 ## Using global Identity Map
 
-In v5, it is no longer possible to use the global identity map. This was a
-common issue that led to weird bugs, as using the global EM without request
-context is almost always wrong, we always need to have a dedicated context for
-each request, so they do not interfere.
+In v5, it is no longer possible to use the global identity map. This was a common issue that led to weird bugs, as using the global EM without request context is almost always wrong, we always need to have a dedicated context for each request, so they do not interfere.
 
-We still can disable this check via `allowGlobalContext` configuration, or
-a connected environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can
-be handy especially in unit tests.
+We still can disable this check via `allowGlobalContext` configuration, or a connected environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can be handy especially in unit tests.
 
 ```ts
 MikroORM.init({
-  allowGlobalContext: true, 
+  allowGlobalContext: true,
 });
 ```
 
 ## Using environment variables
 
-Since v4.5 it is possible to set most of the ORM options via environment variables.
-By default `.env` file from the root directory is loaded - it is also possible to
-set full path to the env file you want to use via `MIKRO_ORM_ENV` environment variable.
+Since v4.5 it is possible to set most of the ORM options via environment variables. By default `.env` file from the root directory is loaded - it is also possible to set full path to the env file you want to use via `MIKRO_ORM_ENV` environment variable.
 
 > Environment variables always have precedence.
 
@@ -582,53 +511,53 @@ MIKRO_ORM_FORCE_UNDEFINED = true
 
 Full list of supported options:
 
-| env variable | config key |
-|--------------|------------|
-| `MIKRO_ORM_BASE_DIR` | `baseDir` |
-| `MIKRO_ORM_TYPE` | `type` |
-| `MIKRO_ORM_ENTITIES` | `entities` |
-| `MIKRO_ORM_ENTITIES_TS` | `entitiesTs` |
-| `MIKRO_ORM_CLIENT_URL` | `clientUrl` |
-| `MIKRO_ORM_HOST` | `host` |
-| `MIKRO_ORM_PORT` | `port` |
-| `MIKRO_ORM_USER` | `user` |
-| `MIKRO_ORM_PASSWORD` | `password` |
-| `MIKRO_ORM_DB_NAME` | `dbName` |
-| `MIKRO_ORM_LOAD_STRATEGY` | `loadStrategy` |
-| `MIKRO_ORM_BATCH_SIZE` | `batchSize` |
-| `MIKRO_ORM_USE_BATCH_INSERTS` | `useBatchInserts` |
-| `MIKRO_ORM_USE_BATCH_UPDATES` | `useBatchUpdates` |
-| `MIKRO_ORM_STRICT` | `strict` |
-| `MIKRO_ORM_VALIDATE` | `validate` |
-| `MIKRO_ORM_AUTO_JOIN_ONE_TO_ONE_OWNER` | `autoJoinOneToOneOwner` |
-| `MIKRO_ORM_PROPAGATE_TO_ONE_OWNER` | `propagateToOneOwner` |
-| `MIKRO_ORM_POPULATE_AFTER_FLUSH` | `populateAfterFlush` |
-| `MIKRO_ORM_FORCE_ENTITY_CONSTRUCTOR` | `forceEntityConstructor` |
-| `MIKRO_ORM_FORCE_UNDEFINED` | `forceUndefined` |
-| `MIKRO_ORM_FORCE_UTC_TIMEZONE` | `forceUtcTimezone` |
-| `MIKRO_ORM_TIMEZONE` | `timezone` |
-| `MIKRO_ORM_ENSURE_INDEXES` | `ensureIndexes` |
-| `MIKRO_ORM_IMPLICIT_TRANSACTIONS` | `implicitTransactions` |
-| `MIKRO_ORM_DEBUG` | `debug` |
-| `MIKRO_ORM_VERBOSE` | `verbose` |
-| `MIKRO_ORM_DISCOVERY_WARN_WHEN_NO_ENTITIES` | `discovery.warnWhenNoEntities` |
-| `MIKRO_ORM_DISCOVERY_REQUIRE_ENTITIES_ARRAY` | `discovery.requireEntitiesArray` |
-| `MIKRO_ORM_DISCOVERY_ALWAYS_ANALYSE_PROPERTIES` | `discovery.alwaysAnalyseProperties` |
-| `MIKRO_ORM_DISCOVERY_DISABLE_DYNAMIC_FILE_ACCESS` | `discovery.disableDynamicFileAccess` |
-| `MIKRO_ORM_MIGRATIONS_TABLE_NAME` | `migrations.tableName` |
-| `MIKRO_ORM_MIGRATIONS_PATH` | `migrations.path` |
-| `MIKRO_ORM_MIGRATIONS_PATH_TS` | `migrations.pathTs` |
-| `MIKRO_ORM_MIGRATIONS_GLOB` | `migrations.glob` |
-| `MIKRO_ORM_MIGRATIONS_TRANSACTIONAL` | `migrations.transactional` |
-| `MIKRO_ORM_MIGRATIONS_DISABLE_FOREIGN_KEYS` | `migrations.disableForeignKeys` |
-| `MIKRO_ORM_MIGRATIONS_ALL_OR_NOTHING` | `migrations.allOrNothing` |
-| `MIKRO_ORM_MIGRATIONS_DROP_TABLES` | `migrations.dropTables` |
-| `MIKRO_ORM_MIGRATIONS_SAFE` | `migrations.safe` |
-| `MIKRO_ORM_MIGRATIONS_EMIT` | `migrations.emit` |
-| `MIKRO_ORM_SCHEMA_GENERATOR_DISABLE_FOREIGN_KEYS` | `migrations.disableForeignKeys` |
+| env variable                                                | config key                               |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `MIKRO_ORM_BASE_DIR`                                        | `baseDir`                                |
+| `MIKRO_ORM_TYPE`                                            | `type`                                   |
+| `MIKRO_ORM_ENTITIES`                                        | `entities`                               |
+| `MIKRO_ORM_ENTITIES_TS`                                     | `entitiesTs`                             |
+| `MIKRO_ORM_CLIENT_URL`                                      | `clientUrl`                              |
+| `MIKRO_ORM_HOST`                                            | `host`                                   |
+| `MIKRO_ORM_PORT`                                            | `port`                                   |
+| `MIKRO_ORM_USER`                                            | `user`                                   |
+| `MIKRO_ORM_PASSWORD`                                        | `password`                               |
+| `MIKRO_ORM_DB_NAME`                                         | `dbName`                                 |
+| `MIKRO_ORM_LOAD_STRATEGY`                                   | `loadStrategy`                           |
+| `MIKRO_ORM_BATCH_SIZE`                                      | `batchSize`                              |
+| `MIKRO_ORM_USE_BATCH_INSERTS`                               | `useBatchInserts`                        |
+| `MIKRO_ORM_USE_BATCH_UPDATES`                               | `useBatchUpdates`                        |
+| `MIKRO_ORM_STRICT`                                          | `strict`                                 |
+| `MIKRO_ORM_VALIDATE`                                        | `validate`                               |
+| `MIKRO_ORM_AUTO_JOIN_ONE_TO_ONE_OWNER`                      | `autoJoinOneToOneOwner`                  |
+| `MIKRO_ORM_PROPAGATE_TO_ONE_OWNER`                          | `propagateToOneOwner`                    |
+| `MIKRO_ORM_POPULATE_AFTER_FLUSH`                            | `populateAfterFlush`                     |
+| `MIKRO_ORM_FORCE_ENTITY_CONSTRUCTOR`                        | `forceEntityConstructor`                 |
+| `MIKRO_ORM_FORCE_UNDEFINED`                                 | `forceUndefined`                         |
+| `MIKRO_ORM_FORCE_UTC_TIMEZONE`                              | `forceUtcTimezone`                       |
+| `MIKRO_ORM_TIMEZONE`                                        | `timezone`                               |
+| `MIKRO_ORM_ENSURE_INDEXES`                                  | `ensureIndexes`                          |
+| `MIKRO_ORM_IMPLICIT_TRANSACTIONS`                           | `implicitTransactions`                   |
+| `MIKRO_ORM_DEBUG`                                           | `debug`                                  |
+| `MIKRO_ORM_VERBOSE`                                         | `verbose`                                |
+| `MIKRO_ORM_DISCOVERY_WARN_WHEN_NO_ENTITIES`                 | `discovery.warnWhenNoEntities`           |
+| `MIKRO_ORM_DISCOVERY_REQUIRE_ENTITIES_ARRAY`                | `discovery.requireEntitiesArray`         |
+| `MIKRO_ORM_DISCOVERY_ALWAYS_ANALYSE_PROPERTIES`             | `discovery.alwaysAnalyseProperties`      |
+| `MIKRO_ORM_DISCOVERY_DISABLE_DYNAMIC_FILE_ACCESS`           | `discovery.disableDynamicFileAccess`     |
+| `MIKRO_ORM_MIGRATIONS_TABLE_NAME`                           | `migrations.tableName`                   |
+| `MIKRO_ORM_MIGRATIONS_PATH`                                 | `migrations.path`                        |
+| `MIKRO_ORM_MIGRATIONS_PATH_TS`                              | `migrations.pathTs`                      |
+| `MIKRO_ORM_MIGRATIONS_GLOB`                                 | `migrations.glob`                        |
+| `MIKRO_ORM_MIGRATIONS_TRANSACTIONAL`                        | `migrations.transactional`               |
+| `MIKRO_ORM_MIGRATIONS_DISABLE_FOREIGN_KEYS`                 | `migrations.disableForeignKeys`          |
+| `MIKRO_ORM_MIGRATIONS_ALL_OR_NOTHING`                       | `migrations.allOrNothing`                |
+| `MIKRO_ORM_MIGRATIONS_DROP_TABLES`                          | `migrations.dropTables`                  |
+| `MIKRO_ORM_MIGRATIONS_SAFE`                                 | `migrations.safe`                        |
+| `MIKRO_ORM_MIGRATIONS_EMIT`                                 | `migrations.emit`                        |
+| `MIKRO_ORM_SCHEMA_GENERATOR_DISABLE_FOREIGN_KEYS`           | `migrations.disableForeignKeys`          |
 | `MIKRO_ORM_SCHEMA_GENERATOR_CREATE_FOREIGN_KEY_CONSTRAINTS` | `migrations.createForeignKeyConstraints` |
-| `MIKRO_ORM_SEEDER_PATH` | `seeder.path` |
-| `MIKRO_ORM_SEEDER_PATH_TS` | `seeder.pathTs` |
-| `MIKRO_ORM_SEEDER_GLOB` | `seeder.glob` |
-| `MIKRO_ORM_SEEDER_EMIT` | `seeder.emit` |
-| `MIKRO_ORM_SEEDER_DEFAULT_SEEDER` | `seeder.defaultSeeder` |
+| `MIKRO_ORM_SEEDER_PATH`                                     | `seeder.path`                            |
+| `MIKRO_ORM_SEEDER_PATH_TS`                                  | `seeder.pathTs`                          |
+| `MIKRO_ORM_SEEDER_GLOB`                                     | `seeder.glob`                            |
+| `MIKRO_ORM_SEEDER_EMIT`                                     | `seeder.emit`                            |
+| `MIKRO_ORM_SEEDER_DEFAULT_SEEDER`                           | `seeder.defaultSeeder`                   |

--- a/docs/versioned_docs/version-5.4/custom-driver.md
+++ b/docs/versioned_docs/version-5.4/custom-driver.md
@@ -2,18 +2,17 @@
 title: Creating Custom Driver
 ---
 
-If you want to use database that is not currently supported, you can implement your own driver.
-To do so, you will need to design 4 classes:
+If you want to use database that is not currently supported, you can implement your own driver. To do so, you will need to design 4 classes:
 
 ## Platform
 
-Platform is a class that provides information about available features of given driver: 
+Platform is a class that provides information about available features of given driver:
 
 ```ts
 import { Platform } from '@mikro-orm/core';
 
 export class MyCustomPlatform extends Platform {
-  
+
   protected abstract schemaHelper: MyCustomSchemaHelper;
 
   // here you can override default settings
@@ -39,7 +38,7 @@ Part of platform is a `SchemaHelper`, that provides information about how to bui
 import { SchemaHelper } from '@mikro-orm/core';
 
 export class MyCustomSchemaHelper extends SchemaHelper {
-  
+
   // here you can override default settings
   getIdentifierQuoteCharacter(): string;
   getSchemaBeginning(): string;
@@ -67,7 +66,7 @@ Next part is connection wrapper, that will be responsible for querying the datab
 import { Connection } from '@mikro-orm/core';
 
 export class MyCustomConnection extends Connection {
-  
+
   // implement abstract methods
   connect(): Promise<void>;
   isConnected(): Promise<boolean>;
@@ -80,12 +79,9 @@ export class MyCustomConnection extends Connection {
 
 ## Driver
 
-Last part is driver, that is responsible for using the connection to persist changes to 
-database. If you are building SQL driver, it might be handy to extend `AbstractSqlDriver`, 
-if not, extend `DatabaseDriver` abstract class. 
+Last part is driver, that is responsible for using the connection to persist changes to database. If you are building SQL driver, it might be handy to extend `AbstractSqlDriver`, if not, extend `DatabaseDriver` abstract class.
 
-If you want to have absolute control, you can implement the whole driver yourself via
-`IDatabaseDriver` interface. 
+If you want to have absolute control, you can implement the whole driver yourself via `IDatabaseDriver` interface.
 
 ```ts
 import { DatabaseDriver } from '@mikro-orm/core';

--- a/docs/versioned_docs/version-5.4/custom-types.md
+++ b/docs/versioned_docs/version-5.4/custom-types.md
@@ -22,13 +22,11 @@ You can define custom types by extending `Type` abstract class. It has several o
 
 - `convertToDatabaseValueSQL(key: string, platform: Platform): string`
 
-  Converts a value from its JS representation to its database representation of this type.
-  _(added in v4.4.2)_
+  Converts a value from its JS representation to its database representation of this type. _(added in v4.4.2)_
 
 - `convertToJSValueSQL(key: string, platform: Platform): string`
 
-  Modifies the SQL expression (identifier, parameter) to convert to a JS value.
-  _(added in v4.4.2)_
+  Modifies the SQL expression (identifier, parameter) to convert to a JS value. _(added in v4.4.2)_
 
 - `compareAsType(): string`
 
@@ -101,9 +99,7 @@ born?: string;
 
 In this example we will combine mapping values via database as well as during runtime.
 
-> The Point type is part of the Spatial extension of MySQL and enables you to store
-> a single location in a coordinate space by using x and y coordinates. You can use
-> the Point type to store a longitude/latitude pair to represent a geographic location.
+> The Point type is part of the Spatial extension of MySQL and enables you to store a single location in a coordinate space by using x and y coordinates. You can use the Point type to store a longitude/latitude pair to represent a geographic location.
 
 First let's define the `Point` class that will be used to represent the value during runtime:
 
@@ -201,8 +197,7 @@ update `location` set `point` = ST_PointFromText('point(2.34 9.87)') where `id` 
 commit
 ```
 
-We do a 2-step conversion here. In the first step, we convert the Point object into a string representation before saving to the database (in the convertToDatabaseValue method) and back into an object
-after fetching the value from the database (in the convertToJSValue method).
+We do a 2-step conversion here. In the first step, we convert the Point object into a string representation before saving to the database (in the convertToDatabaseValue method) and back into an object after fetching the value from the database (in the convertToJSValue method).
 
 The format of the string representation format is called Well-known text (WKT). The advantage of this format is, that it is both human readable and parsable by MySQL.
 
@@ -212,9 +207,7 @@ This is where the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods 
 
 This methods wrap a sql expression (the WKT representation of the Point) into MySQL functions ST_PointFromText and ST_AsText which convert WKT strings to and from the internal format of MySQL.
 
-> When using DQL queries, the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods
-> only apply to identification variables and path expressions in SELECT clauses. Expressions
-> in WHERE clauses are not wrapped!
+> When using DQL queries, the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods only apply to identification variables and path expressions in SELECT clauses. Expressions in WHERE clauses are not wrapped!
 
 ## Types provided by MikroORM
 
@@ -260,18 +253,11 @@ export const types = {
 
 ### ArrayType
 
-In PostgreSQL and MongoDB, it uses native arrays, otherwise it concatenates the values into string separated by commas. This means that you can't use values that contain comma with the `ArrayType` (
-but you can create custom array type that will handle this case, e.g. by using different separator).
+In PostgreSQL and MongoDB, it uses native arrays, otherwise it concatenates the values into string separated by commas. This means that you can't use values that contain comma with the `ArrayType` ( but you can create custom array type that will handle this case, e.g. by using different separator).
 
-By default, array of strings is returned from the type. You can also have arrays of numbers or other data types - to do so, you will need to implement custom
-`hydrate` method that is used for converting the array values to the right type.
+By default, array of strings is returned from the type. You can also have arrays of numbers or other data types - to do so, you will need to implement custom `hydrate` method that is used for converting the array values to the right type.
 
-> `ArrayType` will be used automatically if `type` is set to `array` (default behaviour
-> of reflect-metadata) or `string[]` or `number[]` (either manually or via ts-morph).
-> In case of `number[]` it will automatically handle the conversion to numbers.
-> This means that the following examples would both have the `ArrayType` used
-> automatically (but with reflect-metadata we would have a string array for both
-> unless we specify the type manually as `type: 'number[]')
+> `ArrayType` will be used automatically if `type` is set to `array` (default behaviour of reflect-metadata) or `string[]` or `number[]` (either manually or via ts-morph). In case of `number[]` it will automatically handle the conversion to numbers. This means that the following examples would both have the `ArrayType` used automatically (but with reflect-metadata we would have a string array for both unless we specify the type manually as `type: 'number[]')
 
 ```ts
 @Property({ type: ArrayType, nullable: true })
@@ -294,9 +280,7 @@ id: string;
 
 Blob type can be used to store binary data in the database.
 
-> `BlobType` will be used automatically if you specify the type hint as `Buffer`.
-> This means that the following example should work even without the explicit
-> `type: BlobType` option (with both reflect-metadata and ts-morph providers).
+> `BlobType` will be used automatically if you specify the type hint as `Buffer`. This means that the following example should work even without the explicit `type: BlobType` option (with both reflect-metadata and ts-morph providers).
 
 ```ts
 @Property({ type: BlobType, nullable: true })
@@ -305,8 +289,7 @@ blob?: Buffer;
 
 ### JsonType
 
-To store objects we can use `JsonType`. As some drivers are handling objects automatically and some don't, this type will handle the serialization in a driver independent way (calling `parse`
-and `stringify` only when needed).
+To store objects we can use `JsonType`. As some drivers are handling objects automatically and some don't, this type will handle the serialization in a driver independent way (calling `parse` and `stringify` only when needed).
 
 ```ts
 @Property({ type: JsonType, nullable: true })
@@ -315,8 +298,7 @@ object?: { foo: string; bar: number };
 
 ### DateType
 
-To store dates without time information, we can use `DateType`. It does use `date`
-column type and maps it to the `Date` object.
+To store dates without time information, we can use `DateType`. It does use `date` column type and maps it to the `Date` object.
 
 ```ts
 @Property({ type: DateType, nullable: true })
@@ -325,8 +307,7 @@ born?: Date;
 
 ### TimeType
 
-As opposed to the `DateType`, to store only the time information, we can use
-`TimeType`. It will use the `time` column type, the runtime type is string.
+As opposed to the `DateType`, to store only the time information, we can use `TimeType`. It will use the `time` column type, the runtime type is string.
 
 ```ts
 @Property({ type: TimeType, nullable: true })

--- a/docs/versioned_docs/version-5.4/decorators.md
+++ b/docs/versioned_docs/version-5.4/decorators.md
@@ -6,24 +6,22 @@ title: Decorators
 
 ### @Entity()
 
-`@Entity` decorator is used to mark your model classes as entities. Do not use it for 
-abstract base classes.
+`@Entity` decorator is used to mark your model classes as entities. Do not use it for abstract base classes.
 
-| Parameter          | Type                     | Optional | Description                                                                     |
-|--------------------|--------------------------|----------|---------------------------------------------------------------------------------|
-| `tableName`        | `string`                 | yes      | Override default collection/table name.                                         |
-| `schema`           | `string`                 | yes      | Sets the schema name                                                            |
-| `collection`       | `string`                 | yes      | Alias for `tableName`.                                                          |
-| `comment`          | `string`                 | yes      | Specify comment to table **(SQL only)**                                         |
-| `customRepository` | `() => EntityRepository` | yes      | Set [custom repository class](repositories.md#custom-repository).               |
-| `discriminatorColumn` |  `string` | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance) |                 
-| `discriminatorMap`   |  `Dictionary<string>` | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance) |     
-| `discriminatorValue` |  `number` &#124; `string`| yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance) |
+| Parameter             | Type                     | Optional | Description                                                                     |
+| --------------------- | ------------------------ | -------- | ------------------------------------------------------------------------------- |
+| `tableName`           | `string`                 | yes      | Override default collection/table name.                                         |
+| `schema`              | `string`                 | yes      | Sets the schema name                                                            |
+| `collection`          | `string`                 | yes      | Alias for `tableName`.                                                          |
+| `comment`             | `string`                 | yes      | Specify comment to table **(SQL only)**                                         |
+| `customRepository`    | `() => EntityRepository` | yes      | Set [custom repository class](repositories.md#custom-repository).               |
+| `discriminatorColumn` | `string`                 | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance) |
+| `discriminatorMap`    | `Dictionary<string>`     | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance) |
+| `discriminatorValue`  | `number` &#124; `string` | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance) |
 
 abstract | `boolean`;
 
 readonly | `boolean`;
-
 
 ```ts
 @Entity({ tableName: 'authors' })
@@ -34,11 +32,10 @@ export class Author { ... }
 
 ### @Property()
 
-`@Property()` decorator is used to define regular entity property. All following decorators
-extend the `@Property()` decorator, so you can also use its parameters there.
+`@Property()` decorator is used to define regular entity property. All following decorators extend the `@Property()` decorator, so you can also use its parameters there.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- | --- | --- |
 | `fieldName` | `string` | yes | Override default property name (see [Naming Strategy](naming-strategy.md)). |
 | `type` | `string` &#124; `Constructor<Type>` &#124; `Type` | yes | Explicitly specify the runtime type (see [Metadata Providers](metadata-providers.md) and [Custom Types](custom-types.md)). |
 | `customType` | `Type` | yes | Explicitly specify the mapped type instance for this property (see [Custom Types](custom-types.md)). |
@@ -53,7 +50,7 @@ extend the `@Property()` decorator, so you can also use its parameters there.
 | `unsigned` | `boolean` | yes | Set column as unsigned for [Schema Generator](schema-generator.md).. **(SQL only)** |
 | `comment` | `string` | yes | Specify comment of column for [Schema Generator](schema-generator.md).. **(SQL only)** |
 | `version` | `boolean` | yes | Set to true to enable [Optimistic Locking] via version field (transactions.md#optimistic-locking). **(SQL only)** |
-| `concurrencyCheck` | `boolean` | yes | Set to true to enable [Optimistic Locking] via concurrency fields (transactions.md#concurrency-checks).|
+| `concurrencyCheck` | `boolean` | yes | Set to true to enable [Optimistic Locking] via concurrency fields (transactions.md#concurrency-checks). |
 | `customOrder` | `string[] | number[] | boolean[]` | yes | Specify a custom order for the column. **(SQL only)** |
 
 > You can use property initializers as usual.
@@ -77,14 +74,13 @@ registered = false;
 
 ### @PrimaryKey()
 
-`@PrimaryKey()` decorator is used to define entity's unique primary key identifier. 
+`@PrimaryKey()` decorator is used to define entity's unique primary key identifier.
 
-> `@PrimaryKey()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@PrimaryKey()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 > Every entity needs to have at least one primary key (see composite primary keys).
 
-> Note that if only one PrimaryKey is set and it's type is number it will be set to auto incremented automatically in all SQL drivers. 
+> Note that if only one PrimaryKey is set and it's type is number it will be set to auto incremented automatically in all SQL drivers.
 
 ```ts
 @PrimaryKey()
@@ -102,13 +98,10 @@ _id!: ObjectId; // ObjectId PK in mongodb driver
 
 ### @SerializedPrimaryKey()
 
-> Property marked with `@SerializedPrimaryKey()` is virtual, it will not be persisted 
-> into the database.
+> Property marked with `@SerializedPrimaryKey()` is virtual, it will not be persisted into the database.
 
-For MongoDB you can define serialized primary key, which will be then used in entity 
-serialization via `JSON.stringify()` (through method `entity.toJSON()`).
-You will be able to use it to manipulate with the primary key as string. 
- 
+For MongoDB you can define serialized primary key, which will be then used in entity serialization via `JSON.stringify()` (through method `entity.toJSON()`). You will be able to use it to manipulate with the primary key as string.
+
 See [Usage with MongoDB](usage-with-mongo.md) and [Serializing](serializing.md).
 
 ```ts
@@ -121,19 +114,15 @@ id!: string;
 
 ### @Enum()
 
-> `@Enum()` decorator extend the `@Property()` decorator, so you can use all its 
-> parameters.
+> `@Enum()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
-`@Enum()` decorator can be used for both numeric and string enums. By default enums are 
-considered numeric, and will be represented in the database schema as `tinyint/smallint`. 
-For string enums, if you define the enum in same file, its values will be automatically 
-sniffed. 
+`@Enum()` decorator can be used for both numeric and string enums. By default enums are considered numeric, and will be represented in the database schema as `tinyint/smallint`. For string enums, if you define the enum in same file, its values will be automatically sniffed.
 
 See [Defining Entities](defining-entities.md#enums).
 
-| Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
-| `items` | `number[]` &#124; `string[]` &#124; `() => Dictionary` | yes | Specify enum items explicitly. |
+| Parameter | Type                                                   | Optional | Description                    |
+| --------- | ------------------------------------------------------ | -------- | ------------------------------ |
+| `items`   | `number[]` &#124; `string[]` &#124; `() => Dictionary` | yes      | Specify enum items explicitly. |
 
 ```ts
 @Enum() // with ts-morph metadata provider we do not need to specify anything
@@ -154,14 +143,13 @@ enum4 = 'a';
 
 ### @Formula()
 
-`@Formula()` decorator can be used to map some SQL snippet to your entity. 
-The SQL fragment can be as complex as you want and even include subselects.
+`@Formula()` decorator can be used to map some SQL snippet to your entity. The SQL fragment can be as complex as you want and even include subselects.
 
 See [Defining Entities](defining-entities.md#formulas).
 
-| Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
-| `formula` | `string` &#124; `() => string` | no | SQL fragment that will be part of the select clause.  |
+| Parameter | Type                           | Optional | Description                                          |
+| --------- | ------------------------------ | -------- | ---------------------------------------------------- |
+| `formula` | `string` &#124; `() => string` | no       | SQL fragment that will be part of the select clause. |
 
 ```ts
 @Formula('obj_length * obj_height * obj_width')
@@ -170,18 +158,15 @@ objectVolume?: number;
 
 ### @Index() and @Unique()
 
-Use `@Index()` to create an index, or `@Unique()` to create unique constraint. You can 
-use those decorators both on the entity level and on property level. To create compound
-index, use the decorator on the entity level and provide list of property names via the
-`properties` option.
+Use `@Index()` to create an index, or `@Unique()` to create unique constraint. You can use those decorators both on the entity level and on property level. To create compound index, use the decorator on the entity level and provide list of property names via the `properties` option.
 
 See [Defining Entities](defining-entities.md#indexes).
 
-| Parameter    | Type     | Optional | Description |
-|--------------|----------|----------|-------------|
-| `name`       | `string` | yes      | index name  |
+| Parameter | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `name` | `string` | yes | index name |
 | `properties` | `string` &#124; `string[]` | yes | list of properties, required when using on entity level |
-| `type`       | `string` | yes      | index type, not available for `@Unique()`. Use `fulltext` to enable support for the `$fulltext` operator |
+| `type` | `string` | yes | index type, not available for `@Unique()`. Use `fulltext` to enable support for the `$fulltext` operator |
 
 ```ts
 @Entity()
@@ -207,29 +192,25 @@ export class Author {
 
 ### @Check()
 
-We can define check constraints via `@Check()` decorator. We can use it
-either on entity class, or on entity property. It has a required `expression`
-property, that can be either a string or a callback, that receives map of
-property names to column names. Note that we need to use the generic type
-argument if we want TypeScript suggestions for the property names.
+We can define check constraints via `@Check()` decorator. We can use it either on entity class, or on entity property. It has a required `expression` property, that can be either a string or a callback, that receives map of property names to column names. Note that we need to use the generic type argument if we want TypeScript suggestions for the property names.
 
 > Check constraints are currently supported only in postgres driver.
 
 See [Defining Entities](defining-entities.md#check-constraints).
 
-| Parameter    | Type     | Optional | Description       |
-|--------------|----------|----------|-------------------|
-| `name`       | `string` | yes      | constraint name   |
-| `property`   | `string` | yes      | property name, only used when generating the constraint name |
+| Parameter    | Type                            | Optional | Description                                                                          |
+| ------------ | ------------------------------- | -------- | ------------------------------------------------------------------------------------ |
+| `name`       | `string`                        | yes      | constraint name                                                                      |
+| `property`   | `string`                        | yes      | property name, only used when generating the constraint name                         |
 | `expression` | `string` &#124; `CheckCallback` | no       | constraint definition, can be a callback that gets a map of property to column names |
 
 ```ts
 @Entity()
-// with generated name based on the table name 
+// with generated name based on the table name
 @Check({ expression: 'price1 >= 0' })
-// with explicit name 
+// with explicit name
 @Check({ name: 'foo', expression: columns => `${columns.price1} >= 0` })
-// with explicit type argument we get autocomplete on `columns` 
+// with explicit type argument we get autocomplete on `columns`
 @Check<FooEntity>({ expression: columns => `${columns.price1} >= 0` })
 export class Book {
 
@@ -251,30 +232,22 @@ export class Book {
 
 ## Entity Relationships
 
-All relationship decorators have `entity`, `cascade` and `eager` optional parameters. 
-If you use the default `ReflectMetadataProvider`, then `entity` parameter might be required 
-You will be warned about it being not defined while required during discovery process if you 
-use `ReflectMetadataProvider`. 
+All relationship decorators have `entity`, `cascade` and `eager` optional parameters. If you use the default `ReflectMetadataProvider`, then `entity` parameter might be required You will be warned about it being not defined while required during discovery process if you use `ReflectMetadataProvider`.
 
-You can also use `type` parameter instead of it - the difference being that `type` parameter
-needs to be string, while in `entity` parameter you can provide a reference (wrapped in 
-a callback to overcome issues with circular dependencies) to the entity, which plays nice 
-with refactoring features in IDEs like WebStorm. 
+You can also use `type` parameter instead of it - the difference being that `type` parameter needs to be string, while in `entity` parameter you can provide a reference (wrapped in a callback to overcome issues with circular dependencies) to the entity, which plays nice with refactoring features in IDEs like WebStorm.
 
-> If you explicitly provide `entity` as a reference, it will enable type checks for other
-> reference parameters like `inversedBy` or `mappedBy`.
+> If you explicitly provide `entity` as a reference, it will enable type checks for other reference parameters like `inversedBy` or `mappedBy`.
 
 ### @ManyToOne()
 
-> `@ManyToOne()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@ManyToOne()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 Many instances of the current Entity refer to One instance of the referred Entity.
 
 See [Defining Entities](relationships.md#manytoone) for more examples.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
 | `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
 | `eager` | `boolean` | yes | Always load the relationship. |
@@ -297,15 +270,14 @@ author3?: Author;
 
 ### @OneToOne()
 
-> `@OneToOne()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@OneToOne()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 One instance of the current Entity refers to One instance of the referred Entity.
 
 See [Defining Entities](relationships.md#onetoone) for more examples, including bi-directional 1:1.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
 | `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
 | `eager` | `boolean` | yes | Always load the relationship. |
@@ -335,8 +307,7 @@ bestFriend3!: User;
 
 ### @OneToMany()
 
-> `@OneToMany()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@OneToMany()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 One instance of the current Entity has Many instances (references) to the referred Entity.
 
@@ -345,7 +316,7 @@ See [Defining Entities](relationships.md#onetomany) for more examples, including
 > You need to initialize the value with `Collection<T>` instance.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `mappedBy` | `(string & keyof T)` &#124; `(e: T) => any` | no | Point to the owning side property name. |
 | `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
 | `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
@@ -365,8 +336,7 @@ books2 = new Collection<Book>(this); // target entity type can be read via `TsMo
 
 ### @ManyToMany()
 
-> `@ManyToMany()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@ManyToMany()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 Many instances of the current Entity refers to Many instances of the referred Entity.
 
@@ -375,7 +345,7 @@ See [Defining Entities](relationships.md#manytomany) for more examples, includin
 > You need to initialize the value with `Collection<T>` instance.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
 | `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
 | `eager` | `boolean` | yes | Always load the relationship. |
@@ -399,15 +369,13 @@ tagsUnordered = new Collection<BookTag>(this); // m:n with composite PK
 
 ## Lifecycle Hooks
 
-You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of
-entity methods with them, you can also mark multiple methods with same hook.
+You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of entity methods with them, you can also mark multiple methods with same hook.
 
 > All hooks support async methods with one exception - `@OnInit`.
 
 ### @OnInit()
 
-Fired when new instance of entity is created, either manually `em.create()`, or 
-automatically when new entities are loaded from database
+Fired when new instance of entity is created, either manually `em.create()`, or automatically when new entities are loaded from database
 
 > `@OnInit` is not fired when you create the entity manually via its constructor (`new MyEntity()`)
 
@@ -420,9 +388,7 @@ doStuffOnInit() {
 
 ### @OnLoad()
 
-Fired when new entities are loaded from database. Unlike `@InInit()`, 
-this will be fired only for fully loaded entities (not references). The method
-can be `async`.
+Fired when new entities are loaded from database. Unlike `@InInit()`, this will be fired only for fully loaded entities (not references). The method can be `async`.
 
 ```ts
 @OnLoad()
@@ -444,9 +410,7 @@ async doStuffBeforeCreate() {
 
 ### @AfterCreate()
 
-Fired right after the new entity is created in the database and merged to identity map. 
-Since this event entity will have reference to `EntityManager` and will be 
-enabled to call `wrap(entity).init()` method (including all entity references and collections).
+Fired right after the new entity is created in the database and merged to identity map. Since this event entity will have reference to `EntityManager` and will be enabled to call `wrap(entity).init()` method (including all entity references and collections).
 
 ```ts
 @AfterCreate()
@@ -468,7 +432,7 @@ async doStuffBeforeUpdate() {
 
 ### @AfterUpdate()
 
-Fired right after the entity is updated in the database. 
+Fired right after the entity is updated in the database.
 
 ```ts
 @AfterUpdate()
@@ -479,8 +443,7 @@ async doStuffAfterUpdate() {
 
 ### @BeforeDelete()
 
-Fired right before we delete the record from database. It is fired only when
-removing entity or entity reference, not when deleting records by query. 
+Fired right before we delete the record from database. It is fired only when removing entity or entity reference, not when deleting records by query.
 
 ```ts
 @BeforeDelete()
@@ -504,9 +467,7 @@ async doStuffAfterDelete() {
 
 ### @Subscriber()
 
-Used to register an event subscriber. Keep in mind that you need to make sure the file 
-gets loaded in order to make this decorator registration work (e.g. you import that file 
-explicitly somewhere).
+Used to register an event subscriber. Keep in mind that you need to make sure the file gets loaded in order to make this decorator registration work (e.g. you import that file explicitly somewhere).
 
 ```ts
 @Subscriber()

--- a/docs/versioned_docs/version-5.4/defining-entities.md
+++ b/docs/versioned_docs/version-5.4/defining-entities.md
@@ -5,43 +5,27 @@ title: Defining Entities
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Entities are simple javascript objects (so called POJO) without restrictions and without the need to extend base classes. Using [entity constructors](entity-constructors.md) works as well - they are never executed for managed entities (loaded from database). 
-Every entity is required to have a primary key.
+Entities are simple javascript objects (so called POJO) without restrictions and without the need to extend base classes. Using [entity constructors](entity-constructors.md) works as well - they are never executed for managed entities (loaded from database). Every entity is required to have a primary key.
 
 Entities can be defined in two ways:
 
-- Decorated classes - the attributes of the entity, as well as each property are provided
-  via decorators. We use `@Entity()` decorator on the class. Entity properties are decorated 
-  either with `@Property` decorator, or with one of reference decorators: 
-  `@ManyToOne`, `@OneToMany`, `@OneToOne` and `@ManyToMany`.
-  Check out the full [decorator reference](decorators.md).
-- `EntitySchema` helper - With `EntitySchema` helper we define the schema programmatically.
-  We can use regular classes as well as interfaces. This approach also allows to re-use 
-  partial entity definitions (e.g. traits/mixins). Read more about this 
-  in [Defining Entities via EntitySchema section](entity-schema.md).
+- Decorated classes - the attributes of the entity, as well as each property are provided via decorators. We use `@Entity()` decorator on the class. Entity properties are decorated either with `@Property` decorator, or with one of reference decorators: `@ManyToOne`, `@OneToMany`, `@OneToOne` and `@ManyToMany`. Check out the full [decorator reference](decorators.md).
+- `EntitySchema` helper - With `EntitySchema` helper we define the schema programmatically. We can use regular classes as well as interfaces. This approach also allows to re-use partial entity definitions (e.g. traits/mixins). Read more about this in [Defining Entities via EntitySchema section](entity-schema.md).
 
-Moreover, how the metadata extraction from decorators happens is controlled 
-via `MetadataProvider`. Two main metadata providers are:
+Moreover, how the metadata extraction from decorators happens is controlled via `MetadataProvider`. Two main metadata providers are:
 
-- `ReflectMetadataProvider` - uses `reflect-metadata` to read the property types. Faster
-  but simpler and more verbose. 
-- `TsMorphMetadataProvider` - uses `ts-morph` to read the type information from the
-  TypeScript compiled API. Heavier (requires full TS as a dependency), but allows DRY 
-  entity definition. With `ts-morph` we are able to extract the type as it is defined in
-  the code, including interface names, as well as optionality of properties. 
+- `ReflectMetadataProvider` - uses `reflect-metadata` to read the property types. Faster but simpler and more verbose.
+- `TsMorphMetadataProvider` - uses `ts-morph` to read the type information from the TypeScript compiled API. Heavier (requires full TS as a dependency), but allows DRY entity definition. With `ts-morph` we are able to extract the type as it is defined in the code, including interface names, as well as optionality of properties.
 
 Read more about them in the [Metadata Providers section](metadata-providers.md).
 
-> Current set of decorators in MikroORM is designed to work with the `tsc`. 
-> Using `babel` is also possible, but requires some additional setup. Read more about it
-> [here](usage-with-babel.md). For notes about `webpack`, read the [deployment section](deployment.md).
+> Current set of decorators in MikroORM is designed to work with the `tsc`. Using `babel` is also possible, but requires some additional setup. Read more about it [here](usage-with-babel.md). For notes about `webpack`, read the [deployment section](deployment.md).
 >
 > `ts-morph` is compatible only with the `tsc` approach.
 
 > From v3 we can also use default exports when defining your entity.
 
-Example definition of a `Book` entity follows. We can switch the tabs to see the difference
-for various ways:
+Example definition of a `Book` entity follows. We can switch the tabs to see the difference for various ways:
 
 <Tabs
   groupId="entity-def"
@@ -123,8 +107,7 @@ export const Book = new EntitySchema<IBook, CustomBaseEntity>({
 
 > Including `{ wrappedEntity: true }` in your `IdentifiedReference` property definitions will wrap the reference, providing access to helper methods like `.load` and `.unwrap`, which can be helpful for loading data and changing the type of your references where you plan to use them.
 
-Here is another example of `Author` entity, that was referenced from the `Book` one, this
-time defined for mongo:
+Here is another example of `Author` entity, that was referenced from the `Book` one, this time defined for mongo:
 
 <Tabs
   groupId="entity-def"
@@ -306,9 +289,7 @@ For an example of Vanilla JavaScript usage, take a look [here](usage-with-js.md)
 
 ## Optional Properties
 
-With the default `reflect-metadata` provider, we need to mark each optional property as `nullable: true`.
-When using `ts-morph`, if you define the property as optional (marked with `?`), this will be automatically considered
-as nullable property (mainly for SQL schema generator).
+With the default `reflect-metadata` provider, we need to mark each optional property as `nullable: true`. When using `ts-morph`, if you define the property as optional (marked with `?`), this will be automatically considered as nullable property (mainly for SQL schema generator).
 
 <Tabs
   groupId="entity-def"
@@ -350,21 +331,18 @@ properties: {
 
 We can set default value of a property in 2 ways:
 
-1. Use runtime default value of the property. This approach should be preferred as long
-as we are not using any native database function like `now()`. With this approach our
-entities will have the default value set even before it is actually persisted into the
-database (e.g. when we instantiate new entity via `new Author()` or `em.create(Author, { ... })`.
+1. Use runtime default value of the property. This approach should be preferred as long as we are not using any native database function like `now()`. With this approach our entities will have the default value set even before it is actually persisted into the database (e.g. when we instantiate new entity via `new Author()` or `em.create(Author, { ... })`.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
 @Property()
@@ -405,23 +383,20 @@ properties: {
   </TabItem>
 </Tabs>
 
-2. Use `default` parameter of `@Property` decorator. This way the actual default value
-will be provided by the database, and automatically mapped to the entity property after
-it is being persisted (after flush). To use SQL functions like `now()`, use `defaultRaw`.
+2. Use `default` parameter of `@Property` decorator. This way the actual default value will be provided by the database, and automatically mapped to the entity property after it is being persisted (after flush). To use SQL functions like `now()`, use `defaultRaw`.
 
-  > Since v4 you should use `defaultRaw` for SQL functions, as `default` with string values
-  > will be automatically quoted.
+> Since v4 you should use `defaultRaw` for SQL functions, as `default` with string values will be automatically quoted.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
 @Property({ default: 1 })
@@ -466,25 +441,22 @@ properties: {
 
 To define enum property, use `@Enum()` decorator. Enums can be either numeric or string valued.
 
-For schema generator to work properly in case of string enums, we need to define the enum
-is same file as where it is used, so its values can be automatically discovered. If we want
-to define the enum in another file, we should reexport it also in place where we use it.
+For schema generator to work properly in case of string enums, we need to define the enum is same file as where it is used, so its values can be automatically discovered. If we want to define the enum in another file, we should reexport it also in place where we use it.
 
-Another possibility is to provide the reference to the enum implementation in the decorator
-via `@Enum(() => UserRole)`.
+Another possibility is to provide the reference to the enum implementation in the decorator via `@Enum(() => UserRole)`.
 
 > We can also set enum items manually via `items: string[]` attribute.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
 import { OutsideEnum } from './OutsideEnum.ts';
@@ -580,19 +552,18 @@ properties: {
 
 ## Enum arrays
 
-We can also use array of values for enum, in that case, `EnumArrayType` type
-will be used automatically, that will validate items on flush.
+We can also use array of values for enum, in that case, `EnumArrayType` type will be used automatically, that will validate items on flush.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
 enum Role {
@@ -636,19 +607,18 @@ properties: {
 
 ## Mapping directly to primary keys
 
-Sometimes we might want to work only with the primary key of a relation.
-To do that, we can use `mapToPk` option on M:1 and 1:1 relations:
+Sometimes we might want to work only with the primary key of a relation. To do that, we can use `mapToPk` option on M:1 and 1:1 relations:
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
 @ManyToOne(() => User, { mapToPk: true })
@@ -675,19 +645,18 @@ properties: {
   </TabItem>
 </Tabs>
 
-For composite keys, this will give us ordered tuple representing the raw PKs,
-which is the internal format of composite PK:
+For composite keys, this will give us ordered tuple representing the raw PKs, which is the internal format of composite PK:
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
 @ManyToOne(() => User, { mapToPk: true })
@@ -717,19 +686,18 @@ properties: {
 
 ## Formulas
 
-`@Formula()` decorator can be used to map some SQL snippet to your entity.
-The SQL fragment can be as complex as you want and even include subselects.
+`@Formula()` decorator can be used to map some SQL snippet to your entity. The SQL fragment can be as complex as you want and even include subselects.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Box.ts"
 @Formula('obj_length * obj_height * obj_width')
@@ -757,20 +725,18 @@ properties: {
 </Tabs>
 ```
 
-Formulas will be added to the select clause automatically. In case you are facing
-problems with `NonUniqueFieldNameException`, you can define the formula as a
-callback that will receive the entity alias in the parameter:
+Formulas will be added to the select clause automatically. In case you are facing problems with `NonUniqueFieldNameException`, you can define the formula as a callback that will receive the entity alias in the parameter:
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Box.ts"
 @Formula(alias => `${alias}.obj_length * ${alias}.obj_height * ${alias}.obj_width`)
@@ -799,21 +765,20 @@ properties: {
 
 ## Indexes
 
-We can define indexes via `@Index()` decorator, for unique indexes, we can 
-use `@Unique()` decorator. We can use it either on entity class, or on entity property. 
+We can define indexes via `@Index()` decorator, for unique indexes, we can use `@Unique()` decorator. We can use it either on entity class, or on entity property.
 
 To define complex indexes, we can use index expressions. They allow us to specify the final `create index` query and an index name - this name is then used for index diffing, so the schema generator will only try to create it if it's not there yet, or remove it, if it's no longer defined in the entity. Index expressions are not bound to any property, rather to the entity itself (we can still define them on both entity and property level).
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
 @Entity()
@@ -899,32 +864,28 @@ export const AuthorSchema = new EntitySchema<Author, CustomBaseEntity>({
 
 ## Check constraints
 
-We can define check constraints via `@Check()` decorator. We can use it 
-either on entity class, or on entity property. It has a required `expression`
-property, that can be either a string or a callback, that receives map of
-property names to column names. Note that we need to use the generic type 
-argument if we want TypeScript suggestions for the property names.
+We can define check constraints via `@Check()` decorator. We can use it either on entity class, or on entity property. It has a required `expression` property, that can be either a string or a callback, that receives map of property names to column names. Note that we need to use the generic type argument if we want TypeScript suggestions for the property names.
 
 > Check constraints are currently supported only in postgres driver.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
-// with generated name based on the table name 
+// with generated name based on the table name
 @Check({ expression: 'price1 >= 0' })
-// with explicit name 
+// with explicit name
 @Check({ name: 'foo', expression: columns => `${columns.price1} >= 0` })
-// with explicit type argument we get autocomplete on `columns` 
+// with explicit type argument we get autocomplete on `columns`
 @Check<FooEntity>({ expression: columns => `${columns.price1} >= 0` })
 export class Book {
 
@@ -949,11 +910,11 @@ export class Book {
 
 ```ts title="./entities/Book.ts"
 @Entity()
-// with generated name based on the table name 
+// with generated name based on the table name
 @Check({ expression: 'price1 >= 0' })
-// with explicit name 
+// with explicit name
 @Check({ name: 'foo', expression: columns => `${columns.price1} >= 0` })
-// with explicit type argument we get autocomplete on `columns` 
+// with explicit type argument we get autocomplete on `columns`
 @Check<FooEntity>({ expression: columns => `${columns.price1} >= 0` })
 export class Book {
 
@@ -1012,8 +973,7 @@ We can define custom types by extending `Type` abstract class. It has 4 optional
 
 - `toJSON(value: any, platform: Platform): any`
 
-  Converts a value from its JS representation to its serialized JSON form of this type.
-  By default converts to the database value.
+  Converts a value from its JS representation to its serialized JSON form of this type. By default converts to the database value.
 
 - `getColumnType(prop: EntityProperty, platform: Platform): string`
 
@@ -1023,20 +983,18 @@ More information can be found in [Custom Types](custom-types.md) section.
 
 ## Lazy scalar properties
 
-We can mark any property as `lazy: true` to omit it from the select clause.
-This can be handy for properties that are too large, and you want to have them
-available only sometimes, like a full text of an article.
+We can mark any property as `lazy: true` to omit it from the select clause. This can be handy for properties that are too large, and you want to have them available only sometimes, like a full text of an article.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Property({ columnType: 'text', lazy: true })
@@ -1070,30 +1028,26 @@ const b1 = await em.find(Book, 1); // this will omit the `text` property
 const b2 = await em.find(Book, 1, { populate: ['text'] }); // this will load the `text` property
 ```
 
-> If the entity is already loaded and you need to populate a lazy scalar property,
-> you might need to pass `refresh: true` in the `FindOptions`.
+> If the entity is already loaded and you need to populate a lazy scalar property, you might need to pass `refresh: true` in the `FindOptions`.
 
 ## Virtual Properties
 
 We can define our properties as virtual, either as a method, or via JavaScript `get/set`.
 
-Following example defines User entity with `firstName` and `lastName` database fields, that
-are both hidden from the serialized response, replaced with virtual properties `fullName`
-(defined as a classic method) and `fullName2` (defined as a JavaScript getter).
+Following example defines User entity with `firstName` and `lastName` database fields, that are both hidden from the serialized response, replaced with virtual properties `fullName` (defined as a classic method) and `fullName2` (defined as a JavaScript getter).
 
-> For JavaScript getter you need to provide `{ persist: false }` option otherwise the value
-> would be stored in the database.
+> For JavaScript getter you need to provide `{ persist: false }` option otherwise the value would be stored in the database.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
 @Entity()
@@ -1183,29 +1137,26 @@ console.log(wrap(author).toJSON()); // { fullName: 'Jon Snow', fullName2: 'Jon S
 
 ## Entity file names
 
-Starting with MikroORM 4.2, there is no limitation for entity file names. It is now
-also possible to define multiple entities in a single file using folder based discovery.
+Starting with MikroORM 4.2, there is no limitation for entity file names. It is now also possible to define multiple entities in a single file using folder based discovery.
 
 ## Using custom base entity
 
-We can define our own base entity with properties that are required on all entities, like
-primary key and created/updated time. Single table inheritance is also supported.
+We can define our own base entity with properties that are required on all entities, like primary key and created/updated time. Single table inheritance is also supported.
 
 Read more about this topic in [Inheritance Mapping](inheritance-mapping.md) section.
 
-> If you are initializing the ORM via `entities` option, you need to specify all your
-> base entities as well.
+> If you are initializing the ORM via `entities` option, you need to specify all your base entities as well.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/CustomBaseEntity.ts"
 import { v4 } from 'uuid';
@@ -1270,9 +1221,7 @@ export const schema = new EntitySchema<CustomBaseEntity>({
   </TabItem>
 </Tabs>
 
-There is a special case, when we need to annotate the base entity - if we are using
-folder based discovery, and the base entity is not using any decorators (e.g. it does
-not define any decorated property). In that case, we need to mark it as abstract:
+There is a special case, when we need to annotate the base entity - if we are using folder based discovery, and the base entity is not using any decorators (e.g. it does not define any decorated property). In that case, we need to mark it as abstract:
 
 ```ts
 @Entity({ abstract: true })
@@ -1286,15 +1235,15 @@ export abstract class CustomBaseEntity {
 ### Using id as primary key (SQL drivers)
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
@@ -1364,15 +1313,15 @@ export const BookSchema = new EntitySchema<Book>({
 ### Using UUID as primary key (SQL drivers)
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 import { v4 } from 'uuid';
@@ -1441,15 +1390,15 @@ export const Book = new EntitySchema<IBook>({
 Requires enabling the module via: `create extension "uuid-ossp";`
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
@@ -1511,19 +1460,18 @@ export const BookSchema = new EntitySchema<Book>({
 
 ### Using BigInt as primary key (MySQL and PostgreSQL)
 
-We can use `BigIntType` to support `bigint`s. By default, it will represent the value as
-a `string`.
+We can use `BigIntType` to support `bigint`s. By default, it will represent the value as a `string`.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/CustomBaseEntity.ts"
 @Entity()
@@ -1565,15 +1513,15 @@ If you want to use native `bigint`s, read the following guide: [Using native Big
 ### Example of Mongo entity
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
@@ -1642,8 +1590,7 @@ export const Book = new EntitySchema<IBook>({
 
 ### Using MikroORM's BaseEntity (previously WrappedEntity)
 
-From v4 `BaseEntity` class is provided with `init`, `isInitialized`, `assign`
-and other methods that are otherwise available via the `wrap()` helper.
+From v4 `BaseEntity` class is provided with `init`, `isInitialized`, `assign` and other methods that are otherwise available via the `wrap()` helper.
 
 > Usage of the `BaseEntity` is optional.
 
@@ -1668,5 +1615,4 @@ const book = new Book();
 console.log(book.isInitialized()); // true
 ```
 
-Having the entities set up, we can now start [using entity manager](entity-manager.md) and
-[repositories](repositories.md) as described in following sections.
+Having the entities set up, we can now start [using entity manager](entity-manager.md) and [repositories](repositories.md) as described in following sections.

--- a/docs/versioned_docs/version-5.4/deployment.md
+++ b/docs/versioned_docs/version-5.4/deployment.md
@@ -2,29 +2,19 @@
 title: Deployment
 ---
 
-Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. Thanks to this, 
-defining the type is enough for runtime validation.
+Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. Thanks to this, defining the type is enough for runtime validation.
 
-This has some consequences for deployment of your application. Sometimes you will want to 
-deploy only your compiled output, without TS source files at all. In that case, discovery 
-process will probably fail. You have several options:
+This has some consequences for deployment of your application. Sometimes you will want to deploy only your compiled output, without TS source files at all. In that case, discovery process will probably fail. You have several options:
 
 ## Deploy pre-built cache
 
-By default, output of metadata discovery will be cached in `temp` folder. You can reuse this 
-cache in your deployed application. Currently the cache is saved in files named like the entity
-source file, e.g. `Author.ts` entity will store cache in `temp/Author.ts.json` file.
+By default, output of metadata discovery will be cached in `temp` folder. You can reuse this cache in your deployed application. Currently the cache is saved in files named like the entity source file, e.g. `Author.ts` entity will store cache in `temp/Author.ts.json` file.
 
-When running compiled code, JS entities will be taken into account instead, so you will need to 
-generate the cache by running the compiled code locally. That will generate `temp/Author.js.json`, 
-which is the file you will need to deploy alongside your application. 
+When running compiled code, JS entities will be taken into account instead, so you will need to generate the cache by running the compiled code locally. That will generate `temp/Author.js.json`, which is the file you will need to deploy alongside your application.
 
 ## Fill type or entity attributes everywhere
 
-What discovery process does is to sniff TS types and save their value to string, so it can be 
-used later for validation. You can skip the whole process by simply providing those values 
-manually:
+What discovery process does is to sniff TS types and save their value to string, so it can be used later for validation. You can skip the whole process by simply providing those values manually:
 
 ```ts
 @Entity()
@@ -63,36 +53,28 @@ export enum BookStatus {
 
 ## Deploy your entity source files
 
-Usually it does not matter much that you deploy more files than needed, so the easiest way
-is to just deploy your TS source files next to the compiled output, just like during development.
+Usually it does not matter much that you deploy more files than needed, so the easiest way is to just deploy your TS source files next to the compiled output, just like during development.
 
 ## Deploy a bundle of entities and dependencies with [Webpack](https://webpack.js.org/)
 
-Webpack can be used to bundle every entity and dependency: you get a single file that contains 
-every required module/file and has no external dependencies.
+Webpack can be used to bundle every entity and dependency: you get a single file that contains every required module/file and has no external dependencies.
 
 ### Prepare your project for Webpack
 
-Webpack requires every required file to be hardcoded in your code. Code like this won't work 
-(it will throw an error because Webpack doesn't know which file to include in the bundle):
+Webpack requires every required file to be hardcoded in your code. Code like this won't work (it will throw an error because Webpack doesn't know which file to include in the bundle):
 
 ```ts
 let dependencyNameInVariable = 'dependency';
 const dependency = import(dependencyNameInVariable);
 ```
 
-As Webpack creates a file bundle, it isn't desired that it scans directories for entities 
-or metadata. Therefore you need to provide list of entities in the `entities` option in 
-the initialization function, folder/file based discovery is not supported (see dynamically 
-including entities as an alternative solution). Also you need to fill `type` or `entity` 
-attributes everywhere (see above) and disable caching (it will decrease start-time slightly).
+As Webpack creates a file bundle, it isn't desired that it scans directories for entities or metadata. Therefore you need to provide list of entities in the `entities` option in the initialization function, folder/file based discovery is not supported (see dynamically including entities as an alternative solution). Also you need to fill `type` or `entity` attributes everywhere (see above) and disable caching (it will decrease start-time slightly).
 
 > In v4 caching is disabled by default when using `ReflectMetadataProvider`.
 
 #### Disabling dynamic file access
 
-First thing you should do is to disable dynamic file access in the discovery process via the
-`discovery.disableDynamicFileAccess` toggle. This will effectively do:
+First thing you should do is to disable dynamic file access in the discovery process via the `discovery.disableDynamicFileAccess` toggle. This will effectively do:
 
 - set metadata provider to `ReflectMetadataProvider`
 - disable caching
@@ -113,15 +95,11 @@ await MikroORM.init({
 
 #### Dynamically loading dependencies
 
-This will make use of a Webpack feature called [dynamic imports](https://webpack.js.org/guides/code-splitting/#dynamic-imports). 
-This way you can import dependencies as long as part of the path is known.
+This will make use of a Webpack feature called [dynamic imports](https://webpack.js.org/guides/code-splitting/#dynamic-imports). This way you can import dependencies as long as part of the path is known.
 
-In following example [`require.context`](https://webpack.js.org/guides/dependency-management/#requirecontext) 
-is used. This 'function' is only usable during the building process from Webpack so therefore 
-there is an alternative solution provided that will as long as the environment variable 
-WEBPACK is not set (e.g. during development with `ts-node`).
+In following example [`require.context`](https://webpack.js.org/guides/dependency-management/#requirecontext) is used. This 'function' is only usable during the building process from Webpack so therefore there is an alternative solution provided that will as long as the environment variable WEBPACK is not set (e.g. during development with `ts-node`).
 
-Here, all files with the extension `.ts` will be imported from the directory `../entities`. 
+Here, all files with the extension `.ts` will be imported from the directory `../entities`.
 
 > [`flatMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap) is a method from ECMAScript 2019 and requires [Node.js](https://nodejs.org/) 11 or higher.
 
@@ -152,10 +130,7 @@ async function getEntities(): Promise<any[]> {
 
 ### Webpack configuration
 
-Webpack can be run without [configuration file](https://webpack.js.org/configuration/) but 
-for building MikroORM and [Node.js](https://nodejs.org/) bundles it requires additional 
-configuration. Configuration for Webpack is stored in the root of the project as 
-`webpack.config.js`. For all the options please refer to the following [page](https://webpack.js.org/configuration/).
+Webpack can be run without [configuration file](https://webpack.js.org/configuration/) but for building MikroORM and [Node.js](https://nodejs.org/) bundles it requires additional configuration. Configuration for Webpack is stored in the root of the project as `webpack.config.js`. For all the options please refer to the following [page](https://webpack.js.org/configuration/).
 
 For bundling MikroORM the following configuration is required:
 
@@ -199,7 +174,7 @@ module.exports = {
           mangle: false,
           // Similarly, Terser's compression may at its own discretion change function and class names.
           // While it only rarely does so, it's safest to also disable changing their names here.
-          // This can be controlled in a more granular way if needed (see 
+          // This can be controlled in a more granular way if needed (see
           // https://terser.org/docs/api-reference.html#compress-options).
           compress: {
             keep_classnames: true,
@@ -273,6 +248,4 @@ module.exports = {
 
 ### Running Webpack
 
-To run Webpack execute `webpack` (or `npx webpack` if not installed globally) in the root 
-of the project. It will probably throw a few warnings but you can ignore the errors regarding 
-MikroORM: the mentioned pieces of code won't be executed if properly bundled with Webpack.
+To run Webpack execute `webpack` (or `npx webpack` if not installed globally) in the root of the project. It will probably throw a few warnings but you can ignore the errors regarding MikroORM: the mentioned pieces of code won't be executed if properly bundled with Webpack.

--- a/docs/versioned_docs/version-5.4/embeddables.md
+++ b/docs/versioned_docs/version-5.4/embeddables.md
@@ -8,22 +8,13 @@ import TabItem from '@theme/TabItem';
 
 > Support for embeddables was added in version 4.0
 
-Embeddables are classes which are not entities themselves, but are embedded in 
-entities and can also be queried. You'll mostly want to use them to reduce 
-duplication or separating concerns. Value objects such as date range or address 
-are the primary use case for this feature.
+Embeddables are classes which are not entities themselves, but are embedded in entities and can also be queried. You'll mostly want to use them to reduce duplication or separating concerns. Value objects such as date range or address are the primary use case for this feature.
 
-> Embeddables needs to be discovered just like regular entities, don't forget to 
-> add them to the list of entities when initializing the ORM.
+> Embeddables needs to be discovered just like regular entities, don't forget to add them to the list of entities when initializing the ORM.
 
-Embeddables can contain properties with basic `@Property()` mapping, nested 
-`@Embedded()` properties or arrays of `@Embedded()` properties. From version
-5.0 we can also use `@ManyToOne()` properties.
+Embeddables can contain properties with basic `@Property()` mapping, nested `@Embedded()` properties or arrays of `@Embedded()` properties. From version 5.0 we can also use `@ManyToOne()` properties.
 
-For the purposes of this tutorial, we will assume that you have a `User` class in 
-your application and you would like to store an address in the `User` class. We will 
-model the `Address` class as an embeddable instead of simply adding the respective 
-columns to the `User` class.
+For the purposes of this tutorial, we will assume that you have a `User` class in your application and you would like to store an address in the `User` class. We will model the `Address` class as an embeddable instead of simply adding the respective columns to the `User` class.
 
 <Tabs
   groupId="entity-def"
@@ -144,17 +135,13 @@ export const AddressSchema = new EntitySchema({
   </TabItem>
 </Tabs>
 
-> When using ReflectMetadataProvider, you might need to provide the class in decorator options:
-> `@Embedded(() => Address)` or `@Embedded({ entity: () => Address })`.
+> When using ReflectMetadataProvider, you might need to provide the class in decorator options: `@Embedded(() => Address)` or `@Embedded({ entity: () => Address })`.
 
-In terms of your database schema, MikroORM will automatically inline all columns from 
-the `Address` class into the table of the `User` class, just as if you had declared 
-them directly there.
+In terms of your database schema, MikroORM will automatically inline all columns from the `Address` class into the table of the `User` class, just as if you had declared them directly there.
 
 ## Initializing embeddables
 
-In case all fields in the embeddable are nullable, you might want to initialize the 
-embeddable, to avoid getting a null value instead of the embedded object.
+In case all fields in the embeddable are nullable, you might want to initialize the embeddable, to avoid getting a null value instead of the embedded object.
 
 <Tabs
   groupId="entity-def"
@@ -194,11 +181,9 @@ address: { reference: 'embedded', entity: 'Address', onCreate: () => new Address
 
 By default, MikroORM names your columns by prefixing them, using the value object name.
 
-Following the example above, your columns would be named as `address_street`, 
-`address_postal_code`...
+Following the example above, your columns would be named as `address_street`, `address_postal_code`...
 
-You can change this behaviour to meet your needs by changing the `prefix` attribute 
-in the `@Embedded()` notation.
+You can change this behaviour to meet your needs by changing the `prefix` attribute in the `@Embedded()` notation.
 
 The following example shows you how to set your prefix to `myPrefix_`:
 
@@ -246,8 +231,7 @@ address: { reference: 'embedded', entity: 'Address', prefix: 'myPrefix_' },
   </TabItem>
 </Tabs>
 
-To have MikroORM drop the prefix and use the value object's property name directly, 
-set `prefix: false`:
+To have MikroORM drop the prefix and use the value object's property name directly, set `prefix: false`:
 
 <Tabs
   groupId="entity-def"
@@ -285,8 +269,7 @@ address: { reference: 'embedded', entity: 'Address', prefix: false },
 
 ## Storing embeddables as objects
 
-From MikroORM v4.2 we can also store the embeddable as an object instead of
-inlining its properties to the owing entity.
+From MikroORM v4.2 we can also store the embeddable as an object instead of inlining its properties to the owing entity.
 
 <Tabs
   groupId="entity-def"
@@ -322,17 +305,15 @@ address: { reference: 'embedded', entity: 'Address', object: true },
   </TabItem>
 </Tabs>
 
-In SQL drivers, this will use a JSON column to store the value. 
+In SQL drivers, this will use a JSON column to store the value.
 
 > Only MySQL and PostgreSQL drivers support searching by JSON properties currently.
 
-> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/embeddables.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/embeddables.html) as the behaviour here is pretty much the same.
 
 ## Array of embeddables
 
-Embedded arrays are always stored as JSON. It is possible to use them inside
-nested embeddables. 
+Embedded arrays are always stored as JSON. It is possible to use them inside nested embeddables.
 
 <Tabs
   groupId="entity-def"
@@ -533,10 +514,7 @@ export const IdentitySchema = new EntitySchema({
 
 ## Polymorphic embeddables
 
-Since v5, it is also possible to use polymorphic embeddables. This means we
-can define multiple classes for a single embedded property and the right one
-will be used based on the discriminator column, similar to how single table 
-inheritance work.
+Since v5, it is also possible to use polymorphic embeddables. This means we can define multiple classes for a single embedded property and the right one will be used based on the discriminator column, similar to how single table inheritance work.
 
 <Tabs
   groupId="entity-def"

--- a/docs/versioned_docs/version-5.4/entity-constructors.md
+++ b/docs/versioned_docs/version-5.4/entity-constructors.md
@@ -2,12 +2,9 @@
 title: Using Entity Constructors
 ---
 
-Internally, `MikroORM` never calls entity constructor, so you are free to use it as you wish.
-The constructor will be called only when you instantiate the class yourself via `new` operator,
-so it is a handy place to require your data when creating new entity.
+Internally, `MikroORM` never calls entity constructor, so you are free to use it as you wish. The constructor will be called only when you instantiate the class yourself via `new` operator, so it is a handy place to require your data when creating new entity.
 
-For example following `Book` entity definition will always require to set `title` and `author`, 
-but `publisher` will be optional:
+For example following `Book` entity definition will always require to set `title` and `author`, but `publisher` will be optional:
 
 ```ts
 @Entity()
@@ -38,7 +35,4 @@ export class Book {
 
 ## Using native private properties
 
-If we want to use native private properties inside entities, the default approach of
-how MikroORM creates entity instances via `Object.create()` is not viable (more about this
-in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity
-constructors, we can use [`forceEntityConstructor`](./configuration.md#using-native-private-properties) toggle.
+If we want to use native private properties inside entities, the default approach of how MikroORM creates entity instances via `Object.create()` is not viable (more about this in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity constructors, we can use [`forceEntityConstructor`](./configuration.md#using-native-private-properties) toggle.

--- a/docs/versioned_docs/version-5.4/entity-generator.md
+++ b/docs/versioned_docs/version-5.4/entity-generator.md
@@ -2,12 +2,11 @@
 title: Entity Generator
 ---
 
-To generate entities from existing database schema, you can use `EntityGenerator` helper. 
+To generate entities from existing database schema, you can use `EntityGenerator` helper.
 
-You can use it via CLI: 
+You can use it via CLI:
 
-> To work with the CLI, first install `@mikro-orm/cli` package locally.
-> The version needs to be aligned with the `@mikro-orm/core` package.
+> To work with the CLI, first install `@mikro-orm/cli` package locally. The version needs to be aligned with the `@mikro-orm/core` package.
 
 ```sh
 npx mikro-orm generate-entities --dump  # Dumps all generated entities
@@ -22,14 +21,14 @@ import { MikroORM } from '@mikro-orm/core';
 (async () => {
   const orm = await MikroORM.init({
     discovery: {
-      // we need to disable validation for no entities 
+      // we need to disable validation for no entities
       warnWhenNoEntities: false,
     },
     dbName: 'your-db-name',
     // ...
   });
   const generator = orm.getEntityGenerator();
-  const dump = await generator.generate({ 
+  const dump = await generator.generate({
     save: true,
     baseDir: process.cwd() + '/my-entities',
   });
@@ -46,7 +45,7 @@ $ ts-node generate-entities
 
 ## Advanced configuration
 
-By default, the `EntityGenerator` generates only owning sides of relations (e.g. M:1) and uses decorators for the entity definition. We can adjust its behaviour via `entityGenerator` section in the ORM config. Available options: 
+By default, the `EntityGenerator` generates only owning sides of relations (e.g. M:1) and uses decorators for the entity definition. We can adjust its behaviour via `entityGenerator` section in the ORM config. Available options:
 
 - `bidirectionalRelations` to generate also the inverse sides for them
 - `identifiedReferences` to generate M:1 and 1:1 relations as wrapped references

--- a/docs/versioned_docs/version-5.4/entity-helper.md
+++ b/docs/versioned_docs/version-5.4/entity-helper.md
@@ -5,10 +5,7 @@ sidebar_label: Updating Entity Values
 
 ## Updating Entity Values with `entity.assign()`
 
-When you want to update entity based on user input, you will usually have just plain
-string ids of entity relations as user input. Normally you would need to use 
-`em.getReference()` to create references from each id first, and then
-use those references to update entity relations:
+When you want to update entity based on user input, you will usually have just plain string ids of entity relations as user input. Normally you would need to use `em.getReference()` to create references from each id first, and then use those references to update entity relations:
 
 ```ts
 const jon = new Author('Jon Snow', 'snow@wall.st');
@@ -21,8 +18,8 @@ Same result can be easily achieved with `entity.assign()`:
 ```ts
 import { wrap } from '@mikro-orm/core';
 
-wrap(book).assign({ 
-  title: 'Better Book 1', 
+wrap(book).assign({
+  title: 'Better Book 1',
   author: '...id...',
 });
 console.log(book.title); // 'Better Book 1'
@@ -30,22 +27,19 @@ console.log(book.author); // instance of Author with id: '...id...'
 console.log(book.author.id); // '...id...'
 ```
 
-To use `entity.assign()` on not managed entities, you need to provide `EntityManager` 
-instance explicitly: 
+To use `entity.assign()` on not managed entities, you need to provide `EntityManager` instance explicitly:
 
 ```ts
 import { wrap } from '@mikro-orm/core';
 
 const book = new Book();
-wrap(book).assign({ 
-  title: 'Better Book 1', 
+wrap(book).assign({
+  title: 'Better Book 1',
   author: '...id...',
 }, { em: orm.em });
 ```
 
-By default, `entity.assign(data)` behaves same way as `Object.assign(entity, data)`, 
-e.g. it does not merge things recursively. To enable deep merging of object properties (not referenced entities), 
-use second parameter to enable `mergeObjects` flag:
+By default, `entity.assign(data)` behaves same way as `Object.assign(entity, data)`, e.g. it does not merge things recursively. To enable deep merging of object properties (not referenced entities), use second parameter to enable `mergeObjects` flag:
 
 ```ts
 import { wrap } from '@mikro-orm/core';
@@ -61,9 +55,7 @@ console.log(book.meta); // { foo: 4 }
 
 ### Updating deep entity graph
 
-Since v5, `assign` allows updating deep entity graph by default. To update existing
-entity, we need to provide its PK in the `data`, as well as to **load that entity first
-into current context**.
+Since v5, `assign` allows updating deep entity graph by default. To update existing entity, we need to provide its PK in the `data`, as well as to **load that entity first into current context**.
 
 ```ts
 const book = await em.findOneOrFail(Book, 1, { populate: ['author'] });
@@ -77,8 +69,7 @@ wrap(book).assign({
 });
 ```
 
-If we want to always update the entity, even without the entity PK being present 
-in `data`, we can use `updateByPrimaryKey: false`:
+If we want to always update the entity, even without the entity PK being present in `data`, we can use `updateByPrimaryKey: false`:
 
 ```ts
 const book = await em.findOneOrFail(Book, 1, { populate: ['author'] });
@@ -91,8 +82,7 @@ wrap(book).assign({
 }, { updateByPrimaryKey: false });
 ```
 
-Otherwise the entity data without PK are considered as new entity, and will trigger
-insert query:
+Otherwise the entity data without PK are considered as new entity, and will trigger insert query:
 
 ```ts
 const book = await em.findOneOrFail(Book, 1, { populate: ['author'] });
@@ -105,9 +95,7 @@ wrap(book).assign({
 });
 ```
 
-Same applies to the case when we do not load the child entity first into the context,
-e.g. when we try to assign to a relation that was not populated. Even if we provide
-its PK, it will be considered as new object and trigger an insert query.
+Same applies to the case when we do not load the child entity first into the context, e.g. when we try to assign to a relation that was not populated. Even if we provide its PK, it will be considered as new object and trigger an insert query.
 
 ```ts
 const book = await em.findOneOrFail(Book, 1); // author is not populated
@@ -121,8 +109,7 @@ wrap(book).assign({
 });
 ```
 
-When updating collections, we can either pass complete array of all items, or just
-a single item - in such case, the new item will be appended to the existing items.
+When updating collections, we can either pass complete array of all items, or just a single item - in such case, the new item will be appended to the existing items.
 
 ```ts
 // resets the addresses collection to a single item
@@ -134,8 +121,7 @@ wrap(user).assign({ addresses: new Address(...) });
 
 ## `WrappedEntity` and `wrap()` helper
 
-`IWrappedEntity` is an interface that defines public helper methods provided 
-by the ORM:
+`IWrappedEntity` is an interface that defines public helper methods provided by the ORM:
 
 ```ts
 interface IWrappedEntity<T, PK extends keyof T> {
@@ -149,19 +135,11 @@ interface IWrappedEntity<T, PK extends keyof T> {
 }
 ```
 
-There are two ways to access those methods. You can either extend `BaseEntity` 
-(exported from `@mikro-orm/core`), that defines those methods, or use the 
-`wrap()` helper to access `WrappedEntity` instance, where those methods
-exist.
+There are two ways to access those methods. You can either extend `BaseEntity` (exported from `@mikro-orm/core`), that defines those methods, or use the `wrap()` helper to access `WrappedEntity` instance, where those methods exist.
 
-Users can choose whether they are fine with polluting the entity interface with 
-those additional methods, or they want to keep the interface clean 
-and use the `wrap(entity)` helper method instead to access them. 
+Users can choose whether they are fine with polluting the entity interface with those additional methods, or they want to keep the interface clean and use the `wrap(entity)` helper method instead to access them.
 
-> Since v4 `wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is 
-> being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...),
-> if you want to access internal properties like `__meta` or `__em`, you need to explicitly
-> ask for the helper via `wrap(entity, true)`.
+> Since v4 `wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...), if you want to access internal properties like `__meta` or `__em`, you need to explicitly ask for the helper via `wrap(entity, true)`.
 
 ```ts
 import { BaseEntity } from '@mikro-orm/core';
@@ -180,9 +158,7 @@ console.log(book.meta); // { foo: 3, bar: 2 }
 
 ### Accessing internal prefixed properties
 
-Previously it was possible to access internal properties like `__meta` or `__em` 
-from the `wrap()` helper. Now to access them, you need to use second parameter of
-wrap:
+Previously it was possible to access internal properties like `__meta` or `__em` from the `wrap()` helper. Now to access them, you need to use second parameter of wrap:
 
 ```ts
 @Entity()

--- a/docs/versioned_docs/version-5.4/entity-manager.md
+++ b/docs/versioned_docs/version-5.4/entity-manager.md
@@ -5,21 +5,13 @@ sidebar_label: Entity Manager
 
 ## Persist and Flush
 
-There are 2 methods we should first describe to understand how persisting works in MikroORM: 
-`em.persist()` and `em.flush()`.
+There are 2 methods we should first describe to understand how persisting works in MikroORM: `em.persist()` and `em.flush()`.
 
-`em.persist(entity)` is used to mark new entities for future persisting. 
-It will make the entity managed by given `EntityManager` and once `flush` will be called, it 
-will be written to the database. 
+`em.persist(entity)` is used to mark new entities for future persisting. It will make the entity managed by given `EntityManager` and once `flush` will be called, it will be written to the database.
 
-To understand `flush`, lets first define what managed entity is: An entity is managed if 
-it’s fetched from the database (via `em.find()`, `em.findOne()` or via other managed entity) 
-or registered as new through `em.persist()`.
+To understand `flush`, lets first define what managed entity is: An entity is managed if it’s fetched from the database (via `em.find()`, `em.findOne()` or via other managed entity) or registered as new through `em.persist()`.
 
-`em.flush()` will go through all managed entities, compute appropriate change sets and 
-perform according database queries. As an entity loaded from database becomes managed 
-automatically, we do not have to call persist on those, and flush is enough to update 
-them.
+`em.flush()` will go through all managed entities, compute appropriate change sets and perform according database queries. As an entity loaded from database becomes managed automatically, we do not have to call persist on those, and flush is enough to update them.
 
 ```ts
 const book = await em.findOne(Book, 1);
@@ -31,9 +23,7 @@ await em.flush();
 
 ## Persisting and Cascading
 
-To save entity state to database, we need to persist it. Persist determines 
-whether to use `insert` or `update` and computes appropriate change-set. Entity references
-that are not persisted yet (does not have identifier) will be cascade persisted automatically. 
+To save entity state to database, we need to persist it. Persist determines whether to use `insert` or `update` and computes appropriate change-set. Entity references that are not persisted yet (does not have identifier) will be cascade persisted automatically.
 
 ```ts
 // use constructors in our entities for required parameters
@@ -55,13 +45,13 @@ await em.persistAndFlush([book1, book2, book3]);
 // or one by one
 em.persist(book1);
 em.persist(book2);
-em.persist(book3); 
+em.persist(book3);
 await em.flush(); // flush everything to database at once
 ```
 
 ## Fetching Entities with EntityManager
 
-To fetch entities from database we can use `find()` and `findOne()` of `EntityManager`: 
+To fetch entities from database we can use `find()` and `findOne()` of `EntityManager`:
 
 Example:
 
@@ -91,23 +81,20 @@ To populate entity relations, we can use `populate` parameter.
 const books = await em.find(Book, { foo: 1 }, { populate: ['author.friends'] });
 ```
 
-You can also use `em.populate()` helper to populate relations (or to ensure they 
-are fully populated) on already loaded entities. This is also handy when loading 
-entities via `QueryBuilder`:
+You can also use `em.populate()` helper to populate relations (or to ensure they are fully populated) on already loaded entities. This is also handy when loading entities via `QueryBuilder`:
 
 ```ts
 const authors = await em.createQueryBuilder(Author).select('*').getResult();
 await em.populate(authors, { populate: ['books.tags'] });
 
-// now our Author entities will have `books` collections populated, 
+// now our Author entities will have `books` collections populated,
 // as well as they will have their `tags` collections populated.
 console.log(authors[0].books[0].tags[0]); // initialized BookTag
 ```
 
 ### Conditions Object (`FilterQuery<T>`)
 
-Querying entities via conditions object (`where` in `em.find(Entity, where: FilterQuery<T>)`) 
-supports many different ways:
+Querying entities via conditions object (`where` in `em.find(Entity, where: FilterQuery<T>)`) supports many different ways:
 
 ```ts
 // search by entity properties
@@ -135,9 +122,7 @@ const users = await em.find(User, [1, 2, 3, 4, 5]);
 const user1 = await em.findOne(User, 1);
 ```
 
-As we can see in the fifth example, one can also use operators like `$and`, `$or`, `$gte`, 
-`$gt`, `$lte`, `$lt`, `$in`, `$nin`, `$eq`, `$ne`, `$like`, `$re` and `$fulltext`. More about that can be found in 
-[Query Conditions](query-conditions.md) section.
+As we can see in the fifth example, one can also use operators like `$and`, `$or`, `$gte`, `$gt`, `$lte`, `$lt`, `$in`, `$nin`, `$eq`, `$ne`, `$like`, `$re` and `$fulltext`. More about that can be found in [Query Conditions](query-conditions.md) section.
 
 #### Using custom classes in `FilterQuery`
 
@@ -159,12 +144,9 @@ const res = await em.find(Author, where);
 
 #### Mitigating `Type instantiation is excessively deep and possibly infinite.ts(2589)` error
 
-Sometimes we might be facing TypeScript errors caused by too complex query for it to 
-properly infer all types. Usually it can be solved by providing the type argument 
-explicitly.
+Sometimes we might be facing TypeScript errors caused by too complex query for it to properly infer all types. Usually it can be solved by providing the type argument explicitly.
 
-You can also opt in to use repository instead, as there the type inference should not be
-problematic. 
+You can also opt in to use repository instead, as there the type inference should not be problematic.
 
 > As a last resort, we can always type cast the query to `any`.
 
@@ -176,16 +158,11 @@ const books = await em.getRepository(Book).find({ ... our complex query ... });
 const books = await em.find<any>(Book, { ... our complex query ... }) as Book[];
 ```
 
-Another problem we might be facing is `RangeError: Maximum call stack size exceeded` error 
-thrown during TypeScript compilation (usually from file `node_modules/typescript/lib/typescript.js`).
-The solution to this is the same, just provide the type argument explicitly.
+Another problem we might be facing is `RangeError: Maximum call stack size exceeded` error thrown during TypeScript compilation (usually from file `node_modules/typescript/lib/typescript.js`). The solution to this is the same, just provide the type argument explicitly.
 
 ### Searching by referenced entity fields
 
-You can also search by referenced entity properties. Simply pass nested where condition like 
-this and all requested relationships will be automatically joined. Currently it will only join 
-them so we can search and sort by those. To populate entities, do not forget to pass the populate 
-parameter as well. 
+You can also search by referenced entity properties. Simply pass nested where condition like this and all requested relationships will be automatically joined. Currently it will only join them so we can search and sort by those. To populate entities, do not forget to pass the populate parameter as well.
 
 ```ts
 // find author of a book that has tag specified by name
@@ -198,9 +175,7 @@ console.log(author.books[0].tags.isInitialized()); // true, because it was popul
 console.log(author.books[0].tags[0].isInitialized()); // true, because it was populated
 ```
 
-> This feature is fully available only for SQL drivers. In MongoDB always we need to 
-> query from the owning side - so in the example above, first load book tag by name,
-> then associated book, then the author. Another option is to denormalize the schema.  
+> This feature is fully available only for SQL drivers. In MongoDB always we need to query from the owning side - so in the example above, first load book tag by name, then associated book, then the author. Another option is to denormalize the schema.
 
 ### Fetching Partial Entities
 
@@ -233,23 +208,18 @@ It is also possible to use multiple levels:
 const author = await em.findOne(Author, '...', { fields: ['name', { books: ['title', 'price', 'author', { author: ['email'] }] }] });
 ```
 
-Primary keys are always selected even if we omit them. On the other hand, we are responsible 
-for selecting the FKs - if we omit such property, the relation might not be loaded properly.
-In the following example the books would not be linked the author, because we did not specify 
-the `books.author` field to be loaded.
+Primary keys are always selected even if we omit them. On the other hand, we are responsible for selecting the FKs - if we omit such property, the relation might not be loaded properly. In the following example the books would not be linked the author, because we did not specify the `books.author` field to be loaded.
 
 ```ts
 // this will load both author and book entities, but they won't be connected due to the missing FK in select
 const author = await em.findOne(Author, '...', { fields: ['name', { books: ['title', 'price'] });
 ```
 
-> Same problem can occur in mongo with M:N collections - those are stored as array property 
-> on the owning entity, so we need to make sure to mark such properties too.
+> Same problem can occur in mongo with M:N collections - those are stored as array property on the owning entity, so we need to make sure to mark such properties too.
 
 ### Fetching Paginated Results
 
-If we are going to paginate our results, we can use `em.findAndCount()` that will return
-total count of entities before applying limit and offset.
+If we are going to paginate our results, we can use `em.findAndCount()` that will return total count of entities before applying limit and offset.
 
 ```ts
 const [authors, count] = await em.findAndCount(Author, { ... }, { limit: 10, offset: 50 });
@@ -259,8 +229,7 @@ console.log(count); // total count, e.g. 1327
 
 ### Handling Not Found Entities
 
-When we call `em.findOne()` and no entity is found based on our criteria, `null` will be 
-returned. If we rather have an `Error` instance thrown, we can use `em.findOneOrFail()`:
+When we call `em.findOne()` and no entity is found based on our criteria, `null` will be returned. If we rather have an `Error` instance thrown, we can use `em.findOneOrFail()`:
 
 ```ts
 const author = await em.findOne(Author, { name: 'does-not-exist' });
@@ -274,8 +243,7 @@ try {
 }
 ```
 
-You can customize the error either globally via `findOneOrFailHandler` option, or locally via 
-`failHandler` option in `findOneOrFail` call.
+You can customize the error either globally via `findOneOrFailHandler` option, or locally via `failHandler` option in `findOneOrFail` call.
 
 ```ts
 try {
@@ -291,8 +259,7 @@ try {
 
 It is possible to use any SQL fragment in our `WHERE` query or `ORDER BY` clause:
 
-> The `expr()` helper is an identity function - all it does is to return its parameter.
-> We can use it to bypass the strict type checks in `FilterQuery`.
+> The `expr()` helper is an identity function - all it does is to return its parameter. We can use it to bypass the strict type checks in `FilterQuery`.
 
 ```ts
 const users = await em.find(User, { [expr('lower(email)')]: 'foo@bar.baz' }, {
@@ -303,7 +270,7 @@ const users = await em.find(User, { [expr('lower(email)')]: 'foo@bar.baz' }, {
 This will produce following query:
 
 ```sql
-select `e0`.* 
+select `e0`.*
 from `user` as `e0`
 where lower(email) = 'foo@bar.baz'
 order by (point(loc_latitude, loc_longitude) <@> point(0, 0)) asc
@@ -311,13 +278,9 @@ order by (point(loc_latitude, loc_longitude) <@> point(0, 0)) asc
 
 ## Disabling identity map and change set tracking
 
-Sometimes we might want to disable identity map and change set tracking for some query.
-This is possible via `disableIdentityMap` option. Behind the scenes, it will create new 
-context, load the entities inside that, and clear it afterwards, so the main identity map
-will stay clean.
+Sometimes we might want to disable identity map and change set tracking for some query. This is possible via `disableIdentityMap` option. Behind the scenes, it will create new context, load the entities inside that, and clear it afterwards, so the main identity map will stay clean.
 
-> As opposed to _managed_ entities, such entities are called _detached_. 
-> To be able to work with them, we first need to merge them via `em.registerManaged()`. 
+> As opposed to _managed_ entities, such entities are called _detached_. To be able to work with them, we first need to merge them via `em.registerManaged()`.
 
 ```ts
 const users = await em.find(User, { email: 'foo@bar.baz' }, {
@@ -325,16 +288,14 @@ const users = await em.find(User, { email: 'foo@bar.baz' }, {
   populate: ['cars.brand'],
 });
 users[0].name = 'changed';
-await em.flush(); // calling flush have no effect, as the entity is not managed  
+await em.flush(); // calling flush have no effect, as the entity is not managed
 ```
 
-> Keep in mind that this can also have 
-> [negative effect on the performance](https://stackoverflow.com/questions/9259480/entity-framework-mergeoption-notracking-bad-performance).
+> Keep in mind that this can also have [negative effect on the performance](https://stackoverflow.com/questions/9259480/entity-framework-mergeoption-notracking-bad-performance).
 
 ## Type of Fetched Entities
 
-Both `em.find` and `em.findOne()` methods have generic return types.
-All of following examples are equal and will let typescript correctly infer the entity type:
+Both `em.find` and `em.findOne()` methods have generic return types. All of following examples are equal and will let typescript correctly infer the entity type:
 
 ```ts
 const author1 = await em.findOne<Author>(Author.name, '...id...');
@@ -342,23 +303,17 @@ const author2 = await em.findOne<Author>('Author', '...id...');
 const author3 = await em.findOne(Author, '...id...');
 ```
 
-As the last one is the least verbose, it should be preferred. 
+As the last one is the least verbose, it should be preferred.
 
 ## Entity Repositories
 
-Although we can use `EntityManager` directly, much more convenient way is to use 
-[`EntityRepository` instead](https://mikro-orm.io/repositories/). You can register
-our repositories in dependency injection container like [InversifyJS](http://inversify.io/)
-so we do not need to get them from `EntityManager` each time.
+Although we can use `EntityManager` directly, much more convenient way is to use [`EntityRepository` instead](https://mikro-orm.io/repositories/). You can register our repositories in dependency injection container like [InversifyJS](http://inversify.io/) so we do not need to get them from `EntityManager` each time.
 
-For more examples, take a look at
-[`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts)
-or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).
+For more examples, take a look at [`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts) or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).
 
 ## Custom Property Ordering
 
-Entity properties provide some support for custom ordering via the `customOrder` attribute. This is
-useful for values that have a natural order that doesn't align with their underlying data representation. Consider the code below, the natural sorting order would be `high`, `low`, `medium`. However we can provide the `customOrder` to indicate how the enum values should be sorted.
+Entity properties provide some support for custom ordering via the `customOrder` attribute. This is useful for values that have a natural order that doesn't align with their underlying data representation. Consider the code below, the natural sorting order would be `high`, `low`, `medium`. However we can provide the `customOrder` to indicate how the enum values should be sorted.
 
 ```ts
 enum Priority { Low = 'low', Medium = 'medium', High = 'high' }
@@ -370,9 +325,9 @@ class Task {
   @Property()
   label!: string
 
-  @Enum({ 
-    items: () => Priority, 
-    customOrder: [Priority.Low, Priority.Medium, Priority.High] 
+  @Enum({
+    items: () => Priority,
+    customOrder: [Priority.Low, Priority.Medium, Priority.High]
   })
   priority!: Priority
 }

--- a/docs/versioned_docs/version-5.4/entity-references.md
+++ b/docs/versioned_docs/version-5.4/entity-references.md
@@ -6,12 +6,9 @@ sidebar_label: Entity References
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Every single entity relation is mapped to an entity reference. Reference is an entity that has
-only its identifier. This reference is stored in identity map so you will get the same object 
-reference when fetching the same document from database.
+Every single entity relation is mapped to an entity reference. Reference is an entity that has only its identifier. This reference is stored in identity map so you will get the same object reference when fetching the same document from database.
 
-You can call `await wrap(entity).init()` to initialize the entity. This will trigger database call 
-and populate itself, keeping the same reference in identity map. 
+You can call `await wrap(entity).init()` to initialize the entity. This will trigger database call and populate itself, keeping the same reference in identity map.
 
 ```ts
 const author = orm.em.getReference('...id...');
@@ -26,8 +23,7 @@ console.log(author.name); // defined
 
 ## Better Type-safety with `Reference<T>` Wrapper
 
-When you define `@ManyToOne` and `@OneToOne` properties on your entity, TypeScript compiler
-will think that desired entities are always loaded:
+When you define `@ManyToOne` and `@OneToOne` properties on your entity, TypeScript compiler will think that desired entities are always loaded:
 
 ```ts
 @Entity()
@@ -51,24 +47,20 @@ console.log(book.author.isInitialized()); // false
 console.log(book.author.name); // undefined as `Author` is not loaded yet
 ```
 
-> You can overcome this issue by using the `Reference<T>` wrapper. It simply wraps the entity, 
-defining `load(): Promise<T>` method that will first lazy load the association if not already
-available. You can also use `unwrap(): T` method to access the underlying entity without loading
-it.
+> You can overcome this issue by using the `Reference<T>` wrapper. It simply wraps the entity, defining `load(): Promise<T>` method that will first lazy load the association if not already available. You can also use `unwrap(): T` method to access the underlying entity without loading it.
 
-You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>`, which works like `load()`
-but returns the specified property.
+You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>`, which works like `load()` but returns the specified property.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 import { Entity, IdentifiedReference, ManyToOne, PrimaryKey, Reference } from '@mikro-orm/core';
@@ -143,9 +135,7 @@ console.log((await book.author.load()).name); // ok, author already loaded
 console.log(book.author.unwrap().name); // ok, author already loaded
 ```
 
-There are also `getEntity()` and `getProperty()` methods that are synchronous getters, 
-that will first check if the wrapped entity is initialized, and if not, it will throw 
-and error.
+There are also `getEntity()` and `getProperty()` methods that are synchronous getters, that will first check if the wrapped entity is initialized, and if not, it will throw and error.
 
 ```ts
 const book = await orm.em.findOne(Book, 1);
@@ -157,9 +147,7 @@ console.log((await book.author.load('name'))); // ok, loading the author first
 console.log(book.author.getProperty('name')); // ok, author already loaded
 ```
 
-If you use different metadata provider than `TsMorphMetadataProvider` 
-(e.g. `ReflectMetadataProvider`), you will also need to explicitly set `wrappedReference` 
-parameter:
+If you use different metadata provider than `TsMorphMetadataProvider` (e.g. `ReflectMetadataProvider`), you will also need to explicitly set `wrappedReference` parameter:
 
 ```ts
 @ManyToOne(() => Author, { wrappedReference: true })
@@ -168,9 +156,7 @@ author!: IdentifiedReference<Author>;
 
 ### Assigning to Reference Properties
 
-When you define the property as `Reference` wrapper, you will need to assign the `Reference`
-to it instead of the entity. You can create it via `Reference.create()` factory, or use `wrapped`
-option of `em.getReference()`:
+When you define the property as `Reference` wrapper, you will need to assign the `Reference` to it instead of the entity. You can create it via `Reference.create()` factory, or use `wrapped` option of `em.getReference()`:
 
 ```ts
 const book = await orm.em.findOne(Book, 1);
@@ -183,8 +169,7 @@ book.author = Reference.create(repo.getReference(2));
 await orm.em.flush();
 ```
 
-Since v5 we can also create entity references without access to `EntityManager`. 
-This can be handy if you want to create a reference from inside entity constructor:
+Since v5 we can also create entity references without access to `EntityManager`. This can be handy if you want to create a reference from inside entity constructor:
 
 ```ts
 @Entity()
@@ -200,8 +185,7 @@ export class Book {
 }
 ```
 
-Another way is to use `toReference()` method available as part of 
-[`WrappedEntity` interface](entity-helper.md#wrappedentity-and-wrap-helper):
+Another way is to use `toReference()` method available as part of [`WrappedEntity` interface](entity-helper.md#wrappedentity-and-wrap-helper):
 
 ```ts
 const author = new Author(...)
@@ -216,12 +200,9 @@ book.author.set(new Author(...));
 
 ### What is IdentifiedReference?
 
-`IdentifiedReference` is an intersection type that adds primary key property to the `Reference` 
-interface. It allows to get the primary key from `Reference` instance directly.
+`IdentifiedReference` is an intersection type that adds primary key property to the `Reference` interface. It allows to get the primary key from `Reference` instance directly.
 
-By default, we try to detect the PK by checking if a property with a known name exists.
-We check for those in order: `_id`, `uuid`, `id` - with a way to manually set the property
-name via `PrimaryKeyProp` symbol (`[PrimaryKeyProp]?: 'foo';`). 
+By default, we try to detect the PK by checking if a property with a known name exists. We check for those in order: `_id`, `uuid`, `id` - with a way to manually set the property name via `PrimaryKeyProp` symbol (`[PrimaryKeyProp]?: 'foo';`).
 
 We can also override this via second generic type argument.
 
@@ -239,19 +220,18 @@ const book = await orm.em.findOne(Book, 1);
 console.log(book.author.myPrimaryKey); // ok, returns the PK
 ```
 
-For MongoDB, define the PK generic type argument as `'id' | '_id'` to access both `string` 
-and `ObjectId` PK values:
+For MongoDB, define the PK generic type argument as `'id' | '_id'` to access both `string` and `ObjectId` PK values:
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
@@ -317,5 +297,4 @@ console.log(book.author.id); // ok, returns string PK
 console.log(book.author._id); // ok, returns ObjectId PK
 ```
 
-> As opposed to `EntityHelper.init()` which always refreshes the entity, `Reference.load()` 
-> method will query the database only if the entity is not already loaded in Identity Map. 
+> As opposed to `EntityHelper.init()` which always refreshes the entity, `Reference.load()` method will query the database only if the entity is not already loaded in Identity Map.

--- a/docs/versioned_docs/version-5.4/entity-schema.md
+++ b/docs/versioned_docs/version-5.4/entity-schema.md
@@ -2,7 +2,7 @@
 title: Defining Entities via EntitySchema
 ---
 
-With `EntitySchema` helper we define the schema programmatically. 
+With `EntitySchema` helper we define the schema programmatically.
 
 ```ts title="./entities/Book.ts"
 export interface Book extends CustomBaseEntity {
@@ -13,7 +13,7 @@ export interface Book extends CustomBaseEntity {
 }
 
 // The second type argument is optional, and should be used only with custom
-// base entities, not with the `BaseEntity` class exported from `@mikro-orm/core`. 
+// base entities, not with the `BaseEntity` class exported from `@mikro-orm/core`.
 export const schema = new EntitySchema<Book, CustomBaseEntity>({
   // name should be used only with interfaces
   name: 'Book',
@@ -29,8 +29,7 @@ export const schema = new EntitySchema<Book, CustomBaseEntity>({
 });
 ```
 
-When creating new entity instances, you will need to use `em.create()` method that will
-create instance of internally created class. 
+When creating new entity instances, you will need to use `em.create()` method that will create instance of internally created class.
 
 ```ts
 const repo = em.getRepository<Author>('Author');
@@ -42,7 +41,7 @@ await repo.persistAndFlush(author);
 
 ## Using custom entity classes
 
-You can optionally use custom class for entity instances.  
+You can optionally use custom class for entity instances.
 
 ```ts title="./entities/Author.ts"
 export class Author extends CustomBaseEntity {
@@ -55,7 +54,7 @@ export class Author extends CustomBaseEntity {
   books = new Collection<Book>(this);
   favouriteBook?: Book;
   version?: number;
-  
+
   constructor(name: string, email: string) {
     super();
     this.name = name;
@@ -90,7 +89,7 @@ await repo.persistAndFlush(author);
 
 ## Using custom base entity
 
-Do not forget that base entities needs to be discovered just like normal entities. 
+Do not forget that base entities needs to be discovered just like normal entities.
 
 ```ts title="./entities/BaseEntity.ts"
 export interface CustomBaseEntity {
@@ -112,9 +111,7 @@ export const schema = new EntitySchema<CustomBaseEntity>({
 
 ## Configuration Reference
 
-The parameter of `EntitySchema` requires to provide either `name` or `class` parameters. 
-When using `class`, `extends` will be automatically inferred. You can optionally pass 
-these additional parameters:
+The parameter of `EntitySchema` requires to provide either `name` or `class` parameters. When using `class`, `extends` will be automatically inferred. You can optionally pass these additional parameters:
 
 ```ts
 name: string;
@@ -129,8 +126,7 @@ hooks: Partial<Record<keyof typeof EventType, ((string & keyof T) | NonNullable<
 abstract: boolean;
 ```
 
-Every property then needs to contain a type specification - one of `type`/`customType`/`entity`.
-Here are some examples of various property types:
+Every property then needs to contain a type specification - one of `type`/`customType`/`entity`. Here are some examples of various property types:
 
 ```ts
 export enum MyEnum {
@@ -187,10 +183,7 @@ export const schema = new EntitySchema<BookTag>({
 
 ## Hooks example
 
-Entity hooks can be defined either as a property name, or as a function.
-When defined as a function, the `this` argument will be the entity instance.
-Arrow functions can be used if desired, and the entity will be available at args.entity.
-See [Events and Lifecycle Hooks](events.md) section for more details on `EventArgs`.
+Entity hooks can be defined either as a property name, or as a function. When defined as a function, the `this` argument will be the entity instance. Arrow functions can be used if desired, and the entity will be available at args.entity. See [Events and Lifecycle Hooks](events.md) section for more details on `EventArgs`.
 
 ```ts
 export class BookTag {

--- a/docs/versioned_docs/version-5.4/events.md
+++ b/docs/versioned_docs/version-5.4/events.md
@@ -3,11 +3,10 @@ title: Events and Lifecycle Hooks
 sidebar_label: Events and Hooks
 ---
 
-There are two ways to hook to the lifecycle of an entity: 
+There are two ways to hook to the lifecycle of an entity:
 
 - **Lifecycle hooks** are methods defined on the entity prototype.
-- **EventSubscriber**s are classes that can be used to hook to multiple entities
-  or when we do not want to have the method present on the entity prototype.
+- **EventSubscriber**s are classes that can be used to hook to multiple entities or when we do not want to have the method present on the entity prototype.
 
 > Hooks are internally executed the same way as subscribers.
 
@@ -15,53 +14,37 @@ There are two ways to hook to the lifecycle of an entity:
 
 ## Hooks
 
-We can use lifecycle hooks to run some code when entity gets persisted. We can mark any of
-entity methods with them, we can also mark multiple methods with same hook.
+We can use lifecycle hooks to run some code when entity gets persisted. We can mark any of entity methods with them, we can also mark multiple methods with same hook.
 
 All hooks support async methods with one exception - `@OnInit`.
 
-- `@OnInit` is fired when new instance of entity is created, either manually `em.create()`, or 
-automatically when new entities are loaded from database
+- `@OnInit` is fired when new instance of entity is created, either manually `em.create()`, or automatically when new entities are loaded from database
 
-- `@OnLoad` is fired when new entity is loaded into context (e.g. via `em.find()` or `em.populate()`). As opposed to `@OnInit` this will be fired only for fully loaded entities, not references, and this hook can be async. 
+- `@OnLoad` is fired when new entity is loaded into context (e.g. via `em.find()` or `em.populate()`). As opposed to `@OnInit` this will be fired only for fully loaded entities, not references, and this hook can be async.
 
 - `@BeforeCreate()` and `@BeforeUpdate()` is fired right before we persist the entity in database
 
-- `@AfterCreate()` and `@AfterUpdate()` is fired right after the entity is updated in database and 
-merged to identity map. Since this event entity will have reference to `EntityManager` and will be 
-enabled to call `wrap(entity).init()` method (including all entity references and collections).
+- `@AfterCreate()` and `@AfterUpdate()` is fired right after the entity is updated in database and merged to identity map. Since this event entity will have reference to `EntityManager` and will be enabled to call `wrap(entity).init()` method (including all entity references and collections).
 
-- `@BeforeDelete()` is fired right before we delete the record from database. It is fired only when
-removing entity or entity reference, not when deleting records by query. 
+- `@BeforeDelete()` is fired right before we delete the record from database. It is fired only when removing entity or entity reference, not when deleting records by query.
 
-- `@AfterDelete()` is fired right after the record gets deleted from database and it is unset from 
-the identity map.
+- `@AfterDelete()` is fired right after the record gets deleted from database and it is unset from the identity map.
 
 > `@OnInit` is not fired when we create the entity manually via its constructor (`new MyEntity()`)
 
-> `@OnInit` can be sometimes fired twice, once when the entity reference is
-> created, and once after its populated. To distinguish between those we can
-> use `wrap(this).isInitialized()`.
+> `@OnInit` can be sometimes fired twice, once when the entity reference is created, and once after its populated. To distinguish between those we can use `wrap(this).isInitialized()`.
 
 ## Limitations of lifecycle hooks
 
-Hooks are executed inside the commit action of unit of work, after all change 
-sets are computed. This means that it is not possible to create new entities as
-usual from inside the hook. Calling `em.flush()` from hooks will result in 
-validation error. Calling `em.persist()` can result in undefined behaviour like
-locking errors. 
+Hooks are executed inside the commit action of unit of work, after all change sets are computed. This means that it is not possible to create new entities as usual from inside the hook. Calling `em.flush()` from hooks will result in validation error. Calling `em.persist()` can result in undefined behaviour like locking errors.
 
-> The **internal** instance of `EntityManager` accessible under `wrap(this, true).__em` is 
-> not meant for public usage. 
+> The **internal** instance of `EntityManager` accessible under `wrap(this, true).__em` is not meant for public usage.
 
 ## EventSubscriber
 
-Use `EventSubscriber` to hook to multiple entities or if we do not want to pollute
-the entity prototype. All methods are optional, if we omit the `getSubscribedEntities()`
-method, it means we are subscribing to all entities.
+Use `EventSubscriber` to hook to multiple entities or if we do not want to pollute the entity prototype. All methods are optional, if we omit the `getSubscribedEntities()` method, it means we are subscribing to all entities.
 
-We can either register the subscribers manually in the ORM configuration (via 
-`subscribers` array where we put the instance):
+We can either register the subscribers manually in the ORM configuration (via `subscribers` array where we put the instance):
 
 ```ts
 MikroORM.init({
@@ -69,9 +52,7 @@ MikroORM.init({
 });
 ```
 
-Or use `@Subscriber()` decorator - keep in mind that we need to make sure the file gets 
-loaded in order to make this decorator registration work (e.g. we import that file 
-explicitly somewhere).
+Or use `@Subscriber()` decorator - keep in mind that we need to make sure the file gets loaded in order to make this decorator registration work (e.g. we import that file explicitly somewhere).
 
 ```ts
 import { EntityName, EventArgs, EventSubscriber, Subscriber } from '@mikro-orm/core';
@@ -88,13 +69,13 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
   }
 
   async afterUpdate(args: EventArgs<Author>): Promise<void> {
-    // ... 
+    // ...
   }
 
 }
 ```
 
-Another example, where we register to all the events and all entities: 
+Another example, where we register to all the events and all entities:
 
 ```ts
 import { EventArgs, EventSubscriber, Subscriber } from '@mikro-orm/core';
@@ -111,7 +92,7 @@ export class EverythingSubscriber implements EventSubscriber {
   async afterUpdate<T>(args: EventArgs<T>): Promise<void> { ... }
   async beforeDelete<T>(args: EventArgs<T>): Promise<void> { ... }
   async afterDelete<T>(args: EventArgs<T>): Promise<void> { ... }
-  
+
   // flush events
   async beforeFlush<T>(args: EventArgs<T>): Promise<void> { ... }
   async onFlush<T>(args: EventArgs<T>): Promise<void> { ... }
@@ -130,9 +111,7 @@ export class EverythingSubscriber implements EventSubscriber {
 
 ## EventArgs
 
-As a parameter to the hook method we get `EventArgs` instance. It will always contain
-reference to the current `EntityManager` and the particular entity. Events fired
-from `UnitOfWork` during flush operation also contain the `ChangeSet` object.
+As a parameter to the hook method we get `EventArgs` instance. It will always contain reference to the current `EntityManager` and the particular entity. Events fired from `UnitOfWork` during flush operation also contain the `ChangeSet` object.
 
 ```ts
 interface EventArgs<T> {
@@ -161,28 +140,21 @@ enum ChangeSetType {
 
 ## Flush events
 
-There is a special kind of events executed during the commit phase (flush operation).
-They are executed before, during and after the flush, and they are not bound to any
-entity in particular. 
+There is a special kind of events executed during the commit phase (flush operation). They are executed before, during and after the flush, and they are not bound to any entity in particular.
 
-- `beforeFlush` is executed before change sets are computed, this is the only
-  event where it is safe to persist new entities. 
+- `beforeFlush` is executed before change sets are computed, this is the only event where it is safe to persist new entities.
 - `onFlush` is executed after the change sets are computed.
-- `afterFlush` is executed as the last step just before the `flush` call resolves.
-  it will be executed even if there are no changes to be flushed. 
+- `afterFlush` is executed as the last step just before the `flush` call resolves. it will be executed even if there are no changes to be flushed.
 
-Flush event args will not contain any entity instance, as they are entity agnostic.
-They do contain additional reference to the `UnitOfWork` instance.
+Flush event args will not contain any entity instance, as they are entity agnostic. They do contain additional reference to the `UnitOfWork` instance.
 
 ```ts
 interface FlushEventArgs extends Omit<EventArgs<unknown>, 'entity'> {
   uow?: UnitOfWork;
 }
-``` 
+```
 
-> Flush events are entity agnostic, specifying `getSubscribedEntities()` method
-> will not have any effect for those. They are fired only once per the `flush` 
-> operation.
+> Flush events are entity agnostic, specifying `getSubscribedEntities()` method will not have any effect for those. They are fired only once per the `flush` operation.
 
 ## Transaction events
 
@@ -219,18 +191,12 @@ UnitOfWork.getExtraUpdates(): Set<[AnyEntity, string, (AnyEntity | Reference<Any
 
 ### Using onFlush event
 
-In following example we have 2 entities: `FooBar` and `FooBaz`, connected via 
-M:1 relation. Our subscriber will automatically create new `FooBaz` entity and 
-connect it to the `FooBar` when we detect it in the change sets.
+In following example we have 2 entities: `FooBar` and `FooBaz`, connected via M:1 relation. Our subscriber will automatically create new `FooBaz` entity and connect it to the `FooBar` when we detect it in the change sets.
 
-We first use `uow.getChangeSets()` method to look up the change set of entity
-we are interested in. After we create the `FooBaz` instance and link it with 
-`FooBar`, we need to do two things:
+We first use `uow.getChangeSets()` method to look up the change set of entity we are interested in. After we create the `FooBaz` instance and link it with `FooBar`, we need to do two things:
 
-1. Call `uow.computeChangeSet(baz)` to compute the change set of newly created 
-  `FooBaz` entity
-2. Call `uow.recomputeSingleChangeSet(cs.entity)` to recalculate the existing 
-  change set of the `FooBar` entity.
+1. Call `uow.computeChangeSet(baz)` to compute the change set of newly created `FooBaz` entity
+2. Call `uow.recomputeSingleChangeSet(cs.entity)` to recalculate the existing change set of the `FooBar` entity.
 
 ```ts
 @Subscriber()
@@ -258,7 +224,7 @@ await em.persistAndFlush(bar);
 
 ## Transaction events
 
-Transaction events happen at the beginning and end of a transaction. 
+Transaction events happen at the beginning and end of a transaction.
 
 - `beforeTransactionStart` is executed before a transaction starts.
 - `afterTransactionStart` is executed after a transaction starts.
@@ -267,5 +233,4 @@ Transaction events happen at the beginning and end of a transaction.
 - `beforeTransactionRollback` is executed before a transaction is rolled back.
 - `afterTransactionRollback` is executed after a transaction is rolled back.
 
-They are also entity agnostic and will only reference the transaction, `UnitOfWork` instance
-and `EntityManager` instance.
+They are also entity agnostic and will only reference the transaction, `UnitOfWork` instance and `EntityManager` instance.

--- a/docs/versioned_docs/version-5.4/faq.md
+++ b/docs/versioned_docs/version-5.4/faq.md
@@ -5,6 +5,7 @@ title: Frequently Asked Questions
 ### How can I synchronize my database schema with the entities?
 
 There are two ways:
+
 - [Schema Generator](./schema-generator.md)
 - [Migrations](./migrations.md)
 
@@ -14,21 +15,15 @@ npx mikro-orm schema:update --run
 
 ### I cannot run the CLI
 
-Make sure you install `@mikro-orm/cli` package locally. If you want to have
-global installation, you will need to install driver packages globally too.
+Make sure you install `@mikro-orm/cli` package locally. If you want to have global installation, you will need to install driver packages globally too.
 
 ### EntityManager does not have `createQueryBuilder()` method
 
 The method is there, the issue is in the TS type.
 
-In v4 the `core` package, where `EntityManager` and `EntityRepository` are
-defined, is not dependent on knex, and therefore it cannot have a method
-returning a `QueryBuilder`. You need to import the SQL flavour of the EM
-from the driver package to access the `createQueryBuilder()` method.
+In v4 the `core` package, where `EntityManager` and `EntityRepository` are defined, is not dependent on knex, and therefore it cannot have a method returning a `QueryBuilder`. You need to import the SQL flavour of the EM from the driver package to access the `createQueryBuilder()` method.
 
-> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under
-> this name and under `EntityManager` alias, so you can just change the
-> location from where you import.
+> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ```ts
 import { EntityManager } from '@mikro-orm/mysql'; // or any other SQL driver package
@@ -37,8 +32,7 @@ const em = orm.em as EntityManager;
 const qb = await em.createQueryBuilder(...);
 ```
 
-To have the `orm.em` variable properly typed, we can use generic type parameter of
-`MikroORM.init()`:
+To have the `orm.em` variable properly typed, we can use generic type parameter of `MikroORM.init()`:
 
 ```ts
 import { MySqlDriver } from '@mikro-orm/mysql'; // or any other SQL driver package
@@ -58,25 +52,19 @@ const em = orm.em as EntityManager;
 const ret = await em.aggregate(...);
 ```
 
-> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under
-> this name and under `EntityManager` alias, so you can just change the
-> location from where you import.
+> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ### How can I add columns to pivot table (M:N relation)
 
-You should model your M:N relation transparently, via 1:m and m:1 properties.
-More about this can be found in [Composite Keys section](./composite-keys.md/#use-case-3-join-table-with-metadata).
+You should model your M:N relation transparently, via 1:m and m:1 properties. More about this can be found in [Composite Keys section](./composite-keys.md/#use-case-3-join-table-with-metadata).
 
 ### You cannot call `em.flush()` from inside lifecycle hook handlers
 
-You might see this validation error even if you do not use hooks. If that happens,
-the reason is usually because you do not have [request context](identity-map.md) set up properly, and
-you are reusing one `EntityManager` instance.
+You might see this validation error even if you do not use hooks. If that happens, the reason is usually because you do not have [request context](identity-map.md) set up properly, and you are reusing one `EntityManager` instance.
 
 ### Column is being created with JSON type while the TS type is `string/Date/number/...`
 
-You are probably using the default `ReflectMetadataProvider`, which does not
-support inferring property type when there is a property initializer.
+You are probably using the default `ReflectMetadataProvider`, which does not support inferring property type when there is a property initializer.
 
 ```ts
 @Property()
@@ -84,6 +72,7 @@ foo = 'abc';
 ```
 
 There are two ways around this:
+
 - Use [TsMorphMetadataProvider](./metadata-providers.md/#tsmorphmetadataprovider)
 - Specify the type explicitly:
 
@@ -124,8 +113,7 @@ When creating new entity instances, either with `new Book()` or `em.create(Book,
 Book {}
 ```
 
-But some users might find that this returns an object with properties that are explicitly
-set to `undefined`:
+But some users might find that this returns an object with properties that are explicitly set to `undefined`:
 
 ```ts
 Book {
@@ -135,8 +123,7 @@ Book {
 }
 ```
 
-This can cause unexpected behavior, particularly if you're expecting the database to set a
-default value for a column.
+This can cause unexpected behavior, particularly if you're expecting the database to set a default value for a column.
 
 To fix this, disable the [`useDefineForClassFields`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#the-usedefineforclassfields-flag-and-the-declare-property-modifier) option in your tsconfig:
 
@@ -147,5 +134,3 @@ To fix this, disable the [`useDefineForClassFields`](https://www.typescriptlang.
   }
 }
 ```
-
-

--- a/docs/versioned_docs/version-5.4/filters.md
+++ b/docs/versioned_docs/version-5.4/filters.md
@@ -2,16 +2,11 @@
 title: Filters
 ---
 
-MikroORM has the ability to pre-define filter criteria and attach those filters 
-to given entities. The application can then decide at runtime whether certain 
-filters should be enabled and what their parameter values should be. Filters 
-can be used like database views, but they are parameterized inside the application.
+MikroORM has the ability to pre-define filter criteria and attach those filters to given entities. The application can then decide at runtime whether certain filters should be enabled and what their parameter values should be. Filters can be used like database views, but they are parameterized inside the application.
 
-> Filter can be defined at the entity level, dynamically via EM (global filters) 
-> or in the ORM configuration.
+> Filter can be defined at the entity level, dynamically via EM (global filters) or in the ORM configuration.
 
-Filters are applied to those methods of `EntityManager`: `find()`, `findOne()`, 
-`findAndCount()`, `findOneOrFail()`, `count()`, `nativeUpdate()` and `nativeDelete()`. 
+Filters are applied to those methods of `EntityManager`: `find()`, `findOne()`, `findAndCount()`, `findOneOrFail()`, `count()`, `nativeUpdate()` and `nativeDelete()`.
 
 > The `cond` parameter can be a callback, possibly asynchronous.
 
@@ -36,14 +31,14 @@ const books2 = await orm.em.find(Book, {}, {
 ## Properties of filter
 
 There are three parameters you can use:
+
 - `name` - can be used to enable a filter on the query can also used to pass a parameter
 - `cond` - is the condition that should be added to the query when the filter is enabled. This can be a callback, even async
 - `default` - indicates if the filter is enabled by default on the query
 
 ## Parameters
 
-You can define the `cond` dynamically as a callback. This callback can be also 
-asynchronous. It will get three arguments:
+You can define the `cond` dynamically as a callback. This callback can be also asynchronous. It will get three arguments:
 
 - `args` - dictionary of parameters provided by user
 - `type` - type of operation that is being filtered, one of `'read'`, `'update'`, `'delete'`
@@ -58,8 +53,8 @@ import type { EntityManager } from '@mikro-orm/mysql';
     return {}; // do not apply when updating
   }
 
-  return { 
-    author: { name: args.name }, 
+  return {
+    author: { name: args.name },
     publishedAt: { $lte: em.raw('now()') },
   };
 } })
@@ -74,9 +69,7 @@ const books = await orm.em.find(Book, {}, {
 
 ### Filters without parameters
 
-If we want to have a filter condition that do not need arguments, but we want
-to access the `type` parameter, we will need to explicitly set `args: false`, 
-otherwise error will be raised due to missing parameters:
+If we want to have a filter condition that do not need arguments, but we want to access the `type` parameter, we will need to explicitly set `args: false`, otherwise error will be raised due to missing parameters:
 
 ```ts
 @Filter({
@@ -91,10 +84,7 @@ otherwise error will be raised due to missing parameters:
 
 ## Global filters
 
-We can also register filters dynamically via `EntityManager` API. We call such filters 
-global. They are enabled by default (unless disabled via last parameter in `addFilter()`
-method), and applied to all entities. You can limit the global filter to only specified
-entities. 
+We can also register filters dynamically via `EntityManager` API. We call such filters global. They are enabled by default (unless disabled via last parameter in `addFilter()` method), and applied to all entities. You can limit the global filter to only specified entities.
 
 > Filters as well as filter params set on the EM will be copied to all its forks.
 
@@ -125,12 +115,9 @@ MikroORM.init({
 
 ## Using filters
 
-We can control what filters will be applied via `filter` parameter in `FindOptions`.
-We can either provide an array of names of filters you want to enable, or options 
-object, where we can also disable a filter (that was enabled by default), or pass some
-parameters to those that are expecting them.
+We can control what filters will be applied via `filter` parameter in `FindOptions`. We can either provide an array of names of filters you want to enable, or options object, where we can also disable a filter (that was enabled by default), or pass some parameters to those that are expecting them.
 
-> By passing `filters: false` we can also disable all the filters for given call. 
+> By passing `filters: false` we can also disable all the filters for given call.
 
 ```ts
 em.find(Book, {}); // same as `{ tenantId: 123 }`
@@ -141,17 +128,11 @@ em.find(Book, {}, { filters: false }); // disabled all filters, so truly `{}`
 
 ## Filters and populating of relationships
 
-When populating relationships, filters will be applied only to the root entity of 
-given query, but not to those that are auto-joined. On the other hand, this means that
-when you use the default loading strategy - `LoadStrategy.SELECT_IN` - filters will
-be applied to every entity populated this way, as the child entities will become
-root entities in their respective load calls.
+When populating relationships, filters will be applied only to the root entity of given query, but not to those that are auto-joined. On the other hand, this means that when you use the default loading strategy - `LoadStrategy.SELECT_IN` - filters will be applied to every entity populated this way, as the child entities will become root entities in their respective load calls.
 
 ## Naming of filters
 
-When toggling filters via `FindOptions`, we do not care about the entity name. This
-means that when you have multiple filters defined on different entities, but with 
-the same name, they will be controlled via single toggle in the `FindOptions`. 
+When toggling filters via `FindOptions`, we do not care about the entity name. This means that when you have multiple filters defined on different entities, but with the same name, they will be controlled via single toggle in the `FindOptions`.
 
 ```ts
 @Entity()

--- a/docs/versioned_docs/version-5.4/identity-map.md
+++ b/docs/versioned_docs/version-5.4/identity-map.md
@@ -38,7 +38,7 @@ We can still disable this check via `allowGlobalContext` configuration, or a con
 
 ## <a name="request-context"></a> `RequestContext` helper
 
-If we use dependency injection container like `inversify` or the one in `nestjs` framework, it can be hard to achieve this, because we usually want to access our repositories via DI container, but it will always provide we with the same instance, rather than new one for each request. 
+If we use dependency injection container like `inversify` or the one in `nestjs` framework, it can be hard to achieve this, because we usually want to access our repositories via DI container, but it will always provide we with the same instance, rather than new one for each request.
 
 To solve this, we can use `RequestContext` helper, that will use `node`'s [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) in the background to isolate the request context. MikroORM will always use request specific (forked) entity manager if available, so all we need to do is to create new request context preferably as a middleware:
 
@@ -46,11 +46,11 @@ To solve this, we can use `RequestContext` helper, that will use `node`'s [`Asyn
 app.use((req, res, next) => {
   RequestContext.create(orm.em, next);
 });
-``` 
+```
 
-We should register this middleware as the last one just before request handlers and before any of our custom middleware that is using the ORM. There might be issues when we register it before request processing middleware like `queryParser` or `bodyParser`, so definitely register the context after them. 
+We should register this middleware as the last one just before request handlers and before any of our custom middleware that is using the ORM. There might be issues when we register it before request processing middleware like `queryParser` or `bodyParser`, so definitely register the context after them.
 
-Later on we can then access the request scoped `EntityManager` via `RequestContext.getEntityManager()`. This method is used under the hood automatically, so we should not need it. 
+Later on we can then access the request scoped `EntityManager` via `RequestContext.getEntityManager()`. This method is used under the hood automatically, so we should not need it.
 
 > `RequestContext.getEntityManager()` will return `undefined` if the context was not started yet.
 
@@ -69,20 +69,15 @@ const res = await orm.em.getContext().find(Book, {});
 const res = await RequestContext.getEntityManager().find(Book, {});
 ```
 
-The `RequestContext.getEntityManager()` method then checks `AsyncLocalStorage` static instance we use for creating new EM forks in the `RequestContext.create()` method. 
+The `RequestContext.getEntityManager()` method then checks `AsyncLocalStorage` static instance we use for creating new EM forks in the `RequestContext.create()` method.
 
 The [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) class from Node.js core is the magician here. It allows us to track the context throughout the async calls. It allows us to decouple the `EntityManager` fork creation (usually in a middleware as shown in previous section) from its usage through the global `EntityManager` instance.
 
 ## `@UseRequestContext()` decorator
 
-Middlewares are executed only for regular HTTP request handlers, what if we need
-a request scoped method outside that? One example of that is queue handlers or
-scheduled tasks (e.g. CRON jobs).
+Middlewares are executed only for regular HTTP request handlers, what if we need a request scoped method outside that? One example of that is queue handlers or scheduled tasks (e.g. CRON jobs).
 
-We can use the `@UseRequestContext()` decorator. It requires us to first inject the
-`MikroORM` instance to current context, it will be then used to create the context
-for us. Under the hood, the decorator will register new request context for our
-method and execute it inside the context.
+We can use the `@UseRequestContext()` decorator. It requires us to first inject the `MikroORM` instance to current context, it will be then used to create the context for us. Under the hood, the decorator will register new request context for our method and execute it inside the context.
 
 This decorator will wrap the underlying method in `RequestContext.createAsync()` call. Every call to such method will create new context (new `EntityManager` fork) which will be used inside.
 
@@ -119,11 +114,11 @@ export class MyService {
 
 ## Why is Request Context needed?
 
-Imagine we will use a single Identity Map throughout our application. It will be shared across all request handlers, that can possibly run in parallel. 
+Imagine we will use a single Identity Map throughout our application. It will be shared across all request handlers, that can possibly run in parallel.
 
 ### Problem 1 - growing memory footprint
 
-As there would be only one shared Identity Map, we can't just clear it after our request ends. There can be another request working with it so clearing the Identity Map from one request could break other requests running in parallel. This will result in growing memory footprint, as every entity that became managed at some point in time would be kept in the Identity Map. 
+As there would be only one shared Identity Map, we can't just clear it after our request ends. There can be another request working with it so clearing the Identity Map from one request could break other requests running in parallel. This will result in growing memory footprint, as every entity that became managed at some point in time would be kept in the Identity Map.
 
 ### Problem 2 - unstable response of API endpoints
 
@@ -135,9 +130,9 @@ Let's say there are 2 endpoints
 2. `GET /book-with-author/:id` that returns the book and its author populated
 
 Now when someone requests same book via both of those endpoints, we could end up with both returning the same output:
- 
+
 1. `GET /book/1` returns `Book` without populating its property `author` property
 2. `GET /book-with-author/1` returns `Book`, this time with `author` populated
 3. `GET /book/1` returns `Book`, but this time also with `author` populated
 
-This happens because the information about entity association being populated is stored in the Identity Map. 
+This happens because the information about entity association being populated is stored in the Identity Map.

--- a/docs/versioned_docs/version-5.4/inheritance-mapping.md
+++ b/docs/versioned_docs/version-5.4/inheritance-mapping.md
@@ -4,18 +4,13 @@ title: Inheritance Mapping
 
 ## Mapped Superclasses
 
-A mapped superclass is an abstract or concrete class that provides persistent entity state and mapping information for its subclasses, but which is not itself an entity. Typically, the purpose of such
-a mapped superclass is to define state and mapping information that is common to multiple entity classes.
+A mapped superclass is an abstract or concrete class that provides persistent entity state and mapping information for its subclasses, but which is not itself an entity. Typically, the purpose of such a mapped superclass is to define state and mapping information that is common to multiple entity classes.
 
 Mapped superclasses, just as regular, non-mapped classes, can appear in the middle of an otherwise mapped inheritance hierarchy (through Single Table Inheritance).
 
-> A mapped superclass cannot be an entity, it is not query-able and persistent relationships defined
-> by a mapped superclass must be unidirectional (with an owning side only). This means that One-To-Many
-> associations are not possible on a mapped superclass at all. Furthermore Many-To-Many associations
-> are only possible if the mapped superclass is only used in exactly one entity at the moment. For
-> further support of inheritance, the single table inheritance features have to be used.
+> A mapped superclass cannot be an entity, it is not query-able and persistent relationships defined by a mapped superclass must be unidirectional (with an owning side only). This means that One-To-Many associations are not possible on a mapped superclass at all. Furthermore Many-To-Many associations are only possible if the mapped superclass is only used in exactly one entity at the moment. For further support of inheritance, the single table inheritance features have to be used.
 
-> Also note that we can't use generics to define any relations. This means that we cannot have a generic type argument in the base entity that would be used as a target of some relation. 
+> Also note that we can't use generics to define any relations. This means that we cannot have a generic type argument in the base entity that would be used as a target of some relation.
 
 ```ts
 // do not use @Entity decorator on base classes (mapped superclasses)
@@ -69,16 +64,13 @@ create table `employee` (
 );
 ```
 
-As we can see from this DDL snippet, there is only a single table for the entity subclass. All the mappings from the mapped superclass were inherited to the subclass as if they had been defined on
-that class directly.
+As we can see from this DDL snippet, there is only a single table for the entity subclass. All the mappings from the mapped superclass were inherited to the subclass as if they had been defined on that class directly.
 
 ## Single Table Inheritance
 
 > Support for STI was added in version 4.0
 
-[Single Table Inheritance](https://martinfowler.com/eaaCatalog/singleTableInheritance.html)
-is an inheritance mapping strategy where all classes of a hierarchy are mapped to a single database table. In order to distinguish which row represents which type in the hierarchy a so-called
-discriminator column is used.
+[Single Table Inheritance](https://martinfowler.com/eaaCatalog/singleTableInheritance.html) is an inheritance mapping strategy where all classes of a hierarchy are mapped to a single database table. In order to distinguish which row represents which type in the hierarchy a so-called discriminator column is used.
 
 ```ts
 @Entity({
@@ -98,18 +90,14 @@ export class Employee extends Person {
 Things to note:
 
 - The `discriminatorColumn` option must be specified on the topmost class that is part of the mapped entity hierarchy.
-- The `discriminatorMap` specifies which values of the discriminator column identify a row as being of a certain type. In the case above a value of `person` identifies a row as being of type `Person`
-  and `employee` identifies a row as being of type
-  `Employee`.
+- The `discriminatorMap` specifies which values of the discriminator column identify a row as being of a certain type. In the case above a value of `person` identifies a row as being of type `Person` and `employee` identifies a row as being of type `Employee`.
 - All entity classes that are part of the mapped entity hierarchy (including the topmost class) should be specified in the `discriminatorMap`. In the case above `Person` class included.
 - We can use abstract class as the root entity - then the root class should not be part of the discriminator map
-- If no discriminator map is provided, then the map is generated automatically. The automatically generated discriminator map contains the table names that would be otherwise used in case of regular
-  entities.
+- If no discriminator map is provided, then the map is generated automatically. The automatically generated discriminator map contains the table names that would be otherwise used in case of regular entities.
 
 ### Using `discriminatorValue` instead of `discriminatorMap`
 
-As noted above, the discriminator map can be auto-generated. In that case, we might want to control the tokens that will be used in the map. To do so, we can use
-`discriminatorValue` on the child entities:
+As noted above, the discriminator map can be auto-generated. In that case, we might want to control the tokens that will be used in the map. To do so, we can use `discriminatorValue` on the child entities:
 
 ```ts
 @Entity({
@@ -130,8 +118,7 @@ export class Employee extends Person {
 
 ### Explicit discriminator column
 
-The `discriminatorColumn` specifies the name of special column that will be used to define what type of class should given row be represented with. It will be defined automatically for us and it will
-stay hidden (it won't be hydrated as a regular property).
+The `discriminatorColumn` specifies the name of special column that will be used to define what type of class should given row be represented with. It will be defined automatically for us and it will stay hidden (it won't be hydrated as a regular property).
 
 On the other hand, it is perfectly fine to define the column explicitly. Doing so, we will be able to:
 
@@ -190,18 +177,14 @@ export class Employee extends Person {
 
 ### Design-time considerations
 
-This mapping approach works well when the type hierarchy is fairly simple and stable. Adding a new type to the hierarchy and adding fields to existing supertypes simply involves adding new columns to
-the table, though in large deployments this may have an adverse impact on the index and column layout inside the database.
+This mapping approach works well when the type hierarchy is fairly simple and stable. Adding a new type to the hierarchy and adding fields to existing supertypes simply involves adding new columns to the table, though in large deployments this may have an adverse impact on the index and column layout inside the database.
 
 ### Performance impact
 
-This strategy is very efficient for querying across all types in the hierarchy or for specific types. No table joins are required, only a WHERE clause listing the type identifiers. In particular,
-relationships involving types that employ this mapping strategy are very performant.
+This strategy is very efficient for querying across all types in the hierarchy or for specific types. No table joins are required, only a WHERE clause listing the type identifiers. In particular, relationships involving types that employ this mapping strategy are very performant.
 
 ### SQL Schema considerations
 
-For Single-Table-Inheritance to work in scenarios where we are using either a legacy database schema or a self-written database schema we have to make sure that all columns that are not in the root
-entity but in any of the different sub-entities has to allow null values. Columns that have NOT NULL constraints have to be on the root entity of the single-table inheritance hierarchy.
+For Single-Table-Inheritance to work in scenarios where we are using either a legacy database schema or a self-written database schema we have to make sure that all columns that are not in the root entity but in any of the different sub-entities has to allow null values. Columns that have NOT NULL constraints have to be on the root entity of the single-table inheritance hierarchy.
 
-> This part of documentation is highly inspired by [doctrine docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/inheritance-mapping.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/inheritance-mapping.html) as the behaviour here is pretty much the same.

--- a/docs/versioned_docs/version-5.4/installation.md
+++ b/docs/versioned_docs/version-5.4/installation.md
@@ -2,12 +2,9 @@
 title: Installation & Usage
 ---
 
-First install the module via `yarn` or `npm` and do not forget to install the 
-driver package as well:
+First install the module via `yarn` or `npm` and do not forget to install the driver package as well:
 
-> Since v4, we should install the driver package, but not the db connector itself,
-> e.g. install `@mikro-orm/sqlite`, but not `sqlite3` as that is already included
-> in the driver package.
+> Since v4, we should install the driver package, but not the db connector itself, e.g. install `@mikro-orm/sqlite`, but not `sqlite3` as that is already included in the driver package.
 
 ```sh
 yarn add @mikro-orm/core @mikro-orm/mongodb     # for mongo
@@ -27,8 +24,7 @@ npm i -s @mikro-orm/core @mikro-orm/postgresql  # for postgresql
 npm i -s @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 ```
 
-Next we will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html)
-as well as `esModuleInterop` in `tsconfig.json` via:
+Next we will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html) as well as `esModuleInterop` in `tsconfig.json` via:
 
 ```json
 "experimentalDecorators": true,
@@ -38,9 +34,7 @@ as well as `esModuleInterop` in `tsconfig.json` via:
 
 Then call `MikroORM.init` as part of bootstrapping our app:
 
-> To access driver specific methods like `em.createQueryBuilder()` we need to specify
-> the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the
-> `orm.em` to `EntityManager` exported from the driver package:
+> To access driver specific methods like `em.createQueryBuilder()` we need to specify the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the `orm.em` to `EntityManager` exported from the driver package:
 >
 > ```ts
 > import { EntityManager } from '@mikro-orm/postgresql';
@@ -62,10 +56,7 @@ console.log(orm.em); // access EntityManager via `em` property
 
 > Read more about all the possible configuration options in [Advanced Configuration](configuration.md) section.
 
-We can also provide paths where we store our entities via `entities` array. Internally
-it uses [`globby`](https://github.com/sindresorhus/globby) so we can use 
-[globbing patterns](https://github.com/sindresorhus/globby#globbing-patterns), 
-including negative globs. 
+We can also provide paths where we store our entities via `entities` array. Internally it uses [`globby`](https://github.com/sindresorhus/globby) so we can use [globbing patterns](https://github.com/sindresorhus/globby#globbing-patterns), including negative globs.
 
 ```ts
 const orm = await MikroORM.init<PostgreSqlDriver>({
@@ -75,21 +66,17 @@ const orm = await MikroORM.init<PostgreSqlDriver>({
 });
 ```
 
-If we are experiencing problems with folder based discovery, try using `mikro-orm debug`
-CLI command to check what paths are actually being used.
+If we are experiencing problems with folder based discovery, try using `mikro-orm debug` CLI command to check what paths are actually being used.
 
 > Since v4, we can also use file globs, like `./dist/app/**/entities/*.entity.js`.
 
 We can also set the configuration via [environment variables](configuration.md#using-environment-variables).
 
-> We can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. 
-> The object will be deeply merged, overriding all internally used options.
+> We can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. The object will be deeply merged, overriding all internally used options.
 
 ## Possible issues with circular dependencies
 
-Our entities will most probably contain circular dependencies (e.g. if we use bi-directional 
-relationship). While this is fine, there might be issues caused by wrong order of entities 
-during discovery, especially when we are using the folder based way.
+Our entities will most probably contain circular dependencies (e.g. if we use bi-directional relationship). While this is fine, there might be issues caused by wrong order of entities during discovery, especially when we are using the folder based way.
 
 The errors caused by circular dependencies are usually similar to this one:
 
@@ -110,17 +97,12 @@ TypeError: Cannot read property 'name' of undefined
 
 If we encounter this, we have basically two options:
 
-- Use entity references in `entities` array to have control over the order of discovery. 
-  We might need to play with the actual order we provide here, or possibly with the 
-  order of import statements.
-- Use strings instead of references (e.g. `@OneToMany('Book', 'author')`). The downside 
-  here is that we will lose the typechecking capabilities of the decorators. 
+- Use entity references in `entities` array to have control over the order of discovery. We might need to play with the actual order we provide here, or possibly with the order of import statements.
+- Use strings instead of references (e.g. `@OneToMany('Book', 'author')`). The downside here is that we will lose the typechecking capabilities of the decorators.
 
 ## Entity Discovery in TypeScript
 
-In v4 the default metadata provider is `ReflectMetadataProvider`. If we want to use
-`ts-morph` based discovery (that reads actual TS types via the compiler API), we 
-need to install `@mikro-orm/reflection`.
+In v4 the default metadata provider is `ReflectMetadataProvider`. If we want to use `ts-morph` based discovery (that reads actual TS types via the compiler API), we need to install `@mikro-orm/reflection`.
 
 ```ts
 import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
@@ -141,19 +123,16 @@ const orm = await MikroORM.init<PostgreSqlDriver>({
 });
 ```
 
-> It is important that `entities` will point to the compiled JS files, and `entitiesTs`
-> will point to the TS source files. We should not mix those. 
+> It is important that `entities` will point to the compiled JS files, and `entitiesTs` will point to the TS source files. We should not mix those.
 
-> For `ts-morph` discovery to work in production, we need to deploy `.d.ts` declaration
-> files. Be sure to enable `compilerOptions.declaration` in our `tsconfig.json`.
+> For `ts-morph` discovery to work in production, we need to deploy `.d.ts` declaration files. Be sure to enable `compilerOptions.declaration` in our `tsconfig.json`.
 
 We can also use different [metadata provider](metadata-providers.md) or even write custom one:
 
 - `ReflectMetadataProvider` that uses `reflect-metadata` instead of `ts-morph`
 - `JavaScriptMetadataProvider` that allows we to manually provide the entity schema (mainly for Vanilla JS)
 
-> Using [`EntitySchema`](entity-schema.md) is another way to define our entities, which is better
-> suited than using `JavaScriptMetadataProvider`.
+> Using [`EntitySchema`](entity-schema.md) is another way to define our entities, which is better suited than using `JavaScriptMetadataProvider`.
 
 ```ts
 const orm = await MikroORM.init<PostgreSqlDriver>({
@@ -175,8 +154,7 @@ app.use((req, res, next) => {
 });
 ```
 
-> If the `next` handler needs to be awaited (like in Koa), 
-> use `RequestContext.createAsync()` instead.
+> If the `next` handler needs to be awaited (like in Koa), use `RequestContext.createAsync()` instead.
 >
 > ```ts
 > app.use((ctx, next) => RequestContext.createAsync(orm.em, next));
@@ -186,12 +164,9 @@ More info about `RequestContext` is described [here](identity-map.md#request-con
 
 ## Setting up the Commandline Tool
 
-MikroORM ships with a number of command line tools that are very helpful during development, 
-like `SchemaGenerator` and `EntityGenerator`. We can call this command from the NPM binary 
-directory or use `npx`:
+MikroORM ships with a number of command line tools that are very helpful during development, like `SchemaGenerator` and `EntityGenerator`. We can call this command from the NPM binary directory or use `npx`:
 
-> To work with the CLI, first install `@mikro-orm/cli` package locally.
-> The version needs to be aligned with the `@mikro-orm/core` package.
+> To work with the CLI, first install `@mikro-orm/cli` package locally. The version needs to be aligned with the `@mikro-orm/core` package.
 
 ```sh
 # install the CLI package first!
@@ -207,15 +182,11 @@ $ npx mikro-orm
 $ yarn mikro-orm
 ```
 
-For CLI to be able to access our database, we will need to create `mikro-orm.config.js` file that exports our ORM configuration. 
+For CLI to be able to access our database, we will need to create `mikro-orm.config.js` file that exports our ORM configuration.
 
-> ORM configuration file can export the Promise, like:
-> `export default Promise.resolve({...});`.
+> ORM configuration file can export the Promise, like: `export default Promise.resolve({...});`.
 
-TypeScript is also supported, just enable `useTsNode` flag in our
-`package.json` file. There we can also set up array of possible paths to `mikro-orm.config` file,
-as well as use different file name. The `package.json` file can be located in 
-the current working directory, or in one of its parent folders.
+TypeScript is also supported, just enable `useTsNode` flag in our `package.json` file. There we can also set up array of possible paths to `mikro-orm.config` file, as well as use different file name. The `package.json` file can be located in the current working directory, or in one of its parent folders.
 
 We can use these environment variables to override CLI settings:
 
@@ -225,13 +196,9 @@ We can use these environment variables to override CLI settings:
 
 > Do not forget to install `ts-node` when enabling `useTsNode` flag.
 
-> The `useTsNode` is used only when executing the CLI, it is not respected when 
-> running our app.
+> The `useTsNode` is used only when executing the CLI, it is not respected when running our app.
 
-MikroORM will always try to load the first available config file, based on the 
-order in `configPaths`. This means that if we specify the first item as the TS 
-config, but we do not have `ts-node` enabled and installed, it will fail to 
-load it.
+MikroORM will always try to load the first available config file, based on the order in `configPaths`. This means that if we specify the first item as the TS config, but we do not have `ts-node` enabled and installed, it will fail to load it.
 
 ```json title="./package.json"
 {
@@ -255,23 +222,16 @@ export default {
 };
 ```
 
-When we have `useTsNode` disabled and `ts-node` is not already registered and detected,
-TS config files will be ignored.
+When we have `useTsNode` disabled and `ts-node` is not already registered and detected, TS config files will be ignored.
 
-Once we have the CLI config properly set up, we can omit the `MikroORM.init()` options
-parameter, and the CLI config will be automatically used. This process may fail if we
-use bundlers that use tree shaking. As the config file is not referenced anywhere 
-statically, it would not be compiled - for that the best approach is to provide the config
-explicitly:
+Once we have the CLI config properly set up, we can omit the `MikroORM.init()` options parameter, and the CLI config will be automatically used. This process may fail if we use bundlers that use tree shaking. As the config file is not referenced anywhere statically, it would not be compiled - for that the best approach is to provide the config explicitly:
 
 ```ts
 import config from './mikro-orm.config';
 const orm = await MikroORM.init(config);
 ```
 
-> We can also use different names for this file, simply rename it in the `configPaths` array
-> our in `package.json`. We can also use `MIKRO_ORM_CLI` environment variable with the path
-> to override `configPaths` value.
+> We can also use different names for this file, simply rename it in the `configPaths` array our in `package.json`. We can also use `MIKRO_ORM_CLI` environment variable with the path to override `configPaths` value.
 
 Now we should be able to start using the CLI. All available commands are listed in the CLI help:
 
@@ -308,10 +268,8 @@ Examples:
 
 To verify our setup, we can use `mikro-orm debug` command.
 
-> When we have CLI config properly set up, we can omit the `options` parameter
-> when calling `MikroORM.init()`.
+> When we have CLI config properly set up, we can omit the `options` parameter when calling `MikroORM.init()`.
 
-> Note: When importing a dump file we need `multipleStatements: true` in our
-> configuration. Please check the configuration documentation for more information.
+> Note: When importing a dump file we need `multipleStatements: true` in our configuration. Please check the configuration documentation for more information.
 
 Now we can start [defining our entities](defining-entities.md).

--- a/docs/versioned_docs/version-5.4/json-properties.md
+++ b/docs/versioned_docs/version-5.4/json-properties.md
@@ -4,8 +4,7 @@ title: Using JSON properties
 
 ## Defining JSON properties
 
-Each database driver behaves a bit differently when it comes to JSON properties. MikroORM tries to unify the experience via [JsonType](custom-types.md#jsontype). This type will be also used if we
-specify `type: 'json'`.
+Each database driver behaves a bit differently when it comes to JSON properties. MikroORM tries to unify the experience via [JsonType](custom-types.md#jsontype). This type will be also used if we specify `type: 'json'`.
 
 ```ts
 @Entity()
@@ -42,15 +41,14 @@ const b = await em.findOne(Book, {
 Will produce following query (in postgres):
 
 ```sql
-select "e0".* 
-from "book" as "e0" 
-where ("meta"->>'valid')::bool = true 
-  and "meta"->'nested'->>'foo' = '123' 
-  and ("meta"->'nested'->>'bar')::float8 = 321 
-  and ("meta"->'nested'->'deep'->>'baz')::float8 = 59 
-  and ("meta"->'nested'->'deep'->>'qux')::bool = false 
+select "e0".*
+from "book" as "e0"
+where ("meta"->>'valid')::bool = true
+  and "meta"->'nested'->>'foo' = '123'
+  and ("meta"->'nested'->>'bar')::float8 = 321
+  and ("meta"->'nested'->'deep'->>'baz')::float8 = 59
+  and ("meta"->'nested'->'deep'->>'qux')::bool = false
 limit 1
 ```
 
-> All drivers are currently supported (including sqlite and mongo). In postgres we
-> also try to cast the value if we detect number or boolean on the right-hand side.
+> All drivers are currently supported (including sqlite and mongo). In postgres we also try to cast the value if we detect number or boolean on the right-hand side.

--- a/docs/versioned_docs/version-5.4/loading-strategies.md
+++ b/docs/versioned_docs/version-5.4/loading-strategies.md
@@ -5,9 +5,7 @@ sidebar_label: Loading Strategies
 
 > `JOINED` loading strategy is SQL only feature.
 
-Controls how relationships get loaded when querying. By default, populated relationships
-are loaded via the `select-in` strategy. This strategy issues one additional `SELECT`
-statement per relation being loaded.
+Controls how relationships get loaded when querying. By default, populated relationships are loaded via the `select-in` strategy. This strategy issues one additional `SELECT` statement per relation being loaded.
 
 The loading strategy can be specified both at mapping time and when loading entities.
 
@@ -29,8 +27,7 @@ export class Book {
 }
 ```
 
-The following will issue two SQL statements.
-One to load the author and another to load all the books belonging to that author:
+The following will issue two SQL statements. One to load the author and another to load all the books belonging to that author:
 
 ```ts
 const author = await orm.em.findOne(Author, 1, { populate: ['books'] });
@@ -58,8 +55,7 @@ The following will issue **one** SQL statement:
 const author = await orm.em.findOne(Author, 1, { populate: ['books'] });
 ```
 
-You can also specify the load strategy as needed. This will override whatever strategy is declared in the mapping.
-This also works for nested populates:
+You can also specify the load strategy as needed. This will override whatever strategy is declared in the mapping. This also works for nested populates:
 
 ```ts
 const author = await orm.em.findOne(Author, 1, {
@@ -78,37 +74,27 @@ MikroORM.init({
 });
 ```
 
-This value will be used as the default, specifying the loading strategy on 
-property level has precedence, as well as specifying it in the `FindOptions`.
+This value will be used as the default, specifying the loading strategy on property level has precedence, as well as specifying it in the `FindOptions`.
 
 ## Population where condition
 
 > This applies only to SELECT_IN strategy, as JOINED strategy implies the inference.
 
-In v4, when we used populate hints in `em.find()` and similar methods, the
-query for our entity would be analysed and parts of it extracted and used for
-the population. Following example would find all authors that have books with
-given IDs, and populate their books collection, again using this PK condition,
-resulting in only such books being in those collections.
+In v4, when we used populate hints in `em.find()` and similar methods, the query for our entity would be analysed and parts of it extracted and used for the population. Following example would find all authors that have books with given IDs, and populate their books collection, again using this PK condition, resulting in only such books being in those collections.
 
 ```ts
 // this would end up with `Author.books` collections having only books of PK 1, 2, 3
 const a = await em.find(Author, { books: [1, 2, 3] }, { populate: ['books'] });
 ```
 
-Following this example, if we wanted to load all books, we would need a separate
-`em.populate()` call:
+Following this example, if we wanted to load all books, we would need a separate `em.populate()` call:
 
 ```ts
 const a = await em.find(Author, { books: [1, 2, 3] });
 await em.populate(a, ['books']);
 ```
 
-This behaviour changed and is now configurable both globally and locally, via
-`populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and
-`PopulateHint.INFER`, the former being the default in v5, the latter being the
-default behaviour in v4. Locally (via `FindOptions`) we can also specify custom
-where condition that will be passed to `em.populate()` call.
+This behaviour changed and is now configurable both globally and locally, via `populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and `PopulateHint.INFER`, the former being the default in v5, the latter being the default behaviour in v4. Locally (via `FindOptions`) we can also specify custom where condition that will be passed to `em.populate()` call.
 
 ```ts
 await em.find(Author, { ... }, {

--- a/docs/versioned_docs/version-5.4/logging.md
+++ b/docs/versioned_docs/version-5.4/logging.md
@@ -41,8 +41,7 @@ return MikroORM.init({
 });
 ```
 
-If we want to have more control over logging, we can use `loggerFactory`
-and use our own implementation of the `Logger` interface:
+If we want to have more control over logging, we can use `loggerFactory` and use our own implementation of the `Logger` interface:
 
 ```ts
 import { Logger, LoggerOptions, MikroORM, Configuration } from '@mikro-orm/core';
@@ -109,8 +108,7 @@ If you provide `query-params` then you must also provide `query` in order for it
 
 ## Highlighters
 
-Previously Highlight.js was used to highlight various things in the CLI, like SQL and mongo queries, or migrations or entities generated via CLI. While the library worked fine, it was causing
-performance issues mainly for those bundling via webpack and using lambdas, as the library was huge.
+Previously Highlight.js was used to highlight various things in the CLI, like SQL and mongo queries, or migrations or entities generated via CLI. While the library worked fine, it was causing performance issues mainly for those bundling via webpack and using lambdas, as the library was huge.
 
 Since v4, highlighting is disabled by default, and there are 2 highlighters you can optionally use (you need to install them first).
 
@@ -123,5 +121,4 @@ MikroORM.init({
 });
 ```
 
-For MongoDB you can use `MongoHighlighter` from `@mikro-orm/mongo-highlighter`
-package.
+For MongoDB you can use `MongoHighlighter` from `@mikro-orm/mongo-highlighter` package.

--- a/docs/versioned_docs/version-5.4/metadata-cache.md
+++ b/docs/versioned_docs/version-5.4/metadata-cache.md
@@ -2,32 +2,19 @@
 title: Metadata Cache
 ---
 
-> In v4 and later versions, we need to explicitly install `@mikro-orm/reflection`
-> to use `TsMorphMetadataProvider`.
+> In v4 and later versions, we need to explicitly install `@mikro-orm/reflection` to use `TsMorphMetadataProvider`.
 
-MikroORM allows different ways to [obtain entity metadata](metadata-providers.md).
-One way is to use [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. This 
-process can be performance heavy and time-consuming. For this reason, metadata
-cache is automatically enabled for `TsMorphMetadataProvider`. It can be optionally
-enabled for the other metadata providers, but it should not be needed.
+MikroORM allows different ways to [obtain entity metadata](metadata-providers.md). One way is to use [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. This process can be performance heavy and time-consuming. For this reason, metadata cache is automatically enabled for `TsMorphMetadataProvider`. It can be optionally enabled for the other metadata providers, but it should not be needed.
 
-After the discovery process ends, all metadata will be cached. By default, 
-`FileCacheAdapter` will be used to store the cache inside `./temp` folder to JSON
-files.
+After the discovery process ends, all metadata will be cached. By default, `FileCacheAdapter` will be used to store the cache inside `./temp` folder to JSON files.
 
-If we use folder based discovery, cache will be dependent on environment - if we 
-run via ts-node, the cache will be generated for TS files. To generate production
-cache, we can use the CLI command `mikro-orm cache:generate`.
+If we use folder based discovery, cache will be dependent on environment - if we run via ts-node, the cache will be generated for TS files. To generate production cache, we can use the CLI command `mikro-orm cache:generate`.
 
 ## Automatic Invalidation
 
-Entity metadata are cached together with modified time of the source file, and every time
-the cache is requested, it first checks if the cache is not invalid. This way we can forget 
-about the caching mechanism most of the time.
+Entity metadata are cached together with modified time of the source file, and every time the cache is requested, it first checks if the cache is not invalid. This way we can forget about the caching mechanism most of the time.
 
-One case where we can end up needing to wipe the cache manually is when we work withing a 
-git branch where contents of entities folder differs. 
+One case where we can end up needing to wipe the cache manually is when we work withing a git branch where contents of entities folder differs.
 
 ## Disabling Metadata Cache
 
@@ -65,8 +52,7 @@ await MikroORM.init({
 
 ## Providing Custom Cache Adapter
 
-You can also implement your own cache adapter, for example to store the cache in redis. 
-To do so, just implement simple `CacheAdapter` interface:
+You can also implement your own cache adapter, for example to store the cache in redis. To do so, just implement simple `CacheAdapter` interface:
 
 ```ts
 export interface CacheAdapter {

--- a/docs/versioned_docs/version-5.4/metadata-providers.md
+++ b/docs/versioned_docs/version-5.4/metadata-providers.md
@@ -2,8 +2,7 @@
 title: Metadata Providers
 ---
 
-As part of entity discovery process, MikroORM uses so called `MetadataProvider` to get necessary
-type information about our entities' properties.
+As part of entity discovery process, MikroORM uses so called `MetadataProvider` to get necessary type information about our entities' properties.
 
 > We can also implement custom metadata provider by extending abstract `MetadataProvider` class.
 
@@ -11,9 +10,7 @@ There are 3 built-in metadata providers we can use:
 
 ## TsMorphMetadataProvider
 
-With `TsMorphMetadataProvider` MikroORM will use [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. Thanks to this, 
-defining the type is enough for runtime validation.
+With `TsMorphMetadataProvider` MikroORM will use [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. Thanks to this, defining the type is enough for runtime validation.
 
 To use it, first install the `@mikro-orm/reflection` package.
 
@@ -26,18 +23,11 @@ await MikroORM.init({
 });
 ```
 
-If we use folder-based discovery, we should specify paths to
-the compiled entities via `entities` as well as paths to the TS source files of
-those entities via `entitiesTs`. When we run the ORM via `ts-node`, the latter
-will be used automatically, or if we explicitly pass `tsNode: true` in the config. Note that `tsNode: true` should not be part of production config.
+If we use folder-based discovery, we should specify paths to the compiled entities via `entities` as well as paths to the TS source files of those entities via `entitiesTs`. When we run the ORM via `ts-node`, the latter will be used automatically, or if we explicitly pass `tsNode: true` in the config. Note that `tsNode: true` should not be part of production config.
 
-> When running via `node`, `.d.ts` files are used to obtain the type, so we 
-> need to ship them in the production build. TS source files are no longer 
-> needed (since v4). Be sure to enable `compilerOptions.declaration` in our
-> `tsconfig.json`.
+> When running via `node`, `.d.ts` files are used to obtain the type, so we need to ship them in the production build. TS source files are no longer needed (since v4). Be sure to enable `compilerOptions.declaration` in our `tsconfig.json`.
 
-After the discovery process ends, all [metadata will be cached](metadata-cache.md). By default, 
-`FileCacheAdapter` will be used to store the cache inside `./temp` folder in JSON files. 
+After the discovery process ends, all [metadata will be cached](metadata-cache.md). By default, `FileCacheAdapter` will be used to store the cache inside `./temp` folder in JSON files.
 
 > We can generate production cache via CLI command `mikro-orm cache:generate`.
 
@@ -45,11 +35,9 @@ After the discovery process ends, all [metadata will be cached](metadata-cache.m
 
 ## ReflectMetadataProvider
 
-`ReflectMetadataProvider` uses `reflect-metadata` module to read the type from decorator 
-metadata exported by TypeScript compiler. 
+`ReflectMetadataProvider` uses `reflect-metadata` module to read the type from decorator metadata exported by TypeScript compiler.
 
-We will need to install `reflect-metadata` module and import at the top of our app's 
-bootstrap script (e.g. `main.ts` or `app.ts`). 
+We will need to install `reflect-metadata` module and import at the top of our app's bootstrap script (e.g. `main.ts` or `app.ts`).
 
 ```ts
 import 'reflect-metadata';
@@ -57,7 +45,7 @@ import 'reflect-metadata';
 
 Next step is to enable `emitDecoratorMetadata` flag in our `tsconfig.json`.
 
-> As this approach does not have performance impact, metadata caching is not really necessary. 
+> As this approach does not have performance impact, metadata caching is not really necessary.
 
 ```ts
 await MikroORM.init({
@@ -102,8 +90,7 @@ prop?: string;
 
 #### Enums
 
-By default, enum is considered as numeric type. For string enums, we need to explicitly 
-provide one of:
+By default, enum is considered as numeric type. For string enums, we need to explicitly provide one of:
 
 - reference to the enum (which will force us to define the enum before defining the entity)
   ```ts
@@ -123,31 +110,24 @@ provide one of:
 
 #### Circular dependencies
 
-Reading type of referenced entity in `@ManyToOne` and `@OneToOne` properties fails if there is 
-circular dependency. We will need to explicitly define the type in the decorator (preferably 
-via `entity: () => ...` callback).
+Reading type of referenced entity in `@ManyToOne` and `@OneToOne` properties fails if there is circular dependency. We will need to explicitly define the type in the decorator (preferably via `entity: () => ...` callback).
 
 ```ts
 @ManyToOne({ entity: () => Author })
 author: Author;
-``` 
+```
 
-> There can be recursion issues when we define multiple entities (with circular dependencies 
-> between each other) in single file. In that case, we might want to provide the type via decorator's
-> `type` or `entity` attributes and set the TS property type to something else (like `any` or `object`).
+> There can be recursion issues when we define multiple entities (with circular dependencies between each other) in single file. In that case, we might want to provide the type via decorator's `type` or `entity` attributes and set the TS property type to something else (like `any` or `object`).
 
 #### Additional typings might be required
 
-We might have to install additional typings, one example is use of `ObjectId` in MongoDB, 
-which requires `@types/mongodb` to be installed. 
+We might have to install additional typings, one example is use of `ObjectId` in MongoDB, which requires `@types/mongodb` to be installed.
 
 ## JavaScriptMetadataProvider
 
 > `JavaScriptMetadataProvider` is deprecated, [use `EntitySchema` instead](entity-schema.md).
 
-This provider should be used only if we are not using TypeScript at all and therefore we do 
-not use decorators to annotate our properties. It will require us to specify the whole schema 
-manually. 
+This provider should be used only if we are not using TypeScript at all and therefore we do not use decorators to annotate our properties. It will require us to specify the whole schema manually.
 
 ```ts
 await MikroORM.init({

--- a/docs/versioned_docs/version-5.4/migrations.md
+++ b/docs/versioned_docs/version-5.4/migrations.md
@@ -8,8 +8,7 @@ MikroORM has integrated support for migrations via [umzug](https://github.com/se
 
 > Since v5, migrations are stored without extension.
 
-By default, each migration will be all executed inside a transaction, and all of them will 
-be wrapped in one master transaction, so if one of them fails, everything will be rolled back. 
+By default, each migration will be all executed inside a transaction, and all of them will be wrapped in one master transaction, so if one of them fails, everything will be rolled back.
 
 ## Migration class
 
@@ -27,41 +26,31 @@ export class Migration20191019195930 extends Migration {
 }
 ```
 
-To support undoing those changed, we can implement the `down` method, which throws an error by default. 
+To support undoing those changed, we can implement the `down` method, which throws an error by default.
 
-Migrations are by default wrapped in a transaction. You can override this behaviour on 
-per migration basis by implementing the `isTransactional(): boolean` method.
+Migrations are by default wrapped in a transaction. You can override this behaviour on per migration basis by implementing the `isTransactional(): boolean` method.
 
 `Configuration` object and driver instance are available in the `Migration` class context.
 
-You can execute queries in the migration via `Migration.execute()` method, which 
-will run queries in the same transaction as the rest of the migration. The 
-`Migration.addSql()` method also accepts instances of knex. Knex instance can be 
-accessed via `Migration.getKnex()`; 
+You can execute queries in the migration via `Migration.execute()` method, which will run queries in the same transaction as the rest of the migration. The `Migration.addSql()` method also accepts instances of knex. Knex instance can be accessed via `Migration.getKnex()`;
 
 ## Initial migration
 
 > This is optional and only needed for the specific use case, when both entities and schema already exist.
 
-If we want to start using migrations, and we already have the schema generated, 
-we can do so by creating so called initial migration:
+If we want to start using migrations, and we already have the schema generated, we can do so by creating so called initial migration:
 
-> Initial migration can be created only if there are no migrations previously
-> generated or executed. 
+> Initial migration can be created only if there are no migrations previously generated or executed.
 
 ```sh
 npx mikro-orm migration:create --initial
 ```
 
-This will create the initial migration, containing the schema dump from 
-`schema:create` command. The migration will be automatically marked as executed. 
+This will create the initial migration, containing the schema dump from `schema:create` command. The migration will be automatically marked as executed.
 
 ## Snapshots
 
-Creating new migration will automatically save the target schema snapshot into 
-migrations folder. This snapshot will be then used if we try to create new migration,
-instead of using current database schema. This means that if we try to create new 
-migration before we run the pending ones, we still get the right schema diff.
+Creating new migration will automatically save the target schema snapshot into migrations folder. This snapshot will be then used if we try to create new migration, instead of using current database schema. This means that if we try to create new migration before we run the pending ones, we still get the right schema diff.
 
 > Snapshots should be versioned just like the regular migration files.
 
@@ -71,8 +60,7 @@ Snapshotting can be disabled via `migrations.snapshot: false` in the ORM config.
 
 > Since v5, `umzug` 3.0 is used, and `pattern` option has been replaced with `glob`.
 
-> `migrations.path` and `migrations.pathTs` works the same way as `entities` and 
-> `entitiesTs` in entity discovery.
+> `migrations.path` and `migrations.pathTs` works the same way as `entities` and `entitiesTs` in entity discovery.
 
 ```ts
 await MikroORM.init({
@@ -96,9 +84,7 @@ await MikroORM.init({
 
 ## Running migrations in production
 
-In production environment we might want to use compiled migration files. Since v5,
-this should work almost out of box, all we need to do is to configure the migration
-path accordingly:
+In production environment we might want to use compiled migration files. Since v5, this should work almost out of box, all we need to do is to configure the migration path accordingly:
 
 ```ts
 import { MikroORM, Utils } from '@mikro-orm/core';
@@ -116,15 +102,11 @@ await MikroORM.init({
 });
 ```
 
-This should allow using CLI to generate TS migration files (as in CLI we probably
-have TS support enabled), while using compiled JS files in production, where ts-node
-is not registered.
+This should allow using CLI to generate TS migration files (as in CLI we probably have TS support enabled), while using compiled JS files in production, where ts-node is not registered.
 
 ## Using custom `MigrationGenerator`
 
-When we generate new migrations, `MigrationGenerator` class is responsible for 
-generating the file contents. We can provide our own implementation to do things 
-like formatting the SQL statement. 
+When we generate new migrations, `MigrationGenerator` class is responsible for generating the file contents. We can provide our own implementation to do things like formatting the SQL statement.
 
 ```ts
 import { TSMigrationGenerator } from '@mikro-orm/migrations';
@@ -157,7 +139,7 @@ await MikroORM.init({
 
 ## Using via CLI
 
-You can use it via CLI: 
+You can use it via CLI:
 
 ```sh
 npx mikro-orm migration:create   # Create new migration with current schema diff
@@ -168,11 +150,9 @@ npx mikro-orm migration:pending  # List all pending migrations
 npx mikro-orm migration:fresh    # Drop the database and migrate up to the latest version
 ```
 
-> To create blank migration file, we can use 
-> `npx mikro-orm migration:create --blank`.
+> To create blank migration file, we can use `npx mikro-orm migration:create --blank`.
 
-For `migration:up` and `migration:down` commands we can specify `--from` (`-f`), `--to` (`-t`) 
-and `--only` (`-o`) options to run only a subset of migrations:
+For `migration:up` and `migration:down` commands we can specify `--from` (`-f`), `--to` (`-t`) and `--only` (`-o`) options to run only a subset of migrations:
 
 ```sh
 npx mikro-orm migration:up --from 2019101911 --to 2019102117  # the same as above
@@ -180,14 +160,15 @@ npx mikro-orm migration:up --only 2019101923                  # apply a single m
 npx mikro-orm migration:down --to 0                           # migrate down all migrations
 ```
 
-> To run TS migration files, we will need to [enable `useTsNode` flag](installation.md#setting-up-the-commandline-tool)
-> in our `package.json`.
+> To run TS migration files, we will need to [enable `useTsNode` flag](installation.md#setting-up-the-commandline-tool) in our `package.json`.
 
 For the `migration:fresh` command we can specify `--seed` to seed the database after migrating.
+
 ```shell
 npx mikro-orm migration:fresh --seed              # seed the database with the default database seeder
 npx mikro-orm migration:fresh --seed=UsersSeeder  # seed the database with the UsersSeeder
 ```
+
 > You can specify the default database seeder in the orm config with the key `config.seeder.defaultSeeder`
 
 ## Using the Migrator programmatically
@@ -235,8 +216,7 @@ await orm.em.transactional(async em => {
 
 ## Importing migrations statically
 
-If we do not want to dynamically import a folder (e.g. when bundling our code with webpack) we can import migrations
-directly.
+If we do not want to dynamically import a folder (e.g. when bundling our code with webpack) we can import migrations directly.
 
 ```ts
 import { MikroORM } from '@mikro-orm/core';
@@ -254,8 +234,7 @@ await MikroORM.init({
 });
 ```
 
-With the help of [webpack's context module api](https://webpack.js.org/guides/dependency-management/#context-module-api)
-we can dynamically import the migrations making it possible to import all files in a folder.
+With the help of [webpack's context module api](https://webpack.js.org/guides/dependency-management/#context-module-api) we can dynamically import the migrations making it possible to import all files in a folder.
 
 ```ts
 import { MikroORM } from '@mikro-orm/core';
@@ -311,9 +290,9 @@ import { Migration } from '@mikro-orm/migrations-mongodb';
 export class MigrationTest1 extends Migration {
 
   async up(): Promise<void> {
-    // use `this.getCollection()` to work with the mongodb collection directly 
+    // use `this.getCollection()` to work with the mongodb collection directly
     await this.getCollection('Book').updateMany({}, { $set: { updatedAt: new Date() } }, { session: this.ctx });
-    
+
     // or use `this.driver` to work with the `MongoDriver` API instead
     await this.driver.nativeDelete('Book', { foo: true }, { ctx: this.ctx });
   }
@@ -325,8 +304,7 @@ export class MigrationTest1 extends Migration {
 
 ### MySQL
 
-There is no way to rollback DDL changes in MySQL. An implicit commit is forced for those 
-queries automatically, so transactions are not working as expected. 
+There is no way to rollback DDL changes in MySQL. An implicit commit is forced for those queries automatically, so transactions are not working as expected.
 
 - https://github.com/mikro-orm/mikro-orm/issues/217
 - https://dev.mysql.com/doc/refman/5.7/en/implicit-commit.html

--- a/docs/versioned_docs/version-5.4/multiple-schemas.md
+++ b/docs/versioned_docs/version-5.4/multiple-schemas.md
@@ -2,14 +2,11 @@
 title: Using Multiple Schemas
 ---
 
-In MySQL and PostgreSQL it is possible to define your entities in multiple schemas. In MySQL 
-terminology, it is called database, but from an implementation point of view, it is a schema. 
+In MySQL and PostgreSQL it is possible to define your entities in multiple schemas. In MySQL terminology, it is called database, but from an implementation point of view, it is a schema.
 
-> To use multiple schemas, your connection needs to have access to all of them (multiple 
-> connections are not supported in a single MikroORM instance).
+> To use multiple schemas, your connection needs to have access to all of them (multiple connections are not supported in a single MikroORM instance).
 
-All you need to do is simply define the schema name via `schema` options, or 
-table name including schema name in `tableName` option:
+All you need to do is simply define the schema name via `schema` options, or table name including schema name in `tableName` option:
 
 ```ts
 @Entity({ schema: 'first_schema' })
@@ -20,12 +17,9 @@ export class Foo { ... }
 export class Bar { ... }
 ```
 
-Then use those entities as usual. Resulting SQL queries will use this `tableName` value as a 
-table name so as long as your connection has access to given schema, everything should work 
-as expected.
+Then use those entities as usual. Resulting SQL queries will use this `tableName` value as a table name so as long as your connection has access to given schema, everything should work as expected.
 
-You can also query for entity in specific schema via `EntityManager`, `EntityRepository` or 
-`QueryBuilder`:
+You can also query for entity in specific schema via `EntityManager`, `EntityRepository` or `QueryBuilder`:
 
 ```ts
 const user = await em.findOne(User, { ... }, { schema: 'client-123' });
@@ -40,8 +34,7 @@ await qb.insert({ email: 'foo@bar.com' }).withSchema('client-123');
 
 ## Wildcard Schema
 
-Since v5, MikroORM also supports defining entities that can exist in multiple
-schemas. To do that, we just specify wildcard schema:
+Since v5, MikroORM also supports defining entities that can exist in multiple schemas. To do that, we just specify wildcard schema:
 
 ```ts
 @Entity({ schema: '*' })
@@ -62,19 +55,10 @@ export class Book {
 }
 ```
 
-Entities like this will be by default ignored when using `SchemaGenerator`, 
-as we need to specify which schema to use. For that we need to use the `schema`
-option of the `createSchema/updateSchema/dropSchema` methods or the `--schema` 
-CLI parameter.
+Entities like this will be by default ignored when using `SchemaGenerator`, as we need to specify which schema to use. For that we need to use the `schema` option of the `createSchema/updateSchema/dropSchema` methods or the `--schema` CLI parameter.
 
-On runtime, the wildcard schema will be replaced with either `FindOptions.schema`,
-or with the `schema` option from the ORM config.
+On runtime, the wildcard schema will be replaced with either `FindOptions.schema`, or with the `schema` option from the ORM config.
 
 ### Note about migrations
 
-Currently, this is not supported via migrations, they will always ignore
-wildcard schema entities, and `SchemaGenerator` needs to be used explicitly.
-Given the dynamic nature of such entities, it makes sense to only sync the 
-schema dynamically, e.g. in an API endpoint. We could still use the ORM 
-migrations, but we need to add the dynamic schema queries manually to migration
-files. It makes sense to use the `safe` mode for such queries.
+Currently, this is not supported via migrations, they will always ignore wildcard schema entities, and `SchemaGenerator` needs to be used explicitly. Given the dynamic nature of such entities, it makes sense to only sync the schema dynamically, e.g. in an API endpoint. We could still use the ORM migrations, but we need to add the dynamic schema queries manually to migration files. It makes sense to use the `safe` mode for such queries.

--- a/docs/versioned_docs/version-5.4/naming-strategy.md
+++ b/docs/versioned_docs/version-5.4/naming-strategy.md
@@ -2,15 +2,13 @@
 title: Naming Strategy
 ---
 
-When mapping our entities to database tables and columns, their names will be defined by naming 
-strategy. There are 3 basic naming strategies we can choose from:
+When mapping our entities to database tables and columns, their names will be defined by naming strategy. There are 3 basic naming strategies we can choose from:
 
 - `UnderscoreNamingStrategy` - default of all SQL drivers
 - `MongoNamingStrategy` - default of `MongoDriver`
 - `EntityCaseNamingStrategy` - uses unchanged entity and property names
 
-You can override this when initializing ORM. You can also provide our own naming strategy, just 
-implement `NamingStrategy` interface and provide our implementation when bootstrapping ORM:
+You can override this when initializing ORM. You can also provide our own naming strategy, just implement `NamingStrategy` interface and provide our implementation when bootstrapping ORM:
 
 ```ts
 class MyCustomNamingStrategy implements NamingStrategy {
@@ -24,20 +22,17 @@ const orm = await MikroORM.init({
 });
 ```
 
-> You can also extend `AbstractNamingStrategy` which implements one method for we - `getClassName()`
-> that is used to map entity file name to class name.
+> You can also extend `AbstractNamingStrategy` which implements one method for we - `getClassName()` that is used to map entity file name to class name.
 
 ## Naming Strategy in mongo driver
 
-`MongoNamingStrategy` will simply use all field names as they are defined. Collection names will
-be translated into lower-cased dashed form:
+`MongoNamingStrategy` will simply use all field names as they are defined. Collection names will be translated into lower-cased dashed form:
 
 `MyCoolEntity` will be translated into `my-cool-entity` collection name.
 
 ## Naming Strategy in SQL drivers
 
-`MySqlDriver` defaults to `UnderscoreNamingStrategy`, which means our all our database tables and
-columns will be lower-cased and words divided by underscored:
+`MySqlDriver` defaults to `UnderscoreNamingStrategy`, which means our all our database tables and columns will be lower-cased and words divided by underscored:
 
 ```sql
 CREATE TABLE `author` (
@@ -87,7 +82,7 @@ Return a join column name for a property.
 
 #### `NamingStrategy.joinTableName(sourceEntity: string, targetEntity: string, propertyName: string): string`
 
-Return a join table name. This is used as default value for `pivotTable`. 
+Return a join table name. This is used as default value for `pivotTable`.
 
 ---
 
@@ -99,15 +94,12 @@ Return the foreign key column name for the given parameters.
 
 #### `NamingStrategy.indexName(tableName: string, columns: string[], type: 'primary' | 'foreign' | 'unique' | 'index' | 'sequence'): string`
 
-Returns key/constraint name for given type. Some drivers might not support all 
-the types (e.g. mysql and sqlite enforce the PK name).
+Returns key/constraint name for given type. Some drivers might not support all the types (e.g. mysql and sqlite enforce the PK name).
 
 ---
 
 #### `NamingStrategy.aliasName(entityName: string, index: number): string`
 
-Returns alias name for given entity. The alias needs to be unique across the 
-query, which is by default ensured via appended index parameter. It is optional 
-to use it as long as we ensure it will be unique.
+Returns alias name for given entity. The alias needs to be unique across the query, which is by default ensured via appended index parameter. It is optional to use it as long as we ensure it will be unique.
 
 ---

--- a/docs/versioned_docs/version-5.4/nested-populate.md
+++ b/docs/versioned_docs/version-5.4/nested-populate.md
@@ -2,15 +2,12 @@
 title: Smart Nested Populate
 ---
 
-`MikroORM` is capable of loading large nested structures while maintaining good 
-performance, querying each database table only once. Imagine you have this nested 
-structure:
+`MikroORM` is capable of loading large nested structures while maintaining good performance, querying each database table only once. Imagine you have this nested structure:
 
 - `Book` has one `Publisher` (M:1), one `Author` (M:1) and many `BookTag`s (M:N)
 - `Publisher` has many `Test`s (M:N)
 
-When you use nested populate while querying all `BookTag`s, this is what happens in
-the background:
+When you use nested populate while querying all `BookTag`s, this is what happens in the background:
 
 ```ts
 const tags = await em.findAll(BookTag, { populate: ['books.publisher.tests', 'books.author'] });
@@ -64,7 +61,7 @@ To populate existing entities, you can use `em.populate()`.
 const authors = await em.createQueryBuilder(Author).select('*').getResult();
 await em.populate(authors, ['books.tags']);
 
-// now your Author entities will have `books` collections populated, 
+// now your Author entities will have `books` collections populated,
 // as well as they will have their `tags` collections populated.
 console.log(authors[0].books[0].tags[0]); // initialized BookTag
 ```

--- a/docs/versioned_docs/version-5.4/propagation.md
+++ b/docs/versioned_docs/version-5.4/propagation.md
@@ -2,8 +2,7 @@
 title: Propagation
 ---
 
-By default, MikroORM will propagate all changes made to one side of bi-directional relations to the other side, keeping them in sync. This works for all relations, including M:1 and 1:1. As part of
-the discovery process, all M:1 and 1:1 properties are re-defined as getter/setter.
+By default, MikroORM will propagate all changes made to one side of bi-directional relations to the other side, keeping them in sync. This works for all relations, including M:1 and 1:1. As part of the discovery process, all M:1 and 1:1 properties are re-defined as getter/setter.
 
 ```ts
 const author = new Author(...);
@@ -39,11 +38,10 @@ console.log(tag.books.contains(book)); // true
 
 tag.books.add(book);
 console.log(book.tags.contains(tag)); // true
-``` 
+```
 
 > Collections on both sides have to be initialized, otherwise propagation won't work.
 
-> Although this propagation works also for M:N inverse side, you should always use owning
-> side to manipulate the collection.
+> Although this propagation works also for M:N inverse side, you should always use owning side to manipulate the collection.
 
 Same applies for `Collection.remove()`.

--- a/docs/versioned_docs/version-5.4/property-validation.md
+++ b/docs/versioned_docs/version-5.4/property-validation.md
@@ -63,14 +63,9 @@ When we define our entities, we need to be careful about optional properties. Wi
 
 ## Strict property type validation
 
-> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`.
-> It has performance implications and usually should not be needed, as long as
-> you don't modify your entities via `Object.assign()`.
+> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`. It has performance implications and usually should not be needed, as long as you don't modify your entities via `Object.assign()`.
 
-`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong 
-data types for you automatically. If automatic conversion fails, it will throw an error. You can 
-enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered 
-when persisting the entity. 
+`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong data types for you automatically. If automatic conversion fails, it will throw an error. You can enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered when persisting the entity.
 
 ```ts
 // number instead of string will throw

--- a/docs/versioned_docs/version-5.4/query-builder.md
+++ b/docs/versioned_docs/version-5.4/query-builder.md
@@ -2,12 +2,12 @@
 title: Using Query Builder
 ---
 
-:::info Since v4, we need to make sure we are working with correctly typed `EntityManager`
-or `EntityRepository` to have access to `createQueryBuilder()` method.
+:::info Since v4, we need to make sure we are working with correctly typed `EntityManager` or `EntityRepository` to have access to `createQueryBuilder()` method.
 
 ```ts
 import { EntityManager, EntityRepository } from '@mikro-orm/mysql'; // or any other driver package
 ```
+
 :::
 
 When you need to execute some SQL query without all the ORM stuff involved, you can either compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
@@ -39,8 +39,7 @@ const res2 = await qb.execute('get'); // returns single object
 const res3 = await qb.execute('run'); // returns object like `{ affectedRows: number, insertId: number, row: any }`
 ```
 
-Second argument can be used to disable mapping of database columns to property names (which is enabled by default). In following example, `Book` entity has `createdAt` property defined with implicit
-underscored field name `created_at`:
+Second argument can be used to disable mapping of database columns to property names (which is enabled by default). In following example, `Book` entity has `createdAt` property defined with implicit underscored field name `created_at`:
 
 ```ts
 const res4 = await em.createQueryBuilder(Book).select('*').execute('get', true);
@@ -49,8 +48,7 @@ const res5 = await em.createQueryBuilder(Book).select('*').execute('get', false)
 console.log(res5); // `created_at` will be defined, while `createdAt` will be missing
 ```
 
-To get entity instances from the QueryBuilder result, you can use `getResult()` and `getSingleResult()`
-methods:
+To get entity instances from the QueryBuilder result, you can use `getResult()` and `getSingleResult()` methods:
 
 ```ts
 const book = await em.createQueryBuilder(Book).select('*').where({ id: 1 }).getSingleResult();
@@ -63,21 +61,20 @@ console.log(books[0] instanceof Book); // true
 
 ## Awaiting the QueryBuilder
 
-Since v5 we can await the `QueryBuilder` instance, which will automatically execute the QB and return appropriate response. The QB instance is now typed based on usage
-of `select/insert/update/delete/truncate` methods to one of:
+Since v5 we can await the `QueryBuilder` instance, which will automatically execute the QB and return appropriate response. The QB instance is now typed based on usage of `select/insert/update/delete/truncate` methods to one of:
 
 - `SelectQueryBuilder`
-    - awaiting yields array of entities (as `qb.getResultList()`)
+  - awaiting yields array of entities (as `qb.getResultList()`)
 - `CountQueryBuilder`
-    - awaiting yields number (as `qb.getCount()`)
+  - awaiting yields number (as `qb.getCount()`)
 - `InsertQueryBuilder` (extends `RunQueryBuilder`)
-    - awaiting yields `QueryResult`
+  - awaiting yields `QueryResult`
 - `UpdateQueryBuilder` (extends `RunQueryBuilder`)
-    - awaiting yields `QueryResult`
+  - awaiting yields `QueryResult`
 - `DeleteQueryBuilder` (extends `RunQueryBuilder`)
-    - awaiting yields `QueryResult`
+  - awaiting yields `QueryResult`
 - `TruncateQueryBuilder` (extends `RunQueryBuilder`)
-    - awaiting yields `QueryResult`
+  - awaiting yields `QueryResult`
 
 ```ts
 const res1 = await em.qb(Publisher).insert({
@@ -112,9 +109,7 @@ expect(res5.affectedRows > 0).toBe(true); // test the type
 
 ## Mapping Raw Results to Entities
 
-Another way to create entity from raw results (that are not necessarily mapped to entity properties)
-is to use `map()` method of `EntityManager`, that is basically a shortcut for mapping results via `IDatabaseDriver.mapResult()` (which converts field names to property names - e.g. `created_at`
-to `createdAt`) and `merge()` which converts the data to entity instance and makes it managed.
+Another way to create entity from raw results (that are not necessarily mapped to entity properties) is to use `map()` method of `EntityManager`, that is basically a shortcut for mapping results via `IDatabaseDriver.mapResult()` (which converts field names to property names - e.g. `created_at` to `createdAt`) and `merge()` which converts the data to entity instance and makes it managed.
 
 This method comes handy when you want to use 3rd party query builders, where the result is not mapped to entity properties automatically:
 
@@ -151,12 +146,12 @@ qb.select('*')
   .orderBy({ books: { tags: { createdBy: QueryOrder.DESC } } });
 
 console.log(qb.getQuery());
-// select `e0`.* 
-// from `author` as `e0` 
-// left join `book2` as `e1` on `e0`.`id` = `e1`.`author_id` 
-// left join `book2_to_book_tag2` as `e3` on `e1`.`uuid_pk` = `e3`.`book2_uuid_pk` 
-// left join `book_tag2` as `e2` on `e3`.`book_tag2_id` = `e2`.`id` 
-// where `e2`.`name` = ? 
+// select `e0`.*
+// from `author` as `e0`
+// left join `book2` as `e1` on `e0`.`id` = `e1`.`author_id`
+// left join `book2_to_book_tag2` as `e3` on `e1`.`uuid_pk` = `e3`.`book2_uuid_pk`
+// left join `book_tag2` as `e2` on `e3`.`book_tag2_id` = `e2`.`id`
+// where `e2`.`name` = ?
 // order by `e1`.`tags` asc
 ```
 
@@ -183,8 +178,7 @@ console.log(qb.getQuery());
 
 ## Mapping joined results
 
-To select multiple entities and map them from `QueryBuilder`, we can use
-`joinAndSelect` or `leftJoinAndSelect` method:
+To select multiple entities and map them from `QueryBuilder`, we can use `joinAndSelect` or `leftJoinAndSelect` method:
 
 ```ts
 // `res` will contain array of authors, with books and their tags populated
@@ -215,7 +209,7 @@ const users = em.createQueryBuilder(User)
 This will produce following query:
 
 ```sql
-select `e0`.* 
+select `e0`.*
 from `user` as `e0`
 where lower(email) = 'foo@bar.baz'
 order by (point(loc_latitude, loc_longitude) <@> point(0, 0)) asc
@@ -334,8 +328,7 @@ console.log(qb4.getQuery());
 
 When you want to filter by sub-query on the left-hand side of a predicate, you will need to register it first via `qb.withSubquery()`:
 
-> The dynamic property (`booksTotal`) needs to be defined at the entity level (as `persist: false`).
-> You always need to use prefix in the `qb.withSchema()` (so `a.booksTotal`).
+> The dynamic property (`booksTotal`) needs to be defined at the entity level (as `persist: false`). You always need to use prefix in the `qb.withSchema()` (so `a.booksTotal`).
 
 ```ts
 const knex = em.getKnex();
@@ -383,14 +376,14 @@ console.log(qb.getQuery()); // for MySQL
 
 Available lock modes:
 
-| Mode | Postgres | MySQL |
-|------|----------|-------|
-| `LockMode.PESSIMISTIC_READ` | `for share` | `lock in share mode` |
-| `LockMode.PESSIMISTIC_WRITE` | `for update` | `for update` |
-| `LockMode.PESSIMISTIC_PARTIAL_WRITE` | `for update skip locked` | `for update skip locked` |
-| `LockMode.PESSIMISTIC_WRITE_OR_FAIL` | `for update nowait` | `for update nowait` |
-| `LockMode.PESSIMISTIC_PARTIAL_READ` | `for share skip locked` | `lock in share mode skip locked` |
-| `LockMode.PESSIMISTIC_READ_OR_FAIL` | `for share nowait` | `lock in share mode nowait` |
+| Mode                                 | Postgres                 | MySQL                            |
+| ------------------------------------ | ------------------------ | -------------------------------- |
+| `LockMode.PESSIMISTIC_READ`          | `for share`              | `lock in share mode`             |
+| `LockMode.PESSIMISTIC_WRITE`         | `for update`             | `for update`                     |
+| `LockMode.PESSIMISTIC_PARTIAL_WRITE` | `for update skip locked` | `for update skip locked`         |
+| `LockMode.PESSIMISTIC_WRITE_OR_FAIL` | `for update nowait`      | `for update nowait`              |
+| `LockMode.PESSIMISTIC_PARTIAL_READ`  | `for share skip locked`  | `lock in share mode skip locked` |
+| `LockMode.PESSIMISTIC_READ_OR_FAIL`  | `for share nowait`       | `lock in share mode nowait`      |
 
 Optionally we can also pass list of table aliases we want to lock via second parameter:
 
@@ -402,10 +395,10 @@ qb.select('*')
   .setLockMode(LockMode.PESSIMISTIC_READ, ['u']);
 
 console.log(qb.getQuery()); // for Postgres
-// select ... 
+// select ...
 //   from "user" as "u"
-//   left join "identity" as "i" on "u"."id" = "i"."user_id" 
-//   where "u"."name" = 'Jon' 
+//   left join "identity" as "i" on "u"."id" = "i"."user_id"
+//   where "u"."name" = 'Jon'
 //   for update of "u" skip locked
 ```
 
@@ -425,12 +418,9 @@ const entities = res.map(a => em.map(Author, a));
 console.log(entities); // Author[]
 ```
 
-You can also get clear and configured knex instance from the connection via `getKnex()` method. As this method is not available on the base `Connection` class, you will need to either manually type
-cast the connection to `AbstractSqlConnection` (or the actual implementation you are using, e.g. `MySqlConnection`), or provide correct driver type hint to your `EntityManager` instance, which will be
-then automatically inferred in `em.getConnection()` method.
+You can also get clear and configured knex instance from the connection via `getKnex()` method. As this method is not available on the base `Connection` class, you will need to either manually type cast the connection to `AbstractSqlConnection` (or the actual implementation you are using, e.g. `MySqlConnection`), or provide correct driver type hint to your `EntityManager` instance, which will be then automatically inferred in `em.getConnection()` method.
 
-> Driver and connection implementations are not directly exported from `@mikro-orm/core` module.
-> You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
+> Driver and connection implementations are not directly exported from `@mikro-orm/core` module. You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
 
 ```ts
 const conn = em.getConnection() as AbstractSqlConnection;

--- a/docs/versioned_docs/version-5.4/query-conditions.md
+++ b/docs/versioned_docs/version-5.4/query-conditions.md
@@ -2,8 +2,7 @@
 title: Smart Query Conditions
 ---
 
-When you want to make complex queries, we can easily end up with a lot of boilerplate code
-full of curly brackets:
+When you want to make complex queries, we can easily end up with a lot of boilerplate code full of curly brackets:
 
 ```ts
 const res = await orm.em.find(Author, { $and: [
@@ -20,8 +19,8 @@ const res = await orm.em.find(Author, { $and: [
 For AND condition with single field, we can also do this:
 
 ```ts
-const res = await orm.em.find(Author, { 
-  id: { 
+const res = await orm.em.find(Author, {
+  id: {
     $in: [1, 2, 7],
     $nin: [3, 4],
     $gt: 5,
@@ -33,8 +32,7 @@ const res = await orm.em.find(Author, {
 });
 ```
 
-There is also shortcut for `$in` - simply provide array as value and it 
-will be converted automatically:
+There is also shortcut for `$in` - simply provide array as value and it will be converted automatically:
 
 ```ts
 const res = await orm.em.find(Author, { favouriteBook: [1, 2, 7] });
@@ -50,30 +48,30 @@ const res = await orm.em.find(Author, [1, 2, 7]);
 
 ### Comparison
 
-| operator | name               | description |
-|----------|--------------------|-------------|
-| `$eq`	   | equals             | Matches values that are equal to a specified value. |
-| `$gt`	   | greater            | Matches values that are greater than a specified value. |
-| `$gte`   | greater or equal   | Matches values that are greater than or equal to a specified value. |
-| `$in`	   | contains           | Matches any of the values specified in an array. |
-| `$lt`	   | lower              | Matches values that are less than a specified value. |
-| `$lte`   | lower or equal     | Matches values that are less than or equal to a specified value. |
-| `$ne`	   | not equal          | Matches all values that are not equal to a specified value. |
-| `$nin`   | not contains       | Matches none of the values specified in an array. |
-| `$like`  | like               | Uses LIKE operator |
-| `$re`    | regexp             | Uses REGEXP operator |
-| `$fulltext` | full text       | A driver specific full text search function. See requirements [below](#full-text-searching) |
-| `$ilike` | ilike              | (postgres only) |
-| `$overlap` | &&               | (postgres only) |
-| `$contains` | @>              | (postgres only) |
-| `$contained` | <@             | (postgres only) |
+| operator     | name             | description                                                                                 |
+| ------------ | ---------------- | ------------------------------------------------------------------------------------------- |
+| `$eq`        | equals           | Matches values that are equal to a specified value.                                         |
+| `$gt`        | greater          | Matches values that are greater than a specified value.                                     |
+| `$gte`       | greater or equal | Matches values that are greater than or equal to a specified value.                         |
+| `$in`        | contains         | Matches any of the values specified in an array.                                            |
+| `$lt`        | lower            | Matches values that are less than a specified value.                                        |
+| `$lte`       | lower or equal   | Matches values that are less than or equal to a specified value.                            |
+| `$ne`        | not equal        | Matches all values that are not equal to a specified value.                                 |
+| `$nin`       | not contains     | Matches none of the values specified in an array.                                           |
+| `$like`      | like             | Uses LIKE operator                                                                          |
+| `$re`        | regexp           | Uses REGEXP operator                                                                        |
+| `$fulltext`  | full text        | A driver specific full text search function. See requirements [below](#full-text-searching) |
+| `$ilike`     | ilike            | (postgres only)                                                                             |
+| `$overlap`   | &&               | (postgres only)                                                                             |
+| `$contains`  | @>               | (postgres only)                                                                             |
+| `$contained` | <@               | (postgres only)                                                                             |
 
 ### Logical
 
-| operator | description |
-|----------|-------------|
+| operator | description                                                                                             |
+| -------- | ------------------------------------------------------------------------------------------------------- |
 | `$and`   | Joins query clauses with a logical AND returns all documents that match the conditions of both clauses. |
-| `$not`   | Inverts the effect of a query expression and returns documents that do not match the query expression. |
+| `$not`   | Inverts the effect of a query expression and returns documents that do not match the query expression.  |
 | `$or`    | Joins query clauses with a logical OR returns all documents that match the conditions of either clause. |
 
 ## Full text searching
@@ -89,14 +87,13 @@ PosgreSQL allows to execute queries (pg-query) on the type pg-vector. The pg-vec
 Refer to the [PostgreSQL documentation](https://www.postgresql.org/docs/current/functions-textsearch.html) for possible queries.
 
 <Tabs
-groupId="entity-def"
-defaultValue="as-column"
-values={[
-{label: 'reflect-metadata', value: 'as-column'},
-{label: 'ts-morph', value: 'in-query'},
-]
-}>
-<TabItem value="as-column">
+  groupId="entity-def"
+  defaultValue="as-column"
+  values={[
+    {label: 'reflect-metadata', value: 'as-column'},
+    {label: 'ts-morph', value: 'in-query'},
+  ]}>
+  <TabItem value="as-column">
 
 ```ts title="./entities/Book.ts"
 import { FullTextType } from '@mikro-orm/postgresql';
@@ -136,6 +133,7 @@ And to find results: `repository.findOne({ title: { $fulltext: 'query' } })`
 </Tabs>
 
 ### MySQL, MariaDB
+
 MySQL and MariaDB allow full text searches on all columns with a fulltext index.
 
 Refer to the [MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/fulltext-boolean.html) or [MariaDB documentation](https://mariadb.com/kb/en/full-text-index-overview/#in-boolean-mode) for possible queries.
@@ -158,7 +156,6 @@ And to find results: `repository.findOne({ title: { $fulltext: 'query' } })`
 MongoDB allows full text searches on all columns with a text index. However, when executing a full text search, it selects matches based on all fields with a text index: it's only possible to add one query and only on the top-level of the query object. Refer to the [MongoDB documentation](https://www.mongodb.com/docs/manual/reference/operator/query/text/#behavior) for more information on this behavior.
 
 Refer to the [MongoDB documentation](https://www.mongodb.com/docs/manual/reference/operator/query/text/#definition) for possible queries.
-
 
 ```ts title="./entities/Book.ts"
 @Entity()

--- a/docs/versioned_docs/version-5.4/quick-start.md
+++ b/docs/versioned_docs/version-5.4/quick-start.md
@@ -2,8 +2,7 @@
 title: Quick Start
 ---
 
-First install the module via `yarn` or `npm` and do not forget to install the 
-database driver as well:
+First install the module via `yarn` or `npm` and do not forget to install the database driver as well:
 
 ```sh
 yarn add @mikro-orm/core @mikro-orm/mongodb     # for mongo
@@ -23,8 +22,7 @@ npm i -s @mikro-orm/core @mikro-orm/postgresql  # for postgresql
 npm i -s @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 ```
 
-Next you will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html)
-as well as `esModuleInterop` in `tsconfig.json` via:
+Next you will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html) as well as `esModuleInterop` in `tsconfig.json` via:
 
 ```json
 "experimentalDecorators": true,
@@ -34,9 +32,7 @@ as well as `esModuleInterop` in `tsconfig.json` via:
 
 Then call `MikroORM.init` as part of bootstrapping your app:
 
-> To access driver specific methods like `em.createQueryBuilder()` we need to specify
-> the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the
-> `orm.em` to `EntityManager` exported from the driver package:
+> To access driver specific methods like `em.createQueryBuilder()` we need to specify the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the `orm.em` to `EntityManager` exported from the driver package:
 >
 > ```ts
 > import { EntityManager } from '@mikro-orm/postgresql';
@@ -55,14 +51,11 @@ const orm = await MikroORM.init<PostgreSqlDriver>({
 console.log(orm.em); // access EntityManager via `em` property
 ```
 
-There are more ways to configure your entities, take a look at 
-[installation page](https://mikro-orm.io/installation/).
+There are more ways to configure your entities, take a look at [installation page](https://mikro-orm.io/installation/).
 
 > Read more about all the possible configuration options in [Advanced Configuration](https://mikro-orm.io/docs/configuration) section.
 
-Then you will need to fork entity manager for each request so their 
-[identity maps](https://mikro-orm.io/identity-map/) will not collide. 
-To do so, use the `RequestContext` helper:
+Then you will need to fork entity manager for each request so their [identity maps](https://mikro-orm.io/identity-map/) will not collide. To do so, use the `RequestContext` helper:
 
 ```ts
 const app = express();
@@ -72,15 +65,11 @@ app.use((req, res, next) => {
 });
 ```
 
-> You should register this middleware as the last one just before request handlers and before
-> any of your custom middleware that is using the ORM. There might be issues when you register 
-> it before request processing middleware like `queryParser` or `bodyParser`, so definitely 
-> register the context after them. 
+> You should register this middleware as the last one just before request handlers and before any of your custom middleware that is using the ORM. There might be issues when you register it before request processing middleware like `queryParser` or `bodyParser`, so definitely register the context after them.
 
 More info about `RequestContext` is described [here](https://mikro-orm.io/identity-map/#request-context).
 
-Now you can start defining your entities (in one of the `entities` folders). This is how
-simple entity can look like in mongo driver:
+Now you can start defining your entities (in one of the `entities` folders). This is how simple entity can look like in mongo driver:
 
 ```ts title="./entities/MongoBook.ts"
 @Entity()
@@ -135,15 +124,11 @@ export class UuidBook {
 }
 ```
 
-More information can be found in
-[defining entities section](https://mikro-orm.io/defining-entities/) in docs.
+More information can be found in [defining entities section](https://mikro-orm.io/defining-entities/) in docs.
 
-When you have your entities defined, you can start using ORM either via `EntityManager`
-or via `EntityRepository`s.
+When you have your entities defined, you can start using ORM either via `EntityManager` or via `EntityRepository`s.
 
-To save entity state to database, you need to persist it. Persist determines 
-whether to use `insert` or `update` and computes appropriate change-set. Entity references
-that are not persisted yet (does not have identifier) will be cascade persisted automatically. 
+To save entity state to database, you need to persist it. Persist determines whether to use `insert` or `update` and computes appropriate change-set. Entity references that are not persisted yet (does not have identifier) will be cascade persisted automatically.
 
 ```ts
 // use constructors in your entities for required parameters
@@ -163,7 +148,7 @@ book3.publisher = publisher;
 await em.persistAndFlush([book1, book2, book3]);
 ```
 
-To fetch entities from database you can use `find()` and `findOne()` of `EntityManager`: 
+To fetch entities from database you can use `find()` and `findOne()` of `EntityManager`:
 
 ```ts
 const authors = em.find(Author, {});
@@ -179,13 +164,12 @@ for (const author of authors) {
 }
 ```
 
-More convenient way of fetching entities from database is by using `EntityRepository`, that
-carries the entity name so you do not have to pass it to every `find` and `findOne` calls:
+More convenient way of fetching entities from database is by using `EntityRepository`, that carries the entity name so you do not have to pass it to every `find` and `findOne` calls:
 
 ```ts
 const booksRepository = em.getRepository(Book);
 
-const books = await booksRepository.find({ author: '...' }, { 
+const books = await booksRepository.find({ author: '...' }, {
   populate: ['author'],
   limit: 1,
   offset: 2,
@@ -195,5 +179,4 @@ const books = await booksRepository.find({ author: '...' }, {
 console.log(books); // Book[]
 ```
 
-Take a look at docs about [working with `EntityManager`](https://mikro-orm.io/entity-manager/)
-or [using `EntityRepository` instead](https://mikro-orm.io/repositories/).
+Take a look at docs about [working with `EntityManager`](https://mikro-orm.io/entity-manager/) or [using `EntityRepository` instead](https://mikro-orm.io/repositories/).

--- a/docs/versioned_docs/version-5.4/read-connections.md
+++ b/docs/versioned_docs/version-5.4/read-connections.md
@@ -2,19 +2,13 @@
 title: Read Replica Connections
 ---
 
-Users can specify multiple read connections via `replicas` option. You can provide only fields
-that differ from master connection, rest will be taken from it.
+Users can specify multiple read connections via `replicas` option. You can provide only fields that differ from master connection, rest will be taken from it.
 
-When resolving read connections, the default strategy is to assign random read replicas for all
-read operations (SELECT, COUNT) that are not running inside a transaction.
+When resolving read connections, the default strategy is to assign random read replicas for all read operations (SELECT, COUNT) that are not running inside a transaction.
 
-You can specify an explicit connection type for find and count operations by using the `connectionType`
-property on the corresponding Options argument (i.e. `FindOptions`, `CountOptions`).
+You can specify an explicit connection type for find and count operations by using the `connectionType` property on the corresponding Options argument (i.e. `FindOptions`, `CountOptions`).
 
-The connection resolution strategy can be also inverted by setting the `preferReadReplicas` configuration property
-to `false` so that the default connection will always be a write connection, unless explicitly requested to be read
-(can be useful in applications where read-replicas are available but should only be used for specific use-cases).
-
+The connection resolution strategy can be also inverted by setting the `preferReadReplicas` configuration property to `false` so that the default connection will always be a write connection, unless explicitly requested to be read (can be useful in applications where read-replicas are available but should only be used for specific use-cases).
 
 ```ts
 const orm = await MikroORM.init({
@@ -31,9 +25,7 @@ const orm = await MikroORM.init({
 });
 ```
 
-By default, select queries will use random read connection if not inside transaction. You can
-specify the connection type explicitly in `em.getConnection(type: 'read' | 'write')`.
-
+By default, select queries will use random read connection if not inside transaction. You can specify the connection type explicitly in `em.getConnection(type: 'read' | 'write')`.
 
 ```ts
 const connection = em.getConnection(); // write connection

--- a/docs/versioned_docs/version-5.4/relationships.md
+++ b/docs/versioned_docs/version-5.4/relationships.md
@@ -3,20 +3,16 @@ title: Modeling Entity Relationships
 sidebar_label: Modeling Entity Relationships
 ---
 
-There are 4 types of entity relationships in MikroORM: 
+There are 4 types of entity relationships in MikroORM:
 
 - ManyToOne
 - OneToMany
 - OneToOne
 - ManyToMany
 
-Relations can be unidirectional and bidirectional. Unidirectional are defined only on one 
-side (the owning side). Bidirectional are defined on both sides, while one is owning side 
-(where references are store), marked by `inversedBy` attribute pointing to the inverse side.
-On the inversed side we define it with `mappedBy` attribute pointing back to the owner:
+Relations can be unidirectional and bidirectional. Unidirectional are defined only on one side (the owning side). Bidirectional are defined on both sides, while one is owning side (where references are store), marked by `inversedBy` attribute pointing to the inverse side. On the inversed side we define it with `mappedBy` attribute pointing back to the owner:
 
-> When modeling bidirectional relationship, you can also omit the `inversedBy` attribute, 
-> defining `mappedBy` on the inverse side is enough as it will be auto-wired. 
+> When modeling bidirectional relationship, you can also omit the `inversedBy` attribute, defining `mappedBy` on the inverse side is enough as it will be auto-wired.
 
 ## ManyToOne
 
@@ -43,8 +39,7 @@ export class Book {
 }
 ```
 
-You can also specify how operations on given entity should [cascade](cascading.md) 
-to the referred entity.
+You can also specify how operations on given entity should [cascade](cascading.md) to the referred entity.
 
 ## OneToMany
 
@@ -71,19 +66,15 @@ export class Author {
 }
 ```
 
-As you can see, OneToMany is the inverse side of ManyToOne (which is the owning side).
-More about how collections work can be found on [collections page](collections.md). 
+As you can see, OneToMany is the inverse side of ManyToOne (which is the owning side). More about how collections work can be found on [collections page](collections.md).
 
-You can also specify how operations on given entity should [cascade](cascading.md) to the referred
-entities. There is also more aggressive remove mode called [Orphan Removal](cascading.md#orphan-removal) 
-(`books4` example).
+You can also specify how operations on given entity should [cascade](cascading.md) to the referred entities. There is also more aggressive remove mode called [Orphan Removal](cascading.md#orphan-removal) (`books4` example).
 
 ## OneToOne
 
 > One instance of the current Entity refers to One instance of the referred Entity.
 
-This is a variant of ManyToOne, where there is always just one entity on both sides. This means
-that the foreign key column is also unique.
+This is a variant of ManyToOne, where there is always just one entity on both sides. This means that the foreign key column is also unique.
 
 ### Owning Side
 
@@ -121,8 +112,7 @@ export class User {
 }
 ```
 
-As you can see, relationships can be also self-referencing (all of them. OneToOne also supports 
-[Orphan Removal](cascading.md#orphan-removal). 
+As you can see, relationships can be also self-referencing (all of them. OneToOne also supports [Orphan Removal](cascading.md#orphan-removal).
 
 ## ManyToMany
 
@@ -149,7 +139,7 @@ export class Book {
   @ManyToMany(() => BookTag, 'books', { owner: true })
   tags4 = new Collection<BookTag>(this);
 
-  // to define uni-directional many to many, simply provide only 
+  // to define uni-directional many to many, simply provide only
   @ManyToMany(() => Author)
   friends: Collection<Author> = new Collection<Author>(this);
 
@@ -169,4 +159,4 @@ export class BookTag {
 }
 ```
 
-Again, more information about how collections work can be found on [collections page](collections.md). 
+Again, more information about how collections work can be found on [collections page](collections.md).

--- a/docs/versioned_docs/version-5.4/repositories.md
+++ b/docs/versioned_docs/version-5.4/repositories.md
@@ -3,18 +3,14 @@ title: Using EntityRepository instead of EntityManager
 sidebar_label: Entity Repository
 ---
 
-Entity Repositories are thin layers on top of `EntityManager`. They act as an 
-extension point, so we can add custom methods, or even alter the existing ones. 
-The default, `EntityRepository` implementation just forwards the calls to 
-underlying `EntityManager` instance.
+Entity Repositories are thin layers on top of `EntityManager`. They act as an extension point, so we can add custom methods, or even alter the existing ones. The default, `EntityRepository` implementation just forwards the calls to underlying `EntityManager` instance.
 
-> `EntityRepository` class carries the entity type, so we do not have to pass 
-> it to every `find` or `findOne` calls.
+> `EntityRepository` class carries the entity type, so we do not have to pass it to every `find` or `findOne` calls.
 
 ```ts
 const booksRepository = em.getRepository(Book);
 
-const books = await booksRepository.find({ author: '...' }, { 
+const books = await booksRepository.find({ author: '...' }, {
   populate: ['author'],
   limit: 1,
   offset: 2,
@@ -24,17 +20,11 @@ const books = await booksRepository.find({ author: '...' }, {
 console.log(books); // Book[]
 ```
 
-Note that there is no such thing as "flushing repository" - it is just a shortcut
-to `em.flush()`. In other words, we always flush the whole Unit of Work, not just
-a single entity that this repository represents.
+Note that there is no such thing as "flushing repository" - it is just a shortcut to `em.flush()`. In other words, we always flush the whole Unit of Work, not just a single entity that this repository represents.
 
 ## Custom Repository
 
-:::info
-Since v4, we need to make sure we are working with correctly typed `EntityRepository` 
-to have access to driver specific methods (like `createQueryBuilder()`). Use the one
-exported from your driver package.
-:::
+:::info Since v4, we need to make sure we are working with correctly typed `EntityRepository` to have access to driver specific methods (like `createQueryBuilder()`). Use the one exported from your driver package. :::
 
 To use custom repository, just extend `EntityRepository<T>` class:
 
@@ -60,19 +50,15 @@ export class Author {
 }
 ```
 
-> `@Repository()` decorator has been removed in v5, use
-> `@Entity({ customRepository: () => MyRepository })` instead.
+> `@Repository()` decorator has been removed in v5, use `@Entity({ customRepository: () => MyRepository })` instead.
 
-Note that we need to pass that repository reference inside a callback so we will not run
-into circular dependency issues when using entity references inside that repository.
+Note that we need to pass that repository reference inside a callback so we will not run into circular dependency issues when using entity references inside that repository.
 
 Now we can access our custom repository via `em.getRepository()` method.
 
 ### Inferring custom repository type
 
-To have the `em.getRepository()` method return correctly typed custom repository
-instead of the generic `EntityRepository<T>`, we can use `EntityRepositoryType`
-symbol:
+To have the `em.getRepository()` method return correctly typed custom repository instead of the generic `EntityRepository<T>`, we can use `EntityRepositoryType` symbol:
 
 ```ts
 @Entity({ customRepository: () => AuthorRepository })
@@ -85,9 +71,6 @@ export class Author {
 const repo = em.getRepository(Author); // repo has type AuthorRepository
 ```
 
-> We can also register custom base repository (for all entities where we do not specify 
-> `customRepository`) globally, via `MikroORM.init({ entityRepository: CustomBaseRepository })`.
+> We can also register custom base repository (for all entities where we do not specify `customRepository`) globally, via `MikroORM.init({ entityRepository: CustomBaseRepository })`.
 
-For more examples, take a look at
-[`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts)
-or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).
+For more examples, take a look at [`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts) or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).

--- a/docs/versioned_docs/version-5.4/schema-generator.md
+++ b/docs/versioned_docs/version-5.4/schema-generator.md
@@ -2,51 +2,41 @@
 title: Schema Generator
 ---
 
-> SchemaGenerator can do harm to your database. It will drop or alter tables, indexes, 
-> sequences and such. Please use this tool with caution in development and not on a 
-> production server. It is meant for helping you develop your Database Schema, but NOT 
-> with migrating schema from A to B in production. A safe approach would be generating 
-> the SQL on development server and saving it into SQL Migration files that are executed 
-> manually on the production server.
+> SchemaGenerator can do harm to your database. It will drop or alter tables, indexes, sequences and such. Please use this tool with caution in development and not on a production server. It is meant for helping you develop your Database Schema, but NOT with migrating schema from A to B in production. A safe approach would be generating the SQL on development server and saving it into SQL Migration files that are executed manually on the production server.
 
-> SchemaGenerator assumes your project uses the given database on its own. Update and Drop 
-> commands will mess with other tables if they are not related to the current project 
-> that is using MikroORM. Please be careful!
+> SchemaGenerator assumes your project uses the given database on its own. Update and Drop commands will mess with other tables if they are not related to the current project that is using MikroORM. Please be careful!
 
-To generate schema from your entity metadata, you can use `SchemaGenerator` helper. 
+To generate schema from your entity metadata, you can use `SchemaGenerator` helper.
 
-You can use it via CLI: 
+You can use it via CLI:
 
-> To work with the CLI, first install `@mikro-orm/cli` package locally.
-> The version needs to be aligned with the `@mikro-orm/core` package.
+> To work with the CLI, first install `@mikro-orm/cli` package locally. The version needs to be aligned with the `@mikro-orm/core` package.
 
 ```sh
 npx mikro-orm schema:create --dump   # Dumps create schema SQL
 npx mikro-orm schema:update --dump   # Dumps update schema SQL
-npx mikro-orm schema:drop --dump     # Dumps drop schema SQL 
+npx mikro-orm schema:drop --dump     # Dumps drop schema SQL
 ```
 
-> You can also use `--run` flag to fire all queries, but be careful as it might break your
-> database. Be sure to always check the generated SQL first before executing. Do not use
-> `--run` flag in production! 
+> You can also use `--run` flag to fire all queries, but be careful as it might break your database. Be sure to always check the generated SQL first before executing. Do not use `--run` flag in production!
 
-`schema:create` will automatically create the database if it does not exist. 
+`schema:create` will automatically create the database if it does not exist.
 
-`schema:update` drops all unknown tables by default, you can use `--no-drop-tables` 
-to get around it. There is also `--safe` flag that will disable both table dropping as 
-well as column dropping. 
+`schema:update` drops all unknown tables by default, you can use `--no-drop-tables` to get around it. There is also `--safe` flag that will disable both table dropping as well as column dropping.
 
-`schema:drop` will by default drop all database tables. You can use `--drop-db` flag to drop
-the whole database instead. 
+`schema:drop` will by default drop all database tables. You can use `--drop-db` flag to drop the whole database instead.
 
 ```shell
 npx mikro-orm schema:fresh --run     # !WARNING! Drops the database schema and recreates it
 ```
+
 This command can be run with the `--seed` option to seed the database after it has been created again.
+
 ```shell
 npx mikro-orm schema:fresh --run --seed              # seed the database with the default database seeder
 npx mikro-orm schema:fresh --run --seed=UsersSeeder  # seed the database with the UsersSeeder
 ```
+
 > You can specify the default database seeder in the orm config with the key `config.seeder.defaultSeeder`
 
 ## Configuration
@@ -64,8 +54,7 @@ const orm = await MikroORM.init({
 });
 ```
 
-> Note that if we disable FK constraints and current schema is using them, the 
-> schema diffing will try to remove those that already exist.
+> Note that if we disable FK constraints and current schema is using them, the schema diffing will try to remove those that already exist.
 
 ## Using SchemaGenerator programmatically
 
@@ -99,7 +88,7 @@ import { MikroORM } from '@mikro-orm/core';
   await generator.dropSchema();
   await generator.createSchema();
   await generator.updateSchema();
-  
+
   // in tests it can be handy to use those:
   await generator.refreshDatabase(); // ensure db exists and is fresh
   await generator.clearDatabase(); // removes all data
@@ -116,12 +105,10 @@ $ ts-node create-schema
 
 ## Limitations of SQLite
 
-There are limitations of SQLite database because of which it behaves differently 
-than other SQL drivers. Namely, it is not possible to:
+There are limitations of SQLite database because of which it behaves differently than other SQL drivers. Namely, it is not possible to:
 
 - create foreign key constraints when altering columns
 - create empty tables without columns
 - alter column requires nullability
 
-Because of this, you can end up with different schema with SQLite, so it is not
-suggested to use SQLite for integration tests of your application.
+Because of this, you can end up with different schema with SQLite, so it is not suggested to use SQLite for integration tests of your application.

--- a/docs/versioned_docs/version-5.4/seeding.md
+++ b/docs/versioned_docs/version-5.4/seeding.md
@@ -2,13 +2,11 @@
 title: Seeding
 ---
 
-When initializing your application or testing it can be exhausting to create sample data for your database. The solution is to use seeding. Create factories for your entities and use them in the seed
-script or combine multiple seed scripts.
+When initializing your application or testing it can be exhausting to create sample data for your database. The solution is to use seeding. Create factories for your entities and use them in the seed script or combine multiple seed scripts.
 
 ## Configuration
 
-> `seeder.path` and `seeder.pathTs` works the same way as `entities` and
-> `entitiesTs` in entity discovery.
+> `seeder.path` and `seeder.pathTs` works the same way as `entities` and `entitiesTs` in entity discovery.
 
 The seeder has a few default settings that can be changed easily through the MikroORM config. Underneath you find the configuration options with their defaults.
 
@@ -35,8 +33,7 @@ We can also override these default using the [environment variables](configurati
 
 ## Seeders
 
-A seeder class contains one method `run`. This method is called when you use the command `npx mikro-orm seeder:run`. In the `run` method you define how and what data you want to insert into the
-database. You can create entities using the [EntityManager](http://mikro-orm.io/docs/entity-manager) or you can use [Factories](#using-entity-factories).
+A seeder class contains one method `run`. This method is called when you use the command `npx mikro-orm seeder:run`. In the `run` method you define how and what data you want to insert into the database. You can create entities using the [EntityManager](http://mikro-orm.io/docs/entity-manager) or you can use [Factories](#using-entity-factories).
 
 You can create your own seeder classes using the following CLI command:
 
@@ -46,15 +43,11 @@ npx mikro-orm seeder:create test            # generates the class TestSeeder
 npx mikro-orm seeder:create project-names   # generates the class ProjectNamesSeeder
 ```
 
-This creates a new seeder class. By default, it will be generated in the `./seeders/` directory. You can configure the directory in the config with the key `seeder.path` or using
-the [environment variable](configuration.md#using-environment-variables) `MIKRO_ORM_SEEDER_PATH`. You are allowed to call the `seeder:create` command with a name, class name or hyphenated name.
+This creates a new seeder class. By default, it will be generated in the `./seeders/` directory. You can configure the directory in the config with the key `seeder.path` or using the [environment variable](configuration.md#using-environment-variables) `MIKRO_ORM_SEEDER_PATH`. You are allowed to call the `seeder:create` command with a name, class name or hyphenated name.
 
 As an example we will look at a very basic seeder.
 
-> Note that the `EntityManager` available in seeders will have `persistOnCreate`
-> enabled, hence calling `em.create()` will automatically call `em.persist()`
-> on the created entity. If we use entity constructor instead, we need to call
-> `em.persist()` explicitly.
+> Note that the `EntityManager` available in seeders will have `persistOnCreate` enabled, hence calling `em.create()` will automatically call `em.persist()` on the created entity. If we use entity constructor instead, we need to call `em.persist()` explicitly.
 
 ```ts title="./database/seeder/database.seeder.ts"
 import { EntityManager } from '@mikro-orm/core';
@@ -80,8 +73,7 @@ export class DatabaseSeeder extends Seeder {
 
 ### Using entity factories
 
-Instead of specifying all the attributes for every entity, you can also use [entity factories](#entity-factories). These can be used to generate large amounts of database records. Please read
-the [documentation on how to define factories](#entity-factories) to learn how to define your factories.
+Instead of specifying all the attributes for every entity, you can also use [entity factories](#entity-factories). These can be used to generate large amounts of database records. Please read the [documentation on how to define factories](#entity-factories) to learn how to define your factories.
 
 As an example we will generate 10 authors.
 
@@ -100,8 +92,7 @@ export class DatabaseSeeder extends Seeder {
 
 ### Calling additional seeders
 
-Inside the `run` method you can specify other seeder classes. You can use the `call` method to break up the database seeder into multiple files to prevent a seeder file from becoming too large.
-The `call` method requires an `em` and an array of seeder classes.
+Inside the `run` method you can specify other seeder classes. You can use the `call` method to break up the database seeder into multiple files to prevent a seeder file from becoming too large. The `call` method requires an `em` and an array of seeder classes.
 
 ```ts
 import { EntityManager } from '@mikro-orm/core';
@@ -148,8 +139,7 @@ export class BookSeeder extends Seeder {
 
 ## Entity factories
 
-When testing you may insert entities in the database before starting a test. Instead of specifying every attribute of every entity by hand, you could also use a `Factory` to define a set of default
-attributes for an entity using entity factories.
+When testing you may insert entities in the database before starting a test. Instead of specifying every attribute of every entity by hand, you could also use a `Factory` to define a set of default attributes for an entity using entity factories.
 
 Lets have a look at an example factory for an [Author entity](http://mikro-orm.io/docs/defining-entities).
 
@@ -168,10 +158,9 @@ export class AuthorFactory extends Factory<Author> {
     };
   }
 }
-``` 
+```
 
-Basically you extend the base `Factory` class, define a `model` property and a `definition` method. The `model` defines for which entity the factory generates entity instances. The `definition` method
-returns the default set of attribute values that should be applied when creating an entity using the factory.
+Basically you extend the base `Factory` class, define a `model` property and a `definition` method. The `model` defines for which entity the factory generates entity instances. The `definition` method returns the default set of attribute values that should be applied when creating an entity using the factory.
 
 Via the faker property, factories have access to the [Faker library](https://github.com/faker-js/faker), which allows you to conveniently generate various kinds of random data for testing.
 
@@ -190,18 +179,17 @@ Generate multiple entities by calling the `make` method. The parameter of the `m
 ```ts
 // Generate 5 authors
 const authors = new AuthorFactory(orm.em).make(5);
-``` 
+```
 
 #### Overriding attributes
 
-If you would like to override some of the default values of your factories, you may pass an object to the make method. Only the specified attributes will be replaced while the rest of the attributes
-remain set to their default values as specified by the factory.
+If you would like to override some of the default values of your factories, you may pass an object to the make method. Only the specified attributes will be replaced while the rest of the attributes remain set to their default values as specified by the factory.
 
 ```ts
 const author = new AuthorFactory(orm.em).make({
   name: 'John Snow',
 });
-``` 
+```
 
 ### Persisting entities
 
@@ -231,9 +219,7 @@ const authors = await new AuthorFactory(orm.em).create(5, {
 
 ### Factory relationships
 
-It is nice to create large quantities of data for one entity, but most of the time we want to create data for multiple entities and also have relations between these. For this we can use the `each`
-method which can be chained on a factory. The `each` method can be called with a function that transforms output entity from the factory before returning it. Lets look at some examples for the
-different relations.
+It is nice to create large quantities of data for one entity, but most of the time we want to create data for multiple entities and also have relations between these. For this we can use the `each` method which can be chained on a factory. The `each` method can be called with a function that transforms output entity from the factory before returning it. Lets look at some examples for the different relations.
 
 #### ManyToOne and OneToOne relations
 
@@ -241,7 +227,7 @@ different relations.
 const books: Book[] = new BookFactory(orm.em).each(book => {
   book.author = new AuthorFactory(orm.em).makeOne();
 }).make(5);
-``` 
+```
 
 #### OneToMany and ManyToMany
 
@@ -249,13 +235,11 @@ const books: Book[] = new BookFactory(orm.em).each(book => {
 const books: Book[] = new BookFactory(orm.em).each(book => {
   book.owners.set(new OwnerFactory(orm.em).make(5));
 }).make(5);
-``` 
+```
 
 ## Use with CLI
 
-You may execute the `seeder:run` MikroORM CLI command to seed your database. By default, the `seeder:run` command runs the `DatabaseSeeder` class, which may in turn invoke other seed classes. You can
-configure the default seeder using the key `seeder.defaultSeeder` or using the [environment variable](configuration.md#using-environment-variables) `MIKRO_ORM_SEEDER_DEFAULT_SEEDER`. You can also use
-the `--class` option to specify a seeder class:
+You may execute the `seeder:run` MikroORM CLI command to seed your database. By default, the `seeder:run` command runs the `DatabaseSeeder` class, which may in turn invoke other seed classes. You can configure the default seeder using the key `seeder.defaultSeeder` or using the [environment variable](configuration.md#using-environment-variables) `MIKRO_ORM_SEEDER_DEFAULT_SEEDER`. You can also use the `--class` option to specify a seeder class:
 
 ```shell script
 npx mikro-orm seeder:run
@@ -263,8 +247,7 @@ npx mikro-orm seeder:run
 npx mikro-orm seeder:run --class=BookSeeder
 ```
 
-You may also seed your database using the [`migrate:fresh`](migrations.md#using-via-cli) or [`schema:fresh`](schema-generator.md) command in combination with the `--seed` option, which will drop all
-tables and re-run all of your migrations or generate the database based on the current entities. This command is useful for completely re-building your database:
+You may also seed your database using the [`migrate:fresh`](migrations.md#using-via-cli) or [`schema:fresh`](schema-generator.md) command in combination with the `--seed` option, which will drop all tables and re-run all of your migrations or generate the database based on the current entities. This command is useful for completely re-building your database:
 
 ```shell script
 npx mikro-orm migration:fresh --seed    # will drop the database, run all migrations and the DatabaseSeeder class
@@ -272,8 +255,7 @@ npx mikro-orm migration:fresh --seed    # will drop the database, run all migrat
 npx mikro-orm schema:fresh --seed       # will recreate the database and run the DatabaseSeeder class
 ```
 
-If you do not want to run the `DatabaseSeeder` class you can either specify what the default seeder class should be. This can be done by changing the [default settings](#default-settings). Another
-option is to explicitly define the seeder class you want to run.
+If you do not want to run the `DatabaseSeeder` class you can either specify what the default seeder class should be. This can be done by changing the [default settings](#default-settings). Another option is to explicitly define the seeder class you want to run.
 
 ```shell script
 npx mikro-orm migration:fresh --seed TestSeeder       # will drop the database, run all migrations and the TestSeeder class
@@ -327,6 +309,4 @@ await MikroORM.init({
 });
 ```
 
-This should allow using CLI to generate TS seeder files (as in CLI we probably
-have TS support enabled), while using compiled JS files in production, where ts-node
-is not registered.
+This should allow using CLI to generate TS seeder files (as in CLI we probably have TS support enabled), while using compiled JS files in production, where ts-node is not registered.

--- a/docs/versioned_docs/version-5.4/serializing.md
+++ b/docs/versioned_docs/version-5.4/serializing.md
@@ -12,9 +12,7 @@ export interface AnyEntity<K = number | string> {
 }
 ```
 
-When you serialize your entity via `JSON.stringify(entity)`, its `toJSON` method will be 
-called automatically. You can provide custom implementation for `toJSON`, while using 
-`toObject` for initial serialization:
+When you serialize your entity via `JSON.stringify(entity)`, its `toJSON` method will be called automatically. You can provide custom implementation for `toJSON`, while using `toObject` for initial serialization:
 
 ```ts
 @Entity()
@@ -35,13 +33,11 @@ export class Book {
 }
 ```
 
-> Do not forget to pass rest params when calling `toObject(...args)`, otherwise the results
-> might not be stable.
+> Do not forget to pass rest params when calling `toObject(...args)`, otherwise the results might not be stable.
 
 ## Hidden Properties
 
-If you want to omit some properties from serialized result, you can mark them with `hidden`
-flag on `@Property()` decorator:
+If you want to omit some properties from serialized result, you can mark them with `hidden` flag on `@Property()` decorator:
 
 ```ts
 @Entity()
@@ -59,13 +55,9 @@ console.log(wrap(book).toJSON().hiddenField); // undefined
 
 ## Shadow Properties
 
-The opposite situation where you want to define a property that lives only in memory (is 
-not persisted into database) can be solved by defining your property as `persist: false`. 
-Such property can be assigned via one of `Entity.assign()`, `em.create()` and 
-`em.merge()`. It will be also part of serialized result. 
+The opposite situation where you want to define a property that lives only in memory (is not persisted into database) can be solved by defining your property as `persist: false`. Such property can be assigned via one of `Entity.assign()`, `em.create()` and `em.merge()`. It will be also part of serialized result.
 
-This can be handle when dealing with additional values selected via `QueryBuilder` or 
-MongoDB's aggregations.
+This can be handle when dealing with additional values selected via `QueryBuilder` or MongoDB's aggregations.
 
 ```ts
 @Entity()
@@ -84,8 +76,7 @@ console.log(wrap(book).toJSON().count); // 123
 
 ## Property Serializers
 
-As an alternative to custom `toJSON()` method, we can also use property serializers.
-They allow to specify a callback that will be used when serializing a property:
+As an alternative to custom `toJSON()` method, we can also use property serializers. They allow to specify a callback that will be used when serializing a property:
 
 ```ts
 @Entity()

--- a/docs/versioned_docs/version-5.4/transactions.md
+++ b/docs/versioned_docs/version-5.4/transactions.md
@@ -6,28 +6,17 @@ title: Transactions and Concurrency
 
 ## Transaction Demarcation
 
-Transaction demarcation is the task of defining your transaction boundaries. Proper 
-transaction demarcation is very important because if not done properly it can negatively 
-affect the performance of your application. Many databases and database abstraction 
-layers by default operate in auto-commit mode, which means that every single SQL statement 
-is wrapped in a small transaction. Without any explicit transaction demarcation from your 
-side, this quickly results in poor performance because transactions are not cheap. 
+Transaction demarcation is the task of defining your transaction boundaries. Proper transaction demarcation is very important because if not done properly it can negatively affect the performance of your application. Many databases and database abstraction layers by default operate in auto-commit mode, which means that every single SQL statement is wrapped in a small transaction. Without any explicit transaction demarcation from your side, this quickly results in poor performance because transactions are not cheap.
 
-For the most part, MikroORM already takes care of proper transaction demarcation for you: 
-All the write operations (INSERT/UPDATE/DELETE) are queued until `em.flush()` 
-is invoked which wraps all of these changes in a single transaction.
+For the most part, MikroORM already takes care of proper transaction demarcation for you: All the write operations (INSERT/UPDATE/DELETE) are queued until `em.flush()` is invoked which wraps all of these changes in a single transaction.
 
-However, MikroORM also allows (and encourages) you to take over and control transaction 
-demarcation yourself.
+However, MikroORM also allows (and encourages) you to take over and control transaction demarcation yourself.
 
-These are two ways to deal with transactions when using the MikroORM and are now described 
-in more detail.
+These are two ways to deal with transactions when using the MikroORM and are now described in more detail.
 
 ### Approach 1: Implicitly
 
-The first approach is to use the implicit transaction handling provided by the MikroORM 
-`EntityManager`. Given the following code snippet, without any explicit transaction 
-demarcation:
+The first approach is to use the implicit transaction handling provided by the MikroORM `EntityManager`. Given the following code snippet, without any explicit transaction demarcation:
 
 ```ts
 const user = new User(...);
@@ -35,16 +24,11 @@ user.name = 'George';
 await orm.em.persistAndFlush(user);
 ```
 
-Since we do not do any custom transaction demarcation in the above code, `em.flush()` 
-will begin and commit/rollback a transaction. This behavior is made possible by the 
-aggregation of the DML operations by the MikroORM and is sufficient if all the data 
-manipulation that is part of a unit of work happens through the domain model and thus 
-the ORM.
+Since we do not do any custom transaction demarcation in the above code, `em.flush()` will begin and commit/rollback a transaction. This behavior is made possible by the aggregation of the DML operations by the MikroORM and is sufficient if all the data manipulation that is part of a unit of work happens through the domain model and thus the ORM.
 
 ### Approach 2: Explicitly
 
-The explicit alternative is to use the transactions API directly to control the boundaries. 
-The code then looks like this:
+The explicit alternative is to use the transactions API directly to control the boundaries. The code then looks like this:
 
 ```ts
 await orm.em.transactional(em => {
@@ -55,8 +39,7 @@ await orm.em.transactional(em => {
 });
 ```
 
-Or you can use `begin/commit/rollback` methods explicitly. Following example is
-equivalent to the previous one:
+Or you can use `begin/commit/rollback` methods explicitly. Following example is equivalent to the previous one:
 
 ```ts
 const em = orm.em.fork();
@@ -74,68 +57,37 @@ try {
 }
 ```
 
-Explicit transaction demarcation is required when you want to include custom DBAL operations 
-in a unit of work or when you want to make use of some methods of the EntityManager API 
-that require an active transaction. Such methods will throw a `ValidationError` to inform 
-you of that requirement.
+Explicit transaction demarcation is required when you want to include custom DBAL operations in a unit of work or when you want to make use of some methods of the EntityManager API that require an active transaction. Such methods will throw a `ValidationError` to inform you of that requirement.
 
 `em.transactional(cb)` will flush the inner `EntityManager` prior to transaction commit.
 
 ### Exception Handling
 
-When using implicit transaction demarcation and an exception occurs during 
-`em.flush()`, the transaction is automatically rolled back.
+When using implicit transaction demarcation and an exception occurs during `em.flush()`, the transaction is automatically rolled back.
 
-When using explicit transaction demarcation and an exception occurs, the transaction should 
-be rolled back immediately as demonstrated in the example above. This can be handled elegantly 
-by the control abstractions shown earlier. Note that when catching Exception you should 
-generally re-throw the exception. If you intend to recover from some exceptions, catch them 
-explicitly in earlier catch blocks (but do not forget to rollback the transaction). All 
-other best practices of exception handling apply similarly (i.e. either log or re-throw, 
-not both, etc.).
+When using explicit transaction demarcation and an exception occurs, the transaction should be rolled back immediately as demonstrated in the example above. This can be handled elegantly by the control abstractions shown earlier. Note that when catching Exception you should generally re-throw the exception. If you intend to recover from some exceptions, catch them explicitly in earlier catch blocks (but do not forget to rollback the transaction). All other best practices of exception handling apply similarly (i.e. either log or re-throw, not both, etc.).
 
-As a result of this procedure, all previously managed or removed instances of the `EntityManager` 
-become detached. The state of the detached objects will be the state at the point at which the 
-transaction was rolled back. The state of the objects is in no way rolled back and thus the 
-objects are now out of sync with the database. The application can continue to use the detached 
-objects, knowing that their state is potentially no longer accurate.
+As a result of this procedure, all previously managed or removed instances of the `EntityManager` become detached. The state of the detached objects will be the state at the point at which the transaction was rolled back. The state of the objects is in no way rolled back and thus the objects are now out of sync with the database. The application can continue to use the detached objects, knowing that their state is potentially no longer accurate.
 
-If you intend to start another unit of work after an exception has occurred you should do 
-that with a new `EntityManager`. Simply use `em.fork()` to obtain fresh copy 
-with cleared identity map. 
+If you intend to start another unit of work after an exception has occurred you should do that with a new `EntityManager`. Simply use `em.fork()` to obtain fresh copy with cleared identity map.
 
 ## Locking Support
 
 ### Why we need concurrency control?
 
-If transactions are executed serially (one at a time), no transaction concurrency exists. 
-However, if concurrent transactions with interleaving operations are allowed, you may easily 
-run into one of those problems:
+If transactions are executed serially (one at a time), no transaction concurrency exists. However, if concurrent transactions with interleaving operations are allowed, you may easily run into one of those problems:
 
 1. The lost update problem
 2. The dirty read problem
 3. The incorrect summary problem
 
-To mitigate those problems, MikroORM offers support for Pessimistic and Optimistic locking 
-strategies natively. This allows you to take very fine-grained control over what kind of 
-locking is required for your entities in your application.
+To mitigate those problems, MikroORM offers support for Pessimistic and Optimistic locking strategies natively. This allows you to take very fine-grained control over what kind of locking is required for your entities in your application.
 
 ### Optimistic Locking
 
-Database transactions are fine for concurrency control during a single request. However, a 
-database transaction should not span across requests, the so-called "user think time". Therefore 
-a long-running "business transaction" that spans multiple requests needs to involve several 
-database transactions. Thus, database transactions alone can no longer control concurrency 
-during such a long-running business transaction. Concurrency control becomes the partial 
-responsibility of the application itself.
+Database transactions are fine for concurrency control during a single request. However, a database transaction should not span across requests, the so-called "user think time". Therefore a long-running "business transaction" that spans multiple requests needs to involve several database transactions. Thus, database transactions alone can no longer control concurrency during such a long-running business transaction. Concurrency control becomes the partial responsibility of the application itself.
 
-MikroORM has integrated support for automatic optimistic locking via a version field. In 
-this approach any entity that should be protected against concurrent modifications during 
-long-running business transactions gets a version field that is either a simple number 
-(mapping type: integer) or a timestamp (mapping type: datetime). When changes to such an 
-entity are persisted at the end of a long-running conversation the version of the entity 
-is compared to the version in the database and if they don't match, a `OptimisticLockError` 
-is thrown, indicating that the entity has been modified by someone else already.
+MikroORM has integrated support for automatic optimistic locking via a version field. In this approach any entity that should be protected against concurrent modifications during long-running business transactions gets a version field that is either a simple number (mapping type: integer) or a timestamp (mapping type: datetime). When changes to such an entity are persisted at the end of a long-running conversation the version of the entity is compared to the version in the database and if they don't match, a `OptimisticLockError` is thrown, indicating that the entity has been modified by someone else already.
 
 You designate a version field in an entity as follows. In this example we'll use an integer.
 
@@ -159,23 +111,13 @@ export class User {
 }
 ```
 
-Version numbers (not timestamps) should however be preferred as they can not potentially 
-conflict in a highly concurrent environment, unlike timestamps where this is a possibility, 
-depending on the resolution of the timestamp on the particular database platform.
+Version numbers (not timestamps) should however be preferred as they can not potentially conflict in a highly concurrent environment, unlike timestamps where this is a possibility, depending on the resolution of the timestamp on the particular database platform.
 
-When a version conflict is encountered during `em.flush()`, a `OptimisticLockError` 
-is thrown and the active transaction rolled back (or marked for rollback). This exception 
-can be caught and handled. Potential responses to a `OptimisticLockError` are to present the 
-conflict to the user or to refresh or reload objects in a new transaction and then retrying 
-the transaction.
+When a version conflict is encountered during `em.flush()`, a `OptimisticLockError` is thrown and the active transaction rolled back (or marked for rollback). This exception can be caught and handled. Potential responses to a `OptimisticLockError` are to present the conflict to the user or to refresh or reload objects in a new transaction and then retrying the transaction.
 
-The time between showing an update form and actually modifying the entity can in the worst 
-scenario be as long as your application's session timeout. If changes happen to the entity 
-in that time frame you want to know directly when retrieving the entity that you will hit 
-an optimistic locking exception:
+The time between showing an update form and actually modifying the entity can in the worst scenario be as long as your application's session timeout. If changes happen to the entity in that time frame you want to know directly when retrieving the entity that you will hit an optimistic locking exception:
 
-You can always verify the version of an entity during a request either when calling 
-`em.findOne()`:
+You can always verify the version of an entity during a request either when calling `em.findOne()`:
 
 ```ts
 const theEntityId = 1;
@@ -209,14 +151,9 @@ try {
 
 ### Concurrency Checks
 
-As opposed to version fields that are handled automatically, we can use 
-concurrency checks. They allow us to mark specific properties to be included
-in the concurrency check, just like the version field was. But this time, we
-will be responsible for updating the fields explicitly.
+As opposed to version fields that are handled automatically, we can use concurrency checks. They allow us to mark specific properties to be included in the concurrency check, just like the version field was. But this time, we will be responsible for updating the fields explicitly.
 
-When we try to update such entity without changing one of the concurrency fields,
-`OptimisticLockError` will be thrown. Same mechanism is then used to check whether
-the update succeeded, and throw the same type of error when not.
+When we try to update such entity without changing one of the concurrency fields, `OptimisticLockError` will be thrown. Same mechanism is then used to check whether the update succeeded, and throw the same type of error when not.
 
 ```ts
 @Entity()
@@ -241,23 +178,16 @@ export class ConcurrencyCheckUser {
 
 #### Important Implementation Notes
 
-You can easily get the optimistic locking workflow wrong if you compare the wrong versions. 
-Say you have Alice and Bob editing a hypothetical blog post:
+You can easily get the optimistic locking workflow wrong if you compare the wrong versions. Say you have Alice and Bob editing a hypothetical blog post:
 
 - Alice reads the headline of the blog post being "Foo", at optimistic lock version 1 (GET Request)
 - Bob reads the headline of the blog post being "Foo", at optimistic lock version 1 (GET Request)
 - Bob updates the headline to "Bar", upgrading the optimistic lock version to 2 (POST Request of a Form)
 - Alice updates the headline to "Baz", ... (POST Request of a Form)
 
-Now at the last stage of this scenario the blog post has to be read again from the database 
-before Alice's headline can be applied. At this point you will want to check if the blog 
-post is still at version 1 (which it is not in this scenario).
+Now at the last stage of this scenario the blog post has to be read again from the database before Alice's headline can be applied. At this point you will want to check if the blog post is still at version 1 (which it is not in this scenario).
 
-Using optimistic locking correctly, you **have** to add the version as an additional hidden 
-field (or into the session for more safety). Otherwise you cannot verify the version is still 
-the one being originally read from the database when Alice performed her GET request for the 
-blog post. If this happens you might see lost updates you wanted to prevent with Optimistic 
-Locking.
+Using optimistic locking correctly, you **have** to add the version as an additional hidden field (or into the session for more safety). Otherwise you cannot verify the version is still the one being originally read from the database when Alice performed her GET request for the blog post. If this happens you might see lost updates you wanted to prevent with Optimistic Locking.
 
 See the example code (frontend):
 
@@ -296,33 +226,24 @@ async update(req, res) {
 }
 ```
 
-Your frontend app loads an entity from API, the response includes the version property. 
-User makes some changes and fires PUT request back to the API, with version field included 
-in the payload. The PUT handler of the API then reads the version and passes it to the 
-`em.findOne()` call.
+Your frontend app loads an entity from API, the response includes the version property. User makes some changes and fires PUT request back to the API, with version field included in the payload. The PUT handler of the API then reads the version and passes it to the `em.findOne()` call.
 
 ### Pessimistic Locking
 
-MikroORM supports Pessimistic Locking at the database level. No attempt is being made to implement 
-pessimistic locking inside MikroORM, rather vendor-specific and ANSI-SQL commands are used to 
-acquire row-level locks. Every Entity can be part of a pessimistic lock, there is no special 
-metadata required to use this feature.
+MikroORM supports Pessimistic Locking at the database level. No attempt is being made to implement pessimistic locking inside MikroORM, rather vendor-specific and ANSI-SQL commands are used to acquire row-level locks. Every Entity can be part of a pessimistic lock, there is no special metadata required to use this feature.
 
-However, for Pessimistic Locking to work you have to disable the Auto-Commit Mode of your Database 
-and start a transaction around your pessimistic lock use-case using the "Approach 2: Explicit 
-Transaction Demarcation" described above. MikroORM will throw an Exception if you attempt to 
-acquire a pessimistic lock and no transaction is running.
+However, for Pessimistic Locking to work you have to disable the Auto-Commit Mode of your Database and start a transaction around your pessimistic lock use-case using the "Approach 2: Explicit Transaction Demarcation" described above. MikroORM will throw an Exception if you attempt to acquire a pessimistic lock and no transaction is running.
 
 MikroORM currently supports 6 pessimistic lock modes:
 
-| Mode | Postgres | MySQL |
-|------|----------|-------|
-| `LockMode.PESSIMISTIC_READ` | `for share` | `lock in share mode` |
-| `LockMode.PESSIMISTIC_WRITE` | `for update` | `for update` |
-| `LockMode.PESSIMISTIC_PARTIAL_WRITE` | `for update skip locked` | `for update skip locked` |
-| `LockMode.PESSIMISTIC_WRITE_OR_FAIL` | `for update nowait` | `for update nowait` |
-| `LockMode.PESSIMISTIC_PARTIAL_READ` | `for share skip locked` | `lock in share mode skip locked` |
-| `LockMode.PESSIMISTIC_READ_OR_FAIL` | `for share nowait` | `lock in share mode nowait` |
+| Mode                                 | Postgres                 | MySQL                            |
+| ------------------------------------ | ------------------------ | -------------------------------- |
+| `LockMode.PESSIMISTIC_READ`          | `for share`              | `lock in share mode`             |
+| `LockMode.PESSIMISTIC_WRITE`         | `for update`             | `for update`                     |
+| `LockMode.PESSIMISTIC_PARTIAL_WRITE` | `for update skip locked` | `for update skip locked`         |
+| `LockMode.PESSIMISTIC_WRITE_OR_FAIL` | `for update nowait`      | `for update nowait`              |
+| `LockMode.PESSIMISTIC_PARTIAL_READ`  | `for share skip locked`  | `lock in share mode skip locked` |
+| `LockMode.PESSIMISTIC_READ_OR_FAIL`  | `for share nowait`       | `lock in share mode nowait`      |
 
 You can use pessimistic locks in three different scenarios:
 
@@ -342,10 +263,10 @@ const res = await em.find(User, { name: 'Jon' }, {
   lockTableAliases: ['e0'],
 });
 
-// select ... 
+// select ...
 //   from "user" as "e0"
-//   left join "identity" as "i1" on "e0"."id" = "i1"."user_id" 
-//   where "e0"."name" = 'Jon' 
+//   left join "identity" as "i1" on "e0"."id" = "i1"."user_id"
+//   where "e0"."name" = 'Jon'
 //   for update of "e0" skip locked
 ```
 
@@ -367,5 +288,4 @@ Available isolation levels:
 - `IsolationLevel.REPEATABLE_READ`
 - `IsolationLevel.SERIALIZABLE`
 
-> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html) as the behaviour here is pretty much the same.

--- a/docs/versioned_docs/version-5.4/upgrading-v2-to-v3.md
+++ b/docs/versioned_docs/version-5.4/upgrading-v2-to-v3.md
@@ -2,19 +2,13 @@
 title: Upgrading from v2 to v3
 ---
 
-Following sections describe (hopefully) all breaking changes, most of them might be not valid 
-for you, like if you do not use custom `NamingStrategy` implementation, you do not care about
-the interface being changed.
+Following sections describe (hopefully) all breaking changes, most of them might be not valid for you, like if you do not use custom `NamingStrategy` implementation, you do not care about the interface being changed.
 
 ## Default value of autoFlush has changed to false
 
-> If you had `autoFlush: false` in your ORM configuration before, you can now remove 
-> this line, no changes are needed in your app. 
+> If you had `autoFlush: false` in your ORM configuration before, you can now remove this line, no changes are needed in your app.
 
-Default value for `autoFlush` is now `false`. That means you need to call 
-`em.flush()` yourself to persist changes into database. You can still change this via ORM's
-options to ease the transition but generally it is not recommended as it can cause unwanted
-small transactions being created around each `persist`. 
+Default value for `autoFlush` is now `false`. That means you need to call `em.flush()` yourself to persist changes into database. You can still change this via ORM's options to ease the transition but generally it is not recommended as it can cause unwanted small transactions being created around each `persist`.
 
 ```ts
 orm.em.persist(new Entity()); // no auto-flushing by default
@@ -24,29 +18,20 @@ await orm.em.persist(new Entity(), true); // you can still use second parameter 
 
 ## Reworked entity definition
 
-> Implementing those interfaces is optional.  
+> Implementing those interfaces is optional.
 
-Now it is no longer needed to merge entities with `IEntity` interface, that was polluting entity's 
-interface with internal methods. New interfaces `IdentifiedEntity<T>`, `UuidEntity<T>` and `MongoEntity<T>` 
-are introduced, that can be implemented by entities. They are not adding any new properties or methods, 
-keeping the entity's interface clean. This is also the reason why they can be omitted.
+Now it is no longer needed to merge entities with `IEntity` interface, that was polluting entity's interface with internal methods. New interfaces `IdentifiedEntity<T>`, `UuidEntity<T>` and `MongoEntity<T>` are introduced, that can be implemented by entities. They are not adding any new properties or methods, keeping the entity's interface clean. This is also the reason why they can be omitted.
 
-`IEntity` interface has been renamed to `AnyEntity<T, PK>` and it no longer has public methods 
-like `toJSON()`, `toObject()` or `init()`. One can use `wrap()` method provided by ORM that
-will enhance property type when needed with those methods (`await wrap(book.author).init()`). 
-To keep all methods available on the entity, you can still use interface merging with 
-`WrappedEntity<T, PK>` that both extends `AnyEntity<T, PK>` and defines all those methods.
+`IEntity` interface has been renamed to `AnyEntity<T, PK>` and it no longer has public methods like `toJSON()`, `toObject()` or `init()`. One can use `wrap()` method provided by ORM that will enhance property type when needed with those methods (`await wrap(book.author).init()`). To keep all methods available on the entity, you can still use interface merging with `WrappedEntity<T, PK>` that both extends `AnyEntity<T, PK>` and defines all those methods.
 
 You can mark the entity by implementing one of `*Entity` interfaces:
 
 - `IdEntity<T>` for numeric/string PK on `id` property (`id: number`)
 - `UuidEntity<T>` for string PK on `uuid` property (`uuid: string`)
 - `MongoEntity<T>` for mongo, where `id: string` and `_id: ObjectId` are required
-- `AnyEntity<T, PK>` for other possible properties (fill the PK property name to `PK` 
-parameter, e.g.: `AnyEntity<Book, 'myPrimaryProperty'>'`)
+- `AnyEntity<T, PK>` for other possible properties (fill the PK property name to `PK` parameter, e.g.: `AnyEntity<Book, 'myPrimaryProperty'>'`)
 
-To keep all public methods that were part of `IEntity` interface in v2, you can use 
-`WrappedEntity<T, PK>` via interface merging:
+To keep all public methods that were part of `IEntity` interface in v2, you can use `WrappedEntity<T, PK>` via interface merging:
 
 ```ts
 @Entity()
@@ -58,37 +43,25 @@ For more examples, take a look at [defining entities section](defining-entities.
 
 ## Integrated Knex.js as query builder and runner
 
-`QueryBuilder` now internally uses knex to run all queries. As knex already supports connection 
-pooling, this feature comes without any effort. New configuration for pooling is now available
+`QueryBuilder` now internally uses knex to run all queries. As knex already supports connection pooling, this feature comes without any effort. New configuration for pooling is now available
 
-Transactions now require using `em.transactional()` method, previous helpers 
-`beginTransaction`/`commit`/`rollback` are now removed.
+Transactions now require using `em.transactional()` method, previous helpers `beginTransaction`/`commit`/`rollback` are now removed.
 
-All transaction management has been removed from `IDatabaseDriver` interface, now EM handles 
-this, passing the transaction context (carried by EM, and created by `Connection`) to all 
-driver methods. New methods on EM exists: `isInTransaction()` and `getTransactionContext()`.
+All transaction management has been removed from `IDatabaseDriver` interface, now EM handles this, passing the transaction context (carried by EM, and created by `Connection`) to all driver methods. New methods on EM exists: `isInTransaction()` and `getTransactionContext()`.
 
-In postgres driver, it used to be required to pass parameters as indexed dollar sign 
-($1, $2, ...), while now knex requires the placeholder to be simple question mark (`?`), 
-like in other dialects, so this is now unified with other drivers.
+In postgres driver, it used to be required to pass parameters as indexed dollar sign ($1, $2, ...), while now knex requires the placeholder to be simple question mark (`?`), like in other dialects, so this is now unified with other drivers.
 
 ## ManyToMany now uses composite primary key
 
-Previously it was required to have autoincrement primary key for m:n pivot tables. Now this 
-has changed. By default, only foreign columns are required and composite key over both of them
-is used as primary key.
+Previously it was required to have autoincrement primary key for m:n pivot tables. Now this has changed. By default, only foreign columns are required and composite key over both of them is used as primary key.
 
-To preserve stable order of collections, you can force previous behaviour by defining the 
-m:n property as `fixedOrder: true`, which will start ordering by `id` column. You can also 
-override the order column name via `fixedOrderColumn: 'order'`. 
+To preserve stable order of collections, you can force previous behaviour by defining the m:n property as `fixedOrder: true`, which will start ordering by `id` column. You can also override the order column name via `fixedOrderColumn: 'order'`.
 
 You can also specify default ordering via `orderBy: { ... }` attribute.
 
 ## Entity references now don't have instantiated collections
 
-Previously all entity instances, including entity references (not fully loaded entities where
-we know only the primary key), had instantiated collection classes. Now only initialized entities
-have them.
+Previously all entity instances, including entity references (not fully loaded entities where we know only the primary key), had instantiated collection classes. Now only initialized entities have them.
 
 ```ts
 const book = em.getReference(Book, 1);
@@ -99,12 +72,9 @@ console.log(book.tags); // instance of Collection (not initialized)
 
 ## EntityAssigner.assign() requires EM for new entities
 
-Previously all entities had internal reference to the root EM - the one created when 
-initializing the ORM. Now only managed entities (those merged to the EM, e.g. loaded 
-from the database) have this internal reference. 
+Previously all entities had internal reference to the root EM - the one created when initializing the ORM. Now only managed entities (those merged to the EM, e.g. loaded from the database) have this internal reference.
 
-To use `assign()` method on new (not managed) entities, you need to provide the `em`
-parameter:
+To use `assign()` method on new (not managed) entities, you need to provide the `em` parameter:
 
 ```ts
 const book = new Book();
@@ -113,46 +83,36 @@ wrap(book).assign(data, { em: orm.em });
 
 ## Strict FilterQuery and smart query conditions
 
-`FilterQuery` now does not allow using smart query operators. You can either cast your condition 
-as any or use object syntax instead (instead of `{ 'age:gte': 18 }` use `{ age: { $gte: 18 } }`).
+`FilterQuery` now does not allow using smart query operators. You can either cast your condition as any or use object syntax instead (instead of `{ 'age:gte': 18 }` use `{ age: { $gte: 18 } }`).
 
 ## Logging configuration
 
-Previously to start logging it was required to provide your custom logger. Logger now defaults 
-to `console.log()`, and users can specify what namespaces are they interested in via `debug` 
-option. `true`/`false` will enable/disable all namespaces.
+Previously to start logging it was required to provide your custom logger. Logger now defaults to `console.log()`, and users can specify what namespaces are they interested in via `debug` option. `true`/`false` will enable/disable all namespaces.
 
 Available logger namespaces: `'query' | 'query-params' | 'discovery' | 'info'`.
 
-## Removed deprecated fk option from 1:m and m:1 decorators 
+## Removed deprecated fk option from 1:m and m:1 decorators
 
 Use `mappedBy`/`inversedBy` instead.
 
 ## SchemaGenerator.generate() is now async
 
-If you used `SchemaGenerator`, now there is CLI tool you can use instead. Learn more 
-in [SchemaGenerator docs](schema-generator.md). To setup CLI, take a look at 
-[installation section](installation.md).
+If you used `SchemaGenerator`, now there is CLI tool you can use instead. Learn more in [SchemaGenerator docs](schema-generator.md). To setup CLI, take a look at [installation section](installation.md).
 
 ## New method on NamingStrategy interface
 
-`getClassName()` is used to find entity class name based on its file name. Now users can 
-override the default implementation to accommodate their specific needs.
+`getClassName()` is used to find entity class name based on its file name. Now users can override the default implementation to accommodate their specific needs.
 
-If you used custom naming strategy, you will either need to implement this method yourself, 
-or extend `AbstractNamingStrategy`.
+If you used custom naming strategy, you will either need to implement this method yourself, or extend `AbstractNamingStrategy`.
 
 ## TypescriptMetadataProvider has been renamed
 
-The name is now `TsMorphMetadataProvider`, there is also newly added `ReflectMetadataProvider`
-that uses `reflect-metadata` instead. As `TypescriptMetadataProvider` was the default, no 
-changes should be required. 
+The name is now `TsMorphMetadataProvider`, there is also newly added `ReflectMetadataProvider` that uses `reflect-metadata` instead. As `TypescriptMetadataProvider` was the default, no changes should be required.
 
 ## Updated mongodb driver
 
 MongoDB driver version 3.3.4 or higher is now required.
 
 ## EntityManager.find() now requires where parameter
-`EntityManager` has now same `find` method interface aligned with `EntityRepository`, 
-`where` parameter is now required. To select all entities, use `em.find(Entity, {})` 
-as value.
+
+`EntityManager` has now same `find` method interface aligned with `EntityRepository`, `where` parameter is now required. To select all entities, use `em.find(Entity, {})` as value.

--- a/docs/versioned_docs/version-5.4/upgrading-v3-to-v4.md
+++ b/docs/versioned_docs/version-5.4/upgrading-v3-to-v4.md
@@ -2,24 +2,19 @@
 title: Upgrading from v3 to v4
 ---
 
-> Following sections describe (hopefully) all breaking changes, most of them might be not valid 
-> for you, like if you do not use custom `NamingStrategy` implementation, you do not care about
-> the interface being changed.
+> Following sections describe (hopefully) all breaking changes, most of them might be not valid for you, like if you do not use custom `NamingStrategy` implementation, you do not care about the interface being changed.
 
 ## Node 10.13.0+ required
 
-Support for older node versions was dropped. 
+Support for older node versions was dropped.
 
 ## TypeScript 3.7+ required
 
-Support for older TypeScript versions was dropped. 
+Support for older TypeScript versions was dropped.
 
 ## Monorepo
 
-The ORM has been split into several packages. In v4 one needs to require
-`@mikro-orm/core` and a driver package, e.g. `@mikro-orm/mysql`. This driver
-package already contains the `mysql2` dependency, so you can remove that from
-your `package.json`. 
+The ORM has been split into several packages. In v4 one needs to require `@mikro-orm/core` and a driver package, e.g. `@mikro-orm/mysql`. This driver package already contains the `mysql2` dependency, so you can remove that from your `package.json`.
 
 - `@mikro-orm/core`
 - `@mikro-orm/reflection` - `TsMorphMetadataProvider`
@@ -34,17 +29,13 @@ your `package.json`.
 - `@mikro-orm/postgresql`
 - `@mikro-orm/mongodb`
 
-> For easier transition, meta package mikro-orm is still present, reexporting 
-> core, reflection, migrations, entity-generator and cli packages. You should 
-> **not** install both `mikro-orm` and `@mikro-orm/core` packages together. 
+> For easier transition, meta package mikro-orm is still present, reexporting core, reflection, migrations, entity-generator and cli packages. You should **not** install both `mikro-orm` and `@mikro-orm/core` packages together.
 
-> You should prefer the `@mikro-orm/core` over `mikro-orm` package, there were
-> weird dependency issues reported with the `mikro-orm` meta-package. 
+> You should prefer the `@mikro-orm/core` over `mikro-orm` package, there were weird dependency issues reported with the `mikro-orm` meta-package.
 
 ## Default metadata provider is now `ReflectMetadataProvider`
 
-If you want to use ts-morph, you need to install `@mikro-orm/reflection` package
-and enable the provider explicitly in the ORM config, as described [here](./metadata-providers.md#tsmorphmetadataprovider).
+If you want to use ts-morph, you need to install `@mikro-orm/reflection` package and enable the provider explicitly in the ORM config, as described [here](./metadata-providers.md#tsmorphmetadataprovider).
 
 ```ts
 import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
@@ -55,30 +46,22 @@ await MikroORM.init({
 });
 ```
 
-Using `ReflectMetadataProvider` has some limitations, so be sure to read 
-about them [here](./metadata-providers.md#limitations-and-requirements).
+Using `ReflectMetadataProvider` has some limitations, so be sure to read about them [here](./metadata-providers.md#limitations-and-requirements).
 
-One common gotcha with `reflect-metadata` is that you need to explicitly
-state the property type when using property initializer:
+One common gotcha with `reflect-metadata` is that you need to explicitly state the property type when using property initializer:
 
 ```ts
 @Property()
 createdAt: Date = new Date();
 ```
 
-Without the explicit type, we would infer `Object` instead of `Date`, 
-which would be most probably mapped to JSON column type (depends on driver).
+Without the explicit type, we would infer `Object` instead of `Date`, which would be most probably mapped to JSON column type (depends on driver).
 
 ## SqlEntityManager and MongoEntityManager
 
-In v4 the `core` package, where `EntityManager` and `EntityRepository` are 
-defined, is not dependent on knex, and therefore it cannot have a method 
-returning a `QueryBuilder`. You need to import the SQL flavour of the EM 
-from the driver package to access the `createQueryBuilder()` method.
+In v4 the `core` package, where `EntityManager` and `EntityRepository` are defined, is not dependent on knex, and therefore it cannot have a method returning a `QueryBuilder`. You need to import the SQL flavour of the EM from the driver package to access the `createQueryBuilder()` method.
 
-> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under 
-> this name and under `EntityManager` alias, so you can just change the 
-> location from where you import.
+> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ```ts
 import { EntityManager } from '@mikro-orm/mysql'; // or any other SQL driver package
@@ -96,32 +79,21 @@ const em: EntityManager;
 const ret = await em.aggregate(...);
 ```
 
-> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under 
-> this name and under `EntityManager` alias, so you can just change the 
-> location from where you import.
+> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ## Different default `pivotTable`
 
-Implementation of `UnderscoreNamingStrategy` and `EntityCaseNamingStrategy` 
-`joinTableName()` method has changed. You can use `pivotTable` on the owning side
-of M:N relation to specify the table name manually. 
+Implementation of `UnderscoreNamingStrategy` and `EntityCaseNamingStrategy` `joinTableName()` method has changed. You can use `pivotTable` on the owning side of M:N relation to specify the table name manually.
 
-Previously the table name did not respect property name, if one defined multiple
-M:N relations between same entities, there were conflicts and one would have to 
-specify `pivotTable` name manually at least on one of them. With the new way, 
-we can be sure that the table name won't conflict with other pivot tables. 
+Previously the table name did not respect property name, if one defined multiple M:N relations between same entities, there were conflicts and one would have to specify `pivotTable` name manually at least on one of them. With the new way, we can be sure that the table name won't conflict with other pivot tables.
 
-Previously the name was constructed from 2 entity names as `entity_a_to_entity_b`,
-ignoring the actual property name. In v4 the name will be `entity_a_coll_name` in 
-case of the collection property on the owning side being named `collName`. 
+Previously the name was constructed from 2 entity names as `entity_a_to_entity_b`, ignoring the actual property name. In v4 the name will be `entity_a_coll_name` in case of the collection property on the owning side being named `collName`.
 
 ## Changes in folder-based discovery (`entitiesDirs` removed)
 
-`entitiesDirs` and `entitiesDirsTs` were removed in favour of `entities` and `entitiesTs`,
-`entities` will be used as a default for `entitiesTs` (that is used when we detect `ts-node`).
+`entitiesDirs` and `entitiesDirsTs` were removed in favour of `entities` and `entitiesTs`, `entities` will be used as a default for `entitiesTs` (that is used when we detect `ts-node`).
 
-`entities` can now contain mixture of paths to directories, globs pointing to entities,
-or references to the entities or instances of `EntitySchema`. 
+`entities` can now contain mixture of paths to directories, globs pointing to entities, or references to the entities or instances of `EntitySchema`.
 
 This basically means that all you need to change is renaming `entitiesDirs` to `entities`.
 
@@ -134,26 +106,17 @@ MikroORM.init({
 
 ## Changes in `wrap()` helper, `WrappedEntity` interface and `Reference` wrapper
 
-Previously all the methods and properties of `WrappedEntity` interface were
-added to the entity prototype during discovery. In v4 there is only one property
-added: `__helper: WrappedEntity`. `WrappedEntity` has been converted to actual class.
+Previously all the methods and properties of `WrappedEntity` interface were added to the entity prototype during discovery. In v4 there is only one property added: `__helper: WrappedEntity`. `WrappedEntity` has been converted to actual class.
 
-`wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is 
-being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...),
-if you want to access internal properties like `__meta` or `__em`, you need to explicitly
-ask for the helper via `wrap(entity, true)`.
+`wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...), if you want to access internal properties like `__meta` or `__em`, you need to explicitly ask for the helper via `wrap(entity, true)`.
 
-Internal methods (with `__` prefix) were also removed from the `Reference` class, 
-use `wrap(ref, true)` to access them. 
+Internal methods (with `__` prefix) were also removed from the `Reference` class, use `wrap(ref, true)` to access them.
 
-Instead of interface merging with `WrappedEntity`, one can now use classic inheritance,
-by extending `BaseEntity` exported from `@mikro-orm/core`. If you do so, `wrap(entity)` 
-will return your entity. 
+Instead of interface merging with `WrappedEntity`, one can now use classic inheritance, by extending `BaseEntity` exported from `@mikro-orm/core`. If you do so, `wrap(entity)` will return your entity.
 
 ## Removed `flush` parameter from `persist()` and `remove()` methods
 
-`flush` param is removed, both `persist` and `remove` methods are synchronous and
-require explicit flushing, possibly via fluent interface call.
+`flush` param is removed, both `persist` and `remove` methods are synchronous and require explicit flushing, possibly via fluent interface call.
 
 ```ts
 // before
@@ -167,19 +130,15 @@ await em.remove(jon).flush();
 
 ## `remove()` method requires entity instances
 
-The `em.remove()` method originally allowed to pass either entity instance, or 
-a condition. When one passed a condition, it was firing a native delete query, 
-without handling transactions or hooks. 
+The `em.remove()` method originally allowed to pass either entity instance, or a condition. When one passed a condition, it was firing a native delete query, without handling transactions or hooks.
 
-In v4, the method is now simplified and works only with entity instances. Use 
-`em.nativeDelete()` explicitly if you want to fire a delete query instead of 
-letting the `UnitOfWork` doing its job.
+In v4, the method is now simplified and works only with entity instances. Use `em.nativeDelete()` explicitly if you want to fire a delete query instead of letting the `UnitOfWork` doing its job.
 
 ```ts
 // before
 await em.remove(Author, 1); // fires query directly
 
-// after 
+// after
 await em.nativeDelete(Author, 1);
 ```
 
@@ -187,20 +146,11 @@ await em.nativeDelete(Author, 1);
 
 ## Type safe references
 
-EM now returns `Loaded<T, P>` instead of the entity (`T`). This type automatically
-adds synchronous method `get()` that returns the entity (for references) or array
-of entities (for collections).
+EM now returns `Loaded<T, P>` instead of the entity (`T`). This type automatically adds synchronous method `get()` that returns the entity (for references) or array of entities (for collections).
 
-`Reference.get()` is now available only with correct `Loaded` type hint and is used 
-as a sync getter for the entity, just like `unwrap()`. You can use `Reference.load(prop)` 
-for the original `get()` method functionality. 
+`Reference.get()` is now available only with correct `Loaded` type hint and is used as a sync getter for the entity, just like `unwrap()`. You can use `Reference.load(prop)` for the original `get()` method functionality.
 
-`em.find()` and similar methods now have two type arguments, due to TypeScript not supporting partial
-type inference, when you specify the `T` explicitly (without also explicitly 
-specifying the load hint), the inference will not work. This use case was mainly
-for usage without classes (interfaces + `EntitySchema`) - in that case it is now 
-supported to pass actual instance of `EntitySchema` as the first parameter to these
-methods, that will allow correct type inference:
+`em.find()` and similar methods now have two type arguments, due to TypeScript not supporting partial type inference, when you specify the `T` explicitly (without also explicitly specifying the load hint), the inference will not work. This use case was mainly for usage without classes (interfaces + `EntitySchema`) - in that case it is now supported to pass actual instance of `EntitySchema` as the first parameter to these methods, that will allow correct type inference:
 
 ```ts
 const author = await em.findOne(AuthorSchema, { ... }, ['books']);
@@ -209,59 +159,45 @@ console.log(author.books.get()); // `get()` is now inferred correctly
 
 ## Custom types are now type safe
 
-Generic `Type` class has now two type arguments - the input and output types. 
-Input type defaults to `string`, output type defaults to the input type. 
+Generic `Type` class has now two type arguments - the input and output types. Input type defaults to `string`, output type defaults to the input type.
 
 You might need to explicitly provide the types if your methods are strictly typed.
 
 ## Custom type serialization
 
-Custom types used to be serialized to the database value. In v4, the runtime 
-value is used by default. Implement custom `toJSON()` method if you need to 
-customize this.
+Custom types used to be serialized to the database value. In v4, the runtime value is used by default. Implement custom `toJSON()` method if you need to customize this.
 
 ## Property `default` and `defaultRaw`
 
-Previously the `default` option of properties was used as is, so we had to wrap 
-strings in quotes (e.g. `@Property({ default: "'foo bar'" })`). 
+Previously the `default` option of properties was used as is, so we had to wrap strings in quotes (e.g. `@Property({ default: "'foo bar'" })`).
 
-In v4 the `default` is typed as `string | number | boolean | null` and when used
-with string value, it will be automatically quoted. 
+In v4 the `default` is typed as `string | number | boolean | null` and when used with string value, it will be automatically quoted.
 
 To use SQL functions we now need to use `defaultRaw`: `@Property({ defaultRaw: 'now()' })`.
 
 ## `autoFlush` option has been removed
 
-Also `persistLater()` and `removeLater()` methods are deprecated. Use `persist()` or
-`remove` respectively.
+Also `persistLater()` and `removeLater()` methods are deprecated. Use `persist()` or `remove` respectively.
 
 ## `IdEntity`, `UuidEntity` and `MongoEntity` interfaces are removed
 
-They were actually never needed. 
+They were actually never needed.
 
 ## MongoDB driver is no longer the default
 
-You need to specify the platform type either via `type` option or provide the driver
-implementation via `driver` option. 
+You need to specify the platform type either via `type` option or provide the driver implementation via `driver` option.
 
 Available platforms types: `[ 'mongo', 'mysql', 'mariadb', 'postgresql', 'sqlite' ]`
 
 ## Removed configuration `discovery.tsConfigPath`
 
-Removed as it is no longer needed, it was used only for `TsMorphMetadataProvider`,
-when the `entitiesDirsTs` were not explicitly provided. In v4, this is no longer
-needed, as ts-morph discovery will use `d.ts` files instead, that should be located
-next to the compiled entities. 
+Removed as it is no longer needed, it was used only for `TsMorphMetadataProvider`, when the `entitiesDirsTs` were not explicitly provided. In v4, this is no longer needed, as ts-morph discovery will use `d.ts` files instead, that should be located next to the compiled entities.
 
 ## Changes in query highlighting
 
-Previously Highlight.js was used to highlight various things in the CLI, 
-like SQL and mongo queries, or migrations or entities generated via CLI.
-While the library worked fine, it was causing performance issues mainly 
-for those bundling via webpack and using lambdas, as the library was huge.
+Previously Highlight.js was used to highlight various things in the CLI, like SQL and mongo queries, or migrations or entities generated via CLI. While the library worked fine, it was causing performance issues mainly for those bundling via webpack and using lambdas, as the library was huge.
 
-In v4 highlighting is disabled by default, and there are 2 highlighters 
-you can optionally use (you need to install them first).
+In v4 highlighting is disabled by default, and there are 2 highlighters you can optionally use (you need to install them first).
 
 ```ts
 import { SqlHighlighter } from '@mikro-orm/sql-highlighter';

--- a/docs/versioned_docs/version-5.4/upgrading-v4-to-v5.md
+++ b/docs/versioned_docs/version-5.4/upgrading-v4-to-v5.md
@@ -2,23 +2,19 @@
 title: Upgrading from v4 to v5
 ---
 
-> Following sections describe (hopefully) all breaking changes, most of them might be not valid 
-> for you, like if you do not use custom `NamingStrategy` implementation, you do not care about
-> the interface being changed.
+> Following sections describe (hopefully) all breaking changes, most of them might be not valid for you, like if you do not use custom `NamingStrategy` implementation, you do not care about the interface being changed.
 
 ## Node 14+ required
 
-Support for older node versions was dropped. 
+Support for older node versions was dropped.
 
 ## TypeScript 4.1+ required
 
-Support for older TypeScript versions was dropped. 
+Support for older TypeScript versions was dropped.
 
 ## Options parameters
 
-Previously many methods had many (often boolean) parameters, in v5 such methods are
-refactored to use options object instead to improve readability. Some methods offered
-both signatures - the multi parameter signatures are now removed.
+Previously many methods had many (often boolean) parameters, in v5 such methods are refactored to use options object instead to improve readability. Some methods offered both signatures - the multi parameter signatures are now removed.
 
 List of such methods:
 
@@ -47,10 +43,7 @@ This also applies to the methods on `IDatabaseDriver` interface.
 
 ## Type-safe populate parameter with dot notation
 
-`FindOptions.populate` parameter is now strictly typed and supports only array of 
-strings or a boolean.
-Object way is no longer supported. To set loading strategy, use `FindOptions.strategy`.
-The return type of all such methods now returns properly typed `Loaded` response. 
+`FindOptions.populate` parameter is now strictly typed and supports only array of strings or a boolean. Object way is no longer supported. To set loading strategy, use `FindOptions.strategy`. The return type of all such methods now returns properly typed `Loaded` response.
 
 ## Type-safe fields parameter
 
@@ -58,8 +51,7 @@ The return type of all such methods now returns properly typed `Loaded` response
 
 ## Type-safe orderBy parameter
 
-`FindOptions.orderBy` parameter is now strictly typed. It also allows passing an 
-array of objects instead of just a single object.
+`FindOptions.orderBy` parameter is now strictly typed. It also allows passing an array of objects instead of just a single object.
 
 ```ts
 const books = await em.find(Book, {}, {
@@ -72,41 +64,25 @@ const books = await em.find(Book, {}, {
 
 ## Removed `@Repository()` decorator
 
-The decorator was problematic as it could only work properly it the file was required
-soon enough - before the ORM initialization, otherwise the repository would not be 
-registered at all.
+The decorator was problematic as it could only work properly it the file was required soon enough - before the ORM initialization, otherwise the repository would not be registered at all.
 
-Use `@Entity({ customRepository: () => CustomRepository })` in the entity definition
-instead.
+Use `@Entity({ customRepository: () => CustomRepository })` in the entity definition instead.
 
 ## Disallowed global identity map
 
-In v5, it is no longer possible to use the global identity map. This was a 
-common issue that led to weird bugs, as using the global EM without request
-context is wrong, we always need to have a dedicated context for each request,
-so they do not interfere.
+In v5, it is no longer possible to use the global identity map. This was a common issue that led to weird bugs, as using the global EM without request context is wrong, we always need to have a dedicated context for each request, so they do not interfere.
 
-Now we get a validation error if we try to use the global context. We still can
-disable this check via `allowGlobalContext` configuration, or a connected 
-environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can be handy 
-especially in unit tests.
+Now we get a validation error if we try to use the global context. We still can disable this check via `allowGlobalContext` configuration, or a connected environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can be handy especially in unit tests.
 
 ## `LoadedCollection.get()` and `$` now return the `Collection` instance
 
-Previously those dynamically added getters returned the array copy of collection
-items. In v5, we return the collection instance, which is also iterable and has
-a `length` getter and indexed access support, so it mimics the array. To get the
-array copy as before, call `getItems()` as with a regular collection.
+Previously those dynamically added getters returned the array copy of collection items. In v5, we return the collection instance, which is also iterable and has a `length` getter and indexed access support, so it mimics the array. To get the array copy as before, call `getItems()` as with a regular collection.
 
 ## Different table aliasing for select-in loading strategy and for QueryBuilder
 
-Previously with select-in strategy as well as with QueryBuilder, table aliases
-were always the letter `e` followed by unique index. In v5, we use the same 
-method as with joined strategy - the letter is inferred from the entity name.
+Previously with select-in strategy as well as with QueryBuilder, table aliases were always the letter `e` followed by unique index. In v5, we use the same method as with joined strategy - the letter is inferred from the entity name.
 
-This can be breaking if you used the aliases somewhere, e.g. in custom SQL 
-fragments. We can restore to the old behaviour by implementing custom naming
-strategy, overriding the `aliasName` method:
+This can be breaking if you used the aliases somewhere, e.g. in custom SQL fragments. We can restore to the old behaviour by implementing custom naming strategy, overriding the `aliasName` method:
 
 ```ts
 import { AbstractNamingStrategy } from '@mikro-orm/core';
@@ -118,37 +94,27 @@ class CustomNamingStrategy extends AbstractNamingStrategy {
 }
 ```
 
-Note that in v5 it is possible to use `expr()` helper to access the alias name
-dynamically, e.g. ``expr(alias => `lower('${alias}.name')`)``, which should be 
-now preferred way instead of hardcoding the aliases.
+Note that in v5 it is possible to use `expr()` helper to access the alias name dynamically, e.g. `` expr(alias => `lower('${alias}.name')`) ``, which should be now preferred way instead of hardcoding the aliases.
 
 ## Migrations are now stored without extensions
 
-Running migrations in production via node and ts-node is now handled the same.
-This should actually not be breaking, as old format with extension is still 
-supported (e.g. they still can be rolled back), but newly logged migrations
-will not contain the extension.
+Running migrations in production via node and ts-node is now handled the same. This should actually not be breaking, as old format with extension is still supported (e.g. they still can be rolled back), but newly logged migrations will not contain the extension.
 
 ## Changes in `assign()` helper
 
-Embeddable instances are now created via `EntityFactory` and they respect the
-`forceEntityConstructor` configuration. Due to this we need to have EM instance
-when assigning to embedded properties. 
+Embeddable instances are now created via `EntityFactory` and they respect the `forceEntityConstructor` configuration. Due to this we need to have EM instance when assigning to embedded properties.
 
 Using `em.assign()` should be preferred to get around this.
 
-Deep assigning of child entities now works by default based on the presence of PKs in the payload.
-This behaviour can be disable via updateByPrimaryKey: false in the assign options.
+Deep assigning of child entities now works by default based on the presence of PKs in the payload. This behaviour can be disable via updateByPrimaryKey: false in the assign options.
 
 `mergeObjects` option is now enabled by default.
 
 ## `em.populate()` always return array of entities
 
-Previously it was possible to call `em.populate()` with a single entity input,
-and the output would be again just a single entity.
+Previously it was possible to call `em.populate()` with a single entity input, and the output would be again just a single entity.
 
-Due to issues with TS 4.5, this method now always return array of entities.
-You can use destructing if you want to have a single entity return type:
+Due to issues with TS 4.5, this method now always return array of entities. You can use destructing if you want to have a single entity return type:
 
 ```ts
 const [loadedAuthor] = await em.populate(author, ...);
@@ -156,66 +122,45 @@ const [loadedAuthor] = await em.populate(author, ...);
 
 ## QueryBuilder is awaitable
 
-Previously awaiting of QB instance was a no-op. In v5, QB is promise-like interface,
-so we can await it. More about this in [Awaiting the QueryBuilder](./query-builder.md#awaiting-the-querybuilder) section.
+Previously awaiting of QB instance was a no-op. In v5, QB is promise-like interface, so we can await it. More about this in [Awaiting the QueryBuilder](./query-builder.md#awaiting-the-querybuilder) section.
 
 ## `UnitOfWork.getScheduledCollectionDeletions()` has been removed
 
-Previously scheduled collection deletions were used for a hack when removing 
-1:m collection via orphan removal might require early deletes - in case we were 
-adding the same entity (but different instance), so with same PK - inserting it 
-in the same unit would cause unique constraint failures.
+Previously scheduled collection deletions were used for a hack when removing 1:m collection via orphan removal might require early deletes - in case we were adding the same entity (but different instance), so with same PK - inserting it in the same unit would cause unique constraint failures.
 
 Also `IDatabaseDriver.clearCollection()` method is no longer present in the driver API.
 
 ## `populateAfterFlush` is enabled by default
 
-After flushing a new entity, all relations are marked as populated,
-just like if the entity was loaded from the db. This aligns the serialized
-output of `e.toJSON()` of a loaded entity and just-inserted one.
+After flushing a new entity, all relations are marked as populated, just like if the entity was loaded from the db. This aligns the serialized output of `e.toJSON()` of a loaded entity and just-inserted one.
 
-In v4 this behaviour was disabled by default, so even after the new entity was
-flushed, the serialized form contained only FKs for its relations. We can opt in
-to this old behaviour via `populateAfterFlush: false`.
+In v4 this behaviour was disabled by default, so even after the new entity was flushed, the serialized form contained only FKs for its relations. We can opt in to this old behaviour via `populateAfterFlush: false`.
 
 ## `migrations.pattern` is removed in favour of `migrations.glob`
 
-Migrations are using `umzug` under the hood, which is now upgraded to v3.0.
-With this version, the `pattern` configuration options is no longer available, 
-and has been replaced with `glob`. This change is also reflected in MikroORM.
+Migrations are using `umzug` under the hood, which is now upgraded to v3.0. With this version, the `pattern` configuration options is no longer available, and has been replaced with `glob`. This change is also reflected in MikroORM.
 
-The default value for `glob` is `!(*.d).{js,ts}`, so both JS and TS files are matched
-(but not .d.ts files). You should usually not need to change this option as this default
-suits both development and production environments.
+The default value for `glob` is `!(*.d).{js,ts}`, so both JS and TS files are matched (but not .d.ts files). You should usually not need to change this option as this default suits both development and production environments.
 
 ## Population no longer infers the where condition by default
 
 > This applies only to SELECT_IN strategy, as JOINED strategy implies the inference.
 
-Previously when we used populate hints in `em.find()` and similar methods, the
-query for our entity would be analysed and parts of it extracted and used for 
-the population. Following example would find all authors that have books with 
-given IDs, and populate their books collection, again using this PK condition,
-resulting in only such books being in those collections. 
+Previously when we used populate hints in `em.find()` and similar methods, the query for our entity would be analysed and parts of it extracted and used for the population. Following example would find all authors that have books with given IDs, and populate their books collection, again using this PK condition, resulting in only such books being in those collections.
 
 ```ts
 // this would end up with `Author.books` collections having only books of PK 1, 2, 3
 const a = await em.find(Author, { books: [1, 2, 3] }, { populate: ['books'] });
 ```
 
-Following this example, if we wanted to load all books, we would need a separate 
-`em.populate()` call:
+Following this example, if we wanted to load all books, we would need a separate `em.populate()` call:
 
 ```ts
 const a = await em.find(Author, { books: [1, 2, 3] });
 await em.populate(a, ['books']);
 ```
 
-This behaviour changed and is now configurable both globally and locally, via 
-`populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and 
-`PopulateHint.INFER`, the former being the default in v5, the latter being the
-default behaviour in v4. Locally (via `FindOptions`) we can also specify custom
-where condition that will be passed to `em.populate()` call.
+This behaviour changed and is now configurable both globally and locally, via `populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and `PopulateHint.INFER`, the former being the default in v5, the latter being the default behaviour in v4. Locally (via `FindOptions`) we can also specify custom where condition that will be passed to `em.populate()` call.
 
 ```ts
 // revert back to the old behaviour locally
@@ -227,20 +172,12 @@ const a = await em.find(Author, { books: [1, 2, 3] }, {
 
 ## `em.create()` respects required properties
 
-`em.create()` will now require you to pass all non-optional properties. Some 
-properties might be defined as required for TS, but we have a default value for 
-them (either runtime, or database one) - for such we can use `OptionalProps` 
-symbol to specify which properties should be considered as optional.
+`em.create()` will now require you to pass all non-optional properties. Some properties might be defined as required for TS, but we have a default value for them (either runtime, or database one) - for such we can use `OptionalProps` symbol to specify which properties should be considered as optional.
 
 ## Required properties are validated before insert
 
-Previously the validation took place in the database, so it worked only for SQL
-drivers. Now we have runtime validation based on the entity metadata. This means
-mongo users now need to use `nullable: true` on their optional properties, or
-disable the validation globally via `validateRequired: false` in the ORM config.
+Previously the validation took place in the database, so it worked only for SQL drivers. Now we have runtime validation based on the entity metadata. This means mongo users now need to use `nullable: true` on their optional properties, or disable the validation globally via `validateRequired: false` in the ORM config.
 
 ## `PrimaryKeyType` symbol should be defined as optional
 
-Previously when we had nonstandard PK types, we could use `PrimaryKeyType` symbol
-to let the type system know it. It was required to define this property as 
-required, now it can be defined as optional too.
+Previously when we had nonstandard PK types, we could use `PrimaryKeyType` symbol to let the type system know it. It was required to define this property as required, now it can be defined as optional too.

--- a/docs/versioned_docs/version-5.4/usage-with-adminjs.md
+++ b/docs/versioned_docs/version-5.4/usage-with-adminjs.md
@@ -6,12 +6,15 @@ sidebar_label: Usage with AdminJS
 ## Installation
 
 To use MikroORM with AdminJS you need to install:
+
 1. [`AdminJS Core`](https://github.com/SoftwareBrothers/adminjs):
+
 ```bash
 $ yarn add adminjs
 ```
 
 2. [`MikroORM Adapter`](https://github.com/SoftwareBrothers/adminjs-mikroorm):
+
 ```bash
 $ yarn add @adminjs/mikroorm
 # A MikroORM driver and core package, choose the one which suits you:
@@ -23,7 +26,9 @@ $ yarn add @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 ```
 
 3. A plugin specific to your server's framework:
+
 - [`Express Plugin`](https://github.com/SoftwareBrothers/adminjs-expressjs):
+
 ```bash
 $ yarn add @adminjs/express
 # Peer dependencies
@@ -31,6 +36,7 @@ $ yarn add express express-formidable express-session
 ```
 
 - [`Hapi Plugin`](https://github.com/SoftwareBrothers/adminjs-hapijs):
+
 ```bash
 $ yarn add @adminjs/hapi
 # Peer dependencies
@@ -41,8 +47,7 @@ $ yarn add @hapi/boom @hapi/cookie @hapi/hapi @hapi/inert
 
 ## Setup
 
-Once the installation process is completed, we need to set up AdminJS endpoints and database connection.
-The process is straightforward but differs based on which `plugin` you are using. Below you can find examples specific to supported frameworks:
+Once the installation process is completed, we need to set up AdminJS endpoints and database connection. The process is straightforward but differs based on which `plugin` you are using. Below you can find examples specific to supported frameworks:
 
 ### MikroORM + Express Plugin
 
@@ -133,7 +138,6 @@ const run = async () => {
 run();
 ```
 
-
 You can start your server afterwards and the admin panel will be available at `http://localhost:{PORT}/admin`. If you followed the example setup thoroughly, you should be able to see all of your entities in the sidebar and you should be able to perform basic **CRUD** operations on them.
 
 To further customize your AdminJS panel, please refer to the [`official documentation`](https://adminjs.co/docs.html).
@@ -149,11 +153,13 @@ The examples above set up AdminJS with unauthenticated access. To require your u
 You need to use `AdminJSExpress.buildAuthenticatedRouter` instead of `AdminJS.buildRouter`:
 
 **Before**:
+
 ```ts
   const router = AdminJSExpress.buildRouter(admin);
 ```
 
 **After**:
+
 ```ts
 const ADMIN_EMAIL = 'example@test.com';
 const ADMIN_PASSWORD = 'password';
@@ -174,6 +180,7 @@ const router = AdminJSExpress.buildAuthenticatedRouter(admin, {
 You need to simply add `auth` property to AdminJS options.
 
 **Before**:
+
 ```ts
 const adminOptions = {
   databases: [orm],
@@ -181,6 +188,7 @@ const adminOptions = {
 ```
 
 **After**:
+
 ```ts
 const ADMIN_EMAIL = 'example@test.com';
 const ADMIN_PASSWORD = 'password';

--- a/docs/versioned_docs/version-5.4/usage-with-babel.md
+++ b/docs/versioned_docs/version-5.4/usage-with-babel.md
@@ -2,9 +2,7 @@
 title: Usage with Babel
 ---
 
-When compiling TS via babel, decorators are by default handled different implementation
-than what `tsc` uses. To make the metadata extraction from decorators via Babel work, 
-we need to do use following plugins:
+When compiling TS via babel, decorators are by default handled different implementation than what `tsc` uses. To make the metadata extraction from decorators via Babel work, we need to do use following plugins:
 
 ```json
 {
@@ -18,9 +16,9 @@ we need to do use following plugins:
 
 > Make sure to install the plugins first: `yarn add -D babel-plugin-transform-typescript-metadata @babel/plugin-proposal-decorators @babel/plugin-proposal-class-properties`
 
-Lastly we need to set the `BABEL_DECORATORS_COMPAT` environment variable to `true` to 
-adjust the return value of decorators. 
+Lastly we need to set the `BABEL_DECORATORS_COMPAT` environment variable to `true` to adjust the return value of decorators.
 
 More information about this topic can be found here:
+
 - https://github.com/mikro-orm/mikro-orm/issues/840
 - https://jonahallibonetech.medium.com/next-js-9-mikroorm-eb6f6e08e1a1

--- a/docs/versioned_docs/version-5.4/usage-with-js.md
+++ b/docs/versioned_docs/version-5.4/usage-with-js.md
@@ -67,8 +67,7 @@ module.exports.entity = Author;
 module.exports.schema = schema;
 ```
 
-> Do not forget to provide `name` and `path` schema parameters as well as `entity`
-> and `schema` exports.
+> Do not forget to provide `name` and `path` schema parameters as well as `entity` and `schema` exports.
 
 Reference parameter can be one of (where `SCALAR` is the default one):
 
@@ -95,5 +94,4 @@ const orm = await MikroORM.init({
 
 > We can also pass the `EntitySchema` instance to the `entities` array.
 
-For more examples of plain JavaScript entity definitions take a look
-[Express JavaScript example](https://github.com/mikro-orm/express-js-example-app). 
+For more examples of plain JavaScript entity definitions take a look [Express JavaScript example](https://github.com/mikro-orm/express-js-example-app).

--- a/docs/versioned_docs/version-5.4/usage-with-mongo.md
+++ b/docs/versioned_docs/version-5.4/usage-with-mongo.md
@@ -2,12 +2,9 @@
 title: Usage with MongoDB
 ---
 
-To use MikroORM with mongo database, do not forget to install `@mikro-orm/mongodb`
-dependency. Then call `MikroORM.init()` as part of bootstrapping your app:
+To use MikroORM with mongo database, do not forget to install `@mikro-orm/mongodb` dependency. Then call `MikroORM.init()` as part of bootstrapping your app:
 
-> To access driver specific methods like `em.aggregate()` we need to specify
-> the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the
-> `orm.em` to `EntityManager` exported from the driver package:
+> To access driver specific methods like `em.aggregate()` we need to specify the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the `orm.em` to `EntityManager` exported from the driver package:
 >
 > ```ts
 > import { EntityManager } from '@mikro-orm/mongodb';
@@ -41,13 +38,11 @@ _id: ObjectId;
 id!: string; // won't be saved in the database
 ```
 
-> Only `_id: ObjectId` will be saved in the database. `id: string` is virtual and is 
-> also optional. 
+> Only `_id: ObjectId` will be saved in the database. `id: string` is virtual and is also optional.
 
 ## ObjectId and string id duality
 
-Every entity has both `ObjectId` and `string` id available, also all methods of `EntityManager` 
-and `EntityRepository` supports querying by both of them. 
+Every entity has both `ObjectId` and `string` id available, also all methods of `EntityManager` and `EntityRepository` supports querying by both of them.
 
 ```ts
 const author = orm.em.getReference('...id...');
@@ -66,24 +61,21 @@ const bar2 = await repo.find({ _id: { $in: [new ObjectId(article)] }, favouriteB
 
 ## ManyToMany collections with inlined pivot array
 
-As opposed to SQL drivers that use pivot tables, in mongo we can leverage available array type
-to store array of collection items (identifiers). This approach has two main benefits:
+As opposed to SQL drivers that use pivot tables, in mongo we can leverage available array type to store array of collection items (identifiers). This approach has two main benefits:
 
-1. Collection is stored on owning side entity, so we know how many items are there even before
-initializing the collection.
+1. Collection is stored on owning side entity, so we know how many items are there even before initializing the collection.
 2. As there are no pivot tables, resulting database queries are much simpler.
 
 ## Transactions
 
-Starting with v3.4, MongoDB driver supports transactions. To use transactions, there
-are several things you need to respect:
+Starting with v3.4, MongoDB driver supports transactions. To use transactions, there are several things you need to respect:
 
 - you need to use replica set (see [run-rs](https://github.com/vkarpov15/run-rs))
 - implicit transactions are disabled by default
-    - use `implicitTransactions: true` to enable them globally
-    - or use explicit transaction demarcation via `em.transactional()`
+  - use `implicitTransactions: true` to enable them globally
+  - or use explicit transaction demarcation via `em.transactional()`
 - you need to explicitly create all collections before working with them
-    - use `orm.getSchemaGenerator().createSchema()` method to do so
+  - use `orm.getSchemaGenerator().createSchema()` method to do so
 
 ```sh
 # first create replica set
@@ -105,15 +97,11 @@ const orm = await MikroORM.init<MongoDriver>({
 await orm.getSchemaGenerator().createSchema();
 ```
 
-> The `createCollections` method is present on the `MongoDriver` class only. You need 
-> to have the entity manager correctly typed (as `EntityManager<MongoDriver>`).
+> The `createCollections` method is present on the `MongoDriver` class only. You need to have the entity manager correctly typed (as `EntityManager<MongoDriver>`).
 
 ## Indexes
 
-Starting with v3.4, MongoDB driver supports indexes and unique constraints. You can 
-use `@Index()` and `@Unique()` as described in [Defining Entities section](defining-entities.md#indexes).
-To automatically create new indexes when initializing the ORM, you need to enable
-`ensureIndexes` option. 
+Starting with v3.4, MongoDB driver supports indexes and unique constraints. You can use `@Index()` and `@Unique()` as described in [Defining Entities section](defining-entities.md#indexes). To automatically create new indexes when initializing the ORM, you need to enable `ensureIndexes` option.
 
 ```ts
 const orm = await MikroORM.init<MongoDriver>({
@@ -122,7 +110,7 @@ const orm = await MikroORM.init<MongoDriver>({
   type: 'mongo',
   ensureIndexes: true, // defaults to false
 });
-``` 
+```
 
 Alternatively you can call `ensureIndexes()` method on the `SchemaGenerator`:
 
@@ -133,24 +121,20 @@ await orm.getSchemaGenerator().ensureIndexes();
 ```
 
 > You can pass additional index/unique options via `options` parameter:
-> 
+>
 > `@Unique({ options: { partialFilterExpression: { name: { $exists: true } } }})`
 
 > You can also create text indexes by passing `type` parameter:
-> 
+>
 > `@Index({ properties: ['name', 'caption'], type: 'text' })`
 
-> If you provide only `options` in the index definition, it will be used as is, 
-> this allows to define any kind of index:
+> If you provide only `options` in the index definition, it will be used as is, this allows to define any kind of index:
 >
-> `@Index({ options: { point: '2dsphere', title: -1 } })` 
+> `@Index({ options: { point: '2dsphere', title: -1 } })`
 
 ## Native collection methods
 
-Sometimes you need to perform some bulk operation, or you just want to populate your
-database with initial fixtures. Using ORM for such operations can bring unnecessary
-boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete`
-methods:
+Sometimes you need to perform some bulk operation, or you just want to populate your database with initial fixtures. Using ORM for such operations can bring unnecessary boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete` methods:
 
 ```ts
 em.nativeInsert<T extends AnyEntity>(entityName: string, data: any): Promise<IPrimaryKey>;
@@ -158,9 +142,7 @@ em.nativeUpdate<T extends AnyEntity>(entityName: string, where: FilterQuery<T>, 
 em.nativeDelete<T extends AnyEntity>(entityName: string, where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Those methods execute native driver methods like Mongo's `insertOne/updateMany/deleteMany` collection methods respectively. 
-This is common interface for all drivers, so for MySQL driver, it will fire native SQL queries. 
-Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks. 
+Those methods execute native driver methods like Mongo's `insertOne/updateMany/deleteMany` collection methods respectively. This is common interface for all drivers, so for MySQL driver, it will fire native SQL queries. Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks.
 
 They are also available as `EntityRepository` shortcuts:
 

--- a/docs/versioned_docs/version-5.4/usage-with-nestjs.md
+++ b/docs/versioned_docs/version-5.4/usage-with-nestjs.md
@@ -167,7 +167,7 @@ export class MyService {
 
 > `autoLoadEntities` option was added in v4.1.0
 
-Manually adding entities to the entities array of the connection options can be tedious. In addition, referencing entities from the root module breaks application domain boundaries and causes leaking implementation details to other parts of the  application. To solve this issue, static glob paths can be used.
+Manually adding entities to the entities array of the connection options can be tedious. In addition, referencing entities from the root module breaks application domain boundaries and causes leaking implementation details to other parts of the application. To solve this issue, static glob paths can be used.
 
 Note, however, that glob paths are not supported by webpack, so if you are building your application within a monorepo, you won't be able to use them. To address this issue, an alternative solution is provided. To automatically load entities, set the `autoLoadEntities` property of the configuration object (passed into the `forRoot()` method) to `true`, as shown below:
 
@@ -183,35 +183,23 @@ Note, however, that glob paths are not supported by webpack, so if you are build
 export class AppModule {}
 ```
 
-With that option specified, every entity registered through the `forFeature()`
-method will be automatically added to the entities array of the configuration
-object.
+With that option specified, every entity registered through the `forFeature()` method will be automatically added to the entities array of the configuration object.
 
-> Note that entities that aren't registered through the `forFeature()` method, but
-> are only referenced from the entity (via a relationship), won't be included by
-> way of the `autoLoadEntities` setting.
+> Note that entities that aren't registered through the `forFeature()` method, but are only referenced from the entity (via a relationship), won't be included by way of the `autoLoadEntities` setting.
 
-> Using `autoLoadEntities` also has no effect on the MikroORM CLI - for that we
-> still need CLI config with the full list of entities. On the other hand, we can
-> use globs there, as the CLI won't go through webpack.
+> Using `autoLoadEntities` also has no effect on the MikroORM CLI - for that we still need CLI config with the full list of entities. On the other hand, we can use globs there, as the CLI won't go through webpack.
 
 ## Request scoped handlers in queues
 
 > `@UseRequestContext()` decorator was added in v4.1.0
 
-> Since v5, `@UseRequestContext()` decorator is available in the `@mikro-orm/core`
-> package. It is valid approach not just for nestjs projects.
+> Since v5, `@UseRequestContext()` decorator is available in the `@mikro-orm/core` package. It is valid approach not just for nestjs projects.
 
 As mentioned in the [docs](identity-map.md), we need a clean state for each request. That is handled automatically thanks to the `RequestContext` helper registered via middleware.
 
-But middlewares are executed only for regular HTTP request handles, what if we need
-a request scoped method outside of that? One example of that is queue handlers or
-scheduled tasks.
+But middlewares are executed only for regular HTTP request handles, what if we need a request scoped method outside of that? One example of that is queue handlers or scheduled tasks.
 
-We can use the `@UseRequestContext()` decorator. It requires you to first inject the
-`MikroORM` instance to current context, it will be then used to create the context
-for you. Under the hood, the decorator will register new request context for your
-method and execute it inside the context.
+We can use the `@UseRequestContext()` decorator. It requires you to first inject the `MikroORM` instance to current context, it will be then used to create the context for you. Under the hood, the decorator will register new request context for your method and execute it inside the context.
 
 Keep in mind, that all handlers that are decorated with @UseRequestContext(), should NOT return anything.
 
@@ -244,9 +232,7 @@ export class MyService {
 }
 ```
 
-Another thing to look out for how you combine them with other decorators.
-For example if you use it in combination with NestJS's "[BullJS queues module](https://docs.nestjs.com/techniques/queues)", a safe bet is to extract the part of the code that needs a clean [docs](identity-map.md),
-either in a new method or inject a separate service.
+Another thing to look out for how you combine them with other decorators. For example if you use it in combination with NestJS's "[BullJS queues module](https://docs.nestjs.com/techniques/queues)", a safe bet is to extract the part of the code that needs a clean [docs](identity-map.md), either in a new method or inject a separate service.
 
 ```ts
 @Processor({
@@ -275,27 +261,27 @@ The GraphQL module in NestJS uses `apollo-server-express` which enables `bodypar
 
 This can be done by adding bodyparser to your main.ts file
 
- ```ts
+```ts
 import { NestFactory } from '@nestjs/core';
 import express from 'express';
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule,{ bodyParser: false });
-  app.use(express.json());
-  await app.listen(5555);
+ const app = await NestFactory.create(AppModule,{ bodyParser: false });
+ app.use(express.json());
+ await app.listen(5555);
 }
- ```
+```
 
 And at the same time disabling the bodyparser in the GraphQL Module
 
- ```ts
- @Module({
-  imports: [
-    GraphQLModule.forRoot({
-      bodyParserConfig: false,
-    }),
-  ],
+```ts
+@Module({
+ imports: [
+   GraphQLModule.forRoot({
+     bodyParserConfig: false,
+   }),
+ ],
 })
- ```
+```
 
 ## App shutdown and cleanup
 
@@ -429,10 +415,7 @@ export class PhotoModule {}
 
 ## Using `AsyncLocalStorage` for request context
 
-:::info
-Since v5 `AsyncLocalStorage` is used inside `RequestContext` helper so this section
-is no longer valid.
-:::
+:::info Since v5 `AsyncLocalStorage` is used inside `RequestContext` helper so this section is no longer valid. :::
 
 In older versions, the `domain` api was used in the `RequestContext` helper. Since `@mikro-orm/core@4.0.3`, we can use the new `AsyncLocalStorage` too, if you are on up to date node version:
 
@@ -486,7 +469,7 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
   }
 
   async afterUpdate(args: EventArgs<Author>): Promise<void> {
-    // ... 
+    // ...
   }
 
 }

--- a/docs/versioned_docs/version-5.4/usage-with-sql.md
+++ b/docs/versioned_docs/version-5.4/usage-with-sql.md
@@ -3,8 +3,7 @@ title: Usage with MySQL, MariaDB, PostgreSQL or SQLite
 sidebar_label: Usage with SQL Drivers
 ---
 
-To use `mikro-orm` with MySQL database, simply install the `@mikro-orm/mysql` dependency and set 
-the type option to `mysql` when initializing ORM. Since v4 it is no longer needed to install the `mysql2` package manually.
+To use `mikro-orm` with MySQL database, simply install the `@mikro-orm/mysql` dependency and set the type option to `mysql` when initializing ORM. Since v4 it is no longer needed to install the `mysql2` package manually.
 
 ```sh
 yarn add @mikro-orm/core @mikro-orm/mongodb     # for mongo
@@ -26,9 +25,7 @@ npm i -s @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 
 Then call `MikroORM.init` as part of bootstrapping your app:
 
-> To access driver specific methods like `em.createQueryBuilder()` we need to specify
-> the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the
-> `orm.em` to `EntityManager` exported from the driver package:
+> To access driver specific methods like `em.createQueryBuilder()` we need to specify the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the `orm.em` to `EntityManager` exported from the driver package:
 >
 > ```ts
 > import { EntityManager } from '@mikro-orm/postgresql';
@@ -49,9 +46,7 @@ console.log(orm.em); // access EntityManager via `em` property
 
 ## Custom driver
 
-If you want to use database that is not currently supported, you can implement your own driver.
-More information about how to create one can be [found here](custom-driver.md). Then provide the 
-driver class via `driver` configuration option: 
+If you want to use database that is not currently supported, you can implement your own driver. More information about how to create one can be [found here](custom-driver.md). Then provide the driver class via `driver` configuration option:
 
 ```ts
 import { MyCustomDriver } from './MyCustomDriver.ts';
@@ -65,8 +60,7 @@ const orm = await MikroORM.init<MyCustomDriver>({
 
 ## Schema
 
-Currently you will need to maintain the database schema yourself. For initial dump, you can 
-use [`SchemaGenerator` helper](schema-generator.md).  
+Currently you will need to maintain the database schema yourself. For initial dump, you can use [`SchemaGenerator` helper](schema-generator.md).
 
 ## ManyToMany collections with pivot tables
 
@@ -81,8 +75,7 @@ CREATE TABLE `publisher_to_test` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 ```
 
-You can adjust the name of pivot table via `pivotTable` option in `@ManyToMany` decorator
-defined on owning side: 
+You can adjust the name of pivot table via `pivotTable` option in `@ManyToMany` decorator defined on owning side:
 
 ```ts
 // for unidirectional
@@ -96,8 +89,7 @@ tags = new Collection<BookTag>(this);
 
 ## Using QueryBuilder to execute native SQL queries
 
-When you need to execute some SQL query without all the ORM stuff involved, you can either
-compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
+When you need to execute some SQL query without all the ORM stuff involved, you can either compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
 
 ```ts
 const qb = orm.em.createQueryBuilder(Author);
@@ -140,17 +132,13 @@ QueryBuilder.getParams(): any;
 QueryBuilder.clone(): QueryBuilder;
 ```
 
-For more examples of how to work with `QueryBuilder`, take a look at `QueryBuilder` tests in 
-[`tests/QueryBuilder.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/QueryBuilder.test.ts).
+For more examples of how to work with `QueryBuilder`, take a look at `QueryBuilder` tests in [`tests/QueryBuilder.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/QueryBuilder.test.ts).
 
 ## Transactions
 
-When you call `em.flush()`, all computed changes are queried [inside a database
-transaction](unit-of-work.md) by default, so you do not have to handle transactions manually. 
+When you call `em.flush()`, all computed changes are queried [inside a database transaction](unit-of-work.md) by default, so you do not have to handle transactions manually.
 
-When you need to explicitly handle the transaction, you can use `em.transactional(cb)` 
-to run callback in transaction. It will provide forked `EntityManager` as a parameter 
-with clear isolated identity map - please use that to make changes. 
+When you need to explicitly handle the transaction, you can use `em.transactional(cb)` to run callback in transaction. It will provide forked `EntityManager` as a parameter with clear isolated identity map - please use that to make changes.
 
 ```ts
 // if an error occurs inside the callback, all db queries from inside the callback will be rolled back
@@ -171,16 +159,13 @@ const author3 = new Author2('Author 3', 'a3@example.com');
 await orm.em.persistAndFlush([author1, author2, author3]);
 
 // finds authors with email like '%exa%le.c_m'
-const authors = await orm.em.find(Author2, { email: /exa.*le\.c.m$/ }); 
+const authors = await orm.em.find(Author2, { email: /exa.*le\.c.m$/ });
 console.log(authors); // all 3 authors found
 ```
 
 ## Native Collection Methods
 
-Sometimes you need to perform some bulk operation, or you just want to populate your
-database with initial fixtures. Using ORM for such operations can bring unnecessary
-boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete`
-methods:
+Sometimes you need to perform some bulk operation, or you just want to populate your database with initial fixtures. Using ORM for such operations can bring unnecessary boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete` methods:
 
 ```ts
 em.nativeInsert<T extends AnyEntity>(entityName: string, data: any): Promise<IPrimaryKey>;
@@ -188,9 +173,7 @@ em.nativeUpdate<T extends AnyEntity>(entityName: string, where: FilterQuery<T>, 
 em.nativeDelete<T extends AnyEntity>(entityName: string, where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Those methods execute native SQL queries generated via `QueryBuilder` based on entity 
-metadata. Keep in mind that they do not hydrate results to entities, and they do not 
-trigger lifecycle hooks. 
+Those methods execute native SQL queries generated via `QueryBuilder` based on entity metadata. Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks.
 
 They are also available as `EntityRepository` shortcuts:
 
@@ -200,9 +183,7 @@ EntityRepository.nativeUpdate(where: FilterQuery<T>, data: any): Promise<number>
 EntityRepository.nativeDelete(where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Additionally there is `execute()` method that supports executing raw SQL queries or `QueryBuilder`
-instances. To create `QueryBuilder`, you can use `createQueryBuilder()` factory method on both 
-`EntityManager` and `EntityRepository` classes: 
+Additionally there is `execute()` method that supports executing raw SQL queries or `QueryBuilder` instances. To create `QueryBuilder`, you can use `createQueryBuilder()` factory method on both `EntityManager` and `EntityRepository` classes:
 
 ```ts
 const qb = em.createQueryBuilder('Author');

--- a/docs/versioned_docs/version-5.4/using-bigint-pks.md
+++ b/docs/versioned_docs/version-5.4/using-bigint-pks.md
@@ -2,8 +2,7 @@
 title: Using native BigInt PKs (MySQL and PostgreSQL)
 ---
 
-We can use `BigIntType` to support `bigint`s. By default, it will represent the value as
-a `string`.
+We can use `BigIntType` to support `bigint`s. By default, it will represent the value as a `string`.
 
 ```ts
 import { Entity, PrimaryKey, t } from '@mikro-orm/core';
@@ -17,10 +16,7 @@ export class Book {
 }
 ```
 
-`bigint` can fit larger numbers than JavaScript number, for this reason it
-is mapped to a string. If we want to map it to a number anyway, we can implement
-[custom type](custom-types.md) that will do so. Similarly, we can define one to 
-use the native `bigint` type:
+`bigint` can fit larger numbers than JavaScript number, for this reason it is mapped to a string. If we want to map it to a number anyway, we can implement [custom type](custom-types.md) that will do so. Similarly, we can define one to use the native `bigint` type:
 
 ```ts
 export class NativeBigIntType extends BigIntType {

--- a/docs/versioned_docs/version-5.4/virtual-entities.md
+++ b/docs/versioned_docs/version-5.4/virtual-entities.md
@@ -5,7 +5,7 @@ title: Virtual Entities
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Virtual entities don't represent any database table. Instead, they dynamically resolve to an SQL query (or an aggregation in mongo), allowing to map any kind of results onto an entity. Such entities are mean for read purposes, they don't have a primary key and therefore cannot be tracked for changes. In a sense they are similar to (currently unsupported) database views. 
+Virtual entities don't represent any database table. Instead, they dynamically resolve to an SQL query (or an aggregation in mongo), allowing to map any kind of results onto an entity. Such entities are mean for read purposes, they don't have a primary key and therefore cannot be tracked for changes. In a sense they are similar to (currently unsupported) database views.
 
 To define a virtual entity, provide an `expression`, either as a string (SQL query):
 
@@ -85,7 +85,7 @@ export interface IBookWithAuthor{
   tags: string[];
 }
 
-export const BookWithAuthor = new EntitySchema<IBookWithAuthor>({ 
+export const BookWithAuthor = new EntitySchema<IBookWithAuthor>({
   name: 'BookWithAuthor',
   expression: 'select name, age, ' +
     '(select count(*) from book b where b.author_id = a.id) as total_books, ' +

--- a/docs/versioned_docs/version-5.5/async-local-storage.md
+++ b/docs/versioned_docs/version-5.5/async-local-storage.md
@@ -2,13 +2,9 @@
 title: Using AsyncLocalStorage
 ---
 
-:::info
-Since v5 `AsyncLocalStorage` is used inside `RequestContext` helper so this section
-is no longer valid.
-:::
+:::info Since v5 `AsyncLocalStorage` is used inside `RequestContext` helper so this section is no longer valid. :::
 
-In v4 and older versions, the `domain` api was used in the `RequestContext` helper. Since v4.0.3,
-we can use the new `AsyncLocalStorage` too, if we are on up-to-date node version:
+In v4 and older versions, the `domain` api was used in the `RequestContext` helper. Since v4.0.3, we can use the new `AsyncLocalStorage` too, if we are on up-to-date node version:
 
 ```ts
 const storage = new AsyncLocalStorage<EntityManager>();

--- a/docs/versioned_docs/version-5.5/caching.md
+++ b/docs/versioned_docs/version-5.5/caching.md
@@ -2,12 +2,9 @@
 title: Result cache
 ---
 
-MikroORM has simple result caching mechanism. It works with those methods of
-`EntityManager`: `find()`, `findOne()`, `findAndCount()`, `findOneOrFail()`,
-`count()`, as well as with `QueryBuilder` result methods (including `execute`).
+MikroORM has simple result caching mechanism. It works with those methods of `EntityManager`: `find()`, `findOne()`, `findAndCount()`, `findOneOrFail()`, `count()`, as well as with `QueryBuilder` result methods (including `execute`).
 
-By default, in memory cache is used, that is shared for the whole `MikroORM`
-instance. Default expiration is 1 second.
+By default, in memory cache is used, that is shared for the whole `MikroORM` instance. Default expiration is 1 second.
 
 ```ts
 const res = await em.find(Book, { author: { name: 'Jon Snow' } }, {
@@ -27,8 +24,7 @@ const res = await em.createQueryBuilder(Book)
   .getResultList();
 ```
 
-We can change the default expiration as well as provide custom cache adapter in
-the ORM configuration:
+We can change the default expiration as well as provide custom cache adapter in the ORM configuration:
 
 ```ts
 const orm = await MikroORM.init({
@@ -42,8 +38,7 @@ const orm = await MikroORM.init({
 });
 ```
 
-To clear the cached result, we need to load it with explicit cache key, and later
-on we can use `em.clearCache(cacheKey)` method.
+To clear the cached result, we need to load it with explicit cache key, and later on we can use `em.clearCache(cacheKey)` method.
 
 ```ts
 // set the cache key to 'book-cache-key', with expiration of 60s

--- a/docs/versioned_docs/version-5.5/cascading.md
+++ b/docs/versioned_docs/version-5.5/cascading.md
@@ -5,17 +5,13 @@ sidebar_label: Cascading
 
 > From v4.2, cascade merging is no longer configurable (and is kept enabled for all relations).
 
-> This section is about application level cascading. For that to work, we need
-> to have relations populated. 
+> This section is about application level cascading. For that to work, we need to have relations populated.
 
-When persisting or removing entity, all your references are by default cascade persisted. 
-This means that by persisting any entity, ORM will automatically persist all of its 
-associations. 
+When persisting or removing entity, all your references are by default cascade persisted. This means that by persisting any entity, ORM will automatically persist all of its associations.
 
-You can control this behaviour via `cascade` attribute of `@ManyToOne`, `@ManyToMany`, 
-`@OneToMany` and `@OneToOne` fields.
+You can control this behaviour via `cascade` attribute of `@ManyToOne`, `@ManyToMany`, `@OneToMany` and `@OneToOne` fields.
 
-> New entities without primary key will be always persisted, regardless of `cascade` value. 
+> New entities without primary key will be always persisted, regardless of `cascade` value.
 
 ```ts
 // cascade persist is default value
@@ -55,23 +51,19 @@ book.tags[1].name = 'new name 2';
 await orm.em.persistAndFlush(book); // all book tags and author will be persisted too
 ```
 
-> When cascade persisting collections, keep in mind only fully initialized collections 
-> will be cascade persisted.
+> When cascade persisting collections, keep in mind only fully initialized collections will be cascade persisted.
 
 ## Cascade remove
 
-Cascade remove works same way as cascade persist, just for removing entities. Following 
-example assumes that `Book.publisher` is set to `Cascade.REMOVE`:
+Cascade remove works same way as cascade persist, just for removing entities. Following example assumes that `Book.publisher` is set to `Cascade.REMOVE`:
 
-> Note that cascade remove for collections can be inefficient as it will fire 1 query
-> for each entity in collection.
+> Note that cascade remove for collections can be inefficient as it will fire 1 query for each entity in collection.
 
 ```ts
 await orm.em.remove(book).flush(); // this will also remove book.publisher
 ```
 
-Keep in mind that cascade remove **can be dangerous** when used on `@ManyToOne` fields, 
-as cascade removed entity can stay referenced in another entities that were not removed.
+Keep in mind that cascade remove **can be dangerous** when used on `@ManyToOne` fields, as cascade removed entity can stay referenced in another entities that were not removed.
 
 ```ts
 const publisher = new Publisher(...);
@@ -85,9 +77,7 @@ console.log(book2.publisher, book3.publisher);
 
 ## Orphan removal
 
-In addition to `Cascade.REMOVE`, there is also additional and more aggressive remove 
-cascading mode which can be specified using the `orphanRemoval` flag of the `@OneToOne`
-and `@OneToMany` properties:
+In addition to `Cascade.REMOVE`, there is also additional and more aggressive remove cascading mode which can be specified using the `orphanRemoval` flag of the `@OneToOne` and `@OneToMany` properties:
 
 ```ts
 @Entity()
@@ -99,13 +89,9 @@ export class Author {
 }
 ```
 
-> `orphanRemoval` flag behaves just like `Cascade.REMOVE` for remove operation, so specifying 
-> both is redundant.
+> `orphanRemoval` flag behaves just like `Cascade.REMOVE` for remove operation, so specifying both is redundant.
 
-With simple `Cascade.REMOVE`, you would need to remove the `Author` entity to cascade 
-the operation down to all loaded `Book`s. By enabling orphan removal on the collection, 
-`Book`s will be also removed when they get disconnected from the collection (either via 
-`remove()`, or by replacing collection items via `set()`):
+With simple `Cascade.REMOVE`, you would need to remove the `Author` entity to cascade the operation down to all loaded `Book`s. By enabling orphan removal on the collection, `Book`s will be also removed when they get disconnected from the collection (either via `remove()`, or by replacing collection items via `set()`):
 
 ```ts
 await author.books.set([book1, book2]); // replace whole collection
@@ -113,18 +99,15 @@ await author.books.remove(book1); // remove book from collection
 await orm.em.persistAndFlush(author); // book1 will be removed, as well as all original items (before we called `set()`)
 ```
 
-In this example, no `Book` would be removed with simple `Cascade.REMOVE` as no remove operation
-was executed. 
+In this example, no `Book` would be removed with simple `Cascade.REMOVE` as no remove operation was executed.
 
 ## Declarative Referential Integrity
 
 > This is only supported in SQL drivers.
 
-As opposed to the application level cascading controlled by the `cascade` option, we can
-also define database level referential integrity actions: `on update` and `on delete`.
+As opposed to the application level cascading controlled by the `cascade` option, we can also define database level referential integrity actions: `on update` and `on delete`.
 
-Their values are automatically inferred from the `cascade` option value. You can also 
-control the value manually via `onUpdateIntegrity` and `onDelete` options. 
+Their values are automatically inferred from the `cascade` option value. You can also control the value manually via `onUpdateIntegrity` and `onDelete` options.
 
 ```ts
 @Entity()

--- a/docs/versioned_docs/version-5.5/collections.md
+++ b/docs/versioned_docs/version-5.5/collections.md
@@ -181,7 +181,7 @@ Alternatively, we can work with the pivot entity directly:
 
 ```ts
 // create new item
-const item = em.create(OrderItem, { 
+const item = em.create(OrderItem, {
   order: 123,
   product: 321,
   amount: 999,
@@ -196,8 +196,7 @@ We can as well define the 1:m properties targeting the pivot entity as in the pr
 
 ### Forcing fixed order of collection items
 
-> Since v3 many to many collections does not require having auto increment primary key, that
-> was used to ensure fixed order of collection items.
+> Since v3 many to many collections does not require having auto increment primary key, that was used to ensure fixed order of collection items.
 
 To preserve fixed order of collections, we can use `fixedOrder: true` attribute, which will start ordering by `id` column. Schema generator will convert the pivot table to have auto increment primary key `id`. We can also change the order column name via `fixedOrderColumn: 'order'`.
 
@@ -228,9 +227,9 @@ console.log(tag.books.contains(book)); // true
 
 tag.books.add(book);
 console.log(book.tags.contains(tag)); // true
-``` 
+```
 
->  Since v5.2.2 propagation of adding new items to inverse side M:N relation also works if the owning collection is not initialized. For propagation of remove operation, both sides still have to be initialized.
+> Since v5.2.2 propagation of adding new items to inverse side M:N relation also works if the owning collection is not initialized. For propagation of remove operation, both sides still have to be initialized.
 
 > Although this propagation works also for M:N inverse side, we should always use owning side to manipulate the collection.
 

--- a/docs/versioned_docs/version-5.5/composite-keys.md
+++ b/docs/versioned_docs/version-5.5/composite-keys.md
@@ -5,14 +5,9 @@ sidebar_label: Composite Primary Keys
 
 > Support for composite keys was added in version 3.5
 
-MikroORM supports composite primary keys natively. Composite keys are a very powerful 
-relational database concept and we took good care to make sure MikroORM supports as 
-many of the composite primary key use-cases. MikroORM supports composite keys of primitive 
-data-types as well as foreign keys as primary keys. You can also use your composite key 
-entities in relationships. 
+MikroORM supports composite primary keys natively. Composite keys are a very powerful relational database concept and we took good care to make sure MikroORM supports as many of the composite primary key use-cases. MikroORM supports composite keys of primitive data-types as well as foreign keys as primary keys. You can also use your composite key entities in relationships.
 
-This section shows how the semantics of composite primary keys work and how they map 
-to the database.
+This section shows how the semantics of composite primary keys work and how they map to the database.
 
 ## General Considerations
 
@@ -20,8 +15,7 @@ ID fields have to have their values set before you call `em.persist(entity)`.
 
 ## Primitive Types only
 
-Suppose you want to create a database of cars and use the model-name and year of 
-production as primary keys:
+Suppose you want to create a database of cars and use the model-name and year of production as primary keys:
 
 ```ts
 @Entity()
@@ -50,39 +44,28 @@ const car = new Car('Audi A8', 2010);
 await em.persistAndFlush(car);
 ```
 
-And for querying you need to provide all primary keys in the condition or an array of
-primary keys in the same order as the keys were defined:
+And for querying you need to provide all primary keys in the condition or an array of primary keys in the same order as the keys were defined:
 
 ```ts
 const audi1 = await em.findOneOrFail(Car, { name: 'Audi A8', year: 2010 });
 const audi2 = await em.findOneOrFail(Car, ['Audi A8', 2010]);
 ```
 
-> If we want to use the second approach with primary key tuple, we will need to specify 
-> the type of entity's primary key via `PrimaryKeyType` symbol as shown in the `Car` entity.
+> If we want to use the second approach with primary key tuple, we will need to specify the type of entity's primary key via `PrimaryKeyType` symbol as shown in the `Car` entity.
 
-> `PrimaryKeyType` is not needed when your entity has single scalar primary key under 
-> one of following property names: `id: number | string | bigint`, `_id: any` or 
-> `uuid: string`.
+> `PrimaryKeyType` is not needed when your entity has single scalar primary key under one of following property names: `id: number | string | bigint`, `_id: any` or `uuid: string`.
 
-You can also use this entity in associations. MikroORM will then generate two foreign 
-keys one for name and to year to the related entities.
+You can also use this entity in associations. MikroORM will then generate two foreign keys one for name and to year to the related entities.
 
-This example shows how you can nicely solve the requirement for existing values before 
-`em.persist()`: By adding them as mandatory values for the constructor.
+This example shows how you can nicely solve the requirement for existing values before `em.persist()`: By adding them as mandatory values for the constructor.
 
 ## Identity through foreign Entities
 
-There are tons of use-cases where the identity of an Entity should be determined by 
-the entity of one or many parent entities.
+There are tons of use-cases where the identity of an Entity should be determined by the entity of one or many parent entities.
 
-- Dynamic Attributes of an Entity (for example `Article`). Each Article has many 
-  attributes with primary key `article_id` and `attribute_name`.
-- `Address` object of a `Person`, the primary key of the address is `user_id`. This 
-  is not a case of a composite primary key, but the identity is derived through a 
-  foreign entity and a foreign key.
-- Pivot Tables with metadata can be modelled as Entity, for example connections between 
-  two articles with a little description and a score.
+- Dynamic Attributes of an Entity (for example `Article`). Each Article has many attributes with primary key `article_id` and `attribute_name`.
+- `Address` object of a `Person`, the primary key of the address is `user_id`. This is not a case of a composite primary key, but the identity is derived through a foreign entity and a foreign key.
+- Pivot Tables with metadata can be modelled as Entity, for example connections between two articles with a little description and a score.
 
 The semantics of mapping identity through foreign entities are easy:
 
@@ -133,9 +116,7 @@ export class ArticleAttribute {
 
 ## Use-Case 2: Simple Derived Identity
 
-Sometimes you have the requirement that two objects are related by a `@OneToOne` 
-association and that the dependent class should re-use the primary key of the class 
-it depends on. One good example for this is a user-address relationship:
+Sometimes you have the requirement that two objects are related by a `@OneToOne` association and that the dependent class should re-use the primary key of the class it depends on. One good example for this is a user-address relationship:
 
 ```ts
 @Entity()
@@ -162,9 +143,7 @@ export class Address {
 
 ## Use-Case 3: Join-Table with Metadata
 
-In the classic order product shop example there is the concept of the order item which 
-contains references to order and product and additional data such as the amount of products 
-purchased and maybe even the current price.
+In the classic order product shop example there is the concept of the order item which contains references to order and product and additional data such as the amount of products purchased and maybe even the current price.
 
 ```ts
 @Entity()
@@ -234,8 +213,7 @@ export class OrderItem {
 }
 ```
 
-:::info
-By default, a generated pivot table entity is used under the hood to represent the pivot table. Since v5.1 we can provide our own implementation via `pivotEntity` option.
+:::info By default, a generated pivot table entity is used under the hood to represent the pivot table. Since v5.1 we can provide our own implementation via `pivotEntity` option.
 
 The pivot table entity needs to have exactly two many-to-one properties, where first one needs to point to the owning entity and the second to the target entity of the many-to-many relation.
 
@@ -267,11 +245,11 @@ export class OrderItem {
 }
 ```
 
-Alternatively, we can work with the pivot entity directly: 
+Alternatively, we can work with the pivot entity directly:
 
 ```ts
 // create new item
-const item = em.create(OrderItem, { 
+const item = em.create(OrderItem, {
   order: 123,
   product: 321,
   amount: 999,
@@ -282,13 +260,11 @@ await em.persist(item).flush();
 const em.nativeDelete(OrderItem, { order: 123, product: 321 });
 ```
 
-We can as well define the 1:m properties targeting the pivot entity as in the previous example, and use that for modifying the collection, while using the M:N property for easier reading and filtering purposes.
-:::
+We can as well define the 1:m properties targeting the pivot entity as in the previous example, and use that for modifying the collection, while using the M:N property for easier reading and filtering purposes. :::
 
 ## Using QueryBuilder with composite keys
 
-Internally composite keys are represented as tuples, containing all the values in the
-same order as the primary keys were defined. 
+Internally composite keys are represented as tuples, containing all the values in the same order as the primary keys were defined.
 
 ```ts
 const qb1 = em.createQueryBuilder(CarOwner);
@@ -309,7 +285,6 @@ This also applies when you want to get a reference to entity with composite key:
 ```ts
 const ref = em.getReference(Car, ['Audi A8', 2010]);
 console.log(ref instanceof Car); // true
-``` 
+```
 
-> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/composite-primary-keys.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/composite-primary-keys.html) as the behaviour here is pretty much the same.

--- a/docs/versioned_docs/version-5.5/configuration.md
+++ b/docs/versioned_docs/version-5.5/configuration.md
@@ -4,8 +4,7 @@ title: Configuration
 
 ## Entity Discovery
 
-You can either provide array of entity instances via `entities`, or let the ORM look up your 
-entities in selected folders. 
+You can either provide array of entity instances via `entities`, or let the ORM look up your entities in selected folders.
 
 ```ts
 MikroORM.init({
@@ -13,14 +12,9 @@ MikroORM.init({
 });
 ```
 
-We can also use folder based discovery by providing list of paths to the entities
-we want to discover (globs are supported as well). This way we also need to specify
-`entitiesTs`, where we point the paths to the TS source files instead of the JS 
-compiled files (see more at [Metadata Providers](metadata-providers.md)).
+We can also use folder based discovery by providing list of paths to the entities we want to discover (globs are supported as well). This way we also need to specify `entitiesTs`, where we point the paths to the TS source files instead of the JS compiled files (see more at [Metadata Providers](metadata-providers.md)).
 
-> The `entitiesTs` option is used when running the app via `ts-node`, as the ORM 
-> needs to discover the TS files. Always specify this option if you use folder/file
-> based discovery. 
+> The `entitiesTs` option is used when running the app via `ts-node`, as the ORM needs to discover the TS files. Always specify this option if you use folder/file based discovery.
 
 ```ts
 MikroORM.init({
@@ -31,19 +25,11 @@ MikroORM.init({
 });
 ```
 
-> Be careful when overriding the `baseDir` with dynamic values like `__dirname`, 
-> as you can end up with valid paths from `ts-node`, but invalid paths from `node`.
-> Ideally you should keep the default of `process.cwd()` there to always have the 
-> same base path regardless of how you run the app.
+> Be careful when overriding the `baseDir` with dynamic values like `__dirname`, as you can end up with valid paths from `ts-node`, but invalid paths from `node`. Ideally you should keep the default of `process.cwd()` there to always have the same base path regardless of how you run the app.
 
-By default, `ReflectMetadataProvider` is used that leverages the `reflect-metadata`. 
-You can also use `TsMorphMetadataProvider` by installing `@mikro-orm/reflection`. 
-This provider will analyse your entity source files (or `.d.ts` type definition files). 
-If you aim to use plain JavaScript instead of TypeScript, use `EntitySchema` or 
-the `JavaScriptMetadataProvider`.
+By default, `ReflectMetadataProvider` is used that leverages the `reflect-metadata`. You can also use `TsMorphMetadataProvider` by installing `@mikro-orm/reflection`. This provider will analyse your entity source files (or `.d.ts` type definition files). If you aim to use plain JavaScript instead of TypeScript, use `EntitySchema` or the `JavaScriptMetadataProvider`.
 
-> You can also implement your own metadata provider and use it instead. To do so, extend the 
-> `MetadataProvider` class.
+> You can also implement your own metadata provider and use it instead. To do so, extend the `MetadataProvider` class.
 
 ```ts
 import { MikroORM } from '@mikro-orm/core';
@@ -95,19 +81,17 @@ const orm = await MikroORM.init({
 
 To select driver, you can either use `type` option, or provide the driver class reference.
 
-| type | driver name | dependency | note |
-|------|-------------|------------|------|
-| `mongo` | `MongoDriver` | `mongodb^3.3.4` | - |
-| `mysql` | `MySqlDriver` | `mysql2^2.0.0` | compatible with MariaDB |
-| `mariadb` | `MariaDbDriver` | `mariadb^2.0.0` | compatible with MySQL |
-| `postgresql` | `PostgreSqlDriver` | `pg^7.0.0` | - |
-| `sqlite` | `SqliteDriver` | `sqlite3^4.0.0` | - |
+| type         | driver name        | dependency      | note                    |
+| ------------ | ------------------ | --------------- | ----------------------- |
+| `mongo`      | `MongoDriver`      | `mongodb^3.3.4` | -                       |
+| `mysql`      | `MySqlDriver`      | `mysql2^2.0.0`  | compatible with MariaDB |
+| `mariadb`    | `MariaDbDriver`    | `mariadb^2.0.0` | compatible with MySQL   |
+| `postgresql` | `PostgreSqlDriver` | `pg^7.0.0`      | -                       |
+| `sqlite`     | `SqliteDriver`     | `sqlite3^4.0.0` | -                       |
 
-> Driver and connection implementations are not directly exported from `@mikro-orm/core` module. 
-> You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
+> Driver and connection implementations are not directly exported from `@mikro-orm/core` module. You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
 
-> You can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. 
-> The object will be deeply merged, overriding all internally used options.
+> You can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. The object will be deeply merged, overriding all internally used options.
 
 ```ts
 import { MySqlDriver } from '@mikro-orm/mysql';
@@ -129,8 +113,7 @@ MikroORM.init({
 
 ## Connection
 
-Each platform (driver) provides default connection string, you can override it as a whole
-through `clientUrl`, or partially through one of following options:
+Each platform (driver) provides default connection string, you can override it as a whole through `clientUrl`, or partially through one of following options:
 
 ```ts
 export interface DynamicPassword {
@@ -154,17 +137,16 @@ export interface ConnectionOptions {
 
 Following table shows default client connection strings:
 
-| type | default connection url |
-|------|------------------------|
-| `mongo` | `mongodb://127.0.0.1:27017` |
-| `mysql` | `mysql://root@127.0.0.1:3306` |
-| `mariadb` | `mysql://root@127.0.0.1:3306` |
+| type         | default connection url                 |
+| ------------ | -------------------------------------- |
+| `mongo`      | `mongodb://127.0.0.1:27017`            |
+| `mysql`      | `mysql://root@127.0.0.1:3306`          |
+| `mariadb`    | `mysql://root@127.0.0.1:3306`          |
 | `postgresql` | `postgresql://postgres@127.0.0.1:5432` |
 
 ### Read Replicas
 
-To set up read replicas, you can use `replicas` option. You can provide only those parts of the 
-`ConnectionOptions` interface, they will be used to override the `master` connection options.
+To set up read replicas, you can use `replicas` option. You can provide only those parts of the `ConnectionOptions` interface, they will be used to override the `master` connection options.
 
 ```ts
 MikroORM.init({
@@ -185,10 +167,7 @@ Read more about this in [Installation](installation.md) and [Read Connections](r
 
 ### Using short-lived tokens
 
-Many cloud providers include alternative methods for connecting to database instances 
-using short-lived authentication tokens. MikroORM supports dynamic passwords via 
-a callback function, either synchronous or asynchronous. The callback function must 
-resolve to a string.
+Many cloud providers include alternative methods for connecting to database instances using short-lived authentication tokens. MikroORM supports dynamic passwords via a callback function, either synchronous or asynchronous. The callback function must resolve to a string.
 
 ```ts
 MikroORM.init({
@@ -198,8 +177,7 @@ MikroORM.init({
 });
 ```
 
-The password callback value will be cached, to invalidate this cache we can specify
-`expirationChecker` callback:
+The password callback value will be cached, to invalidate this cache we can specify `expirationChecker` callback:
 
 ```ts
 MikroORM.init({
@@ -214,8 +192,7 @@ MikroORM.init({
 
 ## Naming Strategy
 
-When mapping your entities to database tables and columns, their names will be defined by naming 
-strategy. There are 3 basic naming strategies you can choose from:
+When mapping your entities to database tables and columns, their names will be defined by naming strategy. There are 3 basic naming strategies you can choose from:
 
 - `UnderscoreNamingStrategy` - default of all SQL drivers
 - `MongoNamingStrategy` - default of `MongoDriver`
@@ -233,9 +210,7 @@ Read more about this in [Naming Strategy](naming-strategy.md) section.
 
 ## Auto-join of 1:1 owners
 
-By default, owning side of 1:1 relation will be auto-joined when you select the inverse side 
-so we can have the reference to it. You can disable this behaviour via `autoJoinOneToOneOwner` 
-configuration toggle.
+By default, owning side of 1:1 relation will be auto-joined when you select the inverse side so we can have the reference to it. You can disable this behaviour via `autoJoinOneToOneOwner` configuration toggle.
 
 ```ts
 MikroORM.init({
@@ -245,8 +220,7 @@ MikroORM.init({
 
 ## Propagation of 1:1 and m:1 owners
 
-MikroORM defines getter and setter for every owning side of m:1 and 1:1 relation. This is 
-then used for propagation of changes to the inverse side of bi-directional relations.
+MikroORM defines getter and setter for every owning side of m:1 and 1:1 relation. This is then used for propagation of changes to the inverse side of bi-directional relations.
 
 ```ts
 const author = new Author('n', 'e');
@@ -265,9 +239,7 @@ MikroORM.init({
 
 ## Forcing UTC Timezone
 
-Use `forceUtcTimezone` option to force the `Date`s to be saved in UTC in datetime columns 
-without timezone. It works for MySQL (`datetime` type) and PostgreSQL (`timestamp` type). 
-SQLite does this by default. 
+Use `forceUtcTimezone` option to force the `Date`s to be saved in UTC in datetime columns without timezone. It works for MySQL (`datetime` type) and PostgreSQL (`timestamp` type). SQLite does this by default.
 
 ```ts
 MikroORM.init({
@@ -277,9 +249,7 @@ MikroORM.init({
 
 ## Mapping `null` values to `undefined`
 
-By default `null` values from nullable database columns are hydrated as `null`. 
-Using `forceUndefined` we can tell the ORM to convert those `null` values to
-`undefined` instead. 
+By default `null` values from nullable database columns are hydrated as `null`. Using `forceUndefined` we can tell the ORM to convert those `null` values to `undefined` instead.
 
 ```ts
 MikroORM.init({
@@ -289,13 +259,9 @@ MikroORM.init({
 
 ## Serialization of new entities
 
-After flushing a new entity, all relations are marked as populated,
-just like if the entity was loaded from the db. This aligns the serialized
-output of `e.toJSON()` of a loaded entity and just-inserted one.
+After flushing a new entity, all relations are marked as populated, just like if the entity was loaded from the db. This aligns the serialized output of `e.toJSON()` of a loaded entity and just-inserted one.
 
-In v4 this behaviour was disabled by default, so even after the new entity was 
-flushed, the serialized form contained only FKs for its relations. We can opt in 
-to this old behaviour via `populateAfterFlush: false`.
+In v4 this behaviour was disabled by default, so even after the new entity was flushed, the serialized form contained only FKs for its relations. We can opt in to this old behaviour via `populateAfterFlush: false`.
 
 ```ts
 MikroORM.init({
@@ -307,30 +273,21 @@ MikroORM.init({
 
 > This applies only to SELECT_IN strategy, as JOINED strategy implies the inference.
 
-In v4, when we used populate hints in `em.find()` and similar methods, the
-query for our entity would be analysed and parts of it extracted and used for
-the population. Following example would find all authors that have books with
-given IDs, and populate their books collection, again using this PK condition,
-resulting in only such books being in those collections.
+In v4, when we used populate hints in `em.find()` and similar methods, the query for our entity would be analysed and parts of it extracted and used for the population. Following example would find all authors that have books with given IDs, and populate their books collection, again using this PK condition, resulting in only such books being in those collections.
 
 ```ts
 // this would end up with `Author.books` collections having only books of PK 1, 2, 3
 const a = await em.find(Author, { books: [1, 2, 3] }, { populate: ['books'] });
 ```
 
-Following this example, if we wanted to load all books, we would need a separate
-`em.populate()` call:
+Following this example, if we wanted to load all books, we would need a separate `em.populate()` call:
 
 ```ts
 const a = await em.find(Author, { books: [1, 2, 3] });
 await em.populate(a, ['books']);
 ```
 
-This behaviour changed and is now configurable both globally and locally, via
-`populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and
-`PopulateHint.INFER`, the former being the default in v5, the latter being the
-default behaviour in v4. Locally (via `FindOptions`) we can also specify custom
-where condition that will be passed to `em.populate()` call.
+This behaviour changed and is now configurable both globally and locally, via `populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and `PopulateHint.INFER`, the former being the default in v5, the latter being the default behaviour in v4. Locally (via `FindOptions`) we can also specify custom where condition that will be passed to `em.populate()` call.
 
 ```ts
 MikroORM.init({
@@ -341,8 +298,7 @@ MikroORM.init({
 
 ## Custom Hydrator
 
-Hydrator is responsible for assigning values from the database to entities. 
-You can implement your custom `Hydrator` (by extending the abstract `Hydrator` class):
+Hydrator is responsible for assigning values from the database to entities. You can implement your custom `Hydrator` (by extending the abstract `Hydrator` class):
 
 ```ts
 MikroORM.init({
@@ -352,8 +308,7 @@ MikroORM.init({
 
 ## Custom Repository
 
-You can also register custom base repository (for all entities where you do not specify 
-`customRepository`) globally:
+You can also register custom base repository (for all entities where you do not specify `customRepository`) globally:
 
 > You can still use entity specific repositories in combination with global base repository.
 
@@ -367,14 +322,9 @@ Read more about this in [Repositories](repositories.md) section.
 
 ## Strict Mode and property validation
 
-> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`.
-> It has performance implications and usually should not be needed, as long as
-> you don't modify your entities via `Object.assign()`.
+> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`. It has performance implications and usually should not be needed, as long as you don't modify your entities via `Object.assign()`.
 
-`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong 
-data types for you automatically. If automatic conversion fails, it will throw an error. You can 
-enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered 
-when persisting the entity. 
+`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong data types for you automatically. If automatic conversion fails, it will throw an error. You can enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered when persisting the entity.
 
 ```ts
 MikroORM.init({
@@ -387,12 +337,9 @@ Read more about this in [Property Validation](property-validation.md) section.
 
 ## Required properties validation
 
-Since v5, new entities are validated on runtime (just before executing insert
-queries), based on the entity metadata. This means that mongo users now need 
-to use `nullable: true` on their optional properties too).
+Since v5, new entities are validated on runtime (just before executing insert queries), based on the entity metadata. This means that mongo users now need to use `nullable: true` on their optional properties too).
 
-This behaviour can be disabled globally via `validateRequired: false` in the 
-ORM config.
+This behaviour can be disabled globally via `validateRequired: false` in the ORM config.
 
 ```ts
 MikroORM.init({
@@ -402,8 +349,7 @@ MikroORM.init({
 
 ## Debugging & Logging
 
-You can enable logging with `debug` option. Either set it to `true` to log everything, or 
-provide array of `'query' | 'query-params' | 'discovery' | 'info'` namespaces.
+You can enable logging with `debug` option. Either set it to `true` to log everything, or provide array of `'query' | 'query-params' | 'discovery' | 'info'` namespaces.
 
 ```ts
 MikroORM.init({
@@ -418,8 +364,7 @@ Read more about this in [Debugging](logging.md) section.
 
 ## Custom Fail Handler
 
-When no entity is found during `em.findOneOrFail()` call, a `NotFoundError` will be thrown. 
-You can customize how the `Error` instance is created via `findOneOrFailHandler` (or `findExactlyOneOrFailHandler` if [strict mode](#strict-mode-and-property-validation) is enabled):
+When no entity is found during `em.findOneOrFail()` call, a `NotFoundError` will be thrown. You can customize how the `Error` instance is created via `findOneOrFailHandler` (or `findExactlyOneOrFailHandler` if [strict mode](#strict-mode-and-property-validation) is enabled):
 
 ```ts
 MikroORM.init({
@@ -446,8 +391,7 @@ MikroORM.init({
 
 ## Migrations
 
-Under the `migrations` namespace, you can adjust how the integrated migrations support works.
-Following example shows all possible options and their defaults:
+Under the `migrations` namespace, you can adjust how the integrated migrations support works. Following example shows all possible options and their defaults:
 
 ```ts
 MikroORM.init({
@@ -482,8 +426,7 @@ Read more about this in [seeding docs](seeding.md).
 
 ## Caching
 
-By default, metadata discovery results are cached. You can either disable caching, or adjust 
-how it works. Following example shows all possible options and their defaults:
+By default, metadata discovery results are cached. You can either disable caching, or adjust how it works. Following example shows all possible options and their defaults:
 
 ```ts
 MikroORM.init({
@@ -509,22 +452,20 @@ MikroORM.init({
   ...
 });
 ```
- > This should be disabled in production environments for added security.
+
+> This should be disabled in production environments for added security.
 
 ## Using native private properties
 
-If we want to use native private properties inside entities, the default approach of 
-how MikroORM creates entity instances via `Object.create()` is not viable (more about this
-in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity
-constructors, we can use `forceEntityConstructor` toggle:
+If we want to use native private properties inside entities, the default approach of how MikroORM creates entity instances via `Object.create()` is not viable (more about this in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity constructors, we can use `forceEntityConstructor` toggle:
 
 ```ts
 MikroORM.init({
-  forceEntityConstructor: true, // or specify just some entities via `[Author, 'Book', ...]` 
+  forceEntityConstructor: true, // or specify just some entities via `[Author, 'Book', ...]`
 });
 ```
 
-## Persist created entities automatically 
+## Persist created entities automatically
 
 > Since v5.5 `persistOnCreate` defaults to `true`.
 
@@ -540,26 +481,19 @@ MikroORM.init({
 
 ## Using global Identity Map
 
-In v5, it is no longer possible to use the global identity map. This was a
-common issue that led to weird bugs, as using the global EM without request
-context is almost always wrong, we always need to have a dedicated context for
-each request, so they do not interfere.
+In v5, it is no longer possible to use the global identity map. This was a common issue that led to weird bugs, as using the global EM without request context is almost always wrong, we always need to have a dedicated context for each request, so they do not interfere.
 
-We still can disable this check via `allowGlobalContext` configuration, or
-a connected environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can
-be handy especially in unit tests.
+We still can disable this check via `allowGlobalContext` configuration, or a connected environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can be handy especially in unit tests.
 
 ```ts
 MikroORM.init({
-  allowGlobalContext: true, 
+  allowGlobalContext: true,
 });
 ```
 
 ## Using environment variables
 
-Since v4.5 it is possible to set most of the ORM options via environment variables.
-By default `.env` file from the root directory is loaded - it is also possible to
-set full path to the env file you want to use via `MIKRO_ORM_ENV` environment variable.
+Since v4.5 it is possible to set most of the ORM options via environment variables. By default `.env` file from the root directory is loaded - it is also possible to set full path to the env file you want to use via `MIKRO_ORM_ENV` environment variable.
 
 > Environment variables always have precedence.
 
@@ -579,54 +513,54 @@ MIKRO_ORM_FORCE_UNDEFINED = true
 
 Full list of supported options:
 
-| env variable | config key |
-|--------------|------------|
-| `MIKRO_ORM_BASE_DIR` | `baseDir` |
-| `MIKRO_ORM_TYPE` | `type` |
-| `MIKRO_ORM_ENTITIES` | `entities` |
-| `MIKRO_ORM_ENTITIES_TS` | `entitiesTs` |
-| `MIKRO_ORM_CLIENT_URL` | `clientUrl` |
-| `MIKRO_ORM_HOST` | `host` |
-| `MIKRO_ORM_PORT` | `port` |
-| `MIKRO_ORM_USER` | `user` |
-| `MIKRO_ORM_PASSWORD` | `password` |
-| `MIKRO_ORM_DB_NAME` | `dbName` |
-| `MIKRO_ORM_SCHEMA`  | `schema` |
-| `MIKRO_ORM_LOAD_STRATEGY` | `loadStrategy` |
-| `MIKRO_ORM_BATCH_SIZE` | `batchSize` |
-| `MIKRO_ORM_USE_BATCH_INSERTS` | `useBatchInserts` |
-| `MIKRO_ORM_USE_BATCH_UPDATES` | `useBatchUpdates` |
-| `MIKRO_ORM_STRICT` | `strict` |
-| `MIKRO_ORM_VALIDATE` | `validate` |
-| `MIKRO_ORM_AUTO_JOIN_ONE_TO_ONE_OWNER` | `autoJoinOneToOneOwner` |
-| `MIKRO_ORM_PROPAGATE_TO_ONE_OWNER` | `propagateToOneOwner` |
-| `MIKRO_ORM_POPULATE_AFTER_FLUSH` | `populateAfterFlush` |
-| `MIKRO_ORM_FORCE_ENTITY_CONSTRUCTOR` | `forceEntityConstructor` |
-| `MIKRO_ORM_FORCE_UNDEFINED` | `forceUndefined` |
-| `MIKRO_ORM_FORCE_UTC_TIMEZONE` | `forceUtcTimezone` |
-| `MIKRO_ORM_TIMEZONE` | `timezone` |
-| `MIKRO_ORM_ENSURE_INDEXES` | `ensureIndexes` |
-| `MIKRO_ORM_IMPLICIT_TRANSACTIONS` | `implicitTransactions` |
-| `MIKRO_ORM_DEBUG` | `debug` |
-| `MIKRO_ORM_VERBOSE` | `verbose` |
-| `MIKRO_ORM_DISCOVERY_WARN_WHEN_NO_ENTITIES` | `discovery.warnWhenNoEntities` |
-| `MIKRO_ORM_DISCOVERY_REQUIRE_ENTITIES_ARRAY` | `discovery.requireEntitiesArray` |
-| `MIKRO_ORM_DISCOVERY_ALWAYS_ANALYSE_PROPERTIES` | `discovery.alwaysAnalyseProperties` |
-| `MIKRO_ORM_DISCOVERY_DISABLE_DYNAMIC_FILE_ACCESS` | `discovery.disableDynamicFileAccess` |
-| `MIKRO_ORM_MIGRATIONS_TABLE_NAME` | `migrations.tableName` |
-| `MIKRO_ORM_MIGRATIONS_PATH` | `migrations.path` |
-| `MIKRO_ORM_MIGRATIONS_PATH_TS` | `migrations.pathTs` |
-| `MIKRO_ORM_MIGRATIONS_GLOB` | `migrations.glob` |
-| `MIKRO_ORM_MIGRATIONS_TRANSACTIONAL` | `migrations.transactional` |
-| `MIKRO_ORM_MIGRATIONS_DISABLE_FOREIGN_KEYS` | `migrations.disableForeignKeys` |
-| `MIKRO_ORM_MIGRATIONS_ALL_OR_NOTHING` | `migrations.allOrNothing` |
-| `MIKRO_ORM_MIGRATIONS_DROP_TABLES` | `migrations.dropTables` |
-| `MIKRO_ORM_MIGRATIONS_SAFE` | `migrations.safe` |
-| `MIKRO_ORM_MIGRATIONS_EMIT` | `migrations.emit` |
-| `MIKRO_ORM_SCHEMA_GENERATOR_DISABLE_FOREIGN_KEYS` | `migrations.disableForeignKeys` |
+| env variable                                                | config key                               |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `MIKRO_ORM_BASE_DIR`                                        | `baseDir`                                |
+| `MIKRO_ORM_TYPE`                                            | `type`                                   |
+| `MIKRO_ORM_ENTITIES`                                        | `entities`                               |
+| `MIKRO_ORM_ENTITIES_TS`                                     | `entitiesTs`                             |
+| `MIKRO_ORM_CLIENT_URL`                                      | `clientUrl`                              |
+| `MIKRO_ORM_HOST`                                            | `host`                                   |
+| `MIKRO_ORM_PORT`                                            | `port`                                   |
+| `MIKRO_ORM_USER`                                            | `user`                                   |
+| `MIKRO_ORM_PASSWORD`                                        | `password`                               |
+| `MIKRO_ORM_DB_NAME`                                         | `dbName`                                 |
+| `MIKRO_ORM_SCHEMA`                                          | `schema`                                 |
+| `MIKRO_ORM_LOAD_STRATEGY`                                   | `loadStrategy`                           |
+| `MIKRO_ORM_BATCH_SIZE`                                      | `batchSize`                              |
+| `MIKRO_ORM_USE_BATCH_INSERTS`                               | `useBatchInserts`                        |
+| `MIKRO_ORM_USE_BATCH_UPDATES`                               | `useBatchUpdates`                        |
+| `MIKRO_ORM_STRICT`                                          | `strict`                                 |
+| `MIKRO_ORM_VALIDATE`                                        | `validate`                               |
+| `MIKRO_ORM_AUTO_JOIN_ONE_TO_ONE_OWNER`                      | `autoJoinOneToOneOwner`                  |
+| `MIKRO_ORM_PROPAGATE_TO_ONE_OWNER`                          | `propagateToOneOwner`                    |
+| `MIKRO_ORM_POPULATE_AFTER_FLUSH`                            | `populateAfterFlush`                     |
+| `MIKRO_ORM_FORCE_ENTITY_CONSTRUCTOR`                        | `forceEntityConstructor`                 |
+| `MIKRO_ORM_FORCE_UNDEFINED`                                 | `forceUndefined`                         |
+| `MIKRO_ORM_FORCE_UTC_TIMEZONE`                              | `forceUtcTimezone`                       |
+| `MIKRO_ORM_TIMEZONE`                                        | `timezone`                               |
+| `MIKRO_ORM_ENSURE_INDEXES`                                  | `ensureIndexes`                          |
+| `MIKRO_ORM_IMPLICIT_TRANSACTIONS`                           | `implicitTransactions`                   |
+| `MIKRO_ORM_DEBUG`                                           | `debug`                                  |
+| `MIKRO_ORM_VERBOSE`                                         | `verbose`                                |
+| `MIKRO_ORM_DISCOVERY_WARN_WHEN_NO_ENTITIES`                 | `discovery.warnWhenNoEntities`           |
+| `MIKRO_ORM_DISCOVERY_REQUIRE_ENTITIES_ARRAY`                | `discovery.requireEntitiesArray`         |
+| `MIKRO_ORM_DISCOVERY_ALWAYS_ANALYSE_PROPERTIES`             | `discovery.alwaysAnalyseProperties`      |
+| `MIKRO_ORM_DISCOVERY_DISABLE_DYNAMIC_FILE_ACCESS`           | `discovery.disableDynamicFileAccess`     |
+| `MIKRO_ORM_MIGRATIONS_TABLE_NAME`                           | `migrations.tableName`                   |
+| `MIKRO_ORM_MIGRATIONS_PATH`                                 | `migrations.path`                        |
+| `MIKRO_ORM_MIGRATIONS_PATH_TS`                              | `migrations.pathTs`                      |
+| `MIKRO_ORM_MIGRATIONS_GLOB`                                 | `migrations.glob`                        |
+| `MIKRO_ORM_MIGRATIONS_TRANSACTIONAL`                        | `migrations.transactional`               |
+| `MIKRO_ORM_MIGRATIONS_DISABLE_FOREIGN_KEYS`                 | `migrations.disableForeignKeys`          |
+| `MIKRO_ORM_MIGRATIONS_ALL_OR_NOTHING`                       | `migrations.allOrNothing`                |
+| `MIKRO_ORM_MIGRATIONS_DROP_TABLES`                          | `migrations.dropTables`                  |
+| `MIKRO_ORM_MIGRATIONS_SAFE`                                 | `migrations.safe`                        |
+| `MIKRO_ORM_MIGRATIONS_EMIT`                                 | `migrations.emit`                        |
+| `MIKRO_ORM_SCHEMA_GENERATOR_DISABLE_FOREIGN_KEYS`           | `migrations.disableForeignKeys`          |
 | `MIKRO_ORM_SCHEMA_GENERATOR_CREATE_FOREIGN_KEY_CONSTRAINTS` | `migrations.createForeignKeyConstraints` |
-| `MIKRO_ORM_SEEDER_PATH` | `seeder.path` |
-| `MIKRO_ORM_SEEDER_PATH_TS` | `seeder.pathTs` |
-| `MIKRO_ORM_SEEDER_GLOB` | `seeder.glob` |
-| `MIKRO_ORM_SEEDER_EMIT` | `seeder.emit` |
-| `MIKRO_ORM_SEEDER_DEFAULT_SEEDER` | `seeder.defaultSeeder` |
+| `MIKRO_ORM_SEEDER_PATH`                                     | `seeder.path`                            |
+| `MIKRO_ORM_SEEDER_PATH_TS`                                  | `seeder.pathTs`                          |
+| `MIKRO_ORM_SEEDER_GLOB`                                     | `seeder.glob`                            |
+| `MIKRO_ORM_SEEDER_EMIT`                                     | `seeder.emit`                            |
+| `MIKRO_ORM_SEEDER_DEFAULT_SEEDER`                           | `seeder.defaultSeeder`                   |

--- a/docs/versioned_docs/version-5.5/custom-driver.md
+++ b/docs/versioned_docs/version-5.5/custom-driver.md
@@ -2,18 +2,17 @@
 title: Creating Custom Driver
 ---
 
-If you want to use database that is not currently supported, you can implement your own driver.
-To do so, you will need to design 4 classes:
+If you want to use database that is not currently supported, you can implement your own driver. To do so, you will need to design 4 classes:
 
 ## Platform
 
-Platform is a class that provides information about available features of given driver: 
+Platform is a class that provides information about available features of given driver:
 
 ```ts
 import { Platform } from '@mikro-orm/core';
 
 export class MyCustomPlatform extends Platform {
-  
+
   protected abstract schemaHelper: MyCustomSchemaHelper;
 
   // here you can override default settings
@@ -39,7 +38,7 @@ Part of platform is a `SchemaHelper`, that provides information about how to bui
 import { SchemaHelper } from '@mikro-orm/core';
 
 export class MyCustomSchemaHelper extends SchemaHelper {
-  
+
   // here you can override default settings
   getIdentifierQuoteCharacter(): string;
   getSchemaBeginning(): string;
@@ -67,7 +66,7 @@ Next part is connection wrapper, that will be responsible for querying the datab
 import { Connection } from '@mikro-orm/core';
 
 export class MyCustomConnection extends Connection {
-  
+
   // implement abstract methods
   connect(): Promise<void>;
   isConnected(): Promise<boolean>;
@@ -80,12 +79,9 @@ export class MyCustomConnection extends Connection {
 
 ## Driver
 
-Last part is driver, that is responsible for using the connection to persist changes to 
-database. If you are building SQL driver, it might be handy to extend `AbstractSqlDriver`, 
-if not, extend `DatabaseDriver` abstract class. 
+Last part is driver, that is responsible for using the connection to persist changes to database. If you are building SQL driver, it might be handy to extend `AbstractSqlDriver`, if not, extend `DatabaseDriver` abstract class.
 
-If you want to have absolute control, you can implement the whole driver yourself via
-`IDatabaseDriver` interface. 
+If you want to have absolute control, you can implement the whole driver yourself via `IDatabaseDriver` interface.
 
 ```ts
 import { DatabaseDriver } from '@mikro-orm/core';

--- a/docs/versioned_docs/version-5.5/custom-types.md
+++ b/docs/versioned_docs/version-5.5/custom-types.md
@@ -22,13 +22,11 @@ You can define custom types by extending `Type` abstract class. It has several o
 
 - `convertToDatabaseValueSQL(key: string, platform: Platform): string`
 
-  Converts a value from its JS representation to its database representation of this type.
-  _(added in v4.4.2)_
+  Converts a value from its JS representation to its database representation of this type. _(added in v4.4.2)_
 
 - `convertToJSValueSQL(key: string, platform: Platform): string`
 
-  Modifies the SQL expression (identifier, parameter) to convert to a JS value.
-  _(added in v4.4.2)_
+  Modifies the SQL expression (identifier, parameter) to convert to a JS value. _(added in v4.4.2)_
 
 - `compareAsType(): string`
 
@@ -101,9 +99,7 @@ born?: string;
 
 In this example we will combine mapping values via database as well as during runtime.
 
-> The Point type is part of the Spatial extension of MySQL and enables you to store
-> a single location in a coordinate space by using x and y coordinates. You can use
-> the Point type to store a longitude/latitude pair to represent a geographic location.
+> The Point type is part of the Spatial extension of MySQL and enables you to store a single location in a coordinate space by using x and y coordinates. You can use the Point type to store a longitude/latitude pair to represent a geographic location.
 
 First let's define the `Point` class that will be used to represent the value during runtime:
 
@@ -201,8 +197,7 @@ update `location` set `point` = ST_PointFromText('point(2.34 9.87)') where `id` 
 commit
 ```
 
-We do a 2-step conversion here. In the first step, we convert the Point object into a string representation before saving to the database (in the convertToDatabaseValue method) and back into an object
-after fetching the value from the database (in the convertToJSValue method).
+We do a 2-step conversion here. In the first step, we convert the Point object into a string representation before saving to the database (in the convertToDatabaseValue method) and back into an object after fetching the value from the database (in the convertToJSValue method).
 
 The format of the string representation format is called Well-known text (WKT). The advantage of this format is, that it is both human readable and parsable by MySQL.
 
@@ -212,9 +207,7 @@ This is where the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods 
 
 This methods wrap a sql expression (the WKT representation of the Point) into MySQL functions ST_PointFromText and ST_AsText which convert WKT strings to and from the internal format of MySQL.
 
-> When using DQL queries, the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods
-> only apply to identification variables and path expressions in SELECT clauses. Expressions
-> in WHERE clauses are not wrapped!
+> When using DQL queries, the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods only apply to identification variables and path expressions in SELECT clauses. Expressions in WHERE clauses are not wrapped!
 
 ## Types provided by MikroORM
 
@@ -260,18 +253,11 @@ export const types = {
 
 ### ArrayType
 
-In PostgreSQL and MongoDB, it uses native arrays, otherwise it concatenates the values into string separated by commas. This means that you can't use values that contain comma with the `ArrayType` (
-but you can create custom array type that will handle this case, e.g. by using different separator).
+In PostgreSQL and MongoDB, it uses native arrays, otherwise it concatenates the values into string separated by commas. This means that you can't use values that contain comma with the `ArrayType` ( but you can create custom array type that will handle this case, e.g. by using different separator).
 
-By default, array of strings is returned from the type. You can also have arrays of numbers or other data types - to do so, you will need to implement custom
-`hydrate` method that is used for converting the array values to the right type.
+By default, array of strings is returned from the type. You can also have arrays of numbers or other data types - to do so, you will need to implement custom `hydrate` method that is used for converting the array values to the right type.
 
-> `ArrayType` will be used automatically if `type` is set to `array` (default behaviour
-> of reflect-metadata) or `string[]` or `number[]` (either manually or via ts-morph).
-> In case of `number[]` it will automatically handle the conversion to numbers.
-> This means that the following examples would both have the `ArrayType` used
-> automatically (but with reflect-metadata we would have a string array for both
-> unless we specify the type manually as `type: 'number[]')
+> `ArrayType` will be used automatically if `type` is set to `array` (default behaviour of reflect-metadata) or `string[]` or `number[]` (either manually or via ts-morph). In case of `number[]` it will automatically handle the conversion to numbers. This means that the following examples would both have the `ArrayType` used automatically (but with reflect-metadata we would have a string array for both unless we specify the type manually as `type: 'number[]')
 
 ```ts
 @Property({ type: ArrayType, nullable: true })
@@ -294,9 +280,7 @@ id: string;
 
 Blob type can be used to store binary data in the database.
 
-> `BlobType` will be used automatically if you specify the type hint as `Buffer`.
-> This means that the following example should work even without the explicit
-> `type: BlobType` option (with both reflect-metadata and ts-morph providers).
+> `BlobType` will be used automatically if you specify the type hint as `Buffer`. This means that the following example should work even without the explicit `type: BlobType` option (with both reflect-metadata and ts-morph providers).
 
 ```ts
 @Property({ type: BlobType, nullable: true })
@@ -305,8 +289,7 @@ blob?: Buffer;
 
 ### JsonType
 
-To store objects we can use `JsonType`. As some drivers are handling objects automatically and some don't, this type will handle the serialization in a driver independent way (calling `parse`
-and `stringify` only when needed).
+To store objects we can use `JsonType`. As some drivers are handling objects automatically and some don't, this type will handle the serialization in a driver independent way (calling `parse` and `stringify` only when needed).
 
 ```ts
 @Property({ type: JsonType, nullable: true })
@@ -315,8 +298,7 @@ object?: { foo: string; bar: number };
 
 ### DateType
 
-To store dates without time information, we can use `DateType`. It does use `date`
-column type and maps it to the `Date` object.
+To store dates without time information, we can use `DateType`. It does use `date` column type and maps it to the `Date` object.
 
 ```ts
 @Property({ type: DateType, nullable: true })
@@ -325,8 +307,7 @@ born?: Date;
 
 ### TimeType
 
-As opposed to the `DateType`, to store only the time information, we can use
-`TimeType`. It will use the `time` column type, the runtime type is string.
+As opposed to the `DateType`, to store only the time information, we can use `TimeType`. It will use the `time` column type, the runtime type is string.
 
 ```ts
 @Property({ type: TimeType, nullable: true })

--- a/docs/versioned_docs/version-5.5/decorators.md
+++ b/docs/versioned_docs/version-5.5/decorators.md
@@ -6,24 +6,22 @@ title: Decorators
 
 ### @Entity()
 
-`@Entity` decorator is used to mark your model classes as entities. Do not use it for 
-abstract base classes.
+`@Entity` decorator is used to mark your model classes as entities. Do not use it for abstract base classes.
 
-| Parameter          | Type                     | Optional | Description                                                                     |
-|--------------------|--------------------------|----------|---------------------------------------------------------------------------------|
-| `tableName`        | `string`                 | yes      | Override default collection/table name.                                         |
-| `schema`           | `string`                 | yes      | Sets the schema name                                                            |
-| `collection`       | `string`                 | yes      | Alias for `tableName`.                                                          |
-| `comment`          | `string`                 | yes      | Specify comment to table **(SQL only)**                                         |
-| `customRepository` | `() => EntityRepository` | yes      | Set [custom repository class](repositories.md#custom-repository).               |
-| `discriminatorColumn` |  `string` | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance) |                 
-| `discriminatorMap`   |  `Dictionary<string>` | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance) |     
-| `discriminatorValue` |  `number` &#124; `string` | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance) |
+| Parameter             | Type                     | Optional | Description                                                                     |
+| --------------------- | ------------------------ | -------- | ------------------------------------------------------------------------------- |
+| `tableName`           | `string`                 | yes      | Override default collection/table name.                                         |
+| `schema`              | `string`                 | yes      | Sets the schema name                                                            |
+| `collection`          | `string`                 | yes      | Alias for `tableName`.                                                          |
+| `comment`             | `string`                 | yes      | Specify comment to table **(SQL only)**                                         |
+| `customRepository`    | `() => EntityRepository` | yes      | Set [custom repository class](repositories.md#custom-repository).               |
+| `discriminatorColumn` | `string`                 | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance) |
+| `discriminatorMap`    | `Dictionary<string>`     | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance) |
+| `discriminatorValue`  | `number` &#124; `string` | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance) |
 
 abstract | `boolean`;
 
 readonly | `boolean`;
-
 
 ```ts
 @Entity({ tableName: 'authors' })
@@ -34,11 +32,10 @@ export class Author { ... }
 
 ### @Property()
 
-`@Property()` decorator is used to define regular entity property. All following decorators
-extend the `@Property()` decorator, so you can also use its parameters there.
+`@Property()` decorator is used to define regular entity property. All following decorators extend the `@Property()` decorator, so you can also use its parameters there.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `fieldName` | `string` | yes | Override default property name (see [Naming Strategy](naming-strategy.md)). |
 | `type` | `string` &#124; `Constructor<Type>` &#124; `Type` | yes | Explicitly specify the runtime type (see [Metadata Providers](metadata-providers.md) and [Custom Types](custom-types.md)). |
 | `customType` | `Type` | yes | Explicitly specify the mapped type instance for this property (see [Custom Types](custom-types.md)). |
@@ -53,7 +50,7 @@ extend the `@Property()` decorator, so you can also use its parameters there.
 | `unsigned` | `boolean` | yes | Set column as unsigned for [Schema Generator](schema-generator.md).. **(SQL only)** |
 | `comment` | `string` | yes | Specify comment of column for [Schema Generator](schema-generator.md).. **(SQL only)** |
 | `version` | `boolean` | yes | Set to true to enable [Optimistic Locking] via version field (transactions.md#optimistic-locking). **(SQL only)** |
-| `concurrencyCheck` | `boolean` | yes | Set to true to enable [Optimistic Locking] via concurrency fields (transactions.md#concurrency-checks).|
+| `concurrencyCheck` | `boolean` | yes | Set to true to enable [Optimistic Locking] via concurrency fields (transactions.md#concurrency-checks). |
 | `customOrder` | `string[]` &#124; `number[]` &#124; `boolean[]` | yes | Specify a custom order for the column. **(SQL only)** |
 
 > You can use property initializers as usual.
@@ -77,14 +74,13 @@ registered = false;
 
 ### @PrimaryKey()
 
-`@PrimaryKey()` decorator is used to define entity's unique primary key identifier. 
+`@PrimaryKey()` decorator is used to define entity's unique primary key identifier.
 
-> `@PrimaryKey()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@PrimaryKey()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 > Every entity needs to have at least one primary key (see composite primary keys).
 
-> Note that if only one PrimaryKey is set and it's type is number it will be set to auto incremented automatically in all SQL drivers. 
+> Note that if only one PrimaryKey is set and it's type is number it will be set to auto incremented automatically in all SQL drivers.
 
 ```ts
 @PrimaryKey()
@@ -102,13 +98,10 @@ _id!: ObjectId; // ObjectId PK in mongodb driver
 
 ### @SerializedPrimaryKey()
 
-> Property marked with `@SerializedPrimaryKey()` is virtual, it will not be persisted 
-> into the database.
+> Property marked with `@SerializedPrimaryKey()` is virtual, it will not be persisted into the database.
 
-For MongoDB you can define serialized primary key, which will be then used in entity 
-serialization via `JSON.stringify()` (through method `entity.toJSON()`).
-You will be able to use it to manipulate with the primary key as string. 
- 
+For MongoDB you can define serialized primary key, which will be then used in entity serialization via `JSON.stringify()` (through method `entity.toJSON()`). You will be able to use it to manipulate with the primary key as string.
+
 See [Usage with MongoDB](usage-with-mongo.md) and [Serializing](serializing.md).
 
 ```ts
@@ -121,19 +114,15 @@ id!: string;
 
 ### @Enum()
 
-> `@Enum()` decorator extend the `@Property()` decorator, so you can use all its 
-> parameters.
+> `@Enum()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
-`@Enum()` decorator can be used for both numeric and string enums. By default enums are 
-considered numeric, and will be represented in the database schema as `tinyint/smallint`. 
-For string enums, if you define the enum in same file, its values will be automatically 
-sniffed. 
+`@Enum()` decorator can be used for both numeric and string enums. By default enums are considered numeric, and will be represented in the database schema as `tinyint/smallint`. For string enums, if you define the enum in same file, its values will be automatically sniffed.
 
 See [Defining Entities](defining-entities.md#enums).
 
-| Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
-| `items` | `number[]` &#124; `string[]` &#124; `() => Dictionary` | yes | Specify enum items explicitly. |
+| Parameter | Type                                                   | Optional | Description                    |
+| --------- | ------------------------------------------------------ | -------- | ------------------------------ |
+| `items`   | `number[]` &#124; `string[]` &#124; `() => Dictionary` | yes      | Specify enum items explicitly. |
 
 ```ts
 @Enum() // with ts-morph metadata provider we do not need to specify anything
@@ -154,14 +143,13 @@ enum4 = 'a';
 
 ### @Formula()
 
-`@Formula()` decorator can be used to map some SQL snippet to your entity. 
-The SQL fragment can be as complex as you want and even include subselects.
+`@Formula()` decorator can be used to map some SQL snippet to your entity. The SQL fragment can be as complex as you want and even include subselects.
 
 See [Defining Entities](defining-entities.md#formulas).
 
-| Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
-| `formula` | `string` &#124; `() => string` | no | SQL fragment that will be part of the select clause.  |
+| Parameter | Type                           | Optional | Description                                          |
+| --------- | ------------------------------ | -------- | ---------------------------------------------------- |
+| `formula` | `string` &#124; `() => string` | no       | SQL fragment that will be part of the select clause. |
 
 ```ts
 @Formula('obj_length * obj_height * obj_width')
@@ -170,18 +158,15 @@ objectVolume?: number;
 
 ### @Index() and @Unique()
 
-Use `@Index()` to create an index, or `@Unique()` to create unique constraint. You can 
-use those decorators both on the entity level and on property level. To create compound
-index, use the decorator on the entity level and provide list of property names via the
-`properties` option.
+Use `@Index()` to create an index, or `@Unique()` to create unique constraint. You can use those decorators both on the entity level and on property level. To create compound index, use the decorator on the entity level and provide list of property names via the `properties` option.
 
 See [Defining Entities](defining-entities.md#indexes).
 
-| Parameter    | Type     | Optional | Description |
-|--------------|----------|----------|-------------|
-| `name`       | `string` | yes      | index name  |
+| Parameter | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `name` | `string` | yes | index name |
 | `properties` | `string` &#124; `string[]` | yes | list of properties, required when using on entity level |
-| `type`       | `string` | yes      | index type, not available for `@Unique()`. Use `fulltext` to enable support for the `$fulltext` operator |
+| `type` | `string` | yes | index type, not available for `@Unique()`. Use `fulltext` to enable support for the `$fulltext` operator |
 
 ```ts
 @Entity()
@@ -207,29 +192,25 @@ export class Author {
 
 ### @Check()
 
-We can define check constraints via `@Check()` decorator. We can use it
-either on entity class, or on entity property. It has a required `expression`
-property, that can be either a string or a callback, that receives map of
-property names to column names. Note that we need to use the generic type
-argument if we want TypeScript suggestions for the property names.
+We can define check constraints via `@Check()` decorator. We can use it either on entity class, or on entity property. It has a required `expression` property, that can be either a string or a callback, that receives map of property names to column names. Note that we need to use the generic type argument if we want TypeScript suggestions for the property names.
 
 > Check constraints are currently supported only in postgres driver.
 
 See [Defining Entities](defining-entities.md#check-constraints).
 
-| Parameter    | Type     | Optional | Description       |
-|--------------|----------|----------|-------------------|
-| `name`       | `string` | yes      | constraint name   |
-| `property`   | `string` | yes      | property name, only used when generating the constraint name |
+| Parameter    | Type                            | Optional | Description                                                                          |
+| ------------ | ------------------------------- | -------- | ------------------------------------------------------------------------------------ |
+| `name`       | `string`                        | yes      | constraint name                                                                      |
+| `property`   | `string`                        | yes      | property name, only used when generating the constraint name                         |
 | `expression` | `string` &#124; `CheckCallback` | no       | constraint definition, can be a callback that gets a map of property to column names |
 
 ```ts
 @Entity()
-// with generated name based on the table name 
+// with generated name based on the table name
 @Check({ expression: 'price1 >= 0' })
-// with explicit name 
+// with explicit name
 @Check({ name: 'foo', expression: columns => `${columns.price1} >= 0` })
-// with explicit type argument we get autocomplete on `columns` 
+// with explicit type argument we get autocomplete on `columns`
 @Check<FooEntity>({ expression: columns => `${columns.price1} >= 0` })
 export class Book {
 
@@ -251,39 +232,31 @@ export class Book {
 
 ## Entity Relationships
 
-All relationship decorators have `entity`, `cascade` and `eager` optional parameters. 
-If you use the default `ReflectMetadataProvider`, then `entity` parameter might be required 
-You will be warned about it being not defined while required during discovery process if you 
-use `ReflectMetadataProvider`. 
+All relationship decorators have `entity`, `cascade` and `eager` optional parameters. If you use the default `ReflectMetadataProvider`, then `entity` parameter might be required You will be warned about it being not defined while required during discovery process if you use `ReflectMetadataProvider`.
 
-You can also use `type` parameter instead of it - the difference being that `type` parameter
-needs to be string, while in `entity` parameter you can provide a reference (wrapped in 
-a callback to overcome issues with circular dependencies) to the entity, which plays nice 
-with refactoring features in IDEs like WebStorm. 
+You can also use `type` parameter instead of it - the difference being that `type` parameter needs to be string, while in `entity` parameter you can provide a reference (wrapped in a callback to overcome issues with circular dependencies) to the entity, which plays nice with refactoring features in IDEs like WebStorm.
 
-> If you explicitly provide `entity` as a reference, it will enable type checks for other
-> reference parameters like `inversedBy` or `mappedBy`.
+> If you explicitly provide `entity` as a reference, it will enable type checks for other reference parameters like `inversedBy` or `mappedBy`.
 
 ### @ManyToOne()
 
-> `@ManyToOne()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@ManyToOne()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 Many instances of the current Entity refer to One instance of the referred Entity.
 
 See [Defining Entities](relationships.md#manytoone) for more examples.
 
-| Parameter           | Type | Optional | Description                                                                                                                                               |
-|---------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `entity`            | `string` &#124; `() => EntityName` | yes | Set target entity type.                                                                                                                                   |
-| `cascade`           | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
-| `eager`             | `boolean` | yes | Always load the relationship.                                                                                                                             |
-| `inversedBy`        | `(string & keyof T) ` &#124; ` (e: T) => any` | yes | Point to the inverse side property name.                                                                                                                  |
-| `wrappedReference`  | `boolean` | yes | Wrap the entity in [`Reference` wrapper](type-safe-relations.md).                                                                                         |
-| `ref`               | `boolean` | yes | Alias for `wrappedReference`.                                                                                                                             |
-| `primary`           | `boolean` | yes | Use this relation as primary key.                                                                                                                         |
-| `onDelete`          | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity).                                                                                  |
-| `onUpdateIntegrity` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity).                                                                                  |
+| Parameter | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
+| `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
+| `eager` | `boolean` | yes | Always load the relationship. |
+| `inversedBy` | `(string & keyof T) ` &#124; ` (e: T) => any` | yes | Point to the inverse side property name. |
+| `wrappedReference` | `boolean` | yes | Wrap the entity in [`Reference` wrapper](type-safe-relations.md). |
+| `ref` | `boolean` | yes | Alias for `wrappedReference`. |
+| `primary` | `boolean` | yes | Use this relation as primary key. |
+| `onDelete` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity). |
+| `onUpdateIntegrity` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity). |
 
 ```ts
 @ManyToOne()
@@ -298,28 +271,27 @@ author3?: Author;
 
 ### @OneToOne()
 
-> `@OneToOne()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@OneToOne()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 One instance of the current Entity refers to One instance of the referred Entity.
 
 See [Defining Entities](relationships.md#onetoone) for more examples, including bi-directional 1:1.
 
-| Parameter           | Type | Optional | Description                                                                                                                                               |
-|---------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `entity`            | `string` &#124; `() => EntityName` | yes | Set target entity type.                                                                                                                                   |
-| `cascade`           | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
-| `eager`             | `boolean` | yes | Always load the relationship.                                                                                                                             |
-| `owner`             | `boolean` | yes | Explicitly set as owning side (same as providing `inversedBy`).                                                                                           |
-| `inversedBy`        | `(string & keyof T) ` &#124; ` (e: T) => any` | yes | Point to the inverse side property name.                                                                                                                  |
-| `mappedBy`          | `(string & keyof T)` &#124; `(e: T) => any` | yes | Point to the owning side property name.                                                                                                                   |
-| `wrappedReference`  | `boolean` | yes | Wrap the entity in [`Reference` wrapper](type-safe-relations.md).                                                                                         |
-| `ref`               | `boolean` | yes | Alias for `wrappedReference`                                                                                                                              |
-| `orphanRemoval`     | `boolean` | yes | Remove the entity when it gets disconnected from the relationship (see [Cascading](cascading.md#orphan-removal)).                                         |
-| `joinColumn`        | `string` | yes | Override default database column name on the owning side (see [Naming Strategy](naming-strategy.md)).                                                     |
-| `primary`           | `boolean` | yes | Use this relation as primary key.                                                                                                                         |
-| `onDelete`          | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity).                                                                                  |
-| `onUpdateIntegrity` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity).                                                                                  |
+| Parameter | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
+| `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
+| `eager` | `boolean` | yes | Always load the relationship. |
+| `owner` | `boolean` | yes | Explicitly set as owning side (same as providing `inversedBy`). |
+| `inversedBy` | `(string & keyof T) ` &#124; ` (e: T) => any` | yes | Point to the inverse side property name. |
+| `mappedBy` | `(string & keyof T)` &#124; `(e: T) => any` | yes | Point to the owning side property name. |
+| `wrappedReference` | `boolean` | yes | Wrap the entity in [`Reference` wrapper](type-safe-relations.md). |
+| `ref` | `boolean` | yes | Alias for `wrappedReference` |
+| `orphanRemoval` | `boolean` | yes | Remove the entity when it gets disconnected from the relationship (see [Cascading](cascading.md#orphan-removal)). |
+| `joinColumn` | `string` | yes | Override default database column name on the owning side (see [Naming Strategy](naming-strategy.md)). |
+| `primary` | `boolean` | yes | Use this relation as primary key. |
+| `onDelete` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity). |
+| `onUpdateIntegrity` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity). |
 
 ```ts
 // when none of `owner/inverseBy/mappedBy` is provided, it will be considered owning side
@@ -337,8 +309,7 @@ bestFriend3!: User;
 
 ### @OneToMany()
 
-> `@OneToMany()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@OneToMany()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 One instance of the current Entity has Many instances (references) to the referred Entity.
 
@@ -347,7 +318,7 @@ See [Defining Entities](relationships.md#onetomany) for more examples, including
 > You need to initialize the value with `Collection<T>` instance.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `mappedBy` | `(string & keyof T)` &#124; `(e: T) => any` | no | Point to the owning side property name. |
 | `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
 | `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
@@ -367,8 +338,7 @@ books2 = new Collection<Book>(this); // target entity type can be read via `TsMo
 
 ### @ManyToMany()
 
-> `@ManyToMany()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@ManyToMany()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 Many instances of the current Entity refers to Many instances of the referred Entity.
 
@@ -377,7 +347,7 @@ See [Defining Entities](relationships.md#manytomany) for more examples, includin
 > You need to initialize the value with `Collection<T>` instance.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
 | `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
 | `eager` | `boolean` | yes | Always load the relationship. |
@@ -401,15 +371,13 @@ tagsUnordered = new Collection<BookTag>(this); // m:n with composite PK
 
 ## Lifecycle Hooks
 
-You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of
-entity methods with them, you can also mark multiple methods with same hook.
+You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of entity methods with them, you can also mark multiple methods with same hook.
 
 > All hooks support async methods with one exception - `@OnInit`.
 
 ### @OnInit()
 
-Fired when new instance of entity is created, either manually `em.create()`, or 
-automatically when new entities are loaded from database
+Fired when new instance of entity is created, either manually `em.create()`, or automatically when new entities are loaded from database
 
 > `@OnInit` is not fired when you create the entity manually via its constructor (`new MyEntity()`)
 
@@ -422,9 +390,7 @@ doStuffOnInit() {
 
 ### @OnLoad()
 
-Fired when new entities are loaded from database. Unlike `@InInit()`, 
-this will be fired only for fully loaded entities (not references). The method
-can be `async`.
+Fired when new entities are loaded from database. Unlike `@InInit()`, this will be fired only for fully loaded entities (not references). The method can be `async`.
 
 ```ts
 @OnLoad()
@@ -446,9 +412,7 @@ async doStuffBeforeCreate() {
 
 ### @AfterCreate()
 
-Fired right after the new entity is created in the database and merged to identity map. 
-Since this event entity will have reference to `EntityManager` and will be 
-enabled to call `wrap(entity).init()` method (including all entity references and collections).
+Fired right after the new entity is created in the database and merged to identity map. Since this event entity will have reference to `EntityManager` and will be enabled to call `wrap(entity).init()` method (including all entity references and collections).
 
 ```ts
 @AfterCreate()
@@ -470,7 +434,7 @@ async doStuffBeforeUpdate() {
 
 ### @AfterUpdate()
 
-Fired right after the entity is updated in the database. 
+Fired right after the entity is updated in the database.
 
 ```ts
 @AfterUpdate()
@@ -481,8 +445,7 @@ async doStuffAfterUpdate() {
 
 ### @BeforeDelete()
 
-Fired right before we delete the record from database. It is fired only when
-removing entity or entity reference, not when deleting records by query. 
+Fired right before we delete the record from database. It is fired only when removing entity or entity reference, not when deleting records by query.
 
 ```ts
 @BeforeDelete()
@@ -506,9 +469,7 @@ async doStuffAfterDelete() {
 
 ### @Subscriber()
 
-Used to register an event subscriber. Keep in mind that you need to make sure the file 
-gets loaded in order to make this decorator registration work (e.g. you import that file 
-explicitly somewhere).
+Used to register an event subscriber. Keep in mind that you need to make sure the file gets loaded in order to make this decorator registration work (e.g. you import that file explicitly somewhere).
 
 ```ts
 @Subscriber()

--- a/docs/versioned_docs/version-5.5/defining-entities.md
+++ b/docs/versioned_docs/version-5.5/defining-entities.md
@@ -5,43 +5,27 @@ title: Defining Entities
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Entities are simple javascript objects (so called POJO) without restrictions and without the need to extend base classes. Using [entity constructors](entity-constructors.md) works as well - they are never executed for managed entities (loaded from database). 
-Every entity is required to have a primary key.
+Entities are simple javascript objects (so called POJO) without restrictions and without the need to extend base classes. Using [entity constructors](entity-constructors.md) works as well - they are never executed for managed entities (loaded from database). Every entity is required to have a primary key.
 
 Entities can be defined in two ways:
 
-- Decorated classes - the attributes of the entity, as well as each property are provided
-  via decorators. We use `@Entity()` decorator on the class. Entity properties are decorated 
-  either with `@Property` decorator, or with one of reference decorators: 
-  `@ManyToOne`, `@OneToMany`, `@OneToOne` and `@ManyToMany`.
-  Check out the full [decorator reference](decorators.md).
-- `EntitySchema` helper - With `EntitySchema` helper we define the schema programmatically.
-  We can use regular classes as well as interfaces. This approach also allows to re-use 
-  partial entity definitions (e.g. traits/mixins). Read more about this 
-  in [Defining Entities via EntitySchema section](entity-schema.md).
+- Decorated classes - the attributes of the entity, as well as each property are provided via decorators. We use `@Entity()` decorator on the class. Entity properties are decorated either with `@Property` decorator, or with one of reference decorators: `@ManyToOne`, `@OneToMany`, `@OneToOne` and `@ManyToMany`. Check out the full [decorator reference](decorators.md).
+- `EntitySchema` helper - With `EntitySchema` helper we define the schema programmatically. We can use regular classes as well as interfaces. This approach also allows to re-use partial entity definitions (e.g. traits/mixins). Read more about this in [Defining Entities via EntitySchema section](entity-schema.md).
 
-Moreover, how the metadata extraction from decorators happens is controlled 
-via `MetadataProvider`. Two main metadata providers are:
+Moreover, how the metadata extraction from decorators happens is controlled via `MetadataProvider`. Two main metadata providers are:
 
-- `ReflectMetadataProvider` - uses `reflect-metadata` to read the property types. Faster
-  but simpler and more verbose. 
-- `TsMorphMetadataProvider` - uses `ts-morph` to read the type information from the
-  TypeScript compiled API. Heavier (requires full TS as a dependency), but allows DRY 
-  entity definition. With `ts-morph` we are able to extract the type as it is defined in
-  the code, including interface names, as well as optionality of properties. 
+- `ReflectMetadataProvider` - uses `reflect-metadata` to read the property types. Faster but simpler and more verbose.
+- `TsMorphMetadataProvider` - uses `ts-morph` to read the type information from the TypeScript compiled API. Heavier (requires full TS as a dependency), but allows DRY entity definition. With `ts-morph` we are able to extract the type as it is defined in the code, including interface names, as well as optionality of properties.
 
 Read more about them in the [Metadata Providers section](metadata-providers.md).
 
-> Current set of decorators in MikroORM is designed to work with the `tsc`. 
-> Using `babel` is also possible, but requires some additional setup. Read more about it
-> [here](usage-with-babel.md). For notes about `webpack`, read the [deployment section](deployment.md).
+> Current set of decorators in MikroORM is designed to work with the `tsc`. Using `babel` is also possible, but requires some additional setup. Read more about it [here](usage-with-babel.md). For notes about `webpack`, read the [deployment section](deployment.md).
 >
 > `ts-morph` is compatible only with the `tsc` approach.
 
 > From v3 we can also use default exports when defining your entity.
 
-Example definition of a `Book` entity follows. We can switch the tabs to see the difference
-for various ways:
+Example definition of a `Book` entity follows. We can switch the tabs to see the difference for various ways:
 
 <Tabs
   groupId="entity-def"
@@ -123,8 +107,7 @@ export const Book = new EntitySchema<IBook, CustomBaseEntity>({
 
 > Including `{ wrappedEntity: true }` in your `Ref` property definitions will wrap the reference, providing access to helper methods like `.load` and `.unwrap`, which can be helpful for loading data and changing the type of your references where you plan to use them.
 
-Here is another example of `Author` entity, that was referenced from the `Book` one, this
-time defined for mongo:
+Here is another example of `Author` entity, that was referenced from the `Book` one, this time defined for mongo:
 
 <Tabs
   groupId="entity-def"
@@ -306,9 +289,7 @@ For an example of Vanilla JavaScript usage, take a look [here](usage-with-js.md)
 
 ## Optional Properties
 
-With the default `reflect-metadata` provider, we need to mark each optional property as `nullable: true`.
-When using `ts-morph`, if you define the property as optional (marked with `?`), this will be automatically considered
-as nullable property (mainly for SQL schema generator).
+With the default `reflect-metadata` provider, we need to mark each optional property as `nullable: true`. When using `ts-morph`, if you define the property as optional (marked with `?`), this will be automatically considered as nullable property (mainly for SQL schema generator).
 
 <Tabs
   groupId="entity-def"
@@ -350,21 +331,18 @@ properties: {
 
 We can set default value of a property in 2 ways:
 
-1. Use runtime default value of the property. This approach should be preferred as long
-as we are not using any native database function like `now()`. With this approach our
-entities will have the default value set even before it is actually persisted into the
-database (e.g. when we instantiate new entity via `new Author()` or `em.create(Author, { ... })`.
+1. Use runtime default value of the property. This approach should be preferred as long as we are not using any native database function like `now()`. With this approach our entities will have the default value set even before it is actually persisted into the database (e.g. when we instantiate new entity via `new Author()` or `em.create(Author, { ... })`.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
 @Property()
@@ -405,23 +383,20 @@ properties: {
   </TabItem>
 </Tabs>
 
-2. Use `default` parameter of `@Property` decorator. This way the actual default value
-will be provided by the database, and automatically mapped to the entity property after
-it is being persisted (after flush). To use SQL functions like `now()`, use `defaultRaw`.
+2. Use `default` parameter of `@Property` decorator. This way the actual default value will be provided by the database, and automatically mapped to the entity property after it is being persisted (after flush). To use SQL functions like `now()`, use `defaultRaw`.
 
-  > Since v4 you should use `defaultRaw` for SQL functions, as `default` with string values
-  > will be automatically quoted.
+> Since v4 you should use `defaultRaw` for SQL functions, as `default` with string values will be automatically quoted.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
 @Property({ default: 1 })
@@ -466,25 +441,22 @@ properties: {
 
 To define enum property, use `@Enum()` decorator. Enums can be either numeric or string valued.
 
-For schema generator to work properly in case of string enums, we need to define the enum
-is same file as where it is used, so its values can be automatically discovered. If we want
-to define the enum in another file, we should reexport it also in place where we use it.
+For schema generator to work properly in case of string enums, we need to define the enum is same file as where it is used, so its values can be automatically discovered. If we want to define the enum in another file, we should reexport it also in place where we use it.
 
-Another possibility is to provide the reference to the enum implementation in the decorator
-via `@Enum(() => UserRole)`.
+Another possibility is to provide the reference to the enum implementation in the decorator via `@Enum(() => UserRole)`.
 
 > We can also set enum items manually via `items: string[]` attribute.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
 import { OutsideEnum } from './OutsideEnum.ts';
@@ -580,19 +552,18 @@ properties: {
 
 ## Enum arrays
 
-We can also use array of values for enum, in that case, `EnumArrayType` type
-will be used automatically, that will validate items on flush.
+We can also use array of values for enum, in that case, `EnumArrayType` type will be used automatically, that will validate items on flush.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
 enum Role {
@@ -636,19 +607,18 @@ properties: {
 
 ## Mapping directly to primary keys
 
-Sometimes we might want to work only with the primary key of a relation.
-To do that, we can use `mapToPk` option on M:1 and 1:1 relations:
+Sometimes we might want to work only with the primary key of a relation. To do that, we can use `mapToPk` option on M:1 and 1:1 relations:
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
 @ManyToOne(() => User, { mapToPk: true })
@@ -675,19 +645,18 @@ properties: {
   </TabItem>
 </Tabs>
 
-For composite keys, this will give us ordered tuple representing the raw PKs,
-which is the internal format of composite PK:
+For composite keys, this will give us ordered tuple representing the raw PKs, which is the internal format of composite PK:
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
 @ManyToOne(() => User, { mapToPk: true })
@@ -717,19 +686,18 @@ properties: {
 
 ## Formulas
 
-`@Formula()` decorator can be used to map some SQL snippet to your entity.
-The SQL fragment can be as complex as you want and even include subselects.
+`@Formula()` decorator can be used to map some SQL snippet to your entity. The SQL fragment can be as complex as you want and even include subselects.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Box.ts"
 @Formula('obj_length * obj_height * obj_width')
@@ -757,20 +725,18 @@ properties: {
 </Tabs>
 ```
 
-Formulas will be added to the select clause automatically. In case you are facing
-problems with `NonUniqueFieldNameException`, you can define the formula as a
-callback that will receive the entity alias in the parameter:
+Formulas will be added to the select clause automatically. In case you are facing problems with `NonUniqueFieldNameException`, you can define the formula as a callback that will receive the entity alias in the parameter:
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Box.ts"
 @Formula(alias => `${alias}.obj_length * ${alias}.obj_height * ${alias}.obj_width`)
@@ -799,21 +765,20 @@ properties: {
 
 ## Indexes
 
-We can define indexes via `@Index()` decorator, for unique indexes, we can 
-use `@Unique()` decorator. We can use it either on entity class, or on entity property. 
+We can define indexes via `@Index()` decorator, for unique indexes, we can use `@Unique()` decorator. We can use it either on entity class, or on entity property.
 
 To define complex indexes, we can use index expressions. They allow us to specify the final `create index` query and an index name - this name is then used for index diffing, so the schema generator will only try to create it if it's not there yet, or remove it, if it's no longer defined in the entity. Index expressions are not bound to any property, rather to the entity itself (we can still define them on both entity and property level).
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
 @Entity()
@@ -899,32 +864,28 @@ export const AuthorSchema = new EntitySchema<Author, CustomBaseEntity>({
 
 ## Check constraints
 
-We can define check constraints via `@Check()` decorator. We can use it 
-either on entity class, or on entity property. It has a required `expression`
-property, that can be either a string or a callback, that receives map of
-property names to column names. Note that we need to use the generic type 
-argument if we want TypeScript suggestions for the property names.
+We can define check constraints via `@Check()` decorator. We can use it either on entity class, or on entity property. It has a required `expression` property, that can be either a string or a callback, that receives map of property names to column names. Note that we need to use the generic type argument if we want TypeScript suggestions for the property names.
 
 > Check constraints are currently supported only in postgres driver.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
-// with generated name based on the table name 
+// with generated name based on the table name
 @Check({ expression: 'price1 >= 0' })
-// with explicit name 
+// with explicit name
 @Check({ name: 'foo', expression: columns => `${columns.price1} >= 0` })
-// with explicit type argument we get autocomplete on `columns` 
+// with explicit type argument we get autocomplete on `columns`
 @Check<FooEntity>({ expression: columns => `${columns.price1} >= 0` })
 export class Book {
 
@@ -949,11 +910,11 @@ export class Book {
 
 ```ts title="./entities/Book.ts"
 @Entity()
-// with generated name based on the table name 
+// with generated name based on the table name
 @Check({ expression: 'price1 >= 0' })
-// with explicit name 
+// with explicit name
 @Check({ name: 'foo', expression: columns => `${columns.price1} >= 0` })
-// with explicit type argument we get autocomplete on `columns` 
+// with explicit type argument we get autocomplete on `columns`
 @Check<FooEntity>({ expression: columns => `${columns.price1} >= 0` })
 export class Book {
 
@@ -1012,8 +973,7 @@ We can define custom types by extending `Type` abstract class. It has 4 optional
 
 - `toJSON(value: any, platform: Platform): any`
 
-  Converts a value from its JS representation to its serialized JSON form of this type.
-  By default converts to the database value.
+  Converts a value from its JS representation to its serialized JSON form of this type. By default converts to the database value.
 
 - `getColumnType(prop: EntityProperty, platform: Platform): string`
 
@@ -1023,20 +983,18 @@ More information can be found in [Custom Types](custom-types.md) section.
 
 ## Lazy scalar properties
 
-We can mark any property as `lazy: true` to omit it from the select clause.
-This can be handy for properties that are too large, and you want to have them
-available only sometimes, like a full text of an article.
+We can mark any property as `lazy: true` to omit it from the select clause. This can be handy for properties that are too large, and you want to have them available only sometimes, like a full text of an article.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Property({ columnType: 'text', lazy: true })
@@ -1070,30 +1028,26 @@ const b1 = await em.find(Book, 1); // this will omit the `text` property
 const b2 = await em.find(Book, 1, { populate: ['text'] }); // this will load the `text` property
 ```
 
-> If the entity is already loaded and you need to populate a lazy scalar property,
-> you might need to pass `refresh: true` in the `FindOptions`.
+> If the entity is already loaded and you need to populate a lazy scalar property, you might need to pass `refresh: true` in the `FindOptions`.
 
 ## Virtual Properties
 
 We can define our properties as virtual, either as a method, or via JavaScript `get/set`.
 
-Following example defines User entity with `firstName` and `lastName` database fields, that
-are both hidden from the serialized response, replaced with virtual properties `fullName`
-(defined as a classic method) and `fullName2` (defined as a JavaScript getter).
+Following example defines User entity with `firstName` and `lastName` database fields, that are both hidden from the serialized response, replaced with virtual properties `fullName` (defined as a classic method) and `fullName2` (defined as a JavaScript getter).
 
-> For JavaScript getter you need to provide `{ persist: false }` option otherwise the value
-> would be stored in the database.
+> For JavaScript getter you need to provide `{ persist: false }` option otherwise the value would be stored in the database.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
 @Entity()
@@ -1183,29 +1137,26 @@ console.log(wrap(author).toJSON()); // { fullName: 'Jon Snow', fullName2: 'Jon S
 
 ## Entity file names
 
-Starting with MikroORM 4.2, there is no limitation for entity file names. It is now
-also possible to define multiple entities in a single file using folder based discovery.
+Starting with MikroORM 4.2, there is no limitation for entity file names. It is now also possible to define multiple entities in a single file using folder based discovery.
 
 ## Using custom base entity
 
-We can define our own base entity with properties that are required on all entities, like
-primary key and created/updated time. Single table inheritance is also supported.
+We can define our own base entity with properties that are required on all entities, like primary key and created/updated time. Single table inheritance is also supported.
 
 Read more about this topic in [Inheritance Mapping](inheritance-mapping.md) section.
 
-> If you are initializing the ORM via `entities` option, you need to specify all your
-> base entities as well.
+> If you are initializing the ORM via `entities` option, you need to specify all your base entities as well.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/CustomBaseEntity.ts"
 import { v4 } from 'uuid';
@@ -1270,9 +1221,7 @@ export const schema = new EntitySchema<CustomBaseEntity>({
   </TabItem>
 </Tabs>
 
-There is a special case, when we need to annotate the base entity - if we are using
-folder based discovery, and the base entity is not using any decorators (e.g. it does
-not define any decorated property). In that case, we need to mark it as abstract:
+There is a special case, when we need to annotate the base entity - if we are using folder based discovery, and the base entity is not using any decorators (e.g. it does not define any decorated property). In that case, we need to mark it as abstract:
 
 ```ts
 @Entity({ abstract: true })
@@ -1283,20 +1232,18 @@ export abstract class CustomBaseEntity {
 
 ## SQL Generated columns
 
-Knex currently does not support generated columns, so the schema generator
-cannot properly diff them. To work around this, we can set `ignoreSchemaChanges`
-on a property to avoid a perpetual diff from the schema generator
+Knex currently does not support generated columns, so the schema generator cannot properly diff them. To work around this, we can set `ignoreSchemaChanges` on a property to avoid a perpetual diff from the schema generator
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity
@@ -1359,15 +1306,15 @@ export const Book = new EntitySchema<IBook>({
 ### Using id as primary key (SQL drivers)
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
@@ -1437,15 +1384,15 @@ export const BookSchema = new EntitySchema<Book>({
 ### Using UUID as primary key (SQL drivers)
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 import { v4 } from 'uuid';
@@ -1514,15 +1461,15 @@ export const Book = new EntitySchema<IBook>({
 Requires enabling the module via: `create extension "uuid-ossp";`
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
@@ -1584,19 +1531,18 @@ export const BookSchema = new EntitySchema<Book>({
 
 ### Using BigInt as primary key (MySQL and PostgreSQL)
 
-We can use `BigIntType` to support `bigint`s. By default, it will represent the value as
-a `string`.
+We can use `BigIntType` to support `bigint`s. By default, it will represent the value as a `string`.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/CustomBaseEntity.ts"
 @Entity()
@@ -1638,15 +1584,15 @@ If you want to use native `bigint`s, read the following guide: [Using native Big
 ### Example of Mongo entity
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
@@ -1715,8 +1661,7 @@ export const Book = new EntitySchema<IBook>({
 
 ### Using MikroORM's BaseEntity (previously WrappedEntity)
 
-From v4 `BaseEntity` class is provided with `init`, `isInitialized`, `assign`
-and other methods that are otherwise available via the `wrap()` helper.
+From v4 `BaseEntity` class is provided with `init`, `isInitialized`, `assign` and other methods that are otherwise available via the `wrap()` helper.
 
 > Usage of the `BaseEntity` is optional.
 
@@ -1741,5 +1686,4 @@ const book = new Book();
 console.log(book.isInitialized()); // true
 ```
 
-Having the entities set up, we can now start [using entity manager](entity-manager.md) and
-[repositories](repositories.md) as described in following sections.
+Having the entities set up, we can now start [using entity manager](entity-manager.md) and [repositories](repositories.md) as described in following sections.

--- a/docs/versioned_docs/version-5.5/deployment.md
+++ b/docs/versioned_docs/version-5.5/deployment.md
@@ -2,29 +2,19 @@
 title: Deployment
 ---
 
-Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. Thanks to this, 
-defining the type is enough for runtime validation.
+Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. Thanks to this, defining the type is enough for runtime validation.
 
-This has some consequences for deployment of your application. Sometimes you will want to 
-deploy only your compiled output, without TS source files at all. In that case, discovery 
-process will probably fail. You have several options:
+This has some consequences for deployment of your application. Sometimes you will want to deploy only your compiled output, without TS source files at all. In that case, discovery process will probably fail. You have several options:
 
 ## Deploy pre-built cache
 
-By default, output of metadata discovery will be cached in `temp` folder. You can reuse this 
-cache in your deployed application. Currently the cache is saved in files named like the entity
-source file, e.g. `Author.ts` entity will store cache in `temp/Author.ts.json` file.
+By default, output of metadata discovery will be cached in `temp` folder. You can reuse this cache in your deployed application. Currently the cache is saved in files named like the entity source file, e.g. `Author.ts` entity will store cache in `temp/Author.ts.json` file.
 
-When running compiled code, JS entities will be taken into account instead, so you will need to 
-generate the cache by running the compiled code locally. That will generate `temp/Author.js.json`, 
-which is the file you will need to deploy alongside your application. 
+When running compiled code, JS entities will be taken into account instead, so you will need to generate the cache by running the compiled code locally. That will generate `temp/Author.js.json`, which is the file you will need to deploy alongside your application.
 
 ## Fill type or entity attributes everywhere
 
-What discovery process does is to sniff TS types and save their value to string, so it can be 
-used later for validation. You can skip the whole process by simply providing those values 
-manually:
+What discovery process does is to sniff TS types and save their value to string, so it can be used later for validation. You can skip the whole process by simply providing those values manually:
 
 ```ts
 @Entity()
@@ -63,36 +53,28 @@ export enum BookStatus {
 
 ## Deploy your entity source files
 
-Usually it does not matter much that you deploy more files than needed, so the easiest way
-is to just deploy your TS source files next to the compiled output, just like during development.
+Usually it does not matter much that you deploy more files than needed, so the easiest way is to just deploy your TS source files next to the compiled output, just like during development.
 
 ## Deploy a bundle of entities and dependencies with [Webpack](https://webpack.js.org/)
 
-Webpack can be used to bundle every entity and dependency: you get a single file that contains 
-every required module/file and has no external dependencies.
+Webpack can be used to bundle every entity and dependency: you get a single file that contains every required module/file and has no external dependencies.
 
 ### Prepare your project for Webpack
 
-Webpack requires every required file to be hardcoded in your code. Code like this won't work 
-(it will throw an error because Webpack doesn't know which file to include in the bundle):
+Webpack requires every required file to be hardcoded in your code. Code like this won't work (it will throw an error because Webpack doesn't know which file to include in the bundle):
 
 ```ts
 let dependencyNameInVariable = 'dependency';
 const dependency = import(dependencyNameInVariable);
 ```
 
-As Webpack creates a file bundle, it isn't desired that it scans directories for entities 
-or metadata. Therefore you need to provide list of entities in the `entities` option in 
-the initialization function, folder/file based discovery is not supported (see dynamically 
-including entities as an alternative solution). Also you need to fill `type` or `entity` 
-attributes everywhere (see above) and disable caching (it will decrease start-time slightly).
+As Webpack creates a file bundle, it isn't desired that it scans directories for entities or metadata. Therefore you need to provide list of entities in the `entities` option in the initialization function, folder/file based discovery is not supported (see dynamically including entities as an alternative solution). Also you need to fill `type` or `entity` attributes everywhere (see above) and disable caching (it will decrease start-time slightly).
 
 > In v4 caching is disabled by default when using `ReflectMetadataProvider`.
 
 #### Disabling dynamic file access
 
-First thing you should do is to disable dynamic file access in the discovery process via the
-`discovery.disableDynamicFileAccess` toggle. This will effectively do:
+First thing you should do is to disable dynamic file access in the discovery process via the `discovery.disableDynamicFileAccess` toggle. This will effectively do:
 
 - set metadata provider to `ReflectMetadataProvider`
 - disable caching
@@ -113,15 +95,11 @@ await MikroORM.init({
 
 #### Dynamically loading dependencies
 
-This will make use of a Webpack feature called [dynamic imports](https://webpack.js.org/guides/code-splitting/#dynamic-imports). 
-This way you can import dependencies as long as part of the path is known.
+This will make use of a Webpack feature called [dynamic imports](https://webpack.js.org/guides/code-splitting/#dynamic-imports). This way you can import dependencies as long as part of the path is known.
 
-In following example [`require.context`](https://webpack.js.org/guides/dependency-management/#requirecontext) 
-is used. This 'function' is only usable during the building process from Webpack so therefore 
-there is an alternative solution provided that will as long as the environment variable 
-WEBPACK is not set (e.g. during development with `ts-node`).
+In following example [`require.context`](https://webpack.js.org/guides/dependency-management/#requirecontext) is used. This 'function' is only usable during the building process from Webpack so therefore there is an alternative solution provided that will as long as the environment variable WEBPACK is not set (e.g. during development with `ts-node`).
 
-Here, all files with the extension `.ts` will be imported from the directory `../entities`. 
+Here, all files with the extension `.ts` will be imported from the directory `../entities`.
 
 > [`flatMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap) is a method from ECMAScript 2019 and requires [Node.js](https://nodejs.org/) 11 or higher.
 
@@ -152,10 +130,7 @@ async function getEntities(): Promise<any[]> {
 
 ### Webpack configuration
 
-Webpack can be run without [configuration file](https://webpack.js.org/configuration/) but 
-for building MikroORM and [Node.js](https://nodejs.org/) bundles it requires additional 
-configuration. Configuration for Webpack is stored in the root of the project as 
-`webpack.config.js`. For all the options please refer to the following [page](https://webpack.js.org/configuration/).
+Webpack can be run without [configuration file](https://webpack.js.org/configuration/) but for building MikroORM and [Node.js](https://nodejs.org/) bundles it requires additional configuration. Configuration for Webpack is stored in the root of the project as `webpack.config.js`. For all the options please refer to the following [page](https://webpack.js.org/configuration/).
 
 For bundling MikroORM the following configuration is required:
 
@@ -199,7 +174,7 @@ module.exports = {
           mangle: false,
           // Similarly, Terser's compression may at its own discretion change function and class names.
           // While it only rarely does so, it's safest to also disable changing their names here.
-          // This can be controlled in a more granular way if needed (see 
+          // This can be controlled in a more granular way if needed (see
           // https://terser.org/docs/api-reference.html#compress-options).
           compress: {
             keep_classnames: true,
@@ -273,6 +248,4 @@ module.exports = {
 
 ### Running Webpack
 
-To run Webpack execute `webpack` (or `npx webpack` if not installed globally) in the root 
-of the project. It will probably throw a few warnings but you can ignore the errors regarding 
-MikroORM: the mentioned pieces of code won't be executed if properly bundled with Webpack.
+To run Webpack execute `webpack` (or `npx webpack` if not installed globally) in the root of the project. It will probably throw a few warnings but you can ignore the errors regarding MikroORM: the mentioned pieces of code won't be executed if properly bundled with Webpack.

--- a/docs/versioned_docs/version-5.5/embeddables.md
+++ b/docs/versioned_docs/version-5.5/embeddables.md
@@ -8,22 +8,13 @@ import TabItem from '@theme/TabItem';
 
 > Support for embeddables was added in version 4.0
 
-Embeddables are classes which are not entities themselves, but are embedded in 
-entities and can also be queried. You'll mostly want to use them to reduce 
-duplication or separating concerns. Value objects such as date range or address 
-are the primary use case for this feature.
+Embeddables are classes which are not entities themselves, but are embedded in entities and can also be queried. You'll mostly want to use them to reduce duplication or separating concerns. Value objects such as date range or address are the primary use case for this feature.
 
-> Embeddables needs to be discovered just like regular entities, don't forget to 
-> add them to the list of entities when initializing the ORM.
+> Embeddables needs to be discovered just like regular entities, don't forget to add them to the list of entities when initializing the ORM.
 
-Embeddables can contain properties with basic `@Property()` mapping, nested 
-`@Embedded()` properties or arrays of `@Embedded()` properties. From version
-5.0 we can also use `@ManyToOne()` properties.
+Embeddables can contain properties with basic `@Property()` mapping, nested `@Embedded()` properties or arrays of `@Embedded()` properties. From version 5.0 we can also use `@ManyToOne()` properties.
 
-For the purposes of this tutorial, we will assume that you have a `User` class in 
-your application and you would like to store an address in the `User` class. We will 
-model the `Address` class as an embeddable instead of simply adding the respective 
-columns to the `User` class.
+For the purposes of this tutorial, we will assume that you have a `User` class in your application and you would like to store an address in the `User` class. We will model the `Address` class as an embeddable instead of simply adding the respective columns to the `User` class.
 
 <Tabs
   groupId="entity-def"
@@ -144,17 +135,13 @@ export const AddressSchema = new EntitySchema({
   </TabItem>
 </Tabs>
 
-> When using ReflectMetadataProvider, you might need to provide the class in decorator options:
-> `@Embedded(() => Address)` or `@Embedded({ entity: () => Address })`.
+> When using ReflectMetadataProvider, you might need to provide the class in decorator options: `@Embedded(() => Address)` or `@Embedded({ entity: () => Address })`.
 
-In terms of your database schema, MikroORM will automatically inline all columns from 
-the `Address` class into the table of the `User` class, just as if you had declared 
-them directly there.
+In terms of your database schema, MikroORM will automatically inline all columns from the `Address` class into the table of the `User` class, just as if you had declared them directly there.
 
 ## Initializing embeddables
 
-In case all fields in the embeddable are nullable, you might want to initialize the 
-embeddable, to avoid getting a null value instead of the embedded object.
+In case all fields in the embeddable are nullable, you might want to initialize the embeddable, to avoid getting a null value instead of the embedded object.
 
 <Tabs
   groupId="entity-def"
@@ -194,11 +181,9 @@ address: { reference: 'embedded', entity: 'Address', onCreate: () => new Address
 
 By default, MikroORM names your columns by prefixing them, using the value object name.
 
-Following the example above, your columns would be named as `address_street`, 
-`address_postal_code`...
+Following the example above, your columns would be named as `address_street`, `address_postal_code`...
 
-You can change this behaviour to meet your needs by changing the `prefix` attribute 
-in the `@Embedded()` notation.
+You can change this behaviour to meet your needs by changing the `prefix` attribute in the `@Embedded()` notation.
 
 The following example shows you how to set your prefix to `myPrefix_`:
 
@@ -246,8 +231,7 @@ address: { reference: 'embedded', entity: 'Address', prefix: 'myPrefix_' },
   </TabItem>
 </Tabs>
 
-To have MikroORM drop the prefix and use the value object's property name directly, 
-set `prefix: false`:
+To have MikroORM drop the prefix and use the value object's property name directly, set `prefix: false`:
 
 <Tabs
   groupId="entity-def"
@@ -285,8 +269,7 @@ address: { reference: 'embedded', entity: 'Address', prefix: false },
 
 ## Storing embeddables as objects
 
-From MikroORM v4.2 we can also store the embeddable as an object instead of
-inlining its properties to the owing entity.
+From MikroORM v4.2 we can also store the embeddable as an object instead of inlining its properties to the owing entity.
 
 <Tabs
   groupId="entity-def"
@@ -322,17 +305,15 @@ address: { reference: 'embedded', entity: 'Address', object: true },
   </TabItem>
 </Tabs>
 
-In SQL drivers, this will use a JSON column to store the value. 
+In SQL drivers, this will use a JSON column to store the value.
 
 > Only MySQL and PostgreSQL drivers support searching by JSON properties currently.
 
-> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/embeddables.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/embeddables.html) as the behaviour here is pretty much the same.
 
 ## Array of embeddables
 
-Embedded arrays are always stored as JSON. It is possible to use them inside
-nested embeddables. 
+Embedded arrays are always stored as JSON. It is possible to use them inside nested embeddables.
 
 <Tabs
   groupId="entity-def"
@@ -533,10 +514,7 @@ export const IdentitySchema = new EntitySchema({
 
 ## Polymorphic embeddables
 
-Since v5, it is also possible to use polymorphic embeddables. This means we
-can define multiple classes for a single embedded property and the right one
-will be used based on the discriminator column, similar to how single table 
-inheritance work.
+Since v5, it is also possible to use polymorphic embeddables. This means we can define multiple classes for a single embedded property and the right one will be used based on the discriminator column, similar to how single table inheritance work.
 
 <Tabs
   groupId="entity-def"

--- a/docs/versioned_docs/version-5.5/entity-constructors.md
+++ b/docs/versioned_docs/version-5.5/entity-constructors.md
@@ -2,12 +2,9 @@
 title: Using Entity Constructors
 ---
 
-Internally, `MikroORM` never calls entity constructor, so you are free to use it as you wish.
-The constructor will be called only when you instantiate the class yourself via `new` operator,
-so it is a handy place to require your data when creating new entity.
+Internally, `MikroORM` never calls entity constructor, so you are free to use it as you wish. The constructor will be called only when you instantiate the class yourself via `new` operator, so it is a handy place to require your data when creating new entity.
 
-For example following `Book` entity definition will always require to set `title` and `author`, 
-but `publisher` will be optional:
+For example following `Book` entity definition will always require to set `title` and `author`, but `publisher` will be optional:
 
 ```ts
 @Entity()
@@ -38,7 +35,4 @@ export class Book {
 
 ## Using native private properties
 
-If we want to use native private properties inside entities, the default approach of
-how MikroORM creates entity instances via `Object.create()` is not viable (more about this
-in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity
-constructors, we can use [`forceEntityConstructor`](./configuration.md#using-native-private-properties) toggle.
+If we want to use native private properties inside entities, the default approach of how MikroORM creates entity instances via `Object.create()` is not viable (more about this in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity constructors, we can use [`forceEntityConstructor`](./configuration.md#using-native-private-properties) toggle.

--- a/docs/versioned_docs/version-5.5/entity-generator.md
+++ b/docs/versioned_docs/version-5.5/entity-generator.md
@@ -2,12 +2,11 @@
 title: Entity Generator
 ---
 
-To generate entities from existing database schema, you can use `EntityGenerator` helper. 
+To generate entities from existing database schema, you can use `EntityGenerator` helper.
 
-You can use it via CLI: 
+You can use it via CLI:
 
-> To work with the CLI, first install `@mikro-orm/cli` package locally.
-> The version needs to be aligned with the `@mikro-orm/core` package.
+> To work with the CLI, first install `@mikro-orm/cli` package locally. The version needs to be aligned with the `@mikro-orm/core` package.
 
 ```sh
 npx mikro-orm generate-entities --dump  # Dumps all generated entities
@@ -22,14 +21,14 @@ import { MikroORM } from '@mikro-orm/core';
 (async () => {
   const orm = await MikroORM.init({
     discovery: {
-      // we need to disable validation for no entities 
+      // we need to disable validation for no entities
       warnWhenNoEntities: false,
     },
     dbName: 'your-db-name',
     // ...
   });
   const generator = orm.getEntityGenerator();
-  const dump = await generator.generate({ 
+  const dump = await generator.generate({
     save: true,
     baseDir: process.cwd() + '/my-entities',
   });
@@ -46,7 +45,7 @@ $ ts-node generate-entities
 
 ## Advanced configuration
 
-By default, the `EntityGenerator` generates only owning sides of relations (e.g. M:1) and uses decorators for the entity definition. We can adjust its behaviour via `entityGenerator` section in the ORM config. Available options: 
+By default, the `EntityGenerator` generates only owning sides of relations (e.g. M:1) and uses decorators for the entity definition. We can adjust its behaviour via `entityGenerator` section in the ORM config. Available options:
 
 - `bidirectionalRelations` to generate also the inverse sides for them
 - `identifiedReferences` to generate M:1 and 1:1 relations as wrapped references

--- a/docs/versioned_docs/version-5.5/entity-helper.md
+++ b/docs/versioned_docs/version-5.5/entity-helper.md
@@ -5,10 +5,7 @@ sidebar_label: Updating Entity Values
 
 ## Updating Entity Values with `entity.assign()`
 
-When you want to update entity based on user input, you will usually have just plain
-string ids of entity relations as user input. Normally you would need to use 
-`em.getReference()` to create references from each id first, and then
-use those references to update entity relations:
+When you want to update entity based on user input, you will usually have just plain string ids of entity relations as user input. Normally you would need to use `em.getReference()` to create references from each id first, and then use those references to update entity relations:
 
 ```ts
 const jon = new Author('Jon Snow', 'snow@wall.st');
@@ -21,8 +18,8 @@ Same result can be easily achieved with `entity.assign()`:
 ```ts
 import { wrap } from '@mikro-orm/core';
 
-wrap(book).assign({ 
-  title: 'Better Book 1', 
+wrap(book).assign({
+  title: 'Better Book 1',
   author: '...id...',
 });
 console.log(book.title); // 'Better Book 1'
@@ -30,22 +27,19 @@ console.log(book.author); // instance of Author with id: '...id...'
 console.log(book.author.id); // '...id...'
 ```
 
-To use `entity.assign()` on not managed entities, you need to provide `EntityManager` 
-instance explicitly: 
+To use `entity.assign()` on not managed entities, you need to provide `EntityManager` instance explicitly:
 
 ```ts
 import { wrap } from '@mikro-orm/core';
 
 const book = new Book();
-wrap(book).assign({ 
-  title: 'Better Book 1', 
+wrap(book).assign({
+  title: 'Better Book 1',
   author: '...id...',
 }, { em: orm.em });
 ```
 
-By default, `entity.assign(data)` behaves same way as `Object.assign(entity, data)`, 
-e.g. it does not merge things recursively. To enable deep merging of object properties (not referenced entities), 
-use second parameter to enable `mergeObjects` flag:
+By default, `entity.assign(data)` behaves same way as `Object.assign(entity, data)`, e.g. it does not merge things recursively. To enable deep merging of object properties (not referenced entities), use second parameter to enable `mergeObjects` flag:
 
 ```ts
 import { wrap } from '@mikro-orm/core';
@@ -61,9 +55,7 @@ console.log(book.meta); // { foo: 4 }
 
 ### Updating deep entity graph
 
-Since v5, `assign` allows updating deep entity graph by default. To update existing
-entity, we need to provide its PK in the `data`, as well as to **load that entity first
-into current context**.
+Since v5, `assign` allows updating deep entity graph by default. To update existing entity, we need to provide its PK in the `data`, as well as to **load that entity first into current context**.
 
 ```ts
 const book = await em.findOneOrFail(Book, 1, { populate: ['author'] });
@@ -77,8 +69,7 @@ wrap(book).assign({
 });
 ```
 
-If we want to always update the entity, even without the entity PK being present 
-in `data`, we can use `updateByPrimaryKey: false`:
+If we want to always update the entity, even without the entity PK being present in `data`, we can use `updateByPrimaryKey: false`:
 
 ```ts
 const book = await em.findOneOrFail(Book, 1, { populate: ['author'] });
@@ -91,8 +82,7 @@ wrap(book).assign({
 }, { updateByPrimaryKey: false });
 ```
 
-Otherwise the entity data without PK are considered as new entity, and will trigger
-insert query:
+Otherwise the entity data without PK are considered as new entity, and will trigger insert query:
 
 ```ts
 const book = await em.findOneOrFail(Book, 1, { populate: ['author'] });
@@ -105,9 +95,7 @@ wrap(book).assign({
 });
 ```
 
-Same applies to the case when we do not load the child entity first into the context,
-e.g. when we try to assign to a relation that was not populated. Even if we provide
-its PK, it will be considered as new object and trigger an insert query.
+Same applies to the case when we do not load the child entity first into the context, e.g. when we try to assign to a relation that was not populated. Even if we provide its PK, it will be considered as new object and trigger an insert query.
 
 ```ts
 const book = await em.findOneOrFail(Book, 1); // author is not populated
@@ -121,8 +109,7 @@ wrap(book).assign({
 });
 ```
 
-When updating collections, we can either pass complete array of all items, or just
-a single item - in such case, the new item will be appended to the existing items.
+When updating collections, we can either pass complete array of all items, or just a single item - in such case, the new item will be appended to the existing items.
 
 ```ts
 // resets the addresses collection to a single item
@@ -134,8 +121,7 @@ wrap(user).assign({ addresses: new Address(...) });
 
 ## `WrappedEntity` and `wrap()` helper
 
-`IWrappedEntity` is an interface that defines public helper methods provided 
-by the ORM:
+`IWrappedEntity` is an interface that defines public helper methods provided by the ORM:
 
 ```ts
 interface IWrappedEntity<T, PK extends keyof T> {
@@ -149,19 +135,11 @@ interface IWrappedEntity<T, PK extends keyof T> {
 }
 ```
 
-There are two ways to access those methods. You can either extend `BaseEntity` 
-(exported from `@mikro-orm/core`), that defines those methods, or use the 
-`wrap()` helper to access `WrappedEntity` instance, where those methods
-exist.
+There are two ways to access those methods. You can either extend `BaseEntity` (exported from `@mikro-orm/core`), that defines those methods, or use the `wrap()` helper to access `WrappedEntity` instance, where those methods exist.
 
-Users can choose whether they are fine with polluting the entity interface with 
-those additional methods, or they want to keep the interface clean 
-and use the `wrap(entity)` helper method instead to access them. 
+Users can choose whether they are fine with polluting the entity interface with those additional methods, or they want to keep the interface clean and use the `wrap(entity)` helper method instead to access them.
 
-> Since v4 `wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is 
-> being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...),
-> if you want to access internal properties like `__meta` or `__em`, you need to explicitly
-> ask for the helper via `wrap(entity, true)`.
+> Since v4 `wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...), if you want to access internal properties like `__meta` or `__em`, you need to explicitly ask for the helper via `wrap(entity, true)`.
 
 ```ts
 import { BaseEntity } from '@mikro-orm/core';
@@ -180,9 +158,7 @@ console.log(book.meta); // { foo: 3, bar: 2 }
 
 ### Accessing internal prefixed properties
 
-Previously it was possible to access internal properties like `__meta` or `__em` 
-from the `wrap()` helper. Now to access them, you need to use second parameter of
-wrap:
+Previously it was possible to access internal properties like `__meta` or `__em` from the `wrap()` helper. Now to access them, you need to use second parameter of wrap:
 
 ```ts
 @Entity()

--- a/docs/versioned_docs/version-5.5/entity-manager.md
+++ b/docs/versioned_docs/version-5.5/entity-manager.md
@@ -63,7 +63,7 @@ This will log something like `(User) { id: 1 }`, note the class name being wrapp
 Here is an example of common actions you can do with a reference instead of a fully loaded entity:
 
 ```ts
-// setting relation properties 
+// setting relation properties
 author.favouriteBook = em.getReference(Book, 1);
 
 // removing entity by reference
@@ -144,7 +144,7 @@ You can also use `em.populate()` helper to populate relations (or to ensure they
 const authors = await em.createQueryBuilder(Author).select('*').getResult();
 await em.populate(authors, { populate: ['books.tags'] });
 
-// now our Author entities will have `books` collections populated, 
+// now our Author entities will have `books` collections populated,
 // as well as they will have their `tags` collections populated.
 console.log(authors[0].books[0].tags[0]); // initialized BookTag
 ```
@@ -327,7 +327,7 @@ const users = await em.find(User, { [expr('lower(email)')]: 'foo@bar.baz' }, {
 This will produce following query:
 
 ```sql
-select `e0`.* 
+select `e0`.*
 from `user` as `e0`
 where lower(email) = 'foo@bar.baz'
 order by (point(loc_latitude, loc_longitude) <@> point(0, 0)) asc
@@ -413,13 +413,13 @@ for (const user of users) {
 await em.flush();
 
 // update `user` set
-//   `name` = case 
-//     when (`id` = 1) then 'Peter 1 changed!' 
-//     when (`id` = 2) then 'Peter 2 changed!' 
-//     when (`id` = 3) then 'Peter 3 changed!' 
-//     when (`id` = 4) then 'Peter 4 changed!' 
-//     when (`id` = 5) then 'Peter 5 changed!' 
-//     else `priority` end 
+//   `name` = case
+//     when (`id` = 1) then 'Peter 1 changed!'
+//     when (`id` = 2) then 'Peter 2 changed!'
+//     when (`id` = 3) then 'Peter 3 changed!'
+//     when (`id` = 4) then 'Peter 4 changed!'
+//     when (`id` = 5) then 'Peter 5 changed!'
+//     else `priority` end
 //   where `id` in (1, 2, 3, 4, 5)
 ```
 
@@ -442,7 +442,7 @@ const users = await em.find(User, { email: 'foo@bar.baz' }, {
   populate: ['cars.brand'],
 });
 users[0].name = 'changed';
-await em.flush(); // calling flush have no effect, as the entity is not managed  
+await em.flush(); // calling flush have no effect, as the entity is not managed
 ```
 
 > Keep in mind that this can also have [negative effect on the performance](https://stackoverflow.com/questions/9259480/entity-framework-mergeoption-notracking-bad-performance).

--- a/docs/versioned_docs/version-5.5/entity-schema.md
+++ b/docs/versioned_docs/version-5.5/entity-schema.md
@@ -2,7 +2,7 @@
 title: Defining Entities via EntitySchema
 ---
 
-With `EntitySchema` helper we define the schema programmatically. 
+With `EntitySchema` helper we define the schema programmatically.
 
 ```ts title="./entities/Book.ts"
 export interface Book extends CustomBaseEntity {
@@ -13,7 +13,7 @@ export interface Book extends CustomBaseEntity {
 }
 
 // The second type argument is optional, and should be used only with custom
-// base entities, not with the `BaseEntity` class exported from `@mikro-orm/core`. 
+// base entities, not with the `BaseEntity` class exported from `@mikro-orm/core`.
 export const schema = new EntitySchema<Book, CustomBaseEntity>({
   // name should be used only with interfaces
   name: 'Book',
@@ -29,8 +29,7 @@ export const schema = new EntitySchema<Book, CustomBaseEntity>({
 });
 ```
 
-When creating new entity instances, you will need to use `em.create()` method that will
-create instance of internally created class. 
+When creating new entity instances, you will need to use `em.create()` method that will create instance of internally created class.
 
 ```ts
 const repo = em.getRepository<Author>('Author');
@@ -42,7 +41,7 @@ await repo.persistAndFlush(author);
 
 ## Using custom entity classes
 
-You can optionally use custom class for entity instances.  
+You can optionally use custom class for entity instances.
 
 ```ts title="./entities/Author.ts"
 export class Author extends CustomBaseEntity {
@@ -55,7 +54,7 @@ export class Author extends CustomBaseEntity {
   books = new Collection<Book>(this);
   favouriteBook?: Book;
   version?: number;
-  
+
   constructor(name: string, email: string) {
     super();
     this.name = name;
@@ -90,7 +89,7 @@ await repo.persistAndFlush(author);
 
 ## Using custom base entity
 
-Do not forget that base entities needs to be discovered just like normal entities. 
+Do not forget that base entities needs to be discovered just like normal entities.
 
 ```ts title="./entities/BaseEntity.ts"
 export interface CustomBaseEntity {
@@ -112,9 +111,7 @@ export const schema = new EntitySchema<CustomBaseEntity>({
 
 ## Configuration Reference
 
-The parameter of `EntitySchema` requires to provide either `name` or `class` parameters. 
-When using `class`, `extends` will be automatically inferred. You can optionally pass 
-these additional parameters:
+The parameter of `EntitySchema` requires to provide either `name` or `class` parameters. When using `class`, `extends` will be automatically inferred. You can optionally pass these additional parameters:
 
 ```ts
 name: string;
@@ -129,8 +126,7 @@ hooks: Partial<Record<keyof typeof EventType, ((string & keyof T) | NonNullable<
 abstract: boolean;
 ```
 
-Every property then needs to contain a type specification - one of `type`/`customType`/`entity`.
-Here are some examples of various property types:
+Every property then needs to contain a type specification - one of `type`/`customType`/`entity`. Here are some examples of various property types:
 
 ```ts
 export enum MyEnum {
@@ -187,10 +183,7 @@ export const schema = new EntitySchema<BookTag>({
 
 ## Hooks example
 
-Entity hooks can be defined either as a property name, or as a function.
-When defined as a function, the `this` argument will be the entity instance.
-Arrow functions can be used if desired, and the entity will be available at args.entity.
-See [Events and Lifecycle Hooks](events.md) section for more details on `EventArgs`.
+Entity hooks can be defined either as a property name, or as a function. When defined as a function, the `this` argument will be the entity instance. Arrow functions can be used if desired, and the entity will be available at args.entity. See [Events and Lifecycle Hooks](events.md) section for more details on `EventArgs`.
 
 ```ts
 export class BookTag {

--- a/docs/versioned_docs/version-5.5/events.md
+++ b/docs/versioned_docs/version-5.5/events.md
@@ -3,11 +3,10 @@ title: Events and Lifecycle Hooks
 sidebar_label: Events and Hooks
 ---
 
-There are two ways to hook to the lifecycle of an entity: 
+There are two ways to hook to the lifecycle of an entity:
 
 - **Lifecycle hooks** are methods defined on the entity prototype.
-- **EventSubscriber**s are classes that can be used to hook to multiple entities
-  or when we do not want to have the method present on the entity prototype.
+- **EventSubscriber**s are classes that can be used to hook to multiple entities or when we do not want to have the method present on the entity prototype.
 
 > Hooks are internally executed the same way as subscribers.
 
@@ -15,53 +14,37 @@ There are two ways to hook to the lifecycle of an entity:
 
 ## Hooks
 
-We can use lifecycle hooks to run some code when entity gets persisted. We can mark any of
-entity methods with them, we can also mark multiple methods with same hook.
+We can use lifecycle hooks to run some code when entity gets persisted. We can mark any of entity methods with them, we can also mark multiple methods with same hook.
 
 All hooks support async methods with one exception - `@OnInit`.
 
-- `@OnInit` is fired when new instance of entity is created, either manually `em.create()`, or 
-automatically when new entities are loaded from database
+- `@OnInit` is fired when new instance of entity is created, either manually `em.create()`, or automatically when new entities are loaded from database
 
-- `@OnLoad` is fired when new entity is loaded into context (e.g. via `em.find()` or `em.populate()`). As opposed to `@OnInit` this will be fired only for fully loaded entities, not references, and this hook can be async. 
+- `@OnLoad` is fired when new entity is loaded into context (e.g. via `em.find()` or `em.populate()`). As opposed to `@OnInit` this will be fired only for fully loaded entities, not references, and this hook can be async.
 
 - `@BeforeCreate()` and `@BeforeUpdate()` is fired right before we persist the entity in database
 
-- `@AfterCreate()` and `@AfterUpdate()` is fired right after the entity is updated in database and 
-merged to identity map. Since this event entity will have reference to `EntityManager` and will be 
-enabled to call `wrap(entity).init()` method (including all entity references and collections).
+- `@AfterCreate()` and `@AfterUpdate()` is fired right after the entity is updated in database and merged to identity map. Since this event entity will have reference to `EntityManager` and will be enabled to call `wrap(entity).init()` method (including all entity references and collections).
 
-- `@BeforeDelete()` is fired right before we delete the record from database. It is fired only when
-removing entity or entity reference, not when deleting records by query. 
+- `@BeforeDelete()` is fired right before we delete the record from database. It is fired only when removing entity or entity reference, not when deleting records by query.
 
-- `@AfterDelete()` is fired right after the record gets deleted from database and it is unset from 
-the identity map.
+- `@AfterDelete()` is fired right after the record gets deleted from database and it is unset from the identity map.
 
 > `@OnInit` is not fired when we create the entity manually via its constructor (`new MyEntity()`)
 
-> `@OnInit` can be sometimes fired twice, once when the entity reference is
-> created, and once after its populated. To distinguish between those we can
-> use `wrap(this).isInitialized()`.
+> `@OnInit` can be sometimes fired twice, once when the entity reference is created, and once after its populated. To distinguish between those we can use `wrap(this).isInitialized()`.
 
 ## Limitations of lifecycle hooks
 
-Hooks are executed inside the commit action of unit of work, after all change 
-sets are computed. This means that it is not possible to create new entities as
-usual from inside the hook. Calling `em.flush()` from hooks will result in 
-validation error. Calling `em.persist()` can result in undefined behaviour like
-locking errors. 
+Hooks are executed inside the commit action of unit of work, after all change sets are computed. This means that it is not possible to create new entities as usual from inside the hook. Calling `em.flush()` from hooks will result in validation error. Calling `em.persist()` can result in undefined behaviour like locking errors.
 
-> The **internal** instance of `EntityManager` accessible under `wrap(this, true).__em` is 
-> not meant for public usage. 
+> The **internal** instance of `EntityManager` accessible under `wrap(this, true).__em` is not meant for public usage.
 
 ## EventSubscriber
 
-Use `EventSubscriber` to hook to multiple entities or if we do not want to pollute
-the entity prototype. All methods are optional, if we omit the `getSubscribedEntities()`
-method, it means we are subscribing to all entities.
+Use `EventSubscriber` to hook to multiple entities or if we do not want to pollute the entity prototype. All methods are optional, if we omit the `getSubscribedEntities()` method, it means we are subscribing to all entities.
 
-We can either register the subscribers manually in the ORM configuration (via 
-`subscribers` array where we put the instance):
+We can either register the subscribers manually in the ORM configuration (via `subscribers` array where we put the instance):
 
 ```ts
 MikroORM.init({
@@ -69,9 +52,7 @@ MikroORM.init({
 });
 ```
 
-Or use `@Subscriber()` decorator - keep in mind that we need to make sure the file gets 
-loaded in order to make this decorator registration work (e.g. we import that file 
-explicitly somewhere).
+Or use `@Subscriber()` decorator - keep in mind that we need to make sure the file gets loaded in order to make this decorator registration work (e.g. we import that file explicitly somewhere).
 
 ```ts
 import { EntityName, EventArgs, EventSubscriber, Subscriber } from '@mikro-orm/core';
@@ -88,13 +69,13 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
   }
 
   async afterUpdate(args: EventArgs<Author>): Promise<void> {
-    // ... 
+    // ...
   }
 
 }
 ```
 
-Another example, where we register to all the events and all entities: 
+Another example, where we register to all the events and all entities:
 
 ```ts
 import { EventArgs, EventSubscriber, Subscriber } from '@mikro-orm/core';
@@ -111,7 +92,7 @@ export class EverythingSubscriber implements EventSubscriber {
   async afterUpdate<T>(args: EventArgs<T>): Promise<void> { ... }
   async beforeDelete<T>(args: EventArgs<T>): Promise<void> { ... }
   async afterDelete<T>(args: EventArgs<T>): Promise<void> { ... }
-  
+
   // flush events
   async beforeFlush<T>(args: EventArgs<T>): Promise<void> { ... }
   async onFlush<T>(args: EventArgs<T>): Promise<void> { ... }
@@ -130,9 +111,7 @@ export class EverythingSubscriber implements EventSubscriber {
 
 ## EventArgs
 
-As a parameter to the hook method we get `EventArgs` instance. It will always contain
-reference to the current `EntityManager` and the particular entity. Events fired
-from `UnitOfWork` during flush operation also contain the `ChangeSet` object.
+As a parameter to the hook method we get `EventArgs` instance. It will always contain reference to the current `EntityManager` and the particular entity. Events fired from `UnitOfWork` during flush operation also contain the `ChangeSet` object.
 
 ```ts
 interface EventArgs<T> {
@@ -161,28 +140,21 @@ enum ChangeSetType {
 
 ## Flush events
 
-There is a special kind of events executed during the commit phase (flush operation).
-They are executed before, during and after the flush, and they are not bound to any
-entity in particular. 
+There is a special kind of events executed during the commit phase (flush operation). They are executed before, during and after the flush, and they are not bound to any entity in particular.
 
-- `beforeFlush` is executed before change sets are computed, this is the only
-  event where it is safe to persist new entities. 
+- `beforeFlush` is executed before change sets are computed, this is the only event where it is safe to persist new entities.
 - `onFlush` is executed after the change sets are computed.
-- `afterFlush` is executed as the last step just before the `flush` call resolves.
-  it will be executed even if there are no changes to be flushed. 
+- `afterFlush` is executed as the last step just before the `flush` call resolves. it will be executed even if there are no changes to be flushed.
 
-Flush event args will not contain any entity instance, as they are entity agnostic.
-They do contain additional reference to the `UnitOfWork` instance.
+Flush event args will not contain any entity instance, as they are entity agnostic. They do contain additional reference to the `UnitOfWork` instance.
 
 ```ts
 interface FlushEventArgs extends Omit<EventArgs<unknown>, 'entity'> {
   uow?: UnitOfWork;
 }
-``` 
+```
 
-> Flush events are entity agnostic, specifying `getSubscribedEntities()` method
-> will not have any effect for those. They are fired only once per the `flush` 
-> operation.
+> Flush events are entity agnostic, specifying `getSubscribedEntities()` method will not have any effect for those. They are fired only once per the `flush` operation.
 
 ## Transaction events
 
@@ -219,18 +191,12 @@ UnitOfWork.getExtraUpdates(): Set<[AnyEntity, string, (AnyEntity | Reference<Any
 
 ### Using onFlush event
 
-In following example we have 2 entities: `FooBar` and `FooBaz`, connected via 
-M:1 relation. Our subscriber will automatically create new `FooBaz` entity and 
-connect it to the `FooBar` when we detect it in the change sets.
+In following example we have 2 entities: `FooBar` and `FooBaz`, connected via M:1 relation. Our subscriber will automatically create new `FooBaz` entity and connect it to the `FooBar` when we detect it in the change sets.
 
-We first use `uow.getChangeSets()` method to look up the change set of entity
-we are interested in. After we create the `FooBaz` instance and link it with 
-`FooBar`, we need to do two things:
+We first use `uow.getChangeSets()` method to look up the change set of entity we are interested in. After we create the `FooBaz` instance and link it with `FooBar`, we need to do two things:
 
-1. Call `uow.computeChangeSet(baz)` to compute the change set of newly created 
-  `FooBaz` entity
-2. Call `uow.recomputeSingleChangeSet(cs.entity)` to recalculate the existing 
-  change set of the `FooBar` entity.
+1. Call `uow.computeChangeSet(baz)` to compute the change set of newly created `FooBaz` entity
+2. Call `uow.recomputeSingleChangeSet(cs.entity)` to recalculate the existing change set of the `FooBar` entity.
 
 ```ts
 @Subscriber()
@@ -258,7 +224,7 @@ await em.persistAndFlush(bar);
 
 ## Transaction events
 
-Transaction events happen at the beginning and end of a transaction. 
+Transaction events happen at the beginning and end of a transaction.
 
 - `beforeTransactionStart` is executed before a transaction starts.
 - `afterTransactionStart` is executed after a transaction starts.
@@ -267,5 +233,4 @@ Transaction events happen at the beginning and end of a transaction.
 - `beforeTransactionRollback` is executed before a transaction is rolled back.
 - `afterTransactionRollback` is executed after a transaction is rolled back.
 
-They are also entity agnostic and will only reference the transaction, `UnitOfWork` instance
-and `EntityManager` instance.
+They are also entity agnostic and will only reference the transaction, `UnitOfWork` instance and `EntityManager` instance.

--- a/docs/versioned_docs/version-5.5/faq.md
+++ b/docs/versioned_docs/version-5.5/faq.md
@@ -5,6 +5,7 @@ title: Frequently Asked Questions
 ### How can I synchronize my database schema with the entities?
 
 There are two ways:
+
 - [Schema Generator](./schema-generator.md)
 - [Migrations](./migrations.md)
 
@@ -14,21 +15,15 @@ npx mikro-orm schema:update --run
 
 ### I cannot run the CLI
 
-Make sure you install `@mikro-orm/cli` package locally. If you want to have
-global installation, you will need to install driver packages globally too.
+Make sure you install `@mikro-orm/cli` package locally. If you want to have global installation, you will need to install driver packages globally too.
 
 ### EntityManager does not have `createQueryBuilder()` method
 
 The method is there, the issue is in the TS type.
 
-In v4 the `core` package, where `EntityManager` and `EntityRepository` are
-defined, is not dependent on knex, and therefore it cannot have a method
-returning a `QueryBuilder`. You need to import the SQL flavour of the EM
-from the driver package to access the `createQueryBuilder()` method.
+In v4 the `core` package, where `EntityManager` and `EntityRepository` are defined, is not dependent on knex, and therefore it cannot have a method returning a `QueryBuilder`. You need to import the SQL flavour of the EM from the driver package to access the `createQueryBuilder()` method.
 
-> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under
-> this name and under `EntityManager` alias, so you can just change the
-> location from where you import.
+> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ```ts
 import { EntityManager } from '@mikro-orm/mysql'; // or any other SQL driver package
@@ -37,8 +32,7 @@ const em = orm.em as EntityManager;
 const qb = await em.createQueryBuilder(...);
 ```
 
-To have the `orm.em` variable properly typed, we can use generic type parameter of
-`MikroORM.init()`:
+To have the `orm.em` variable properly typed, we can use generic type parameter of `MikroORM.init()`:
 
 ```ts
 import { MySqlDriver } from '@mikro-orm/mysql'; // or any other SQL driver package
@@ -58,25 +52,19 @@ const em = orm.em as EntityManager;
 const ret = await em.aggregate(...);
 ```
 
-> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under
-> this name and under `EntityManager` alias, so you can just change the
-> location from where you import.
+> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ### How can I add columns to pivot table (M:N relation)
 
-You should model your M:N relation transparently, via 1:m and m:1 properties.
-More about this can be found in [Composite Keys section](./composite-keys.md/#use-case-3-join-table-with-metadata).
+You should model your M:N relation transparently, via 1:m and m:1 properties. More about this can be found in [Composite Keys section](./composite-keys.md/#use-case-3-join-table-with-metadata).
 
 ### You cannot call `em.flush()` from inside lifecycle hook handlers
 
-You might see this validation error even if you do not use hooks. If that happens,
-the reason is usually because you do not have [request context](identity-map.md) set up properly, and
-you are reusing one `EntityManager` instance.
+You might see this validation error even if you do not use hooks. If that happens, the reason is usually because you do not have [request context](identity-map.md) set up properly, and you are reusing one `EntityManager` instance.
 
 ### Column is being created with JSON type while the TS type is `string/Date/number/...`
 
-You are probably using the default `ReflectMetadataProvider`, which does not
-support inferring property type when there is a property initializer.
+You are probably using the default `ReflectMetadataProvider`, which does not support inferring property type when there is a property initializer.
 
 ```ts
 @Property()
@@ -84,6 +72,7 @@ foo = 'abc';
 ```
 
 There are two ways around this:
+
 - Use [TsMorphMetadataProvider](./metadata-providers.md/#tsmorphmetadataprovider)
 - Specify the type explicitly:
 
@@ -124,8 +113,7 @@ When creating new entity instances, either with `new Book()` or `em.create(Book,
 Book {}
 ```
 
-But some users might find that this returns an object with properties that are explicitly
-set to `undefined`:
+But some users might find that this returns an object with properties that are explicitly set to `undefined`:
 
 ```ts
 Book {
@@ -135,8 +123,7 @@ Book {
 }
 ```
 
-This can cause unexpected behavior, particularly if you're expecting the database to set a
-default value for a column.
+This can cause unexpected behavior, particularly if you're expecting the database to set a default value for a column.
 
 To fix this, disable the [`useDefineForClassFields`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#the-usedefineforclassfields-flag-and-the-declare-property-modifier) option in your tsconfig:
 
@@ -147,5 +134,3 @@ To fix this, disable the [`useDefineForClassFields`](https://www.typescriptlang.
   }
 }
 ```
-
-

--- a/docs/versioned_docs/version-5.5/filters.md
+++ b/docs/versioned_docs/version-5.5/filters.md
@@ -2,16 +2,11 @@
 title: Filters
 ---
 
-MikroORM has the ability to pre-define filter criteria and attach those filters 
-to given entities. The application can then decide at runtime whether certain 
-filters should be enabled and what their parameter values should be. Filters 
-can be used like database views, but they are parameterized inside the application.
+MikroORM has the ability to pre-define filter criteria and attach those filters to given entities. The application can then decide at runtime whether certain filters should be enabled and what their parameter values should be. Filters can be used like database views, but they are parameterized inside the application.
 
-> Filter can be defined at the entity level, dynamically via EM (global filters) 
-> or in the ORM configuration.
+> Filter can be defined at the entity level, dynamically via EM (global filters) or in the ORM configuration.
 
-Filters are applied to those methods of `EntityManager`: `find()`, `findOne()`, 
-`findAndCount()`, `findOneOrFail()`, `count()`, `nativeUpdate()` and `nativeDelete()`. 
+Filters are applied to those methods of `EntityManager`: `find()`, `findOne()`, `findAndCount()`, `findOneOrFail()`, `count()`, `nativeUpdate()` and `nativeDelete()`.
 
 > The `cond` parameter can be a callback, possibly asynchronous.
 
@@ -36,14 +31,14 @@ const books2 = await orm.em.find(Book, {}, {
 ## Properties of filter
 
 There are three parameters you can use:
+
 - `name` - can be used to enable a filter on the query can also used to pass a parameter
 - `cond` - is the condition that should be added to the query when the filter is enabled. This can be a callback, even async
 - `default` - indicates if the filter is enabled by default on the query
 
 ## Parameters
 
-You can define the `cond` dynamically as a callback. This callback can be also 
-asynchronous. It will get three arguments:
+You can define the `cond` dynamically as a callback. This callback can be also asynchronous. It will get three arguments:
 
 - `args` - dictionary of parameters provided by user
 - `type` - type of operation that is being filtered, one of `'read'`, `'update'`, `'delete'`
@@ -58,8 +53,8 @@ import type { EntityManager } from '@mikro-orm/mysql';
     return {}; // do not apply when updating
   }
 
-  return { 
-    author: { name: args.name }, 
+  return {
+    author: { name: args.name },
     publishedAt: { $lte: em.raw('now()') },
   };
 } })
@@ -74,9 +69,7 @@ const books = await orm.em.find(Book, {}, {
 
 ### Filters without parameters
 
-If we want to have a filter condition that do not need arguments, but we want
-to access the `type` parameter, we will need to explicitly set `args: false`, 
-otherwise error will be raised due to missing parameters:
+If we want to have a filter condition that do not need arguments, but we want to access the `type` parameter, we will need to explicitly set `args: false`, otherwise error will be raised due to missing parameters:
 
 ```ts
 @Filter({
@@ -91,10 +84,7 @@ otherwise error will be raised due to missing parameters:
 
 ## Global filters
 
-We can also register filters dynamically via `EntityManager` API. We call such filters 
-global. They are enabled by default (unless disabled via last parameter in `addFilter()`
-method), and applied to all entities. You can limit the global filter to only specified
-entities. 
+We can also register filters dynamically via `EntityManager` API. We call such filters global. They are enabled by default (unless disabled via last parameter in `addFilter()` method), and applied to all entities. You can limit the global filter to only specified entities.
 
 > Filters as well as filter params set on the EM will be copied to all its forks.
 
@@ -125,12 +115,9 @@ MikroORM.init({
 
 ## Using filters
 
-We can control what filters will be applied via `filter` parameter in `FindOptions`.
-We can either provide an array of names of filters you want to enable, or options 
-object, where we can also disable a filter (that was enabled by default), or pass some
-parameters to those that are expecting them.
+We can control what filters will be applied via `filter` parameter in `FindOptions`. We can either provide an array of names of filters you want to enable, or options object, where we can also disable a filter (that was enabled by default), or pass some parameters to those that are expecting them.
 
-> By passing `filters: false` we can also disable all the filters for given call. 
+> By passing `filters: false` we can also disable all the filters for given call.
 
 ```ts
 em.find(Book, {}); // same as `{ tenantId: 123 }`
@@ -141,17 +128,11 @@ em.find(Book, {}, { filters: false }); // disabled all filters, so truly `{}`
 
 ## Filters and populating of relationships
 
-When populating relationships, filters will be applied only to the root entity of 
-given query, but not to those that are auto-joined. On the other hand, this means that
-when you use the default loading strategy - `LoadStrategy.SELECT_IN` - filters will
-be applied to every entity populated this way, as the child entities will become
-root entities in their respective load calls.
+When populating relationships, filters will be applied only to the root entity of given query, but not to those that are auto-joined. On the other hand, this means that when you use the default loading strategy - `LoadStrategy.SELECT_IN` - filters will be applied to every entity populated this way, as the child entities will become root entities in their respective load calls.
 
 ## Naming of filters
 
-When toggling filters via `FindOptions`, we do not care about the entity name. This
-means that when you have multiple filters defined on different entities, but with 
-the same name, they will be controlled via single toggle in the `FindOptions`. 
+When toggling filters via `FindOptions`, we do not care about the entity name. This means that when you have multiple filters defined on different entities, but with the same name, they will be controlled via single toggle in the `FindOptions`.
 
 ```ts
 @Entity()

--- a/docs/versioned_docs/version-5.5/identity-map.md
+++ b/docs/versioned_docs/version-5.5/identity-map.md
@@ -38,7 +38,7 @@ We can still disable this check via `allowGlobalContext` configuration, or a con
 
 ## <a name="request-context"></a> `RequestContext` helper
 
-If we use dependency injection container like `inversify` or the one in `nestjs` framework, it can be hard to achieve this, because we usually want to access our repositories via DI container, but it will always provide we with the same instance, rather than new one for each request. 
+If we use dependency injection container like `inversify` or the one in `nestjs` framework, it can be hard to achieve this, because we usually want to access our repositories via DI container, but it will always provide we with the same instance, rather than new one for each request.
 
 To solve this, we can use `RequestContext` helper, that will use `node`'s [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) in the background to isolate the request context. MikroORM will always use request specific (forked) entity manager if available, so all we need to do is to create new request context preferably as a middleware:
 
@@ -46,11 +46,11 @@ To solve this, we can use `RequestContext` helper, that will use `node`'s [`Asyn
 app.use((req, res, next) => {
   RequestContext.create(orm.em, next);
 });
-``` 
+```
 
-We should register this middleware as the last one just before request handlers and before any of our custom middleware that is using the ORM. There might be issues when we register it before request processing middleware like `queryParser` or `bodyParser`, so definitely register the context after them. 
+We should register this middleware as the last one just before request handlers and before any of our custom middleware that is using the ORM. There might be issues when we register it before request processing middleware like `queryParser` or `bodyParser`, so definitely register the context after them.
 
-Later on we can then access the request scoped `EntityManager` via `RequestContext.getEntityManager()`. This method is used under the hood automatically, so we should not need it. 
+Later on we can then access the request scoped `EntityManager` via `RequestContext.getEntityManager()`. This method is used under the hood automatically, so we should not need it.
 
 > `RequestContext.getEntityManager()` will return `undefined` if the context was not started yet.
 
@@ -69,20 +69,15 @@ const res = await orm.em.getContext().find(Book, {});
 const res = await RequestContext.getEntityManager().find(Book, {});
 ```
 
-The `RequestContext.getEntityManager()` method then checks `AsyncLocalStorage` static instance we use for creating new EM forks in the `RequestContext.create()` method. 
+The `RequestContext.getEntityManager()` method then checks `AsyncLocalStorage` static instance we use for creating new EM forks in the `RequestContext.create()` method.
 
 The [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) class from Node.js core is the magician here. It allows us to track the context throughout the async calls. It allows us to decouple the `EntityManager` fork creation (usually in a middleware as shown in previous section) from its usage through the global `EntityManager` instance.
 
 ## `@UseRequestContext()` decorator
 
-Middlewares are executed only for regular HTTP request handlers, what if we need
-a request scoped method outside that? One example of that is queue handlers or
-scheduled tasks (e.g. CRON jobs).
+Middlewares are executed only for regular HTTP request handlers, what if we need a request scoped method outside that? One example of that is queue handlers or scheduled tasks (e.g. CRON jobs).
 
-We can use the `@UseRequestContext()` decorator. It requires us to first inject the
-`MikroORM` instance to current context, it will be then used to create the context
-for us. Under the hood, the decorator will register new request context for our
-method and execute it inside the context.
+We can use the `@UseRequestContext()` decorator. It requires us to first inject the `MikroORM` instance to current context, it will be then used to create the context for us. Under the hood, the decorator will register new request context for our method and execute it inside the context.
 
 This decorator will wrap the underlying method in `RequestContext.createAsync()` call. Every call to such method will create new context (new `EntityManager` fork) which will be used inside.
 
@@ -119,11 +114,11 @@ export class MyService {
 
 ## Why is Request Context needed?
 
-Imagine we will use a single Identity Map throughout our application. It will be shared across all request handlers, that can possibly run in parallel. 
+Imagine we will use a single Identity Map throughout our application. It will be shared across all request handlers, that can possibly run in parallel.
 
 ### Problem 1 - growing memory footprint
 
-As there would be only one shared Identity Map, we can't just clear it after our request ends. There can be another request working with it so clearing the Identity Map from one request could break other requests running in parallel. This will result in growing memory footprint, as every entity that became managed at some point in time would be kept in the Identity Map. 
+As there would be only one shared Identity Map, we can't just clear it after our request ends. There can be another request working with it so clearing the Identity Map from one request could break other requests running in parallel. This will result in growing memory footprint, as every entity that became managed at some point in time would be kept in the Identity Map.
 
 ### Problem 2 - unstable response of API endpoints
 
@@ -135,9 +130,9 @@ Let's say there are 2 endpoints
 2. `GET /book-with-author/:id` that returns the book and its author populated
 
 Now when someone requests same book via both of those endpoints, we could end up with both returning the same output:
- 
+
 1. `GET /book/1` returns `Book` without populating its property `author` property
 2. `GET /book-with-author/1` returns `Book`, this time with `author` populated
 3. `GET /book/1` returns `Book`, but this time also with `author` populated
 
-This happens because the information about entity association being populated is stored in the Identity Map. 
+This happens because the information about entity association being populated is stored in the Identity Map.

--- a/docs/versioned_docs/version-5.5/inheritance-mapping.md
+++ b/docs/versioned_docs/version-5.5/inheritance-mapping.md
@@ -4,18 +4,13 @@ title: Inheritance Mapping
 
 ## Mapped Superclasses
 
-A mapped superclass is an abstract or concrete class that provides persistent entity state and mapping information for its subclasses, but which is not itself an entity. Typically, the purpose of such
-a mapped superclass is to define state and mapping information that is common to multiple entity classes.
+A mapped superclass is an abstract or concrete class that provides persistent entity state and mapping information for its subclasses, but which is not itself an entity. Typically, the purpose of such a mapped superclass is to define state and mapping information that is common to multiple entity classes.
 
 Mapped superclasses, just as regular, non-mapped classes, can appear in the middle of an otherwise mapped inheritance hierarchy (through Single Table Inheritance).
 
-> A mapped superclass cannot be an entity, it is not query-able and persistent relationships defined
-> by a mapped superclass must be unidirectional (with an owning side only). This means that One-To-Many
-> associations are not possible on a mapped superclass at all. Furthermore Many-To-Many associations
-> are only possible if the mapped superclass is only used in exactly one entity at the moment. For
-> further support of inheritance, the single table inheritance features have to be used.
+> A mapped superclass cannot be an entity, it is not query-able and persistent relationships defined by a mapped superclass must be unidirectional (with an owning side only). This means that One-To-Many associations are not possible on a mapped superclass at all. Furthermore Many-To-Many associations are only possible if the mapped superclass is only used in exactly one entity at the moment. For further support of inheritance, the single table inheritance features have to be used.
 
-> Also note that we can't use generics to define any relations. This means that we cannot have a generic type argument in the base entity that would be used as a target of some relation. 
+> Also note that we can't use generics to define any relations. This means that we cannot have a generic type argument in the base entity that would be used as a target of some relation.
 
 ```ts
 // do not use @Entity decorator on base classes (mapped superclasses)
@@ -69,16 +64,13 @@ create table `employee` (
 );
 ```
 
-As we can see from this DDL snippet, there is only a single table for the entity subclass. All the mappings from the mapped superclass were inherited to the subclass as if they had been defined on
-that class directly.
+As we can see from this DDL snippet, there is only a single table for the entity subclass. All the mappings from the mapped superclass were inherited to the subclass as if they had been defined on that class directly.
 
 ## Single Table Inheritance
 
 > Support for STI was added in version 4.0
 
-[Single Table Inheritance](https://martinfowler.com/eaaCatalog/singleTableInheritance.html)
-is an inheritance mapping strategy where all classes of a hierarchy are mapped to a single database table. In order to distinguish which row represents which type in the hierarchy a so-called
-discriminator column is used.
+[Single Table Inheritance](https://martinfowler.com/eaaCatalog/singleTableInheritance.html) is an inheritance mapping strategy where all classes of a hierarchy are mapped to a single database table. In order to distinguish which row represents which type in the hierarchy a so-called discriminator column is used.
 
 ```ts
 @Entity({
@@ -98,18 +90,14 @@ export class Employee extends Person {
 Things to note:
 
 - The `discriminatorColumn` option must be specified on the topmost class that is part of the mapped entity hierarchy.
-- The `discriminatorMap` specifies which values of the discriminator column identify a row as being of a certain type. In the case above a value of `person` identifies a row as being of type `Person`
-  and `employee` identifies a row as being of type
-  `Employee`.
+- The `discriminatorMap` specifies which values of the discriminator column identify a row as being of a certain type. In the case above a value of `person` identifies a row as being of type `Person` and `employee` identifies a row as being of type `Employee`.
 - All entity classes that are part of the mapped entity hierarchy (including the topmost class) should be specified in the `discriminatorMap`. In the case above `Person` class included.
 - We can use abstract class as the root entity - then the root class should not be part of the discriminator map
-- If no discriminator map is provided, then the map is generated automatically. The automatically generated discriminator map contains the table names that would be otherwise used in case of regular
-  entities.
+- If no discriminator map is provided, then the map is generated automatically. The automatically generated discriminator map contains the table names that would be otherwise used in case of regular entities.
 
 ### Using `discriminatorValue` instead of `discriminatorMap`
 
-As noted above, the discriminator map can be auto-generated. In that case, we might want to control the tokens that will be used in the map. To do so, we can use
-`discriminatorValue` on the child entities:
+As noted above, the discriminator map can be auto-generated. In that case, we might want to control the tokens that will be used in the map. To do so, we can use `discriminatorValue` on the child entities:
 
 ```ts
 @Entity({
@@ -130,8 +118,7 @@ export class Employee extends Person {
 
 ### Explicit discriminator column
 
-The `discriminatorColumn` specifies the name of special column that will be used to define what type of class should given row be represented with. It will be defined automatically for us and it will
-stay hidden (it won't be hydrated as a regular property).
+The `discriminatorColumn` specifies the name of special column that will be used to define what type of class should given row be represented with. It will be defined automatically for us and it will stay hidden (it won't be hydrated as a regular property).
 
 On the other hand, it is perfectly fine to define the column explicitly. Doing so, we will be able to:
 
@@ -190,18 +177,14 @@ export class Employee extends Person {
 
 ### Design-time considerations
 
-This mapping approach works well when the type hierarchy is fairly simple and stable. Adding a new type to the hierarchy and adding fields to existing supertypes simply involves adding new columns to
-the table, though in large deployments this may have an adverse impact on the index and column layout inside the database.
+This mapping approach works well when the type hierarchy is fairly simple and stable. Adding a new type to the hierarchy and adding fields to existing supertypes simply involves adding new columns to the table, though in large deployments this may have an adverse impact on the index and column layout inside the database.
 
 ### Performance impact
 
-This strategy is very efficient for querying across all types in the hierarchy or for specific types. No table joins are required, only a WHERE clause listing the type identifiers. In particular,
-relationships involving types that employ this mapping strategy are very performant.
+This strategy is very efficient for querying across all types in the hierarchy or for specific types. No table joins are required, only a WHERE clause listing the type identifiers. In particular, relationships involving types that employ this mapping strategy are very performant.
 
 ### SQL Schema considerations
 
-For Single-Table-Inheritance to work in scenarios where we are using either a legacy database schema or a self-written database schema we have to make sure that all columns that are not in the root
-entity but in any of the different sub-entities has to allow null values. Columns that have NOT NULL constraints have to be on the root entity of the single-table inheritance hierarchy.
+For Single-Table-Inheritance to work in scenarios where we are using either a legacy database schema or a self-written database schema we have to make sure that all columns that are not in the root entity but in any of the different sub-entities has to allow null values. Columns that have NOT NULL constraints have to be on the root entity of the single-table inheritance hierarchy.
 
-> This part of documentation is highly inspired by [doctrine docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/inheritance-mapping.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/inheritance-mapping.html) as the behaviour here is pretty much the same.

--- a/docs/versioned_docs/version-5.5/installation.md
+++ b/docs/versioned_docs/version-5.5/installation.md
@@ -2,12 +2,9 @@
 title: Installation & Usage
 ---
 
-First install the module via `yarn` or `npm` and do not forget to install the 
-driver package as well:
+First install the module via `yarn` or `npm` and do not forget to install the driver package as well:
 
-> Since v4, we should install the driver package, but not the db connector itself,
-> e.g. install `@mikro-orm/sqlite`, but not `sqlite3` as that is already included
-> in the driver package.
+> Since v4, we should install the driver package, but not the db connector itself, e.g. install `@mikro-orm/sqlite`, but not `sqlite3` as that is already included in the driver package.
 
 ```sh
 yarn add @mikro-orm/core @mikro-orm/mongodb     # for mongo
@@ -27,8 +24,7 @@ npm i -s @mikro-orm/core @mikro-orm/postgresql  # for postgresql
 npm i -s @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 ```
 
-Next we will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html)
-as well as `esModuleInterop` in `tsconfig.json` via:
+Next we will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html) as well as `esModuleInterop` in `tsconfig.json` via:
 
 ```json
 "experimentalDecorators": true,
@@ -38,9 +34,7 @@ as well as `esModuleInterop` in `tsconfig.json` via:
 
 Then call `MikroORM.init` as part of bootstrapping our app:
 
-> To access driver specific methods like `em.createQueryBuilder()` we need to specify
-> the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the
-> `orm.em` to `EntityManager` exported from the driver package:
+> To access driver specific methods like `em.createQueryBuilder()` we need to specify the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the `orm.em` to `EntityManager` exported from the driver package:
 >
 > ```ts
 > import { EntityManager } from '@mikro-orm/postgresql';
@@ -62,10 +56,7 @@ console.log(orm.em); // access EntityManager via `em` property
 
 > Read more about all the possible configuration options in [Advanced Configuration](configuration.md) section.
 
-We can also provide paths where we store our entities via `entities` array. Internally
-it uses [`globby`](https://github.com/sindresorhus/globby) so we can use 
-[globbing patterns](https://github.com/sindresorhus/globby#globbing-patterns), 
-including negative globs. 
+We can also provide paths where we store our entities via `entities` array. Internally it uses [`globby`](https://github.com/sindresorhus/globby) so we can use [globbing patterns](https://github.com/sindresorhus/globby#globbing-patterns), including negative globs.
 
 ```ts
 const orm = await MikroORM.init<PostgreSqlDriver>({
@@ -75,21 +66,17 @@ const orm = await MikroORM.init<PostgreSqlDriver>({
 });
 ```
 
-If we are experiencing problems with folder based discovery, try using `mikro-orm debug`
-CLI command to check what paths are actually being used.
+If we are experiencing problems with folder based discovery, try using `mikro-orm debug` CLI command to check what paths are actually being used.
 
 > Since v4, we can also use file globs, like `./dist/app/**/entities/*.entity.js`.
 
 We can also set the configuration via [environment variables](configuration.md#using-environment-variables).
 
-> We can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. 
-> The object will be deeply merged, overriding all internally used options.
+> We can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. The object will be deeply merged, overriding all internally used options.
 
 ## Possible issues with circular dependencies
 
-Our entities will most probably contain circular dependencies (e.g. if we use bi-directional 
-relationship). While this is fine, there might be issues caused by wrong order of entities 
-during discovery, especially when we are using the folder based way.
+Our entities will most probably contain circular dependencies (e.g. if we use bi-directional relationship). While this is fine, there might be issues caused by wrong order of entities during discovery, especially when we are using the folder based way.
 
 The errors caused by circular dependencies are usually similar to this one:
 
@@ -110,17 +97,12 @@ TypeError: Cannot read property 'name' of undefined
 
 If we encounter this, we have basically two options:
 
-- Use entity references in `entities` array to have control over the order of discovery. 
-  We might need to play with the actual order we provide here, or possibly with the 
-  order of import statements.
-- Use strings instead of references (e.g. `@OneToMany('Book', 'author')`). The downside 
-  here is that we will lose the typechecking capabilities of the decorators. 
+- Use entity references in `entities` array to have control over the order of discovery. We might need to play with the actual order we provide here, or possibly with the order of import statements.
+- Use strings instead of references (e.g. `@OneToMany('Book', 'author')`). The downside here is that we will lose the typechecking capabilities of the decorators.
 
 ## Entity Discovery in TypeScript
 
-In v4 the default metadata provider is `ReflectMetadataProvider`. If we want to use
-`ts-morph` based discovery (that reads actual TS types via the compiler API), we 
-need to install `@mikro-orm/reflection`.
+In v4 the default metadata provider is `ReflectMetadataProvider`. If we want to use `ts-morph` based discovery (that reads actual TS types via the compiler API), we need to install `@mikro-orm/reflection`.
 
 ```ts
 import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
@@ -141,19 +123,16 @@ const orm = await MikroORM.init<PostgreSqlDriver>({
 });
 ```
 
-> It is important that `entities` will point to the compiled JS files, and `entitiesTs`
-> will point to the TS source files. We should not mix those. 
+> It is important that `entities` will point to the compiled JS files, and `entitiesTs` will point to the TS source files. We should not mix those.
 
-> For `ts-morph` discovery to work in production, we need to deploy `.d.ts` declaration
-> files. Be sure to enable `compilerOptions.declaration` in our `tsconfig.json`.
+> For `ts-morph` discovery to work in production, we need to deploy `.d.ts` declaration files. Be sure to enable `compilerOptions.declaration` in our `tsconfig.json`.
 
 We can also use different [metadata provider](metadata-providers.md) or even write custom one:
 
 - `ReflectMetadataProvider` that uses `reflect-metadata` instead of `ts-morph`
 - `JavaScriptMetadataProvider` that allows we to manually provide the entity schema (mainly for Vanilla JS)
 
-> Using [`EntitySchema`](entity-schema.md) is another way to define our entities, which is better
-> suited than using `JavaScriptMetadataProvider`.
+> Using [`EntitySchema`](entity-schema.md) is another way to define our entities, which is better suited than using `JavaScriptMetadataProvider`.
 
 ```ts
 const orm = await MikroORM.init<PostgreSqlDriver>({
@@ -175,8 +154,7 @@ app.use((req, res, next) => {
 });
 ```
 
-> If the `next` handler needs to be awaited (like in Koa), 
-> use `RequestContext.createAsync()` instead.
+> If the `next` handler needs to be awaited (like in Koa), use `RequestContext.createAsync()` instead.
 >
 > ```ts
 > app.use((ctx, next) => RequestContext.createAsync(orm.em, next));
@@ -186,12 +164,9 @@ More info about `RequestContext` is described [here](identity-map.md#request-con
 
 ## Setting up the Commandline Tool
 
-MikroORM ships with a number of command line tools that are very helpful during development, 
-like `SchemaGenerator` and `EntityGenerator`. We can call this command from the NPM binary 
-directory or use `npx`:
+MikroORM ships with a number of command line tools that are very helpful during development, like `SchemaGenerator` and `EntityGenerator`. We can call this command from the NPM binary directory or use `npx`:
 
-> To work with the CLI, first install `@mikro-orm/cli` package locally.
-> The version needs to be aligned with the `@mikro-orm/core` package.
+> To work with the CLI, first install `@mikro-orm/cli` package locally. The version needs to be aligned with the `@mikro-orm/core` package.
 
 ```sh
 # install the CLI package first!
@@ -207,15 +182,11 @@ $ npx mikro-orm
 $ yarn mikro-orm
 ```
 
-For CLI to be able to access our database, we will need to create `mikro-orm.config.js` file that exports our ORM configuration. 
+For CLI to be able to access our database, we will need to create `mikro-orm.config.js` file that exports our ORM configuration.
 
-> ORM configuration file can export the Promise, like:
-> `export default Promise.resolve({...});`.
+> ORM configuration file can export the Promise, like: `export default Promise.resolve({...});`.
 
-TypeScript is also supported, just enable `useTsNode` flag in our
-`package.json` file. There we can also set up array of possible paths to `mikro-orm.config` file,
-as well as use different file name. The `package.json` file can be located in 
-the current working directory, or in one of its parent folders.
+TypeScript is also supported, just enable `useTsNode` flag in our `package.json` file. There we can also set up array of possible paths to `mikro-orm.config` file, as well as use different file name. The `package.json` file can be located in the current working directory, or in one of its parent folders.
 
 We can use these environment variables to override CLI settings:
 
@@ -225,13 +196,9 @@ We can use these environment variables to override CLI settings:
 
 > Do not forget to install `ts-node` when enabling `useTsNode` flag.
 
-> The `useTsNode` is used only when executing the CLI, it is not respected when 
-> running our app.
+> The `useTsNode` is used only when executing the CLI, it is not respected when running our app.
 
-MikroORM will always try to load the first available config file, based on the 
-order in `configPaths`. This means that if we specify the first item as the TS 
-config, but we do not have `ts-node` enabled and installed, it will fail to 
-load it.
+MikroORM will always try to load the first available config file, based on the order in `configPaths`. This means that if we specify the first item as the TS config, but we do not have `ts-node` enabled and installed, it will fail to load it.
 
 ```json title="./package.json"
 {
@@ -277,23 +244,16 @@ export default defineConfig({
 });
 ```
 
-When we have `useTsNode` disabled and `ts-node` is not already registered and detected,
-TS config files will be ignored.
+When we have `useTsNode` disabled and `ts-node` is not already registered and detected, TS config files will be ignored.
 
-Once we have the CLI config properly set up, we can omit the `MikroORM.init()` options
-parameter, and the CLI config will be automatically used. This process may fail if we
-use bundlers that use tree shaking. As the config file is not referenced anywhere 
-statically, it would not be compiled - for that the best approach is to provide the config
-explicitly:
+Once we have the CLI config properly set up, we can omit the `MikroORM.init()` options parameter, and the CLI config will be automatically used. This process may fail if we use bundlers that use tree shaking. As the config file is not referenced anywhere statically, it would not be compiled - for that the best approach is to provide the config explicitly:
 
 ```ts
 import config from './mikro-orm.config';
 const orm = await MikroORM.init(config);
 ```
 
-> We can also use different names for this file, simply rename it in the `configPaths` array
-> our in `package.json`. We can also use `MIKRO_ORM_CLI` environment variable with the path
-> to override `configPaths` value.
+> We can also use different names for this file, simply rename it in the `configPaths` array our in `package.json`. We can also use `MIKRO_ORM_CLI` environment variable with the path to override `configPaths` value.
 
 Now we should be able to start using the CLI. All available commands are listed in the CLI help:
 
@@ -330,10 +290,8 @@ Examples:
 
 To verify our setup, we can use `mikro-orm debug` command.
 
-> When we have CLI config properly set up, we can omit the `options` parameter
-> when calling `MikroORM.init()`.
+> When we have CLI config properly set up, we can omit the `options` parameter when calling `MikroORM.init()`.
 
-> Note: When importing a dump file we need `multipleStatements: true` in our
-> configuration. Please check the configuration documentation for more information.
+> Note: When importing a dump file we need `multipleStatements: true` in our configuration. Please check the configuration documentation for more information.
 
 Now we can start [defining our entities](defining-entities.md).

--- a/docs/versioned_docs/version-5.5/json-properties.md
+++ b/docs/versioned_docs/version-5.5/json-properties.md
@@ -4,8 +4,7 @@ title: Using JSON properties
 
 ## Defining JSON properties
 
-Each database driver behaves a bit differently when it comes to JSON properties. MikroORM tries to unify the experience via [JsonType](custom-types.md#jsontype). This type will be also used if we
-specify `type: 'json'`.
+Each database driver behaves a bit differently when it comes to JSON properties. MikroORM tries to unify the experience via [JsonType](custom-types.md#jsontype). This type will be also used if we specify `type: 'json'`.
 
 ```ts
 @Entity()
@@ -42,15 +41,14 @@ const b = await em.findOne(Book, {
 Will produce following query (in postgres):
 
 ```sql
-select "e0".* 
-from "book" as "e0" 
-where ("meta"->>'valid')::bool = true 
-  and "meta"->'nested'->>'foo' = '123' 
-  and ("meta"->'nested'->>'bar')::float8 = 321 
-  and ("meta"->'nested'->'deep'->>'baz')::float8 = 59 
-  and ("meta"->'nested'->'deep'->>'qux')::bool = false 
+select "e0".*
+from "book" as "e0"
+where ("meta"->>'valid')::bool = true
+  and "meta"->'nested'->>'foo' = '123'
+  and ("meta"->'nested'->>'bar')::float8 = 321
+  and ("meta"->'nested'->'deep'->>'baz')::float8 = 59
+  and ("meta"->'nested'->'deep'->>'qux')::bool = false
 limit 1
 ```
 
-> All drivers are currently supported (including sqlite and mongo). In postgres we
-> also try to cast the value if we detect number or boolean on the right-hand side.
+> All drivers are currently supported (including sqlite and mongo). In postgres we also try to cast the value if we detect number or boolean on the right-hand side.

--- a/docs/versioned_docs/version-5.5/loading-strategies.md
+++ b/docs/versioned_docs/version-5.5/loading-strategies.md
@@ -5,9 +5,7 @@ sidebar_label: Loading Strategies
 
 > `JOINED` loading strategy is SQL only feature.
 
-Controls how relationships get loaded when querying. By default, populated relationships
-are loaded via the `select-in` strategy. This strategy issues one additional `SELECT`
-statement per relation being loaded.
+Controls how relationships get loaded when querying. By default, populated relationships are loaded via the `select-in` strategy. This strategy issues one additional `SELECT` statement per relation being loaded.
 
 The loading strategy can be specified both at mapping time and when loading entities.
 
@@ -29,8 +27,7 @@ export class Book {
 }
 ```
 
-The following will issue two SQL statements.
-One to load the author and another to load all the books belonging to that author:
+The following will issue two SQL statements. One to load the author and another to load all the books belonging to that author:
 
 ```ts
 const author = await orm.em.findOne(Author, 1, { populate: ['books'] });
@@ -58,8 +55,7 @@ The following will issue **one** SQL statement:
 const author = await orm.em.findOne(Author, 1, { populate: ['books'] });
 ```
 
-You can also specify the load strategy as needed. This will override whatever strategy is declared in the mapping.
-This also works for nested populates:
+You can also specify the load strategy as needed. This will override whatever strategy is declared in the mapping. This also works for nested populates:
 
 ```ts
 const author = await orm.em.findOne(Author, 1, {
@@ -78,37 +74,27 @@ MikroORM.init({
 });
 ```
 
-This value will be used as the default, specifying the loading strategy on 
-property level has precedence, as well as specifying it in the `FindOptions`.
+This value will be used as the default, specifying the loading strategy on property level has precedence, as well as specifying it in the `FindOptions`.
 
 ## Population where condition
 
 > This applies only to SELECT_IN strategy, as JOINED strategy implies the inference.
 
-In v4, when we used populate hints in `em.find()` and similar methods, the
-query for our entity would be analysed and parts of it extracted and used for
-the population. Following example would find all authors that have books with
-given IDs, and populate their books collection, again using this PK condition,
-resulting in only such books being in those collections.
+In v4, when we used populate hints in `em.find()` and similar methods, the query for our entity would be analysed and parts of it extracted and used for the population. Following example would find all authors that have books with given IDs, and populate their books collection, again using this PK condition, resulting in only such books being in those collections.
 
 ```ts
 // this would end up with `Author.books` collections having only books of PK 1, 2, 3
 const a = await em.find(Author, { books: [1, 2, 3] }, { populate: ['books'] });
 ```
 
-Following this example, if we wanted to load all books, we would need a separate
-`em.populate()` call:
+Following this example, if we wanted to load all books, we would need a separate `em.populate()` call:
 
 ```ts
 const a = await em.find(Author, { books: [1, 2, 3] });
 await em.populate(a, ['books']);
 ```
 
-This behaviour changed and is now configurable both globally and locally, via
-`populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and
-`PopulateHint.INFER`, the former being the default in v5, the latter being the
-default behaviour in v4. Locally (via `FindOptions`) we can also specify custom
-where condition that will be passed to `em.populate()` call.
+This behaviour changed and is now configurable both globally and locally, via `populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and `PopulateHint.INFER`, the former being the default in v5, the latter being the default behaviour in v4. Locally (via `FindOptions`) we can also specify custom where condition that will be passed to `em.populate()` call.
 
 ```ts
 await em.find(Author, { ... }, {

--- a/docs/versioned_docs/version-5.5/logging.md
+++ b/docs/versioned_docs/version-5.5/logging.md
@@ -41,8 +41,7 @@ return MikroORM.init({
 });
 ```
 
-If we want to have more control over logging, we can use `loggerFactory`
-and use our own implementation of the `Logger` interface:
+If we want to have more control over logging, we can use `loggerFactory` and use our own implementation of the `Logger` interface:
 
 ```ts
 import { Logger, LoggerOptions, MikroORM, Configuration } from '@mikro-orm/core';
@@ -109,8 +108,7 @@ If you provide `query-params` then you must also provide `query` in order for it
 
 ## Highlighters
 
-Previously Highlight.js was used to highlight various things in the CLI, like SQL and mongo queries, or migrations or entities generated via CLI. While the library worked fine, it was causing
-performance issues mainly for those bundling via webpack and using lambdas, as the library was huge.
+Previously Highlight.js was used to highlight various things in the CLI, like SQL and mongo queries, or migrations or entities generated via CLI. While the library worked fine, it was causing performance issues mainly for those bundling via webpack and using lambdas, as the library was huge.
 
 Since v4, highlighting is disabled by default, and there are 2 highlighters you can optionally use (you need to install them first).
 
@@ -123,5 +121,4 @@ MikroORM.init({
 });
 ```
 
-For MongoDB you can use `MongoHighlighter` from `@mikro-orm/mongo-highlighter`
-package.
+For MongoDB you can use `MongoHighlighter` from `@mikro-orm/mongo-highlighter` package.

--- a/docs/versioned_docs/version-5.5/metadata-cache.md
+++ b/docs/versioned_docs/version-5.5/metadata-cache.md
@@ -2,32 +2,19 @@
 title: Metadata Cache
 ---
 
-> In v4 and later versions, we need to explicitly install `@mikro-orm/reflection`
-> to use `TsMorphMetadataProvider`.
+> In v4 and later versions, we need to explicitly install `@mikro-orm/reflection` to use `TsMorphMetadataProvider`.
 
-MikroORM allows different ways to [obtain entity metadata](metadata-providers.md).
-One way is to use [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. This 
-process can be performance heavy and time-consuming. For this reason, metadata
-cache is automatically enabled for `TsMorphMetadataProvider`. It can be optionally
-enabled for the other metadata providers, but it should not be needed.
+MikroORM allows different ways to [obtain entity metadata](metadata-providers.md). One way is to use [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. This process can be performance heavy and time-consuming. For this reason, metadata cache is automatically enabled for `TsMorphMetadataProvider`. It can be optionally enabled for the other metadata providers, but it should not be needed.
 
-After the discovery process ends, all metadata will be cached. By default, 
-`FileCacheAdapter` will be used to store the cache inside `./temp` folder to JSON
-files.
+After the discovery process ends, all metadata will be cached. By default, `FileCacheAdapter` will be used to store the cache inside `./temp` folder to JSON files.
 
-If we use folder based discovery, cache will be dependent on environment - if we 
-run via ts-node, the cache will be generated for TS files. To generate production
-cache, we can use the CLI command `mikro-orm cache:generate`.
+If we use folder based discovery, cache will be dependent on environment - if we run via ts-node, the cache will be generated for TS files. To generate production cache, we can use the CLI command `mikro-orm cache:generate`.
 
 ## Automatic Invalidation
 
-Entity metadata are cached together with modified time of the source file, and every time
-the cache is requested, it first checks if the cache is not invalid. This way we can forget 
-about the caching mechanism most of the time.
+Entity metadata are cached together with modified time of the source file, and every time the cache is requested, it first checks if the cache is not invalid. This way we can forget about the caching mechanism most of the time.
 
-One case where we can end up needing to wipe the cache manually is when we work withing a 
-git branch where contents of entities folder differs. 
+One case where we can end up needing to wipe the cache manually is when we work withing a git branch where contents of entities folder differs.
 
 ## Disabling Metadata Cache
 
@@ -65,8 +52,7 @@ await MikroORM.init({
 
 ## Providing Custom Cache Adapter
 
-You can also implement your own cache adapter, for example to store the cache in redis. 
-To do so, just implement simple `CacheAdapter` interface:
+You can also implement your own cache adapter, for example to store the cache in redis. To do so, just implement simple `CacheAdapter` interface:
 
 ```ts
 export interface CacheAdapter {

--- a/docs/versioned_docs/version-5.5/metadata-providers.md
+++ b/docs/versioned_docs/version-5.5/metadata-providers.md
@@ -2,8 +2,7 @@
 title: Metadata Providers
 ---
 
-As part of entity discovery process, MikroORM uses so called `MetadataProvider` to get necessary
-type information about our entities' properties.
+As part of entity discovery process, MikroORM uses so called `MetadataProvider` to get necessary type information about our entities' properties.
 
 > We can also implement custom metadata provider by extending abstract `MetadataProvider` class.
 
@@ -11,9 +10,7 @@ There are 3 built-in metadata providers we can use:
 
 ## TsMorphMetadataProvider
 
-With `TsMorphMetadataProvider` MikroORM will use [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. Thanks to this, 
-defining the type is enough for runtime validation.
+With `TsMorphMetadataProvider` MikroORM will use [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. Thanks to this, defining the type is enough for runtime validation.
 
 To use it, first install the `@mikro-orm/reflection` package.
 
@@ -26,18 +23,11 @@ await MikroORM.init({
 });
 ```
 
-If we use folder-based discovery, we should specify paths to
-the compiled entities via `entities` as well as paths to the TS source files of
-those entities via `entitiesTs`. When we run the ORM via `ts-node`, the latter
-will be used automatically, or if we explicitly pass `tsNode: true` in the config. Note that `tsNode: true` should not be part of production config.
+If we use folder-based discovery, we should specify paths to the compiled entities via `entities` as well as paths to the TS source files of those entities via `entitiesTs`. When we run the ORM via `ts-node`, the latter will be used automatically, or if we explicitly pass `tsNode: true` in the config. Note that `tsNode: true` should not be part of production config.
 
-> When running via `node`, `.d.ts` files are used to obtain the type, so we 
-> need to ship them in the production build. TS source files are no longer 
-> needed (since v4). Be sure to enable `compilerOptions.declaration` in our
-> `tsconfig.json`.
+> When running via `node`, `.d.ts` files are used to obtain the type, so we need to ship them in the production build. TS source files are no longer needed (since v4). Be sure to enable `compilerOptions.declaration` in our `tsconfig.json`.
 
-After the discovery process ends, all [metadata will be cached](metadata-cache.md). By default, 
-`FileCacheAdapter` will be used to store the cache inside `./temp` folder in JSON files. 
+After the discovery process ends, all [metadata will be cached](metadata-cache.md). By default, `FileCacheAdapter` will be used to store the cache inside `./temp` folder in JSON files.
 
 > We can generate production cache via CLI command `mikro-orm cache:generate`.
 
@@ -45,11 +35,9 @@ After the discovery process ends, all [metadata will be cached](metadata-cache.m
 
 ## ReflectMetadataProvider
 
-`ReflectMetadataProvider` uses `reflect-metadata` module to read the type from decorator 
-metadata exported by TypeScript compiler. 
+`ReflectMetadataProvider` uses `reflect-metadata` module to read the type from decorator metadata exported by TypeScript compiler.
 
-We will need to install `reflect-metadata` module and import at the top of our app's 
-bootstrap script (e.g. `main.ts` or `app.ts`). 
+We will need to install `reflect-metadata` module and import at the top of our app's bootstrap script (e.g. `main.ts` or `app.ts`).
 
 ```ts
 import 'reflect-metadata';
@@ -57,7 +45,7 @@ import 'reflect-metadata';
 
 Next step is to enable `emitDecoratorMetadata` flag in our `tsconfig.json`.
 
-> As this approach does not have performance impact, metadata caching is not really necessary. 
+> As this approach does not have performance impact, metadata caching is not really necessary.
 
 ```ts
 await MikroORM.init({
@@ -102,8 +90,7 @@ prop?: string;
 
 #### Enums
 
-By default, enum is considered as numeric type. For string enums, we need to explicitly 
-provide one of:
+By default, enum is considered as numeric type. For string enums, we need to explicitly provide one of:
 
 - reference to the enum (which will force us to define the enum before defining the entity)
   ```ts
@@ -123,31 +110,24 @@ provide one of:
 
 #### Circular dependencies
 
-Reading type of referenced entity in `@ManyToOne` and `@OneToOne` properties fails if there is 
-circular dependency. We will need to explicitly define the type in the decorator (preferably 
-via `entity: () => ...` callback).
+Reading type of referenced entity in `@ManyToOne` and `@OneToOne` properties fails if there is circular dependency. We will need to explicitly define the type in the decorator (preferably via `entity: () => ...` callback).
 
 ```ts
 @ManyToOne({ entity: () => Author })
 author: Author;
-``` 
+```
 
-> There can be recursion issues when we define multiple entities (with circular dependencies 
-> between each other) in single file. In that case, we might want to provide the type via decorator's
-> `type` or `entity` attributes and set the TS property type to something else (like `any` or `object`).
+> There can be recursion issues when we define multiple entities (with circular dependencies between each other) in single file. In that case, we might want to provide the type via decorator's `type` or `entity` attributes and set the TS property type to something else (like `any` or `object`).
 
 #### Additional typings might be required
 
-We might have to install additional typings, one example is use of `ObjectId` in MongoDB, 
-which requires `@types/mongodb` to be installed. 
+We might have to install additional typings, one example is use of `ObjectId` in MongoDB, which requires `@types/mongodb` to be installed.
 
 ## JavaScriptMetadataProvider
 
 > `JavaScriptMetadataProvider` is deprecated, [use `EntitySchema` instead](entity-schema.md).
 
-This provider should be used only if we are not using TypeScript at all and therefore we do 
-not use decorators to annotate our properties. It will require us to specify the whole schema 
-manually. 
+This provider should be used only if we are not using TypeScript at all and therefore we do not use decorators to annotate our properties. It will require us to specify the whole schema manually.
 
 ```ts
 await MikroORM.init({

--- a/docs/versioned_docs/version-5.5/migrations.md
+++ b/docs/versioned_docs/version-5.5/migrations.md
@@ -8,8 +8,7 @@ MikroORM has integrated support for migrations via [umzug](https://github.com/se
 
 > Since v5, migrations are stored without extension.
 
-By default, each migration will be all executed inside a transaction, and all of them will 
-be wrapped in one master transaction, so if one of them fails, everything will be rolled back. 
+By default, each migration will be all executed inside a transaction, and all of them will be wrapped in one master transaction, so if one of them fails, everything will be rolled back.
 
 ## Migration class
 
@@ -27,41 +26,31 @@ export class Migration20191019195930 extends Migration {
 }
 ```
 
-To support undoing those changed, we can implement the `down` method, which throws an error by default. 
+To support undoing those changed, we can implement the `down` method, which throws an error by default.
 
-Migrations are by default wrapped in a transaction. You can override this behaviour on 
-per migration basis by implementing the `isTransactional(): boolean` method.
+Migrations are by default wrapped in a transaction. You can override this behaviour on per migration basis by implementing the `isTransactional(): boolean` method.
 
 `Configuration` object and driver instance are available in the `Migration` class context.
 
-You can execute queries in the migration via `Migration.execute()` method, which 
-will run queries in the same transaction as the rest of the migration. The 
-`Migration.addSql()` method also accepts instances of knex. Knex instance can be 
-accessed via `Migration.getKnex()`; 
+You can execute queries in the migration via `Migration.execute()` method, which will run queries in the same transaction as the rest of the migration. The `Migration.addSql()` method also accepts instances of knex. Knex instance can be accessed via `Migration.getKnex()`;
 
 ## Initial migration
 
 > This is optional and only needed for the specific use case, when both entities and schema already exist.
 
-If we want to start using migrations, and we already have the schema generated, 
-we can do so by creating so called initial migration:
+If we want to start using migrations, and we already have the schema generated, we can do so by creating so called initial migration:
 
-> Initial migration can be created only if there are no migrations previously
-> generated or executed. 
+> Initial migration can be created only if there are no migrations previously generated or executed.
 
 ```sh
 npx mikro-orm migration:create --initial
 ```
 
-This will create the initial migration, containing the schema dump from 
-`schema:create` command. The migration will be automatically marked as executed. 
+This will create the initial migration, containing the schema dump from `schema:create` command. The migration will be automatically marked as executed.
 
 ## Snapshots
 
-Creating new migration will automatically save the target schema snapshot into 
-migrations folder. This snapshot will be then used if we try to create new migration,
-instead of using current database schema. This means that if we try to create new 
-migration before we run the pending ones, we still get the right schema diff.
+Creating new migration will automatically save the target schema snapshot into migrations folder. This snapshot will be then used if we try to create new migration, instead of using current database schema. This means that if we try to create new migration before we run the pending ones, we still get the right schema diff.
 
 > Snapshots should be versioned just like the regular migration files.
 
@@ -71,8 +60,7 @@ Snapshotting can be disabled via `migrations.snapshot: false` in the ORM config.
 
 > Since v5, `umzug` 3.0 is used, and `pattern` option has been replaced with `glob`.
 
-> `migrations.path` and `migrations.pathTs` works the same way as `entities` and 
-> `entitiesTs` in entity discovery.
+> `migrations.path` and `migrations.pathTs` works the same way as `entities` and `entitiesTs` in entity discovery.
 
 ```ts
 await MikroORM.init({
@@ -96,9 +84,7 @@ await MikroORM.init({
 
 ## Running migrations in production
 
-In production environment we might want to use compiled migration files. Since v5,
-this should work almost out of box, all we need to do is to configure the migration
-path accordingly:
+In production environment we might want to use compiled migration files. Since v5, this should work almost out of box, all we need to do is to configure the migration path accordingly:
 
 ```ts
 import { MikroORM, Utils } from '@mikro-orm/core';
@@ -116,15 +102,11 @@ await MikroORM.init({
 });
 ```
 
-This should allow using CLI to generate TS migration files (as in CLI we probably
-have TS support enabled), while using compiled JS files in production, where ts-node
-is not registered.
+This should allow using CLI to generate TS migration files (as in CLI we probably have TS support enabled), while using compiled JS files in production, where ts-node is not registered.
 
 ## Using custom `MigrationGenerator`
 
-When we generate new migrations, `MigrationGenerator` class is responsible for 
-generating the file contents. We can provide our own implementation to do things 
-like formatting the SQL statement. 
+When we generate new migrations, `MigrationGenerator` class is responsible for generating the file contents. We can provide our own implementation to do things like formatting the SQL statement.
 
 ```ts
 import { TSMigrationGenerator } from '@mikro-orm/migrations';
@@ -157,7 +139,7 @@ await MikroORM.init({
 
 ## Using via CLI
 
-You can use it via CLI: 
+You can use it via CLI:
 
 ```sh
 npx mikro-orm migration:create   # Create new migration with current schema diff
@@ -168,11 +150,9 @@ npx mikro-orm migration:pending  # List all pending migrations
 npx mikro-orm migration:fresh    # Drop the database and migrate up to the latest version
 ```
 
-> To create blank migration file, we can use 
-> `npx mikro-orm migration:create --blank`.
+> To create blank migration file, we can use `npx mikro-orm migration:create --blank`.
 
-For `migration:up` and `migration:down` commands we can specify `--from` (`-f`), `--to` (`-t`) 
-and `--only` (`-o`) options to run only a subset of migrations:
+For `migration:up` and `migration:down` commands we can specify `--from` (`-f`), `--to` (`-t`) and `--only` (`-o`) options to run only a subset of migrations:
 
 ```sh
 npx mikro-orm migration:up --from 2019101911 --to 2019102117  # the same as above
@@ -180,14 +160,15 @@ npx mikro-orm migration:up --only 2019101923                  # apply a single m
 npx mikro-orm migration:down --to 0                           # migrate down all migrations
 ```
 
-> To run TS migration files, we will need to [enable `useTsNode` flag](installation.md#setting-up-the-commandline-tool)
-> in our `package.json`.
+> To run TS migration files, we will need to [enable `useTsNode` flag](installation.md#setting-up-the-commandline-tool) in our `package.json`.
 
 For the `migration:fresh` command we can specify `--seed` to seed the database after migrating.
+
 ```shell
 npx mikro-orm migration:fresh --seed              # seed the database with the default database seeder
 npx mikro-orm migration:fresh --seed=UsersSeeder  # seed the database with the UsersSeeder
 ```
+
 > You can specify the default database seeder in the orm config with the key `config.seeder.defaultSeeder`
 
 ## Using the Migrator programmatically
@@ -235,8 +216,7 @@ await orm.em.transactional(async em => {
 
 ## Importing migrations statically
 
-If we do not want to dynamically import a folder (e.g. when bundling our code with webpack) we can import migrations
-directly.
+If we do not want to dynamically import a folder (e.g. when bundling our code with webpack) we can import migrations directly.
 
 ```ts
 import { MikroORM } from '@mikro-orm/core';
@@ -254,8 +234,7 @@ await MikroORM.init({
 });
 ```
 
-With the help of [webpack's context module api](https://webpack.js.org/guides/dependency-management/#context-module-api)
-we can dynamically import the migrations making it possible to import all files in a folder.
+With the help of [webpack's context module api](https://webpack.js.org/guides/dependency-management/#context-module-api) we can dynamically import the migrations making it possible to import all files in a folder.
 
 ```ts
 import { MikroORM } from '@mikro-orm/core';
@@ -311,9 +290,9 @@ import { Migration } from '@mikro-orm/migrations-mongodb';
 export class MigrationTest1 extends Migration {
 
   async up(): Promise<void> {
-    // use `this.getCollection()` to work with the mongodb collection directly 
+    // use `this.getCollection()` to work with the mongodb collection directly
     await this.getCollection('Book').updateMany({}, { $set: { updatedAt: new Date() } }, { session: this.ctx });
-    
+
     // or use `this.driver` to work with the `MongoDriver` API instead
     await this.driver.nativeDelete('Book', { foo: true }, { ctx: this.ctx });
   }
@@ -325,8 +304,7 @@ export class MigrationTest1 extends Migration {
 
 ### MySQL
 
-There is no way to rollback DDL changes in MySQL. An implicit commit is forced for those 
-queries automatically, so transactions are not working as expected. 
+There is no way to rollback DDL changes in MySQL. An implicit commit is forced for those queries automatically, so transactions are not working as expected.
 
 - https://github.com/mikro-orm/mikro-orm/issues/217
 - https://dev.mysql.com/doc/refman/5.7/en/implicit-commit.html

--- a/docs/versioned_docs/version-5.5/multiple-schemas.md
+++ b/docs/versioned_docs/version-5.5/multiple-schemas.md
@@ -2,14 +2,11 @@
 title: Using Multiple Schemas
 ---
 
-In MySQL and PostgreSQL it is possible to define your entities in multiple schemas. In MySQL 
-terminology, it is called database, but from an implementation point of view, it is a schema. 
+In MySQL and PostgreSQL it is possible to define your entities in multiple schemas. In MySQL terminology, it is called database, but from an implementation point of view, it is a schema.
 
-> To use multiple schemas, your connection needs to have access to all of them (multiple 
-> connections are not supported in a single MikroORM instance).
+> To use multiple schemas, your connection needs to have access to all of them (multiple connections are not supported in a single MikroORM instance).
 
-All you need to do is simply define the schema name via `schema` options, or 
-table name including schema name in `tableName` option:
+All you need to do is simply define the schema name via `schema` options, or table name including schema name in `tableName` option:
 
 ```ts
 @Entity({ schema: 'first_schema' })
@@ -20,12 +17,9 @@ export class Foo { ... }
 export class Bar { ... }
 ```
 
-Then use those entities as usual. Resulting SQL queries will use this `tableName` value as a 
-table name so as long as your connection has access to given schema, everything should work 
-as expected.
+Then use those entities as usual. Resulting SQL queries will use this `tableName` value as a table name so as long as your connection has access to given schema, everything should work as expected.
 
-You can also query for entity in specific schema via `EntityManager`, `EntityRepository` or 
-`QueryBuilder`:
+You can also query for entity in specific schema via `EntityManager`, `EntityRepository` or `QueryBuilder`:
 
 ```ts
 const user = await em.findOne(User, { ... }, { schema: 'client-123' });
@@ -40,8 +34,7 @@ await qb.insert({ email: 'foo@bar.com' }).withSchema('client-123');
 
 ## Wildcard Schema
 
-Since v5, MikroORM also supports defining entities that can exist in multiple
-schemas. To do that, we just specify wildcard schema:
+Since v5, MikroORM also supports defining entities that can exist in multiple schemas. To do that, we just specify wildcard schema:
 
 ```ts
 @Entity({ schema: '*' })
@@ -62,19 +55,10 @@ export class Book {
 }
 ```
 
-Entities like this will be by default ignored when using `SchemaGenerator`, 
-as we need to specify which schema to use. For that we need to use the `schema`
-option of the `createSchema/updateSchema/dropSchema` methods or the `--schema` 
-CLI parameter.
+Entities like this will be by default ignored when using `SchemaGenerator`, as we need to specify which schema to use. For that we need to use the `schema` option of the `createSchema/updateSchema/dropSchema` methods or the `--schema` CLI parameter.
 
-On runtime, the wildcard schema will be replaced with either `FindOptions.schema`,
-or with the `schema` option from the ORM config.
+On runtime, the wildcard schema will be replaced with either `FindOptions.schema`, or with the `schema` option from the ORM config.
 
 ### Note about migrations
 
-Currently, this is not supported via migrations, they will always ignore
-wildcard schema entities, and `SchemaGenerator` needs to be used explicitly.
-Given the dynamic nature of such entities, it makes sense to only sync the 
-schema dynamically, e.g. in an API endpoint. We could still use the ORM 
-migrations, but we need to add the dynamic schema queries manually to migration
-files. It makes sense to use the `safe` mode for such queries.
+Currently, this is not supported via migrations, they will always ignore wildcard schema entities, and `SchemaGenerator` needs to be used explicitly. Given the dynamic nature of such entities, it makes sense to only sync the schema dynamically, e.g. in an API endpoint. We could still use the ORM migrations, but we need to add the dynamic schema queries manually to migration files. It makes sense to use the `safe` mode for such queries.

--- a/docs/versioned_docs/version-5.5/naming-strategy.md
+++ b/docs/versioned_docs/version-5.5/naming-strategy.md
@@ -2,15 +2,13 @@
 title: Naming Strategy
 ---
 
-When mapping our entities to database tables and columns, their names will be defined by naming 
-strategy. There are 3 basic naming strategies we can choose from:
+When mapping our entities to database tables and columns, their names will be defined by naming strategy. There are 3 basic naming strategies we can choose from:
 
 - `UnderscoreNamingStrategy` - default of all SQL drivers
 - `MongoNamingStrategy` - default of `MongoDriver`
 - `EntityCaseNamingStrategy` - uses unchanged entity and property names
 
-You can override this when initializing ORM. You can also provide our own naming strategy, just 
-implement `NamingStrategy` interface and provide our implementation when bootstrapping ORM:
+You can override this when initializing ORM. You can also provide our own naming strategy, just implement `NamingStrategy` interface and provide our implementation when bootstrapping ORM:
 
 ```ts
 class MyCustomNamingStrategy implements NamingStrategy {
@@ -24,20 +22,17 @@ const orm = await MikroORM.init({
 });
 ```
 
-> You can also extend `AbstractNamingStrategy` which implements one method for we - `getClassName()`
-> that is used to map entity file name to class name.
+> You can also extend `AbstractNamingStrategy` which implements one method for we - `getClassName()` that is used to map entity file name to class name.
 
 ## Naming Strategy in mongo driver
 
-`MongoNamingStrategy` will simply use all field names as they are defined. Collection names will
-be translated into lower-cased dashed form:
+`MongoNamingStrategy` will simply use all field names as they are defined. Collection names will be translated into lower-cased dashed form:
 
 `MyCoolEntity` will be translated into `my-cool-entity` collection name.
 
 ## Naming Strategy in SQL drivers
 
-`MySqlDriver` defaults to `UnderscoreNamingStrategy`, which means our all our database tables and
-columns will be lower-cased and words divided by underscored:
+`MySqlDriver` defaults to `UnderscoreNamingStrategy`, which means our all our database tables and columns will be lower-cased and words divided by underscored:
 
 ```sql
 CREATE TABLE `author` (
@@ -87,7 +82,7 @@ Return a join column name for a property.
 
 #### `NamingStrategy.joinTableName(sourceEntity: string, targetEntity: string, propertyName: string): string`
 
-Return a join table name. This is used as default value for `pivotTable`. 
+Return a join table name. This is used as default value for `pivotTable`.
 
 ---
 
@@ -99,15 +94,12 @@ Return the foreign key column name for the given parameters.
 
 #### `NamingStrategy.indexName(tableName: string, columns: string[], type: 'primary' | 'foreign' | 'unique' | 'index' | 'sequence'): string`
 
-Returns key/constraint name for given type. Some drivers might not support all 
-the types (e.g. mysql and sqlite enforce the PK name).
+Returns key/constraint name for given type. Some drivers might not support all the types (e.g. mysql and sqlite enforce the PK name).
 
 ---
 
 #### `NamingStrategy.aliasName(entityName: string, index: number): string`
 
-Returns alias name for given entity. The alias needs to be unique across the 
-query, which is by default ensured via appended index parameter. It is optional 
-to use it as long as we ensure it will be unique.
+Returns alias name for given entity. The alias needs to be unique across the query, which is by default ensured via appended index parameter. It is optional to use it as long as we ensure it will be unique.
 
 ---

--- a/docs/versioned_docs/version-5.5/nested-populate.md
+++ b/docs/versioned_docs/version-5.5/nested-populate.md
@@ -2,15 +2,12 @@
 title: Smart Nested Populate
 ---
 
-`MikroORM` is capable of loading large nested structures while maintaining good 
-performance, querying each database table only once. Imagine you have this nested 
-structure:
+`MikroORM` is capable of loading large nested structures while maintaining good performance, querying each database table only once. Imagine you have this nested structure:
 
 - `Book` has one `Publisher` (M:1), one `Author` (M:1) and many `BookTag`s (M:N)
 - `Publisher` has many `Test`s (M:N)
 
-When you use nested populate while querying all `BookTag`s, this is what happens in
-the background:
+When you use nested populate while querying all `BookTag`s, this is what happens in the background:
 
 ```ts
 const tags = await em.findAll(BookTag, { populate: ['books.publisher.tests', 'books.author'] });
@@ -64,7 +61,7 @@ To populate existing entities, you can use `em.populate()`.
 const authors = await em.createQueryBuilder(Author).select('*').getResult();
 await em.populate(authors, ['books.tags']);
 
-// now your Author entities will have `books` collections populated, 
+// now your Author entities will have `books` collections populated,
 // as well as they will have their `tags` collections populated.
 console.log(authors[0].books[0].tags[0]); // initialized BookTag
 ```

--- a/docs/versioned_docs/version-5.5/propagation.md
+++ b/docs/versioned_docs/version-5.5/propagation.md
@@ -2,8 +2,7 @@
 title: Propagation
 ---
 
-By default, MikroORM will propagate all changes made to one side of bi-directional relations to the other side, keeping them in sync. This works for all relations, including M:1 and 1:1. As part of
-the discovery process, all M:1 and 1:1 properties are re-defined as getter/setter.
+By default, MikroORM will propagate all changes made to one side of bi-directional relations to the other side, keeping them in sync. This works for all relations, including M:1 and 1:1. As part of the discovery process, all M:1 and 1:1 properties are re-defined as getter/setter.
 
 ```ts
 const author = new Author(...);
@@ -39,11 +38,10 @@ console.log(tag.books.contains(book)); // true
 
 tag.books.add(book);
 console.log(book.tags.contains(tag)); // true
-``` 
+```
 
 > Collections on both sides have to be initialized, otherwise propagation won't work.
 
-> Although this propagation works also for M:N inverse side, you should always use owning
-> side to manipulate the collection.
+> Although this propagation works also for M:N inverse side, you should always use owning side to manipulate the collection.
 
 Same applies for `Collection.remove()`.

--- a/docs/versioned_docs/version-5.5/property-validation.md
+++ b/docs/versioned_docs/version-5.5/property-validation.md
@@ -63,14 +63,9 @@ When we define our entities, we need to be careful about optional properties. Wi
 
 ## Strict property type validation
 
-> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`.
-> It has performance implications and usually should not be needed, as long as
-> you don't modify your entities via `Object.assign()`.
+> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`. It has performance implications and usually should not be needed, as long as you don't modify your entities via `Object.assign()`.
 
-`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong 
-data types for you automatically. If automatic conversion fails, it will throw an error. You can 
-enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered 
-when persisting the entity. 
+`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong data types for you automatically. If automatic conversion fails, it will throw an error. You can enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered when persisting the entity.
 
 ```ts
 // number instead of string will throw

--- a/docs/versioned_docs/version-5.5/query-builder.md
+++ b/docs/versioned_docs/version-5.5/query-builder.md
@@ -2,12 +2,12 @@
 title: Using Query Builder
 ---
 
-:::info Since v4, we need to make sure we are working with correctly typed `EntityManager`
-or `EntityRepository` to have access to `createQueryBuilder()` method.
+:::info Since v4, we need to make sure we are working with correctly typed `EntityManager` or `EntityRepository` to have access to `createQueryBuilder()` method.
 
 ```ts
 import { EntityManager, EntityRepository } from '@mikro-orm/mysql'; // or any other driver package
 ```
+
 :::
 
 When you need to execute some SQL query without all the ORM stuff involved, you can either compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
@@ -39,8 +39,7 @@ const res2 = await qb.execute('get'); // returns single object
 const res3 = await qb.execute('run'); // returns object like `{ affectedRows: number, insertId: number, row: any }`
 ```
 
-Second argument can be used to disable mapping of database columns to property names (which is enabled by default). In following example, `Book` entity has `createdAt` property defined with implicit
-underscored field name `created_at`:
+Second argument can be used to disable mapping of database columns to property names (which is enabled by default). In following example, `Book` entity has `createdAt` property defined with implicit underscored field name `created_at`:
 
 ```ts
 const res4 = await em.createQueryBuilder(Book).select('*').execute('get', true);
@@ -49,8 +48,7 @@ const res5 = await em.createQueryBuilder(Book).select('*').execute('get', false)
 console.log(res5); // `created_at` will be defined, while `createdAt` will be missing
 ```
 
-To get entity instances from the QueryBuilder result, you can use `getResult()` and `getSingleResult()`
-methods:
+To get entity instances from the QueryBuilder result, you can use `getResult()` and `getSingleResult()` methods:
 
 ```ts
 const book = await em.createQueryBuilder(Book).select('*').where({ id: 1 }).getSingleResult();
@@ -63,21 +61,20 @@ console.log(books[0] instanceof Book); // true
 
 ## Awaiting the QueryBuilder
 
-Since v5 we can await the `QueryBuilder` instance, which will automatically execute the QB and return appropriate response. The QB instance is now typed based on usage
-of `select/insert/update/delete/truncate` methods to one of:
+Since v5 we can await the `QueryBuilder` instance, which will automatically execute the QB and return appropriate response. The QB instance is now typed based on usage of `select/insert/update/delete/truncate` methods to one of:
 
 - `SelectQueryBuilder`
-    - awaiting yields array of entities (as `qb.getResultList()`)
+  - awaiting yields array of entities (as `qb.getResultList()`)
 - `CountQueryBuilder`
-    - awaiting yields number (as `qb.getCount()`)
+  - awaiting yields number (as `qb.getCount()`)
 - `InsertQueryBuilder` (extends `RunQueryBuilder`)
-    - awaiting yields `QueryResult`
+  - awaiting yields `QueryResult`
 - `UpdateQueryBuilder` (extends `RunQueryBuilder`)
-    - awaiting yields `QueryResult`
+  - awaiting yields `QueryResult`
 - `DeleteQueryBuilder` (extends `RunQueryBuilder`)
-    - awaiting yields `QueryResult`
+  - awaiting yields `QueryResult`
 - `TruncateQueryBuilder` (extends `RunQueryBuilder`)
-    - awaiting yields `QueryResult`
+  - awaiting yields `QueryResult`
 
 ```ts
 const res1 = await em.qb(Publisher).insert({
@@ -112,9 +109,7 @@ expect(res5.affectedRows > 0).toBe(true); // test the type
 
 ## Mapping Raw Results to Entities
 
-Another way to create entity from raw results (that are not necessarily mapped to entity properties)
-is to use `map()` method of `EntityManager`, that is basically a shortcut for mapping results via `IDatabaseDriver.mapResult()` (which converts field names to property names - e.g. `created_at`
-to `createdAt`) and `merge()` which converts the data to entity instance and makes it managed.
+Another way to create entity from raw results (that are not necessarily mapped to entity properties) is to use `map()` method of `EntityManager`, that is basically a shortcut for mapping results via `IDatabaseDriver.mapResult()` (which converts field names to property names - e.g. `created_at` to `createdAt`) and `merge()` which converts the data to entity instance and makes it managed.
 
 This method comes handy when you want to use 3rd party query builders, where the result is not mapped to entity properties automatically:
 
@@ -151,12 +146,12 @@ qb.select('*')
   .orderBy({ books: { tags: { createdBy: QueryOrder.DESC } } });
 
 console.log(qb.getQuery());
-// select `e0`.* 
-// from `author` as `e0` 
-// left join `book2` as `e1` on `e0`.`id` = `e1`.`author_id` 
-// left join `book2_to_book_tag2` as `e3` on `e1`.`uuid_pk` = `e3`.`book2_uuid_pk` 
-// left join `book_tag2` as `e2` on `e3`.`book_tag2_id` = `e2`.`id` 
-// where `e2`.`name` = ? 
+// select `e0`.*
+// from `author` as `e0`
+// left join `book2` as `e1` on `e0`.`id` = `e1`.`author_id`
+// left join `book2_to_book_tag2` as `e3` on `e1`.`uuid_pk` = `e3`.`book2_uuid_pk`
+// left join `book_tag2` as `e2` on `e3`.`book_tag2_id` = `e2`.`id`
+// where `e2`.`name` = ?
 // order by `e1`.`tags` asc
 ```
 
@@ -183,8 +178,7 @@ console.log(qb.getQuery());
 
 ## Mapping joined results
 
-To select multiple entities and map them from `QueryBuilder`, we can use
-`joinAndSelect` or `leftJoinAndSelect` method:
+To select multiple entities and map them from `QueryBuilder`, we can use `joinAndSelect` or `leftJoinAndSelect` method:
 
 ```ts
 // `res` will contain array of authors, with books and their tags populated
@@ -215,7 +209,7 @@ const users = em.createQueryBuilder(User)
 This will produce following query:
 
 ```sql
-select `e0`.* 
+select `e0`.*
 from `user` as `e0`
 where lower(email) = 'foo@bar.baz'
 order by (point(loc_latitude, loc_longitude) <@> point(0, 0)) asc
@@ -298,7 +292,7 @@ This will also remove any existing limit and offset from the query (the QB will 
 
 ## Overriding FROM clause
 
-You can specify the table used in the `FROM` clause, replacing the current table name if one has already been specified. This is typically used to specify a sub-query expression in SQL. 
+You can specify the table used in the `FROM` clause, replacing the current table name if one has already been specified. This is typically used to specify a sub-query expression in SQL.
 
 ```ts
 const qb = em.createQueryBuilder(Book2);
@@ -368,8 +362,7 @@ console.log(qb4.getQuery());
 
 When you want to filter by sub-query on the left-hand side of a predicate, you will need to register it first via `qb.withSubquery()`:
 
-> The dynamic property (`booksTotal`) needs to be defined at the entity level (as `persist: false`).
-> You always need to use prefix in the `qb.withSchema()` (so `a.booksTotal`).
+> The dynamic property (`booksTotal`) needs to be defined at the entity level (as `persist: false`). You always need to use prefix in the `qb.withSchema()` (so `a.booksTotal`).
 
 ```ts
 const knex = em.getKnex();
@@ -417,14 +410,14 @@ console.log(qb.getQuery()); // for MySQL
 
 Available lock modes:
 
-| Mode | Postgres | MySQL |
-|------|----------|-------|
-| `LockMode.PESSIMISTIC_READ` | `for share` | `lock in share mode` |
-| `LockMode.PESSIMISTIC_WRITE` | `for update` | `for update` |
-| `LockMode.PESSIMISTIC_PARTIAL_WRITE` | `for update skip locked` | `for update skip locked` |
-| `LockMode.PESSIMISTIC_WRITE_OR_FAIL` | `for update nowait` | `for update nowait` |
-| `LockMode.PESSIMISTIC_PARTIAL_READ` | `for share skip locked` | `lock in share mode skip locked` |
-| `LockMode.PESSIMISTIC_READ_OR_FAIL` | `for share nowait` | `lock in share mode nowait` |
+| Mode                                 | Postgres                 | MySQL                            |
+| ------------------------------------ | ------------------------ | -------------------------------- |
+| `LockMode.PESSIMISTIC_READ`          | `for share`              | `lock in share mode`             |
+| `LockMode.PESSIMISTIC_WRITE`         | `for update`             | `for update`                     |
+| `LockMode.PESSIMISTIC_PARTIAL_WRITE` | `for update skip locked` | `for update skip locked`         |
+| `LockMode.PESSIMISTIC_WRITE_OR_FAIL` | `for update nowait`      | `for update nowait`              |
+| `LockMode.PESSIMISTIC_PARTIAL_READ`  | `for share skip locked`  | `lock in share mode skip locked` |
+| `LockMode.PESSIMISTIC_READ_OR_FAIL`  | `for share nowait`       | `lock in share mode nowait`      |
 
 Optionally we can also pass list of table aliases we want to lock via second parameter:
 
@@ -436,10 +429,10 @@ qb.select('*')
   .setLockMode(LockMode.PESSIMISTIC_READ, ['u']);
 
 console.log(qb.getQuery()); // for Postgres
-// select ... 
+// select ...
 //   from "user" as "u"
-//   left join "identity" as "i" on "u"."id" = "i"."user_id" 
-//   where "u"."name" = 'Jon' 
+//   left join "identity" as "i" on "u"."id" = "i"."user_id"
+//   where "u"."name" = 'Jon'
 //   for update of "u" skip locked
 ```
 
@@ -459,12 +452,9 @@ const entities = res.map(a => em.map(Author, a));
 console.log(entities); // Author[]
 ```
 
-You can also get clear and configured knex instance from the connection via `getKnex()` method. As this method is not available on the base `Connection` class, you will need to either manually type
-cast the connection to `AbstractSqlConnection` (or the actual implementation you are using, e.g. `MySqlConnection`), or provide correct driver type hint to your `EntityManager` instance, which will be
-then automatically inferred in `em.getConnection()` method.
+You can also get clear and configured knex instance from the connection via `getKnex()` method. As this method is not available on the base `Connection` class, you will need to either manually type cast the connection to `AbstractSqlConnection` (or the actual implementation you are using, e.g. `MySqlConnection`), or provide correct driver type hint to your `EntityManager` instance, which will be then automatically inferred in `em.getConnection()` method.
 
-> Driver and connection implementations are not directly exported from `@mikro-orm/core` module.
-> You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
+> Driver and connection implementations are not directly exported from `@mikro-orm/core` module. You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
 
 ```ts
 const conn = em.getConnection() as AbstractSqlConnection;

--- a/docs/versioned_docs/version-5.5/query-conditions.md
+++ b/docs/versioned_docs/version-5.5/query-conditions.md
@@ -2,8 +2,7 @@
 title: Smart Query Conditions
 ---
 
-When you want to make complex queries, we can easily end up with a lot of boilerplate code
-full of curly brackets:
+When you want to make complex queries, we can easily end up with a lot of boilerplate code full of curly brackets:
 
 ```ts
 const res = await orm.em.find(Author, { $and: [
@@ -20,8 +19,8 @@ const res = await orm.em.find(Author, { $and: [
 For AND condition with single field, we can also do this:
 
 ```ts
-const res = await orm.em.find(Author, { 
-  id: { 
+const res = await orm.em.find(Author, {
+  id: {
     $in: [1, 2, 7],
     $nin: [3, 4],
     $gt: 5,
@@ -33,8 +32,7 @@ const res = await orm.em.find(Author, {
 });
 ```
 
-There is also shortcut for `$in` - simply provide array as value and it 
-will be converted automatically:
+There is also shortcut for `$in` - simply provide array as value and it will be converted automatically:
 
 ```ts
 const res = await orm.em.find(Author, { favouriteBook: [1, 2, 7] });
@@ -50,30 +48,30 @@ const res = await orm.em.find(Author, [1, 2, 7]);
 
 ### Comparison
 
-| operator | name               | description |
-|----------|--------------------|-------------|
-| `$eq`	   | equals             | Matches values that are equal to a specified value. |
-| `$gt`	   | greater            | Matches values that are greater than a specified value. |
-| `$gte`   | greater or equal   | Matches values that are greater than or equal to a specified value. |
-| `$in`	   | contains           | Matches any of the values specified in an array. |
-| `$lt`	   | lower              | Matches values that are less than a specified value. |
-| `$lte`   | lower or equal     | Matches values that are less than or equal to a specified value. |
-| `$ne`	   | not equal          | Matches all values that are not equal to a specified value. |
-| `$nin`   | not contains       | Matches none of the values specified in an array. |
-| `$like`  | like               | Uses LIKE operator |
-| `$re`    | regexp             | Uses REGEXP operator |
-| `$fulltext` | full text       | A driver specific full text search function. See requirements [below](#full-text-searching) |
-| `$ilike` | ilike              | (postgres only) |
-| `$overlap` | &&               | (postgres only) |
-| `$contains` | @>              | (postgres only) |
-| `$contained` | <@             | (postgres only) |
+| operator     | name             | description                                                                                 |
+| ------------ | ---------------- | ------------------------------------------------------------------------------------------- |
+| `$eq`        | equals           | Matches values that are equal to a specified value.                                         |
+| `$gt`        | greater          | Matches values that are greater than a specified value.                                     |
+| `$gte`       | greater or equal | Matches values that are greater than or equal to a specified value.                         |
+| `$in`        | contains         | Matches any of the values specified in an array.                                            |
+| `$lt`        | lower            | Matches values that are less than a specified value.                                        |
+| `$lte`       | lower or equal   | Matches values that are less than or equal to a specified value.                            |
+| `$ne`        | not equal        | Matches all values that are not equal to a specified value.                                 |
+| `$nin`       | not contains     | Matches none of the values specified in an array.                                           |
+| `$like`      | like             | Uses LIKE operator                                                                          |
+| `$re`        | regexp           | Uses REGEXP operator                                                                        |
+| `$fulltext`  | full text        | A driver specific full text search function. See requirements [below](#full-text-searching) |
+| `$ilike`     | ilike            | (postgres only)                                                                             |
+| `$overlap`   | &&               | (postgres only)                                                                             |
+| `$contains`  | @>               | (postgres only)                                                                             |
+| `$contained` | <@               | (postgres only)                                                                             |
 
 ### Logical
 
-| operator | description |
-|----------|-------------|
+| operator | description                                                                                             |
+| -------- | ------------------------------------------------------------------------------------------------------- |
 | `$and`   | Joins query clauses with a logical AND returns all documents that match the conditions of both clauses. |
-| `$not`   | Inverts the effect of a query expression and returns documents that do not match the query expression. |
+| `$not`   | Inverts the effect of a query expression and returns documents that do not match the query expression.  |
 | `$or`    | Joins query clauses with a logical OR returns all documents that match the conditions of either clause. |
 
 ## Full text searching
@@ -89,14 +87,13 @@ PosgreSQL allows to execute queries (pg-query) on the type pg-vector. The pg-vec
 Refer to the [PostgreSQL documentation](https://www.postgresql.org/docs/current/functions-textsearch.html) for possible queries.
 
 <Tabs
-groupId="entity-def"
-defaultValue="as-column"
-values={[
-{label: 'reflect-metadata', value: 'as-column'},
-{label: 'ts-morph', value: 'in-query'},
-]
-}>
-<TabItem value="as-column">
+  groupId="entity-def"
+  defaultValue="as-column"
+  values={[
+    {label: 'reflect-metadata', value: 'as-column'},
+    {label: 'ts-morph', value: 'in-query'},
+  ]}>
+  <TabItem value="as-column">
 
 ```ts title="./entities/Book.ts"
 import { FullTextType } from '@mikro-orm/postgresql';
@@ -136,6 +133,7 @@ And to find results: `repository.findOne({ title: { $fulltext: 'query' } })`
 </Tabs>
 
 ### MySQL, MariaDB
+
 MySQL and MariaDB allow full text searches on all columns with a fulltext index.
 
 Refer to the [MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/fulltext-boolean.html) or [MariaDB documentation](https://mariadb.com/kb/en/full-text-index-overview/#in-boolean-mode) for possible queries.
@@ -158,7 +156,6 @@ And to find results: `repository.findOne({ title: { $fulltext: 'query' } })`
 MongoDB allows full text searches on all columns with a text index. However, when executing a full text search, it selects matches based on all fields with a text index: it's only possible to add one query and only on the top-level of the query object. Refer to the [MongoDB documentation](https://www.mongodb.com/docs/manual/reference/operator/query/text/#behavior) for more information on this behavior.
 
 Refer to the [MongoDB documentation](https://www.mongodb.com/docs/manual/reference/operator/query/text/#definition) for possible queries.
-
 
 ```ts title="./entities/Book.ts"
 @Entity()

--- a/docs/versioned_docs/version-5.5/quick-start.md
+++ b/docs/versioned_docs/version-5.5/quick-start.md
@@ -2,8 +2,7 @@
 title: Quick Start
 ---
 
-First install the module via `yarn` or `npm` and do not forget to install the 
-database driver as well:
+First install the module via `yarn` or `npm` and do not forget to install the database driver as well:
 
 ```sh
 yarn add @mikro-orm/core @mikro-orm/mongodb     # for mongo
@@ -23,8 +22,7 @@ npm i -s @mikro-orm/core @mikro-orm/postgresql  # for postgresql
 npm i -s @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 ```
 
-Next you will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html)
-as well as `esModuleInterop` in `tsconfig.json` via:
+Next you will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html) as well as `esModuleInterop` in `tsconfig.json` via:
 
 ```json
 "experimentalDecorators": true,
@@ -34,9 +32,7 @@ as well as `esModuleInterop` in `tsconfig.json` via:
 
 Then call `MikroORM.init` as part of bootstrapping your app:
 
-> To access driver specific methods like `em.createQueryBuilder()` we need to specify
-> the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the
-> `orm.em` to `EntityManager` exported from the driver package:
+> To access driver specific methods like `em.createQueryBuilder()` we need to specify the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the `orm.em` to `EntityManager` exported from the driver package:
 >
 > ```ts
 > import { EntityManager } from '@mikro-orm/postgresql';
@@ -55,14 +51,11 @@ const orm = await MikroORM.init<PostgreSqlDriver>({
 console.log(orm.em); // access EntityManager via `em` property
 ```
 
-There are more ways to configure your entities, take a look at 
-[installation page](https://mikro-orm.io/installation/).
+There are more ways to configure your entities, take a look at [installation page](https://mikro-orm.io/installation/).
 
 > Read more about all the possible configuration options in [Advanced Configuration](https://mikro-orm.io/docs/configuration) section.
 
-Then you will need to fork entity manager for each request so their 
-[identity maps](https://mikro-orm.io/identity-map/) will not collide. 
-To do so, use the `RequestContext` helper:
+Then you will need to fork entity manager for each request so their [identity maps](https://mikro-orm.io/identity-map/) will not collide. To do so, use the `RequestContext` helper:
 
 ```ts
 const app = express();
@@ -72,15 +65,11 @@ app.use((req, res, next) => {
 });
 ```
 
-> You should register this middleware as the last one just before request handlers and before
-> any of your custom middleware that is using the ORM. There might be issues when you register 
-> it before request processing middleware like `queryParser` or `bodyParser`, so definitely 
-> register the context after them. 
+> You should register this middleware as the last one just before request handlers and before any of your custom middleware that is using the ORM. There might be issues when you register it before request processing middleware like `queryParser` or `bodyParser`, so definitely register the context after them.
 
 More info about `RequestContext` is described [here](https://mikro-orm.io/identity-map/#request-context).
 
-Now you can start defining your entities (in one of the `entities` folders). This is how
-simple entity can look like in mongo driver:
+Now you can start defining your entities (in one of the `entities` folders). This is how simple entity can look like in mongo driver:
 
 ```ts title="./entities/MongoBook.ts"
 @Entity()
@@ -135,15 +124,11 @@ export class UuidBook {
 }
 ```
 
-More information can be found in
-[defining entities section](https://mikro-orm.io/defining-entities/) in docs.
+More information can be found in [defining entities section](https://mikro-orm.io/defining-entities/) in docs.
 
-When you have your entities defined, you can start using ORM either via `EntityManager`
-or via `EntityRepository`s.
+When you have your entities defined, you can start using ORM either via `EntityManager` or via `EntityRepository`s.
 
-To save entity state to database, you need to persist it. Persist determines 
-whether to use `insert` or `update` and computes appropriate change-set. Entity references
-that are not persisted yet (does not have identifier) will be cascade persisted automatically. 
+To save entity state to database, you need to persist it. Persist determines whether to use `insert` or `update` and computes appropriate change-set. Entity references that are not persisted yet (does not have identifier) will be cascade persisted automatically.
 
 ```ts
 // use constructors in your entities for required parameters
@@ -163,7 +148,7 @@ book3.publisher = publisher;
 await em.persistAndFlush([book1, book2, book3]);
 ```
 
-To fetch entities from database you can use `find()` and `findOne()` of `EntityManager`: 
+To fetch entities from database you can use `find()` and `findOne()` of `EntityManager`:
 
 ```ts
 const authors = em.find(Author, {});
@@ -179,13 +164,12 @@ for (const author of authors) {
 }
 ```
 
-More convenient way of fetching entities from database is by using `EntityRepository`, that
-carries the entity name so you do not have to pass it to every `find` and `findOne` calls:
+More convenient way of fetching entities from database is by using `EntityRepository`, that carries the entity name so you do not have to pass it to every `find` and `findOne` calls:
 
 ```ts
 const booksRepository = em.getRepository(Book);
 
-const books = await booksRepository.find({ author: '...' }, { 
+const books = await booksRepository.find({ author: '...' }, {
   populate: ['author'],
   limit: 1,
   offset: 2,
@@ -195,5 +179,4 @@ const books = await booksRepository.find({ author: '...' }, {
 console.log(books); // Book[]
 ```
 
-Take a look at docs about [working with `EntityManager`](https://mikro-orm.io/entity-manager/)
-or [using `EntityRepository` instead](https://mikro-orm.io/repositories/).
+Take a look at docs about [working with `EntityManager`](https://mikro-orm.io/entity-manager/) or [using `EntityRepository` instead](https://mikro-orm.io/repositories/).

--- a/docs/versioned_docs/version-5.5/read-connections.md
+++ b/docs/versioned_docs/version-5.5/read-connections.md
@@ -2,19 +2,13 @@
 title: Read Replica Connections
 ---
 
-Users can specify multiple read connections via `replicas` option. You can provide only fields
-that differ from master connection, rest will be taken from it.
+Users can specify multiple read connections via `replicas` option. You can provide only fields that differ from master connection, rest will be taken from it.
 
-When resolving read connections, the default strategy is to assign random read replicas for all
-read operations (SELECT, COUNT) that are not running inside a transaction.
+When resolving read connections, the default strategy is to assign random read replicas for all read operations (SELECT, COUNT) that are not running inside a transaction.
 
-You can specify an explicit connection type for find and count operations by using the `connectionType`
-property on the corresponding Options argument (i.e. `FindOptions`, `CountOptions`).
+You can specify an explicit connection type for find and count operations by using the `connectionType` property on the corresponding Options argument (i.e. `FindOptions`, `CountOptions`).
 
-The connection resolution strategy can be also inverted by setting the `preferReadReplicas` configuration property
-to `false` so that the default connection will always be a write connection, unless explicitly requested to be read
-(can be useful in applications where read-replicas are available but should only be used for specific use-cases).
-
+The connection resolution strategy can be also inverted by setting the `preferReadReplicas` configuration property to `false` so that the default connection will always be a write connection, unless explicitly requested to be read (can be useful in applications where read-replicas are available but should only be used for specific use-cases).
 
 ```ts
 const orm = await MikroORM.init({
@@ -31,9 +25,7 @@ const orm = await MikroORM.init({
 });
 ```
 
-By default, select queries will use random read connection if not inside transaction. You can
-specify the connection type explicitly in `em.getConnection(type: 'read' | 'write')`.
-
+By default, select queries will use random read connection if not inside transaction. You can specify the connection type explicitly in `em.getConnection(type: 'read' | 'write')`.
 
 ```ts
 const connection = em.getConnection(); // write connection

--- a/docs/versioned_docs/version-5.5/relationships.md
+++ b/docs/versioned_docs/version-5.5/relationships.md
@@ -3,20 +3,16 @@ title: Modeling Entity Relationships
 sidebar_label: Modeling Entity Relationships
 ---
 
-There are 4 types of entity relationships in MikroORM: 
+There are 4 types of entity relationships in MikroORM:
 
 - ManyToOne
 - OneToMany
 - OneToOne
 - ManyToMany
 
-Relations can be unidirectional and bidirectional. Unidirectional are defined only on one 
-side (the owning side). Bidirectional are defined on both sides, while one is owning side 
-(where references are store), marked by `inversedBy` attribute pointing to the inverse side.
-On the inversed side we define it with `mappedBy` attribute pointing back to the owner:
+Relations can be unidirectional and bidirectional. Unidirectional are defined only on one side (the owning side). Bidirectional are defined on both sides, while one is owning side (where references are store), marked by `inversedBy` attribute pointing to the inverse side. On the inversed side we define it with `mappedBy` attribute pointing back to the owner:
 
-> When modeling bidirectional relationship, you can also omit the `inversedBy` attribute, 
-> defining `mappedBy` on the inverse side is enough as it will be auto-wired. 
+> When modeling bidirectional relationship, you can also omit the `inversedBy` attribute, defining `mappedBy` on the inverse side is enough as it will be auto-wired.
 
 ## ManyToOne
 
@@ -43,8 +39,7 @@ export class Book {
 }
 ```
 
-You can also specify how operations on given entity should [cascade](cascading.md) 
-to the referred entity.
+You can also specify how operations on given entity should [cascade](cascading.md) to the referred entity.
 
 ## OneToMany
 
@@ -71,19 +66,15 @@ export class Author {
 }
 ```
 
-As you can see, OneToMany is the inverse side of ManyToOne (which is the owning side).
-More about how collections work can be found on [collections page](collections.md). 
+As you can see, OneToMany is the inverse side of ManyToOne (which is the owning side). More about how collections work can be found on [collections page](collections.md).
 
-You can also specify how operations on given entity should [cascade](cascading.md) to the referred
-entities. There is also more aggressive remove mode called [Orphan Removal](cascading.md#orphan-removal) 
-(`books4` example).
+You can also specify how operations on given entity should [cascade](cascading.md) to the referred entities. There is also more aggressive remove mode called [Orphan Removal](cascading.md#orphan-removal) (`books4` example).
 
 ## OneToOne
 
 > One instance of the current Entity refers to One instance of the referred Entity.
 
-This is a variant of ManyToOne, where there is always just one entity on both sides. This means
-that the foreign key column is also unique.
+This is a variant of ManyToOne, where there is always just one entity on both sides. This means that the foreign key column is also unique.
 
 ### Owning Side
 
@@ -121,8 +112,7 @@ export class User {
 }
 ```
 
-As you can see, relationships can be also self-referencing (all of them. OneToOne also supports 
-[Orphan Removal](cascading.md#orphan-removal). 
+As you can see, relationships can be also self-referencing (all of them. OneToOne also supports [Orphan Removal](cascading.md#orphan-removal).
 
 ## ManyToMany
 
@@ -149,7 +139,7 @@ export class Book {
   @ManyToMany(() => BookTag, 'books', { owner: true })
   tags4 = new Collection<BookTag>(this);
 
-  // to define uni-directional many to many, simply provide only 
+  // to define uni-directional many to many, simply provide only
   @ManyToMany(() => Author)
   friends: Collection<Author> = new Collection<Author>(this);
 
@@ -169,4 +159,4 @@ export class BookTag {
 }
 ```
 
-Again, more information about how collections work can be found on [collections page](collections.md). 
+Again, more information about how collections work can be found on [collections page](collections.md).

--- a/docs/versioned_docs/version-5.5/repositories.md
+++ b/docs/versioned_docs/version-5.5/repositories.md
@@ -3,18 +3,14 @@ title: Using EntityRepository instead of EntityManager
 sidebar_label: Entity Repository
 ---
 
-Entity Repositories are thin layers on top of `EntityManager`. They act as an 
-extension point, so we can add custom methods, or even alter the existing ones. 
-The default, `EntityRepository` implementation just forwards the calls to 
-underlying `EntityManager` instance.
+Entity Repositories are thin layers on top of `EntityManager`. They act as an extension point, so we can add custom methods, or even alter the existing ones. The default, `EntityRepository` implementation just forwards the calls to underlying `EntityManager` instance.
 
-> `EntityRepository` class carries the entity type, so we do not have to pass 
-> it to every `find` or `findOne` calls.
+> `EntityRepository` class carries the entity type, so we do not have to pass it to every `find` or `findOne` calls.
 
 ```ts
 const booksRepository = em.getRepository(Book);
 
-const books = await booksRepository.find({ author: '...' }, { 
+const books = await booksRepository.find({ author: '...' }, {
   populate: ['author'],
   limit: 1,
   offset: 2,
@@ -24,17 +20,11 @@ const books = await booksRepository.find({ author: '...' }, {
 console.log(books); // Book[]
 ```
 
-Note that there is no such thing as "flushing repository" - it is just a shortcut
-to `em.flush()`. In other words, we always flush the whole Unit of Work, not just
-a single entity that this repository represents.
+Note that there is no such thing as "flushing repository" - it is just a shortcut to `em.flush()`. In other words, we always flush the whole Unit of Work, not just a single entity that this repository represents.
 
 ## Custom Repository
 
-:::info
-Since v4, we need to make sure we are working with correctly typed `EntityRepository` 
-to have access to driver specific methods (like `createQueryBuilder()`). Use the one
-exported from your driver package.
-:::
+:::info Since v4, we need to make sure we are working with correctly typed `EntityRepository` to have access to driver specific methods (like `createQueryBuilder()`). Use the one exported from your driver package. :::
 
 To use custom repository, just extend `EntityRepository<T>` class:
 
@@ -60,19 +50,15 @@ export class Author {
 }
 ```
 
-> `@Repository()` decorator has been removed in v5, use
-> `@Entity({ customRepository: () => MyRepository })` instead.
+> `@Repository()` decorator has been removed in v5, use `@Entity({ customRepository: () => MyRepository })` instead.
 
-Note that we need to pass that repository reference inside a callback so we will not run
-into circular dependency issues when using entity references inside that repository.
+Note that we need to pass that repository reference inside a callback so we will not run into circular dependency issues when using entity references inside that repository.
 
 Now we can access our custom repository via `em.getRepository()` method.
 
 ### Inferring custom repository type
 
-To have the `em.getRepository()` method return correctly typed custom repository
-instead of the generic `EntityRepository<T>`, we can use `EntityRepositoryType`
-symbol:
+To have the `em.getRepository()` method return correctly typed custom repository instead of the generic `EntityRepository<T>`, we can use `EntityRepositoryType` symbol:
 
 ```ts
 @Entity({ customRepository: () => AuthorRepository })
@@ -85,9 +71,6 @@ export class Author {
 const repo = em.getRepository(Author); // repo has type AuthorRepository
 ```
 
-> We can also register custom base repository (for all entities where we do not specify 
-> `customRepository`) globally, via `MikroORM.init({ entityRepository: CustomBaseRepository })`.
+> We can also register custom base repository (for all entities where we do not specify `customRepository`) globally, via `MikroORM.init({ entityRepository: CustomBaseRepository })`.
 
-For more examples, take a look at
-[`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts)
-or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).
+For more examples, take a look at [`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts) or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).

--- a/docs/versioned_docs/version-5.5/schema-generator.md
+++ b/docs/versioned_docs/version-5.5/schema-generator.md
@@ -2,51 +2,41 @@
 title: Schema Generator
 ---
 
-> SchemaGenerator can do harm to your database. It will drop or alter tables, indexes, 
-> sequences and such. Please use this tool with caution in development and not on a 
-> production server. It is meant for helping you develop your Database Schema, but NOT 
-> with migrating schema from A to B in production. A safe approach would be generating 
-> the SQL on development server and saving it into SQL Migration files that are executed 
-> manually on the production server.
+> SchemaGenerator can do harm to your database. It will drop or alter tables, indexes, sequences and such. Please use this tool with caution in development and not on a production server. It is meant for helping you develop your Database Schema, but NOT with migrating schema from A to B in production. A safe approach would be generating the SQL on development server and saving it into SQL Migration files that are executed manually on the production server.
 
-> SchemaGenerator assumes your project uses the given database on its own. Update and Drop 
-> commands will mess with other tables if they are not related to the current project 
-> that is using MikroORM. Please be careful!
+> SchemaGenerator assumes your project uses the given database on its own. Update and Drop commands will mess with other tables if they are not related to the current project that is using MikroORM. Please be careful!
 
-To generate schema from your entity metadata, you can use `SchemaGenerator` helper. 
+To generate schema from your entity metadata, you can use `SchemaGenerator` helper.
 
-You can use it via CLI: 
+You can use it via CLI:
 
-> To work with the CLI, first install `@mikro-orm/cli` package locally.
-> The version needs to be aligned with the `@mikro-orm/core` package.
+> To work with the CLI, first install `@mikro-orm/cli` package locally. The version needs to be aligned with the `@mikro-orm/core` package.
 
 ```sh
 npx mikro-orm schema:create --dump   # Dumps create schema SQL
 npx mikro-orm schema:update --dump   # Dumps update schema SQL
-npx mikro-orm schema:drop --dump     # Dumps drop schema SQL 
+npx mikro-orm schema:drop --dump     # Dumps drop schema SQL
 ```
 
-> You can also use `--run` flag to fire all queries, but be careful as it might break your
-> database. Be sure to always check the generated SQL first before executing. Do not use
-> `--run` flag in production! 
+> You can also use `--run` flag to fire all queries, but be careful as it might break your database. Be sure to always check the generated SQL first before executing. Do not use `--run` flag in production!
 
-`schema:create` will automatically create the database if it does not exist. 
+`schema:create` will automatically create the database if it does not exist.
 
-`schema:update` drops all unknown tables by default, you can use `--no-drop-tables` 
-to get around it. There is also `--safe` flag that will disable both table dropping as 
-well as column dropping. 
+`schema:update` drops all unknown tables by default, you can use `--no-drop-tables` to get around it. There is also `--safe` flag that will disable both table dropping as well as column dropping.
 
-`schema:drop` will by default drop all database tables. You can use `--drop-db` flag to drop
-the whole database instead. 
+`schema:drop` will by default drop all database tables. You can use `--drop-db` flag to drop the whole database instead.
 
 ```shell
 npx mikro-orm schema:fresh --run     # !WARNING! Drops the database schema and recreates it
 ```
+
 This command can be run with the `--seed` option to seed the database after it has been created again.
+
 ```shell
 npx mikro-orm schema:fresh --run --seed              # seed the database with the default database seeder
 npx mikro-orm schema:fresh --run --seed=UsersSeeder  # seed the database with the UsersSeeder
 ```
+
 > You can specify the default database seeder in the orm config with the key `config.seeder.defaultSeeder`
 
 ## Configuration
@@ -64,8 +54,7 @@ const orm = await MikroORM.init({
 });
 ```
 
-> Note that if we disable FK constraints and current schema is using them, the 
-> schema diffing will try to remove those that already exist.
+> Note that if we disable FK constraints and current schema is using them, the schema diffing will try to remove those that already exist.
 
 ## Using SchemaGenerator programmatically
 
@@ -99,7 +88,7 @@ import { MikroORM } from '@mikro-orm/core';
   await generator.dropSchema();
   await generator.createSchema();
   await generator.updateSchema();
-  
+
   // in tests it can be handy to use those:
   await generator.refreshDatabase(); // ensure db exists and is fresh
   await generator.clearDatabase(); // removes all data
@@ -122,12 +111,10 @@ See the [SQL Generated columns](defining-entities.md#SQL Generated columns) sect
 
 ## Limitations of SQLite
 
-There are limitations of SQLite database because of which it behaves differently 
-than other SQL drivers. Namely, it is not possible to:
+There are limitations of SQLite database because of which it behaves differently than other SQL drivers. Namely, it is not possible to:
 
 - create foreign key constraints when altering columns
 - create empty tables without columns
 - alter column requires nullability
 
-Because of this, you can end up with different schema with SQLite, so it is not
-suggested to use SQLite for integration tests of your application.
+Because of this, you can end up with different schema with SQLite, so it is not suggested to use SQLite for integration tests of your application.

--- a/docs/versioned_docs/version-5.5/seeding.md
+++ b/docs/versioned_docs/version-5.5/seeding.md
@@ -2,13 +2,11 @@
 title: Seeding
 ---
 
-When initializing your application or testing it can be exhausting to create sample data for your database. The solution is to use seeding. Create factories for your entities and use them in the seed
-script or combine multiple seed scripts.
+When initializing your application or testing it can be exhausting to create sample data for your database. The solution is to use seeding. Create factories for your entities and use them in the seed script or combine multiple seed scripts.
 
 ## Configuration
 
-> `seeder.path` and `seeder.pathTs` works the same way as `entities` and
-> `entitiesTs` in entity discovery.
+> `seeder.path` and `seeder.pathTs` works the same way as `entities` and `entitiesTs` in entity discovery.
 
 The seeder has a few default settings that can be changed easily through the MikroORM config. Underneath you find the configuration options with their defaults.
 
@@ -35,8 +33,7 @@ We can also override these default using the [environment variables](configurati
 
 ## Seeders
 
-A seeder class contains one method `run`. This method is called when you use the command `npx mikro-orm seeder:run`. In the `run` method you define how and what data you want to insert into the
-database. You can create entities using the [EntityManager](http://mikro-orm.io/docs/entity-manager) or you can use [Factories](#using-entity-factories).
+A seeder class contains one method `run`. This method is called when you use the command `npx mikro-orm seeder:run`. In the `run` method you define how and what data you want to insert into the database. You can create entities using the [EntityManager](http://mikro-orm.io/docs/entity-manager) or you can use [Factories](#using-entity-factories).
 
 You can create your own seeder classes using the following CLI command:
 
@@ -46,15 +43,11 @@ npx mikro-orm seeder:create test            # generates the class TestSeeder
 npx mikro-orm seeder:create project-names   # generates the class ProjectNamesSeeder
 ```
 
-This creates a new seeder class. By default, it will be generated in the `./seeders/` directory. You can configure the directory in the config with the key `seeder.path` or using
-the [environment variable](configuration.md#using-environment-variables) `MIKRO_ORM_SEEDER_PATH`. You are allowed to call the `seeder:create` command with a name, class name or hyphenated name.
+This creates a new seeder class. By default, it will be generated in the `./seeders/` directory. You can configure the directory in the config with the key `seeder.path` or using the [environment variable](configuration.md#using-environment-variables) `MIKRO_ORM_SEEDER_PATH`. You are allowed to call the `seeder:create` command with a name, class name or hyphenated name.
 
 As an example we will look at a very basic seeder.
 
-> Note that the `EntityManager` available in seeders will have `persistOnCreate`
-> enabled, hence calling `em.create()` will automatically call `em.persist()`
-> on the created entity. If we use entity constructor instead, we need to call
-> `em.persist()` explicitly.
+> Note that the `EntityManager` available in seeders will have `persistOnCreate` enabled, hence calling `em.create()` will automatically call `em.persist()` on the created entity. If we use entity constructor instead, we need to call `em.persist()` explicitly.
 
 ```ts title="./database/seeder/database.seeder.ts"
 import { EntityManager } from '@mikro-orm/core';
@@ -80,8 +73,7 @@ export class DatabaseSeeder extends Seeder {
 
 ### Using entity factories
 
-Instead of specifying all the attributes for every entity, you can also use [entity factories](#entity-factories). These can be used to generate large amounts of database records. Please read
-the [documentation on how to define factories](#entity-factories) to learn how to define your factories.
+Instead of specifying all the attributes for every entity, you can also use [entity factories](#entity-factories). These can be used to generate large amounts of database records. Please read the [documentation on how to define factories](#entity-factories) to learn how to define your factories.
 
 As an example we will generate 10 authors.
 
@@ -100,8 +92,7 @@ export class DatabaseSeeder extends Seeder {
 
 ### Calling additional seeders
 
-Inside the `run` method you can specify other seeder classes. You can use the `call` method to break up the database seeder into multiple files to prevent a seeder file from becoming too large.
-The `call` method requires an `em` and an array of seeder classes.
+Inside the `run` method you can specify other seeder classes. You can use the `call` method to break up the database seeder into multiple files to prevent a seeder file from becoming too large. The `call` method requires an `em` and an array of seeder classes.
 
 ```ts
 import { EntityManager } from '@mikro-orm/core';
@@ -148,8 +139,7 @@ export class BookSeeder extends Seeder {
 
 ## Entity factories
 
-When testing you may insert entities in the database before starting a test. Instead of specifying every attribute of every entity by hand, you could also use a `Factory` to define a set of default
-attributes for an entity using entity factories.
+When testing you may insert entities in the database before starting a test. Instead of specifying every attribute of every entity by hand, you could also use a `Factory` to define a set of default attributes for an entity using entity factories.
 
 Lets have a look at an example factory for an [Author entity](http://mikro-orm.io/docs/defining-entities).
 
@@ -168,10 +158,9 @@ export class AuthorFactory extends Factory<Author> {
     };
   }
 }
-``` 
+```
 
-Basically you extend the base `Factory` class, define a `model` property and a `definition` method. The `model` defines for which entity the factory generates entity instances. The `definition` method
-returns the default set of attribute values that should be applied when creating an entity using the factory.
+Basically you extend the base `Factory` class, define a `model` property and a `definition` method. The `model` defines for which entity the factory generates entity instances. The `definition` method returns the default set of attribute values that should be applied when creating an entity using the factory.
 
 Via the faker property, factories have access to the [Faker library](https://github.com/faker-js/faker), which allows you to conveniently generate various kinds of random data for testing.
 
@@ -190,18 +179,17 @@ Generate multiple entities by calling the `make` method. The parameter of the `m
 ```ts
 // Generate 5 authors
 const authors = new AuthorFactory(orm.em).make(5);
-``` 
+```
 
 #### Overriding attributes
 
-If you would like to override some of the default values of your factories, you may pass an object to the make method. Only the specified attributes will be replaced while the rest of the attributes
-remain set to their default values as specified by the factory.
+If you would like to override some of the default values of your factories, you may pass an object to the make method. Only the specified attributes will be replaced while the rest of the attributes remain set to their default values as specified by the factory.
 
 ```ts
 const author = new AuthorFactory(orm.em).make({
   name: 'John Snow',
 });
-``` 
+```
 
 ### Persisting entities
 
@@ -231,9 +219,7 @@ const authors = await new AuthorFactory(orm.em).create(5, {
 
 ### Factory relationships
 
-It is nice to create large quantities of data for one entity, but most of the time we want to create data for multiple entities and also have relations between these. For this we can use the `each`
-method which can be chained on a factory. The `each` method can be called with a function that transforms output entity from the factory before returning it. Lets look at some examples for the
-different relations.
+It is nice to create large quantities of data for one entity, but most of the time we want to create data for multiple entities and also have relations between these. For this we can use the `each` method which can be chained on a factory. The `each` method can be called with a function that transforms output entity from the factory before returning it. Lets look at some examples for the different relations.
 
 #### ManyToOne and OneToOne relations
 
@@ -241,7 +227,7 @@ different relations.
 const books: Book[] = new BookFactory(orm.em).each(book => {
   book.author = new AuthorFactory(orm.em).makeOne();
 }).make(5);
-``` 
+```
 
 #### OneToMany and ManyToMany
 
@@ -249,13 +235,11 @@ const books: Book[] = new BookFactory(orm.em).each(book => {
 const books: Book[] = new BookFactory(orm.em).each(book => {
   book.owners.set(new OwnerFactory(orm.em).make(5));
 }).make(5);
-``` 
+```
 
 ## Use with CLI
 
-You may execute the `seeder:run` MikroORM CLI command to seed your database. By default, the `seeder:run` command runs the `DatabaseSeeder` class, which may in turn invoke other seed classes. You can
-configure the default seeder using the key `seeder.defaultSeeder` or using the [environment variable](configuration.md#using-environment-variables) `MIKRO_ORM_SEEDER_DEFAULT_SEEDER`. You can also use
-the `--class` option to specify a seeder class:
+You may execute the `seeder:run` MikroORM CLI command to seed your database. By default, the `seeder:run` command runs the `DatabaseSeeder` class, which may in turn invoke other seed classes. You can configure the default seeder using the key `seeder.defaultSeeder` or using the [environment variable](configuration.md#using-environment-variables) `MIKRO_ORM_SEEDER_DEFAULT_SEEDER`. You can also use the `--class` option to specify a seeder class:
 
 ```shell script
 npx mikro-orm seeder:run
@@ -263,8 +247,7 @@ npx mikro-orm seeder:run
 npx mikro-orm seeder:run --class=BookSeeder
 ```
 
-You may also seed your database using the [`migrate:fresh`](migrations.md#using-via-cli) or [`schema:fresh`](schema-generator.md) command in combination with the `--seed` option, which will drop all
-tables and re-run all of your migrations or generate the database based on the current entities. This command is useful for completely re-building your database:
+You may also seed your database using the [`migrate:fresh`](migrations.md#using-via-cli) or [`schema:fresh`](schema-generator.md) command in combination with the `--seed` option, which will drop all tables and re-run all of your migrations or generate the database based on the current entities. This command is useful for completely re-building your database:
 
 ```shell script
 npx mikro-orm migration:fresh --seed    # will drop the database, run all migrations and the DatabaseSeeder class
@@ -272,8 +255,7 @@ npx mikro-orm migration:fresh --seed    # will drop the database, run all migrat
 npx mikro-orm schema:fresh --seed       # will recreate the database and run the DatabaseSeeder class
 ```
 
-If you do not want to run the `DatabaseSeeder` class you can either specify what the default seeder class should be. This can be done by changing the [default settings](#default-settings). Another
-option is to explicitly define the seeder class you want to run.
+If you do not want to run the `DatabaseSeeder` class you can either specify what the default seeder class should be. This can be done by changing the [default settings](#default-settings). Another option is to explicitly define the seeder class you want to run.
 
 ```shell script
 npx mikro-orm migration:fresh --seed TestSeeder       # will drop the database, run all migrations and the TestSeeder class
@@ -327,6 +309,4 @@ await MikroORM.init({
 });
 ```
 
-This should allow using CLI to generate TS seeder files (as in CLI we probably
-have TS support enabled), while using compiled JS files in production, where ts-node
-is not registered.
+This should allow using CLI to generate TS seeder files (as in CLI we probably have TS support enabled), while using compiled JS files in production, where ts-node is not registered.

--- a/docs/versioned_docs/version-5.5/serializing.md
+++ b/docs/versioned_docs/version-5.5/serializing.md
@@ -12,9 +12,7 @@ export interface AnyEntity<K = number | string> {
 }
 ```
 
-When you serialize your entity via `JSON.stringify(entity)`, its `toJSON` method will be 
-called automatically. You can provide custom implementation for `toJSON`, while using 
-`toObject` for initial serialization:
+When you serialize your entity via `JSON.stringify(entity)`, its `toJSON` method will be called automatically. You can provide custom implementation for `toJSON`, while using `toObject` for initial serialization:
 
 ```ts
 @Entity()
@@ -35,13 +33,11 @@ export class Book {
 }
 ```
 
-> Do not forget to pass rest params when calling `toObject(...args)`, otherwise the results
-> might not be stable.
+> Do not forget to pass rest params when calling `toObject(...args)`, otherwise the results might not be stable.
 
 ## Hidden Properties
 
-If you want to omit some properties from serialized result, you can mark them with `hidden`
-flag on `@Property()` decorator:
+If you want to omit some properties from serialized result, you can mark them with `hidden` flag on `@Property()` decorator:
 
 ```ts
 @Entity()
@@ -59,13 +55,9 @@ console.log(wrap(book).toJSON().hiddenField); // undefined
 
 ## Shadow Properties
 
-The opposite situation where you want to define a property that lives only in memory (is 
-not persisted into database) can be solved by defining your property as `persist: false`. 
-Such property can be assigned via one of `Entity.assign()`, `em.create()` and 
-`em.merge()`. It will be also part of serialized result. 
+The opposite situation where you want to define a property that lives only in memory (is not persisted into database) can be solved by defining your property as `persist: false`. Such property can be assigned via one of `Entity.assign()`, `em.create()` and `em.merge()`. It will be also part of serialized result.
 
-This can be handle when dealing with additional values selected via `QueryBuilder` or 
-MongoDB's aggregations.
+This can be handle when dealing with additional values selected via `QueryBuilder` or MongoDB's aggregations.
 
 ```ts
 @Entity()
@@ -84,8 +76,7 @@ console.log(wrap(book).toJSON().count); // 123
 
 ## Property Serializers
 
-As an alternative to custom `toJSON()` method, we can also use property serializers.
-They allow to specify a callback that will be used when serializing a property:
+As an alternative to custom `toJSON()` method, we can also use property serializers. They allow to specify a callback that will be used when serializing a property:
 
 ```ts
 @Entity()

--- a/docs/versioned_docs/version-5.5/transactions.md
+++ b/docs/versioned_docs/version-5.5/transactions.md
@@ -6,28 +6,17 @@ title: Transactions and Concurrency
 
 ## Transaction Demarcation
 
-Transaction demarcation is the task of defining your transaction boundaries. Proper 
-transaction demarcation is very important because if not done properly it can negatively 
-affect the performance of your application. Many databases and database abstraction 
-layers by default operate in auto-commit mode, which means that every single SQL statement 
-is wrapped in a small transaction. Without any explicit transaction demarcation from your 
-side, this quickly results in poor performance because transactions are not cheap. 
+Transaction demarcation is the task of defining your transaction boundaries. Proper transaction demarcation is very important because if not done properly it can negatively affect the performance of your application. Many databases and database abstraction layers by default operate in auto-commit mode, which means that every single SQL statement is wrapped in a small transaction. Without any explicit transaction demarcation from your side, this quickly results in poor performance because transactions are not cheap.
 
-For the most part, MikroORM already takes care of proper transaction demarcation for you: 
-All the write operations (INSERT/UPDATE/DELETE) are queued until `em.flush()` 
-is invoked which wraps all of these changes in a single transaction.
+For the most part, MikroORM already takes care of proper transaction demarcation for you: All the write operations (INSERT/UPDATE/DELETE) are queued until `em.flush()` is invoked which wraps all of these changes in a single transaction.
 
-However, MikroORM also allows (and encourages) you to take over and control transaction 
-demarcation yourself.
+However, MikroORM also allows (and encourages) you to take over and control transaction demarcation yourself.
 
-These are two ways to deal with transactions when using the MikroORM and are now described 
-in more detail.
+These are two ways to deal with transactions when using the MikroORM and are now described in more detail.
 
 ### Approach 1: Implicitly
 
-The first approach is to use the implicit transaction handling provided by the MikroORM 
-`EntityManager`. Given the following code snippet, without any explicit transaction 
-demarcation:
+The first approach is to use the implicit transaction handling provided by the MikroORM `EntityManager`. Given the following code snippet, without any explicit transaction demarcation:
 
 ```ts
 const user = new User(...);
@@ -35,16 +24,11 @@ user.name = 'George';
 await orm.em.persistAndFlush(user);
 ```
 
-Since we do not do any custom transaction demarcation in the above code, `em.flush()` 
-will begin and commit/rollback a transaction. This behavior is made possible by the 
-aggregation of the DML operations by the MikroORM and is sufficient if all the data 
-manipulation that is part of a unit of work happens through the domain model and thus 
-the ORM.
+Since we do not do any custom transaction demarcation in the above code, `em.flush()` will begin and commit/rollback a transaction. This behavior is made possible by the aggregation of the DML operations by the MikroORM and is sufficient if all the data manipulation that is part of a unit of work happens through the domain model and thus the ORM.
 
 ### Approach 2: Explicitly
 
-The explicit alternative is to use the transactions API directly to control the boundaries. 
-The code then looks like this:
+The explicit alternative is to use the transactions API directly to control the boundaries. The code then looks like this:
 
 ```ts
 await orm.em.transactional(em => {
@@ -55,8 +39,7 @@ await orm.em.transactional(em => {
 });
 ```
 
-Or you can use `begin/commit/rollback` methods explicitly. Following example is
-equivalent to the previous one:
+Or you can use `begin/commit/rollback` methods explicitly. Following example is equivalent to the previous one:
 
 ```ts
 const em = orm.em.fork();
@@ -74,68 +57,37 @@ try {
 }
 ```
 
-Explicit transaction demarcation is required when you want to include custom DBAL operations 
-in a unit of work or when you want to make use of some methods of the EntityManager API 
-that require an active transaction. Such methods will throw a `ValidationError` to inform 
-you of that requirement.
+Explicit transaction demarcation is required when you want to include custom DBAL operations in a unit of work or when you want to make use of some methods of the EntityManager API that require an active transaction. Such methods will throw a `ValidationError` to inform you of that requirement.
 
 `em.transactional(cb)` will flush the inner `EntityManager` prior to transaction commit.
 
 ### Exception Handling
 
-When using implicit transaction demarcation and an exception occurs during 
-`em.flush()`, the transaction is automatically rolled back.
+When using implicit transaction demarcation and an exception occurs during `em.flush()`, the transaction is automatically rolled back.
 
-When using explicit transaction demarcation and an exception occurs, the transaction should 
-be rolled back immediately as demonstrated in the example above. This can be handled elegantly 
-by the control abstractions shown earlier. Note that when catching Exception you should 
-generally re-throw the exception. If you intend to recover from some exceptions, catch them 
-explicitly in earlier catch blocks (but do not forget to rollback the transaction). All 
-other best practices of exception handling apply similarly (i.e. either log or re-throw, 
-not both, etc.).
+When using explicit transaction demarcation and an exception occurs, the transaction should be rolled back immediately as demonstrated in the example above. This can be handled elegantly by the control abstractions shown earlier. Note that when catching Exception you should generally re-throw the exception. If you intend to recover from some exceptions, catch them explicitly in earlier catch blocks (but do not forget to rollback the transaction). All other best practices of exception handling apply similarly (i.e. either log or re-throw, not both, etc.).
 
-As a result of this procedure, all previously managed or removed instances of the `EntityManager` 
-become detached. The state of the detached objects will be the state at the point at which the 
-transaction was rolled back. The state of the objects is in no way rolled back and thus the 
-objects are now out of sync with the database. The application can continue to use the detached 
-objects, knowing that their state is potentially no longer accurate.
+As a result of this procedure, all previously managed or removed instances of the `EntityManager` become detached. The state of the detached objects will be the state at the point at which the transaction was rolled back. The state of the objects is in no way rolled back and thus the objects are now out of sync with the database. The application can continue to use the detached objects, knowing that their state is potentially no longer accurate.
 
-If you intend to start another unit of work after an exception has occurred you should do 
-that with a new `EntityManager`. Simply use `em.fork()` to obtain fresh copy 
-with cleared identity map. 
+If you intend to start another unit of work after an exception has occurred you should do that with a new `EntityManager`. Simply use `em.fork()` to obtain fresh copy with cleared identity map.
 
 ## Locking Support
 
 ### Why we need concurrency control?
 
-If transactions are executed serially (one at a time), no transaction concurrency exists. 
-However, if concurrent transactions with interleaving operations are allowed, you may easily 
-run into one of those problems:
+If transactions are executed serially (one at a time), no transaction concurrency exists. However, if concurrent transactions with interleaving operations are allowed, you may easily run into one of those problems:
 
 1. The lost update problem
 2. The dirty read problem
 3. The incorrect summary problem
 
-To mitigate those problems, MikroORM offers support for Pessimistic and Optimistic locking 
-strategies natively. This allows you to take very fine-grained control over what kind of 
-locking is required for your entities in your application.
+To mitigate those problems, MikroORM offers support for Pessimistic and Optimistic locking strategies natively. This allows you to take very fine-grained control over what kind of locking is required for your entities in your application.
 
 ### Optimistic Locking
 
-Database transactions are fine for concurrency control during a single request. However, a 
-database transaction should not span across requests, the so-called "user think time". Therefore 
-a long-running "business transaction" that spans multiple requests needs to involve several 
-database transactions. Thus, database transactions alone can no longer control concurrency 
-during such a long-running business transaction. Concurrency control becomes the partial 
-responsibility of the application itself.
+Database transactions are fine for concurrency control during a single request. However, a database transaction should not span across requests, the so-called "user think time". Therefore a long-running "business transaction" that spans multiple requests needs to involve several database transactions. Thus, database transactions alone can no longer control concurrency during such a long-running business transaction. Concurrency control becomes the partial responsibility of the application itself.
 
-MikroORM has integrated support for automatic optimistic locking via a version field. In 
-this approach any entity that should be protected against concurrent modifications during 
-long-running business transactions gets a version field that is either a simple number 
-(mapping type: integer) or a timestamp (mapping type: datetime). When changes to such an 
-entity are persisted at the end of a long-running conversation the version of the entity 
-is compared to the version in the database and if they don't match, a `OptimisticLockError` 
-is thrown, indicating that the entity has been modified by someone else already.
+MikroORM has integrated support for automatic optimistic locking via a version field. In this approach any entity that should be protected against concurrent modifications during long-running business transactions gets a version field that is either a simple number (mapping type: integer) or a timestamp (mapping type: datetime). When changes to such an entity are persisted at the end of a long-running conversation the version of the entity is compared to the version in the database and if they don't match, a `OptimisticLockError` is thrown, indicating that the entity has been modified by someone else already.
 
 You designate a version field in an entity as follows. In this example we'll use an integer.
 
@@ -159,23 +111,13 @@ export class User {
 }
 ```
 
-Version numbers (not timestamps) should however be preferred as they can not potentially 
-conflict in a highly concurrent environment, unlike timestamps where this is a possibility, 
-depending on the resolution of the timestamp on the particular database platform.
+Version numbers (not timestamps) should however be preferred as they can not potentially conflict in a highly concurrent environment, unlike timestamps where this is a possibility, depending on the resolution of the timestamp on the particular database platform.
 
-When a version conflict is encountered during `em.flush()`, a `OptimisticLockError` 
-is thrown and the active transaction rolled back (or marked for rollback). This exception 
-can be caught and handled. Potential responses to a `OptimisticLockError` are to present the 
-conflict to the user or to refresh or reload objects in a new transaction and then retrying 
-the transaction.
+When a version conflict is encountered during `em.flush()`, a `OptimisticLockError` is thrown and the active transaction rolled back (or marked for rollback). This exception can be caught and handled. Potential responses to a `OptimisticLockError` are to present the conflict to the user or to refresh or reload objects in a new transaction and then retrying the transaction.
 
-The time between showing an update form and actually modifying the entity can in the worst 
-scenario be as long as your application's session timeout. If changes happen to the entity 
-in that time frame you want to know directly when retrieving the entity that you will hit 
-an optimistic locking exception:
+The time between showing an update form and actually modifying the entity can in the worst scenario be as long as your application's session timeout. If changes happen to the entity in that time frame you want to know directly when retrieving the entity that you will hit an optimistic locking exception:
 
-You can always verify the version of an entity during a request either when calling 
-`em.findOne()`:
+You can always verify the version of an entity during a request either when calling `em.findOne()`:
 
 ```ts
 const theEntityId = 1;
@@ -209,14 +151,9 @@ try {
 
 ### Concurrency Checks
 
-As opposed to version fields that are handled automatically, we can use 
-concurrency checks. They allow us to mark specific properties to be included
-in the concurrency check, just like the version field was. But this time, we
-will be responsible for updating the fields explicitly.
+As opposed to version fields that are handled automatically, we can use concurrency checks. They allow us to mark specific properties to be included in the concurrency check, just like the version field was. But this time, we will be responsible for updating the fields explicitly.
 
-When we try to update such entity without changing one of the concurrency fields,
-`OptimisticLockError` will be thrown. Same mechanism is then used to check whether
-the update succeeded, and throw the same type of error when not.
+When we try to update such entity without changing one of the concurrency fields, `OptimisticLockError` will be thrown. Same mechanism is then used to check whether the update succeeded, and throw the same type of error when not.
 
 ```ts
 @Entity()
@@ -241,23 +178,16 @@ export class ConcurrencyCheckUser {
 
 #### Important Implementation Notes
 
-You can easily get the optimistic locking workflow wrong if you compare the wrong versions. 
-Say you have Alice and Bob editing a hypothetical blog post:
+You can easily get the optimistic locking workflow wrong if you compare the wrong versions. Say you have Alice and Bob editing a hypothetical blog post:
 
 - Alice reads the headline of the blog post being "Foo", at optimistic lock version 1 (GET Request)
 - Bob reads the headline of the blog post being "Foo", at optimistic lock version 1 (GET Request)
 - Bob updates the headline to "Bar", upgrading the optimistic lock version to 2 (POST Request of a Form)
 - Alice updates the headline to "Baz", ... (POST Request of a Form)
 
-Now at the last stage of this scenario the blog post has to be read again from the database 
-before Alice's headline can be applied. At this point you will want to check if the blog 
-post is still at version 1 (which it is not in this scenario).
+Now at the last stage of this scenario the blog post has to be read again from the database before Alice's headline can be applied. At this point you will want to check if the blog post is still at version 1 (which it is not in this scenario).
 
-Using optimistic locking correctly, you **have** to add the version as an additional hidden 
-field (or into the session for more safety). Otherwise you cannot verify the version is still 
-the one being originally read from the database when Alice performed her GET request for the 
-blog post. If this happens you might see lost updates you wanted to prevent with Optimistic 
-Locking.
+Using optimistic locking correctly, you **have** to add the version as an additional hidden field (or into the session for more safety). Otherwise you cannot verify the version is still the one being originally read from the database when Alice performed her GET request for the blog post. If this happens you might see lost updates you wanted to prevent with Optimistic Locking.
 
 See the example code (frontend):
 
@@ -296,33 +226,24 @@ async update(req, res) {
 }
 ```
 
-Your frontend app loads an entity from API, the response includes the version property. 
-User makes some changes and fires PUT request back to the API, with version field included 
-in the payload. The PUT handler of the API then reads the version and passes it to the 
-`em.findOne()` call.
+Your frontend app loads an entity from API, the response includes the version property. User makes some changes and fires PUT request back to the API, with version field included in the payload. The PUT handler of the API then reads the version and passes it to the `em.findOne()` call.
 
 ### Pessimistic Locking
 
-MikroORM supports Pessimistic Locking at the database level. No attempt is being made to implement 
-pessimistic locking inside MikroORM, rather vendor-specific and ANSI-SQL commands are used to 
-acquire row-level locks. Every Entity can be part of a pessimistic lock, there is no special 
-metadata required to use this feature.
+MikroORM supports Pessimistic Locking at the database level. No attempt is being made to implement pessimistic locking inside MikroORM, rather vendor-specific and ANSI-SQL commands are used to acquire row-level locks. Every Entity can be part of a pessimistic lock, there is no special metadata required to use this feature.
 
-However, for Pessimistic Locking to work you have to disable the Auto-Commit Mode of your Database 
-and start a transaction around your pessimistic lock use-case using the "Approach 2: Explicit 
-Transaction Demarcation" described above. MikroORM will throw an Exception if you attempt to 
-acquire a pessimistic lock and no transaction is running.
+However, for Pessimistic Locking to work you have to disable the Auto-Commit Mode of your Database and start a transaction around your pessimistic lock use-case using the "Approach 2: Explicit Transaction Demarcation" described above. MikroORM will throw an Exception if you attempt to acquire a pessimistic lock and no transaction is running.
 
 MikroORM currently supports 6 pessimistic lock modes:
 
-| Mode | Postgres | MySQL |
-|------|----------|-------|
-| `LockMode.PESSIMISTIC_READ` | `for share` | `lock in share mode` |
-| `LockMode.PESSIMISTIC_WRITE` | `for update` | `for update` |
-| `LockMode.PESSIMISTIC_PARTIAL_WRITE` | `for update skip locked` | `for update skip locked` |
-| `LockMode.PESSIMISTIC_WRITE_OR_FAIL` | `for update nowait` | `for update nowait` |
-| `LockMode.PESSIMISTIC_PARTIAL_READ` | `for share skip locked` | `lock in share mode skip locked` |
-| `LockMode.PESSIMISTIC_READ_OR_FAIL` | `for share nowait` | `lock in share mode nowait` |
+| Mode                                 | Postgres                 | MySQL                            |
+| ------------------------------------ | ------------------------ | -------------------------------- |
+| `LockMode.PESSIMISTIC_READ`          | `for share`              | `lock in share mode`             |
+| `LockMode.PESSIMISTIC_WRITE`         | `for update`             | `for update`                     |
+| `LockMode.PESSIMISTIC_PARTIAL_WRITE` | `for update skip locked` | `for update skip locked`         |
+| `LockMode.PESSIMISTIC_WRITE_OR_FAIL` | `for update nowait`      | `for update nowait`              |
+| `LockMode.PESSIMISTIC_PARTIAL_READ`  | `for share skip locked`  | `lock in share mode skip locked` |
+| `LockMode.PESSIMISTIC_READ_OR_FAIL`  | `for share nowait`       | `lock in share mode nowait`      |
 
 You can use pessimistic locks in three different scenarios:
 
@@ -342,10 +263,10 @@ const res = await em.find(User, { name: 'Jon' }, {
   lockTableAliases: ['e0'],
 });
 
-// select ... 
+// select ...
 //   from "user" as "e0"
-//   left join "identity" as "i1" on "e0"."id" = "i1"."user_id" 
-//   where "e0"."name" = 'Jon' 
+//   left join "identity" as "i1" on "e0"."id" = "i1"."user_id"
+//   where "e0"."name" = 'Jon'
 //   for update of "e0" skip locked
 ```
 
@@ -367,5 +288,4 @@ Available isolation levels:
 - `IsolationLevel.REPEATABLE_READ`
 - `IsolationLevel.SERIALIZABLE`
 
-> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html) as the behaviour here is pretty much the same.

--- a/docs/versioned_docs/version-5.5/type-safe-relations.md
+++ b/docs/versioned_docs/version-5.5/type-safe-relations.md
@@ -58,15 +58,15 @@ You can overcome this issue by using the `Reference` wrapper. It simply wraps th
 You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>`, which works like `load()` but returns the specified property.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 import { Entity, Ref, ManyToOne, PrimaryKey, ref } from '@mikro-orm/core';
@@ -329,15 +329,15 @@ console.log(book.author.myPrimaryKey); // ok, returns the PK
 For MongoDB, define the PK generic type argument as `'id' | '_id'` to access both `string` and `ObjectId` PK values:
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
@@ -403,4 +403,4 @@ console.log(book.author.id); // ok, returns string PK
 console.log(book.author._id); // ok, returns ObjectId PK
 ```
 
-> As opposed to `wrap(e).init()` which always refreshes the entity, `Reference.load()` method will query the database only if the entity is not already loaded in Identity Map. 
+> As opposed to `wrap(e).init()` which always refreshes the entity, `Reference.load()` method will query the database only if the entity is not already loaded in Identity Map.

--- a/docs/versioned_docs/version-5.5/upgrading-v2-to-v3.md
+++ b/docs/versioned_docs/version-5.5/upgrading-v2-to-v3.md
@@ -2,19 +2,13 @@
 title: Upgrading from v2 to v3
 ---
 
-Following sections describe (hopefully) all breaking changes, most of them might be not valid 
-for you, like if you do not use custom `NamingStrategy` implementation, you do not care about
-the interface being changed.
+Following sections describe (hopefully) all breaking changes, most of them might be not valid for you, like if you do not use custom `NamingStrategy` implementation, you do not care about the interface being changed.
 
 ## Default value of autoFlush has changed to false
 
-> If you had `autoFlush: false` in your ORM configuration before, you can now remove 
-> this line, no changes are needed in your app. 
+> If you had `autoFlush: false` in your ORM configuration before, you can now remove this line, no changes are needed in your app.
 
-Default value for `autoFlush` is now `false`. That means you need to call 
-`em.flush()` yourself to persist changes into database. You can still change this via ORM's
-options to ease the transition but generally it is not recommended as it can cause unwanted
-small transactions being created around each `persist`. 
+Default value for `autoFlush` is now `false`. That means you need to call `em.flush()` yourself to persist changes into database. You can still change this via ORM's options to ease the transition but generally it is not recommended as it can cause unwanted small transactions being created around each `persist`.
 
 ```ts
 orm.em.persist(new Entity()); // no auto-flushing by default
@@ -24,29 +18,20 @@ await orm.em.persist(new Entity(), true); // you can still use second parameter 
 
 ## Reworked entity definition
 
-> Implementing those interfaces is optional.  
+> Implementing those interfaces is optional.
 
-Now it is no longer needed to merge entities with `IEntity` interface, that was polluting entity's 
-interface with internal methods. New interfaces `IdentifiedEntity<T>`, `UuidEntity<T>` and `MongoEntity<T>` 
-are introduced, that can be implemented by entities. They are not adding any new properties or methods, 
-keeping the entity's interface clean. This is also the reason why they can be omitted.
+Now it is no longer needed to merge entities with `IEntity` interface, that was polluting entity's interface with internal methods. New interfaces `IdentifiedEntity<T>`, `UuidEntity<T>` and `MongoEntity<T>` are introduced, that can be implemented by entities. They are not adding any new properties or methods, keeping the entity's interface clean. This is also the reason why they can be omitted.
 
-`IEntity` interface has been renamed to `AnyEntity<T, PK>` and it no longer has public methods 
-like `toJSON()`, `toObject()` or `init()`. One can use `wrap()` method provided by ORM that
-will enhance property type when needed with those methods (`await wrap(book.author).init()`). 
-To keep all methods available on the entity, you can still use interface merging with 
-`WrappedEntity<T, PK>` that both extends `AnyEntity<T, PK>` and defines all those methods.
+`IEntity` interface has been renamed to `AnyEntity<T, PK>` and it no longer has public methods like `toJSON()`, `toObject()` or `init()`. One can use `wrap()` method provided by ORM that will enhance property type when needed with those methods (`await wrap(book.author).init()`). To keep all methods available on the entity, you can still use interface merging with `WrappedEntity<T, PK>` that both extends `AnyEntity<T, PK>` and defines all those methods.
 
 You can mark the entity by implementing one of `*Entity` interfaces:
 
 - `IdEntity<T>` for numeric/string PK on `id` property (`id: number`)
 - `UuidEntity<T>` for string PK on `uuid` property (`uuid: string`)
 - `MongoEntity<T>` for mongo, where `id: string` and `_id: ObjectId` are required
-- `AnyEntity<T, PK>` for other possible properties (fill the PK property name to `PK` 
-parameter, e.g.: `AnyEntity<Book, 'myPrimaryProperty'>'`)
+- `AnyEntity<T, PK>` for other possible properties (fill the PK property name to `PK` parameter, e.g.: `AnyEntity<Book, 'myPrimaryProperty'>'`)
 
-To keep all public methods that were part of `IEntity` interface in v2, you can use 
-`WrappedEntity<T, PK>` via interface merging:
+To keep all public methods that were part of `IEntity` interface in v2, you can use `WrappedEntity<T, PK>` via interface merging:
 
 ```ts
 @Entity()
@@ -58,37 +43,25 @@ For more examples, take a look at [defining entities section](defining-entities.
 
 ## Integrated Knex.js as query builder and runner
 
-`QueryBuilder` now internally uses knex to run all queries. As knex already supports connection 
-pooling, this feature comes without any effort. New configuration for pooling is now available
+`QueryBuilder` now internally uses knex to run all queries. As knex already supports connection pooling, this feature comes without any effort. New configuration for pooling is now available
 
-Transactions now require using `em.transactional()` method, previous helpers 
-`beginTransaction`/`commit`/`rollback` are now removed.
+Transactions now require using `em.transactional()` method, previous helpers `beginTransaction`/`commit`/`rollback` are now removed.
 
-All transaction management has been removed from `IDatabaseDriver` interface, now EM handles 
-this, passing the transaction context (carried by EM, and created by `Connection`) to all 
-driver methods. New methods on EM exists: `isInTransaction()` and `getTransactionContext()`.
+All transaction management has been removed from `IDatabaseDriver` interface, now EM handles this, passing the transaction context (carried by EM, and created by `Connection`) to all driver methods. New methods on EM exists: `isInTransaction()` and `getTransactionContext()`.
 
-In postgres driver, it used to be required to pass parameters as indexed dollar sign 
-($1, $2, ...), while now knex requires the placeholder to be simple question mark (`?`), 
-like in other dialects, so this is now unified with other drivers.
+In postgres driver, it used to be required to pass parameters as indexed dollar sign ($1, $2, ...), while now knex requires the placeholder to be simple question mark (`?`), like in other dialects, so this is now unified with other drivers.
 
 ## ManyToMany now uses composite primary key
 
-Previously it was required to have autoincrement primary key for m:n pivot tables. Now this 
-has changed. By default, only foreign columns are required and composite key over both of them
-is used as primary key.
+Previously it was required to have autoincrement primary key for m:n pivot tables. Now this has changed. By default, only foreign columns are required and composite key over both of them is used as primary key.
 
-To preserve stable order of collections, you can force previous behaviour by defining the 
-m:n property as `fixedOrder: true`, which will start ordering by `id` column. You can also 
-override the order column name via `fixedOrderColumn: 'order'`. 
+To preserve stable order of collections, you can force previous behaviour by defining the m:n property as `fixedOrder: true`, which will start ordering by `id` column. You can also override the order column name via `fixedOrderColumn: 'order'`.
 
 You can also specify default ordering via `orderBy: { ... }` attribute.
 
 ## Entity references now don't have instantiated collections
 
-Previously all entity instances, including entity references (not fully loaded entities where
-we know only the primary key), had instantiated collection classes. Now only initialized entities
-have them.
+Previously all entity instances, including entity references (not fully loaded entities where we know only the primary key), had instantiated collection classes. Now only initialized entities have them.
 
 ```ts
 const book = em.getReference(Book, 1);
@@ -99,12 +72,9 @@ console.log(book.tags); // instance of Collection (not initialized)
 
 ## EntityAssigner.assign() requires EM for new entities
 
-Previously all entities had internal reference to the root EM - the one created when 
-initializing the ORM. Now only managed entities (those merged to the EM, e.g. loaded 
-from the database) have this internal reference. 
+Previously all entities had internal reference to the root EM - the one created when initializing the ORM. Now only managed entities (those merged to the EM, e.g. loaded from the database) have this internal reference.
 
-To use `assign()` method on new (not managed) entities, you need to provide the `em`
-parameter:
+To use `assign()` method on new (not managed) entities, you need to provide the `em` parameter:
 
 ```ts
 const book = new Book();
@@ -113,46 +83,36 @@ wrap(book).assign(data, { em: orm.em });
 
 ## Strict FilterQuery and smart query conditions
 
-`FilterQuery` now does not allow using smart query operators. You can either cast your condition 
-as any or use object syntax instead (instead of `{ 'age:gte': 18 }` use `{ age: { $gte: 18 } }`).
+`FilterQuery` now does not allow using smart query operators. You can either cast your condition as any or use object syntax instead (instead of `{ 'age:gte': 18 }` use `{ age: { $gte: 18 } }`).
 
 ## Logging configuration
 
-Previously to start logging it was required to provide your custom logger. Logger now defaults 
-to `console.log()`, and users can specify what namespaces are they interested in via `debug` 
-option. `true`/`false` will enable/disable all namespaces.
+Previously to start logging it was required to provide your custom logger. Logger now defaults to `console.log()`, and users can specify what namespaces are they interested in via `debug` option. `true`/`false` will enable/disable all namespaces.
 
 Available logger namespaces: `'query' | 'query-params' | 'discovery' | 'info'`.
 
-## Removed deprecated fk option from 1:m and m:1 decorators 
+## Removed deprecated fk option from 1:m and m:1 decorators
 
 Use `mappedBy`/`inversedBy` instead.
 
 ## SchemaGenerator.generate() is now async
 
-If you used `SchemaGenerator`, now there is CLI tool you can use instead. Learn more 
-in [SchemaGenerator docs](schema-generator.md). To setup CLI, take a look at 
-[installation section](installation.md).
+If you used `SchemaGenerator`, now there is CLI tool you can use instead. Learn more in [SchemaGenerator docs](schema-generator.md). To setup CLI, take a look at [installation section](installation.md).
 
 ## New method on NamingStrategy interface
 
-`getClassName()` is used to find entity class name based on its file name. Now users can 
-override the default implementation to accommodate their specific needs.
+`getClassName()` is used to find entity class name based on its file name. Now users can override the default implementation to accommodate their specific needs.
 
-If you used custom naming strategy, you will either need to implement this method yourself, 
-or extend `AbstractNamingStrategy`.
+If you used custom naming strategy, you will either need to implement this method yourself, or extend `AbstractNamingStrategy`.
 
 ## TypescriptMetadataProvider has been renamed
 
-The name is now `TsMorphMetadataProvider`, there is also newly added `ReflectMetadataProvider`
-that uses `reflect-metadata` instead. As `TypescriptMetadataProvider` was the default, no 
-changes should be required. 
+The name is now `TsMorphMetadataProvider`, there is also newly added `ReflectMetadataProvider` that uses `reflect-metadata` instead. As `TypescriptMetadataProvider` was the default, no changes should be required.
 
 ## Updated mongodb driver
 
 MongoDB driver version 3.3.4 or higher is now required.
 
 ## EntityManager.find() now requires where parameter
-`EntityManager` has now same `find` method interface aligned with `EntityRepository`, 
-`where` parameter is now required. To select all entities, use `em.find(Entity, {})` 
-as value.
+
+`EntityManager` has now same `find` method interface aligned with `EntityRepository`, `where` parameter is now required. To select all entities, use `em.find(Entity, {})` as value.

--- a/docs/versioned_docs/version-5.5/upgrading-v3-to-v4.md
+++ b/docs/versioned_docs/version-5.5/upgrading-v3-to-v4.md
@@ -2,24 +2,19 @@
 title: Upgrading from v3 to v4
 ---
 
-> Following sections describe (hopefully) all breaking changes, most of them might be not valid 
-> for you, like if you do not use custom `NamingStrategy` implementation, you do not care about
-> the interface being changed.
+> Following sections describe (hopefully) all breaking changes, most of them might be not valid for you, like if you do not use custom `NamingStrategy` implementation, you do not care about the interface being changed.
 
 ## Node 10.13.0+ required
 
-Support for older node versions was dropped. 
+Support for older node versions was dropped.
 
 ## TypeScript 3.7+ required
 
-Support for older TypeScript versions was dropped. 
+Support for older TypeScript versions was dropped.
 
 ## Monorepo
 
-The ORM has been split into several packages. In v4 one needs to require
-`@mikro-orm/core` and a driver package, e.g. `@mikro-orm/mysql`. This driver
-package already contains the `mysql2` dependency, so you can remove that from
-your `package.json`. 
+The ORM has been split into several packages. In v4 one needs to require `@mikro-orm/core` and a driver package, e.g. `@mikro-orm/mysql`. This driver package already contains the `mysql2` dependency, so you can remove that from your `package.json`.
 
 - `@mikro-orm/core`
 - `@mikro-orm/reflection` - `TsMorphMetadataProvider`
@@ -34,17 +29,13 @@ your `package.json`.
 - `@mikro-orm/postgresql`
 - `@mikro-orm/mongodb`
 
-> For easier transition, meta package mikro-orm is still present, reexporting 
-> core, reflection, migrations, entity-generator and cli packages. You should 
-> **not** install both `mikro-orm` and `@mikro-orm/core` packages together. 
+> For easier transition, meta package mikro-orm is still present, reexporting core, reflection, migrations, entity-generator and cli packages. You should **not** install both `mikro-orm` and `@mikro-orm/core` packages together.
 
-> You should prefer the `@mikro-orm/core` over `mikro-orm` package, there were
-> weird dependency issues reported with the `mikro-orm` meta-package. 
+> You should prefer the `@mikro-orm/core` over `mikro-orm` package, there were weird dependency issues reported with the `mikro-orm` meta-package.
 
 ## Default metadata provider is now `ReflectMetadataProvider`
 
-If you want to use ts-morph, you need to install `@mikro-orm/reflection` package
-and enable the provider explicitly in the ORM config, as described [here](./metadata-providers.md#tsmorphmetadataprovider).
+If you want to use ts-morph, you need to install `@mikro-orm/reflection` package and enable the provider explicitly in the ORM config, as described [here](./metadata-providers.md#tsmorphmetadataprovider).
 
 ```ts
 import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
@@ -55,30 +46,22 @@ await MikroORM.init({
 });
 ```
 
-Using `ReflectMetadataProvider` has some limitations, so be sure to read 
-about them [here](./metadata-providers.md#limitations-and-requirements).
+Using `ReflectMetadataProvider` has some limitations, so be sure to read about them [here](./metadata-providers.md#limitations-and-requirements).
 
-One common gotcha with `reflect-metadata` is that you need to explicitly
-state the property type when using property initializer:
+One common gotcha with `reflect-metadata` is that you need to explicitly state the property type when using property initializer:
 
 ```ts
 @Property()
 createdAt: Date = new Date();
 ```
 
-Without the explicit type, we would infer `Object` instead of `Date`, 
-which would be most probably mapped to JSON column type (depends on driver).
+Without the explicit type, we would infer `Object` instead of `Date`, which would be most probably mapped to JSON column type (depends on driver).
 
 ## SqlEntityManager and MongoEntityManager
 
-In v4 the `core` package, where `EntityManager` and `EntityRepository` are 
-defined, is not dependent on knex, and therefore it cannot have a method 
-returning a `QueryBuilder`. You need to import the SQL flavour of the EM 
-from the driver package to access the `createQueryBuilder()` method.
+In v4 the `core` package, where `EntityManager` and `EntityRepository` are defined, is not dependent on knex, and therefore it cannot have a method returning a `QueryBuilder`. You need to import the SQL flavour of the EM from the driver package to access the `createQueryBuilder()` method.
 
-> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under 
-> this name and under `EntityManager` alias, so you can just change the 
-> location from where you import.
+> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ```ts
 import { EntityManager } from '@mikro-orm/mysql'; // or any other SQL driver package
@@ -96,32 +79,21 @@ const em: EntityManager;
 const ret = await em.aggregate(...);
 ```
 
-> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under 
-> this name and under `EntityManager` alias, so you can just change the 
-> location from where you import.
+> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ## Different default `pivotTable`
 
-Implementation of `UnderscoreNamingStrategy` and `EntityCaseNamingStrategy` 
-`joinTableName()` method has changed. You can use `pivotTable` on the owning side
-of M:N relation to specify the table name manually. 
+Implementation of `UnderscoreNamingStrategy` and `EntityCaseNamingStrategy` `joinTableName()` method has changed. You can use `pivotTable` on the owning side of M:N relation to specify the table name manually.
 
-Previously the table name did not respect property name, if one defined multiple
-M:N relations between same entities, there were conflicts and one would have to 
-specify `pivotTable` name manually at least on one of them. With the new way, 
-we can be sure that the table name won't conflict with other pivot tables. 
+Previously the table name did not respect property name, if one defined multiple M:N relations between same entities, there were conflicts and one would have to specify `pivotTable` name manually at least on one of them. With the new way, we can be sure that the table name won't conflict with other pivot tables.
 
-Previously the name was constructed from 2 entity names as `entity_a_to_entity_b`,
-ignoring the actual property name. In v4 the name will be `entity_a_coll_name` in 
-case of the collection property on the owning side being named `collName`. 
+Previously the name was constructed from 2 entity names as `entity_a_to_entity_b`, ignoring the actual property name. In v4 the name will be `entity_a_coll_name` in case of the collection property on the owning side being named `collName`.
 
 ## Changes in folder-based discovery (`entitiesDirs` removed)
 
-`entitiesDirs` and `entitiesDirsTs` were removed in favour of `entities` and `entitiesTs`,
-`entities` will be used as a default for `entitiesTs` (that is used when we detect `ts-node`).
+`entitiesDirs` and `entitiesDirsTs` were removed in favour of `entities` and `entitiesTs`, `entities` will be used as a default for `entitiesTs` (that is used when we detect `ts-node`).
 
-`entities` can now contain mixture of paths to directories, globs pointing to entities,
-or references to the entities or instances of `EntitySchema`. 
+`entities` can now contain mixture of paths to directories, globs pointing to entities, or references to the entities or instances of `EntitySchema`.
 
 This basically means that all you need to change is renaming `entitiesDirs` to `entities`.
 
@@ -134,26 +106,17 @@ MikroORM.init({
 
 ## Changes in `wrap()` helper, `WrappedEntity` interface and `Reference` wrapper
 
-Previously all the methods and properties of `WrappedEntity` interface were
-added to the entity prototype during discovery. In v4 there is only one property
-added: `__helper: WrappedEntity`. `WrappedEntity` has been converted to actual class.
+Previously all the methods and properties of `WrappedEntity` interface were added to the entity prototype during discovery. In v4 there is only one property added: `__helper: WrappedEntity`. `WrappedEntity` has been converted to actual class.
 
-`wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is 
-being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...),
-if you want to access internal properties like `__meta` or `__em`, you need to explicitly
-ask for the helper via `wrap(entity, true)`.
+`wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...), if you want to access internal properties like `__meta` or `__em`, you need to explicitly ask for the helper via `wrap(entity, true)`.
 
-Internal methods (with `__` prefix) were also removed from the `Reference` class, 
-use `wrap(ref, true)` to access them. 
+Internal methods (with `__` prefix) were also removed from the `Reference` class, use `wrap(ref, true)` to access them.
 
-Instead of interface merging with `WrappedEntity`, one can now use classic inheritance,
-by extending `BaseEntity` exported from `@mikro-orm/core`. If you do so, `wrap(entity)` 
-will return your entity. 
+Instead of interface merging with `WrappedEntity`, one can now use classic inheritance, by extending `BaseEntity` exported from `@mikro-orm/core`. If you do so, `wrap(entity)` will return your entity.
 
 ## Removed `flush` parameter from `persist()` and `remove()` methods
 
-`flush` param is removed, both `persist` and `remove` methods are synchronous and
-require explicit flushing, possibly via fluent interface call.
+`flush` param is removed, both `persist` and `remove` methods are synchronous and require explicit flushing, possibly via fluent interface call.
 
 ```ts
 // before
@@ -167,19 +130,15 @@ await em.remove(jon).flush();
 
 ## `remove()` method requires entity instances
 
-The `em.remove()` method originally allowed to pass either entity instance, or 
-a condition. When one passed a condition, it was firing a native delete query, 
-without handling transactions or hooks. 
+The `em.remove()` method originally allowed to pass either entity instance, or a condition. When one passed a condition, it was firing a native delete query, without handling transactions or hooks.
 
-In v4, the method is now simplified and works only with entity instances. Use 
-`em.nativeDelete()` explicitly if you want to fire a delete query instead of 
-letting the `UnitOfWork` doing its job.
+In v4, the method is now simplified and works only with entity instances. Use `em.nativeDelete()` explicitly if you want to fire a delete query instead of letting the `UnitOfWork` doing its job.
 
 ```ts
 // before
 await em.remove(Author, 1); // fires query directly
 
-// after 
+// after
 await em.nativeDelete(Author, 1);
 ```
 
@@ -187,20 +146,11 @@ await em.nativeDelete(Author, 1);
 
 ## Type safe references
 
-EM now returns `Loaded<T, P>` instead of the entity (`T`). This type automatically
-adds synchronous method `get()` that returns the entity (for references) or array
-of entities (for collections).
+EM now returns `Loaded<T, P>` instead of the entity (`T`). This type automatically adds synchronous method `get()` that returns the entity (for references) or array of entities (for collections).
 
-`Reference.get()` is now available only with correct `Loaded` type hint and is used 
-as a sync getter for the entity, just like `unwrap()`. You can use `Reference.load(prop)` 
-for the original `get()` method functionality. 
+`Reference.get()` is now available only with correct `Loaded` type hint and is used as a sync getter for the entity, just like `unwrap()`. You can use `Reference.load(prop)` for the original `get()` method functionality.
 
-`em.find()` and similar methods now have two type arguments, due to TypeScript not supporting partial
-type inference, when you specify the `T` explicitly (without also explicitly 
-specifying the load hint), the inference will not work. This use case was mainly
-for usage without classes (interfaces + `EntitySchema`) - in that case it is now 
-supported to pass actual instance of `EntitySchema` as the first parameter to these
-methods, that will allow correct type inference:
+`em.find()` and similar methods now have two type arguments, due to TypeScript not supporting partial type inference, when you specify the `T` explicitly (without also explicitly specifying the load hint), the inference will not work. This use case was mainly for usage without classes (interfaces + `EntitySchema`) - in that case it is now supported to pass actual instance of `EntitySchema` as the first parameter to these methods, that will allow correct type inference:
 
 ```ts
 const author = await em.findOne(AuthorSchema, { ... }, ['books']);
@@ -209,59 +159,45 @@ console.log(author.books.get()); // `get()` is now inferred correctly
 
 ## Custom types are now type safe
 
-Generic `Type` class has now two type arguments - the input and output types. 
-Input type defaults to `string`, output type defaults to the input type. 
+Generic `Type` class has now two type arguments - the input and output types. Input type defaults to `string`, output type defaults to the input type.
 
 You might need to explicitly provide the types if your methods are strictly typed.
 
 ## Custom type serialization
 
-Custom types used to be serialized to the database value. In v4, the runtime 
-value is used by default. Implement custom `toJSON()` method if you need to 
-customize this.
+Custom types used to be serialized to the database value. In v4, the runtime value is used by default. Implement custom `toJSON()` method if you need to customize this.
 
 ## Property `default` and `defaultRaw`
 
-Previously the `default` option of properties was used as is, so we had to wrap 
-strings in quotes (e.g. `@Property({ default: "'foo bar'" })`). 
+Previously the `default` option of properties was used as is, so we had to wrap strings in quotes (e.g. `@Property({ default: "'foo bar'" })`).
 
-In v4 the `default` is typed as `string | number | boolean | null` and when used
-with string value, it will be automatically quoted. 
+In v4 the `default` is typed as `string | number | boolean | null` and when used with string value, it will be automatically quoted.
 
 To use SQL functions we now need to use `defaultRaw`: `@Property({ defaultRaw: 'now()' })`.
 
 ## `autoFlush` option has been removed
 
-Also `persistLater()` and `removeLater()` methods are deprecated. Use `persist()` or
-`remove` respectively.
+Also `persistLater()` and `removeLater()` methods are deprecated. Use `persist()` or `remove` respectively.
 
 ## `IdEntity`, `UuidEntity` and `MongoEntity` interfaces are removed
 
-They were actually never needed. 
+They were actually never needed.
 
 ## MongoDB driver is no longer the default
 
-You need to specify the platform type either via `type` option or provide the driver
-implementation via `driver` option. 
+You need to specify the platform type either via `type` option or provide the driver implementation via `driver` option.
 
 Available platforms types: `[ 'mongo', 'mysql', 'mariadb', 'postgresql', 'sqlite' ]`
 
 ## Removed configuration `discovery.tsConfigPath`
 
-Removed as it is no longer needed, it was used only for `TsMorphMetadataProvider`,
-when the `entitiesDirsTs` were not explicitly provided. In v4, this is no longer
-needed, as ts-morph discovery will use `d.ts` files instead, that should be located
-next to the compiled entities. 
+Removed as it is no longer needed, it was used only for `TsMorphMetadataProvider`, when the `entitiesDirsTs` were not explicitly provided. In v4, this is no longer needed, as ts-morph discovery will use `d.ts` files instead, that should be located next to the compiled entities.
 
 ## Changes in query highlighting
 
-Previously Highlight.js was used to highlight various things in the CLI, 
-like SQL and mongo queries, or migrations or entities generated via CLI.
-While the library worked fine, it was causing performance issues mainly 
-for those bundling via webpack and using lambdas, as the library was huge.
+Previously Highlight.js was used to highlight various things in the CLI, like SQL and mongo queries, or migrations or entities generated via CLI. While the library worked fine, it was causing performance issues mainly for those bundling via webpack and using lambdas, as the library was huge.
 
-In v4 highlighting is disabled by default, and there are 2 highlighters 
-you can optionally use (you need to install them first).
+In v4 highlighting is disabled by default, and there are 2 highlighters you can optionally use (you need to install them first).
 
 ```ts
 import { SqlHighlighter } from '@mikro-orm/sql-highlighter';

--- a/docs/versioned_docs/version-5.5/upgrading-v4-to-v5.md
+++ b/docs/versioned_docs/version-5.5/upgrading-v4-to-v5.md
@@ -2,23 +2,19 @@
 title: Upgrading from v4 to v5
 ---
 
-> Following sections describe (hopefully) all breaking changes, most of them might be not valid 
-> for you, like if you do not use custom `NamingStrategy` implementation, you do not care about
-> the interface being changed.
+> Following sections describe (hopefully) all breaking changes, most of them might be not valid for you, like if you do not use custom `NamingStrategy` implementation, you do not care about the interface being changed.
 
 ## Node 14+ required
 
-Support for older node versions was dropped. 
+Support for older node versions was dropped.
 
 ## TypeScript 4.1+ required
 
-Support for older TypeScript versions was dropped. 
+Support for older TypeScript versions was dropped.
 
 ## Options parameters
 
-Previously many methods had many (often boolean) parameters, in v5 such methods are
-refactored to use options object instead to improve readability. Some methods offered
-both signatures - the multi parameter signatures are now removed.
+Previously many methods had many (often boolean) parameters, in v5 such methods are refactored to use options object instead to improve readability. Some methods offered both signatures - the multi parameter signatures are now removed.
 
 List of such methods:
 
@@ -47,10 +43,7 @@ This also applies to the methods on `IDatabaseDriver` interface.
 
 ## Type-safe populate parameter with dot notation
 
-`FindOptions.populate` parameter is now strictly typed and supports only array of 
-strings or a boolean.
-Object way is no longer supported. To set loading strategy, use `FindOptions.strategy`.
-The return type of all such methods now returns properly typed `Loaded` response. 
+`FindOptions.populate` parameter is now strictly typed and supports only array of strings or a boolean. Object way is no longer supported. To set loading strategy, use `FindOptions.strategy`. The return type of all such methods now returns properly typed `Loaded` response.
 
 ## Type-safe fields parameter
 
@@ -58,8 +51,7 @@ The return type of all such methods now returns properly typed `Loaded` response
 
 ## Type-safe orderBy parameter
 
-`FindOptions.orderBy` parameter is now strictly typed. It also allows passing an 
-array of objects instead of just a single object.
+`FindOptions.orderBy` parameter is now strictly typed. It also allows passing an array of objects instead of just a single object.
 
 ```ts
 const books = await em.find(Book, {}, {
@@ -72,41 +64,25 @@ const books = await em.find(Book, {}, {
 
 ## Removed `@Repository()` decorator
 
-The decorator was problematic as it could only work properly it the file was required
-soon enough - before the ORM initialization, otherwise the repository would not be 
-registered at all.
+The decorator was problematic as it could only work properly it the file was required soon enough - before the ORM initialization, otherwise the repository would not be registered at all.
 
-Use `@Entity({ customRepository: () => CustomRepository })` in the entity definition
-instead.
+Use `@Entity({ customRepository: () => CustomRepository })` in the entity definition instead.
 
 ## Disallowed global identity map
 
-In v5, it is no longer possible to use the global identity map. This was a 
-common issue that led to weird bugs, as using the global EM without request
-context is wrong, we always need to have a dedicated context for each request,
-so they do not interfere.
+In v5, it is no longer possible to use the global identity map. This was a common issue that led to weird bugs, as using the global EM without request context is wrong, we always need to have a dedicated context for each request, so they do not interfere.
 
-Now we get a validation error if we try to use the global context. We still can
-disable this check via `allowGlobalContext` configuration, or a connected 
-environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can be handy 
-especially in unit tests.
+Now we get a validation error if we try to use the global context. We still can disable this check via `allowGlobalContext` configuration, or a connected environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can be handy especially in unit tests.
 
 ## `LoadedCollection.get()` and `$` now return the `Collection` instance
 
-Previously those dynamically added getters returned the array copy of collection
-items. In v5, we return the collection instance, which is also iterable and has
-a `length` getter and indexed access support, so it mimics the array. To get the
-array copy as before, call `getItems()` as with a regular collection.
+Previously those dynamically added getters returned the array copy of collection items. In v5, we return the collection instance, which is also iterable and has a `length` getter and indexed access support, so it mimics the array. To get the array copy as before, call `getItems()` as with a regular collection.
 
 ## Different table aliasing for select-in loading strategy and for QueryBuilder
 
-Previously with select-in strategy as well as with QueryBuilder, table aliases
-were always the letter `e` followed by unique index. In v5, we use the same 
-method as with joined strategy - the letter is inferred from the entity name.
+Previously with select-in strategy as well as with QueryBuilder, table aliases were always the letter `e` followed by unique index. In v5, we use the same method as with joined strategy - the letter is inferred from the entity name.
 
-This can be breaking if you used the aliases somewhere, e.g. in custom SQL 
-fragments. We can restore to the old behaviour by implementing custom naming
-strategy, overriding the `aliasName` method:
+This can be breaking if you used the aliases somewhere, e.g. in custom SQL fragments. We can restore to the old behaviour by implementing custom naming strategy, overriding the `aliasName` method:
 
 ```ts
 import { AbstractNamingStrategy } from '@mikro-orm/core';
@@ -118,37 +94,27 @@ class CustomNamingStrategy extends AbstractNamingStrategy {
 }
 ```
 
-Note that in v5 it is possible to use `expr()` helper to access the alias name
-dynamically, e.g. ``expr(alias => `lower('${alias}.name')`)``, which should be 
-now preferred way instead of hardcoding the aliases.
+Note that in v5 it is possible to use `expr()` helper to access the alias name dynamically, e.g. `` expr(alias => `lower('${alias}.name')`) ``, which should be now preferred way instead of hardcoding the aliases.
 
 ## Migrations are now stored without extensions
 
-Running migrations in production via node and ts-node is now handled the same.
-This should actually not be breaking, as old format with extension is still 
-supported (e.g. they still can be rolled back), but newly logged migrations
-will not contain the extension.
+Running migrations in production via node and ts-node is now handled the same. This should actually not be breaking, as old format with extension is still supported (e.g. they still can be rolled back), but newly logged migrations will not contain the extension.
 
 ## Changes in `assign()` helper
 
-Embeddable instances are now created via `EntityFactory` and they respect the
-`forceEntityConstructor` configuration. Due to this we need to have EM instance
-when assigning to embedded properties. 
+Embeddable instances are now created via `EntityFactory` and they respect the `forceEntityConstructor` configuration. Due to this we need to have EM instance when assigning to embedded properties.
 
 Using `em.assign()` should be preferred to get around this.
 
-Deep assigning of child entities now works by default based on the presence of PKs in the payload.
-This behaviour can be disable via updateByPrimaryKey: false in the assign options.
+Deep assigning of child entities now works by default based on the presence of PKs in the payload. This behaviour can be disable via updateByPrimaryKey: false in the assign options.
 
 `mergeObjects` option is now enabled by default.
 
 ## `em.populate()` always return array of entities
 
-Previously it was possible to call `em.populate()` with a single entity input,
-and the output would be again just a single entity.
+Previously it was possible to call `em.populate()` with a single entity input, and the output would be again just a single entity.
 
-Due to issues with TS 4.5, this method now always return array of entities.
-You can use destructing if you want to have a single entity return type:
+Due to issues with TS 4.5, this method now always return array of entities. You can use destructing if you want to have a single entity return type:
 
 ```ts
 const [loadedAuthor] = await em.populate(author, ...);
@@ -156,66 +122,45 @@ const [loadedAuthor] = await em.populate(author, ...);
 
 ## QueryBuilder is awaitable
 
-Previously awaiting of QB instance was a no-op. In v5, QB is promise-like interface,
-so we can await it. More about this in [Awaiting the QueryBuilder](./query-builder.md#awaiting-the-querybuilder) section.
+Previously awaiting of QB instance was a no-op. In v5, QB is promise-like interface, so we can await it. More about this in [Awaiting the QueryBuilder](./query-builder.md#awaiting-the-querybuilder) section.
 
 ## `UnitOfWork.getScheduledCollectionDeletions()` has been removed
 
-Previously scheduled collection deletions were used for a hack when removing 
-1:m collection via orphan removal might require early deletes - in case we were 
-adding the same entity (but different instance), so with same PK - inserting it 
-in the same unit would cause unique constraint failures.
+Previously scheduled collection deletions were used for a hack when removing 1:m collection via orphan removal might require early deletes - in case we were adding the same entity (but different instance), so with same PK - inserting it in the same unit would cause unique constraint failures.
 
 Also `IDatabaseDriver.clearCollection()` method is no longer present in the driver API.
 
 ## `populateAfterFlush` is enabled by default
 
-After flushing a new entity, all relations are marked as populated,
-just like if the entity was loaded from the db. This aligns the serialized
-output of `e.toJSON()` of a loaded entity and just-inserted one.
+After flushing a new entity, all relations are marked as populated, just like if the entity was loaded from the db. This aligns the serialized output of `e.toJSON()` of a loaded entity and just-inserted one.
 
-In v4 this behaviour was disabled by default, so even after the new entity was
-flushed, the serialized form contained only FKs for its relations. We can opt in
-to this old behaviour via `populateAfterFlush: false`.
+In v4 this behaviour was disabled by default, so even after the new entity was flushed, the serialized form contained only FKs for its relations. We can opt in to this old behaviour via `populateAfterFlush: false`.
 
 ## `migrations.pattern` is removed in favour of `migrations.glob`
 
-Migrations are using `umzug` under the hood, which is now upgraded to v3.0.
-With this version, the `pattern` configuration options is no longer available, 
-and has been replaced with `glob`. This change is also reflected in MikroORM.
+Migrations are using `umzug` under the hood, which is now upgraded to v3.0. With this version, the `pattern` configuration options is no longer available, and has been replaced with `glob`. This change is also reflected in MikroORM.
 
-The default value for `glob` is `!(*.d).{js,ts}`, so both JS and TS files are matched
-(but not .d.ts files). You should usually not need to change this option as this default
-suits both development and production environments.
+The default value for `glob` is `!(*.d).{js,ts}`, so both JS and TS files are matched (but not .d.ts files). You should usually not need to change this option as this default suits both development and production environments.
 
 ## Population no longer infers the where condition by default
 
 > This applies only to SELECT_IN strategy, as JOINED strategy implies the inference.
 
-Previously when we used populate hints in `em.find()` and similar methods, the
-query for our entity would be analysed and parts of it extracted and used for 
-the population. Following example would find all authors that have books with 
-given IDs, and populate their books collection, again using this PK condition,
-resulting in only such books being in those collections. 
+Previously when we used populate hints in `em.find()` and similar methods, the query for our entity would be analysed and parts of it extracted and used for the population. Following example would find all authors that have books with given IDs, and populate their books collection, again using this PK condition, resulting in only such books being in those collections.
 
 ```ts
 // this would end up with `Author.books` collections having only books of PK 1, 2, 3
 const a = await em.find(Author, { books: [1, 2, 3] }, { populate: ['books'] });
 ```
 
-Following this example, if we wanted to load all books, we would need a separate 
-`em.populate()` call:
+Following this example, if we wanted to load all books, we would need a separate `em.populate()` call:
 
 ```ts
 const a = await em.find(Author, { books: [1, 2, 3] });
 await em.populate(a, ['books']);
 ```
 
-This behaviour changed and is now configurable both globally and locally, via 
-`populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and 
-`PopulateHint.INFER`, the former being the default in v5, the latter being the
-default behaviour in v4. Locally (via `FindOptions`) we can also specify custom
-where condition that will be passed to `em.populate()` call.
+This behaviour changed and is now configurable both globally and locally, via `populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and `PopulateHint.INFER`, the former being the default in v5, the latter being the default behaviour in v4. Locally (via `FindOptions`) we can also specify custom where condition that will be passed to `em.populate()` call.
 
 ```ts
 // revert back to the old behaviour locally
@@ -227,20 +172,12 @@ const a = await em.find(Author, { books: [1, 2, 3] }, {
 
 ## `em.create()` respects required properties
 
-`em.create()` will now require you to pass all non-optional properties. Some 
-properties might be defined as required for TS, but we have a default value for 
-them (either runtime, or database one) - for such we can use `OptionalProps` 
-symbol to specify which properties should be considered as optional.
+`em.create()` will now require you to pass all non-optional properties. Some properties might be defined as required for TS, but we have a default value for them (either runtime, or database one) - for such we can use `OptionalProps` symbol to specify which properties should be considered as optional.
 
 ## Required properties are validated before insert
 
-Previously the validation took place in the database, so it worked only for SQL
-drivers. Now we have runtime validation based on the entity metadata. This means
-mongo users now need to use `nullable: true` on their optional properties, or
-disable the validation globally via `validateRequired: false` in the ORM config.
+Previously the validation took place in the database, so it worked only for SQL drivers. Now we have runtime validation based on the entity metadata. This means mongo users now need to use `nullable: true` on their optional properties, or disable the validation globally via `validateRequired: false` in the ORM config.
 
 ## `PrimaryKeyType` symbol should be defined as optional
 
-Previously when we had nonstandard PK types, we could use `PrimaryKeyType` symbol
-to let the type system know it. It was required to define this property as 
-required, now it can be defined as optional too.
+Previously when we had nonstandard PK types, we could use `PrimaryKeyType` symbol to let the type system know it. It was required to define this property as required, now it can be defined as optional too.

--- a/docs/versioned_docs/version-5.5/usage-with-adminjs.md
+++ b/docs/versioned_docs/version-5.5/usage-with-adminjs.md
@@ -6,12 +6,15 @@ sidebar_label: Usage with AdminJS
 ## Installation
 
 To use MikroORM with AdminJS you need to install:
+
 1. [`AdminJS Core`](https://github.com/SoftwareBrothers/adminjs):
+
 ```bash
 $ yarn add adminjs
 ```
 
 2. [`MikroORM Adapter`](https://github.com/SoftwareBrothers/adminjs-mikroorm):
+
 ```bash
 $ yarn add @adminjs/mikroorm
 # A MikroORM driver and core package, choose the one which suits you:
@@ -23,7 +26,9 @@ $ yarn add @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 ```
 
 3. A plugin specific to your server's framework:
+
 - [`Express Plugin`](https://github.com/SoftwareBrothers/adminjs-expressjs):
+
 ```bash
 $ yarn add @adminjs/express
 # Peer dependencies
@@ -31,6 +36,7 @@ $ yarn add express express-formidable express-session
 ```
 
 - [`Hapi Plugin`](https://github.com/SoftwareBrothers/adminjs-hapijs):
+
 ```bash
 $ yarn add @adminjs/hapi
 # Peer dependencies
@@ -41,8 +47,7 @@ $ yarn add @hapi/boom @hapi/cookie @hapi/hapi @hapi/inert
 
 ## Setup
 
-Once the installation process is completed, we need to set up AdminJS endpoints and database connection.
-The process is straightforward but differs based on which `plugin` you are using. Below you can find examples specific to supported frameworks:
+Once the installation process is completed, we need to set up AdminJS endpoints and database connection. The process is straightforward but differs based on which `plugin` you are using. Below you can find examples specific to supported frameworks:
 
 ### MikroORM + Express Plugin
 
@@ -133,7 +138,6 @@ const run = async () => {
 run();
 ```
 
-
 You can start your server afterwards and the admin panel will be available at `http://localhost:{PORT}/admin`. If you followed the example setup thoroughly, you should be able to see all of your entities in the sidebar and you should be able to perform basic **CRUD** operations on them.
 
 To further customize your AdminJS panel, please refer to the [`official documentation`](https://adminjs.co/docs.html).
@@ -149,11 +153,13 @@ The examples above set up AdminJS with unauthenticated access. To require your u
 You need to use `AdminJSExpress.buildAuthenticatedRouter` instead of `AdminJS.buildRouter`:
 
 **Before**:
+
 ```ts
   const router = AdminJSExpress.buildRouter(admin);
 ```
 
 **After**:
+
 ```ts
 const ADMIN_EMAIL = 'example@test.com';
 const ADMIN_PASSWORD = 'password';
@@ -174,6 +180,7 @@ const router = AdminJSExpress.buildAuthenticatedRouter(admin, {
 You need to simply add `auth` property to AdminJS options.
 
 **Before**:
+
 ```ts
 const adminOptions = {
   databases: [orm],
@@ -181,6 +188,7 @@ const adminOptions = {
 ```
 
 **After**:
+
 ```ts
 const ADMIN_EMAIL = 'example@test.com';
 const ADMIN_PASSWORD = 'password';

--- a/docs/versioned_docs/version-5.5/usage-with-babel.md
+++ b/docs/versioned_docs/version-5.5/usage-with-babel.md
@@ -2,9 +2,7 @@
 title: Usage with Babel
 ---
 
-When compiling TS via babel, decorators are by default handled different implementation
-than what `tsc` uses. To make the metadata extraction from decorators via Babel work, 
-we need to do use following plugins:
+When compiling TS via babel, decorators are by default handled different implementation than what `tsc` uses. To make the metadata extraction from decorators via Babel work, we need to do use following plugins:
 
 ```json
 {
@@ -18,9 +16,9 @@ we need to do use following plugins:
 
 > Make sure to install the plugins first: `yarn add -D babel-plugin-transform-typescript-metadata @babel/plugin-proposal-decorators @babel/plugin-proposal-class-properties`
 
-Lastly we need to set the `BABEL_DECORATORS_COMPAT` environment variable to `true` to 
-adjust the return value of decorators. 
+Lastly we need to set the `BABEL_DECORATORS_COMPAT` environment variable to `true` to adjust the return value of decorators.
 
 More information about this topic can be found here:
+
 - https://github.com/mikro-orm/mikro-orm/issues/840
 - https://jonahallibonetech.medium.com/next-js-9-mikroorm-eb6f6e08e1a1

--- a/docs/versioned_docs/version-5.5/usage-with-js.md
+++ b/docs/versioned_docs/version-5.5/usage-with-js.md
@@ -67,8 +67,7 @@ module.exports.entity = Author;
 module.exports.schema = schema;
 ```
 
-> Do not forget to provide `name` and `path` schema parameters as well as `entity`
-> and `schema` exports.
+> Do not forget to provide `name` and `path` schema parameters as well as `entity` and `schema` exports.
 
 Reference parameter can be one of (where `SCALAR` is the default one):
 
@@ -95,5 +94,4 @@ const orm = await MikroORM.init({
 
 > We can also pass the `EntitySchema` instance to the `entities` array.
 
-For more examples of plain JavaScript entity definitions take a look
-[Express JavaScript example](https://github.com/mikro-orm/express-js-example-app). 
+For more examples of plain JavaScript entity definitions take a look [Express JavaScript example](https://github.com/mikro-orm/express-js-example-app).

--- a/docs/versioned_docs/version-5.5/usage-with-mongo.md
+++ b/docs/versioned_docs/version-5.5/usage-with-mongo.md
@@ -2,12 +2,9 @@
 title: Usage with MongoDB
 ---
 
-To use MikroORM with mongo database, do not forget to install `@mikro-orm/mongodb`
-dependency. Then call `MikroORM.init()` as part of bootstrapping your app:
+To use MikroORM with mongo database, do not forget to install `@mikro-orm/mongodb` dependency. Then call `MikroORM.init()` as part of bootstrapping your app:
 
-> To access driver specific methods like `em.aggregate()` we need to specify
-> the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the
-> `orm.em` to `EntityManager` exported from the driver package:
+> To access driver specific methods like `em.aggregate()` we need to specify the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the `orm.em` to `EntityManager` exported from the driver package:
 >
 > ```ts
 > import { EntityManager } from '@mikro-orm/mongodb';
@@ -41,13 +38,11 @@ _id: ObjectId;
 id!: string; // won't be saved in the database
 ```
 
-> Only `_id: ObjectId` will be saved in the database. `id: string` is virtual and is 
-> also optional. 
+> Only `_id: ObjectId` will be saved in the database. `id: string` is virtual and is also optional.
 
 ## ObjectId and string id duality
 
-Every entity has both `ObjectId` and `string` id available, also all methods of `EntityManager` 
-and `EntityRepository` supports querying by both of them. 
+Every entity has both `ObjectId` and `string` id available, also all methods of `EntityManager` and `EntityRepository` supports querying by both of them.
 
 ```ts
 const author = orm.em.getReference('...id...');
@@ -66,24 +61,21 @@ const bar2 = await repo.find({ _id: { $in: [new ObjectId(article)] }, favouriteB
 
 ## ManyToMany collections with inlined pivot array
 
-As opposed to SQL drivers that use pivot tables, in mongo we can leverage available array type
-to store array of collection items (identifiers). This approach has two main benefits:
+As opposed to SQL drivers that use pivot tables, in mongo we can leverage available array type to store array of collection items (identifiers). This approach has two main benefits:
 
-1. Collection is stored on owning side entity, so we know how many items are there even before
-initializing the collection.
+1. Collection is stored on owning side entity, so we know how many items are there even before initializing the collection.
 2. As there are no pivot tables, resulting database queries are much simpler.
 
 ## Transactions
 
-Starting with v3.4, MongoDB driver supports transactions. To use transactions, there
-are several things you need to respect:
+Starting with v3.4, MongoDB driver supports transactions. To use transactions, there are several things you need to respect:
 
 - you need to use replica set (see [run-rs](https://github.com/vkarpov15/run-rs))
 - implicit transactions are disabled by default
-    - use `implicitTransactions: true` to enable them globally
-    - or use explicit transaction demarcation via `em.transactional()`
+  - use `implicitTransactions: true` to enable them globally
+  - or use explicit transaction demarcation via `em.transactional()`
 - you need to explicitly create all collections before working with them
-    - use `orm.getSchemaGenerator().createSchema()` method to do so
+  - use `orm.getSchemaGenerator().createSchema()` method to do so
 
 ```sh
 # first create replica set
@@ -105,15 +97,11 @@ const orm = await MikroORM.init<MongoDriver>({
 await orm.getSchemaGenerator().createSchema();
 ```
 
-> The `createCollections` method is present on the `MongoDriver` class only. You need 
-> to have the entity manager correctly typed (as `EntityManager<MongoDriver>`).
+> The `createCollections` method is present on the `MongoDriver` class only. You need to have the entity manager correctly typed (as `EntityManager<MongoDriver>`).
 
 ## Indexes
 
-Starting with v3.4, MongoDB driver supports indexes and unique constraints. You can 
-use `@Index()` and `@Unique()` as described in [Defining Entities section](defining-entities.md#indexes).
-To automatically create new indexes when initializing the ORM, you need to enable
-`ensureIndexes` option. 
+Starting with v3.4, MongoDB driver supports indexes and unique constraints. You can use `@Index()` and `@Unique()` as described in [Defining Entities section](defining-entities.md#indexes). To automatically create new indexes when initializing the ORM, you need to enable `ensureIndexes` option.
 
 ```ts
 const orm = await MikroORM.init<MongoDriver>({
@@ -122,7 +110,7 @@ const orm = await MikroORM.init<MongoDriver>({
   type: 'mongo',
   ensureIndexes: true, // defaults to false
 });
-``` 
+```
 
 Alternatively you can call `ensureIndexes()` method on the `SchemaGenerator`:
 
@@ -133,24 +121,20 @@ await orm.getSchemaGenerator().ensureIndexes();
 ```
 
 > You can pass additional index/unique options via `options` parameter:
-> 
+>
 > `@Unique({ options: { partialFilterExpression: { name: { $exists: true } } }})`
 
 > You can also create text indexes by passing `type` parameter:
-> 
+>
 > `@Index({ properties: ['name', 'caption'], type: 'text' })`
 
-> If you provide only `options` in the index definition, it will be used as is, 
-> this allows to define any kind of index:
+> If you provide only `options` in the index definition, it will be used as is, this allows to define any kind of index:
 >
-> `@Index({ options: { point: '2dsphere', title: -1 } })` 
+> `@Index({ options: { point: '2dsphere', title: -1 } })`
 
 ## Native collection methods
 
-Sometimes you need to perform some bulk operation, or you just want to populate your
-database with initial fixtures. Using ORM for such operations can bring unnecessary
-boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete`
-methods:
+Sometimes you need to perform some bulk operation, or you just want to populate your database with initial fixtures. Using ORM for such operations can bring unnecessary boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete` methods:
 
 ```ts
 em.nativeInsert<T extends AnyEntity>(entityName: string, data: any): Promise<IPrimaryKey>;
@@ -158,9 +142,7 @@ em.nativeUpdate<T extends AnyEntity>(entityName: string, where: FilterQuery<T>, 
 em.nativeDelete<T extends AnyEntity>(entityName: string, where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Those methods execute native driver methods like Mongo's `insertOne/updateMany/deleteMany` collection methods respectively. 
-This is common interface for all drivers, so for MySQL driver, it will fire native SQL queries. 
-Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks. 
+Those methods execute native driver methods like Mongo's `insertOne/updateMany/deleteMany` collection methods respectively. This is common interface for all drivers, so for MySQL driver, it will fire native SQL queries. Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks.
 
 They are also available as `EntityRepository` shortcuts:
 

--- a/docs/versioned_docs/version-5.5/usage-with-nestjs.md
+++ b/docs/versioned_docs/version-5.5/usage-with-nestjs.md
@@ -167,7 +167,7 @@ export class MyService {
 
 > `autoLoadEntities` option was added in v4.1.0
 
-Manually adding entities to the entities array of the connection options can be tedious. In addition, referencing entities from the root module breaks application domain boundaries and causes leaking implementation details to other parts of the  application. To solve this issue, static glob paths can be used.
+Manually adding entities to the entities array of the connection options can be tedious. In addition, referencing entities from the root module breaks application domain boundaries and causes leaking implementation details to other parts of the application. To solve this issue, static glob paths can be used.
 
 Note, however, that glob paths are not supported by webpack, so if you are building your application within a monorepo, you won't be able to use them. To address this issue, an alternative solution is provided. To automatically load entities, set the `autoLoadEntities` property of the configuration object (passed into the `forRoot()` method) to `true`, as shown below:
 
@@ -183,35 +183,23 @@ Note, however, that glob paths are not supported by webpack, so if you are build
 export class AppModule {}
 ```
 
-With that option specified, every entity registered through the `forFeature()`
-method will be automatically added to the entities array of the configuration
-object.
+With that option specified, every entity registered through the `forFeature()` method will be automatically added to the entities array of the configuration object.
 
-> Note that entities that aren't registered through the `forFeature()` method, but
-> are only referenced from the entity (via a relationship), won't be included by
-> way of the `autoLoadEntities` setting.
+> Note that entities that aren't registered through the `forFeature()` method, but are only referenced from the entity (via a relationship), won't be included by way of the `autoLoadEntities` setting.
 
-> Using `autoLoadEntities` also has no effect on the MikroORM CLI - for that we
-> still need CLI config with the full list of entities. On the other hand, we can
-> use globs there, as the CLI won't go through webpack.
+> Using `autoLoadEntities` also has no effect on the MikroORM CLI - for that we still need CLI config with the full list of entities. On the other hand, we can use globs there, as the CLI won't go through webpack.
 
 ## Request scoped handlers in queues
 
 > `@UseRequestContext()` decorator was added in v4.1.0
 
-> Since v5, `@UseRequestContext()` decorator is available in the `@mikro-orm/core`
-> package. It is valid approach not just for nestjs projects.
+> Since v5, `@UseRequestContext()` decorator is available in the `@mikro-orm/core` package. It is valid approach not just for nestjs projects.
 
 As mentioned in the [docs](identity-map.md), we need a clean state for each request. That is handled automatically thanks to the `RequestContext` helper registered via middleware.
 
-But middlewares are executed only for regular HTTP request handles, what if we need
-a request scoped method outside of that? One example of that is queue handlers or
-scheduled tasks.
+But middlewares are executed only for regular HTTP request handles, what if we need a request scoped method outside of that? One example of that is queue handlers or scheduled tasks.
 
-We can use the `@UseRequestContext()` decorator. It requires you to first inject the
-`MikroORM` instance to current context, it will be then used to create the context
-for you. Under the hood, the decorator will register new request context for your
-method and execute it inside the context.
+We can use the `@UseRequestContext()` decorator. It requires you to first inject the `MikroORM` instance to current context, it will be then used to create the context for you. Under the hood, the decorator will register new request context for your method and execute it inside the context.
 
 Keep in mind, that all handlers that are decorated with @UseRequestContext(), should NOT return anything.
 
@@ -244,9 +232,7 @@ export class MyService {
 }
 ```
 
-Another thing to look out for how you combine them with other decorators.
-For example if you use it in combination with NestJS's "[BullJS queues module](https://docs.nestjs.com/techniques/queues)", a safe bet is to extract the part of the code that needs a clean [docs](identity-map.md),
-either in a new method or inject a separate service.
+Another thing to look out for how you combine them with other decorators. For example if you use it in combination with NestJS's "[BullJS queues module](https://docs.nestjs.com/techniques/queues)", a safe bet is to extract the part of the code that needs a clean [docs](identity-map.md), either in a new method or inject a separate service.
 
 ```ts
 @Processor({
@@ -275,27 +261,27 @@ The GraphQL module in NestJS uses `apollo-server-express` which enables `bodypar
 
 This can be done by adding bodyparser to your main.ts file
 
- ```ts
+```ts
 import { NestFactory } from '@nestjs/core';
 import express from 'express';
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule,{ bodyParser: false });
-  app.use(express.json());
-  await app.listen(5555);
+ const app = await NestFactory.create(AppModule,{ bodyParser: false });
+ app.use(express.json());
+ await app.listen(5555);
 }
- ```
+```
 
 And at the same time disabling the bodyparser in the GraphQL Module
 
- ```ts
- @Module({
-  imports: [
-    GraphQLModule.forRoot({
-      bodyParserConfig: false,
-    }),
-  ],
+```ts
+@Module({
+ imports: [
+   GraphQLModule.forRoot({
+     bodyParserConfig: false,
+   }),
+ ],
 })
- ```
+```
 
 ## App shutdown and cleanup
 
@@ -429,10 +415,7 @@ export class PhotoModule {}
 
 ## Using `AsyncLocalStorage` for request context
 
-:::info
-Since v5 `AsyncLocalStorage` is used inside `RequestContext` helper so this section
-is no longer valid.
-:::
+:::info Since v5 `AsyncLocalStorage` is used inside `RequestContext` helper so this section is no longer valid. :::
 
 In older versions, the `domain` api was used in the `RequestContext` helper. Since `@mikro-orm/core@4.0.3`, we can use the new `AsyncLocalStorage` too, if you are on up to date node version:
 
@@ -486,7 +469,7 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
   }
 
   async afterUpdate(args: EventArgs<Author>): Promise<void> {
-    // ... 
+    // ...
   }
 
 }

--- a/docs/versioned_docs/version-5.5/usage-with-sql.md
+++ b/docs/versioned_docs/version-5.5/usage-with-sql.md
@@ -3,8 +3,7 @@ title: Usage with MySQL, MariaDB, PostgreSQL or SQLite
 sidebar_label: Usage with SQL Drivers
 ---
 
-To use `mikro-orm` with MySQL database, simply install the `@mikro-orm/mysql` dependency and set 
-the type option to `mysql` when initializing ORM. Since v4 it is no longer needed to install the `mysql2` package manually.
+To use `mikro-orm` with MySQL database, simply install the `@mikro-orm/mysql` dependency and set the type option to `mysql` when initializing ORM. Since v4 it is no longer needed to install the `mysql2` package manually.
 
 ```sh
 yarn add @mikro-orm/core @mikro-orm/mongodb     # for mongo
@@ -26,9 +25,7 @@ npm i -s @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 
 Then call `MikroORM.init` as part of bootstrapping your app:
 
-> To access driver specific methods like `em.createQueryBuilder()` we need to specify
-> the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the
-> `orm.em` to `EntityManager` exported from the driver package:
+> To access driver specific methods like `em.createQueryBuilder()` we need to specify the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the `orm.em` to `EntityManager` exported from the driver package:
 >
 > ```ts
 > import { EntityManager } from '@mikro-orm/postgresql';
@@ -49,9 +46,7 @@ console.log(orm.em); // access EntityManager via `em` property
 
 ## Custom driver
 
-If you want to use database that is not currently supported, you can implement your own driver.
-More information about how to create one can be [found here](custom-driver.md). Then provide the 
-driver class via `driver` configuration option: 
+If you want to use database that is not currently supported, you can implement your own driver. More information about how to create one can be [found here](custom-driver.md). Then provide the driver class via `driver` configuration option:
 
 ```ts
 import { MyCustomDriver } from './MyCustomDriver.ts';
@@ -65,8 +60,7 @@ const orm = await MikroORM.init<MyCustomDriver>({
 
 ## Schema
 
-Currently you will need to maintain the database schema yourself. For initial dump, you can 
-use [`SchemaGenerator` helper](schema-generator.md).  
+Currently you will need to maintain the database schema yourself. For initial dump, you can use [`SchemaGenerator` helper](schema-generator.md).
 
 ## ManyToMany collections with pivot tables
 
@@ -81,8 +75,7 @@ CREATE TABLE `publisher_to_test` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 ```
 
-You can adjust the name of pivot table via `pivotTable` option in `@ManyToMany` decorator
-defined on owning side: 
+You can adjust the name of pivot table via `pivotTable` option in `@ManyToMany` decorator defined on owning side:
 
 ```ts
 // for unidirectional
@@ -96,8 +89,7 @@ tags = new Collection<BookTag>(this);
 
 ## Using QueryBuilder to execute native SQL queries
 
-When you need to execute some SQL query without all the ORM stuff involved, you can either
-compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
+When you need to execute some SQL query without all the ORM stuff involved, you can either compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
 
 ```ts
 const qb = orm.em.createQueryBuilder(Author);
@@ -140,17 +132,13 @@ QueryBuilder.getParams(): any;
 QueryBuilder.clone(): QueryBuilder;
 ```
 
-For more examples of how to work with `QueryBuilder`, take a look at `QueryBuilder` tests in 
-[`tests/QueryBuilder.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/QueryBuilder.test.ts).
+For more examples of how to work with `QueryBuilder`, take a look at `QueryBuilder` tests in [`tests/QueryBuilder.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/QueryBuilder.test.ts).
 
 ## Transactions
 
-When you call `em.flush()`, all computed changes are queried [inside a database
-transaction](unit-of-work.md) by default, so you do not have to handle transactions manually. 
+When you call `em.flush()`, all computed changes are queried [inside a database transaction](unit-of-work.md) by default, so you do not have to handle transactions manually.
 
-When you need to explicitly handle the transaction, you can use `em.transactional(cb)` 
-to run callback in transaction. It will provide forked `EntityManager` as a parameter 
-with clear isolated identity map - please use that to make changes. 
+When you need to explicitly handle the transaction, you can use `em.transactional(cb)` to run callback in transaction. It will provide forked `EntityManager` as a parameter with clear isolated identity map - please use that to make changes.
 
 ```ts
 // if an error occurs inside the callback, all db queries from inside the callback will be rolled back
@@ -171,16 +159,13 @@ const author3 = new Author2('Author 3', 'a3@example.com');
 await orm.em.persistAndFlush([author1, author2, author3]);
 
 // finds authors with email like '%exa%le.c_m'
-const authors = await orm.em.find(Author2, { email: /exa.*le\.c.m$/ }); 
+const authors = await orm.em.find(Author2, { email: /exa.*le\.c.m$/ });
 console.log(authors); // all 3 authors found
 ```
 
 ## Native Collection Methods
 
-Sometimes you need to perform some bulk operation, or you just want to populate your
-database with initial fixtures. Using ORM for such operations can bring unnecessary
-boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete`
-methods:
+Sometimes you need to perform some bulk operation, or you just want to populate your database with initial fixtures. Using ORM for such operations can bring unnecessary boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete` methods:
 
 ```ts
 em.nativeInsert<T extends AnyEntity>(entityName: string, data: any): Promise<IPrimaryKey>;
@@ -188,9 +173,7 @@ em.nativeUpdate<T extends AnyEntity>(entityName: string, where: FilterQuery<T>, 
 em.nativeDelete<T extends AnyEntity>(entityName: string, where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Those methods execute native SQL queries generated via `QueryBuilder` based on entity 
-metadata. Keep in mind that they do not hydrate results to entities, and they do not 
-trigger lifecycle hooks. 
+Those methods execute native SQL queries generated via `QueryBuilder` based on entity metadata. Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks.
 
 They are also available as `EntityRepository` shortcuts:
 
@@ -200,9 +183,7 @@ EntityRepository.nativeUpdate(where: FilterQuery<T>, data: any): Promise<number>
 EntityRepository.nativeDelete(where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Additionally there is `execute()` method that supports executing raw SQL queries or `QueryBuilder`
-instances. To create `QueryBuilder`, you can use `createQueryBuilder()` factory method on both 
-`EntityManager` and `EntityRepository` classes: 
+Additionally there is `execute()` method that supports executing raw SQL queries or `QueryBuilder` instances. To create `QueryBuilder`, you can use `createQueryBuilder()` factory method on both `EntityManager` and `EntityRepository` classes:
 
 ```ts
 const qb = em.createQueryBuilder('Author');

--- a/docs/versioned_docs/version-5.5/using-bigint-pks.md
+++ b/docs/versioned_docs/version-5.5/using-bigint-pks.md
@@ -2,8 +2,7 @@
 title: Using native BigInt PKs (MySQL and PostgreSQL)
 ---
 
-We can use `BigIntType` to support `bigint`s. By default, it will represent the value as
-a `string`.
+We can use `BigIntType` to support `bigint`s. By default, it will represent the value as a `string`.
 
 ```ts
 import { Entity, PrimaryKey, t } from '@mikro-orm/core';
@@ -17,10 +16,7 @@ export class Book {
 }
 ```
 
-`bigint` can fit larger numbers than JavaScript number, for this reason it
-is mapped to a string. If we want to map it to a number anyway, we can implement
-[custom type](custom-types.md) that will do so. Similarly, we can define one to 
-use the native `bigint` type:
+`bigint` can fit larger numbers than JavaScript number, for this reason it is mapped to a string. If we want to map it to a number anyway, we can implement [custom type](custom-types.md) that will do so. Similarly, we can define one to use the native `bigint` type:
 
 ```ts
 export class NativeBigIntType extends BigIntType {

--- a/docs/versioned_docs/version-5.5/virtual-entities.md
+++ b/docs/versioned_docs/version-5.5/virtual-entities.md
@@ -5,7 +5,7 @@ title: Virtual Entities
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Virtual entities don't represent any database table. Instead, they dynamically resolve to an SQL query (or an aggregation in mongo), allowing to map any kind of results onto an entity. Such entities are mean for read purposes, they don't have a primary key and therefore cannot be tracked for changes. In a sense they are similar to (currently unsupported) database views. 
+Virtual entities don't represent any database table. Instead, they dynamically resolve to an SQL query (or an aggregation in mongo), allowing to map any kind of results onto an entity. Such entities are mean for read purposes, they don't have a primary key and therefore cannot be tracked for changes. In a sense they are similar to (currently unsupported) database views.
 
 To define a virtual entity, provide an `expression`, either as a string (SQL query):
 
@@ -85,7 +85,7 @@ export interface IBookWithAuthor{
   tags: string[];
 }
 
-export const BookWithAuthor = new EntitySchema<IBookWithAuthor>({ 
+export const BookWithAuthor = new EntitySchema<IBookWithAuthor>({
   name: 'BookWithAuthor',
   expression: 'select name, age, ' +
     '(select count(*) from book b where b.author_id = a.id) as total_books, ' +

--- a/docs/versioned_docs/version-5.6/async-local-storage.md
+++ b/docs/versioned_docs/version-5.6/async-local-storage.md
@@ -2,13 +2,9 @@
 title: Using AsyncLocalStorage
 ---
 
-:::info
-Since v5 `AsyncLocalStorage` is used inside `RequestContext` helper so this section
-is no longer valid.
-:::
+:::info Since v5 `AsyncLocalStorage` is used inside `RequestContext` helper so this section is no longer valid. :::
 
-In v4 and older versions, the `domain` api was used in the `RequestContext` helper. Since v4.0.3,
-we can use the new `AsyncLocalStorage` too, if we are on up-to-date node version:
+In v4 and older versions, the `domain` api was used in the `RequestContext` helper. Since v4.0.3, we can use the new `AsyncLocalStorage` too, if we are on up-to-date node version:
 
 ```ts
 const storage = new AsyncLocalStorage<EntityManager>();

--- a/docs/versioned_docs/version-5.6/caching.md
+++ b/docs/versioned_docs/version-5.6/caching.md
@@ -2,12 +2,9 @@
 title: Result cache
 ---
 
-MikroORM has simple result caching mechanism. It works with those methods of
-`EntityManager`: `find()`, `findOne()`, `findAndCount()`, `findOneOrFail()`,
-`count()`, as well as with `QueryBuilder` result methods (including `execute`).
+MikroORM has simple result caching mechanism. It works with those methods of `EntityManager`: `find()`, `findOne()`, `findAndCount()`, `findOneOrFail()`, `count()`, as well as with `QueryBuilder` result methods (including `execute`).
 
-By default, in memory cache is used, that is shared for the whole `MikroORM`
-instance. Default expiration is 1 second.
+By default, in memory cache is used, that is shared for the whole `MikroORM` instance. Default expiration is 1 second.
 
 ```ts
 const res = await em.find(Book, { author: { name: 'Jon Snow' } }, {
@@ -27,8 +24,7 @@ const res = await em.createQueryBuilder(Book)
   .getResultList();
 ```
 
-We can change the default expiration as well as provide custom cache adapter in
-the ORM configuration:
+We can change the default expiration as well as provide custom cache adapter in the ORM configuration:
 
 ```ts
 const orm = await MikroORM.init({
@@ -42,8 +38,7 @@ const orm = await MikroORM.init({
 });
 ```
 
-To clear the cached result, we need to load it with explicit cache key, and later
-on we can use `em.clearCache(cacheKey)` method.
+To clear the cached result, we need to load it with explicit cache key, and later on we can use `em.clearCache(cacheKey)` method.
 
 ```ts
 // set the cache key to 'book-cache-key', with expiration of 60s

--- a/docs/versioned_docs/version-5.6/cascading.md
+++ b/docs/versioned_docs/version-5.6/cascading.md
@@ -5,17 +5,13 @@ sidebar_label: Cascading
 
 > From v4.2, cascade merging is no longer configurable (and is kept enabled for all relations).
 
-> This section is about application level cascading. For that to work, we need
-> to have relations populated. 
+> This section is about application level cascading. For that to work, we need to have relations populated.
 
-When persisting or removing entity, all your references are by default cascade persisted. 
-This means that by persisting any entity, ORM will automatically persist all of its 
-associations. 
+When persisting or removing entity, all your references are by default cascade persisted. This means that by persisting any entity, ORM will automatically persist all of its associations.
 
-You can control this behaviour via `cascade` attribute of `@ManyToOne`, `@ManyToMany`, 
-`@OneToMany` and `@OneToOne` fields.
+You can control this behaviour via `cascade` attribute of `@ManyToOne`, `@ManyToMany`, `@OneToMany` and `@OneToOne` fields.
 
-> New entities without primary key will be always persisted, regardless of `cascade` value. 
+> New entities without primary key will be always persisted, regardless of `cascade` value.
 
 ```ts
 // cascade persist is default value
@@ -55,23 +51,19 @@ book.tags[1].name = 'new name 2';
 await orm.em.persistAndFlush(book); // all book tags and author will be persisted too
 ```
 
-> When cascade persisting collections, keep in mind only fully initialized collections 
-> will be cascade persisted.
+> When cascade persisting collections, keep in mind only fully initialized collections will be cascade persisted.
 
 ## Cascade remove
 
-Cascade remove works same way as cascade persist, just for removing entities. Following 
-example assumes that `Book.publisher` is set to `Cascade.REMOVE`:
+Cascade remove works same way as cascade persist, just for removing entities. Following example assumes that `Book.publisher` is set to `Cascade.REMOVE`:
 
-> Note that cascade remove for collections can be inefficient as it will fire 1 query
-> for each entity in collection.
+> Note that cascade remove for collections can be inefficient as it will fire 1 query for each entity in collection.
 
 ```ts
 await orm.em.remove(book).flush(); // this will also remove book.publisher
 ```
 
-Keep in mind that cascade remove **can be dangerous** when used on `@ManyToOne` fields, 
-as cascade removed entity can stay referenced in another entities that were not removed.
+Keep in mind that cascade remove **can be dangerous** when used on `@ManyToOne` fields, as cascade removed entity can stay referenced in another entities that were not removed.
 
 ```ts
 const publisher = new Publisher(...);
@@ -85,9 +77,7 @@ console.log(book2.publisher, book3.publisher);
 
 ## Orphan removal
 
-In addition to `Cascade.REMOVE`, there is also additional and more aggressive remove 
-cascading mode which can be specified using the `orphanRemoval` flag of the `@OneToOne`
-and `@OneToMany` properties:
+In addition to `Cascade.REMOVE`, there is also additional and more aggressive remove cascading mode which can be specified using the `orphanRemoval` flag of the `@OneToOne` and `@OneToMany` properties:
 
 ```ts
 @Entity()
@@ -99,13 +89,9 @@ export class Author {
 }
 ```
 
-> `orphanRemoval` flag behaves just like `Cascade.REMOVE` for remove operation, so specifying 
-> both is redundant.
+> `orphanRemoval` flag behaves just like `Cascade.REMOVE` for remove operation, so specifying both is redundant.
 
-With simple `Cascade.REMOVE`, you would need to remove the `Author` entity to cascade 
-the operation down to all loaded `Book`s. By enabling orphan removal on the collection, 
-`Book`s will be also removed when they get disconnected from the collection (either via 
-`remove()`, or by replacing collection items via `set()`):
+With simple `Cascade.REMOVE`, you would need to remove the `Author` entity to cascade the operation down to all loaded `Book`s. By enabling orphan removal on the collection, `Book`s will be also removed when they get disconnected from the collection (either via `remove()`, or by replacing collection items via `set()`):
 
 ```ts
 await author.books.set([book1, book2]); // replace whole collection
@@ -113,18 +99,15 @@ await author.books.remove(book1); // remove book from collection
 await orm.em.persistAndFlush(author); // book1 will be removed, as well as all original items (before we called `set()`)
 ```
 
-In this example, no `Book` would be removed with simple `Cascade.REMOVE` as no remove operation
-was executed. 
+In this example, no `Book` would be removed with simple `Cascade.REMOVE` as no remove operation was executed.
 
 ## Declarative Referential Integrity
 
 > This is only supported in SQL drivers.
 
-As opposed to the application level cascading controlled by the `cascade` option, we can
-also define database level referential integrity actions: `on update` and `on delete`.
+As opposed to the application level cascading controlled by the `cascade` option, we can also define database level referential integrity actions: `on update` and `on delete`.
 
-Their values are automatically inferred from the `cascade` option value. You can also 
-control the value manually via `onUpdateIntegrity` and `onDelete` options. 
+Their values are automatically inferred from the `cascade` option value. You can also control the value manually via `onUpdateIntegrity` and `onDelete` options.
 
 ```ts
 @Entity()

--- a/docs/versioned_docs/version-5.6/collections.md
+++ b/docs/versioned_docs/version-5.6/collections.md
@@ -66,9 +66,7 @@ console.log(await author.books.loadItems()); // Book[]
 
 ### Removing items from collection
 
-Removing items from a collection does not necessarily imply deleting the target entity, it means we are disconnecting the relation - removing items from collection, not removing entities from database - `Collection.remove()` is not the same as `em.remove()`. When you use `em.assign()` to update entities you can also remove/disconnect entities from a collection, they do not get automatically removed from the database.  If we want to delete the entity by removing it from collection, we need to enable `orphanRemoval: true`, which tells the ORM we don't want orphaned entities to exist, so we know those should be removed. Also check the documentation on [Orphan Removal](cascading.md#orphan-removal)
-
-
+Removing items from a collection does not necessarily imply deleting the target entity, it means we are disconnecting the relation - removing items from collection, not removing entities from database - `Collection.remove()` is not the same as `em.remove()`. When you use `em.assign()` to update entities you can also remove/disconnect entities from a collection, they do not get automatically removed from the database. If we want to delete the entity by removing it from collection, we need to enable `orphanRemoval: true`, which tells the ORM we don't want orphaned entities to exist, so we know those should be removed. Also check the documentation on [Orphan Removal](cascading.md#orphan-removal)
 
 ## OneToMany Collections
 
@@ -195,7 +193,7 @@ Alternatively, we can work with the pivot entity directly:
 
 ```ts
 // create new item
-const item = em.create(OrderItem, { 
+const item = em.create(OrderItem, {
   order: 123,
   product: 321,
   amount: 999,
@@ -210,8 +208,7 @@ We can as well define the 1:m properties targeting the pivot entity as in the pr
 
 ### Forcing fixed order of collection items
 
-> Since v3 many to many collections does not require having auto increment primary key, that
-> was used to ensure fixed order of collection items.
+> Since v3 many to many collections does not require having auto increment primary key, that was used to ensure fixed order of collection items.
 
 To preserve fixed order of collections, we can use `fixedOrder: true` attribute, which will start ordering by `id` column. Schema generator will convert the pivot table to have auto increment primary key `id`. We can also change the order column name via `fixedOrderColumn: 'order'`.
 
@@ -242,9 +239,9 @@ console.log(tag.books.contains(book)); // true
 
 tag.books.add(book);
 console.log(book.tags.contains(tag)); // true
-``` 
+```
 
->  Since v5.2.2 propagation of adding new items to inverse side M:N relation also works if the owning collection is not initialized. For propagation of remove operation, both sides still have to be initialized.
+> Since v5.2.2 propagation of adding new items to inverse side M:N relation also works if the owning collection is not initialized. For propagation of remove operation, both sides still have to be initialized.
 
 > Although this propagation works also for M:N inverse side, we should always use owning side to manipulate the collection.
 

--- a/docs/versioned_docs/version-5.6/composite-keys.md
+++ b/docs/versioned_docs/version-5.6/composite-keys.md
@@ -5,14 +5,9 @@ sidebar_label: Composite Primary Keys
 
 > Support for composite keys was added in version 3.5
 
-MikroORM supports composite primary keys natively. Composite keys are a very powerful 
-relational database concept and we took good care to make sure MikroORM supports as 
-many of the composite primary key use-cases. MikroORM supports composite keys of primitive 
-data-types as well as foreign keys as primary keys. You can also use your composite key 
-entities in relationships. 
+MikroORM supports composite primary keys natively. Composite keys are a very powerful relational database concept and we took good care to make sure MikroORM supports as many of the composite primary key use-cases. MikroORM supports composite keys of primitive data-types as well as foreign keys as primary keys. You can also use your composite key entities in relationships.
 
-This section shows how the semantics of composite primary keys work and how they map 
-to the database.
+This section shows how the semantics of composite primary keys work and how they map to the database.
 
 ## General Considerations
 
@@ -20,8 +15,7 @@ ID fields have to have their values set before you call `em.persist(entity)`.
 
 ## Primitive Types only
 
-Suppose you want to create a database of cars and use the model-name and year of 
-production as primary keys:
+Suppose you want to create a database of cars and use the model-name and year of production as primary keys:
 
 ```ts
 @Entity()
@@ -50,39 +44,28 @@ const car = new Car('Audi A8', 2010);
 await em.persistAndFlush(car);
 ```
 
-And for querying you need to provide all primary keys in the condition or an array of
-primary keys in the same order as the keys were defined:
+And for querying you need to provide all primary keys in the condition or an array of primary keys in the same order as the keys were defined:
 
 ```ts
 const audi1 = await em.findOneOrFail(Car, { name: 'Audi A8', year: 2010 });
 const audi2 = await em.findOneOrFail(Car, ['Audi A8', 2010]);
 ```
 
-> If we want to use the second approach with primary key tuple, we will need to specify 
-> the type of entity's primary key via `PrimaryKeyType` symbol as shown in the `Car` entity.
+> If we want to use the second approach with primary key tuple, we will need to specify the type of entity's primary key via `PrimaryKeyType` symbol as shown in the `Car` entity.
 
-> `PrimaryKeyType` is not needed when your entity has single scalar primary key under 
-> one of following property names: `id: number | string | bigint`, `_id: any` or 
-> `uuid: string`.
+> `PrimaryKeyType` is not needed when your entity has single scalar primary key under one of following property names: `id: number | string | bigint`, `_id: any` or `uuid: string`.
 
-You can also use this entity in associations. MikroORM will then generate two foreign 
-keys one for name and to year to the related entities.
+You can also use this entity in associations. MikroORM will then generate two foreign keys one for name and to year to the related entities.
 
-This example shows how you can nicely solve the requirement for existing values before 
-`em.persist()`: By adding them as mandatory values for the constructor.
+This example shows how you can nicely solve the requirement for existing values before `em.persist()`: By adding them as mandatory values for the constructor.
 
 ## Identity through foreign Entities
 
-There are tons of use-cases where the identity of an Entity should be determined by 
-the entity of one or many parent entities.
+There are tons of use-cases where the identity of an Entity should be determined by the entity of one or many parent entities.
 
-- Dynamic Attributes of an Entity (for example `Article`). Each Article has many 
-  attributes with primary key `article_id` and `attribute_name`.
-- `Address` object of a `Person`, the primary key of the address is `user_id`. This 
-  is not a case of a composite primary key, but the identity is derived through a 
-  foreign entity and a foreign key.
-- Pivot Tables with metadata can be modelled as Entity, for example connections between 
-  two articles with a little description and a score.
+- Dynamic Attributes of an Entity (for example `Article`). Each Article has many attributes with primary key `article_id` and `attribute_name`.
+- `Address` object of a `Person`, the primary key of the address is `user_id`. This is not a case of a composite primary key, but the identity is derived through a foreign entity and a foreign key.
+- Pivot Tables with metadata can be modelled as Entity, for example connections between two articles with a little description and a score.
 
 The semantics of mapping identity through foreign entities are easy:
 
@@ -133,9 +116,7 @@ export class ArticleAttribute {
 
 ## Use-Case 2: Simple Derived Identity
 
-Sometimes you have the requirement that two objects are related by a `@OneToOne` 
-association and that the dependent class should re-use the primary key of the class 
-it depends on. One good example for this is a user-address relationship:
+Sometimes you have the requirement that two objects are related by a `@OneToOne` association and that the dependent class should re-use the primary key of the class it depends on. One good example for this is a user-address relationship:
 
 ```ts
 @Entity()
@@ -162,9 +143,7 @@ export class Address {
 
 ## Use-Case 3: Join-Table with Metadata
 
-In the classic order product shop example there is the concept of the order item which 
-contains references to order and product and additional data such as the amount of products 
-purchased and maybe even the current price.
+In the classic order product shop example there is the concept of the order item which contains references to order and product and additional data such as the amount of products purchased and maybe even the current price.
 
 ```ts
 @Entity()
@@ -234,8 +213,7 @@ export class OrderItem {
 }
 ```
 
-:::info
-By default, a generated pivot table entity is used under the hood to represent the pivot table. Since v5.1 we can provide our own implementation via `pivotEntity` option.
+:::info By default, a generated pivot table entity is used under the hood to represent the pivot table. Since v5.1 we can provide our own implementation via `pivotEntity` option.
 
 The pivot table entity needs to have exactly two many-to-one properties, where first one needs to point to the owning entity and the second to the target entity of the many-to-many relation.
 
@@ -279,11 +257,11 @@ export class OrderItem {
 }
 ```
 
-Alternatively, we can work with the pivot entity directly: 
+Alternatively, we can work with the pivot entity directly:
 
 ```ts
 // create new item
-const item = em.create(OrderItem, { 
+const item = em.create(OrderItem, {
   order: 123,
   product: 321,
   amount: 999,
@@ -294,13 +272,11 @@ await em.persist(item).flush();
 const em.nativeDelete(OrderItem, { order: 123, product: 321 });
 ```
 
-We can as well define the 1:m properties targeting the pivot entity as in the previous example, and use that for modifying the collection, while using the M:N property for easier reading and filtering purposes.
-:::
+We can as well define the 1:m properties targeting the pivot entity as in the previous example, and use that for modifying the collection, while using the M:N property for easier reading and filtering purposes. :::
 
 ## Using QueryBuilder with composite keys
 
-Internally composite keys are represented as tuples, containing all the values in the
-same order as the primary keys were defined. 
+Internally composite keys are represented as tuples, containing all the values in the same order as the primary keys were defined.
 
 ```ts
 const qb1 = em.createQueryBuilder(CarOwner);
@@ -321,7 +297,6 @@ This also applies when you want to get a reference to entity with composite key:
 ```ts
 const ref = em.getReference(Car, ['Audi A8', 2010]);
 console.log(ref instanceof Car); // true
-``` 
+```
 
-> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/composite-primary-keys.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/composite-primary-keys.html) as the behaviour here is pretty much the same.

--- a/docs/versioned_docs/version-5.6/configuration.md
+++ b/docs/versioned_docs/version-5.6/configuration.md
@@ -4,8 +4,7 @@ title: Configuration
 
 ## Entity Discovery
 
-You can either provide array of entity instances via `entities`, or let the ORM look up your 
-entities in selected folders. 
+You can either provide array of entity instances via `entities`, or let the ORM look up your entities in selected folders.
 
 ```ts
 MikroORM.init({
@@ -13,14 +12,9 @@ MikroORM.init({
 });
 ```
 
-We can also use folder based discovery by providing list of paths to the entities
-we want to discover (globs are supported as well). This way we also need to specify
-`entitiesTs`, where we point the paths to the TS source files instead of the JS 
-compiled files (see more at [Metadata Providers](metadata-providers.md)).
+We can also use folder based discovery by providing list of paths to the entities we want to discover (globs are supported as well). This way we also need to specify `entitiesTs`, where we point the paths to the TS source files instead of the JS compiled files (see more at [Metadata Providers](metadata-providers.md)).
 
-> The `entitiesTs` option is used when running the app via `ts-node`, as the ORM 
-> needs to discover the TS files. Always specify this option if you use folder/file
-> based discovery. 
+> The `entitiesTs` option is used when running the app via `ts-node`, as the ORM needs to discover the TS files. Always specify this option if you use folder/file based discovery.
 
 ```ts
 MikroORM.init({
@@ -31,19 +25,11 @@ MikroORM.init({
 });
 ```
 
-> Be careful when overriding the `baseDir` with dynamic values like `__dirname`, 
-> as you can end up with valid paths from `ts-node`, but invalid paths from `node`.
-> Ideally you should keep the default of `process.cwd()` there to always have the 
-> same base path regardless of how you run the app.
+> Be careful when overriding the `baseDir` with dynamic values like `__dirname`, as you can end up with valid paths from `ts-node`, but invalid paths from `node`. Ideally you should keep the default of `process.cwd()` there to always have the same base path regardless of how you run the app.
 
-By default, `ReflectMetadataProvider` is used that leverages the `reflect-metadata`. 
-You can also use `TsMorphMetadataProvider` by installing `@mikro-orm/reflection`. 
-This provider will analyse your entity source files (or `.d.ts` type definition files). 
-If you aim to use plain JavaScript instead of TypeScript, use `EntitySchema` or 
-the `JavaScriptMetadataProvider`.
+By default, `ReflectMetadataProvider` is used that leverages the `reflect-metadata`. You can also use `TsMorphMetadataProvider` by installing `@mikro-orm/reflection`. This provider will analyse your entity source files (or `.d.ts` type definition files). If you aim to use plain JavaScript instead of TypeScript, use `EntitySchema` or the `JavaScriptMetadataProvider`.
 
-> You can also implement your own metadata provider and use it instead. To do so, extend the 
-> `MetadataProvider` class.
+> You can also implement your own metadata provider and use it instead. To do so, extend the `MetadataProvider` class.
 
 ```ts
 import { MikroORM } from '@mikro-orm/core';
@@ -113,19 +99,17 @@ const orm = await MikroORM.init({
 
 To select driver, you can either use `type` option, or provide the driver class reference.
 
-| type | driver name | dependency | note |
-|------|-------------|------------|------|
-| `mongo` | `MongoDriver` | `mongodb^3.3.4` | - |
-| `mysql` | `MySqlDriver` | `mysql2^2.0.0` | compatible with MariaDB |
-| `mariadb` | `MariaDbDriver` | `mariadb^2.0.0` | compatible with MySQL |
-| `postgresql` | `PostgreSqlDriver` | `pg^7.0.0` | - |
-| `sqlite` | `SqliteDriver` | `sqlite3^4.0.0` | - |
+| type         | driver name        | dependency      | note                    |
+| ------------ | ------------------ | --------------- | ----------------------- |
+| `mongo`      | `MongoDriver`      | `mongodb^3.3.4` | -                       |
+| `mysql`      | `MySqlDriver`      | `mysql2^2.0.0`  | compatible with MariaDB |
+| `mariadb`    | `MariaDbDriver`    | `mariadb^2.0.0` | compatible with MySQL   |
+| `postgresql` | `PostgreSqlDriver` | `pg^7.0.0`      | -                       |
+| `sqlite`     | `SqliteDriver`     | `sqlite3^4.0.0` | -                       |
 
-> Driver and connection implementations are not directly exported from `@mikro-orm/core` module. 
-> You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
+> Driver and connection implementations are not directly exported from `@mikro-orm/core` module. You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
 
-> You can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. 
-> The object will be deeply merged, overriding all internally used options.
+> You can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. The object will be deeply merged, overriding all internally used options.
 
 ```ts
 import { MySqlDriver } from '@mikro-orm/mysql';
@@ -147,8 +131,7 @@ MikroORM.init({
 
 ## Connection
 
-Each platform (driver) provides default connection string, you can override it as a whole
-through `clientUrl`, or partially through one of following options:
+Each platform (driver) provides default connection string, you can override it as a whole through `clientUrl`, or partially through one of following options:
 
 ```ts
 export interface DynamicPassword {
@@ -172,17 +155,16 @@ export interface ConnectionOptions {
 
 Following table shows default client connection strings:
 
-| type | default connection url |
-|------|------------------------|
-| `mongo` | `mongodb://127.0.0.1:27017` |
-| `mysql` | `mysql://root@127.0.0.1:3306` |
-| `mariadb` | `mysql://root@127.0.0.1:3306` |
+| type         | default connection url                 |
+| ------------ | -------------------------------------- |
+| `mongo`      | `mongodb://127.0.0.1:27017`            |
+| `mysql`      | `mysql://root@127.0.0.1:3306`          |
+| `mariadb`    | `mysql://root@127.0.0.1:3306`          |
 | `postgresql` | `postgresql://postgres@127.0.0.1:5432` |
 
 ### Read Replicas
 
-To set up read replicas, you can use `replicas` option. You can provide only those parts of the 
-`ConnectionOptions` interface, they will be used to override the `master` connection options.
+To set up read replicas, you can use `replicas` option. You can provide only those parts of the `ConnectionOptions` interface, they will be used to override the `master` connection options.
 
 ```ts
 MikroORM.init({
@@ -203,10 +185,7 @@ Read more about this in [Installation](installation.md) and [Read Connections](r
 
 ### Using short-lived tokens
 
-Many cloud providers include alternative methods for connecting to database instances 
-using short-lived authentication tokens. MikroORM supports dynamic passwords via 
-a callback function, either synchronous or asynchronous. The callback function must 
-resolve to a string.
+Many cloud providers include alternative methods for connecting to database instances using short-lived authentication tokens. MikroORM supports dynamic passwords via a callback function, either synchronous or asynchronous. The callback function must resolve to a string.
 
 ```ts
 MikroORM.init({
@@ -216,8 +195,7 @@ MikroORM.init({
 });
 ```
 
-The password callback value will be cached, to invalidate this cache we can specify
-`expirationChecker` callback:
+The password callback value will be cached, to invalidate this cache we can specify `expirationChecker` callback:
 
 ```ts
 MikroORM.init({
@@ -232,8 +210,7 @@ MikroORM.init({
 
 ## Naming Strategy
 
-When mapping your entities to database tables and columns, their names will be defined by naming 
-strategy. There are 3 basic naming strategies you can choose from:
+When mapping your entities to database tables and columns, their names will be defined by naming strategy. There are 3 basic naming strategies you can choose from:
 
 - `UnderscoreNamingStrategy` - default of all SQL drivers
 - `MongoNamingStrategy` - default of `MongoDriver`
@@ -251,9 +228,7 @@ Read more about this in [Naming Strategy](naming-strategy.md) section.
 
 ## Auto-join of 1:1 owners
 
-By default, owning side of 1:1 relation will be auto-joined when you select the inverse side 
-so we can have the reference to it. You can disable this behaviour via `autoJoinOneToOneOwner` 
-configuration toggle.
+By default, owning side of 1:1 relation will be auto-joined when you select the inverse side so we can have the reference to it. You can disable this behaviour via `autoJoinOneToOneOwner` configuration toggle.
 
 ```ts
 MikroORM.init({
@@ -263,8 +238,7 @@ MikroORM.init({
 
 ## Propagation of 1:1 and m:1 owners
 
-MikroORM defines getter and setter for every owning side of m:1 and 1:1 relation. This is 
-then used for propagation of changes to the inverse side of bi-directional relations.
+MikroORM defines getter and setter for every owning side of m:1 and 1:1 relation. This is then used for propagation of changes to the inverse side of bi-directional relations.
 
 ```ts
 const author = new Author('n', 'e');
@@ -283,9 +257,7 @@ MikroORM.init({
 
 ## Forcing UTC Timezone
 
-Use `forceUtcTimezone` option to force the `Date`s to be saved in UTC in datetime columns 
-without timezone. It works for MySQL (`datetime` type) and PostgreSQL (`timestamp` type). 
-SQLite does this by default. 
+Use `forceUtcTimezone` option to force the `Date`s to be saved in UTC in datetime columns without timezone. It works for MySQL (`datetime` type) and PostgreSQL (`timestamp` type). SQLite does this by default.
 
 ```ts
 MikroORM.init({
@@ -295,9 +267,7 @@ MikroORM.init({
 
 ## Mapping `null` values to `undefined`
 
-By default `null` values from nullable database columns are hydrated as `null`. 
-Using `forceUndefined` we can tell the ORM to convert those `null` values to
-`undefined` instead. 
+By default `null` values from nullable database columns are hydrated as `null`. Using `forceUndefined` we can tell the ORM to convert those `null` values to `undefined` instead.
 
 ```ts
 MikroORM.init({
@@ -307,13 +277,9 @@ MikroORM.init({
 
 ## Serialization of new entities
 
-After flushing a new entity, all relations are marked as populated,
-just like if the entity was loaded from the db. This aligns the serialized
-output of `e.toJSON()` of a loaded entity and just-inserted one.
+After flushing a new entity, all relations are marked as populated, just like if the entity was loaded from the db. This aligns the serialized output of `e.toJSON()` of a loaded entity and just-inserted one.
 
-In v4 this behaviour was disabled by default, so even after the new entity was 
-flushed, the serialized form contained only FKs for its relations. We can opt in 
-to this old behaviour via `populateAfterFlush: false`.
+In v4 this behaviour was disabled by default, so even after the new entity was flushed, the serialized form contained only FKs for its relations. We can opt in to this old behaviour via `populateAfterFlush: false`.
 
 ```ts
 MikroORM.init({
@@ -325,30 +291,21 @@ MikroORM.init({
 
 > This applies only to SELECT_IN strategy, as JOINED strategy implies the inference.
 
-In v4, when we used populate hints in `em.find()` and similar methods, the
-query for our entity would be analysed and parts of it extracted and used for
-the population. Following example would find all authors that have books with
-given IDs, and populate their books collection, again using this PK condition,
-resulting in only such books being in those collections.
+In v4, when we used populate hints in `em.find()` and similar methods, the query for our entity would be analysed and parts of it extracted and used for the population. Following example would find all authors that have books with given IDs, and populate their books collection, again using this PK condition, resulting in only such books being in those collections.
 
 ```ts
 // this would end up with `Author.books` collections having only books of PK 1, 2, 3
 const a = await em.find(Author, { books: [1, 2, 3] }, { populate: ['books'] });
 ```
 
-Following this example, if we wanted to load all books, we would need a separate
-`em.populate()` call:
+Following this example, if we wanted to load all books, we would need a separate `em.populate()` call:
 
 ```ts
 const a = await em.find(Author, { books: [1, 2, 3] });
 await em.populate(a, ['books']);
 ```
 
-This behaviour changed and is now configurable both globally and locally, via
-`populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and
-`PopulateHint.INFER`, the former being the default in v5, the latter being the
-default behaviour in v4. Locally (via `FindOptions`) we can also specify custom
-where condition that will be passed to `em.populate()` call.
+This behaviour changed and is now configurable both globally and locally, via `populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and `PopulateHint.INFER`, the former being the default in v5, the latter being the default behaviour in v4. Locally (via `FindOptions`) we can also specify custom where condition that will be passed to `em.populate()` call.
 
 ```ts
 MikroORM.init({
@@ -359,8 +316,7 @@ MikroORM.init({
 
 ## Custom Hydrator
 
-Hydrator is responsible for assigning values from the database to entities. 
-You can implement your custom `Hydrator` (by extending the abstract `Hydrator` class):
+Hydrator is responsible for assigning values from the database to entities. You can implement your custom `Hydrator` (by extending the abstract `Hydrator` class):
 
 ```ts
 MikroORM.init({
@@ -370,8 +326,7 @@ MikroORM.init({
 
 ## Custom Repository
 
-You can also register custom base repository (for all entities where you do not specify 
-`customRepository`) globally:
+You can also register custom base repository (for all entities where you do not specify `customRepository`) globally:
 
 > You can still use entity specific repositories in combination with global base repository.
 
@@ -385,14 +340,9 @@ Read more about this in [Repositories](repositories.md) section.
 
 ## Strict Mode and property validation
 
-> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`.
-> It has performance implications and usually should not be needed, as long as
-> you don't modify your entities via `Object.assign()`.
+> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`. It has performance implications and usually should not be needed, as long as you don't modify your entities via `Object.assign()`.
 
-`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong 
-data types for you automatically. If automatic conversion fails, it will throw an error. You can 
-enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered 
-when persisting the entity. 
+`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong data types for you automatically. If automatic conversion fails, it will throw an error. You can enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered when persisting the entity.
 
 ```ts
 MikroORM.init({
@@ -405,12 +355,9 @@ Read more about this in [Property Validation](property-validation.md) section.
 
 ## Required properties validation
 
-Since v5, new entities are validated on runtime (just before executing insert
-queries), based on the entity metadata. This means that mongo users now need 
-to use `nullable: true` on their optional properties too).
+Since v5, new entities are validated on runtime (just before executing insert queries), based on the entity metadata. This means that mongo users now need to use `nullable: true` on their optional properties too).
 
-This behaviour can be disabled globally via `validateRequired: false` in the 
-ORM config.
+This behaviour can be disabled globally via `validateRequired: false` in the ORM config.
 
 ```ts
 MikroORM.init({
@@ -420,8 +367,7 @@ MikroORM.init({
 
 ## Debugging & Logging
 
-You can enable logging with `debug` option. Either set it to `true` to log everything, or 
-provide array of `'query' | 'query-params' | 'discovery' | 'info'` namespaces.
+You can enable logging with `debug` option. Either set it to `true` to log everything, or provide array of `'query' | 'query-params' | 'discovery' | 'info'` namespaces.
 
 ```ts
 MikroORM.init({
@@ -436,8 +382,7 @@ Read more about this in [Debugging](logging.md) section.
 
 ## Custom Fail Handler
 
-When no entity is found during `em.findOneOrFail()` call, a `NotFoundError` will be thrown. 
-You can customize how the `Error` instance is created via `findOneOrFailHandler` (or `findExactlyOneOrFailHandler` if [strict mode](#strict-mode-and-property-validation) is enabled):
+When no entity is found during `em.findOneOrFail()` call, a `NotFoundError` will be thrown. You can customize how the `Error` instance is created via `findOneOrFailHandler` (or `findExactlyOneOrFailHandler` if [strict mode](#strict-mode-and-property-validation) is enabled):
 
 ```ts
 MikroORM.init({
@@ -464,8 +409,7 @@ MikroORM.init({
 
 ## Migrations
 
-Under the `migrations` namespace, you can adjust how the integrated migrations support works.
-Following example shows all possible options and their defaults:
+Under the `migrations` namespace, you can adjust how the integrated migrations support works. Following example shows all possible options and their defaults:
 
 ```ts
 MikroORM.init({
@@ -500,8 +444,7 @@ Read more about this in [seeding docs](seeding.md).
 
 ## Caching
 
-By default, metadata discovery results are cached. You can either disable caching, or adjust 
-how it works. Following example shows all possible options and their defaults:
+By default, metadata discovery results are cached. You can either disable caching, or adjust how it works. Following example shows all possible options and their defaults:
 
 ```ts
 MikroORM.init({
@@ -527,22 +470,20 @@ MikroORM.init({
   ...
 });
 ```
- > This should be disabled in production environments for added security.
+
+> This should be disabled in production environments for added security.
 
 ## Using native private properties
 
-If we want to use native private properties inside entities, the default approach of 
-how MikroORM creates entity instances via `Object.create()` is not viable (more about this
-in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity
-constructors, we can use `forceEntityConstructor` toggle:
+If we want to use native private properties inside entities, the default approach of how MikroORM creates entity instances via `Object.create()` is not viable (more about this in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity constructors, we can use `forceEntityConstructor` toggle:
 
 ```ts
 MikroORM.init({
-  forceEntityConstructor: true, // or specify just some entities via `[Author, 'Book', ...]` 
+  forceEntityConstructor: true, // or specify just some entities via `[Author, 'Book', ...]`
 });
 ```
 
-## Persist created entities automatically 
+## Persist created entities automatically
 
 > Since v5.5 `persistOnCreate` defaults to `true`.
 
@@ -558,26 +499,19 @@ MikroORM.init({
 
 ## Using global Identity Map
 
-In v5, it is no longer possible to use the global identity map. This was a
-common issue that led to weird bugs, as using the global EM without request
-context is almost always wrong, we always need to have a dedicated context for
-each request, so they do not interfere.
+In v5, it is no longer possible to use the global identity map. This was a common issue that led to weird bugs, as using the global EM without request context is almost always wrong, we always need to have a dedicated context for each request, so they do not interfere.
 
-We still can disable this check via `allowGlobalContext` configuration, or
-a connected environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can
-be handy especially in unit tests.
+We still can disable this check via `allowGlobalContext` configuration, or a connected environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can be handy especially in unit tests.
 
 ```ts
 MikroORM.init({
-  allowGlobalContext: true, 
+  allowGlobalContext: true,
 });
 ```
 
 ## Using environment variables
 
-Since v4.5 it is possible to set most of the ORM options via environment variables.
-By default `.env` file from the root directory is loaded - it is also possible to
-set full path to the env file you want to use via `MIKRO_ORM_ENV` environment variable.
+Since v4.5 it is possible to set most of the ORM options via environment variables. By default `.env` file from the root directory is loaded - it is also possible to set full path to the env file you want to use via `MIKRO_ORM_ENV` environment variable.
 
 > Environment variables always have precedence.
 
@@ -597,54 +531,54 @@ MIKRO_ORM_FORCE_UNDEFINED = true
 
 Full list of supported options:
 
-| env variable | config key |
-|--------------|------------|
-| `MIKRO_ORM_BASE_DIR` | `baseDir` |
-| `MIKRO_ORM_TYPE` | `type` |
-| `MIKRO_ORM_ENTITIES` | `entities` |
-| `MIKRO_ORM_ENTITIES_TS` | `entitiesTs` |
-| `MIKRO_ORM_CLIENT_URL` | `clientUrl` |
-| `MIKRO_ORM_HOST` | `host` |
-| `MIKRO_ORM_PORT` | `port` |
-| `MIKRO_ORM_USER` | `user` |
-| `MIKRO_ORM_PASSWORD` | `password` |
-| `MIKRO_ORM_DB_NAME` | `dbName` |
-| `MIKRO_ORM_SCHEMA`  | `schema` |
-| `MIKRO_ORM_LOAD_STRATEGY` | `loadStrategy` |
-| `MIKRO_ORM_BATCH_SIZE` | `batchSize` |
-| `MIKRO_ORM_USE_BATCH_INSERTS` | `useBatchInserts` |
-| `MIKRO_ORM_USE_BATCH_UPDATES` | `useBatchUpdates` |
-| `MIKRO_ORM_STRICT` | `strict` |
-| `MIKRO_ORM_VALIDATE` | `validate` |
-| `MIKRO_ORM_AUTO_JOIN_ONE_TO_ONE_OWNER` | `autoJoinOneToOneOwner` |
-| `MIKRO_ORM_PROPAGATE_TO_ONE_OWNER` | `propagateToOneOwner` |
-| `MIKRO_ORM_POPULATE_AFTER_FLUSH` | `populateAfterFlush` |
-| `MIKRO_ORM_FORCE_ENTITY_CONSTRUCTOR` | `forceEntityConstructor` |
-| `MIKRO_ORM_FORCE_UNDEFINED` | `forceUndefined` |
-| `MIKRO_ORM_FORCE_UTC_TIMEZONE` | `forceUtcTimezone` |
-| `MIKRO_ORM_TIMEZONE` | `timezone` |
-| `MIKRO_ORM_ENSURE_INDEXES` | `ensureIndexes` |
-| `MIKRO_ORM_IMPLICIT_TRANSACTIONS` | `implicitTransactions` |
-| `MIKRO_ORM_DEBUG` | `debug` |
-| `MIKRO_ORM_VERBOSE` | `verbose` |
-| `MIKRO_ORM_DISCOVERY_WARN_WHEN_NO_ENTITIES` | `discovery.warnWhenNoEntities` |
-| `MIKRO_ORM_DISCOVERY_REQUIRE_ENTITIES_ARRAY` | `discovery.requireEntitiesArray` |
-| `MIKRO_ORM_DISCOVERY_ALWAYS_ANALYSE_PROPERTIES` | `discovery.alwaysAnalyseProperties` |
-| `MIKRO_ORM_DISCOVERY_DISABLE_DYNAMIC_FILE_ACCESS` | `discovery.disableDynamicFileAccess` |
-| `MIKRO_ORM_MIGRATIONS_TABLE_NAME` | `migrations.tableName` |
-| `MIKRO_ORM_MIGRATIONS_PATH` | `migrations.path` |
-| `MIKRO_ORM_MIGRATIONS_PATH_TS` | `migrations.pathTs` |
-| `MIKRO_ORM_MIGRATIONS_GLOB` | `migrations.glob` |
-| `MIKRO_ORM_MIGRATIONS_TRANSACTIONAL` | `migrations.transactional` |
-| `MIKRO_ORM_MIGRATIONS_DISABLE_FOREIGN_KEYS` | `migrations.disableForeignKeys` |
-| `MIKRO_ORM_MIGRATIONS_ALL_OR_NOTHING` | `migrations.allOrNothing` |
-| `MIKRO_ORM_MIGRATIONS_DROP_TABLES` | `migrations.dropTables` |
-| `MIKRO_ORM_MIGRATIONS_SAFE` | `migrations.safe` |
-| `MIKRO_ORM_MIGRATIONS_EMIT` | `migrations.emit` |
-| `MIKRO_ORM_SCHEMA_GENERATOR_DISABLE_FOREIGN_KEYS` | `migrations.disableForeignKeys` |
+| env variable                                                | config key                               |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `MIKRO_ORM_BASE_DIR`                                        | `baseDir`                                |
+| `MIKRO_ORM_TYPE`                                            | `type`                                   |
+| `MIKRO_ORM_ENTITIES`                                        | `entities`                               |
+| `MIKRO_ORM_ENTITIES_TS`                                     | `entitiesTs`                             |
+| `MIKRO_ORM_CLIENT_URL`                                      | `clientUrl`                              |
+| `MIKRO_ORM_HOST`                                            | `host`                                   |
+| `MIKRO_ORM_PORT`                                            | `port`                                   |
+| `MIKRO_ORM_USER`                                            | `user`                                   |
+| `MIKRO_ORM_PASSWORD`                                        | `password`                               |
+| `MIKRO_ORM_DB_NAME`                                         | `dbName`                                 |
+| `MIKRO_ORM_SCHEMA`                                          | `schema`                                 |
+| `MIKRO_ORM_LOAD_STRATEGY`                                   | `loadStrategy`                           |
+| `MIKRO_ORM_BATCH_SIZE`                                      | `batchSize`                              |
+| `MIKRO_ORM_USE_BATCH_INSERTS`                               | `useBatchInserts`                        |
+| `MIKRO_ORM_USE_BATCH_UPDATES`                               | `useBatchUpdates`                        |
+| `MIKRO_ORM_STRICT`                                          | `strict`                                 |
+| `MIKRO_ORM_VALIDATE`                                        | `validate`                               |
+| `MIKRO_ORM_AUTO_JOIN_ONE_TO_ONE_OWNER`                      | `autoJoinOneToOneOwner`                  |
+| `MIKRO_ORM_PROPAGATE_TO_ONE_OWNER`                          | `propagateToOneOwner`                    |
+| `MIKRO_ORM_POPULATE_AFTER_FLUSH`                            | `populateAfterFlush`                     |
+| `MIKRO_ORM_FORCE_ENTITY_CONSTRUCTOR`                        | `forceEntityConstructor`                 |
+| `MIKRO_ORM_FORCE_UNDEFINED`                                 | `forceUndefined`                         |
+| `MIKRO_ORM_FORCE_UTC_TIMEZONE`                              | `forceUtcTimezone`                       |
+| `MIKRO_ORM_TIMEZONE`                                        | `timezone`                               |
+| `MIKRO_ORM_ENSURE_INDEXES`                                  | `ensureIndexes`                          |
+| `MIKRO_ORM_IMPLICIT_TRANSACTIONS`                           | `implicitTransactions`                   |
+| `MIKRO_ORM_DEBUG`                                           | `debug`                                  |
+| `MIKRO_ORM_VERBOSE`                                         | `verbose`                                |
+| `MIKRO_ORM_DISCOVERY_WARN_WHEN_NO_ENTITIES`                 | `discovery.warnWhenNoEntities`           |
+| `MIKRO_ORM_DISCOVERY_REQUIRE_ENTITIES_ARRAY`                | `discovery.requireEntitiesArray`         |
+| `MIKRO_ORM_DISCOVERY_ALWAYS_ANALYSE_PROPERTIES`             | `discovery.alwaysAnalyseProperties`      |
+| `MIKRO_ORM_DISCOVERY_DISABLE_DYNAMIC_FILE_ACCESS`           | `discovery.disableDynamicFileAccess`     |
+| `MIKRO_ORM_MIGRATIONS_TABLE_NAME`                           | `migrations.tableName`                   |
+| `MIKRO_ORM_MIGRATIONS_PATH`                                 | `migrations.path`                        |
+| `MIKRO_ORM_MIGRATIONS_PATH_TS`                              | `migrations.pathTs`                      |
+| `MIKRO_ORM_MIGRATIONS_GLOB`                                 | `migrations.glob`                        |
+| `MIKRO_ORM_MIGRATIONS_TRANSACTIONAL`                        | `migrations.transactional`               |
+| `MIKRO_ORM_MIGRATIONS_DISABLE_FOREIGN_KEYS`                 | `migrations.disableForeignKeys`          |
+| `MIKRO_ORM_MIGRATIONS_ALL_OR_NOTHING`                       | `migrations.allOrNothing`                |
+| `MIKRO_ORM_MIGRATIONS_DROP_TABLES`                          | `migrations.dropTables`                  |
+| `MIKRO_ORM_MIGRATIONS_SAFE`                                 | `migrations.safe`                        |
+| `MIKRO_ORM_MIGRATIONS_EMIT`                                 | `migrations.emit`                        |
+| `MIKRO_ORM_SCHEMA_GENERATOR_DISABLE_FOREIGN_KEYS`           | `migrations.disableForeignKeys`          |
 | `MIKRO_ORM_SCHEMA_GENERATOR_CREATE_FOREIGN_KEY_CONSTRAINTS` | `migrations.createForeignKeyConstraints` |
-| `MIKRO_ORM_SEEDER_PATH` | `seeder.path` |
-| `MIKRO_ORM_SEEDER_PATH_TS` | `seeder.pathTs` |
-| `MIKRO_ORM_SEEDER_GLOB` | `seeder.glob` |
-| `MIKRO_ORM_SEEDER_EMIT` | `seeder.emit` |
-| `MIKRO_ORM_SEEDER_DEFAULT_SEEDER` | `seeder.defaultSeeder` |
+| `MIKRO_ORM_SEEDER_PATH`                                     | `seeder.path`                            |
+| `MIKRO_ORM_SEEDER_PATH_TS`                                  | `seeder.pathTs`                          |
+| `MIKRO_ORM_SEEDER_GLOB`                                     | `seeder.glob`                            |
+| `MIKRO_ORM_SEEDER_EMIT`                                     | `seeder.emit`                            |
+| `MIKRO_ORM_SEEDER_DEFAULT_SEEDER`                           | `seeder.defaultSeeder`                   |

--- a/docs/versioned_docs/version-5.6/custom-driver.md
+++ b/docs/versioned_docs/version-5.6/custom-driver.md
@@ -2,18 +2,17 @@
 title: Creating Custom Driver
 ---
 
-If you want to use database that is not currently supported, you can implement your own driver.
-To do so, you will need to design 4 classes:
+If you want to use database that is not currently supported, you can implement your own driver. To do so, you will need to design 4 classes:
 
 ## Platform
 
-Platform is a class that provides information about available features of given driver: 
+Platform is a class that provides information about available features of given driver:
 
 ```ts
 import { Platform } from '@mikro-orm/core';
 
 export class MyCustomPlatform extends Platform {
-  
+
   protected abstract schemaHelper: MyCustomSchemaHelper;
 
   // here you can override default settings
@@ -39,7 +38,7 @@ Part of platform is a `SchemaHelper`, that provides information about how to bui
 import { SchemaHelper } from '@mikro-orm/core';
 
 export class MyCustomSchemaHelper extends SchemaHelper {
-  
+
   // here you can override default settings
   getIdentifierQuoteCharacter(): string;
   getSchemaBeginning(): string;
@@ -67,7 +66,7 @@ Next part is connection wrapper, that will be responsible for querying the datab
 import { Connection } from '@mikro-orm/core';
 
 export class MyCustomConnection extends Connection {
-  
+
   // implement abstract methods
   connect(): Promise<void>;
   isConnected(): Promise<boolean>;
@@ -80,12 +79,9 @@ export class MyCustomConnection extends Connection {
 
 ## Driver
 
-Last part is driver, that is responsible for using the connection to persist changes to 
-database. If you are building SQL driver, it might be handy to extend `AbstractSqlDriver`, 
-if not, extend `DatabaseDriver` abstract class. 
+Last part is driver, that is responsible for using the connection to persist changes to database. If you are building SQL driver, it might be handy to extend `AbstractSqlDriver`, if not, extend `DatabaseDriver` abstract class.
 
-If you want to have absolute control, you can implement the whole driver yourself via
-`IDatabaseDriver` interface. 
+If you want to have absolute control, you can implement the whole driver yourself via `IDatabaseDriver` interface.
 
 ```ts
 import { DatabaseDriver } from '@mikro-orm/core';

--- a/docs/versioned_docs/version-5.6/custom-types.md
+++ b/docs/versioned_docs/version-5.6/custom-types.md
@@ -22,13 +22,11 @@ You can define custom types by extending `Type` abstract class. It has several o
 
 - `convertToDatabaseValueSQL(key: string, platform: Platform): string`
 
-  Converts a value from its JS representation to its database representation of this type.
-  _(added in v4.4.2)_
+  Converts a value from its JS representation to its database representation of this type. _(added in v4.4.2)_
 
 - `convertToJSValueSQL(key: string, platform: Platform): string`
 
-  Modifies the SQL expression (identifier, parameter) to convert to a JS value.
-  _(added in v4.4.2)_
+  Modifies the SQL expression (identifier, parameter) to convert to a JS value. _(added in v4.4.2)_
 
 - `compareAsType(): string`
 
@@ -101,9 +99,7 @@ born?: string;
 
 In this example we will combine mapping values via database as well as during runtime.
 
-> The Point type is part of the Spatial extension of MySQL and enables you to store
-> a single location in a coordinate space by using x and y coordinates. You can use
-> the Point type to store a longitude/latitude pair to represent a geographic location.
+> The Point type is part of the Spatial extension of MySQL and enables you to store a single location in a coordinate space by using x and y coordinates. You can use the Point type to store a longitude/latitude pair to represent a geographic location.
 
 First let's define the `Point` class that will be used to represent the value during runtime:
 
@@ -201,8 +197,7 @@ update `location` set `point` = ST_PointFromText('point(2.34 9.87)') where `id` 
 commit
 ```
 
-We do a 2-step conversion here. In the first step, we convert the Point object into a string representation before saving to the database (in the convertToDatabaseValue method) and back into an object
-after fetching the value from the database (in the convertToJSValue method).
+We do a 2-step conversion here. In the first step, we convert the Point object into a string representation before saving to the database (in the convertToDatabaseValue method) and back into an object after fetching the value from the database (in the convertToJSValue method).
 
 The format of the string representation format is called Well-known text (WKT). The advantage of this format is, that it is both human readable and parsable by MySQL.
 
@@ -212,9 +207,7 @@ This is where the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods 
 
 This methods wrap a sql expression (the WKT representation of the Point) into MySQL functions ST_PointFromText and ST_AsText which convert WKT strings to and from the internal format of MySQL.
 
-> When using DQL queries, the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods
-> only apply to identification variables and path expressions in SELECT clauses. Expressions
-> in WHERE clauses are not wrapped!
+> When using DQL queries, the `convertToJSValueSQL` and `convertToDatabaseValueSQL` methods only apply to identification variables and path expressions in SELECT clauses. Expressions in WHERE clauses are not wrapped!
 
 ## Types provided by MikroORM
 
@@ -260,18 +253,11 @@ export const types = {
 
 ### ArrayType
 
-In PostgreSQL and MongoDB, it uses native arrays, otherwise it concatenates the values into string separated by commas. This means that you can't use values that contain comma with the `ArrayType` (
-but you can create custom array type that will handle this case, e.g. by using different separator).
+In PostgreSQL and MongoDB, it uses native arrays, otherwise it concatenates the values into string separated by commas. This means that you can't use values that contain comma with the `ArrayType` ( but you can create custom array type that will handle this case, e.g. by using different separator).
 
-By default, array of strings is returned from the type. You can also have arrays of numbers or other data types - to do so, you will need to implement custom
-`hydrate` method that is used for converting the array values to the right type.
+By default, array of strings is returned from the type. You can also have arrays of numbers or other data types - to do so, you will need to implement custom `hydrate` method that is used for converting the array values to the right type.
 
-> `ArrayType` will be used automatically if `type` is set to `array` (default behaviour
-> of reflect-metadata) or `string[]` or `number[]` (either manually or via ts-morph).
-> In case of `number[]` it will automatically handle the conversion to numbers.
-> This means that the following examples would both have the `ArrayType` used
-> automatically (but with reflect-metadata we would have a string array for both
-> unless we specify the type manually as `type: 'number[]')
+> `ArrayType` will be used automatically if `type` is set to `array` (default behaviour of reflect-metadata) or `string[]` or `number[]` (either manually or via ts-morph). In case of `number[]` it will automatically handle the conversion to numbers. This means that the following examples would both have the `ArrayType` used automatically (but with reflect-metadata we would have a string array for both unless we specify the type manually as `type: 'number[]')
 
 ```ts
 @Property({ type: ArrayType, nullable: true })
@@ -294,9 +280,7 @@ id: string;
 
 Blob type can be used to store binary data in the database.
 
-> `BlobType` will be used automatically if you specify the type hint as `Buffer`.
-> This means that the following example should work even without the explicit
-> `type: BlobType` option (with both reflect-metadata and ts-morph providers).
+> `BlobType` will be used automatically if you specify the type hint as `Buffer`. This means that the following example should work even without the explicit `type: BlobType` option (with both reflect-metadata and ts-morph providers).
 
 ```ts
 @Property({ type: BlobType, nullable: true })
@@ -305,8 +289,7 @@ blob?: Buffer;
 
 ### JsonType
 
-To store objects we can use `JsonType`. As some drivers are handling objects automatically and some don't, this type will handle the serialization in a driver independent way (calling `parse`
-and `stringify` only when needed).
+To store objects we can use `JsonType`. As some drivers are handling objects automatically and some don't, this type will handle the serialization in a driver independent way (calling `parse` and `stringify` only when needed).
 
 ```ts
 @Property({ type: JsonType, nullable: true })
@@ -315,8 +298,7 @@ object?: { foo: string; bar: number };
 
 ### DateType
 
-To store dates without time information, we can use `DateType`. It does use `date`
-column type and maps it to the `Date` object.
+To store dates without time information, we can use `DateType`. It does use `date` column type and maps it to the `Date` object.
 
 ```ts
 @Property({ type: DateType, nullable: true })
@@ -325,8 +307,7 @@ born?: Date;
 
 ### TimeType
 
-As opposed to the `DateType`, to store only the time information, we can use
-`TimeType`. It will use the `time` column type, the runtime type is string.
+As opposed to the `DateType`, to store only the time information, we can use `TimeType`. It will use the `time` column type, the runtime type is string.
 
 ```ts
 @Property({ type: TimeType, nullable: true })

--- a/docs/versioned_docs/version-5.6/decorators.md
+++ b/docs/versioned_docs/version-5.6/decorators.md
@@ -6,24 +6,22 @@ title: Decorators
 
 ### @Entity()
 
-`@Entity` decorator is used to mark your model classes as entities. Do not use it for 
-abstract base classes.
+`@Entity` decorator is used to mark your model classes as entities. Do not use it for abstract base classes.
 
-| Parameter          | Type                     | Optional | Description                                                                     |
-|--------------------|--------------------------|----------|---------------------------------------------------------------------------------|
-| `tableName`        | `string`                 | yes      | Override default collection/table name.                                         |
-| `schema`           | `string`                 | yes      | Sets the schema name                                                            |
-| `collection`       | `string`                 | yes      | Alias for `tableName`.                                                          |
-| `comment`          | `string`                 | yes      | Specify comment to table **(SQL only)**                                         |
-| `customRepository` | `() => EntityRepository` | yes      | Set [custom repository class](repositories.md#custom-repository).               |
-| `discriminatorColumn` |  `string` | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance) |                 
-| `discriminatorMap`   |  `Dictionary<string>` | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance) |     
-| `discriminatorValue` |  `number` &#124; `string` | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance) |
+| Parameter             | Type                     | Optional | Description                                                                     |
+| --------------------- | ------------------------ | -------- | ------------------------------------------------------------------------------- |
+| `tableName`           | `string`                 | yes      | Override default collection/table name.                                         |
+| `schema`              | `string`                 | yes      | Sets the schema name                                                            |
+| `collection`          | `string`                 | yes      | Alias for `tableName`.                                                          |
+| `comment`             | `string`                 | yes      | Specify comment to table **(SQL only)**                                         |
+| `customRepository`    | `() => EntityRepository` | yes      | Set [custom repository class](repositories.md#custom-repository).               |
+| `discriminatorColumn` | `string`                 | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance) |
+| `discriminatorMap`    | `Dictionary<string>`     | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance) |
+| `discriminatorValue`  | `number` &#124; `string` | yes      | For [Single Table Inheritance](inheritance-mapping.md#single-table-inheritance) |
 
 abstract | `boolean`;
 
 readonly | `boolean`;
-
 
 ```ts
 @Entity({ tableName: 'authors' })
@@ -34,11 +32,10 @@ export class Author { ... }
 
 ### @Property()
 
-`@Property()` decorator is used to define regular entity property. All following decorators
-extend the `@Property()` decorator, so you can also use its parameters there.
+`@Property()` decorator is used to define regular entity property. All following decorators extend the `@Property()` decorator, so you can also use its parameters there.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `fieldName` | `string` | yes | Override default property name (see [Naming Strategy](naming-strategy.md)). |
 | `type` | `string` &#124; `Constructor<Type>` &#124; `Type` | yes | Explicitly specify the runtime type (see [Metadata Providers](metadata-providers.md) and [Custom Types](custom-types.md)). |
 | `customType` | `Type` | yes | Explicitly specify the mapped type instance for this property (see [Custom Types](custom-types.md)). |
@@ -53,7 +50,7 @@ extend the `@Property()` decorator, so you can also use its parameters there.
 | `unsigned` | `boolean` | yes | Set column as unsigned for [Schema Generator](schema-generator.md).. **(SQL only)** |
 | `comment` | `string` | yes | Specify comment of column for [Schema Generator](schema-generator.md).. **(SQL only)** |
 | `version` | `boolean` | yes | Set to true to enable [Optimistic Locking] via version field (transactions.md#optimistic-locking). **(SQL only)** |
-| `concurrencyCheck` | `boolean` | yes | Set to true to enable [Optimistic Locking] via concurrency fields (transactions.md#concurrency-checks).|
+| `concurrencyCheck` | `boolean` | yes | Set to true to enable [Optimistic Locking] via concurrency fields (transactions.md#concurrency-checks). |
 | `customOrder` | `string[]` &#124; `number[]` &#124; `boolean[]` | yes | Specify a custom order for the column. **(SQL only)** |
 
 > You can use property initializers as usual.
@@ -77,14 +74,13 @@ registered = false;
 
 ### @PrimaryKey()
 
-`@PrimaryKey()` decorator is used to define entity's unique primary key identifier. 
+`@PrimaryKey()` decorator is used to define entity's unique primary key identifier.
 
-> `@PrimaryKey()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@PrimaryKey()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 > Every entity needs to have at least one primary key (see composite primary keys).
 
-> Note that if only one PrimaryKey is set and it's type is number it will be set to auto incremented automatically in all SQL drivers. 
+> Note that if only one PrimaryKey is set and it's type is number it will be set to auto incremented automatically in all SQL drivers.
 
 ```ts
 @PrimaryKey()
@@ -102,13 +98,10 @@ _id!: ObjectId; // ObjectId PK in mongodb driver
 
 ### @SerializedPrimaryKey()
 
-> Property marked with `@SerializedPrimaryKey()` is virtual, it will not be persisted 
-> into the database.
+> Property marked with `@SerializedPrimaryKey()` is virtual, it will not be persisted into the database.
 
-For MongoDB you can define serialized primary key, which will be then used in entity 
-serialization via `JSON.stringify()` (through method `entity.toJSON()`).
-You will be able to use it to manipulate with the primary key as string. 
- 
+For MongoDB you can define serialized primary key, which will be then used in entity serialization via `JSON.stringify()` (through method `entity.toJSON()`). You will be able to use it to manipulate with the primary key as string.
+
 See [Usage with MongoDB](usage-with-mongo.md) and [Serializing](serializing.md).
 
 ```ts
@@ -121,19 +114,15 @@ id!: string;
 
 ### @Enum()
 
-> `@Enum()` decorator extend the `@Property()` decorator, so you can use all its 
-> parameters.
+> `@Enum()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
-`@Enum()` decorator can be used for both numeric and string enums. By default enums are 
-considered numeric, and will be represented in the database schema as `tinyint/smallint`. 
-For string enums, if you define the enum in same file, its values will be automatically 
-sniffed. 
+`@Enum()` decorator can be used for both numeric and string enums. By default enums are considered numeric, and will be represented in the database schema as `tinyint/smallint`. For string enums, if you define the enum in same file, its values will be automatically sniffed.
 
 See [Defining Entities](defining-entities.md#enums).
 
-| Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
-| `items` | `number[]` &#124; `string[]` &#124; `() => Dictionary` | yes | Specify enum items explicitly. |
+| Parameter | Type                                                   | Optional | Description                    |
+| --------- | ------------------------------------------------------ | -------- | ------------------------------ |
+| `items`   | `number[]` &#124; `string[]` &#124; `() => Dictionary` | yes      | Specify enum items explicitly. |
 
 ```ts
 @Enum() // with ts-morph metadata provider we do not need to specify anything
@@ -154,14 +143,13 @@ enum4 = 'a';
 
 ### @Formula()
 
-`@Formula()` decorator can be used to map some SQL snippet to your entity. 
-The SQL fragment can be as complex as you want and even include subselects.
+`@Formula()` decorator can be used to map some SQL snippet to your entity. The SQL fragment can be as complex as you want and even include subselects.
 
 See [Defining Entities](defining-entities.md#formulas).
 
-| Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
-| `formula` | `string` &#124; `() => string` | no | SQL fragment that will be part of the select clause.  |
+| Parameter | Type                           | Optional | Description                                          |
+| --------- | ------------------------------ | -------- | ---------------------------------------------------- |
+| `formula` | `string` &#124; `() => string` | no       | SQL fragment that will be part of the select clause. |
 
 ```ts
 @Formula('obj_length * obj_height * obj_width')
@@ -170,18 +158,15 @@ objectVolume?: number;
 
 ### @Index() and @Unique()
 
-Use `@Index()` to create an index, or `@Unique()` to create unique constraint. You can 
-use those decorators both on the entity level and on property level. To create compound
-index, use the decorator on the entity level and provide list of property names via the
-`properties` option.
+Use `@Index()` to create an index, or `@Unique()` to create unique constraint. You can use those decorators both on the entity level and on property level. To create compound index, use the decorator on the entity level and provide list of property names via the `properties` option.
 
 See [Defining Entities](defining-entities.md#indexes).
 
-| Parameter    | Type     | Optional | Description |
-|--------------|----------|----------|-------------|
-| `name`       | `string` | yes      | index name  |
+| Parameter | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `name` | `string` | yes | index name |
 | `properties` | `string` &#124; `string[]` | yes | list of properties, required when using on entity level |
-| `type`       | `string` | yes      | index type, not available for `@Unique()`. Use `fulltext` to enable support for the `$fulltext` operator |
+| `type` | `string` | yes | index type, not available for `@Unique()`. Use `fulltext` to enable support for the `$fulltext` operator |
 
 ```ts
 @Entity()
@@ -207,29 +192,25 @@ export class Author {
 
 ### @Check()
 
-We can define check constraints via `@Check()` decorator. We can use it
-either on entity class, or on entity property. It has a required `expression`
-property, that can be either a string or a callback, that receives map of
-property names to column names. Note that we need to use the generic type
-argument if we want TypeScript suggestions for the property names.
+We can define check constraints via `@Check()` decorator. We can use it either on entity class, or on entity property. It has a required `expression` property, that can be either a string or a callback, that receives map of property names to column names. Note that we need to use the generic type argument if we want TypeScript suggestions for the property names.
 
 > Check constraints are currently supported only in postgres driver.
 
 See [Defining Entities](defining-entities.md#check-constraints).
 
-| Parameter    | Type     | Optional | Description       |
-|--------------|----------|----------|-------------------|
-| `name`       | `string` | yes      | constraint name   |
-| `property`   | `string` | yes      | property name, only used when generating the constraint name |
+| Parameter    | Type                            | Optional | Description                                                                          |
+| ------------ | ------------------------------- | -------- | ------------------------------------------------------------------------------------ |
+| `name`       | `string`                        | yes      | constraint name                                                                      |
+| `property`   | `string`                        | yes      | property name, only used when generating the constraint name                         |
 | `expression` | `string` &#124; `CheckCallback` | no       | constraint definition, can be a callback that gets a map of property to column names |
 
 ```ts
 @Entity()
-// with generated name based on the table name 
+// with generated name based on the table name
 @Check({ expression: 'price1 >= 0' })
-// with explicit name 
+// with explicit name
 @Check({ name: 'foo', expression: columns => `${columns.price1} >= 0` })
-// with explicit type argument we get autocomplete on `columns` 
+// with explicit type argument we get autocomplete on `columns`
 @Check<FooEntity>({ expression: columns => `${columns.price1} >= 0` })
 export class Book {
 
@@ -251,39 +232,31 @@ export class Book {
 
 ## Entity Relationships
 
-All relationship decorators have `entity`, `cascade` and `eager` optional parameters. 
-If you use the default `ReflectMetadataProvider`, then `entity` parameter might be required 
-You will be warned about it being not defined while required during discovery process if you 
-use `ReflectMetadataProvider`. 
+All relationship decorators have `entity`, `cascade` and `eager` optional parameters. If you use the default `ReflectMetadataProvider`, then `entity` parameter might be required You will be warned about it being not defined while required during discovery process if you use `ReflectMetadataProvider`.
 
-You can also use `type` parameter instead of it - the difference being that `type` parameter
-needs to be string, while in `entity` parameter you can provide a reference (wrapped in 
-a callback to overcome issues with circular dependencies) to the entity, which plays nice 
-with refactoring features in IDEs like WebStorm. 
+You can also use `type` parameter instead of it - the difference being that `type` parameter needs to be string, while in `entity` parameter you can provide a reference (wrapped in a callback to overcome issues with circular dependencies) to the entity, which plays nice with refactoring features in IDEs like WebStorm.
 
-> If you explicitly provide `entity` as a reference, it will enable type checks for other
-> reference parameters like `inversedBy` or `mappedBy`.
+> If you explicitly provide `entity` as a reference, it will enable type checks for other reference parameters like `inversedBy` or `mappedBy`.
 
 ### @ManyToOne()
 
-> `@ManyToOne()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@ManyToOne()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 Many instances of the current Entity refer to One instance of the referred Entity.
 
 See [Defining Entities](relationships.md#manytoone) for more examples.
 
-| Parameter           | Type | Optional | Description                                                                                                                                               |
-|---------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `entity`            | `string` &#124; `() => EntityName` | yes | Set target entity type.                                                                                                                                   |
-| `cascade`           | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
-| `eager`             | `boolean` | yes | Always load the relationship.                                                                                                                             |
-| `inversedBy`        | `(string & keyof T) ` &#124; ` (e: T) => any` | yes | Point to the inverse side property name.                                                                                                                  |
-| `wrappedReference`  | `boolean` | yes | Wrap the entity in [`Reference` wrapper](type-safe-relations.md).                                                                                         |
-| `ref`               | `boolean` | yes | Alias for `wrappedReference`.                                                                                                                             |
-| `primary`           | `boolean` | yes | Use this relation as primary key.                                                                                                                         |
-| `onDelete`          | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity).                                                                                  |
-| `onUpdateIntegrity` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity).                                                                                  |
+| Parameter | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
+| `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
+| `eager` | `boolean` | yes | Always load the relationship. |
+| `inversedBy` | `(string & keyof T) ` &#124; ` (e: T) => any` | yes | Point to the inverse side property name. |
+| `wrappedReference` | `boolean` | yes | Wrap the entity in [`Reference` wrapper](type-safe-relations.md). |
+| `ref` | `boolean` | yes | Alias for `wrappedReference`. |
+| `primary` | `boolean` | yes | Use this relation as primary key. |
+| `onDelete` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity). |
+| `onUpdateIntegrity` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity). |
 
 ```ts
 @ManyToOne()
@@ -298,28 +271,27 @@ author3?: Author;
 
 ### @OneToOne()
 
-> `@OneToOne()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@OneToOne()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 One instance of the current Entity refers to One instance of the referred Entity.
 
 See [Defining Entities](relationships.md#onetoone) for more examples, including bi-directional 1:1.
 
-| Parameter           | Type | Optional | Description                                                                                                                                               |
-|---------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `entity`            | `string` &#124; `() => EntityName` | yes | Set target entity type.                                                                                                                                   |
-| `cascade`           | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
-| `eager`             | `boolean` | yes | Always load the relationship.                                                                                                                             |
-| `owner`             | `boolean` | yes | Explicitly set as owning side (same as providing `inversedBy`).                                                                                           |
-| `inversedBy`        | `(string & keyof T) ` &#124; ` (e: T) => any` | yes | Point to the inverse side property name.                                                                                                                  |
-| `mappedBy`          | `(string & keyof T)` &#124; `(e: T) => any` | yes | Point to the owning side property name.                                                                                                                   |
-| `wrappedReference`  | `boolean` | yes | Wrap the entity in [`Reference` wrapper](type-safe-relations.md).                                                                                         |
-| `ref`               | `boolean` | yes | Alias for `wrappedReference`.                                                                                                                             |
-| `orphanRemoval`     | `boolean` | yes | Remove the entity when it gets disconnected from the relationship (see [Cascading](cascading.md#orphan-removal)).                                         |
-| `joinColumn`        | `string` | yes | Override default database column name on the owning side (see [Naming Strategy](naming-strategy.md)).                                                     |
-| `primary`           | `boolean` | yes | Use this relation as primary key.                                                                                                                         |
-| `onDelete`          | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity).                                                                                  |
-| `onUpdateIntegrity` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity).                                                                                  |
+| Parameter | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
+| `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
+| `eager` | `boolean` | yes | Always load the relationship. |
+| `owner` | `boolean` | yes | Explicitly set as owning side (same as providing `inversedBy`). |
+| `inversedBy` | `(string & keyof T) ` &#124; ` (e: T) => any` | yes | Point to the inverse side property name. |
+| `mappedBy` | `(string & keyof T)` &#124; `(e: T) => any` | yes | Point to the owning side property name. |
+| `wrappedReference` | `boolean` | yes | Wrap the entity in [`Reference` wrapper](type-safe-relations.md). |
+| `ref` | `boolean` | yes | Alias for `wrappedReference`. |
+| `orphanRemoval` | `boolean` | yes | Remove the entity when it gets disconnected from the relationship (see [Cascading](cascading.md#orphan-removal)). |
+| `joinColumn` | `string` | yes | Override default database column name on the owning side (see [Naming Strategy](naming-strategy.md)). |
+| `primary` | `boolean` | yes | Use this relation as primary key. |
+| `onDelete` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity). |
+| `onUpdateIntegrity` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity). |
 
 ```ts
 // when none of `owner/inverseBy/mappedBy` is provided, it will be considered owning side
@@ -337,8 +309,7 @@ bestFriend3!: User;
 
 ### @OneToMany()
 
-> `@OneToMany()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@OneToMany()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 One instance of the current Entity has Many instances (references) to the referred Entity.
 
@@ -347,7 +318,7 @@ See [Defining Entities](relationships.md#onetomany) for more examples, including
 > You need to initialize the value with `Collection<T>` instance.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `mappedBy` | `(string & keyof T)` &#124; `(e: T) => any` | no | Point to the owning side property name. |
 | `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
 | `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
@@ -367,8 +338,7 @@ books2 = new Collection<Book>(this); // target entity type can be read via `TsMo
 
 ### @ManyToMany()
 
-> `@ManyToMany()` decorator extend the `@Property()` decorator, so you can use all 
-> its parameters.
+> `@ManyToMany()` decorator extend the `@Property()` decorator, so you can use all its parameters.
 
 Many instances of the current Entity refers to Many instances of the referred Entity.
 
@@ -377,7 +347,7 @@ See [Defining Entities](relationships.md#manytomany) for more examples, includin
 > You need to initialize the value with `Collection<T>` instance.
 
 | Parameter | Type | Optional | Description |
-|-----------|------|----------|-------------|
+| --- | --- | --- | --- |
 | `entity` | `string` &#124; `() => EntityName` | yes | Set target entity type. |
 | `cascade` | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
 | `eager` | `boolean` | yes | Always load the relationship. |
@@ -401,15 +371,13 @@ tagsUnordered = new Collection<BookTag>(this); // m:n with composite PK
 
 ## Lifecycle Hooks
 
-You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of
-entity methods with them, you can also mark multiple methods with same hook.
+You can use lifecycle hooks to run some code when entity gets persisted. You can mark any of entity methods with them, you can also mark multiple methods with same hook.
 
 > All hooks support async methods with one exception - `@OnInit`.
 
 ### @OnInit()
 
-Fired when new instance of entity is created, either manually `em.create()`, or 
-automatically when new entities are loaded from database
+Fired when new instance of entity is created, either manually `em.create()`, or automatically when new entities are loaded from database
 
 > `@OnInit` is not fired when you create the entity manually via its constructor (`new MyEntity()`)
 
@@ -422,9 +390,7 @@ doStuffOnInit() {
 
 ### @OnLoad()
 
-Fired when new entities are loaded from database. Unlike `@InInit()`, 
-this will be fired only for fully loaded entities (not references). The method
-can be `async`.
+Fired when new entities are loaded from database. Unlike `@InInit()`, this will be fired only for fully loaded entities (not references). The method can be `async`.
 
 ```ts
 @OnLoad()
@@ -446,9 +412,7 @@ async doStuffBeforeCreate() {
 
 ### @AfterCreate()
 
-Fired right after the new entity is created in the database and merged to identity map. 
-Since this event entity will have reference to `EntityManager` and will be 
-enabled to call `wrap(entity).init()` method (including all entity references and collections).
+Fired right after the new entity is created in the database and merged to identity map. Since this event entity will have reference to `EntityManager` and will be enabled to call `wrap(entity).init()` method (including all entity references and collections).
 
 ```ts
 @AfterCreate()
@@ -470,7 +434,7 @@ async doStuffBeforeUpdate() {
 
 ### @AfterUpdate()
 
-Fired right after the entity is updated in the database. 
+Fired right after the entity is updated in the database.
 
 ```ts
 @AfterUpdate()
@@ -481,8 +445,7 @@ async doStuffAfterUpdate() {
 
 ### @BeforeDelete()
 
-Fired right before we delete the record from database. It is fired only when
-removing entity or entity reference, not when deleting records by query. 
+Fired right before we delete the record from database. It is fired only when removing entity or entity reference, not when deleting records by query.
 
 ```ts
 @BeforeDelete()
@@ -506,9 +469,7 @@ async doStuffAfterDelete() {
 
 ### @Subscriber()
 
-Used to register an event subscriber. Keep in mind that you need to make sure the file 
-gets loaded in order to make this decorator registration work (e.g. you import that file 
-explicitly somewhere).
+Used to register an event subscriber. Keep in mind that you need to make sure the file gets loaded in order to make this decorator registration work (e.g. you import that file explicitly somewhere).
 
 ```ts
 @Subscriber()

--- a/docs/versioned_docs/version-5.6/defining-entities.md
+++ b/docs/versioned_docs/version-5.6/defining-entities.md
@@ -5,43 +5,27 @@ title: Defining Entities
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Entities are simple javascript objects (so called POJO) without restrictions and without the need to extend base classes. Using [entity constructors](entity-constructors.md) works as well - they are never executed for managed entities (loaded from database). 
-Every entity is required to have a primary key.
+Entities are simple javascript objects (so called POJO) without restrictions and without the need to extend base classes. Using [entity constructors](entity-constructors.md) works as well - they are never executed for managed entities (loaded from database). Every entity is required to have a primary key.
 
 Entities can be defined in two ways:
 
-- Decorated classes - the attributes of the entity, as well as each property are provided
-  via decorators. We use `@Entity()` decorator on the class. Entity properties are decorated 
-  either with `@Property` decorator, or with one of reference decorators: 
-  `@ManyToOne`, `@OneToMany`, `@OneToOne` and `@ManyToMany`.
-  Check out the full [decorator reference](decorators.md).
-- `EntitySchema` helper - With `EntitySchema` helper we define the schema programmatically.
-  We can use regular classes as well as interfaces. This approach also allows to re-use 
-  partial entity definitions (e.g. traits/mixins). Read more about this 
-  in [Defining Entities via EntitySchema section](entity-schema.md).
+- Decorated classes - the attributes of the entity, as well as each property are provided via decorators. We use `@Entity()` decorator on the class. Entity properties are decorated either with `@Property` decorator, or with one of reference decorators: `@ManyToOne`, `@OneToMany`, `@OneToOne` and `@ManyToMany`. Check out the full [decorator reference](decorators.md).
+- `EntitySchema` helper - With `EntitySchema` helper we define the schema programmatically. We can use regular classes as well as interfaces. This approach also allows to re-use partial entity definitions (e.g. traits/mixins). Read more about this in [Defining Entities via EntitySchema section](entity-schema.md).
 
-Moreover, how the metadata extraction from decorators happens is controlled 
-via `MetadataProvider`. Two main metadata providers are:
+Moreover, how the metadata extraction from decorators happens is controlled via `MetadataProvider`. Two main metadata providers are:
 
-- `ReflectMetadataProvider` - uses `reflect-metadata` to read the property types. Faster
-  but simpler and more verbose. 
-- `TsMorphMetadataProvider` - uses `ts-morph` to read the type information from the
-  TypeScript compiled API. Heavier (requires full TS as a dependency), but allows DRY 
-  entity definition. With `ts-morph` we are able to extract the type as it is defined in
-  the code, including interface names, as well as optionality of properties. 
+- `ReflectMetadataProvider` - uses `reflect-metadata` to read the property types. Faster but simpler and more verbose.
+- `TsMorphMetadataProvider` - uses `ts-morph` to read the type information from the TypeScript compiled API. Heavier (requires full TS as a dependency), but allows DRY entity definition. With `ts-morph` we are able to extract the type as it is defined in the code, including interface names, as well as optionality of properties.
 
 Read more about them in the [Metadata Providers section](metadata-providers.md).
 
-> Current set of decorators in MikroORM is designed to work with the `tsc`. 
-> Using `babel` is also possible, but requires some additional setup. Read more about it
-> [here](usage-with-babel.md). For notes about `webpack`, read the [deployment section](deployment.md).
+> Current set of decorators in MikroORM is designed to work with the `tsc`. Using `babel` is also possible, but requires some additional setup. Read more about it [here](usage-with-babel.md). For notes about `webpack`, read the [deployment section](deployment.md).
 >
 > `ts-morph` is compatible only with the `tsc` approach.
 
 > From v3 we can also use default exports when defining your entity.
 
-Example definition of a `Book` entity follows. We can switch the tabs to see the difference
-for various ways:
+Example definition of a `Book` entity follows. We can switch the tabs to see the difference for various ways:
 
 <Tabs
   groupId="entity-def"
@@ -123,8 +107,7 @@ export const Book = new EntitySchema<IBook, CustomBaseEntity>({
 
 > Including `{ wrappedEntity: true }` in your `Ref` property definitions will wrap the reference, providing access to helper methods like `.load` and `.unwrap`, which can be helpful for loading data and changing the type of your references where you plan to use them.
 
-Here is another example of `Author` entity, that was referenced from the `Book` one, this
-time defined for mongo:
+Here is another example of `Author` entity, that was referenced from the `Book` one, this time defined for mongo:
 
 <Tabs
   groupId="entity-def"
@@ -306,9 +289,7 @@ For an example of Vanilla JavaScript usage, take a look [here](usage-with-js.md)
 
 ## Optional Properties
 
-With the default `reflect-metadata` provider, we need to mark each optional property as `nullable: true`.
-When using `ts-morph`, if you define the property as optional (marked with `?`), this will be automatically considered
-as nullable property (mainly for SQL schema generator).
+With the default `reflect-metadata` provider, we need to mark each optional property as `nullable: true`. When using `ts-morph`, if you define the property as optional (marked with `?`), this will be automatically considered as nullable property (mainly for SQL schema generator).
 
 <Tabs
   groupId="entity-def"
@@ -350,21 +331,18 @@ properties: {
 
 We can set default value of a property in 2 ways:
 
-1. Use runtime default value of the property. This approach should be preferred as long
-as we are not using any native database function like `now()`. With this approach our
-entities will have the default value set even before it is actually persisted into the
-database (e.g. when we instantiate new entity via `new Author()` or `em.create(Author, { ... })`.
+1. Use runtime default value of the property. This approach should be preferred as long as we are not using any native database function like `now()`. With this approach our entities will have the default value set even before it is actually persisted into the database (e.g. when we instantiate new entity via `new Author()` or `em.create(Author, { ... })`.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
 @Property()
@@ -405,23 +383,20 @@ properties: {
   </TabItem>
 </Tabs>
 
-2. Use `default` parameter of `@Property` decorator. This way the actual default value
-will be provided by the database, and automatically mapped to the entity property after
-it is being persisted (after flush). To use SQL functions like `now()`, use `defaultRaw`.
+2. Use `default` parameter of `@Property` decorator. This way the actual default value will be provided by the database, and automatically mapped to the entity property after it is being persisted (after flush). To use SQL functions like `now()`, use `defaultRaw`.
 
-  > Since v4 you should use `defaultRaw` for SQL functions, as `default` with string values
-  > will be automatically quoted.
+> Since v4 you should use `defaultRaw` for SQL functions, as `default` with string values will be automatically quoted.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
 @Property({ default: 1 })
@@ -466,25 +441,22 @@ properties: {
 
 To define an enum property, use `@Enum()` decorator. Enums can be either numeric or string values.
 
-For schema generator to work properly in case of string enums, we need to define the enum
-in the same file as where it is used, so its values can be automatically discovered. If we want
-to define the enum in another file, we should re-export it also in place where we use it.
+For schema generator to work properly in case of string enums, we need to define the enum in the same file as where it is used, so its values can be automatically discovered. If we want to define the enum in another file, we should re-export it also in place where we use it.
 
-Another possibility is to provide the reference to the enum implementation in the decorator
-via `@Enum(() => UserRole)`.
+Another possibility is to provide the reference to the enum implementation in the decorator via `@Enum(() => UserRole)`.
 
 > We can also set enum items manually via `items: string[]` attribute.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
 import { OutsideEnum } from './OutsideEnum.ts';
@@ -580,19 +552,18 @@ properties: {
 
 ## Enum arrays
 
-We can also use array of values for enum, in that case, `EnumArrayType` type
-will be used automatically, that will validate items on flush.
+We can also use array of values for enum, in that case, `EnumArrayType` type will be used automatically, that will validate items on flush.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
 enum Role {
@@ -636,19 +607,18 @@ properties: {
 
 ## Mapping directly to primary keys
 
-Sometimes we might want to work only with the primary key of a relation.
-To do that, we can use `mapToPk` option on M:1 and 1:1 relations:
+Sometimes we might want to work only with the primary key of a relation. To do that, we can use `mapToPk` option on M:1 and 1:1 relations:
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
 @ManyToOne(() => User, { mapToPk: true })
@@ -675,19 +645,18 @@ properties: {
   </TabItem>
 </Tabs>
 
-For composite keys, this will give us ordered tuple representing the raw PKs,
-which is the internal format of composite PK:
+For composite keys, this will give us ordered tuple representing the raw PKs, which is the internal format of composite PK:
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
 @ManyToOne(() => User, { mapToPk: true })
@@ -717,19 +686,18 @@ properties: {
 
 ## Formulas
 
-`@Formula()` decorator can be used to map some SQL snippet to your entity.
-The SQL fragment can be as complex as you want and even include subselects.
+`@Formula()` decorator can be used to map some SQL snippet to your entity. The SQL fragment can be as complex as you want and even include subselects.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Box.ts"
 @Formula('obj_length * obj_height * obj_width')
@@ -757,20 +725,18 @@ properties: {
 </Tabs>
 ```
 
-Formulas will be added to the select clause automatically. In case you are facing
-problems with `NonUniqueFieldNameException`, you can define the formula as a
-callback that will receive the entity alias in the parameter:
+Formulas will be added to the select clause automatically. In case you are facing problems with `NonUniqueFieldNameException`, you can define the formula as a callback that will receive the entity alias in the parameter:
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Box.ts"
 @Formula(alias => `${alias}.obj_length * ${alias}.obj_height * ${alias}.obj_width`)
@@ -799,21 +765,20 @@ properties: {
 
 ## Indexes
 
-We can define indexes via `@Index()` decorator, for unique indexes, we can 
-use `@Unique()` decorator. We can use it either on entity class, or on entity property. 
+We can define indexes via `@Index()` decorator, for unique indexes, we can use `@Unique()` decorator. We can use it either on entity class, or on entity property.
 
 To define complex indexes, we can use index expressions. They allow us to specify the final `create index` query and an index name - this name is then used for index diffing, so the schema generator will only try to create it if it's not there yet, or remove it, if it's no longer defined in the entity. Index expressions are not bound to any property, rather to the entity itself (we can still define them on both entity and property level).
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
 @Entity()
@@ -899,32 +864,28 @@ export const AuthorSchema = new EntitySchema<Author, CustomBaseEntity>({
 
 ## Check constraints
 
-We can define check constraints via `@Check()` decorator. We can use it 
-either on entity class, or on entity property. It has a required `expression`
-property, that can be either a string or a callback, that receives map of
-property names to column names. Note that we need to use the generic type 
-argument if we want TypeScript suggestions for the property names.
+We can define check constraints via `@Check()` decorator. We can use it either on entity class, or on entity property. It has a required `expression` property, that can be either a string or a callback, that receives map of property names to column names. Note that we need to use the generic type argument if we want TypeScript suggestions for the property names.
 
 > Check constraints are currently supported only in postgres driver.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
-// with generated name based on the table name 
+// with generated name based on the table name
 @Check({ expression: 'price1 >= 0' })
-// with explicit name 
+// with explicit name
 @Check({ name: 'foo', expression: columns => `${columns.price1} >= 0` })
-// with explicit type argument we get autocomplete on `columns` 
+// with explicit type argument we get autocomplete on `columns`
 @Check<FooEntity>({ expression: columns => `${columns.price1} >= 0` })
 export class Book {
 
@@ -949,11 +910,11 @@ export class Book {
 
 ```ts title="./entities/Book.ts"
 @Entity()
-// with generated name based on the table name 
+// with generated name based on the table name
 @Check({ expression: 'price1 >= 0' })
-// with explicit name 
+// with explicit name
 @Check({ name: 'foo', expression: columns => `${columns.price1} >= 0` })
-// with explicit type argument we get autocomplete on `columns` 
+// with explicit type argument we get autocomplete on `columns`
 @Check<FooEntity>({ expression: columns => `${columns.price1} >= 0` })
 export class Book {
 
@@ -1012,8 +973,7 @@ We can define custom types by extending `Type` abstract class. It has 4 optional
 
 - `toJSON(value: any, platform: Platform): any`
 
-  Converts a value from its JS representation to its serialized JSON form of this type.
-  By default converts to the database value.
+  Converts a value from its JS representation to its serialized JSON form of this type. By default converts to the database value.
 
 - `getColumnType(prop: EntityProperty, platform: Platform): string`
 
@@ -1023,20 +983,18 @@ More information can be found in [Custom Types](custom-types.md) section.
 
 ## Lazy scalar properties
 
-We can mark any property as `lazy: true` to omit it from the select clause.
-This can be handy for properties that are too large, and you want to have them
-available only sometimes, like a full text of an article.
+We can mark any property as `lazy: true` to omit it from the select clause. This can be handy for properties that are too large, and you want to have them available only sometimes, like a full text of an article.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Property({ columnType: 'text', lazy: true })
@@ -1070,30 +1028,26 @@ const b1 = await em.find(Book, 1); // this will omit the `text` property
 const b2 = await em.find(Book, 1, { populate: ['text'] }); // this will load the `text` property
 ```
 
-> If the entity is already loaded and you need to populate a lazy scalar property,
-> you might need to pass `refresh: true` in the `FindOptions`.
+> If the entity is already loaded and you need to populate a lazy scalar property, you might need to pass `refresh: true` in the `FindOptions`.
 
 ## Virtual Properties
 
 We can define our properties as virtual, either as a method, or via JavaScript `get/set`.
 
-Following example defines User entity with `firstName` and `lastName` database fields, that
-are both hidden from the serialized response, replaced with virtual properties `fullName`
-(defined as a classic method) and `fullName2` (defined as a JavaScript getter).
+Following example defines User entity with `firstName` and `lastName` database fields, that are both hidden from the serialized response, replaced with virtual properties `fullName` (defined as a classic method) and `fullName2` (defined as a JavaScript getter).
 
-> For JavaScript getter you need to provide `{ persist: false }` option otherwise the value
-> would be stored in the database.
+> For JavaScript getter you need to provide `{ persist: false }` option otherwise the value would be stored in the database.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
 @Entity()
@@ -1183,29 +1137,26 @@ console.log(wrap(author).toJSON()); // { fullName: 'Jon Snow', fullName2: 'Jon S
 
 ## Entity file names
 
-Starting with MikroORM 4.2, there is no limitation for entity file names. It is now
-also possible to define multiple entities in a single file using folder based discovery.
+Starting with MikroORM 4.2, there is no limitation for entity file names. It is now also possible to define multiple entities in a single file using folder based discovery.
 
 ## Using custom base entity
 
-We can define our own base entity with properties that are required on all entities, like
-primary key and created/updated time. Single table inheritance is also supported.
+We can define our own base entity with properties that are required on all entities, like primary key and created/updated time. Single table inheritance is also supported.
 
 Read more about this topic in [Inheritance Mapping](inheritance-mapping.md) section.
 
-> If you are initializing the ORM via `entities` option, you need to specify all your
-> base entities as well.
+> If you are initializing the ORM via `entities` option, you need to specify all your base entities as well.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/CustomBaseEntity.ts"
 import { v4 } from 'uuid';
@@ -1270,9 +1221,7 @@ export const schema = new EntitySchema<CustomBaseEntity>({
   </TabItem>
 </Tabs>
 
-There is a special case, when we need to annotate the base entity - if we are using
-folder based discovery, and the base entity is not using any decorators (e.g. it does
-not define any decorated property). In that case, we need to mark it as abstract:
+There is a special case, when we need to annotate the base entity - if we are using folder based discovery, and the base entity is not using any decorators (e.g. it does not define any decorated property). In that case, we need to mark it as abstract:
 
 ```ts
 @Entity({ abstract: true })
@@ -1283,20 +1232,18 @@ export abstract class CustomBaseEntity {
 
 ## SQL Generated columns
 
-Knex currently does not support generated columns, so the schema generator
-cannot properly diff them. To work around this, we can set `ignoreSchemaChanges`
-on a property to avoid a perpetual diff from the schema generator
+Knex currently does not support generated columns, so the schema generator cannot properly diff them. To work around this, we can set `ignoreSchemaChanges` on a property to avoid a perpetual diff from the schema generator
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity
@@ -1359,15 +1306,15 @@ export const Book = new EntitySchema<IBook>({
 ### Using id as primary key (SQL drivers)
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
@@ -1437,15 +1384,15 @@ export const BookSchema = new EntitySchema<Book>({
 ### Using UUID as primary key (SQL drivers)
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 import { v4 } from 'uuid';
@@ -1514,15 +1461,15 @@ export const Book = new EntitySchema<IBook>({
 Requires enabling the module via: `create extension "uuid-ossp";`
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
@@ -1584,19 +1531,18 @@ export const BookSchema = new EntitySchema<Book>({
 
 ### Using BigInt as primary key (MySQL and PostgreSQL)
 
-We can use `BigIntType` to support `bigint`s. By default, it will represent the value as
-a `string`.
+We can use `BigIntType` to support `bigint`s. By default, it will represent the value as a `string`.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/CustomBaseEntity.ts"
 @Entity()
@@ -1638,15 +1584,15 @@ If you want to use native `bigint`s, read the following guide: [Using native Big
 ### Example of Mongo entity
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
@@ -1715,8 +1661,7 @@ export const Book = new EntitySchema<IBook>({
 
 ### Using MikroORM's BaseEntity (previously WrappedEntity)
 
-From v4 `BaseEntity` class is provided with `init`, `isInitialized`, `assign`
-and other methods that are otherwise available via the `wrap()` helper.
+From v4 `BaseEntity` class is provided with `init`, `isInitialized`, `assign` and other methods that are otherwise available via the `wrap()` helper.
 
 > Usage of the `BaseEntity` is optional.
 
@@ -1741,5 +1686,4 @@ const book = new Book();
 console.log(book.isInitialized()); // true
 ```
 
-Having the entities set up, we can now start [using entity manager](entity-manager.md) and
-[repositories](repositories.md) as described in following sections.
+Having the entities set up, we can now start [using entity manager](entity-manager.md) and [repositories](repositories.md) as described in following sections.

--- a/docs/versioned_docs/version-5.6/deployment.md
+++ b/docs/versioned_docs/version-5.6/deployment.md
@@ -2,29 +2,19 @@
 title: Deployment
 ---
 
-Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. Thanks to this, 
-defining the type is enough for runtime validation.
+Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. Thanks to this, defining the type is enough for runtime validation.
 
-This has some consequences for deployment of your application. Sometimes you will want to 
-deploy only your compiled output, without TS source files at all. In that case, discovery 
-process will probably fail. You have several options:
+This has some consequences for deployment of your application. Sometimes you will want to deploy only your compiled output, without TS source files at all. In that case, discovery process will probably fail. You have several options:
 
 ## Deploy pre-built cache
 
-By default, output of metadata discovery will be cached in `temp` folder. You can reuse this 
-cache in your deployed application. Currently the cache is saved in files named like the entity
-source file, e.g. `Author.ts` entity will store cache in `temp/Author.ts.json` file.
+By default, output of metadata discovery will be cached in `temp` folder. You can reuse this cache in your deployed application. Currently the cache is saved in files named like the entity source file, e.g. `Author.ts` entity will store cache in `temp/Author.ts.json` file.
 
-When running compiled code, JS entities will be taken into account instead, so you will need to 
-generate the cache by running the compiled code locally. That will generate `temp/Author.js.json`, 
-which is the file you will need to deploy alongside your application. 
+When running compiled code, JS entities will be taken into account instead, so you will need to generate the cache by running the compiled code locally. That will generate `temp/Author.js.json`, which is the file you will need to deploy alongside your application.
 
 ## Fill type or entity attributes everywhere
 
-What discovery process does is to sniff TS types and save their value to string, so it can be 
-used later for validation. You can skip the whole process by simply providing those values 
-manually:
+What discovery process does is to sniff TS types and save their value to string, so it can be used later for validation. You can skip the whole process by simply providing those values manually:
 
 ```ts
 @Entity()
@@ -63,36 +53,28 @@ export enum BookStatus {
 
 ## Deploy your entity source files
 
-Usually it does not matter much that you deploy more files than needed, so the easiest way
-is to just deploy your TS source files next to the compiled output, just like during development.
+Usually it does not matter much that you deploy more files than needed, so the easiest way is to just deploy your TS source files next to the compiled output, just like during development.
 
 ## Deploy a bundle of entities and dependencies with [Webpack](https://webpack.js.org/)
 
-Webpack can be used to bundle every entity and dependency: you get a single file that contains 
-every required module/file and has no external dependencies.
+Webpack can be used to bundle every entity and dependency: you get a single file that contains every required module/file and has no external dependencies.
 
 ### Prepare your project for Webpack
 
-Webpack requires every required file to be hardcoded in your code. Code like this won't work 
-(it will throw an error because Webpack doesn't know which file to include in the bundle):
+Webpack requires every required file to be hardcoded in your code. Code like this won't work (it will throw an error because Webpack doesn't know which file to include in the bundle):
 
 ```ts
 let dependencyNameInVariable = 'dependency';
 const dependency = import(dependencyNameInVariable);
 ```
 
-As Webpack creates a file bundle, it isn't desired that it scans directories for entities 
-or metadata. Therefore you need to provide list of entities in the `entities` option in 
-the initialization function, folder/file based discovery is not supported (see dynamically 
-including entities as an alternative solution). Also you need to fill `type` or `entity` 
-attributes everywhere (see above) and disable caching (it will decrease start-time slightly).
+As Webpack creates a file bundle, it isn't desired that it scans directories for entities or metadata. Therefore you need to provide list of entities in the `entities` option in the initialization function, folder/file based discovery is not supported (see dynamically including entities as an alternative solution). Also you need to fill `type` or `entity` attributes everywhere (see above) and disable caching (it will decrease start-time slightly).
 
 > In v4 caching is disabled by default when using `ReflectMetadataProvider`.
 
 #### Disabling dynamic file access
 
-First thing you should do is to disable dynamic file access in the discovery process via the
-`discovery.disableDynamicFileAccess` toggle. This will effectively do:
+First thing you should do is to disable dynamic file access in the discovery process via the `discovery.disableDynamicFileAccess` toggle. This will effectively do:
 
 - set metadata provider to `ReflectMetadataProvider`
 - disable caching
@@ -113,15 +95,11 @@ await MikroORM.init({
 
 #### Dynamically loading dependencies
 
-This will make use of a Webpack feature called [dynamic imports](https://webpack.js.org/guides/code-splitting/#dynamic-imports). 
-This way you can import dependencies as long as part of the path is known.
+This will make use of a Webpack feature called [dynamic imports](https://webpack.js.org/guides/code-splitting/#dynamic-imports). This way you can import dependencies as long as part of the path is known.
 
-In following example [`require.context`](https://webpack.js.org/guides/dependency-management/#requirecontext) 
-is used. This 'function' is only usable during the building process from Webpack so therefore 
-there is an alternative solution provided that will as long as the environment variable 
-WEBPACK is not set (e.g. during development with `ts-node`).
+In following example [`require.context`](https://webpack.js.org/guides/dependency-management/#requirecontext) is used. This 'function' is only usable during the building process from Webpack so therefore there is an alternative solution provided that will as long as the environment variable WEBPACK is not set (e.g. during development with `ts-node`).
 
-Here, all files with the extension `.ts` will be imported from the directory `../entities`. 
+Here, all files with the extension `.ts` will be imported from the directory `../entities`.
 
 > [`flatMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap) is a method from ECMAScript 2019 and requires [Node.js](https://nodejs.org/) 11 or higher.
 
@@ -152,10 +130,7 @@ async function getEntities(): Promise<any[]> {
 
 ### Webpack configuration
 
-Webpack can be run without [configuration file](https://webpack.js.org/configuration/) but 
-for building MikroORM and [Node.js](https://nodejs.org/) bundles it requires additional 
-configuration. Configuration for Webpack is stored in the root of the project as 
-`webpack.config.js`. For all the options please refer to the following [page](https://webpack.js.org/configuration/).
+Webpack can be run without [configuration file](https://webpack.js.org/configuration/) but for building MikroORM and [Node.js](https://nodejs.org/) bundles it requires additional configuration. Configuration for Webpack is stored in the root of the project as `webpack.config.js`. For all the options please refer to the following [page](https://webpack.js.org/configuration/).
 
 For bundling MikroORM the following configuration is required:
 
@@ -199,7 +174,7 @@ module.exports = {
           mangle: false,
           // Similarly, Terser's compression may at its own discretion change function and class names.
           // While it only rarely does so, it's safest to also disable changing their names here.
-          // This can be controlled in a more granular way if needed (see 
+          // This can be controlled in a more granular way if needed (see
           // https://terser.org/docs/api-reference.html#compress-options).
           compress: {
             keep_classnames: true,
@@ -273,6 +248,4 @@ module.exports = {
 
 ### Running Webpack
 
-To run Webpack execute `webpack` (or `npx webpack` if not installed globally) in the root 
-of the project. It will probably throw a few warnings but you can ignore the errors regarding 
-MikroORM: the mentioned pieces of code won't be executed if properly bundled with Webpack.
+To run Webpack execute `webpack` (or `npx webpack` if not installed globally) in the root of the project. It will probably throw a few warnings but you can ignore the errors regarding MikroORM: the mentioned pieces of code won't be executed if properly bundled with Webpack.

--- a/docs/versioned_docs/version-5.6/embeddables.md
+++ b/docs/versioned_docs/version-5.6/embeddables.md
@@ -8,22 +8,13 @@ import TabItem from '@theme/TabItem';
 
 > Support for embeddables was added in version 4.0
 
-Embeddables are classes which are not entities themselves, but are embedded in 
-entities and can also be queried. You'll mostly want to use them to reduce 
-duplication or separating concerns. Value objects such as date range or address 
-are the primary use case for this feature.
+Embeddables are classes which are not entities themselves, but are embedded in entities and can also be queried. You'll mostly want to use them to reduce duplication or separating concerns. Value objects such as date range or address are the primary use case for this feature.
 
-> Embeddables needs to be discovered just like regular entities, don't forget to 
-> add them to the list of entities when initializing the ORM.
+> Embeddables needs to be discovered just like regular entities, don't forget to add them to the list of entities when initializing the ORM.
 
-Embeddables can contain properties with basic `@Property()` mapping, nested 
-`@Embedded()` properties or arrays of `@Embedded()` properties. From version
-5.0 we can also use `@ManyToOne()` properties.
+Embeddables can contain properties with basic `@Property()` mapping, nested `@Embedded()` properties or arrays of `@Embedded()` properties. From version 5.0 we can also use `@ManyToOne()` properties.
 
-For the purposes of this tutorial, we will assume that you have a `User` class in 
-your application and you would like to store an address in the `User` class. We will 
-model the `Address` class as an embeddable instead of simply adding the respective 
-columns to the `User` class.
+For the purposes of this tutorial, we will assume that you have a `User` class in your application and you would like to store an address in the `User` class. We will model the `Address` class as an embeddable instead of simply adding the respective columns to the `User` class.
 
 <Tabs
   groupId="entity-def"
@@ -144,17 +135,13 @@ export const AddressSchema = new EntitySchema({
   </TabItem>
 </Tabs>
 
-> When using ReflectMetadataProvider, you might need to provide the class in decorator options:
-> `@Embedded(() => Address)` or `@Embedded({ entity: () => Address })`.
+> When using ReflectMetadataProvider, you might need to provide the class in decorator options: `@Embedded(() => Address)` or `@Embedded({ entity: () => Address })`.
 
-In terms of your database schema, MikroORM will automatically inline all columns from 
-the `Address` class into the table of the `User` class, just as if you had declared 
-them directly there.
+In terms of your database schema, MikroORM will automatically inline all columns from the `Address` class into the table of the `User` class, just as if you had declared them directly there.
 
 ## Initializing embeddables
 
-In case all fields in the embeddable are nullable, you might want to initialize the 
-embeddable, to avoid getting a null value instead of the embedded object.
+In case all fields in the embeddable are nullable, you might want to initialize the embeddable, to avoid getting a null value instead of the embedded object.
 
 <Tabs
   groupId="entity-def"
@@ -194,11 +181,9 @@ address: { reference: 'embedded', entity: 'Address', onCreate: () => new Address
 
 By default, MikroORM names your columns by prefixing them, using the value object name.
 
-Following the example above, your columns would be named as `address_street`, 
-`address_postal_code`...
+Following the example above, your columns would be named as `address_street`, `address_postal_code`...
 
-You can change this behaviour to meet your needs by changing the `prefix` attribute 
-in the `@Embedded()` notation.
+You can change this behaviour to meet your needs by changing the `prefix` attribute in the `@Embedded()` notation.
 
 The following example shows you how to set your prefix to `myPrefix_`:
 
@@ -246,8 +231,7 @@ address: { reference: 'embedded', entity: 'Address', prefix: 'myPrefix_' },
   </TabItem>
 </Tabs>
 
-To have MikroORM drop the prefix and use the value object's property name directly, 
-set `prefix: false`:
+To have MikroORM drop the prefix and use the value object's property name directly, set `prefix: false`:
 
 <Tabs
   groupId="entity-def"
@@ -285,8 +269,7 @@ address: { reference: 'embedded', entity: 'Address', prefix: false },
 
 ## Storing embeddables as objects
 
-From MikroORM v4.2 we can also store the embeddable as an object instead of
-inlining its properties to the owing entity.
+From MikroORM v4.2 we can also store the embeddable as an object instead of inlining its properties to the owing entity.
 
 <Tabs
   groupId="entity-def"
@@ -322,17 +305,15 @@ address: { reference: 'embedded', entity: 'Address', object: true },
   </TabItem>
 </Tabs>
 
-In SQL drivers, this will use a JSON column to store the value. 
+In SQL drivers, this will use a JSON column to store the value.
 
 > Only MySQL and PostgreSQL drivers support searching by JSON properties currently.
 
-> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/embeddables.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/embeddables.html) as the behaviour here is pretty much the same.
 
 ## Array of embeddables
 
-Embedded arrays are always stored as JSON. It is possible to use them inside
-nested embeddables. 
+Embedded arrays are always stored as JSON. It is possible to use them inside nested embeddables.
 
 <Tabs
   groupId="entity-def"
@@ -533,10 +514,7 @@ export const IdentitySchema = new EntitySchema({
 
 ## Polymorphic embeddables
 
-Since v5, it is also possible to use polymorphic embeddables. This means we
-can define multiple classes for a single embedded property and the right one
-will be used based on the discriminator column, similar to how single table 
-inheritance work.
+Since v5, it is also possible to use polymorphic embeddables. This means we can define multiple classes for a single embedded property and the right one will be used based on the discriminator column, similar to how single table inheritance work.
 
 <Tabs
   groupId="entity-def"

--- a/docs/versioned_docs/version-5.6/entity-constructors.md
+++ b/docs/versioned_docs/version-5.6/entity-constructors.md
@@ -84,7 +84,7 @@ The `rel()` helper will create entity instance that is not yet managed (as we do
 
 > `rel()` is a shortcut for `Reference.createNakedFromPK()`.
 
-And if you want to be safer and use the `Reference` wrapper, the `ref()` helper also accepts this new signature: 
+And if you want to be safer and use the `Reference` wrapper, the `ref()` helper also accepts this new signature:
 
 ```ts
 @ManyToOne({ entity: () => Author, ref: true })

--- a/docs/versioned_docs/version-5.6/entity-generator.md
+++ b/docs/versioned_docs/version-5.6/entity-generator.md
@@ -2,12 +2,11 @@
 title: Entity Generator
 ---
 
-To generate entities from existing database schema, you can use `EntityGenerator` helper. 
+To generate entities from existing database schema, you can use `EntityGenerator` helper.
 
-You can use it via CLI: 
+You can use it via CLI:
 
-> To work with the CLI, first install `@mikro-orm/cli` package locally.
-> The version needs to be aligned with the `@mikro-orm/core` package.
+> To work with the CLI, first install `@mikro-orm/cli` package locally. The version needs to be aligned with the `@mikro-orm/core` package.
 
 ```sh
 npx mikro-orm generate-entities --dump  # Dumps all generated entities
@@ -22,14 +21,14 @@ import { MikroORM } from '@mikro-orm/core';
 (async () => {
   const orm = await MikroORM.init({
     discovery: {
-      // we need to disable validation for no entities 
+      // we need to disable validation for no entities
       warnWhenNoEntities: false,
     },
     dbName: 'your-db-name',
     // ...
   });
   const generator = orm.getEntityGenerator();
-  const dump = await generator.generate({ 
+  const dump = await generator.generate({
     save: true,
     baseDir: process.cwd() + '/my-entities',
   });
@@ -46,7 +45,7 @@ $ ts-node generate-entities
 
 ## Advanced configuration
 
-By default, the `EntityGenerator` generates only owning sides of relations (e.g. M:1) and uses decorators for the entity definition. We can adjust its behaviour via `entityGenerator` section in the ORM config. Available options: 
+By default, the `EntityGenerator` generates only owning sides of relations (e.g. M:1) and uses decorators for the entity definition. We can adjust its behaviour via `entityGenerator` section in the ORM config. Available options:
 
 - `bidirectionalRelations` to generate also the inverse sides for them
 - `identifiedReferences` to generate M:1 and 1:1 relations as wrapped references

--- a/docs/versioned_docs/version-5.6/entity-helper.md
+++ b/docs/versioned_docs/version-5.6/entity-helper.md
@@ -18,8 +18,8 @@ Same result can be easily achieved with `assign()`:
 ```ts
 import { wrap } from '@mikro-orm/core';
 
-wrap(book).assign({ 
-  title: 'Better Book 1', 
+wrap(book).assign({
+  title: 'Better Book 1',
   author: '...id...',
 });
 console.log(book.title); // 'Better Book 1'
@@ -33,8 +33,8 @@ To use `assign()` on not managed entities, you need to provide `EntityManager` i
 import { wrap } from '@mikro-orm/core';
 
 const book = new Book();
-wrap(book).assign({ 
-  title: 'Better Book 1', 
+wrap(book).assign({
+  title: 'Better Book 1',
   author: '...id...',
 }, { em });
 ```
@@ -55,9 +55,7 @@ console.log(book.meta); // { foo: 4 }
 
 ### Updating deep entity graph
 
-Since v5, `assign` allows updating deep entity graph by default. To update existing
-entity, we need to provide its PK in the `data`, as well as to **load that entity first
-into current context**.
+Since v5, `assign` allows updating deep entity graph by default. To update existing entity, we need to provide its PK in the `data`, as well as to **load that entity first into current context**.
 
 ```ts
 const book = await em.findOneOrFail(Book, 1, { populate: ['author'] });
@@ -71,8 +69,7 @@ wrap(book).assign({
 });
 ```
 
-If we want to always update the entity, even without the entity PK being present
-in `data`, we can use `updateByPrimaryKey: false`:
+If we want to always update the entity, even without the entity PK being present in `data`, we can use `updateByPrimaryKey: false`:
 
 ```ts
 const book = await em.findOneOrFail(Book, 1, { populate: ['author'] });
@@ -85,8 +82,7 @@ wrap(book).assign({
 }, { updateByPrimaryKey: false });
 ```
 
-Otherwise the entity data without PK are considered as new entity, and will trigger
-insert query:
+Otherwise the entity data without PK are considered as new entity, and will trigger insert query:
 
 ```ts
 const book = await em.findOneOrFail(Book, 1, { populate: ['author'] });
@@ -99,9 +95,7 @@ wrap(book).assign({
 });
 ```
 
-Same applies to the case when we do not load the child entity first into the context,
-e.g. when we try to assign to a relation that was not populated. Even if we provide
-its PK, it will be considered as new object and trigger an insert query.
+Same applies to the case when we do not load the child entity first into the context, e.g. when we try to assign to a relation that was not populated. Even if we provide its PK, it will be considered as new object and trigger an insert query.
 
 ```ts
 const book = await em.findOneOrFail(Book, 1); // author is not populated
@@ -115,12 +109,7 @@ wrap(book).assign({
 });
 ```
 
-When updating collections, we can either pass complete array of all items, or just
-a single item - in such case, the new item will be appended to the existing items.
-Passing a completely new array of items will replace the existing items. Previously
-existing items will be disconnected/removed from the collection. Also check the
-[Collection page](collections.md#removing-items-from-collection) on the effects of
-removing entities from collections.
+When updating collections, we can either pass complete array of all items, or just a single item - in such case, the new item will be appended to the existing items. Passing a completely new array of items will replace the existing items. Previously existing items will be disconnected/removed from the collection. Also check the [Collection page](collections.md#removing-items-from-collection) on the effects of removing entities from collections.
 
 ```ts
 // resets the addresses collection to a single item
@@ -175,7 +164,7 @@ There are two ways to access those methods. You can either extend `BaseEntity` (
 
 Users can choose whether they are fine with polluting the entity interface with those additional methods, or they want to keep the interface clean and use the `wrap(entity)` helper method instead to access them.
 
-> Since v4, `wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is  being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...), if you want to access internal properties like `__meta` or `__em`, you need to explicitly ask for the helper via `wrap(entity, true)`.
+> Since v4, `wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...), if you want to access internal properties like `__meta` or `__em`, you need to explicitly ask for the helper via `wrap(entity, true)`.
 
 ```ts
 import { BaseEntity } from '@mikro-orm/core';
@@ -194,9 +183,7 @@ console.log(book.meta); // { foo: 3, bar: 2 }
 
 ### Accessing internal prefixed properties
 
-Previously it was possible to access internal properties like `__meta` or `__em`
-from the `wrap()` helper. Now to access them, you need to use second parameter of
-wrap:
+Previously it was possible to access internal properties like `__meta` or `__em` from the `wrap()` helper. Now to access them, you need to use second parameter of wrap:
 
 ```ts
 @Entity()

--- a/docs/versioned_docs/version-5.6/entity-manager.md
+++ b/docs/versioned_docs/version-5.6/entity-manager.md
@@ -58,12 +58,12 @@ const userRef = em.getReference(User, 1);
 console.log(userRef);
 ```
 
-This will log something like `(User) { id: 1 }`, note the class name being wrapped in parens - this tells you the entity is not-initialized state and represents just the primary key. 
+This will log something like `(User) { id: 1 }`, note the class name being wrapped in parens - this tells you the entity is not-initialized state and represents just the primary key.
 
 Here is an example of common actions you can do with a reference instead of a fully loaded entity:
 
 ```ts
-// setting relation properties 
+// setting relation properties
 author.favouriteBook = em.getReference(Book, 1);
 
 // removing entity by reference
@@ -144,7 +144,7 @@ You can also use `em.populate()` helper to populate relations (or to ensure they
 const authors = await em.createQueryBuilder(Author).select('*').getResult();
 await em.populate(authors, { populate: ['books.tags'] });
 
-// now our Author entities will have `books` collections populated, 
+// now our Author entities will have `books` collections populated,
 // as well as they will have their `tags` collections populated.
 console.log(authors[0].books[0].tags[0]); // initialized BookTag
 ```
@@ -327,7 +327,7 @@ const users = await em.find(User, { [expr('lower(email)')]: 'foo@bar.baz' }, {
 This will produce following query:
 
 ```sql
-select `e0`.* 
+select `e0`.*
 from `user` as `e0`
 where lower(email) = 'foo@bar.baz'
 order by (point(loc_latitude, loc_longitude) <@> point(0, 0)) asc
@@ -430,13 +430,13 @@ for (const user of users) {
 await em.flush();
 
 // update `user` set
-//   `name` = case 
-//     when (`id` = 1) then 'Peter 1 changed!' 
-//     when (`id` = 2) then 'Peter 2 changed!' 
-//     when (`id` = 3) then 'Peter 3 changed!' 
-//     when (`id` = 4) then 'Peter 4 changed!' 
-//     when (`id` = 5) then 'Peter 5 changed!' 
-//     else `priority` end 
+//   `name` = case
+//     when (`id` = 1) then 'Peter 1 changed!'
+//     when (`id` = 2) then 'Peter 2 changed!'
+//     when (`id` = 3) then 'Peter 3 changed!'
+//     when (`id` = 4) then 'Peter 4 changed!'
+//     when (`id` = 5) then 'Peter 5 changed!'
+//     else `priority` end
 //   where `id` in (1, 2, 3, 4, 5)
 ```
 
@@ -459,7 +459,7 @@ const users = await em.find(User, { email: 'foo@bar.baz' }, {
   populate: ['cars.brand'],
 });
 users[0].name = 'changed';
-await em.flush(); // calling flush have no effect, as the entity is not managed  
+await em.flush(); // calling flush have no effect, as the entity is not managed
 ```
 
 > Keep in mind that this can also have [negative effect on the performance](https://stackoverflow.com/questions/9259480/entity-framework-mergeoption-notracking-bad-performance).

--- a/docs/versioned_docs/version-5.6/entity-schema.md
+++ b/docs/versioned_docs/version-5.6/entity-schema.md
@@ -2,7 +2,7 @@
 title: Defining Entities via EntitySchema
 ---
 
-With `EntitySchema` helper we define the schema programmatically. 
+With `EntitySchema` helper we define the schema programmatically.
 
 ```ts title="./entities/Book.ts"
 export interface Book extends CustomBaseEntity {
@@ -13,7 +13,7 @@ export interface Book extends CustomBaseEntity {
 }
 
 // The second type argument is optional, and should be used only with custom
-// base entities, not with the `BaseEntity` class exported from `@mikro-orm/core`. 
+// base entities, not with the `BaseEntity` class exported from `@mikro-orm/core`.
 export const schema = new EntitySchema<Book, CustomBaseEntity>({
   // name should be used only with interfaces
   name: 'Book',
@@ -29,8 +29,7 @@ export const schema = new EntitySchema<Book, CustomBaseEntity>({
 });
 ```
 
-When creating new entity instances, you will need to use `em.create()` method that will
-create instance of internally created class. 
+When creating new entity instances, you will need to use `em.create()` method that will create instance of internally created class.
 
 ```ts
 const repo = em.getRepository<Author>('Author');
@@ -42,7 +41,7 @@ await repo.persistAndFlush(author);
 
 ## Using custom entity classes
 
-You can optionally use custom class for entity instances.  
+You can optionally use custom class for entity instances.
 
 ```ts title="./entities/Author.ts"
 export class Author extends CustomBaseEntity {
@@ -55,7 +54,7 @@ export class Author extends CustomBaseEntity {
   books = new Collection<Book>(this);
   favouriteBook?: Book;
   version?: number;
-  
+
   constructor(name: string, email: string) {
     super();
     this.name = name;
@@ -90,7 +89,7 @@ await repo.persistAndFlush(author);
 
 ## Using custom base entity
 
-Do not forget that base entities needs to be discovered just like normal entities. 
+Do not forget that base entities needs to be discovered just like normal entities.
 
 ```ts title="./entities/BaseEntity.ts"
 export interface CustomBaseEntity {
@@ -112,9 +111,7 @@ export const schema = new EntitySchema<CustomBaseEntity>({
 
 ## Configuration Reference
 
-The parameter of `EntitySchema` requires to provide either `name` or `class` parameters. 
-When using `class`, `extends` will be automatically inferred. You can optionally pass 
-these additional parameters:
+The parameter of `EntitySchema` requires to provide either `name` or `class` parameters. When using `class`, `extends` will be automatically inferred. You can optionally pass these additional parameters:
 
 ```ts
 name: string;
@@ -129,8 +126,7 @@ hooks: Partial<Record<keyof typeof EventType, ((string & keyof T) | NonNullable<
 abstract: boolean;
 ```
 
-Every property then needs to contain a type specification - one of `type`/`customType`/`entity`.
-Here are some examples of various property types:
+Every property then needs to contain a type specification - one of `type`/`customType`/`entity`. Here are some examples of various property types:
 
 ```ts
 export enum MyEnum {
@@ -187,10 +183,7 @@ export const schema = new EntitySchema<BookTag>({
 
 ## Hooks example
 
-Entity hooks can be defined either as a property name, or as a function.
-When defined as a function, the `this` argument will be the entity instance.
-Arrow functions can be used if desired, and the entity will be available at args.entity.
-See [Events and Lifecycle Hooks](events.md) section for more details on `EventArgs`.
+Entity hooks can be defined either as a property name, or as a function. When defined as a function, the `this` argument will be the entity instance. Arrow functions can be used if desired, and the entity will be available at args.entity. See [Events and Lifecycle Hooks](events.md) section for more details on `EventArgs`.
 
 ```ts
 export class BookTag {

--- a/docs/versioned_docs/version-5.6/events.md
+++ b/docs/versioned_docs/version-5.6/events.md
@@ -3,11 +3,10 @@ title: Events and Lifecycle Hooks
 sidebar_label: Events and Hooks
 ---
 
-There are two ways to hook to the lifecycle of an entity: 
+There are two ways to hook to the lifecycle of an entity:
 
 - **Lifecycle hooks** are methods defined on the entity prototype.
-- **EventSubscriber**s are classes that can be used to hook to multiple entities
-  or when we do not want to have the method present on the entity prototype.
+- **EventSubscriber**s are classes that can be used to hook to multiple entities or when we do not want to have the method present on the entity prototype.
 
 > Hooks are internally executed the same way as subscribers.
 
@@ -15,53 +14,37 @@ There are two ways to hook to the lifecycle of an entity:
 
 ## Hooks
 
-We can use lifecycle hooks to run some code when entity gets persisted. We can mark any of
-entity methods with them, we can also mark multiple methods with same hook.
+We can use lifecycle hooks to run some code when entity gets persisted. We can mark any of entity methods with them, we can also mark multiple methods with same hook.
 
 All hooks support async methods with one exception - `@OnInit`.
 
-- `@OnInit` is fired when new instance of entity is created, either manually `em.create()`, or 
-automatically when new entities are loaded from database
+- `@OnInit` is fired when new instance of entity is created, either manually `em.create()`, or automatically when new entities are loaded from database
 
-- `@OnLoad` is fired when new entity is loaded into context (e.g. via `em.find()` or `em.populate()`). As opposed to `@OnInit` this will be fired only for fully loaded entities, not references, and this hook can be async. 
+- `@OnLoad` is fired when new entity is loaded into context (e.g. via `em.find()` or `em.populate()`). As opposed to `@OnInit` this will be fired only for fully loaded entities, not references, and this hook can be async.
 
 - `@BeforeCreate()` and `@BeforeUpdate()` is fired right before we persist the entity in database
 
-- `@AfterCreate()` and `@AfterUpdate()` is fired right after the entity is updated in database and 
-merged to identity map. Since this event entity will have reference to `EntityManager` and will be 
-enabled to call `wrap(entity).init()` method (including all entity references and collections).
+- `@AfterCreate()` and `@AfterUpdate()` is fired right after the entity is updated in database and merged to identity map. Since this event entity will have reference to `EntityManager` and will be enabled to call `wrap(entity).init()` method (including all entity references and collections).
 
-- `@BeforeDelete()` is fired right before we delete the record from database. It is fired only when
-removing entity or entity reference, not when deleting records by query. 
+- `@BeforeDelete()` is fired right before we delete the record from database. It is fired only when removing entity or entity reference, not when deleting records by query.
 
-- `@AfterDelete()` is fired right after the record gets deleted from database and it is unset from 
-the identity map.
+- `@AfterDelete()` is fired right after the record gets deleted from database and it is unset from the identity map.
 
 > `@OnInit` is not fired when we create the entity manually via its constructor (`new MyEntity()`)
 
-> `@OnInit` can be sometimes fired twice, once when the entity reference is
-> created, and once after its populated. To distinguish between those we can
-> use `wrap(this).isInitialized()`.
+> `@OnInit` can be sometimes fired twice, once when the entity reference is created, and once after its populated. To distinguish between those we can use `wrap(this).isInitialized()`.
 
 ## Limitations of lifecycle hooks
 
-Hooks are executed inside the commit action of unit of work, after all change 
-sets are computed. This means that it is not possible to create new entities as
-usual from inside the hook. Calling `em.flush()` from hooks will result in 
-validation error. Calling `em.persist()` can result in undefined behaviour like
-locking errors. 
+Hooks are executed inside the commit action of unit of work, after all change sets are computed. This means that it is not possible to create new entities as usual from inside the hook. Calling `em.flush()` from hooks will result in validation error. Calling `em.persist()` can result in undefined behaviour like locking errors.
 
-> The **internal** instance of `EntityManager` accessible under `wrap(this, true).__em` is 
-> not meant for public usage. 
+> The **internal** instance of `EntityManager` accessible under `wrap(this, true).__em` is not meant for public usage.
 
 ## EventSubscriber
 
-Use `EventSubscriber` to hook to multiple entities or if we do not want to pollute
-the entity prototype. All methods are optional, if we omit the `getSubscribedEntities()`
-method, it means we are subscribing to all entities.
+Use `EventSubscriber` to hook to multiple entities or if we do not want to pollute the entity prototype. All methods are optional, if we omit the `getSubscribedEntities()` method, it means we are subscribing to all entities.
 
-We can either register the subscribers manually in the ORM configuration (via 
-`subscribers` array where we put the instance):
+We can either register the subscribers manually in the ORM configuration (via `subscribers` array where we put the instance):
 
 ```ts
 MikroORM.init({
@@ -69,9 +52,7 @@ MikroORM.init({
 });
 ```
 
-Or use `@Subscriber()` decorator - keep in mind that we need to make sure the file gets 
-loaded in order to make this decorator registration work (e.g. we import that file 
-explicitly somewhere).
+Or use `@Subscriber()` decorator - keep in mind that we need to make sure the file gets loaded in order to make this decorator registration work (e.g. we import that file explicitly somewhere).
 
 ```ts
 import { EntityName, EventArgs, EventSubscriber, Subscriber } from '@mikro-orm/core';
@@ -88,13 +69,13 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
   }
 
   async afterUpdate(args: EventArgs<Author>): Promise<void> {
-    // ... 
+    // ...
   }
 
 }
 ```
 
-Another example, where we register to all the events and all entities: 
+Another example, where we register to all the events and all entities:
 
 ```ts
 import { EventArgs, EventSubscriber, Subscriber } from '@mikro-orm/core';
@@ -111,7 +92,7 @@ export class EverythingSubscriber implements EventSubscriber {
   async afterUpdate<T>(args: EventArgs<T>): Promise<void> { ... }
   async beforeDelete<T>(args: EventArgs<T>): Promise<void> { ... }
   async afterDelete<T>(args: EventArgs<T>): Promise<void> { ... }
-  
+
   // flush events
   async beforeFlush<T>(args: EventArgs<T>): Promise<void> { ... }
   async onFlush<T>(args: EventArgs<T>): Promise<void> { ... }
@@ -130,9 +111,7 @@ export class EverythingSubscriber implements EventSubscriber {
 
 ## EventArgs
 
-As a parameter to the hook method we get `EventArgs` instance. It will always contain
-reference to the current `EntityManager` and the particular entity. Events fired
-from `UnitOfWork` during flush operation also contain the `ChangeSet` object.
+As a parameter to the hook method we get `EventArgs` instance. It will always contain reference to the current `EntityManager` and the particular entity. Events fired from `UnitOfWork` during flush operation also contain the `ChangeSet` object.
 
 ```ts
 interface EventArgs<T> {
@@ -161,28 +140,21 @@ enum ChangeSetType {
 
 ## Flush events
 
-There is a special kind of events executed during the commit phase (flush operation).
-They are executed before, during and after the flush, and they are not bound to any
-entity in particular. 
+There is a special kind of events executed during the commit phase (flush operation). They are executed before, during and after the flush, and they are not bound to any entity in particular.
 
-- `beforeFlush` is executed before change sets are computed, this is the only
-  event where it is safe to persist new entities. 
+- `beforeFlush` is executed before change sets are computed, this is the only event where it is safe to persist new entities.
 - `onFlush` is executed after the change sets are computed.
-- `afterFlush` is executed as the last step just before the `flush` call resolves.
-  it will be executed even if there are no changes to be flushed. 
+- `afterFlush` is executed as the last step just before the `flush` call resolves. it will be executed even if there are no changes to be flushed.
 
-Flush event args will not contain any entity instance, as they are entity agnostic.
-They do contain additional reference to the `UnitOfWork` instance.
+Flush event args will not contain any entity instance, as they are entity agnostic. They do contain additional reference to the `UnitOfWork` instance.
 
 ```ts
 interface FlushEventArgs extends Omit<EventArgs<unknown>, 'entity'> {
   uow?: UnitOfWork;
 }
-``` 
+```
 
-> Flush events are entity agnostic, specifying `getSubscribedEntities()` method
-> will not have any effect for those. They are fired only once per the `flush` 
-> operation.
+> Flush events are entity agnostic, specifying `getSubscribedEntities()` method will not have any effect for those. They are fired only once per the `flush` operation.
 
 ## Transaction events
 
@@ -219,18 +191,12 @@ UnitOfWork.getExtraUpdates(): Set<[AnyEntity, string, (AnyEntity | Reference<Any
 
 ### Using onFlush event
 
-In following example we have 2 entities: `FooBar` and `FooBaz`, connected via 
-M:1 relation. Our subscriber will automatically create new `FooBaz` entity and 
-connect it to the `FooBar` when we detect it in the change sets.
+In following example we have 2 entities: `FooBar` and `FooBaz`, connected via M:1 relation. Our subscriber will automatically create new `FooBaz` entity and connect it to the `FooBar` when we detect it in the change sets.
 
-We first use `uow.getChangeSets()` method to look up the change set of entity
-we are interested in. After we create the `FooBaz` instance and link it with 
-`FooBar`, we need to do two things:
+We first use `uow.getChangeSets()` method to look up the change set of entity we are interested in. After we create the `FooBaz` instance and link it with `FooBar`, we need to do two things:
 
-1. Call `uow.computeChangeSet(baz)` to compute the change set of newly created 
-  `FooBaz` entity
-2. Call `uow.recomputeSingleChangeSet(cs.entity)` to recalculate the existing 
-  change set of the `FooBar` entity.
+1. Call `uow.computeChangeSet(baz)` to compute the change set of newly created `FooBaz` entity
+2. Call `uow.recomputeSingleChangeSet(cs.entity)` to recalculate the existing change set of the `FooBar` entity.
 
 ```ts
 @Subscriber()
@@ -258,7 +224,7 @@ await em.persistAndFlush(bar);
 
 ## Transaction events
 
-Transaction events happen at the beginning and end of a transaction. 
+Transaction events happen at the beginning and end of a transaction.
 
 - `beforeTransactionStart` is executed before a transaction starts.
 - `afterTransactionStart` is executed after a transaction starts.
@@ -267,5 +233,4 @@ Transaction events happen at the beginning and end of a transaction.
 - `beforeTransactionRollback` is executed before a transaction is rolled back.
 - `afterTransactionRollback` is executed after a transaction is rolled back.
 
-They are also entity agnostic and will only reference the transaction, `UnitOfWork` instance
-and `EntityManager` instance.
+They are also entity agnostic and will only reference the transaction, `UnitOfWork` instance and `EntityManager` instance.

--- a/docs/versioned_docs/version-5.6/faq.md
+++ b/docs/versioned_docs/version-5.6/faq.md
@@ -5,6 +5,7 @@ title: Frequently Asked Questions
 ### How can I synchronize my database schema with the entities?
 
 There are two ways:
+
 - [Schema Generator](./schema-generator.md)
 - [Migrations](./migrations.md)
 
@@ -14,21 +15,15 @@ npx mikro-orm schema:update --run
 
 ### I cannot run the CLI
 
-Make sure you install `@mikro-orm/cli` package locally. If you want to have
-global installation, you will need to install driver packages globally too.
+Make sure you install `@mikro-orm/cli` package locally. If you want to have global installation, you will need to install driver packages globally too.
 
 ### EntityManager does not have `createQueryBuilder()` method
 
 The method is there, the issue is in the TS type.
 
-In v4 the `core` package, where `EntityManager` and `EntityRepository` are
-defined, is not dependent on knex, and therefore it cannot have a method
-returning a `QueryBuilder`. You need to import the SQL flavour of the EM
-from the driver package to access the `createQueryBuilder()` method.
+In v4 the `core` package, where `EntityManager` and `EntityRepository` are defined, is not dependent on knex, and therefore it cannot have a method returning a `QueryBuilder`. You need to import the SQL flavour of the EM from the driver package to access the `createQueryBuilder()` method.
 
-> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under
-> this name and under `EntityManager` alias, so you can just change the
-> location from where you import.
+> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ```ts
 import { EntityManager } from '@mikro-orm/mysql'; // or any other SQL driver package
@@ -37,8 +32,7 @@ const em = orm.em as EntityManager;
 const qb = await em.createQueryBuilder(...);
 ```
 
-To have the `orm.em` variable properly typed, we can use generic type parameter of
-`MikroORM.init()`:
+To have the `orm.em` variable properly typed, we can use generic type parameter of `MikroORM.init()`:
 
 ```ts
 import { MySqlDriver } from '@mikro-orm/mysql'; // or any other SQL driver package
@@ -58,25 +52,19 @@ const em = orm.em as EntityManager;
 const ret = await em.aggregate(...);
 ```
 
-> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under
-> this name and under `EntityManager` alias, so you can just change the
-> location from where you import.
+> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ### How can I add columns to pivot table (M:N relation)
 
-You should model your M:N relation transparently, via 1:m and m:1 properties.
-More about this can be found in [Composite Keys section](./composite-keys.md/#use-case-3-join-table-with-metadata).
+You should model your M:N relation transparently, via 1:m and m:1 properties. More about this can be found in [Composite Keys section](./composite-keys.md/#use-case-3-join-table-with-metadata).
 
 ### You cannot call `em.flush()` from inside lifecycle hook handlers
 
-You might see this validation error even if you do not use hooks. If that happens,
-the reason is usually because you do not have [request context](identity-map.md) set up properly, and
-you are reusing one `EntityManager` instance.
+You might see this validation error even if you do not use hooks. If that happens, the reason is usually because you do not have [request context](identity-map.md) set up properly, and you are reusing one `EntityManager` instance.
 
 ### Column is being created with JSON type while the TS type is `string/Date/number/...`
 
-You are probably using the default `ReflectMetadataProvider`, which does not
-support inferring property type when there is a property initializer.
+You are probably using the default `ReflectMetadataProvider`, which does not support inferring property type when there is a property initializer.
 
 ```ts
 @Property()
@@ -84,6 +72,7 @@ foo = 'abc';
 ```
 
 There are two ways around this:
+
 - Use [TsMorphMetadataProvider](./metadata-providers.md/#tsmorphmetadataprovider)
 - Specify the type explicitly:
 
@@ -124,8 +113,7 @@ When creating new entity instances, either with `new Book()` or `em.create(Book,
 Book {}
 ```
 
-But some users might find that this returns an object with properties that are explicitly
-set to `undefined`:
+But some users might find that this returns an object with properties that are explicitly set to `undefined`:
 
 ```ts
 Book {
@@ -135,8 +123,7 @@ Book {
 }
 ```
 
-This can cause unexpected behavior, particularly if you're expecting the database to set a
-default value for a column.
+This can cause unexpected behavior, particularly if you're expecting the database to set a default value for a column.
 
 To fix this, disable the [`useDefineForClassFields`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#the-usedefineforclassfields-flag-and-the-declare-property-modifier) option in your tsconfig:
 
@@ -147,5 +134,3 @@ To fix this, disable the [`useDefineForClassFields`](https://www.typescriptlang.
   }
 }
 ```
-
-

--- a/docs/versioned_docs/version-5.6/filters.md
+++ b/docs/versioned_docs/version-5.6/filters.md
@@ -2,16 +2,11 @@
 title: Filters
 ---
 
-MikroORM has the ability to pre-define filter criteria and attach those filters 
-to given entities. The application can then decide at runtime whether certain 
-filters should be enabled and what their parameter values should be. Filters 
-can be used like database views, but they are parameterized inside the application.
+MikroORM has the ability to pre-define filter criteria and attach those filters to given entities. The application can then decide at runtime whether certain filters should be enabled and what their parameter values should be. Filters can be used like database views, but they are parameterized inside the application.
 
-> Filter can be defined at the entity level, dynamically via EM (global filters) 
-> or in the ORM configuration.
+> Filter can be defined at the entity level, dynamically via EM (global filters) or in the ORM configuration.
 
-Filters are applied to those methods of `EntityManager`: `find()`, `findOne()`, 
-`findAndCount()`, `findOneOrFail()`, `count()`, `nativeUpdate()` and `nativeDelete()`. 
+Filters are applied to those methods of `EntityManager`: `find()`, `findOne()`, `findAndCount()`, `findOneOrFail()`, `count()`, `nativeUpdate()` and `nativeDelete()`.
 
 > The `cond` parameter can be a callback, possibly asynchronous.
 
@@ -36,14 +31,14 @@ const books2 = await orm.em.find(Book, {}, {
 ## Properties of filter
 
 There are three parameters you can use:
+
 - `name` - can be used to enable a filter on the query can also used to pass a parameter
 - `cond` - is the condition that should be added to the query when the filter is enabled. This can be a callback, even async
 - `default` - indicates if the filter is enabled by default on the query
 
 ## Parameters
 
-You can define the `cond` dynamically as a callback. This callback can be also 
-asynchronous. It will get three arguments:
+You can define the `cond` dynamically as a callback. This callback can be also asynchronous. It will get three arguments:
 
 - `args` - dictionary of parameters provided by user
 - `type` - type of operation that is being filtered, one of `'read'`, `'update'`, `'delete'`
@@ -58,8 +53,8 @@ import type { EntityManager } from '@mikro-orm/mysql';
     return {}; // do not apply when updating
   }
 
-  return { 
-    author: { name: args.name }, 
+  return {
+    author: { name: args.name },
     publishedAt: { $lte: em.raw('now()') },
   };
 } })
@@ -74,9 +69,7 @@ const books = await orm.em.find(Book, {}, {
 
 ### Filters without parameters
 
-If we want to have a filter condition that do not need arguments, but we want
-to access the `type` parameter, we will need to explicitly set `args: false`, 
-otherwise error will be raised due to missing parameters:
+If we want to have a filter condition that do not need arguments, but we want to access the `type` parameter, we will need to explicitly set `args: false`, otherwise error will be raised due to missing parameters:
 
 ```ts
 @Filter({
@@ -91,10 +84,7 @@ otherwise error will be raised due to missing parameters:
 
 ## Global filters
 
-We can also register filters dynamically via `EntityManager` API. We call such filters 
-global. They are enabled by default (unless disabled via last parameter in `addFilter()`
-method), and applied to all entities. You can limit the global filter to only specified
-entities. 
+We can also register filters dynamically via `EntityManager` API. We call such filters global. They are enabled by default (unless disabled via last parameter in `addFilter()` method), and applied to all entities. You can limit the global filter to only specified entities.
 
 > Filters as well as filter params set on the EM will be copied to all its forks.
 
@@ -125,12 +115,9 @@ MikroORM.init({
 
 ## Using filters
 
-We can control what filters will be applied via `filter` parameter in `FindOptions`.
-We can either provide an array of names of filters you want to enable, or options 
-object, where we can also disable a filter (that was enabled by default), or pass some
-parameters to those that are expecting them.
+We can control what filters will be applied via `filter` parameter in `FindOptions`. We can either provide an array of names of filters you want to enable, or options object, where we can also disable a filter (that was enabled by default), or pass some parameters to those that are expecting them.
 
-> By passing `filters: false` we can also disable all the filters for given call. 
+> By passing `filters: false` we can also disable all the filters for given call.
 
 ```ts
 em.find(Book, {}); // same as `{ tenantId: 123 }`
@@ -141,17 +128,11 @@ em.find(Book, {}, { filters: false }); // disabled all filters, so truly `{}`
 
 ## Filters and populating of relationships
 
-When populating relationships, filters will be applied only to the root entity of 
-given query, but not to those that are auto-joined. On the other hand, this means that
-when you use the default loading strategy - `LoadStrategy.SELECT_IN` - filters will
-be applied to every entity populated this way, as the child entities will become
-root entities in their respective load calls.
+When populating relationships, filters will be applied only to the root entity of given query, but not to those that are auto-joined. On the other hand, this means that when you use the default loading strategy - `LoadStrategy.SELECT_IN` - filters will be applied to every entity populated this way, as the child entities will become root entities in their respective load calls.
 
 ## Naming of filters
 
-When toggling filters via `FindOptions`, we do not care about the entity name. This
-means that when you have multiple filters defined on different entities, but with 
-the same name, they will be controlled via single toggle in the `FindOptions`. 
+When toggling filters via `FindOptions`, we do not care about the entity name. This means that when you have multiple filters defined on different entities, but with the same name, they will be controlled via single toggle in the `FindOptions`.
 
 ```ts
 @Entity()

--- a/docs/versioned_docs/version-5.6/inheritance-mapping.md
+++ b/docs/versioned_docs/version-5.6/inheritance-mapping.md
@@ -4,18 +4,13 @@ title: Inheritance Mapping
 
 ## Mapped Superclasses
 
-A mapped superclass is an abstract or concrete class that provides persistent entity state and mapping information for its subclasses, but which is not itself an entity. Typically, the purpose of such
-a mapped superclass is to define state and mapping information that is common to multiple entity classes.
+A mapped superclass is an abstract or concrete class that provides persistent entity state and mapping information for its subclasses, but which is not itself an entity. Typically, the purpose of such a mapped superclass is to define state and mapping information that is common to multiple entity classes.
 
 Mapped superclasses, just as regular, non-mapped classes, can appear in the middle of an otherwise mapped inheritance hierarchy (through Single Table Inheritance).
 
-> A mapped superclass cannot be an entity, it is not query-able and persistent relationships defined
-> by a mapped superclass must be unidirectional (with an owning side only). This means that One-To-Many
-> associations are not possible on a mapped superclass at all. Furthermore Many-To-Many associations
-> are only possible if the mapped superclass is only used in exactly one entity at the moment. For
-> further support of inheritance, the single table inheritance features have to be used.
+> A mapped superclass cannot be an entity, it is not query-able and persistent relationships defined by a mapped superclass must be unidirectional (with an owning side only). This means that One-To-Many associations are not possible on a mapped superclass at all. Furthermore Many-To-Many associations are only possible if the mapped superclass is only used in exactly one entity at the moment. For further support of inheritance, the single table inheritance features have to be used.
 
-> Also note that we can't use generics to define any relations. This means that we cannot have a generic type argument in the base entity that would be used as a target of some relation. 
+> Also note that we can't use generics to define any relations. This means that we cannot have a generic type argument in the base entity that would be used as a target of some relation.
 
 ```ts
 // do not use @Entity decorator on base classes (mapped superclasses)
@@ -69,16 +64,13 @@ create table `employee` (
 );
 ```
 
-As we can see from this DDL snippet, there is only a single table for the entity subclass. All the mappings from the mapped superclass were inherited to the subclass as if they had been defined on
-that class directly.
+As we can see from this DDL snippet, there is only a single table for the entity subclass. All the mappings from the mapped superclass were inherited to the subclass as if they had been defined on that class directly.
 
 ## Single Table Inheritance
 
 > Support for STI was added in version 4.0
 
-[Single Table Inheritance](https://martinfowler.com/eaaCatalog/singleTableInheritance.html)
-is an inheritance mapping strategy where all classes of a hierarchy are mapped to a single database table. In order to distinguish which row represents which type in the hierarchy a so-called
-discriminator column is used.
+[Single Table Inheritance](https://martinfowler.com/eaaCatalog/singleTableInheritance.html) is an inheritance mapping strategy where all classes of a hierarchy are mapped to a single database table. In order to distinguish which row represents which type in the hierarchy a so-called discriminator column is used.
 
 ```ts
 @Entity({
@@ -98,18 +90,14 @@ export class Employee extends Person {
 Things to note:
 
 - The `discriminatorColumn` option must be specified on the topmost class that is part of the mapped entity hierarchy.
-- The `discriminatorMap` specifies which values of the discriminator column identify a row as being of a certain type. In the case above a value of `person` identifies a row as being of type `Person`
-  and `employee` identifies a row as being of type
-  `Employee`.
+- The `discriminatorMap` specifies which values of the discriminator column identify a row as being of a certain type. In the case above a value of `person` identifies a row as being of type `Person` and `employee` identifies a row as being of type `Employee`.
 - All entity classes that are part of the mapped entity hierarchy (including the topmost class) should be specified in the `discriminatorMap`. In the case above `Person` class included.
 - We can use abstract class as the root entity - then the root class should not be part of the discriminator map
-- If no discriminator map is provided, then the map is generated automatically. The automatically generated discriminator map contains the table names that would be otherwise used in case of regular
-  entities.
+- If no discriminator map is provided, then the map is generated automatically. The automatically generated discriminator map contains the table names that would be otherwise used in case of regular entities.
 
 ### Using `discriminatorValue` instead of `discriminatorMap`
 
-As noted above, the discriminator map can be auto-generated. In that case, we might want to control the tokens that will be used in the map. To do so, we can use
-`discriminatorValue` on the child entities:
+As noted above, the discriminator map can be auto-generated. In that case, we might want to control the tokens that will be used in the map. To do so, we can use `discriminatorValue` on the child entities:
 
 ```ts
 @Entity({
@@ -130,8 +118,7 @@ export class Employee extends Person {
 
 ### Explicit discriminator column
 
-The `discriminatorColumn` specifies the name of special column that will be used to define what type of class should given row be represented with. It will be defined automatically for us and it will
-stay hidden (it won't be hydrated as a regular property).
+The `discriminatorColumn` specifies the name of special column that will be used to define what type of class should given row be represented with. It will be defined automatically for us and it will stay hidden (it won't be hydrated as a regular property).
 
 On the other hand, it is perfectly fine to define the column explicitly. Doing so, we will be able to:
 
@@ -190,18 +177,14 @@ export class Employee extends Person {
 
 ### Design-time considerations
 
-This mapping approach works well when the type hierarchy is fairly simple and stable. Adding a new type to the hierarchy and adding fields to existing supertypes simply involves adding new columns to
-the table, though in large deployments this may have an adverse impact on the index and column layout inside the database.
+This mapping approach works well when the type hierarchy is fairly simple and stable. Adding a new type to the hierarchy and adding fields to existing supertypes simply involves adding new columns to the table, though in large deployments this may have an adverse impact on the index and column layout inside the database.
 
 ### Performance impact
 
-This strategy is very efficient for querying across all types in the hierarchy or for specific types. No table joins are required, only a WHERE clause listing the type identifiers. In particular,
-relationships involving types that employ this mapping strategy are very performant.
+This strategy is very efficient for querying across all types in the hierarchy or for specific types. No table joins are required, only a WHERE clause listing the type identifiers. In particular, relationships involving types that employ this mapping strategy are very performant.
 
 ### SQL Schema considerations
 
-For Single-Table-Inheritance to work in scenarios where we are using either a legacy database schema or a self-written database schema we have to make sure that all columns that are not in the root
-entity but in any of the different sub-entities has to allow null values. Columns that have NOT NULL constraints have to be on the root entity of the single-table inheritance hierarchy.
+For Single-Table-Inheritance to work in scenarios where we are using either a legacy database schema or a self-written database schema we have to make sure that all columns that are not in the root entity but in any of the different sub-entities has to allow null values. Columns that have NOT NULL constraints have to be on the root entity of the single-table inheritance hierarchy.
 
-> This part of documentation is highly inspired by [doctrine docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/inheritance-mapping.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/inheritance-mapping.html) as the behaviour here is pretty much the same.

--- a/docs/versioned_docs/version-5.6/installation.md
+++ b/docs/versioned_docs/version-5.6/installation.md
@@ -2,12 +2,9 @@
 title: Installation & Usage
 ---
 
-First install the module via `yarn` or `npm` and do not forget to install the 
-driver package as well:
+First install the module via `yarn` or `npm` and do not forget to install the driver package as well:
 
-> Since v4, we should install the driver package, but not the db connector itself,
-> e.g. install `@mikro-orm/sqlite`, but not `sqlite3` as that is already included
-> in the driver package.
+> Since v4, we should install the driver package, but not the db connector itself, e.g. install `@mikro-orm/sqlite`, but not `sqlite3` as that is already included in the driver package.
 
 ```sh
 yarn add @mikro-orm/core @mikro-orm/mongodb     # for mongo
@@ -27,8 +24,7 @@ npm i -s @mikro-orm/core @mikro-orm/postgresql  # for postgresql
 npm i -s @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 ```
 
-Next we will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html)
-as well as `esModuleInterop` in `tsconfig.json` via:
+Next we will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html) as well as `esModuleInterop` in `tsconfig.json` via:
 
 ```json
 "experimentalDecorators": true,
@@ -38,9 +34,7 @@ as well as `esModuleInterop` in `tsconfig.json` via:
 
 Then call `MikroORM.init` as part of bootstrapping our app:
 
-> To access driver specific methods like `em.createQueryBuilder()` we need to specify
-> the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the
-> `orm.em` to `EntityManager` exported from the driver package:
+> To access driver specific methods like `em.createQueryBuilder()` we need to specify the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the `orm.em` to `EntityManager` exported from the driver package:
 >
 > ```ts
 > import { EntityManager } from '@mikro-orm/postgresql';
@@ -62,10 +56,7 @@ console.log(orm.em); // access EntityManager via `em` property
 
 > Read more about all the possible configuration options in [Advanced Configuration](configuration.md) section.
 
-We can also provide paths where we store our entities via `entities` array. Internally
-it uses [`globby`](https://github.com/sindresorhus/globby) so we can use 
-[globbing patterns](https://github.com/sindresorhus/globby#globbing-patterns), 
-including negative globs. 
+We can also provide paths where we store our entities via `entities` array. Internally it uses [`globby`](https://github.com/sindresorhus/globby) so we can use [globbing patterns](https://github.com/sindresorhus/globby#globbing-patterns), including negative globs.
 
 ```ts
 const orm = await MikroORM.init<PostgreSqlDriver>({
@@ -75,21 +66,17 @@ const orm = await MikroORM.init<PostgreSqlDriver>({
 });
 ```
 
-If we are experiencing problems with folder based discovery, try using `mikro-orm debug`
-CLI command to check what paths are actually being used.
+If we are experiencing problems with folder based discovery, try using `mikro-orm debug` CLI command to check what paths are actually being used.
 
 > Since v4, we can also use file globs, like `./dist/app/**/entities/*.entity.js`.
 
 We can also set the configuration via [environment variables](configuration.md#using-environment-variables).
 
-> We can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. 
-> The object will be deeply merged, overriding all internally used options.
+> We can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. The object will be deeply merged, overriding all internally used options.
 
 ## Possible issues with circular dependencies
 
-Our entities will most probably contain circular dependencies (e.g. if we use bi-directional 
-relationship). While this is fine, there might be issues caused by wrong order of entities 
-during discovery, especially when we are using the folder based way.
+Our entities will most probably contain circular dependencies (e.g. if we use bi-directional relationship). While this is fine, there might be issues caused by wrong order of entities during discovery, especially when we are using the folder based way.
 
 The errors caused by circular dependencies are usually similar to this one:
 
@@ -110,17 +97,12 @@ TypeError: Cannot read property 'name' of undefined
 
 If we encounter this, we have basically two options:
 
-- Use entity references in `entities` array to have control over the order of discovery. 
-  We might need to play with the actual order we provide here, or possibly with the 
-  order of import statements.
-- Use strings instead of references (e.g. `@OneToMany('Book', 'author')`). The downside 
-  here is that we will lose the typechecking capabilities of the decorators. 
+- Use entity references in `entities` array to have control over the order of discovery. We might need to play with the actual order we provide here, or possibly with the order of import statements.
+- Use strings instead of references (e.g. `@OneToMany('Book', 'author')`). The downside here is that we will lose the typechecking capabilities of the decorators.
 
 ## Entity Discovery in TypeScript
 
-In v4 the default metadata provider is `ReflectMetadataProvider`. If we want to use
-`ts-morph` based discovery (that reads actual TS types via the compiler API), we 
-need to install `@mikro-orm/reflection`.
+In v4 the default metadata provider is `ReflectMetadataProvider`. If we want to use `ts-morph` based discovery (that reads actual TS types via the compiler API), we need to install `@mikro-orm/reflection`.
 
 ```ts
 import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
@@ -141,19 +123,16 @@ const orm = await MikroORM.init<PostgreSqlDriver>({
 });
 ```
 
-> It is important that `entities` will point to the compiled JS files, and `entitiesTs`
-> will point to the TS source files. We should not mix those. 
+> It is important that `entities` will point to the compiled JS files, and `entitiesTs` will point to the TS source files. We should not mix those.
 
-> For `ts-morph` discovery to work in production, we need to deploy `.d.ts` declaration
-> files. Be sure to enable `compilerOptions.declaration` in our `tsconfig.json`.
+> For `ts-morph` discovery to work in production, we need to deploy `.d.ts` declaration files. Be sure to enable `compilerOptions.declaration` in our `tsconfig.json`.
 
 We can also use different [metadata provider](metadata-providers.md) or even write custom one:
 
 - `ReflectMetadataProvider` that uses `reflect-metadata` instead of `ts-morph`
 - `JavaScriptMetadataProvider` that allows us to manually provide the entity schema (mainly for Vanilla JS)
 
-> Using [`EntitySchema`](entity-schema.md) is another way to define our entities, which is better
-> suited than using `JavaScriptMetadataProvider`.
+> Using [`EntitySchema`](entity-schema.md) is another way to define our entities, which is better suited than using `JavaScriptMetadataProvider`.
 
 ```ts
 const orm = await MikroORM.init<PostgreSqlDriver>({
@@ -175,8 +154,7 @@ app.use((req, res, next) => {
 });
 ```
 
-> If the `next` handler needs to be awaited (like in Koa), 
-> use `RequestContext.createAsync()` instead.
+> If the `next` handler needs to be awaited (like in Koa), use `RequestContext.createAsync()` instead.
 >
 > ```ts
 > app.use((ctx, next) => RequestContext.createAsync(orm.em, next));
@@ -186,12 +164,9 @@ More info about `RequestContext` is described [here](identity-map.md#request-con
 
 ## Setting up the Commandline Tool
 
-MikroORM ships with a number of command line tools that are very helpful during development, 
-like `SchemaGenerator` and `EntityGenerator`. We can call this command from the NPM binary 
-directory or use `npx`:
+MikroORM ships with a number of command line tools that are very helpful during development, like `SchemaGenerator` and `EntityGenerator`. We can call this command from the NPM binary directory or use `npx`:
 
-> To work with the CLI, first install `@mikro-orm/cli` package locally.
-> The version needs to be aligned with the `@mikro-orm/core` package.
+> To work with the CLI, first install `@mikro-orm/cli` package locally. The version needs to be aligned with the `@mikro-orm/core` package.
 
 ```sh
 # install the CLI package first!
@@ -207,15 +182,11 @@ $ npx mikro-orm
 $ yarn mikro-orm
 ```
 
-For CLI to be able to access our database, we will need to create `mikro-orm.config.js` file that exports our ORM configuration. 
+For CLI to be able to access our database, we will need to create `mikro-orm.config.js` file that exports our ORM configuration.
 
-> ORM configuration file can export the Promise, like:
-> `export default Promise.resolve({...});`.
+> ORM configuration file can export the Promise, like: `export default Promise.resolve({...});`.
 
-TypeScript is also supported, just enable `useTsNode` flag in our
-`package.json` file. There we can also set up array of possible paths to `mikro-orm.config` file,
-as well as use different file name. The `package.json` file can be located in 
-the current working directory, or in one of its parent folders.
+TypeScript is also supported, just enable `useTsNode` flag in our `package.json` file. There we can also set up array of possible paths to `mikro-orm.config` file, as well as use different file name. The `package.json` file can be located in the current working directory, or in one of its parent folders.
 
 We can use these environment variables to override CLI settings:
 
@@ -225,13 +196,9 @@ We can use these environment variables to override CLI settings:
 
 > Do not forget to install `ts-node` when enabling `useTsNode` flag.
 
-> The `useTsNode` is used only when executing the CLI, it is not respected when 
-> running our app.
+> The `useTsNode` is used only when executing the CLI, it is not respected when running our app.
 
-MikroORM will always try to load the first available config file, based on the 
-order in `configPaths`. This means that if we specify the first item as the TS 
-config, but we do not have `ts-node` enabled and installed, it will fail to 
-load it.
+MikroORM will always try to load the first available config file, based on the order in `configPaths`. This means that if we specify the first item as the TS config, but we do not have `ts-node` enabled and installed, it will fail to load it.
 
 ```json title="./package.json"
 {
@@ -277,23 +244,16 @@ export default defineConfig({
 });
 ```
 
-When we have `useTsNode` disabled and `ts-node` is not already registered and detected,
-TS config files will be ignored.
+When we have `useTsNode` disabled and `ts-node` is not already registered and detected, TS config files will be ignored.
 
-Once we have the CLI config properly set up, we can omit the `MikroORM.init()` options
-parameter, and the CLI config will be automatically used. This process may fail if we
-use bundlers that use tree shaking. As the config file is not referenced anywhere 
-statically, it would not be compiled - for that the best approach is to provide the config
-explicitly:
+Once we have the CLI config properly set up, we can omit the `MikroORM.init()` options parameter, and the CLI config will be automatically used. This process may fail if we use bundlers that use tree shaking. As the config file is not referenced anywhere statically, it would not be compiled - for that the best approach is to provide the config explicitly:
 
 ```ts
 import config from './mikro-orm.config';
 const orm = await MikroORM.init(config);
 ```
 
-> We can also use different names for this file, simply rename it in the `configPaths` array
-> our in `package.json`. We can also use `MIKRO_ORM_CLI` environment variable with the path
-> to override `configPaths` value.
+> We can also use different names for this file, simply rename it in the `configPaths` array our in `package.json`. We can also use `MIKRO_ORM_CLI` environment variable with the path to override `configPaths` value.
 
 Now we should be able to start using the CLI. All available commands are listed in the CLI help:
 
@@ -330,10 +290,8 @@ Examples:
 
 To verify our setup, we can use `mikro-orm debug` command.
 
-> When we have CLI config properly set up, we can omit the `options` parameter
-> when calling `MikroORM.init()`.
+> When we have CLI config properly set up, we can omit the `options` parameter when calling `MikroORM.init()`.
 
-> Note: When importing a dump file we need `multipleStatements: true` in our
-> configuration. Please check the configuration documentation for more information.
+> Note: When importing a dump file we need `multipleStatements: true` in our configuration. Please check the configuration documentation for more information.
 
 Now we can start [defining our entities](defining-entities.md).

--- a/docs/versioned_docs/version-5.6/json-properties.md
+++ b/docs/versioned_docs/version-5.6/json-properties.md
@@ -4,8 +4,7 @@ title: Using JSON properties
 
 ## Defining JSON properties
 
-Each database driver behaves a bit differently when it comes to JSON properties. MikroORM tries to unify the experience via [JsonType](custom-types.md#jsontype). This type will be also used if we
-specify `type: 'json'`.
+Each database driver behaves a bit differently when it comes to JSON properties. MikroORM tries to unify the experience via [JsonType](custom-types.md#jsontype). This type will be also used if we specify `type: 'json'`.
 
 ```ts
 @Entity()
@@ -42,15 +41,14 @@ const b = await em.findOne(Book, {
 Will produce following query (in postgres):
 
 ```sql
-select "e0".* 
-from "book" as "e0" 
-where ("meta"->>'valid')::bool = true 
-  and "meta"->'nested'->>'foo' = '123' 
-  and ("meta"->'nested'->>'bar')::float8 = 321 
-  and ("meta"->'nested'->'deep'->>'baz')::float8 = 59 
-  and ("meta"->'nested'->'deep'->>'qux')::bool = false 
+select "e0".*
+from "book" as "e0"
+where ("meta"->>'valid')::bool = true
+  and "meta"->'nested'->>'foo' = '123'
+  and ("meta"->'nested'->>'bar')::float8 = 321
+  and ("meta"->'nested'->'deep'->>'baz')::float8 = 59
+  and ("meta"->'nested'->'deep'->>'qux')::bool = false
 limit 1
 ```
 
-> All drivers are currently supported (including sqlite and mongo). In postgres we
-> also try to cast the value if we detect number or boolean on the right-hand side.
+> All drivers are currently supported (including sqlite and mongo). In postgres we also try to cast the value if we detect number or boolean on the right-hand side.

--- a/docs/versioned_docs/version-5.6/loading-strategies.md
+++ b/docs/versioned_docs/version-5.6/loading-strategies.md
@@ -5,9 +5,7 @@ sidebar_label: Loading Strategies
 
 > `JOINED` loading strategy is SQL only feature.
 
-Controls how relationships get loaded when querying. By default, populated relationships
-are loaded via the `select-in` strategy. This strategy issues one additional `SELECT`
-statement per relation being loaded.
+Controls how relationships get loaded when querying. By default, populated relationships are loaded via the `select-in` strategy. This strategy issues one additional `SELECT` statement per relation being loaded.
 
 The loading strategy can be specified both at mapping time and when loading entities.
 
@@ -29,8 +27,7 @@ export class Book {
 }
 ```
 
-The following will issue two SQL statements.
-One to load the author and another to load all the books belonging to that author:
+The following will issue two SQL statements. One to load the author and another to load all the books belonging to that author:
 
 ```ts
 const author = await orm.em.findOne(Author, 1, { populate: ['books'] });
@@ -58,8 +55,7 @@ The following will issue **one** SQL statement:
 const author = await orm.em.findOne(Author, 1, { populate: ['books'] });
 ```
 
-You can also specify the load strategy as needed. This will override whatever strategy is declared in the mapping.
-This also works for nested populates:
+You can also specify the load strategy as needed. This will override whatever strategy is declared in the mapping. This also works for nested populates:
 
 ```ts
 const author = await orm.em.findOne(Author, 1, {
@@ -78,37 +74,27 @@ MikroORM.init({
 });
 ```
 
-This value will be used as the default, specifying the loading strategy on 
-property level has precedence, as well as specifying it in the `FindOptions`.
+This value will be used as the default, specifying the loading strategy on property level has precedence, as well as specifying it in the `FindOptions`.
 
 ## Population where condition
 
 > This applies only to SELECT_IN strategy, as JOINED strategy implies the inference.
 
-In v4, when we used populate hints in `em.find()` and similar methods, the
-query for our entity would be analysed and parts of it extracted and used for
-the population. Following example would find all authors that have books with
-given IDs, and populate their books collection, again using this PK condition,
-resulting in only such books being in those collections.
+In v4, when we used populate hints in `em.find()` and similar methods, the query for our entity would be analysed and parts of it extracted and used for the population. Following example would find all authors that have books with given IDs, and populate their books collection, again using this PK condition, resulting in only such books being in those collections.
 
 ```ts
 // this would end up with `Author.books` collections having only books of PK 1, 2, 3
 const a = await em.find(Author, { books: [1, 2, 3] }, { populate: ['books'] });
 ```
 
-Following this example, if we wanted to load all books, we would need a separate
-`em.populate()` call:
+Following this example, if we wanted to load all books, we would need a separate `em.populate()` call:
 
 ```ts
 const a = await em.find(Author, { books: [1, 2, 3] });
 await em.populate(a, ['books']);
 ```
 
-This behaviour changed and is now configurable both globally and locally, via
-`populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and
-`PopulateHint.INFER`, the former being the default in v5, the latter being the
-default behaviour in v4. Locally (via `FindOptions`) we can also specify custom
-where condition that will be passed to `em.populate()` call.
+This behaviour changed and is now configurable both globally and locally, via `populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and `PopulateHint.INFER`, the former being the default in v5, the latter being the default behaviour in v4. Locally (via `FindOptions`) we can also specify custom where condition that will be passed to `em.populate()` call.
 
 ```ts
 await em.find(Author, { ... }, {

--- a/docs/versioned_docs/version-5.6/logging.md
+++ b/docs/versioned_docs/version-5.6/logging.md
@@ -41,8 +41,7 @@ return MikroORM.init({
 });
 ```
 
-If we want to have more control over logging, we can use `loggerFactory`
-and use our own implementation of the `Logger` interface:
+If we want to have more control over logging, we can use `loggerFactory` and use our own implementation of the `Logger` interface:
 
 ```ts
 import { Logger, LoggerOptions, MikroORM, Configuration } from '@mikro-orm/core';
@@ -109,8 +108,7 @@ If you provide `query-params` then you must also provide `query` in order for it
 
 ## Highlighters
 
-Previously Highlight.js was used to highlight various things in the CLI, like SQL and mongo queries, or migrations or entities generated via CLI. While the library worked fine, it was causing
-performance issues mainly for those bundling via webpack and using lambdas, as the library was huge.
+Previously Highlight.js was used to highlight various things in the CLI, like SQL and mongo queries, or migrations or entities generated via CLI. While the library worked fine, it was causing performance issues mainly for those bundling via webpack and using lambdas, as the library was huge.
 
 Since v4, highlighting is disabled by default, and there are 2 highlighters you can optionally use (you need to install them first).
 
@@ -123,5 +121,4 @@ MikroORM.init({
 });
 ```
 
-For MongoDB you can use `MongoHighlighter` from `@mikro-orm/mongo-highlighter`
-package.
+For MongoDB you can use `MongoHighlighter` from `@mikro-orm/mongo-highlighter` package.

--- a/docs/versioned_docs/version-5.6/metadata-cache.md
+++ b/docs/versioned_docs/version-5.6/metadata-cache.md
@@ -2,32 +2,19 @@
 title: Metadata Cache
 ---
 
-> In v4 and later versions, we need to explicitly install `@mikro-orm/reflection`
-> to use `TsMorphMetadataProvider`.
+> In v4 and later versions, we need to explicitly install `@mikro-orm/reflection` to use `TsMorphMetadataProvider`.
 
-MikroORM allows different ways to [obtain entity metadata](metadata-providers.md).
-One way is to use [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. This 
-process can be performance heavy and time-consuming. For this reason, metadata
-cache is automatically enabled for `TsMorphMetadataProvider`. It can be optionally
-enabled for the other metadata providers, but it should not be needed.
+MikroORM allows different ways to [obtain entity metadata](metadata-providers.md). One way is to use [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. This process can be performance heavy and time-consuming. For this reason, metadata cache is automatically enabled for `TsMorphMetadataProvider`. It can be optionally enabled for the other metadata providers, but it should not be needed.
 
-After the discovery process ends, all metadata will be cached. By default, 
-`FileCacheAdapter` will be used to store the cache inside `./temp` folder to JSON
-files.
+After the discovery process ends, all metadata will be cached. By default, `FileCacheAdapter` will be used to store the cache inside `./temp` folder to JSON files.
 
-If we use folder based discovery, cache will be dependent on environment - if we 
-run via ts-node, the cache will be generated for TS files. To generate production
-cache, we can use the CLI command `mikro-orm cache:generate`.
+If we use folder based discovery, cache will be dependent on environment - if we run via ts-node, the cache will be generated for TS files. To generate production cache, we can use the CLI command `mikro-orm cache:generate`.
 
 ## Automatic Invalidation
 
-Entity metadata are cached together with modified time of the source file, and every time
-the cache is requested, it first checks if the cache is not invalid. This way we can forget 
-about the caching mechanism most of the time.
+Entity metadata are cached together with modified time of the source file, and every time the cache is requested, it first checks if the cache is not invalid. This way we can forget about the caching mechanism most of the time.
 
-One case where we can end up needing to wipe the cache manually is when we work withing a 
-git branch where contents of entities folder differs. 
+One case where we can end up needing to wipe the cache manually is when we work withing a git branch where contents of entities folder differs.
 
 ## Disabling Metadata Cache
 
@@ -65,8 +52,7 @@ await MikroORM.init({
 
 ## Providing Custom Cache Adapter
 
-You can also implement your own cache adapter, for example to store the cache in redis. 
-To do so, just implement simple `CacheAdapter` interface:
+You can also implement your own cache adapter, for example to store the cache in redis. To do so, just implement simple `CacheAdapter` interface:
 
 ```ts
 export interface CacheAdapter {

--- a/docs/versioned_docs/version-5.6/metadata-providers.md
+++ b/docs/versioned_docs/version-5.6/metadata-providers.md
@@ -2,8 +2,7 @@
 title: Metadata Providers
 ---
 
-As part of entity discovery process, MikroORM uses so called `MetadataProvider` to get necessary
-type information about our entities' properties.
+As part of entity discovery process, MikroORM uses so called `MetadataProvider` to get necessary type information about our entities' properties.
 
 > We can also implement custom metadata provider by extending abstract `MetadataProvider` class.
 
@@ -11,9 +10,7 @@ There are 3 built-in metadata providers we can use:
 
 ## TsMorphMetadataProvider
 
-With `TsMorphMetadataProvider` MikroORM will use [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
-TypeScript source files of all entities to be able to detect all types. Thanks to this, 
-defining the type is enough for runtime validation.
+With `TsMorphMetadataProvider` MikroORM will use [`ts-morph`](https://github.com/dsherret/ts-morph) to read TypeScript source files of all entities to be able to detect all types. Thanks to this, defining the type is enough for runtime validation.
 
 To use it, first install the `@mikro-orm/reflection` package.
 
@@ -26,18 +23,11 @@ await MikroORM.init({
 });
 ```
 
-If we use folder-based discovery, we should specify paths to
-the compiled entities via `entities` as well as paths to the TS source files of
-those entities via `entitiesTs`. When we run the ORM via `ts-node`, the latter
-will be used automatically, or if we explicitly pass `tsNode: true` in the config. Note that `tsNode: true` should not be part of production config.
+If we use folder-based discovery, we should specify paths to the compiled entities via `entities` as well as paths to the TS source files of those entities via `entitiesTs`. When we run the ORM via `ts-node`, the latter will be used automatically, or if we explicitly pass `tsNode: true` in the config. Note that `tsNode: true` should not be part of production config.
 
-> When running via `node`, `.d.ts` files are used to obtain the type, so we 
-> need to ship them in the production build. TS source files are no longer 
-> needed (since v4). Be sure to enable `compilerOptions.declaration` in our
-> `tsconfig.json`.
+> When running via `node`, `.d.ts` files are used to obtain the type, so we need to ship them in the production build. TS source files are no longer needed (since v4). Be sure to enable `compilerOptions.declaration` in our `tsconfig.json`.
 
-After the discovery process ends, all [metadata will be cached](metadata-cache.md). By default, 
-`FileCacheAdapter` will be used to store the cache inside `./temp` folder in JSON files. 
+After the discovery process ends, all [metadata will be cached](metadata-cache.md). By default, `FileCacheAdapter` will be used to store the cache inside `./temp` folder in JSON files.
 
 > We can generate production cache via CLI command `mikro-orm cache:generate`.
 
@@ -45,11 +35,9 @@ After the discovery process ends, all [metadata will be cached](metadata-cache.m
 
 ## ReflectMetadataProvider
 
-`ReflectMetadataProvider` uses `reflect-metadata` module to read the type from decorator 
-metadata exported by TypeScript compiler. 
+`ReflectMetadataProvider` uses `reflect-metadata` module to read the type from decorator metadata exported by TypeScript compiler.
 
-We will need to install `reflect-metadata` module and import at the top of our app's 
-bootstrap script (e.g. `main.ts` or `app.ts`). 
+We will need to install `reflect-metadata` module and import at the top of our app's bootstrap script (e.g. `main.ts` or `app.ts`).
 
 ```ts
 import 'reflect-metadata';
@@ -57,7 +45,7 @@ import 'reflect-metadata';
 
 Next step is to enable `emitDecoratorMetadata` flag in our `tsconfig.json`.
 
-> As this approach does not have performance impact, metadata caching is not really necessary. 
+> As this approach does not have performance impact, metadata caching is not really necessary.
 
 ```ts
 await MikroORM.init({
@@ -102,8 +90,7 @@ prop?: string;
 
 #### Enums
 
-By default, enum is considered as numeric type. For string enums, we need to explicitly 
-provide one of:
+By default, enum is considered as numeric type. For string enums, we need to explicitly provide one of:
 
 - reference to the enum (which will force us to define the enum before defining the entity)
   ```ts
@@ -123,31 +110,24 @@ provide one of:
 
 #### Circular dependencies
 
-Reading type of referenced entity in `@ManyToOne` and `@OneToOne` properties fails if there is 
-circular dependency. We will need to explicitly define the type in the decorator (preferably 
-via `entity: () => ...` callback).
+Reading type of referenced entity in `@ManyToOne` and `@OneToOne` properties fails if there is circular dependency. We will need to explicitly define the type in the decorator (preferably via `entity: () => ...` callback).
 
 ```ts
 @ManyToOne({ entity: () => Author })
 author: Author;
-``` 
+```
 
-> There can be recursion issues when we define multiple entities (with circular dependencies 
-> between each other) in single file. In that case, we might want to provide the type via decorator's
-> `type` or `entity` attributes and set the TS property type to something else (like `any` or `object`).
+> There can be recursion issues when we define multiple entities (with circular dependencies between each other) in single file. In that case, we might want to provide the type via decorator's `type` or `entity` attributes and set the TS property type to something else (like `any` or `object`).
 
 #### Additional typings might be required
 
-We might have to install additional typings, one example is use of `ObjectId` in MongoDB, 
-which requires `@types/mongodb` to be installed. 
+We might have to install additional typings, one example is use of `ObjectId` in MongoDB, which requires `@types/mongodb` to be installed.
 
 ## JavaScriptMetadataProvider
 
 > `JavaScriptMetadataProvider` is deprecated, [use `EntitySchema` instead](entity-schema.md).
 
-This provider should be used only if we are not using TypeScript at all and therefore we do 
-not use decorators to annotate our properties. It will require us to specify the whole schema 
-manually. 
+This provider should be used only if we are not using TypeScript at all and therefore we do not use decorators to annotate our properties. It will require us to specify the whole schema manually.
 
 ```ts
 await MikroORM.init({

--- a/docs/versioned_docs/version-5.6/migrations.md
+++ b/docs/versioned_docs/version-5.6/migrations.md
@@ -8,8 +8,7 @@ MikroORM has integrated support for migrations via [umzug](https://github.com/se
 
 > Since v5, migrations are stored without extension.
 
-By default, each migration will be all executed inside a transaction, and all of them will 
-be wrapped in one master transaction, so if one of them fails, everything will be rolled back. 
+By default, each migration will be all executed inside a transaction, and all of them will be wrapped in one master transaction, so if one of them fails, everything will be rolled back.
 
 ## Migration class
 
@@ -27,41 +26,31 @@ export class Migration20191019195930 extends Migration {
 }
 ```
 
-To support undoing those changed, we can implement the `down` method, which throws an error by default. 
+To support undoing those changed, we can implement the `down` method, which throws an error by default.
 
-Migrations are by default wrapped in a transaction. You can override this behaviour on 
-per migration basis by implementing the `isTransactional(): boolean` method.
+Migrations are by default wrapped in a transaction. You can override this behaviour on per migration basis by implementing the `isTransactional(): boolean` method.
 
 `Configuration` object and driver instance are available in the `Migration` class context.
 
-You can execute queries in the migration via `Migration.execute()` method, which 
-will run queries in the same transaction as the rest of the migration. The 
-`Migration.addSql()` method also accepts instances of knex. Knex instance can be 
-accessed via `Migration.getKnex()`; 
+You can execute queries in the migration via `Migration.execute()` method, which will run queries in the same transaction as the rest of the migration. The `Migration.addSql()` method also accepts instances of knex. Knex instance can be accessed via `Migration.getKnex()`;
 
 ## Initial migration
 
 > This is optional and only needed for the specific use case, when both entities and schema already exist.
 
-If we want to start using migrations, and we already have the schema generated, 
-we can do so by creating so called initial migration:
+If we want to start using migrations, and we already have the schema generated, we can do so by creating so called initial migration:
 
-> Initial migration can be created only if there are no migrations previously
-> generated or executed. 
+> Initial migration can be created only if there are no migrations previously generated or executed.
 
 ```sh
 npx mikro-orm migration:create --initial
 ```
 
-This will create the initial migration, containing the schema dump from 
-`schema:create` command. The migration will be automatically marked as executed. 
+This will create the initial migration, containing the schema dump from `schema:create` command. The migration will be automatically marked as executed.
 
 ## Snapshots
 
-Creating new migration will automatically save the target schema snapshot into 
-migrations folder. This snapshot will be then used if we try to create new migration,
-instead of using current database schema. This means that if we try to create new 
-migration before we run the pending ones, we still get the right schema diff.
+Creating new migration will automatically save the target schema snapshot into migrations folder. This snapshot will be then used if we try to create new migration, instead of using current database schema. This means that if we try to create new migration before we run the pending ones, we still get the right schema diff.
 
 > Snapshots should be versioned just like the regular migration files.
 
@@ -71,8 +60,7 @@ Snapshotting can be disabled via `migrations.snapshot: false` in the ORM config.
 
 > Since v5, `umzug` 3.0 is used, and `pattern` option has been replaced with `glob`.
 
-> `migrations.path` and `migrations.pathTs` works the same way as `entities` and 
-> `entitiesTs` in entity discovery.
+> `migrations.path` and `migrations.pathTs` works the same way as `entities` and `entitiesTs` in entity discovery.
 
 ```ts
 await MikroORM.init({
@@ -96,9 +84,7 @@ await MikroORM.init({
 
 ## Running migrations in production
 
-In production environment we might want to use compiled migration files. Since v5,
-this should work almost out of box, all we need to do is to configure the migration
-path accordingly:
+In production environment we might want to use compiled migration files. Since v5, this should work almost out of box, all we need to do is to configure the migration path accordingly:
 
 ```ts
 import { MikroORM, Utils } from '@mikro-orm/core';
@@ -116,15 +102,11 @@ await MikroORM.init({
 });
 ```
 
-This should allow using CLI to generate TS migration files (as in CLI we probably
-have TS support enabled), while using compiled JS files in production, where ts-node
-is not registered.
+This should allow using CLI to generate TS migration files (as in CLI we probably have TS support enabled), while using compiled JS files in production, where ts-node is not registered.
 
 ## Using custom `MigrationGenerator`
 
-When we generate new migrations, `MigrationGenerator` class is responsible for 
-generating the file contents. We can provide our own implementation to do things 
-like formatting the SQL statement. 
+When we generate new migrations, `MigrationGenerator` class is responsible for generating the file contents. We can provide our own implementation to do things like formatting the SQL statement.
 
 ```ts
 import { TSMigrationGenerator } from '@mikro-orm/migrations';
@@ -157,7 +139,7 @@ await MikroORM.init({
 
 ## Using via CLI
 
-You can use it via CLI: 
+You can use it via CLI:
 
 ```sh
 npx mikro-orm migration:create   # Create new migration with current schema diff
@@ -168,11 +150,9 @@ npx mikro-orm migration:pending  # List all pending migrations
 npx mikro-orm migration:fresh    # Drop the database and migrate up to the latest version
 ```
 
-> To create blank migration file, we can use 
-> `npx mikro-orm migration:create --blank`.
+> To create blank migration file, we can use `npx mikro-orm migration:create --blank`.
 
-For `migration:up` and `migration:down` commands we can specify `--from` (`-f`), `--to` (`-t`) 
-and `--only` (`-o`) options to run only a subset of migrations:
+For `migration:up` and `migration:down` commands we can specify `--from` (`-f`), `--to` (`-t`) and `--only` (`-o`) options to run only a subset of migrations:
 
 ```sh
 npx mikro-orm migration:up --from 2019101911 --to 2019102117  # the same as above
@@ -180,14 +160,15 @@ npx mikro-orm migration:up --only 2019101923                  # apply a single m
 npx mikro-orm migration:down --to 0                           # migrate down all migrations
 ```
 
-> To run TS migration files, we will need to [enable `useTsNode` flag](installation.md#setting-up-the-commandline-tool)
-> in our `package.json`.
+> To run TS migration files, we will need to [enable `useTsNode` flag](installation.md#setting-up-the-commandline-tool) in our `package.json`.
 
 For the `migration:fresh` command we can specify `--seed` to seed the database after migrating.
+
 ```shell
 npx mikro-orm migration:fresh --seed              # seed the database with the default database seeder
 npx mikro-orm migration:fresh --seed=UsersSeeder  # seed the database with the UsersSeeder
 ```
+
 > You can specify the default database seeder in the orm config with the key `config.seeder.defaultSeeder`
 
 ## Using the Migrator programmatically
@@ -235,8 +216,7 @@ await orm.em.transactional(async em => {
 
 ## Importing migrations statically
 
-If we do not want to dynamically import a folder (e.g. when bundling our code with webpack) we can import migrations
-directly.
+If we do not want to dynamically import a folder (e.g. when bundling our code with webpack) we can import migrations directly.
 
 ```ts
 import { MikroORM } from '@mikro-orm/core';
@@ -254,8 +234,7 @@ await MikroORM.init({
 });
 ```
 
-With the help of [webpack's context module api](https://webpack.js.org/guides/dependency-management/#context-module-api)
-we can dynamically import the migrations making it possible to import all files in a folder.
+With the help of [webpack's context module api](https://webpack.js.org/guides/dependency-management/#context-module-api) we can dynamically import the migrations making it possible to import all files in a folder.
 
 ```ts
 import { MikroORM } from '@mikro-orm/core';
@@ -311,9 +290,9 @@ import { Migration } from '@mikro-orm/migrations-mongodb';
 export class MigrationTest1 extends Migration {
 
   async up(): Promise<void> {
-    // use `this.getCollection()` to work with the mongodb collection directly 
+    // use `this.getCollection()` to work with the mongodb collection directly
     await this.getCollection('Book').updateMany({}, { $set: { updatedAt: new Date() } }, { session: this.ctx });
-    
+
     // or use `this.driver` to work with the `MongoDriver` API instead
     await this.driver.nativeDelete('Book', { foo: true }, { ctx: this.ctx });
   }
@@ -325,8 +304,7 @@ export class MigrationTest1 extends Migration {
 
 ### MySQL
 
-There is no way to rollback DDL changes in MySQL. An implicit commit is forced for those 
-queries automatically, so transactions are not working as expected. 
+There is no way to rollback DDL changes in MySQL. An implicit commit is forced for those queries automatically, so transactions are not working as expected.
 
 - https://github.com/mikro-orm/mikro-orm/issues/217
 - https://dev.mysql.com/doc/refman/5.7/en/implicit-commit.html

--- a/docs/versioned_docs/version-5.6/multiple-schemas.md
+++ b/docs/versioned_docs/version-5.6/multiple-schemas.md
@@ -2,14 +2,11 @@
 title: Using Multiple Schemas
 ---
 
-In MySQL and PostgreSQL it is possible to define your entities in multiple schemas. In MySQL 
-terminology, it is called database, but from an implementation point of view, it is a schema. 
+In MySQL and PostgreSQL it is possible to define your entities in multiple schemas. In MySQL terminology, it is called database, but from an implementation point of view, it is a schema.
 
-> To use multiple schemas, your connection needs to have access to all of them (multiple 
-> connections are not supported in a single MikroORM instance).
+> To use multiple schemas, your connection needs to have access to all of them (multiple connections are not supported in a single MikroORM instance).
 
-All you need to do is simply define the schema name via `schema` options, or 
-table name including schema name in `tableName` option:
+All you need to do is simply define the schema name via `schema` options, or table name including schema name in `tableName` option:
 
 ```ts
 @Entity({ schema: 'first_schema' })
@@ -20,12 +17,9 @@ export class Foo { ... }
 export class Bar { ... }
 ```
 
-Then use those entities as usual. Resulting SQL queries will use this `tableName` value as a 
-table name so as long as your connection has access to given schema, everything should work 
-as expected.
+Then use those entities as usual. Resulting SQL queries will use this `tableName` value as a table name so as long as your connection has access to given schema, everything should work as expected.
 
-You can also query for entity in specific schema via `EntityManager`, `EntityRepository` or 
-`QueryBuilder`:
+You can also query for entity in specific schema via `EntityManager`, `EntityRepository` or `QueryBuilder`:
 
 ```ts
 const user = await em.findOne(User, { ... }, { schema: 'client-123' });
@@ -40,8 +34,7 @@ await qb.insert({ email: 'foo@bar.com' }).withSchema('client-123');
 
 ## Wildcard Schema
 
-Since v5, MikroORM also supports defining entities that can exist in multiple
-schemas. To do that, we just specify wildcard schema:
+Since v5, MikroORM also supports defining entities that can exist in multiple schemas. To do that, we just specify wildcard schema:
 
 ```ts
 @Entity({ schema: '*' })
@@ -62,19 +55,10 @@ export class Book {
 }
 ```
 
-Entities like this will be by default ignored when using `SchemaGenerator`, 
-as we need to specify which schema to use. For that we need to use the `schema`
-option of the `createSchema/updateSchema/dropSchema` methods or the `--schema` 
-CLI parameter.
+Entities like this will be by default ignored when using `SchemaGenerator`, as we need to specify which schema to use. For that we need to use the `schema` option of the `createSchema/updateSchema/dropSchema` methods or the `--schema` CLI parameter.
 
-On runtime, the wildcard schema will be replaced with either `FindOptions.schema`,
-or with the `schema` option from the ORM config.
+On runtime, the wildcard schema will be replaced with either `FindOptions.schema`, or with the `schema` option from the ORM config.
 
 ### Note about migrations
 
-Currently, this is not supported via migrations, they will always ignore
-wildcard schema entities, and `SchemaGenerator` needs to be used explicitly.
-Given the dynamic nature of such entities, it makes sense to only sync the 
-schema dynamically, e.g. in an API endpoint. We could still use the ORM 
-migrations, but we need to add the dynamic schema queries manually to migration
-files. It makes sense to use the `safe` mode for such queries.
+Currently, this is not supported via migrations, they will always ignore wildcard schema entities, and `SchemaGenerator` needs to be used explicitly. Given the dynamic nature of such entities, it makes sense to only sync the schema dynamically, e.g. in an API endpoint. We could still use the ORM migrations, but we need to add the dynamic schema queries manually to migration files. It makes sense to use the `safe` mode for such queries.

--- a/docs/versioned_docs/version-5.6/naming-strategy.md
+++ b/docs/versioned_docs/version-5.6/naming-strategy.md
@@ -2,15 +2,13 @@
 title: Naming Strategy
 ---
 
-When mapping our entities to database tables and columns, their names will be defined by naming 
-strategy. There are 3 basic naming strategies we can choose from:
+When mapping our entities to database tables and columns, their names will be defined by naming strategy. There are 3 basic naming strategies we can choose from:
 
 - `UnderscoreNamingStrategy` - default of all SQL drivers
 - `MongoNamingStrategy` - default of `MongoDriver`
 - `EntityCaseNamingStrategy` - uses unchanged entity and property names
 
-You can override this when initializing ORM. You can also provide our own naming strategy, just 
-implement `NamingStrategy` interface and provide our implementation when bootstrapping ORM:
+You can override this when initializing ORM. You can also provide our own naming strategy, just implement `NamingStrategy` interface and provide our implementation when bootstrapping ORM:
 
 ```ts
 class MyCustomNamingStrategy implements NamingStrategy {
@@ -24,20 +22,17 @@ const orm = await MikroORM.init({
 });
 ```
 
-> You can also extend `AbstractNamingStrategy` which implements one method for we - `getClassName()`
-> that is used to map entity file name to class name.
+> You can also extend `AbstractNamingStrategy` which implements one method for we - `getClassName()` that is used to map entity file name to class name.
 
 ## Naming Strategy in mongo driver
 
-`MongoNamingStrategy` will simply use all field names as they are defined. Collection names will
-be translated into lower-cased dashed form:
+`MongoNamingStrategy` will simply use all field names as they are defined. Collection names will be translated into lower-cased dashed form:
 
 `MyCoolEntity` will be translated into `my-cool-entity` collection name.
 
 ## Naming Strategy in SQL drivers
 
-`MySqlDriver` defaults to `UnderscoreNamingStrategy`, which means our all our database tables and
-columns will be lower-cased and words divided by underscored:
+`MySqlDriver` defaults to `UnderscoreNamingStrategy`, which means our all our database tables and columns will be lower-cased and words divided by underscored:
 
 ```sql
 CREATE TABLE `author` (
@@ -87,7 +82,7 @@ Return a join column name for a property.
 
 #### `NamingStrategy.joinTableName(sourceEntity: string, targetEntity: string, propertyName: string): string`
 
-Return a join table name. This is used as default value for `pivotTable`. 
+Return a join table name. This is used as default value for `pivotTable`.
 
 ---
 
@@ -99,15 +94,12 @@ Return the foreign key column name for the given parameters.
 
 #### `NamingStrategy.indexName(tableName: string, columns: string[], type: 'primary' | 'foreign' | 'unique' | 'index' | 'sequence'): string`
 
-Returns key/constraint name for given type. Some drivers might not support all 
-the types (e.g. mysql and sqlite enforce the PK name).
+Returns key/constraint name for given type. Some drivers might not support all the types (e.g. mysql and sqlite enforce the PK name).
 
 ---
 
 #### `NamingStrategy.aliasName(entityName: string, index: number): string`
 
-Returns alias name for given entity. The alias needs to be unique across the 
-query, which is by default ensured via appended index parameter. It is optional 
-to use it as long as we ensure it will be unique.
+Returns alias name for given entity. The alias needs to be unique across the query, which is by default ensured via appended index parameter. It is optional to use it as long as we ensure it will be unique.
 
 ---

--- a/docs/versioned_docs/version-5.6/nested-populate.md
+++ b/docs/versioned_docs/version-5.6/nested-populate.md
@@ -2,15 +2,12 @@
 title: Smart Nested Populate
 ---
 
-`MikroORM` is capable of loading large nested structures while maintaining good 
-performance, querying each database table only once. Imagine you have this nested 
-structure:
+`MikroORM` is capable of loading large nested structures while maintaining good performance, querying each database table only once. Imagine you have this nested structure:
 
 - `Book` has one `Publisher` (M:1), one `Author` (M:1) and many `BookTag`s (M:N)
 - `Publisher` has many `Test`s (M:N)
 
-When you use nested populate while querying all `BookTag`s, this is what happens in
-the background:
+When you use nested populate while querying all `BookTag`s, this is what happens in the background:
 
 ```ts
 const tags = await em.findAll(BookTag, { populate: ['books.publisher.tests', 'books.author'] });
@@ -61,6 +58,7 @@ db.getCollection("author").find({"_id":{"$in":[...]}}).toArray();
 The request to populate can be ambiguous. For example, let's say as a hypothetical that there's a `Book` called `'One'` with tags `'Fiction'` and `'Hard Cover'`.
 
 Then you run the following:
+
 ```ts
 const books = await em.find(Book, { tags: { name: 'Fiction' } }, {
   populate: ['tags'],
@@ -71,8 +69,8 @@ You're requesting books that have the tag of `'Fiction'` then asking to populate
 
 Both behaviors are useful in different cases, so MikroORM provides an option that allows you to control this called `populateWhere`. There are two options, `INFER` and `ALL`. The default is `ALL` which will ensure that all possible members of the collection are fetched in the populate (e.g. the the first interpretation above).
 
-
 You can specify this globally:
+
 ```ts
 const orm = await MikroORM.init({
     // We want our populate fetches to respect the outer filter passed in a where condition.
@@ -81,6 +79,7 @@ const orm = await MikroORM.init({
 ```
 
 Or you can override this on a query by query basis:
+
 ```ts
 const books = await em.find(Book, { tags: { name: 'Fiction' } }, {
   populate: ['tags'],
@@ -106,7 +105,7 @@ To populate existing entities, you can use `em.populate()`.
 const authors = await em.createQueryBuilder(Author).select('*').getResult();
 await em.populate(authors, ['books.tags']);
 
-// now your Author entities will have `books` collections populated, 
+// now your Author entities will have `books` collections populated,
 // as well as they will have their `tags` collections populated.
 console.log(authors[0].books[0].tags[0]); // initialized BookTag
 ```

--- a/docs/versioned_docs/version-5.6/propagation.md
+++ b/docs/versioned_docs/version-5.6/propagation.md
@@ -2,8 +2,7 @@
 title: Propagation
 ---
 
-By default, MikroORM will propagate all changes made to one side of bi-directional relations to the other side, keeping them in sync. This works for all relations, including M:1 and 1:1. As part of
-the discovery process, all M:1 and 1:1 properties are re-defined as getter/setter.
+By default, MikroORM will propagate all changes made to one side of bi-directional relations to the other side, keeping them in sync. This works for all relations, including M:1 and 1:1. As part of the discovery process, all M:1 and 1:1 properties are re-defined as getter/setter.
 
 ```ts
 const author = new Author(...);
@@ -39,11 +38,10 @@ console.log(tag.books.contains(book)); // true
 
 tag.books.add(book);
 console.log(book.tags.contains(tag)); // true
-``` 
+```
 
 > Collections on both sides have to be initialized, otherwise propagation won't work.
 
-> Although this propagation works also for M:N inverse side, you should always use owning
-> side to manipulate the collection.
+> Although this propagation works also for M:N inverse side, you should always use owning side to manipulate the collection.
 
 Same applies for `Collection.remove()`.

--- a/docs/versioned_docs/version-5.6/property-validation.md
+++ b/docs/versioned_docs/version-5.6/property-validation.md
@@ -63,14 +63,9 @@ When we define our entities, we need to be careful about optional properties. Wi
 
 ## Strict property type validation
 
-> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`.
-> It has performance implications and usually should not be needed, as long as
-> you don't modify your entities via `Object.assign()`.
+> Since v4.0.3 the validation needs to be explicitly enabled via `validate: true`. It has performance implications and usually should not be needed, as long as you don't modify your entities via `Object.assign()`.
 
-`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong 
-data types for you automatically. If automatic conversion fails, it will throw an error. You can 
-enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered 
-when persisting the entity. 
+`MikroORM` will validate your properties before actual persisting happens. It will try to fix wrong data types for you automatically. If automatic conversion fails, it will throw an error. You can enable strict mode to disable this feature and let ORM throw errors instead. Validation is triggered when persisting the entity.
 
 ```ts
 // number instead of string will throw

--- a/docs/versioned_docs/version-5.6/query-builder.md
+++ b/docs/versioned_docs/version-5.6/query-builder.md
@@ -2,12 +2,12 @@
 title: Using Query Builder
 ---
 
-:::info Since v4, we need to make sure we are working with correctly typed `EntityManager`
-or `EntityRepository` to have access to `createQueryBuilder()` method.
+:::info Since v4, we need to make sure we are working with correctly typed `EntityManager` or `EntityRepository` to have access to `createQueryBuilder()` method.
 
 ```ts
 import { EntityManager, EntityRepository } from '@mikro-orm/mysql'; // or any other driver package
 ```
+
 :::
 
 When you need to execute some SQL query without all the ORM stuff involved, you can either compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
@@ -39,8 +39,7 @@ const res2 = await qb.execute('get'); // returns single object
 const res3 = await qb.execute('run'); // returns object like `{ affectedRows: number, insertId: number, row: any }`
 ```
 
-Second argument can be used to disable mapping of database columns to property names (which is enabled by default). In following example, `Book` entity has `createdAt` property defined with implicit
-underscored field name `created_at`:
+Second argument can be used to disable mapping of database columns to property names (which is enabled by default). In following example, `Book` entity has `createdAt` property defined with implicit underscored field name `created_at`:
 
 ```ts
 const res4 = await em.createQueryBuilder(Book).select('*').execute('get', true);
@@ -49,8 +48,7 @@ const res5 = await em.createQueryBuilder(Book).select('*').execute('get', false)
 console.log(res5); // `created_at` will be defined, while `createdAt` will be missing
 ```
 
-To get entity instances from the QueryBuilder result, you can use `getResult()` and `getSingleResult()`
-methods:
+To get entity instances from the QueryBuilder result, you can use `getResult()` and `getSingleResult()` methods:
 
 ```ts
 const book = await em.createQueryBuilder(Book).select('*').where({ id: 1 }).getSingleResult();
@@ -63,21 +61,20 @@ console.log(books[0] instanceof Book); // true
 
 ## Awaiting the QueryBuilder
 
-Since v5 we can await the `QueryBuilder` instance, which will automatically execute the QB and return appropriate response. The QB instance is now typed based on usage
-of `select/insert/update/delete/truncate` methods to one of:
+Since v5 we can await the `QueryBuilder` instance, which will automatically execute the QB and return appropriate response. The QB instance is now typed based on usage of `select/insert/update/delete/truncate` methods to one of:
 
 - `SelectQueryBuilder`
-    - awaiting yields array of entities (as `qb.getResultList()`)
+  - awaiting yields array of entities (as `qb.getResultList()`)
 - `CountQueryBuilder`
-    - awaiting yields number (as `qb.getCount()`)
+  - awaiting yields number (as `qb.getCount()`)
 - `InsertQueryBuilder` (extends `RunQueryBuilder`)
-    - awaiting yields `QueryResult`
+  - awaiting yields `QueryResult`
 - `UpdateQueryBuilder` (extends `RunQueryBuilder`)
-    - awaiting yields `QueryResult`
+  - awaiting yields `QueryResult`
 - `DeleteQueryBuilder` (extends `RunQueryBuilder`)
-    - awaiting yields `QueryResult`
+  - awaiting yields `QueryResult`
 - `TruncateQueryBuilder` (extends `RunQueryBuilder`)
-    - awaiting yields `QueryResult`
+  - awaiting yields `QueryResult`
 
 ```ts
 const res1 = await em.qb(Publisher).insert({
@@ -112,9 +109,7 @@ expect(res5.affectedRows > 0).toBe(true); // test the type
 
 ## Mapping Raw Results to Entities
 
-Another way to create entity from raw results (that are not necessarily mapped to entity properties)
-is to use `map()` method of `EntityManager`, that is basically a shortcut for mapping results via `IDatabaseDriver.mapResult()` (which converts field names to property names - e.g. `created_at`
-to `createdAt`) and `merge()` which converts the data to entity instance and makes it managed.
+Another way to create entity from raw results (that are not necessarily mapped to entity properties) is to use `map()` method of `EntityManager`, that is basically a shortcut for mapping results via `IDatabaseDriver.mapResult()` (which converts field names to property names - e.g. `created_at` to `createdAt`) and `merge()` which converts the data to entity instance and makes it managed.
 
 This method comes handy when you want to use 3rd party query builders, where the result is not mapped to entity properties automatically:
 
@@ -151,12 +146,12 @@ qb.select('*')
   .orderBy({ books: { tags: { createdBy: QueryOrder.DESC } } });
 
 console.log(qb.getQuery());
-// select `e0`.* 
-// from `author` as `e0` 
-// left join `book2` as `e1` on `e0`.`id` = `e1`.`author_id` 
-// left join `book2_to_book_tag2` as `e3` on `e1`.`uuid_pk` = `e3`.`book2_uuid_pk` 
-// left join `book_tag2` as `e2` on `e3`.`book_tag2_id` = `e2`.`id` 
-// where `e2`.`name` = ? 
+// select `e0`.*
+// from `author` as `e0`
+// left join `book2` as `e1` on `e0`.`id` = `e1`.`author_id`
+// left join `book2_to_book_tag2` as `e3` on `e1`.`uuid_pk` = `e3`.`book2_uuid_pk`
+// left join `book_tag2` as `e2` on `e3`.`book_tag2_id` = `e2`.`id`
+// where `e2`.`name` = ?
 // order by `e1`.`tags` asc
 ```
 
@@ -183,8 +178,7 @@ console.log(qb.getQuery());
 
 ## Mapping joined results
 
-To select multiple entities and map them from `QueryBuilder`, we can use
-`joinAndSelect` or `leftJoinAndSelect` method:
+To select multiple entities and map them from `QueryBuilder`, we can use `joinAndSelect` or `leftJoinAndSelect` method:
 
 ```ts
 // `res` will contain array of authors, with books and their tags populated
@@ -215,7 +209,7 @@ const users = em.createQueryBuilder(User)
 This will produce following query:
 
 ```sql
-select `e0`.* 
+select `e0`.*
 from `user` as `e0`
 where lower(email) = 'foo@bar.baz'
 order by (point(loc_latitude, loc_longitude) <@> point(0, 0)) asc
@@ -298,7 +292,7 @@ This will also remove any existing limit and offset from the query (the QB will 
 
 ## Overriding FROM clause
 
-You can specify the table used in the `FROM` clause, replacing the current table name if one has already been specified. This is typically used to specify a sub-query expression in SQL. 
+You can specify the table used in the `FROM` clause, replacing the current table name if one has already been specified. This is typically used to specify a sub-query expression in SQL.
 
 ```ts
 const qb = em.createQueryBuilder(Book2);
@@ -368,8 +362,7 @@ console.log(qb4.getQuery());
 
 When you want to filter by sub-query on the left-hand side of a predicate, you will need to register it first via `qb.withSubquery()`:
 
-> The dynamic property (`booksTotal`) needs to be defined at the entity level (as `persist: false`).
-> You always need to use prefix in the `qb.withSchema()` (so `a.booksTotal`).
+> The dynamic property (`booksTotal`) needs to be defined at the entity level (as `persist: false`). You always need to use prefix in the `qb.withSchema()` (so `a.booksTotal`).
 
 ```ts
 const knex = em.getKnex();
@@ -417,14 +410,14 @@ console.log(qb.getQuery()); // for MySQL
 
 Available lock modes:
 
-| Mode | Postgres | MySQL |
-|------|----------|-------|
-| `LockMode.PESSIMISTIC_READ` | `for share` | `lock in share mode` |
-| `LockMode.PESSIMISTIC_WRITE` | `for update` | `for update` |
-| `LockMode.PESSIMISTIC_PARTIAL_WRITE` | `for update skip locked` | `for update skip locked` |
-| `LockMode.PESSIMISTIC_WRITE_OR_FAIL` | `for update nowait` | `for update nowait` |
-| `LockMode.PESSIMISTIC_PARTIAL_READ` | `for share skip locked` | `lock in share mode skip locked` |
-| `LockMode.PESSIMISTIC_READ_OR_FAIL` | `for share nowait` | `lock in share mode nowait` |
+| Mode                                 | Postgres                 | MySQL                            |
+| ------------------------------------ | ------------------------ | -------------------------------- |
+| `LockMode.PESSIMISTIC_READ`          | `for share`              | `lock in share mode`             |
+| `LockMode.PESSIMISTIC_WRITE`         | `for update`             | `for update`                     |
+| `LockMode.PESSIMISTIC_PARTIAL_WRITE` | `for update skip locked` | `for update skip locked`         |
+| `LockMode.PESSIMISTIC_WRITE_OR_FAIL` | `for update nowait`      | `for update nowait`              |
+| `LockMode.PESSIMISTIC_PARTIAL_READ`  | `for share skip locked`  | `lock in share mode skip locked` |
+| `LockMode.PESSIMISTIC_READ_OR_FAIL`  | `for share nowait`       | `lock in share mode nowait`      |
 
 Optionally we can also pass list of table aliases we want to lock via second parameter:
 
@@ -436,10 +429,10 @@ qb.select('*')
   .setLockMode(LockMode.PESSIMISTIC_READ, ['u']);
 
 console.log(qb.getQuery()); // for Postgres
-// select ... 
+// select ...
 //   from "user" as "u"
-//   left join "identity" as "i" on "u"."id" = "i"."user_id" 
-//   where "u"."name" = 'Jon' 
+//   left join "identity" as "i" on "u"."id" = "i"."user_id"
+//   where "u"."name" = 'Jon'
 //   for update of "u" skip locked
 ```
 
@@ -459,12 +452,9 @@ const entities = res.map(a => em.map(Author, a));
 console.log(entities); // Author[]
 ```
 
-You can also get clear and configured knex instance from the connection via `getKnex()` method. As this method is not available on the base `Connection` class, you will need to either manually type
-cast the connection to `AbstractSqlConnection` (or the actual implementation you are using, e.g. `MySqlConnection`), or provide correct driver type hint to your `EntityManager` instance, which will be
-then automatically inferred in `em.getConnection()` method.
+You can also get clear and configured knex instance from the connection via `getKnex()` method. As this method is not available on the base `Connection` class, you will need to either manually type cast the connection to `AbstractSqlConnection` (or the actual implementation you are using, e.g. `MySqlConnection`), or provide correct driver type hint to your `EntityManager` instance, which will be then automatically inferred in `em.getConnection()` method.
 
-> Driver and connection implementations are not directly exported from `@mikro-orm/core` module.
-> You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
+> Driver and connection implementations are not directly exported from `@mikro-orm/core` module. You can import them from the driver packages (e.g. `import { PostgreSqlDriver } from '@mikro-orm/postgresql'`).
 
 ```ts
 const conn = em.getConnection() as AbstractSqlConnection;

--- a/docs/versioned_docs/version-5.6/query-conditions.md
+++ b/docs/versioned_docs/version-5.6/query-conditions.md
@@ -2,8 +2,7 @@
 title: Smart Query Conditions
 ---
 
-When you want to make complex queries, we can easily end up with a lot of boilerplate code
-full of curly brackets:
+When you want to make complex queries, we can easily end up with a lot of boilerplate code full of curly brackets:
 
 ```ts
 const res = await orm.em.find(Author, { $and: [
@@ -20,8 +19,8 @@ const res = await orm.em.find(Author, { $and: [
 For AND condition with single field, we can also do this:
 
 ```ts
-const res = await orm.em.find(Author, { 
-  id: { 
+const res = await orm.em.find(Author, {
+  id: {
     $in: [1, 2, 7],
     $nin: [3, 4],
     $gt: 5,
@@ -33,8 +32,7 @@ const res = await orm.em.find(Author, {
 });
 ```
 
-There is also shortcut for `$in` - simply provide array as value and it 
-will be converted automatically:
+There is also shortcut for `$in` - simply provide array as value and it will be converted automatically:
 
 ```ts
 const res = await orm.em.find(Author, { favouriteBook: [1, 2, 7] });
@@ -50,30 +48,30 @@ const res = await orm.em.find(Author, [1, 2, 7]);
 
 ### Comparison
 
-| operator | name               | description |
-|----------|--------------------|-------------|
-| `$eq`	   | equals             | Matches values that are equal to a specified value. |
-| `$gt`	   | greater            | Matches values that are greater than a specified value. |
-| `$gte`   | greater or equal   | Matches values that are greater than or equal to a specified value. |
-| `$in`	   | contains           | Matches any of the values specified in an array. |
-| `$lt`	   | lower              | Matches values that are less than a specified value. |
-| `$lte`   | lower or equal     | Matches values that are less than or equal to a specified value. |
-| `$ne`	   | not equal          | Matches all values that are not equal to a specified value. |
-| `$nin`   | not contains       | Matches none of the values specified in an array. |
-| `$like`  | like               | Uses LIKE operator |
-| `$re`    | regexp             | Uses REGEXP operator |
-| `$fulltext` | full text       | A driver specific full text search function. See requirements [below](#full-text-searching) |
-| `$ilike` | ilike              | (postgres only) |
-| `$overlap` | &&               | (postgres only) |
-| `$contains` | @>              | (postgres only) |
-| `$contained` | <@             | (postgres only) |
+| operator     | name             | description                                                                                 |
+| ------------ | ---------------- | ------------------------------------------------------------------------------------------- |
+| `$eq`        | equals           | Matches values that are equal to a specified value.                                         |
+| `$gt`        | greater          | Matches values that are greater than a specified value.                                     |
+| `$gte`       | greater or equal | Matches values that are greater than or equal to a specified value.                         |
+| `$in`        | contains         | Matches any of the values specified in an array.                                            |
+| `$lt`        | lower            | Matches values that are less than a specified value.                                        |
+| `$lte`       | lower or equal   | Matches values that are less than or equal to a specified value.                            |
+| `$ne`        | not equal        | Matches all values that are not equal to a specified value.                                 |
+| `$nin`       | not contains     | Matches none of the values specified in an array.                                           |
+| `$like`      | like             | Uses LIKE operator                                                                          |
+| `$re`        | regexp           | Uses REGEXP operator                                                                        |
+| `$fulltext`  | full text        | A driver specific full text search function. See requirements [below](#full-text-searching) |
+| `$ilike`     | ilike            | (postgres only)                                                                             |
+| `$overlap`   | &&               | (postgres only)                                                                             |
+| `$contains`  | @>               | (postgres only)                                                                             |
+| `$contained` | <@               | (postgres only)                                                                             |
 
 ### Logical
 
-| operator | description |
-|----------|-------------|
+| operator | description                                                                                             |
+| -------- | ------------------------------------------------------------------------------------------------------- |
 | `$and`   | Joins query clauses with a logical AND returns all documents that match the conditions of both clauses. |
-| `$not`   | Inverts the effect of a query expression and returns documents that do not match the query expression. |
+| `$not`   | Inverts the effect of a query expression and returns documents that do not match the query expression.  |
 | `$or`    | Joins query clauses with a logical OR returns all documents that match the conditions of either clause. |
 
 ## Full text searching
@@ -89,14 +87,13 @@ PosgreSQL allows to execute queries (pg-query) on the type pg-vector. The pg-vec
 Refer to the [PostgreSQL documentation](https://www.postgresql.org/docs/current/functions-textsearch.html) for possible queries.
 
 <Tabs
-groupId="entity-def"
-defaultValue="as-column"
-values={[
-{label: 'reflect-metadata', value: 'as-column'},
-{label: 'ts-morph', value: 'in-query'},
-]
-}>
-<TabItem value="as-column">
+  groupId="entity-def"
+  defaultValue="as-column"
+  values={[
+    {label: 'reflect-metadata', value: 'as-column'},
+    {label: 'ts-morph', value: 'in-query'},
+  ]}>
+  <TabItem value="as-column">
 
 ```ts title="./entities/Book.ts"
 import { FullTextType } from '@mikro-orm/postgresql';
@@ -136,6 +133,7 @@ And to find results: `repository.findOne({ title: { $fulltext: 'query' } })`
 </Tabs>
 
 ### MySQL, MariaDB
+
 MySQL and MariaDB allow full text searches on all columns with a fulltext index.
 
 Refer to the [MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/fulltext-boolean.html) or [MariaDB documentation](https://mariadb.com/kb/en/full-text-index-overview/#in-boolean-mode) for possible queries.
@@ -158,7 +156,6 @@ And to find results: `repository.findOne({ title: { $fulltext: 'query' } })`
 MongoDB allows full text searches on all columns with a text index. However, when executing a full text search, it selects matches based on all fields with a text index: it's only possible to add one query and only on the top-level of the query object. Refer to the [MongoDB documentation](https://www.mongodb.com/docs/manual/reference/operator/query/text/#behavior) for more information on this behavior.
 
 Refer to the [MongoDB documentation](https://www.mongodb.com/docs/manual/reference/operator/query/text/#definition) for possible queries.
-
 
 ```ts title="./entities/Book.ts"
 @Entity()

--- a/docs/versioned_docs/version-5.6/quick-start.md
+++ b/docs/versioned_docs/version-5.6/quick-start.md
@@ -2,8 +2,7 @@
 title: Quick Start
 ---
 
-First install the module via `yarn` or `npm` and do not forget to install the 
-database driver as well:
+First install the module via `yarn` or `npm` and do not forget to install the database driver as well:
 
 ```sh
 yarn add @mikro-orm/core @mikro-orm/mongodb     # for mongo
@@ -23,8 +22,7 @@ npm i -s @mikro-orm/core @mikro-orm/postgresql  # for postgresql
 npm i -s @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 ```
 
-Next you will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html)
-as well as `esModuleInterop` in `tsconfig.json` via:
+Next you will need to enable support for [decorators](https://www.typescriptlang.org/docs/handbook/decorators.html) as well as `esModuleInterop` in `tsconfig.json` via:
 
 ```json
 "experimentalDecorators": true,
@@ -34,9 +32,7 @@ as well as `esModuleInterop` in `tsconfig.json` via:
 
 Then call `MikroORM.init` as part of bootstrapping your app:
 
-> To access driver specific methods like `em.createQueryBuilder()` we need to specify
-> the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the
-> `orm.em` to `EntityManager` exported from the driver package:
+> To access driver specific methods like `em.createQueryBuilder()` we need to specify the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the `orm.em` to `EntityManager` exported from the driver package:
 >
 > ```ts
 > import { EntityManager } from '@mikro-orm/postgresql';
@@ -55,14 +51,11 @@ const orm = await MikroORM.init<PostgreSqlDriver>({
 console.log(orm.em); // access EntityManager via `em` property
 ```
 
-There are more ways to configure your entities, take a look at 
-[installation page](https://mikro-orm.io/installation/).
+There are more ways to configure your entities, take a look at [installation page](https://mikro-orm.io/installation/).
 
 > Read more about all the possible configuration options in [Advanced Configuration](https://mikro-orm.io/docs/configuration) section.
 
-Then you will need to fork entity manager for each request so their 
-[identity maps](https://mikro-orm.io/identity-map/) will not collide. 
-To do so, use the `RequestContext` helper:
+Then you will need to fork entity manager for each request so their [identity maps](https://mikro-orm.io/identity-map/) will not collide. To do so, use the `RequestContext` helper:
 
 ```ts
 const app = express();
@@ -72,15 +65,11 @@ app.use((req, res, next) => {
 });
 ```
 
-> You should register this middleware as the last one just before request handlers and before
-> any of your custom middleware that is using the ORM. There might be issues when you register 
-> it before request processing middleware like `queryParser` or `bodyParser`, so definitely 
-> register the context after them. 
+> You should register this middleware as the last one just before request handlers and before any of your custom middleware that is using the ORM. There might be issues when you register it before request processing middleware like `queryParser` or `bodyParser`, so definitely register the context after them.
 
 More info about `RequestContext` is described [here](https://mikro-orm.io/identity-map/#request-context).
 
-Now you can start defining your entities (in one of the `entities` folders). This is how
-simple entity can look like in mongo driver:
+Now you can start defining your entities (in one of the `entities` folders). This is how simple entity can look like in mongo driver:
 
 ```ts title="./entities/MongoBook.ts"
 @Entity()
@@ -135,15 +124,11 @@ export class UuidBook {
 }
 ```
 
-More information can be found in
-[defining entities section](https://mikro-orm.io/defining-entities/) in docs.
+More information can be found in [defining entities section](https://mikro-orm.io/defining-entities/) in docs.
 
-When you have your entities defined, you can start using ORM either via `EntityManager`
-or via `EntityRepository`s.
+When you have your entities defined, you can start using ORM either via `EntityManager` or via `EntityRepository`s.
 
-To save entity state to database, you need to persist it. Persist determines 
-whether to use `insert` or `update` and computes appropriate change-set. Entity references
-that are not persisted yet (does not have identifier) will be cascade persisted automatically. 
+To save entity state to database, you need to persist it. Persist determines whether to use `insert` or `update` and computes appropriate change-set. Entity references that are not persisted yet (does not have identifier) will be cascade persisted automatically.
 
 ```ts
 // use constructors in your entities for required parameters
@@ -163,7 +148,7 @@ book3.publisher = publisher;
 await em.persistAndFlush([book1, book2, book3]);
 ```
 
-To fetch entities from database you can use `find()` and `findOne()` of `EntityManager`: 
+To fetch entities from database you can use `find()` and `findOne()` of `EntityManager`:
 
 ```ts
 const authors = em.find(Author, {});
@@ -179,13 +164,12 @@ for (const author of authors) {
 }
 ```
 
-More convenient way of fetching entities from database is by using `EntityRepository`, that
-carries the entity name so you do not have to pass it to every `find` and `findOne` calls:
+More convenient way of fetching entities from database is by using `EntityRepository`, that carries the entity name so you do not have to pass it to every `find` and `findOne` calls:
 
 ```ts
 const booksRepository = em.getRepository(Book);
 
-const books = await booksRepository.find({ author: '...' }, { 
+const books = await booksRepository.find({ author: '...' }, {
   populate: ['author'],
   limit: 1,
   offset: 2,
@@ -195,5 +179,4 @@ const books = await booksRepository.find({ author: '...' }, {
 console.log(books); // Book[]
 ```
 
-Take a look at docs about [working with `EntityManager`](https://mikro-orm.io/entity-manager/)
-or [using `EntityRepository` instead](https://mikro-orm.io/repositories/).
+Take a look at docs about [working with `EntityManager`](https://mikro-orm.io/entity-manager/) or [using `EntityRepository` instead](https://mikro-orm.io/repositories/).

--- a/docs/versioned_docs/version-5.6/read-connections.md
+++ b/docs/versioned_docs/version-5.6/read-connections.md
@@ -2,19 +2,13 @@
 title: Read Replica Connections
 ---
 
-Users can specify multiple read connections via `replicas` option. You can provide only fields
-that differ from master connection, rest will be taken from it.
+Users can specify multiple read connections via `replicas` option. You can provide only fields that differ from master connection, rest will be taken from it.
 
-When resolving read connections, the default strategy is to assign random read replicas for all
-read operations (SELECT, COUNT) that are not running inside a transaction.
+When resolving read connections, the default strategy is to assign random read replicas for all read operations (SELECT, COUNT) that are not running inside a transaction.
 
-You can specify an explicit connection type for find and count operations by using the `connectionType`
-property on the corresponding Options argument (i.e. `FindOptions`, `CountOptions`).
+You can specify an explicit connection type for find and count operations by using the `connectionType` property on the corresponding Options argument (i.e. `FindOptions`, `CountOptions`).
 
-The connection resolution strategy can be also inverted by setting the `preferReadReplicas` configuration property
-to `false` so that the default connection will always be a write connection, unless explicitly requested to be read
-(can be useful in applications where read-replicas are available but should only be used for specific use-cases).
-
+The connection resolution strategy can be also inverted by setting the `preferReadReplicas` configuration property to `false` so that the default connection will always be a write connection, unless explicitly requested to be read (can be useful in applications where read-replicas are available but should only be used for specific use-cases).
 
 ```ts
 const orm = await MikroORM.init({
@@ -31,9 +25,7 @@ const orm = await MikroORM.init({
 });
 ```
 
-By default, select queries will use random read connection if not inside transaction. You can
-specify the connection type explicitly in `em.getConnection(type: 'read' | 'write')`.
-
+By default, select queries will use random read connection if not inside transaction. You can specify the connection type explicitly in `em.getConnection(type: 'read' | 'write')`.
 
 ```ts
 const connection = em.getConnection(); // write connection

--- a/docs/versioned_docs/version-5.6/relationships.md
+++ b/docs/versioned_docs/version-5.6/relationships.md
@@ -3,20 +3,16 @@ title: Modeling Entity Relationships
 sidebar_label: Modeling Entity Relationships
 ---
 
-There are 4 types of entity relationships in MikroORM: 
+There are 4 types of entity relationships in MikroORM:
 
 - ManyToOne
 - OneToMany
 - OneToOne
 - ManyToMany
 
-Relations can be unidirectional and bidirectional. Unidirectional are defined only on one 
-side (the owning side). Bidirectional are defined on both sides, while one is owning side 
-(where references are store), marked by `inversedBy` attribute pointing to the inverse side.
-On the inversed side we define it with `mappedBy` attribute pointing back to the owner:
+Relations can be unidirectional and bidirectional. Unidirectional are defined only on one side (the owning side). Bidirectional are defined on both sides, while one is owning side (where references are store), marked by `inversedBy` attribute pointing to the inverse side. On the inversed side we define it with `mappedBy` attribute pointing back to the owner:
 
-> When modeling bidirectional relationship, you can also omit the `inversedBy` attribute, 
-> defining `mappedBy` on the inverse side is enough as it will be auto-wired. 
+> When modeling bidirectional relationship, you can also omit the `inversedBy` attribute, defining `mappedBy` on the inverse side is enough as it will be auto-wired.
 
 ## ManyToOne
 
@@ -43,8 +39,7 @@ export class Book {
 }
 ```
 
-You can also specify how operations on given entity should [cascade](cascading.md) 
-to the referred entity.
+You can also specify how operations on given entity should [cascade](cascading.md) to the referred entity.
 
 ## OneToMany
 
@@ -71,19 +66,15 @@ export class Author {
 }
 ```
 
-As you can see, OneToMany is the inverse side of ManyToOne (which is the owning side).
-More about how collections work can be found on [collections page](collections.md). 
+As you can see, OneToMany is the inverse side of ManyToOne (which is the owning side). More about how collections work can be found on [collections page](collections.md).
 
-You can also specify how operations on given entity should [cascade](cascading.md) to the referred
-entities. There is also more aggressive remove mode called [Orphan Removal](cascading.md#orphan-removal) 
-(`books4` example).
+You can also specify how operations on given entity should [cascade](cascading.md) to the referred entities. There is also more aggressive remove mode called [Orphan Removal](cascading.md#orphan-removal) (`books4` example).
 
 ## OneToOne
 
 > One instance of the current Entity refers to One instance of the referred Entity.
 
-This is a variant of ManyToOne, where there is always just one entity on both sides. This means
-that the foreign key column is also unique.
+This is a variant of ManyToOne, where there is always just one entity on both sides. This means that the foreign key column is also unique.
 
 ### Owning Side
 
@@ -121,8 +112,7 @@ export class User {
 }
 ```
 
-As you can see, relationships can be also self-referencing (all of them. OneToOne also supports 
-[Orphan Removal](cascading.md#orphan-removal). 
+As you can see, relationships can be also self-referencing (all of them. OneToOne also supports [Orphan Removal](cascading.md#orphan-removal).
 
 ## ManyToMany
 
@@ -149,7 +139,7 @@ export class Book {
   @ManyToMany(() => BookTag, 'books', { owner: true })
   tags4 = new Collection<BookTag>(this);
 
-  // to define uni-directional many to many, simply provide only 
+  // to define uni-directional many to many, simply provide only
   @ManyToMany(() => Author)
   friends: Collection<Author> = new Collection<Author>(this);
 
@@ -169,7 +159,7 @@ export class BookTag {
 }
 ```
 
-Again, more information about how collections work can be found on [collections page](collections.md). 
+Again, more information about how collections work can be found on [collections page](collections.md).
 
 ## Relations in ESM projects
 

--- a/docs/versioned_docs/version-5.6/repositories.md
+++ b/docs/versioned_docs/version-5.6/repositories.md
@@ -3,18 +3,14 @@ title: Using EntityRepository instead of EntityManager
 sidebar_label: Entity Repository
 ---
 
-Entity Repositories are thin layers on top of `EntityManager`. They act as an 
-extension point, so we can add custom methods, or even alter the existing ones. 
-The default, `EntityRepository` implementation just forwards the calls to 
-underlying `EntityManager` instance.
+Entity Repositories are thin layers on top of `EntityManager`. They act as an extension point, so we can add custom methods, or even alter the existing ones. The default, `EntityRepository` implementation just forwards the calls to underlying `EntityManager` instance.
 
-> `EntityRepository` class carries the entity type, so we do not have to pass 
-> it to every `find` or `findOne` calls.
+> `EntityRepository` class carries the entity type, so we do not have to pass it to every `find` or `findOne` calls.
 
 ```ts
 const booksRepository = em.getRepository(Book);
 
-const books = await booksRepository.find({ author: '...' }, { 
+const books = await booksRepository.find({ author: '...' }, {
   populate: ['author'],
   limit: 1,
   offset: 2,
@@ -24,17 +20,11 @@ const books = await booksRepository.find({ author: '...' }, {
 console.log(books); // Book[]
 ```
 
-Note that there is no such thing as "flushing repository" - it is just a shortcut
-to `em.flush()`. In other words, we always flush the whole Unit of Work, not just
-a single entity that this repository represents.
+Note that there is no such thing as "flushing repository" - it is just a shortcut to `em.flush()`. In other words, we always flush the whole Unit of Work, not just a single entity that this repository represents.
 
 ## Custom Repository
 
-:::info
-Since v4, we need to make sure we are working with correctly typed `EntityRepository` 
-to have access to driver specific methods (like `createQueryBuilder()`). Use the one
-exported from your driver package.
-:::
+:::info Since v4, we need to make sure we are working with correctly typed `EntityRepository` to have access to driver specific methods (like `createQueryBuilder()`). Use the one exported from your driver package. :::
 
 To use custom repository, just extend `EntityRepository<T>` class:
 
@@ -60,19 +50,15 @@ export class Author {
 }
 ```
 
-> `@Repository()` decorator has been removed in v5, use
-> `@Entity({ customRepository: () => MyRepository })` instead.
+> `@Repository()` decorator has been removed in v5, use `@Entity({ customRepository: () => MyRepository })` instead.
 
-Note that we need to pass that repository reference inside a callback so we will not run
-into circular dependency issues when using entity references inside that repository.
+Note that we need to pass that repository reference inside a callback so we will not run into circular dependency issues when using entity references inside that repository.
 
 Now we can access our custom repository via `em.getRepository()` method.
 
 ### Inferring custom repository type
 
-To have the `em.getRepository()` method return correctly typed custom repository
-instead of the generic `EntityRepository<T>`, we can use `EntityRepositoryType`
-symbol:
+To have the `em.getRepository()` method return correctly typed custom repository instead of the generic `EntityRepository<T>`, we can use `EntityRepositoryType` symbol:
 
 ```ts
 @Entity({ customRepository: () => AuthorRepository })
@@ -85,9 +71,6 @@ export class Author {
 const repo = em.getRepository(Author); // repo has type AuthorRepository
 ```
 
-> We can also register custom base repository (for all entities where we do not specify 
-> `customRepository`) globally, via `MikroORM.init({ entityRepository: CustomBaseRepository })`.
+> We can also register custom base repository (for all entities where we do not specify `customRepository`) globally, via `MikroORM.init({ entityRepository: CustomBaseRepository })`.
 
-For more examples, take a look at
-[`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts)
-or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).
+For more examples, take a look at [`tests/EntityManager.mongo.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mongo.test.ts) or [`tests/EntityManager.mysql.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/EntityManager.mysql.test.ts).

--- a/docs/versioned_docs/version-5.6/schema-generator.md
+++ b/docs/versioned_docs/version-5.6/schema-generator.md
@@ -2,51 +2,41 @@
 title: Schema Generator
 ---
 
-> SchemaGenerator can do harm to your database. It will drop or alter tables, indexes, 
-> sequences and such. Please use this tool with caution in development and not on a 
-> production server. It is meant for helping you develop your Database Schema, but NOT 
-> with migrating schema from A to B in production. A safe approach would be generating 
-> the SQL on development server and saving it into SQL Migration files that are executed 
-> manually on the production server.
+> SchemaGenerator can do harm to your database. It will drop or alter tables, indexes, sequences and such. Please use this tool with caution in development and not on a production server. It is meant for helping you develop your Database Schema, but NOT with migrating schema from A to B in production. A safe approach would be generating the SQL on development server and saving it into SQL Migration files that are executed manually on the production server.
 
-> SchemaGenerator assumes your project uses the given database on its own. Update and Drop 
-> commands will mess with other tables if they are not related to the current project 
-> that is using MikroORM. Please be careful!
+> SchemaGenerator assumes your project uses the given database on its own. Update and Drop commands will mess with other tables if they are not related to the current project that is using MikroORM. Please be careful!
 
-To generate schema from your entity metadata, you can use `SchemaGenerator` helper. 
+To generate schema from your entity metadata, you can use `SchemaGenerator` helper.
 
-You can use it via CLI: 
+You can use it via CLI:
 
-> To work with the CLI, first install `@mikro-orm/cli` package locally.
-> The version needs to be aligned with the `@mikro-orm/core` package.
+> To work with the CLI, first install `@mikro-orm/cli` package locally. The version needs to be aligned with the `@mikro-orm/core` package.
 
 ```sh
 npx mikro-orm schema:create --dump   # Dumps create schema SQL
 npx mikro-orm schema:update --dump   # Dumps update schema SQL
-npx mikro-orm schema:drop --dump     # Dumps drop schema SQL 
+npx mikro-orm schema:drop --dump     # Dumps drop schema SQL
 ```
 
-> You can also use `--run` flag to fire all queries, but be careful as it might break your
-> database. Be sure to always check the generated SQL first before executing. Do not use
-> `--run` flag in production! 
+> You can also use `--run` flag to fire all queries, but be careful as it might break your database. Be sure to always check the generated SQL first before executing. Do not use `--run` flag in production!
 
-`schema:create` will automatically create the database if it does not exist. 
+`schema:create` will automatically create the database if it does not exist.
 
-`schema:update` drops all unknown tables by default, you can use `--no-drop-tables` 
-to get around it. There is also `--safe` flag that will disable both table dropping as 
-well as column dropping. 
+`schema:update` drops all unknown tables by default, you can use `--no-drop-tables` to get around it. There is also `--safe` flag that will disable both table dropping as well as column dropping.
 
-`schema:drop` will by default drop all database tables. You can use `--drop-db` flag to drop
-the whole database instead. 
+`schema:drop` will by default drop all database tables. You can use `--drop-db` flag to drop the whole database instead.
 
 ```shell
 npx mikro-orm schema:fresh --run     # !WARNING! Drops the database schema and recreates it
 ```
+
 This command can be run with the `--seed` option to seed the database after it has been created again.
+
 ```shell
 npx mikro-orm schema:fresh --run --seed              # seed the database with the default database seeder
 npx mikro-orm schema:fresh --run --seed=UsersSeeder  # seed the database with the UsersSeeder
 ```
+
 > You can specify the default database seeder in the orm config with the key `config.seeder.defaultSeeder`
 
 ## Configuration
@@ -64,8 +54,7 @@ const orm = await MikroORM.init({
 });
 ```
 
-> Note that if we disable FK constraints and current schema is using them, the 
-> schema diffing will try to remove those that already exist.
+> Note that if we disable FK constraints and current schema is using them, the schema diffing will try to remove those that already exist.
 
 ## Using SchemaGenerator programmatically
 
@@ -99,7 +88,7 @@ import { MikroORM } from '@mikro-orm/core';
   await generator.dropSchema();
   await generator.createSchema();
   await generator.updateSchema();
-  
+
   // in tests it can be handy to use those:
   await generator.refreshDatabase(); // ensure db exists and is fresh
   await generator.clearDatabase(); // removes all data
@@ -122,12 +111,10 @@ See the [SQL Generated columns](defining-entities.md#SQL Generated columns) sect
 
 ## Limitations of SQLite
 
-There are limitations of SQLite database because of which it behaves differently 
-than other SQL drivers. Namely, it is not possible to:
+There are limitations of SQLite database because of which it behaves differently than other SQL drivers. Namely, it is not possible to:
 
 - create foreign key constraints when altering columns
 - create empty tables without columns
 - alter column requires nullability
 
-Because of this, you can end up with different schema with SQLite, so it is not
-suggested to use SQLite for integration tests of your application.
+Because of this, you can end up with different schema with SQLite, so it is not suggested to use SQLite for integration tests of your application.

--- a/docs/versioned_docs/version-5.6/seeding.md
+++ b/docs/versioned_docs/version-5.6/seeding.md
@@ -2,13 +2,11 @@
 title: Seeding
 ---
 
-When initializing your application or testing it can be exhausting to create sample data for your database. The solution is to use seeding. Create factories for your entities and use them in the seed
-script or combine multiple seed scripts.
+When initializing your application or testing it can be exhausting to create sample data for your database. The solution is to use seeding. Create factories for your entities and use them in the seed script or combine multiple seed scripts.
 
 ## Configuration
 
-> `seeder.path` and `seeder.pathTs` works the same way as `entities` and
-> `entitiesTs` in entity discovery.
+> `seeder.path` and `seeder.pathTs` works the same way as `entities` and `entitiesTs` in entity discovery.
 
 The seeder has a few default settings that can be changed easily through the MikroORM config. Underneath you find the configuration options with their defaults.
 
@@ -35,8 +33,7 @@ We can also override these default using the [environment variables](configurati
 
 ## Seeders
 
-A seeder class contains one method `run`. This method is called when you use the command `npx mikro-orm seeder:run`. In the `run` method you define how and what data you want to insert into the
-database. You can create entities using the [EntityManager](http://mikro-orm.io/docs/entity-manager) or you can use [Factories](#using-entity-factories).
+A seeder class contains one method `run`. This method is called when you use the command `npx mikro-orm seeder:run`. In the `run` method you define how and what data you want to insert into the database. You can create entities using the [EntityManager](http://mikro-orm.io/docs/entity-manager) or you can use [Factories](#using-entity-factories).
 
 You can create your own seeder classes using the following CLI command:
 
@@ -46,15 +43,11 @@ npx mikro-orm seeder:create test            # generates the class TestSeeder
 npx mikro-orm seeder:create project-names   # generates the class ProjectNamesSeeder
 ```
 
-This creates a new seeder class. By default, it will be generated in the `./seeders/` directory. You can configure the directory in the config with the key `seeder.path` or using
-the [environment variable](configuration.md#using-environment-variables) `MIKRO_ORM_SEEDER_PATH`. You are allowed to call the `seeder:create` command with a name, class name or hyphenated name.
+This creates a new seeder class. By default, it will be generated in the `./seeders/` directory. You can configure the directory in the config with the key `seeder.path` or using the [environment variable](configuration.md#using-environment-variables) `MIKRO_ORM_SEEDER_PATH`. You are allowed to call the `seeder:create` command with a name, class name or hyphenated name.
 
 As an example we will look at a very basic seeder.
 
-> Note that the `EntityManager` available in seeders will have `persistOnCreate`
-> enabled, hence calling `em.create()` will automatically call `em.persist()`
-> on the created entity. If we use entity constructor instead, we need to call
-> `em.persist()` explicitly.
+> Note that the `EntityManager` available in seeders will have `persistOnCreate` enabled, hence calling `em.create()` will automatically call `em.persist()` on the created entity. If we use entity constructor instead, we need to call `em.persist()` explicitly.
 
 ```ts title="./database/seeder/database.seeder.ts"
 import { EntityManager } from '@mikro-orm/core';
@@ -80,8 +73,7 @@ export class DatabaseSeeder extends Seeder {
 
 ### Using entity factories
 
-Instead of specifying all the attributes for every entity, you can also use [entity factories](#entity-factories). These can be used to generate large amounts of database records. Please read
-the [documentation on how to define factories](#entity-factories) to learn how to define your factories.
+Instead of specifying all the attributes for every entity, you can also use [entity factories](#entity-factories). These can be used to generate large amounts of database records. Please read the [documentation on how to define factories](#entity-factories) to learn how to define your factories.
 
 As an example we will generate 10 authors.
 
@@ -100,8 +92,7 @@ export class DatabaseSeeder extends Seeder {
 
 ### Calling additional seeders
 
-Inside the `run` method you can specify other seeder classes. You can use the `call` method to break up the database seeder into multiple files to prevent a seeder file from becoming too large.
-The `call` method requires an `em` and an array of seeder classes.
+Inside the `run` method you can specify other seeder classes. You can use the `call` method to break up the database seeder into multiple files to prevent a seeder file from becoming too large. The `call` method requires an `em` and an array of seeder classes.
 
 ```ts
 import { EntityManager } from '@mikro-orm/core';
@@ -148,8 +139,7 @@ export class BookSeeder extends Seeder {
 
 ## Entity factories
 
-When testing you may insert entities in the database before starting a test. Instead of specifying every attribute of every entity by hand, you could also use a `Factory` to define a set of default
-attributes for an entity using entity factories.
+When testing you may insert entities in the database before starting a test. Instead of specifying every attribute of every entity by hand, you could also use a `Factory` to define a set of default attributes for an entity using entity factories.
 
 Lets have a look at an example factory for an [Author entity](http://mikro-orm.io/docs/defining-entities).
 
@@ -168,10 +158,9 @@ export class AuthorFactory extends Factory<Author> {
     };
   }
 }
-``` 
+```
 
-Basically you extend the base `Factory` class, define a `model` property and a `definition` method. The `model` defines for which entity the factory generates entity instances. The `definition` method
-returns the default set of attribute values that should be applied when creating an entity using the factory.
+Basically you extend the base `Factory` class, define a `model` property and a `definition` method. The `model` defines for which entity the factory generates entity instances. The `definition` method returns the default set of attribute values that should be applied when creating an entity using the factory.
 
 Via the faker property, factories have access to the [Faker library](https://github.com/faker-js/faker), which allows you to conveniently generate various kinds of random data for testing.
 
@@ -190,18 +179,17 @@ Generate multiple entities by calling the `make` method. The parameter of the `m
 ```ts
 // Generate 5 authors
 const authors = new AuthorFactory(orm.em).make(5);
-``` 
+```
 
 #### Overriding attributes
 
-If you would like to override some of the default values of your factories, you may pass an object to the make method. Only the specified attributes will be replaced while the rest of the attributes
-remain set to their default values as specified by the factory.
+If you would like to override some of the default values of your factories, you may pass an object to the make method. Only the specified attributes will be replaced while the rest of the attributes remain set to their default values as specified by the factory.
 
 ```ts
 const author = new AuthorFactory(orm.em).make({
   name: 'John Snow',
 });
-``` 
+```
 
 ### Persisting entities
 
@@ -231,9 +219,7 @@ const authors = await new AuthorFactory(orm.em).create(5, {
 
 ### Factory relationships
 
-It is nice to create large quantities of data for one entity, but most of the time we want to create data for multiple entities and also have relations between these. For this we can use the `each`
-method which can be chained on a factory. The `each` method can be called with a function that transforms output entity from the factory before returning it. Lets look at some examples for the
-different relations.
+It is nice to create large quantities of data for one entity, but most of the time we want to create data for multiple entities and also have relations between these. For this we can use the `each` method which can be chained on a factory. The `each` method can be called with a function that transforms output entity from the factory before returning it. Lets look at some examples for the different relations.
 
 #### ManyToOne and OneToOne relations
 
@@ -241,7 +227,7 @@ different relations.
 const books: Book[] = new BookFactory(orm.em).each(book => {
   book.author = new AuthorFactory(orm.em).makeOne();
 }).make(5);
-``` 
+```
 
 #### OneToMany and ManyToMany
 
@@ -249,13 +235,11 @@ const books: Book[] = new BookFactory(orm.em).each(book => {
 const books: Book[] = new BookFactory(orm.em).each(book => {
   book.owners.set(new OwnerFactory(orm.em).make(5));
 }).make(5);
-``` 
+```
 
 ## Use with CLI
 
-You may execute the `seeder:run` MikroORM CLI command to seed your database. By default, the `seeder:run` command runs the `DatabaseSeeder` class, which may in turn invoke other seed classes. You can
-configure the default seeder using the key `seeder.defaultSeeder` or using the [environment variable](configuration.md#using-environment-variables) `MIKRO_ORM_SEEDER_DEFAULT_SEEDER`. You can also use
-the `--class` option to specify a seeder class:
+You may execute the `seeder:run` MikroORM CLI command to seed your database. By default, the `seeder:run` command runs the `DatabaseSeeder` class, which may in turn invoke other seed classes. You can configure the default seeder using the key `seeder.defaultSeeder` or using the [environment variable](configuration.md#using-environment-variables) `MIKRO_ORM_SEEDER_DEFAULT_SEEDER`. You can also use the `--class` option to specify a seeder class:
 
 ```shell script
 npx mikro-orm seeder:run
@@ -263,8 +247,7 @@ npx mikro-orm seeder:run
 npx mikro-orm seeder:run --class=BookSeeder
 ```
 
-You may also seed your database using the [`migrate:fresh`](migrations.md#using-via-cli) or [`schema:fresh`](schema-generator.md) command in combination with the `--seed` option, which will drop all
-tables and re-run all of your migrations or generate the database based on the current entities. This command is useful for completely re-building your database:
+You may also seed your database using the [`migrate:fresh`](migrations.md#using-via-cli) or [`schema:fresh`](schema-generator.md) command in combination with the `--seed` option, which will drop all tables and re-run all of your migrations or generate the database based on the current entities. This command is useful for completely re-building your database:
 
 ```shell script
 npx mikro-orm migration:fresh --seed    # will drop the database, run all migrations and the DatabaseSeeder class
@@ -272,8 +255,7 @@ npx mikro-orm migration:fresh --seed    # will drop the database, run all migrat
 npx mikro-orm schema:fresh --seed       # will recreate the database and run the DatabaseSeeder class
 ```
 
-If you do not want to run the `DatabaseSeeder` class you can either specify what the default seeder class should be. This can be done by changing the [default settings](#default-settings). Another
-option is to explicitly define the seeder class you want to run.
+If you do not want to run the `DatabaseSeeder` class you can either specify what the default seeder class should be. This can be done by changing the [default settings](#default-settings). Another option is to explicitly define the seeder class you want to run.
 
 ```shell script
 npx mikro-orm migration:fresh --seed TestSeeder       # will drop the database, run all migrations and the TestSeeder class
@@ -327,6 +309,4 @@ await MikroORM.init({
 });
 ```
 
-This should allow using CLI to generate TS seeder files (as in CLI we probably
-have TS support enabled), while using compiled JS files in production, where ts-node
-is not registered.
+This should allow using CLI to generate TS seeder files (as in CLI we probably have TS support enabled), while using compiled JS files in production, where ts-node is not registered.

--- a/docs/versioned_docs/version-5.6/serializing.md
+++ b/docs/versioned_docs/version-5.6/serializing.md
@@ -12,9 +12,7 @@ export interface AnyEntity<K = number | string> {
 }
 ```
 
-When you serialize your entity via `JSON.stringify(entity)`, its `toJSON` method will be 
-called automatically. You can provide custom implementation for `toJSON`, while using 
-`toObject` for initial serialization:
+When you serialize your entity via `JSON.stringify(entity)`, its `toJSON` method will be called automatically. You can provide custom implementation for `toJSON`, while using `toObject` for initial serialization:
 
 ```ts
 @Entity()
@@ -35,13 +33,11 @@ export class Book {
 }
 ```
 
-> Do not forget to pass rest params when calling `toObject(...args)`, otherwise the results
-> might not be stable.
+> Do not forget to pass rest params when calling `toObject(...args)`, otherwise the results might not be stable.
 
 ## Hidden Properties
 
-If you want to omit some properties from serialized result, you can mark them with `hidden`
-flag on `@Property()` decorator:
+If you want to omit some properties from serialized result, you can mark them with `hidden` flag on `@Property()` decorator:
 
 ```ts
 @Entity()
@@ -59,13 +55,9 @@ console.log(wrap(book).toJSON().hiddenField); // undefined
 
 ## Shadow Properties
 
-The opposite situation where you want to define a property that lives only in memory (is 
-not persisted into database) can be solved by defining your property as `persist: false`. 
-Such property can be assigned via one of `Entity.assign()`, `em.create()` and 
-`em.merge()`. It will be also part of serialized result. 
+The opposite situation where you want to define a property that lives only in memory (is not persisted into database) can be solved by defining your property as `persist: false`. Such property can be assigned via one of `Entity.assign()`, `em.create()` and `em.merge()`. It will be also part of serialized result.
 
-This can be handled when dealing with additional values selected via `QueryBuilder` or 
-MongoDB's aggregations.
+This can be handled when dealing with additional values selected via `QueryBuilder` or MongoDB's aggregations.
 
 ```ts
 @Entity()
@@ -84,8 +76,7 @@ console.log(wrap(book).toJSON().count); // 123
 
 ## Property Serializers
 
-As an alternative to custom `toJSON()` method, we can also use property serializers.
-They allow to specify a callback that will be used when serializing a property:
+As an alternative to custom `toJSON()` method, we can also use property serializers. They allow to specify a callback that will be used when serializing a property:
 
 ```ts
 @Entity()
@@ -144,7 +135,7 @@ import { serialize } from '@mikro-orm/core';
 const dto = serialize(author, {
   populate: ['books.author', 'books.publisher', 'favouriteBook'], // populate some relations
   exclude: ['books.author.email'], // skip property of some relation
-  forceObject: true, // not populated or not initialized relations will result in object, e.g. `{ author: { id: 1 } }` 
+  forceObject: true, // not populated or not initialized relations will result in object, e.g. `{ author: { id: 1 } }`
   skipNull: true, // properties with `null` value won't be part of the result
 });
 ```

--- a/docs/versioned_docs/version-5.6/transactions.md
+++ b/docs/versioned_docs/version-5.6/transactions.md
@@ -6,28 +6,17 @@ title: Transactions and Concurrency
 
 ## Transaction Demarcation
 
-Transaction demarcation is the task of defining your transaction boundaries. Proper 
-transaction demarcation is very important because if not done properly it can negatively 
-affect the performance of your application. Many databases and database abstraction 
-layers by default operate in auto-commit mode, which means that every single SQL statement 
-is wrapped in a small transaction. Without any explicit transaction demarcation from your 
-side, this quickly results in poor performance because transactions are not cheap. 
+Transaction demarcation is the task of defining your transaction boundaries. Proper transaction demarcation is very important because if not done properly it can negatively affect the performance of your application. Many databases and database abstraction layers by default operate in auto-commit mode, which means that every single SQL statement is wrapped in a small transaction. Without any explicit transaction demarcation from your side, this quickly results in poor performance because transactions are not cheap.
 
-For the most part, MikroORM already takes care of proper transaction demarcation for you: 
-All the write operations (INSERT/UPDATE/DELETE) are queued until `em.flush()` 
-is invoked which wraps all of these changes in a single transaction.
+For the most part, MikroORM already takes care of proper transaction demarcation for you: All the write operations (INSERT/UPDATE/DELETE) are queued until `em.flush()` is invoked which wraps all of these changes in a single transaction.
 
-However, MikroORM also allows (and encourages) you to take over and control transaction 
-demarcation yourself.
+However, MikroORM also allows (and encourages) you to take over and control transaction demarcation yourself.
 
-These are two ways to deal with transactions when using the MikroORM and are now described 
-in more detail.
+These are two ways to deal with transactions when using the MikroORM and are now described in more detail.
 
 ### Approach 1: Implicitly
 
-The first approach is to use the implicit transaction handling provided by the MikroORM 
-`EntityManager`. Given the following code snippet, without any explicit transaction 
-demarcation:
+The first approach is to use the implicit transaction handling provided by the MikroORM `EntityManager`. Given the following code snippet, without any explicit transaction demarcation:
 
 ```ts
 const user = new User(...);
@@ -35,16 +24,11 @@ user.name = 'George';
 await orm.em.persistAndFlush(user);
 ```
 
-Since we do not do any custom transaction demarcation in the above code, `em.flush()` 
-will begin and commit/rollback a transaction. This behavior is made possible by the 
-aggregation of the DML operations by the MikroORM and is sufficient if all the data 
-manipulation that is part of a unit of work happens through the domain model and thus 
-the ORM.
+Since we do not do any custom transaction demarcation in the above code, `em.flush()` will begin and commit/rollback a transaction. This behavior is made possible by the aggregation of the DML operations by the MikroORM and is sufficient if all the data manipulation that is part of a unit of work happens through the domain model and thus the ORM.
 
 ### Approach 2: Explicitly
 
-The explicit alternative is to use the transactions API directly to control the boundaries. 
-The code then looks like this:
+The explicit alternative is to use the transactions API directly to control the boundaries. The code then looks like this:
 
 ```ts
 await orm.em.transactional(em => {
@@ -55,8 +39,7 @@ await orm.em.transactional(em => {
 });
 ```
 
-Or you can use `begin/commit/rollback` methods explicitly. Following example is
-equivalent to the previous one:
+Or you can use `begin/commit/rollback` methods explicitly. Following example is equivalent to the previous one:
 
 ```ts
 const em = orm.em.fork();
@@ -74,68 +57,37 @@ try {
 }
 ```
 
-Explicit transaction demarcation is required when you want to include custom DBAL operations 
-in a unit of work or when you want to make use of some methods of the EntityManager API 
-that require an active transaction. Such methods will throw a `ValidationError` to inform 
-you of that requirement.
+Explicit transaction demarcation is required when you want to include custom DBAL operations in a unit of work or when you want to make use of some methods of the EntityManager API that require an active transaction. Such methods will throw a `ValidationError` to inform you of that requirement.
 
 `em.transactional(cb)` will flush the inner `EntityManager` prior to transaction commit.
 
 ### Exception Handling
 
-When using implicit transaction demarcation and an exception occurs during 
-`em.flush()`, the transaction is automatically rolled back.
+When using implicit transaction demarcation and an exception occurs during `em.flush()`, the transaction is automatically rolled back.
 
-When using explicit transaction demarcation and an exception occurs, the transaction should 
-be rolled back immediately as demonstrated in the example above. This can be handled elegantly 
-by the control abstractions shown earlier. Note that when catching Exception you should 
-generally re-throw the exception. If you intend to recover from some exceptions, catch them 
-explicitly in earlier catch blocks (but do not forget to rollback the transaction). All 
-other best practices of exception handling apply similarly (i.e. either log or re-throw, 
-not both, etc.).
+When using explicit transaction demarcation and an exception occurs, the transaction should be rolled back immediately as demonstrated in the example above. This can be handled elegantly by the control abstractions shown earlier. Note that when catching Exception you should generally re-throw the exception. If you intend to recover from some exceptions, catch them explicitly in earlier catch blocks (but do not forget to rollback the transaction). All other best practices of exception handling apply similarly (i.e. either log or re-throw, not both, etc.).
 
-As a result of this procedure, all previously managed or removed instances of the `EntityManager` 
-become detached. The state of the detached objects will be the state at the point at which the 
-transaction was rolled back. The state of the objects is in no way rolled back and thus the 
-objects are now out of sync with the database. The application can continue to use the detached 
-objects, knowing that their state is potentially no longer accurate.
+As a result of this procedure, all previously managed or removed instances of the `EntityManager` become detached. The state of the detached objects will be the state at the point at which the transaction was rolled back. The state of the objects is in no way rolled back and thus the objects are now out of sync with the database. The application can continue to use the detached objects, knowing that their state is potentially no longer accurate.
 
-If you intend to start another unit of work after an exception has occurred you should do 
-that with a new `EntityManager`. Simply use `em.fork()` to obtain fresh copy 
-with cleared identity map. 
+If you intend to start another unit of work after an exception has occurred you should do that with a new `EntityManager`. Simply use `em.fork()` to obtain fresh copy with cleared identity map.
 
 ## Locking Support
 
 ### Why we need concurrency control?
 
-If transactions are executed serially (one at a time), no transaction concurrency exists. 
-However, if concurrent transactions with interleaving operations are allowed, you may easily 
-run into one of those problems:
+If transactions are executed serially (one at a time), no transaction concurrency exists. However, if concurrent transactions with interleaving operations are allowed, you may easily run into one of those problems:
 
 1. The lost update problem
 2. The dirty read problem
 3. The incorrect summary problem
 
-To mitigate those problems, MikroORM offers support for Pessimistic and Optimistic locking 
-strategies natively. This allows you to take very fine-grained control over what kind of 
-locking is required for your entities in your application.
+To mitigate those problems, MikroORM offers support for Pessimistic and Optimistic locking strategies natively. This allows you to take very fine-grained control over what kind of locking is required for your entities in your application.
 
 ### Optimistic Locking
 
-Database transactions are fine for concurrency control during a single request. However, a 
-database transaction should not span across requests, the so-called "user think time". Therefore 
-a long-running "business transaction" that spans multiple requests needs to involve several 
-database transactions. Thus, database transactions alone can no longer control concurrency 
-during such a long-running business transaction. Concurrency control becomes the partial 
-responsibility of the application itself.
+Database transactions are fine for concurrency control during a single request. However, a database transaction should not span across requests, the so-called "user think time". Therefore a long-running "business transaction" that spans multiple requests needs to involve several database transactions. Thus, database transactions alone can no longer control concurrency during such a long-running business transaction. Concurrency control becomes the partial responsibility of the application itself.
 
-MikroORM has integrated support for automatic optimistic locking via a version field. In 
-this approach any entity that should be protected against concurrent modifications during 
-long-running business transactions gets a version field that is either a simple number 
-(mapping type: integer) or a timestamp (mapping type: datetime). When changes to such an 
-entity are persisted at the end of a long-running conversation the version of the entity 
-is compared to the version in the database and if they don't match, a `OptimisticLockError` 
-is thrown, indicating that the entity has been modified by someone else already.
+MikroORM has integrated support for automatic optimistic locking via a version field. In this approach any entity that should be protected against concurrent modifications during long-running business transactions gets a version field that is either a simple number (mapping type: integer) or a timestamp (mapping type: datetime). When changes to such an entity are persisted at the end of a long-running conversation the version of the entity is compared to the version in the database and if they don't match, a `OptimisticLockError` is thrown, indicating that the entity has been modified by someone else already.
 
 You designate a version field in an entity as follows. In this example we'll use an integer.
 
@@ -159,23 +111,13 @@ export class User {
 }
 ```
 
-Version numbers (not timestamps) should however be preferred as they can not potentially 
-conflict in a highly concurrent environment, unlike timestamps where this is a possibility, 
-depending on the resolution of the timestamp on the particular database platform.
+Version numbers (not timestamps) should however be preferred as they can not potentially conflict in a highly concurrent environment, unlike timestamps where this is a possibility, depending on the resolution of the timestamp on the particular database platform.
 
-When a version conflict is encountered during `em.flush()`, a `OptimisticLockError` 
-is thrown and the active transaction rolled back (or marked for rollback). This exception 
-can be caught and handled. Potential responses to a `OptimisticLockError` are to present the 
-conflict to the user or to refresh or reload objects in a new transaction and then retrying 
-the transaction.
+When a version conflict is encountered during `em.flush()`, a `OptimisticLockError` is thrown and the active transaction rolled back (or marked for rollback). This exception can be caught and handled. Potential responses to a `OptimisticLockError` are to present the conflict to the user or to refresh or reload objects in a new transaction and then retrying the transaction.
 
-The time between showing an update form and actually modifying the entity can in the worst 
-scenario be as long as your application's session timeout. If changes happen to the entity 
-in that time frame you want to know directly when retrieving the entity that you will hit 
-an optimistic locking exception:
+The time between showing an update form and actually modifying the entity can in the worst scenario be as long as your application's session timeout. If changes happen to the entity in that time frame you want to know directly when retrieving the entity that you will hit an optimistic locking exception:
 
-You can always verify the version of an entity during a request either when calling 
-`em.findOne()`:
+You can always verify the version of an entity during a request either when calling `em.findOne()`:
 
 ```ts
 const theEntityId = 1;
@@ -209,14 +151,9 @@ try {
 
 ### Concurrency Checks
 
-As opposed to version fields that are handled automatically, we can use 
-concurrency checks. They allow us to mark specific properties to be included
-in the concurrency check, just like the version field was. But this time, we
-will be responsible for updating the fields explicitly.
+As opposed to version fields that are handled automatically, we can use concurrency checks. They allow us to mark specific properties to be included in the concurrency check, just like the version field was. But this time, we will be responsible for updating the fields explicitly.
 
-When we try to update such entity without changing one of the concurrency fields,
-`OptimisticLockError` will be thrown. Same mechanism is then used to check whether
-the update succeeded, and throw the same type of error when not.
+When we try to update such entity without changing one of the concurrency fields, `OptimisticLockError` will be thrown. Same mechanism is then used to check whether the update succeeded, and throw the same type of error when not.
 
 ```ts
 @Entity()
@@ -241,23 +178,16 @@ export class ConcurrencyCheckUser {
 
 #### Important Implementation Notes
 
-You can easily get the optimistic locking workflow wrong if you compare the wrong versions. 
-Say you have Alice and Bob editing a hypothetical blog post:
+You can easily get the optimistic locking workflow wrong if you compare the wrong versions. Say you have Alice and Bob editing a hypothetical blog post:
 
 - Alice reads the headline of the blog post being "Foo", at optimistic lock version 1 (GET Request)
 - Bob reads the headline of the blog post being "Foo", at optimistic lock version 1 (GET Request)
 - Bob updates the headline to "Bar", upgrading the optimistic lock version to 2 (POST Request of a Form)
 - Alice updates the headline to "Baz", ... (POST Request of a Form)
 
-Now at the last stage of this scenario the blog post has to be read again from the database 
-before Alice's headline can be applied. At this point you will want to check if the blog 
-post is still at version 1 (which it is not in this scenario).
+Now at the last stage of this scenario the blog post has to be read again from the database before Alice's headline can be applied. At this point you will want to check if the blog post is still at version 1 (which it is not in this scenario).
 
-Using optimistic locking correctly, you **have** to add the version as an additional hidden 
-field (or into the session for more safety). Otherwise you cannot verify the version is still 
-the one being originally read from the database when Alice performed her GET request for the 
-blog post. If this happens you might see lost updates you wanted to prevent with Optimistic 
-Locking.
+Using optimistic locking correctly, you **have** to add the version as an additional hidden field (or into the session for more safety). Otherwise you cannot verify the version is still the one being originally read from the database when Alice performed her GET request for the blog post. If this happens you might see lost updates you wanted to prevent with Optimistic Locking.
 
 See the example code (frontend):
 
@@ -296,33 +226,24 @@ async update(req, res) {
 }
 ```
 
-Your frontend app loads an entity from API, the response includes the version property. 
-User makes some changes and fires PUT request back to the API, with version field included 
-in the payload. The PUT handler of the API then reads the version and passes it to the 
-`em.findOne()` call.
+Your frontend app loads an entity from API, the response includes the version property. User makes some changes and fires PUT request back to the API, with version field included in the payload. The PUT handler of the API then reads the version and passes it to the `em.findOne()` call.
 
 ### Pessimistic Locking
 
-MikroORM supports Pessimistic Locking at the database level. No attempt is being made to implement 
-pessimistic locking inside MikroORM, rather vendor-specific and ANSI-SQL commands are used to 
-acquire row-level locks. Every Entity can be part of a pessimistic lock, there is no special 
-metadata required to use this feature.
+MikroORM supports Pessimistic Locking at the database level. No attempt is being made to implement pessimistic locking inside MikroORM, rather vendor-specific and ANSI-SQL commands are used to acquire row-level locks. Every Entity can be part of a pessimistic lock, there is no special metadata required to use this feature.
 
-However, for Pessimistic Locking to work you have to disable the Auto-Commit Mode of your Database 
-and start a transaction around your pessimistic lock use-case using the "Approach 2: Explicit 
-Transaction Demarcation" described above. MikroORM will throw an Exception if you attempt to 
-acquire a pessimistic lock and no transaction is running.
+However, for Pessimistic Locking to work you have to disable the Auto-Commit Mode of your Database and start a transaction around your pessimistic lock use-case using the "Approach 2: Explicit Transaction Demarcation" described above. MikroORM will throw an Exception if you attempt to acquire a pessimistic lock and no transaction is running.
 
 MikroORM currently supports 6 pessimistic lock modes:
 
-| Mode | Postgres | MySQL |
-|------|----------|-------|
-| `LockMode.PESSIMISTIC_READ` | `for share` | `lock in share mode` |
-| `LockMode.PESSIMISTIC_WRITE` | `for update` | `for update` |
-| `LockMode.PESSIMISTIC_PARTIAL_WRITE` | `for update skip locked` | `for update skip locked` |
-| `LockMode.PESSIMISTIC_WRITE_OR_FAIL` | `for update nowait` | `for update nowait` |
-| `LockMode.PESSIMISTIC_PARTIAL_READ` | `for share skip locked` | `lock in share mode skip locked` |
-| `LockMode.PESSIMISTIC_READ_OR_FAIL` | `for share nowait` | `lock in share mode nowait` |
+| Mode                                 | Postgres                 | MySQL                            |
+| ------------------------------------ | ------------------------ | -------------------------------- |
+| `LockMode.PESSIMISTIC_READ`          | `for share`              | `lock in share mode`             |
+| `LockMode.PESSIMISTIC_WRITE`         | `for update`             | `for update`                     |
+| `LockMode.PESSIMISTIC_PARTIAL_WRITE` | `for update skip locked` | `for update skip locked`         |
+| `LockMode.PESSIMISTIC_WRITE_OR_FAIL` | `for update nowait`      | `for update nowait`              |
+| `LockMode.PESSIMISTIC_PARTIAL_READ`  | `for share skip locked`  | `lock in share mode skip locked` |
+| `LockMode.PESSIMISTIC_READ_OR_FAIL`  | `for share nowait`       | `lock in share mode nowait`      |
 
 You can use pessimistic locks in three different scenarios:
 
@@ -342,10 +263,10 @@ const res = await em.find(User, { name: 'Jon' }, {
   lockTableAliases: ['e0'],
 });
 
-// select ... 
+// select ...
 //   from "user" as "e0"
-//   left join "identity" as "i1" on "e0"."id" = "i1"."user_id" 
-//   where "e0"."name" = 'Jon' 
+//   left join "identity" as "i1" on "e0"."id" = "i1"."user_id"
+//   where "e0"."name" = 'Jon'
 //   for update of "e0" skip locked
 ```
 
@@ -367,5 +288,4 @@ Available isolation levels:
 - `IsolationLevel.REPEATABLE_READ`
 - `IsolationLevel.SERIALIZABLE`
 
-> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html)
-> as the behaviour here is pretty much the same.
+> This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html) as the behaviour here is pretty much the same.

--- a/docs/versioned_docs/version-5.6/type-safe-relations.md
+++ b/docs/versioned_docs/version-5.6/type-safe-relations.md
@@ -58,15 +58,15 @@ You can overcome this issue by using the `Reference` wrapper. It simply wraps th
 You can also use `load<K extends keyof T>(prop: K): Promise<T[K]>`, which works like `load()` but returns the specified property.
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 import { Entity, Ref, ManyToOne, PrimaryKey, ref } from '@mikro-orm/core';
@@ -308,7 +308,7 @@ book.author.set(new Author(...));
 
 `Ref` is an intersection type that adds primary key property to the `Reference` interface. It allows to get the primary key from `Reference` instance directly.
 
-By default, we try to detect the PK by checking if a property with a known name exists. We check for those in order: `_id`, `uuid`, `id` - with a way to manually set the property name via `PrimaryKeyProp` symbol (`[PrimaryKeyProp]?: 'foo';`). 
+By default, we try to detect the PK by checking if a property with a known name exists. We check for those in order: `_id`, `uuid`, `id` - with a way to manually set the property name via `PrimaryKeyProp` symbol (`[PrimaryKeyProp]?: 'foo';`).
 
 We can also override this via second generic type argument.
 
@@ -329,15 +329,15 @@ console.log(book.author.myPrimaryKey); // ok, returns the PK
 For MongoDB, define the PK generic type argument as `'id' | '_id'` to access both `string` and `ObjectId` PK values:
 
 <Tabs
-groupId="entity-def"
-defaultValue="reflect-metadata"
-values={[
-{label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
-]
-}>
-<TabItem value="reflect-metadata">
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
 @Entity()
@@ -403,4 +403,4 @@ console.log(book.author.id); // ok, returns string PK
 console.log(book.author._id); // ok, returns ObjectId PK
 ```
 
-> As opposed to `wrap(e).init()` which always refreshes the entity, `Reference.load()` method will query the database only if the entity is not already loaded in Identity Map. 
+> As opposed to `wrap(e).init()` which always refreshes the entity, `Reference.load()` method will query the database only if the entity is not already loaded in Identity Map.

--- a/docs/versioned_docs/version-5.6/upgrading-v2-to-v3.md
+++ b/docs/versioned_docs/version-5.6/upgrading-v2-to-v3.md
@@ -2,19 +2,13 @@
 title: Upgrading from v2 to v3
 ---
 
-Following sections describe (hopefully) all breaking changes, most of them might be not valid 
-for you, like if you do not use custom `NamingStrategy` implementation, you do not care about
-the interface being changed.
+Following sections describe (hopefully) all breaking changes, most of them might be not valid for you, like if you do not use custom `NamingStrategy` implementation, you do not care about the interface being changed.
 
 ## Default value of autoFlush has changed to false
 
-> If you had `autoFlush: false` in your ORM configuration before, you can now remove 
-> this line, no changes are needed in your app. 
+> If you had `autoFlush: false` in your ORM configuration before, you can now remove this line, no changes are needed in your app.
 
-Default value for `autoFlush` is now `false`. That means you need to call 
-`em.flush()` yourself to persist changes into database. You can still change this via ORM's
-options to ease the transition but generally it is not recommended as it can cause unwanted
-small transactions being created around each `persist`. 
+Default value for `autoFlush` is now `false`. That means you need to call `em.flush()` yourself to persist changes into database. You can still change this via ORM's options to ease the transition but generally it is not recommended as it can cause unwanted small transactions being created around each `persist`.
 
 ```ts
 orm.em.persist(new Entity()); // no auto-flushing by default
@@ -24,29 +18,20 @@ await orm.em.persist(new Entity(), true); // you can still use second parameter 
 
 ## Reworked entity definition
 
-> Implementing those interfaces is optional.  
+> Implementing those interfaces is optional.
 
-Now it is no longer needed to merge entities with `IEntity` interface, that was polluting entity's 
-interface with internal methods. New interfaces `IdentifiedEntity<T>`, `UuidEntity<T>` and `MongoEntity<T>` 
-are introduced, that can be implemented by entities. They are not adding any new properties or methods, 
-keeping the entity's interface clean. This is also the reason why they can be omitted.
+Now it is no longer needed to merge entities with `IEntity` interface, that was polluting entity's interface with internal methods. New interfaces `IdentifiedEntity<T>`, `UuidEntity<T>` and `MongoEntity<T>` are introduced, that can be implemented by entities. They are not adding any new properties or methods, keeping the entity's interface clean. This is also the reason why they can be omitted.
 
-`IEntity` interface has been renamed to `AnyEntity<T, PK>` and it no longer has public methods 
-like `toJSON()`, `toObject()` or `init()`. One can use `wrap()` method provided by ORM that
-will enhance property type when needed with those methods (`await wrap(book.author).init()`). 
-To keep all methods available on the entity, you can still use interface merging with 
-`WrappedEntity<T, PK>` that both extends `AnyEntity<T, PK>` and defines all those methods.
+`IEntity` interface has been renamed to `AnyEntity<T, PK>` and it no longer has public methods like `toJSON()`, `toObject()` or `init()`. One can use `wrap()` method provided by ORM that will enhance property type when needed with those methods (`await wrap(book.author).init()`). To keep all methods available on the entity, you can still use interface merging with `WrappedEntity<T, PK>` that both extends `AnyEntity<T, PK>` and defines all those methods.
 
 You can mark the entity by implementing one of `*Entity` interfaces:
 
 - `IdEntity<T>` for numeric/string PK on `id` property (`id: number`)
 - `UuidEntity<T>` for string PK on `uuid` property (`uuid: string`)
 - `MongoEntity<T>` for mongo, where `id: string` and `_id: ObjectId` are required
-- `AnyEntity<T, PK>` for other possible properties (fill the PK property name to `PK` 
-parameter, e.g.: `AnyEntity<Book, 'myPrimaryProperty'>'`)
+- `AnyEntity<T, PK>` for other possible properties (fill the PK property name to `PK` parameter, e.g.: `AnyEntity<Book, 'myPrimaryProperty'>'`)
 
-To keep all public methods that were part of `IEntity` interface in v2, you can use 
-`WrappedEntity<T, PK>` via interface merging:
+To keep all public methods that were part of `IEntity` interface in v2, you can use `WrappedEntity<T, PK>` via interface merging:
 
 ```ts
 @Entity()
@@ -58,37 +43,25 @@ For more examples, take a look at [defining entities section](defining-entities.
 
 ## Integrated Knex.js as query builder and runner
 
-`QueryBuilder` now internally uses knex to run all queries. As knex already supports connection 
-pooling, this feature comes without any effort. New configuration for pooling is now available
+`QueryBuilder` now internally uses knex to run all queries. As knex already supports connection pooling, this feature comes without any effort. New configuration for pooling is now available
 
-Transactions now require using `em.transactional()` method, previous helpers 
-`beginTransaction`/`commit`/`rollback` are now removed.
+Transactions now require using `em.transactional()` method, previous helpers `beginTransaction`/`commit`/`rollback` are now removed.
 
-All transaction management has been removed from `IDatabaseDriver` interface, now EM handles 
-this, passing the transaction context (carried by EM, and created by `Connection`) to all 
-driver methods. New methods on EM exists: `isInTransaction()` and `getTransactionContext()`.
+All transaction management has been removed from `IDatabaseDriver` interface, now EM handles this, passing the transaction context (carried by EM, and created by `Connection`) to all driver methods. New methods on EM exists: `isInTransaction()` and `getTransactionContext()`.
 
-In postgres driver, it used to be required to pass parameters as indexed dollar sign 
-($1, $2, ...), while now knex requires the placeholder to be simple question mark (`?`), 
-like in other dialects, so this is now unified with other drivers.
+In postgres driver, it used to be required to pass parameters as indexed dollar sign ($1, $2, ...), while now knex requires the placeholder to be simple question mark (`?`), like in other dialects, so this is now unified with other drivers.
 
 ## ManyToMany now uses composite primary key
 
-Previously it was required to have autoincrement primary key for m:n pivot tables. Now this 
-has changed. By default, only foreign columns are required and composite key over both of them
-is used as primary key.
+Previously it was required to have autoincrement primary key for m:n pivot tables. Now this has changed. By default, only foreign columns are required and composite key over both of them is used as primary key.
 
-To preserve stable order of collections, you can force previous behaviour by defining the 
-m:n property as `fixedOrder: true`, which will start ordering by `id` column. You can also 
-override the order column name via `fixedOrderColumn: 'order'`. 
+To preserve stable order of collections, you can force previous behaviour by defining the m:n property as `fixedOrder: true`, which will start ordering by `id` column. You can also override the order column name via `fixedOrderColumn: 'order'`.
 
 You can also specify default ordering via `orderBy: { ... }` attribute.
 
 ## Entity references now don't have instantiated collections
 
-Previously all entity instances, including entity references (not fully loaded entities where
-we know only the primary key), had instantiated collection classes. Now only initialized entities
-have them.
+Previously all entity instances, including entity references (not fully loaded entities where we know only the primary key), had instantiated collection classes. Now only initialized entities have them.
 
 ```ts
 const book = em.getReference(Book, 1);
@@ -99,12 +72,9 @@ console.log(book.tags); // instance of Collection (not initialized)
 
 ## EntityAssigner.assign() requires EM for new entities
 
-Previously all entities had internal reference to the root EM - the one created when 
-initializing the ORM. Now only managed entities (those merged to the EM, e.g. loaded 
-from the database) have this internal reference. 
+Previously all entities had internal reference to the root EM - the one created when initializing the ORM. Now only managed entities (those merged to the EM, e.g. loaded from the database) have this internal reference.
 
-To use `assign()` method on new (not managed) entities, you need to provide the `em`
-parameter:
+To use `assign()` method on new (not managed) entities, you need to provide the `em` parameter:
 
 ```ts
 const book = new Book();
@@ -113,46 +83,36 @@ wrap(book).assign(data, { em: orm.em });
 
 ## Strict FilterQuery and smart query conditions
 
-`FilterQuery` now does not allow using smart query operators. You can either cast your condition 
-as any or use object syntax instead (instead of `{ 'age:gte': 18 }` use `{ age: { $gte: 18 } }`).
+`FilterQuery` now does not allow using smart query operators. You can either cast your condition as any or use object syntax instead (instead of `{ 'age:gte': 18 }` use `{ age: { $gte: 18 } }`).
 
 ## Logging configuration
 
-Previously to start logging it was required to provide your custom logger. Logger now defaults 
-to `console.log()`, and users can specify what namespaces are they interested in via `debug` 
-option. `true`/`false` will enable/disable all namespaces.
+Previously to start logging it was required to provide your custom logger. Logger now defaults to `console.log()`, and users can specify what namespaces are they interested in via `debug` option. `true`/`false` will enable/disable all namespaces.
 
 Available logger namespaces: `'query' | 'query-params' | 'discovery' | 'info'`.
 
-## Removed deprecated fk option from 1:m and m:1 decorators 
+## Removed deprecated fk option from 1:m and m:1 decorators
 
 Use `mappedBy`/`inversedBy` instead.
 
 ## SchemaGenerator.generate() is now async
 
-If you used `SchemaGenerator`, now there is CLI tool you can use instead. Learn more 
-in [SchemaGenerator docs](schema-generator.md). To setup CLI, take a look at 
-[installation section](installation.md).
+If you used `SchemaGenerator`, now there is CLI tool you can use instead. Learn more in [SchemaGenerator docs](schema-generator.md). To setup CLI, take a look at [installation section](installation.md).
 
 ## New method on NamingStrategy interface
 
-`getClassName()` is used to find entity class name based on its file name. Now users can 
-override the default implementation to accommodate their specific needs.
+`getClassName()` is used to find entity class name based on its file name. Now users can override the default implementation to accommodate their specific needs.
 
-If you used custom naming strategy, you will either need to implement this method yourself, 
-or extend `AbstractNamingStrategy`.
+If you used custom naming strategy, you will either need to implement this method yourself, or extend `AbstractNamingStrategy`.
 
 ## TypescriptMetadataProvider has been renamed
 
-The name is now `TsMorphMetadataProvider`, there is also newly added `ReflectMetadataProvider`
-that uses `reflect-metadata` instead. As `TypescriptMetadataProvider` was the default, no 
-changes should be required. 
+The name is now `TsMorphMetadataProvider`, there is also newly added `ReflectMetadataProvider` that uses `reflect-metadata` instead. As `TypescriptMetadataProvider` was the default, no changes should be required.
 
 ## Updated mongodb driver
 
 MongoDB driver version 3.3.4 or higher is now required.
 
 ## EntityManager.find() now requires where parameter
-`EntityManager` has now same `find` method interface aligned with `EntityRepository`, 
-`where` parameter is now required. To select all entities, use `em.find(Entity, {})` 
-as value.
+
+`EntityManager` has now same `find` method interface aligned with `EntityRepository`, `where` parameter is now required. To select all entities, use `em.find(Entity, {})` as value.

--- a/docs/versioned_docs/version-5.6/upgrading-v3-to-v4.md
+++ b/docs/versioned_docs/version-5.6/upgrading-v3-to-v4.md
@@ -2,24 +2,19 @@
 title: Upgrading from v3 to v4
 ---
 
-> Following sections describe (hopefully) all breaking changes, most of them might be not valid 
-> for you, like if you do not use custom `NamingStrategy` implementation, you do not care about
-> the interface being changed.
+> Following sections describe (hopefully) all breaking changes, most of them might be not valid for you, like if you do not use custom `NamingStrategy` implementation, you do not care about the interface being changed.
 
 ## Node 10.13.0+ required
 
-Support for older node versions was dropped. 
+Support for older node versions was dropped.
 
 ## TypeScript 3.7+ required
 
-Support for older TypeScript versions was dropped. 
+Support for older TypeScript versions was dropped.
 
 ## Monorepo
 
-The ORM has been split into several packages. In v4 one needs to require
-`@mikro-orm/core` and a driver package, e.g. `@mikro-orm/mysql`. This driver
-package already contains the `mysql2` dependency, so you can remove that from
-your `package.json`. 
+The ORM has been split into several packages. In v4 one needs to require `@mikro-orm/core` and a driver package, e.g. `@mikro-orm/mysql`. This driver package already contains the `mysql2` dependency, so you can remove that from your `package.json`.
 
 - `@mikro-orm/core`
 - `@mikro-orm/reflection` - `TsMorphMetadataProvider`
@@ -34,17 +29,13 @@ your `package.json`.
 - `@mikro-orm/postgresql`
 - `@mikro-orm/mongodb`
 
-> For easier transition, meta package mikro-orm is still present, reexporting 
-> core, reflection, migrations, entity-generator and cli packages. You should 
-> **not** install both `mikro-orm` and `@mikro-orm/core` packages together. 
+> For easier transition, meta package mikro-orm is still present, reexporting core, reflection, migrations, entity-generator and cli packages. You should **not** install both `mikro-orm` and `@mikro-orm/core` packages together.
 
-> You should prefer the `@mikro-orm/core` over `mikro-orm` package, there were
-> weird dependency issues reported with the `mikro-orm` meta-package. 
+> You should prefer the `@mikro-orm/core` over `mikro-orm` package, there were weird dependency issues reported with the `mikro-orm` meta-package.
 
 ## Default metadata provider is now `ReflectMetadataProvider`
 
-If you want to use ts-morph, you need to install `@mikro-orm/reflection` package
-and enable the provider explicitly in the ORM config, as described [here](./metadata-providers.md#tsmorphmetadataprovider).
+If you want to use ts-morph, you need to install `@mikro-orm/reflection` package and enable the provider explicitly in the ORM config, as described [here](./metadata-providers.md#tsmorphmetadataprovider).
 
 ```ts
 import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
@@ -55,30 +46,22 @@ await MikroORM.init({
 });
 ```
 
-Using `ReflectMetadataProvider` has some limitations, so be sure to read 
-about them [here](./metadata-providers.md#limitations-and-requirements).
+Using `ReflectMetadataProvider` has some limitations, so be sure to read about them [here](./metadata-providers.md#limitations-and-requirements).
 
-One common gotcha with `reflect-metadata` is that you need to explicitly
-state the property type when using property initializer:
+One common gotcha with `reflect-metadata` is that you need to explicitly state the property type when using property initializer:
 
 ```ts
 @Property()
 createdAt: Date = new Date();
 ```
 
-Without the explicit type, we would infer `Object` instead of `Date`, 
-which would be most probably mapped to JSON column type (depends on driver).
+Without the explicit type, we would infer `Object` instead of `Date`, which would be most probably mapped to JSON column type (depends on driver).
 
 ## SqlEntityManager and MongoEntityManager
 
-In v4 the `core` package, where `EntityManager` and `EntityRepository` are 
-defined, is not dependent on knex, and therefore it cannot have a method 
-returning a `QueryBuilder`. You need to import the SQL flavour of the EM 
-from the driver package to access the `createQueryBuilder()` method.
+In v4 the `core` package, where `EntityManager` and `EntityRepository` are defined, is not dependent on knex, and therefore it cannot have a method returning a `QueryBuilder`. You need to import the SQL flavour of the EM from the driver package to access the `createQueryBuilder()` method.
 
-> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under 
-> this name and under `EntityManager` alias, so you can just change the 
-> location from where you import.
+> The SQL flavour of EM is actually called `SqlEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ```ts
 import { EntityManager } from '@mikro-orm/mysql'; // or any other SQL driver package
@@ -96,32 +79,21 @@ const em: EntityManager;
 const ret = await em.aggregate(...);
 ```
 
-> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under 
-> this name and under `EntityManager` alias, so you can just change the 
-> location from where you import.
+> The mongo flavour of EM is actually called `MongoEntityManager`, it is exported both under this name and under `EntityManager` alias, so you can just change the location from where you import.
 
 ## Different default `pivotTable`
 
-Implementation of `UnderscoreNamingStrategy` and `EntityCaseNamingStrategy` 
-`joinTableName()` method has changed. You can use `pivotTable` on the owning side
-of M:N relation to specify the table name manually. 
+Implementation of `UnderscoreNamingStrategy` and `EntityCaseNamingStrategy` `joinTableName()` method has changed. You can use `pivotTable` on the owning side of M:N relation to specify the table name manually.
 
-Previously the table name did not respect property name, if one defined multiple
-M:N relations between same entities, there were conflicts and one would have to 
-specify `pivotTable` name manually at least on one of them. With the new way, 
-we can be sure that the table name won't conflict with other pivot tables. 
+Previously the table name did not respect property name, if one defined multiple M:N relations between same entities, there were conflicts and one would have to specify `pivotTable` name manually at least on one of them. With the new way, we can be sure that the table name won't conflict with other pivot tables.
 
-Previously the name was constructed from 2 entity names as `entity_a_to_entity_b`,
-ignoring the actual property name. In v4 the name will be `entity_a_coll_name` in 
-case of the collection property on the owning side being named `collName`. 
+Previously the name was constructed from 2 entity names as `entity_a_to_entity_b`, ignoring the actual property name. In v4 the name will be `entity_a_coll_name` in case of the collection property on the owning side being named `collName`.
 
 ## Changes in folder-based discovery (`entitiesDirs` removed)
 
-`entitiesDirs` and `entitiesDirsTs` were removed in favour of `entities` and `entitiesTs`,
-`entities` will be used as a default for `entitiesTs` (that is used when we detect `ts-node`).
+`entitiesDirs` and `entitiesDirsTs` were removed in favour of `entities` and `entitiesTs`, `entities` will be used as a default for `entitiesTs` (that is used when we detect `ts-node`).
 
-`entities` can now contain mixture of paths to directories, globs pointing to entities,
-or references to the entities or instances of `EntitySchema`. 
+`entities` can now contain mixture of paths to directories, globs pointing to entities, or references to the entities or instances of `EntitySchema`.
 
 This basically means that all you need to change is renaming `entitiesDirs` to `entities`.
 
@@ -134,26 +106,17 @@ MikroORM.init({
 
 ## Changes in `wrap()` helper, `WrappedEntity` interface and `Reference` wrapper
 
-Previously all the methods and properties of `WrappedEntity` interface were
-added to the entity prototype during discovery. In v4 there is only one property
-added: `__helper: WrappedEntity`. `WrappedEntity` has been converted to actual class.
+Previously all the methods and properties of `WrappedEntity` interface were added to the entity prototype during discovery. In v4 there is only one property added: `__helper: WrappedEntity`. `WrappedEntity` has been converted to actual class.
 
-`wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is 
-being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...),
-if you want to access internal properties like `__meta` or `__em`, you need to explicitly
-ask for the helper via `wrap(entity, true)`.
+`wrap(entity)` no longer returns the entity, now the `WrappedEntity` instance is being returned. It contains only public methods (`init`, `assign`, `isInitialized`, ...), if you want to access internal properties like `__meta` or `__em`, you need to explicitly ask for the helper via `wrap(entity, true)`.
 
-Internal methods (with `__` prefix) were also removed from the `Reference` class, 
-use `wrap(ref, true)` to access them. 
+Internal methods (with `__` prefix) were also removed from the `Reference` class, use `wrap(ref, true)` to access them.
 
-Instead of interface merging with `WrappedEntity`, one can now use classic inheritance,
-by extending `BaseEntity` exported from `@mikro-orm/core`. If you do so, `wrap(entity)` 
-will return your entity. 
+Instead of interface merging with `WrappedEntity`, one can now use classic inheritance, by extending `BaseEntity` exported from `@mikro-orm/core`. If you do so, `wrap(entity)` will return your entity.
 
 ## Removed `flush` parameter from `persist()` and `remove()` methods
 
-`flush` param is removed, both `persist` and `remove` methods are synchronous and
-require explicit flushing, possibly via fluent interface call.
+`flush` param is removed, both `persist` and `remove` methods are synchronous and require explicit flushing, possibly via fluent interface call.
 
 ```ts
 // before
@@ -167,19 +130,15 @@ await em.remove(jon).flush();
 
 ## `remove()` method requires entity instances
 
-The `em.remove()` method originally allowed to pass either entity instance, or 
-a condition. When one passed a condition, it was firing a native delete query, 
-without handling transactions or hooks. 
+The `em.remove()` method originally allowed to pass either entity instance, or a condition. When one passed a condition, it was firing a native delete query, without handling transactions or hooks.
 
-In v4, the method is now simplified and works only with entity instances. Use 
-`em.nativeDelete()` explicitly if you want to fire a delete query instead of 
-letting the `UnitOfWork` doing its job.
+In v4, the method is now simplified and works only with entity instances. Use `em.nativeDelete()` explicitly if you want to fire a delete query instead of letting the `UnitOfWork` doing its job.
 
 ```ts
 // before
 await em.remove(Author, 1); // fires query directly
 
-// after 
+// after
 await em.nativeDelete(Author, 1);
 ```
 
@@ -187,20 +146,11 @@ await em.nativeDelete(Author, 1);
 
 ## Type safe references
 
-EM now returns `Loaded<T, P>` instead of the entity (`T`). This type automatically
-adds synchronous method `get()` that returns the entity (for references) or array
-of entities (for collections).
+EM now returns `Loaded<T, P>` instead of the entity (`T`). This type automatically adds synchronous method `get()` that returns the entity (for references) or array of entities (for collections).
 
-`Reference.get()` is now available only with correct `Loaded` type hint and is used 
-as a sync getter for the entity, just like `unwrap()`. You can use `Reference.load(prop)` 
-for the original `get()` method functionality. 
+`Reference.get()` is now available only with correct `Loaded` type hint and is used as a sync getter for the entity, just like `unwrap()`. You can use `Reference.load(prop)` for the original `get()` method functionality.
 
-`em.find()` and similar methods now have two type arguments, due to TypeScript not supporting partial
-type inference, when you specify the `T` explicitly (without also explicitly 
-specifying the load hint), the inference will not work. This use case was mainly
-for usage without classes (interfaces + `EntitySchema`) - in that case it is now 
-supported to pass actual instance of `EntitySchema` as the first parameter to these
-methods, that will allow correct type inference:
+`em.find()` and similar methods now have two type arguments, due to TypeScript not supporting partial type inference, when you specify the `T` explicitly (without also explicitly specifying the load hint), the inference will not work. This use case was mainly for usage without classes (interfaces + `EntitySchema`) - in that case it is now supported to pass actual instance of `EntitySchema` as the first parameter to these methods, that will allow correct type inference:
 
 ```ts
 const author = await em.findOne(AuthorSchema, { ... }, ['books']);
@@ -209,59 +159,45 @@ console.log(author.books.get()); // `get()` is now inferred correctly
 
 ## Custom types are now type safe
 
-Generic `Type` class has now two type arguments - the input and output types. 
-Input type defaults to `string`, output type defaults to the input type. 
+Generic `Type` class has now two type arguments - the input and output types. Input type defaults to `string`, output type defaults to the input type.
 
 You might need to explicitly provide the types if your methods are strictly typed.
 
 ## Custom type serialization
 
-Custom types used to be serialized to the database value. In v4, the runtime 
-value is used by default. Implement custom `toJSON()` method if you need to 
-customize this.
+Custom types used to be serialized to the database value. In v4, the runtime value is used by default. Implement custom `toJSON()` method if you need to customize this.
 
 ## Property `default` and `defaultRaw`
 
-Previously the `default` option of properties was used as is, so we had to wrap 
-strings in quotes (e.g. `@Property({ default: "'foo bar'" })`). 
+Previously the `default` option of properties was used as is, so we had to wrap strings in quotes (e.g. `@Property({ default: "'foo bar'" })`).
 
-In v4 the `default` is typed as `string | number | boolean | null` and when used
-with string value, it will be automatically quoted. 
+In v4 the `default` is typed as `string | number | boolean | null` and when used with string value, it will be automatically quoted.
 
 To use SQL functions we now need to use `defaultRaw`: `@Property({ defaultRaw: 'now()' })`.
 
 ## `autoFlush` option has been removed
 
-Also `persistLater()` and `removeLater()` methods are deprecated. Use `persist()` or
-`remove` respectively.
+Also `persistLater()` and `removeLater()` methods are deprecated. Use `persist()` or `remove` respectively.
 
 ## `IdEntity`, `UuidEntity` and `MongoEntity` interfaces are removed
 
-They were actually never needed. 
+They were actually never needed.
 
 ## MongoDB driver is no longer the default
 
-You need to specify the platform type either via `type` option or provide the driver
-implementation via `driver` option. 
+You need to specify the platform type either via `type` option or provide the driver implementation via `driver` option.
 
 Available platforms types: `[ 'mongo', 'mysql', 'mariadb', 'postgresql', 'sqlite' ]`
 
 ## Removed configuration `discovery.tsConfigPath`
 
-Removed as it is no longer needed, it was used only for `TsMorphMetadataProvider`,
-when the `entitiesDirsTs` were not explicitly provided. In v4, this is no longer
-needed, as ts-morph discovery will use `d.ts` files instead, that should be located
-next to the compiled entities. 
+Removed as it is no longer needed, it was used only for `TsMorphMetadataProvider`, when the `entitiesDirsTs` were not explicitly provided. In v4, this is no longer needed, as ts-morph discovery will use `d.ts` files instead, that should be located next to the compiled entities.
 
 ## Changes in query highlighting
 
-Previously Highlight.js was used to highlight various things in the CLI, 
-like SQL and mongo queries, or migrations or entities generated via CLI.
-While the library worked fine, it was causing performance issues mainly 
-for those bundling via webpack and using lambdas, as the library was huge.
+Previously Highlight.js was used to highlight various things in the CLI, like SQL and mongo queries, or migrations or entities generated via CLI. While the library worked fine, it was causing performance issues mainly for those bundling via webpack and using lambdas, as the library was huge.
 
-In v4 highlighting is disabled by default, and there are 2 highlighters 
-you can optionally use (you need to install them first).
+In v4 highlighting is disabled by default, and there are 2 highlighters you can optionally use (you need to install them first).
 
 ```ts
 import { SqlHighlighter } from '@mikro-orm/sql-highlighter';

--- a/docs/versioned_docs/version-5.6/upgrading-v4-to-v5.md
+++ b/docs/versioned_docs/version-5.6/upgrading-v4-to-v5.md
@@ -2,23 +2,19 @@
 title: Upgrading from v4 to v5
 ---
 
-> Following sections describe (hopefully) all breaking changes, most of them might be not valid 
-> for you, like if you do not use custom `NamingStrategy` implementation, you do not care about
-> the interface being changed.
+> Following sections describe (hopefully) all breaking changes, most of them might be not valid for you, like if you do not use custom `NamingStrategy` implementation, you do not care about the interface being changed.
 
 ## Node 14+ required
 
-Support for older node versions was dropped. 
+Support for older node versions was dropped.
 
 ## TypeScript 4.1+ required
 
-Support for older TypeScript versions was dropped. 
+Support for older TypeScript versions was dropped.
 
 ## Options parameters
 
-Previously many methods had many (often boolean) parameters, in v5 such methods are
-refactored to use options object instead to improve readability. Some methods offered
-both signatures - the multi parameter signatures are now removed.
+Previously many methods had many (often boolean) parameters, in v5 such methods are refactored to use options object instead to improve readability. Some methods offered both signatures - the multi parameter signatures are now removed.
 
 List of such methods:
 
@@ -47,10 +43,7 @@ This also applies to the methods on `IDatabaseDriver` interface.
 
 ## Type-safe populate parameter with dot notation
 
-`FindOptions.populate` parameter is now strictly typed and supports only array of 
-strings or a boolean.
-Object way is no longer supported. To set loading strategy, use `FindOptions.strategy`.
-The return type of all such methods now returns properly typed `Loaded` response. 
+`FindOptions.populate` parameter is now strictly typed and supports only array of strings or a boolean. Object way is no longer supported. To set loading strategy, use `FindOptions.strategy`. The return type of all such methods now returns properly typed `Loaded` response.
 
 ## Type-safe fields parameter
 
@@ -58,8 +51,7 @@ The return type of all such methods now returns properly typed `Loaded` response
 
 ## Type-safe orderBy parameter
 
-`FindOptions.orderBy` parameter is now strictly typed. It also allows passing an 
-array of objects instead of just a single object.
+`FindOptions.orderBy` parameter is now strictly typed. It also allows passing an array of objects instead of just a single object.
 
 ```ts
 const books = await em.find(Book, {}, {
@@ -72,41 +64,25 @@ const books = await em.find(Book, {}, {
 
 ## Removed `@Repository()` decorator
 
-The decorator was problematic as it could only work properly it the file was required
-soon enough - before the ORM initialization, otherwise the repository would not be 
-registered at all.
+The decorator was problematic as it could only work properly it the file was required soon enough - before the ORM initialization, otherwise the repository would not be registered at all.
 
-Use `@Entity({ customRepository: () => CustomRepository })` in the entity definition
-instead.
+Use `@Entity({ customRepository: () => CustomRepository })` in the entity definition instead.
 
 ## Disallowed global identity map
 
-In v5, it is no longer possible to use the global identity map. This was a 
-common issue that led to weird bugs, as using the global EM without request
-context is wrong, we always need to have a dedicated context for each request,
-so they do not interfere.
+In v5, it is no longer possible to use the global identity map. This was a common issue that led to weird bugs, as using the global EM without request context is wrong, we always need to have a dedicated context for each request, so they do not interfere.
 
-Now we get a validation error if we try to use the global context. We still can
-disable this check via `allowGlobalContext` configuration, or a connected 
-environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can be handy 
-especially in unit tests.
+Now we get a validation error if we try to use the global context. We still can disable this check via `allowGlobalContext` configuration, or a connected environment variable `MIKRO_ORM_ALLOW_GLOBAL_CONTEXT` - this can be handy especially in unit tests.
 
 ## `LoadedCollection.get()` and `$` now return the `Collection` instance
 
-Previously those dynamically added getters returned the array copy of collection
-items. In v5, we return the collection instance, which is also iterable and has
-a `length` getter and indexed access support, so it mimics the array. To get the
-array copy as before, call `getItems()` as with a regular collection.
+Previously those dynamically added getters returned the array copy of collection items. In v5, we return the collection instance, which is also iterable and has a `length` getter and indexed access support, so it mimics the array. To get the array copy as before, call `getItems()` as with a regular collection.
 
 ## Different table aliasing for select-in loading strategy and for QueryBuilder
 
-Previously with select-in strategy as well as with QueryBuilder, table aliases
-were always the letter `e` followed by unique index. In v5, we use the same 
-method as with joined strategy - the letter is inferred from the entity name.
+Previously with select-in strategy as well as with QueryBuilder, table aliases were always the letter `e` followed by unique index. In v5, we use the same method as with joined strategy - the letter is inferred from the entity name.
 
-This can be breaking if you used the aliases somewhere, e.g. in custom SQL 
-fragments. We can restore to the old behaviour by implementing custom naming
-strategy, overriding the `aliasName` method:
+This can be breaking if you used the aliases somewhere, e.g. in custom SQL fragments. We can restore to the old behaviour by implementing custom naming strategy, overriding the `aliasName` method:
 
 ```ts
 import { AbstractNamingStrategy } from '@mikro-orm/core';
@@ -118,37 +94,27 @@ class CustomNamingStrategy extends AbstractNamingStrategy {
 }
 ```
 
-Note that in v5 it is possible to use `expr()` helper to access the alias name
-dynamically, e.g. ``expr(alias => `lower('${alias}.name')`)``, which should be 
-now preferred way instead of hardcoding the aliases.
+Note that in v5 it is possible to use `expr()` helper to access the alias name dynamically, e.g. `` expr(alias => `lower('${alias}.name')`) ``, which should be now preferred way instead of hardcoding the aliases.
 
 ## Migrations are now stored without extensions
 
-Running migrations in production via node and ts-node is now handled the same.
-This should actually not be breaking, as old format with extension is still 
-supported (e.g. they still can be rolled back), but newly logged migrations
-will not contain the extension.
+Running migrations in production via node and ts-node is now handled the same. This should actually not be breaking, as old format with extension is still supported (e.g. they still can be rolled back), but newly logged migrations will not contain the extension.
 
 ## Changes in `assign()` helper
 
-Embeddable instances are now created via `EntityFactory` and they respect the
-`forceEntityConstructor` configuration. Due to this we need to have EM instance
-when assigning to embedded properties. 
+Embeddable instances are now created via `EntityFactory` and they respect the `forceEntityConstructor` configuration. Due to this we need to have EM instance when assigning to embedded properties.
 
 Using `em.assign()` should be preferred to get around this.
 
-Deep assigning of child entities now works by default based on the presence of PKs in the payload.
-This behaviour can be disable via updateByPrimaryKey: false in the assign options.
+Deep assigning of child entities now works by default based on the presence of PKs in the payload. This behaviour can be disable via updateByPrimaryKey: false in the assign options.
 
 `mergeObjects` option is now enabled by default.
 
 ## `em.populate()` always return array of entities
 
-Previously it was possible to call `em.populate()` with a single entity input,
-and the output would be again just a single entity.
+Previously it was possible to call `em.populate()` with a single entity input, and the output would be again just a single entity.
 
-Due to issues with TS 4.5, this method now always return array of entities.
-You can use destructing if you want to have a single entity return type:
+Due to issues with TS 4.5, this method now always return array of entities. You can use destructing if you want to have a single entity return type:
 
 ```ts
 const [loadedAuthor] = await em.populate(author, ...);
@@ -156,66 +122,45 @@ const [loadedAuthor] = await em.populate(author, ...);
 
 ## QueryBuilder is awaitable
 
-Previously awaiting of QB instance was a no-op. In v5, QB is promise-like interface,
-so we can await it. More about this in [Awaiting the QueryBuilder](./query-builder.md#awaiting-the-querybuilder) section.
+Previously awaiting of QB instance was a no-op. In v5, QB is promise-like interface, so we can await it. More about this in [Awaiting the QueryBuilder](./query-builder.md#awaiting-the-querybuilder) section.
 
 ## `UnitOfWork.getScheduledCollectionDeletions()` has been removed
 
-Previously scheduled collection deletions were used for a hack when removing 
-1:m collection via orphan removal might require early deletes - in case we were 
-adding the same entity (but different instance), so with same PK - inserting it 
-in the same unit would cause unique constraint failures.
+Previously scheduled collection deletions were used for a hack when removing 1:m collection via orphan removal might require early deletes - in case we were adding the same entity (but different instance), so with same PK - inserting it in the same unit would cause unique constraint failures.
 
 Also `IDatabaseDriver.clearCollection()` method is no longer present in the driver API.
 
 ## `populateAfterFlush` is enabled by default
 
-After flushing a new entity, all relations are marked as populated,
-just like if the entity was loaded from the db. This aligns the serialized
-output of `e.toJSON()` of a loaded entity and just-inserted one.
+After flushing a new entity, all relations are marked as populated, just like if the entity was loaded from the db. This aligns the serialized output of `e.toJSON()` of a loaded entity and just-inserted one.
 
-In v4 this behaviour was disabled by default, so even after the new entity was
-flushed, the serialized form contained only FKs for its relations. We can opt in
-to this old behaviour via `populateAfterFlush: false`.
+In v4 this behaviour was disabled by default, so even after the new entity was flushed, the serialized form contained only FKs for its relations. We can opt in to this old behaviour via `populateAfterFlush: false`.
 
 ## `migrations.pattern` is removed in favour of `migrations.glob`
 
-Migrations are using `umzug` under the hood, which is now upgraded to v3.0.
-With this version, the `pattern` configuration options is no longer available, 
-and has been replaced with `glob`. This change is also reflected in MikroORM.
+Migrations are using `umzug` under the hood, which is now upgraded to v3.0. With this version, the `pattern` configuration options is no longer available, and has been replaced with `glob`. This change is also reflected in MikroORM.
 
-The default value for `glob` is `!(*.d).{js,ts}`, so both JS and TS files are matched
-(but not .d.ts files). You should usually not need to change this option as this default
-suits both development and production environments.
+The default value for `glob` is `!(*.d).{js,ts}`, so both JS and TS files are matched (but not .d.ts files). You should usually not need to change this option as this default suits both development and production environments.
 
 ## Population no longer infers the where condition by default
 
 > This applies only to SELECT_IN strategy, as JOINED strategy implies the inference.
 
-Previously when we used populate hints in `em.find()` and similar methods, the
-query for our entity would be analysed and parts of it extracted and used for 
-the population. Following example would find all authors that have books with 
-given IDs, and populate their books collection, again using this PK condition,
-resulting in only such books being in those collections. 
+Previously when we used populate hints in `em.find()` and similar methods, the query for our entity would be analysed and parts of it extracted and used for the population. Following example would find all authors that have books with given IDs, and populate their books collection, again using this PK condition, resulting in only such books being in those collections.
 
 ```ts
 // this would end up with `Author.books` collections having only books of PK 1, 2, 3
 const a = await em.find(Author, { books: [1, 2, 3] }, { populate: ['books'] });
 ```
 
-Following this example, if we wanted to load all books, we would need a separate 
-`em.populate()` call:
+Following this example, if we wanted to load all books, we would need a separate `em.populate()` call:
 
 ```ts
 const a = await em.find(Author, { books: [1, 2, 3] });
 await em.populate(a, ['books']);
 ```
 
-This behaviour changed and is now configurable both globally and locally, via 
-`populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and 
-`PopulateHint.INFER`, the former being the default in v5, the latter being the
-default behaviour in v4. Locally (via `FindOptions`) we can also specify custom
-where condition that will be passed to `em.populate()` call.
+This behaviour changed and is now configurable both globally and locally, via `populateWhere` option. Globally we can specify one of `PopulateHint.ALL` and `PopulateHint.INFER`, the former being the default in v5, the latter being the default behaviour in v4. Locally (via `FindOptions`) we can also specify custom where condition that will be passed to `em.populate()` call.
 
 ```ts
 // revert back to the old behaviour locally
@@ -227,20 +172,12 @@ const a = await em.find(Author, { books: [1, 2, 3] }, {
 
 ## `em.create()` respects required properties
 
-`em.create()` will now require you to pass all non-optional properties. Some 
-properties might be defined as required for TS, but we have a default value for 
-them (either runtime, or database one) - for such we can use `OptionalProps` 
-symbol to specify which properties should be considered as optional.
+`em.create()` will now require you to pass all non-optional properties. Some properties might be defined as required for TS, but we have a default value for them (either runtime, or database one) - for such we can use `OptionalProps` symbol to specify which properties should be considered as optional.
 
 ## Required properties are validated before insert
 
-Previously the validation took place in the database, so it worked only for SQL
-drivers. Now we have runtime validation based on the entity metadata. This means
-mongo users now need to use `nullable: true` on their optional properties, or
-disable the validation globally via `validateRequired: false` in the ORM config.
+Previously the validation took place in the database, so it worked only for SQL drivers. Now we have runtime validation based on the entity metadata. This means mongo users now need to use `nullable: true` on their optional properties, or disable the validation globally via `validateRequired: false` in the ORM config.
 
 ## `PrimaryKeyType` symbol should be defined as optional
 
-Previously when we had nonstandard PK types, we could use `PrimaryKeyType` symbol
-to let the type system know it. It was required to define this property as 
-required, now it can be defined as optional too.
+Previously when we had nonstandard PK types, we could use `PrimaryKeyType` symbol to let the type system know it. It was required to define this property as required, now it can be defined as optional too.

--- a/docs/versioned_docs/version-5.6/usage-with-adminjs.md
+++ b/docs/versioned_docs/version-5.6/usage-with-adminjs.md
@@ -6,12 +6,15 @@ sidebar_label: Usage with AdminJS
 ## Installation
 
 To use MikroORM with AdminJS you need to install:
+
 1. [`AdminJS Core`](https://github.com/SoftwareBrothers/adminjs):
+
 ```bash
 $ yarn add adminjs
 ```
 
 2. [`MikroORM Adapter`](https://github.com/SoftwareBrothers/adminjs-mikroorm):
+
 ```bash
 $ yarn add @adminjs/mikroorm
 # A MikroORM driver and core package, choose the one which suits you:
@@ -23,7 +26,9 @@ $ yarn add @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 ```
 
 3. A plugin specific to your server's framework:
+
 - [`Express Plugin`](https://github.com/SoftwareBrothers/adminjs-expressjs):
+
 ```bash
 $ yarn add @adminjs/express
 # Peer dependencies
@@ -31,6 +36,7 @@ $ yarn add express express-formidable express-session
 ```
 
 - [`Hapi Plugin`](https://github.com/SoftwareBrothers/adminjs-hapijs):
+
 ```bash
 $ yarn add @adminjs/hapi
 # Peer dependencies
@@ -41,8 +47,7 @@ $ yarn add @hapi/boom @hapi/cookie @hapi/hapi @hapi/inert
 
 ## Setup
 
-Once the installation process is completed, we need to set up AdminJS endpoints and database connection.
-The process is straightforward but differs based on which `plugin` you are using. Below you can find examples specific to supported frameworks:
+Once the installation process is completed, we need to set up AdminJS endpoints and database connection. The process is straightforward but differs based on which `plugin` you are using. Below you can find examples specific to supported frameworks:
 
 ### MikroORM + Express Plugin
 
@@ -133,7 +138,6 @@ const run = async () => {
 run();
 ```
 
-
 You can start your server afterwards and the admin panel will be available at `http://localhost:{PORT}/admin`. If you followed the example setup thoroughly, you should be able to see all of your entities in the sidebar and you should be able to perform basic **CRUD** operations on them.
 
 To further customize your AdminJS panel, please refer to the [`official documentation`](https://adminjs.co/docs.html).
@@ -149,11 +153,13 @@ The examples above set up AdminJS with unauthenticated access. To require your u
 You need to use `AdminJSExpress.buildAuthenticatedRouter` instead of `AdminJS.buildRouter`:
 
 **Before**:
+
 ```ts
   const router = AdminJSExpress.buildRouter(admin);
 ```
 
 **After**:
+
 ```ts
 const ADMIN_EMAIL = 'example@test.com';
 const ADMIN_PASSWORD = 'password';
@@ -174,6 +180,7 @@ const router = AdminJSExpress.buildAuthenticatedRouter(admin, {
 You need to simply add `auth` property to AdminJS options.
 
 **Before**:
+
 ```ts
 const adminOptions = {
   databases: [orm],
@@ -181,6 +188,7 @@ const adminOptions = {
 ```
 
 **After**:
+
 ```ts
 const ADMIN_EMAIL = 'example@test.com';
 const ADMIN_PASSWORD = 'password';

--- a/docs/versioned_docs/version-5.6/usage-with-babel.md
+++ b/docs/versioned_docs/version-5.6/usage-with-babel.md
@@ -2,9 +2,7 @@
 title: Usage with Babel
 ---
 
-When compiling TS via babel, decorators are by default handled different implementation
-than what `tsc` uses. To make the metadata extraction from decorators via Babel work, 
-we need to do use following plugins:
+When compiling TS via babel, decorators are by default handled different implementation than what `tsc` uses. To make the metadata extraction from decorators via Babel work, we need to do use following plugins:
 
 ```json
 {
@@ -18,9 +16,9 @@ we need to do use following plugins:
 
 > Make sure to install the plugins first: `yarn add -D babel-plugin-transform-typescript-metadata @babel/plugin-proposal-decorators @babel/plugin-proposal-class-properties`
 
-Lastly we need to set the `BABEL_DECORATORS_COMPAT` environment variable to `true` to 
-adjust the return value of decorators. 
+Lastly we need to set the `BABEL_DECORATORS_COMPAT` environment variable to `true` to adjust the return value of decorators.
 
 More information about this topic can be found here:
+
 - https://github.com/mikro-orm/mikro-orm/issues/840
 - https://jonahallibonetech.medium.com/next-js-9-mikroorm-eb6f6e08e1a1

--- a/docs/versioned_docs/version-5.6/usage-with-js.md
+++ b/docs/versioned_docs/version-5.6/usage-with-js.md
@@ -67,8 +67,7 @@ module.exports.entity = Author;
 module.exports.schema = schema;
 ```
 
-> Do not forget to provide `name` and `path` schema parameters as well as `entity`
-> and `schema` exports.
+> Do not forget to provide `name` and `path` schema parameters as well as `entity` and `schema` exports.
 
 Reference parameter can be one of (where `SCALAR` is the default one):
 
@@ -95,5 +94,4 @@ const orm = await MikroORM.init({
 
 > We can also pass the `EntitySchema` instance to the `entities` array.
 
-For more examples of plain JavaScript entity definitions take a look
-[Express JavaScript example](https://github.com/mikro-orm/express-js-example-app). 
+For more examples of plain JavaScript entity definitions take a look [Express JavaScript example](https://github.com/mikro-orm/express-js-example-app).

--- a/docs/versioned_docs/version-5.6/usage-with-mongo.md
+++ b/docs/versioned_docs/version-5.6/usage-with-mongo.md
@@ -2,12 +2,9 @@
 title: Usage with MongoDB
 ---
 
-To use MikroORM with mongo database, do not forget to install `@mikro-orm/mongodb`
-dependency. Then call `MikroORM.init()` as part of bootstrapping your app:
+To use MikroORM with mongo database, do not forget to install `@mikro-orm/mongodb` dependency. Then call `MikroORM.init()` as part of bootstrapping your app:
 
-> To access driver specific methods like `em.aggregate()` we need to specify
-> the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the
-> `orm.em` to `EntityManager` exported from the driver package:
+> To access driver specific methods like `em.aggregate()` we need to specify the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the `orm.em` to `EntityManager` exported from the driver package:
 >
 > ```ts
 > import { EntityManager } from '@mikro-orm/mongodb';
@@ -41,13 +38,11 @@ _id: ObjectId;
 id!: string; // won't be saved in the database
 ```
 
-> Only `_id: ObjectId` will be saved in the database. `id: string` is virtual and is 
-> also optional. 
+> Only `_id: ObjectId` will be saved in the database. `id: string` is virtual and is also optional.
 
 ## ObjectId and string id duality
 
-Every entity has both `ObjectId` and `string` id available, also all methods of `EntityManager` 
-and `EntityRepository` supports querying by both of them. 
+Every entity has both `ObjectId` and `string` id available, also all methods of `EntityManager` and `EntityRepository` supports querying by both of them.
 
 ```ts
 const author = orm.em.getReference('...id...');
@@ -66,24 +61,21 @@ const bar2 = await repo.find({ _id: { $in: [new ObjectId(article)] }, favouriteB
 
 ## ManyToMany collections with inlined pivot array
 
-As opposed to SQL drivers that use pivot tables, in mongo we can leverage available array type
-to store array of collection items (identifiers). This approach has two main benefits:
+As opposed to SQL drivers that use pivot tables, in mongo we can leverage available array type to store array of collection items (identifiers). This approach has two main benefits:
 
-1. Collection is stored on owning side entity, so we know how many items are there even before
-initializing the collection.
+1. Collection is stored on owning side entity, so we know how many items are there even before initializing the collection.
 2. As there are no pivot tables, resulting database queries are much simpler.
 
 ## Transactions
 
-Starting with v3.4, MongoDB driver supports transactions. To use transactions, there
-are several things you need to respect:
+Starting with v3.4, MongoDB driver supports transactions. To use transactions, there are several things you need to respect:
 
 - you need to use replica set (see [run-rs](https://github.com/vkarpov15/run-rs))
 - implicit transactions are disabled by default
-    - use `implicitTransactions: true` to enable them globally
-    - or use explicit transaction demarcation via `em.transactional()`
+  - use `implicitTransactions: true` to enable them globally
+  - or use explicit transaction demarcation via `em.transactional()`
 - you need to explicitly create all collections before working with them
-    - use `orm.getSchemaGenerator().createSchema()` method to do so
+  - use `orm.getSchemaGenerator().createSchema()` method to do so
 
 ```sh
 # first create replica set
@@ -105,15 +97,11 @@ const orm = await MikroORM.init<MongoDriver>({
 await orm.getSchemaGenerator().createSchema();
 ```
 
-> The `createCollections` method is present on the `MongoDriver` class only. You need 
-> to have the entity manager correctly typed (as `EntityManager<MongoDriver>`).
+> The `createCollections` method is present on the `MongoDriver` class only. You need to have the entity manager correctly typed (as `EntityManager<MongoDriver>`).
 
 ## Indexes
 
-Starting with v3.4, MongoDB driver supports indexes and unique constraints. You can 
-use `@Index()` and `@Unique()` as described in [Defining Entities section](defining-entities.md#indexes).
-To automatically create new indexes when initializing the ORM, you need to enable
-`ensureIndexes` option. 
+Starting with v3.4, MongoDB driver supports indexes and unique constraints. You can use `@Index()` and `@Unique()` as described in [Defining Entities section](defining-entities.md#indexes). To automatically create new indexes when initializing the ORM, you need to enable `ensureIndexes` option.
 
 ```ts
 const orm = await MikroORM.init<MongoDriver>({
@@ -122,7 +110,7 @@ const orm = await MikroORM.init<MongoDriver>({
   type: 'mongo',
   ensureIndexes: true, // defaults to false
 });
-``` 
+```
 
 Alternatively you can call `ensureIndexes()` method on the `SchemaGenerator`:
 
@@ -133,24 +121,20 @@ await orm.getSchemaGenerator().ensureIndexes();
 ```
 
 > You can pass additional index/unique options via `options` parameter:
-> 
+>
 > `@Unique({ options: { partialFilterExpression: { name: { $exists: true } } }})`
 
 > You can also create text indexes by passing `type` parameter:
-> 
+>
 > `@Index({ properties: ['name', 'caption'], type: 'text' })`
 
-> If you provide only `options` in the index definition, it will be used as is, 
-> this allows to define any kind of index:
+> If you provide only `options` in the index definition, it will be used as is, this allows to define any kind of index:
 >
-> `@Index({ options: { point: '2dsphere', title: -1 } })` 
+> `@Index({ options: { point: '2dsphere', title: -1 } })`
 
 ## Native collection methods
 
-Sometimes you need to perform some bulk operation, or you just want to populate your
-database with initial fixtures. Using ORM for such operations can bring unnecessary
-boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete`
-methods:
+Sometimes you need to perform some bulk operation, or you just want to populate your database with initial fixtures. Using ORM for such operations can bring unnecessary boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete` methods:
 
 ```ts
 em.nativeInsert<T extends AnyEntity>(entityName: string, data: any): Promise<IPrimaryKey>;
@@ -158,9 +142,7 @@ em.nativeUpdate<T extends AnyEntity>(entityName: string, where: FilterQuery<T>, 
 em.nativeDelete<T extends AnyEntity>(entityName: string, where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Those methods execute native driver methods like Mongo's `insertOne/updateMany/deleteMany` collection methods respectively. 
-This is common interface for all drivers, so for MySQL driver, it will fire native SQL queries. 
-Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks. 
+Those methods execute native driver methods like Mongo's `insertOne/updateMany/deleteMany` collection methods respectively. This is common interface for all drivers, so for MySQL driver, it will fire native SQL queries. Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks.
 
 They are also available as `EntityRepository` shortcuts:
 

--- a/docs/versioned_docs/version-5.6/usage-with-nestjs.md
+++ b/docs/versioned_docs/version-5.6/usage-with-nestjs.md
@@ -167,7 +167,7 @@ export class MyService {
 
 > `autoLoadEntities` option was added in v4.1.0
 
-Manually adding entities to the entities array of the connection options can be tedious. In addition, referencing entities from the root module breaks application domain boundaries and causes leaking implementation details to other parts of the  application. To solve this issue, static glob paths can be used.
+Manually adding entities to the entities array of the connection options can be tedious. In addition, referencing entities from the root module breaks application domain boundaries and causes leaking implementation details to other parts of the application. To solve this issue, static glob paths can be used.
 
 Note, however, that glob paths are not supported by webpack, so if you are building your application within a monorepo, you won't be able to use them. To address this issue, an alternative solution is provided. To automatically load entities, set the `autoLoadEntities` property of the configuration object (passed into the `forRoot()` method) to `true`, as shown below:
 
@@ -183,35 +183,23 @@ Note, however, that glob paths are not supported by webpack, so if you are build
 export class AppModule {}
 ```
 
-With that option specified, every entity registered through the `forFeature()`
-method will be automatically added to the entities array of the configuration
-object.
+With that option specified, every entity registered through the `forFeature()` method will be automatically added to the entities array of the configuration object.
 
-> Note that entities that aren't registered through the `forFeature()` method, but
-> are only referenced from the entity (via a relationship), won't be included by
-> way of the `autoLoadEntities` setting.
+> Note that entities that aren't registered through the `forFeature()` method, but are only referenced from the entity (via a relationship), won't be included by way of the `autoLoadEntities` setting.
 
-> Using `autoLoadEntities` also has no effect on the MikroORM CLI - for that we
-> still need CLI config with the full list of entities. On the other hand, we can
-> use globs there, as the CLI won't go through webpack.
+> Using `autoLoadEntities` also has no effect on the MikroORM CLI - for that we still need CLI config with the full list of entities. On the other hand, we can use globs there, as the CLI won't go through webpack.
 
 ## Request scoped handlers in queues
 
 > `@UseRequestContext()` decorator was added in v4.1.0
 
-> Since v5, `@UseRequestContext()` decorator is available in the `@mikro-orm/core`
-> package. It is valid approach not just for nestjs projects.
+> Since v5, `@UseRequestContext()` decorator is available in the `@mikro-orm/core` package. It is valid approach not just for nestjs projects.
 
 As mentioned in the [docs](identity-map.md), we need a clean state for each request. That is handled automatically thanks to the `RequestContext` helper registered via middleware.
 
-But middlewares are executed only for regular HTTP request handles, what if we need
-a request scoped method outside of that? One example of that is queue handlers or
-scheduled tasks.
+But middlewares are executed only for regular HTTP request handles, what if we need a request scoped method outside of that? One example of that is queue handlers or scheduled tasks.
 
-We can use the `@UseRequestContext()` decorator. It requires you to first inject the
-`MikroORM` instance to current context, it will be then used to create the context
-for you. Under the hood, the decorator will register new request context for your
-method and execute it inside the context.
+We can use the `@UseRequestContext()` decorator. It requires you to first inject the `MikroORM` instance to current context, it will be then used to create the context for you. Under the hood, the decorator will register new request context for your method and execute it inside the context.
 
 Keep in mind, that all handlers that are decorated with @UseRequestContext(), should NOT return anything.
 
@@ -244,9 +232,7 @@ export class MyService {
 }
 ```
 
-Another thing to look out for how you combine them with other decorators.
-For example if you use it in combination with NestJS's "[BullJS queues module](https://docs.nestjs.com/techniques/queues)", a safe bet is to extract the part of the code that needs a clean [docs](identity-map.md),
-either in a new method or inject a separate service.
+Another thing to look out for how you combine them with other decorators. For example if you use it in combination with NestJS's "[BullJS queues module](https://docs.nestjs.com/techniques/queues)", a safe bet is to extract the part of the code that needs a clean [docs](identity-map.md), either in a new method or inject a separate service.
 
 ```ts
 @Processor({
@@ -275,27 +261,27 @@ The GraphQL module in NestJS uses `apollo-server-express` which enables `bodypar
 
 This can be done by adding bodyparser to your main.ts file
 
- ```ts
+```ts
 import { NestFactory } from '@nestjs/core';
 import express from 'express';
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule,{ bodyParser: false });
-  app.use(express.json());
-  await app.listen(5555);
+ const app = await NestFactory.create(AppModule,{ bodyParser: false });
+ app.use(express.json());
+ await app.listen(5555);
 }
- ```
+```
 
 And at the same time disabling the bodyparser in the GraphQL Module
 
- ```ts
- @Module({
-  imports: [
-    GraphQLModule.forRoot({
-      bodyParserConfig: false,
-    }),
-  ],
+```ts
+@Module({
+ imports: [
+   GraphQLModule.forRoot({
+     bodyParserConfig: false,
+   }),
+ ],
 })
- ```
+```
 
 ## App shutdown and cleanup
 
@@ -429,10 +415,7 @@ export class PhotoModule {}
 
 ## Using `AsyncLocalStorage` for request context
 
-:::info
-Since v5 `AsyncLocalStorage` is used inside `RequestContext` helper so this section
-is no longer valid.
-:::
+:::info Since v5 `AsyncLocalStorage` is used inside `RequestContext` helper so this section is no longer valid. :::
 
 In older versions, the `domain` api was used in the `RequestContext` helper. Since `@mikro-orm/core@4.0.3`, we can use the new `AsyncLocalStorage` too, if you are on up to date node version:
 
@@ -486,7 +469,7 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
   }
 
   async afterUpdate(args: EventArgs<Author>): Promise<void> {
-    // ... 
+    // ...
   }
 
 }

--- a/docs/versioned_docs/version-5.6/usage-with-sql.md
+++ b/docs/versioned_docs/version-5.6/usage-with-sql.md
@@ -3,8 +3,7 @@ title: Usage with MySQL, MariaDB, PostgreSQL or SQLite
 sidebar_label: Usage with SQL Drivers
 ---
 
-To use `mikro-orm` with MySQL database, simply install the `@mikro-orm/mysql` dependency and set 
-the type option to `mysql` when initializing ORM. Since v4 it is no longer needed to install the `mysql2` package manually.
+To use `mikro-orm` with MySQL database, simply install the `@mikro-orm/mysql` dependency and set the type option to `mysql` when initializing ORM. Since v4 it is no longer needed to install the `mysql2` package manually.
 
 ```sh
 yarn add @mikro-orm/core @mikro-orm/mongodb     # for mongo
@@ -26,9 +25,7 @@ npm i -s @mikro-orm/core @mikro-orm/sqlite      # for sqlite
 
 Then call `MikroORM.init` as part of bootstrapping your app:
 
-> To access driver specific methods like `em.createQueryBuilder()` we need to specify
-> the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the
-> `orm.em` to `EntityManager` exported from the driver package:
+> To access driver specific methods like `em.createQueryBuilder()` we need to specify the driver type when calling `MikroORM.init<D>()`. Alternatively we can cast the `orm.em` to `EntityManager` exported from the driver package:
 >
 > ```ts
 > import { EntityManager } from '@mikro-orm/postgresql';
@@ -49,9 +46,7 @@ console.log(orm.em); // access EntityManager via `em` property
 
 ## Custom driver
 
-If you want to use database that is not currently supported, you can implement your own driver.
-More information about how to create one can be [found here](custom-driver.md). Then provide the 
-driver class via `driver` configuration option: 
+If you want to use database that is not currently supported, you can implement your own driver. More information about how to create one can be [found here](custom-driver.md). Then provide the driver class via `driver` configuration option:
 
 ```ts
 import { MyCustomDriver } from './MyCustomDriver.ts';
@@ -65,8 +60,7 @@ const orm = await MikroORM.init<MyCustomDriver>({
 
 ## Schema
 
-Currently you will need to maintain the database schema yourself. For initial dump, you can 
-use [`SchemaGenerator` helper](schema-generator.md).  
+Currently you will need to maintain the database schema yourself. For initial dump, you can use [`SchemaGenerator` helper](schema-generator.md).
 
 ## ManyToMany collections with pivot tables
 
@@ -81,8 +75,7 @@ CREATE TABLE `publisher_to_test` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 ```
 
-You can adjust the name of pivot table via `pivotTable` option in `@ManyToMany` decorator
-defined on owning side: 
+You can adjust the name of pivot table via `pivotTable` option in `@ManyToMany` decorator defined on owning side:
 
 ```ts
 // for unidirectional
@@ -96,8 +89,7 @@ tags = new Collection<BookTag>(this);
 
 ## Using QueryBuilder to execute native SQL queries
 
-When you need to execute some SQL query without all the ORM stuff involved, you can either
-compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
+When you need to execute some SQL query without all the ORM stuff involved, you can either compose the query yourself, or use the `QueryBuilder` helper to construct the query for you:
 
 ```ts
 const qb = orm.em.createQueryBuilder(Author);
@@ -140,17 +132,13 @@ QueryBuilder.getParams(): any;
 QueryBuilder.clone(): QueryBuilder;
 ```
 
-For more examples of how to work with `QueryBuilder`, take a look at `QueryBuilder` tests in 
-[`tests/QueryBuilder.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/QueryBuilder.test.ts).
+For more examples of how to work with `QueryBuilder`, take a look at `QueryBuilder` tests in [`tests/QueryBuilder.test.ts`](https://github.com/mikro-orm/mikro-orm/blob/master/tests/QueryBuilder.test.ts).
 
 ## Transactions
 
-When you call `em.flush()`, all computed changes are queried [inside a database
-transaction](unit-of-work.md) by default, so you do not have to handle transactions manually. 
+When you call `em.flush()`, all computed changes are queried [inside a database transaction](unit-of-work.md) by default, so you do not have to handle transactions manually.
 
-When you need to explicitly handle the transaction, you can use `em.transactional(cb)` 
-to run callback in transaction. It will provide forked `EntityManager` as a parameter 
-with clear isolated identity map - please use that to make changes. 
+When you need to explicitly handle the transaction, you can use `em.transactional(cb)` to run callback in transaction. It will provide forked `EntityManager` as a parameter with clear isolated identity map - please use that to make changes.
 
 ```ts
 // if an error occurs inside the callback, all db queries from inside the callback will be rolled back
@@ -171,16 +159,13 @@ const author3 = new Author2('Author 3', 'a3@example.com');
 await orm.em.persistAndFlush([author1, author2, author3]);
 
 // finds authors with email like '%exa%le.c_m'
-const authors = await orm.em.find(Author2, { email: /exa.*le\.c.m$/ }); 
+const authors = await orm.em.find(Author2, { email: /exa.*le\.c.m$/ });
 console.log(authors); // all 3 authors found
 ```
 
 ## Native Collection Methods
 
-Sometimes you need to perform some bulk operation, or you just want to populate your
-database with initial fixtures. Using ORM for such operations can bring unnecessary
-boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete`
-methods:
+Sometimes you need to perform some bulk operation, or you just want to populate your database with initial fixtures. Using ORM for such operations can bring unnecessary boilerplate code. In this case, you can use one of `nativeInsert/nativeUpdate/nativeDelete` methods:
 
 ```ts
 em.nativeInsert<T extends AnyEntity>(entityName: string, data: any): Promise<IPrimaryKey>;
@@ -188,9 +173,7 @@ em.nativeUpdate<T extends AnyEntity>(entityName: string, where: FilterQuery<T>, 
 em.nativeDelete<T extends AnyEntity>(entityName: string, where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Those methods execute native SQL queries generated via `QueryBuilder` based on entity 
-metadata. Keep in mind that they do not hydrate results to entities, and they do not 
-trigger lifecycle hooks. 
+Those methods execute native SQL queries generated via `QueryBuilder` based on entity metadata. Keep in mind that they do not hydrate results to entities, and they do not trigger lifecycle hooks.
 
 They are also available as `EntityRepository` shortcuts:
 
@@ -200,9 +183,7 @@ EntityRepository.nativeUpdate(where: FilterQuery<T>, data: any): Promise<number>
 EntityRepository.nativeDelete(where: FilterQuery<T> | any): Promise<number>;
 ```
 
-Additionally there is `execute()` method that supports executing raw SQL queries or `QueryBuilder`
-instances. To create `QueryBuilder`, you can use `createQueryBuilder()` factory method on both 
-`EntityManager` and `EntityRepository` classes: 
+Additionally there is `execute()` method that supports executing raw SQL queries or `QueryBuilder` instances. To create `QueryBuilder`, you can use `createQueryBuilder()` factory method on both `EntityManager` and `EntityRepository` classes:
 
 ```ts
 const qb = em.createQueryBuilder('Author');

--- a/docs/versioned_docs/version-5.6/using-bigint-pks.md
+++ b/docs/versioned_docs/version-5.6/using-bigint-pks.md
@@ -2,8 +2,7 @@
 title: Using native BigInt PKs (MySQL and PostgreSQL)
 ---
 
-We can use `BigIntType` to support `bigint`s. By default, it will represent the value as
-a `string`.
+We can use `BigIntType` to support `bigint`s. By default, it will represent the value as a `string`.
 
 ```ts
 import { Entity, PrimaryKey, t } from '@mikro-orm/core';
@@ -17,10 +16,7 @@ export class Book {
 }
 ```
 
-`bigint` can fit larger numbers than JavaScript number, for this reason it
-is mapped to a string. If we want to map it to a number anyway, we can implement
-[custom type](custom-types.md) that will do so. Similarly, we can define one to 
-use the native `bigint` type:
+`bigint` can fit larger numbers than JavaScript number, for this reason it is mapped to a string. If we want to map it to a number anyway, we can implement [custom type](custom-types.md) that will do so. Similarly, we can define one to use the native `bigint` type:
 
 ```ts
 export class NativeBigIntType extends BigIntType {

--- a/docs/versioned_docs/version-5.6/virtual-entities.md
+++ b/docs/versioned_docs/version-5.6/virtual-entities.md
@@ -5,7 +5,7 @@ title: Virtual Entities
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Virtual entities don't represent any database table. Instead, they dynamically resolve to an SQL query (or an aggregation in mongo), allowing to map any kind of results onto an entity. Such entities are mean for read purposes, they don't have a primary key and therefore cannot be tracked for changes. In a sense they are similar to (currently unsupported) database views. 
+Virtual entities don't represent any database table. Instead, they dynamically resolve to an SQL query (or an aggregation in mongo), allowing to map any kind of results onto an entity. Such entities are mean for read purposes, they don't have a primary key and therefore cannot be tracked for changes. In a sense they are similar to (currently unsupported) database views.
 
 To define a virtual entity, provide an `expression`, either as a string (SQL query):
 
@@ -85,7 +85,7 @@ export interface IBookWithAuthor{
   tags: string[];
 }
 
-export const BookWithAuthor = new EntitySchema<IBookWithAuthor>({ 
+export const BookWithAuthor = new EntitySchema<IBookWithAuthor>({
   name: 'BookWithAuthor',
   expression: 'select name, age, ' +
     '(select count(*) from book b where b.author_id = a.id) as total_books, ' +

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -6246,6 +6246,7 @@ __metadata:
     "@docusaurus/preset-classic": 2.3.1
     classnames: 2.3.2
     docusaurus-plugin-typedoc-api: 2.5.1
+    prettier: ^2.8.4
     react: 18.2.0
     react-dom: 18.2.0
     typescript: 4.9.5
@@ -9957,6 +9958,15 @@ __metadata:
   version: 2.0.0
   resolution: "prepend-http@npm:2.0.0"
   checksum: 7694a9525405447662c1ffd352fcb41b6410c705b739b6f4e3a3e21cf5fdede8377890088e8934436b8b17ba55365a615f153960f30877bf0d0392f9e93503ea
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^2.8.4":
+  version: 2.8.4
+  resolution: "prettier@npm:2.8.4"
+  bin:
+    prettier: bin-prettier.js
+  checksum: c173064bf3df57b6d93d19aa98753b9b9dd7657212e33b41ada8e2e9f9884066bb9ca0b4005b89b3ab137efffdf8fbe0b462785aba20364798ff4303aadda57e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Mainly to remove the line breaks from prose.

Still nothing that could be automated, as prettier breaks the docusaurus code tabs as well as imports. 