### PR TITLE
refactor(core): remove `persist/remove/flush` methods from `EntityRepository`

### DIFF
--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -1,6 +1,6 @@
 import type { CreateOptions, EntityManager, MergeOptions } from '../EntityManager';
 import type { AssignOptions } from './EntityAssigner';
-import type { EntityData, EntityName, AnyEntity, Primary, Loaded, FilterQuery, EntityDictionary, AutoPath, RequiredEntityData, Ref } from '../typings';
+import type { EntityData, EntityName, Primary, Loaded, FilterQuery, EntityDictionary, AutoPath, RequiredEntityData, Ref } from '../typings';
 import type {
   CountOptions,
   DeleteOptions,
@@ -20,28 +20,8 @@ import type { Cursor } from '../utils/Cursor';
 
 export class EntityRepository<Entity extends object> {
 
-  constructor(protected readonly _em: EntityManager,
+  constructor(protected readonly em: EntityManager,
               protected readonly entityName: EntityName<Entity>) { }
-
-  /**
-   * Tells the EntityManager to make an instance managed and persistent.
-   * The entity will be entered into the database at or before transaction commit or as a result of the flush operation.
-   *
-   * @deprecated this method will be removed in v6, you should work with the EntityManager instead
-   */
-  persist(entity: AnyEntity | AnyEntity[]): EntityManager {
-    return this.getEntityManager().persist(entity);
-  }
-
-  /**
-   * Persists your entity immediately, flushing all not yet persisted changes to the database too.
-   * Equivalent to `em.persist(e).flush()`.
-   *
-   * @deprecated this method will be removed in v6, you should work with the EntityManager instead
-   */
-  async persistAndFlush(entity: AnyEntity | AnyEntity[]): Promise<void> {
-    await this.getEntityManager().persistAndFlush(entity);
-  }
 
   /**
    * Finds first entity matching your `where` query.
@@ -162,40 +142,6 @@ export class EntityRepository<Entity extends object> {
   }
 
   /**
-   * Marks entity for removal.
-   * A removed entity will be removed from the database at or before transaction commit or as a result of the flush operation.
-   *
-   * To remove entities by condition, use `em.nativeDelete()`.
-   *
-   * @deprecated this method will be removed in v6, you should work with the EntityManager instead
-   */
-  remove(entity: AnyEntity): EntityManager {
-    return this.getEntityManager().remove(entity);
-  }
-
-  /**
-   * Removes an entity instance immediately, flushing all not yet persisted changes to the database too.
-   * Equivalent to `em.remove(e).flush()`
-   *
-   * @deprecated this method will be removed in v6, you should work with the EntityManager instead
-   */
-  async removeAndFlush(entity: AnyEntity): Promise<void> {
-    await this.getEntityManager().removeAndFlush(entity);
-  }
-
-  /**
-   * Flushes all changes to objects that have been queued up to now to the database.
-   * This effectively synchronizes the in-memory state of managed objects with the database.
-   * This method is a shortcut for `em.flush()`, in other words, it will flush the whole UoW,
-   * not just entities registered via this particular repository.
-   *
-   * @deprecated this method will be removed in v6, you should work with the EntityManager instead
-   */
-  async flush(): Promise<void> {
-    return this.getEntityManager().flush();
-  }
-
-  /**
    * @inheritDoc EntityManager.insert
    */
   async insert(data: Entity | EntityData<Entity>, options?: NativeInsertUpdateOptions<Entity>): Promise<Primary<Entity>> {
@@ -306,17 +252,10 @@ export class EntityRepository<Entity extends object> {
   }
 
   /**
-   * @deprecated this method will be removed in v6, use the public `getEntityManager()` method instead
-   */
-  protected get em(): EntityManager {
-    return this._em;
-  }
-
-  /**
    * Returns the underlying EntityManager instance
    */
   getEntityManager(): EntityManager {
-    return this._em;
+    return this.em;
   }
 
   protected validateRepositoryType(entities: Entity[] | Entity, method: string) {

--- a/packages/knex/src/SqlEntityRepository.ts
+++ b/packages/knex/src/SqlEntityRepository.ts
@@ -6,9 +6,9 @@ import type { QueryBuilder } from './query';
 
 export class SqlEntityRepository<T extends object> extends EntityRepository<T> {
 
-  constructor(protected override readonly _em: SqlEntityManager,
+  constructor(protected override readonly em: SqlEntityManager,
               entityName: EntityName<T>) {
-    super(_em, entityName);
+    super(em, entityName);
   }
 
   /**
@@ -29,21 +29,14 @@ export class SqlEntityRepository<T extends object> extends EntityRepository<T> {
    * Returns configured knex instance.
    */
   getKnex(type?: ConnectionType): Knex {
-    return this.getEntityManager().getConnection(type).getKnex();
+    return this.getEntityManager().getKnex();
   }
 
   /**
    * @inheritDoc
    */
   override getEntityManager(): SqlEntityManager {
-    return this._em;
-  }
-
-  /**
-   * @inheritDoc
-   */
-  protected override get em(): SqlEntityManager {
-    return this._em;
+    return this.em;
   }
 
 }

--- a/packages/mongodb/src/MongoEntityRepository.ts
+++ b/packages/mongodb/src/MongoEntityRepository.ts
@@ -5,9 +5,9 @@ import type { MongoEntityManager } from './MongoEntityManager';
 
 export class MongoEntityRepository<T extends object> extends EntityRepository<T> {
 
-  constructor(protected override readonly _em: MongoEntityManager,
+  constructor(protected override readonly em: MongoEntityManager,
               entityName: EntityName<T>) {
-    super(_em, entityName);
+    super(em, entityName);
   }
 
   /**
@@ -25,14 +25,7 @@ export class MongoEntityRepository<T extends object> extends EntityRepository<T>
    * @inheritDoc
    */
   override getEntityManager(): MongoEntityManager {
-    return this._em;
-  }
-
-  /**
-   * @inheritDoc
-   */
-  protected override get em(): MongoEntityManager {
-    return this._em;
+    return this.em;
   }
 
 }

--- a/tests/EntityManager.mariadb.test.ts
+++ b/tests/EntityManager.mariadb.test.ts
@@ -122,11 +122,10 @@ describe('EntityManagerMariaDb', () => {
     book3.createdAt = new Date(Date.now() + 3);
     book3.publisher = wrap(publisher).toReference();
 
-    const repo = orm.em.getRepository(Book2);
-    repo.persist(book1);
-    repo.persist(book2);
-    repo.persist(book3);
-    await repo.flush();
+    orm.em.persist(book1);
+    orm.em.persist(book2);
+    orm.em.persist(book3);
+    await orm.em.flush();
     orm.em.clear();
 
     const publisher7k = (await orm.em.getRepository(Publisher2).findOne({ name: '7K publisher' }))!;
@@ -224,7 +223,7 @@ describe('EntityManagerMariaDb', () => {
     expect(lastBook[0].title).toBe('My Life on The Wall, part 1');
     expect(lastBook[0].author).toBeInstanceOf(Author2);
     expect(wrap(lastBook[0].author).isInitialized()).toBe(true);
-    await orm.em.getRepository(Book2).remove(lastBook[0]).flush();
+    await orm.em.remove(lastBook[0]).flush();
   });
 
   afterAll(async () => orm.close(true));

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -181,7 +181,7 @@ describe('EntityManagerMySql', () => {
     const author = new Author2('name', 'email');
     author.termsAccepted = true;
     author.favouriteAuthor = author;
-    await repo.persistAndFlush(author);
+    await orm.em.persistAndFlush(author);
     const a = await repo.findOne(author);
 
     const authors = await repo.find({ favouriteAuthor: author });
@@ -242,10 +242,10 @@ describe('EntityManagerMySql', () => {
   test('should work with boolean values', async () => {
     const repo = orm.em.getRepository(Author2);
     const author = new Author2('name', 'email');
-    await repo.persistAndFlush(author);
+    await orm.em.persistAndFlush(author);
     expect(author.termsAccepted).toBe(false);
     author.termsAccepted = true;
-    await repo.persistAndFlush(author);
+    await orm.em.persistAndFlush(author);
     expect(author.termsAccepted).toBe(true);
     orm.em.clear();
 
@@ -254,7 +254,7 @@ describe('EntityManagerMySql', () => {
     const a2 = (await repo.findOne({ termsAccepted: true }))!;
     expect(a2).not.toBeNull();
     a2.termsAccepted = false;
-    await repo.persistAndFlush(a2);
+    await orm.em.persistAndFlush(a2);
     orm.em.clear();
 
     const a3 = (await repo.findOne({ termsAccepted: false }))!;
@@ -466,11 +466,10 @@ describe('EntityManagerMySql', () => {
     book3.createdAt = new Date(Date.now() + 3);
     book3.publisher = wrap(publisher).toReference();
 
-    const repo = orm.em.getRepository(Book2);
-    repo.persist(book1);
-    repo.persist(book2);
-    repo.persist(book3);
-    await repo.flush();
+    orm.em.persist(book1);
+    orm.em.persist(book2);
+    orm.em.persist(book3);
+    await orm.em.flush();
     orm.em.clear();
 
     const publisher7k = (await orm.em.getRepository(Publisher2).findOne({ name: '7K publisher' }))!;
@@ -579,7 +578,7 @@ describe('EntityManagerMySql', () => {
     expect(lastBook[0].title).toBe('My Life on The Wall, part 1');
     expect(lastBook[0].author).toBeInstanceOf(Author2);
     expect(wrap(lastBook[0].author).isInitialized()).toBe(true);
-    await orm.em.getRepository(Book2).remove(lastBook[0]).flush();
+    await orm.em.remove(lastBook[0]).flush();
   });
 
   test('json properties', async () => {
@@ -940,7 +939,7 @@ describe('EntityManagerMySql', () => {
   test('findOne by id', async () => {
     const authorRepository = orm.em.getRepository(Author2);
     const jon = new Author2('Jon Snow', 'snow@wall.st');
-    await authorRepository.persistAndFlush(jon);
+    await orm.em.persistAndFlush(jon);
 
     orm.em.clear();
     let author = (await authorRepository.findOne(jon.id))!;
@@ -1393,7 +1392,7 @@ describe('EntityManagerMySql', () => {
   test('trying to populate non-existing or non-reference property will throw', async () => {
     const repo = orm.em.getRepository(Author2);
     const author = new Author2('Johny Cash', 'johny@cash.com');
-    await repo.persistAndFlush(author);
+    await orm.em.persistAndFlush(author);
     orm.em.clear();
 
     await expect(repo.findAll({ populate: ['tests'] as never })).rejects.toThrowError(`Entity 'Author2' does not have property 'tests'`);
@@ -1408,7 +1407,7 @@ describe('EntityManagerMySql', () => {
     let t3 = Test2.create('t3');
     await orm.em.persistAndFlush([t1, t2, t3]);
     publisher.tests.add(t2, t1, t3);
-    await repo.persistAndFlush(publisher);
+    await orm.em.persistAndFlush(publisher);
     orm.em.clear();
 
     const ent = (await repo.findOne(publisher.id, { populate: ['tests'] }))!;
@@ -1420,7 +1419,7 @@ describe('EntityManagerMySql', () => {
 
     [t1, t2, t3] = ent.tests.getItems();
     ent.tests.set([t3, t2, t1]);
-    await repo.flush();
+    await orm.em.flush();
     orm.em.clear();
 
     const ent1 = (await repo.findOne(publisher.id, { populate: ['tests'] }))!;
@@ -1673,10 +1672,10 @@ describe('EntityManagerMySql', () => {
     await expect(author.updatedAt).toBeDefined();
     // allow 1 ms difference as updated time is recalculated when persisting
     await expect(+author.updatedAt - +author.createdAt).toBeLessThanOrEqual(1);
-    await repo.persistAndFlush(author);
+    await orm.em.persistAndFlush(author);
 
     author.name = 'name1';
-    await repo.persistAndFlush(author);
+    await orm.em.persistAndFlush(author);
     await expect(author.createdAt).toBeDefined();
     await expect(author.updatedAt).toBeDefined();
     await expect(author.updatedAt).not.toEqual(author.createdAt);

--- a/tests/EntityManager.sqlite.test.ts
+++ b/tests/EntityManager.sqlite.test.ts
@@ -94,7 +94,7 @@ describe('EntityManagerSqlite', () => {
   test('should convert entity to PK when trying to search by entity', async () => {
     const repo = orm.em.getRepository<any>(Author3);
     const author = new Author3('name', 'email');
-    await repo.persistAndFlush(author);
+    await orm.em.persistAndFlush(author);
     const a = await repo.findOne(author);
     const authors = await repo.find({ id: author });
     expect(a).toBe(author);
@@ -216,11 +216,10 @@ describe('EntityManagerSqlite', () => {
     const book3 = new Book3('My Life on The Wall, part 3', author);
     book3.publisher = publisher;
 
-    const repo = orm.em.getRepository(Book3);
-    repo.persist(book1);
-    repo.persist(book2);
-    repo.persist(book3);
-    await repo.flush();
+    orm.em.persist(book1);
+    orm.em.persist(book2);
+    orm.em.persist(book3);
+    await orm.em.flush();
     orm.em.clear();
 
     const publisher7k = (await orm.em.getRepository<any>(Publisher3).findOne({ name: '7K publisher' }))!;
@@ -313,7 +312,7 @@ describe('EntityManagerSqlite', () => {
     expect(lastBook[0].title).toBe('My Life on The Wall, part 1');
     expect(lastBook[0].author).toBeInstanceOf(Author3);
     expect(lastBook[0].author.isInitialized()).toBe(true);
-    await orm.em.getRepository(Book3).remove(lastBook[0]).flush();
+    await orm.em.remove(lastBook[0]).flush();
   });
 
   test('findOne should initialize entity that is already in IM', async () => {
@@ -533,7 +532,7 @@ describe('EntityManagerSqlite', () => {
   test('findOne by id', async () => {
     const authorRepository = orm.em.getRepository<any>(Author3);
     const jon = new Author3('Jon Snow', 'snow@wall.st');
-    await authorRepository.persistAndFlush(jon);
+    await orm.em.persistAndFlush(jon);
 
     orm.em.clear();
     let author = (await authorRepository.findOne(jon.id))!;
@@ -740,7 +739,7 @@ describe('EntityManagerSqlite', () => {
     expect(author.baseVersion).toBeUndefined();
     expect(author.baseVersionAsString).toBeUndefined();
 
-    await repo.persistAndFlush(author);
+    await orm.em.persistAndFlush(author);
     expect(author.id).toBeDefined();
     expect(author.version).toBe(1);
     expect(author.versionAsString).toBe('v1');
@@ -748,7 +747,7 @@ describe('EntityManagerSqlite', () => {
     expect(author.baseVersionAsString).toBe('v1');
 
     author.name = 'John Snow';
-    await repo.persistAndFlush(author);
+    await orm.em.persistAndFlush(author);
     expect(author.version).toBe(3);
     expect(author.versionAsString).toBe('v3');
     expect(author.baseVersion).toBe(3);
@@ -758,15 +757,15 @@ describe('EntityManagerSqlite', () => {
     expect(Author3.afterDestroyCalled).toBe(0);
     expect(BaseEntity4.beforeDestroyCalled).toBe(0);
     expect(BaseEntity4.afterDestroyCalled).toBe(0);
-    await repo.remove(author).flush();
+    await orm.em.remove(author).flush();
     expect(Author3.beforeDestroyCalled).toBe(2);
     expect(Author3.afterDestroyCalled).toBe(2);
     expect(BaseEntity4.beforeDestroyCalled).toBe(2);
     expect(BaseEntity4.afterDestroyCalled).toBe(2);
 
     const author2 = new Author3('Johny Cash', 'johny@cash.com');
-    await repo.persistAndFlush(author2);
-    await repo.remove(author2).flush();
+    await orm.em.persistAndFlush(author2);
+    await orm.em.remove(author2).flush();
     expect(Author3.beforeDestroyCalled).toBe(4);
     expect(Author3.afterDestroyCalled).toBe(4);
     expect(BaseEntity4.beforeDestroyCalled).toBe(4);
@@ -776,7 +775,7 @@ describe('EntityManagerSqlite', () => {
   test('trying to populate non-existing or non-reference property will throw', async () => {
     const repo = orm.em.getRepository(Author3);
     const author = new Author3('Johny Cash', 'johny@cash.com');
-    await repo.persistAndFlush(author);
+    await orm.em.persistAndFlush(author);
     orm.em.clear();
 
     await expect(repo.findAll({ populate: ['tests'] as never })).rejects.toThrowError(`Entity 'Author3' does not have property 'tests'`);
@@ -791,7 +790,7 @@ describe('EntityManagerSqlite', () => {
     const t3 = Test3.create('t3');
     await orm.em.persist([t1, t2, t3]).flush();
     publisher.tests.add(t2, t1, t3);
-    await repo.persistAndFlush(publisher);
+    await orm.em.persistAndFlush(publisher);
     orm.em.clear();
 
     const ent = (await repo.findOne(publisher.id, { populate: ['tests'] }))!;
@@ -809,11 +808,11 @@ describe('EntityManagerSqlite', () => {
     await expect(author.updatedAt).toBeDefined();
     // allow 1 ms difference as updated time is recalculated when persisting
     await expect(+author.updatedAt - +author.createdAt).toBeLessThanOrEqual(1);
-    await repo.persistAndFlush(author);
+    await orm.em.persistAndFlush(author);
 
     author.name = 'name1';
     await new Promise(resolve => setTimeout(resolve, 10));
-    await repo.persistAndFlush(author);
+    await orm.em.persistAndFlush(author);
     await expect(author.createdAt).toBeDefined();
     await expect(author.updatedAt).toBeDefined();
     await expect(author.updatedAt).not.toEqual(author.createdAt);

--- a/tests/EntityManager.sqlite2.test.ts
+++ b/tests/EntityManager.sqlite2.test.ts
@@ -35,7 +35,7 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
   test('should convert entity to PK when trying to search by entity', async () => {
     const repo = orm.em.getRepository(Author4);
     const author = orm.em.create(Author4, { name: 'name', email: 'email' });
-    await repo.flush();
+    await orm.em.flush();
     const a = await repo.findOne(author);
     const authors = await repo.find({ id: author.id });
     expect(a).toBe(author);
@@ -45,7 +45,7 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
   test('hydration with `forceUndefined` converts null values', async () => {
     const repo = orm.em.getRepository(Author4);
     const author = orm.em.create(Author4, { name: 'name', email: 'email' });
-    await repo.flush();
+    await orm.em.flush();
     orm.em.clear();
 
     const a = await repo.findOneOrFail(author);
@@ -290,7 +290,7 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
     expect(lastBook[0].title).toBe('My Life on The Wall, part 1');
     expect(lastBook[0].author!.constructor.name).toBe('Author4');
     expect(wrap(lastBook[0].author!).isInitialized()).toBe(true);
-    await orm.em.getRepository(Book4).remove(lastBook[0]).flush();
+    await orm.em.remove(lastBook[0]).flush();
   });
 
   test('findOne should initialize entity that is already in IM', async () => {
@@ -557,7 +557,7 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
   test('findOne by id', async () => {
     const authorRepository = orm.em.getRepository(Author4);
     const jon = orm.em.create(Author4, { name: 'Jon Snow', email: 'snow@wall.st' });
-    await authorRepository.persistAndFlush(jon);
+    await orm.em.persistAndFlush(jon);
 
     orm.em.clear();
     let author = (await authorRepository.findOne(jon.id))!;
@@ -837,7 +837,7 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
   test('trying to populate non-existing or non-reference property will throw', async () => {
     const repo = orm.em.getRepository(Author4);
     const author = orm.em.create(Author4, { name: 'Johny Cash', email: 'johny@cash.com' });
-    await repo.persistAndFlush(author);
+    await orm.em.persistAndFlush(author);
     orm.em.clear();
 
     await expect(repo.findAll({ populate: ['tests'] as never })).rejects.toThrowError(`Entity 'Author4' does not have property 'tests'`);
@@ -852,7 +852,7 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
     const t3 = orm.em.create(Test4, { name: 't3' });
     await orm.em.persist([t1, t2, t3]).flush();
     publisher.tests.add(t2, t1, t3);
-    await repo.persistAndFlush(publisher);
+    await orm.em.persistAndFlush(publisher);
     orm.em.clear();
 
     const ent = (await repo.findOne(publisher.id, { populate: ['tests'] }))!;
@@ -866,7 +866,7 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
   test('property onUpdate hook (updatedAt field)', async () => {
     const repo = orm.em.getRepository(Author4);
     const author = orm.em.create(Author4, { name: 'name', email: 'email' });
-    await repo.persistAndFlush(author);
+    await orm.em.persistAndFlush(author);
     expect(author.createdAt).toBeDefined();
     expect(author.updatedAt).toBeDefined();
     // allow 1 ms difference as updated time is recalculated when persisting
@@ -874,7 +874,7 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
 
     author.name = 'name1';
     await new Promise(resolve => setTimeout(resolve, 10));
-    await repo.persistAndFlush(author);
+    await orm.em.persistAndFlush(author);
     await expect(author.createdAt).toBeDefined();
     await expect(author.updatedAt).toBeDefined();
     await expect(author.updatedAt).not.toEqual(author.createdAt);

--- a/tests/EntityManager.sqlite3.test.ts
+++ b/tests/EntityManager.sqlite3.test.ts
@@ -1,4 +1,4 @@
-import { Collection, EntityManager, MikroORM, QueryOrder } from '@mikro-orm/core';
+import { EntityManager, MikroORM } from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
 import {  initORMSqlite3 } from './bootstrap';
@@ -22,12 +22,12 @@ describe('EntityManagerSqlite fts5 table', () => {
     const book5 = new Book5('My Death in a grass field, part 5');
 
     const repo = orm.em.getRepository(Book5);
-    repo.persist(book1);
-    repo.persist(book2);
-    repo.persist(book3);
-    repo.persist(book4);
-    repo.persist(book5);
-    await repo.flush();
+    orm.em.persist(book1);
+    orm.em.persist(book2);
+    orm.em.persist(book3);
+    orm.em.persist(book4);
+    orm.em.persist(book5);
+    await orm.em.flush();
     orm.em.clear();
 
     expect((await repo.count())!).toBe(5);

--- a/tests/EntityRepository.test.ts
+++ b/tests/EntityRepository.test.ts
@@ -1,4 +1,3 @@
-import type { AnyEntity } from '@mikro-orm/core';
 import { Configuration, QueryOrder } from '@mikro-orm/core';
 import type { EntityManager } from '@mikro-orm/knex';
 import { EntityRepository } from '@mikro-orm/knex';
@@ -8,8 +7,6 @@ import { MongoDriver, MongoEntityRepository } from '@mikro-orm/mongodb';
 
 const methods = {
   getReference: jest.fn(),
-  persist: jest.fn(),
-  persistAndFlush: jest.fn(),
   createQueryBuilder: jest.fn(),
   qb: jest.fn(),
   findOne: jest.fn(),
@@ -19,9 +16,6 @@ const methods = {
   find: jest.fn(),
   findAndCount: jest.fn(),
   findByCursor: jest.fn(),
-  remove: jest.fn(),
-  removeAndFlush: jest.fn(),
-  flush: jest.fn(),
   canPopulate: jest.fn(),
   populate: jest.fn(),
   count: jest.fn(),
@@ -49,10 +43,6 @@ describe('EntityRepository', () => {
     repo.getReference('bar');
     expect(methods.getReference.mock.calls[0]).toEqual([Publisher, 'bar', undefined]);
     const e = Object.create(Publisher.prototype);
-    repo.persist(e);
-    expect(methods.persist.mock.calls[0]).toEqual([e]);
-    await repo.persistAndFlush(e);
-    expect(methods.persistAndFlush.mock.calls[0]).toEqual([e]);
     await repo.find({ name: 'bar' });
     expect(methods.find.mock.calls[0]).toEqual([Publisher, { name: 'bar' }, undefined]);
     await repo.findAndCount({ name: 'bar' });
@@ -71,11 +61,6 @@ describe('EntityRepository', () => {
     expect(methods.createQueryBuilder.mock.calls[0]).toEqual([Publisher, undefined]);
     await repo.qb();
     expect(methods.createQueryBuilder.mock.calls[0]).toEqual([Publisher, undefined]);
-    repo.remove(e);
-    expect(methods.remove.mock.calls[0]).toEqual([e]);
-    const entity = {} as AnyEntity;
-    await repo.removeAndFlush(entity);
-    expect(methods.removeAndFlush.mock.calls[0]).toEqual([entity]);
     await repo.create({ name: 'bar' });
     expect(methods.create.mock.calls[0]).toEqual([Publisher, { name: 'bar' }]);
     await repo.assign(e, { name: 'bar' });

--- a/tests/features/events/events.mysql.test.ts
+++ b/tests/features/events/events.mysql.test.ts
@@ -50,14 +50,13 @@ describe('events (mysql)', () => {
     expect(Author2Subscriber.log).toEqual([]);
     Author2.beforeDestroyCalled = 0;
     Author2.afterDestroyCalled = 0;
-    const repo = orm.em.getRepository(Author2);
     const author = new Author2('Jon Snow', 'snow@wall.st');
     expect(author.id).toBeUndefined();
     expect(author.version).toBeUndefined();
     expect(author.versionAsString).toBeUndefined();
     expect(author.hookParams).toHaveLength(0);
 
-    await repo.persistAndFlush(author);
+    await orm.em.persistAndFlush(author);
     expect(author.id).toBeDefined();
     expect(author.version).toBe(1);
     expect(author.versionAsString).toBe('v1');
@@ -65,7 +64,7 @@ describe('events (mysql)', () => {
     expect(author.hookParams[0].changeSet).toMatchObject({ entity: author, type: 'create', payload: { name: 'Jon Snow' } });
 
     author.name = 'John Snow';
-    await repo.persistAndFlush(author);
+    await orm.em.persistAndFlush(author);
     expect(author.version).toBe(2);
     expect(author.versionAsString).toBe('v2');
     expect(author.hookParams[2].em).toBe(orm.em);
@@ -73,13 +72,13 @@ describe('events (mysql)', () => {
 
     expect(Author2.beforeDestroyCalled).toBe(0);
     expect(Author2.afterDestroyCalled).toBe(0);
-    await repo.removeAndFlush(author);
+    await orm.em.removeAndFlush(author);
     expect(Author2.beforeDestroyCalled).toBe(1);
     expect(Author2.afterDestroyCalled).toBe(1);
 
     const author2 = new Author2('Johny Cash', 'johny@cash.com');
-    await repo.persistAndFlush(author2);
-    await repo.removeAndFlush(author2);
+    await orm.em.persistAndFlush(author2);
+    await orm.em.removeAndFlush(author2);
     expect(Author2.beforeDestroyCalled).toBe(2);
     expect(Author2.afterDestroyCalled).toBe(2);
 

--- a/tests/features/fulltext/full-text-search-tsvector.postgres.test.ts
+++ b/tests/features/fulltext/full-text-search-tsvector.postgres.test.ts
@@ -39,18 +39,15 @@ describe('full text search tsvector in postgres', () => {
   afterAll(() => orm.close(true));
 
   test('load entities', async () => {
-    const repo = orm.em.getRepository(Book);
-
     const book1 = new Book('My Life on The ? Wall, part 1');
-    await repo.persist(book1).flush();
+    await orm.em.persist(book1).flush();
 
+    const repo = orm.em.getRepository(Book);
     const fullTextBooks = (await repo.find({ searchableTitle: { $fulltext: 'life wall' } }))!;
     expect(fullTextBooks.length).toBe(1);
   });
 
   test('load entities (multi)', async () => {
-    const repo = orm.em.getRepository(Book);
-
     const book1 = new Book('My Life on The ? Wall, part 1');
     const book2 = new Book('My Life on The Wall, part 2');
     const book3 = new Book('My Life on The Wall, part 3');
@@ -58,9 +55,9 @@ describe('full text search tsvector in postgres', () => {
     const book5 = new Book('My Life on The House');
     const book6 = new Book(null);
 
-    repo.persist([book1, book2, book3, book4, book5, book6]);
-    await repo.flush();
+    await orm.em.persist([book1, book2, book3, book4, book5, book6]).flush();
 
+    const repo = orm.em.getRepository(Book);
     const fullTextBooks = (await repo.find({ searchableTitle: { $fulltext: 'life wall' } }))!;
     expect(fullTextBooks).toHaveLength(3);
   });

--- a/tests/issues/GH1902.test.ts
+++ b/tests/issues/GH1902.test.ts
@@ -90,21 +90,19 @@ describe('GH issue 1902', () => {
   });
 
   test(`GH issue 1902`, async () => {
-    const repoUser = orm.em.getRepository(UserEntity);
     const user = orm.em.create(UserEntity, { name: 'user one', email: 'one@email' });
-    await repoUser.persistAndFlush(user);
+    await orm.em.flush();
 
-    const repoTenant = orm.em.getRepository(TenantEntity);
     const tenant1 = orm.em.create(TenantEntity, { name: 'tenant one', schema: 'tenant_one' });
-    await repoTenant.persistAndFlush(tenant1);
+    await orm.em.flush();
     const tenant2 = orm.em.create(TenantEntity, { name: 'tenant two', schema: 'tenant_two' });
-    await repoTenant.persistAndFlush(tenant2);
+    await orm.em.flush();
 
     const repoUserTenant = orm.em.getRepository(UserTenantEntity);
-    const ut1 = orm.em.create(UserTenantEntity, { user, tenant: tenant1, isActive: true });
-    await repoTenant.persistAndFlush(ut1);
-    const ut2 = orm.em.create(UserTenantEntity, { user, tenant: tenant2, isActive: false });
-    await repoTenant.persistAndFlush(ut2);
+    orm.em.create(UserTenantEntity, { user, tenant: tenant1, isActive: true });
+    await orm.em.flush();
+    orm.em.create(UserTenantEntity, { user, tenant: tenant2, isActive: false });
+    await orm.em.flush();
     orm.em.clear();
 
     const findOpts = {

--- a/tests/issues/GH3988.test.ts
+++ b/tests/issues/GH3988.test.ts
@@ -89,8 +89,6 @@ afterAll(async () => {
 });
 
 it('should create and persist entity along with child entity', async () => {
-  const parentRepository = orm.em.fork().getRepository(ParentEntity);
-
   // Create parent
   const parent = new ParentEntity();
   parent.id = new Id(1);
@@ -104,7 +102,7 @@ it('should create and persist entity along with child entity', async () => {
   parent.children.add(child);
 
   const mock = mockLogger(orm);
-  await parentRepository.persistAndFlush(parent);
+  await orm.em.persistAndFlush(parent);
   expect(mock.mock.calls).toEqual([
     ['[query] begin'],
     ['[query] insert into `parent_entity` (`id`, `id2`) values (1, 2)'],

--- a/tests/issues/GH4057.test.ts
+++ b/tests/issues/GH4057.test.ts
@@ -20,12 +20,11 @@ test('null dates stay null when fetched', async () => {
 
   await orm.getSchemaGenerator().refreshDatabase();
 
-  const repo = orm.em.fork().getRepository(Test);
-  const c = repo.create({
+  orm.em.create(Test, {
     id: '123',
     date: undefined,
   });
-  await repo.persistAndFlush(c);
+  await orm.em.flush();
 
   const entity = await orm.em.fork().findOne(Test, '123');
 


### PR DESCRIPTION
Following methods are no longer available on the `EntityRepository` instance.

- `persist`
- `persistAndFlush`
- `remove`
- `removeAndFlush`
- `flush`

They were confusing as they gave a false sense of working with a scoped context (e.g. only with a `User` type), while in fact, they were only shortcuts for the same methods of underlying `EntityManager`. You should work with the `EntityManager` directly instead of using a repository when it comes to entity persistence, repositories should be treated as an extension point for custom logic (e.g. wrapping query builder usage).

```diff
-userRepository.persist(user);
-await userRepository.flush();
+em.persist(user);
+await em.flush();
```

> Alternatively, you can use the `repository.getEntityManager()` method to access those methods directly on the `EntityManager`.

If you want to keep those methods on the repository level, you can define custom base repository and use it globally:

```ts
import { EntityManager, EntityRepository, AnyEntity } from '@mikro-orm/mysql';

export class ExtendedEntityRepository<T extends object> extends EntityRepository<T> {

  persist(entity: AnyEntity | AnyEntity[]): EntityManager {
    return this.em.persist(entity);
  }

  async persistAndFlush(entity: AnyEntity | AnyEntity[]): Promise<void> {
    await this.em.persistAndFlush(entity);
  }

  remove(entity: AnyEntity): EntityManager {
    return this.em.remove(entity);
  }

  async removeAndFlush(entity: AnyEntity): Promise<void> {
    await this.em.removeAndFlush(entity);
  }

  async flush(): Promise<void> {
    return this.em.flush();
  }

}
```

And specify it in the ORM config:

```ts
MikroORM.init({
   entityRepository: () => ExtendedEntityRepository,
})
```

You might as well want to use the `EntityRepositoryType` symbol, possibly in a custom base entity.

Related: #3989