### PR TITLE
docs: fix typo `uuid-osp` -> `uuid-ossp`

### DIFF
--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -1456,7 +1456,7 @@ export const Book = new EntitySchema<IBook>({
   </TabItem>
 </Tabs>
 
-### Using PostgreSQL [uuid-osp](https://www.postgresql.org/docs/current/uuid-ossp.html) module function as primary key
+### Using PostgreSQL [uuid-ossp](https://www.postgresql.org/docs/current/uuid-ossp.html) module function as primary key
 
 Requires enabling the module via: `create extension "uuid-ossp";`
 

--- a/docs/versioned_docs/version-4.5/defining-entities.md
+++ b/docs/versioned_docs/version-4.5/defining-entities.md
@@ -1272,7 +1272,7 @@ export const Book = new EntitySchema<IBook>({
   </TabItem>
 </Tabs>
 
-### Using PostgreSQL [uuid-osp](https://www.postgresql.org/docs/current/uuid-ossp.html) module function as primary key
+### Using PostgreSQL [uuid-ossp](https://www.postgresql.org/docs/current/uuid-ossp.html) module function as primary key
 
 Requires enabling the module via: `create extension "uuid-ossp";`
 

--- a/docs/versioned_docs/version-5.4/defining-entities.md
+++ b/docs/versioned_docs/version-5.4/defining-entities.md
@@ -1385,7 +1385,7 @@ export const Book = new EntitySchema<IBook>({
   </TabItem>
 </Tabs>
 
-### Using PostgreSQL [uuid-osp](https://www.postgresql.org/docs/current/uuid-ossp.html) module function as primary key
+### Using PostgreSQL [uuid-ossp](https://www.postgresql.org/docs/current/uuid-ossp.html) module function as primary key
 
 Requires enabling the module via: `create extension "uuid-ossp";`
 

--- a/docs/versioned_docs/version-5.5/defining-entities.md
+++ b/docs/versioned_docs/version-5.5/defining-entities.md
@@ -1456,7 +1456,7 @@ export const Book = new EntitySchema<IBook>({
   </TabItem>
 </Tabs>
 
-### Using PostgreSQL [uuid-osp](https://www.postgresql.org/docs/current/uuid-ossp.html) module function as primary key
+### Using PostgreSQL [uuid-ossp](https://www.postgresql.org/docs/current/uuid-ossp.html) module function as primary key
 
 Requires enabling the module via: `create extension "uuid-ossp";`
 

--- a/docs/versioned_docs/version-5.6/defining-entities.md
+++ b/docs/versioned_docs/version-5.6/defining-entities.md
@@ -1456,7 +1456,7 @@ export const Book = new EntitySchema<IBook>({
   </TabItem>
 </Tabs>
 
-### Using PostgreSQL [uuid-osp](https://www.postgresql.org/docs/current/uuid-ossp.html) module function as primary key
+### Using PostgreSQL [uuid-ossp](https://www.postgresql.org/docs/current/uuid-ossp.html) module function as primary key
 
 Requires enabling the module via: `create extension "uuid-ossp";`
 


### PR DESCRIPTION
I believe `uuid-osp` is a typo of `uuid-ossp`, so fixed it.