### PR TITLE
fix(core): respect explicit `unsigned` option

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1152,10 +1152,7 @@ export class MetadataDiscovery {
       return;
     }
 
-    prop.unsigned = (prop.primary || prop.unsigned)
-      && prop.unsigned !== false  // Allow explicit opt-out of unsigned for primary keys
-      && this.isNumericProperty(prop)
-      && this.platform.supportsUnsigned();
+    prop.unsigned ??= (prop.primary || prop.unsigned) && this.isNumericProperty(prop) && this.platform.supportsUnsigned();
   }
 
   private initIndexes(prop: EntityProperty): void {

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1152,7 +1152,10 @@ export class MetadataDiscovery {
       return;
     }
 
-    prop.unsigned = (prop.primary || prop.unsigned) && this.isNumericProperty(prop) && this.platform.supportsUnsigned();
+    prop.unsigned = (prop.primary || prop.unsigned)
+      && prop.unsigned !== false  // Allow explicit opt-out of unsigned for primary keys
+      && this.isNumericProperty(prop)
+      && this.platform.supportsUnsigned();
   }
 
   private initIndexes(prop: EntityProperty): void {

--- a/tests/features/schema-generator/signed-primary-key.test.ts
+++ b/tests/features/schema-generator/signed-primary-key.test.ts
@@ -1,0 +1,29 @@
+import {
+  Entity,
+  PrimaryKey,
+} from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/mysql';
+
+@Entity()
+class Article {
+
+  @PrimaryKey()
+  id!: number;
+
+  @PrimaryKey({ unsigned: false })
+  someOtherId!: number;
+
+}
+
+test('allow signed primary key when explicitly specified', async () => {
+  const orm = await MikroORM.init({
+    dbName: 'mikro_orm_signed_primary_key',
+    entities: [Article],
+  });
+
+  expect(await orm.schema.getCreateSchemaSQL({ wrap: false })).toBe(
+    'create table `article` (`id` int unsigned not null, `some_other_id` int not null, primary key (`id`, `some_other_id`)) default character set utf8mb4 engine = InnoDB;\n\n',
+  );
+
+  await orm.close(true);
+});


### PR DESCRIPTION
Users don't necessarily want all numeric primary key columns to be unsigned.

Alternatively, we can change the behavior such that _only_ autoincrement pkeys are unsigned and just let numeric pkeys be signed by default, but that seems like a more major behavior change.