### PR TITLE
fix(cli): await the yargs.parse call in esm.ts

### DIFF
--- a/packages/cli/src/esm.ts
+++ b/packages/cli/src/esm.ts
@@ -11,7 +11,8 @@ import { CLIHelper } from './CLIHelper';
 import { CLIConfigurator } from './CLIConfigurator';
 
 (async () => {
-  const args = (await CLIConfigurator.configure()).parse(process.argv.slice(2)) as { _: string[] };
+  const argv = await CLIConfigurator.configure();
+  const args = await argv.parse(process.argv.slice(2)) as { _: string[] };
 
   if (args._.length === 0) {
     CLIHelper.showHelp();


### PR DESCRIPTION
Related to https://github.com/mikro-orm/mikro-orm/issues/4265

https://github.com/mikro-orm/mikro-orm/commit/37574723d0ce37a8d0d3284124d836a517f451a7 did fix the call in `cli.ts` but forgot to update `esm.ts`.