### PR TITLE
fix(core): rework JSON value processing

### DIFF
--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -96,7 +96,7 @@ export class EntityFactory {
 
   mergeData<T extends object>(meta: EntityMetadata<T>, entity: T, data: EntityData<T>, options: FactoryOptions = {}): void {
     // merge unchanged properties automatically
-    data = QueryHelper.processParams({ ...data });
+    data = QueryHelper.processParams(Utils.copy(data));
     const existsData = this.comparator.prepareEntity(entity);
     const originalEntityData = helper(entity).__originalEntityData ?? {} as EntityData<T>;
     const diff = this.comparator.diffEntities(meta.className, originalEntityData, existsData);

--- a/packages/core/src/hydration/Hydrator.ts
+++ b/packages/core/src/hydration/Hydrator.ts
@@ -16,7 +16,7 @@ export abstract class Hydrator implements IHydrator {
   /**
    * @inheritDoc
    */
-  hydrate<T>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, factory: EntityFactory, type: 'full' | 'returning' | 'reference', newEntity = false, convertCustomTypes = false, schema?: string): void {
+  hydrate<T extends object>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, factory: EntityFactory, type: 'full' | 'returning' | 'reference', newEntity = false, convertCustomTypes = false, schema?: string): void {
     this.running = true;
     const props = this.getProperties(meta, type);
 
@@ -29,7 +29,7 @@ export abstract class Hydrator implements IHydrator {
   /**
    * @inheritDoc
    */
-  hydrateReference<T>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, factory: EntityFactory, convertCustomTypes?: boolean, schema?: string): void {
+  hydrateReference<T extends object>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, factory: EntityFactory, convertCustomTypes?: boolean, schema?: string): void {
     this.running = true;
     meta.primaryKeys.forEach(pk => {
       this.hydrateProperty<T>(entity, meta.properties[pk], data, factory, false, convertCustomTypes);
@@ -41,7 +41,7 @@ export abstract class Hydrator implements IHydrator {
     return this.running;
   }
 
-  protected getProperties<T>(meta: EntityMetadata<T>, type: 'full' | 'returning' | 'reference'): EntityProperty<T>[] {
+  protected getProperties<T extends object>(meta: EntityMetadata<T>, type: 'full' | 'returning' | 'reference'): EntityProperty<T>[] {
     if (type === 'reference') {
       return meta.primaryKeys.map(pk => meta.properties[pk]);
     }
@@ -53,7 +53,7 @@ export abstract class Hydrator implements IHydrator {
     return meta.hydrateProps;
   }
 
-  protected hydrateProperty<T>(entity: T, prop: EntityProperty, data: EntityData<T>, factory: EntityFactory, newEntity?: boolean, convertCustomTypes?: boolean): void {
+  protected hydrateProperty<T extends object>(entity: T, prop: EntityProperty, data: EntityData<T>, factory: EntityFactory, newEntity?: boolean, convertCustomTypes?: boolean): void {
     entity[prop.name] = data[prop.name];
   }
 

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -11,9 +11,10 @@ import {
   ArrayType, BigIntType, BlobType, BooleanType, DateType, DecimalType, DoubleType, JsonType, SmallIntType, TimeType,
   TinyIntType, Type, UuidType, StringType, IntegerType, FloatType, DateTimeType, TextType, EnumType, UnknownType, MediumIntType,
 } from '../types';
-import { Utils } from '../utils/Utils';
+import { parseJsonSafe, Utils } from '../utils/Utils';
 import { ReferenceType } from '../enums';
 import type { MikroORM } from '../MikroORM';
+import type { TransformContext } from '../types/Type';
 
 export const JsonProperty = Symbol('JsonProperty');
 
@@ -320,8 +321,17 @@ export abstract class Platform {
     throw new Error('Full text searching is not supported by this driver.');
   }
 
+  // TODO v6: remove the `marshall` parameter
   convertsJsonAutomatically(marshall = false): boolean {
-    return !marshall;
+    return true;
+  }
+
+  convertJsonToDatabaseValue(value: unknown, context?: TransformContext): unknown {
+    return JSON.stringify(value);
+  }
+
+  convertJsonToJSValue(value: unknown): unknown {
+    return parseJsonSafe(value);
   }
 
   getRepositoryClass<T extends object>(): Constructor<EntityRepository<T>> {

--- a/packages/core/src/types/JsonType.ts
+++ b/packages/core/src/types/JsonType.ts
@@ -1,28 +1,29 @@
+import type { TransformContext } from './Type';
 import { Type } from './Type';
 import type { Platform } from '../platforms';
-import type { EntityProperty } from '../typings';
-import { Utils } from '../utils';
+import type { EntityMetadata, EntityProperty } from '../typings';
 
 export class JsonType extends Type<unknown, string | null> {
 
-  convertToDatabaseValue(value: unknown, platform: Platform): string | null {
-    if (platform.convertsJsonAutomatically(true) || value === null) {
-      return value as string;
+  // TODO v6: remove the boolean variant
+  convertToDatabaseValue(value: unknown, platform: Platform, context?: TransformContext | boolean): string | null {
+    if (value == null) {
+      return value as null;
     }
 
-    return JSON.stringify(value);
+    return platform.convertJsonToDatabaseValue(value, typeof context === 'boolean' ? { fromQuery: context } : context) as string;
   }
 
   convertToJSValue(value: string | unknown, platform: Platform): unknown {
-    if (!platform.convertsJsonAutomatically() && Utils.isString(value)) {
-      return JSON.parse(value);
-    }
-
-    return value;
+    return platform.convertJsonToJSValue(value);
   }
 
   getColumnType(prop: EntityProperty, platform: Platform): string {
     return platform.getJsonDeclarationSQL();
+  }
+
+  ensureComparable<T extends object>(meta: EntityMetadata<T>, prop: EntityProperty<T>): boolean {
+    return !prop.embedded || !meta.properties[prop.embedded[0]].object;
   }
 
 }

--- a/packages/core/src/types/Type.ts
+++ b/packages/core/src/types/Type.ts
@@ -5,7 +5,7 @@ import type { Constructor, EntityMetadata, EntityProperty } from '../typings';
 export interface TransformContext {
   fromQuery?: boolean;
   key?: string;
-  mode?: 'hydration' | 'query' | 'discovery' | 'serialization';
+  mode?: 'hydration' | 'query' | 'query-data' | 'discovery' | 'serialization';
 }
 
 export abstract class Type<JSType = string, DBType = JSType> {
@@ -53,7 +53,7 @@ export abstract class Type<JSType = string, DBType = JSType> {
    * as often the raw database response is not the same as the `convertToDatabaseValue` result.
    * This allows to disable the additional conversion in case you know it is not needed.
    */
-  ensureComparable(): boolean {
+  ensureComparable<T extends object>(meta: EntityMetadata<T>, prop: EntityProperty<T>): boolean {
     return true;
   }
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,4 +1,4 @@
-import { Type } from './Type';
+import { Type, TransformContext } from './Type';
 import { DateType } from './DateType';
 import { TimeType } from './TimeType';
 import { DateTimeType } from './DateTimeType';
@@ -24,7 +24,7 @@ import { UnknownType } from './UnknownType';
 export {
   Type, DateType, TimeType, DateTimeType, BigIntType, BlobType, ArrayType, EnumArrayType, EnumType,
   JsonType, IntegerType, SmallIntType, TinyIntType, MediumIntType, FloatType, DoubleType, BooleanType, DecimalType,
-  StringType, UuidType, TextType, UnknownType,
+  StringType, UuidType, TextType, UnknownType, TransformContext,
 };
 
 export const types = {

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -10,7 +10,7 @@ import type {
 } from '../typings';
 import { ReferenceType } from '../enums';
 import type { Platform } from '../platforms';
-import { compareArrays, compareBooleans, compareBuffers, compareObjects, equals, Utils } from './Utils';
+import { compareArrays, compareBooleans, compareBuffers, compareObjects, equals, parseJsonSafe, Utils } from './Utils';
 import { JsonType } from '../types/JsonType';
 
 type Comparator<T> = (a: T, b: T) => EntityData<T>;
@@ -318,8 +318,9 @@ export class EntityComparator {
           lines.push(`  }`);
         }
       } else if (prop.reference === ReferenceType.EMBEDDED && prop.object && !this.platform.convertsJsonAutomatically()) {
+        context.set('parseJsonSafe', parseJsonSafe);
         lines.push(`  if (typeof ${propName(prop.fieldNames[0])} !== 'undefined') {`);
-        lines.push(`    ret${this.wrap(prop.name)} = ${propName(prop.fieldNames[0])} == null ? ${propName(prop.fieldNames[0])} : JSON.parse(${propName(prop.fieldNames[0])});`);
+        lines.push(`    ret${this.wrap(prop.name)} = ${propName(prop.fieldNames[0])} == null ? ${propName(prop.fieldNames[0])} : parseJsonSafe(${propName(prop.fieldNames[0])});`);
         lines.push(`    ${propName(prop.fieldNames[0], 'mapped')} = true;`);
         lines.push(`  }`);
       } else {

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -153,6 +153,19 @@ export function equals(a: any, b: any): boolean {
 
 const equalsFn = equals;
 
+export function parseJsonSafe<T = unknown>(value: unknown): T {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch {
+      // ignore and return the value, as sometimes we get the parsed value,
+      // e.g. when it is a string value in JSON column
+    }
+  }
+
+  return value as T;
+}
+
 export class Utils {
 
   static readonly PK_SEPARATOR = '~~~';

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -341,7 +341,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
 
     const addParams = (prop: EntityProperty<T>, row: Dictionary) => {
       if (options.convertCustomTypes && prop.customType) {
-        return params.push(prop.customType.convertToDatabaseValue(row[prop.name], this.platform, { key: prop.name, mode: 'query' }));
+        return params.push(prop.customType.convertToDatabaseValue(row[prop.name], this.platform, { key: prop.name, mode: 'query-data' }));
       }
 
       params.push(row[prop.name]);

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -786,7 +786,7 @@ export class QueryBuilderHelper {
       }
 
       if (prop.customType && convertCustomTypes && !this.platform.isRaw(data[k])) {
-        data[k] = prop.customType.convertToDatabaseValue(data[k], this.platform, { fromQuery: true, key: k, mode: 'query' });
+        data[k] = prop.customType.convertToDatabaseValue(data[k], this.platform, { fromQuery: true, key: k, mode: 'query-data' });
       }
 
       if (prop.customType && 'convertToDatabaseValueSQL' in prop.customType && !this.platform.isRaw(data[k])) {

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -70,6 +70,14 @@ export class MongoPlatform extends Platform {
     return true;
   }
 
+  convertJsonToDatabaseValue(value: unknown): unknown {
+    return value;
+  }
+
+  convertJsonToJSValue(value: unknown): unknown {
+    return value;
+  }
+
   marshallArray(values: string[]): string {
     return values as unknown as string;
   }

--- a/packages/mysql/src/MySqlPlatform.ts
+++ b/packages/mysql/src/MySqlPlatform.ts
@@ -1,7 +1,7 @@
 import { AbstractSqlPlatform } from '@mikro-orm/knex';
 import { MySqlSchemaHelper } from './MySqlSchemaHelper';
 import { MySqlExceptionConverter } from './MySqlExceptionConverter';
-import type { SimpleColumnMeta, Type } from '@mikro-orm/core';
+import type { SimpleColumnMeta, Type, TransformContext } from '@mikro-orm/core';
 import { expr, Utils } from '@mikro-orm/core';
 
 export class MySqlPlatform extends AbstractSqlPlatform {
@@ -11,6 +11,14 @@ export class MySqlPlatform extends AbstractSqlPlatform {
 
   getDefaultCharset(): string {
     return 'utf8mb4';
+  }
+
+  convertJsonToDatabaseValue(value: unknown, context?: TransformContext): unknown {
+    if (context?.mode === 'query') {
+      return value;
+    }
+
+    return JSON.stringify(value);
   }
 
   getSearchJsonPropertyKey(path: string[], type: string, aliased: boolean): string {

--- a/packages/postgresql/src/PostgreSqlConnection.ts
+++ b/packages/postgresql/src/PostgreSqlConnection.ts
@@ -1,4 +1,4 @@
-import { types, defaults } from 'pg';
+import TypeOverrides from 'pg/lib/type-overrides';
 import type { Dictionary } from '@mikro-orm/core';
 import type { Knex } from '@mikro-orm/knex';
 import { AbstractSqlConnection, MonkeyPatchable } from '@mikro-orm/knex';
@@ -16,11 +16,13 @@ export class PostgreSqlConnection extends AbstractSqlConnection {
 
   getConnectionOptions(): Knex.PgConnectionConfig {
     const ret = super.getConnectionOptions() as Knex.PgConnectionConfig;
+    const types = new TypeOverrides();
     [1082].forEach(oid => types.setTypeParser(oid, str => str)); // date type
 
     if (this.config.get('forceUtcTimezone')) {
       [1114].forEach(oid => types.setTypeParser(oid, str => new Date(str + 'Z'))); // timestamp w/o TZ type
-      (defaults as any).parseInputDatesAsUTC = true;
+      ret.parseInputDatesAsUTC = true;
+      ret.types = types as any;
     }
 
     return ret;

--- a/tests/EntityManager.mariadb.test.ts
+++ b/tests/EntityManager.mariadb.test.ts
@@ -31,7 +31,7 @@ describe('EntityManagerMariaDb', () => {
       forceUtcTimezone: true,
     } as any, false);
     const driver = new MariaDbDriver(config);
-    expect(driver.getConnection().getConnectionOptions()).toEqual({
+    expect(driver.getConnection().getConnectionOptions()).toMatchObject({
       database: 'db_name',
       host: '127.0.0.10',
       password: 'secret',

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -47,7 +47,7 @@ describe('EntityManagerMySql', () => {
     } as any, false);
     config.reset('debug');
     const driver = new MySqlDriver(config);
-    expect(driver.getConnection().getConnectionOptions()).toEqual({
+    expect(driver.getConnection().getConnectionOptions()).toMatchObject({
       database: 'db_name',
       host: '127.0.0.10',
       password: 'secret',
@@ -807,24 +807,30 @@ describe('EntityManagerMySql', () => {
     await orm.em.persistAndFlush(bible);
     orm.em.clear();
 
-    const qb1 = orm.em.createQueryBuilder(Book2);
+    const qb1 = orm.em.fork().createQueryBuilder(Book2);
     const res1 = await qb1.select('*').where({ 'JSON_CONTAINS(`b0`.`meta`, ?)': [{ foo: 'bar' }, false] }).execute('get');
     expect(res1.createdAt).toBeDefined();
     // @ts-expect-error
     expect(res1.created_at).not.toBeDefined();
     expect(res1.meta).toEqual({ category: 'foo', items: 1 });
 
-    const qb2 = orm.em.createQueryBuilder(Book2);
+    const qb2 = orm.em.fork().createQueryBuilder(Book2);
     const res2 = await qb2.select('*').where({ 'JSON_CONTAINS(meta, ?)': [{ category: 'foo' }, true] }).execute('get', false);
     expect(res2.createdAt).not.toBeDefined();
     // @ts-expect-error
     expect(res2.created_at).toBeDefined();
     expect(res2.meta).toEqual({ category: 'foo', items: 1 });
 
-    const res3 = await orm.em.findOneOrFail(Book2, { [expr('JSON_CONTAINS(meta, ?)')]: [{ items: 1 }, true] });
+    const qb3 = orm.em.fork().createQueryBuilder(Book2);
+    const res3 = await qb3.select('*').where({ 'JSON_CONTAINS(meta, ?)': [{ category: 'foo' }, true] }).getSingleResult();
     expect(res3).toBeInstanceOf(Book2);
-    expect(res3.createdAt).toBeDefined();
-    expect(res3.meta).toEqual({ category: 'foo', items: 1 });
+    expect(res3!.createdAt).toBeDefined();
+    expect(res3!.meta).toEqual({ category: 'foo', items: 1 });
+
+    const res4 = await orm.em.fork().findOneOrFail(Book2, { [expr('JSON_CONTAINS(meta, ?)')]: [{ items: 1 }, true] });
+    expect(res4).toBeInstanceOf(Book2);
+    expect(res4.createdAt).toBeDefined();
+    expect(res4.meta).toEqual({ category: 'foo', items: 1 });
   });
 
   test('tuple comparison', async () => {

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -58,7 +58,7 @@ describe('EntityManagerPostgre', () => {
       forceUtcTimezone: true,
     } as any, false);
     const driver = new PostgreSqlDriver(config);
-    expect(driver.getConnection().getConnectionOptions()).toEqual({
+    expect(driver.getConnection().getConnectionOptions()).toMatchObject({
       database: 'db_name',
       host: '127.0.0.10',
       password: 'secret',
@@ -1886,14 +1886,14 @@ describe('EntityManagerPostgre', () => {
       ],
     } as any, false);
     const driver = new PostgreSqlDriver(config);
-    expect(driver.getConnection('write').getConnectionOptions()).toEqual({
+    expect(driver.getConnection('write').getConnectionOptions()).toMatchObject({
       database: 'db_name',
       host: '127.0.0.10',
       password: 'secret',
       user: 'user',
       port: 1234,
     });
-    expect(driver.getConnection('read').getConnectionOptions()).toEqual({
+    expect(driver.getConnection('read').getConnectionOptions()).toMatchObject({
       database: 'db_name',
       host: 'read_host_1',
       password: 'secret',

--- a/tests/features/custom-types/GH4193.test.ts
+++ b/tests/features/custom-types/GH4193.test.ts
@@ -1,0 +1,36 @@
+import { MikroORM } from '@mikro-orm/mysql';
+import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity()
+class User {
+
+  @PrimaryKey({ type: 'number' })
+  id?: number;
+
+  @Property({ type: 'json' })
+  value!: string;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: 'mo-test',
+    port: 3308,
+    entities: [User],
+  });
+  await orm.schema.refreshDatabase();
+});
+
+afterAll(() => orm.close());
+
+test('It should fetch record matching by json column', async () => {
+  const user = new User();
+  user.id = 1;
+  user.value = 'test';
+  await orm.em.fork().persistAndFlush(user);
+
+  const c = await orm.em.findOne(User, { value: 'test' });
+  expect(c).not.toBeNull();
+});

--- a/tests/features/custom-types/json-hydration.postgres.test.ts
+++ b/tests/features/custom-types/json-hydration.postgres.test.ts
@@ -1,5 +1,6 @@
 import { MikroORM } from '@mikro-orm/postgresql';
 import { Embedded, Entity, PrimaryKey, Embeddable, OneToOne, Property } from '@mikro-orm/core';
+import { mockLogger } from '../../helpers';
 
 @Embeddable()
 export class Page {
@@ -13,11 +14,23 @@ export class Page {
   }
 
   set attestations(value: string[]) {
-    if (typeof value === 'string') {
-      Page.log.push(value);
-    } else {
-      Page.log.push(value);
-    }
+    Page.log.push(value);
+    this._attestations = value;
+  }
+
+}
+
+@Embeddable()
+export class Page2 {
+
+  @Property({ type: 'jsonb' })
+  private _attestations!: string[];
+
+  get attestations() {
+    return this._attestations;
+  }
+
+  setAttestations(value: string[] = []) {
     this._attestations = value;
   }
 
@@ -29,8 +42,11 @@ export class Customization {
   @PrimaryKey()
   id!: number;
 
-  @Embedded(() => Page, { object: true })
-  pages!: Page;
+  @Embedded(() => Page, { object: true, nullable: true })
+  page!: Page;
+
+  @Embedded(() => Page2, { object: true, nullable: true })
+  page2!: Page2;
 
 }
 
@@ -55,10 +71,10 @@ beforeAll(async () => {
   await orm.schema.refreshDatabase();
 });
 
+beforeEach(() => orm.schema.clearDatabase());
 afterAll(() => orm.close(true));
 
-// FIXME this test was false positive because of the `jsonb` type, which is now fixed and the test correctly fails
-test.skip('json property hydration', async () => {
+test('json property hydration 1/2', async () => {
   const p1 = new Page();
   p1.attestations = [
     'attestation1',
@@ -68,15 +84,41 @@ test.skip('json property hydration', async () => {
   const cr1 = new Course();
   const c1 = new Customization();
   cr1.published = c1;
-  c1.pages = p1;
+  c1.page = p1;
   await orm.em.persistAndFlush(cr1);
   orm.em.clear();
 
   Page.log = [];
   const results = await orm.em.find(Course, {}, { populate: true });
-  expect(results[0].published?.pages.attestations).toEqual(['attestation1', 'attestation2']);
+  expect(results[0].published?.page.attestations).toEqual(['attestation1', 'attestation2']);
   expect(Page.log).toEqual([
     ['attestation1', 'attestation2'],
     ['attestation1', 'attestation2'],
   ]);
+
+  const mock = mockLogger(orm);
+  await orm.em.flush();
+  expect(mock).not.toBeCalled();
+});
+
+test('json property hydration 2/2', async () => {
+  const p1 = new Page2();
+  p1.setAttestations([
+    'attestation1',
+    'attestation2',
+  ]);
+
+  const cr1 = new Course();
+  const c1 = new Customization();
+  cr1.published = c1;
+  c1.page2 = p1;
+  await orm.em.persistAndFlush(cr1);
+  orm.em.clear();
+
+  const results = await orm.em.find(Course, {}, { populate: true });
+  expect(results[0].published?.page2.attestations).toEqual(['attestation1', 'attestation2']);
+
+  const mock = mockLogger(orm);
+  await orm.em.flush();
+  expect(mock).not.toBeCalled();
 });

--- a/tests/features/custom-types/json-properties.test.ts
+++ b/tests/features/custom-types/json-properties.test.ts
@@ -1,0 +1,134 @@
+import { MikroORM, Entity, PrimaryKey, Property, SimpleLogger } from '@mikro-orm/core';
+import { mockLogger } from '../../helpers';
+
+@Entity()
+export class User {
+
+  static id = 1;
+
+  @PrimaryKey({ name: '_id' })
+  id: number = User.id++;
+
+  @Property({ type: 'json' })
+  value: any;
+
+}
+
+const options = {
+  'sqlite': { dbName: ':memory:' },
+  'better-sqlite': { dbName: ':memory:' },
+  'mysql': { dbName: 'mikro_orm_json_props', port: 3308 },
+  'mariadb': { dbName: 'mikro_orm_json_props', port: 3309 },
+  'postgresql': { dbName: 'mikro_orm_json_props' },
+  'mongo': { dbName: 'mikro_orm_json_props' },
+};
+
+describe.each(Object.keys(options))('JSON properties [%s]',  type => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [User],
+      type,
+      loggerFactory: options => new SimpleLogger(options),
+      ...options[type],
+    });
+    await orm.schema.refreshDatabase();
+  });
+
+  beforeEach(async () => {
+    await orm.schema.clearDatabase();
+    User.id = 1;
+  });
+
+  afterAll(() => orm.close());
+
+  test('em.insert()', async () => {
+    await orm.em.insert(User, { value: 'test' });
+    const res = await orm.em.findOneOrFail(User, { value: 'test' });
+    expect(res.value).toBe('test');
+
+    await orm.em.insert(User, { value: true });
+    const res2 = await orm.em.findOneOrFail(User, { value: true });
+    expect(res2.value).toBe(true);
+
+    // this should work in v6, once the `raw()` helper refactor will be merged
+    // await orm.em.insert(User, { value: [1, 2, 3] });
+    // const res3 = await orm.em.findOneOrFail(User, { value: { $eq: [1, 2, 3] } });
+    // expect(res3.value).toEqual([1, 2, 3]);
+  });
+
+  test('em.insert() with object value', async () => {
+    await orm.em.insert(User, { value: { foo: 'test' } });
+    const res = await orm.em.findOneOrFail(User, { value: { foo: 'test' } });
+    expect(res.value).toEqual({ foo: 'test' });
+  });
+
+  test('em.insertMany()', async () => {
+    await orm.em.insertMany(User, [{ value: 'test' }, { value: 'test' }]);
+    const res = await orm.em.findOneOrFail(User, { value: 'test' });
+    expect(res.value).toBe('test');
+  });
+
+  test('em.flush()', async () => {
+    orm.em.create(User, { value: 'test' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const res = await orm.em.findOneOrFail(User, { value: 'test' });
+    expect(res.value).toBe('test');
+
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock).not.toBeCalled();
+  });
+
+  test('em.flush() with various JSON values', async () => {
+    orm.em.create(User, { value: { foo: 'test' } });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const res = await orm.em.findOneOrFail(User, { value: { foo: 'test' } });
+    expect(res.value).toEqual({ foo: 'test' });
+
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock).not.toBeCalled();
+
+    res.value = 'bar';
+    await orm.em.flush();
+    expect(mock).toBeCalled();
+    mock.mockReset();
+    await orm.em.flush();
+    expect(mock).not.toBeCalled();
+
+    res.value = 123;
+    await orm.em.flush();
+    expect(mock).toBeCalled();
+    mock.mockReset();
+    await orm.em.flush();
+    expect(mock).not.toBeCalled();
+
+    res.value = [1, 2, 3];
+    await orm.em.flush();
+    expect(mock).toBeCalled();
+    mock.mockReset();
+    await orm.em.flush();
+    expect(mock).not.toBeCalled();
+
+    res.value = false;
+    await orm.em.flush();
+    expect(mock).toBeCalled();
+    mock.mockReset();
+    await orm.em.flush();
+    expect(mock).not.toBeCalled();
+
+    res.value = { lol: true };
+    await orm.em.flush();
+    expect(mock).toBeCalled();
+    mock.mockReset();
+    await orm.em.flush();
+    expect(mock).not.toBeCalled();
+  });
+
+});

--- a/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
@@ -19,7 +19,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
     entity.pet = null;
   }
   if (typeof data.pet === 'string') {
-    data.pet = JSON.parse(data.pet);
+    data.pet = parseJsonSafe(data.pet);
   }
   if (data.pet != null) {
     if (data.pet.type == '1' && entity.pet == null) {
@@ -36,7 +36,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
     entity.pet = null;
   }
   if (typeof data.pet2 === 'string') {
-    data.pet2 = JSON.parse(data.pet2);
+    data.pet2 = parseJsonSafe(data.pet2);
   }
   if (data.pet2 != null) {
     if (data.pet2.type == '1' && entity.pet2 == null) {
@@ -53,13 +53,13 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
     entity.pet2 = null;
   }
   if (typeof data.pets === 'string') {
-    data.pets = JSON.parse(data.pets);
+    data.pets = parseJsonSafe(data.pets);
   }
   if (Array.isArray(data.pets)) {
     entity.pets = [];
     data.pets.forEach((_, idx_0) => {
       if (typeof data.pets[idx_0] === 'string') {
-        data.pets[idx_0] = JSON.parse(data.pets[idx_0]);
+        data.pets[idx_0] = parseJsonSafe(data.pets[idx_0]);
       }
       if (data.pets[idx_0] != null) {
         if (data.pets[idx_0].type == '1' && entity.pets[idx_0] == null) {


### PR DESCRIPTION
Every driver behaves a bit differently when it comes to handling JSON columns. While SQLite is not processing then anyhow, and MongoDB supports them natively, all the others have rather quirky and not very configurable JSON parsing and stringification implemented. It is crucial to have the JSON values properly parsed, as well as normalized in the entity snapshot, so we can correctly detect updates. 

This PR makes the JSON parsing fail-safe, returning the value directly if it is not a valid JSON string, and ensures the entity data are in the right shape. 

Closes #4193