### PR TITLE
fix(migrations): respect custom migration name in migration class names

### DIFF
--- a/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
+++ b/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
@@ -9,8 +9,14 @@ export abstract class AbstractNamingStrategy implements NamingStrategy {
     return ret.charAt(0).toUpperCase() + ret.slice(1);
   }
 
-  classToMigrationName(timestamp: string): string {
-    return `Migration${timestamp}`;
+  classToMigrationName(timestamp: string, customMigrationName?: string): string {
+    let migrationName = `Migration${timestamp}`;
+
+    if (customMigrationName) {
+      migrationName += `_${customMigrationName}`;
+    }
+
+    return migrationName;
   }
 
   indexName(tableName: string, columns: string[], type: 'primary' | 'foreign' | 'unique' | 'index' | 'sequence' | 'check'): string {

--- a/packages/core/src/naming-strategy/NamingStrategy.ts
+++ b/packages/core/src/naming-strategy/NamingStrategy.ts
@@ -13,7 +13,7 @@ export interface NamingStrategy {
   /**
    * Return a migration name. This name should allow ordering.
    */
-  classToMigrationName(timestamp: string): string;
+  classToMigrationName(timestamp: string, customMigrationName?: string): string;
 
   /**
    * Return a column name for a property

--- a/packages/migrations-mongodb/src/MigrationGenerator.ts
+++ b/packages/migrations-mongodb/src/MigrationGenerator.ts
@@ -13,14 +13,14 @@ export abstract class MigrationGenerator implements IMigrationGenerator {
   /**
    * @inheritDoc
    */
-  async generate(diff: { up: string[]; down: string[] }, path?: string): Promise<[string, string]> {
+  async generate(diff: { up: string[]; down: string[] }, path?: string, name?: string): Promise<[string, string]> {
     /* istanbul ignore next */
     const defaultPath = this.options.emit === 'ts' && this.options.pathTs ? this.options.pathTs : this.options.path!;
     path = Utils.normalizePath(this.driver.config.get('baseDir'), path ?? defaultPath);
     await ensureDir(path);
     const timestamp = new Date().toISOString().replace(/[-T:]|\.\d{3}z$/ig, '');
-    const className = this.namingStrategy.classToMigrationName(timestamp);
-    const fileName = `${this.options.fileName!(timestamp)}.${this.options.emit}`;
+    const className = this.namingStrategy.classToMigrationName(timestamp, name);
+    const fileName = `${this.options.fileName!(timestamp, name)}.${this.options.emit}`;
     const ret = this.generateMigrationFile(className, diff);
     await writeFile(path + '/' + fileName, ret);
 

--- a/packages/migrations-mongodb/src/Migrator.ts
+++ b/packages/migrations-mongodb/src/Migrator.ts
@@ -37,10 +37,10 @@ export class Migrator implements IMigrator {
   /**
    * @inheritDoc
    */
-  async createMigration(path?: string): Promise<MigrationResult> {
+  async createMigration(path?: string, blank = false, initial = false, name?: string): Promise<MigrationResult> {
     await this.ensureMigrationsDirExists();
     const diff = { up: [], down: [] };
-    const migration = await this.generator.generate(diff, path);
+    const migration = await this.generator.generate(diff, path, name);
 
     return {
       fileName: migration[1],

--- a/packages/migrations/src/MigrationGenerator.ts
+++ b/packages/migrations/src/MigrationGenerator.ts
@@ -18,7 +18,7 @@ export abstract class MigrationGenerator implements IMigrationGenerator {
     path = Utils.normalizePath(this.driver.config.get('baseDir'), path ?? defaultPath);
     await ensureDir(path);
     const timestamp = new Date().toISOString().replace(/[-T:]|\.\d{3}z$/ig, '');
-    const className = this.namingStrategy.classToMigrationName(timestamp);
+    const className = this.namingStrategy.classToMigrationName(timestamp, name);
     const fileName = `${this.options.fileName!(timestamp, name)}.${this.options.emit}`;
     const ret = this.generateMigrationFile(className, diff);
     await writeFile(path + '/' + fileName, ret);

--- a/tests/features/migrations/Migrator.mongo.test.ts
+++ b/tests/features/migrations/Migrator.mongo.test.ts
@@ -83,6 +83,30 @@ describe('Migrator (mongo)', () => {
     downMock.mockRestore();
   });
 
+  test('generate migration with custom name with name option', async () => {
+    const dateMock = jest.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
+    const migrationsSettings = orm.config.get('migrations');
+    orm.config.set('migrations', { ...migrationsSettings, fileName: (time, name) => `migration${time}_${name}` });
+    const migrator = orm.migrator;
+    const migration = await migrator.createMigration(undefined, false, false, 'custom_name');
+    expect(migration).toMatchSnapshot('migration-dump');
+    expect(migration.fileName).toEqual('migration20191013214813_custom_name.ts');
+    const upMock = jest.spyOn(Umzug.prototype, 'up');
+    upMock.mockImplementation(() => void 0 as any);
+    const downMock = jest.spyOn(Umzug.prototype, 'down');
+    downMock.mockImplementation(() => void 0 as any);
+    await migrator.up();
+    await migrator.down(migration.fileName.replace('.ts', ''));
+    await migrator.up();
+    await migrator.down(migration.fileName);
+    await migrator.up();
+    orm.config.set('migrations', migrationsSettings); // Revert migration config changes
+    await remove(process.cwd() + '/temp/migrations-mongo/' + migration.fileName);
+    upMock.mockRestore();
+    downMock.mockRestore();
+  });
+
   test('generate blank migration', async () => {
     const dateMock = jest.spyOn(Date.prototype, 'toISOString');
     dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');

--- a/tests/features/migrations/__snapshots__/Migrator.mongo.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.mongo.test.ts.snap
@@ -45,7 +45,7 @@ exports[`Migrator (mongo) generate migration with custom name: migration-dump 1`
 {
   "code": "import { Migration } from '@mikro-orm/migrations-mongodb';
 
-export class Migration20191013214813 extends Migration {
+export class Migration20191013214813_custom_name extends Migration {
 
   async up(): Promise<void> {
   }
@@ -56,7 +56,7 @@ export class Migration20191013214813 extends Migration {
     "down": [],
     "up": [],
   },
-  "fileName": "migration-20191013214813.ts",
+  "fileName": "migration-20191013214813_custom_name.ts",
 }
 `;
 

--- a/tests/features/migrations/__snapshots__/Migrator.mongo.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.mongo.test.ts.snap
@@ -41,7 +41,7 @@ exports.Migration20191013214813 = Migration20191013214813;
 }
 `;
 
-exports[`Migrator (mongo) generate migration with custom name: migration-dump 1`] = `
+exports[`Migrator (mongo) generate migration with custom name with name option: migration-dump 1`] = `
 {
   "code": "import { Migration } from '@mikro-orm/migrations-mongodb';
 
@@ -56,7 +56,26 @@ export class Migration20191013214813_custom_name extends Migration {
     "down": [],
     "up": [],
   },
-  "fileName": "migration-20191013214813_custom_name.ts",
+  "fileName": "migration20191013214813_custom_name.ts",
+}
+`;
+
+exports[`Migrator (mongo) generate migration with custom name: migration-dump 1`] = `
+{
+  "code": "import { Migration } from '@mikro-orm/migrations-mongodb';
+
+export class Migration20191013214813 extends Migration {
+
+  async up(): Promise<void> {
+  }
+
+}
+",
+  "diff": {
+    "down": [],
+    "up": [],
+  },
+  "fileName": "migration-20191013214813.ts",
 }
 `;
 

--- a/tests/features/migrations/__snapshots__/Migrator.postgres.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.postgres.test.ts.snap
@@ -465,7 +465,7 @@ exports[`Migrator (postgres) generate migration with custom name with name optio
 {
   "code": "import { Migration } from '@mikro-orm/migrations';
 
-export class Migration20191013214813 extends Migration {
+export class Migration20191013214813_custom_name extends Migration {
 
   async up(): Promise<void> {
     this.addSql('alter table "custom"."book2" alter column "double" type double precision using ("double"::double precision);');


### PR DESCRIPTION
Fixes:

- Custom migration name was not used in the migration class name for SQL drivers.
- Custom migration name was not used in the migration file name or class name for the Mongo driver.

### Side note

I am having some trouble running the Mongo tests on Ubuntu 22.04. Getting an error because libcrypto 1.1 is not found.

I manually updated the Mongo snapshot to what I think the correct value is. We'll have to see if that test passes in CI.