### PR TITLE
feat(core): allow using `Ref` wrapper on scalar properties

### DIFF
--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -1098,6 +1098,22 @@ const b2 = await em.find(Book, 1, { populate: ['text'] }); // this will load the
 
 > If the entity is already loaded and you need to populate a lazy scalar property, you might need to pass `refresh: true` in the `FindOptions`.
 
+### `ScalarReference` wrapper
+
+Similarly to the `Reference` wrapper, we can also wrap lazy scalars with `Ref` into a `ScalarReference` object.
+
+```ts
+@Property({ lazy: true, ref: true })
+passwordHash!: Ref<string>;
+```
+
+The `Ref` type automatically resolves to `ScalarReference` for non-object types. You can use it explicitly if you want to wrap an object scalar property (e.g. JSON value).
+
+```ts
+const user = await em.findOne(User, 1);
+const passwordHash = await user.passwordHash.load();
+```
+
 ## Virtual Properties
 
 We can define our properties as virtual, either as a method, or via JavaScript `get/set`.

--- a/docs/docs/type-safe-relations.md
+++ b/docs/docs/type-safe-relations.md
@@ -178,6 +178,22 @@ await book2.author.load(); // no additional query, already loaded
 
 > As opposed to `wrap(e).init()` which always refreshes the entity, `Reference.load()` method will query the database only if the entity is not already loaded in Identity Map.
 
+### `ScalarReference` wrapper
+
+Similarly to the `Reference` wrapper, we can also wrap scalars with `Ref` into a `ScalarReference` object. This is handy for lazy scalar properties.
+
+```ts
+@Property({ lazy: true, ref: true })
+passwordHash!: Ref<string>;
+```
+
+The `Ref` type automatically resolves to `ScalarReference` for non-object types. You can use it explicitly if you want to wrap an object scalar property (e.g. JSON value).
+
+```ts
+const user = await em.findOne(User, 1);
+const passwordHash = await user.passwordHash.load();
+```
+
 ## `Loaded` type
 
 If you check the return type of `em.find` and `em.findOne` methods, you might be a bit confused - instead of the entity, they return `Loaded` type:

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1243,7 +1243,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<Entity extends object>(entityName: EntityName<Entity>, id: Primary<Entity>, options: GetReferenceOptions = {}): Entity | Reference<Entity> {
+  getReference<Entity extends object>(entityName: EntityName<Entity>, id: Primary<Entity>, options: GetReferenceOptions = {}): Entity | Ref<Entity> | Reference<Entity> {
     options.convertCustomTypes ??= false;
     const meta = this.metadata.get(Utils.className(entityName));
 

--- a/packages/core/src/decorators/Property.ts
+++ b/packages/core/src/decorators/Property.ts
@@ -140,6 +140,10 @@ export type PropertyOptions<Owner> = {
    */
   hydrate?: boolean;
   /**
+   * Enable `ScalarReference` wrapper for lazy values. Use this in combination with `lazy: true` to have a type-safe accessor object in place of the value.
+   */
+  ref?: boolean;
+  /**
    * Set false to disable change tracking on a property level.
    *
    * @see https://mikro-orm.io/docs/unit-of-work#change-tracking-and-performance-considerations

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -17,6 +17,7 @@ import { ValidationError } from '../errors';
 import type { Collection } from './Collection';
 import type { LockMode, PopulateHint, QueryOrderMap } from '../enums';
 import { LoadStrategy, QueryOrder, ReferenceKind } from '../enums';
+import type { ScalarReference } from './Reference';
 import { Reference } from './Reference';
 import type { EntityField, FindOptions } from '../drivers/IDatabaseDriver';
 import type { MetadataStorage } from '../metadata/MetadataStorage';
@@ -174,7 +175,7 @@ export class EntityLoader {
     const prop = meta.properties[field];
 
     if (prop.kind === ReferenceKind.SCALAR && prop.lazy) {
-      const filtered = entities.filter(e => options.refresh || e[prop.name] === undefined);
+      const filtered = entities.filter(e => options.refresh || (prop.ref ? !(e[prop.name] as ScalarReference<any>)?.isInitialized() : e[prop.name] === undefined));
 
       if (options.ignoreLazyScalarProperties || filtered.length === 0) {
         return entities as AnyEntity[];

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -194,7 +194,7 @@ export class EntityRepository<Entity extends object> {
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference(id: Primary<Entity>, options?: GetReferenceOptions): Entity | Reference<Entity> {
+  getReference(id: Primary<Entity>, options?: GetReferenceOptions): Entity | Ref<Entity> | Reference<Entity> {
     return this.getEntityManager().getReference<Entity>(this.entityName, id, options);
   }
 

--- a/packages/core/src/entity/wrap.ts
+++ b/packages/core/src/entity/wrap.ts
@@ -31,6 +31,6 @@ export function wrap<T extends object>(entity: T & Dictionary, preferHelper = fa
  * use `preferHelper = true` to have access to the internal `__` properties like `__meta` or `__em`
  * @internal
  */
-export function helper<T extends object>(entity: T): IWrappedEntityInternal<T> {
+export function helper<T>(entity: T): IWrappedEntityInternal<T> {
   return (entity as Dictionary).__helper;
 }

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -467,10 +467,11 @@ export class EntityComparator {
 
   private getPropertySnapshot<T>(meta: EntityMetadata<T>, prop: EntityProperty<T>, context: Map<string, any>, dataKey: string, entityKey: string, path: string[], level = 1, object?: boolean): string {
     const convertorKey = this.safeKey(prop.name);
+    const unwrap = prop.ref ? '?.unwrap()' : '';
     let ret = `  if (${this.getPropertyCondition(prop, entityKey, path)}) {\n`;
 
     if (['number', 'string', 'boolean'].includes(prop.type.toLowerCase())) {
-      return ret + `    ret${dataKey} = entity${entityKey};\n  }\n`;
+      return ret + `    ret${dataKey} = entity${entityKey}${unwrap};\n  }\n`;
     }
 
     if (prop.kind === ReferenceKind.EMBEDDED) {
@@ -513,18 +514,18 @@ export class EntityComparator {
       context.set(`convertToDatabaseValue_${convertorKey}`, (val: any) => prop.customType.convertToDatabaseValue(val, this.platform, { mode: 'serialization' }));
 
       if (['number', 'string', 'boolean'].includes(prop.customType.compareAsType().toLowerCase())) {
-        return ret + `    ret${dataKey} = convertToDatabaseValue_${convertorKey}(entity${entityKey});\n  }\n`;
+        return ret + `    ret${dataKey} = convertToDatabaseValue_${convertorKey}(entity${entityKey}${unwrap});\n  }\n`;
       }
 
-      return ret + `    ret${dataKey} = clone(convertToDatabaseValue_${convertorKey}(entity${entityKey}));\n  }\n`;
+      return ret + `    ret${dataKey} = clone(convertToDatabaseValue_${convertorKey}(entity${entityKey}${unwrap}));\n  }\n`;
     }
 
     if (prop.type.toLowerCase() === 'date') {
       context.set('processDateProperty', this.platform.processDateProperty.bind(this.platform));
-      return ret + `    ret${dataKey} = clone(processDateProperty(entity${entityKey}));\n  }\n`;
+      return ret + `    ret${dataKey} = clone(processDateProperty(entity${entityKey}${unwrap}));\n  }\n`;
     }
 
-    return ret + `    ret${dataKey} = clone(entity${entityKey});\n  }\n`;
+    return ret + `    ret${dataKey} = clone(entity${entityKey}${unwrap});\n  }\n`;
   }
 
   /**

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -26,6 +26,7 @@ import { GroupOperator, PlainObject, QueryOperator, ReferenceKind } from '../enu
 import type { Collection } from '../entity/Collection';
 import type { Platform } from '../platforms';
 import { helper } from '../entity/wrap';
+import type { ScalarReference } from '../entity/Reference';
 
 export const ObjectBindingPattern = Symbol('ObjectBindingPattern');
 
@@ -635,6 +636,13 @@ export class Utils {
     }
 
     return !!data.__entity;
+  }
+
+  /**
+   * Checks whether given object is a scalar reference.
+   */
+  static isScalarReference<T = unknown>(data: any, allowReference = false): data is ScalarReference<any> & {} {
+    return typeof data === 'object' && data != null && data.__scalarReference;
   }
 
   /**

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -22,8 +22,9 @@ import {
   NullHighlighter,
   PopulateHint,
   raw,
+  ref,
 } from '@mikro-orm/core';
-import { MySqlDriver, MySqlConnection } from '@mikro-orm/mysql';
+import { MySqlDriver, MySqlConnection, ScalarReference } from '@mikro-orm/mysql';
 import { Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, PublisherType, Test2 } from './entities-sql';
 import { initORMMySql, mockLogger } from './bootstrap';
 import { Author2Subscriber } from './subscribers/Author2Subscriber';
@@ -1500,11 +1501,11 @@ describe('EntityManagerMySql', () => {
   test('many to many with composite pk', async () => {
     const author = new Author2('Jon Snow', 'snow@wall.st');
     const book1 = new Book2('My Life on The Wall, part 1', author);
-    book1.perex = 'asd 1';
+    book1.perex = ref('asd 1');
     const book2 = new Book2('My Life on The Wall, part 2', author);
-    book2.perex = 'asd 2';
+    book2.perex = ref('asd 2');
     const book3 = new Book2('My Life on The Wall, part 3', author);
-    book3.perex = 'asd 3';
+    book3.perex = ref('asd 3');
     const tag1 = new BookTag2('silly');
     const tag2 = new BookTag2('funny');
     const tag3 = new BookTag2('sick');
@@ -1533,6 +1534,8 @@ describe('EntityManagerMySql', () => {
       'where `b0`.`author_id` is not null and `b1`.`name` != ? ' +
       'order by `b0`.`title` desc');
     await expect(books.length).toBe(3);
+    expect(books[0].perex).toBeInstanceOf(ScalarReference);
+    expect(books[0].perex?.$).toBe('asd 3');
     await expect(books[0].title).toBe('My Life on The Wall, part 3');
     await expect(books[0].tagsUnordered.getItems().map(t => t.name)).toEqual(['awkward', 'sexy', 'strange']);
     await expect(books[1].title).toBe('My Life on The Wall, part 2');

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -43,8 +43,8 @@ export class Book2 {
   @Property({ nullable: true, default: '' })
   title?: string;
 
-  @Property({ type: t.text, nullable: true, lazy: true })
-  perex?: string;
+  @Property({ type: t.text, nullable: true, lazy: true, ref: true })
+  perex?: Ref<Date>;
 
   @Property({ type: t.decimal, precision: 8, scale: 2, nullable: true })
   price?: number;

--- a/tests/features/auto-flush.postgre.test.ts
+++ b/tests/features/auto-flush.postgre.test.ts
@@ -1,5 +1,5 @@
 import type { MikroORM } from '@mikro-orm/core';
-import { FlushMode, wrap } from '@mikro-orm/core';
+import { FlushMode, ref, wrap } from '@mikro-orm/core';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 
 import { initORMPostgreSql, mockLogger } from '../bootstrap';
@@ -26,13 +26,13 @@ describe('automatic flushing when querying for overlapping entities via em.find/
     god.age = 999;
     god.identities = ['a', 'b', 'c'];
     const b1 = new Book2('Bible 1', god);
-    b1.perex = 'b1 perex';
+    b1.perex = ref('b1 perex');
     b1.price = 123;
     const b2 = new Book2('Bible 2', god);
-    b2.perex = 'b2 perex';
+    b2.perex = ref('b2 perex');
     b2.price = 456;
     const b3 = new Book2('Bible 3', god);
-    b3.perex = 'b3 perex';
+    b3.perex = ref('b3 perex');
     b3.price = 789;
     await orm.em.fork().persistAndFlush(god);
 
@@ -207,13 +207,13 @@ describe('automatic flushing when querying for overlapping entities via em.find/
       god.age = 999;
       god.identities = ['a', 'b', 'c'];
       const b1 = new Book2(`Bible 1-${i}`, god);
-      b1.perex = `b1-${i} perex`;
+      b1.perex = ref(`b1-${i} perex`);
       b1.price = 123;
       const b2 = new Book2(`Bible 2-${i}`, god);
-      b2.perex = `b2-${i} perex`;
+      b2.perex = ref(`b2-${i} perex`);
       b2.price = 456;
       const b3 = new Book2(`Bible 3-${i}`, god);
-      b3.perex = `b3-${i} perex`;
+      b3.perex = ref(`b3-${i} perex`);
       b3.price = 789;
       fork.persist(god);
     }

--- a/tests/features/auto-refreshing.postgre.test.ts
+++ b/tests/features/auto-refreshing.postgre.test.ts
@@ -1,5 +1,5 @@
 import type { MikroORM } from '@mikro-orm/core';
-import { FlushMode, LoadStrategy, wrap } from '@mikro-orm/core';
+import { FlushMode, LoadStrategy, ref, wrap } from '@mikro-orm/core';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 
 import { initORMPostgreSql, mockLogger } from '../bootstrap';
@@ -20,13 +20,13 @@ describe('automatic refreshing of already loaded entities', () => {
     god.age = 999;
     god.identities = ['a', 'b', 'c'];
     const b1 = new Book2('Bible 1', god);
-    b1.perex = 'b1 perex';
+    b1.perex = ref('b1 perex');
     b1.price = 123;
     const b2 = new Book2('Bible 2', god);
-    b2.perex = 'b2 perex';
+    b2.perex = ref('b2 perex');
     b2.price = 456;
     const b3 = new Book2('Bible 3', god);
-    b3.perex = 'b3 perex';
+    b3.perex = ref('b3 perex');
     b3.price = 789;
     await orm.em.fork().persistAndFlush(god);
 
@@ -76,7 +76,7 @@ describe('automatic refreshing of already loaded entities', () => {
     expect(r2[0].email).toBe('lol@lol.lol');
     expect(r2[0].books[0].title).toBe('Bible 1');
     expect(r2[0].books[0].price).toBe('123.00');
-    expect(r2[0].books[0].perex).toBe('b1 perex');
+    expect(r2[0].books[0].perex?.$).toBe('b1 perex');
     expect(r1[0]).toBe(r2[0]);
 
     const mock = mockLogger(orm);
@@ -105,7 +105,7 @@ describe('automatic refreshing of already loaded entities', () => {
     // @ts-expect-error
     expect(r1[0].books[0].price).toBeUndefined();
     // @ts-expect-error
-    expect(r1[0].books[0].perex).toBeUndefined();
+    expect(r1[0].books[0].perex.$).toBeUndefined();
     // with auto-flush mode, this would trigger flushing as we have dirty author and we query for authors
     const r2 = await orm.em.find(Author2, god, { populate: ['books', 'books.perex'], strategy: LoadStrategy.JOINED, flushMode: FlushMode.COMMIT });
     expect(r2).toHaveLength(1);
@@ -115,7 +115,7 @@ describe('automatic refreshing of already loaded entities', () => {
     expect(r2[0].email).toBe('lol@lol.lol');
     expect(r2[0].books[0].title).toBe('lol');
     expect(r2[0].books[0].price).toBe('123.00');
-    expect(r2[0].books[0].perex).toBe('b1 perex');
+    expect(r2[0].books[0].perex?.$).toBe('b1 perex');
     expect(r1[0]).toBe(r2[0]);
 
     const mock = mockLogger(orm);

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.mongo.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.mongo.test.ts.snap
@@ -219,24 +219,48 @@ exports[`embedded entities in mongo diffing 1`] = `
 
 exports[`embedded entities in mongo diffing 2`] = `
 "function(entity, data, factory, newEntity, convertCustomTypes, schema) {
-  if (typeof data._id !== 'undefined') entity._id = data._id;
-  if (typeof data.name !== 'undefined') entity.name = data.name;
+  if (data._id === null) {
+    entity._id = null;
+  } else if (typeof data._id !== 'undefined') {
+    entity._id = data._id;
+  }
+  if (data.name === null) {
+    entity.name = null;
+  } else if (typeof data.name !== 'undefined') {
+    entity.name = data.name;
+  }
   if (data.profile1_username !== undefined || data.profile1_identity_email !== undefined || data.profile1_identity_meta_foo != null || data.profile1_identity_meta_bar != null || data.profile1_identity_meta_source != null || data.profile1_identity_links !== undefined || data.profile1_identity_source !== undefined || data.profile1_source !== undefined) {
     if (entity.profile1 == null) {
       entity.profile1 = factory.createEmbeddable('Profile', data, { newEntity, convertCustomTypes });
     }
-    if (typeof data.profile1_username !== 'undefined') entity.profile1.username = data.profile1_username;
+    if (data.profile1_username === null) {
+      entity.profile1.username = null;
+    } else if (typeof data.profile1_username !== 'undefined') {
+      entity.profile1.username = data.profile1_username;
+    }
     if (data.profile1_identity_email !== undefined || data.profile1_identity_meta_foo != null || data.profile1_identity_meta_bar != null || data.profile1_identity_meta_source != null || data.profile1_identity_links !== undefined || data.profile1_identity_source !== undefined) {
       if (entity.profile1.identity == null) {
         entity.profile1.identity = factory.createEmbeddable('Identity', data, { newEntity, convertCustomTypes });
       }
-      if (typeof data.profile1_identity_email !== 'undefined') entity.profile1.identity.email = data.profile1_identity_email;
+      if (data.profile1_identity_email === null) {
+        entity.profile1.identity.email = null;
+      } else if (typeof data.profile1_identity_email !== 'undefined') {
+        entity.profile1.identity.email = data.profile1_identity_email;
+      }
       if (data.profile1_identity_meta_foo != null || data.profile1_identity_meta_bar != null || data.profile1_identity_meta_source != null) {
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data, { newEntity, convertCustomTypes });
         }
-        if (typeof data.profile1_identity_meta_foo !== 'undefined') entity.profile1.identity.meta.foo = data.profile1_identity_meta_foo;
-        if (typeof data.profile1_identity_meta_bar !== 'undefined') entity.profile1.identity.meta.bar = data.profile1_identity_meta_bar;
+        if (data.profile1_identity_meta_foo === null) {
+          entity.profile1.identity.meta.foo = null;
+        } else if (typeof data.profile1_identity_meta_foo !== 'undefined') {
+          entity.profile1.identity.meta.foo = data.profile1_identity_meta_foo;
+        }
+        if (data.profile1_identity_meta_bar === null) {
+          entity.profile1.identity.meta.bar = null;
+        } else if (typeof data.profile1_identity_meta_bar !== 'undefined') {
+          entity.profile1.identity.meta.bar = data.profile1_identity_meta_bar;
+        }
         if (data.profile1_identity_meta_source === null) {
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
@@ -253,8 +277,16 @@ exports[`embedded entities in mongo diffing 2`] = `
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity_meta, { newEntity, convertCustomTypes });
         }
-        if (data.profile1_identity_meta && typeof data.profile1_identity_meta.foo !== 'undefined') entity.profile1.identity.meta.foo = data.profile1_identity_meta.foo;
-        if (data.profile1_identity_meta && typeof data.profile1_identity_meta.bar !== 'undefined') entity.profile1.identity.meta.bar = data.profile1_identity_meta.bar;
+        if (data.profile1_identity_meta.foo === null) {
+          entity.profile1.identity.meta.foo = null;
+        } else if (typeof data.profile1_identity_meta.foo !== 'undefined') {
+          entity.profile1.identity.meta.foo = data.profile1_identity_meta.foo;
+        }
+        if (data.profile1_identity_meta.bar === null) {
+          entity.profile1.identity.meta.bar = null;
+        } else if (typeof data.profile1_identity_meta.bar !== 'undefined') {
+          entity.profile1.identity.meta.bar = data.profile1_identity_meta.bar;
+        }
         if (data.profile1_identity_meta.source === null) {
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta.source !== 'undefined') {
@@ -269,66 +301,89 @@ exports[`embedded entities in mongo diffing 2`] = `
       }
       if (Array.isArray(data.profile1_identity_links)) {
         entity.profile1.identity.links = [];
-        data.profile1_identity_links.forEach((_, idx_0) => {
-          if (data.profile1_identity_links[idx_0] != null) {
-            if (entity.profile1.identity.links[idx_0] == null) {
-              entity.profile1.identity.links[idx_0] = factory.createEmbeddable('IdentityLink', data.profile1_identity_links[idx_0], { newEntity, convertCustomTypes });
+        data.profile1_identity_links.forEach((_, idx_8) => {
+          if (data.profile1_identity_links[idx_8] != null) {
+            if (entity.profile1.identity.links[idx_8] == null) {
+              entity.profile1.identity.links[idx_8] = factory.createEmbeddable('IdentityLink', data.profile1_identity_links[idx_8], { newEntity, convertCustomTypes });
             }
-            if (data.profile1_identity_links && data.profile1_identity_links[idx_0] && typeof data.profile1_identity_links[idx_0].url !== 'undefined') entity.profile1.identity.links[idx_0].url = data.profile1_identity_links[idx_0].url;
-            if (data.profile1_identity_links && data.profile1_identity_links[idx_0] && data.profile1_identity_links[idx_0].createdAt) entity.profile1.identity.links[idx_0].createdAt = new Date(data.profile1_identity_links[idx_0].createdAt);
-            else if (data.profile1_identity_links && data.profile1_identity_links[idx_0] && data.profile1_identity_links[idx_0].createdAt === null) entity.profile1.identity.links[idx_0].createdAt = null;
-            if (data.profile1_identity_links[idx_0].meta != null) {
-              if (entity.profile1.identity.links[idx_0].meta == null) {
-                entity.profile1.identity.links[idx_0].meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity_links[idx_0].meta, { newEntity, convertCustomTypes });
+            if (data.profile1_identity_links[idx_8].url === null) {
+              entity.profile1.identity.links[idx_8].url = null;
+            } else if (typeof data.profile1_identity_links[idx_8].url !== 'undefined') {
+              entity.profile1.identity.links[idx_8].url = data.profile1_identity_links[idx_8].url;
+            }
+            if (data.profile1_identity_links[idx_8].createdAt === null) {
+              entity.profile1.identity.links[idx_8].createdAt = null;
+            } else if (typeof data.profile1_identity_links[idx_8].createdAt !== 'undefined') {
+              entity.profile1.identity.links[idx_8].createdAt = new Date(data.profile1_identity_links[idx_8].createdAt);
+            }
+            if (data.profile1_identity_links[idx_8].meta != null) {
+              if (entity.profile1.identity.links[idx_8].meta == null) {
+                entity.profile1.identity.links[idx_8].meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity_links[idx_8].meta, { newEntity, convertCustomTypes });
               }
-              if (data.profile1_identity_links && data.profile1_identity_links[idx_0] && data.profile1_identity_links[idx_0].meta && typeof data.profile1_identity_links[idx_0].meta.foo !== 'undefined') entity.profile1.identity.links[idx_0].meta.foo = data.profile1_identity_links[idx_0].meta.foo;
-              if (data.profile1_identity_links && data.profile1_identity_links[idx_0] && data.profile1_identity_links[idx_0].meta && typeof data.profile1_identity_links[idx_0].meta.bar !== 'undefined') entity.profile1.identity.links[idx_0].meta.bar = data.profile1_identity_links[idx_0].meta.bar;
-              if (data.profile1_identity_links[idx_0].meta.source === null) {
-    entity.profile1.identity.links[idx_0].meta.source = null;
-              } else if (typeof data.profile1_identity_links[idx_0].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile1_identity_links[idx_0].meta.source, true)) {
-                  entity.profile1.identity.links[idx_0].meta.source = factory.createReference('Source', data.profile1_identity_links[idx_0].meta.source, { merge: true, convertCustomTypes, schema });
-                } else if (data.profile1_identity_links[idx_0].meta.source && typeof data.profile1_identity_links[idx_0].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_0].meta.source = factory.create('Source', data.profile1_identity_links[idx_0].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+              if (data.profile1_identity_links[idx_8].meta.foo === null) {
+                entity.profile1.identity.links[idx_8].meta.foo = null;
+              } else if (typeof data.profile1_identity_links[idx_8].meta.foo !== 'undefined') {
+                entity.profile1.identity.links[idx_8].meta.foo = data.profile1_identity_links[idx_8].meta.foo;
+              }
+              if (data.profile1_identity_links[idx_8].meta.bar === null) {
+                entity.profile1.identity.links[idx_8].meta.bar = null;
+              } else if (typeof data.profile1_identity_links[idx_8].meta.bar !== 'undefined') {
+                entity.profile1.identity.links[idx_8].meta.bar = data.profile1_identity_links[idx_8].meta.bar;
+              }
+              if (data.profile1_identity_links[idx_8].meta.source === null) {
+    entity.profile1.identity.links[idx_8].meta.source = null;
+              } else if (typeof data.profile1_identity_links[idx_8].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile1_identity_links[idx_8].meta.source, true)) {
+                  entity.profile1.identity.links[idx_8].meta.source = factory.createReference('Source', data.profile1_identity_links[idx_8].meta.source, { merge: true, convertCustomTypes, schema });
+                } else if (data.profile1_identity_links[idx_8].meta.source && typeof data.profile1_identity_links[idx_8].meta.source === 'object') {
+                  entity.profile1.identity.links[idx_8].meta.source = factory.create('Source', data.profile1_identity_links[idx_8].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                 }
               }
-            } else if (data.profile1_identity_links[idx_0].meta === null) {
-              entity.profile1.identity.links[idx_0].meta = null;
+            } else if (data.profile1_identity_links[idx_8].meta === null) {
+              entity.profile1.identity.links[idx_8].meta = null;
             }
-            if (Array.isArray(data.profile1_identity_links[idx_0].metas)) {
-              entity.profile1.identity.links[idx_0].metas = [];
-              data.profile1_identity_links[idx_0].metas.forEach((_, idx_1) => {
-                if (data.profile1_identity_links[idx_0].metas[idx_1] != null) {
-                  if (entity.profile1.identity.links[idx_0].metas[idx_1] == null) {
-                    entity.profile1.identity.links[idx_0].metas[idx_1] = factory.createEmbeddable('IdentityMeta', data.profile1_identity_links[idx_0].metas[idx_1], { newEntity, convertCustomTypes });
+            if (Array.isArray(data.profile1_identity_links[idx_8].metas)) {
+              entity.profile1.identity.links[idx_8].metas = [];
+              data.profile1_identity_links[idx_8].metas.forEach((_, idx_13) => {
+                if (data.profile1_identity_links[idx_8].metas[idx_13] != null) {
+                  if (entity.profile1.identity.links[idx_8].metas[idx_13] == null) {
+                    entity.profile1.identity.links[idx_8].metas[idx_13] = factory.createEmbeddable('IdentityMeta', data.profile1_identity_links[idx_8].metas[idx_13], { newEntity, convertCustomTypes });
                   }
-                  if (data.profile1_identity_links && data.profile1_identity_links[idx_0] && data.profile1_identity_links[idx_0].metas && data.profile1_identity_links[idx_0].metas[idx_1] && typeof data.profile1_identity_links[idx_0].metas[idx_1].foo !== 'undefined') entity.profile1.identity.links[idx_0].metas[idx_1].foo = data.profile1_identity_links[idx_0].metas[idx_1].foo;
-                  if (data.profile1_identity_links && data.profile1_identity_links[idx_0] && data.profile1_identity_links[idx_0].metas && data.profile1_identity_links[idx_0].metas[idx_1] && typeof data.profile1_identity_links[idx_0].metas[idx_1].bar !== 'undefined') entity.profile1.identity.links[idx_0].metas[idx_1].bar = data.profile1_identity_links[idx_0].metas[idx_1].bar;
-                  if (data.profile1_identity_links[idx_0].metas[idx_1].source === null) {
-    entity.profile1.identity.links[idx_0].metas[idx_1].source = null;
-                  } else if (typeof data.profile1_identity_links[idx_0].metas[idx_1].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile1_identity_links[idx_0].metas[idx_1].source, true)) {
-                      entity.profile1.identity.links[idx_0].metas[idx_1].source = factory.createReference('Source', data.profile1_identity_links[idx_0].metas[idx_1].source, { merge: true, convertCustomTypes, schema });
-                    } else if (data.profile1_identity_links[idx_0].metas[idx_1].source && typeof data.profile1_identity_links[idx_0].metas[idx_1].source === 'object') {
-                      entity.profile1.identity.links[idx_0].metas[idx_1].source = factory.create('Source', data.profile1_identity_links[idx_0].metas[idx_1].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  if (data.profile1_identity_links[idx_8].metas[idx_13].foo === null) {
+                    entity.profile1.identity.links[idx_8].metas[idx_13].foo = null;
+                  } else if (typeof data.profile1_identity_links[idx_8].metas[idx_13].foo !== 'undefined') {
+                    entity.profile1.identity.links[idx_8].metas[idx_13].foo = data.profile1_identity_links[idx_8].metas[idx_13].foo;
+                  }
+                  if (data.profile1_identity_links[idx_8].metas[idx_13].bar === null) {
+                    entity.profile1.identity.links[idx_8].metas[idx_13].bar = null;
+                  } else if (typeof data.profile1_identity_links[idx_8].metas[idx_13].bar !== 'undefined') {
+                    entity.profile1.identity.links[idx_8].metas[idx_13].bar = data.profile1_identity_links[idx_8].metas[idx_13].bar;
+                  }
+                  if (data.profile1_identity_links[idx_8].metas[idx_13].source === null) {
+    entity.profile1.identity.links[idx_8].metas[idx_13].source = null;
+                  } else if (typeof data.profile1_identity_links[idx_8].metas[idx_13].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile1_identity_links[idx_8].metas[idx_13].source, true)) {
+                      entity.profile1.identity.links[idx_8].metas[idx_13].source = factory.createReference('Source', data.profile1_identity_links[idx_8].metas[idx_13].source, { merge: true, convertCustomTypes, schema });
+                    } else if (data.profile1_identity_links[idx_8].metas[idx_13].source && typeof data.profile1_identity_links[idx_8].metas[idx_13].source === 'object') {
+                      entity.profile1.identity.links[idx_8].metas[idx_13].source = factory.create('Source', data.profile1_identity_links[idx_8].metas[idx_13].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                     }
                   }
-                } else if (data.profile1_identity_links[idx_0].metas[idx_1] === null) {
-                  entity.profile1.identity.links[idx_0].metas[idx_1] = null;
+                } else if (data.profile1_identity_links[idx_8].metas[idx_13] === null) {
+                  entity.profile1.identity.links[idx_8].metas[idx_13] = null;
                 }
               });
             }
-            if (data.profile1_identity_links[idx_0].source === null) {
-    entity.profile1.identity.links[idx_0].source = null;
-            } else if (typeof data.profile1_identity_links[idx_0].source !== 'undefined') {
-              if (isPrimaryKey(data.profile1_identity_links[idx_0].source, true)) {
-                entity.profile1.identity.links[idx_0].source = factory.createReference('Source', data.profile1_identity_links[idx_0].source, { merge: true, convertCustomTypes, schema });
-              } else if (data.profile1_identity_links[idx_0].source && typeof data.profile1_identity_links[idx_0].source === 'object') {
-                entity.profile1.identity.links[idx_0].source = factory.create('Source', data.profile1_identity_links[idx_0].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            if (data.profile1_identity_links[idx_8].source === null) {
+    entity.profile1.identity.links[idx_8].source = null;
+            } else if (typeof data.profile1_identity_links[idx_8].source !== 'undefined') {
+              if (isPrimaryKey(data.profile1_identity_links[idx_8].source, true)) {
+                entity.profile1.identity.links[idx_8].source = factory.createReference('Source', data.profile1_identity_links[idx_8].source, { merge: true, convertCustomTypes, schema });
+              } else if (data.profile1_identity_links[idx_8].source && typeof data.profile1_identity_links[idx_8].source === 'object') {
+                entity.profile1.identity.links[idx_8].source = factory.create('Source', data.profile1_identity_links[idx_8].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
               }
             }
-          } else if (data.profile1_identity_links[idx_0] === null) {
-            entity.profile1.identity.links[idx_0] = null;
+          } else if (data.profile1_identity_links[idx_8] === null) {
+            entity.profile1.identity.links[idx_8] = null;
           }
         });
       }
@@ -348,13 +403,25 @@ exports[`embedded entities in mongo diffing 2`] = `
       if (entity.profile1.identity == null) {
         entity.profile1.identity = factory.createEmbeddable('Identity', data.profile1_identity, { newEntity, convertCustomTypes });
       }
-      if (data.profile1_identity && typeof data.profile1_identity.email !== 'undefined') entity.profile1.identity.email = data.profile1_identity.email;
+      if (data.profile1_identity.email === null) {
+        entity.profile1.identity.email = null;
+      } else if (typeof data.profile1_identity.email !== 'undefined') {
+        entity.profile1.identity.email = data.profile1_identity.email;
+      }
       if (data.profile1_identity_meta_foo != null || data.profile1_identity_meta_bar != null || data.profile1_identity_meta_source != null) {
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data, { newEntity, convertCustomTypes });
         }
-        if (typeof data.profile1_identity_meta_foo !== 'undefined') entity.profile1.identity.meta.foo = data.profile1_identity_meta_foo;
-        if (typeof data.profile1_identity_meta_bar !== 'undefined') entity.profile1.identity.meta.bar = data.profile1_identity_meta_bar;
+        if (data.profile1_identity_meta_foo === null) {
+          entity.profile1.identity.meta.foo = null;
+        } else if (typeof data.profile1_identity_meta_foo !== 'undefined') {
+          entity.profile1.identity.meta.foo = data.profile1_identity_meta_foo;
+        }
+        if (data.profile1_identity_meta_bar === null) {
+          entity.profile1.identity.meta.bar = null;
+        } else if (typeof data.profile1_identity_meta_bar !== 'undefined') {
+          entity.profile1.identity.meta.bar = data.profile1_identity_meta_bar;
+        }
         if (data.profile1_identity_meta_source === null) {
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
@@ -371,8 +438,16 @@ exports[`embedded entities in mongo diffing 2`] = `
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity.meta, { newEntity, convertCustomTypes });
         }
-        if (data.profile1_identity && data.profile1_identity.meta && typeof data.profile1_identity.meta.foo !== 'undefined') entity.profile1.identity.meta.foo = data.profile1_identity.meta.foo;
-        if (data.profile1_identity && data.profile1_identity.meta && typeof data.profile1_identity.meta.bar !== 'undefined') entity.profile1.identity.meta.bar = data.profile1_identity.meta.bar;
+        if (data.profile1_identity.meta.foo === null) {
+          entity.profile1.identity.meta.foo = null;
+        } else if (typeof data.profile1_identity.meta.foo !== 'undefined') {
+          entity.profile1.identity.meta.foo = data.profile1_identity.meta.foo;
+        }
+        if (data.profile1_identity.meta.bar === null) {
+          entity.profile1.identity.meta.bar = null;
+        } else if (typeof data.profile1_identity.meta.bar !== 'undefined') {
+          entity.profile1.identity.meta.bar = data.profile1_identity.meta.bar;
+        }
         if (data.profile1_identity.meta.source === null) {
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity.meta.source !== 'undefined') {
@@ -387,66 +462,89 @@ exports[`embedded entities in mongo diffing 2`] = `
       }
       if (Array.isArray(data.profile1_identity.links)) {
         entity.profile1.identity.links = [];
-        data.profile1_identity.links.forEach((_, idx_2) => {
-          if (data.profile1_identity.links[idx_2] != null) {
-            if (entity.profile1.identity.links[idx_2] == null) {
-              entity.profile1.identity.links[idx_2] = factory.createEmbeddable('IdentityLink', data.profile1_identity.links[idx_2], { newEntity, convertCustomTypes });
+        data.profile1_identity.links.forEach((_, idx_21) => {
+          if (data.profile1_identity.links[idx_21] != null) {
+            if (entity.profile1.identity.links[idx_21] == null) {
+              entity.profile1.identity.links[idx_21] = factory.createEmbeddable('IdentityLink', data.profile1_identity.links[idx_21], { newEntity, convertCustomTypes });
             }
-            if (data.profile1_identity && data.profile1_identity.links && data.profile1_identity.links[idx_2] && typeof data.profile1_identity.links[idx_2].url !== 'undefined') entity.profile1.identity.links[idx_2].url = data.profile1_identity.links[idx_2].url;
-            if (data.profile1_identity && data.profile1_identity.links && data.profile1_identity.links[idx_2] && data.profile1_identity.links[idx_2].createdAt) entity.profile1.identity.links[idx_2].createdAt = new Date(data.profile1_identity.links[idx_2].createdAt);
-            else if (data.profile1_identity && data.profile1_identity.links && data.profile1_identity.links[idx_2] && data.profile1_identity.links[idx_2].createdAt === null) entity.profile1.identity.links[idx_2].createdAt = null;
-            if (data.profile1_identity.links[idx_2].meta != null) {
-              if (entity.profile1.identity.links[idx_2].meta == null) {
-                entity.profile1.identity.links[idx_2].meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity.links[idx_2].meta, { newEntity, convertCustomTypes });
+            if (data.profile1_identity.links[idx_21].url === null) {
+              entity.profile1.identity.links[idx_21].url = null;
+            } else if (typeof data.profile1_identity.links[idx_21].url !== 'undefined') {
+              entity.profile1.identity.links[idx_21].url = data.profile1_identity.links[idx_21].url;
+            }
+            if (data.profile1_identity.links[idx_21].createdAt === null) {
+              entity.profile1.identity.links[idx_21].createdAt = null;
+            } else if (typeof data.profile1_identity.links[idx_21].createdAt !== 'undefined') {
+              entity.profile1.identity.links[idx_21].createdAt = new Date(data.profile1_identity.links[idx_21].createdAt);
+            }
+            if (data.profile1_identity.links[idx_21].meta != null) {
+              if (entity.profile1.identity.links[idx_21].meta == null) {
+                entity.profile1.identity.links[idx_21].meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity.links[idx_21].meta, { newEntity, convertCustomTypes });
               }
-              if (data.profile1_identity && data.profile1_identity.links && data.profile1_identity.links[idx_2] && data.profile1_identity.links[idx_2].meta && typeof data.profile1_identity.links[idx_2].meta.foo !== 'undefined') entity.profile1.identity.links[idx_2].meta.foo = data.profile1_identity.links[idx_2].meta.foo;
-              if (data.profile1_identity && data.profile1_identity.links && data.profile1_identity.links[idx_2] && data.profile1_identity.links[idx_2].meta && typeof data.profile1_identity.links[idx_2].meta.bar !== 'undefined') entity.profile1.identity.links[idx_2].meta.bar = data.profile1_identity.links[idx_2].meta.bar;
-              if (data.profile1_identity.links[idx_2].meta.source === null) {
-    entity.profile1.identity.links[idx_2].meta.source = null;
-              } else if (typeof data.profile1_identity.links[idx_2].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile1_identity.links[idx_2].meta.source, true)) {
-                  entity.profile1.identity.links[idx_2].meta.source = factory.createReference('Source', data.profile1_identity.links[idx_2].meta.source, { merge: true, convertCustomTypes, schema });
-                } else if (data.profile1_identity.links[idx_2].meta.source && typeof data.profile1_identity.links[idx_2].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_2].meta.source = factory.create('Source', data.profile1_identity.links[idx_2].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+              if (data.profile1_identity.links[idx_21].meta.foo === null) {
+                entity.profile1.identity.links[idx_21].meta.foo = null;
+              } else if (typeof data.profile1_identity.links[idx_21].meta.foo !== 'undefined') {
+                entity.profile1.identity.links[idx_21].meta.foo = data.profile1_identity.links[idx_21].meta.foo;
+              }
+              if (data.profile1_identity.links[idx_21].meta.bar === null) {
+                entity.profile1.identity.links[idx_21].meta.bar = null;
+              } else if (typeof data.profile1_identity.links[idx_21].meta.bar !== 'undefined') {
+                entity.profile1.identity.links[idx_21].meta.bar = data.profile1_identity.links[idx_21].meta.bar;
+              }
+              if (data.profile1_identity.links[idx_21].meta.source === null) {
+    entity.profile1.identity.links[idx_21].meta.source = null;
+              } else if (typeof data.profile1_identity.links[idx_21].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile1_identity.links[idx_21].meta.source, true)) {
+                  entity.profile1.identity.links[idx_21].meta.source = factory.createReference('Source', data.profile1_identity.links[idx_21].meta.source, { merge: true, convertCustomTypes, schema });
+                } else if (data.profile1_identity.links[idx_21].meta.source && typeof data.profile1_identity.links[idx_21].meta.source === 'object') {
+                  entity.profile1.identity.links[idx_21].meta.source = factory.create('Source', data.profile1_identity.links[idx_21].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                 }
               }
-            } else if (data.profile1_identity.links[idx_2].meta === null) {
-              entity.profile1.identity.links[idx_2].meta = null;
+            } else if (data.profile1_identity.links[idx_21].meta === null) {
+              entity.profile1.identity.links[idx_21].meta = null;
             }
-            if (Array.isArray(data.profile1_identity.links[idx_2].metas)) {
-              entity.profile1.identity.links[idx_2].metas = [];
-              data.profile1_identity.links[idx_2].metas.forEach((_, idx_3) => {
-                if (data.profile1_identity.links[idx_2].metas[idx_3] != null) {
-                  if (entity.profile1.identity.links[idx_2].metas[idx_3] == null) {
-                    entity.profile1.identity.links[idx_2].metas[idx_3] = factory.createEmbeddable('IdentityMeta', data.profile1_identity.links[idx_2].metas[idx_3], { newEntity, convertCustomTypes });
+            if (Array.isArray(data.profile1_identity.links[idx_21].metas)) {
+              entity.profile1.identity.links[idx_21].metas = [];
+              data.profile1_identity.links[idx_21].metas.forEach((_, idx_26) => {
+                if (data.profile1_identity.links[idx_21].metas[idx_26] != null) {
+                  if (entity.profile1.identity.links[idx_21].metas[idx_26] == null) {
+                    entity.profile1.identity.links[idx_21].metas[idx_26] = factory.createEmbeddable('IdentityMeta', data.profile1_identity.links[idx_21].metas[idx_26], { newEntity, convertCustomTypes });
                   }
-                  if (data.profile1_identity && data.profile1_identity.links && data.profile1_identity.links[idx_2] && data.profile1_identity.links[idx_2].metas && data.profile1_identity.links[idx_2].metas[idx_3] && typeof data.profile1_identity.links[idx_2].metas[idx_3].foo !== 'undefined') entity.profile1.identity.links[idx_2].metas[idx_3].foo = data.profile1_identity.links[idx_2].metas[idx_3].foo;
-                  if (data.profile1_identity && data.profile1_identity.links && data.profile1_identity.links[idx_2] && data.profile1_identity.links[idx_2].metas && data.profile1_identity.links[idx_2].metas[idx_3] && typeof data.profile1_identity.links[idx_2].metas[idx_3].bar !== 'undefined') entity.profile1.identity.links[idx_2].metas[idx_3].bar = data.profile1_identity.links[idx_2].metas[idx_3].bar;
-                  if (data.profile1_identity.links[idx_2].metas[idx_3].source === null) {
-    entity.profile1.identity.links[idx_2].metas[idx_3].source = null;
-                  } else if (typeof data.profile1_identity.links[idx_2].metas[idx_3].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile1_identity.links[idx_2].metas[idx_3].source, true)) {
-                      entity.profile1.identity.links[idx_2].metas[idx_3].source = factory.createReference('Source', data.profile1_identity.links[idx_2].metas[idx_3].source, { merge: true, convertCustomTypes, schema });
-                    } else if (data.profile1_identity.links[idx_2].metas[idx_3].source && typeof data.profile1_identity.links[idx_2].metas[idx_3].source === 'object') {
-                      entity.profile1.identity.links[idx_2].metas[idx_3].source = factory.create('Source', data.profile1_identity.links[idx_2].metas[idx_3].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  if (data.profile1_identity.links[idx_21].metas[idx_26].foo === null) {
+                    entity.profile1.identity.links[idx_21].metas[idx_26].foo = null;
+                  } else if (typeof data.profile1_identity.links[idx_21].metas[idx_26].foo !== 'undefined') {
+                    entity.profile1.identity.links[idx_21].metas[idx_26].foo = data.profile1_identity.links[idx_21].metas[idx_26].foo;
+                  }
+                  if (data.profile1_identity.links[idx_21].metas[idx_26].bar === null) {
+                    entity.profile1.identity.links[idx_21].metas[idx_26].bar = null;
+                  } else if (typeof data.profile1_identity.links[idx_21].metas[idx_26].bar !== 'undefined') {
+                    entity.profile1.identity.links[idx_21].metas[idx_26].bar = data.profile1_identity.links[idx_21].metas[idx_26].bar;
+                  }
+                  if (data.profile1_identity.links[idx_21].metas[idx_26].source === null) {
+    entity.profile1.identity.links[idx_21].metas[idx_26].source = null;
+                  } else if (typeof data.profile1_identity.links[idx_21].metas[idx_26].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile1_identity.links[idx_21].metas[idx_26].source, true)) {
+                      entity.profile1.identity.links[idx_21].metas[idx_26].source = factory.createReference('Source', data.profile1_identity.links[idx_21].metas[idx_26].source, { merge: true, convertCustomTypes, schema });
+                    } else if (data.profile1_identity.links[idx_21].metas[idx_26].source && typeof data.profile1_identity.links[idx_21].metas[idx_26].source === 'object') {
+                      entity.profile1.identity.links[idx_21].metas[idx_26].source = factory.create('Source', data.profile1_identity.links[idx_21].metas[idx_26].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                     }
                   }
-                } else if (data.profile1_identity.links[idx_2].metas[idx_3] === null) {
-                  entity.profile1.identity.links[idx_2].metas[idx_3] = null;
+                } else if (data.profile1_identity.links[idx_21].metas[idx_26] === null) {
+                  entity.profile1.identity.links[idx_21].metas[idx_26] = null;
                 }
               });
             }
-            if (data.profile1_identity.links[idx_2].source === null) {
-    entity.profile1.identity.links[idx_2].source = null;
-            } else if (typeof data.profile1_identity.links[idx_2].source !== 'undefined') {
-              if (isPrimaryKey(data.profile1_identity.links[idx_2].source, true)) {
-                entity.profile1.identity.links[idx_2].source = factory.createReference('Source', data.profile1_identity.links[idx_2].source, { merge: true, convertCustomTypes, schema });
-              } else if (data.profile1_identity.links[idx_2].source && typeof data.profile1_identity.links[idx_2].source === 'object') {
-                entity.profile1.identity.links[idx_2].source = factory.create('Source', data.profile1_identity.links[idx_2].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            if (data.profile1_identity.links[idx_21].source === null) {
+    entity.profile1.identity.links[idx_21].source = null;
+            } else if (typeof data.profile1_identity.links[idx_21].source !== 'undefined') {
+              if (isPrimaryKey(data.profile1_identity.links[idx_21].source, true)) {
+                entity.profile1.identity.links[idx_21].source = factory.createReference('Source', data.profile1_identity.links[idx_21].source, { merge: true, convertCustomTypes, schema });
+              } else if (data.profile1_identity.links[idx_21].source && typeof data.profile1_identity.links[idx_21].source === 'object') {
+                entity.profile1.identity.links[idx_21].source = factory.create('Source', data.profile1_identity.links[idx_21].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
               }
             }
-          } else if (data.profile1_identity.links[idx_2] === null) {
-            entity.profile1.identity.links[idx_2] = null;
+          } else if (data.profile1_identity.links[idx_21] === null) {
+            entity.profile1.identity.links[idx_21] = null;
           }
         });
       }
@@ -478,18 +576,34 @@ exports[`embedded entities in mongo diffing 2`] = `
     if (entity.profile1 == null) {
       entity.profile1 = factory.createEmbeddable('Profile', data.profile1, { newEntity, convertCustomTypes });
     }
-    if (data.profile1 && typeof data.profile1.username !== 'undefined') entity.profile1.username = data.profile1.username;
+    if (data.profile1.username === null) {
+      entity.profile1.username = null;
+    } else if (typeof data.profile1.username !== 'undefined') {
+      entity.profile1.username = data.profile1.username;
+    }
     if (data.profile1_identity_email !== undefined || data.profile1_identity_meta_foo != null || data.profile1_identity_meta_bar != null || data.profile1_identity_meta_source != null || data.profile1_identity_links !== undefined || data.profile1_identity_source !== undefined) {
       if (entity.profile1.identity == null) {
         entity.profile1.identity = factory.createEmbeddable('Identity', data, { newEntity, convertCustomTypes });
       }
-      if (typeof data.profile1_identity_email !== 'undefined') entity.profile1.identity.email = data.profile1_identity_email;
+      if (data.profile1_identity_email === null) {
+        entity.profile1.identity.email = null;
+      } else if (typeof data.profile1_identity_email !== 'undefined') {
+        entity.profile1.identity.email = data.profile1_identity_email;
+      }
       if (data.profile1_identity_meta_foo != null || data.profile1_identity_meta_bar != null || data.profile1_identity_meta_source != null) {
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data, { newEntity, convertCustomTypes });
         }
-        if (typeof data.profile1_identity_meta_foo !== 'undefined') entity.profile1.identity.meta.foo = data.profile1_identity_meta_foo;
-        if (typeof data.profile1_identity_meta_bar !== 'undefined') entity.profile1.identity.meta.bar = data.profile1_identity_meta_bar;
+        if (data.profile1_identity_meta_foo === null) {
+          entity.profile1.identity.meta.foo = null;
+        } else if (typeof data.profile1_identity_meta_foo !== 'undefined') {
+          entity.profile1.identity.meta.foo = data.profile1_identity_meta_foo;
+        }
+        if (data.profile1_identity_meta_bar === null) {
+          entity.profile1.identity.meta.bar = null;
+        } else if (typeof data.profile1_identity_meta_bar !== 'undefined') {
+          entity.profile1.identity.meta.bar = data.profile1_identity_meta_bar;
+        }
         if (data.profile1_identity_meta_source === null) {
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
@@ -506,8 +620,16 @@ exports[`embedded entities in mongo diffing 2`] = `
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity_meta, { newEntity, convertCustomTypes });
         }
-        if (data.profile1_identity_meta && typeof data.profile1_identity_meta.foo !== 'undefined') entity.profile1.identity.meta.foo = data.profile1_identity_meta.foo;
-        if (data.profile1_identity_meta && typeof data.profile1_identity_meta.bar !== 'undefined') entity.profile1.identity.meta.bar = data.profile1_identity_meta.bar;
+        if (data.profile1_identity_meta.foo === null) {
+          entity.profile1.identity.meta.foo = null;
+        } else if (typeof data.profile1_identity_meta.foo !== 'undefined') {
+          entity.profile1.identity.meta.foo = data.profile1_identity_meta.foo;
+        }
+        if (data.profile1_identity_meta.bar === null) {
+          entity.profile1.identity.meta.bar = null;
+        } else if (typeof data.profile1_identity_meta.bar !== 'undefined') {
+          entity.profile1.identity.meta.bar = data.profile1_identity_meta.bar;
+        }
         if (data.profile1_identity_meta.source === null) {
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta.source !== 'undefined') {
@@ -522,66 +644,89 @@ exports[`embedded entities in mongo diffing 2`] = `
       }
       if (Array.isArray(data.profile1_identity_links)) {
         entity.profile1.identity.links = [];
-        data.profile1_identity_links.forEach((_, idx_4) => {
-          if (data.profile1_identity_links[idx_4] != null) {
-            if (entity.profile1.identity.links[idx_4] == null) {
-              entity.profile1.identity.links[idx_4] = factory.createEmbeddable('IdentityLink', data.profile1_identity_links[idx_4], { newEntity, convertCustomTypes });
+        data.profile1_identity_links.forEach((_, idx_35) => {
+          if (data.profile1_identity_links[idx_35] != null) {
+            if (entity.profile1.identity.links[idx_35] == null) {
+              entity.profile1.identity.links[idx_35] = factory.createEmbeddable('IdentityLink', data.profile1_identity_links[idx_35], { newEntity, convertCustomTypes });
             }
-            if (data.profile1_identity_links && data.profile1_identity_links[idx_4] && typeof data.profile1_identity_links[idx_4].url !== 'undefined') entity.profile1.identity.links[idx_4].url = data.profile1_identity_links[idx_4].url;
-            if (data.profile1_identity_links && data.profile1_identity_links[idx_4] && data.profile1_identity_links[idx_4].createdAt) entity.profile1.identity.links[idx_4].createdAt = new Date(data.profile1_identity_links[idx_4].createdAt);
-            else if (data.profile1_identity_links && data.profile1_identity_links[idx_4] && data.profile1_identity_links[idx_4].createdAt === null) entity.profile1.identity.links[idx_4].createdAt = null;
-            if (data.profile1_identity_links[idx_4].meta != null) {
-              if (entity.profile1.identity.links[idx_4].meta == null) {
-                entity.profile1.identity.links[idx_4].meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity_links[idx_4].meta, { newEntity, convertCustomTypes });
+            if (data.profile1_identity_links[idx_35].url === null) {
+              entity.profile1.identity.links[idx_35].url = null;
+            } else if (typeof data.profile1_identity_links[idx_35].url !== 'undefined') {
+              entity.profile1.identity.links[idx_35].url = data.profile1_identity_links[idx_35].url;
+            }
+            if (data.profile1_identity_links[idx_35].createdAt === null) {
+              entity.profile1.identity.links[idx_35].createdAt = null;
+            } else if (typeof data.profile1_identity_links[idx_35].createdAt !== 'undefined') {
+              entity.profile1.identity.links[idx_35].createdAt = new Date(data.profile1_identity_links[idx_35].createdAt);
+            }
+            if (data.profile1_identity_links[idx_35].meta != null) {
+              if (entity.profile1.identity.links[idx_35].meta == null) {
+                entity.profile1.identity.links[idx_35].meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity_links[idx_35].meta, { newEntity, convertCustomTypes });
               }
-              if (data.profile1_identity_links && data.profile1_identity_links[idx_4] && data.profile1_identity_links[idx_4].meta && typeof data.profile1_identity_links[idx_4].meta.foo !== 'undefined') entity.profile1.identity.links[idx_4].meta.foo = data.profile1_identity_links[idx_4].meta.foo;
-              if (data.profile1_identity_links && data.profile1_identity_links[idx_4] && data.profile1_identity_links[idx_4].meta && typeof data.profile1_identity_links[idx_4].meta.bar !== 'undefined') entity.profile1.identity.links[idx_4].meta.bar = data.profile1_identity_links[idx_4].meta.bar;
-              if (data.profile1_identity_links[idx_4].meta.source === null) {
-    entity.profile1.identity.links[idx_4].meta.source = null;
-              } else if (typeof data.profile1_identity_links[idx_4].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile1_identity_links[idx_4].meta.source, true)) {
-                  entity.profile1.identity.links[idx_4].meta.source = factory.createReference('Source', data.profile1_identity_links[idx_4].meta.source, { merge: true, convertCustomTypes, schema });
-                } else if (data.profile1_identity_links[idx_4].meta.source && typeof data.profile1_identity_links[idx_4].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_4].meta.source = factory.create('Source', data.profile1_identity_links[idx_4].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+              if (data.profile1_identity_links[idx_35].meta.foo === null) {
+                entity.profile1.identity.links[idx_35].meta.foo = null;
+              } else if (typeof data.profile1_identity_links[idx_35].meta.foo !== 'undefined') {
+                entity.profile1.identity.links[idx_35].meta.foo = data.profile1_identity_links[idx_35].meta.foo;
+              }
+              if (data.profile1_identity_links[idx_35].meta.bar === null) {
+                entity.profile1.identity.links[idx_35].meta.bar = null;
+              } else if (typeof data.profile1_identity_links[idx_35].meta.bar !== 'undefined') {
+                entity.profile1.identity.links[idx_35].meta.bar = data.profile1_identity_links[idx_35].meta.bar;
+              }
+              if (data.profile1_identity_links[idx_35].meta.source === null) {
+    entity.profile1.identity.links[idx_35].meta.source = null;
+              } else if (typeof data.profile1_identity_links[idx_35].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile1_identity_links[idx_35].meta.source, true)) {
+                  entity.profile1.identity.links[idx_35].meta.source = factory.createReference('Source', data.profile1_identity_links[idx_35].meta.source, { merge: true, convertCustomTypes, schema });
+                } else if (data.profile1_identity_links[idx_35].meta.source && typeof data.profile1_identity_links[idx_35].meta.source === 'object') {
+                  entity.profile1.identity.links[idx_35].meta.source = factory.create('Source', data.profile1_identity_links[idx_35].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                 }
               }
-            } else if (data.profile1_identity_links[idx_4].meta === null) {
-              entity.profile1.identity.links[idx_4].meta = null;
+            } else if (data.profile1_identity_links[idx_35].meta === null) {
+              entity.profile1.identity.links[idx_35].meta = null;
             }
-            if (Array.isArray(data.profile1_identity_links[idx_4].metas)) {
-              entity.profile1.identity.links[idx_4].metas = [];
-              data.profile1_identity_links[idx_4].metas.forEach((_, idx_5) => {
-                if (data.profile1_identity_links[idx_4].metas[idx_5] != null) {
-                  if (entity.profile1.identity.links[idx_4].metas[idx_5] == null) {
-                    entity.profile1.identity.links[idx_4].metas[idx_5] = factory.createEmbeddable('IdentityMeta', data.profile1_identity_links[idx_4].metas[idx_5], { newEntity, convertCustomTypes });
+            if (Array.isArray(data.profile1_identity_links[idx_35].metas)) {
+              entity.profile1.identity.links[idx_35].metas = [];
+              data.profile1_identity_links[idx_35].metas.forEach((_, idx_40) => {
+                if (data.profile1_identity_links[idx_35].metas[idx_40] != null) {
+                  if (entity.profile1.identity.links[idx_35].metas[idx_40] == null) {
+                    entity.profile1.identity.links[idx_35].metas[idx_40] = factory.createEmbeddable('IdentityMeta', data.profile1_identity_links[idx_35].metas[idx_40], { newEntity, convertCustomTypes });
                   }
-                  if (data.profile1_identity_links && data.profile1_identity_links[idx_4] && data.profile1_identity_links[idx_4].metas && data.profile1_identity_links[idx_4].metas[idx_5] && typeof data.profile1_identity_links[idx_4].metas[idx_5].foo !== 'undefined') entity.profile1.identity.links[idx_4].metas[idx_5].foo = data.profile1_identity_links[idx_4].metas[idx_5].foo;
-                  if (data.profile1_identity_links && data.profile1_identity_links[idx_4] && data.profile1_identity_links[idx_4].metas && data.profile1_identity_links[idx_4].metas[idx_5] && typeof data.profile1_identity_links[idx_4].metas[idx_5].bar !== 'undefined') entity.profile1.identity.links[idx_4].metas[idx_5].bar = data.profile1_identity_links[idx_4].metas[idx_5].bar;
-                  if (data.profile1_identity_links[idx_4].metas[idx_5].source === null) {
-    entity.profile1.identity.links[idx_4].metas[idx_5].source = null;
-                  } else if (typeof data.profile1_identity_links[idx_4].metas[idx_5].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile1_identity_links[idx_4].metas[idx_5].source, true)) {
-                      entity.profile1.identity.links[idx_4].metas[idx_5].source = factory.createReference('Source', data.profile1_identity_links[idx_4].metas[idx_5].source, { merge: true, convertCustomTypes, schema });
-                    } else if (data.profile1_identity_links[idx_4].metas[idx_5].source && typeof data.profile1_identity_links[idx_4].metas[idx_5].source === 'object') {
-                      entity.profile1.identity.links[idx_4].metas[idx_5].source = factory.create('Source', data.profile1_identity_links[idx_4].metas[idx_5].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  if (data.profile1_identity_links[idx_35].metas[idx_40].foo === null) {
+                    entity.profile1.identity.links[idx_35].metas[idx_40].foo = null;
+                  } else if (typeof data.profile1_identity_links[idx_35].metas[idx_40].foo !== 'undefined') {
+                    entity.profile1.identity.links[idx_35].metas[idx_40].foo = data.profile1_identity_links[idx_35].metas[idx_40].foo;
+                  }
+                  if (data.profile1_identity_links[idx_35].metas[idx_40].bar === null) {
+                    entity.profile1.identity.links[idx_35].metas[idx_40].bar = null;
+                  } else if (typeof data.profile1_identity_links[idx_35].metas[idx_40].bar !== 'undefined') {
+                    entity.profile1.identity.links[idx_35].metas[idx_40].bar = data.profile1_identity_links[idx_35].metas[idx_40].bar;
+                  }
+                  if (data.profile1_identity_links[idx_35].metas[idx_40].source === null) {
+    entity.profile1.identity.links[idx_35].metas[idx_40].source = null;
+                  } else if (typeof data.profile1_identity_links[idx_35].metas[idx_40].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile1_identity_links[idx_35].metas[idx_40].source, true)) {
+                      entity.profile1.identity.links[idx_35].metas[idx_40].source = factory.createReference('Source', data.profile1_identity_links[idx_35].metas[idx_40].source, { merge: true, convertCustomTypes, schema });
+                    } else if (data.profile1_identity_links[idx_35].metas[idx_40].source && typeof data.profile1_identity_links[idx_35].metas[idx_40].source === 'object') {
+                      entity.profile1.identity.links[idx_35].metas[idx_40].source = factory.create('Source', data.profile1_identity_links[idx_35].metas[idx_40].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                     }
                   }
-                } else if (data.profile1_identity_links[idx_4].metas[idx_5] === null) {
-                  entity.profile1.identity.links[idx_4].metas[idx_5] = null;
+                } else if (data.profile1_identity_links[idx_35].metas[idx_40] === null) {
+                  entity.profile1.identity.links[idx_35].metas[idx_40] = null;
                 }
               });
             }
-            if (data.profile1_identity_links[idx_4].source === null) {
-    entity.profile1.identity.links[idx_4].source = null;
-            } else if (typeof data.profile1_identity_links[idx_4].source !== 'undefined') {
-              if (isPrimaryKey(data.profile1_identity_links[idx_4].source, true)) {
-                entity.profile1.identity.links[idx_4].source = factory.createReference('Source', data.profile1_identity_links[idx_4].source, { merge: true, convertCustomTypes, schema });
-              } else if (data.profile1_identity_links[idx_4].source && typeof data.profile1_identity_links[idx_4].source === 'object') {
-                entity.profile1.identity.links[idx_4].source = factory.create('Source', data.profile1_identity_links[idx_4].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            if (data.profile1_identity_links[idx_35].source === null) {
+    entity.profile1.identity.links[idx_35].source = null;
+            } else if (typeof data.profile1_identity_links[idx_35].source !== 'undefined') {
+              if (isPrimaryKey(data.profile1_identity_links[idx_35].source, true)) {
+                entity.profile1.identity.links[idx_35].source = factory.createReference('Source', data.profile1_identity_links[idx_35].source, { merge: true, convertCustomTypes, schema });
+              } else if (data.profile1_identity_links[idx_35].source && typeof data.profile1_identity_links[idx_35].source === 'object') {
+                entity.profile1.identity.links[idx_35].source = factory.create('Source', data.profile1_identity_links[idx_35].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
               }
             }
-          } else if (data.profile1_identity_links[idx_4] === null) {
-            entity.profile1.identity.links[idx_4] = null;
+          } else if (data.profile1_identity_links[idx_35] === null) {
+            entity.profile1.identity.links[idx_35] = null;
           }
         });
       }
@@ -601,13 +746,25 @@ exports[`embedded entities in mongo diffing 2`] = `
       if (entity.profile1.identity == null) {
         entity.profile1.identity = factory.createEmbeddable('Identity', data.profile1.identity, { newEntity, convertCustomTypes });
       }
-      if (data.profile1 && data.profile1.identity && typeof data.profile1.identity.email !== 'undefined') entity.profile1.identity.email = data.profile1.identity.email;
+      if (data.profile1.identity.email === null) {
+        entity.profile1.identity.email = null;
+      } else if (typeof data.profile1.identity.email !== 'undefined') {
+        entity.profile1.identity.email = data.profile1.identity.email;
+      }
       if (data.profile1_identity_meta_foo != null || data.profile1_identity_meta_bar != null || data.profile1_identity_meta_source != null) {
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data, { newEntity, convertCustomTypes });
         }
-        if (typeof data.profile1_identity_meta_foo !== 'undefined') entity.profile1.identity.meta.foo = data.profile1_identity_meta_foo;
-        if (typeof data.profile1_identity_meta_bar !== 'undefined') entity.profile1.identity.meta.bar = data.profile1_identity_meta_bar;
+        if (data.profile1_identity_meta_foo === null) {
+          entity.profile1.identity.meta.foo = null;
+        } else if (typeof data.profile1_identity_meta_foo !== 'undefined') {
+          entity.profile1.identity.meta.foo = data.profile1_identity_meta_foo;
+        }
+        if (data.profile1_identity_meta_bar === null) {
+          entity.profile1.identity.meta.bar = null;
+        } else if (typeof data.profile1_identity_meta_bar !== 'undefined') {
+          entity.profile1.identity.meta.bar = data.profile1_identity_meta_bar;
+        }
         if (data.profile1_identity_meta_source === null) {
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
@@ -624,8 +781,16 @@ exports[`embedded entities in mongo diffing 2`] = `
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data.profile1.identity.meta, { newEntity, convertCustomTypes });
         }
-        if (data.profile1 && data.profile1.identity && data.profile1.identity.meta && typeof data.profile1.identity.meta.foo !== 'undefined') entity.profile1.identity.meta.foo = data.profile1.identity.meta.foo;
-        if (data.profile1 && data.profile1.identity && data.profile1.identity.meta && typeof data.profile1.identity.meta.bar !== 'undefined') entity.profile1.identity.meta.bar = data.profile1.identity.meta.bar;
+        if (data.profile1.identity.meta.foo === null) {
+          entity.profile1.identity.meta.foo = null;
+        } else if (typeof data.profile1.identity.meta.foo !== 'undefined') {
+          entity.profile1.identity.meta.foo = data.profile1.identity.meta.foo;
+        }
+        if (data.profile1.identity.meta.bar === null) {
+          entity.profile1.identity.meta.bar = null;
+        } else if (typeof data.profile1.identity.meta.bar !== 'undefined') {
+          entity.profile1.identity.meta.bar = data.profile1.identity.meta.bar;
+        }
         if (data.profile1.identity.meta.source === null) {
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1.identity.meta.source !== 'undefined') {
@@ -640,66 +805,89 @@ exports[`embedded entities in mongo diffing 2`] = `
       }
       if (Array.isArray(data.profile1.identity.links)) {
         entity.profile1.identity.links = [];
-        data.profile1.identity.links.forEach((_, idx_6) => {
-          if (data.profile1.identity.links[idx_6] != null) {
-            if (entity.profile1.identity.links[idx_6] == null) {
-              entity.profile1.identity.links[idx_6] = factory.createEmbeddable('IdentityLink', data.profile1.identity.links[idx_6], { newEntity, convertCustomTypes });
+        data.profile1.identity.links.forEach((_, idx_48) => {
+          if (data.profile1.identity.links[idx_48] != null) {
+            if (entity.profile1.identity.links[idx_48] == null) {
+              entity.profile1.identity.links[idx_48] = factory.createEmbeddable('IdentityLink', data.profile1.identity.links[idx_48], { newEntity, convertCustomTypes });
             }
-            if (data.profile1 && data.profile1.identity && data.profile1.identity.links && data.profile1.identity.links[idx_6] && typeof data.profile1.identity.links[idx_6].url !== 'undefined') entity.profile1.identity.links[idx_6].url = data.profile1.identity.links[idx_6].url;
-            if (data.profile1 && data.profile1.identity && data.profile1.identity.links && data.profile1.identity.links[idx_6] && data.profile1.identity.links[idx_6].createdAt) entity.profile1.identity.links[idx_6].createdAt = new Date(data.profile1.identity.links[idx_6].createdAt);
-            else if (data.profile1 && data.profile1.identity && data.profile1.identity.links && data.profile1.identity.links[idx_6] && data.profile1.identity.links[idx_6].createdAt === null) entity.profile1.identity.links[idx_6].createdAt = null;
-            if (data.profile1.identity.links[idx_6].meta != null) {
-              if (entity.profile1.identity.links[idx_6].meta == null) {
-                entity.profile1.identity.links[idx_6].meta = factory.createEmbeddable('IdentityMeta', data.profile1.identity.links[idx_6].meta, { newEntity, convertCustomTypes });
+            if (data.profile1.identity.links[idx_48].url === null) {
+              entity.profile1.identity.links[idx_48].url = null;
+            } else if (typeof data.profile1.identity.links[idx_48].url !== 'undefined') {
+              entity.profile1.identity.links[idx_48].url = data.profile1.identity.links[idx_48].url;
+            }
+            if (data.profile1.identity.links[idx_48].createdAt === null) {
+              entity.profile1.identity.links[idx_48].createdAt = null;
+            } else if (typeof data.profile1.identity.links[idx_48].createdAt !== 'undefined') {
+              entity.profile1.identity.links[idx_48].createdAt = new Date(data.profile1.identity.links[idx_48].createdAt);
+            }
+            if (data.profile1.identity.links[idx_48].meta != null) {
+              if (entity.profile1.identity.links[idx_48].meta == null) {
+                entity.profile1.identity.links[idx_48].meta = factory.createEmbeddable('IdentityMeta', data.profile1.identity.links[idx_48].meta, { newEntity, convertCustomTypes });
               }
-              if (data.profile1 && data.profile1.identity && data.profile1.identity.links && data.profile1.identity.links[idx_6] && data.profile1.identity.links[idx_6].meta && typeof data.profile1.identity.links[idx_6].meta.foo !== 'undefined') entity.profile1.identity.links[idx_6].meta.foo = data.profile1.identity.links[idx_6].meta.foo;
-              if (data.profile1 && data.profile1.identity && data.profile1.identity.links && data.profile1.identity.links[idx_6] && data.profile1.identity.links[idx_6].meta && typeof data.profile1.identity.links[idx_6].meta.bar !== 'undefined') entity.profile1.identity.links[idx_6].meta.bar = data.profile1.identity.links[idx_6].meta.bar;
-              if (data.profile1.identity.links[idx_6].meta.source === null) {
-    entity.profile1.identity.links[idx_6].meta.source = null;
-              } else if (typeof data.profile1.identity.links[idx_6].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile1.identity.links[idx_6].meta.source, true)) {
-                  entity.profile1.identity.links[idx_6].meta.source = factory.createReference('Source', data.profile1.identity.links[idx_6].meta.source, { merge: true, convertCustomTypes, schema });
-                } else if (data.profile1.identity.links[idx_6].meta.source && typeof data.profile1.identity.links[idx_6].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_6].meta.source = factory.create('Source', data.profile1.identity.links[idx_6].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+              if (data.profile1.identity.links[idx_48].meta.foo === null) {
+                entity.profile1.identity.links[idx_48].meta.foo = null;
+              } else if (typeof data.profile1.identity.links[idx_48].meta.foo !== 'undefined') {
+                entity.profile1.identity.links[idx_48].meta.foo = data.profile1.identity.links[idx_48].meta.foo;
+              }
+              if (data.profile1.identity.links[idx_48].meta.bar === null) {
+                entity.profile1.identity.links[idx_48].meta.bar = null;
+              } else if (typeof data.profile1.identity.links[idx_48].meta.bar !== 'undefined') {
+                entity.profile1.identity.links[idx_48].meta.bar = data.profile1.identity.links[idx_48].meta.bar;
+              }
+              if (data.profile1.identity.links[idx_48].meta.source === null) {
+    entity.profile1.identity.links[idx_48].meta.source = null;
+              } else if (typeof data.profile1.identity.links[idx_48].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile1.identity.links[idx_48].meta.source, true)) {
+                  entity.profile1.identity.links[idx_48].meta.source = factory.createReference('Source', data.profile1.identity.links[idx_48].meta.source, { merge: true, convertCustomTypes, schema });
+                } else if (data.profile1.identity.links[idx_48].meta.source && typeof data.profile1.identity.links[idx_48].meta.source === 'object') {
+                  entity.profile1.identity.links[idx_48].meta.source = factory.create('Source', data.profile1.identity.links[idx_48].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                 }
               }
-            } else if (data.profile1.identity.links[idx_6].meta === null) {
-              entity.profile1.identity.links[idx_6].meta = null;
+            } else if (data.profile1.identity.links[idx_48].meta === null) {
+              entity.profile1.identity.links[idx_48].meta = null;
             }
-            if (Array.isArray(data.profile1.identity.links[idx_6].metas)) {
-              entity.profile1.identity.links[idx_6].metas = [];
-              data.profile1.identity.links[idx_6].metas.forEach((_, idx_7) => {
-                if (data.profile1.identity.links[idx_6].metas[idx_7] != null) {
-                  if (entity.profile1.identity.links[idx_6].metas[idx_7] == null) {
-                    entity.profile1.identity.links[idx_6].metas[idx_7] = factory.createEmbeddable('IdentityMeta', data.profile1.identity.links[idx_6].metas[idx_7], { newEntity, convertCustomTypes });
+            if (Array.isArray(data.profile1.identity.links[idx_48].metas)) {
+              entity.profile1.identity.links[idx_48].metas = [];
+              data.profile1.identity.links[idx_48].metas.forEach((_, idx_53) => {
+                if (data.profile1.identity.links[idx_48].metas[idx_53] != null) {
+                  if (entity.profile1.identity.links[idx_48].metas[idx_53] == null) {
+                    entity.profile1.identity.links[idx_48].metas[idx_53] = factory.createEmbeddable('IdentityMeta', data.profile1.identity.links[idx_48].metas[idx_53], { newEntity, convertCustomTypes });
                   }
-                  if (data.profile1 && data.profile1.identity && data.profile1.identity.links && data.profile1.identity.links[idx_6] && data.profile1.identity.links[idx_6].metas && data.profile1.identity.links[idx_6].metas[idx_7] && typeof data.profile1.identity.links[idx_6].metas[idx_7].foo !== 'undefined') entity.profile1.identity.links[idx_6].metas[idx_7].foo = data.profile1.identity.links[idx_6].metas[idx_7].foo;
-                  if (data.profile1 && data.profile1.identity && data.profile1.identity.links && data.profile1.identity.links[idx_6] && data.profile1.identity.links[idx_6].metas && data.profile1.identity.links[idx_6].metas[idx_7] && typeof data.profile1.identity.links[idx_6].metas[idx_7].bar !== 'undefined') entity.profile1.identity.links[idx_6].metas[idx_7].bar = data.profile1.identity.links[idx_6].metas[idx_7].bar;
-                  if (data.profile1.identity.links[idx_6].metas[idx_7].source === null) {
-    entity.profile1.identity.links[idx_6].metas[idx_7].source = null;
-                  } else if (typeof data.profile1.identity.links[idx_6].metas[idx_7].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile1.identity.links[idx_6].metas[idx_7].source, true)) {
-                      entity.profile1.identity.links[idx_6].metas[idx_7].source = factory.createReference('Source', data.profile1.identity.links[idx_6].metas[idx_7].source, { merge: true, convertCustomTypes, schema });
-                    } else if (data.profile1.identity.links[idx_6].metas[idx_7].source && typeof data.profile1.identity.links[idx_6].metas[idx_7].source === 'object') {
-                      entity.profile1.identity.links[idx_6].metas[idx_7].source = factory.create('Source', data.profile1.identity.links[idx_6].metas[idx_7].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  if (data.profile1.identity.links[idx_48].metas[idx_53].foo === null) {
+                    entity.profile1.identity.links[idx_48].metas[idx_53].foo = null;
+                  } else if (typeof data.profile1.identity.links[idx_48].metas[idx_53].foo !== 'undefined') {
+                    entity.profile1.identity.links[idx_48].metas[idx_53].foo = data.profile1.identity.links[idx_48].metas[idx_53].foo;
+                  }
+                  if (data.profile1.identity.links[idx_48].metas[idx_53].bar === null) {
+                    entity.profile1.identity.links[idx_48].metas[idx_53].bar = null;
+                  } else if (typeof data.profile1.identity.links[idx_48].metas[idx_53].bar !== 'undefined') {
+                    entity.profile1.identity.links[idx_48].metas[idx_53].bar = data.profile1.identity.links[idx_48].metas[idx_53].bar;
+                  }
+                  if (data.profile1.identity.links[idx_48].metas[idx_53].source === null) {
+    entity.profile1.identity.links[idx_48].metas[idx_53].source = null;
+                  } else if (typeof data.profile1.identity.links[idx_48].metas[idx_53].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile1.identity.links[idx_48].metas[idx_53].source, true)) {
+                      entity.profile1.identity.links[idx_48].metas[idx_53].source = factory.createReference('Source', data.profile1.identity.links[idx_48].metas[idx_53].source, { merge: true, convertCustomTypes, schema });
+                    } else if (data.profile1.identity.links[idx_48].metas[idx_53].source && typeof data.profile1.identity.links[idx_48].metas[idx_53].source === 'object') {
+                      entity.profile1.identity.links[idx_48].metas[idx_53].source = factory.create('Source', data.profile1.identity.links[idx_48].metas[idx_53].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                     }
                   }
-                } else if (data.profile1.identity.links[idx_6].metas[idx_7] === null) {
-                  entity.profile1.identity.links[idx_6].metas[idx_7] = null;
+                } else if (data.profile1.identity.links[idx_48].metas[idx_53] === null) {
+                  entity.profile1.identity.links[idx_48].metas[idx_53] = null;
                 }
               });
             }
-            if (data.profile1.identity.links[idx_6].source === null) {
-    entity.profile1.identity.links[idx_6].source = null;
-            } else if (typeof data.profile1.identity.links[idx_6].source !== 'undefined') {
-              if (isPrimaryKey(data.profile1.identity.links[idx_6].source, true)) {
-                entity.profile1.identity.links[idx_6].source = factory.createReference('Source', data.profile1.identity.links[idx_6].source, { merge: true, convertCustomTypes, schema });
-              } else if (data.profile1.identity.links[idx_6].source && typeof data.profile1.identity.links[idx_6].source === 'object') {
-                entity.profile1.identity.links[idx_6].source = factory.create('Source', data.profile1.identity.links[idx_6].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            if (data.profile1.identity.links[idx_48].source === null) {
+    entity.profile1.identity.links[idx_48].source = null;
+            } else if (typeof data.profile1.identity.links[idx_48].source !== 'undefined') {
+              if (isPrimaryKey(data.profile1.identity.links[idx_48].source, true)) {
+                entity.profile1.identity.links[idx_48].source = factory.createReference('Source', data.profile1.identity.links[idx_48].source, { merge: true, convertCustomTypes, schema });
+              } else if (data.profile1.identity.links[idx_48].source && typeof data.profile1.identity.links[idx_48].source === 'object') {
+                entity.profile1.identity.links[idx_48].source = factory.create('Source', data.profile1.identity.links[idx_48].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
               }
             }
-          } else if (data.profile1.identity.links[idx_6] === null) {
-            entity.profile1.identity.links[idx_6] = null;
+          } else if (data.profile1.identity.links[idx_48] === null) {
+            entity.profile1.identity.links[idx_48] = null;
           }
         });
       }
@@ -731,18 +919,34 @@ exports[`embedded entities in mongo diffing 2`] = `
     if (entity.profile2 == null) {
       entity.profile2 = factory.createEmbeddable('Profile', data.profile2, { newEntity, convertCustomTypes });
     }
-    if (data.profile2 && typeof data.profile2.username !== 'undefined') entity.profile2.username = data.profile2.username;
+    if (data.profile2.username === null) {
+      entity.profile2.username = null;
+    } else if (typeof data.profile2.username !== 'undefined') {
+      entity.profile2.username = data.profile2.username;
+    }
     if (data.profile2.identity != null) {
       if (entity.profile2.identity == null) {
         entity.profile2.identity = factory.createEmbeddable('Identity', data.profile2.identity, { newEntity, convertCustomTypes });
       }
-      if (data.profile2 && data.profile2.identity && typeof data.profile2.identity.email !== 'undefined') entity.profile2.identity.email = data.profile2.identity.email;
+      if (data.profile2.identity.email === null) {
+        entity.profile2.identity.email = null;
+      } else if (typeof data.profile2.identity.email !== 'undefined') {
+        entity.profile2.identity.email = data.profile2.identity.email;
+      }
       if (data.profile2.identity.meta != null) {
         if (entity.profile2.identity.meta == null) {
           entity.profile2.identity.meta = factory.createEmbeddable('IdentityMeta', data.profile2.identity.meta, { newEntity, convertCustomTypes });
         }
-        if (data.profile2 && data.profile2.identity && data.profile2.identity.meta && typeof data.profile2.identity.meta.foo !== 'undefined') entity.profile2.identity.meta.foo = data.profile2.identity.meta.foo;
-        if (data.profile2 && data.profile2.identity && data.profile2.identity.meta && typeof data.profile2.identity.meta.bar !== 'undefined') entity.profile2.identity.meta.bar = data.profile2.identity.meta.bar;
+        if (data.profile2.identity.meta.foo === null) {
+          entity.profile2.identity.meta.foo = null;
+        } else if (typeof data.profile2.identity.meta.foo !== 'undefined') {
+          entity.profile2.identity.meta.foo = data.profile2.identity.meta.foo;
+        }
+        if (data.profile2.identity.meta.bar === null) {
+          entity.profile2.identity.meta.bar = null;
+        } else if (typeof data.profile2.identity.meta.bar !== 'undefined') {
+          entity.profile2.identity.meta.bar = data.profile2.identity.meta.bar;
+        }
         if (data.profile2.identity.meta.source === null) {
     entity.profile2.identity.meta.source = null;
         } else if (typeof data.profile2.identity.meta.source !== 'undefined') {
@@ -757,66 +961,89 @@ exports[`embedded entities in mongo diffing 2`] = `
       }
       if (Array.isArray(data.profile2.identity.links)) {
         entity.profile2.identity.links = [];
-        data.profile2.identity.links.forEach((_, idx_8) => {
-          if (data.profile2.identity.links[idx_8] != null) {
-            if (entity.profile2.identity.links[idx_8] == null) {
-              entity.profile2.identity.links[idx_8] = factory.createEmbeddable('IdentityLink', data.profile2.identity.links[idx_8], { newEntity, convertCustomTypes });
+        data.profile2.identity.links.forEach((_, idx_60) => {
+          if (data.profile2.identity.links[idx_60] != null) {
+            if (entity.profile2.identity.links[idx_60] == null) {
+              entity.profile2.identity.links[idx_60] = factory.createEmbeddable('IdentityLink', data.profile2.identity.links[idx_60], { newEntity, convertCustomTypes });
             }
-            if (data.profile2 && data.profile2.identity && data.profile2.identity.links && data.profile2.identity.links[idx_8] && typeof data.profile2.identity.links[idx_8].url !== 'undefined') entity.profile2.identity.links[idx_8].url = data.profile2.identity.links[idx_8].url;
-            if (data.profile2 && data.profile2.identity && data.profile2.identity.links && data.profile2.identity.links[idx_8] && data.profile2.identity.links[idx_8].createdAt) entity.profile2.identity.links[idx_8].createdAt = new Date(data.profile2.identity.links[idx_8].createdAt);
-            else if (data.profile2 && data.profile2.identity && data.profile2.identity.links && data.profile2.identity.links[idx_8] && data.profile2.identity.links[idx_8].createdAt === null) entity.profile2.identity.links[idx_8].createdAt = null;
-            if (data.profile2.identity.links[idx_8].meta != null) {
-              if (entity.profile2.identity.links[idx_8].meta == null) {
-                entity.profile2.identity.links[idx_8].meta = factory.createEmbeddable('IdentityMeta', data.profile2.identity.links[idx_8].meta, { newEntity, convertCustomTypes });
+            if (data.profile2.identity.links[idx_60].url === null) {
+              entity.profile2.identity.links[idx_60].url = null;
+            } else if (typeof data.profile2.identity.links[idx_60].url !== 'undefined') {
+              entity.profile2.identity.links[idx_60].url = data.profile2.identity.links[idx_60].url;
+            }
+            if (data.profile2.identity.links[idx_60].createdAt === null) {
+              entity.profile2.identity.links[idx_60].createdAt = null;
+            } else if (typeof data.profile2.identity.links[idx_60].createdAt !== 'undefined') {
+              entity.profile2.identity.links[idx_60].createdAt = new Date(data.profile2.identity.links[idx_60].createdAt);
+            }
+            if (data.profile2.identity.links[idx_60].meta != null) {
+              if (entity.profile2.identity.links[idx_60].meta == null) {
+                entity.profile2.identity.links[idx_60].meta = factory.createEmbeddable('IdentityMeta', data.profile2.identity.links[idx_60].meta, { newEntity, convertCustomTypes });
               }
-              if (data.profile2 && data.profile2.identity && data.profile2.identity.links && data.profile2.identity.links[idx_8] && data.profile2.identity.links[idx_8].meta && typeof data.profile2.identity.links[idx_8].meta.foo !== 'undefined') entity.profile2.identity.links[idx_8].meta.foo = data.profile2.identity.links[idx_8].meta.foo;
-              if (data.profile2 && data.profile2.identity && data.profile2.identity.links && data.profile2.identity.links[idx_8] && data.profile2.identity.links[idx_8].meta && typeof data.profile2.identity.links[idx_8].meta.bar !== 'undefined') entity.profile2.identity.links[idx_8].meta.bar = data.profile2.identity.links[idx_8].meta.bar;
-              if (data.profile2.identity.links[idx_8].meta.source === null) {
-    entity.profile2.identity.links[idx_8].meta.source = null;
-              } else if (typeof data.profile2.identity.links[idx_8].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile2.identity.links[idx_8].meta.source, true)) {
-                  entity.profile2.identity.links[idx_8].meta.source = factory.createReference('Source', data.profile2.identity.links[idx_8].meta.source, { merge: true, convertCustomTypes, schema });
-                } else if (data.profile2.identity.links[idx_8].meta.source && typeof data.profile2.identity.links[idx_8].meta.source === 'object') {
-                  entity.profile2.identity.links[idx_8].meta.source = factory.create('Source', data.profile2.identity.links[idx_8].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+              if (data.profile2.identity.links[idx_60].meta.foo === null) {
+                entity.profile2.identity.links[idx_60].meta.foo = null;
+              } else if (typeof data.profile2.identity.links[idx_60].meta.foo !== 'undefined') {
+                entity.profile2.identity.links[idx_60].meta.foo = data.profile2.identity.links[idx_60].meta.foo;
+              }
+              if (data.profile2.identity.links[idx_60].meta.bar === null) {
+                entity.profile2.identity.links[idx_60].meta.bar = null;
+              } else if (typeof data.profile2.identity.links[idx_60].meta.bar !== 'undefined') {
+                entity.profile2.identity.links[idx_60].meta.bar = data.profile2.identity.links[idx_60].meta.bar;
+              }
+              if (data.profile2.identity.links[idx_60].meta.source === null) {
+    entity.profile2.identity.links[idx_60].meta.source = null;
+              } else if (typeof data.profile2.identity.links[idx_60].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile2.identity.links[idx_60].meta.source, true)) {
+                  entity.profile2.identity.links[idx_60].meta.source = factory.createReference('Source', data.profile2.identity.links[idx_60].meta.source, { merge: true, convertCustomTypes, schema });
+                } else if (data.profile2.identity.links[idx_60].meta.source && typeof data.profile2.identity.links[idx_60].meta.source === 'object') {
+                  entity.profile2.identity.links[idx_60].meta.source = factory.create('Source', data.profile2.identity.links[idx_60].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                 }
               }
-            } else if (data.profile2.identity.links[idx_8].meta === null) {
-              entity.profile2.identity.links[idx_8].meta = null;
+            } else if (data.profile2.identity.links[idx_60].meta === null) {
+              entity.profile2.identity.links[idx_60].meta = null;
             }
-            if (Array.isArray(data.profile2.identity.links[idx_8].metas)) {
-              entity.profile2.identity.links[idx_8].metas = [];
-              data.profile2.identity.links[idx_8].metas.forEach((_, idx_9) => {
-                if (data.profile2.identity.links[idx_8].metas[idx_9] != null) {
-                  if (entity.profile2.identity.links[idx_8].metas[idx_9] == null) {
-                    entity.profile2.identity.links[idx_8].metas[idx_9] = factory.createEmbeddable('IdentityMeta', data.profile2.identity.links[idx_8].metas[idx_9], { newEntity, convertCustomTypes });
+            if (Array.isArray(data.profile2.identity.links[idx_60].metas)) {
+              entity.profile2.identity.links[idx_60].metas = [];
+              data.profile2.identity.links[idx_60].metas.forEach((_, idx_65) => {
+                if (data.profile2.identity.links[idx_60].metas[idx_65] != null) {
+                  if (entity.profile2.identity.links[idx_60].metas[idx_65] == null) {
+                    entity.profile2.identity.links[idx_60].metas[idx_65] = factory.createEmbeddable('IdentityMeta', data.profile2.identity.links[idx_60].metas[idx_65], { newEntity, convertCustomTypes });
                   }
-                  if (data.profile2 && data.profile2.identity && data.profile2.identity.links && data.profile2.identity.links[idx_8] && data.profile2.identity.links[idx_8].metas && data.profile2.identity.links[idx_8].metas[idx_9] && typeof data.profile2.identity.links[idx_8].metas[idx_9].foo !== 'undefined') entity.profile2.identity.links[idx_8].metas[idx_9].foo = data.profile2.identity.links[idx_8].metas[idx_9].foo;
-                  if (data.profile2 && data.profile2.identity && data.profile2.identity.links && data.profile2.identity.links[idx_8] && data.profile2.identity.links[idx_8].metas && data.profile2.identity.links[idx_8].metas[idx_9] && typeof data.profile2.identity.links[idx_8].metas[idx_9].bar !== 'undefined') entity.profile2.identity.links[idx_8].metas[idx_9].bar = data.profile2.identity.links[idx_8].metas[idx_9].bar;
-                  if (data.profile2.identity.links[idx_8].metas[idx_9].source === null) {
-    entity.profile2.identity.links[idx_8].metas[idx_9].source = null;
-                  } else if (typeof data.profile2.identity.links[idx_8].metas[idx_9].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile2.identity.links[idx_8].metas[idx_9].source, true)) {
-                      entity.profile2.identity.links[idx_8].metas[idx_9].source = factory.createReference('Source', data.profile2.identity.links[idx_8].metas[idx_9].source, { merge: true, convertCustomTypes, schema });
-                    } else if (data.profile2.identity.links[idx_8].metas[idx_9].source && typeof data.profile2.identity.links[idx_8].metas[idx_9].source === 'object') {
-                      entity.profile2.identity.links[idx_8].metas[idx_9].source = factory.create('Source', data.profile2.identity.links[idx_8].metas[idx_9].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  if (data.profile2.identity.links[idx_60].metas[idx_65].foo === null) {
+                    entity.profile2.identity.links[idx_60].metas[idx_65].foo = null;
+                  } else if (typeof data.profile2.identity.links[idx_60].metas[idx_65].foo !== 'undefined') {
+                    entity.profile2.identity.links[idx_60].metas[idx_65].foo = data.profile2.identity.links[idx_60].metas[idx_65].foo;
+                  }
+                  if (data.profile2.identity.links[idx_60].metas[idx_65].bar === null) {
+                    entity.profile2.identity.links[idx_60].metas[idx_65].bar = null;
+                  } else if (typeof data.profile2.identity.links[idx_60].metas[idx_65].bar !== 'undefined') {
+                    entity.profile2.identity.links[idx_60].metas[idx_65].bar = data.profile2.identity.links[idx_60].metas[idx_65].bar;
+                  }
+                  if (data.profile2.identity.links[idx_60].metas[idx_65].source === null) {
+    entity.profile2.identity.links[idx_60].metas[idx_65].source = null;
+                  } else if (typeof data.profile2.identity.links[idx_60].metas[idx_65].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile2.identity.links[idx_60].metas[idx_65].source, true)) {
+                      entity.profile2.identity.links[idx_60].metas[idx_65].source = factory.createReference('Source', data.profile2.identity.links[idx_60].metas[idx_65].source, { merge: true, convertCustomTypes, schema });
+                    } else if (data.profile2.identity.links[idx_60].metas[idx_65].source && typeof data.profile2.identity.links[idx_60].metas[idx_65].source === 'object') {
+                      entity.profile2.identity.links[idx_60].metas[idx_65].source = factory.create('Source', data.profile2.identity.links[idx_60].metas[idx_65].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                     }
                   }
-                } else if (data.profile2.identity.links[idx_8].metas[idx_9] === null) {
-                  entity.profile2.identity.links[idx_8].metas[idx_9] = null;
+                } else if (data.profile2.identity.links[idx_60].metas[idx_65] === null) {
+                  entity.profile2.identity.links[idx_60].metas[idx_65] = null;
                 }
               });
             }
-            if (data.profile2.identity.links[idx_8].source === null) {
-    entity.profile2.identity.links[idx_8].source = null;
-            } else if (typeof data.profile2.identity.links[idx_8].source !== 'undefined') {
-              if (isPrimaryKey(data.profile2.identity.links[idx_8].source, true)) {
-                entity.profile2.identity.links[idx_8].source = factory.createReference('Source', data.profile2.identity.links[idx_8].source, { merge: true, convertCustomTypes, schema });
-              } else if (data.profile2.identity.links[idx_8].source && typeof data.profile2.identity.links[idx_8].source === 'object') {
-                entity.profile2.identity.links[idx_8].source = factory.create('Source', data.profile2.identity.links[idx_8].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            if (data.profile2.identity.links[idx_60].source === null) {
+    entity.profile2.identity.links[idx_60].source = null;
+            } else if (typeof data.profile2.identity.links[idx_60].source !== 'undefined') {
+              if (isPrimaryKey(data.profile2.identity.links[idx_60].source, true)) {
+                entity.profile2.identity.links[idx_60].source = factory.createReference('Source', data.profile2.identity.links[idx_60].source, { merge: true, convertCustomTypes, schema });
+              } else if (data.profile2.identity.links[idx_60].source && typeof data.profile2.identity.links[idx_60].source === 'object') {
+                entity.profile2.identity.links[idx_60].source = factory.create('Source', data.profile2.identity.links[idx_60].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
               }
             }
-          } else if (data.profile2.identity.links[idx_8] === null) {
-            entity.profile2.identity.links[idx_8] = null;
+          } else if (data.profile2.identity.links[idx_60] === null) {
+            entity.profile2.identity.links[idx_60] = null;
           }
         });
       }

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
@@ -219,24 +219,48 @@ exports[`embedded entities in postgres diffing 1`] = `
 
 exports[`embedded entities in postgres diffing 2`] = `
 "function(entity, data, factory, newEntity, convertCustomTypes, schema) {
-  if (typeof data.id !== 'undefined') entity.id = data.id;
-  if (typeof data.name !== 'undefined') entity.name = data.name;
+  if (data.id === null) {
+    entity.id = null;
+  } else if (typeof data.id !== 'undefined') {
+    entity.id = data.id;
+  }
+  if (data.name === null) {
+    entity.name = null;
+  } else if (typeof data.name !== 'undefined') {
+    entity.name = data.name;
+  }
   if (data.profile1_username !== undefined || data.profile1_identity_email !== undefined || data.profile1_identity_meta_foo != null || data.profile1_identity_meta_bar != null || data.profile1_identity_meta_source != null || data.profile1_identity_links !== undefined || data.profile1_identity_source !== undefined || data.profile1_source !== undefined) {
     if (entity.profile1 == null) {
       entity.profile1 = factory.createEmbeddable('Profile', data, { newEntity, convertCustomTypes });
     }
-    if (typeof data.profile1_username !== 'undefined') entity.profile1.username = data.profile1_username;
+    if (data.profile1_username === null) {
+      entity.profile1.username = null;
+    } else if (typeof data.profile1_username !== 'undefined') {
+      entity.profile1.username = data.profile1_username;
+    }
     if (data.profile1_identity_email !== undefined || data.profile1_identity_meta_foo != null || data.profile1_identity_meta_bar != null || data.profile1_identity_meta_source != null || data.profile1_identity_links !== undefined || data.profile1_identity_source !== undefined) {
       if (entity.profile1.identity == null) {
         entity.profile1.identity = factory.createEmbeddable('Identity', data, { newEntity, convertCustomTypes });
       }
-      if (typeof data.profile1_identity_email !== 'undefined') entity.profile1.identity.email = data.profile1_identity_email;
+      if (data.profile1_identity_email === null) {
+        entity.profile1.identity.email = null;
+      } else if (typeof data.profile1_identity_email !== 'undefined') {
+        entity.profile1.identity.email = data.profile1_identity_email;
+      }
       if (data.profile1_identity_meta_foo != null || data.profile1_identity_meta_bar != null || data.profile1_identity_meta_source != null) {
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data, { newEntity, convertCustomTypes });
         }
-        if (typeof data.profile1_identity_meta_foo !== 'undefined') entity.profile1.identity.meta.foo = data.profile1_identity_meta_foo;
-        if (typeof data.profile1_identity_meta_bar !== 'undefined') entity.profile1.identity.meta.bar = data.profile1_identity_meta_bar;
+        if (data.profile1_identity_meta_foo === null) {
+          entity.profile1.identity.meta.foo = null;
+        } else if (typeof data.profile1_identity_meta_foo !== 'undefined') {
+          entity.profile1.identity.meta.foo = data.profile1_identity_meta_foo;
+        }
+        if (data.profile1_identity_meta_bar === null) {
+          entity.profile1.identity.meta.bar = null;
+        } else if (typeof data.profile1_identity_meta_bar !== 'undefined') {
+          entity.profile1.identity.meta.bar = data.profile1_identity_meta_bar;
+        }
         if (data.profile1_identity_meta_source === null) {
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
@@ -253,8 +277,16 @@ exports[`embedded entities in postgres diffing 2`] = `
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity_meta, { newEntity, convertCustomTypes });
         }
-        if (data.profile1_identity_meta && typeof data.profile1_identity_meta.foo !== 'undefined') entity.profile1.identity.meta.foo = data.profile1_identity_meta.foo;
-        if (data.profile1_identity_meta && typeof data.profile1_identity_meta.bar !== 'undefined') entity.profile1.identity.meta.bar = data.profile1_identity_meta.bar;
+        if (data.profile1_identity_meta.foo === null) {
+          entity.profile1.identity.meta.foo = null;
+        } else if (typeof data.profile1_identity_meta.foo !== 'undefined') {
+          entity.profile1.identity.meta.foo = data.profile1_identity_meta.foo;
+        }
+        if (data.profile1_identity_meta.bar === null) {
+          entity.profile1.identity.meta.bar = null;
+        } else if (typeof data.profile1_identity_meta.bar !== 'undefined') {
+          entity.profile1.identity.meta.bar = data.profile1_identity_meta.bar;
+        }
         if (data.profile1_identity_meta.source === null) {
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta.source !== 'undefined') {
@@ -269,66 +301,89 @@ exports[`embedded entities in postgres diffing 2`] = `
       }
       if (Array.isArray(data.profile1_identity_links)) {
         entity.profile1.identity.links = [];
-        data.profile1_identity_links.forEach((_, idx_0) => {
-          if (data.profile1_identity_links[idx_0] != null) {
-            if (entity.profile1.identity.links[idx_0] == null) {
-              entity.profile1.identity.links[idx_0] = factory.createEmbeddable('IdentityLink', data.profile1_identity_links[idx_0], { newEntity, convertCustomTypes });
+        data.profile1_identity_links.forEach((_, idx_8) => {
+          if (data.profile1_identity_links[idx_8] != null) {
+            if (entity.profile1.identity.links[idx_8] == null) {
+              entity.profile1.identity.links[idx_8] = factory.createEmbeddable('IdentityLink', data.profile1_identity_links[idx_8], { newEntity, convertCustomTypes });
             }
-            if (data.profile1_identity_links && data.profile1_identity_links[idx_0] && typeof data.profile1_identity_links[idx_0].url !== 'undefined') entity.profile1.identity.links[idx_0].url = data.profile1_identity_links[idx_0].url;
-            if (data.profile1_identity_links && data.profile1_identity_links[idx_0] && data.profile1_identity_links[idx_0].createdAt) entity.profile1.identity.links[idx_0].createdAt = new Date(data.profile1_identity_links[idx_0].createdAt);
-            else if (data.profile1_identity_links && data.profile1_identity_links[idx_0] && data.profile1_identity_links[idx_0].createdAt === null) entity.profile1.identity.links[idx_0].createdAt = null;
-            if (data.profile1_identity_links[idx_0].meta != null) {
-              if (entity.profile1.identity.links[idx_0].meta == null) {
-                entity.profile1.identity.links[idx_0].meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity_links[idx_0].meta, { newEntity, convertCustomTypes });
+            if (data.profile1_identity_links[idx_8].url === null) {
+              entity.profile1.identity.links[idx_8].url = null;
+            } else if (typeof data.profile1_identity_links[idx_8].url !== 'undefined') {
+              entity.profile1.identity.links[idx_8].url = data.profile1_identity_links[idx_8].url;
+            }
+            if (data.profile1_identity_links[idx_8].createdAt === null) {
+              entity.profile1.identity.links[idx_8].createdAt = null;
+            } else if (typeof data.profile1_identity_links[idx_8].createdAt !== 'undefined') {
+              entity.profile1.identity.links[idx_8].createdAt = new Date(data.profile1_identity_links[idx_8].createdAt);
+            }
+            if (data.profile1_identity_links[idx_8].meta != null) {
+              if (entity.profile1.identity.links[idx_8].meta == null) {
+                entity.profile1.identity.links[idx_8].meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity_links[idx_8].meta, { newEntity, convertCustomTypes });
               }
-              if (data.profile1_identity_links && data.profile1_identity_links[idx_0] && data.profile1_identity_links[idx_0].meta && typeof data.profile1_identity_links[idx_0].meta.foo !== 'undefined') entity.profile1.identity.links[idx_0].meta.foo = data.profile1_identity_links[idx_0].meta.foo;
-              if (data.profile1_identity_links && data.profile1_identity_links[idx_0] && data.profile1_identity_links[idx_0].meta && typeof data.profile1_identity_links[idx_0].meta.bar !== 'undefined') entity.profile1.identity.links[idx_0].meta.bar = data.profile1_identity_links[idx_0].meta.bar;
-              if (data.profile1_identity_links[idx_0].meta.source === null) {
-    entity.profile1.identity.links[idx_0].meta.source = null;
-              } else if (typeof data.profile1_identity_links[idx_0].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile1_identity_links[idx_0].meta.source, true)) {
-                  entity.profile1.identity.links[idx_0].meta.source = factory.createReference('Source', data.profile1_identity_links[idx_0].meta.source, { merge: true, convertCustomTypes, schema });
-                } else if (data.profile1_identity_links[idx_0].meta.source && typeof data.profile1_identity_links[idx_0].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_0].meta.source = factory.create('Source', data.profile1_identity_links[idx_0].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+              if (data.profile1_identity_links[idx_8].meta.foo === null) {
+                entity.profile1.identity.links[idx_8].meta.foo = null;
+              } else if (typeof data.profile1_identity_links[idx_8].meta.foo !== 'undefined') {
+                entity.profile1.identity.links[idx_8].meta.foo = data.profile1_identity_links[idx_8].meta.foo;
+              }
+              if (data.profile1_identity_links[idx_8].meta.bar === null) {
+                entity.profile1.identity.links[idx_8].meta.bar = null;
+              } else if (typeof data.profile1_identity_links[idx_8].meta.bar !== 'undefined') {
+                entity.profile1.identity.links[idx_8].meta.bar = data.profile1_identity_links[idx_8].meta.bar;
+              }
+              if (data.profile1_identity_links[idx_8].meta.source === null) {
+    entity.profile1.identity.links[idx_8].meta.source = null;
+              } else if (typeof data.profile1_identity_links[idx_8].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile1_identity_links[idx_8].meta.source, true)) {
+                  entity.profile1.identity.links[idx_8].meta.source = factory.createReference('Source', data.profile1_identity_links[idx_8].meta.source, { merge: true, convertCustomTypes, schema });
+                } else if (data.profile1_identity_links[idx_8].meta.source && typeof data.profile1_identity_links[idx_8].meta.source === 'object') {
+                  entity.profile1.identity.links[idx_8].meta.source = factory.create('Source', data.profile1_identity_links[idx_8].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                 }
               }
-            } else if (data.profile1_identity_links[idx_0].meta === null) {
-              entity.profile1.identity.links[idx_0].meta = null;
+            } else if (data.profile1_identity_links[idx_8].meta === null) {
+              entity.profile1.identity.links[idx_8].meta = null;
             }
-            if (Array.isArray(data.profile1_identity_links[idx_0].metas)) {
-              entity.profile1.identity.links[idx_0].metas = [];
-              data.profile1_identity_links[idx_0].metas.forEach((_, idx_1) => {
-                if (data.profile1_identity_links[idx_0].metas[idx_1] != null) {
-                  if (entity.profile1.identity.links[idx_0].metas[idx_1] == null) {
-                    entity.profile1.identity.links[idx_0].metas[idx_1] = factory.createEmbeddable('IdentityMeta', data.profile1_identity_links[idx_0].metas[idx_1], { newEntity, convertCustomTypes });
+            if (Array.isArray(data.profile1_identity_links[idx_8].metas)) {
+              entity.profile1.identity.links[idx_8].metas = [];
+              data.profile1_identity_links[idx_8].metas.forEach((_, idx_13) => {
+                if (data.profile1_identity_links[idx_8].metas[idx_13] != null) {
+                  if (entity.profile1.identity.links[idx_8].metas[idx_13] == null) {
+                    entity.profile1.identity.links[idx_8].metas[idx_13] = factory.createEmbeddable('IdentityMeta', data.profile1_identity_links[idx_8].metas[idx_13], { newEntity, convertCustomTypes });
                   }
-                  if (data.profile1_identity_links && data.profile1_identity_links[idx_0] && data.profile1_identity_links[idx_0].metas && data.profile1_identity_links[idx_0].metas[idx_1] && typeof data.profile1_identity_links[idx_0].metas[idx_1].foo !== 'undefined') entity.profile1.identity.links[idx_0].metas[idx_1].foo = data.profile1_identity_links[idx_0].metas[idx_1].foo;
-                  if (data.profile1_identity_links && data.profile1_identity_links[idx_0] && data.profile1_identity_links[idx_0].metas && data.profile1_identity_links[idx_0].metas[idx_1] && typeof data.profile1_identity_links[idx_0].metas[idx_1].bar !== 'undefined') entity.profile1.identity.links[idx_0].metas[idx_1].bar = data.profile1_identity_links[idx_0].metas[idx_1].bar;
-                  if (data.profile1_identity_links[idx_0].metas[idx_1].source === null) {
-    entity.profile1.identity.links[idx_0].metas[idx_1].source = null;
-                  } else if (typeof data.profile1_identity_links[idx_0].metas[idx_1].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile1_identity_links[idx_0].metas[idx_1].source, true)) {
-                      entity.profile1.identity.links[idx_0].metas[idx_1].source = factory.createReference('Source', data.profile1_identity_links[idx_0].metas[idx_1].source, { merge: true, convertCustomTypes, schema });
-                    } else if (data.profile1_identity_links[idx_0].metas[idx_1].source && typeof data.profile1_identity_links[idx_0].metas[idx_1].source === 'object') {
-                      entity.profile1.identity.links[idx_0].metas[idx_1].source = factory.create('Source', data.profile1_identity_links[idx_0].metas[idx_1].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  if (data.profile1_identity_links[idx_8].metas[idx_13].foo === null) {
+                    entity.profile1.identity.links[idx_8].metas[idx_13].foo = null;
+                  } else if (typeof data.profile1_identity_links[idx_8].metas[idx_13].foo !== 'undefined') {
+                    entity.profile1.identity.links[idx_8].metas[idx_13].foo = data.profile1_identity_links[idx_8].metas[idx_13].foo;
+                  }
+                  if (data.profile1_identity_links[idx_8].metas[idx_13].bar === null) {
+                    entity.profile1.identity.links[idx_8].metas[idx_13].bar = null;
+                  } else if (typeof data.profile1_identity_links[idx_8].metas[idx_13].bar !== 'undefined') {
+                    entity.profile1.identity.links[idx_8].metas[idx_13].bar = data.profile1_identity_links[idx_8].metas[idx_13].bar;
+                  }
+                  if (data.profile1_identity_links[idx_8].metas[idx_13].source === null) {
+    entity.profile1.identity.links[idx_8].metas[idx_13].source = null;
+                  } else if (typeof data.profile1_identity_links[idx_8].metas[idx_13].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile1_identity_links[idx_8].metas[idx_13].source, true)) {
+                      entity.profile1.identity.links[idx_8].metas[idx_13].source = factory.createReference('Source', data.profile1_identity_links[idx_8].metas[idx_13].source, { merge: true, convertCustomTypes, schema });
+                    } else if (data.profile1_identity_links[idx_8].metas[idx_13].source && typeof data.profile1_identity_links[idx_8].metas[idx_13].source === 'object') {
+                      entity.profile1.identity.links[idx_8].metas[idx_13].source = factory.create('Source', data.profile1_identity_links[idx_8].metas[idx_13].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                     }
                   }
-                } else if (data.profile1_identity_links[idx_0].metas[idx_1] === null) {
-                  entity.profile1.identity.links[idx_0].metas[idx_1] = null;
+                } else if (data.profile1_identity_links[idx_8].metas[idx_13] === null) {
+                  entity.profile1.identity.links[idx_8].metas[idx_13] = null;
                 }
               });
             }
-            if (data.profile1_identity_links[idx_0].source === null) {
-    entity.profile1.identity.links[idx_0].source = null;
-            } else if (typeof data.profile1_identity_links[idx_0].source !== 'undefined') {
-              if (isPrimaryKey(data.profile1_identity_links[idx_0].source, true)) {
-                entity.profile1.identity.links[idx_0].source = factory.createReference('Source', data.profile1_identity_links[idx_0].source, { merge: true, convertCustomTypes, schema });
-              } else if (data.profile1_identity_links[idx_0].source && typeof data.profile1_identity_links[idx_0].source === 'object') {
-                entity.profile1.identity.links[idx_0].source = factory.create('Source', data.profile1_identity_links[idx_0].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            if (data.profile1_identity_links[idx_8].source === null) {
+    entity.profile1.identity.links[idx_8].source = null;
+            } else if (typeof data.profile1_identity_links[idx_8].source !== 'undefined') {
+              if (isPrimaryKey(data.profile1_identity_links[idx_8].source, true)) {
+                entity.profile1.identity.links[idx_8].source = factory.createReference('Source', data.profile1_identity_links[idx_8].source, { merge: true, convertCustomTypes, schema });
+              } else if (data.profile1_identity_links[idx_8].source && typeof data.profile1_identity_links[idx_8].source === 'object') {
+                entity.profile1.identity.links[idx_8].source = factory.create('Source', data.profile1_identity_links[idx_8].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
               }
             }
-          } else if (data.profile1_identity_links[idx_0] === null) {
-            entity.profile1.identity.links[idx_0] = null;
+          } else if (data.profile1_identity_links[idx_8] === null) {
+            entity.profile1.identity.links[idx_8] = null;
           }
         });
       }
@@ -348,13 +403,25 @@ exports[`embedded entities in postgres diffing 2`] = `
       if (entity.profile1.identity == null) {
         entity.profile1.identity = factory.createEmbeddable('Identity', data.profile1_identity, { newEntity, convertCustomTypes });
       }
-      if (data.profile1_identity && typeof data.profile1_identity.email !== 'undefined') entity.profile1.identity.email = data.profile1_identity.email;
+      if (data.profile1_identity.email === null) {
+        entity.profile1.identity.email = null;
+      } else if (typeof data.profile1_identity.email !== 'undefined') {
+        entity.profile1.identity.email = data.profile1_identity.email;
+      }
       if (data.profile1_identity_meta_foo != null || data.profile1_identity_meta_bar != null || data.profile1_identity_meta_source != null) {
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data, { newEntity, convertCustomTypes });
         }
-        if (typeof data.profile1_identity_meta_foo !== 'undefined') entity.profile1.identity.meta.foo = data.profile1_identity_meta_foo;
-        if (typeof data.profile1_identity_meta_bar !== 'undefined') entity.profile1.identity.meta.bar = data.profile1_identity_meta_bar;
+        if (data.profile1_identity_meta_foo === null) {
+          entity.profile1.identity.meta.foo = null;
+        } else if (typeof data.profile1_identity_meta_foo !== 'undefined') {
+          entity.profile1.identity.meta.foo = data.profile1_identity_meta_foo;
+        }
+        if (data.profile1_identity_meta_bar === null) {
+          entity.profile1.identity.meta.bar = null;
+        } else if (typeof data.profile1_identity_meta_bar !== 'undefined') {
+          entity.profile1.identity.meta.bar = data.profile1_identity_meta_bar;
+        }
         if (data.profile1_identity_meta_source === null) {
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
@@ -371,8 +438,16 @@ exports[`embedded entities in postgres diffing 2`] = `
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity.meta, { newEntity, convertCustomTypes });
         }
-        if (data.profile1_identity && data.profile1_identity.meta && typeof data.profile1_identity.meta.foo !== 'undefined') entity.profile1.identity.meta.foo = data.profile1_identity.meta.foo;
-        if (data.profile1_identity && data.profile1_identity.meta && typeof data.profile1_identity.meta.bar !== 'undefined') entity.profile1.identity.meta.bar = data.profile1_identity.meta.bar;
+        if (data.profile1_identity.meta.foo === null) {
+          entity.profile1.identity.meta.foo = null;
+        } else if (typeof data.profile1_identity.meta.foo !== 'undefined') {
+          entity.profile1.identity.meta.foo = data.profile1_identity.meta.foo;
+        }
+        if (data.profile1_identity.meta.bar === null) {
+          entity.profile1.identity.meta.bar = null;
+        } else if (typeof data.profile1_identity.meta.bar !== 'undefined') {
+          entity.profile1.identity.meta.bar = data.profile1_identity.meta.bar;
+        }
         if (data.profile1_identity.meta.source === null) {
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity.meta.source !== 'undefined') {
@@ -387,66 +462,89 @@ exports[`embedded entities in postgres diffing 2`] = `
       }
       if (Array.isArray(data.profile1_identity.links)) {
         entity.profile1.identity.links = [];
-        data.profile1_identity.links.forEach((_, idx_2) => {
-          if (data.profile1_identity.links[idx_2] != null) {
-            if (entity.profile1.identity.links[idx_2] == null) {
-              entity.profile1.identity.links[idx_2] = factory.createEmbeddable('IdentityLink', data.profile1_identity.links[idx_2], { newEntity, convertCustomTypes });
+        data.profile1_identity.links.forEach((_, idx_21) => {
+          if (data.profile1_identity.links[idx_21] != null) {
+            if (entity.profile1.identity.links[idx_21] == null) {
+              entity.profile1.identity.links[idx_21] = factory.createEmbeddable('IdentityLink', data.profile1_identity.links[idx_21], { newEntity, convertCustomTypes });
             }
-            if (data.profile1_identity && data.profile1_identity.links && data.profile1_identity.links[idx_2] && typeof data.profile1_identity.links[idx_2].url !== 'undefined') entity.profile1.identity.links[idx_2].url = data.profile1_identity.links[idx_2].url;
-            if (data.profile1_identity && data.profile1_identity.links && data.profile1_identity.links[idx_2] && data.profile1_identity.links[idx_2].createdAt) entity.profile1.identity.links[idx_2].createdAt = new Date(data.profile1_identity.links[idx_2].createdAt);
-            else if (data.profile1_identity && data.profile1_identity.links && data.profile1_identity.links[idx_2] && data.profile1_identity.links[idx_2].createdAt === null) entity.profile1.identity.links[idx_2].createdAt = null;
-            if (data.profile1_identity.links[idx_2].meta != null) {
-              if (entity.profile1.identity.links[idx_2].meta == null) {
-                entity.profile1.identity.links[idx_2].meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity.links[idx_2].meta, { newEntity, convertCustomTypes });
+            if (data.profile1_identity.links[idx_21].url === null) {
+              entity.profile1.identity.links[idx_21].url = null;
+            } else if (typeof data.profile1_identity.links[idx_21].url !== 'undefined') {
+              entity.profile1.identity.links[idx_21].url = data.profile1_identity.links[idx_21].url;
+            }
+            if (data.profile1_identity.links[idx_21].createdAt === null) {
+              entity.profile1.identity.links[idx_21].createdAt = null;
+            } else if (typeof data.profile1_identity.links[idx_21].createdAt !== 'undefined') {
+              entity.profile1.identity.links[idx_21].createdAt = new Date(data.profile1_identity.links[idx_21].createdAt);
+            }
+            if (data.profile1_identity.links[idx_21].meta != null) {
+              if (entity.profile1.identity.links[idx_21].meta == null) {
+                entity.profile1.identity.links[idx_21].meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity.links[idx_21].meta, { newEntity, convertCustomTypes });
               }
-              if (data.profile1_identity && data.profile1_identity.links && data.profile1_identity.links[idx_2] && data.profile1_identity.links[idx_2].meta && typeof data.profile1_identity.links[idx_2].meta.foo !== 'undefined') entity.profile1.identity.links[idx_2].meta.foo = data.profile1_identity.links[idx_2].meta.foo;
-              if (data.profile1_identity && data.profile1_identity.links && data.profile1_identity.links[idx_2] && data.profile1_identity.links[idx_2].meta && typeof data.profile1_identity.links[idx_2].meta.bar !== 'undefined') entity.profile1.identity.links[idx_2].meta.bar = data.profile1_identity.links[idx_2].meta.bar;
-              if (data.profile1_identity.links[idx_2].meta.source === null) {
-    entity.profile1.identity.links[idx_2].meta.source = null;
-              } else if (typeof data.profile1_identity.links[idx_2].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile1_identity.links[idx_2].meta.source, true)) {
-                  entity.profile1.identity.links[idx_2].meta.source = factory.createReference('Source', data.profile1_identity.links[idx_2].meta.source, { merge: true, convertCustomTypes, schema });
-                } else if (data.profile1_identity.links[idx_2].meta.source && typeof data.profile1_identity.links[idx_2].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_2].meta.source = factory.create('Source', data.profile1_identity.links[idx_2].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+              if (data.profile1_identity.links[idx_21].meta.foo === null) {
+                entity.profile1.identity.links[idx_21].meta.foo = null;
+              } else if (typeof data.profile1_identity.links[idx_21].meta.foo !== 'undefined') {
+                entity.profile1.identity.links[idx_21].meta.foo = data.profile1_identity.links[idx_21].meta.foo;
+              }
+              if (data.profile1_identity.links[idx_21].meta.bar === null) {
+                entity.profile1.identity.links[idx_21].meta.bar = null;
+              } else if (typeof data.profile1_identity.links[idx_21].meta.bar !== 'undefined') {
+                entity.profile1.identity.links[idx_21].meta.bar = data.profile1_identity.links[idx_21].meta.bar;
+              }
+              if (data.profile1_identity.links[idx_21].meta.source === null) {
+    entity.profile1.identity.links[idx_21].meta.source = null;
+              } else if (typeof data.profile1_identity.links[idx_21].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile1_identity.links[idx_21].meta.source, true)) {
+                  entity.profile1.identity.links[idx_21].meta.source = factory.createReference('Source', data.profile1_identity.links[idx_21].meta.source, { merge: true, convertCustomTypes, schema });
+                } else if (data.profile1_identity.links[idx_21].meta.source && typeof data.profile1_identity.links[idx_21].meta.source === 'object') {
+                  entity.profile1.identity.links[idx_21].meta.source = factory.create('Source', data.profile1_identity.links[idx_21].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                 }
               }
-            } else if (data.profile1_identity.links[idx_2].meta === null) {
-              entity.profile1.identity.links[idx_2].meta = null;
+            } else if (data.profile1_identity.links[idx_21].meta === null) {
+              entity.profile1.identity.links[idx_21].meta = null;
             }
-            if (Array.isArray(data.profile1_identity.links[idx_2].metas)) {
-              entity.profile1.identity.links[idx_2].metas = [];
-              data.profile1_identity.links[idx_2].metas.forEach((_, idx_3) => {
-                if (data.profile1_identity.links[idx_2].metas[idx_3] != null) {
-                  if (entity.profile1.identity.links[idx_2].metas[idx_3] == null) {
-                    entity.profile1.identity.links[idx_2].metas[idx_3] = factory.createEmbeddable('IdentityMeta', data.profile1_identity.links[idx_2].metas[idx_3], { newEntity, convertCustomTypes });
+            if (Array.isArray(data.profile1_identity.links[idx_21].metas)) {
+              entity.profile1.identity.links[idx_21].metas = [];
+              data.profile1_identity.links[idx_21].metas.forEach((_, idx_26) => {
+                if (data.profile1_identity.links[idx_21].metas[idx_26] != null) {
+                  if (entity.profile1.identity.links[idx_21].metas[idx_26] == null) {
+                    entity.profile1.identity.links[idx_21].metas[idx_26] = factory.createEmbeddable('IdentityMeta', data.profile1_identity.links[idx_21].metas[idx_26], { newEntity, convertCustomTypes });
                   }
-                  if (data.profile1_identity && data.profile1_identity.links && data.profile1_identity.links[idx_2] && data.profile1_identity.links[idx_2].metas && data.profile1_identity.links[idx_2].metas[idx_3] && typeof data.profile1_identity.links[idx_2].metas[idx_3].foo !== 'undefined') entity.profile1.identity.links[idx_2].metas[idx_3].foo = data.profile1_identity.links[idx_2].metas[idx_3].foo;
-                  if (data.profile1_identity && data.profile1_identity.links && data.profile1_identity.links[idx_2] && data.profile1_identity.links[idx_2].metas && data.profile1_identity.links[idx_2].metas[idx_3] && typeof data.profile1_identity.links[idx_2].metas[idx_3].bar !== 'undefined') entity.profile1.identity.links[idx_2].metas[idx_3].bar = data.profile1_identity.links[idx_2].metas[idx_3].bar;
-                  if (data.profile1_identity.links[idx_2].metas[idx_3].source === null) {
-    entity.profile1.identity.links[idx_2].metas[idx_3].source = null;
-                  } else if (typeof data.profile1_identity.links[idx_2].metas[idx_3].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile1_identity.links[idx_2].metas[idx_3].source, true)) {
-                      entity.profile1.identity.links[idx_2].metas[idx_3].source = factory.createReference('Source', data.profile1_identity.links[idx_2].metas[idx_3].source, { merge: true, convertCustomTypes, schema });
-                    } else if (data.profile1_identity.links[idx_2].metas[idx_3].source && typeof data.profile1_identity.links[idx_2].metas[idx_3].source === 'object') {
-                      entity.profile1.identity.links[idx_2].metas[idx_3].source = factory.create('Source', data.profile1_identity.links[idx_2].metas[idx_3].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  if (data.profile1_identity.links[idx_21].metas[idx_26].foo === null) {
+                    entity.profile1.identity.links[idx_21].metas[idx_26].foo = null;
+                  } else if (typeof data.profile1_identity.links[idx_21].metas[idx_26].foo !== 'undefined') {
+                    entity.profile1.identity.links[idx_21].metas[idx_26].foo = data.profile1_identity.links[idx_21].metas[idx_26].foo;
+                  }
+                  if (data.profile1_identity.links[idx_21].metas[idx_26].bar === null) {
+                    entity.profile1.identity.links[idx_21].metas[idx_26].bar = null;
+                  } else if (typeof data.profile1_identity.links[idx_21].metas[idx_26].bar !== 'undefined') {
+                    entity.profile1.identity.links[idx_21].metas[idx_26].bar = data.profile1_identity.links[idx_21].metas[idx_26].bar;
+                  }
+                  if (data.profile1_identity.links[idx_21].metas[idx_26].source === null) {
+    entity.profile1.identity.links[idx_21].metas[idx_26].source = null;
+                  } else if (typeof data.profile1_identity.links[idx_21].metas[idx_26].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile1_identity.links[idx_21].metas[idx_26].source, true)) {
+                      entity.profile1.identity.links[idx_21].metas[idx_26].source = factory.createReference('Source', data.profile1_identity.links[idx_21].metas[idx_26].source, { merge: true, convertCustomTypes, schema });
+                    } else if (data.profile1_identity.links[idx_21].metas[idx_26].source && typeof data.profile1_identity.links[idx_21].metas[idx_26].source === 'object') {
+                      entity.profile1.identity.links[idx_21].metas[idx_26].source = factory.create('Source', data.profile1_identity.links[idx_21].metas[idx_26].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                     }
                   }
-                } else if (data.profile1_identity.links[idx_2].metas[idx_3] === null) {
-                  entity.profile1.identity.links[idx_2].metas[idx_3] = null;
+                } else if (data.profile1_identity.links[idx_21].metas[idx_26] === null) {
+                  entity.profile1.identity.links[idx_21].metas[idx_26] = null;
                 }
               });
             }
-            if (data.profile1_identity.links[idx_2].source === null) {
-    entity.profile1.identity.links[idx_2].source = null;
-            } else if (typeof data.profile1_identity.links[idx_2].source !== 'undefined') {
-              if (isPrimaryKey(data.profile1_identity.links[idx_2].source, true)) {
-                entity.profile1.identity.links[idx_2].source = factory.createReference('Source', data.profile1_identity.links[idx_2].source, { merge: true, convertCustomTypes, schema });
-              } else if (data.profile1_identity.links[idx_2].source && typeof data.profile1_identity.links[idx_2].source === 'object') {
-                entity.profile1.identity.links[idx_2].source = factory.create('Source', data.profile1_identity.links[idx_2].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            if (data.profile1_identity.links[idx_21].source === null) {
+    entity.profile1.identity.links[idx_21].source = null;
+            } else if (typeof data.profile1_identity.links[idx_21].source !== 'undefined') {
+              if (isPrimaryKey(data.profile1_identity.links[idx_21].source, true)) {
+                entity.profile1.identity.links[idx_21].source = factory.createReference('Source', data.profile1_identity.links[idx_21].source, { merge: true, convertCustomTypes, schema });
+              } else if (data.profile1_identity.links[idx_21].source && typeof data.profile1_identity.links[idx_21].source === 'object') {
+                entity.profile1.identity.links[idx_21].source = factory.create('Source', data.profile1_identity.links[idx_21].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
               }
             }
-          } else if (data.profile1_identity.links[idx_2] === null) {
-            entity.profile1.identity.links[idx_2] = null;
+          } else if (data.profile1_identity.links[idx_21] === null) {
+            entity.profile1.identity.links[idx_21] = null;
           }
         });
       }
@@ -478,18 +576,34 @@ exports[`embedded entities in postgres diffing 2`] = `
     if (entity.profile1 == null) {
       entity.profile1 = factory.createEmbeddable('Profile', data.profile1, { newEntity, convertCustomTypes });
     }
-    if (data.profile1 && typeof data.profile1.username !== 'undefined') entity.profile1.username = data.profile1.username;
+    if (data.profile1.username === null) {
+      entity.profile1.username = null;
+    } else if (typeof data.profile1.username !== 'undefined') {
+      entity.profile1.username = data.profile1.username;
+    }
     if (data.profile1_identity_email !== undefined || data.profile1_identity_meta_foo != null || data.profile1_identity_meta_bar != null || data.profile1_identity_meta_source != null || data.profile1_identity_links !== undefined || data.profile1_identity_source !== undefined) {
       if (entity.profile1.identity == null) {
         entity.profile1.identity = factory.createEmbeddable('Identity', data, { newEntity, convertCustomTypes });
       }
-      if (typeof data.profile1_identity_email !== 'undefined') entity.profile1.identity.email = data.profile1_identity_email;
+      if (data.profile1_identity_email === null) {
+        entity.profile1.identity.email = null;
+      } else if (typeof data.profile1_identity_email !== 'undefined') {
+        entity.profile1.identity.email = data.profile1_identity_email;
+      }
       if (data.profile1_identity_meta_foo != null || data.profile1_identity_meta_bar != null || data.profile1_identity_meta_source != null) {
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data, { newEntity, convertCustomTypes });
         }
-        if (typeof data.profile1_identity_meta_foo !== 'undefined') entity.profile1.identity.meta.foo = data.profile1_identity_meta_foo;
-        if (typeof data.profile1_identity_meta_bar !== 'undefined') entity.profile1.identity.meta.bar = data.profile1_identity_meta_bar;
+        if (data.profile1_identity_meta_foo === null) {
+          entity.profile1.identity.meta.foo = null;
+        } else if (typeof data.profile1_identity_meta_foo !== 'undefined') {
+          entity.profile1.identity.meta.foo = data.profile1_identity_meta_foo;
+        }
+        if (data.profile1_identity_meta_bar === null) {
+          entity.profile1.identity.meta.bar = null;
+        } else if (typeof data.profile1_identity_meta_bar !== 'undefined') {
+          entity.profile1.identity.meta.bar = data.profile1_identity_meta_bar;
+        }
         if (data.profile1_identity_meta_source === null) {
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
@@ -506,8 +620,16 @@ exports[`embedded entities in postgres diffing 2`] = `
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity_meta, { newEntity, convertCustomTypes });
         }
-        if (data.profile1_identity_meta && typeof data.profile1_identity_meta.foo !== 'undefined') entity.profile1.identity.meta.foo = data.profile1_identity_meta.foo;
-        if (data.profile1_identity_meta && typeof data.profile1_identity_meta.bar !== 'undefined') entity.profile1.identity.meta.bar = data.profile1_identity_meta.bar;
+        if (data.profile1_identity_meta.foo === null) {
+          entity.profile1.identity.meta.foo = null;
+        } else if (typeof data.profile1_identity_meta.foo !== 'undefined') {
+          entity.profile1.identity.meta.foo = data.profile1_identity_meta.foo;
+        }
+        if (data.profile1_identity_meta.bar === null) {
+          entity.profile1.identity.meta.bar = null;
+        } else if (typeof data.profile1_identity_meta.bar !== 'undefined') {
+          entity.profile1.identity.meta.bar = data.profile1_identity_meta.bar;
+        }
         if (data.profile1_identity_meta.source === null) {
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta.source !== 'undefined') {
@@ -522,66 +644,89 @@ exports[`embedded entities in postgres diffing 2`] = `
       }
       if (Array.isArray(data.profile1_identity_links)) {
         entity.profile1.identity.links = [];
-        data.profile1_identity_links.forEach((_, idx_4) => {
-          if (data.profile1_identity_links[idx_4] != null) {
-            if (entity.profile1.identity.links[idx_4] == null) {
-              entity.profile1.identity.links[idx_4] = factory.createEmbeddable('IdentityLink', data.profile1_identity_links[idx_4], { newEntity, convertCustomTypes });
+        data.profile1_identity_links.forEach((_, idx_35) => {
+          if (data.profile1_identity_links[idx_35] != null) {
+            if (entity.profile1.identity.links[idx_35] == null) {
+              entity.profile1.identity.links[idx_35] = factory.createEmbeddable('IdentityLink', data.profile1_identity_links[idx_35], { newEntity, convertCustomTypes });
             }
-            if (data.profile1_identity_links && data.profile1_identity_links[idx_4] && typeof data.profile1_identity_links[idx_4].url !== 'undefined') entity.profile1.identity.links[idx_4].url = data.profile1_identity_links[idx_4].url;
-            if (data.profile1_identity_links && data.profile1_identity_links[idx_4] && data.profile1_identity_links[idx_4].createdAt) entity.profile1.identity.links[idx_4].createdAt = new Date(data.profile1_identity_links[idx_4].createdAt);
-            else if (data.profile1_identity_links && data.profile1_identity_links[idx_4] && data.profile1_identity_links[idx_4].createdAt === null) entity.profile1.identity.links[idx_4].createdAt = null;
-            if (data.profile1_identity_links[idx_4].meta != null) {
-              if (entity.profile1.identity.links[idx_4].meta == null) {
-                entity.profile1.identity.links[idx_4].meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity_links[idx_4].meta, { newEntity, convertCustomTypes });
+            if (data.profile1_identity_links[idx_35].url === null) {
+              entity.profile1.identity.links[idx_35].url = null;
+            } else if (typeof data.profile1_identity_links[idx_35].url !== 'undefined') {
+              entity.profile1.identity.links[idx_35].url = data.profile1_identity_links[idx_35].url;
+            }
+            if (data.profile1_identity_links[idx_35].createdAt === null) {
+              entity.profile1.identity.links[idx_35].createdAt = null;
+            } else if (typeof data.profile1_identity_links[idx_35].createdAt !== 'undefined') {
+              entity.profile1.identity.links[idx_35].createdAt = new Date(data.profile1_identity_links[idx_35].createdAt);
+            }
+            if (data.profile1_identity_links[idx_35].meta != null) {
+              if (entity.profile1.identity.links[idx_35].meta == null) {
+                entity.profile1.identity.links[idx_35].meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity_links[idx_35].meta, { newEntity, convertCustomTypes });
               }
-              if (data.profile1_identity_links && data.profile1_identity_links[idx_4] && data.profile1_identity_links[idx_4].meta && typeof data.profile1_identity_links[idx_4].meta.foo !== 'undefined') entity.profile1.identity.links[idx_4].meta.foo = data.profile1_identity_links[idx_4].meta.foo;
-              if (data.profile1_identity_links && data.profile1_identity_links[idx_4] && data.profile1_identity_links[idx_4].meta && typeof data.profile1_identity_links[idx_4].meta.bar !== 'undefined') entity.profile1.identity.links[idx_4].meta.bar = data.profile1_identity_links[idx_4].meta.bar;
-              if (data.profile1_identity_links[idx_4].meta.source === null) {
-    entity.profile1.identity.links[idx_4].meta.source = null;
-              } else if (typeof data.profile1_identity_links[idx_4].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile1_identity_links[idx_4].meta.source, true)) {
-                  entity.profile1.identity.links[idx_4].meta.source = factory.createReference('Source', data.profile1_identity_links[idx_4].meta.source, { merge: true, convertCustomTypes, schema });
-                } else if (data.profile1_identity_links[idx_4].meta.source && typeof data.profile1_identity_links[idx_4].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_4].meta.source = factory.create('Source', data.profile1_identity_links[idx_4].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+              if (data.profile1_identity_links[idx_35].meta.foo === null) {
+                entity.profile1.identity.links[idx_35].meta.foo = null;
+              } else if (typeof data.profile1_identity_links[idx_35].meta.foo !== 'undefined') {
+                entity.profile1.identity.links[idx_35].meta.foo = data.profile1_identity_links[idx_35].meta.foo;
+              }
+              if (data.profile1_identity_links[idx_35].meta.bar === null) {
+                entity.profile1.identity.links[idx_35].meta.bar = null;
+              } else if (typeof data.profile1_identity_links[idx_35].meta.bar !== 'undefined') {
+                entity.profile1.identity.links[idx_35].meta.bar = data.profile1_identity_links[idx_35].meta.bar;
+              }
+              if (data.profile1_identity_links[idx_35].meta.source === null) {
+    entity.profile1.identity.links[idx_35].meta.source = null;
+              } else if (typeof data.profile1_identity_links[idx_35].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile1_identity_links[idx_35].meta.source, true)) {
+                  entity.profile1.identity.links[idx_35].meta.source = factory.createReference('Source', data.profile1_identity_links[idx_35].meta.source, { merge: true, convertCustomTypes, schema });
+                } else if (data.profile1_identity_links[idx_35].meta.source && typeof data.profile1_identity_links[idx_35].meta.source === 'object') {
+                  entity.profile1.identity.links[idx_35].meta.source = factory.create('Source', data.profile1_identity_links[idx_35].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                 }
               }
-            } else if (data.profile1_identity_links[idx_4].meta === null) {
-              entity.profile1.identity.links[idx_4].meta = null;
+            } else if (data.profile1_identity_links[idx_35].meta === null) {
+              entity.profile1.identity.links[idx_35].meta = null;
             }
-            if (Array.isArray(data.profile1_identity_links[idx_4].metas)) {
-              entity.profile1.identity.links[idx_4].metas = [];
-              data.profile1_identity_links[idx_4].metas.forEach((_, idx_5) => {
-                if (data.profile1_identity_links[idx_4].metas[idx_5] != null) {
-                  if (entity.profile1.identity.links[idx_4].metas[idx_5] == null) {
-                    entity.profile1.identity.links[idx_4].metas[idx_5] = factory.createEmbeddable('IdentityMeta', data.profile1_identity_links[idx_4].metas[idx_5], { newEntity, convertCustomTypes });
+            if (Array.isArray(data.profile1_identity_links[idx_35].metas)) {
+              entity.profile1.identity.links[idx_35].metas = [];
+              data.profile1_identity_links[idx_35].metas.forEach((_, idx_40) => {
+                if (data.profile1_identity_links[idx_35].metas[idx_40] != null) {
+                  if (entity.profile1.identity.links[idx_35].metas[idx_40] == null) {
+                    entity.profile1.identity.links[idx_35].metas[idx_40] = factory.createEmbeddable('IdentityMeta', data.profile1_identity_links[idx_35].metas[idx_40], { newEntity, convertCustomTypes });
                   }
-                  if (data.profile1_identity_links && data.profile1_identity_links[idx_4] && data.profile1_identity_links[idx_4].metas && data.profile1_identity_links[idx_4].metas[idx_5] && typeof data.profile1_identity_links[idx_4].metas[idx_5].foo !== 'undefined') entity.profile1.identity.links[idx_4].metas[idx_5].foo = data.profile1_identity_links[idx_4].metas[idx_5].foo;
-                  if (data.profile1_identity_links && data.profile1_identity_links[idx_4] && data.profile1_identity_links[idx_4].metas && data.profile1_identity_links[idx_4].metas[idx_5] && typeof data.profile1_identity_links[idx_4].metas[idx_5].bar !== 'undefined') entity.profile1.identity.links[idx_4].metas[idx_5].bar = data.profile1_identity_links[idx_4].metas[idx_5].bar;
-                  if (data.profile1_identity_links[idx_4].metas[idx_5].source === null) {
-    entity.profile1.identity.links[idx_4].metas[idx_5].source = null;
-                  } else if (typeof data.profile1_identity_links[idx_4].metas[idx_5].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile1_identity_links[idx_4].metas[idx_5].source, true)) {
-                      entity.profile1.identity.links[idx_4].metas[idx_5].source = factory.createReference('Source', data.profile1_identity_links[idx_4].metas[idx_5].source, { merge: true, convertCustomTypes, schema });
-                    } else if (data.profile1_identity_links[idx_4].metas[idx_5].source && typeof data.profile1_identity_links[idx_4].metas[idx_5].source === 'object') {
-                      entity.profile1.identity.links[idx_4].metas[idx_5].source = factory.create('Source', data.profile1_identity_links[idx_4].metas[idx_5].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  if (data.profile1_identity_links[idx_35].metas[idx_40].foo === null) {
+                    entity.profile1.identity.links[idx_35].metas[idx_40].foo = null;
+                  } else if (typeof data.profile1_identity_links[idx_35].metas[idx_40].foo !== 'undefined') {
+                    entity.profile1.identity.links[idx_35].metas[idx_40].foo = data.profile1_identity_links[idx_35].metas[idx_40].foo;
+                  }
+                  if (data.profile1_identity_links[idx_35].metas[idx_40].bar === null) {
+                    entity.profile1.identity.links[idx_35].metas[idx_40].bar = null;
+                  } else if (typeof data.profile1_identity_links[idx_35].metas[idx_40].bar !== 'undefined') {
+                    entity.profile1.identity.links[idx_35].metas[idx_40].bar = data.profile1_identity_links[idx_35].metas[idx_40].bar;
+                  }
+                  if (data.profile1_identity_links[idx_35].metas[idx_40].source === null) {
+    entity.profile1.identity.links[idx_35].metas[idx_40].source = null;
+                  } else if (typeof data.profile1_identity_links[idx_35].metas[idx_40].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile1_identity_links[idx_35].metas[idx_40].source, true)) {
+                      entity.profile1.identity.links[idx_35].metas[idx_40].source = factory.createReference('Source', data.profile1_identity_links[idx_35].metas[idx_40].source, { merge: true, convertCustomTypes, schema });
+                    } else if (data.profile1_identity_links[idx_35].metas[idx_40].source && typeof data.profile1_identity_links[idx_35].metas[idx_40].source === 'object') {
+                      entity.profile1.identity.links[idx_35].metas[idx_40].source = factory.create('Source', data.profile1_identity_links[idx_35].metas[idx_40].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                     }
                   }
-                } else if (data.profile1_identity_links[idx_4].metas[idx_5] === null) {
-                  entity.profile1.identity.links[idx_4].metas[idx_5] = null;
+                } else if (data.profile1_identity_links[idx_35].metas[idx_40] === null) {
+                  entity.profile1.identity.links[idx_35].metas[idx_40] = null;
                 }
               });
             }
-            if (data.profile1_identity_links[idx_4].source === null) {
-    entity.profile1.identity.links[idx_4].source = null;
-            } else if (typeof data.profile1_identity_links[idx_4].source !== 'undefined') {
-              if (isPrimaryKey(data.profile1_identity_links[idx_4].source, true)) {
-                entity.profile1.identity.links[idx_4].source = factory.createReference('Source', data.profile1_identity_links[idx_4].source, { merge: true, convertCustomTypes, schema });
-              } else if (data.profile1_identity_links[idx_4].source && typeof data.profile1_identity_links[idx_4].source === 'object') {
-                entity.profile1.identity.links[idx_4].source = factory.create('Source', data.profile1_identity_links[idx_4].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            if (data.profile1_identity_links[idx_35].source === null) {
+    entity.profile1.identity.links[idx_35].source = null;
+            } else if (typeof data.profile1_identity_links[idx_35].source !== 'undefined') {
+              if (isPrimaryKey(data.profile1_identity_links[idx_35].source, true)) {
+                entity.profile1.identity.links[idx_35].source = factory.createReference('Source', data.profile1_identity_links[idx_35].source, { merge: true, convertCustomTypes, schema });
+              } else if (data.profile1_identity_links[idx_35].source && typeof data.profile1_identity_links[idx_35].source === 'object') {
+                entity.profile1.identity.links[idx_35].source = factory.create('Source', data.profile1_identity_links[idx_35].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
               }
             }
-          } else if (data.profile1_identity_links[idx_4] === null) {
-            entity.profile1.identity.links[idx_4] = null;
+          } else if (data.profile1_identity_links[idx_35] === null) {
+            entity.profile1.identity.links[idx_35] = null;
           }
         });
       }
@@ -601,13 +746,25 @@ exports[`embedded entities in postgres diffing 2`] = `
       if (entity.profile1.identity == null) {
         entity.profile1.identity = factory.createEmbeddable('Identity', data.profile1.identity, { newEntity, convertCustomTypes });
       }
-      if (data.profile1 && data.profile1.identity && typeof data.profile1.identity.email !== 'undefined') entity.profile1.identity.email = data.profile1.identity.email;
+      if (data.profile1.identity.email === null) {
+        entity.profile1.identity.email = null;
+      } else if (typeof data.profile1.identity.email !== 'undefined') {
+        entity.profile1.identity.email = data.profile1.identity.email;
+      }
       if (data.profile1_identity_meta_foo != null || data.profile1_identity_meta_bar != null || data.profile1_identity_meta_source != null) {
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data, { newEntity, convertCustomTypes });
         }
-        if (typeof data.profile1_identity_meta_foo !== 'undefined') entity.profile1.identity.meta.foo = data.profile1_identity_meta_foo;
-        if (typeof data.profile1_identity_meta_bar !== 'undefined') entity.profile1.identity.meta.bar = data.profile1_identity_meta_bar;
+        if (data.profile1_identity_meta_foo === null) {
+          entity.profile1.identity.meta.foo = null;
+        } else if (typeof data.profile1_identity_meta_foo !== 'undefined') {
+          entity.profile1.identity.meta.foo = data.profile1_identity_meta_foo;
+        }
+        if (data.profile1_identity_meta_bar === null) {
+          entity.profile1.identity.meta.bar = null;
+        } else if (typeof data.profile1_identity_meta_bar !== 'undefined') {
+          entity.profile1.identity.meta.bar = data.profile1_identity_meta_bar;
+        }
         if (data.profile1_identity_meta_source === null) {
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
@@ -624,8 +781,16 @@ exports[`embedded entities in postgres diffing 2`] = `
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data.profile1.identity.meta, { newEntity, convertCustomTypes });
         }
-        if (data.profile1 && data.profile1.identity && data.profile1.identity.meta && typeof data.profile1.identity.meta.foo !== 'undefined') entity.profile1.identity.meta.foo = data.profile1.identity.meta.foo;
-        if (data.profile1 && data.profile1.identity && data.profile1.identity.meta && typeof data.profile1.identity.meta.bar !== 'undefined') entity.profile1.identity.meta.bar = data.profile1.identity.meta.bar;
+        if (data.profile1.identity.meta.foo === null) {
+          entity.profile1.identity.meta.foo = null;
+        } else if (typeof data.profile1.identity.meta.foo !== 'undefined') {
+          entity.profile1.identity.meta.foo = data.profile1.identity.meta.foo;
+        }
+        if (data.profile1.identity.meta.bar === null) {
+          entity.profile1.identity.meta.bar = null;
+        } else if (typeof data.profile1.identity.meta.bar !== 'undefined') {
+          entity.profile1.identity.meta.bar = data.profile1.identity.meta.bar;
+        }
         if (data.profile1.identity.meta.source === null) {
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1.identity.meta.source !== 'undefined') {
@@ -640,66 +805,89 @@ exports[`embedded entities in postgres diffing 2`] = `
       }
       if (Array.isArray(data.profile1.identity.links)) {
         entity.profile1.identity.links = [];
-        data.profile1.identity.links.forEach((_, idx_6) => {
-          if (data.profile1.identity.links[idx_6] != null) {
-            if (entity.profile1.identity.links[idx_6] == null) {
-              entity.profile1.identity.links[idx_6] = factory.createEmbeddable('IdentityLink', data.profile1.identity.links[idx_6], { newEntity, convertCustomTypes });
+        data.profile1.identity.links.forEach((_, idx_48) => {
+          if (data.profile1.identity.links[idx_48] != null) {
+            if (entity.profile1.identity.links[idx_48] == null) {
+              entity.profile1.identity.links[idx_48] = factory.createEmbeddable('IdentityLink', data.profile1.identity.links[idx_48], { newEntity, convertCustomTypes });
             }
-            if (data.profile1 && data.profile1.identity && data.profile1.identity.links && data.profile1.identity.links[idx_6] && typeof data.profile1.identity.links[idx_6].url !== 'undefined') entity.profile1.identity.links[idx_6].url = data.profile1.identity.links[idx_6].url;
-            if (data.profile1 && data.profile1.identity && data.profile1.identity.links && data.profile1.identity.links[idx_6] && data.profile1.identity.links[idx_6].createdAt) entity.profile1.identity.links[idx_6].createdAt = new Date(data.profile1.identity.links[idx_6].createdAt);
-            else if (data.profile1 && data.profile1.identity && data.profile1.identity.links && data.profile1.identity.links[idx_6] && data.profile1.identity.links[idx_6].createdAt === null) entity.profile1.identity.links[idx_6].createdAt = null;
-            if (data.profile1.identity.links[idx_6].meta != null) {
-              if (entity.profile1.identity.links[idx_6].meta == null) {
-                entity.profile1.identity.links[idx_6].meta = factory.createEmbeddable('IdentityMeta', data.profile1.identity.links[idx_6].meta, { newEntity, convertCustomTypes });
+            if (data.profile1.identity.links[idx_48].url === null) {
+              entity.profile1.identity.links[idx_48].url = null;
+            } else if (typeof data.profile1.identity.links[idx_48].url !== 'undefined') {
+              entity.profile1.identity.links[idx_48].url = data.profile1.identity.links[idx_48].url;
+            }
+            if (data.profile1.identity.links[idx_48].createdAt === null) {
+              entity.profile1.identity.links[idx_48].createdAt = null;
+            } else if (typeof data.profile1.identity.links[idx_48].createdAt !== 'undefined') {
+              entity.profile1.identity.links[idx_48].createdAt = new Date(data.profile1.identity.links[idx_48].createdAt);
+            }
+            if (data.profile1.identity.links[idx_48].meta != null) {
+              if (entity.profile1.identity.links[idx_48].meta == null) {
+                entity.profile1.identity.links[idx_48].meta = factory.createEmbeddable('IdentityMeta', data.profile1.identity.links[idx_48].meta, { newEntity, convertCustomTypes });
               }
-              if (data.profile1 && data.profile1.identity && data.profile1.identity.links && data.profile1.identity.links[idx_6] && data.profile1.identity.links[idx_6].meta && typeof data.profile1.identity.links[idx_6].meta.foo !== 'undefined') entity.profile1.identity.links[idx_6].meta.foo = data.profile1.identity.links[idx_6].meta.foo;
-              if (data.profile1 && data.profile1.identity && data.profile1.identity.links && data.profile1.identity.links[idx_6] && data.profile1.identity.links[idx_6].meta && typeof data.profile1.identity.links[idx_6].meta.bar !== 'undefined') entity.profile1.identity.links[idx_6].meta.bar = data.profile1.identity.links[idx_6].meta.bar;
-              if (data.profile1.identity.links[idx_6].meta.source === null) {
-    entity.profile1.identity.links[idx_6].meta.source = null;
-              } else if (typeof data.profile1.identity.links[idx_6].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile1.identity.links[idx_6].meta.source, true)) {
-                  entity.profile1.identity.links[idx_6].meta.source = factory.createReference('Source', data.profile1.identity.links[idx_6].meta.source, { merge: true, convertCustomTypes, schema });
-                } else if (data.profile1.identity.links[idx_6].meta.source && typeof data.profile1.identity.links[idx_6].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_6].meta.source = factory.create('Source', data.profile1.identity.links[idx_6].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+              if (data.profile1.identity.links[idx_48].meta.foo === null) {
+                entity.profile1.identity.links[idx_48].meta.foo = null;
+              } else if (typeof data.profile1.identity.links[idx_48].meta.foo !== 'undefined') {
+                entity.profile1.identity.links[idx_48].meta.foo = data.profile1.identity.links[idx_48].meta.foo;
+              }
+              if (data.profile1.identity.links[idx_48].meta.bar === null) {
+                entity.profile1.identity.links[idx_48].meta.bar = null;
+              } else if (typeof data.profile1.identity.links[idx_48].meta.bar !== 'undefined') {
+                entity.profile1.identity.links[idx_48].meta.bar = data.profile1.identity.links[idx_48].meta.bar;
+              }
+              if (data.profile1.identity.links[idx_48].meta.source === null) {
+    entity.profile1.identity.links[idx_48].meta.source = null;
+              } else if (typeof data.profile1.identity.links[idx_48].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile1.identity.links[idx_48].meta.source, true)) {
+                  entity.profile1.identity.links[idx_48].meta.source = factory.createReference('Source', data.profile1.identity.links[idx_48].meta.source, { merge: true, convertCustomTypes, schema });
+                } else if (data.profile1.identity.links[idx_48].meta.source && typeof data.profile1.identity.links[idx_48].meta.source === 'object') {
+                  entity.profile1.identity.links[idx_48].meta.source = factory.create('Source', data.profile1.identity.links[idx_48].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                 }
               }
-            } else if (data.profile1.identity.links[idx_6].meta === null) {
-              entity.profile1.identity.links[idx_6].meta = null;
+            } else if (data.profile1.identity.links[idx_48].meta === null) {
+              entity.profile1.identity.links[idx_48].meta = null;
             }
-            if (Array.isArray(data.profile1.identity.links[idx_6].metas)) {
-              entity.profile1.identity.links[idx_6].metas = [];
-              data.profile1.identity.links[idx_6].metas.forEach((_, idx_7) => {
-                if (data.profile1.identity.links[idx_6].metas[idx_7] != null) {
-                  if (entity.profile1.identity.links[idx_6].metas[idx_7] == null) {
-                    entity.profile1.identity.links[idx_6].metas[idx_7] = factory.createEmbeddable('IdentityMeta', data.profile1.identity.links[idx_6].metas[idx_7], { newEntity, convertCustomTypes });
+            if (Array.isArray(data.profile1.identity.links[idx_48].metas)) {
+              entity.profile1.identity.links[idx_48].metas = [];
+              data.profile1.identity.links[idx_48].metas.forEach((_, idx_53) => {
+                if (data.profile1.identity.links[idx_48].metas[idx_53] != null) {
+                  if (entity.profile1.identity.links[idx_48].metas[idx_53] == null) {
+                    entity.profile1.identity.links[idx_48].metas[idx_53] = factory.createEmbeddable('IdentityMeta', data.profile1.identity.links[idx_48].metas[idx_53], { newEntity, convertCustomTypes });
                   }
-                  if (data.profile1 && data.profile1.identity && data.profile1.identity.links && data.profile1.identity.links[idx_6] && data.profile1.identity.links[idx_6].metas && data.profile1.identity.links[idx_6].metas[idx_7] && typeof data.profile1.identity.links[idx_6].metas[idx_7].foo !== 'undefined') entity.profile1.identity.links[idx_6].metas[idx_7].foo = data.profile1.identity.links[idx_6].metas[idx_7].foo;
-                  if (data.profile1 && data.profile1.identity && data.profile1.identity.links && data.profile1.identity.links[idx_6] && data.profile1.identity.links[idx_6].metas && data.profile1.identity.links[idx_6].metas[idx_7] && typeof data.profile1.identity.links[idx_6].metas[idx_7].bar !== 'undefined') entity.profile1.identity.links[idx_6].metas[idx_7].bar = data.profile1.identity.links[idx_6].metas[idx_7].bar;
-                  if (data.profile1.identity.links[idx_6].metas[idx_7].source === null) {
-    entity.profile1.identity.links[idx_6].metas[idx_7].source = null;
-                  } else if (typeof data.profile1.identity.links[idx_6].metas[idx_7].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile1.identity.links[idx_6].metas[idx_7].source, true)) {
-                      entity.profile1.identity.links[idx_6].metas[idx_7].source = factory.createReference('Source', data.profile1.identity.links[idx_6].metas[idx_7].source, { merge: true, convertCustomTypes, schema });
-                    } else if (data.profile1.identity.links[idx_6].metas[idx_7].source && typeof data.profile1.identity.links[idx_6].metas[idx_7].source === 'object') {
-                      entity.profile1.identity.links[idx_6].metas[idx_7].source = factory.create('Source', data.profile1.identity.links[idx_6].metas[idx_7].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  if (data.profile1.identity.links[idx_48].metas[idx_53].foo === null) {
+                    entity.profile1.identity.links[idx_48].metas[idx_53].foo = null;
+                  } else if (typeof data.profile1.identity.links[idx_48].metas[idx_53].foo !== 'undefined') {
+                    entity.profile1.identity.links[idx_48].metas[idx_53].foo = data.profile1.identity.links[idx_48].metas[idx_53].foo;
+                  }
+                  if (data.profile1.identity.links[idx_48].metas[idx_53].bar === null) {
+                    entity.profile1.identity.links[idx_48].metas[idx_53].bar = null;
+                  } else if (typeof data.profile1.identity.links[idx_48].metas[idx_53].bar !== 'undefined') {
+                    entity.profile1.identity.links[idx_48].metas[idx_53].bar = data.profile1.identity.links[idx_48].metas[idx_53].bar;
+                  }
+                  if (data.profile1.identity.links[idx_48].metas[idx_53].source === null) {
+    entity.profile1.identity.links[idx_48].metas[idx_53].source = null;
+                  } else if (typeof data.profile1.identity.links[idx_48].metas[idx_53].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile1.identity.links[idx_48].metas[idx_53].source, true)) {
+                      entity.profile1.identity.links[idx_48].metas[idx_53].source = factory.createReference('Source', data.profile1.identity.links[idx_48].metas[idx_53].source, { merge: true, convertCustomTypes, schema });
+                    } else if (data.profile1.identity.links[idx_48].metas[idx_53].source && typeof data.profile1.identity.links[idx_48].metas[idx_53].source === 'object') {
+                      entity.profile1.identity.links[idx_48].metas[idx_53].source = factory.create('Source', data.profile1.identity.links[idx_48].metas[idx_53].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                     }
                   }
-                } else if (data.profile1.identity.links[idx_6].metas[idx_7] === null) {
-                  entity.profile1.identity.links[idx_6].metas[idx_7] = null;
+                } else if (data.profile1.identity.links[idx_48].metas[idx_53] === null) {
+                  entity.profile1.identity.links[idx_48].metas[idx_53] = null;
                 }
               });
             }
-            if (data.profile1.identity.links[idx_6].source === null) {
-    entity.profile1.identity.links[idx_6].source = null;
-            } else if (typeof data.profile1.identity.links[idx_6].source !== 'undefined') {
-              if (isPrimaryKey(data.profile1.identity.links[idx_6].source, true)) {
-                entity.profile1.identity.links[idx_6].source = factory.createReference('Source', data.profile1.identity.links[idx_6].source, { merge: true, convertCustomTypes, schema });
-              } else if (data.profile1.identity.links[idx_6].source && typeof data.profile1.identity.links[idx_6].source === 'object') {
-                entity.profile1.identity.links[idx_6].source = factory.create('Source', data.profile1.identity.links[idx_6].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            if (data.profile1.identity.links[idx_48].source === null) {
+    entity.profile1.identity.links[idx_48].source = null;
+            } else if (typeof data.profile1.identity.links[idx_48].source !== 'undefined') {
+              if (isPrimaryKey(data.profile1.identity.links[idx_48].source, true)) {
+                entity.profile1.identity.links[idx_48].source = factory.createReference('Source', data.profile1.identity.links[idx_48].source, { merge: true, convertCustomTypes, schema });
+              } else if (data.profile1.identity.links[idx_48].source && typeof data.profile1.identity.links[idx_48].source === 'object') {
+                entity.profile1.identity.links[idx_48].source = factory.create('Source', data.profile1.identity.links[idx_48].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
               }
             }
-          } else if (data.profile1.identity.links[idx_6] === null) {
-            entity.profile1.identity.links[idx_6] = null;
+          } else if (data.profile1.identity.links[idx_48] === null) {
+            entity.profile1.identity.links[idx_48] = null;
           }
         });
       }
@@ -731,18 +919,34 @@ exports[`embedded entities in postgres diffing 2`] = `
     if (entity.profile2 == null) {
       entity.profile2 = factory.createEmbeddable('Profile', data.profile2, { newEntity, convertCustomTypes });
     }
-    if (data.profile2 && typeof data.profile2.username !== 'undefined') entity.profile2.username = data.profile2.username;
+    if (data.profile2.username === null) {
+      entity.profile2.username = null;
+    } else if (typeof data.profile2.username !== 'undefined') {
+      entity.profile2.username = data.profile2.username;
+    }
     if (data.profile2.identity != null) {
       if (entity.profile2.identity == null) {
         entity.profile2.identity = factory.createEmbeddable('Identity', data.profile2.identity, { newEntity, convertCustomTypes });
       }
-      if (data.profile2 && data.profile2.identity && typeof data.profile2.identity.email !== 'undefined') entity.profile2.identity.email = data.profile2.identity.email;
+      if (data.profile2.identity.email === null) {
+        entity.profile2.identity.email = null;
+      } else if (typeof data.profile2.identity.email !== 'undefined') {
+        entity.profile2.identity.email = data.profile2.identity.email;
+      }
       if (data.profile2.identity.meta != null) {
         if (entity.profile2.identity.meta == null) {
           entity.profile2.identity.meta = factory.createEmbeddable('IdentityMeta', data.profile2.identity.meta, { newEntity, convertCustomTypes });
         }
-        if (data.profile2 && data.profile2.identity && data.profile2.identity.meta && typeof data.profile2.identity.meta.foo !== 'undefined') entity.profile2.identity.meta.foo = data.profile2.identity.meta.foo;
-        if (data.profile2 && data.profile2.identity && data.profile2.identity.meta && typeof data.profile2.identity.meta.bar !== 'undefined') entity.profile2.identity.meta.bar = data.profile2.identity.meta.bar;
+        if (data.profile2.identity.meta.foo === null) {
+          entity.profile2.identity.meta.foo = null;
+        } else if (typeof data.profile2.identity.meta.foo !== 'undefined') {
+          entity.profile2.identity.meta.foo = data.profile2.identity.meta.foo;
+        }
+        if (data.profile2.identity.meta.bar === null) {
+          entity.profile2.identity.meta.bar = null;
+        } else if (typeof data.profile2.identity.meta.bar !== 'undefined') {
+          entity.profile2.identity.meta.bar = data.profile2.identity.meta.bar;
+        }
         if (data.profile2.identity.meta.source === null) {
     entity.profile2.identity.meta.source = null;
         } else if (typeof data.profile2.identity.meta.source !== 'undefined') {
@@ -757,66 +961,89 @@ exports[`embedded entities in postgres diffing 2`] = `
       }
       if (Array.isArray(data.profile2.identity.links)) {
         entity.profile2.identity.links = [];
-        data.profile2.identity.links.forEach((_, idx_8) => {
-          if (data.profile2.identity.links[idx_8] != null) {
-            if (entity.profile2.identity.links[idx_8] == null) {
-              entity.profile2.identity.links[idx_8] = factory.createEmbeddable('IdentityLink', data.profile2.identity.links[idx_8], { newEntity, convertCustomTypes });
+        data.profile2.identity.links.forEach((_, idx_60) => {
+          if (data.profile2.identity.links[idx_60] != null) {
+            if (entity.profile2.identity.links[idx_60] == null) {
+              entity.profile2.identity.links[idx_60] = factory.createEmbeddable('IdentityLink', data.profile2.identity.links[idx_60], { newEntity, convertCustomTypes });
             }
-            if (data.profile2 && data.profile2.identity && data.profile2.identity.links && data.profile2.identity.links[idx_8] && typeof data.profile2.identity.links[idx_8].url !== 'undefined') entity.profile2.identity.links[idx_8].url = data.profile2.identity.links[idx_8].url;
-            if (data.profile2 && data.profile2.identity && data.profile2.identity.links && data.profile2.identity.links[idx_8] && data.profile2.identity.links[idx_8].createdAt) entity.profile2.identity.links[idx_8].createdAt = new Date(data.profile2.identity.links[idx_8].createdAt);
-            else if (data.profile2 && data.profile2.identity && data.profile2.identity.links && data.profile2.identity.links[idx_8] && data.profile2.identity.links[idx_8].createdAt === null) entity.profile2.identity.links[idx_8].createdAt = null;
-            if (data.profile2.identity.links[idx_8].meta != null) {
-              if (entity.profile2.identity.links[idx_8].meta == null) {
-                entity.profile2.identity.links[idx_8].meta = factory.createEmbeddable('IdentityMeta', data.profile2.identity.links[idx_8].meta, { newEntity, convertCustomTypes });
+            if (data.profile2.identity.links[idx_60].url === null) {
+              entity.profile2.identity.links[idx_60].url = null;
+            } else if (typeof data.profile2.identity.links[idx_60].url !== 'undefined') {
+              entity.profile2.identity.links[idx_60].url = data.profile2.identity.links[idx_60].url;
+            }
+            if (data.profile2.identity.links[idx_60].createdAt === null) {
+              entity.profile2.identity.links[idx_60].createdAt = null;
+            } else if (typeof data.profile2.identity.links[idx_60].createdAt !== 'undefined') {
+              entity.profile2.identity.links[idx_60].createdAt = new Date(data.profile2.identity.links[idx_60].createdAt);
+            }
+            if (data.profile2.identity.links[idx_60].meta != null) {
+              if (entity.profile2.identity.links[idx_60].meta == null) {
+                entity.profile2.identity.links[idx_60].meta = factory.createEmbeddable('IdentityMeta', data.profile2.identity.links[idx_60].meta, { newEntity, convertCustomTypes });
               }
-              if (data.profile2 && data.profile2.identity && data.profile2.identity.links && data.profile2.identity.links[idx_8] && data.profile2.identity.links[idx_8].meta && typeof data.profile2.identity.links[idx_8].meta.foo !== 'undefined') entity.profile2.identity.links[idx_8].meta.foo = data.profile2.identity.links[idx_8].meta.foo;
-              if (data.profile2 && data.profile2.identity && data.profile2.identity.links && data.profile2.identity.links[idx_8] && data.profile2.identity.links[idx_8].meta && typeof data.profile2.identity.links[idx_8].meta.bar !== 'undefined') entity.profile2.identity.links[idx_8].meta.bar = data.profile2.identity.links[idx_8].meta.bar;
-              if (data.profile2.identity.links[idx_8].meta.source === null) {
-    entity.profile2.identity.links[idx_8].meta.source = null;
-              } else if (typeof data.profile2.identity.links[idx_8].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile2.identity.links[idx_8].meta.source, true)) {
-                  entity.profile2.identity.links[idx_8].meta.source = factory.createReference('Source', data.profile2.identity.links[idx_8].meta.source, { merge: true, convertCustomTypes, schema });
-                } else if (data.profile2.identity.links[idx_8].meta.source && typeof data.profile2.identity.links[idx_8].meta.source === 'object') {
-                  entity.profile2.identity.links[idx_8].meta.source = factory.create('Source', data.profile2.identity.links[idx_8].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+              if (data.profile2.identity.links[idx_60].meta.foo === null) {
+                entity.profile2.identity.links[idx_60].meta.foo = null;
+              } else if (typeof data.profile2.identity.links[idx_60].meta.foo !== 'undefined') {
+                entity.profile2.identity.links[idx_60].meta.foo = data.profile2.identity.links[idx_60].meta.foo;
+              }
+              if (data.profile2.identity.links[idx_60].meta.bar === null) {
+                entity.profile2.identity.links[idx_60].meta.bar = null;
+              } else if (typeof data.profile2.identity.links[idx_60].meta.bar !== 'undefined') {
+                entity.profile2.identity.links[idx_60].meta.bar = data.profile2.identity.links[idx_60].meta.bar;
+              }
+              if (data.profile2.identity.links[idx_60].meta.source === null) {
+    entity.profile2.identity.links[idx_60].meta.source = null;
+              } else if (typeof data.profile2.identity.links[idx_60].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile2.identity.links[idx_60].meta.source, true)) {
+                  entity.profile2.identity.links[idx_60].meta.source = factory.createReference('Source', data.profile2.identity.links[idx_60].meta.source, { merge: true, convertCustomTypes, schema });
+                } else if (data.profile2.identity.links[idx_60].meta.source && typeof data.profile2.identity.links[idx_60].meta.source === 'object') {
+                  entity.profile2.identity.links[idx_60].meta.source = factory.create('Source', data.profile2.identity.links[idx_60].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                 }
               }
-            } else if (data.profile2.identity.links[idx_8].meta === null) {
-              entity.profile2.identity.links[idx_8].meta = null;
+            } else if (data.profile2.identity.links[idx_60].meta === null) {
+              entity.profile2.identity.links[idx_60].meta = null;
             }
-            if (Array.isArray(data.profile2.identity.links[idx_8].metas)) {
-              entity.profile2.identity.links[idx_8].metas = [];
-              data.profile2.identity.links[idx_8].metas.forEach((_, idx_9) => {
-                if (data.profile2.identity.links[idx_8].metas[idx_9] != null) {
-                  if (entity.profile2.identity.links[idx_8].metas[idx_9] == null) {
-                    entity.profile2.identity.links[idx_8].metas[idx_9] = factory.createEmbeddable('IdentityMeta', data.profile2.identity.links[idx_8].metas[idx_9], { newEntity, convertCustomTypes });
+            if (Array.isArray(data.profile2.identity.links[idx_60].metas)) {
+              entity.profile2.identity.links[idx_60].metas = [];
+              data.profile2.identity.links[idx_60].metas.forEach((_, idx_65) => {
+                if (data.profile2.identity.links[idx_60].metas[idx_65] != null) {
+                  if (entity.profile2.identity.links[idx_60].metas[idx_65] == null) {
+                    entity.profile2.identity.links[idx_60].metas[idx_65] = factory.createEmbeddable('IdentityMeta', data.profile2.identity.links[idx_60].metas[idx_65], { newEntity, convertCustomTypes });
                   }
-                  if (data.profile2 && data.profile2.identity && data.profile2.identity.links && data.profile2.identity.links[idx_8] && data.profile2.identity.links[idx_8].metas && data.profile2.identity.links[idx_8].metas[idx_9] && typeof data.profile2.identity.links[idx_8].metas[idx_9].foo !== 'undefined') entity.profile2.identity.links[idx_8].metas[idx_9].foo = data.profile2.identity.links[idx_8].metas[idx_9].foo;
-                  if (data.profile2 && data.profile2.identity && data.profile2.identity.links && data.profile2.identity.links[idx_8] && data.profile2.identity.links[idx_8].metas && data.profile2.identity.links[idx_8].metas[idx_9] && typeof data.profile2.identity.links[idx_8].metas[idx_9].bar !== 'undefined') entity.profile2.identity.links[idx_8].metas[idx_9].bar = data.profile2.identity.links[idx_8].metas[idx_9].bar;
-                  if (data.profile2.identity.links[idx_8].metas[idx_9].source === null) {
-    entity.profile2.identity.links[idx_8].metas[idx_9].source = null;
-                  } else if (typeof data.profile2.identity.links[idx_8].metas[idx_9].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile2.identity.links[idx_8].metas[idx_9].source, true)) {
-                      entity.profile2.identity.links[idx_8].metas[idx_9].source = factory.createReference('Source', data.profile2.identity.links[idx_8].metas[idx_9].source, { merge: true, convertCustomTypes, schema });
-                    } else if (data.profile2.identity.links[idx_8].metas[idx_9].source && typeof data.profile2.identity.links[idx_8].metas[idx_9].source === 'object') {
-                      entity.profile2.identity.links[idx_8].metas[idx_9].source = factory.create('Source', data.profile2.identity.links[idx_8].metas[idx_9].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  if (data.profile2.identity.links[idx_60].metas[idx_65].foo === null) {
+                    entity.profile2.identity.links[idx_60].metas[idx_65].foo = null;
+                  } else if (typeof data.profile2.identity.links[idx_60].metas[idx_65].foo !== 'undefined') {
+                    entity.profile2.identity.links[idx_60].metas[idx_65].foo = data.profile2.identity.links[idx_60].metas[idx_65].foo;
+                  }
+                  if (data.profile2.identity.links[idx_60].metas[idx_65].bar === null) {
+                    entity.profile2.identity.links[idx_60].metas[idx_65].bar = null;
+                  } else if (typeof data.profile2.identity.links[idx_60].metas[idx_65].bar !== 'undefined') {
+                    entity.profile2.identity.links[idx_60].metas[idx_65].bar = data.profile2.identity.links[idx_60].metas[idx_65].bar;
+                  }
+                  if (data.profile2.identity.links[idx_60].metas[idx_65].source === null) {
+    entity.profile2.identity.links[idx_60].metas[idx_65].source = null;
+                  } else if (typeof data.profile2.identity.links[idx_60].metas[idx_65].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile2.identity.links[idx_60].metas[idx_65].source, true)) {
+                      entity.profile2.identity.links[idx_60].metas[idx_65].source = factory.createReference('Source', data.profile2.identity.links[idx_60].metas[idx_65].source, { merge: true, convertCustomTypes, schema });
+                    } else if (data.profile2.identity.links[idx_60].metas[idx_65].source && typeof data.profile2.identity.links[idx_60].metas[idx_65].source === 'object') {
+                      entity.profile2.identity.links[idx_60].metas[idx_65].source = factory.create('Source', data.profile2.identity.links[idx_60].metas[idx_65].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
                     }
                   }
-                } else if (data.profile2.identity.links[idx_8].metas[idx_9] === null) {
-                  entity.profile2.identity.links[idx_8].metas[idx_9] = null;
+                } else if (data.profile2.identity.links[idx_60].metas[idx_65] === null) {
+                  entity.profile2.identity.links[idx_60].metas[idx_65] = null;
                 }
               });
             }
-            if (data.profile2.identity.links[idx_8].source === null) {
-    entity.profile2.identity.links[idx_8].source = null;
-            } else if (typeof data.profile2.identity.links[idx_8].source !== 'undefined') {
-              if (isPrimaryKey(data.profile2.identity.links[idx_8].source, true)) {
-                entity.profile2.identity.links[idx_8].source = factory.createReference('Source', data.profile2.identity.links[idx_8].source, { merge: true, convertCustomTypes, schema });
-              } else if (data.profile2.identity.links[idx_8].source && typeof data.profile2.identity.links[idx_8].source === 'object') {
-                entity.profile2.identity.links[idx_8].source = factory.create('Source', data.profile2.identity.links[idx_8].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            if (data.profile2.identity.links[idx_60].source === null) {
+    entity.profile2.identity.links[idx_60].source = null;
+            } else if (typeof data.profile2.identity.links[idx_60].source !== 'undefined') {
+              if (isPrimaryKey(data.profile2.identity.links[idx_60].source, true)) {
+                entity.profile2.identity.links[idx_60].source = factory.createReference('Source', data.profile2.identity.links[idx_60].source, { merge: true, convertCustomTypes, schema });
+              } else if (data.profile2.identity.links[idx_60].source && typeof data.profile2.identity.links[idx_60].source === 'object') {
+                entity.profile2.identity.links[idx_60].source = factory.create('Source', data.profile2.identity.links[idx_60].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
               }
             }
-          } else if (data.profile2.identity.links[idx_8] === null) {
-            entity.profile2.identity.links[idx_8] = null;
+          } else if (data.profile2.identity.links[idx_60] === null) {
+            entity.profile2.identity.links[idx_60] = null;
           }
         });
       }

--- a/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
@@ -2,8 +2,16 @@
 
 exports[`polymorphic embeddables in sqlite diffing 1`] = `
 "function(entity, data, factory, newEntity, convertCustomTypes, schema) {
-  if (typeof data.id !== 'undefined') entity.id = data.id;
-  if (typeof data.name !== 'undefined') entity.name = data.name;
+  if (data.id === null) {
+    entity.id = null;
+  } else if (typeof data.id !== 'undefined') {
+    entity.id = data.id;
+  }
+  if (data.name === null) {
+    entity.name = null;
+  } else if (typeof data.name !== 'undefined') {
+    entity.name = data.name;
+  }
   if (data.pet_canBark !== undefined || data.pet_type !== undefined || data.pet_name !== undefined || data.pet_canMeow !== undefined) {
     if (data.pet_type == '1' && entity.pet == null) {
       entity.pet = factory.createEmbeddable('Dog', data, { newEntity, convertCustomTypes });
@@ -11,10 +19,26 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
     if (data.pet_type == '0' && entity.pet == null) {
       entity.pet = factory.createEmbeddable('Cat', data, { newEntity, convertCustomTypes });
     }
-    if (typeof data.pet_canBark !== 'undefined') entity.pet.canBark = data.pet_canBark === null ? null : !!data.pet_canBark;
-    if (typeof data.pet_type !== 'undefined') entity.pet.type = data.pet_type;
-    if (typeof data.pet_name !== 'undefined') entity.pet.name = data.pet_name;
-    if (typeof data.pet_canMeow !== 'undefined') entity.pet.canMeow = data.pet_canMeow === null ? null : !!data.pet_canMeow;
+    if (data.pet_canBark === null) {
+      entity.pet.canBark = null;
+    } else if (typeof data.pet_canBark !== 'undefined') {
+      entity.pet.canBark = data.pet_canBark === null ? null : !!data.pet_canBark;
+    }
+    if (data.pet_type === null) {
+      entity.pet.type = null;
+    } else if (typeof data.pet_type !== 'undefined') {
+      entity.pet.type = data.pet_type;
+    }
+    if (data.pet_name === null) {
+      entity.pet.name = null;
+    } else if (typeof data.pet_name !== 'undefined') {
+      entity.pet.name = data.pet_name;
+    }
+    if (data.pet_canMeow === null) {
+      entity.pet.canMeow = null;
+    } else if (typeof data.pet_canMeow !== 'undefined') {
+      entity.pet.canMeow = data.pet_canMeow === null ? null : !!data.pet_canMeow;
+    }
   } else if (data.pet === null) {
     entity.pet = null;
   }
@@ -28,10 +52,26 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
     if (data.pet.type == '0' && entity.pet == null) {
       entity.pet = factory.createEmbeddable('Cat', data.pet, { newEntity, convertCustomTypes });
     }
-    if (data.pet && typeof data.pet.canBark !== 'undefined') entity.pet.canBark = data.pet.canBark === null ? null : !!data.pet.canBark;
-    if (data.pet && typeof data.pet.type !== 'undefined') entity.pet.type = data.pet.type;
-    if (data.pet && typeof data.pet.name !== 'undefined') entity.pet.name = data.pet.name;
-    if (data.pet && typeof data.pet.canMeow !== 'undefined') entity.pet.canMeow = data.pet.canMeow === null ? null : !!data.pet.canMeow;
+    if (data.pet.canBark === null) {
+      entity.pet.canBark = null;
+    } else if (typeof data.pet.canBark !== 'undefined') {
+      entity.pet.canBark = data.pet.canBark === null ? null : !!data.pet.canBark;
+    }
+    if (data.pet.type === null) {
+      entity.pet.type = null;
+    } else if (typeof data.pet.type !== 'undefined') {
+      entity.pet.type = data.pet.type;
+    }
+    if (data.pet.name === null) {
+      entity.pet.name = null;
+    } else if (typeof data.pet.name !== 'undefined') {
+      entity.pet.name = data.pet.name;
+    }
+    if (data.pet.canMeow === null) {
+      entity.pet.canMeow = null;
+    } else if (typeof data.pet.canMeow !== 'undefined') {
+      entity.pet.canMeow = data.pet.canMeow === null ? null : !!data.pet.canMeow;
+    }
   } else if (data.pet === null) {
     entity.pet = null;
   }
@@ -45,10 +85,26 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
     if (data.pet2.type == '0' && entity.pet2 == null) {
       entity.pet2 = factory.createEmbeddable('Cat', data.pet2, { newEntity, convertCustomTypes });
     }
-    if (data.pet2 && typeof data.pet2.canBark !== 'undefined') entity.pet2.canBark = data.pet2.canBark === null ? null : !!data.pet2.canBark;
-    if (data.pet2 && typeof data.pet2.type !== 'undefined') entity.pet2.type = data.pet2.type;
-    if (data.pet2 && typeof data.pet2.name !== 'undefined') entity.pet2.name = data.pet2.name;
-    if (data.pet2 && typeof data.pet2.canMeow !== 'undefined') entity.pet2.canMeow = data.pet2.canMeow === null ? null : !!data.pet2.canMeow;
+    if (data.pet2.canBark === null) {
+      entity.pet2.canBark = null;
+    } else if (typeof data.pet2.canBark !== 'undefined') {
+      entity.pet2.canBark = data.pet2.canBark === null ? null : !!data.pet2.canBark;
+    }
+    if (data.pet2.type === null) {
+      entity.pet2.type = null;
+    } else if (typeof data.pet2.type !== 'undefined') {
+      entity.pet2.type = data.pet2.type;
+    }
+    if (data.pet2.name === null) {
+      entity.pet2.name = null;
+    } else if (typeof data.pet2.name !== 'undefined') {
+      entity.pet2.name = data.pet2.name;
+    }
+    if (data.pet2.canMeow === null) {
+      entity.pet2.canMeow = null;
+    } else if (typeof data.pet2.canMeow !== 'undefined') {
+      entity.pet2.canMeow = data.pet2.canMeow === null ? null : !!data.pet2.canMeow;
+    }
   } else if (data.pet2 === null) {
     entity.pet2 = null;
   }
@@ -57,23 +113,39 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
   }
   if (Array.isArray(data.pets)) {
     entity.pets = [];
-    data.pets.forEach((_, idx_0) => {
-      if (typeof data.pets[idx_0] === 'string') {
-        data.pets[idx_0] = parseJsonSafe(data.pets[idx_0]);
+    data.pets.forEach((_, idx_14) => {
+      if (typeof data.pets[idx_14] === 'string') {
+        data.pets[idx_14] = parseJsonSafe(data.pets[idx_14]);
       }
-      if (data.pets[idx_0] != null) {
-        if (data.pets[idx_0].type == '1' && entity.pets[idx_0] == null) {
-          entity.pets[idx_0] = factory.createEmbeddable('Dog', data.pets[idx_0], { newEntity, convertCustomTypes });
+      if (data.pets[idx_14] != null) {
+        if (data.pets[idx_14].type == '1' && entity.pets[idx_14] == null) {
+          entity.pets[idx_14] = factory.createEmbeddable('Dog', data.pets[idx_14], { newEntity, convertCustomTypes });
         }
-        if (data.pets[idx_0].type == '0' && entity.pets[idx_0] == null) {
-          entity.pets[idx_0] = factory.createEmbeddable('Cat', data.pets[idx_0], { newEntity, convertCustomTypes });
+        if (data.pets[idx_14].type == '0' && entity.pets[idx_14] == null) {
+          entity.pets[idx_14] = factory.createEmbeddable('Cat', data.pets[idx_14], { newEntity, convertCustomTypes });
         }
-        if (data.pets && data.pets[idx_0] && typeof data.pets[idx_0].canBark !== 'undefined') entity.pets[idx_0].canBark = data.pets[idx_0].canBark === null ? null : !!data.pets[idx_0].canBark;
-        if (data.pets && data.pets[idx_0] && typeof data.pets[idx_0].type !== 'undefined') entity.pets[idx_0].type = data.pets[idx_0].type;
-        if (data.pets && data.pets[idx_0] && typeof data.pets[idx_0].name !== 'undefined') entity.pets[idx_0].name = data.pets[idx_0].name;
-        if (data.pets && data.pets[idx_0] && typeof data.pets[idx_0].canMeow !== 'undefined') entity.pets[idx_0].canMeow = data.pets[idx_0].canMeow === null ? null : !!data.pets[idx_0].canMeow;
-      } else if (data.pets[idx_0] === null) {
-        entity.pets[idx_0] = null;
+        if (data.pets[idx_14].canBark === null) {
+          entity.pets[idx_14].canBark = null;
+        } else if (typeof data.pets[idx_14].canBark !== 'undefined') {
+          entity.pets[idx_14].canBark = data.pets[idx_14].canBark === null ? null : !!data.pets[idx_14].canBark;
+        }
+        if (data.pets[idx_14].type === null) {
+          entity.pets[idx_14].type = null;
+        } else if (typeof data.pets[idx_14].type !== 'undefined') {
+          entity.pets[idx_14].type = data.pets[idx_14].type;
+        }
+        if (data.pets[idx_14].name === null) {
+          entity.pets[idx_14].name = null;
+        } else if (typeof data.pets[idx_14].name !== 'undefined') {
+          entity.pets[idx_14].name = data.pets[idx_14].name;
+        }
+        if (data.pets[idx_14].canMeow === null) {
+          entity.pets[idx_14].canMeow = null;
+        } else if (typeof data.pets[idx_14].canMeow !== 'undefined') {
+          entity.pets[idx_14].canMeow = data.pets[idx_14].canMeow === null ? null : !!data.pets[idx_14].canMeow;
+        }
+      } else if (data.pets[idx_14] === null) {
+        entity.pets[idx_14] = null;
       }
     });
   }

--- a/tests/features/lazy-scalar-properties/lazy-scalar-properties.mysql.test.ts
+++ b/tests/features/lazy-scalar-properties/lazy-scalar-properties.mysql.test.ts
@@ -1,4 +1,5 @@
 import type { MikroORM } from '@mikro-orm/core';
+import { ref, wrap } from '@mikro-orm/core';
 import { MySqlDriver } from '@mikro-orm/mysql';
 import { initORMMySql, mockLogger } from '../../bootstrap';
 import { Author2, Book2 } from '../../entities-sql';
@@ -12,26 +13,29 @@ describe('lazy scalar properties (mysql)', () => {
 
   test('lazy scalar properties', async () => {
     const book = new Book2('b', new Author2('n', 'e'));
-    book.perex = '123';
+    book.perex = ref('123');
     await orm.em.persistAndFlush(book);
     orm.em.clear();
 
     const mock = mockLogger(orm, ['query']);
 
     const r1 = await orm.em.find(Author2, {}, { populate: ['books'] });
-    expect(r1[0].books[0].perex).not.toBe('123');
-    expect(mock.mock.calls).toHaveLength(2);
+    expect(r1[0].books[0].perex?.unwrap()).not.toBe('123');
+    await wrap(r1[0]).populate(['books.perex']);
+    expect(r1[0].books[0].perex?.unwrap()).toBe('123');
+    expect(mock.mock.calls).toHaveLength(3);
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `a1`.`author_id` as `address_author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id`');
     expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `test_id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`author_id` in (?) ' +
       'order by `b0`.`title` asc');
+    expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`perex` from `book2` as `b0` where `b0`.`author_id` is not null and `b0`.`uuid_pk` in (?)');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     const r2 = await orm.em.find(Author2, {}, { populate: ['books.perex'] });
-    expect(r2[0].books[0].perex).toBe('123');
+    expect(r2[0].books[0].perex?.get()).toBe('123');
     expect(mock.mock.calls).toHaveLength(2);
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `a1`.`author_id` as `address_author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id`');
     expect(mock.mock.calls[1][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `test_id` ' +
@@ -43,19 +47,21 @@ describe('lazy scalar properties (mysql)', () => {
     orm.em.clear();
     mock.mock.calls.length = 0;
     const r3 = await orm.em.findOne(Author2, book.author, { populate: ['books'] });
-    expect(r3!.books[0].perex).not.toBe('123');
-    expect(mock.mock.calls).toHaveLength(2);
+    expect(r3!.books[0].perex?.unwrap()).not.toBe('123');
+    await expect(r3!.books[0].perex?.load()).resolves.toBe('123');
+    expect(mock.mock.calls).toHaveLength(3);
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `a1`.`author_id` as `address_author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id`');
     expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `test_id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`author_id` in (?) ' +
       'order by `b0`.`title` asc');
+    expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`perex` from `book2` as `b0` where `b0`.`author_id` is not null and `b0`.`uuid_pk` in (?)');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     const r4 = await orm.em.findOne(Author2, book.author, { populate: ['books.perex'] });
-    expect(r4!.books[0].perex).toBe('123');
+    expect(r4!.books[0].perex?.$).toBe('123');
     expect(mock.mock.calls).toHaveLength(2);
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `a1`.`author_id` as `address_author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id`');
     expect(mock.mock.calls[1][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `test_id` ' +
@@ -67,7 +73,7 @@ describe('lazy scalar properties (mysql)', () => {
 
   test('em.populate() respects lazy scalar properties', async () => {
     const book = new Book2('b', new Author2('n', 'e'));
-    book.perex = '123';
+    book.perex = ref('123');
     await orm.em.persistAndFlush(book);
     orm.em.clear();
 
@@ -75,9 +81,9 @@ describe('lazy scalar properties (mysql)', () => {
 
     const r1 = await orm.em.find(Author2, {});
     await orm.em.populate(r1, ['books']);
-    expect(r1[0].books[0].perex).not.toBe('123');
+    expect(r1[0].books[0].perex?.unwrap()).not.toBe('123');
     await orm.em.populate(r1, ['books.perex']);
-    expect(r1[0].books[0].perex).toBe('123');
+    expect(r1[0].books[0].perex?.unwrap()).toBe('123');
 
     expect(mock.mock.calls).toHaveLength(3);
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `a1`.`author_id` as `address_author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id`');


### PR DESCRIPTION
### `ScalarReference` wrapper

Similarly to the `Reference` wrapper, we can also wrap scalars with `Ref` into a `ScalarReference` object. This is handy for lazy scalar properties.

```ts
@Property({ lazy: true, ref: true })
passwordHash!: Ref<string>;
```

The `Ref` type automatically resolves to `ScalarReference` for non-object types. You can use it explicitly if you want to wrap an object scalar property (e.g. JSON value).

```ts
const user = await em.findOne(User, 1);
const passwordHash = await user.passwordHash.load();
```