### PR TITLE
Update defining-entities.md on default values

### DIFF
--- a/docs/versioned_docs/version-5.7/defining-entities.md
+++ b/docs/versioned_docs/version-5.7/defining-entities.md
@@ -437,6 +437,9 @@ properties: {
   </TabItem>
 </Tabs>
 
+### Type validation of properties with default values
+Having defined the default value for our property, we also need to make sure that TypeScript understands that the property is in fact optional when its entity is created or updated, but required when the entity is read. Read about how to inform TypeScript about this [here](property-validation.md#properties-with-default-value).
+
 ## Enums
 
 To define an enum property, use `@Enum()` decorator. Enums can be either numeric or string values.


### PR DESCRIPTION
Hello, I would like to suggest creating this link to another part of documentation. I had difficulties web searching for this specific information and got here via an issue on Github. So maybe this link will be helpful for others.

Also, do you agree with the notion of the property being optional only when the entity of this property is created or updated?
I also would find such mention helpful, to indicate it has a different effect than simply using `?` before someone even click the link. Maybe even adding this notion in the actual Type validation document would also be helpful. 