### PR TITLE
fix(core): rework `Collection` initialization to use `em.populate()`

### DIFF
--- a/packages/core/src/entity/ArrayCollection.ts
+++ b/packages/core/src/entity/ArrayCollection.ts
@@ -247,7 +247,7 @@ export class ArrayCollection<T extends object, O extends object> {
   }
 
   protected propagateToInverseSide(item: T, method: 'add' | 'remove' | 'takeSnapshot'): void {
-    const collection = item[this.property.inversedBy as keyof T] as unknown as ArrayCollection<O, T>;
+    const collection = item[this.property.inversedBy as keyof T] as ArrayCollection<O, T>;
 
     if (this.shouldPropagateToCollection(collection, method)) {
       collection[method as 'add'](this.owner);
@@ -303,7 +303,7 @@ export class ArrayCollection<T extends object, O extends object> {
   }
 
   protected incrementCount(value: number) {
-    if (typeof this._count === 'number') {
+    if (typeof this._count === 'number' && this.initialized) {
       this._count += value;
     }
   }

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -203,10 +203,11 @@ export class EntityLoader {
     if (prop.kind === ReferenceKind.EMBEDDED) {
       return [];
     }
+
     const filtered = this.filterCollections<Entity>(entities, field, options);
     const innerOrderBy = Utils.asArray(options.orderBy)
-      .filter(orderBy => Utils.isObject(orderBy[prop.name]))
-      .map(orderBy => orderBy[prop.name]);
+      .filter(orderBy => (Array.isArray(orderBy[prop.name]) && (orderBy[prop.name] as unknown[]).length > 0) || Utils.isObject(orderBy[prop.name]))
+      .flatMap(orderBy => orderBy[prop.name]);
 
     if (prop.kind === ReferenceKind.MANY_TO_MANY && this.driver.getPlatform().usesPivotTable()) {
       return this.findChildrenFromPivotTable<Entity>(filtered, prop, options, innerOrderBy as QueryOrderMap<Entity>[], populate);
@@ -214,18 +215,18 @@ export class EntityLoader {
 
     const where = await this.extractChildCondition(options, prop);
     const data = await this.findChildren<Entity>(entities, prop, populate, { ...options, where, orderBy: innerOrderBy! });
-    this.initializeCollections<Entity>(filtered, prop, field, data);
+    this.initializeCollections<Entity>(filtered, prop, field, data, innerOrderBy.length > 0);
 
     return data;
   }
 
-  private initializeCollections<Entity extends object>(filtered: Entity[], prop: EntityProperty, field: keyof Entity, children: AnyEntity[]): void {
+  private initializeCollections<Entity extends object>(filtered: Entity[], prop: EntityProperty, field: keyof Entity, children: AnyEntity[], customOrder: boolean): void {
     if (prop.kind === ReferenceKind.ONE_TO_MANY) {
       this.initializeOneToMany<Entity>(filtered, children, prop, field);
     }
 
-    if (prop.kind === ReferenceKind.MANY_TO_MANY && !prop.owner && !this.driver.getPlatform().usesPivotTable()) {
-      this.initializeManyToMany<Entity>(filtered, children, prop, field);
+    if (prop.kind === ReferenceKind.MANY_TO_MANY && !this.driver.getPlatform().usesPivotTable()) {
+      this.initializeManyToMany<Entity>(filtered, children, prop, field, customOrder);
     }
   }
 
@@ -258,10 +259,23 @@ export class EntityLoader {
     });
   }
 
-  private initializeManyToMany<Entity>(filtered: Entity[], children: AnyEntity[], prop: EntityProperty, field: keyof Entity): void {
-    for (const entity of filtered) {
-      const items = children.filter(child => (child[prop.mappedBy] as unknown as Collection<AnyEntity>).contains(entity as AnyEntity));
-      (entity[field] as unknown as Collection<AnyEntity>).hydrate(items, true);
+  private initializeManyToMany<Entity>(filtered: Entity[], children: AnyEntity[], prop: EntityProperty<Entity>, field: keyof Entity, customOrder: boolean): void {
+    if (prop.mappedBy) {
+      for (const entity of filtered) {
+        const items = children.filter(child => (child[prop.mappedBy] as Collection<AnyEntity>).contains(entity as AnyEntity, false));
+        (entity[field] as Collection<AnyEntity>).hydrate(items, true);
+      }
+    } else { // owning side of M:N without pivot table needs to be reordered
+      for (const entity of filtered) {
+        const order = !customOrder ? [...(entity[prop.name] as Collection<AnyEntity>).getItems(false)] : []; // copy order of references
+        const items = children.filter(child => (entity[prop.name] as Collection<AnyEntity>).contains(child, false));
+
+        if (!customOrder) {
+          items.sort((a, b) => order.indexOf(a) - order.indexOf(b));
+        }
+
+        (entity[field] as Collection<AnyEntity>).hydrate(items, true);
+      }
     }
   }
 
@@ -296,7 +310,7 @@ export class EntityLoader {
 
     return this.em.find(prop.type, where, {
       refresh, filters, convertCustomTypes, lockMode, populateWhere, logging,
-      orderBy: [...Utils.asArray(options.orderBy), ...Utils.asArray(prop.orderBy), { [fk]: QueryOrder.ASC }] as QueryOrderMap<Entity>[],
+      orderBy: [...Utils.asArray(options.orderBy), ...Utils.asArray(prop.orderBy)] as QueryOrderMap<Entity>[],
       populate: populate.children as never ?? populate.all ?? [],
       strategy, fields, schema, connectionType,
       // @ts-ignore not a public option, will be propagated to the populate call

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -716,12 +716,14 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
       qb.limit(options.limit, options.offset);
     }
 
+    const schema = this.config.get('schema');
+
     if (prop.targetMeta!.schema !== '*' && pivotMeta.schema === '*' && options?.schema) {
       // eslint-disable-next-line dot-notation
       qb['finalize']();
       // eslint-disable-next-line dot-notation
       Object.values(qb['_joins']).forEach(join => {
-        join.schema = options.schema;
+        join.schema = schema;
       });
     }
 

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -802,7 +802,7 @@ describe('EntityManagerMongo', () => {
     }
 
     orm.em.clear();
-    const tags = await orm.em.find(BookTag, {});
+    let tags = await orm.em.find(BookTag, {});
     expect(tags[0].books.isInitialized()).toBe(false);
     expect(tags[0].books.isDirty()).toBe(false);
     expect(() => tags[0].books.getItems()).toThrowError(/Collection<Book> of entity BookTag\[\w{24}] not initialized/);
@@ -812,6 +812,7 @@ describe('EntityManagerMongo', () => {
 
     // test M:N lazy load
     orm.em.clear();
+    tags = await orm.em.find(BookTag, {});
     await tags[0].books.init();
     expect(tags[0].books.count()).toBe(2);
     expect(tags[0].books.getItems()[0]).toBeInstanceOf(Book);
@@ -1409,7 +1410,7 @@ describe('EntityManagerMongo', () => {
     await orm.em.persistAndFlush(publisher);
     orm.em.clear();
 
-    const ent = (await repo.findOne(publisher.id))!;
+    const ent = await repo.findOneOrFail(publisher.id);
     await expect(ent.tests.count()).toBe(3);
     await expect(ent.tests.getIdentifiers('id')).toEqual([t2.id, t1.id, t3.id]);
 

--- a/tests/EntityManager.mongo2.test.ts
+++ b/tests/EntityManager.mongo2.test.ts
@@ -1,8 +1,8 @@
 import type { MikroORM } from '@mikro-orm/core';
-import { ref, wrap } from '@mikro-orm/core';
+import { ArrayCollection, ref, ValidationError, wrap } from '@mikro-orm/core';
 import type { MongoDriver } from '@mikro-orm/mongodb';
 
-import { Author, Book, BookTag, Publisher } from './entities';
+import { Author, Book, BookTag, Publisher, Test } from './entities';
 import { initORMMongo } from './bootstrap';
 
 describe('EntityManagerMongo2', () => {
@@ -60,8 +60,11 @@ describe('EntityManagerMongo2', () => {
 
     bible = await orm.em.findOneOrFail(Book, bible.id);
     await expect(bible.tags.loadCount()).resolves.toEqual(3);
+    const tag1 = await orm.em.findOneOrFail(BookTag, { name: 't1' });
+    await expect(tag1.books.loadCount()).resolves.toEqual(1);
     bible.tags.removeAll();
     await expect(bible.tags.loadCount()).resolves.toEqual(0);
+    await expect(tag1.books.loadCount()).resolves.toEqual(1);
   });
 
   test('required fields validation', async () => {
@@ -74,6 +77,135 @@ describe('EntityManagerMongo2', () => {
     // @ts-expect-error publisher can be null
     const p1 = b[0]?.publisher.$.name;
     const p2 = b[0]?.publisher?.$.name;
+  });
+
+  test('partial loading of collections', async () => {
+    const author = orm.em.create(Author, { name: 'Jon Snow', email: 'snow@wall.st' });
+
+    for (let i = 1; i <= 15; i++) {
+      const book = orm.em.create(Book, { author, title: `book ${('' + i).padStart(2, '0')}` });
+
+      for (let j = 1; j <= 15; j++) {
+        const tag1 = orm.em.create(BookTag, { name: `tag ${('' + i).padStart(2, '0')}-${('' + j).padStart(2, '0')}` });
+        book.tags.add(tag1);
+      }
+    }
+
+    await orm.em.persist(author).flush();
+    orm.em.clear();
+
+    const a = await orm.em.findOneOrFail(Author, author);
+    const books = await a.books.matching({ limit: 5, offset: 10, orderBy: { title: 'asc' } });
+    expect(books).toHaveLength(5);
+    expect(a.books.getItems(false)).not.toHaveLength(5);
+    expect(books.map(b => b.title)).toEqual(['book 11', 'book 12', 'book 13', 'book 14', 'book 15']);
+
+    const tags = await books[0].tags.matching({ limit: 5, offset: 5, orderBy: { name: 'asc' }, store: true });
+    expect(tags).toHaveLength(5);
+    expect(books[0].tags).toHaveLength(5);
+    expect(tags.map(t => t.name)).toEqual(['tag 11-06', 'tag 11-07', 'tag 11-08', 'tag 11-09', 'tag 11-10']);
+    expect(() => books[0].tags.add(orm.em.create(BookTag, { name: 'new' }))).toThrowError('You cannot modify collection Book.tags as it is marked as readonly.');
+    expect(wrap(books[0]).toObject()).toMatchObject({
+      tags: books[0].tags.getItems().map(t => ({ name: t.name })),
+    });
+
+    const [book11, ...rest] = await tags[0].books.matching({ where: { title: 'book 11' } });
+    expect(book11.title).toBe('book 11');
+    expect(rest).toHaveLength(0);
+
+    orm.em.addFilter('testFilter', { name: 'tag 11-08' }, BookTag, false);
+    const filteredTags = await books[0].tags.matching({ filters: { testFilter: true } });
+    expect(filteredTags).toHaveLength(1);
+    expect(filteredTags[0].name).toBe('tag 11-08');
+  });
+
+  test('loadCount to get the number of entries without initializing the collection (GH issue #949)', async () => {
+    let author = orm.em.create(Author, { name: 'Jon Doe', email: 'doe-jon@wall.st' });
+    orm.em.create(Book, { title: 'bo1', author });
+    // Entity not managed yet
+    await expect(author.books.loadCount()).rejects.toThrow(ValidationError);
+    await orm.em.persistAndFlush(author);
+
+    const reloadedBook = await author.books.loadCount();
+    expect(reloadedBook).toBe(1);
+
+    // Adding new items
+    const laterRemoved = orm.em.create(Book, { title: 'bo2', author });
+    author.books.add(laterRemoved, orm.em.create(Book, { title: 'bo3', author }));
+    const threeItms = await author.books.loadCount();
+    expect(threeItms).toEqual(3);
+
+    // Force refresh
+    expect(await author.books.loadCount(true)).toEqual(1);
+    // Testing array collection implementation
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Updates when removing an item
+    author = (await orm.em.findOneOrFail(Author, author.id));
+    expect(await author.books.loadCount()).toEqual(3);
+    await author.books.init();
+    author.books.remove(author.books[0]);
+    expect(await author.books.loadCount()).toEqual(2);
+    expect(await author.books.loadCount(true)).toEqual(3);
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Resets the counter when hydrating
+    author = (await orm.em.findOneOrFail(Author, author.id));
+    await author.books.loadCount();
+    author.books.hydrate([]);
+    expect(await author.books.loadCount()).toEqual(0);
+    expect(await author.books.loadCount(true)).toEqual(2);
+
+    const coll = new ArrayCollection(author);
+    expect(await coll.loadCount()).toEqual(0);
+
+    // n:m relations
+    let taggedBook = orm.em.create(Book, { title: 'FullyTagged', author });
+    await orm.em.persistAndFlush(taggedBook);
+    const tags = [orm.em.create(BookTag, { name: 'science-fiction' }), orm.em.create(BookTag, { name: 'adventure' }), orm.em.create(BookTag, { name: 'horror' })] as const;
+    taggedBook.tags.add(...tags);
+    await expect(taggedBook.tags.loadCount()).resolves.toEqual(3); // with mongo m:n owners this works based on the collection state
+    await orm.em.flush();
+    orm.em.clear();
+
+    taggedBook = await orm.em.findOneOrFail(Book, taggedBook.id);
+    await expect(taggedBook.tags.loadCount()).resolves.toEqual(tags.length);
+    expect(taggedBook.tags.isInitialized()).toBe(true); // mongo m:n owner is always (partially) initialized
+    await taggedBook.tags.init();
+    await expect(taggedBook.tags.loadCount()).resolves.toEqual(tags.length);
+    const removing  = taggedBook.tags[0];
+    taggedBook.tags.remove(removing);
+    await expect(taggedBook.tags.loadCount()).resolves.toEqual(tags.length - 1);
+    await expect(taggedBook.tags.loadCount(true)).resolves.toEqual(tags.length - 1); // with mongo m:n owners this works based on the collection state
+    await orm.em.flush();
+    orm.em.clear();
+
+    taggedBook = await orm.em.findOneOrFail(Book, taggedBook.id);
+    await expect(taggedBook.tags.loadCount()).resolves.toEqual(tags.length - 1);
+  });
+
+  test('loadCount with unidirectional m:n (GH issue #1608)', async () => {
+    const publisher = orm.em.create(Publisher, { name: 'pub' });
+    const t1 = orm.em.create(Test, { name: 't1' });
+    const t2 = orm.em.create(Test, { name: 't2' });
+    const t3 = orm.em.create(Test, { name: 't3' });
+    await orm.em.persist([t1, t2, t3]).flush();
+    publisher.tests.add(t2, t1, t3);
+    await orm.em.persistAndFlush(publisher);
+    orm.em.clear();
+
+    let ent = await orm.em.findOneOrFail(Publisher, publisher.id);
+    await expect(ent.tests.loadCount()).resolves.toBe(3);
+    await ent.tests.init();
+    await expect(ent.tests.loadCount()).resolves.toBe(3);
+    orm.em.clear();
+
+    ent = await orm.em.findOneOrFail(Publisher, publisher.id, { populate: ['tests'] as const });
+    await expect(ent.tests.loadCount()).resolves.toBe(3);
+    await ent.tests.init();
+    await expect(ent.tests.loadCount()).resolves.toBe(3);
   });
 
   afterAll(async () => orm.close(true));

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -1012,7 +1012,7 @@ describe('EntityManagerMySql', () => {
 
     const b1 = (await orm.em.findOne(FooBaz2, { id: baz.id }, { populate: ['bar'] }))!;
     expect(mock.mock.calls[1][0]).toMatch('select `f0`.*, `f1`.`id` as `bar_id` from `foo_baz2` as `f0` left join `foo_bar2` as `f1` on `f0`.`id` = `f1`.`baz_id` where `f0`.`id` = ? limit ?');
-    expect(mock.mock.calls[2][0]).toMatch('select `f0`.*, (select 123) as `random` from `foo_bar2` as `f0` where `f0`.`id` in (?) order by `f0`.`id` asc');
+    expect(mock.mock.calls[2][0]).toMatch('select `f0`.*, (select 123) as `random` from `foo_bar2` as `f0` where `f0`.`id` in (?)');
     expect(b1.bar).toBeInstanceOf(FooBar2);
     expect(b1.bar!.id).toBe(bar.id);
     expect(wrap(b1).toJSON()).toMatchObject({ bar: { id: bar.id, baz: baz.id, name: 'bar' } });
@@ -1020,7 +1020,7 @@ describe('EntityManagerMySql', () => {
 
     const b2 = (await orm.em.findOne(FooBaz2, { bar: bar.id }, { populate: ['bar'] }))!;
     expect(mock.mock.calls[3][0]).toMatch('select `f0`.*, `f1`.`id` as `bar_id` from `foo_baz2` as `f0` left join `foo_bar2` as `f1` on `f0`.`id` = `f1`.`baz_id` where `f1`.`id` = ? limit ?');
-    expect(mock.mock.calls[4][0]).toMatch('select `f0`.*, (select 123) as `random` from `foo_bar2` as `f0` where `f0`.`id` in (?) order by `f0`.`id` asc');
+    expect(mock.mock.calls[4][0]).toMatch('select `f0`.*, (select 123) as `random` from `foo_bar2` as `f0` where `f0`.`id` in (?)');
     expect(b2.bar).toBeInstanceOf(FooBar2);
     expect(b2.bar!.id).toBe(bar.id);
     expect(wrap(b2).toJSON()).toMatchObject({ bar: { id: bar.id, baz: baz.id, name: 'bar' } });
@@ -2319,7 +2319,7 @@ describe('EntityManagerMySql', () => {
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`author_id` in (?) ' +
-      'order by `b0`.`title` asc, `b0`.`author_id` asc');
+      'order by `b0`.`title` asc');
 
     const a2 = await orm.em.fork().find(Author2, { favouriteBook: { $or: [{ priceTaxed: '1190.0000' }] } }, { populate: ['books'] });
     expect(a2[0].books[0].price).toBe('1000.00');
@@ -2333,7 +2333,7 @@ describe('EntityManagerMySql', () => {
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`author_id` in (?) ' +
-      'order by `b0`.`title` asc, `b0`.`author_id` asc');
+      'order by `b0`.`title` asc');
   });
 
   test('refreshing already loaded entity', async () => {

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -351,7 +351,7 @@ describe('EntityManagerPostgre', () => {
     expect(mock.mock.calls[3][0]).toMatch(`select "t0".*, "p1"."test2_id" as "fk__test2_id", "p1"."publisher2_id" as "fk__publisher2_id" from "test2" as "t0" left join "publisher2_tests" as "p1" on "t0"."id" = "p1"."test2_id" where "p1"."publisher2_id" in ($1) order by "p1"."id" asc for update`);
     expect(mock.mock.calls[4][0]).toMatch(`savepoint trx`);
     expect(mock.mock.calls[5][0]).toMatch(`release savepoint trx`);
-    expect(mock.mock.calls[6][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."publisher_id" = $1 order by "b0"."uuid_pk" asc for update`);
+    expect(mock.mock.calls[6][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."publisher_id" in ($1) for update`);
     expect(mock.mock.calls[7][0]).toMatch(`commit`);
   });
 
@@ -863,7 +863,7 @@ describe('EntityManagerPostgre', () => {
     expect(mock.mock.calls.length).toBe(5);
     expect(mock.mock.calls[0][0]).toMatch('begin');
     expect(mock.mock.calls[1][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null for update skip locked`);
-    expect(mock.mock.calls[2][0]).toMatch(`select "a0".* from "author2" as "a0" where "a0"."id" in ($1) and "a0"."id" is not null order by "a0"."id" asc for update skip locked`);
+    expect(mock.mock.calls[2][0]).toMatch(`select "a0".* from "author2" as "a0" where "a0"."id" in ($1) and "a0"."id" is not null for update skip locked`);
     expect(mock.mock.calls[3][0]).toMatch(`select "b0".*, "b1"."book_tag2_id" as "fk__book_tag2_id", "b1"."book2_uuid_pk" as "fk__book2_uuid_pk" from "book_tag2" as "b0" left join "book2_tags" as "b1" on "b0"."id" = "b1"."book_tag2_id" where "b1"."book2_uuid_pk" in ($1, $2, $3) order by "b1"."order" asc for update skip locked`);
     expect(mock.mock.calls[4][0]).toMatch('commit');
   });
@@ -1023,7 +1023,7 @@ describe('EntityManagerPostgre', () => {
 
     const b1 = await orm.em.findOneOrFail(FooBaz2, { id: baz.id }, { populate: ['bar'] });
     expect(mock.mock.calls[1][0]).toMatch('select "f0".*, "f1"."id" as "bar_id" from "foo_baz2" as "f0" left join "foo_bar2" as "f1" on "f0"."id" = "f1"."baz_id" where "f0"."id" = $1 limit $2');
-    expect(mock.mock.calls[2][0]).toMatch('select "f0".*, (select 123) as "random" from "foo_bar2" as "f0" where "f0"."baz_id" in ($1) order by "f0"."baz_id" asc');
+    expect(mock.mock.calls[2][0]).toMatch('select "f0".*, (select 123) as "random" from "foo_bar2" as "f0" where "f0"."baz_id" in ($1)');
     expect(b1.bar).toBeInstanceOf(FooBar2);
     expect(b1.bar!.id).toBe(bar.id);
     expect(wrap(b1).toJSON()).toMatchObject({ bar: { id: bar.id, baz: baz.id, name: 'bar' } });
@@ -1031,7 +1031,7 @@ describe('EntityManagerPostgre', () => {
 
     const b2 = await orm.em.findOneOrFail(FooBaz2, { bar: bar.id }, { populate: ['bar'] });
     expect(mock.mock.calls[3][0]).toMatch('select "f0".*, "f1"."id" as "bar_id" from "foo_baz2" as "f0" left join "foo_bar2" as "f1" on "f0"."id" = "f1"."baz_id" where "f1"."id" = $1 limit $2');
-    expect(mock.mock.calls[4][0]).toMatch('select "f0".*, (select 123) as "random" from "foo_bar2" as "f0" where "f0"."baz_id" in ($1) order by "f0"."baz_id" asc');
+    expect(mock.mock.calls[4][0]).toMatch('select "f0".*, (select 123) as "random" from "foo_bar2" as "f0" where "f0"."baz_id" in ($1)');
     expect(b2.bar).toBeInstanceOf(FooBar2);
     expect(b2.bar!.id).toBe(bar.id);
     expect(wrap(b2).toJSON()).toMatchObject({ bar: { id: bar.id, baz: baz.id, name: 'bar' } });
@@ -1283,7 +1283,7 @@ describe('EntityManagerPostgre', () => {
       'new book',
     ]);
 
-    expect(mock.mock.calls[0][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."author_id" = $1 order by "b0"."title" asc`);
+    expect(mock.mock.calls[0][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."author_id" in ($1) order by "b0"."title" asc`);
     expect(mock.mock.calls[1][0]).toMatch(`begin`);
     expect(mock.mock.calls[2][0]).toMatch(`insert into "book2" ("uuid_pk", "created_at", "title", "price", "author_id") values ($1, $2, $3, $4, $5)`);
     expect(mock.mock.calls[3][0]).toMatch(`commit`);

--- a/tests/entities/Author.ts
+++ b/tests/entities/Author.ts
@@ -1,7 +1,25 @@
 import type { EntityDTO, Dictionary } from '@mikro-orm/core';
 import {
-  AfterCreate, AfterDelete, AfterUpdate, BeforeCreate, BeforeDelete, BeforeUpdate, DateType, Collection, Filter,
-  Cascade, Entity, ManyToMany, ManyToOne, OneToMany, Property, Index, Unique, EntityAssigner, EntityRepositoryType,
+  AfterCreate,
+  AfterDelete,
+  AfterUpdate,
+  BeforeCreate,
+  BeforeDelete,
+  BeforeUpdate,
+  DateType,
+  Collection,
+  Filter,
+  Cascade,
+  Entity,
+  ManyToMany,
+  ManyToOne,
+  OneToMany,
+  Property,
+  Index,
+  Unique,
+  EntityAssigner,
+  EntityRepositoryType,
+  QueryOrder,
 } from '@mikro-orm/core';
 
 import { Book } from './Book';
@@ -50,7 +68,12 @@ export class Author extends BaseEntity<Author, 'termsAccepted' | 'code2' | 'vers
   @Index()
   born?: Date;
 
-  @OneToMany(() => Book, book => book.author, { referenceColumnName: '_id', cascade: [Cascade.PERSIST], orphanRemoval: true })
+  @OneToMany(() => Book, book => book.author, {
+    referenceColumnName: '_id',
+    cascade: [Cascade.PERSIST],
+    orphanRemoval: true,
+    orderBy: { title: QueryOrder.ASC },
+  })
   books = new Collection<Book>(this);
 
   @ManyToMany(() => Author)

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -46,7 +46,7 @@ export class Book extends BaseEntity3 {
   @Index({ name: 'publisher_idx' })
   publisher!: Ref<Publisher> | null;
 
-  @ManyToMany(() => BookTag)
+  @ManyToMany(() => BookTag, undefined, { orderBy: { title: 'asc' } })
   tags = new Collection<BookTag>(this);
 
   @Property({ type: 'json', nullable: true })

--- a/tests/features/cursor-based-pagination/__snapshots__/complex-cursor.test.ts.snap
+++ b/tests/features/cursor-based-pagination/__snapshots__/complex-cursor.test.ts.snap
@@ -24,7 +24,7 @@ exports[`simple cursor based pagination (better-sqlite) complex joined cursor ba
 exports[`simple cursor based pagination (better-sqlite) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
 [
   "[query] select \`u0\`.* from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3' and \`u1\`.\`email\` <= 'email-96' and \`u1\`.\`name\` <= 'User 3' and ((\`u1\`.\`email\` < 'email-96' and \`u1\`.\`name\` < 'User 3') or (\`u0\`.\`name\` >= 'User 3' and (\`u0\`.\`name\` > 'User 3' or (\`u0\`.\`age\` <= 38 and (\`u0\`.\`age\` < 38 or \`u0\`.\`email\` < 'email-76'))))) order by \`u1\`.\`email\` desc, \`u1\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
-  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` in (5) order by \`u0\`.\`email\` asc, \`u0\`.\`name\` asc, \`u0\`.\`_id\` asc",
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` in (5) order by \`u0\`.\`email\` asc, \`u0\`.\`name\` asc",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3'",
 ]
 `;
@@ -67,7 +67,7 @@ exports[`simple cursor based pagination (mysql) complex joined cursor based pagi
 exports[`simple cursor based pagination (mysql) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
 [
   "[query] select \`u0\`.* from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3' and \`u1\`.\`email\` <= 'email-96' and \`u1\`.\`name\` <= 'User 3' and ((\`u1\`.\`email\` < 'email-96' and \`u1\`.\`name\` < 'User 3') or (\`u0\`.\`name\` >= 'User 3' and (\`u0\`.\`name\` > 'User 3' or (\`u0\`.\`age\` <= 38 and (\`u0\`.\`age\` < 38 or \`u0\`.\`email\` < 'email-76'))))) order by \`u1\`.\`email\` desc, \`u1\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
-  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` in (5) order by \`u0\`.\`email\` asc, \`u0\`.\`name\` asc, \`u0\`.\`_id\` asc",
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` in (5) order by \`u0\`.\`email\` asc, \`u0\`.\`name\` asc",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3'",
 ]
 `;
@@ -96,7 +96,7 @@ exports[`simple cursor based pagination (postgresql) complex joined cursor based
 exports[`simple cursor based pagination (postgresql) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
 [
   "[query] select "u0".* from "user" as "u0" left join "user" as "u1" on "u0"."best_friend__id" = "u1"."_id" where "u1"."name" = 'User 3' and "u1"."email" <= 'email-96' and "u1"."name" <= 'User 3' and (("u1"."email" < 'email-96' and "u1"."name" < 'User 3') or ("u0"."name" >= 'User 3' and ("u0"."name" > 'User 3' or ("u0"."age" <= 38 and ("u0"."age" < 38 or "u0"."email" < 'email-76'))))) order by "u1"."email" desc, "u1"."name" desc, "u0"."name" asc, "u0"."age" desc, "u0"."email" desc limit 6",
-  "[query] select "u0".* from "user" as "u0" where "u0"."_id" in (5) order by "u0"."email" asc, "u0"."name" asc, "u0"."_id" asc",
+  "[query] select "u0".* from "user" as "u0" where "u0"."_id" in (5) order by "u0"."email" asc, "u0"."name" asc",
   "[query] select count(*) as "count" from "user" as "u0" left join "user" as "u1" on "u0"."best_friend__id" = "u1"."_id" where "u1"."name" = 'User 3'",
 ]
 `;
@@ -125,7 +125,7 @@ exports[`simple cursor based pagination (sqlite) complex joined cursor based pag
 exports[`simple cursor based pagination (sqlite) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
 [
   "[query] select \`u0\`.* from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3' and \`u1\`.\`email\` <= 'email-96' and \`u1\`.\`name\` <= 'User 3' and ((\`u1\`.\`email\` < 'email-96' and \`u1\`.\`name\` < 'User 3') or (\`u0\`.\`name\` >= 'User 3' and (\`u0\`.\`name\` > 'User 3' or (\`u0\`.\`age\` <= 38 and (\`u0\`.\`age\` < 38 or \`u0\`.\`email\` < 'email-76'))))) order by \`u1\`.\`email\` desc, \`u1\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
-  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` in (5) order by \`u0\`.\`email\` asc, \`u0\`.\`name\` asc, \`u0\`.\`_id\` asc",
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` in (5) order by \`u0\`.\`email\` asc, \`u0\`.\`name\` asc",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3'",
 ]
 `;

--- a/tests/features/custom-order/custom-order.mysql.test.ts
+++ b/tests/features/custom-order/custom-order.mysql.test.ts
@@ -250,6 +250,6 @@ describe('custom order [mysql]', () => {
     const ret = users.flatMap(u => u.tasks.getItems()).map(({ owner, label }) => `${owner?.name}-${label}`);
     expect(ret).toEqual(['u1-1c', 'u1-1b', 'u1-1a', 'u2-2b', 'u2-2a', 'u2-2c']);
     expect(mock.mock.calls[4][0]).toMatch('select `u0`.* from `user` as `u0` left join `task` as `t1` on `u0`.`id` = `t1`.`owner_id` order by `u0`.`name` asc, (case when `t1`.`priority` = \'low\' then 0 when `t1`.`priority` = \'medium\' then 1 when `t1`.`priority` = \'high\' then 2 else null end) asc');
-    expect(mock.mock.calls[5][0]).toMatch('select `t0`.* from `task` as `t0` where `t0`.`owner_id` in (1, 2) order by (case when `t0`.`priority` = \'low\' then 0 when `t0`.`priority` = \'medium\' then 1 when `t0`.`priority` = \'high\' then 2 else null end) asc, `t0`.`owner_id` asc');
+    expect(mock.mock.calls[5][0]).toMatch('select `t0`.* from `task` as `t0` where `t0`.`owner_id` in (1, 2) order by (case when `t0`.`priority` = \'low\' then 0 when `t0`.`priority` = \'medium\' then 1 when `t0`.`priority` = \'high\' then 2 else null end) asc');
   });
 });

--- a/tests/features/custom-order/custom-order.postgres.test.ts
+++ b/tests/features/custom-order/custom-order.postgres.test.ts
@@ -252,6 +252,6 @@ describe('custom order [postgres]', () => {
     const ret = users.flatMap(u => u.tasks.getItems()).map(({ owner, label }) => `${owner?.name}-${label}`);
     expect(ret).toEqual(['u1-1c', 'u1-1b', 'u1-1a', 'u2-2b', 'u2-2a', 'u2-2c']);
     expect(mock.mock.calls[4][0]).toMatch(`select "u0".* from "user" as "u0" left join "task" as "t1" on "u0"."id" = "t1"."owner_id" order by "u0"."name" asc, (case when "t1"."priority" = 'low' then 0 when "t1"."priority" = 'medium' then 1 when "t1"."priority" = 'high' then 2 else null end) asc`);
-    expect(mock.mock.calls[5][0]).toMatch(`select "t0".* from "task" as "t0" where "t0"."owner_id" in (1, 2) order by (case when "t0"."priority" = 'low' then 0 when "t0"."priority" = 'medium' then 1 when "t0"."priority" = 'high' then 2 else null end) asc, "t0"."owner_id" asc`);
+    expect(mock.mock.calls[5][0]).toMatch(`select "t0".* from "task" as "t0" where "t0"."owner_id" in (1, 2) order by (case when "t0"."priority" = 'low' then 0 when "t0"."priority" = 'medium' then 1 when "t0"."priority" = 'high' then 2 else null end) asc`);
   });
 });

--- a/tests/features/custom-order/custom-order.sqlite.test.ts
+++ b/tests/features/custom-order/custom-order.sqlite.test.ts
@@ -252,7 +252,7 @@ describe('custom order [sqlite]', () => {
     const ret = users.flatMap(u => u.tasks.getItems()).map(({ owner, label }) => `${owner?.name}-${label}`);
     expect(ret).toEqual(['u1-1c', 'u1-1b', 'u1-1a', 'u2-2b', 'u2-2a', 'u2-2c']);
     expect(mock.mock.calls[4][0]).toMatch('select `u0`.* from `user` as `u0` left join `task` as `t1` on `u0`.`id` = `t1`.`owner_id` order by `u0`.`name` asc, (case when `t1`.`priority` = \'low\' then 0 when `t1`.`priority` = \'medium\' then 1 when `t1`.`priority` = \'high\' then 2 else null end) asc');
-    expect(mock.mock.calls[5][0]).toMatch('select `t0`.* from `task` as `t0` where `t0`.`owner_id` in (1, 2) order by (case when `t0`.`priority` = \'low\' then 0 when `t0`.`priority` = \'medium\' then 1 when `t0`.`priority` = \'high\' then 2 else null end) asc, `t0`.`owner_id` asc');
+    expect(mock.mock.calls[5][0]).toMatch('select `t0`.* from `task` as `t0` where `t0`.`owner_id` in (1, 2) order by (case when `t0`.`priority` = \'low\' then 0 when `t0`.`priority` = \'medium\' then 1 when `t0`.`priority` = \'high\' then 2 else null end) asc');
   });
 
 });

--- a/tests/features/embeddables/entities-in-embeddables.mongo.test.ts
+++ b/tests/features/embeddables/entities-in-embeddables.mongo.test.ts
@@ -399,11 +399,11 @@ describe('embedded entities in mongo', () => {
     });
 
     expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('user').find({}, {}).sort([ [ 'name', -1 ] ]).toArray();`);
-    expect(mock.mock.calls[1][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000004'), ObjectId('600000000000000000000012') ] } }, {}).sort([ [ '_id', 1 ] ]).toArray();`);
-    expect(mock.mock.calls[2][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000003'), ObjectId('600000000000000000000013') ] } }, {}).sort([ [ '_id', 1 ] ]).toArray();`);
-    expect(mock.mock.calls[3][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000002') ] } }, {}).sort([ [ '_id', 1 ] ]).toArray();`);
-    expect(mock.mock.calls[4][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000014'), ObjectId('600000000000000000000015') ] } }, {}).sort([ [ '_id', 1 ] ]).toArray();`);
-    expect(mock.mock.calls[5][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000016'), ObjectId('600000000000000000000017'), ObjectId('600000000000000000000018'), ObjectId('600000000000000000000019'), ObjectId('60000000000000000000001a'), ObjectId('60000000000000000000001b') ] } }, {}).sort([ [ '_id', 1 ] ]).toArray();`);
+    expect(mock.mock.calls[1][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000004'), ObjectId('600000000000000000000012') ] } }, {}).toArray();`);
+    expect(mock.mock.calls[2][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000003'), ObjectId('600000000000000000000013') ] } }, {}).toArray();`);
+    expect(mock.mock.calls[3][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000002') ] } }, {}).toArray();`);
+    expect(mock.mock.calls[4][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000014'), ObjectId('600000000000000000000015') ] } }, {}).toArray();`);
+    expect(mock.mock.calls[5][0]).toMatch(`db.getCollection('source').find({ _id: { '$in': [ ObjectId('600000000000000000000016'), ObjectId('600000000000000000000017'), ObjectId('600000000000000000000018'), ObjectId('600000000000000000000019'), ObjectId('60000000000000000000001a'), ObjectId('60000000000000000000001b') ] } }, {}).toArray();`);
     expect(wrap(users[0].profile1.source!).isInitialized()).toBe(true);
     expect(users[0].profile1.source!.name).toBe('s1');
     expect(wrap(users[1].profile1.identity.links[1].source!).isInitialized()).toBe(true);

--- a/tests/features/embeddables/entities-in-embeddables.postgres.test.ts
+++ b/tests/features/embeddables/entities-in-embeddables.postgres.test.ts
@@ -392,10 +392,10 @@ describe('embedded entities in postgres', () => {
     });
 
     expect(mock.mock.calls[0][0]).toMatch(`select "u0".* from "user" as "u0" order by "u0"."name" desc`);
-    expect(mock.mock.calls[1][0]).toMatch(`select "s0".* from "source" as "s0" where "s0"."id" in (1, 7) order by "s0"."id" asc`);
-    expect(mock.mock.calls[2][0]).toMatch(`select "s0".* from "source" as "s0" where "s0"."id" in (2, 8) order by "s0"."id" asc`);
-    expect(mock.mock.calls[3][0]).toMatch(`select "s0".* from "source" as "s0" where "s0"."id" in (3) order by "s0"."id" asc`);
-    expect(mock.mock.calls[4][0]).toMatch(`select "s0".* from "source" as "s0" where "s0"."id" in (11, 12, 13, 14, 15, 16) order by "s0"."id" asc`);
+    expect(mock.mock.calls[1][0]).toMatch(`select "s0".* from "source" as "s0" where "s0"."id" in (1, 7)`);
+    expect(mock.mock.calls[2][0]).toMatch(`select "s0".* from "source" as "s0" where "s0"."id" in (2, 8)`);
+    expect(mock.mock.calls[3][0]).toMatch(`select "s0".* from "source" as "s0" where "s0"."id" in (3)`);
+    expect(mock.mock.calls[4][0]).toMatch(`select "s0".* from "source" as "s0" where "s0"."id" in (11, 12, 13, 14, 15, 16)`);
     expect(wrap(users[1].profile1.identity.links[1].metas[2].source!).isInitialized()).toBe(true);
     expect(users[1].profile1.identity.links[1].metas[2].source!.name).toBe('ilms323');
 

--- a/tests/features/joined-strategy.postgre.test.ts
+++ b/tests/features/joined-strategy.postgre.test.ts
@@ -399,6 +399,7 @@ describe('Joined loading strategy', () => {
 
     const tags = await repo.findAll({
       populate: ['books.author', 'books.publisher.tests'],
+      // TODO maybe this could be resolved too when we fix the ordering via em.populate?
       orderBy: { name: 'asc', books: { publisher: { tests: { name: 'asc' } } } }, // TODO should be implicit as we have fixed order there
       strategy: LoadStrategy.JOINED,
     });

--- a/tests/features/lazy-scalar-properties/lazy-scalar-properties.mongo.test.ts
+++ b/tests/features/lazy-scalar-properties/lazy-scalar-properties.mongo.test.ts
@@ -67,7 +67,7 @@ describe('lazy scalar properties (mongo)', () => {
 
     expect(mock.mock.calls).toHaveLength(3);
     expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('author').find({}, {}).toArray();`);
-    expect(mock.mock.calls[1][0]).toMatch(`db.getCollection('books-table').find({ author: { '$in': [ ObjectId('61a2438bdd2b18c64de57d04') ] } }, { projection: { _id: 1, createdAt: 1, title: 1, author: 1, publisher: 1, tags: 1, metaObject: 1, metaArray: 1, metaArrayOfStrings: 1, point: 1, tenant: 1 } }).toArray();`);
+    expect(mock.mock.calls[1][0]).toMatch(`db.getCollection('books-table').find({ author: { '$in': [ ObjectId('61a2438bdd2b18c64de57d04') ] } }, { projection: { _id: 1, createdAt: 1, title: 1, author: 1, publisher: 1, tags: 1, metaObject: 1, metaArray: 1, metaArrayOfStrings: 1, point: 1, tenant: 1 } }).sort([ [ 'title', 1 ] ]).toArray();`);
     expect(mock.mock.calls[2][0]).toMatch(`db.getCollection('books-table').find({ _id: { '$in': [ ObjectId('61a24373938899ec672b4ee4') ] } }, { projection: { _id: 1, perex: 1 } }).toArray();`);
   });
 

--- a/tests/features/lazy-scalar-properties/lazy-scalar-properties.mongo.test.ts
+++ b/tests/features/lazy-scalar-properties/lazy-scalar-properties.mongo.test.ts
@@ -67,7 +67,7 @@ describe('lazy scalar properties (mongo)', () => {
 
     expect(mock.mock.calls).toHaveLength(3);
     expect(mock.mock.calls[0][0]).toMatch(`db.getCollection('author').find({}, {}).toArray();`);
-    expect(mock.mock.calls[1][0]).toMatch(`db.getCollection('books-table').find({ author: { '$in': [ ObjectId('61a2438bdd2b18c64de57d04') ] } }, { projection: { _id: 1, createdAt: 1, title: 1, author: 1, publisher: 1, tags: 1, metaObject: 1, metaArray: 1, metaArrayOfStrings: 1, point: 1, tenant: 1 } }).sort([ [ 'author', 1 ] ]).toArray();`);
+    expect(mock.mock.calls[1][0]).toMatch(`db.getCollection('books-table').find({ author: { '$in': [ ObjectId('61a2438bdd2b18c64de57d04') ] } }, { projection: { _id: 1, createdAt: 1, title: 1, author: 1, publisher: 1, tags: 1, metaObject: 1, metaArray: 1, metaArrayOfStrings: 1, point: 1, tenant: 1 } }).toArray();`);
     expect(mock.mock.calls[2][0]).toMatch(`db.getCollection('books-table').find({ _id: { '$in': [ ObjectId('61a24373938899ec672b4ee4') ] } }, { projection: { _id: 1, perex: 1 } }).toArray();`);
   });
 

--- a/tests/features/lazy-scalar-properties/lazy-scalar-properties.mysql.test.ts
+++ b/tests/features/lazy-scalar-properties/lazy-scalar-properties.mysql.test.ts
@@ -91,7 +91,7 @@ describe('lazy scalar properties (mysql)', () => {
 
     expect(mock.mock.calls).toHaveLength(3);
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `a1`.`author_id` as `address_author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id`');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `test_id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`author_id` is not null and `b0`.`author_id` in (?) order by `b0`.`title` asc, `b0`.`author_id` asc');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `test_id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`author_id` is not null and `b0`.`author_id` in (?) order by `b0`.`title` asc');
     expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`perex` from `book2` as `b0` where `b0`.`author_id` is not null and `b0`.`uuid_pk` in (?)');
 
     mock.mockReset();

--- a/tests/features/multiple-schemas/GH3177.test.ts
+++ b/tests/features/multiple-schemas/GH3177.test.ts
@@ -94,8 +94,8 @@ test(`GH issue 3177`, async () => {
   expect(mock.mock.calls[4][0]).toMatch(`insert into "tenant_01"."access_profile_permission" ("access_profile_id", "permission_id") values (1, 1), (1, 2), (1, 3)`);
   expect(mock.mock.calls[5][0]).toMatch(`commit`);
   expect(mock.mock.calls[6][0]).toMatch(`select "u0".* from "tenant_01"."user" as "u0" where "u0"."id" = 1 limit 1`);
-  expect(mock.mock.calls[7][0]).toMatch(`select "p0".* from "public"."permission" as "p0" where "p0"."id" in (1, 2, 3)`);
+  expect(mock.mock.calls[7][0]).toMatch(`select "p0".*, "a1"."permission_id" as "fk__permission_id", "a1"."access_profile_id" as "fk__access_profile_id" from "public"."permission" as "p0" left join "tenant_01"."access_profile_permission" as "a1" on "p0"."id" = "a1"."permission_id" where "a1"."access_profile_id" in (1)`);
   expect(mock.mock.calls[8][0]).toMatch(`select "u0".* from "tenant_01"."user" as "u0" where "u0"."id" = 1 limit 1`);
-  expect(mock.mock.calls[9][0]).toMatch(`select "u0".* from "tenant_01"."user_access_profile" as "u0" where "u0"."id" in (1) order by "u0"."id" asc`);
+  expect(mock.mock.calls[9][0]).toMatch(`select "u0".* from "tenant_01"."user_access_profile" as "u0" where "u0"."id" in (1)`);
   expect(mock.mock.calls[10][0]).toMatch(`select "p0".*, "a1"."permission_id" as "fk__permission_id", "a1"."access_profile_id" as "fk__access_profile_id" from "public"."permission" as "p0" left join "tenant_01"."access_profile_permission" as "a1" on "p0"."id" = "a1"."permission_id" where "a1"."access_profile_id" in (1)`);
 });

--- a/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
+++ b/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
@@ -297,7 +297,7 @@ describe('multiple connected schemas in postgres', () => {
     await fork.findOneOrFail(Author, author, { populate: true, schema: 'n5' });
 
     expect(mock.mock.calls[0][0]).toMatch(`select "a0".* from "n1"."author" as "a0" where "a0"."id" = 1 limit 1`);
-    expect(mock.mock.calls[1][0]).toMatch(`select "b0".* from "n5"."book" as "b0" where "b0"."author_id" in (1) order by "b0"."author_id" asc`);
+    expect(mock.mock.calls[1][0]).toMatch(`select "b0".* from "n5"."book" as "b0" where "b0"."author_id" in (1)`);
     expect(mock.mock.calls[2][0]).toMatch(`select "b0".*, "b1"."book_tag_id" as "fk__book_tag_id", "b1"."book_id" as "fk__book_id" from "n5"."book_tag" as "b0" left join "n5"."book_tags" as "b1" on "b0"."id" = "b1"."book_tag_id" where "b1"."book_id" in (2, 1)`);
     mock.mockReset();
 

--- a/tests/features/partial-loading/partial-loading.mongo.test.ts
+++ b/tests/features/partial-loading/partial-loading.mongo.test.ts
@@ -49,7 +49,7 @@ describe('partial loading (mongo)', () => {
     expect(r1[0].books[0].tenant).toBeUndefined();
     expect(r1[0].books[0].author).toBeDefined();
     expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: ObjectId\('.*'\) }, { projection: { _id: 1 } }\)\.toArray\(\);/);
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ author: { '\$in': \[ ObjectId\('.*'\) ] } }, { projection: { _id: 1, author: 1, title: 1 } }\)\.sort\(\[ \[ 'author', 1 ] ]\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ author: { '\$in': \[ ObjectId\('.*'\) ] } }, { projection: { _id: 1, author: 1, title: 1 } }\)\.toArray\(\);/);
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -67,7 +67,7 @@ describe('partial loading (mongo)', () => {
     expect(r2[0].books[0].tenant).toBeUndefined();
     expect(r2[0].books[0].author).toBeDefined();
     expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: ObjectId\('.*'\) }, { projection: { _id: 1 } }\)\.toArray\(\);/);
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ author: { '\$in': \[ ObjectId\('.*'\) ] } }, { projection: { _id: 1, author: 1, title: 1 } }\)\.sort\(\[ \[ 'author', 1 ] ]\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ author: { '\$in': \[ ObjectId\('.*'\) ] } }, { projection: { _id: 1, author: 1, title: 1 } }\)\.toArray\(\);/);
   });
 
   test('partial nested loading (m:1)', async () => {
@@ -99,7 +99,7 @@ describe('partial loading (mongo)', () => {
     expect(r1[0].author.name).toBeUndefined();
     expect(r1[0].author.email).toBeDefined();
     expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ _id: ObjectId\('.*'\) }, { projection: { _id: 1, title: 1, author: 1 } }\)\.toArray\(\);/);
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { projection: { _id: 1, email: 1 } }\)\.sort\(\[ \[ '_id', 1 ] ]\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { projection: { _id: 1, email: 1 } }\)\.toArray\(\);/);
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -119,7 +119,7 @@ describe('partial loading (mongo)', () => {
     expect(r2[0].author.name).toBeUndefined();
     expect(r2[0].author.email).toBeDefined();
     expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ _id: ObjectId\('.*'\) }, { projection: { _id: 1, title: 1, author: 1 } }\)\.toArray\(\);/);
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { projection: { _id: 1, email: 1 } }\)\.sort\(\[ \[ '_id', 1 ] ]\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { projection: { _id: 1, email: 1 } }\)\.toArray\(\);/);
   });
 
   test('partial nested loading (m:n)', async () => {
@@ -152,7 +152,7 @@ describe('partial loading (mongo)', () => {
     // @ts-expect-error
     expect(r1[0].books[0].author).toBeUndefined();
     expect(mock.mock.calls[0][0]).toMatch('db.getCollection(\'book-tag\').find({}, { projection: { _id: 1, name: 1 } }).toArray();');
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\) ] } }, { projection: { _id: 1, title: 1, tags: 1 } }\)\.sort\(\[ \[ 'tags', 1 ] ]\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\) ] } }, { projection: { _id: 1, title: 1, tags: 1 } }\)\.toArray\(\);/);
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -169,7 +169,7 @@ describe('partial loading (mongo)', () => {
     // @ts-expect-error
     expect(r2[0].books[0].author).toBeUndefined();
     expect(mock.mock.calls[0][0]).toMatch('db.getCollection(\'book-tag\').find({ name: \'t1\' }, { projection: { _id: 1, name: 1 } }).toArray();');
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\) ] } }, { projection: { _id: 1, title: 1, tags: 1 } }\)\.sort\(\[ \[ 'tags', 1 ] ]\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\) ] } }, { projection: { _id: 1, title: 1, tags: 1 } }\)\.toArray\(\);/);
   });
 
   test('partial nested loading (mixed)', async () => {
@@ -204,8 +204,8 @@ describe('partial loading (mongo)', () => {
     expect(r1[0].books[0].author.name).toBeUndefined();
     expect(r1[0].books[0].author.email).toBe(god.email);
     expect(mock.mock.calls[0][0]).toMatch('db.getCollection(\'book-tag\').find({}, { projection: { _id: 1, name: 1 } }).toArray();');
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\) ] } }, { projection: { _id: 1, title: 1, tags: 1, author: 1 } }\)\.sort\(\[ \[ 'tags', 1 ] ]\)\.toArray\(\);/);
-    expect(mock.mock.calls[2][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { projection: { _id: 1, email: 1 } }\)\.sort\(\[ \[ '_id', 1 ] ]\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\) ] } }, { projection: { _id: 1, title: 1, tags: 1, author: 1 } }\)\.toArray\(\);/);
+    expect(mock.mock.calls[2][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { projection: { _id: 1, email: 1 } }\)\.toArray\(\);/);
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -225,8 +225,8 @@ describe('partial loading (mongo)', () => {
     expect(r2[0].books[0].author.name).toBeUndefined();
     expect(r2[0].books[0].author.email).toBe(god.email);
     expect(mock.mock.calls[0][0]).toMatch('db.getCollection(\'book-tag\').find({}, { projection: { _id: 1, name: 1 } }).toArray();');
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\) ] } }, { projection: { _id: 1, title: 1, tags: 1, author: 1 } }\)\.sort\(\[ \[ 'tags', 1 ] ]\)\.toArray\(\);/);
-    expect(mock.mock.calls[2][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { projection: { _id: 1, email: 1 } }\)\.sort\(\[ \[ '_id', 1 ] ]\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ tags: { '\$in': \[ ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\), ObjectId\('.*'\) ] } }, { projection: { _id: 1, title: 1, tags: 1, author: 1 } }\)\.toArray\(\);/);
+    expect(mock.mock.calls[2][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: { '\$in': \[ ObjectId\('.*'\) ] } }, { projection: { _id: 1, email: 1 } }\)\.toArray\(\);/);
   });
 
 });

--- a/tests/features/partial-loading/partial-loading.mongo.test.ts
+++ b/tests/features/partial-loading/partial-loading.mongo.test.ts
@@ -49,7 +49,7 @@ describe('partial loading (mongo)', () => {
     expect(r1[0].books[0].tenant).toBeUndefined();
     expect(r1[0].books[0].author).toBeDefined();
     expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: ObjectId\('.*'\) }, { projection: { _id: 1 } }\)\.toArray\(\);/);
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ author: { '\$in': \[ ObjectId\('.*'\) ] } }, { projection: { _id: 1, author: 1, title: 1 } }\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ author: { '\$in': \[ ObjectId\('.*'\) ] } }, { projection: { _id: 1, author: 1, title: 1 } }\)\.sort\(\[ \[ 'title', 1 ] ]\)\.toArray\(\);/);
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -67,7 +67,7 @@ describe('partial loading (mongo)', () => {
     expect(r2[0].books[0].tenant).toBeUndefined();
     expect(r2[0].books[0].author).toBeDefined();
     expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('author'\)\.find\({ _id: ObjectId\('.*'\) }, { projection: { _id: 1 } }\)\.toArray\(\);/);
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ author: { '\$in': \[ ObjectId\('.*'\) ] } }, { projection: { _id: 1, author: 1, title: 1 } }\)\.toArray\(\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.find\({ author: { '\$in': \[ ObjectId\('.*'\) ] } }, { projection: { _id: 1, author: 1, title: 1 } }\)\.sort\(\[ \[ 'title', 1 ] ]\)\.toArray\(\);/);
   });
 
   test('partial nested loading (m:1)', async () => {

--- a/tests/features/partial-loading/partial-loading.mysql.test.ts
+++ b/tests/features/partial-loading/partial-loading.mysql.test.ts
@@ -177,7 +177,7 @@ describe('partial loading (mysql)', () => {
     expect(r1[0].author.name).toBeUndefined();
     expect(r1[0].author.email).toBeDefined();
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`title`, `b0`.`author_id` from `book2` as `b0` where `b0`.`uuid_pk` = ?');
-    expect(mock.mock.calls[1][0]).toMatch('select `a0`.`id`, `a0`.`email` from `author2` as `a0` where `a0`.`id` in (?) order by `a0`.`id` asc');
+    expect(mock.mock.calls[1][0]).toMatch('select `a0`.`id`, `a0`.`email` from `author2` as `a0` where `a0`.`id` in (?)');
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -197,7 +197,7 @@ describe('partial loading (mysql)', () => {
     expect(r2[0].author.name).toBeUndefined();
     expect(r2[0].author.email).toBeDefined();
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`title`, `b0`.`author_id` from `book2` as `b0` where `b0`.`uuid_pk` = ?');
-    expect(mock.mock.calls[1][0]).toMatch('select `a0`.`id`, `a0`.`email` from `author2` as `a0` where `a0`.`id` in (?) order by `a0`.`id` asc');
+    expect(mock.mock.calls[1][0]).toMatch('select `a0`.`id`, `a0`.`email` from `author2` as `a0` where `a0`.`id` in (?)');
   });
 
   test('partial nested loading (m:n)', async () => {
@@ -250,7 +250,7 @@ describe('partial loading (mysql)', () => {
     expect(r1[0].books[0].author.email).toBe(god.email);
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name` from `book_tag2` as `b0`');
     expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`title`, `b0`.`author_id`, `b1`.`book_tag2_id` as `fk__book_tag2_id`, `b1`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `t2`.`id` as `test_id` from `book2` as `b0` left join `book2_tags` as `b1` on `b0`.`uuid_pk` = `b1`.`book2_uuid_pk` left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` where `b1`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) order by `b1`.`order` asc');
-    expect(mock.mock.calls[2][0]).toMatch('select `a0`.`id`, `a0`.`email` from `author2` as `a0` where `a0`.`id` in (?) order by `a0`.`id` asc');
+    expect(mock.mock.calls[2][0]).toMatch('select `a0`.`id`, `a0`.`email` from `author2` as `a0` where `a0`.`id` in (?)');
   });
 
   test('partial nested loading (with joined strategy and dot notation)', async () => {
@@ -321,7 +321,7 @@ describe('partial loading (mysql)', () => {
     expect(r2[0].books[0].author.email).toBe(god.email);
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name` from `book_tag2` as `b0`');
     expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`title`, `b0`.`author_id`, `b1`.`book_tag2_id` as `fk__book_tag2_id`, `b1`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `t2`.`id` as `test_id` from `book2` as `b0` left join `book2_tags` as `b1` on `b0`.`uuid_pk` = `b1`.`book2_uuid_pk` left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` where `b1`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) order by `b1`.`order` asc');
-    expect(mock.mock.calls[2][0]).toMatch('select `a0`.`id`, `a0`.`email` from `author2` as `a0` where `a0`.`id` in (?) order by `a0`.`id` asc');
+    expect(mock.mock.calls[2][0]).toMatch('select `a0`.`id`, `a0`.`email` from `author2` as `a0` where `a0`.`id` in (?)');
   });
 
   test('partial nested loading (with joined strategy)', async () => {

--- a/tests/features/serialization/GH4464.test.ts
+++ b/tests/features/serialization/GH4464.test.ts
@@ -1,0 +1,58 @@
+import { Collection, Entity, ManyToMany, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
+
+@Entity()
+class A {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  test1!: string;
+
+  @ManyToMany({ entity: () => B, mappedBy: 'a' })
+  b = new Collection<B>(this);
+
+}
+
+@Entity()
+class B {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  test2!: string;
+
+  @Property()
+  test3!: string;
+
+  @ManyToMany({ entity: () => A, inversedBy: 'b' })
+  a = new Collection<A>(this);
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [A, B],
+    dbName: ':memory:',
+  });
+  await orm.schema.refreshDatabase();
+});
+
+afterAll(() => orm.close());
+
+test('loadItems with fields (#4464)', async () => {
+  const a = orm.em.create(A, { test1: 'yxcv', b: [
+    { test2: 'qwer', test3: 'asdf' },
+  ] });
+
+  await orm.em.flush();
+  orm.em.clear();
+
+  await orm.em.findOne(B, 1, { fields: ['test2'] });
+  const a2 = await orm.em.findOneOrFail(A, 1);
+  const test3 = (await a2.b.loadItems())[0].test3;
+  expect(test3).toMatch('asdf');
+});

--- a/tests/issues/GH1657.test.ts
+++ b/tests/issues/GH1657.test.ts
@@ -79,7 +79,7 @@ describe('GH issue 1657', () => {
     // first query loads item and joins the order2 relation (eager + joined strategy)
     expect(mock.mock.calls[0][0]).toMatch('select `o0`.`id`, `o0`.`order1_id`, `o0`.`order2_id`, `o1`.`id` as `o1__id` from `order_item` as `o0` left join `order` as `o1` on `o0`.`order2_id` = `o1`.`id` where `o0`.`id` <= 100');
     // second query loads order1 relation (eager + select-in strategy)
-    expect(mock.mock.calls[1][0]).toMatch('select `o0`.* from `order` as `o0` where `o0`.`id` in (1) order by `o0`.`id` asc');
+    expect(mock.mock.calls[1][0]).toMatch('select `o0`.* from `order` as `o0` where `o0`.`id` in (1)');
 
     expect(mock.mock.calls).toHaveLength(2);
   });

--- a/tests/issues/GH1882.test.ts
+++ b/tests/issues/GH1882.test.ts
@@ -61,12 +61,12 @@ describe('GH issue 1882', () => {
 
     await orm.em.fork().find(Foo, cond, { populate: ['barItems'], populateWhere: PopulateHint.INFER });
     expect(mock.mock.calls[0][0]).toMatch('select `f0`.* from `foo` as `f0` left join `bar` as `b1` on `f0`.`id` = `b1`.`foo_id` where (`b1`.`id` = ? or `f0`.`name` = ?)');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.* from `bar` as `b0` where `b0`.`foo_id` in (?) and `b0`.`id` = ? order by `b0`.`foo_id` asc');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.* from `bar` as `b0` where `b0`.`foo_id` in (?) and `b0`.`id` = ?');
     mock.mockReset();
 
     await orm.em.fork().find(Foo, cond, { populate: ['barItems'] });
     expect(mock.mock.calls[0][0]).toMatch('select `f0`.* from `foo` as `f0` left join `bar` as `b1` on `f0`.`id` = `b1`.`foo_id` where (`b1`.`id` = ? or `f0`.`name` = ?)');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.* from `bar` as `b0` where `b0`.`foo_id` in (?) order by `b0`.`foo_id` asc');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.* from `bar` as `b0` where `b0`.`foo_id` in (?)');
   });
 
   test(`GH issue 1882-2`, async () => {
@@ -89,14 +89,14 @@ describe('GH issue 1882', () => {
     orm.em.clear();
 
     expect(mock.mock.calls[0][0]).toMatch('select `f0`.* from `foo` as `f0` left join `bar` as `b1` on `f0`.`id` = `b1`.`foo_id` where `b1`.`id` = ?');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.* from `bar` as `b0` where `b0`.`foo_id` in (?) and `b0`.`id` = ? order by `b0`.`foo_id` asc');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.* from `bar` as `b0` where `b0`.`foo_id` in (?) and `b0`.`id` = ?');
     mock.mockReset();
 
     await orm.em.find(Foo, cond, { populate: ['barItems'] });
     orm.em.clear();
 
     expect(mock.mock.calls[0][0]).toMatch('select `f0`.* from `foo` as `f0` left join `bar` as `b1` on `f0`.`id` = `b1`.`foo_id` where `b1`.`id` = ?');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.* from `bar` as `b0` where `b0`.`foo_id` in (?) order by `b0`.`foo_id` asc');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.* from `bar` as `b0` where `b0`.`foo_id` in (?)');
   });
 
 });

--- a/tests/issues/GH2784.test.ts
+++ b/tests/issues/GH2784.test.ts
@@ -38,7 +38,7 @@ describe('GH issue 2784', () => {
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Address],
-      dbName: 'mikro_orm_test_2781',
+      dbName: 'mikro_orm_test_2784',
     });
     await orm.schema.refreshDatabase();
   });


### PR DESCRIPTION
This unifies the population mechanism for to-many relations by using the `em.populate()` internally.

Previously, the `Collection.init` (and methods using it, e.g. `loadItems`) were using custom implementation, which in some cases resulting in different results as opposed to `em.populate()`. With this PR, the `init` method is also using `em.populate`, yielding the same results as if you would populate the relation.

Closes #4464