### PR TITLE
fix(core): fix returning clause for upsert with embeddables

### DIFF
--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -426,7 +426,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
         qb.insert(data as T)
           .onConflict(uniqueFields.map(p => meta?.properties[p]?.fieldNames[0] ?? p))
           .merge(Object.keys(data).filter(f => !uniqueFields.includes(f)))
-          .returning(meta?.comparableProps.filter(p => !p.lazy && !(p.name in data)).map(p => p.name) ?? '*');
+          .returning(meta?.comparableProps.filter(p => !p.lazy && !p.embeddable && !(p.name in data)).map(p => p.name) ?? '*');
       } else {
         qb.update(data).where(where);
       }
@@ -452,7 +452,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
       qb.insert(data)
         .onConflict(uniqueFields.map(p => meta.properties[p]?.fieldNames[0] ?? p))
         .merge(Object.keys(data[0]).filter(f => !uniqueFields.includes(f)))
-        .returning(meta.comparableProps.filter(p => !p.lazy && !(p.name in data[0])).map(p => p.name) ?? '*');
+        .returning(meta.comparableProps.filter(p => !p.lazy && !p.embeddable && !(p.name in data[0])).map(p => p.name) ?? '*');
       return qb.execute('run', false);
     }
 

--- a/tests/features/upsert/upsert.test.ts
+++ b/tests/features/upsert/upsert.test.ts
@@ -474,13 +474,13 @@ describe.each(Object.keys(options))('em.upsert [%s]',  type => {
   test('em.upsert(entity) with embeddable', async () => {
     const testEntity = orm.em.create(FooBarWithEmbeddable, { fooBarEmbeddable: {} });
 
-    const insertedEntity = await orm.em.upsert(FooBarWithEmbeddable, testEntity);
+    await orm.em.upsert(testEntity);
 
-    expect(insertedEntity.id).toBeDefined();
+    expect(testEntity.id).toBeDefined();
 
     const [insertedEntity2] = await orm.em.upsertMany(FooBarWithEmbeddable, [{ id: testEntity.id, fooBarEmbeddable: {} }]);
 
-    expect(insertedEntity2).toBe(insertedEntity);
+    expect(insertedEntity2).toBe(testEntity);
   });
 
 });

--- a/tests/features/upsert/upsert.test.ts
+++ b/tests/features/upsert/upsert.test.ts
@@ -1,6 +1,6 @@
 import {
   MikroORM, Entity, PrimaryKey, ManyToOne, Property, SimpleLogger,
-  Unique, Ref, ref, EventSubscriber, EventArgs, OneToMany, Collection,
+  Unique, Ref, ref, EventSubscriber, EventArgs, OneToMany, Collection, Embeddable, Embedded,
 } from '@mikro-orm/core';
 import { mockLogger } from '../../helpers';
 
@@ -74,6 +74,27 @@ export class FooBar {
 
 }
 
+@Entity()
+export class FooBarWithEmbeddable {
+
+  static id = 1;
+
+  @PrimaryKey({ name: '_id' })
+  id: number = FooBar.id++;
+
+  @Embedded(() => FooBarEmbeddable)
+  fooBarEmbeddable = new FooBarEmbeddable();
+
+}
+
+@Embeddable()
+export class FooBarEmbeddable {
+
+  @Property({ nullable: true })
+  name?: string;
+
+}
+
 class Subscriber implements EventSubscriber {
 
   static log: any[] = [];
@@ -106,7 +127,7 @@ describe.each(Object.keys(options))('em.upsert [%s]',  type => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      entities: [Author, Book, FooBar],
+      entities: [Author, Book, FooBar, FooBarWithEmbeddable],
       type,
       loggerFactory: options => new SimpleLogger(options),
       subscribers: [new Subscriber()],
@@ -447,6 +468,19 @@ describe.each(Object.keys(options))('em.upsert [%s]',  type => {
     expect(fb3).toBe(fooBar3);
 
     await assertFooBars([fooBar1, fooBar2, fooBar3], mock);
+  });
+
+
+  test('em.upsert(entity) with embeddable', async () => {
+    const testEntity = orm.em.create(FooBarWithEmbeddable, { fooBarEmbeddable: {} });
+
+    const insertedEntity = await orm.em.upsert(FooBarWithEmbeddable, testEntity);
+
+    expect(insertedEntity.id).toBeDefined();
+
+    const [insertedEntity2] = await orm.em.upsertMany(FooBarWithEmbeddable, [{ id: testEntity.id, fooBarEmbeddable: {} }]);
+
+    expect(insertedEntity2).toBe(insertedEntity);
   });
 
 });


### PR DESCRIPTION
…hen upserting with embeddables

Currently, when you run upsert on an entity with an embeddable, the name of the embeddable is included in the returning statement and causing `InvalidFieldNameException`.

The produced query without the change:
``` 
insert into `foo_bar_with_embeddable` (`_id`) values (1) on conflict (`_id`) do nothing returning `fooBarEmbeddable`, `foo_bar_embeddable_name`;
````