### PR TITLE
fix(mongo): sorting with UnderscoreNamingStrategy

### DIFF
--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -33,7 +33,10 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
 
     const fields = this.buildFields(entityName, options.populate as unknown as PopulateOptions<T>[] || [], options.fields);
     where = this.renameFields(entityName, where, true);
-    const res = await this.rethrow(this.getConnection('read').find(entityName, where, options.orderBy, options.limit, options.offset, fields, options.ctx));
+    const orderBy = Utils.asArray(options.orderBy).map(orderBy =>
+      this.renameFields(entityName, orderBy, false),
+    );
+    const res = await this.rethrow(this.getConnection('read').find(entityName, where, orderBy, options.limit, options.offset, fields, options.ctx));
 
     return res.map(r => this.mapResult<T>(r, this.metadata.find<T>(entityName))!);
   }
@@ -51,7 +54,10 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
 
     const fields = this.buildFields(entityName, options.populate as unknown as PopulateOptions<T>[] || [], options.fields);
     where = this.renameFields(entityName, where, true);
-    const res = await this.rethrow(this.getConnection('read').find(entityName, where, options.orderBy, 1, undefined, fields, options.ctx));
+    const orderBy = Utils.asArray(options.orderBy).map(orderBy =>
+      this.renameFields(entityName, orderBy, false),
+    );
+    const res = await this.rethrow(this.getConnection('read').find(entityName, where, orderBy, 1, undefined, fields, options.ctx));
 
     return this.mapResult<T>(res[0], this.metadata.find(entityName)!);
   }

--- a/tests/issues/GH4313.test.ts
+++ b/tests/issues/GH4313.test.ts
@@ -30,7 +30,7 @@ describe('GH issue 4313', () => {
     a.complexName = 'a';
     const b = new A();
     b.complexName = 'b';
-    await orm.em.persistAndFlush([a,b]);
+    await orm.em.persistAndFlush([a, b]);
     orm.em.clear();
   });
 
@@ -81,6 +81,5 @@ describe('GH issue 4313', () => {
       orderBy: [{ complexName: 'desc' }],
     });
     expect(data4!.complexName).toBe('b');
-
   });
 });

--- a/tests/issues/GH4313.test.ts
+++ b/tests/issues/GH4313.test.ts
@@ -1,0 +1,86 @@
+import { Entity, MikroORM, PrimaryKey, Property, UnderscoreNamingStrategy } from '@mikro-orm/core';
+import { MongoDriver } from '@mikro-orm/mongodb';
+import { randomUUID } from 'crypto';
+
+@Entity()
+export class A {
+
+  @PrimaryKey()
+  _id = randomUUID();
+
+  @Property()
+  complexName!: string;
+
+}
+
+let orm: MikroORM<MongoDriver>;
+
+describe('GH issue 4313', () => {
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [A],
+      clientUrl: 'mongodb://localhost:27017/mikro-orm-test',
+      driver: MongoDriver,
+      namingStrategy: UnderscoreNamingStrategy,
+    });
+    await orm.schema.clearDatabase();
+
+    const a = new A();
+    a.complexName = 'a';
+    const b = new A();
+    b.complexName = 'b';
+    await orm.em.persistAndFlush([a,b]);
+    orm.em.clear();
+  });
+
+  afterAll(async () => {
+    await orm.close();
+  });
+
+  test('Find with sort by complexName field that is camel case string', async () => {
+    const data1 = await orm.em.find(A, {}, {
+      orderBy: { complexName: 'asc' },
+    });
+    expect(data1[0].complexName).toBe('a');
+
+    const data2 = await orm.em.find(A, {}, {
+      orderBy: { complexName: 'desc' },
+    });
+    expect(data2[0].complexName).toBe('b');
+
+    const data3 = await orm.em.find(A, {}, {
+      orderBy: [{ complexName: 'asc' }],
+    });
+    expect(data3[0].complexName).toBe('a');
+
+    const data4 = await orm.em.find(A, {}, {
+      orderBy: [{ complexName: 'desc' }],
+    });
+    expect(data4[0].complexName).toBe('b');
+
+  });
+
+  test('FindOne with sort by complexName field that is camel case string', async () => {
+    const data1 = await orm.em.findOne(A, { complexName: { $ne: null } }, {
+      orderBy: { complexName: 'asc' },
+    });
+    expect(data1!.complexName).toBe('a');
+
+    const data2 = await orm.em.findOne(A, { complexName: { $ne: null } }, {
+      orderBy: { complexName: 'desc' },
+    });
+    expect(data2!.complexName).toBe('b');
+
+    const data3 = await orm.em.findOne(A, { complexName: { $ne: null } }, {
+      orderBy: [{ complexName: 'asc' }],
+    });
+    expect(data3!.complexName).toBe('a');
+
+    const data4 = await orm.em.findOne(A, { complexName: { $ne: null } }, {
+      orderBy: [{ complexName: 'desc' }],
+    });
+    expect(data4!.complexName).toBe('b');
+
+  });
+});


### PR DESCRIPTION
Fixes #4313 

I propose to apply `this.renameFields` to `options.orderBy` the same way it is used for `where`