### PR TITLE
fix(core): refactor mapping of `Date` properties

### DIFF
--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -359,3 +359,9 @@ const dtos = serialize([user1, user, ...], { exclude: ['id', 'email'], forceObje
 const [dto1] = serialize(user, { exclude: ['id', 'email'], forceObject: true });
 const dto2 = wrap(user).serialize({ exclude: ['id', 'email'], forceObject: true });
 ```
+
+## Changes in `Date` property mapping 
+
+Previously, mapping of datetime columns to JS `Date` objects was dependent on the driver, while SQLite didn't have this out of box support and required manual conversion on various places. All drivers now have disabled `Date` conversion and this is now handled explicitly, in the same way for all of them.
+
+Moreover, the `date` type was previously seen as a `datetime`, while now only `Date` (with uppercase `D`) will be considered as `datetime`, while `date` is just a `date`.

--- a/packages/better-sqlite/src/BetterSqlitePlatform.ts
+++ b/packages/better-sqlite/src/BetterSqlitePlatform.ts
@@ -82,7 +82,7 @@ export class BetterSqlitePlatform extends AbstractSqlPlatform {
   }
 
   override quoteVersionValue(value: Date | number, prop: EntityProperty): Date | string | number {
-    if (prop.type.toLowerCase() === 'date') {
+    if (prop.runtimeType === 'Date') {
       return escape(value, true, this.timezone).replace(/^'|\.\d{3}'$/g, '');
     }
 

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1137,7 +1137,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     Object.keys(data).forEach(k => {
       const prop = meta.properties[k];
 
-      if (prop && prop.kind === ReferenceKind.SCALAR && SCALAR_TYPES.includes(prop.type.toLowerCase()) && (prop.setter || !prop.getter)) {
+      if (prop && prop.kind === ReferenceKind.SCALAR && SCALAR_TYPES.includes(prop.runtimeType) && (prop.setter || !prop.getter)) {
         data[k] = this.validator.validateProperty(prop, data[k], data);
       }
     });

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -105,11 +105,11 @@ export class EntityAssigner {
       return EntityAssigner.assignReference<T>(entity, value, prop, options.em, options);
     }
 
-    if (prop?.kind === ReferenceKind.SCALAR && SCALAR_TYPES.includes(prop.type.toLowerCase()) && (prop.setter || !prop.getter)) {
+    if (prop.kind === ReferenceKind.SCALAR && SCALAR_TYPES.includes(prop.runtimeType) && (prop.setter || !prop.getter)) {
       return entity[propName as keyof T] = validator.validateProperty(prop, value, entity);
     }
 
-    if (prop?.kind === ReferenceKind.EMBEDDED && EntityAssigner.validateEM(options.em)) {
+    if (prop.kind === ReferenceKind.EMBEDDED && EntityAssigner.validateEM(options.em)) {
       return EntityAssigner.assignEmbeddable(entity, value, prop, options.em, options);
     }
 

--- a/packages/core/src/entity/EntityValidator.ts
+++ b/packages/core/src/entity/EntityValidator.ts
@@ -18,9 +18,9 @@ export class EntityValidator {
         this.validateCollection(entity, prop);
       }
 
-      const SCALAR_TYPES = ['string', 'number', 'boolean', 'date'];
+      const SCALAR_TYPES = ['string', 'number', 'boolean', 'Date'];
 
-      if (prop.kind !== ReferenceKind.SCALAR || !SCALAR_TYPES.includes(prop.type.toLowerCase())) {
+      if (prop.kind !== ReferenceKind.SCALAR || !SCALAR_TYPES.includes(prop.type)) {
         return;
       }
 
@@ -66,7 +66,7 @@ export class EntityValidator {
       return givenValue;
     }
 
-    const expectedType = prop.type.toLowerCase();
+    const expectedType = prop.runtimeType;
     let givenType = Utils.getObjectType(givenValue);
     let ret = givenValue;
 
@@ -136,7 +136,7 @@ export class EntityValidator {
   }
 
   private fixTypes(expectedType: string, givenType: string, givenValue: any): any {
-    if (expectedType === 'date' && ['string', 'number'].includes(givenType)) {
+    if (expectedType === 'Date' && ['string', 'number'].includes(givenType)) {
       givenValue = this.fixDateType(givenValue);
     }
 

--- a/packages/core/src/enums.ts
+++ b/packages/core/src/enums.ts
@@ -96,7 +96,7 @@ export enum QueryFlag {
   AUTO_JOIN_ONE_TO_ONE_OWNER = 'AUTO_JOIN_ONE_TO_ONE_OWNER',
 }
 
-export const SCALAR_TYPES = ['string', 'number', 'boolean', 'date', 'buffer', 'regexp'];
+export const SCALAR_TYPES = ['string', 'number', 'boolean', 'Date', 'Buffer', 'RegExp'];
 
 export enum ReferenceKind {
   SCALAR = 'scalar',

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1007,8 +1007,7 @@ export class MetadataDiscovery {
 
       // but still use object values for type inference if not explicitly set, e.g. `createdAt = new Date()`
       if (prop.kind === ReferenceKind.SCALAR && prop.type == null && entity1[prop.name] != null) {
-        const type = Utils.getObjectType(entity1[prop.name]);
-        prop.type = type === 'object' ? 'string' : type;
+        prop.type = Utils.getObjectType(entity1[prop.name]);
       }
     } catch {
       // ignore
@@ -1080,8 +1079,17 @@ export class MetadataDiscovery {
       prop.customType = new JsonType();
     }
 
-    if (!prop.customType && this.getMappedType(prop) instanceof BigIntType) {
+    const mappedType = this.getMappedType(prop);
+
+    if (!prop.customType && mappedType instanceof BigIntType) {
       prop.customType = new BigIntType();
+    }
+
+    if (prop.customType && !prop.columnTypes) {
+      const mappedType = this.getMappedType({ columnTypes: [prop.customType.getColumnType(prop, this.platform)] } as EntityProperty);
+      prop.runtimeType ??= mappedType.runtimeType as typeof prop.runtimeType;
+    } else {
+      prop.runtimeType ??= mappedType.runtimeType as typeof prop.runtimeType;
     }
 
     if (prop.customType) {
@@ -1094,11 +1102,10 @@ export class MetadataDiscovery {
     }
 
     if (Type.isMappedType(prop.customType) && prop.kind === ReferenceKind.SCALAR && !prop.type?.toString().endsWith('[]')) {
-      prop.type = prop.customType.constructor.name;
+      prop.type = prop.customType.name;
     }
 
     if (prop.kind === ReferenceKind.SCALAR) {
-      const mappedType = this.getMappedType(prop);
       prop.columnTypes ??= [mappedType.getColumnType(prop, this.platform)];
 
       // use only custom types provided by user, we don't need to use the ones provided by ORM,
@@ -1165,7 +1172,11 @@ export class MetadataDiscovery {
   }
 
   private getMappedType(prop: EntityProperty): Type<unknown> {
-    let t = prop.columnTypes?.[0] ?? prop.type.toLowerCase();
+    if (prop.customType) {
+      return prop.customType;
+    }
+
+    let t = prop.columnTypes?.[0] ?? prop.type;
 
     if (prop.nativeEnumName) {
       t = 'enum';
@@ -1173,11 +1184,11 @@ export class MetadataDiscovery {
       t = prop.items?.every(item => Utils.isString(item)) ? 'enum' : 'tinyint';
     }
 
-    if (t === 'date') {
+    if (t === 'Date') {
       t = 'datetime';
     }
 
-    return prop.customType ?? this.platform.getMappedType(t);
+    return this.platform.getMappedType(t);
   }
 
   private initUnsigned(prop: EntityProperty): void {

--- a/packages/core/src/metadata/MetadataValidator.ts
+++ b/packages/core/src/metadata/MetadataValidator.ts
@@ -222,9 +222,9 @@ export class MetadataValidator {
     }
 
     const prop = meta.properties[meta.versionProperty];
-    const type = prop.type.toLowerCase();
+    const type = prop.runtimeType ?? prop.columnTypes?.[0] ?? prop.type;
 
-    if (type !== 'number' && type !== 'date' && !type.startsWith('timestamp') && !type.startsWith('datetime')) {
+    if (type !== 'number' && type !== 'Date' && !type.startsWith('timestamp') && !type.startsWith('datetime')) {
       throw MetadataError.invalidVersionFieldType(meta);
     }
   }

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -398,6 +398,10 @@ export abstract class Platform {
     return this.config;
   }
 
+  getTimezone() {
+    return this.timezone;
+  }
+
   isNumericColumn(mappedType: Type<unknown>): boolean {
     return [IntegerType, SmallIntType, BigIntType].some(t => mappedType instanceof t);
   }

--- a/packages/core/src/types/ArrayType.ts
+++ b/packages/core/src/types/ArrayType.ts
@@ -11,7 +11,7 @@ export class ArrayType<T extends string | number = string> extends Type<T[] | nu
     super();
   }
 
-  override convertToDatabaseValue(value: T[] | null, platform: Platform, context?: TransformContext | boolean): string | null {
+  override convertToDatabaseValue(value: T[] | null, platform: Platform, context?: TransformContext): string | null {
     if (!value) {
       return value as null;
     }
@@ -21,7 +21,7 @@ export class ArrayType<T extends string | number = string> extends Type<T[] | nu
     }
 
     /* istanbul ignore next */
-    if (typeof context === 'boolean' ? context : context?.fromQuery) {
+    if (context?.fromQuery) {
       return value;
     }
 

--- a/packages/core/src/types/EnumArrayType.ts
+++ b/packages/core/src/types/EnumArrayType.ts
@@ -20,7 +20,7 @@ export class EnumArrayType<T extends string | number = string> extends ArrayType
     super(mapHydrator(items, hydrate));
   }
 
-  override convertToDatabaseValue(value: T[] | null, platform: Platform, context: TransformContext | boolean): string | null {
+  override convertToDatabaseValue(value: T[] | null, platform: Platform, context?: TransformContext): string | null {
     /* istanbul ignore else */
     if (Array.isArray(value) && Array.isArray(this.items)) {
       const invalid = value.filter(v => !this.items!.includes(v));

--- a/packages/core/src/types/JsonType.ts
+++ b/packages/core/src/types/JsonType.ts
@@ -33,4 +33,12 @@ export class JsonType extends Type<unknown, string | null> {
     return !prop.embedded || !meta.properties[prop.embedded[0]].object;
   }
 
+  override compareAsType(): string {
+    return 'any';
+  }
+
+  override get runtimeType(): string {
+    return 'object';
+  }
+
 }

--- a/packages/core/src/types/Type.ts
+++ b/packages/core/src/types/Type.ts
@@ -19,7 +19,7 @@ export abstract class Type<JSType = string, DBType = JSType> {
   /**
    * Converts a value from its JS representation to its database representation of this type.
    */
-  convertToDatabaseValue(value: JSType | DBType, platform: Platform, context?: TransformContext | boolean): DBType {
+  convertToDatabaseValue(value: JSType | DBType, platform: Platform, context?: TransformContext): DBType {
     return value as DBType;
   }
 
@@ -46,6 +46,15 @@ export abstract class Type<JSType = string, DBType = JSType> {
    */
   compareAsType(): string {
     return 'any';
+  }
+
+  get runtimeType(): string {
+    const compareType = this.compareAsType();
+    return compareType === 'any' ? 'string' : compareType;
+  }
+
+  get name(): string {
+    return this.constructor.name;
   }
 
   /**

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -270,6 +270,7 @@ export interface EntityProperty<Owner = any, Target = any> {
   name: EntityKey<Owner>;
   entity: () => EntityName<Owner>;
   type: keyof typeof types | AnyString;
+  runtimeType: 'number' | 'string' | 'boolean' | 'bigint' | 'Buffer' | 'Date';
   targetMeta?: EntityMetadata<Target>;
   columnTypes: string[];
   customType: Type<any>;

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -14,6 +14,7 @@ import { ReferenceKind } from '../enums';
 export class ChangeSetPersister {
 
   private readonly platform = this.driver.getPlatform();
+  private readonly comparator = this.config.getComparator(this.metadata);
 
   constructor(private readonly driver: IDatabaseDriver,
               private readonly metadata: MetadataStorage,
@@ -422,18 +423,9 @@ export class ChangeSetPersister {
    */
   mapReturnedValues<T extends object>(entity: T, payload: EntityDictionary<T>, row: Dictionary | undefined, meta: EntityMetadata<T>): void {
     if (this.platform.usesReturningStatement() && row && Utils.hasObjectKeys(row)) {
-      const data = meta.props.reduce((ret, prop) => {
-        if (prop.fieldNames && row[prop.fieldNames[0]] != null && (entity[prop.name] == null || Utils.isRawSql(entity[prop.name]))) {
-          ret[prop.name] = row[prop.fieldNames[0]];
-        }
-
-        return ret;
-      }, {} as Dictionary);
-
-      if (Utils.hasObjectKeys(data)) {
-        this.hydrator.hydrate(entity, meta, data as EntityData<T>, this.factory, 'full', false, true);
-        Object.assign(payload, data); // merge to the changeset payload, so it gets saved to the entity snapshot
-      }
+      const mapped = this.comparator.mapResult<T>(meta.className, row as EntityDictionary<T>);
+      this.hydrator.hydrate(entity, meta, mapped, this.factory, 'full', false, true);
+      Object.assign(payload, mapped); // merge to the changeset payload, so it gets saved to the entity snapshot
     }
   }
 

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -727,8 +727,20 @@ export class Utils {
    * Gets the type of the argument.
    */
   static getObjectType(value: any): string {
+    const simple = typeof value;
+
+    if (['string', 'number', 'boolean', 'bigint'].includes(simple)) {
+      return simple;
+    }
+
     const objectType = Object.prototype.toString.call(value);
-    return objectType.match(/\[object (\w+)]/)![1].toLowerCase();
+    const type = objectType.match(/\[object (\w+)]/)![1];
+
+    if (type === 'Uint8Array') {
+      return 'Buffer';
+    }
+
+    return ['Date', 'Buffer', 'RegExp'].includes(type) ? type : type.toLowerCase();
   }
 
   /**

--- a/packages/entity-generator/src/SourceFile.ts
+++ b/packages/entity-generator/src/SourceFile.ts
@@ -250,9 +250,9 @@ export class SourceFile {
   }
 
   protected getScalarPropertyDecoratorOptions(options: Dictionary, prop: EntityProperty): void {
-    let t = prop.type.toLowerCase();
+    let t = prop.type;
 
-    if (t === 'date') {
+    if (t === 'Date') {
       t = 'datetime';
     }
 

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -279,12 +279,18 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
         return;
       }
 
+      const tz = this.platform.getTimezone();
+
       meta2.props
         .filter(prop => this.platform.shouldHaveColumn(prop, p.children as any || []))
         .forEach(prop => {
           if (prop.fieldNames.length > 1) { // composite keys
             relationPojo[prop.name] = prop.fieldNames.map(name => root![`${relationAlias}__${name}` as EntityKey<T>]) as EntityValue<T>;
             prop.fieldNames.map(name => delete root![`${relationAlias}__${name}` as EntityKey<T>]);
+          } else if (prop.runtimeType === 'Date') {
+            const alias = `${relationAlias}__${prop.fieldNames[0]}` as EntityKey<T>;
+            relationPojo[prop.name] = (typeof root![alias] === 'string' ? new Date(root![alias] as string) : root![alias]) as EntityValue<T>;
+            delete root![alias];
           } else {
             const alias = `${relationAlias}__${prop.fieldNames[0]}` as EntityKey<T>;
             relationPojo[prop.name] = root![alias];
@@ -560,7 +566,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
       const quotedFieldName = this.platform.quoteIdentifier(versionProperty.fieldNames[0]);
       sql += `${quotedFieldName} = `;
 
-      if (versionProperty.type.toLowerCase() === 'date') {
+      if (versionProperty.runtimeType === 'Date') {
         sql += this.platform.getCurrentTimestampSQL(versionProperty.length);
       } else {
         sql += `${quotedFieldName} + 1`;

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -680,7 +680,7 @@ export class QueryBuilderHelper {
     const versionProperty = meta.properties[meta.versionProperty];
     let sql = this.platform.quoteIdentifier(versionProperty.fieldNames[0]) + ' + 1';
 
-    if (versionProperty.type.toLowerCase() === 'date') {
+    if (versionProperty.runtimeType === 'Date') {
       sql = this.platform.getCurrentTimestampSQL(versionProperty.length);
     }
 

--- a/packages/mariadb/src/MariaDbConnection.ts
+++ b/packages/mariadb/src/MariaDbConnection.ts
@@ -39,6 +39,7 @@ export class MariaDbConnection extends AbstractSqlConnection {
 
     ret.bigNumberStrings = true;
     ret.supportBigNumbers = true;
+    ret.dateStrings = true;
     // @ts-ignore
     ret.checkDuplicate = false;
 

--- a/packages/mysql/src/MySqlConnection.ts
+++ b/packages/mysql/src/MySqlConnection.ts
@@ -47,7 +47,7 @@ export class MySqlConnection extends AbstractSqlConnection {
     }
 
     ret.supportBigNumbers = true;
-    ret.dateStrings = ['DATE'] as any;
+    ret.dateStrings = true;
 
     return ret;
   }

--- a/packages/postgresql/src/PostgreSqlConnection.ts
+++ b/packages/postgresql/src/PostgreSqlConnection.ts
@@ -19,13 +19,8 @@ export class PostgreSqlConnection extends AbstractSqlConnection {
   override getConnectionOptions(): Knex.PgConnectionConfig {
     const ret = super.getConnectionOptions() as Knex.PgConnectionConfig;
     const types = new TypeOverrides();
-    [1082].forEach(oid => types.setTypeParser(oid, str => str)); // date type
+    [1082, 1114, 1184].forEach(oid => types.setTypeParser(oid, str => str)); // date, timestamp, timestamptz type
     ret.types = types as any;
-
-    if (this.config.get('forceUtcTimezone')) {
-      [1114].forEach(oid => types.setTypeParser(oid, str => new Date(str + 'Z'))); // timestamp w/o TZ type
-      ret.parseInputDatesAsUTC = true;
-    }
 
     return ret;
   }

--- a/packages/reflection/src/TsMorphMetadataProvider.ts
+++ b/packages/reflection/src/TsMorphMetadataProvider.ts
@@ -64,6 +64,7 @@ export class TsMorphMetadataProvider extends MetadataProvider {
   private initPropertyType(meta: EntityMetadata, prop: EntityProperty): void {
     const { type, optional } = this.readTypeFromSource(meta, prop);
     prop.type = type;
+    prop.runtimeType = type as 'string';
 
     if (optional) {
       prop.optional = true;

--- a/packages/sqlite/src/SqlitePlatform.ts
+++ b/packages/sqlite/src/SqlitePlatform.ts
@@ -82,7 +82,7 @@ export class SqlitePlatform extends AbstractSqlPlatform {
   }
 
   override quoteVersionValue(value: Date | number, prop: EntityProperty): Date | string | number {
-    if (prop.type.toLowerCase() === 'date') {
+    if (prop.runtimeType === 'Date') {
       return escape(value, true, this.timezone).replace(/^'|\.\d{3}'$/g, '');
     }
 

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -78,7 +78,7 @@ describe('EntityManagerMySql', () => {
       port: 3308,
       user: 'user',
       timezone: 'Z',
-      dateStrings: ['DATE'],
+      dateStrings: true,
       supportBigNumbers: true,
     });
   });

--- a/tests/features/embeddables/GH4360.test.ts
+++ b/tests/features/embeddables/GH4360.test.ts
@@ -1,0 +1,50 @@
+import { Embeddable, Embedded, Entity, PrimaryKey, Property } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/sqlite';
+import { mockLogger } from '../../helpers';
+
+@Embeddable()
+class Animal {
+
+  @Property()
+  birthday!: Date;
+
+}
+
+@Entity()
+class Owner {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Embedded(() => Animal, { array: true })
+  pets!: Animal[];
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Owner],
+    dbName: ':memory:',
+  });
+
+  await orm.schema.refreshDatabase();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('conversion of Date properties in object embeddables', async () => {
+  await orm.em.insert(Owner, {
+    id: 1,
+    pets: [
+      { birthday: new Date() },
+    ],
+  });
+  await orm.em.findOneOrFail(Owner, 1);
+  const mock = mockLogger(orm);
+  await orm.em.flush();
+  expect(mock).not.toBeCalled();
+});

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.mongo.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.mongo.test.ts.snap
@@ -314,7 +314,11 @@ exports[`embedded entities in mongo diffing 2`] = `
             if (data.profile1_identity_links[idx_8].createdAt === null) {
               entity.profile1.identity.links[idx_8].createdAt = null;
             } else if (typeof data.profile1_identity_links[idx_8].createdAt !== 'undefined') {
-              entity.profile1.identity.links[idx_8].createdAt = new Date(data.profile1_identity_links[idx_8].createdAt);
+              if (data.profile1_identity_links[idx_8].createdAt instanceof Date) {
+                entity.profile1.identity.links[idx_8].createdAt = data.profile1_identity_links[idx_8].createdAt;
+              } else {
+                entity.profile1.identity.links[idx_8].createdAt = new Date(data.profile1_identity_links[idx_8].createdAt);
+              }
             }
             if (data.profile1_identity_links[idx_8].meta != null) {
               if (entity.profile1.identity.links[idx_8].meta == null) {
@@ -475,7 +479,11 @@ exports[`embedded entities in mongo diffing 2`] = `
             if (data.profile1_identity.links[idx_21].createdAt === null) {
               entity.profile1.identity.links[idx_21].createdAt = null;
             } else if (typeof data.profile1_identity.links[idx_21].createdAt !== 'undefined') {
-              entity.profile1.identity.links[idx_21].createdAt = new Date(data.profile1_identity.links[idx_21].createdAt);
+              if (data.profile1_identity.links[idx_21].createdAt instanceof Date) {
+                entity.profile1.identity.links[idx_21].createdAt = data.profile1_identity.links[idx_21].createdAt;
+              } else {
+                entity.profile1.identity.links[idx_21].createdAt = new Date(data.profile1_identity.links[idx_21].createdAt);
+              }
             }
             if (data.profile1_identity.links[idx_21].meta != null) {
               if (entity.profile1.identity.links[idx_21].meta == null) {
@@ -657,7 +665,11 @@ exports[`embedded entities in mongo diffing 2`] = `
             if (data.profile1_identity_links[idx_35].createdAt === null) {
               entity.profile1.identity.links[idx_35].createdAt = null;
             } else if (typeof data.profile1_identity_links[idx_35].createdAt !== 'undefined') {
-              entity.profile1.identity.links[idx_35].createdAt = new Date(data.profile1_identity_links[idx_35].createdAt);
+              if (data.profile1_identity_links[idx_35].createdAt instanceof Date) {
+                entity.profile1.identity.links[idx_35].createdAt = data.profile1_identity_links[idx_35].createdAt;
+              } else {
+                entity.profile1.identity.links[idx_35].createdAt = new Date(data.profile1_identity_links[idx_35].createdAt);
+              }
             }
             if (data.profile1_identity_links[idx_35].meta != null) {
               if (entity.profile1.identity.links[idx_35].meta == null) {
@@ -818,7 +830,11 @@ exports[`embedded entities in mongo diffing 2`] = `
             if (data.profile1.identity.links[idx_48].createdAt === null) {
               entity.profile1.identity.links[idx_48].createdAt = null;
             } else if (typeof data.profile1.identity.links[idx_48].createdAt !== 'undefined') {
-              entity.profile1.identity.links[idx_48].createdAt = new Date(data.profile1.identity.links[idx_48].createdAt);
+              if (data.profile1.identity.links[idx_48].createdAt instanceof Date) {
+                entity.profile1.identity.links[idx_48].createdAt = data.profile1.identity.links[idx_48].createdAt;
+              } else {
+                entity.profile1.identity.links[idx_48].createdAt = new Date(data.profile1.identity.links[idx_48].createdAt);
+              }
             }
             if (data.profile1.identity.links[idx_48].meta != null) {
               if (entity.profile1.identity.links[idx_48].meta == null) {
@@ -974,7 +990,11 @@ exports[`embedded entities in mongo diffing 2`] = `
             if (data.profile2.identity.links[idx_60].createdAt === null) {
               entity.profile2.identity.links[idx_60].createdAt = null;
             } else if (typeof data.profile2.identity.links[idx_60].createdAt !== 'undefined') {
-              entity.profile2.identity.links[idx_60].createdAt = new Date(data.profile2.identity.links[idx_60].createdAt);
+              if (data.profile2.identity.links[idx_60].createdAt instanceof Date) {
+                entity.profile2.identity.links[idx_60].createdAt = data.profile2.identity.links[idx_60].createdAt;
+              } else {
+                entity.profile2.identity.links[idx_60].createdAt = new Date(data.profile2.identity.links[idx_60].createdAt);
+              }
             }
             if (data.profile2.identity.links[idx_60].meta != null) {
               if (entity.profile2.identity.links[idx_60].meta == null) {

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
@@ -314,7 +314,11 @@ exports[`embedded entities in postgres diffing 2`] = `
             if (data.profile1_identity_links[idx_8].createdAt === null) {
               entity.profile1.identity.links[idx_8].createdAt = null;
             } else if (typeof data.profile1_identity_links[idx_8].createdAt !== 'undefined') {
-              entity.profile1.identity.links[idx_8].createdAt = new Date(data.profile1_identity_links[idx_8].createdAt);
+              if (data.profile1_identity_links[idx_8].createdAt instanceof Date) {
+                entity.profile1.identity.links[idx_8].createdAt = data.profile1_identity_links[idx_8].createdAt;
+              } else {
+                entity.profile1.identity.links[idx_8].createdAt = new Date(data.profile1_identity_links[idx_8].createdAt);
+              }
             }
             if (data.profile1_identity_links[idx_8].meta != null) {
               if (entity.profile1.identity.links[idx_8].meta == null) {
@@ -475,7 +479,11 @@ exports[`embedded entities in postgres diffing 2`] = `
             if (data.profile1_identity.links[idx_21].createdAt === null) {
               entity.profile1.identity.links[idx_21].createdAt = null;
             } else if (typeof data.profile1_identity.links[idx_21].createdAt !== 'undefined') {
-              entity.profile1.identity.links[idx_21].createdAt = new Date(data.profile1_identity.links[idx_21].createdAt);
+              if (data.profile1_identity.links[idx_21].createdAt instanceof Date) {
+                entity.profile1.identity.links[idx_21].createdAt = data.profile1_identity.links[idx_21].createdAt;
+              } else {
+                entity.profile1.identity.links[idx_21].createdAt = new Date(data.profile1_identity.links[idx_21].createdAt);
+              }
             }
             if (data.profile1_identity.links[idx_21].meta != null) {
               if (entity.profile1.identity.links[idx_21].meta == null) {
@@ -657,7 +665,11 @@ exports[`embedded entities in postgres diffing 2`] = `
             if (data.profile1_identity_links[idx_35].createdAt === null) {
               entity.profile1.identity.links[idx_35].createdAt = null;
             } else if (typeof data.profile1_identity_links[idx_35].createdAt !== 'undefined') {
-              entity.profile1.identity.links[idx_35].createdAt = new Date(data.profile1_identity_links[idx_35].createdAt);
+              if (data.profile1_identity_links[idx_35].createdAt instanceof Date) {
+                entity.profile1.identity.links[idx_35].createdAt = data.profile1_identity_links[idx_35].createdAt;
+              } else {
+                entity.profile1.identity.links[idx_35].createdAt = new Date(data.profile1_identity_links[idx_35].createdAt);
+              }
             }
             if (data.profile1_identity_links[idx_35].meta != null) {
               if (entity.profile1.identity.links[idx_35].meta == null) {
@@ -818,7 +830,11 @@ exports[`embedded entities in postgres diffing 2`] = `
             if (data.profile1.identity.links[idx_48].createdAt === null) {
               entity.profile1.identity.links[idx_48].createdAt = null;
             } else if (typeof data.profile1.identity.links[idx_48].createdAt !== 'undefined') {
-              entity.profile1.identity.links[idx_48].createdAt = new Date(data.profile1.identity.links[idx_48].createdAt);
+              if (data.profile1.identity.links[idx_48].createdAt instanceof Date) {
+                entity.profile1.identity.links[idx_48].createdAt = data.profile1.identity.links[idx_48].createdAt;
+              } else {
+                entity.profile1.identity.links[idx_48].createdAt = new Date(data.profile1.identity.links[idx_48].createdAt);
+              }
             }
             if (data.profile1.identity.links[idx_48].meta != null) {
               if (entity.profile1.identity.links[idx_48].meta == null) {
@@ -974,7 +990,11 @@ exports[`embedded entities in postgres diffing 2`] = `
             if (data.profile2.identity.links[idx_60].createdAt === null) {
               entity.profile2.identity.links[idx_60].createdAt = null;
             } else if (typeof data.profile2.identity.links[idx_60].createdAt !== 'undefined') {
-              entity.profile2.identity.links[idx_60].createdAt = new Date(data.profile2.identity.links[idx_60].createdAt);
+              if (data.profile2.identity.links[idx_60].createdAt instanceof Date) {
+                entity.profile2.identity.links[idx_60].createdAt = data.profile2.identity.links[idx_60].createdAt;
+              } else {
+                entity.profile2.identity.links[idx_60].createdAt = new Date(data.profile2.identity.links[idx_60].createdAt);
+              }
             }
             if (data.profile2.identity.links[idx_60].meta != null) {
               if (entity.profile2.identity.links[idx_60].meta == null) {

--- a/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
@@ -22,7 +22,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
     if (data.pet_canBark === null) {
       entity.pet.canBark = null;
     } else if (typeof data.pet_canBark !== 'undefined') {
-      entity.pet.canBark = data.pet_canBark === null ? null : !!data.pet_canBark;
+      entity.pet.canBark = !!data.pet_canBark;
     }
     if (data.pet_type === null) {
       entity.pet.type = null;
@@ -37,7 +37,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
     if (data.pet_canMeow === null) {
       entity.pet.canMeow = null;
     } else if (typeof data.pet_canMeow !== 'undefined') {
-      entity.pet.canMeow = data.pet_canMeow === null ? null : !!data.pet_canMeow;
+      entity.pet.canMeow = !!data.pet_canMeow;
     }
   } else if (data.pet === null) {
     entity.pet = null;
@@ -55,7 +55,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
     if (data.pet.canBark === null) {
       entity.pet.canBark = null;
     } else if (typeof data.pet.canBark !== 'undefined') {
-      entity.pet.canBark = data.pet.canBark === null ? null : !!data.pet.canBark;
+      entity.pet.canBark = !!data.pet.canBark;
     }
     if (data.pet.type === null) {
       entity.pet.type = null;
@@ -70,7 +70,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
     if (data.pet.canMeow === null) {
       entity.pet.canMeow = null;
     } else if (typeof data.pet.canMeow !== 'undefined') {
-      entity.pet.canMeow = data.pet.canMeow === null ? null : !!data.pet.canMeow;
+      entity.pet.canMeow = !!data.pet.canMeow;
     }
   } else if (data.pet === null) {
     entity.pet = null;
@@ -88,7 +88,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
     if (data.pet2.canBark === null) {
       entity.pet2.canBark = null;
     } else if (typeof data.pet2.canBark !== 'undefined') {
-      entity.pet2.canBark = data.pet2.canBark === null ? null : !!data.pet2.canBark;
+      entity.pet2.canBark = !!data.pet2.canBark;
     }
     if (data.pet2.type === null) {
       entity.pet2.type = null;
@@ -103,7 +103,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
     if (data.pet2.canMeow === null) {
       entity.pet2.canMeow = null;
     } else if (typeof data.pet2.canMeow !== 'undefined') {
-      entity.pet2.canMeow = data.pet2.canMeow === null ? null : !!data.pet2.canMeow;
+      entity.pet2.canMeow = !!data.pet2.canMeow;
     }
   } else if (data.pet2 === null) {
     entity.pet2 = null;
@@ -127,7 +127,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
         if (data.pets[idx_14].canBark === null) {
           entity.pets[idx_14].canBark = null;
         } else if (typeof data.pets[idx_14].canBark !== 'undefined') {
-          entity.pets[idx_14].canBark = data.pets[idx_14].canBark === null ? null : !!data.pets[idx_14].canBark;
+          entity.pets[idx_14].canBark = !!data.pets[idx_14].canBark;
         }
         if (data.pets[idx_14].type === null) {
           entity.pets[idx_14].type = null;
@@ -142,7 +142,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
         if (data.pets[idx_14].canMeow === null) {
           entity.pets[idx_14].canMeow = null;
         } else if (typeof data.pets[idx_14].canMeow !== 'undefined') {
-          entity.pets[idx_14].canMeow = data.pets[idx_14].canMeow === null ? null : !!data.pets[idx_14].canMeow;
+          entity.pets[idx_14].canMeow = !!data.pets[idx_14].canMeow;
         }
       } else if (data.pets[idx_14] === null) {
         entity.pets[idx_14] = null;

--- a/tests/features/multiple-schemas/different-schema-from-config.postgres.test.ts
+++ b/tests/features/multiple-schemas/different-schema-from-config.postgres.test.ts
@@ -42,7 +42,7 @@ describe('different schema from config', () => {
     orm = await MikroORM.init({
       driver: PostgreSqlDriver,
       entities: [Book, BookTag],
-      dbName: 'mikro_orm_test_gh_2740',
+      dbName: 'mikro_orm_test_gh_2740_2',
       schema: 'privateschema',
     });
     await orm.schema.refreshDatabase();

--- a/tests/features/schema-generator/adding-composite-fk.postgres.test.ts
+++ b/tests/features/schema-generator/adding-composite-fk.postgres.test.ts
@@ -114,7 +114,7 @@ describe('adding m:1 with composite PK (FK as PK + scalar PK) (GH 1687)', () => 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [City, User, Country, State],
-      dbName: `mikro_orm_test_gh_1687`,
+      dbName: `mikro_orm_test_gh_1687_2`,
       driver: PostgreSqlDriver,
     });
     await orm.schema.ensureDatabase();

--- a/tests/features/schema-generator/default-value-inference.test.ts
+++ b/tests/features/schema-generator/default-value-inference.test.ts
@@ -58,6 +58,7 @@ test('infer property type from its default value when type is not set', async ()
     `create table "author2" ("id" serial primary key, "age" int not null default 0, "nullable" int null, "created_at" timestamptz not null, "data" bytea not null);\n\n`,
   );
   expect(meta.properties.age.type).toBe('number');
-  expect(meta.properties.createdAt.type).toBe('date');
-  expect(meta.properties.data.type).toBe('uint8array');
+  expect(meta.properties.createdAt.type).toBe('Date');
+  expect(meta.properties.data.type).toBe('BlobType');
+  expect(meta.properties.data.runtimeType).toBe('Buffer');
 });

--- a/tests/features/unit-of-work/UnitOfWork.test.ts
+++ b/tests/features/unit-of-work/UnitOfWork.test.ts
@@ -28,7 +28,7 @@ describe('UnitOfWork', () => {
 
     // string date with unknown format will throw
     Object.assign(author, { name: '333', email: '444', createdAt: 'asd' });
-    expect(() => computer.computeChangeSet(author)).toThrowError(`Trying to set Author.createdAt of type 'date' to 'asd' of type 'string'`);
+    expect(() => computer.computeChangeSet(author)).toThrowError(`Trying to set Author.createdAt of type 'Date' to 'asd' of type 'string'`);
     delete author.createdAt;
 
     // number bool with other value than 0/1 will throw
@@ -66,7 +66,7 @@ describe('UnitOfWork', () => {
     Object.assign(author, { age: 'asd' });
     expect(() => computer.computeChangeSet(author)).toThrowError(`Trying to set Author.age of type 'number' to 'asd' of type 'string'`);
     Object.assign(author, { age: new Date() });
-    expect(() => computer.computeChangeSet(author)).toThrowError(/Trying to set Author\.age of type 'number' to '.*' of type 'date'/);
+    expect(() => computer.computeChangeSet(author)).toThrowError(/Trying to set Author\.age of type 'number' to '.*' of type 'Date'/);
     Object.assign(author, { age: false });
     expect(() => computer.computeChangeSet(author)).toThrowError(`Trying to set Author.age of type 'number' to 'false' of type 'boolean'`);
     author.age = 21;
@@ -83,7 +83,7 @@ describe('UnitOfWork', () => {
 
     // string date with correct format will not be auto-corrected in strict mode
     const payload = { name: '333', email: '444', createdAt: '2018-01-01', termsAccepted: 1 };
-    expect(() => validator.validate(author, payload, orm.getMetadata().get(Author.name))).toThrowError(`Trying to set Author.createdAt of type 'date' to '2018-01-01' of type 'string'`);
+    expect(() => validator.validate(author, payload, orm.getMetadata().get(Author.name))).toThrowError(`Trying to set Author.createdAt of type 'Date' to '2018-01-01' of type 'string'`);
   });
 
   test('changeSet is null for empty payload', async () => {

--- a/tests/features/upsert/GH4242-2.test.ts
+++ b/tests/features/upsert/GH4242-2.test.ts
@@ -44,6 +44,7 @@ beforeAll(async () => {
     entities: [B, D],
     dbName: `gh-4242`,
     port: 3308,
+    strict: true,
     loggerFactory: options => new SimpleLogger(options),
   });
 

--- a/tests/features/upsert/GH4242.test.ts
+++ b/tests/features/upsert/GH4242.test.ts
@@ -114,6 +114,7 @@ test('4242 2/4', async () => {
   expect(loadedDs4).toEqual([{
     id: expect.any(String),
     updatedAt: expect.any(Date),
+    optional: null,
     tenantWorkflowId: 1,
   }]);
   await orm.em.flush();
@@ -180,6 +181,7 @@ test('4242 4/4', async () => {
   expect(loadedDs4).toEqual({
     id: expect.any(String),
     updatedAt: expect.any(Date),
+    optional: null,
     tenantWorkflowId: 1,
   });
   await orm.em.flush();

--- a/tests/issues/GH910.test.ts
+++ b/tests/issues/GH910.test.ts
@@ -18,7 +18,7 @@ export class Sku {
 
 export class SkuType extends Type<Sku, string> {
 
-  override convertToDatabaseValue(value: Sku | string, platform: Platform, fromQuery?: boolean): string {
+  override convertToDatabaseValue(value: Sku | string, platform: Platform): string {
     return value.toString();
   }
 


### PR DESCRIPTION
Previously, mapping of datetime columns to JS `Date` objects was dependent on the driver, while SQLite didn't have this out of box support and required manual conversion on various places. There were also places that didn't convert dates properly, e.g. inside embedded objects. All drivers now have disabled `Date` conversion and this is handled explicitly, in the same way for all the drivers.

Moreover, the `date` type was previously seen as a `datetime`, while now only `Date` (with uppercase `D`) will be considered as `datetime`, while `date` is just a `date`.

Closes #4362
Closes #4360
Closes #1476