### PR TITLE
Fix return value inside `ensureDatabase()`

### DIFF
--- a/packages/knex/src/schema/SchemaGenerator.ts
+++ b/packages/knex/src/schema/SchemaGenerator.ts
@@ -43,7 +43,7 @@ export class SchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDriver> 
     const dbName = this.config.get('dbName')!;
 
     if (this.lastEnsuredDatabase === dbName) {
-      return true;
+      return false;
     }
 
     const exists = await this.helper.databaseExists(this.connection, dbName);


### PR DESCRIPTION
Regarding the way `ensureDatabase` must behave based on the comment, I think that in the case of an already ensured database the method should return false because no database was created. 