### PR TITLE
fix(seeder): allow run method to return without promise

### DIFF
--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -822,7 +822,7 @@ export interface ISeedManager {
 }
 
 export interface Seeder<T extends Dictionary = Dictionary> {
-  run(em: EntityManager, context?: T): Promise<void>;
+  run(em: EntityManager, context?: T): void | Promise<void>;
 }
 
 export type MaybePromise<T> = T | Promise<T>;

--- a/packages/seeder/src/Seeder.ts
+++ b/packages/seeder/src/Seeder.ts
@@ -2,7 +2,7 @@ import type { Dictionary, EntityManager } from '@mikro-orm/core';
 
 export abstract class Seeder<T extends Dictionary = Dictionary> {
 
-  abstract run(em: EntityManager, context?: T): Promise<void>;
+  abstract run(em: EntityManager, context?: T): void | Promise<void>;
 
   protected async call(em: EntityManager, seeders: { new(): Seeder }[], context: T = {} as T): Promise<void> {
     for (const Seeder of seeders) {


### PR DESCRIPTION
I noticed the `Seeder#run` method only allows returning a `Promise<void>`, although it is completely possible for it to return only `void`, without being async.

This isn't anything major, but I have ESLint rules that forbid me to have an `async` function if it isn't really async, and i'd like to stick by it. It'd be great if the signature of the function didn't force us to have it `async`.

Thank you!