### PR TITLE
fix: use schema-qualified table names for auto-increment and comment statements in postgresql

### DIFF
--- a/packages/knex/src/schema/SchemaGenerator.ts
+++ b/packages/knex/src/schema/SchemaGenerator.ts
@@ -388,7 +388,7 @@ export class SchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDriver> 
           continue; // will be handled via knex
         }
 
-        this.helper.pushTableQuery(table, this.helper.getChangeColumnCommentSQL(tableName, column));
+        this.helper.pushTableQuery(table, this.helper.getChangeColumnCommentSQL(tableName, column, schemaName));
       }
 
       for (const [oldColumnName, column] of Object.entries(diff.renamedColumns)) {

--- a/packages/knex/src/schema/SchemaHelper.ts
+++ b/packages/knex/src/schema/SchemaHelper.ts
@@ -173,11 +173,11 @@ export abstract class SchemaHelper {
     return '';
   }
 
-  getAlterColumnAutoincrement(tableName: string, column: Column): string {
+  getAlterColumnAutoincrement(tableName: string, column: Column, schemaName?: string): string {
     return '';
   }
 
-  getChangeColumnCommentSQL(tableName: string, to: Column): string {
+  getChangeColumnCommentSQL(tableName: string, to: Column, schemaName?: string): string {
     return '';
   }
 

--- a/packages/mariadb/src/MariaDbSchemaHelper.ts
+++ b/packages/mariadb/src/MariaDbSchemaHelper.ts
@@ -240,7 +240,7 @@ export class MariaDbSchemaHelper extends SchemaHelper {
     return `alter table ${tableName} rename index ${oldIndexName} to ${keyName}`;
   }
 
-  getChangeColumnCommentSQL(tableName: string, to: Column): string {
+  getChangeColumnCommentSQL(tableName: string, to: Column, schemaName?: string): string {
     tableName = this.platform.quoteIdentifier(tableName);
     const columnName = this.platform.quoteIdentifier(to.name);
 

--- a/packages/mysql/src/MySqlSchemaHelper.ts
+++ b/packages/mysql/src/MySqlSchemaHelper.ts
@@ -221,7 +221,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
     return `alter table ${tableName} rename index ${oldIndexName} to ${keyName}`;
   }
 
-  getChangeColumnCommentSQL(tableName: string, to: Column): string {
+  getChangeColumnCommentSQL(tableName: string, to: Column, schemaName?: string): string {
     tableName = this.platform.quoteIdentifier(tableName);
     const columnName = this.platform.quoteIdentifier(to.name);
 


### PR DESCRIPTION
When using comment in @Property annotations for a postgresql database, the generated SQL only uses the table name, and not the fully qualified schema name and table name (e.g. `comment on "table_name"."column_name" is \'hello world\';`). This PR changes this to instead generate fully qualified table names (`comment on "schema_name"."table_name"."column_name" is \'hello world\';`). 

Closes #4108 