### PR TITLE
feat(cli): improve `migration:check` command to also print the schema diff

### DIFF
--- a/packages/cli/src/commands/MigrationCommandFactory.ts
+++ b/packages/cli/src/commands/MigrationCommandFactory.ts
@@ -179,7 +179,10 @@ export class MigrationCommandFactory {
     }
     const diff = await migrator.getSchemaDiff(false, false);
     await orm.close(true);
-    CLIHelper.dump(colors.yellow(`Changes detected. Please create migration to update schema.\n\nPending changes:\n${diff.up.join('\n')}`));
+    CLIHelper.dump(colors.yellow(`Changes detected. Please create migration to update schema.`));
+    CLIHelper.dump(colors.yellow(``));
+    CLIHelper.dump(colors.yellow(`Pending changes:`));
+    CLIHelper.dump(colors.yellow(diff.up.join('\n')));
     process.exit(1);
   }
 

--- a/packages/cli/src/commands/MigrationCommandFactory.ts
+++ b/packages/cli/src/commands/MigrationCommandFactory.ts
@@ -177,8 +177,9 @@ export class MigrationCommandFactory {
     if (!await migrator.checkMigrationNeeded()) {
       return CLIHelper.dump(colors.green(`No changes required, schema is up-to-date`));
     }
+    const diff = await migrator.getSchemaDiff(false, false);
     await orm.close(true);
-    CLIHelper.dump(colors.yellow(`Changes detected. Please create migration to update schema.`));
+    CLIHelper.dump(colors.yellow(`Changes detected. Please create migration to update schema.\n\nPending changes:\n${diff.up.join('\n')}`));
     process.exit(1);
   }
 

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -638,6 +638,11 @@ export interface IMigrator {
   getPendingMigrations(): Promise<UmzugMigration[]>;
 
   /**
+   * Returns the schema diff.
+   */
+  getSchemaDiff(blank: boolean, initial: boolean): Promise<{ up: string[]; down: string[] }>;
+
+  /**
    * Executes specified migrations. Without parameter it will migrate up to the latest version.
    */
   up(options?: string | string[] | MigrateOptions): Promise<UmzugMigration[]>;

--- a/packages/migrations-mongodb/src/Migrator.ts
+++ b/packages/migrations-mongodb/src/Migrator.ts
@@ -56,6 +56,10 @@ export class Migrator implements IMigrator {
     return true;
   }
 
+  async getSchemaDiff(blank: boolean, initial: boolean): Promise<{ up: string[]; down: string[] }> {
+    return { up: [], down: [] };
+  }
+
   /**
    * @inheritDoc
    */

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -285,7 +285,7 @@ export class Migrator implements IMigrator {
     };
   }
 
-  private async getSchemaDiff(blank: boolean, initial: boolean): Promise<{ up: string[]; down: string[] }> {
+  async getSchemaDiff(blank: boolean, initial: boolean): Promise<{ up: string[]; down: string[] }> {
     const up: string[] = [];
     const down: string[] = [];
 

--- a/tests/features/cli/CheckMigrationsCommand.test.ts
+++ b/tests/features/cli/CheckMigrationsCommand.test.ts
@@ -40,7 +40,7 @@ describe('CheckMigrationCommand', () => {
     await expect(cmd.handler({} as any)).rejects.toThrowError('Mock');
     expect(checkMigrationMock.mock.calls.length).toBe(1);
     expect(closeSpy).toBeCalledTimes(1);
-    expect(dumpMock).toHaveBeenLastCalledWith('Changes detected. Please create migration to update schema.');
+    expect(dumpMock).toHaveBeenNthCalledWith(1, 'Changes detected. Please create migration to update schema.');
     expect(mockExit).toBeCalledTimes(1);
 
     checkMigrationMock.mockImplementationOnce(async () => false);


### PR DESCRIPTION
I think the `migration:check` command would be better if it also reported what the diff is. I am planning to run it in CI to ensure there isn't any migration drift, and I think it is helpful to have more information when it errors.

Example output:

![Screenshot 2023-05-25 at 16 46 06](https://github.com/mikro-orm/mikro-orm/assets/1991151/bc48a76b-b341-44b1-a09c-75319dc43649)

This isn't super polished as I am not sure exactly how you'd prefer for it to work, so please let me know if there's any changes you'd like to see. Thanks!
