### PR TITLE
feat(migrations): add support for custom migration names

### DIFF
--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -153,6 +153,14 @@ npx mikro-orm migration:fresh    # Drop the database and migrate up to the lates
 
 > To create blank migration file, we can use `npx mikro-orm migration:create --blank`.
 
+> To specify a name for your migration file, we can use `npx mikro-orm migration:create --name=newName`
+
+You can customize the naming convention for your migration file by utilizing the `fileName` callback and overriding its default behavior.
+```sh
+    migrations: {
+      fileName: (time, name) => time + name
+    }
+```
 For `migration:up` and `migration:down` commands we can specify `--from` (`-f`), `--to` (`-t`) and `--only` (`-o`) options to run only a subset of migrations:
 
 ```sh

--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -262,14 +262,21 @@ await MikroORM.init({
   },
 });
 ```
-## Using custom migration names
-To specify a name for your migration file, we can use `npx mikro-orm migration:create --name=newName`
 
-> Each migration filename should contains a timestamp that allows Mikro-orm to determine the order of the migrations
+## Using custom migration names
+
+We can add a name to migration files via a CLI
+
+```
+npx mikro-orm migration:create --name=newName
+```
+
+The default behavior support `name` option, here's how it works, if we set `name` option to equal `add_email_property_to_user_table` the name of the generated file will be as follows "Migration20191013214813_add_email_property_to_user_table"
 
 You can customize the naming convention for your migration file by utilizing the `fileName` callback and overriding its default behavior.
 
-If we would like to always specfiy a name, we should throw an error in case the name is not provided.
+If we would like to always specify a name, we should throw an error in case the name is not provided.
+
 ```ts
 migrations: {
   fileName: (timestamp: string, name?: string) => {
@@ -282,7 +289,10 @@ migrations: {
 },
 ```
 
+> Each migration filename should contains a timestamp that allows MikroOrm to determine the order of the migrations
+
 If we just want to change the filename without throwing an error in case the name is not provided
+
 ```ts
 migrations: {
   fileName: (timestamp: string, name?: string) => {
@@ -290,6 +300,7 @@ migrations: {
   },
 },
 ```
+
 ## MongoDB support
 
 Support for migrations in MongoDB has been added in v5.3. It uses its own package: `@mikro-orm/migrations-mongodb`, and should be otherwise compatible with the current CLI commands. Use `this.driver` or `this.getCollection()` to manipulate with the database.

--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -265,21 +265,19 @@ await MikroORM.init({
 
 ## Using custom migration names
 
-We can add a name to migration files via a CLI
+Since v5.7, you can specify a custom migration name via `--name` CLI option. It will be appended to the generated prefix:
 
+```sh
+# generates file Migration20230421212713_add_email_property_to_user_table.ts
+npx mikro-orm migration:create --name=add_email_property_to_user_table
 ```
-npx mikro-orm migration:create --name=newName
-```
 
-The default behavior support `name` option, here's how it works, if we set `name` option to equal `add_email_property_to_user_table` the name of the generated file will be as follows "Migration20191013214813_add_email_property_to_user_table"
-
-You can customize the naming convention for your migration file by utilizing the `fileName` callback and overriding its default behavior.
-
-If we would like to always specify a name, we should throw an error in case the name is not provided.
+You can customize the naming convention for your migration file by utilizing the `fileName` callback, or even use it to enforce migrations with names:
 
 ```ts
 migrations: {
   fileName: (timestamp: string, name?: string) => {
+    // force user to provide the name, otherwise we would end up with `Migration20230421212713_undefined`
     if (!name) {
       throw new Error('Specify migration name via `mikro-orm migration:create --name=...`');
     }
@@ -289,17 +287,11 @@ migrations: {
 },
 ```
 
-> Each migration filename should contains a timestamp that allows MikroOrm to determine the order of the migrations
+:::caution Warning
 
-If we just want to change the filename without throwing an error in case the name is not provided
+When overriding the `migrations.fileName` strategy, keep in mind that your migration files need to be sortable, you should never start the filename with the custom `name` option as it could result in wrong order of execution.
 
-```ts
-migrations: {
-  fileName: (timestamp: string, name?: string) => {
-    return `CustomMigration${timestamp}_${name ? name : '' }`;
-  },
-},
-```
+:::
 
 ## MongoDB support
 

--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -158,7 +158,7 @@ npx mikro-orm migration:fresh    # Drop the database and migrate up to the lates
 You can customize the naming convention for your migration file by utilizing the `fileName` callback and overriding its default behavior.
 ```sh
     migrations: {
-      fileName: (time, name) => time + name
+      fileName: (time, name) =>`Migration-${time}+${name}`
     }
 ```
 For `migration:up` and `migration:down` commands we can specify `--from` (`-f`), `--to` (`-t`) and `--only` (`-o`) options to run only a subset of migrations:

--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -153,14 +153,6 @@ npx mikro-orm migration:fresh    # Drop the database and migrate up to the lates
 
 > To create blank migration file, we can use `npx mikro-orm migration:create --blank`.
 
-> To specify a name for your migration file, we can use `npx mikro-orm migration:create --name=newName`
-
-You can customize the naming convention for your migration file by utilizing the `fileName` callback and overriding its default behavior.
-```sh
-    migrations: {
-      fileName: (time, name) =>`Migration-${time}+${name}`
-    }
-```
 For `migration:up` and `migration:down` commands we can specify `--from` (`-f`), `--to` (`-t`) and `--only` (`-o`) options to run only a subset of migrations:
 
 ```sh
@@ -270,7 +262,34 @@ await MikroORM.init({
   },
 });
 ```
+## Using custom migration names
+To specify a name for your migration file, we can use `npx mikro-orm migration:create --name=newName`
 
+> Each migration filename should contains a timestamp that allows Mikro-orm to determine the order of the migrations
+
+You can customize the naming convention for your migration file by utilizing the `fileName` callback and overriding its default behavior.
+
+If we would like to always specfiy a name, we should throw an error in case the name is not provided.
+```ts
+migrations: {
+  fileName: (timestamp: string, name?: string) => {
+    if (!name) {
+      throw new Error('Specify migration name via `mikro-orm migration:create --name=...`');
+    }
+
+    return `Migration${timestamp}_${name}`;
+  },
+},
+```
+
+If we just want to change the filename without throwing an error in case the name is not provided
+```ts
+migrations: {
+  fileName: (timestamp: string, name?: string) => {
+    return `CustomMigration${timestamp}_${name ? name : '' }`;
+  },
+},
+```
 ## MongoDB support
 
 Support for migrations in MongoDB has been added in v5.3. It uses its own package: `@mikro-orm/migrations-mongodb`, and should be otherwise compatible with the current CLI commands. Use `this.driver` or `this.getCollection()` to manipulate with the database.

--- a/packages/cli/src/commands/MigrationCommandFactory.ts
+++ b/packages/cli/src/commands/MigrationCommandFactory.ts
@@ -80,6 +80,11 @@ export class MigrationCommandFactory {
       type: 'string',
       desc: 'Sets path to directory where to save entities',
     });
+    args.option('name', {
+      alias: 'name',
+      type: 'string',
+      desc: 'Specify custom name for the file',
+    });
   }
 
   static async handleMigrationCommand(args: ArgumentsCamelCase<Options>, method: MigratorMethod): Promise<void> {
@@ -145,7 +150,7 @@ export class MigrationCommandFactory {
   }
 
   private static async handleCreateCommand(migrator: IMigrator, args: ArgumentsCamelCase<Options>, config: Configuration): Promise<void> {
-    const ret = await migrator.createMigration(args.path, args.blank, args.initial);
+    const ret = await migrator.createMigration(args.path, args.blank, args.initial, args.name);
 
     if (ret.diff.up.length === 0) {
       return CLIHelper.dump(colors.green(`No changes required, schema is up-to-date`));
@@ -237,5 +242,5 @@ export class MigrationCommandFactory {
 
 type MigratorMethod = 'create' | 'check' | 'up' | 'down' | 'list' | 'pending' | 'fresh';
 type CliUpDownOptions = { to?: string | number; from?: string | number; only?: string };
-type GenerateOptions = { dump?: boolean; blank?: boolean; initial?: boolean; path?: string; disableFkChecks?: boolean; seed: string };
+type GenerateOptions = { dump?: boolean; blank?: boolean; initial?: boolean; path?: string; disableFkChecks?: boolean; seed: string; name?: string };
 type Options = GenerateOptions & CliUpDownOptions;

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -597,7 +597,7 @@ export interface IMigrator {
   /**
    * Checks current schema for changes, generates new migration if there are any.
    */
-  createMigration(path?: string, blank?: boolean, initial?: boolean): Promise<MigrationResult>;
+  createMigration(path?: string, blank?: boolean, initial?: boolean, name?: string): Promise<MigrationResult>;
 
   /**
    * Checks current schema for changes.
@@ -647,7 +647,7 @@ export interface IMigrationGenerator {
   /**
    * Generates the full contents of migration file. Uses `generateMigrationFile` to get the file contents.
    */
-  generate(diff: MigrationDiff, path?: string): Promise<[string, string]>;
+  generate(diff: MigrationDiff, path?: string, name?: string): Promise<[string, string]>;
 
   /**
    * Creates single migration statement. By default adds `this.addSql(sql);` to the code.

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -97,7 +97,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
       safe: false,
       snapshot: true,
       emit: 'ts',
-      fileName: (timestamp: string) => `Migration${timestamp}`,
+      fileName: (timestamp: string, name?: string) => `Migration${timestamp}${name ? '_' + name : ''}`,
     },
     schemaGenerator: {
       disableForeignKeys: true,

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -452,7 +452,7 @@ export type MigrationsOptions = {
   snapshotName?: string;
   emit?: 'js' | 'ts' | 'cjs';
   generator?: Constructor<IMigrationGenerator>;
-  fileName?: (timestamp: string) => string;
+  fileName?: (timestamp: string, name?: string) => string;
   migrationsList?: MigrationObject[];
 };
 

--- a/packages/migrations/src/MigrationGenerator.ts
+++ b/packages/migrations/src/MigrationGenerator.ts
@@ -19,11 +19,7 @@ export abstract class MigrationGenerator implements IMigrationGenerator {
     await ensureDir(path);
     const timestamp = new Date().toISOString().replace(/[-T:]|\.\d{3}z$/ig, '');
     const className = this.namingStrategy.classToMigrationName(timestamp);
-    let fileName = `${this.options.fileName!(timestamp)}`;
-    if (name) {
-      fileName = `${fileName}_${name}`;
-    }
-    fileName = `${fileName}.${this.options.emit}`;
+    const fileName = `${this.options.fileName!(timestamp, name)}.${this.options.emit}`;
     const ret = this.generateMigrationFile(className, diff);
     await writeFile(path + '/' + fileName, ret);
 

--- a/packages/migrations/src/MigrationGenerator.ts
+++ b/packages/migrations/src/MigrationGenerator.ts
@@ -12,14 +12,18 @@ export abstract class MigrationGenerator implements IMigrationGenerator {
   /**
    * @inheritDoc
    */
-  async generate(diff: { up: string[]; down: string[] }, path?: string): Promise<[string, string]> {
+  async generate(diff: { up: string[]; down: string[] }, path?: string, name?: string): Promise<[string, string]> {
     /* istanbul ignore next */
     const defaultPath = this.options.emit === 'ts' && this.options.pathTs ? this.options.pathTs : this.options.path!;
     path = Utils.normalizePath(this.driver.config.get('baseDir'), path ?? defaultPath);
     await ensureDir(path);
     const timestamp = new Date().toISOString().replace(/[-T:]|\.\d{3}z$/ig, '');
     const className = this.namingStrategy.classToMigrationName(timestamp);
-    const fileName = `${this.options.fileName!(timestamp)}.${this.options.emit}`;
+    let fileName = `${this.options.fileName!(timestamp)}`;
+    if (name) {
+      fileName = `${fileName}_${name}`;
+    }
+    fileName = `${fileName}.${this.options.emit}`;
     const ret = this.generateMigrationFile(className, diff);
     await writeFile(path + '/' + fileName, ret);
 

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -47,7 +47,7 @@ export class Migrator implements IMigrator {
   /**
    * @inheritDoc
    */
-  async createMigration(path?: string, blank = false, initial = false): Promise<MigrationResult> {
+  async createMigration(path?: string, blank = false, initial = false, name?: string): Promise<MigrationResult> {
     if (initial) {
       return this.createInitialMigration(path);
     }
@@ -60,8 +60,7 @@ export class Migrator implements IMigrator {
     }
 
     await this.storeCurrentSchema();
-    const migration = await this.generator.generate(diff, path);
-
+    const migration = await this.generator.generate(diff, path, name);
     return {
       fileName: migration[1],
       code: migration[0],

--- a/tests/features/migrations/Migrator.postgres.test.ts
+++ b/tests/features/migrations/Migrator.postgres.test.ts
@@ -124,11 +124,11 @@ describe('Migrator (postgres)', () => {
     const dateMock = jest.spyOn(Date.prototype, 'toISOString');
     dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
     const migrationsSettings = orm.config.get('migrations');
-    orm.config.set('migrations', { ...migrationsSettings });
+    orm.config.set('migrations', { ...migrationsSettings, fileName: (time, name) => `migration${time}_${name}` });
     const migrator = orm.migrator;
     const migration = await migrator.createMigration(undefined, false, false, 'custom_name');
     expect(migration).toMatchSnapshot('migration-dump');
-    expect(migration.fileName).toEqual('Migration20191013214813_custom_name.ts');
+    expect(migration.fileName).toEqual('migration20191013214813_custom_name.ts');
     const upMock = jest.spyOn(Umzug.prototype, 'up');
     upMock.mockImplementation(() => void 0 as any);
     const downMock = jest.spyOn(Umzug.prototype, 'down');

--- a/tests/features/migrations/Migrator.postgres.test.ts
+++ b/tests/features/migrations/Migrator.postgres.test.ts
@@ -120,6 +120,30 @@ describe('Migrator (postgres)', () => {
     downMock.mockRestore();
   });
 
+  test('generate migration with custom name with name option', async () => {
+    const dateMock = jest.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
+    const migrationsSettings = orm.config.get('migrations');
+    orm.config.set('migrations', { ...migrationsSettings });
+    const migrator = orm.migrator;
+    const migration = await migrator.createMigration(undefined, false, false, 'custom_name');
+    expect(migration).toMatchSnapshot('migration-dump');
+    expect(migration.fileName).toEqual('Migration20191013214813_custom_name.ts');
+    const upMock = jest.spyOn(Umzug.prototype, 'up');
+    upMock.mockImplementation(() => void 0 as any);
+    const downMock = jest.spyOn(Umzug.prototype, 'down');
+    downMock.mockImplementation(() => void 0 as any);
+    await migrator.up();
+    await migrator.down(migration.fileName.replace('.ts', ''));
+    await migrator.up();
+    await migrator.down(migration.fileName);
+    await migrator.up();
+    orm.config.set('migrations', migrationsSettings); // Revert migration config changes
+    await remove(process.cwd() + '/temp/migrations/' + migration.fileName);
+    upMock.mockRestore();
+    downMock.mockRestore();
+  });
+
   test('generate schema migration', async () => {
     const dateMock = jest.spyOn(Date.prototype, 'toISOString');
     dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');

--- a/tests/features/migrations/__snapshots__/Migrator.postgres.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.postgres.test.ts.snap
@@ -511,7 +511,7 @@ export class Migration20191013214813 extends Migration {
       "alter table "custom"."test2" drop column "path";",
     ],
   },
-  "fileName": "Migration20191013214813_custom_name.ts",
+  "fileName": "migration20191013214813_custom_name.ts",
 }
 `;
 

--- a/tests/features/migrations/__snapshots__/Migrator.postgres.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.postgres.test.ts.snap
@@ -475,6 +475,46 @@ export class Migration20191013214813 extends Migration {
 }
 `;
 
+exports[`Migrator (postgres) generate migration with custom name with name option: migration-dump 1`] = `
+{
+  "code": "import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20191013214813 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql('alter table "custom"."book2" alter column "double" type double precision using ("double"::double precision);');
+    this.addSql('alter table "custom"."book2" drop column "foo";');
+
+    this.addSql('alter table "custom"."test2" drop column "path";');
+  }
+
+  async down(): Promise<void> {
+    this.addSql('alter table "custom"."book2" add column "foo" varchar null default \\'lol\\';');
+    this.addSql('alter table "custom"."book2" alter column "double" type numeric using ("double"::numeric);');
+
+    this.addSql('alter table "custom"."test2" add column "path" polygon null default null;');
+  }
+
+}
+",
+  "diff": {
+    "down": [
+      "alter table "custom"."book2" add column "foo" varchar null default 'lol';",
+      "alter table "custom"."book2" alter column "double" type numeric using ("double"::numeric);",
+      "",
+      "alter table "custom"."test2" add column "path" polygon null default null;",
+    ],
+    "up": [
+      "alter table "custom"."book2" alter column "double" type double precision using ("double"::double precision);",
+      "alter table "custom"."book2" drop column "foo";",
+      "",
+      "alter table "custom"."test2" drop column "path";",
+    ],
+  },
+  "fileName": "Migration20191013214813_custom_name.ts",
+}
+`;
+
 exports[`Migrator (postgres) generate migration with custom name: migration-dump 1`] = `
 {
   "code": "import { Migration } from '@mikro-orm/migrations';


### PR DESCRIPTION
This PR adds a new option to the `migrations:create` command that allows developers to specify custom names for migration files. Previously, the migration files were automatically named based on the current timestamp, but with this new option, developers can now give the migration file a more descriptive name that is easier to understand and manage.

This feature was inspired by the functionality in Laravel and Ruby on Rails, and I believe it will bring many benefits, including improved readability and organization of migration files.

I created a discussion before on this: https://github.com/mikro-orm/mikro-orm/discussions/3987