### PR TITLE
fix(core): prevent tuple type properties from being converted to array when serializing entities

### DIFF
--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -228,7 +228,7 @@ export type EntityDTOProp<T> = T extends Scalar
         : T extends { $: infer U }
           ? (U extends readonly (infer V)[] ? EntityDTO<V>[] : EntityDTO<U>)
           : T extends readonly (infer U)[]
-            ? U[]
+            ? (T extends readonly [infer U, ...infer V] ? T : U[])
             : T extends Relation<T>
               ? EntityDTO<T>
               : T;

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -562,4 +562,7 @@ describe('check typings', () => {
     q = { [OptionalProps]: 'bar' };
   });
 
+  test('tuple type after entity serializized', async () => {
+    assert<IsExact<EntityDTO<Book>['point'], [number, number] | undefined>>(true);
+  });
 });


### PR DESCRIPTION
This commit fixes an issue where properties with tuple type were being converted to array
when entities were serialized. The fix ensures that tuple type properties are correctly
preserved during the serialization process.