### PR TITLE
feat(migrator): allow disabling logging via `migrations.silent`

### DIFF
--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -89,6 +89,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
       tableName: 'mikro_orm_migrations',
       path: './migrations',
       glob: '!(*.d).{js,ts,cjs}',
+      silent: false,
       transactional: true,
       disableForeignKeys: true,
       allOrNothing: true,
@@ -441,6 +442,7 @@ export type MigrationsOptions = {
   path?: string;
   pathTs?: string;
   glob?: string;
+  silent?: boolean;
   transactional?: boolean;
   disableForeignKeys?: boolean;
   allOrNothing?: boolean;

--- a/packages/migrations-mongodb/src/Migrator.ts
+++ b/packages/migrations-mongodb/src/Migrator.ts
@@ -83,11 +83,13 @@ export class Migrator implements IMigrator {
       migrations,
     });
 
-    const logger = this.config.get('logger');
-    this.umzug.on('migrating', event => logger(`Processing '${event.name}'`));
-    this.umzug.on('migrated', event => logger(`Applied '${event.name}'`));
-    this.umzug.on('reverting', event => logger(`Processing '${event.name}'`));
-    this.umzug.on('reverted', event => logger(`Reverted '${event.name}'`));
+    if (!this.options.silent) {
+      const logger = this.config.get('logger');
+      this.umzug.on('migrating', event => logger(`Processing '${event.name}'`));
+      this.umzug.on('migrated', event => logger(`Applied '${event.name}'`));
+      this.umzug.on('reverting', event => logger(`Processing '${event.name}'`));
+      this.umzug.on('reverted', event => logger(`Reverted '${event.name}'`));
+    }
 
     /* istanbul ignore next */
     if (this.options.generator) {

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -115,11 +115,13 @@ export class Migrator implements IMigrator {
       migrations,
     });
 
-    const logger = this.config.get('logger');
-    this.umzug.on('migrating', event => logger(`Processing '${event.name}'`));
-    this.umzug.on('migrated', event => logger(`Applied '${event.name}'`));
-    this.umzug.on('reverting', event => logger(`Processing '${event.name}'`));
-    this.umzug.on('reverted', event => logger(`Reverted '${event.name}'`));
+    if (!this.options.silent) {
+      const logger = this.config.get('logger');
+      this.umzug.on('migrating', event => logger(`Processing '${event.name}'`));
+      this.umzug.on('migrated', event => logger(`Applied '${event.name}'`));
+      this.umzug.on('reverting', event => logger(`Processing '${event.name}'`));
+      this.umzug.on('reverted', event => logger(`Reverted '${event.name}'`));
+    }
 
     if (this.options.generator) {
       this.generator = new this.options.generator(this.driver, this.config.getNamingStrategy(), this.options);


### PR DESCRIPTION
This provides an option to make the migration logs silent.

Closes #4124