### PR TITLE
feat(core): add `GeneratedCacheAdapter` for production usage

### DIFF
--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -8,9 +8,30 @@ This has some consequences for deployment of your application. Sometimes you wil
 
 ## Deploy pre-built cache
 
-By default, output of metadata discovery will be cached in `temp` folder. You can reuse this cache in your deployed application. Currently the cache is saved in files named like the entity source file, e.g. `Author.ts` entity will store cache in `temp/Author.ts.json` file.
+Since v6, MikroORM lets you generate production cache bundle into a single JSON file via CLI:
 
-When running compiled code, JS entities will be taken into account instead, so you will need to generate the cache by running the compiled code locally. That will generate `temp/Author.js.json`, which is the file you will need to deploy alongside your application.
+```bash
+npx mikro-orm cache:generate --combined
+```
+
+This will create `./temp/metadata.json` file which can be used together with `GeneratedCacheAdapter` in your production configuration:
+
+```ts
+import { GeneratedCacheAdapter, MikroORM } from '@mikro-orm/core';
+
+await MikroORM.init({
+  metadataCache: {
+    enabled: true,
+    adapter: GeneratedCacheAdapter, 
+    options: { data: require('./temp/metadata.json') },
+  },
+  // ...
+});
+```
+
+This way you can keep the `@mikro-orm/reflection` package as a development dependency only, use the CLI to create the cache bundle, and depend only on that in your production build.
+
+> The cache bundle can be statically imported, which is handy in case you are using some bundler.
 
 ## Fill type or entity attributes everywhere
 

--- a/packages/cli/src/commands/GenerateCacheCommand.ts
+++ b/packages/cli/src/commands/GenerateCacheCommand.ts
@@ -1,8 +1,8 @@
 import type { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
-import { MetadataDiscovery, MetadataStorage, colors } from '@mikro-orm/core';
+import { MetadataDiscovery, MetadataStorage, colors, FileCacheAdapter } from '@mikro-orm/core';
 import { CLIHelper } from '../CLIHelper';
 
-type CacheArgs = { ts?: boolean };
+type CacheArgs = { ts?: boolean; combined?: string };
 export class GenerateCacheCommand<T> implements CommandModule<T, CacheArgs> {
 
   command = 'cache:generate';
@@ -13,6 +13,10 @@ export class GenerateCacheCommand<T> implements CommandModule<T, CacheArgs> {
       type: 'boolean',
       desc: `Use ts-node to generate '.ts' cache`,
     });
+    args.option('combined', {
+      alias: 'c',
+      desc: `Generate production cache into a single JSON file that can be used with the GeneratedCacheAdapter.`,
+    });
     return args as Argv<CacheArgs>;
   };
 
@@ -20,18 +24,19 @@ export class GenerateCacheCommand<T> implements CommandModule<T, CacheArgs> {
    * @inheritDoc
    */
   async handler(args: ArgumentsCamelCase<CacheArgs>) {
-    const config = await CLIHelper.getConfiguration();
+    const options = args.combined ? { combined: './metadata.json' } : {};
+    const config = await CLIHelper.getConfiguration(true, {
+      metadataCache: { enabled: true, adapter: FileCacheAdapter, options },
+    });
 
-    if (!config.get('metadataCache').enabled) {
-      return CLIHelper.dump(colors.red('Metadata cache is disabled in your configuration. Set cache.enabled to true to use this command.'));
-    }
-
+    config.getMetadataCacheAdapter().clear();
     config.set('logger', CLIHelper.dump.bind(null));
     config.set('debug', true);
     const discovery = new MetadataDiscovery(MetadataStorage.init(), config.getDriver().getPlatform(), config);
     await discovery.discover(args.ts ?? false);
 
-    CLIHelper.dump(colors.green(`${args.ts ? 'TS' : 'JS'} metadata cache was successfully generated`));
+    const combined = args.combined && config.get('metadataCache').combined;
+    CLIHelper.dump(colors.green(`${combined ? 'Combined ' : ''}${args.ts ? 'TS' : 'JS'} metadata cache was successfully generated${combined ? ' to ' + combined : ''}`));
   }
 
 }

--- a/packages/core/src/cache/CacheAdapter.ts
+++ b/packages/core/src/cache/CacheAdapter.ts
@@ -44,4 +44,9 @@ export interface SyncCacheAdapter extends CacheAdapter {
    */
   remove(name: string): void;
 
+  /**
+   * Generates a combined cache from all existing entries.
+   */
+  combine?(): string | void;
+
 }

--- a/packages/core/src/cache/GeneratedCacheAdapter.ts
+++ b/packages/core/src/cache/GeneratedCacheAdapter.ts
@@ -1,0 +1,43 @@
+import type { CacheAdapter } from './CacheAdapter';
+import type { Dictionary } from '../typings';
+
+export class GeneratedCacheAdapter implements CacheAdapter {
+
+  private readonly data = new Map<string, { data: Dictionary }>();
+
+  constructor(private readonly options: { data: Dictionary }) {
+    this.data = new Map<string, { data: any }>(Object.entries(options.data));
+  }
+
+  /**
+   * @inheritDoc
+   */
+  get<T = any>(name: string): T | undefined {
+    const key = name.replace(/\.[jt]s$/, '');
+    const data = this.data.get(key);
+
+    return data as T;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  set(name: string, data: any, origin: string): void {
+    this.data.set(name, { data });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  remove(name: string): void {
+    this.data.delete(name);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  clear(): void {
+    this.data.clear();
+  }
+
+}

--- a/packages/core/src/cache/index.ts
+++ b/packages/core/src/cache/index.ts
@@ -2,3 +2,4 @@ export * from './CacheAdapter';
 export * from './NullCacheAdapter';
 export * from './FileCacheAdapter';
 export * from './MemoryCacheAdapter';
+export * from './GeneratedCacheAdapter';

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -104,6 +104,12 @@ export class MetadataDiscovery {
     }
 
     discovered.forEach(meta => meta.sync(true));
+    const combinedCachePath = this.cache.combine?.();
+
+    // override the path in the options, so we can log it from the CLI in `cache:generate` command
+    if (combinedCachePath) {
+      this.config.get('metadataCache').combined = combinedCachePath;
+    }
 
     return discovered.map(meta => this.metadata.get(meta.className));
   }

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -546,6 +546,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
   };
   metadataCache: {
     enabled?: boolean;
+    combined?: boolean | string;
     pretty?: boolean;
     adapter?: { new(...params: any[]): SyncCacheAdapter };
     options?: Dictionary;

--- a/tests/features/cli/GenerateCacheCommand.test.ts
+++ b/tests/features/cli/GenerateCacheCommand.test.ts
@@ -35,15 +35,4 @@ describe('GenerateCacheCommand', () => {
     expect(discoverMock.mock.calls[1][0]).toBe(true);
   });
 
-  test('handler throws when cache is disabled', async () => {
-    getConfigurationMock.mockResolvedValue(new Configuration({ driver: MySqlDriver, metadataCache: { enabled: false }, getDriver: () => ({ getPlatform: jest.fn() }) } as any, false));
-    discoverMock.mockReset();
-    discoverMock.mockResolvedValue({} as MetadataStorage);
-
-    const cmd = new GenerateCacheCommand();
-
-    expect(discoverMock.mock.calls.length).toBe(0);
-    await expect(cmd.handler({} as any)).resolves.toBeUndefined();
-    expect(discoverMock.mock.calls.length).toBe(0);
-  });
 });

--- a/tests/features/reflection/TsMorphMetadataProvider.test.ts
+++ b/tests/features/reflection/TsMorphMetadataProvider.test.ts
@@ -91,7 +91,7 @@ describe('TsMorphMetadataProvider', () => {
     // customType should be re-hydrated when loading metadata from cache
     const provider = new TsMorphMetadataProvider(orm.config);
     const cacheAdapter = orm.config.getMetadataCacheAdapter();
-    const cache = await cacheAdapter.get('Publisher.ts');
+    const cache = cacheAdapter.get('Publisher.ts');
     const meta = { properties: {
       types: { name: 'types', customType: new EnumArrayType('Publisher.types') },
       types2: { name: 'types2', customType: new EnumArrayType('Publisher.types2') },
@@ -111,7 +111,7 @@ describe('TsMorphMetadataProvider', () => {
     const provider = new TsMorphMetadataProvider({} as any);
     const initProperties = jest.spyOn(TsMorphMetadataProvider.prototype, 'initProperties' as any);
     expect(initProperties).toBeCalledTimes(0);
-    await provider.loadEntityMetadata({} as any, 'name');
+    provider.loadEntityMetadata({} as any, 'name');
     expect(initProperties).toBeCalledTimes(0);
   });
 

--- a/tests/features/reflection/production-cache/.gitignore
+++ b/tests/features/reflection/production-cache/.gitignore
@@ -1,0 +1,1 @@
+metadata-cache.json

--- a/tests/features/reflection/production-cache/production-cache.test.ts
+++ b/tests/features/reflection/production-cache/production-cache.test.ts
@@ -1,0 +1,57 @@
+import {
+  Collection as Collection_,
+  Entity,
+  FileCacheAdapter,
+  GeneratedCacheAdapter,
+  IsUnknown,
+  ManyToOne,
+  MikroORM,
+  OneToMany,
+  PrimaryKey, PrimaryProperty,
+  Property,
+  Reference as Reference_,
+} from '@mikro-orm/better-sqlite';
+import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
+
+export class Collection<T extends object> extends Collection_<T> { }
+export class Reference<T extends object> extends Reference_<T> { }
+export type Ref<T extends object> = true extends IsUnknown<PrimaryProperty<T>>
+  ? Reference<T>
+  : ({ [K in PrimaryProperty<T> & keyof T]: T[K] } & Reference<T>);
+
+@Entity()
+export class A {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  types!: number[];
+
+  @ManyToOne()
+  parent?: Ref<A>;
+
+  @OneToMany({ mappedBy: 'parent' })
+  children = new Collection<A>(this);
+
+}
+
+test('bundler friendly production cache', async () => {
+  // warm up cache by doing async init, this creates a single metadata.json file
+  const orm1 = await MikroORM.init({
+    metadataCache: { enabled: true, pretty: true, adapter: FileCacheAdapter, options: { combined: './metadata-cache.json', cacheDir: __dirname } },
+    entities: [A],
+    dbName: ':memory:',
+    metadataProvider: TsMorphMetadataProvider,
+    connect: false,
+  });
+  await orm1.close();
+
+  // now we can use the combined cached to init the ORM synchronously, without the ts-morph dependency
+  const orm2 = MikroORM.initSync({
+    metadataCache: { enabled: true, adapter: GeneratedCacheAdapter, options: { data: require('./metadata-cache.json') } },
+    entities: [A],
+    dbName: ':memory:',
+  });
+  await orm2.close();
+});


### PR DESCRIPTION
MikroORM now lets you generate production cache bundle into a single JSON file via CLI:

```bash
npx mikro-orm cache:generate --combined
```

This will create `./temp/metadata.json` file which can be used together with `GeneratedCacheAdapter` in your production configuration:

```ts
import { GeneratedCacheAdapter, MikroORM } from '@mikro-orm/core';

await MikroORM.init({
  metadataCache: {
    enabled: true,
    adapter: GeneratedCacheAdapter, 
    options: { data: require('./temp/metadata.json') },
  },
  // ...
});
```

This way you can keep the `@mikro-orm/reflection` package as a development dependency only, use the CLI to create the cache bundle, and depend only on that in your production build.

> The cache bundle can be statically imported, which is handy in case you are using some bundler.

Closes #4164