### PR TITLE
feat(core): allow disabling transactions

### DIFF
--- a/docs/docs/transactions.md
+++ b/docs/docs/transactions.md
@@ -270,7 +270,7 @@ const res = await em.find(User, { name: 'Jon' }, {
 //   for update of "e0" skip locked
 ```
 
-### Isolation levels
+## Isolation levels
 
 We can set the transaction isolation levels:
 
@@ -287,5 +287,26 @@ Available isolation levels:
 - `IsolationLevel.SNAPSHOT`
 - `IsolationLevel.REPEATABLE_READ`
 - `IsolationLevel.SERIALIZABLE`
+
+## Disabling transactions
+
+Since v5.7 is it possible to disable transactions, either globally via `disableTransactions` config option, or locally when using `em.transactional()`.
+
+```ts
+// only the outer transaction will be opened
+await orm.em.transactional(async em => {
+  // but the inner calls to both em.transactional and em.begin will be no-op
+  await em.transactional(...);
+}, { disableTransactions: true });
+```
+
+Alternatively, you can disable transactions when creating new forks:
+
+```ts
+const em = await orm.em.fork({ disableTransactions: true });
+await em.transactional(...); // no-op
+await em.begin(...); // no-op
+await em.commit(...); // commit still calls `flush`
+```
 
 > This part of documentation is highly inspired by [doctrine internals docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html) as the behaviour here is pretty much the same.

--- a/packages/core/src/enums.ts
+++ b/packages/core/src/enums.ts
@@ -169,6 +169,7 @@ export interface TransactionOptions {
   ctx?: Transaction;
   isolationLevel?: IsolationLevel;
   flushMode?: FlushMode;
+  ignoreNestedTransactions?: boolean;
 }
 
 export abstract class PlainObject {

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -30,7 +30,7 @@ export abstract class Platform {
   }
 
   supportsTransactions(): boolean {
-    return true;
+    return !this.config.get('disableTransactions');
   }
 
   usesImplicitTransactions(): boolean {

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -508,6 +508,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
   driverOptions: Dictionary;
   namingStrategy?: { new(): NamingStrategy };
   implicitTransactions?: boolean;
+  disableTransactions?: boolean;
   connect: boolean;
   verbose: boolean;
   autoJoinOneToOneOwner: boolean;

--- a/packages/mongodb/src/MongoEntityManager.ts
+++ b/packages/mongodb/src/MongoEntityManager.ts
@@ -31,7 +31,7 @@ export class MongoEntityManager<D extends MongoDriver = MongoDriver> extends Ent
   /**
    * @inheritDoc
    */
-  async begin(options: TransactionOptions & MongoTransactionOptions = {}): Promise<void> {
+  async begin(options: Omit<TransactionOptions, 'ignoreNestedTransactions'> & MongoTransactionOptions = {}): Promise<void> {
     return super.begin(options);
   }
 

--- a/tests/features/disable-transactions/disable-nested-transactions.test.ts
+++ b/tests/features/disable-transactions/disable-nested-transactions.test.ts
@@ -1,0 +1,139 @@
+import { MikroORM } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+import { mockLogger } from '../../helpers';
+
+@Entity()
+export class Example {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+}
+
+let orm: MikroORM;
+
+beforeEach(async () => {
+  orm = await MikroORM.init({
+    entities: [Example],
+    dbName: ':memory:',
+  });
+  await orm.schema.refreshDatabase();
+});
+
+afterEach(async () => {
+  await orm.close(true);
+});
+
+test('should only commit once', async () => {
+  const mock = mockLogger(orm, ['query']);
+
+  await orm.em.transactional(async em => {
+    await em.transactional(async () => {
+      em.create(Example, { name: 'foo' });
+
+      await em.flush();
+
+      const count = await em.count(Example);
+
+      expect(count).toBe(1);
+    });
+
+    em.create(Example, { name: 'bar' });
+
+    await em.flush();
+
+    const count = await em.count(Example);
+
+    expect(count).toBe(2);
+  }, { ignoreNestedTransactions: true });
+
+  const count = await orm.em.count(Example);
+
+  expect(count).toBe(2);
+
+  expect(mock.mock.calls).toHaveLength(7);
+  expect(mock.mock.calls[0][0]).toMatch('begin');
+  expect(mock.mock.calls[1][0]).toMatch('insert into `example` (`name`) values (?) returning `id`');
+  expect(mock.mock.calls[2][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+  expect(mock.mock.calls[3][0]).toMatch('insert into `example` (`name`) values (?) returning `id`');
+  expect(mock.mock.calls[4][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+  expect(mock.mock.calls[5][0]).toMatch('commit');
+  expect(mock.mock.calls[6][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+});
+
+test('should handle rollback in real transaction', async () => {
+  const mock = mockLogger(orm, ['query']);
+
+  const transaction = orm.em.transactional(async em => {
+    await em.transactional(async () => {
+      em.create(Example, { name: 'foo' });
+
+      await em.flush();
+
+      const count = await em.count(Example);
+
+      expect(count).toBe(1);
+    });
+
+    em.create(Example, { name: 'bar' });
+
+    await em.flush();
+
+    const count = await em.count(Example);
+
+    expect(count).toBe(2);
+
+    throw new Error('roll me back');
+  }, { ignoreNestedTransactions: true });
+
+  await expect(transaction).rejects.toThrowError('roll me back');
+
+  const count = await orm.em.count(Example);
+
+  expect(count).toBe(0);
+
+  expect(mock.mock.calls).toHaveLength(7);
+  expect(mock.mock.calls[0][0]).toMatch('begin');
+  expect(mock.mock.calls[1][0]).toMatch('insert into `example` (`name`) values (?) returning `id`');
+  expect(mock.mock.calls[2][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+  expect(mock.mock.calls[3][0]).toMatch('insert into `example` (`name`) values (?) returning `id`');
+  expect(mock.mock.calls[4][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+  expect(mock.mock.calls[5][0]).toMatch('rollback');
+  expect(mock.mock.calls[6][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+});
+
+test('should handle rollback in no-op transaction', async () => {
+  const mock = mockLogger(orm, ['query']);
+
+  const transaction = orm.em.transactional(async em => {
+    await em.transactional(async () => {
+      em.create(Example, { name: 'foo' });
+
+      await em.flush();
+
+      const count = await em.count(Example);
+
+      expect(count).toBe(1);
+
+      throw new Error('roll me back');
+    });
+
+    throw new Error('should not get here');
+  }, { ignoreNestedTransactions: true });
+
+  await expect(transaction).rejects.toThrowError('roll me back');
+
+  const count = await orm.em.count(Example);
+
+  expect(count).toBe(0);
+
+  expect(mock.mock.calls).toHaveLength(5);
+  expect(mock.mock.calls[0][0]).toMatch('begin');
+  expect(mock.mock.calls[1][0]).toMatch('insert into `example` (`name`) values (?) returning `id`');
+  expect(mock.mock.calls[2][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+  expect(mock.mock.calls[3][0]).toMatch('rollback');
+  expect(mock.mock.calls[4][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+});

--- a/tests/features/disable-transactions/disable-transactions.test.ts
+++ b/tests/features/disable-transactions/disable-transactions.test.ts
@@ -1,0 +1,168 @@
+import { MikroORM } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+import { mockLogger } from '../../helpers';
+
+@Entity()
+export class Example {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+}
+
+let orm: MikroORM;
+
+beforeEach(async () => {
+  orm = await MikroORM.init({
+    entities: [Example],
+    dbName: ':memory:',
+    disableTransactions: true,
+  });
+  await orm.schema.refreshDatabase();
+});
+
+afterEach(async () => {
+  await orm.close(true);
+});
+
+test('should skip transactions completely', async () => {
+  const mock = mockLogger(orm, ['query']);
+
+  await orm.em.transactional(async em => {
+    await em.transactional(async () => {
+      em.create(Example, { name: 'foo' });
+
+      await em.flush();
+
+      const count = await em.count(Example);
+
+      expect(count).toBe(1);
+    });
+
+    em.create(Example, { name: 'bar' });
+
+    await em.flush();
+
+    const count = await em.count(Example);
+
+    expect(count).toBe(2);
+  });
+
+  const count = await orm.em.count(Example);
+
+  expect(count).toBe(2);
+
+  expect(mock.mock.calls).toHaveLength(5);
+  expect(mock.mock.calls[0][0]).toMatch('insert into `example` (`name`) values (?) returning `id`');
+  expect(mock.mock.calls[1][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+  expect(mock.mock.calls[2][0]).toMatch('insert into `example` (`name`) values (?) returning `id`');
+  expect(mock.mock.calls[3][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+  expect(mock.mock.calls[4][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+});
+
+test('should skip transactions completely (begin/commit/rollback', async () => {
+  const mock = mockLogger(orm, ['query']);
+
+  await orm.em.begin();
+
+  await orm.em.transactional(async em => {
+    em.create(Example, { name: 'foo' });
+
+    await em.flush();
+
+    const count = await em.count(Example);
+
+    expect(count).toBe(1);
+    await orm.em.rollback();
+  });
+
+  orm.em.create(Example, { name: 'bar' });
+
+  await orm.em.commit();
+
+  const count = await orm.em.count(Example);
+
+  expect(count).toBe(2);
+
+  const count2 = await orm.em.count(Example);
+
+  expect(count2).toBe(2);
+
+  expect(mock.mock.calls).toHaveLength(5);
+  expect(mock.mock.calls[0][0]).toMatch('insert into `example` (`name`) values (?) returning `id`');
+  expect(mock.mock.calls[1][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+  expect(mock.mock.calls[2][0]).toMatch('insert into `example` (`name`) values (?) returning `id`');
+  expect(mock.mock.calls[3][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+  expect(mock.mock.calls[4][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+});
+
+test('no rollback as transactions are disabled', async () => {
+  const mock = mockLogger(orm, ['query']);
+
+  const transaction = orm.em.transactional(async em => {
+    await em.transactional(async () => {
+      em.create(Example, { name: 'foo' });
+
+      await em.flush();
+
+      const count = await em.count(Example);
+
+      expect(count).toBe(1);
+    });
+
+    em.create(Example, { name: 'bar' });
+
+    await em.flush();
+
+    const count = await em.count(Example);
+
+    expect(count).toBe(2);
+
+    throw new Error('roll me back');
+  });
+
+  await expect(transaction).rejects.toThrowError('roll me back');
+
+  const count = await orm.em.count(Example);
+  expect(count).toBe(2); // rollback didn't happen
+
+  expect(mock.mock.calls).toHaveLength(5);
+  expect(mock.mock.calls[0][0]).toMatch('insert into `example` (`name`) values (?) returning `id`');
+  expect(mock.mock.calls[1][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+  expect(mock.mock.calls[2][0]).toMatch('insert into `example` (`name`) values (?) returning `id`');
+  expect(mock.mock.calls[3][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+  expect(mock.mock.calls[4][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+});
+
+test('should handle rollback in no-op transaction', async () => {
+  const mock = mockLogger(orm, ['query']);
+
+  const transaction = orm.em.transactional(async em => {
+    await em.transactional(async () => {
+      em.create(Example, { name: 'foo' });
+
+      await em.flush();
+
+      const count = await em.count(Example);
+
+      expect(count).toBe(1);
+
+      throw new Error('roll me back');
+    });
+
+    throw new Error('should not get here');
+  });
+
+  await expect(transaction).rejects.toThrowError('roll me back');
+
+  const count = await orm.em.count(Example);
+  expect(count).toBe(1); // rollback didn't happen
+
+  expect(mock.mock.calls).toHaveLength(3);
+  expect(mock.mock.calls[0][0]).toMatch('insert into `example` (`name`) values (?) returning `id`');
+  expect(mock.mock.calls[1][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+  expect(mock.mock.calls[2][0]).toMatch('select count(*) as `count` from `example` as `e0`');
+});


### PR DESCRIPTION
Is it now possible to disable transactions, either globally via `disableTransactions` config option, or locally when using `em.transactional()`.

```ts
// only the outer transaction will be opened
await orm.em.transactional(async em => {
  // but the inner calls to both em.transactional and em.begin will be no-op
  await em.transactional(...);
}, { disableTransactions: true });
```

Alternatively, you can disable transactions when creating new forks:

```ts
const em = await orm.em.fork({ disableTransactions: true });
await em.transactional(...); // no-op
await em.begin(...); // no-op
await em.commit(...); // commit still calls `flush`
```

Closes #3747
Closes #3992