### PR TITLE
docs(core): updated lifecycle docs to indicate subscriber error

### DIFF
--- a/docs/docs/events.md
+++ b/docs/docs/events.md
@@ -74,13 +74,26 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
 
 }
 ```
+> &#x26a0;&#xfe0f;**Warning**
+>
+> Do not mix and match the `@Subscriber()` decorator and the `subscribers`
+> array in the configuration. If you use the decorator, you **should not
+> use** the `subscribers` array, and vice versa.
+>
+> **This is due to an issue that will cause every subscriber to be
+> registered
+> twice, which will result in duplicate events being fired.**
+>
+> Additionally, future versions of MikroORM will be dropping support for the
+> `@Subscriber()` decorator in favor of the `subscribers` array in the configuration.
+> As such, it is not recommended to use the `@Subscriber()` decorator and to
+> instead use the `subscribers` array in the configuration.
 
 Another example, where we register to all the events and all entities:
 
 ```ts
-import { EventArgs, EventSubscriber, Subscriber } from '@mikro-orm/core';
+import { EventArgs, EventSubscriber } from '@mikro-orm/core';
 
-@Subscriber()
 export class EverythingSubscriber implements EventSubscriber {
 
   // entity life cycle events
@@ -199,7 +212,6 @@ We first use `uow.getChangeSets()` method to look up the change set of entity we
 2. Call `uow.recomputeSingleChangeSet(cs.entity)` to recalculate the existing change set of the `FooBar` entity.
 
 ```ts
-@Subscriber()
 export class FooBarSubscriber implements EventSubscriber {
 
   async onFlush(args: FlushEventArgs): Promise<void> {

--- a/docs/docs/events.md
+++ b/docs/docs/events.md
@@ -74,20 +74,19 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
 
 }
 ```
-> &#x26a0;&#xfe0f;**Warning**
->
-> Do not mix and match the `@Subscriber()` decorator and the `subscribers`
-> array in the configuration. If you use the decorator, you **should not
-> use** the `subscribers` array, and vice versa.
->
-> **This is due to an issue that will cause every subscriber to be
-> registered
-> twice, which will result in duplicate events being fired.**
->
-> Additionally, future versions of MikroORM will be dropping support for the
-> `@Subscriber()` decorator in favor of the `subscribers` array in the configuration.
-> As such, it is not recommended to use the `@Subscriber()` decorator and to
-> instead use the `subscribers` array in the configuration.
+:::caution Warning
+Do not mix and match the `@Subscriber()` decorator and the `subscribers`
+array in the configuration. If you use the decorator, you **should not
+use** the `subscribers` array, and vice versa.
+
+**This is due to an issue that will cause every subscriber to be registered
+twice, which will result in duplicate events being fired.**
+
+Additionally, future versions of MikroORM will be dropping support for the
+`@Subscriber()` decorator in favor of the `subscribers` array in the configuration.
+As such, it is not recommended to use the `@Subscriber()` decorator and to
+instead use the `subscribers` array in the configuration.
+:::
 
 Another example, where we register to all the events and all entities:
 

--- a/docs/docs/events.md
+++ b/docs/docs/events.md
@@ -79,8 +79,9 @@ Do not mix and match the `@Subscriber()` decorator and the `subscribers`
 array in the configuration. If you use the decorator, you **should not
 use** the `subscribers` array, and vice versa.
 
-**This is due to an issue that will cause every subscriber to be registered
-twice, which will result in duplicate events being fired.**
+**This is due to an issue that will cause each subscriber in the configuration 
+array annotated with `@Subscriber()` to be registered twice, which will result 
+in duplicate events being fired.**
 
 Additionally, future versions of MikroORM will be dropping support for the
 `@Subscriber()` decorator in favor of the `subscribers` array in the configuration.

--- a/docs/docs/events.md
+++ b/docs/docs/events.md
@@ -75,18 +75,11 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
 }
 ```
 :::caution Warning
-Do not mix and match the `@Subscriber()` decorator and the `subscribers`
-array in the configuration. If you use the decorator, you **should not
-use** the `subscribers` array, and vice versa.
+Do not mix and match the `@Subscriber()` decorator and the `subscribers` array in the configuration. If you use the decorator, you **should not use** the `subscribers` array, and vice versa.
 
-**This is due to an issue that will cause each subscriber in the configuration 
-array annotated with `@Subscriber()` to be registered twice, which will result 
-in duplicate events being fired.**
+This is due to an issue that will cause each subscriber in the configuration array annotated with `@Subscriber()` to be registered twice, **which will result in duplicate events being fired.**
 
-Additionally, future versions of MikroORM will be dropping support for the
-`@Subscriber()` decorator in favor of the `subscribers` array in the configuration.
-As such, it is not recommended to use the `@Subscriber()` decorator and to
-instead use the `subscribers` array in the configuration.
+Additionally, future versions of MikroORM will be dropping support for the`@Subscriber()` decorator in favor of the `subscribers` array in the configuration. Therefore, it is not recommended to use the `@Subscriber()` decorator and to instead use the `subscribers` array in the configuration.
 :::
 
 Another example, where we register to all the events and all entities:

--- a/docs/versioned_docs/version-4.5/lifecycle-hooks.md
+++ b/docs/versioned_docs/version-4.5/lifecycle-hooks.md
@@ -72,24 +72,13 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
 
 }
 ```
-> &#x26a0;&#xfe0f;**Warning**<br>
-> Do not mix and match the `@Subscriber()` decorator and the `subscribers` 
-> array in the configuration. If you use the decorator, you <b>should not 
-> use</b> the `subscribers` array, and vice versa.
-> <br><br><b>This is due to an issue that will cause every subscriber to be 
-> registered 
-> twice, which will result in duplicate events being fired.</b><br><br>
-> Additionally, future versions of MikroORM will be dropping support for the 
-> `@Subscriber()` decorator in favor of the `subscribers` array in the configuration.
-> As such, it is not recommended to use the `@Subscriber()` decorator and to 
-> instead use the `subscribers` array in the configuration.
- 
 
 Another example, where we register to all the events and all entities:
 
 ```typescript
 import { EventArgs, EventSubscriber, Subscriber } from '@mikro-orm/core';
 
+@Subscriber()
 export class EverythingSubscriber implements EventSubscriber {
 
   async beforeCreate<T>(args: EventArgs<T>): Promise<void> { ... }
@@ -175,6 +164,7 @@ We first use `uow.getChangeSets()` method to look up the change set of entity we
 2. Call `uow.recomputeSingleChangeSet(cs.entity)` to recalculate the existing change set of the `FooBar` entity.
 
 ```typescript
+@Subscriber()
 export class FooBarSubscriber implements EventSubscriber {
 
   async onFlush(args: FlushEventArgs): Promise<void> {

--- a/docs/versioned_docs/version-4.5/lifecycle-hooks.md
+++ b/docs/versioned_docs/version-4.5/lifecycle-hooks.md
@@ -72,13 +72,24 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
 
 }
 ```
+> &#x26a0;&#xfe0f;**Warning**<br>
+> Do not mix and match the `@Subscriber()` decorator and the `subscribers` 
+> array in the configuration. If you use the decorator, you <b>should not 
+> use</b> the `subscribers` array, and vice versa.
+> <br><br><b>This is due to an issue that will cause every subscriber to be 
+> registered 
+> twice, which will result in duplicate events being fired.</b><br><br>
+> Additionally, future versions of MikroORM will be dropping support for the 
+> `@Subscriber()` decorator in favor of the `subscribers` array in the configuration.
+> As such, it is not recommended to use the `@Subscriber()` decorator and to 
+> instead use the `subscribers` array in the configuration.
+ 
 
 Another example, where we register to all the events and all entities:
 
 ```typescript
 import { EventArgs, EventSubscriber, Subscriber } from '@mikro-orm/core';
 
-@Subscriber()
 export class EverythingSubscriber implements EventSubscriber {
 
   async beforeCreate<T>(args: EventArgs<T>): Promise<void> { ... }
@@ -164,7 +175,6 @@ We first use `uow.getChangeSets()` method to look up the change set of entity we
 2. Call `uow.recomputeSingleChangeSet(cs.entity)` to recalculate the existing change set of the `FooBar` entity.
 
 ```typescript
-@Subscriber()
 export class FooBarSubscriber implements EventSubscriber {
 
   async onFlush(args: FlushEventArgs): Promise<void> {

--- a/docs/versioned_docs/version-5.6/events.md
+++ b/docs/versioned_docs/version-5.6/events.md
@@ -74,13 +74,26 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
 
 }
 ```
+> &#x26a0;&#xfe0f;**Warning**
+>
+> Do not mix and match the `@Subscriber()` decorator and the `subscribers`
+> array in the configuration. If you use the decorator, you **should not
+> use** the `subscribers` array, and vice versa.
+>
+> **This is due to an issue that will cause every subscriber to be
+> registered
+> twice, which will result in duplicate events being fired.**
+>
+> Additionally, future versions of MikroORM will be dropping support for the
+> `@Subscriber()` decorator in favor of the `subscribers` array in the configuration.
+> As such, it is not recommended to use the `@Subscriber()` decorator and to
+> instead use the `subscribers` array in the configuration.
 
 Another example, where we register to all the events and all entities:
 
 ```ts
-import { EventArgs, EventSubscriber, Subscriber } from '@mikro-orm/core';
+import { EventArgs, EventSubscriber } from '@mikro-orm/core';
 
-@Subscriber()
 export class EverythingSubscriber implements EventSubscriber {
 
   // entity life cycle events
@@ -199,7 +212,6 @@ We first use `uow.getChangeSets()` method to look up the change set of entity we
 2. Call `uow.recomputeSingleChangeSet(cs.entity)` to recalculate the existing change set of the `FooBar` entity.
 
 ```ts
-@Subscriber()
 export class FooBarSubscriber implements EventSubscriber {
 
   async onFlush(args: FlushEventArgs): Promise<void> {

--- a/docs/versioned_docs/version-5.6/events.md
+++ b/docs/versioned_docs/version-5.6/events.md
@@ -76,17 +76,11 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
 ```
 
 :::caution Warning
-Do not mix and match the `@Subscriber()` decorator and the `subscribers`
-array in the configuration. If you use the decorator, you **should not
-use** the `subscribers` array, and vice versa.
+Do not mix and match the `@Subscriber()` decorator and the `subscribers` array in the configuration. If you use the decorator, you **should not use** the `subscribers` array, and vice versa.
 
-**This is due to an issue that will cause each subscriber in the configuration array annotated with `@Subscriber()` to be registered
-twice, which will result in duplicate events being fired.**
+This is due to an issue that will cause each subscriber in the configuration array annotated with `@Subscriber()` to be registered twice, **which will result in duplicate events being fired.**
 
-Additionally, future versions of MikroORM will be dropping support for the
-`@Subscriber()` decorator in favor of the `subscribers` array in the configuration.
-As such, it is not recommended to use the `@Subscriber()` decorator and to
-instead use the `subscribers` array in the configuration.
+Additionally, future versions of MikroORM will be dropping support for the`@Subscriber()` decorator in favor of the `subscribers` array in the configuration. Therefore, it is not recommended to use the `@Subscriber()` decorator and to instead use the `subscribers` array in the configuration.
 :::
 
 Another example, where we register to all the events and all entities:

--- a/docs/versioned_docs/version-5.6/events.md
+++ b/docs/versioned_docs/version-5.6/events.md
@@ -80,7 +80,7 @@ Do not mix and match the `@Subscriber()` decorator and the `subscribers`
 array in the configuration. If you use the decorator, you **should not
 use** the `subscribers` array, and vice versa.
 
-**This is due to an issue that will cause every subscriber to be registered
+**This is due to an issue that will cause each subscriber in the configuration array annotated with `@Subscriber()` to be registered
 twice, which will result in duplicate events being fired.**
 
 Additionally, future versions of MikroORM will be dropping support for the

--- a/docs/versioned_docs/version-5.6/events.md
+++ b/docs/versioned_docs/version-5.6/events.md
@@ -74,20 +74,20 @@ export class AuthorSubscriber implements EventSubscriber<Author> {
 
 }
 ```
-> &#x26a0;&#xfe0f;**Warning**
->
-> Do not mix and match the `@Subscriber()` decorator and the `subscribers`
-> array in the configuration. If you use the decorator, you **should not
-> use** the `subscribers` array, and vice versa.
->
-> **This is due to an issue that will cause every subscriber to be
-> registered
-> twice, which will result in duplicate events being fired.**
->
-> Additionally, future versions of MikroORM will be dropping support for the
-> `@Subscriber()` decorator in favor of the `subscribers` array in the configuration.
-> As such, it is not recommended to use the `@Subscriber()` decorator and to
-> instead use the `subscribers` array in the configuration.
+
+:::caution Warning
+Do not mix and match the `@Subscriber()` decorator and the `subscribers`
+array in the configuration. If you use the decorator, you **should not
+use** the `subscribers` array, and vice versa.
+
+**This is due to an issue that will cause every subscriber to be registered
+twice, which will result in duplicate events being fired.**
+
+Additionally, future versions of MikroORM will be dropping support for the
+`@Subscriber()` decorator in favor of the `subscribers` array in the configuration.
+As such, it is not recommended to use the `@Subscriber()` decorator and to
+instead use the `subscribers` array in the configuration.
+:::
 
 Another example, where we register to all the events and all entities:
 


### PR DESCRIPTION
Updated `docs/docs/events.md` and `docs/versioned_docs/version-5.6/events.md` to indicate an issue when using the `@Subscriber()` decorator in addition to instantiating a subscriber class in the configuration.

Related: #4231