### PR TITLE
feat(core): add `MikroORM.initSync()` helper

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -66,13 +66,22 @@ const orm = await MikroORM.init<PostgreSqlDriver>({
 });
 ```
 
-If we are experiencing problems with folder based discovery, try using `mikro-orm debug` CLI command to check what paths are actually being used.
+If you are experiencing problems with folder based discovery, try using `mikro-orm debug` CLI command to check what paths are actually being used.
 
-> Since v4, we can also use file globs, like `./dist/app/**/entities/*.entity.js`.
+> Since v4, you can also use file globs, like `./dist/app/**/entities/*.entity.js`.
 
-We can also set the configuration via [environment variables](configuration.md#using-environment-variables).
+You can also set the configuration via [environment variables](configuration.md#using-environment-variables).
 
 > We can pass additional options to the underlying driver (e.g. `mysql2`) via `driverOptions`. The object will be deeply merged, overriding all internally used options.
+
+## Synchronous initialization
+
+As opposed to the async `MikroORM.init` method, you can prefer to use synchronous variant `initSync`. This method has some limitations:
+
+- database connection will be established when you first interact with the database (or you can use `orm.connect()` explicitly)
+- no loading of the `config` file, `options` parameter is mandatory
+- no support for folder based discovery
+- no check for mismatched package versions
 
 ## Possible issues with circular dependencies
 

--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -230,3 +230,7 @@ ref.age = raw(`age * 2`);
 await em.flush();
 console.log(ref.age); // real value is available after flush
 ```
+
+## Metadata CacheAdapter requires sync API
+
+To allow working with cache inside `MikroORM.initSync`, the metadata cache now enforces sync API. You should usually depend on the file-based cache for the metadata, which now uses sync methods to work with the file system.

--- a/packages/better-sqlite/src/BetterSqliteConnection.ts
+++ b/packages/better-sqlite/src/BetterSqliteConnection.ts
@@ -15,6 +15,7 @@ export class BetterSqliteConnection extends AbstractSqlConnection {
     this.getPatchedDialect();
     this.client = this.createKnexClient('better-sqlite3');
     await this.client.raw('pragma foreign_keys = on');
+    this.connected = true;
   }
 
   getDefaultClientUrl(): string {

--- a/packages/better-sqlite/src/BetterSqliteMikroORM.ts
+++ b/packages/better-sqlite/src/BetterSqliteMikroORM.ts
@@ -16,6 +16,13 @@ export class BetterSqliteMikroORM extends MikroORM<BetterSqliteDriver> {
     return super.init(options);
   }
 
+  /**
+   * @inheritDoc
+   */
+  static override initSync<D extends IDatabaseDriver = BetterSqliteDriver>(options: Options<D>): MikroORM<D> {
+    return super.initSync(options);
+  }
+
 }
 
 export type BetterSqliteOptions = Options<BetterSqliteDriver>;

--- a/packages/cli/src/commands/ClearCacheCommand.ts
+++ b/packages/cli/src/commands/ClearCacheCommand.ts
@@ -18,7 +18,7 @@ export class ClearCacheCommand implements CommandModule {
       return;
     }
 
-    const cache = config.getCacheAdapter();
+    const cache = config.getMetadataCacheAdapter();
     await cache.clear();
 
     CLIHelper.dump(colors.green('Metadata cache was successfully cleared'));

--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -66,6 +66,38 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
     return orm;
   }
 
+  /**
+   * Synchronous variant of the `init` method with some limitations:
+   * - database connection will be established when you first interact with the database (or you can use `orm.connect()` explicitly)
+   * - no loading of the `config` file, `options` parameter is mandatory
+   * - no support for folder based discovery
+   * - no check for mismatched package versions
+   */
+  static initSync<D extends IDatabaseDriver = IDatabaseDriver>(options: Options<D>): MikroORM<D> {
+    ConfigurationLoader.registerDotenv(options);
+    const env = ConfigurationLoader.loadEnvironmentVars<D>();
+    options = Utils.merge(options, env);
+
+    if ('DRIVER' in this && !options!.driver) {
+      (options as Options).driver = (this as unknown as { DRIVER: Constructor<IDatabaseDriver> }).DRIVER;
+    }
+
+    const orm = new MikroORM(options!);
+
+    // we need to allow global context here as we are not in a scope of requests yet
+    const allowGlobalContext = orm.config.get('allowGlobalContext');
+    orm.config.set('allowGlobalContext', true);
+    orm.discoverEntitiesSync();
+    orm.config.set('allowGlobalContext', allowGlobalContext);
+    orm.driver.getPlatform().lookupExtensions(orm);
+
+    for (const extension of orm.config.get('extensions')) {
+      extension.register(orm);
+    }
+
+    return orm;
+  }
+
   constructor(options: Options<D> | Configuration<D>) {
     if (options instanceof Configuration) {
       this.config = options;
@@ -135,8 +167,8 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
       await this.driver.close(force);
     }
 
-    if (this.config.getCacheAdapter()?.close) {
-      await this.config.getCacheAdapter().close!();
+    if (this.config.getMetadataCacheAdapter()?.close) {
+      await this.config.getMetadataCacheAdapter().close!();
     }
 
     if (this.config.getResultCacheAdapter()?.close) {
@@ -154,6 +186,15 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
 
   async discoverEntities(): Promise<void> {
     this.metadata = await this.discovery.discover(this.config.get('tsNode'));
+    this.createEntityManager();
+  }
+
+  discoverEntitiesSync(): void {
+    this.metadata = this.discovery.discoverSync(this.config.get('tsNode'));
+    this.createEntityManager();
+  }
+
+  private createEntityManager(): void {
     this.driver.setMetadata(this.metadata);
     this.em = this.driver.createEntityManager<D>();
     (this.em as { global: boolean }).global = true;
@@ -164,11 +205,11 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Allows dynamically discovering new entity by reference, handy for testing schema diffing.
    */
-  async discoverEntity(entities: Constructor | Constructor[]): Promise<void> {
+  discoverEntity(entities: Constructor | Constructor[]): void {
     entities = Utils.asArray(entities);
-    const tmp = await this.discovery.discoverReferences(entities);
+    const tmp = this.discovery.discoverReferences(entities);
     new MetadataValidator().validateDiscovered([...Object.values(this.metadata.getAll()), ...tmp], this.config.get('discovery').warnWhenNoEntities!);
-    const metadata = await this.discovery.processDiscoveredEntities(tmp);
+    const metadata = this.discovery.processDiscoveredEntities(tmp);
     metadata.forEach(meta => this.metadata.set(meta.className, meta));
     this.metadata.decorate(this.em);
   }

--- a/packages/core/src/cache/CacheAdapter.ts
+++ b/packages/core/src/cache/CacheAdapter.ts
@@ -3,26 +3,45 @@ export interface CacheAdapter {
   /**
    * Gets the items under `name` key from the cache.
    */
-  get(name: string): Promise<any>;
+  get<T = any>(name: string): T | Promise<T> | undefined;
 
   /**
    * Sets the item to the cache. `origin` is used for cache invalidation and should reflect the change in data.
    */
-  set(name: string, data: any, origin: string, expiration?: number): Promise<void>;
+  set(name: string, data: any, origin: string, expiration?: number): void | Promise<void>;
 
   /**
    * Removes the item from cache.
    */
-  remove(name: string): Promise<void>;
+  remove(name: string): void | Promise<void>;
 
   /**
    * Clears all items stored in the cache.
    */
-  clear(): Promise<void>;
+  clear(): void | Promise<void>;
 
   /**
    * Called inside `MikroORM.close()` Allows graceful shutdowns (e.g. for redis).
    */
-  close?(): Promise<void>;
+  close?(): void | Promise<void>;
+
+}
+
+export interface SyncCacheAdapter extends CacheAdapter {
+
+  /**
+   * Gets the items under `name` key from the cache.
+   */
+  get<T = any>(name: string): T | undefined;
+
+  /**
+   * Sets the item to the cache. `origin` is used for cache invalidation and should reflect the change in data.
+   */
+  set(name: string, data: any, origin: string, expiration?: number): void;
+
+  /**
+   * Removes the item from cache.
+   */
+  remove(name: string): void;
 
 }

--- a/packages/core/src/cache/FileCacheAdapter.ts
+++ b/packages/core/src/cache/FileCacheAdapter.ts
@@ -1,10 +1,10 @@
 import globby from 'globby';
-import { ensureDir, pathExists, readFile, readJSON, unlink, writeJSON } from 'fs-extra';
+import { ensureDirSync, pathExistsSync, readFileSync, readJSONSync, unlinkSync, writeJSONSync } from 'fs-extra';
 
-import type { CacheAdapter } from './CacheAdapter';
+import type { SyncCacheAdapter } from './CacheAdapter';
 import { Utils } from '../utils/Utils';
 
-export class FileCacheAdapter implements CacheAdapter {
+export class FileCacheAdapter implements SyncCacheAdapter {
 
   private readonly VERSION = Utils.getORMVersion();
 
@@ -15,15 +15,15 @@ export class FileCacheAdapter implements CacheAdapter {
   /**
    * @inheritDoc
    */
-  async get(name: string): Promise<any> {
-    const path = await this.path(name);
+  get(name: string): any {
+    const path = this.path(name);
 
-    if (!await pathExists(path)) {
+    if (!pathExistsSync(path)) {
       return null;
     }
 
-    const payload = await readJSON(path);
-    const hash = await this.getHash(payload.origin);
+    const payload = readJSONSync(path);
+    const hash = this.getHash(payload.origin);
 
     if (!hash || payload.hash !== hash) {
       return null;
@@ -35,46 +35,43 @@ export class FileCacheAdapter implements CacheAdapter {
   /**
    * @inheritDoc
    */
-  async set(name: string, data: any, origin: string): Promise<void> {
-    const [path, hash] = await Promise.all([
-      this.path(name),
-      this.getHash(origin),
-    ]);
-
+  set(name: string, data: any, origin: string): void {
+    const path = this.path(name);
+    const hash = this.getHash(origin);
     const opts = this.pretty ? { spaces: 2 } : {};
-    await writeJSON(path!, { data, origin, hash, version: this.VERSION }, opts);
+    writeJSONSync(path!, { data, origin, hash, version: this.VERSION }, opts);
   }
 
   /**
    * @inheritDoc
    */
-  async remove(name: string): Promise<void> {
-    const path = await this.path(name);
-    await unlink(path);
+  remove(name: string): void {
+    const path = this.path(name);
+    unlinkSync(path);
   }
 
   /**
    * @inheritDoc
    */
-  async clear(): Promise<void> {
-    const path = await this.path('*');
-    const files = await globby(path);
-    await Promise.all(files.map(file => unlink(file)));
+  clear(): void {
+    const path = this.path('*');
+    const files = globby.sync(path);
+    files.forEach(file => unlinkSync(file));
   }
 
-  private async path(name: string): Promise<string> {
-    await ensureDir(this.options.cacheDir);
+  private path(name: string): string {
+    ensureDirSync(this.options.cacheDir);
     return `${this.options.cacheDir}/${name}.json`;
   }
 
-  private async getHash(origin: string): Promise<string | null> {
+  private getHash(origin: string): string | null {
     origin = Utils.absolutePath(origin, this.baseDir);
 
-    if (!await pathExists(origin)) {
+    if (!pathExistsSync(origin)) {
       return null;
     }
 
-    const contents = await readFile(origin);
+    const contents = readFileSync(origin);
 
     return Utils.hash(contents.toString() + this.VERSION);
   }

--- a/packages/core/src/cache/MemoryCacheAdapter.ts
+++ b/packages/core/src/cache/MemoryCacheAdapter.ts
@@ -9,7 +9,7 @@ export class MemoryCacheAdapter implements CacheAdapter {
   /**
    * @inheritDoc
    */
-  async get<T = any>(name: string): Promise<T | undefined> {
+  get<T = any>(name: string): T | undefined {
     const data = this.data.get(name);
 
     if (data) {
@@ -26,21 +26,21 @@ export class MemoryCacheAdapter implements CacheAdapter {
   /**
    * @inheritDoc
    */
-  async set(name: string, data: any, origin: string, expiration?: number): Promise<void> {
+  set(name: string, data: any, origin: string, expiration?: number): void {
     this.data.set(name, { data, expiration: Date.now() + (expiration ?? this.options.expiration) });
   }
 
   /**
    * @inheritDoc
    */
-  async remove(name: string): Promise<void> {
+  remove(name: string): void {
     this.data.delete(name);
   }
 
   /**
    * @inheritDoc
    */
-  async clear(): Promise<void> {
+  clear(): void {
     this.data.clear();
   }
 

--- a/packages/core/src/cache/NullCacheAdapter.ts
+++ b/packages/core/src/cache/NullCacheAdapter.ts
@@ -1,32 +1,32 @@
-import type { CacheAdapter } from './CacheAdapter';
+import type { SyncCacheAdapter } from './CacheAdapter';
 
-export class NullCacheAdapter implements CacheAdapter {
+export class NullCacheAdapter implements SyncCacheAdapter {
 
   /**
    * @inheritDoc
    */
-  async get(name: string): Promise<any> {
+  get(name: string): any {
     return null;
   }
 
   /**
    * @inheritDoc
    */
-  async set(name: string, data: any, origin: string): Promise<void> {
+  set(name: string, data: any, origin: string): void {
     // ignore
   }
 
   /**
    * @inheritDoc
    */
-  async remove(name: string): Promise<void> {
+  remove(name: string): void {
     // ignore
   }
 
   /**
    * @inheritDoc
    */
-  async clear(): Promise<void> {
+  clear(): void {
     // ignore
   }
 

--- a/packages/core/src/connections/Connection.ts
+++ b/packages/core/src/connections/Connection.ts
@@ -14,6 +14,7 @@ export abstract class Connection {
   protected readonly options: ConnectionOptions;
   protected abstract client: unknown;
   protected readonly logger = this.config.getLogger();
+  protected connected = false;
 
   constructor(protected readonly config: Configuration,
               options?: ConnectionOptions,
@@ -32,7 +33,7 @@ export abstract class Connection {
   /**
    * Establishes connection to database
    */
-  abstract connect(): Promise<void>;
+  abstract connect(): void | Promise<void>;
 
   /**
    * Are we connected to the database
@@ -46,6 +47,15 @@ export abstract class Connection {
     Object.keys(this.options)
       .filter(k => k !== 'name')
       .forEach(k => delete this.options[k as keyof ConnectionOptions]);
+  }
+
+  /**
+   * Ensure the connection exists, this is used to support lazy connect when using `MikroORM.initSync()`
+   */
+  async ensureConnection(): Promise<void> {
+    if (!this.connected) {
+      await this.connect();
+    }
   }
 
   /**

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -19,7 +19,7 @@ export class MetadataDiscovery {
 
   private readonly namingStrategy = this.config.getNamingStrategy();
   private readonly metadataProvider = this.config.getMetadataProvider();
-  private readonly cache = this.config.getCacheAdapter();
+  private readonly cache = this.config.getMetadataCacheAdapter();
   private readonly logger = this.config.getLogger();
   private readonly schemaHelper = this.platform.getSchemaHelper();
   private readonly validator = new MetadataValidator();
@@ -33,11 +33,27 @@ export class MetadataDiscovery {
     const startTime = Date.now();
     this.logger.log('discovery', `ORM entity discovery started, using ${colors.cyan(this.metadataProvider.constructor.name)}`);
     await this.findEntities(preferTsNode);
-    await this.processDiscoveredEntities(this.discovered);
+    this.processDiscoveredEntities(this.discovered);
 
     const diff = Date.now() - startTime;
     this.logger.log('discovery', `- entity discovery finished, found ${colors.green('' + this.discovered.length)} entities, took ${colors.green(`${diff} ms`)}`);
 
+    return this.mapDiscoveredEntities();
+  }
+
+  discoverSync(preferTsNode = true): MetadataStorage {
+    const startTime = Date.now();
+    this.logger.log('discovery', `ORM entity discovery started, using ${colors.cyan(this.metadataProvider.constructor.name)} in sync mode`);
+    this.findEntities(preferTsNode, true);
+    this.processDiscoveredEntities(this.discovered);
+
+    const diff = Date.now() - startTime;
+    this.logger.log('discovery', `- entity discovery finished, found ${colors.green('' + this.discovered.length)} entities, took ${colors.green(`${diff} ms`)}`);
+
+    return this.mapDiscoveredEntities();
+  }
+
+  private mapDiscoveredEntities(): MetadataStorage {
     const discovered = new MetadataStorage();
 
     this.discovered
@@ -51,7 +67,7 @@ export class MetadataDiscovery {
     return discovered;
   }
 
-  async processDiscoveredEntities(discovered: EntityMetadata[]): Promise<EntityMetadata[]> {
+  processDiscoveredEntities(discovered: EntityMetadata[]): EntityMetadata[] {
     for (const meta of discovered) {
       let i = 1;
       Object.values(meta.properties).forEach(prop => meta.propertyOrder.set(prop.name, i++));
@@ -76,7 +92,7 @@ export class MetadataDiscovery {
 
     for (const meta of filtered) {
       for (const prop of Object.values(meta.properties)) {
-        await this.initColumnType(meta, prop, meta.path);
+        this.initColumnType(prop);
       }
     }
 
@@ -84,7 +100,7 @@ export class MetadataDiscovery {
     filtered.forEach(meta => this.autoWireBidirectionalProperties(meta));
 
     for (const meta of filtered) {
-      discovered.push(...await this.processEntity(meta));
+      discovered.push(...this.processEntity(meta));
     }
 
     discovered.forEach(meta => meta.sync(true));
@@ -92,26 +108,37 @@ export class MetadataDiscovery {
     return discovered.map(meta => this.metadata.get(meta.className));
   }
 
-  private async findEntities(preferTsNode: boolean): Promise<EntityMetadata[]> {
+  private findEntities(preferTsNode: boolean, sync: true): EntityMetadata[];
+  private findEntities(preferTsNode: boolean, sync?: false): Promise<EntityMetadata[]>;
+  private findEntities(preferTsNode: boolean, sync = false): EntityMetadata[] | Promise<EntityMetadata[]> {
     this.discovered.length = 0;
 
     const key = (preferTsNode && this.config.get('tsNode', Utils.detectTsNode()) && this.config.get('entitiesTs').length > 0) ? 'entitiesTs' : 'entities';
     const paths = this.config.get(key).filter(item => Utils.isString(item)) as string[];
     const refs = this.config.get(key).filter(item => !Utils.isString(item)) as Constructor<AnyEntity>[];
 
-    if (this.config.get('discovery').requireEntitiesArray && paths.length > 0) {
-      throw new Error(`[requireEntitiesArray] Explicit list of entities is required, please use the 'entities' option.`);
+    if (paths.length > 0) {
+      if (sync || this.config.get('discovery').requireEntitiesArray) {
+        throw new Error(`[requireEntitiesArray] Explicit list of entities is required, please use the 'entities' option.`);
+      }
+
+      return this.discoverDirectories(paths).then(() => {
+        this.discoverReferences(refs);
+        this.discoverMissingTargets();
+        this.validator.validateDiscovered(this.discovered, this.config.get('discovery').warnWhenNoEntities!);
+
+        return this.discovered;
+      });
     }
 
-    await this.discoverDirectories(paths);
-    await this.discoverReferences(refs);
-    await this.discoverMissingTargets();
+    this.discoverReferences(refs);
+    this.discoverMissingTargets();
     this.validator.validateDiscovered(this.discovered, this.config.get('discovery').warnWhenNoEntities!);
 
     return this.discovered;
   }
 
-  private async discoverMissingTargets(): Promise<void> {
+  private discoverMissingTargets(): void {
     const unwrap = (type: string) => type
       .replace(/Array<(.*)>/, '$1') // unwrap array
       .replace(/\[]$/, '')          // remove array suffix
@@ -136,15 +163,15 @@ export class MetadataDiscovery {
     }));
 
     if (missing.length > 0) {
-      await this.tryDiscoverTargets(missing);
+      this.tryDiscoverTargets(missing);
     }
   }
 
-  private async tryDiscoverTargets(targets: Constructor[]): Promise<void> {
+  private tryDiscoverTargets(targets: Constructor[]): void {
     for (const target of targets) {
       if (typeof target === 'function' && target.name && !this.metadata.has(target.name)) {
-        await this.discoverReferences([target]);
-        await this.discoverMissingTargets();
+        this.discoverReferences([target]);
+        this.discoverMissingTargets();
       }
     }
   }
@@ -194,11 +221,11 @@ export class MetadataDiscovery {
     }
 
     for (const [entity, path] of found) {
-      await this.discoverEntity(entity, path);
+      this.discoverEntity(entity, path);
     }
   }
 
-  async discoverReferences<T>(refs: Constructor<T>[]): Promise<EntityMetadata<T>[]> {
+  discoverReferences<T>(refs: Constructor<T>[]): EntityMetadata<T>[] {
     const found: Constructor<T>[] = [];
 
     for (const entity of refs) {
@@ -209,7 +236,7 @@ export class MetadataDiscovery {
     }
 
     for (const entity of found) {
-      await this.discoverEntity(entity);
+      this.discoverEntity(entity);
     }
 
     // discover parents (base entities) automatically
@@ -221,7 +248,7 @@ export class MetadataDiscovery {
       const parent = Object.getPrototypeOf(meta.class);
 
       if (parent.name !== '' && !this.metadata.has(parent.name)) {
-        await this.discoverReferences([parent]);
+        this.discoverReferences([parent]);
       }
     }
 
@@ -271,7 +298,7 @@ export class MetadataDiscovery {
     return schema;
   }
 
-  private async discoverEntity<T>(entity: EntityClass<T> | EntityClassGroup<T> | EntitySchema<T>, path?: string): Promise<void> {
+  private discoverEntity<T>(entity: EntityClass<T> | EntityClassGroup<T> | EntitySchema<T>, path?: string): void {
     entity = this.prepare(entity);
     this.logger.log('discovery', `- processing entity ${colors.cyan((entity as EntityClass<T>).name)}${colors.grey(path ? ` (${path})` : '')}`);
     const schema = this.getSchema(entity as Constructor<T>);
@@ -279,7 +306,7 @@ export class MetadataDiscovery {
     const root = Utils.getRootEntity(this.metadata, meta);
     this.metadata.set(meta.className, meta);
     schema.meta.path = Utils.relativePath(path || meta.path, this.config.get('baseDir'));
-    const cache = meta.useCache && meta.path && await this.cache.get(meta.className + extname(meta.path));
+    const cache = meta.useCache && meta.path && this.cache.get(meta.className + extname(meta.path));
 
     if (cache) {
       this.logger.log('discovery', `- using cached metadata for entity ${colors.cyan(meta.className)}`);
@@ -294,7 +321,7 @@ export class MetadataDiscovery {
     Utils.values(meta.properties).forEach(prop => this.inferDefaultValue(meta, prop));
 
     // if the definition is using EntitySchema we still want it to go through the metadata provider to validate no types are missing
-    await this.metadataProvider.loadEntityMetadata(meta, meta.className);
+    this.metadataProvider.loadEntityMetadata(meta, meta.className);
 
     if (!meta.collection && meta.name) {
       const entityName = root.discriminatorColumn ? root.name : meta.name;
@@ -302,12 +329,12 @@ export class MetadataDiscovery {
     }
 
     delete (meta as any).root; // to allow caching (as root can contain cycles)
-    await this.saveToCache(meta);
+    this.saveToCache(meta);
     meta.root = root;
     this.discovered.push(meta);
   }
 
-  private async saveToCache<T>(meta: EntityMetadata): Promise<void> {
+  private saveToCache<T>(meta: EntityMetadata): void {
     if (!meta.useCache) {
       return;
     }
@@ -325,7 +352,7 @@ export class MetadataDiscovery {
 
     // base entity without properties might not have path, but nothing to cache there
     if (meta.path) {
-      await this.cache.set(meta.className + extname(meta.path), copy, meta.path);
+      this.cache.set(meta.className + extname(meta.path), copy, meta.path);
     }
   }
 
@@ -472,7 +499,7 @@ export class MetadataDiscovery {
     }
   }
 
-  private async processEntity(meta: EntityMetadata): Promise<EntityMetadata[]> {
+  private processEntity(meta: EntityMetadata): EntityMetadata[] {
     const pks = Object.values(meta.properties).filter(prop => prop.primary);
     meta.primaryKeys = pks.map(prop => prop.name);
     meta.compositePK = pks.length > 1;
@@ -491,7 +518,7 @@ export class MetadataDiscovery {
       this.initDefaultValue(prop);
       this.initVersionProperty(meta, prop);
       this.initCustomType(meta, prop);
-      await this.initColumnType(meta, prop, meta.path);
+      this.initColumnType(prop);
       this.initRelation(prop);
     }
 
@@ -502,18 +529,13 @@ export class MetadataDiscovery {
       serializedPKProp.persist = false;
     }
 
-    const ret: EntityMetadata[] = [];
-
     if (this.platform.usesPivotTable()) {
-      const pivotProps = Object.values(meta.properties).filter(prop => {
-        return prop.kind === ReferenceKind.MANY_TO_MANY && prop.owner && prop.pivotTable;
-      });
-      await Utils.runSerial(pivotProps, async prop => {
-        return ret.push(await this.definePivotTableEntity(meta, prop));
-      });
+      return Object.values(meta.properties)
+        .filter(prop => prop.kind === ReferenceKind.MANY_TO_MANY && prop.owner && prop.pivotTable)
+        .map(prop => this.definePivotTableEntity(meta, prop));
     }
 
-    return ret;
+    return [];
   }
 
   private initFactoryField<T>(meta: EntityMetadata<T>, prop: EntityProperty<T>): void {
@@ -546,7 +568,7 @@ export class MetadataDiscovery {
     return [first, second];
   }
 
-  private async definePivotTableEntity(meta: EntityMetadata, prop: EntityProperty): Promise<EntityMetadata> {
+  private definePivotTableEntity(meta: EntityMetadata, prop: EntityProperty): EntityMetadata {
     const pivotMeta = this.metadata.find(prop.pivotEntity);
 
     if (pivotMeta) {
@@ -573,7 +595,7 @@ export class MetadataDiscovery {
     prop.pivotEntity = data.className;
 
     if (prop.fixedOrder) {
-      const primaryProp = await this.defineFixedOrderProperty(meta, prop, targetType);
+      const primaryProp = this.defineFixedOrderProperty(prop, targetType);
       data.properties[primaryProp.name] = primaryProp;
     } else {
       data.compositePK = true;
@@ -591,13 +613,13 @@ export class MetadataDiscovery {
       }
     }
 
-    data.properties[meta.root.name + '_owner'] = await this.definePivotProperty(prop, meta.root.name + '_owner', meta.root.name!, targetType + '_inverse', true);
-    data.properties[targetType + '_inverse'] = await this.definePivotProperty(prop, targetType + '_inverse', targetType, meta.root.name + '_owner', false);
+    data.properties[meta.root.name + '_owner'] = this.definePivotProperty(prop, meta.root.name + '_owner', meta.root.name!, targetType + '_inverse', true);
+    data.properties[targetType + '_inverse'] = this.definePivotProperty(prop, targetType + '_inverse', targetType, meta.root.name + '_owner', false);
 
     return this.metadata.set(data.className, data);
   }
 
-  private async defineFixedOrderProperty(meta: EntityMetadata, prop: EntityProperty, targetType: string): Promise<EntityProperty> {
+  private defineFixedOrderProperty(prop: EntityProperty, targetType: string): EntityProperty {
     const pk = prop.fixedOrderColumn || this.namingStrategy.referenceColumnName();
     const primaryProp = {
       name: pk,
@@ -608,7 +630,7 @@ export class MetadataDiscovery {
       unsigned: this.platform.supportsUnsigned(),
     } as EntityProperty;
     this.initFieldName(primaryProp);
-    await this.initColumnType(meta, primaryProp);
+    this.initColumnType(primaryProp);
     prop.fixedOrderColumn = pk;
 
     if (prop.inversedBy) {
@@ -620,7 +642,7 @@ export class MetadataDiscovery {
     return primaryProp;
   }
 
-  private async definePivotProperty(prop: EntityProperty, name: string, type: string, inverse: string, owner: boolean): Promise<EntityProperty> {
+  private definePivotProperty(prop: EntityProperty, name: string, type: string, inverse: string, owner: boolean): EntityProperty {
     const ret = {
       name,
       type,
@@ -668,7 +690,7 @@ export class MetadataDiscovery {
       });
     }
 
-    await this.initColumnType(meta, ret);
+    this.initColumnType(ret);
 
     return ret;
   }
@@ -1081,7 +1103,7 @@ export class MetadataDiscovery {
     prop.targetMeta = meta2;
   }
 
-  private async initColumnType(meta: EntityMetadata, prop: EntityProperty, path?: string): Promise<void> {
+  private initColumnType(prop: EntityProperty): void {
     this.initUnsigned(prop);
     this.metadata.find(prop.type)?.getPrimaryProps().map(pk => {
       prop.length ??= pk.length;
@@ -1091,10 +1113,6 @@ export class MetadataDiscovery {
 
     if (prop.columnTypes || !this.schemaHelper) {
       return;
-    }
-
-    if (prop.enum && !prop.items && prop.type && path) {
-      await this.initEnumValues(meta, prop, path);
     }
 
     if (prop.kind === ReferenceKind.SCALAR) {
@@ -1113,7 +1131,7 @@ export class MetadataDiscovery {
 
     for (const pk of targetMeta.getPrimaryProps()) {
       this.initCustomType(targetMeta, pk);
-      await this.initColumnType(targetMeta, pk);
+      this.initColumnType(pk);
 
       const mappedType = this.getMappedType(pk);
       let columnTypes = pk.columnTypes;
@@ -1142,26 +1160,6 @@ export class MetadataDiscovery {
     }
 
     return prop.customType ?? this.platform.getMappedType(t);
-  }
-
-  private async initEnumValues(meta: EntityMetadata, prop: EntityProperty, path: string): Promise<void> {
-    path = Utils.normalizePath(this.config.get('baseDir'), path);
-    const exports: Dictionary = {};
-
-    /* istanbul ignore next */
-    try {
-      Object.assign(exports, await Utils.dynamicImport(path));
-    } catch (e) {
-      throw new Error(`Unable to discover enum values for ${meta.className}.${prop.name}, specify the type via decorator options: @Enum({ items: () => YourEnumType })`);
-    }
-
-    /* istanbul ignore next */
-    const target = exports[prop.type] || exports.default;
-
-    if (target) {
-      const items = Utils.extractEnumValues(target);
-      Utils.defaultValue(prop, 'items', items);
-    }
   }
 
   private initUnsigned(prop: EntityProperty): void {

--- a/packages/core/src/metadata/MetadataProvider.ts
+++ b/packages/core/src/metadata/MetadataProvider.ts
@@ -10,7 +10,7 @@ export abstract class MetadataProvider {
 
   constructor(protected readonly config: IConfiguration) { }
 
-  abstract loadEntityMetadata(meta: EntityMetadata, name: string): Promise<void>;
+  abstract loadEntityMetadata(meta: EntityMetadata, name: string): void;
 
   /**
    * Re-hydrates missing attributes like `customType` (functions/instances are lost when caching to JSON)
@@ -33,20 +33,6 @@ export abstract class MetadataProvider {
 
   useCache(): boolean {
     return this.config.get('metadataCache').enabled ?? false;
-  }
-
-  protected async initProperties(meta: EntityMetadata, fallback: (prop: EntityProperty) => void | Promise<void>): Promise<void> {
-    // load types and column names
-    for (const prop of Object.values(meta.properties)) {
-      if (Utils.isString(prop.entity)) {
-        prop.type = prop.entity;
-      } else if (prop.entity) {
-        const tmp = prop.entity();
-        prop.type = Array.isArray(tmp) ? tmp.map(t => Utils.className(t)).sort().join(' | ') : Utils.className(tmp);
-      } else if (!prop.type) {
-        await fallback(prop);
-      }
-    }
   }
 
 }

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -1,6 +1,6 @@
 import { pathExistsSync } from 'fs-extra';
 import type { NamingStrategy } from '../naming-strategy';
-import type { CacheAdapter } from '../cache';
+import type { CacheAdapter, SyncCacheAdapter } from '../cache';
 import { FileCacheAdapter, NullCacheAdapter } from '../cache';
 import type { EntityRepository } from '../entity/EntityRepository';
 import type {
@@ -264,9 +264,9 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
   }
 
   /**
-   * Gets instance of CacheAdapter. (cached)
+   * Gets instance of metadata CacheAdapter. (cached)
    */
-  getCacheAdapter(): CacheAdapter {
+  getMetadataCacheAdapter(): SyncCacheAdapter {
     return this.getCachedService(this.options.metadataCache.adapter!, this.options.metadataCache.options, this.options.baseDir, this.options.metadataCache.pretty);
   }
 
@@ -547,7 +547,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
   metadataCache: {
     enabled?: boolean;
     pretty?: boolean;
-    adapter?: { new(...params: any[]): CacheAdapter };
+    adapter?: { new(...params: any[]): SyncCacheAdapter };
     options?: Dictionary;
   };
   resultCache: {

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "rootDir": "./src"
   },
   "include": ["src/**/*"]
 }

--- a/packages/knex/src/AbstractSqlConnection.ts
+++ b/packages/knex/src/AbstractSqlConnection.ts
@@ -104,6 +104,8 @@ export abstract class AbstractSqlConnection extends Connection {
   }
 
   async execute<T extends QueryResult | EntityData<AnyEntity> | EntityData<AnyEntity>[] = EntityData<AnyEntity>[]>(queryOrKnex: string | Knex.QueryBuilder | Knex.Raw, params: unknown[] = [], method: 'all' | 'get' | 'run' = 'all', ctx?: Transaction): Promise<T> {
+    await this.ensureConnection();
+
     if (Utils.isObject<Knex.QueryBuilder | Knex.Raw>(queryOrKnex)) {
       ctx ??= ((queryOrKnex as any).client.transacting ? queryOrKnex : null);
       const q = queryOrKnex.toSQL();

--- a/packages/mariadb/src/MariaDbConnection.ts
+++ b/packages/mariadb/src/MariaDbConnection.ts
@@ -4,8 +4,9 @@ import { AbstractSqlConnection, MonkeyPatchable } from '@mikro-orm/knex';
 
 export class MariaDbConnection extends AbstractSqlConnection {
 
-  async connect(): Promise<void> {
+  connect(): void {
     this.client = this.createKnexClient(this.getPatchedDialect());
+    this.connected = true;
   }
 
   private getPatchedDialect() {

--- a/packages/mariadb/src/MariaDbMikroORM.ts
+++ b/packages/mariadb/src/MariaDbMikroORM.ts
@@ -16,6 +16,13 @@ export class MariaDbMikroORM extends MikroORM<MariaDbDriver> {
     return super.init(options);
   }
 
+  /**
+   * @inheritDoc
+   */
+  static override initSync<D extends IDatabaseDriver = MariaDbDriver>(options: Options<D>): MikroORM<D> {
+    return super.initSync(options);
+  }
+
 }
 
 export type MariaDbOptions = Options<MariaDbDriver>;

--- a/packages/mongodb/src/MongoMikroORM.ts
+++ b/packages/mongodb/src/MongoMikroORM.ts
@@ -16,6 +16,13 @@ export class MongoMikroORM extends MikroORM<MongoDriver> {
     return super.init(options);
   }
 
+  /**
+   * @inheritDoc
+   */
+  static override initSync<D extends IDatabaseDriver = MongoDriver>(options: Options<D>): MikroORM<D> {
+    return super.initSync(options);
+  }
+
 }
 
 export type MongoOptions = Options<MongoDriver>;

--- a/packages/mysql/src/MySqlConnection.ts
+++ b/packages/mysql/src/MySqlConnection.ts
@@ -3,9 +3,10 @@ import { AbstractSqlConnection, MonkeyPatchable } from '@mikro-orm/knex';
 
 export class MySqlConnection extends AbstractSqlConnection {
 
-  async connect(): Promise<void> {
+  connect(): void {
     this.patchKnex();
     this.client = this.createKnexClient('mysql2');
+    this.connected = true;
   }
 
   private patchKnex() {

--- a/packages/mysql/src/MySqlMikroORM.ts
+++ b/packages/mysql/src/MySqlMikroORM.ts
@@ -16,6 +16,13 @@ export class MySqlMikroORM extends MikroORM<MySqlDriver> {
     return super.init(options);
   }
 
+  /**
+   * @inheritDoc
+   */
+  static override initSync<D extends IDatabaseDriver = MySqlDriver>(options: Options<D>): MikroORM<D> {
+    return super.initSync(options);
+  }
+
 }
 
 export type MySqlOptions = Options<MySqlDriver>;

--- a/packages/postgresql/src/PostgreSqlConnection.ts
+++ b/packages/postgresql/src/PostgreSqlConnection.ts
@@ -5,9 +5,10 @@ import { AbstractSqlConnection, MonkeyPatchable } from '@mikro-orm/knex';
 
 export class PostgreSqlConnection extends AbstractSqlConnection {
 
-  async connect(): Promise<void> {
+  connect(): void {
     this.patchKnex();
     this.client = this.createKnexClient('pg');
+    this.connected = true;
   }
 
   getDefaultClientUrl(): string {

--- a/packages/postgresql/src/PostgreSqlMikroORM.ts
+++ b/packages/postgresql/src/PostgreSqlMikroORM.ts
@@ -16,6 +16,13 @@ export class PostgreSqlMikroORM extends MikroORM<PostgreSqlDriver> {
     return super.init(options);
   }
 
+  /**
+   * @inheritDoc
+   */
+  static override initSync<D extends IDatabaseDriver = PostgreSqlDriver>(options: Options<D>): MikroORM<D> {
+    return super.initSync(options);
+  }
+
 }
 
 export type PostgreSqlOptions = Options<PostgreSqlDriver>;

--- a/packages/reflection/src/TsMorphMetadataProvider.ts
+++ b/packages/reflection/src/TsMorphMetadataProvider.ts
@@ -18,31 +18,31 @@ export class TsMorphMetadataProvider extends MetadataProvider {
     return this.config.get('metadataCache').enabled ?? true;
   }
 
-  async loadEntityMetadata(meta: EntityMetadata, name: string): Promise<void> {
+  loadEntityMetadata(meta: EntityMetadata, name: string): void {
     if (!meta.path) {
       return;
     }
 
-    await this.initProperties(meta);
+    this.initProperties(meta);
   }
 
-  async getExistingSourceFile(path: string, ext?: string, validate = true): Promise<SourceFile> {
+  getExistingSourceFile(path: string, ext?: string, validate = true): SourceFile {
     if (!ext) {
-      return await this.getExistingSourceFile(path, '.d.ts', false) || await this.getExistingSourceFile(path, '.ts');
+      return this.getExistingSourceFile(path, '.d.ts', false) || this.getExistingSourceFile(path, '.ts');
     }
 
     const tsPath = path.match(/.*\/[^/]+$/)![0].replace(/\.js$/, ext);
 
-    return (await this.getSourceFile(tsPath, validate))!;
+    return this.getSourceFile(tsPath, validate)!;
   }
 
-  protected override async initProperties(meta: EntityMetadata): Promise<void> {
+  protected initProperties(meta: EntityMetadata): void {
     // load types and column names
     for (const prop of Object.values(meta.properties)) {
       const type = this.extractType(prop);
 
       if (!type || this.config.get('discovery').alwaysAnalyseProperties) {
-        await this.initPropertyType(meta, prop);
+        this.initPropertyType(meta, prop);
       }
 
       prop.type = type || prop.type;
@@ -61,8 +61,8 @@ export class TsMorphMetadataProvider extends MetadataProvider {
     return prop.type;
   }
 
-  private async initPropertyType(meta: EntityMetadata, prop: EntityProperty): Promise<void> {
-    const { type, optional } = await this.readTypeFromSource(meta, prop);
+  private initPropertyType(meta: EntityMetadata, prop: EntityProperty): void {
+    const { type, optional } = this.readTypeFromSource(meta, prop);
     prop.type = type;
 
     if (optional) {
@@ -75,8 +75,8 @@ export class TsMorphMetadataProvider extends MetadataProvider {
     this.processWrapper(prop, 'Collection');
   }
 
-  private async readTypeFromSource(meta: EntityMetadata, prop: EntityProperty): Promise<{ type: string; optional?: boolean }> {
-    const source = await this.getExistingSourceFile(meta.path);
+  private readTypeFromSource(meta: EntityMetadata, prop: EntityProperty): { type: string; optional?: boolean } {
+    const source = this.getExistingSourceFile(meta.path);
     const cls = source.getClass(meta.className);
 
     /* istanbul ignore next */
@@ -130,9 +130,9 @@ export class TsMorphMetadataProvider extends MetadataProvider {
     return { type, optional };
   }
 
-  private async getSourceFile(tsPath: string, validate: boolean): Promise<SourceFile | undefined> {
+  private getSourceFile(tsPath: string, validate: boolean): SourceFile | undefined {
     if (!this.sources) {
-      await this.initSourceFiles();
+      this.initSourceFiles();
     }
 
     const source = this.sources.find(s => s.getFilePath().endsWith(tsPath.replace(/^\.+/, '')));
@@ -164,9 +164,9 @@ export class TsMorphMetadataProvider extends MetadataProvider {
     }
   }
 
-  private async initSourceFiles(): Promise<void> {
+  private initSourceFiles(): void {
     // All entity files are first required during the discovery, before we reach here, so it is safe to get the parts from the global
-    // metadata storage. We know the path thanks the the decorators being executed. In case we are running via ts-node, the extension
+    // metadata storage. We know the path thanks the decorators being executed. In case we are running via ts-node, the extension
     // will be already `.ts`, so no change needed. `.js` files will get renamed to `.d.ts` files as they will be used as a source for
     // the ts-morph reflection.
     const paths = Object.values(MetadataStorage.getMetadata()).map(m => m.path.replace(/\.js$/, '.d.ts'));

--- a/packages/sqlite/src/SqliteConnection.ts
+++ b/packages/sqlite/src/SqliteConnection.ts
@@ -14,6 +14,7 @@ export class SqliteConnection extends AbstractSqlConnection {
     await ensureDir(dirname(this.config.get('dbName')!));
     this.client = this.createKnexClient(this.getPatchedDialect());
     await this.client.raw('pragma foreign_keys = on');
+    this.connected = true;
   }
 
   getDefaultClientUrl(): string {

--- a/packages/sqlite/src/SqliteMikroORM.ts
+++ b/packages/sqlite/src/SqliteMikroORM.ts
@@ -16,6 +16,13 @@ export class SqliteMikroORM extends MikroORM<SqliteDriver> {
     return super.init(options);
   }
 
+  /**
+   * @inheritDoc
+   */
+  static override initSync<D extends IDatabaseDriver = SqliteDriver>(options: Options<D>): MikroORM<D> {
+    return super.initSync(options);
+  }
+
 }
 
 export type SqliteOptions = Options<SqliteDriver>;

--- a/tests/Connection.test.ts
+++ b/tests/Connection.test.ts
@@ -11,7 +11,7 @@ class CustomConnection extends Connection {
     return undefined;
   }
 
-  async connect(): Promise<void> {
+  connect(): void {
     return undefined;
   }
 

--- a/tests/FileCacheAdapter.test.ts
+++ b/tests/FileCacheAdapter.test.ts
@@ -8,26 +8,26 @@ describe('FileCacheAdapter', () => {
     const origin = TEMP_DIR + '/.origin';
     const cache = new FileCacheAdapter({ cacheDir: TEMP_DIR }, TEMP_DIR);
     writeFileSync(origin, '123');
-    await cache.set('cache-test-handle-1', 123, origin);
-    await expect(cache.get('cache-test-handle-1')).resolves.toBe(123);
+    cache.set('cache-test-handle-1', 123, origin);
+    await expect(cache.get('cache-test-handle-1')).toBe(123);
 
     await new Promise(resolve => setTimeout(resolve, 10));
     writeFileSync(origin, '321');
-    await expect(cache.get('cache-test-handle-1')).resolves.toBeNull();
+    await expect(cache.get('cache-test-handle-1')).toBeNull();
 
-    await cache.set('cache-test-handle-1', 123, origin);
-    await expect(cache.get('cache-test-handle-1')).resolves.toBe(123);
-    await cache.remove('cache-test-handle-1');
-    await expect(cache.get('cache-test-handle-1')).resolves.toBeNull();
+    cache.set('cache-test-handle-1', 123, origin);
+    await expect(cache.get('cache-test-handle-1')).toBe(123);
+    cache.remove('cache-test-handle-1');
+    await expect(cache.get('cache-test-handle-1')).toBeNull();
 
-    await cache.clear();
+    cache.clear();
   });
 
   test('should ignore if cached origin not found on file system', async () => {
     const cache = new FileCacheAdapter({ cacheDir: TEMP_DIR }, TEMP_DIR);
-    await cache.set('cache-test-handle-2', 123, 'not-existing-path');
-    await expect(cache.get('cache-test-handle-2')).resolves.toBeNull();
-    await cache.clear();
+    cache.set('cache-test-handle-2', 123, 'not-existing-path');
+    expect(cache.get('cache-test-handle-2')).toBeNull();
+    cache.clear();
   });
 
 });

--- a/tests/MemoryCacheAdapter.test.ts
+++ b/tests/MemoryCacheAdapter.test.ts
@@ -4,12 +4,12 @@ describe('MemoryCacheAdapter', () => {
 
   test('should ignore old cache', async () => {
     const cache = new MemoryCacheAdapter({ expiration: 10 });
-    await cache.set('cache-test-handle-1', 123, '');
-    await expect(cache.get('cache-test-handle-1')).resolves.toBe(123);
+    cache.set('cache-test-handle-1', 123, '');
+    expect(cache.get('cache-test-handle-1')).toBe(123);
 
     await new Promise(resolve => setTimeout(resolve, 20));
-    await expect(cache.get('cache-test-handle-1')).resolves.toBeUndefined();
-    await cache.clear();
+    expect(cache.get('cache-test-handle-1')).toBeUndefined();
+    cache.clear();
   });
 
 });

--- a/tests/NullCacheAdapter.test.ts
+++ b/tests/NullCacheAdapter.test.ts
@@ -6,11 +6,11 @@ describe('NullCacheAdapter', () => {
   test('should ignore old cache', async () => {
     const origin = TEMP_DIR + '/.origin';
     const cache = new NullCacheAdapter();
-    await cache.set('cache-test-handle', 123, origin);
-    await expect(cache.get('cache-test-handle')).resolves.toBeNull();
-    await cache.remove('cache-test-handle');
-    await expect(cache.get('cache-test-handle')).resolves.toBeNull();
-    await cache.clear();
+    cache.set('cache-test-handle', 123, origin);
+    expect(cache.get('cache-test-handle')).toBeNull();
+    cache.remove('cache-test-handle');
+    expect(cache.get('cache-test-handle')).toBeNull();
+    cache.clear();
   });
 
 });

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -134,7 +134,7 @@ export async function initORMMySql<D extends MySqlDriver | MariaDbDriver = MySql
 }
 
 export async function initORMPostgreSql(loadStrategy = LoadStrategy.SELECT_IN, entities: any[] = []) {
-  const orm = await MikroORM.init({
+  const orm = MikroORM.initSync({
     entities: [Author2, Address2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, FooParam2, Label2, Configuration2, ...entities],
     dbName: `mikro_orm_test`,
     baseDir: BASE_DIR,
@@ -182,7 +182,7 @@ export async function initORMSqlite() {
 }
 
 export async function initORMSqlite2(type: 'sqlite' | 'better-sqlite' = 'sqlite') {
-  const orm = await MikroORM.init<any>({
+  const orm = MikroORM.initSync<any>({
     entities: [Author4, Book4, BookTag4, Publisher4, Test4, FooBar4, FooBaz4, BaseEntity5, IdentitySchema],
     dbName: ':memory:',
     baseDir: BASE_DIR,
@@ -191,7 +191,6 @@ export async function initORMSqlite2(type: 'sqlite' | 'better-sqlite' = 'sqlite'
     propagateToOneOwner: false,
     forceUndefined: true,
     logger: i => i,
-    metadataCache: { pretty: true },
     migrations: { path: BASE_DIR + '/../temp/migrations', snapshot: false },
     extensions: [Migrator, SeedManager, EntityGenerator],
   });

--- a/tests/features/reflection/TsMorphMetadataProvider.test.ts
+++ b/tests/features/reflection/TsMorphMetadataProvider.test.ts
@@ -90,7 +90,7 @@ describe('TsMorphMetadataProvider', () => {
 
     // customType should be re-hydrated when loading metadata from cache
     const provider = new TsMorphMetadataProvider(orm.config);
-    const cacheAdapter = orm.config.getCacheAdapter();
+    const cacheAdapter = orm.config.getMetadataCacheAdapter();
     const cache = await cacheAdapter.get('Publisher.ts');
     const meta = { properties: {
       types: { name: 'types', customType: new EnumArrayType('Publisher.types') },
@@ -118,7 +118,7 @@ describe('TsMorphMetadataProvider', () => {
   test('should throw when source file not found', async () => {
     const provider = new TsMorphMetadataProvider({} as any);
     const error = `Source file './path/to/entity.ts' not found. Check your 'entitiesTs' option and verify you have 'compilerOptions.declaration' enabled in your 'tsconfig.json'. If you are using webpack, see https://bit.ly/35pPDNn`;
-    await expect(provider.getExistingSourceFile('./path/to/entity.js')).rejects.toThrowError(error);
+    expect(() => provider.getExistingSourceFile('./path/to/entity.js')).toThrowError(error);
   });
 
 });

--- a/tests/features/schema-generator/__snapshots__/comment-diffing.postgres.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/comment-diffing.postgres.test.ts.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`comment diffing in postgres 1`] = `
-"comment on column "foo"."book"."id" is 'this is primary''s key';
+"drop table if exists "book" cascade;
+
+comment on column "foo"."book"."id" is 'this is primary''s key';
 comment on column "foo"."book"."name" is 'this is name of book';
 comment on table "foo"."book" is 'this is book''s table';
 

--- a/tests/features/schema-generator/__snapshots__/comment-diffing.postgres.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/comment-diffing.postgres.test.ts.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`comment diffing in postgres 1`] = `
-"drop table if exists "book" cascade;
-
-comment on column "foo"."book"."id" is 'this is primary''s key';
+"comment on column "foo"."book"."id" is 'this is primary''s key';
 comment on column "foo"."book"."name" is 'this is name of book';
 comment on table "foo"."book" is 'this is book''s table';
 


### PR DESCRIPTION
As opposed to the async `MikroORM.init` method, you can prefer to use synchronous variant `initSync`. This method has some limitations:

- database connection will be established when you first interact with the database (or you can use `orm.connect()` explicitly)
- no loading of the `config` file, `options` parameter is mandatory
- no support for folder based discovery
- no check for mismatched package versions

Related: #4164