### PR TITLE
docs: postgres >= 13 has built-in  uuid function "get_random_uuid"

### DIFF
--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -1456,9 +1456,7 @@ export const Book = new EntitySchema<IBook>({
   </TabItem>
 </Tabs>
 
-### Using PostgreSQL [uuid-ossp](https://www.postgresql.org/docs/current/uuid-ossp.html) module function as primary key
-
-Requires enabling the module via: `create extension "uuid-ossp";`
+### Using PostgreSQL built-in [gen_random_uuid](https://www.postgresql.org/docs/current/functions-uuid.html) function as primary key
 
 <Tabs
 groupId="entity-def"

--- a/docs/versioned_docs/version-4.5/defining-entities.md
+++ b/docs/versioned_docs/version-4.5/defining-entities.md
@@ -1272,9 +1272,7 @@ export const Book = new EntitySchema<IBook>({
   </TabItem>
 </Tabs>
 
-### Using PostgreSQL [uuid-ossp](https://www.postgresql.org/docs/current/uuid-ossp.html) module function as primary key
-
-Requires enabling the module via: `create extension "uuid-ossp";`
+### Using PostgreSQL built-in [gen_random_uuid](https://www.postgresql.org/docs/current/functions-uuid.html) function as primary key
 
 <Tabs
   groupId="entity-def"

--- a/docs/versioned_docs/version-5.4/defining-entities.md
+++ b/docs/versioned_docs/version-5.4/defining-entities.md
@@ -1385,9 +1385,7 @@ export const Book = new EntitySchema<IBook>({
   </TabItem>
 </Tabs>
 
-### Using PostgreSQL [uuid-ossp](https://www.postgresql.org/docs/current/uuid-ossp.html) module function as primary key
-
-Requires enabling the module via: `create extension "uuid-ossp";`
+### Using PostgreSQL built-in [gen_random_uuid](https://www.postgresql.org/docs/current/functions-uuid.html) function as primary key
 
 <Tabs
   groupId="entity-def"

--- a/docs/versioned_docs/version-5.5/defining-entities.md
+++ b/docs/versioned_docs/version-5.5/defining-entities.md
@@ -1456,9 +1456,7 @@ export const Book = new EntitySchema<IBook>({
   </TabItem>
 </Tabs>
 
-### Using PostgreSQL [uuid-ossp](https://www.postgresql.org/docs/current/uuid-ossp.html) module function as primary key
-
-Requires enabling the module via: `create extension "uuid-ossp";`
+### Using PostgreSQL built-in [gen_random_uuid](https://www.postgresql.org/docs/current/functions-uuid.html) function as primary key
 
 <Tabs
   groupId="entity-def"

--- a/docs/versioned_docs/version-5.6/defining-entities.md
+++ b/docs/versioned_docs/version-5.6/defining-entities.md
@@ -1456,9 +1456,7 @@ export const Book = new EntitySchema<IBook>({
   </TabItem>
 </Tabs>
 
-### Using PostgreSQL [uuid-ossp](https://www.postgresql.org/docs/current/uuid-ossp.html) module function as primary key
-
-Requires enabling the module via: `create extension "uuid-ossp";`
+### Using PostgreSQL built-in [gen_random_uuid](https://www.postgresql.org/docs/current/functions-uuid.html) function as primary key
 
 <Tabs
   groupId="entity-def"

--- a/docs/versioned_docs/version-5.7/defining-entities.md
+++ b/docs/versioned_docs/version-5.7/defining-entities.md
@@ -1456,9 +1456,7 @@ export const Book = new EntitySchema<IBook>({
   </TabItem>
 </Tabs>
 
-### Using PostgreSQL [uuid-ossp](https://www.postgresql.org/docs/current/uuid-ossp.html) module function as primary key
-
-Requires enabling the module via: `create extension "uuid-ossp";`
+### Using PostgreSQL built-in [gen_random_uuid](https://www.postgresql.org/docs/current/functions-uuid.html) function as primary key
 
 <Tabs
 groupId="entity-def"


### PR DESCRIPTION
Following https://github.com/mikro-orm/mikro-orm/discussions/4403

Since Postgres 13 no additional module is necessary to use 'gen_random_uuid' function.