### PR TITLE
importing `Rel` without `import type` fails

### DIFF
--- a/docs/versioned_docs/version-5.6/relationships.md
+++ b/docs/versioned_docs/version-5.6/relationships.md
@@ -170,7 +170,7 @@ If you use ESM in your TypeScript project with `reflect-metadata`, you might fal
 To get around them, use the `Rel` mapped type. It is an identity type, which disables the problematic inference from `reflect-metadata`, that causes ESM projects to fail.
 
 ```ts
-import { Rel } from '@mikro-orm/core';
+import type { Rel } from '@mikro-orm/core';
 
 @Entity()
 export class Book {


### PR DESCRIPTION
The error message is as follows

```
The requested module '@mikro-orm/core' does not provide an export named 'Rel'
```