### PR TITLE
v6 docs updates

### DIFF
--- a/docs/docs/decorators.md
+++ b/docs/docs/decorators.md
@@ -248,16 +248,16 @@ Many instances of the current Entity refer to One instance of the referred Entit
 
 See [Defining Entities](relationships.md#manytoone) for more examples.
 
-| Parameter    | Type | Optional | Description                                                                                                                                               |
-|--------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `entity`     | `string` &#124; `() => EntityName` | yes | Set target entity type.                                                                                                                                   |
-| `cascade`    | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
-| `eager`      | `boolean` | yes | Always load the relationship.                                                                                                                             |
-| `inversedBy` | `(string & keyof T) ` &#124; ` (e: T) => any` | yes | Point to the inverse side property name.                                                                                                                  |
-| `ref`        | `boolean` | yes | Wrap the entity in [`Reference` wrapper](type-safe-relations.md).                                                                                         |
-| `primary`    | `boolean` | yes | Use this relation as primary key.                                                                                                                         |
+| Parameter    | Type | Optional | Description                                                                                                                                                |
+|--------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `entity`     | `string` &#124; `() => EntityName` | yes | Set target entity type.                                                                                                           |
+| `cascade`    | `Cascade[]` | yes | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)).|
+| `eager`      | `boolean` | yes | Always load the relationship. (Discouraged for use with to-many relations.)                                                                                 |
+| `inversedBy` | `(string & keyof T) ` &#124; ` (e: T) => any` | yes | Point to the inverse side property name.                                                                               |
+| `ref`        | `boolean` | yes | Wrap the entity in [`Reference` wrapper](type-safe-relations.md).                                                                                          |
+| `primary`    | `boolean` | yes | Use this relation as primary key.                                                                                                                          |
 | `deleteRule`   | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity).                                                                                  |
-| `updateRule` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity).                                                                                  |
+| `updateRule` | `string` | yes | [Referential integrity](cascading.md#declarative-referential-integrity).                                                                                    |
 
 ```ts
 @ManyToOne()
@@ -282,7 +282,7 @@ See [Defining Entities](relationships.md#onetoone) for more examples, including 
 |-----------------|-----------------------------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `entity`        | `string` &#124; `() => EntityName`            | yes      | Set target entity type.                                                                                                                                    |
 | `cascade`       | `Cascade[]`                                   | yes      | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)).  |
-| `eager`         | `boolean`                                     | yes      | Always load the relationship.                                                                                                                              |
+| `eager`         | `boolean`                                     | yes      | Always load the relationship. (Discouraged for use with to-many relations.)                                                                                |
 | `owner`         | `boolean`                                     | yes      | Explicitly set as owning side (same as providing `inversedBy`).                                                                                            |
 | `inversedBy`    | `(string & keyof T) ` &#124; ` (e: T) => any` | yes      | Point to the inverse side property name.                                                                                                                   |
 | `mappedBy`      | `(string & keyof T)` &#124; `(e: T) => any`   | yes      | Point to the owning side property name.                                                                                                                    |
@@ -323,7 +323,7 @@ See [Defining Entities](relationships.md#onetomany) for more examples, including
 | `mappedBy`          | `(string & keyof T)` &#124; `(e: T) => any` | no       | Point to the owning side property name.                                                                                                                   |
 | `entity`            | `string` &#124; `() => EntityName`          | yes      | Set target entity type.                                                                                                                                   |
 | `cascade`           | `Cascade[]`                                 | yes      | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
-| `eager`             | `boolean`                                   | yes      | Always load the relationship.                                                                                                                             |
+| `eager`             | `boolean`                                   | yes      | Always load the relationship. (Discouraged for use with to-many relations.)                                                                               |
 | `orphanRemoval`     | `boolean`                                   | yes      | Remove the entity when it gets disconnected from the connection (see [Cascading](cascading.md#orphan-removal)).                                           |
 | `orderBy`           | `{ [field: string]: QueryOrder }`           | yes      | Set default ordering condition.                                                                                                                           |
 | `joinColumn`        | `string`                                    | yes      | Override default database column name on the owning side (see [Naming Strategy](naming-strategy.md)).                                                     |
@@ -351,7 +351,7 @@ See [Defining Entities](relationships.md#manytomany) for more examples, includin
 |---------------------|-----------------------------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `entity`            | `string` &#124; `() => EntityName`            | yes      | Set target entity type.                                                                                                                                   |
 | `cascade`           | `Cascade[]`                                   | yes      | Set what actions on owning entity should be cascaded to the relationship. Defaults to `[Cascade.PERSIST, Cascade.MERGE]` (see [Cascading](cascading.md)). |
-| `eager`             | `boolean`                                     | yes      | Always load the relationship.                                                                                                                             |
+| `eager`             | `boolean`                                     | yes      | Always load the relationship. (Discouraged for use with to-many relations.)                                                                               |
 | `owner`             | `boolean`                                     | yes      | Explicitly set as owning side (same as providing `inversedBy`).                                                                                           |
 | `inversedBy`        | `(string & keyof T) ` &#124; ` (e: T) => any` | yes      | Point to the inverse side property name.                                                                                                                  |
 | `mappedBy`          | `(string & keyof T)` &#124; `(e: T) => any`   | yes      | Point to the owning side property name.                                                                                                                   |

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -1669,7 +1669,7 @@ From v4 `BaseEntity` class is provided with `init`, `isInitialized`, `assign` an
 import { BaseEntity } from '@mikro-orm/core';
 
 @Entity()
-export class Book extends BaseEntity<Book, 'id'> {
+export class Book extends BaseEntity {
 
   @PrimaryKey()
   id!: number;

--- a/docs/docs/entity-helper.md
+++ b/docs/docs/entity-helper.md
@@ -170,7 +170,7 @@ Users can choose whether they are fine with polluting the entity interface with 
 import { BaseEntity } from '@mikro-orm/core';
 
 @Entity()
-export class Book extends BaseEntity<Book, 'id'> { ... }
+export class Book extends BaseEntity { ... }
 ```
 
 Then you can work with those methods directly:

--- a/docs/docs/type-safe-relations.md
+++ b/docs/docs/type-safe-relations.md
@@ -137,7 +137,6 @@ book1.author; // Ref<Author> (instance of `Reference` class)
 book1.author.name; // type error, there is no `name` property
 book1.author.unwrap().name; // unsafe sync access, undefined as author is not loaded
 book1.author.isInitialized(); // false
-(await book1.author.load()).name; // async safe access
 
 const book2 = await em.findOne(Book, 1, { populate: ['author'] });
 book2.author; // LoadedReference<Author> (instance of `Reference` class)
@@ -162,6 +161,22 @@ If you use different metadata provider than `TsMorphMetadataProvider` (e.g. `Ref
 @ManyToOne(() => Author, { ref: true })
 author!: Ref<Author>;
 ```
+
+### Using `Reference.load()`
+
+After retrieving a reference, you can load the full entity by utilizing the asynchronous `Reference.load()` method.
+
+```ts
+const book1 = await em.findOne(Book, 1);
+(await book1.author.load()).name; // async safe access
+
+const book2 = await em.findOne(Book, 2);
+const author = await book2.author.load();
+author.name;
+await book2.author.load(); // no additional query, already loaded
+```
+
+> As opposed to `wrap(e).init()` which always refreshes the entity, `Reference.load()` method will query the database only if the entity is not already loaded in Identity Map.
 
 ## `Loaded` type
 
@@ -405,5 +420,3 @@ const book = await em.findOne(Book, 1);
 console.log(book.author.id); // ok, returns string PK
 console.log(book.author._id); // ok, returns ObjectId PK
 ```
-
-> As opposed to `wrap(e).init()` which always refreshes the entity, `Reference.load()` method will query the database only if the entity is not already loaded in Identity Map.

--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -8,7 +8,7 @@ title: Upgrading from v5 to v6
 
 Support for older node versions was dropped. 
 
-## ⚠️ TypeScript 4.9+ required
+## ⚠️ TypeScript 5.0+ required
 
 Support for older TypeScript versions was dropped. 
 

--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -8,7 +8,7 @@ title: Upgrading from v5 to v6
 
 Support for older node versions was dropped. 
 
-## TypeScript 4.9+ required
+## ⚠️ TypeScript 4.9+ required
 
 Support for older TypeScript versions was dropped. 
 
@@ -229,6 +229,16 @@ const ref = em.getReference(User, 1);
 ref.age = raw(`age * 2`);
 await em.flush();
 console.log(ref.age); // real value is available after flush
+```
+
+## Changed default PostgreSQL `Date` mapping precision
+
+Previously, all drivers defaulted the `Date` type mapping to a timestamp with 0 precision (so seconds). This is [discouraged in PostgreSQL](https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_timestamp.280.29_or_timestamptz.280.29), and is no longer valid - the default mapping without the `length` property being explicitly set is now `timestamptz`, which stores microsecond precision, so equivalent to `timestampz(6)`.
+
+To revert back to the v5 behavior, you can either set the `columnType: 'timestampz(0)'`, or use `length: 0`:
+
+```ts
+@Property({ length: 0 })
 ```
 
 ## Metadata CacheAdapter requires sync API


### PR DESCRIPTION
- Adding a warning icon to the upgrade notes about typescript
- Separating `.load` into a dedicated section for clarity
- Removing stale references to `BaseEntity`

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/6445731/230470881-5a2b8e24-685b-4029-9737-1ca36792c079.png">

