### PR TITLE
fix(sqlite): allow using `clientUrl` without a `host`

### DIFF
--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -327,7 +327,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
       this.set('implicitTransactions', this.platform.usesImplicitTransactions());
     }
 
-    const url = this.getClientUrl().match(/:\/\/.+\/([^?]+)/);
+    const url = this.getClientUrl().match(/:\/\/.*\/([^?]+)/);
 
     if (url) {
       this.options.dbName = this.get('dbName', decodeURIComponent(url[1]));


### PR DESCRIPTION
As documented [here](https://mikro-orm.io/docs/configuration#connection) it's possible to use `clientUrl` to pass database options in one string.

However it's broken for SQLite when connection string doesn't contain some options (such as host): library throws an error
```
✖ The "path" argument must be of type string. Received undefined

  stack: >
    SqliteConnection.connect
    (node_modules/@mikro-orm/sqlite/SqliteConnection.js:10:60)

    SqliteDriver.connect (node_modules/@mikro-orm/core/drivers/DatabaseDriver.js:53:31)

    MikroORM.connect (node_modules/@mikro-orm/core/MikroORM.js:70:46)

    Function.init (node_modules/@mikro-orm/core/MikroORM.js:39:23)
```

Example:

```js
MikroORM.init({
    type: 'sqlite',
    clientUrl: 'sqlite:///:memory:',
})
```

Workaround:

```js
MikroORM.init({
    type: 'sqlite',
    clientUrl: 'sqlite://noop/:memory:',
})
```

References: 

- Symfony Docs > [Changing the Default DATABASE_URL Value in .env](https://symfony.com/doc/current/the-fast-track/en/8-doctrine.html#changing-the-default-database-url-value-in-env)