### PR TITLE
fix(migrations-mongodb): use loggerFactory

### DIFF
--- a/packages/migrations-mongodb/src/Migrator.ts
+++ b/packages/migrations-mongodb/src/Migrator.ts
@@ -83,7 +83,7 @@ export class Migrator implements IMigrator {
       migrations,
     });
 
-    const logger = this.config.get('logger');
+    const logger = (message: string) => this.config.getLogger().log('info', message);
     this.umzug.on('migrating', event => logger(`Processing '${event.name}'`));
     this.umzug.on('migrated', event => logger(`Applied '${event.name}'`));
     this.umzug.on('reverting', event => logger(`Processing '${event.name}'`));


### PR DESCRIPTION
I've noticed that `@mikro-orm/migrations` does not use the logger defined through `config.loggerFactory`, but instead uses the logger defined in `config.logger`. This is an attempt to fix that.