### PR TITLE
refactor(core): keep v5 `serialize` api

### DIFF
--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -362,18 +362,6 @@ const dto = wrap(user).toObject();
 
 **This also works for embeddables, including nesting and object mode.**
 
-## `serialize` helper always returns array
-
-This method used to return a single object conditionally based on its inputs, but the solution broke intellisense for the `populate` option. The method signature still accepts single object or an array of objects, but always returns an array.
-
-To serialize single entity, you can use array destructing, or use `wrap(entity).serialize()` which handles a single entity only.
-
-```ts
-const dtos = serialize([user1, user, ...], { exclude: ['id', 'email'], forceObject: true });
-const [dto1] = serialize(user, { exclude: ['id', 'email'], forceObject: true });
-const dto2 = wrap(user).serialize({ exclude: ['id', 'email'], forceObject: true });
-```
-
 ## Changes in `Date` property mapping 
 
 Previously, mapping of datetime columns to JS `Date` objects was dependent on the driver, while SQLite didn't have this out of box support and required manual conversion on various places. All drivers now have disabled `Date` conversion and this is now handled explicitly, in the same way for all of them.

--- a/packages/core/src/serialization/EntitySerializer.ts
+++ b/packages/core/src/serialization/EntitySerializer.ts
@@ -1,5 +1,6 @@
 import type { Collection } from '../entity/Collection';
 import type {
+  ArrayElement,
   AutoPath,
   Dictionary,
   EntityDTO,
@@ -238,19 +239,20 @@ export interface SerializeOptions<T, P extends string = never, E extends string 
   /** Skip properties with `null` value. */
   skipNull?: boolean;
 }
+/**
+ * Converts entity instance to POJO, converting the `Collection`s to arrays and unwrapping the `Reference` wrapper, while respecting the serialization options.
+ */
+export function serialize<T extends object, P extends string = never, E extends string = never>(entity: T, options?: SerializeOptions<T, P, E>): T extends object[] ? EntityDTO<Loaded<ArrayElement<T>, P>>[] : EntityDTO<Loaded<T, P>>;
 
 /**
  * Converts entity instance to POJO, converting the `Collection`s to arrays and unwrapping the `Reference` wrapper, while respecting the serialization options.
- * This method accepts either a single entity or array of entities, and always returns an array of entities. To serialize single entity, you can use array destructing,
- * or use `wrap(entity).serialize()` which handles a single entity only.
- *
- * ```ts
- * const dtos = serialize([user1, user, ...], { exclude: ['id', 'email'], forceObject: true });
- * const [dto1] = serialize(user, { exclude: ['id', 'email'], forceObject: true });
- * const dto2 = wrap(user).serialize({ exclude: ['id', 'email'], forceObject: true });
- * ```
- *
  */
-export function serialize<T extends object, P extends string = never, E extends string = never>(entities: T | T[], options?: SerializeOptions<T, P, E>): EntityDTO<Loaded<T, P>>[] {
-  return Utils.asArray(entities).map(e => EntitySerializer.serialize(e, options));
+export function serialize<T extends object, P extends string = never, E extends string = never>(entities: T | T[], options?: SerializeOptions<T, P, E>): EntityDTO<Loaded<T, P>> | EntityDTO<Loaded<T, P>>[] {
+  const ret = Utils.asArray(entities).map(e => EntitySerializer.serialize(e, options));
+
+  if (Array.isArray(entities)) {
+    return ret;
+  }
+
+  return ret[0];
 }

--- a/packages/core/src/serialization/EntitySerializer.ts
+++ b/packages/core/src/serialization/EntitySerializer.ts
@@ -242,7 +242,7 @@ export interface SerializeOptions<T, P extends string = never, E extends string 
 /**
  * Converts entity instance to POJO, converting the `Collection`s to arrays and unwrapping the `Reference` wrapper, while respecting the serialization options.
  */
-export function serialize<T extends object, P extends string = never, E extends string = never>(entity: T, options?: SerializeOptions<T, P, E>): T extends object[] ? EntityDTO<Loaded<ArrayElement<T>, P>>[] : EntityDTO<Loaded<T, P>>;
+export function serialize<T extends object, P extends string = never, E extends string = never>(entity: T, options?: SerializeOptions<T extends object[] ? ArrayElement<T> : T, P, E>): T extends object[] ? EntityDTO<Loaded<ArrayElement<T>, P>>[] : EntityDTO<Loaded<T, P>>;
 
 /**
  * Converts entity instance to POJO, converting the `Collection`s to arrays and unwrapping the `Reference` wrapper, while respecting the serialization options.

--- a/packages/core/src/serialization/EntitySerializer.ts
+++ b/packages/core/src/serialization/EntitySerializer.ts
@@ -241,6 +241,15 @@ export interface SerializeOptions<T, P extends string = never, E extends string 
 }
 /**
  * Converts entity instance to POJO, converting the `Collection`s to arrays and unwrapping the `Reference` wrapper, while respecting the serialization options.
+ * This method accepts either a single entity or an array of entities, and returns the corresponding POJO or an array of POJO.
+ * To serialize single entity, you can also use `wrap(entity).serialize()` which handles a single entity only.
+ *
+ * ```ts
+ * const dtos = serialize([user1, user, ...], { exclude: ['id', 'email'], forceObject: true });
+ * const [dto2, dto3] = serialize([user2, user3], { exclude: ['id', 'email'], forceObject: true });
+ * const dto1 = serialize(user, { exclude: ['id', 'email'], forceObject: true });
+ * const dto2 = wrap(user).serialize({ exclude: ['id', 'email'], forceObject: true });
+ * ```
  */
 export function serialize<T extends object, P extends string = never, E extends string = never>(entity: T, options?: SerializeOptions<T extends object[] ? ArrayElement<T> : T, P, E>): T extends object[] ? EntityDTO<Loaded<ArrayElement<T>, P>>[] : EntityDTO<Loaded<T, P>>;
 
@@ -257,11 +266,9 @@ export function serialize<T extends object, P extends string = never, E extends 
  * ```
  */
 export function serialize<T extends object, P extends string = never, E extends string = never>(entities: T | T[], options?: SerializeOptions<T, P, E>): EntityDTO<Loaded<T, P>> | EntityDTO<Loaded<T, P>>[] {
-  const ret = Utils.asArray(entities).map(e => EntitySerializer.serialize(e, options));
-
   if (Array.isArray(entities)) {
-    return ret;
+    return entities.map(e => EntitySerializer.serialize(e, options));
   }
 
-  return ret[0];
+  return EntitySerializer.serialize(entities, options);
 }

--- a/packages/core/src/serialization/EntitySerializer.ts
+++ b/packages/core/src/serialization/EntitySerializer.ts
@@ -246,6 +246,15 @@ export function serialize<T extends object, P extends string = never, E extends 
 
 /**
  * Converts entity instance to POJO, converting the `Collection`s to arrays and unwrapping the `Reference` wrapper, while respecting the serialization options.
+ * This method accepts either a single entity or an array of entities, and returns the corresponding POJO or an array of POJO.
+ * To serialize single entity, you can also use `wrap(entity).serialize()` which handles a single entity only.
+ *
+ * ```ts
+ * const dtos = serialize([user1, user, ...], { exclude: ['id', 'email'], forceObject: true });
+ * const [dto2, dto3] = serialize([user2, user3], { exclude: ['id', 'email'], forceObject: true });
+ * const dto1 = serialize(user, { exclude: ['id', 'email'], forceObject: true });
+ * const dto2 = wrap(user).serialize({ exclude: ['id', 'email'], forceObject: true });
+ * ```
  */
 export function serialize<T extends object, P extends string = never, E extends string = never>(entities: T | T[], options?: SerializeOptions<T, P, E>): EntityDTO<Loaded<T, P>> | EntityDTO<Loaded<T, P>>[] {
   const ret = Utils.asArray(entities).map(e => EntitySerializer.serialize(e, options));

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -745,6 +745,9 @@ export type AutoPath<O, P extends string, E extends string = never, D extends Pr
       : never
     : never;
 
+export type ArrayElement<ArrayType extends unknown[]> =
+  ArrayType extends (infer ElementType)[] ? ElementType : never;
+
 export type ExpandProperty<T> = T extends Reference<infer U>
   ? NonNullable<U>
   : T extends Collection<infer U, any>

--- a/tests/EntityHelper.mongo.test.ts
+++ b/tests/EntityHelper.mongo.test.ts
@@ -277,7 +277,7 @@ describe('EntityHelperMongo', () => {
     orm.em.clear();
 
     const jon = await orm.em.findOneOrFail(Author, god, { populate: true });
-    const [o] = serialize([jon], { populate: true });
+    const o = serialize(jon, { populate: true });
     expect(o).toMatchObject({
       id: jon.id,
       createdAt: jon.createdAt,

--- a/tests/features/serialization/GH3788.test.ts
+++ b/tests/features/serialization/GH3788.test.ts
@@ -50,6 +50,6 @@ test('serialization of not managed relations (#3788)', async () => {
     },
   });
   expect(JSON.stringify(mainItem)).toBe(`{"name":"yyyy","coverImage":{"url":"xxxx","itemEntity":{"name":"yyyy"}}}`);
-  expect(JSON.stringify(serialize(mainItem)[0])).toBe(`{"name":"yyyy","coverImage":{"url":"xxxx","itemEntity":{"name":"yyyy"}}}`);
-  expect(JSON.stringify(serialize(mainItem, { populate: ['coverImage'] })[0])).toBe(`{"name":"yyyy","coverImage":{"url":"xxxx","itemEntity":{"name":"yyyy"}}}`);
+  expect(JSON.stringify(serialize(mainItem))).toBe(`{"name":"yyyy","coverImage":{"url":"xxxx","itemEntity":{"name":"yyyy"}}}`);
+  expect(JSON.stringify(serialize(mainItem, { populate: ['coverImage'] }))).toBe(`{"name":"yyyy","coverImage":{"url":"xxxx","itemEntity":{"name":"yyyy"}}}`);
 });

--- a/tests/features/serialization/GH4263.test.ts
+++ b/tests/features/serialization/GH4263.test.ts
@@ -42,6 +42,6 @@ test('serialization with nulls', async () => {
   const expDto = { id: '1', details: { code: 2 } };
   await orm.em.insert(ListEntity2Test, expDto);
   const entity = await orm.em.findOneOrFail(ListEntity2Test, { id: '1' });
-  const [dto] = serialize(entity, { skipNull: true });
+  const dto = serialize(entity, { skipNull: true });
   expect(dto).toEqual(expDto);
 });

--- a/tests/features/serialization/explicit-serialization.test.ts
+++ b/tests/features/serialization/explicit-serialization.test.ts
@@ -73,7 +73,7 @@ test('explicit serialization', async () => {
     name: 'Jon Snow',
   });
 
-  const [o2] = serialize([jon], { populate: ['books'], skipNull: true });
+  const o2 = serialize(jon, { populate: ['books'], skipNull: true });
   expect(o2).toMatchObject({
     id: jon.id,
     createdAt: jon.createdAt,
@@ -90,7 +90,7 @@ test('explicit serialization', async () => {
   });
   expect('age' in o2).toBe(false);
 
-  const [o3] = serialize(jon, { populate: ['books', 'favouriteBook'] });
+  const o3 = serialize(jon, { populate: ['books', 'favouriteBook'] });
   expect(o3).toMatchObject({
     id: jon.id,
     createdAt: jon.createdAt,
@@ -106,7 +106,7 @@ test('explicit serialization', async () => {
     name: 'Jon Snow',
   });
 
-  const [o4] = serialize(jon, { populate: ['books.author', 'favouriteBook'] });
+  const o4 = serialize(jon, { populate: ['books.author', 'favouriteBook'] });
   expect(o4).toMatchObject({
     id: jon.id,
     createdAt: jon.createdAt,
@@ -122,7 +122,7 @@ test('explicit serialization', async () => {
     name: 'Jon Snow',
   });
 
-  const [o5] = serialize(jon, { populate: ['books.author', 'favouriteBook'], forceObject: true });
+  const o5 = serialize(jon, { populate: ['books.author', 'favouriteBook'], forceObject: true });
   expect(o5).toMatchObject({
     id: jon.id,
     createdAt: jon.createdAt,
@@ -138,7 +138,7 @@ test('explicit serialization', async () => {
     name: 'Jon Snow',
   });
 
-  const [o6] = serialize(jon, { populate: ['books.author', 'books.publisher', 'favouriteBook'] });
+  const o6 = serialize(jon, { populate: ['books.author', 'books.publisher', 'favouriteBook'] });
   expect(o6).toMatchObject({
     id: jon.id,
     createdAt: jon.createdAt,
@@ -154,7 +154,7 @@ test('explicit serialization', async () => {
     name: 'Jon Snow',
   });
 
-  const [o7] = serialize(jon, {
+  const o7 = serialize(jon, {
     populate: ['books.author', 'books.publisher', 'favouriteBook'],
     exclude: ['books.author.email'],
   });
@@ -181,7 +181,7 @@ test('explicit serialization with populate: true', async () => {
   const { god, author, publisher } = await createEntities();
   const jon = await orm.em.findOneOrFail(Author2, author, { populate: true })!;
 
-  const [o8] = serialize(jon, { populate: true });
+  const o8 = serialize(jon, { populate: true });
   expect(o8).toMatchObject({
     id: jon.id,
     createdAt: jon.createdAt,
@@ -202,7 +202,7 @@ test('explicit serialization with not initialized properties', async () => {
   const { author } = await createEntities();
   const jon = await orm.em.findOneOrFail(Author2, author)!;
 
-  const [o] = serialize(jon, { populate: true });
+  const o = serialize(jon, { populate: true });
   expect(o).toMatchObject({
     id: jon.id,
     createdAt: jon.createdAt,
@@ -213,7 +213,7 @@ test('explicit serialization with not initialized properties', async () => {
     name: 'Jon Snow',
   });
 
-  const [o2] = serialize(jon.favouriteBook!, { populate: true });
+  const o2 = serialize(jon.favouriteBook!, { populate: true });
   expect(o2).toEqual({
     uuid: jon.favouriteBook!.uuid,
   });


### PR DESCRIPTION
This pull request aims to fix the intellisense issue with `serialize` in V5 while keeping the v5 API.

related: https://github.com/mikro-orm/mikro-orm/blob/v6/docs/docs/upgrading-v5-to-v6.md#serialize-helper-always-returns-array

What do you think about this ? 
Also should this pull request be applied to master ?