### PR TITLE
fix(core): rework JSON property hydration

### DIFF
--- a/packages/better-sqlite/src/BetterSqlitePlatform.ts
+++ b/packages/better-sqlite/src/BetterSqlitePlatform.ts
@@ -59,10 +59,6 @@ export class BetterSqlitePlatform extends AbstractSqlPlatform {
     return 'text';
   }
 
-  override convertsJsonAutomatically(): boolean {
-    return false;
-  }
-
   override allowsComparingTuples() {
     return false;
   }

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -88,6 +88,7 @@ export class WrappedEntity<Entity extends object> {
     if ('assign' in this.entity) {
       return (this.entity as Dictionary).assign(data, options);
     }
+    [].slice();
 
     return EntityAssigner.assign(this.entity, data, options);
   }

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -11,7 +11,7 @@ import {
   ArrayType, BigIntType, BlobType, Uint8ArrayType, BooleanType, DateType, DecimalType, DoubleType, JsonType, SmallIntType, TimeType,
   TinyIntType, Type, UuidType, StringType, IntegerType, FloatType, DateTimeType, TextType, EnumType, UnknownType, MediumIntType,
 } from '../types';
-import { parseJsonSafe, Utils } from '../utils/Utils';
+import { Utils } from '../utils/Utils';
 import { ReferenceKind } from '../enums';
 import type { MikroORM } from '../MikroORM';
 import type { TransformContext } from '../types/Type';
@@ -328,7 +328,7 @@ export abstract class Platform {
   }
 
   convertsJsonAutomatically(): boolean {
-    return true;
+    return false;
   }
 
   convertJsonToDatabaseValue(value: unknown, context?: TransformContext): unknown {
@@ -336,7 +336,9 @@ export abstract class Platform {
   }
 
   convertJsonToJSValue(value: unknown): unknown {
-    return parseJsonSafe(value);
+    // parsing is implemented in the result mapper layer, so we have the values
+    // parsed without the need to hydrate entity (e.g. when using `qb.execute()`)
+    return value;
   }
 
   getRepositoryClass<T extends object>(): Constructor<EntityRepository<T>> {

--- a/packages/core/src/types/JsonType.ts
+++ b/packages/core/src/types/JsonType.ts
@@ -21,7 +21,7 @@ export class JsonType extends Type<unknown, string | null> {
     return key + platform.castColumn(this.prop);
   }
 
-  override convertToJSValue(value: string | unknown, platform: Platform): unknown {
+  override convertToJSValue(value: string, platform: Platform): unknown {
     return platform.convertJsonToJSValue(value);
   }
 

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -352,7 +352,10 @@ export class EntityComparator {
           lines.push(`    ${propName(prop.fieldNames[0], 'mapped')} = true;`);
           lines.push(`  }`);
         }
-      } else if (prop.kind === ReferenceKind.EMBEDDED && prop.object && !this.platform.convertsJsonAutomatically()) {
+      } else if (((prop.kind === ReferenceKind.EMBEDDED && prop.object) || prop.customType instanceof JsonType) && !this.platform.convertsJsonAutomatically()) {
+        // We need to parse inside a try/catch block, mainly because the mapping is done in hydration layer and that might
+        // be also called from inside `em.create()` which can get the parsed data provided by user, as well as encoded data
+        // from the database.
         context.set('parseJsonSafe', parseJsonSafe);
         lines.push(`  if (typeof ${propName(prop.fieldNames[0])} !== 'undefined') {`);
         lines.push(`    ret${this.wrap(prop.name)} = ${propName(prop.fieldNames[0])} == null ? ${propName(prop.fieldNames[0])} : parseJsonSafe(${propName(prop.fieldNames[0])});`);

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -155,6 +155,7 @@ export function equals(a: any, b: any): boolean {
 const equalsFn = equals;
 
 export function parseJsonSafe<T = unknown>(value: unknown): T {
+  // return JSON.parse(value);
   if (typeof value === 'string') {
     try {
       return JSON.parse(value);

--- a/packages/mariadb/src/MariaDbConnection.ts
+++ b/packages/mariadb/src/MariaDbConnection.ts
@@ -42,6 +42,13 @@ export class MariaDbConnection extends AbstractSqlConnection {
     ret.dateStrings = true;
     // @ts-ignore
     ret.checkDuplicate = false;
+    ret.typeCast = (field: any, next: any) => {
+      if (field.type === 'BLOB') {
+        return field.string('utf8');
+      }
+
+      return next();
+    };
 
     return ret;
   }

--- a/packages/mysql/src/MySqlConnection.ts
+++ b/packages/mysql/src/MySqlConnection.ts
@@ -48,6 +48,13 @@ export class MySqlConnection extends AbstractSqlConnection {
 
     ret.supportBigNumbers = true;
     ret.dateStrings = true;
+    ret.typeCast = (field: any, next: any) => {
+      if (field.type === 'JSON') {
+        return field.string('utf8');
+      }
+
+      return next();
+    };
 
     return ret;
   }

--- a/packages/postgresql/src/PostgreSqlConnection.ts
+++ b/packages/postgresql/src/PostgreSqlConnection.ts
@@ -19,7 +19,8 @@ export class PostgreSqlConnection extends AbstractSqlConnection {
   override getConnectionOptions(): Knex.PgConnectionConfig {
     const ret = super.getConnectionOptions() as Knex.PgConnectionConfig;
     const types = new TypeOverrides();
-    [1082, 1114, 1184].forEach(oid => types.setTypeParser(oid, str => str)); // date, timestamp, timestamptz type
+    // disable parsing for following types: `date`, `timestamp`, `timestamptz`, `json`, `jsonb`
+    [1082, 1114, 1184, 114, 3802].forEach(oid => types.setTypeParser(oid, str => str));
     ret.types = types as any;
 
     return ret;

--- a/packages/sqlite/src/SqlitePlatform.ts
+++ b/packages/sqlite/src/SqlitePlatform.ts
@@ -59,10 +59,6 @@ export class SqlitePlatform extends AbstractSqlPlatform {
     return 'text';
   }
 
-  override convertsJsonAutomatically(): boolean {
-    return false;
-  }
-
   override allowsComparingTuples() {
     return false;
   }

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -835,14 +835,17 @@ describe('EntityManagerMySql', () => {
     expect(res1.createdAt).toBeDefined();
     // @ts-expect-error
     expect(res1.created_at).not.toBeDefined();
-    expect(res1.meta).toEqual({ category: 'foo', items: 1 });
+    expect(res1.createdAt).toBeInstanceOf(Date); // mapped to Date
+    expect(res1.meta).toEqual({ category: 'foo', items: 1 }); // parsed to object
 
     const qb2 = orm.em.fork().createQueryBuilder(Book2);
     const res2 = await qb2.select('*').where({ [raw('JSON_CONTAINS(meta, ?)', [{ category: 'foo' }])]: true }).execute('get', false);
     expect(res2.createdAt).not.toBeDefined();
     // @ts-expect-error
     expect(res2.created_at).toBeDefined();
-    expect(res2.meta).toEqual({ category: 'foo', items: 1 });
+    // @ts-expect-error
+    expect(typeof res2.created_at).toBe('string'); // kept as string
+    expect(res2.meta).toEqual('{"items": 1, "category": "foo"}'); // kept as string
 
     const qb3 = orm.em.fork().createQueryBuilder(Book2);
     const res3 = await qb3.select('*').where({ [raw('JSON_CONTAINS(meta, ?)', [{ category: 'foo' }])]: true }).getSingleResult();

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -194,7 +194,7 @@ export async function initORMSqlite2(type: 'sqlite' | 'better-sqlite' = 'sqlite'
     propagateToOneOwner: false,
     forceUndefined: true,
     logger: i => i,
-    migrations: { path: BASE_DIR + '/../temp/migrations', snapshot: false },
+    migrations: { path: BASE_DIR + '/../temp/migrations-sqlite', snapshot: false },
     extensions: [Migrator, SeedManager, EntityGenerator],
   });
   await orm.schema.refreshDatabase();

--- a/tests/features/custom-types/json-properties.test.ts
+++ b/tests/features/custom-types/json-properties.test.ts
@@ -94,6 +94,24 @@ describe.each(Utils.keys(options))('JSON properties [%s]',  type => {
     expect(mock).not.toBeCalled();
   });
 
+  test('em.flush() with numeric string', async () => {
+    orm.em.create(User, { value: '123' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const res = await orm.em.findOneOrFail(User, { value: '123' });
+    expect(res.value).toBe('123');
+
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock).not.toBeCalled();
+    res.value = 456;
+    await orm.em.flush();
+
+    const res2 = await orm.em.findOneOrFail(User, { value: 456 });
+    expect(res2.value).toBe(456);
+  });
+
   test('em.flush() with various JSON values', async () => {
     orm.em.create(User, { value: { foo: 'test' } });
     await orm.em.flush();

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
@@ -273,6 +273,9 @@ exports[`embedded entities in postgres diffing 2`] = `
       } else if (data.profile1_identity_meta === null) {
         entity.profile1.identity.meta = null;
       }
+      if (typeof data.profile1_identity_meta === 'string') {
+        data.profile1_identity_meta = parseJsonSafe(data.profile1_identity_meta);
+      }
       if (data.profile1_identity_meta != null) {
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity_meta, { newEntity, convertCustomTypes });
@@ -299,9 +302,15 @@ exports[`embedded entities in postgres diffing 2`] = `
       } else if (data.profile1_identity_meta === null) {
         entity.profile1.identity.meta = null;
       }
+      if (typeof data.profile1_identity_links === 'string') {
+        data.profile1_identity_links = parseJsonSafe(data.profile1_identity_links);
+      }
       if (Array.isArray(data.profile1_identity_links)) {
         entity.profile1.identity.links = [];
         data.profile1_identity_links.forEach((_, idx_8) => {
+          if (typeof data.profile1_identity_links[idx_8] === 'string') {
+            data.profile1_identity_links[idx_8] = parseJsonSafe(data.profile1_identity_links[idx_8]);
+          }
           if (data.profile1_identity_links[idx_8] != null) {
             if (entity.profile1.identity.links[idx_8] == null) {
               entity.profile1.identity.links[idx_8] = factory.createEmbeddable('IdentityLink', data.profile1_identity_links[idx_8], { newEntity, convertCustomTypes });
@@ -319,6 +328,9 @@ exports[`embedded entities in postgres diffing 2`] = `
               } else {
                 entity.profile1.identity.links[idx_8].createdAt = new Date(data.profile1_identity_links[idx_8].createdAt);
               }
+            }
+            if (typeof data.profile1_identity_links[idx_8].meta === 'string') {
+              data.profile1_identity_links[idx_8].meta = parseJsonSafe(data.profile1_identity_links[idx_8].meta);
             }
             if (data.profile1_identity_links[idx_8].meta != null) {
               if (entity.profile1.identity.links[idx_8].meta == null) {
@@ -346,9 +358,15 @@ exports[`embedded entities in postgres diffing 2`] = `
             } else if (data.profile1_identity_links[idx_8].meta === null) {
               entity.profile1.identity.links[idx_8].meta = null;
             }
+            if (typeof data.profile1_identity_links[idx_8].metas === 'string') {
+              data.profile1_identity_links[idx_8].metas = parseJsonSafe(data.profile1_identity_links[idx_8].metas);
+            }
             if (Array.isArray(data.profile1_identity_links[idx_8].metas)) {
               entity.profile1.identity.links[idx_8].metas = [];
               data.profile1_identity_links[idx_8].metas.forEach((_, idx_13) => {
+                if (typeof data.profile1_identity_links[idx_8].metas[idx_13] === 'string') {
+                  data.profile1_identity_links[idx_8].metas[idx_13] = parseJsonSafe(data.profile1_identity_links[idx_8].metas[idx_13]);
+                }
                 if (data.profile1_identity_links[idx_8].metas[idx_13] != null) {
                   if (entity.profile1.identity.links[idx_8].metas[idx_13] == null) {
                     entity.profile1.identity.links[idx_8].metas[idx_13] = factory.createEmbeddable('IdentityMeta', data.profile1_identity_links[idx_8].metas[idx_13], { newEntity, convertCustomTypes });
@@ -403,6 +421,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     } else if (data.profile1_identity === null) {
       entity.profile1.identity = null;
     }
+    if (typeof data.profile1_identity === 'string') {
+      data.profile1_identity = parseJsonSafe(data.profile1_identity);
+    }
     if (data.profile1_identity != null) {
       if (entity.profile1.identity == null) {
         entity.profile1.identity = factory.createEmbeddable('Identity', data.profile1_identity, { newEntity, convertCustomTypes });
@@ -438,6 +459,9 @@ exports[`embedded entities in postgres diffing 2`] = `
       } else if (data.profile1_identity.meta === null) {
         entity.profile1.identity.meta = null;
       }
+      if (typeof data.profile1_identity.meta === 'string') {
+        data.profile1_identity.meta = parseJsonSafe(data.profile1_identity.meta);
+      }
       if (data.profile1_identity.meta != null) {
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity.meta, { newEntity, convertCustomTypes });
@@ -464,9 +488,15 @@ exports[`embedded entities in postgres diffing 2`] = `
       } else if (data.profile1_identity.meta === null) {
         entity.profile1.identity.meta = null;
       }
+      if (typeof data.profile1_identity.links === 'string') {
+        data.profile1_identity.links = parseJsonSafe(data.profile1_identity.links);
+      }
       if (Array.isArray(data.profile1_identity.links)) {
         entity.profile1.identity.links = [];
         data.profile1_identity.links.forEach((_, idx_21) => {
+          if (typeof data.profile1_identity.links[idx_21] === 'string') {
+            data.profile1_identity.links[idx_21] = parseJsonSafe(data.profile1_identity.links[idx_21]);
+          }
           if (data.profile1_identity.links[idx_21] != null) {
             if (entity.profile1.identity.links[idx_21] == null) {
               entity.profile1.identity.links[idx_21] = factory.createEmbeddable('IdentityLink', data.profile1_identity.links[idx_21], { newEntity, convertCustomTypes });
@@ -484,6 +514,9 @@ exports[`embedded entities in postgres diffing 2`] = `
               } else {
                 entity.profile1.identity.links[idx_21].createdAt = new Date(data.profile1_identity.links[idx_21].createdAt);
               }
+            }
+            if (typeof data.profile1_identity.links[idx_21].meta === 'string') {
+              data.profile1_identity.links[idx_21].meta = parseJsonSafe(data.profile1_identity.links[idx_21].meta);
             }
             if (data.profile1_identity.links[idx_21].meta != null) {
               if (entity.profile1.identity.links[idx_21].meta == null) {
@@ -511,9 +544,15 @@ exports[`embedded entities in postgres diffing 2`] = `
             } else if (data.profile1_identity.links[idx_21].meta === null) {
               entity.profile1.identity.links[idx_21].meta = null;
             }
+            if (typeof data.profile1_identity.links[idx_21].metas === 'string') {
+              data.profile1_identity.links[idx_21].metas = parseJsonSafe(data.profile1_identity.links[idx_21].metas);
+            }
             if (Array.isArray(data.profile1_identity.links[idx_21].metas)) {
               entity.profile1.identity.links[idx_21].metas = [];
               data.profile1_identity.links[idx_21].metas.forEach((_, idx_26) => {
+                if (typeof data.profile1_identity.links[idx_21].metas[idx_26] === 'string') {
+                  data.profile1_identity.links[idx_21].metas[idx_26] = parseJsonSafe(data.profile1_identity.links[idx_21].metas[idx_26]);
+                }
                 if (data.profile1_identity.links[idx_21].metas[idx_26] != null) {
                   if (entity.profile1.identity.links[idx_21].metas[idx_26] == null) {
                     entity.profile1.identity.links[idx_21].metas[idx_26] = factory.createEmbeddable('IdentityMeta', data.profile1_identity.links[idx_21].metas[idx_26], { newEntity, convertCustomTypes });
@@ -580,6 +619,9 @@ exports[`embedded entities in postgres diffing 2`] = `
   } else if (data.profile1 === null) {
     entity.profile1 = null;
   }
+  if (typeof data.profile1 === 'string') {
+    data.profile1 = parseJsonSafe(data.profile1);
+  }
   if (data.profile1 != null) {
     if (entity.profile1 == null) {
       entity.profile1 = factory.createEmbeddable('Profile', data.profile1, { newEntity, convertCustomTypes });
@@ -624,6 +666,9 @@ exports[`embedded entities in postgres diffing 2`] = `
       } else if (data.profile1_identity_meta === null) {
         entity.profile1.identity.meta = null;
       }
+      if (typeof data.profile1_identity_meta === 'string') {
+        data.profile1_identity_meta = parseJsonSafe(data.profile1_identity_meta);
+      }
       if (data.profile1_identity_meta != null) {
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data.profile1_identity_meta, { newEntity, convertCustomTypes });
@@ -650,9 +695,15 @@ exports[`embedded entities in postgres diffing 2`] = `
       } else if (data.profile1_identity_meta === null) {
         entity.profile1.identity.meta = null;
       }
+      if (typeof data.profile1_identity_links === 'string') {
+        data.profile1_identity_links = parseJsonSafe(data.profile1_identity_links);
+      }
       if (Array.isArray(data.profile1_identity_links)) {
         entity.profile1.identity.links = [];
         data.profile1_identity_links.forEach((_, idx_35) => {
+          if (typeof data.profile1_identity_links[idx_35] === 'string') {
+            data.profile1_identity_links[idx_35] = parseJsonSafe(data.profile1_identity_links[idx_35]);
+          }
           if (data.profile1_identity_links[idx_35] != null) {
             if (entity.profile1.identity.links[idx_35] == null) {
               entity.profile1.identity.links[idx_35] = factory.createEmbeddable('IdentityLink', data.profile1_identity_links[idx_35], { newEntity, convertCustomTypes });
@@ -670,6 +721,9 @@ exports[`embedded entities in postgres diffing 2`] = `
               } else {
                 entity.profile1.identity.links[idx_35].createdAt = new Date(data.profile1_identity_links[idx_35].createdAt);
               }
+            }
+            if (typeof data.profile1_identity_links[idx_35].meta === 'string') {
+              data.profile1_identity_links[idx_35].meta = parseJsonSafe(data.profile1_identity_links[idx_35].meta);
             }
             if (data.profile1_identity_links[idx_35].meta != null) {
               if (entity.profile1.identity.links[idx_35].meta == null) {
@@ -697,9 +751,15 @@ exports[`embedded entities in postgres diffing 2`] = `
             } else if (data.profile1_identity_links[idx_35].meta === null) {
               entity.profile1.identity.links[idx_35].meta = null;
             }
+            if (typeof data.profile1_identity_links[idx_35].metas === 'string') {
+              data.profile1_identity_links[idx_35].metas = parseJsonSafe(data.profile1_identity_links[idx_35].metas);
+            }
             if (Array.isArray(data.profile1_identity_links[idx_35].metas)) {
               entity.profile1.identity.links[idx_35].metas = [];
               data.profile1_identity_links[idx_35].metas.forEach((_, idx_40) => {
+                if (typeof data.profile1_identity_links[idx_35].metas[idx_40] === 'string') {
+                  data.profile1_identity_links[idx_35].metas[idx_40] = parseJsonSafe(data.profile1_identity_links[idx_35].metas[idx_40]);
+                }
                 if (data.profile1_identity_links[idx_35].metas[idx_40] != null) {
                   if (entity.profile1.identity.links[idx_35].metas[idx_40] == null) {
                     entity.profile1.identity.links[idx_35].metas[idx_40] = factory.createEmbeddable('IdentityMeta', data.profile1_identity_links[idx_35].metas[idx_40], { newEntity, convertCustomTypes });
@@ -754,6 +814,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     } else if (data.profile1.identity === null) {
       entity.profile1.identity = null;
     }
+    if (typeof data.profile1.identity === 'string') {
+      data.profile1.identity = parseJsonSafe(data.profile1.identity);
+    }
     if (data.profile1.identity != null) {
       if (entity.profile1.identity == null) {
         entity.profile1.identity = factory.createEmbeddable('Identity', data.profile1.identity, { newEntity, convertCustomTypes });
@@ -789,6 +852,9 @@ exports[`embedded entities in postgres diffing 2`] = `
       } else if (data.profile1.identity.meta === null) {
         entity.profile1.identity.meta = null;
       }
+      if (typeof data.profile1.identity.meta === 'string') {
+        data.profile1.identity.meta = parseJsonSafe(data.profile1.identity.meta);
+      }
       if (data.profile1.identity.meta != null) {
         if (entity.profile1.identity.meta == null) {
           entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', data.profile1.identity.meta, { newEntity, convertCustomTypes });
@@ -815,9 +881,15 @@ exports[`embedded entities in postgres diffing 2`] = `
       } else if (data.profile1.identity.meta === null) {
         entity.profile1.identity.meta = null;
       }
+      if (typeof data.profile1.identity.links === 'string') {
+        data.profile1.identity.links = parseJsonSafe(data.profile1.identity.links);
+      }
       if (Array.isArray(data.profile1.identity.links)) {
         entity.profile1.identity.links = [];
         data.profile1.identity.links.forEach((_, idx_48) => {
+          if (typeof data.profile1.identity.links[idx_48] === 'string') {
+            data.profile1.identity.links[idx_48] = parseJsonSafe(data.profile1.identity.links[idx_48]);
+          }
           if (data.profile1.identity.links[idx_48] != null) {
             if (entity.profile1.identity.links[idx_48] == null) {
               entity.profile1.identity.links[idx_48] = factory.createEmbeddable('IdentityLink', data.profile1.identity.links[idx_48], { newEntity, convertCustomTypes });
@@ -835,6 +907,9 @@ exports[`embedded entities in postgres diffing 2`] = `
               } else {
                 entity.profile1.identity.links[idx_48].createdAt = new Date(data.profile1.identity.links[idx_48].createdAt);
               }
+            }
+            if (typeof data.profile1.identity.links[idx_48].meta === 'string') {
+              data.profile1.identity.links[idx_48].meta = parseJsonSafe(data.profile1.identity.links[idx_48].meta);
             }
             if (data.profile1.identity.links[idx_48].meta != null) {
               if (entity.profile1.identity.links[idx_48].meta == null) {
@@ -862,9 +937,15 @@ exports[`embedded entities in postgres diffing 2`] = `
             } else if (data.profile1.identity.links[idx_48].meta === null) {
               entity.profile1.identity.links[idx_48].meta = null;
             }
+            if (typeof data.profile1.identity.links[idx_48].metas === 'string') {
+              data.profile1.identity.links[idx_48].metas = parseJsonSafe(data.profile1.identity.links[idx_48].metas);
+            }
             if (Array.isArray(data.profile1.identity.links[idx_48].metas)) {
               entity.profile1.identity.links[idx_48].metas = [];
               data.profile1.identity.links[idx_48].metas.forEach((_, idx_53) => {
+                if (typeof data.profile1.identity.links[idx_48].metas[idx_53] === 'string') {
+                  data.profile1.identity.links[idx_48].metas[idx_53] = parseJsonSafe(data.profile1.identity.links[idx_48].metas[idx_53]);
+                }
                 if (data.profile1.identity.links[idx_48].metas[idx_53] != null) {
                   if (entity.profile1.identity.links[idx_48].metas[idx_53] == null) {
                     entity.profile1.identity.links[idx_48].metas[idx_53] = factory.createEmbeddable('IdentityMeta', data.profile1.identity.links[idx_48].metas[idx_53], { newEntity, convertCustomTypes });
@@ -931,6 +1012,9 @@ exports[`embedded entities in postgres diffing 2`] = `
   } else if (data.profile1 === null) {
     entity.profile1 = null;
   }
+  if (typeof data.profile2 === 'string') {
+    data.profile2 = parseJsonSafe(data.profile2);
+  }
   if (data.profile2 != null) {
     if (entity.profile2 == null) {
       entity.profile2 = factory.createEmbeddable('Profile', data.profile2, { newEntity, convertCustomTypes });
@@ -940,6 +1024,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     } else if (typeof data.profile2.username !== 'undefined') {
       entity.profile2.username = data.profile2.username;
     }
+    if (typeof data.profile2.identity === 'string') {
+      data.profile2.identity = parseJsonSafe(data.profile2.identity);
+    }
     if (data.profile2.identity != null) {
       if (entity.profile2.identity == null) {
         entity.profile2.identity = factory.createEmbeddable('Identity', data.profile2.identity, { newEntity, convertCustomTypes });
@@ -948,6 +1035,9 @@ exports[`embedded entities in postgres diffing 2`] = `
         entity.profile2.identity.email = null;
       } else if (typeof data.profile2.identity.email !== 'undefined') {
         entity.profile2.identity.email = data.profile2.identity.email;
+      }
+      if (typeof data.profile2.identity.meta === 'string') {
+        data.profile2.identity.meta = parseJsonSafe(data.profile2.identity.meta);
       }
       if (data.profile2.identity.meta != null) {
         if (entity.profile2.identity.meta == null) {
@@ -975,9 +1065,15 @@ exports[`embedded entities in postgres diffing 2`] = `
       } else if (data.profile2.identity.meta === null) {
         entity.profile2.identity.meta = null;
       }
+      if (typeof data.profile2.identity.links === 'string') {
+        data.profile2.identity.links = parseJsonSafe(data.profile2.identity.links);
+      }
       if (Array.isArray(data.profile2.identity.links)) {
         entity.profile2.identity.links = [];
         data.profile2.identity.links.forEach((_, idx_60) => {
+          if (typeof data.profile2.identity.links[idx_60] === 'string') {
+            data.profile2.identity.links[idx_60] = parseJsonSafe(data.profile2.identity.links[idx_60]);
+          }
           if (data.profile2.identity.links[idx_60] != null) {
             if (entity.profile2.identity.links[idx_60] == null) {
               entity.profile2.identity.links[idx_60] = factory.createEmbeddable('IdentityLink', data.profile2.identity.links[idx_60], { newEntity, convertCustomTypes });
@@ -995,6 +1091,9 @@ exports[`embedded entities in postgres diffing 2`] = `
               } else {
                 entity.profile2.identity.links[idx_60].createdAt = new Date(data.profile2.identity.links[idx_60].createdAt);
               }
+            }
+            if (typeof data.profile2.identity.links[idx_60].meta === 'string') {
+              data.profile2.identity.links[idx_60].meta = parseJsonSafe(data.profile2.identity.links[idx_60].meta);
             }
             if (data.profile2.identity.links[idx_60].meta != null) {
               if (entity.profile2.identity.links[idx_60].meta == null) {
@@ -1022,9 +1121,15 @@ exports[`embedded entities in postgres diffing 2`] = `
             } else if (data.profile2.identity.links[idx_60].meta === null) {
               entity.profile2.identity.links[idx_60].meta = null;
             }
+            if (typeof data.profile2.identity.links[idx_60].metas === 'string') {
+              data.profile2.identity.links[idx_60].metas = parseJsonSafe(data.profile2.identity.links[idx_60].metas);
+            }
             if (Array.isArray(data.profile2.identity.links[idx_60].metas)) {
               entity.profile2.identity.links[idx_60].metas = [];
               data.profile2.identity.links[idx_60].metas.forEach((_, idx_65) => {
+                if (typeof data.profile2.identity.links[idx_60].metas[idx_65] === 'string') {
+                  data.profile2.identity.links[idx_60].metas[idx_65] = parseJsonSafe(data.profile2.identity.links[idx_60].metas[idx_65]);
+                }
                 if (data.profile2.identity.links[idx_60].metas[idx_65] != null) {
                   if (entity.profile2.identity.links[idx_60].metas[idx_65] == null) {
                     entity.profile2.identity.links[idx_60].metas[idx_65] = factory.createEmbeddable('IdentityMeta', data.profile2.identity.links[idx_60].metas[idx_65], { newEntity, convertCustomTypes });

--- a/tests/features/migrations/Migrator.postgres.test.ts
+++ b/tests/features/migrations/Migrator.postgres.test.ts
@@ -55,7 +55,7 @@ describe('Migrator (postgres)', () => {
       driver: PostgreSqlDriver,
       schema: 'custom',
       logger: () => void 0,
-      migrations: { path: BASE_DIR + '/../temp/migrations', snapshot: false },
+      migrations: { path: BASE_DIR + '/../temp/migrations-pg', snapshot: false },
       extensions: [Migrator],
     });
 
@@ -64,7 +64,7 @@ describe('Migrator (postgres)', () => {
     await schemaGenerator.execute('alter table "custom"."book2" add column "foo" varchar null default \'lol\';');
     await schemaGenerator.execute('alter table "custom"."book2" alter column "double" type numeric using ("double"::numeric);');
     await schemaGenerator.execute('alter table "custom"."test2" add column "path" polygon null default null;');
-    await remove(process.cwd() + '/temp/migrations');
+    await remove(process.cwd() + '/temp/migrations-pg');
   });
   beforeEach(() => orm.config.resetServiceCache());
   afterAll(async () => orm.close(true));
@@ -77,7 +77,7 @@ describe('Migrator (postgres)', () => {
     const migration = await orm.migrator.createMigration();
     expect(migration).toMatchSnapshot('migration-js-dump');
     orm.config.set('migrations', migrationsSettings); // Revert migration config changes
-    await remove(process.cwd() + '/temp/migrations/' + migration.fileName);
+    await remove(process.cwd() + '/temp/migrations-pg/' + migration.fileName);
   });
 
   test('generate migration with custom migrator', async () => {
@@ -102,7 +102,7 @@ describe('Migrator (postgres)', () => {
     const migration = await migrator.createMigration();
     expect(migration).toMatchSnapshot('migration-ts-dump');
     orm.config.set('migrations', migrationsSettings); // Revert migration config changes
-    await remove(process.cwd() + '/temp/migrations/' + migration.fileName);
+    await remove(process.cwd() + '/temp/migrations-pg/' + migration.fileName);
   });
 
   test('generate migration with custom name', async () => {
@@ -124,7 +124,7 @@ describe('Migrator (postgres)', () => {
     await migrator.up();
     await migrator.down(migration.fileName.replace('migration-', '').replace('.ts', ''));
     orm.config.set('migrations', migrationsSettings); // Revert migration config changes
-    await remove(process.cwd() + '/temp/migrations/' + migration.fileName);
+    await remove(process.cwd() + '/temp/migrations-pg/' + migration.fileName);
     upMock.mockRestore();
     downMock.mockRestore();
   });
@@ -148,7 +148,7 @@ describe('Migrator (postgres)', () => {
     await migrator.down(migration.fileName);
     await migrator.up();
     orm.config.set('migrations', migrationsSettings); // Revert migration config changes
-    await remove(process.cwd() + '/temp/migrations/' + migration.fileName);
+    await remove(process.cwd() + '/temp/migrations-pg/' + migration.fileName);
     upMock.mockRestore();
     downMock.mockRestore();
   });
@@ -159,7 +159,7 @@ describe('Migrator (postgres)', () => {
     const migrator = orm.migrator;
     const migration = await migrator.createMigration();
     expect(migration).toMatchSnapshot('migration-dump');
-    await remove(process.cwd() + '/temp/migrations/' + migration.fileName);
+    await remove(process.cwd() + '/temp/migrations-pg/' + migration.fileName);
   });
 
   test('generate migration with snapshot', async () => {
@@ -171,7 +171,7 @@ describe('Migrator (postgres)', () => {
     const migrator = orm.migrator;
     const migration1 = await migrator.createMigration();
     expect(migration1).toMatchSnapshot('migration-snapshot-dump-1');
-    await remove(process.cwd() + '/temp/migrations/' + migration1.fileName);
+    await remove(process.cwd() + '/temp/migrations-pg/' + migration1.fileName);
 
     // will use the snapshot, so should be empty
     const migration2 = await migrator.createMigration();
@@ -215,13 +215,13 @@ describe('Migrator (postgres)', () => {
     const migration1 = await migrator.createInitialMigration(undefined);
     expect(logMigrationMock).not.toBeCalledWith('Migration20191013214813.ts');
     expect(migration1).toMatchSnapshot('initial-migration-dump');
-    await remove(process.cwd() + '/temp/migrations/' + migration1.fileName);
+    await remove(process.cwd() + '/temp/migrations-pg/' + migration1.fileName);
 
     await orm.em.getKnex().schema.dropTableIfExists(orm.config.get('migrations').tableName!).withSchema('custom');
     const migration2 = await migrator.createInitialMigration(undefined);
     expect(logMigrationMock).toBeCalledWith({ name: 'Migration20191013214813.ts', context: null });
     expect(migration2).toMatchSnapshot('initial-migration-dump');
-    await remove(process.cwd() + '/temp/migrations/' + migration2.fileName);
+    await remove(process.cwd() + '/temp/migrations-pg/' + migration2.fileName);
   });
 
   test('migration storage getter', async () => {
@@ -269,7 +269,7 @@ describe('Migrator (postgres)', () => {
   });
 
   test('run schema migration without existing migrations folder (GH #907)', async () => {
-    await remove(process.cwd() + '/temp/migrations');
+    await remove(process.cwd() + '/temp/migrations-pg');
     const migrator = orm.migrator;
     await migrator.up();
   });
@@ -335,7 +335,7 @@ describe('Migrator (postgres)', () => {
     const migrator = orm.migrator;
     // @ts-ignore
     migrator.options.disableForeignKeys = false;
-    const path = process.cwd() + '/temp/migrations';
+    const path = process.cwd() + '/temp/migrations-pg';
 
     const migration = await migrator.createMigration(path, true);
     const migratorMock = jest.spyOn(Migration.prototype, 'down');
@@ -364,7 +364,7 @@ describe('Migrator (postgres)', () => {
   test('up/down with explicit transaction', async () => {
     await orm.em.getKnex().schema.dropTableIfExists(orm.config.get('migrations').tableName!).withSchema('custom').withSchema('custom');
     const migrator = orm.migrator;
-    const path = process.cwd() + '/temp/migrations';
+    const path = process.cwd() + '/temp/migrations-pg';
 
     // @ts-ignore
     migrator.options.disableForeignKeys = false;
@@ -408,7 +408,7 @@ describe('Migrator (postgres)', () => {
     migrator.options.disableForeignKeys = false;
     // @ts-ignore
     migrator.options.allOrNothing = false;
-    const path = process.cwd() + '/temp/migrations';
+    const path = process.cwd() + '/temp/migrations-pg';
 
     const migration = await migrator.createMigration(path, true);
     const migratorMock = jest.spyOn(Migration.prototype, 'down');
@@ -442,7 +442,7 @@ test('ensureTable when the schema does not exist', async () => {
     dbName: `mikro_orm_test_migrations2`,
     driver: PostgreSqlDriver,
     schema: 'custom2',
-    migrations: { path: BASE_DIR + '/../temp/migrations', snapshot: false },
+    migrations: { path: BASE_DIR + '/../temp/migrations-pg', snapshot: false },
     extensions: [Migrator],
   });
   await orm.schema.ensureDatabase();

--- a/tests/features/migrations/Migrator.sqlite.test.ts
+++ b/tests/features/migrations/Migrator.sqlite.test.ts
@@ -39,7 +39,7 @@ describe('Migrator (sqlite)', () => {
 
   beforeAll(async () => {
     orm = await initORMSqlite2();
-    await remove(process.cwd() + '/temp/migrations');
+    await remove(process.cwd() + '/temp/migrations-sqlite');
   });
   afterAll(async () => orm.close(true));
 
@@ -52,7 +52,7 @@ describe('Migrator (sqlite)', () => {
     const migration = await migrator.createMigration();
     expect(migration).toMatchSnapshot('migration-js-dump');
     orm.config.set('migrations', migrationsSettings); // Revert migration config changes
-    await remove(process.cwd() + '/temp/migrations/' + migration.fileName);
+    await remove(process.cwd() + '/temp/migrations-sqlite/' + migration.fileName);
   });
 
   test('generate migration with custom name', async () => {
@@ -74,7 +74,7 @@ describe('Migrator (sqlite)', () => {
     await migrator.up();
     await migrator.down(migration.fileName.replace('migration-', '').replace('.ts', ''));
     orm.config.set('migrations', migrationsSettings); // Revert migration config changes
-    await remove(process.cwd() + '/temp/migrations/' + migration.fileName);
+    await remove(process.cwd() + '/temp/migrations-sqlite/' + migration.fileName);
     upMock.mockRestore();
     downMock.mockRestore();
   });
@@ -85,7 +85,7 @@ describe('Migrator (sqlite)', () => {
     const migrator = new Migrator(orm.em);
     const migration = await migrator.createMigration();
     expect(migration).toMatchSnapshot('migration-dump');
-    await remove(process.cwd() + '/temp/migrations/' + migration.fileName);
+    await remove(process.cwd() + '/temp/migrations-sqlite/' + migration.fileName);
   });
 
   test('generate migration with snapshot', async () => {
@@ -97,7 +97,7 @@ describe('Migrator (sqlite)', () => {
     const migrator = new Migrator(orm.em);
     const migration1 = await migrator.createMigration();
     expect(migration1).toMatchSnapshot('migration-snapshot-dump-1');
-    await remove(process.cwd() + '/temp/migrations/' + migration1.fileName);
+    await remove(process.cwd() + '/temp/migrations-sqlite/' + migration1.fileName);
 
     // will use the snapshot, so should be empty
     const migration2 = await migrator.createMigration();
@@ -140,13 +140,13 @@ describe('Migrator (sqlite)', () => {
     expect(migration1).toMatchSnapshot('initial-migration-dump');
     const outOfSync = await migrator.checkMigrationNeeded();
     expect(outOfSync).toBe(false);
-    await remove(process.cwd() + '/temp/migrations/' + migration1.fileName);
+    await remove(process.cwd() + '/temp/migrations-sqlite/' + migration1.fileName);
 
     await orm.em.getKnex().schema.dropTableIfExists(orm.config.get('migrations').tableName!);
     const migration2 = await migrator.createInitialMigration(undefined);
     expect(logMigrationMock).toBeCalledWith({ name: 'Migration20191013214813.ts', context: null });
     expect(migration2).toMatchSnapshot('initial-migration-dump');
-    await remove(process.cwd() + '/temp/migrations/' + migration2.fileName);
+    await remove(process.cwd() + '/temp/migrations-sqlite/' + migration2.fileName);
   });
 
   test('migration storage getter', async () => {
@@ -179,7 +179,7 @@ describe('Migrator (sqlite)', () => {
   });
 
   test('run schema migration without existing migrations folder (GH #907)', async () => {
-    await remove(process.cwd() + '/temp/migrations');
+    await remove(process.cwd() + '/temp/migrations-sqlite');
     const migrator = new Migrator(orm.em);
     await migrator.up();
   });
@@ -247,7 +247,7 @@ describe('Migrator (sqlite)', () => {
     const migrator = new Migrator(orm.em);
     // @ts-ignore
     migrator.options.disableForeignKeys = false;
-    const path = process.cwd() + '/temp/migrations';
+    const path = process.cwd() + '/temp/migrations-sqlite';
 
     const migration = await migrator.createMigration(path, true);
     const migratorMock = jest.spyOn(Migration.prototype, 'down');
@@ -280,7 +280,7 @@ describe('Migrator (sqlite)', () => {
     migrator.options.disableForeignKeys = false;
     // @ts-ignore
     migrator.options.allOrNothing = false;
-    const path = process.cwd() + '/temp/migrations';
+    const path = process.cwd() + '/temp/migrations-sqlite';
 
     const migration = await migrator.createMigration(path, true);
     const migratorMock = jest.spyOn(Migration.prototype, 'down');

--- a/tests/features/schema-generator/SchemaGenerator.mysql.test.ts
+++ b/tests/features/schema-generator/SchemaGenerator.mysql.test.ts
@@ -32,7 +32,7 @@ describe('SchemaGenerator', () => {
       port: 3308,
       baseDir: BASE_DIR,
       driver: MySqlDriver,
-      migrations: { path: BASE_DIR + '/../temp/migrations' },
+      migrations: { path: BASE_DIR + '/../temp/migrations-mysql' },
     });
 
     await orm.schema.createSchema();
@@ -67,7 +67,7 @@ describe('SchemaGenerator', () => {
       port: 3308,
       baseDir: BASE_DIR,
       driver: MariaDbDriver,
-      migrations: { path: BASE_DIR + '/../temp/migrations' },
+      migrations: { path: BASE_DIR + '/../temp/migrations-mysql' },
       multipleStatements: true,
     });
 

--- a/tests/features/schema-generator/SchemaGenerator.mysql2.test.ts
+++ b/tests/features/schema-generator/SchemaGenerator.mysql2.test.ts
@@ -42,7 +42,7 @@ describe('SchemaGenerator (no FKs)', () => {
       port: 3308,
       baseDir: BASE_DIR,
       driver: MySqlDriver,
-      migrations: { path: BASE_DIR + '/../temp/migrations' },
+      migrations: { path: BASE_DIR + '/../temp/migrations-mysql2' },
       schemaGenerator: { createForeignKeyConstraints: false, disableForeignKeys: false },
       multipleStatements: true,
     });

--- a/tests/features/schema-generator/SchemaGenerator.postgres.test.ts
+++ b/tests/features/schema-generator/SchemaGenerator.postgres.test.ts
@@ -129,7 +129,7 @@ describe('SchemaGenerator [postgres]', () => {
       dbName,
       baseDir: BASE_DIR,
       driver: PostgreSqlDriver,
-      migrations: { path: BASE_DIR + '/../temp/migrations', tableName: 'public.mikro_orm_migrations' },
+      migrations: { path: BASE_DIR + '/../temp/migrations-pg', tableName: 'public.mikro_orm_migrations' },
     });
 
     await orm.schema.createSchema();


### PR DESCRIPTION
The JSON properties are no longer mapped automatically on the driver level. The mapping from JSON strings is now implemented in the result mapping layer

The motivation behind this change was to support property mapping of numeric values and finally put an end to the JSON mapping bugs, which were mostly originating from small differences and bugs in how the underlying libraries were trying to do it on their own.

Closes #4476