### PR TITLE
feat(postgres): add support for native enums

### DIFF
--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -550,6 +550,74 @@ properties: {
   </TabItem>
 </Tabs>
 
+### PostgreSQL native enums
+
+By default, the PostgreSQL driver, represents enums as a text columns with check constraints. Since v6, you can opt-in for a native enums by setting the `nativeEnumName` option.
+
+<Tabs
+groupId="entity-def"
+defaultValue="reflect-metadata"
+values={[
+{label: 'reflect-metadata', value: 'reflect-metadata'},
+{label: 'ts-morph', value: 'ts-morph'},
+{label: 'EntitySchema', value: 'entity-schema'},
+]
+}>
+<TabItem value="reflect-metadata">
+
+```ts title="./entities/Author.ts"
+@Entity()
+export class User {
+
+  @Enum({ items: () => UserRole, nativeEnumName: 'user_role' })
+  role!: UserRole;
+
+}
+
+export enum UserRole {
+  ADMIN = 'admin',
+  MODERATOR = 'moderator',
+  USER = 'user',
+}
+```
+
+  </TabItem>
+  <TabItem value="ts-morph">
+
+```ts title="./entities/Author.ts"
+@Entity()
+export class User {
+
+  @Enum({ items: () => UserRole, nativeEnumName: 'user_role' })
+  role!: UserRole;
+
+}
+
+export enum UserRole {
+  ADMIN = 'admin',
+  MODERATOR = 'moderator',
+  USER = 'user',
+}
+```
+
+  </TabItem>
+  <TabItem value="entity-schema">
+
+```ts title="./entities/Author.ts"
+export enum UserRole {
+  ADMIN = 'admin',
+  MODERATOR = 'moderator',
+  USER = 'user',
+}
+
+properties: {
+  role: { enum: true, nativeEnumName: 'user_role', items: () => UserRole },
+},
+```
+
+  </TabItem>
+</Tabs>
+
 ## Enum arrays
 
 We can also use array of values for enum, in that case, `EnumArrayType` type will be used automatically, that will validate items on flush.

--- a/packages/core/src/decorators/Enum.ts
+++ b/packages/core/src/decorators/Enum.ts
@@ -22,4 +22,6 @@ export function Enum<T extends object>(options: EnumOptions<AnyEntity> | (() => 
 export interface EnumOptions<T> extends PropertyOptions<T> {
   items?: (number | string)[] | (() => Dictionary);
   array?: boolean;
+  /** for postgres, by default it uses text column with check constraint */
+  nativeEnumName?: string;
 }

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -131,6 +131,11 @@ export class EntitySchema<T = any, U = never> {
       prop.enum = false;
     }
 
+    // force string labels on native enums
+    if (prop.nativeEnumName && Array.isArray(prop.items)) {
+      prop.items = prop.items.map(val => '' + val);
+    }
+
     this.addProperty(name, this.internal ? type : type || 'enum', prop);
   }
 

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1166,7 +1166,9 @@ export class MetadataDiscovery {
   private getMappedType(prop: EntityProperty): Type<unknown> {
     let t = prop.columnTypes?.[0] ?? prop.type.toLowerCase();
 
-    if (prop.enum) {
+    if (prop.nativeEnumName) {
+      t = 'enum';
+    } else if (prop.enum) {
       t = prop.items?.every(item => Utils.isString(item)) ? 'enum' : 'tinyint';
     }
 

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -49,6 +49,11 @@ export abstract class Platform {
     return false;
   }
 
+  /** for postgres native enums */
+  supportsNativeEnums(): boolean {
+    return false;
+  }
+
   getSchemaHelper(): unknown {
     return undefined;
   }

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -297,6 +297,7 @@ export interface EntityProperty<T = any> {
   hidden?: boolean;
   enum?: boolean;
   items?: (number | string)[];
+  nativeEnumName?: string; // for postgres, by default it uses text column with check constraint
   version?: boolean;
   concurrencyCheck?: boolean;
   eager?: boolean;

--- a/packages/knex/src/schema/DatabaseSchema.ts
+++ b/packages/knex/src/schema/DatabaseSchema.ts
@@ -60,14 +60,14 @@ export class DatabaseSchema {
     return [...this.namespaces];
   }
 
-  static async create(connection: AbstractSqlConnection, platform: AbstractSqlPlatform, config: Configuration, schemaName?: string): Promise<DatabaseSchema> {
+  static async create(connection: AbstractSqlConnection, platform: AbstractSqlPlatform, config: Configuration, schemaName?: string, schemas?: string[]): Promise<DatabaseSchema> {
     const schema = new DatabaseSchema(platform, schemaName ?? config.get('schema') ?? platform.getDefaultSchemaName());
     const allTables = await connection.execute<Table[]>(platform.getSchemaHelper()!.getListTablesSQL());
     const parts = config.get('migrations').tableName!.split('.');
     const migrationsTableName = parts[1] ?? parts[0];
     const migrationsSchemaName = parts.length > 1 ? parts[0] : config.get('schema', platform.getDefaultSchemaName());
     const tables = allTables.filter(t => t.table_name !== migrationsTableName || (t.schema_name && t.schema_name !== migrationsSchemaName));
-    await platform.getSchemaHelper()!.loadInformationSchema(schema, connection, tables);
+    await platform.getSchemaHelper()!.loadInformationSchema(schema, connection, tables, schemas && schemas.length > 0 ? schemas : undefined);
 
     return schema;
   }

--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -13,6 +13,7 @@ export class DatabaseTable {
   private indexes: IndexDef[] = [];
   private checks: CheckDef[] = [];
   private foreignKeys: Dictionary<ForeignKey> = {};
+  public nativeEnums: Dictionary<unknown[]> = {}; // for postgres
   public comment?: string;
 
   constructor(private readonly platform: AbstractSqlPlatform,
@@ -51,7 +52,7 @@ export class DatabaseTable {
       const type = v.name in enums ? 'enum' : v.type;
       v.mappedType = this.platform.getMappedType(type);
       v.default = v.default?.toString().startsWith('nextval(') ? null : v.default;
-      v.enumItems = enums[v.name] || [];
+      v.enumItems ??= enums[v.name] || [];
       o[v.name] = v;
 
       return o;
@@ -90,12 +91,13 @@ export class DatabaseTable {
         unsigned: prop.unsigned && this.platform.isNumericColumn(mappedType),
         autoincrement: prop.autoincrement ?? primary,
         primary,
+        nativeEnumName: prop.nativeEnumName,
         nullable: !!prop.nullable,
         length: prop.length,
         precision: prop.precision,
         scale: prop.scale,
         default: prop.defaultRaw,
-        enumItems: prop.items?.every(Utils.isString) ? prop.items as string[] : undefined,
+        enumItems: prop.nativeEnumName || prop.items?.every(Utils.isString) ? prop.items as string[] : undefined,
         comment: prop.comment,
         extra: prop.extra,
         ignoreSchemaChanges: prop.ignoreSchemaChanges,

--- a/packages/knex/src/schema/SchemaHelper.ts
+++ b/packages/knex/src/schema/SchemaHelper.ts
@@ -64,7 +64,15 @@ export abstract class SchemaHelper {
     return {};
   }
 
-  async loadInformationSchema(schema: DatabaseSchema, connection: AbstractSqlConnection, tables: Table[]): Promise<void> {
+  getDropNativeEnumSQL(name: string, schema?: string): string {
+    throw new Error('Not supported by given driver');
+  }
+
+  getAlterNativeEnumSQL(name: string, schema?: string, value?: string): string {
+    throw new Error('Not supported by given driver');
+  }
+
+  async loadInformationSchema(schema: DatabaseSchema, connection: AbstractSqlConnection, tables: Table[], schemas?: string[]): Promise<void> {
     for (const t of tables) {
       const table = schema.addTable(t.table_name, t.schema_name);
       table.comment = t.table_comment;

--- a/packages/knex/src/typings.ts
+++ b/packages/knex/src/typings.ts
@@ -47,6 +47,7 @@ export interface Column {
   scale?: number;
   default?: string | null;
   comment?: string;
+  nativeEnumName?: string;
   enumItems?: string[];
   primary?: boolean;
   unique?: boolean;

--- a/packages/postgresql/src/PostgreSqlConnection.ts
+++ b/packages/postgresql/src/PostgreSqlConnection.ts
@@ -136,11 +136,7 @@ export class PostgreSqlConnection extends AbstractSqlConnection {
     const quotedTableName = this.tableName();
     const defaultTo = col.modified.defaultTo;
 
-    if (!defaultTo) {
-      return;
-    }
-
-    if (defaultTo[0] === null) {
+    if (defaultTo?.[0] == null) {
       this.pushQuery({ sql: `alter table ${quotedTableName} alter column ${colName} drop default`, bindings: [] });
     }
   }

--- a/packages/postgresql/src/PostgreSqlConnection.ts
+++ b/packages/postgresql/src/PostgreSqlConnection.ts
@@ -2,6 +2,7 @@ import TypeOverrides from 'pg/lib/type-overrides';
 import type { Dictionary } from '@mikro-orm/core';
 import type { Knex } from '@mikro-orm/knex';
 import { AbstractSqlConnection, MonkeyPatchable } from '@mikro-orm/knex';
+import * as console from 'console';
 
 export class PostgreSqlConnection extends AbstractSqlConnection {
 
@@ -72,19 +73,29 @@ export class PostgreSqlConnection extends AbstractSqlConnection {
     const type = col.getColumnType();
     const colName = this.client.wrapIdentifier(col.getColumnName(), col.columnBuilder.queryContext());
     const constraintName = `${this.tableNameRaw.replace(/^.*\.(.*)$/, '$1')}_${col.getColumnName()}_check`;
-    that.dropColumnDefault.call(this, col, colName);
+    const useNative = col.args?.[2]?.useNative;
+    const alterType = col.columnBuilder.alterType;
+    const alterNullable = col.columnBuilder.alterNullable;
+    const defaultTo = col.modified.defaultTo;
 
-    if (col.type === 'enu') {
-      this.pushQuery({ sql: `alter table ${quotedTableName} alter column ${colName} type text using (${colName}::text)`, bindings: [] });
+    if (defaultTo != null) {
+      that.dropColumnDefault.call(this, col, colName);
+    }
+
+    if (col.type === 'enu' && !useNative) {
+      if (alterType) {
+        this.pushQuery({ sql: `alter table ${quotedTableName} alter column ${colName} type text using (${colName}::text)`, bindings: [] });
+      }
+
       /* istanbul ignore else */
-      if (options.createForeignKeyConstraints) {
+      if (options.createForeignKeyConstraints && alterNullable) {
         this.pushQuery({ sql: `alter table ${quotedTableName} add constraint "${constraintName}" ${type.replace(/^text /, '')}`, bindings: [] });
       }
     } else if (type === 'uuid') {
       // we need to drop the default as it would be invalid
       this.pushQuery({ sql: `alter table ${quotedTableName} alter column ${colName} drop default`, bindings: [] });
       this.pushQuery({ sql: `alter table ${quotedTableName} alter column ${colName} type ${type} using (${colName}::text::uuid)`, bindings: [] });
-    } else {
+    } else if (alterType) {
       this.pushQuery({ sql: `alter table ${quotedTableName} alter column ${colName} type ${type} using (${colName}::${type})`, bindings: [] });
     }
 

--- a/packages/postgresql/src/PostgreSqlPlatform.ts
+++ b/packages/postgresql/src/PostgreSqlPlatform.ts
@@ -129,7 +129,11 @@ export class PostgreSqlPlatform extends AbstractSqlPlatform {
     return 'double precision';
   }
 
-  override getEnumTypeDeclarationSQL(column: { fieldNames: string[]; items?: unknown[] }): string {
+  override getEnumTypeDeclarationSQL(column: { fieldNames: string[]; items?: unknown[]; nativeEnumName?: string }): string {
+    if (column.nativeEnumName) {
+      return column.nativeEnumName;
+    }
+
     if (column.items?.every(item => Utils.isString(item))) {
       return 'text';
     }

--- a/packages/postgresql/src/PostgreSqlPlatform.ts
+++ b/packages/postgresql/src/PostgreSqlPlatform.ts
@@ -18,6 +18,10 @@ export class PostgreSqlPlatform extends AbstractSqlPlatform {
     return true;
   }
 
+  override supportsNativeEnums(): boolean {
+    return true;
+  }
+
   override supportsCustomPrimaryKeyNames(): boolean {
     return true;
   }

--- a/packages/postgresql/src/PostgreSqlSchemaHelper.ts
+++ b/packages/postgresql/src/PostgreSqlSchemaHelper.ts
@@ -1,5 +1,5 @@
 import type { Dictionary } from '@mikro-orm/core';
-import { BigIntType, EnumType, Utils } from '@mikro-orm/core';
+import { BigIntType, EnumType, Type, Utils } from '@mikro-orm/core';
 import type { AbstractSqlConnection, CheckDef, Column, DatabaseSchema, DatabaseTable, ForeignKey, IndexDef, Table, TableDifference, Knex } from '@mikro-orm/knex';
 import { SchemaHelper } from '@mikro-orm/knex';
 
@@ -57,11 +57,15 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
   }
 
   override async loadInformationSchema(schema: DatabaseSchema, connection: AbstractSqlConnection, tables: Table[]): Promise<void> {
+    const schemas = tables.length === 0 ? [schema.name] : tables.map(t => t.schema_name ?? schema.name);
+    const nativeEnums = await this.getNativeEnumDefinitions(connection, schemas);
+    schema.setNativeEnums(nativeEnums);
+
     if (tables.length === 0) {
       return;
     }
 
-    const columns = await this.getAllColumns(connection, tables);
+    const columns = await this.getAllColumns(connection, tables, nativeEnums);
     const indexes = await this.getAllIndexes(connection, tables);
     const checks = await this.getAllChecks(connection, tables);
     const fks = await this.getAllForeignKeys(connection, tables);
@@ -96,7 +100,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     return ret;
   }
 
-  async getAllColumns(connection: AbstractSqlConnection, tables: Table[]): Promise<Dictionary<Column[]>> {
+  async getAllColumns(connection: AbstractSqlConnection, tables: Table[], nativeEnums?: Dictionary<string[]>): Promise<Dictionary<Column[]>> {
     const sql = `select table_schema as schema_name, table_name, column_name,
       column_default,
       is_nullable,
@@ -121,7 +125,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
       const increments = col.column_default?.includes('nextval') && connection.getPlatform().isNumericColumn(mappedType);
       const key = this.getTableKey(col);
       ret[key] ??= [];
-      ret[key].push({
+      const column: Column = {
         name: col.column_name,
         type: col.data_type.toLowerCase() === 'array' ? col.udt_name.replace(/^_(.*)$/, '$1[]') : col.udt_name,
         mappedType,
@@ -133,7 +137,15 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
         unsigned: increments,
         autoincrement: increments,
         comment: col.column_comment,
-      });
+      };
+
+      if (nativeEnums?.[column.type]) {
+        column.mappedType = Type.getType(EnumType);
+        column.nativeEnumName = column.type;
+        column.enumItems = nativeEnums[column.type];
+      }
+
+      ret[key].push(column);
     }
 
     return ret;
@@ -194,6 +206,20 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     return ret;
   }
 
+  async getNativeEnumDefinitions(connection: AbstractSqlConnection, schemas: string[]): Promise<Dictionary<string[]>> {
+    const res = await connection.execute('select t.typname as enum_name, array_agg(e.enumlabel order by e.enumsortorder) as enum_value ' +
+      'from pg_type t ' +
+      'join pg_enum e on t.oid = e.enumtypid ' +
+      'join pg_catalog.pg_namespace n on n.oid = t.typnamespace ' +
+      'where n.nspname in (?) ' +
+      'group by t.typname', Utils.unique(schemas));
+
+    return res.reduce((o, row) => {
+      o[row.enum_name] = this.platform.unmarshallArray(row.enum_value);
+      return o;
+    }, {});
+  }
+
   override async getEnumDefinitions(connection: AbstractSqlConnection, checks: CheckDef[], tableName?: string, schemaName?: string): Promise<Dictionary<string[]>> {
     const found: number[] = [];
     const enums = checks.reduce((o, item, index) => {
@@ -237,6 +263,15 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
       }
 
       return table.increments(column.name, { primaryKey });
+    }
+
+    if (column.nativeEnumName && column.enumItems) {
+      return table.enum(column.name, column.enumItems, {
+        useNative: true,
+        enumName: column.nativeEnumName,
+        schemaName: fromTable.schema && fromTable.schema !== this.platform.getDefaultSchemaName() ? fromTable.schema : undefined,
+        existingType: changedProperties ? column.nativeEnumName in fromTable.nativeEnums : false,
+      });
     }
 
     if (column.mappedType instanceof EnumType && column.enumItems?.every(item => Utils.isString(item))) {

--- a/tests/SchemaHelper.test.ts
+++ b/tests/SchemaHelper.test.ts
@@ -15,6 +15,8 @@ describe('SchemaHelper', () => {
     expect(helper.getChangeColumnCommentSQL('a', {} as any)).toBe('');
     await expect(helper.getEnumDefinitions(jest.fn() as any, [], '')).resolves.toEqual({});
     expect(() => helper.getListTablesSQL()).toThrowError('Not supported by given driver');
+    expect(() => helper.getAlterNativeEnumSQL('table')).toThrowError('Not supported by given driver');
+    expect(() => helper.getDropNativeEnumSQL('table')).toThrowError('Not supported by given driver');
     expect(() => helper.getForeignKeysSQL('table')).toThrowError('Not supported by given driver');
     await expect(helper.getColumns({} as any, 'table')).rejects.toThrowError('Not supported by given driver');
     await expect(helper.getIndexes({} as any, 'table')).rejects.toThrowError('Not supported by given driver');

--- a/tests/features/schema-generator/__snapshots__/native-enums.postgres.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/native-enums.postgres.test.ts.snap
@@ -1,26 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`native enums in postgres enum diffing: postgres-update-schema-enums-1 1`] = `
-"create table "new_table" ("id" serial primary key, "enum_test" varchar(255) not null);
+"create schema if not exists "different_schema";
+
+create table "different_schema"."new_table" ("id" serial primary key, "enum_test" varchar(255) not null);
 
 "
 `;
 
 exports[`native enums in postgres enum diffing: postgres-update-schema-enums-2 1`] = `
-"create type "enum_test" as enum ('a', 'b');
-alter table "new_table" alter column "enum_test" type "enum_test" using ("enum_test"::"enum_test");
+"create type "different_schema"."enum_test" as enum ('a', 'b');
+alter table "different_schema"."new_table" alter column "enum_test" type "different_schema"."enum_test" using ("enum_test"::"different_schema"."enum_test");
 
 "
 `;
 
 exports[`native enums in postgres enum diffing: postgres-update-schema-enums-3 1`] = `
-"alter type "enum_test" add value 'c';
+"alter type "different_schema"."enum_test" add value 'c';
 
 "
 `;
 
 exports[`native enums in postgres enum diffing: postgres-update-schema-enums-4 1`] = `
-"alter table "new_table" alter column "enum_test" type text using ("enum_test"::text);
+"alter table "different_schema"."new_table" alter column "enum_test" type text using ("enum_test"::text);
 
 "
 `;
@@ -52,7 +54,6 @@ drop type "enum4";
 drop type "enum5";
 drop type "enum_entity_type";
 drop type "enum_entity_type2";
-drop type "enum_test";
 
 set session_replication_role = 'origin';
 "

--- a/tests/features/schema-generator/__snapshots__/native-enums.postgres.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/native-enums.postgres.test.ts.snap
@@ -1,0 +1,77 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`native enums in postgres enum diffing: postgres-update-schema-enums-1 1`] = `
+"create table "new_table" ("id" serial primary key, "enum_test" varchar(255) not null);
+
+"
+`;
+
+exports[`native enums in postgres enum diffing: postgres-update-schema-enums-2 1`] = `
+"create type "enum_test" as enum ('a', 'b');
+alter table "new_table" alter column "enum_test" type "enum_test" using ("enum_test"::"enum_test");
+
+"
+`;
+
+exports[`native enums in postgres enum diffing: postgres-update-schema-enums-3 1`] = `
+"alter type "enum_test" add value 'c';
+
+"
+`;
+
+exports[`native enums in postgres enum diffing: postgres-update-schema-enums-4 1`] = `
+"alter table "new_table" alter column "enum_test" type text using ("enum_test"::text);
+
+"
+`;
+
+exports[`native enums in postgres generate schema from metadata [postgres]: postgres-create-schema-dump 1`] = `
+"set names 'utf8';
+set session_replication_role = 'replica';
+
+create type "enum5" as enum ('a');
+create type "enum4" as enum ('a', 'b', 'c');
+create type "enum3" as enum ('1', '2', '3');
+create type "enum2" as enum ('1', '2');
+create type "enum_entity_type2" as enum ('LOCAL', 'GLOBAL');
+create type "enum_entity_type" as enum ('local', 'global');
+create table "enum_entity" ("id" serial primary key, "type" "enum_entity_type" not null default 'local', "type2" "enum_entity_type2" not null default 'LOCAL', "enum2" "enum2" null, "enum3" "enum3" null, "enum4" "enum4" null, "enum5" "enum5" null);
+
+set session_replication_role = 'origin';
+"
+`;
+
+exports[`native enums in postgres generate schema from metadata [postgres]: postgres-drop-schema-dump 1`] = `
+"set names 'utf8';
+set session_replication_role = 'replica';
+
+drop table if exists "enum_entity" cascade;
+drop type "enum2";
+drop type "enum3";
+drop type "enum4";
+drop type "enum5";
+drop type "enum_entity_type";
+drop type "enum_entity_type2";
+drop type "enum_test";
+
+set session_replication_role = 'origin';
+"
+`;
+
+exports[`native enums in postgres generate schema from metadata [postgres]: postgres-schema-dump 1`] = `
+"set names 'utf8';
+set session_replication_role = 'replica';
+
+create type "enum5" as enum ('a');
+create type "enum4" as enum ('a', 'b', 'c');
+create type "enum3" as enum ('1', '2', '3');
+create type "enum2" as enum ('1', '2');
+create type "enum_entity_type2" as enum ('LOCAL', 'GLOBAL');
+create type "enum_entity_type" as enum ('local', 'global');
+create table "enum_entity" ("id" serial primary key, "type" "enum_entity_type" not null default 'local', "type2" "enum_entity_type2" not null default 'LOCAL', "enum2" "enum2" null, "enum3" "enum3" null, "enum4" "enum4" null, "enum5" "enum5" null);
+
+set session_replication_role = 'origin';
+"
+`;
+
+exports[`native enums in postgres generate schema from metadata [postgres]: postgres-update-schema-dump 1`] = `""`;

--- a/tests/features/schema-generator/native-enums.postgres.test.ts
+++ b/tests/features/schema-generator/native-enums.postgres.test.ts
@@ -1,0 +1,144 @@
+import { MikroORM } from '@mikro-orm/postgresql';
+import { Entity, Enum, EntitySchema, EnumType, Type, PrimaryKey } from '@mikro-orm/core';
+
+export enum PublisherType {
+  LOCAL = 'local',
+  GLOBAL = 'global',
+}
+
+export enum PublisherType2 {
+  LOCAL = 'LOCAL',
+  GLOBAL = 'GLOBAL',
+}
+
+export const enum Enum1 {
+  Value1,
+  Value2,
+}
+
+export enum Enum2 {
+  PROP1 = 1,
+  PROP2 = 2,
+}
+
+@Entity()
+export class EnumEntity {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Enum({ items: () => PublisherType, nativeEnumName: 'enum_entity_type' })
+  type = PublisherType.LOCAL;
+
+  @Enum({ items: () => PublisherType2, nativeEnumName: 'enum_entity_type2' })
+  type2 = PublisherType2.LOCAL;
+
+  @Enum({ items: () => Enum2, nullable: true, nativeEnumName: 'enum2' })
+  enum2?: Enum2;
+
+  @Enum({ items: [1, 2, 3], nullable: true, nativeEnumName: 'enum3' })
+  enum3?: any;
+
+  @Enum({ items: ['a', 'b', 'c'], nullable: true, nativeEnumName: 'enum4' })
+  enum4?: any;
+
+  @Enum({ items: ['a'], nullable: true, nativeEnumName: 'enum5' })
+  enum5?: any;
+
+}
+
+describe('native enums in postgres', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [EnumEntity],
+      dbName: `mikro_orm_native_enum`,
+    });
+
+    await orm.schema.ensureDatabase();
+    await orm.schema.execute('drop table if exists new_table cascade');
+    await orm.schema.refreshDatabase();
+  });
+
+  afterAll(() => orm.close());
+
+  test('enum diffing', async () => {
+    orm.em.getConnection().execute('drop table if exists new_table cascade');
+    const newTableMeta = new EntitySchema({
+      properties: {
+        id: {
+          primary: true,
+          name: 'id',
+          type: 'number',
+          fieldName: 'id',
+          columnType: 'int',
+        },
+        enumTest: {
+          type: 'string',
+          name: 'enumTest',
+          fieldName: 'enum_test',
+          columnType: 'varchar(255)',
+        },
+      },
+      name: 'NewTable',
+      tableName: 'new_table',
+    }).init().meta;
+    orm.getMetadata().set('NewTable', newTableMeta);
+    let diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toMatchSnapshot('postgres-update-schema-enums-1');
+    await orm.schema.execute(diff);
+
+    // change type to enum
+    newTableMeta.properties.enumTest.items = ['a', 'b'];
+    newTableMeta.properties.enumTest.enum = true;
+    newTableMeta.properties.enumTest.nativeEnumName = 'enum_test';
+    newTableMeta.properties.enumTest.type = 'object';
+    newTableMeta.properties.enumTest.columnTypes[0] = Type.getType(EnumType).getColumnType(newTableMeta.properties.enumTest, orm.em.getPlatform());
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toMatchSnapshot('postgres-update-schema-enums-2');
+    await orm.schema.execute(diff);
+
+    // change enum items
+    newTableMeta.properties.enumTest.items = ['a', 'b', 'c'];
+    newTableMeta.properties.enumTest.columnTypes[0] = Type.getType(EnumType).getColumnType(newTableMeta.properties.enumTest, orm.em.getPlatform());
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toMatchSnapshot('postgres-update-schema-enums-3');
+    await orm.schema.execute(diff);
+
+    // check that we do not produce anything as the schema should be up-to-date
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    // change the type from enum to int
+    delete newTableMeta.properties.enumTest.items;
+    delete newTableMeta.properties.enumTest.nativeEnumName;
+    newTableMeta.properties.enumTest.columnTypes[0] = 'text';
+    newTableMeta.properties.enumTest.enum = false;
+    newTableMeta.properties.enumTest.type = 'string';
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toMatchSnapshot('postgres-update-schema-enums-4');
+    await orm.schema.execute(diff);
+  });
+
+  test('generate schema from metadata [postgres]', async () => {
+    orm.getMetadata().reset('NewTable');
+    orm.em.getConnection().execute('drop table if exists new_table cascade');
+    const dump = await orm.schema.getCreateSchemaSQL();
+    expect(dump).toMatchSnapshot('postgres-schema-dump');
+
+    const dropDump = await orm.schema.getDropSchemaSQL();
+    expect(dropDump).toMatchSnapshot('postgres-drop-schema-dump');
+    await orm.schema.execute(dropDump, { wrap: true });
+
+    const createDump = await orm.schema.getCreateSchemaSQL();
+    expect(createDump).toMatchSnapshot('postgres-create-schema-dump');
+    await orm.schema.execute(createDump, { wrap: true });
+
+    const updateDump = await orm.schema.getUpdateSchemaSQL();
+    expect(updateDump).toMatchSnapshot('postgres-update-schema-dump');
+    await orm.schema.execute(updateDump, { wrap: true });
+  });
+
+});

--- a/tests/features/schema-generator/native-enums.postgres.test.ts
+++ b/tests/features/schema-generator/native-enums.postgres.test.ts
@@ -65,8 +65,9 @@ describe('native enums in postgres', () => {
   afterAll(() => orm.close());
 
   test('enum diffing', async () => {
-    orm.em.getConnection().execute('drop table if exists new_table cascade');
+    orm.em.getConnection().execute('drop schema if exists different_schema cascade');
     const newTableMeta = new EntitySchema({
+      schema: 'different_schema',
       properties: {
         id: {
           primary: true,
@@ -124,7 +125,7 @@ describe('native enums in postgres', () => {
 
   test('generate schema from metadata [postgres]', async () => {
     orm.getMetadata().reset('NewTable');
-    orm.em.getConnection().execute('drop table if exists new_table cascade');
+    orm.em.getConnection().execute('drop schema if exists different_schema cascade');
     const dump = await orm.schema.getCreateSchemaSQL();
     expect(dump).toMatchSnapshot('postgres-schema-dump');
 


### PR DESCRIPTION
By default, the PostgreSQL driver, represents enums as a text columns with check constraints. Since v6, you can opt-in for a native enums by setting the `nativeEnumName` option.

```ts
@Entity()
export class User {

  @Enum({ items: () => UserRole, nativeEnumName: 'user_role' })
  role!: UserRole;

}

export enum UserRole {
  ADMIN = 'admin',
  MODERATOR = 'moderator',
  USER = 'user',
}
```

Closes #2764