### PR TITLE
feat(core): allow disabling duplicate entities discovery validation

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -106,7 +106,7 @@ export class MetadataDiscovery {
     await this.discoverDirectories(paths);
     await this.discoverReferences(refs);
     await this.discoverMissingTargets();
-    this.validator.validateDiscovered(this.discovered, options.warnWhenNoEntities, options.checkDuplicateTableNames, this.config.get('discovery').duplicateEntityStrategy);
+    this.validator.validateDiscovered(this.discovered, options.warnWhenNoEntities, options.checkDuplicateTableNames, options.checkDuplicateEntities);
 
     return this.discovered;
   }

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -106,7 +106,7 @@ export class MetadataDiscovery {
     await this.discoverDirectories(paths);
     await this.discoverReferences(refs);
     await this.discoverMissingTargets();
-    this.validator.validateDiscovered(this.discovered, options.warnWhenNoEntities, options.checkDuplicateTableNames);
+    this.validator.validateDiscovered(this.discovered, options.warnWhenNoEntities, options.checkDuplicateTableNames, this.config.get('discovery').duplicateEntityStrategy);
 
     return this.discovered;
   }

--- a/packages/core/src/metadata/MetadataValidator.ts
+++ b/packages/core/src/metadata/MetadataValidator.ts
@@ -53,14 +53,14 @@ export class MetadataValidator {
     }
   }
 
-  validateDiscovered(discovered: EntityMetadata[], warnWhenNoEntities?: boolean, checkDuplicateTableNames?: boolean, duplicateEntityStrategy: 'forbidden' | 'keep' | 'replace' = 'forbidden'): void {
+  validateDiscovered(discovered: EntityMetadata[], warnWhenNoEntities?: boolean, checkDuplicateTableNames?: boolean, checkDuplicateEntities = true): void {
     if (discovered.length === 0 && warnWhenNoEntities) {
       throw MetadataError.noEntityDiscovered();
     }
 
     const duplicates = Utils.findDuplicates(discovered.map(meta => meta.className));
 
-    if (duplicates.length > 0 && duplicateEntityStrategy === 'forbidden') {
+    if (duplicates.length > 0 && checkDuplicateEntities) {
       throw MetadataError.duplicateEntityDiscovered(duplicates);
     }
 
@@ -70,7 +70,7 @@ export class MetadataValidator {
       return (meta.schema ? '.' + meta.schema : '') + tableName;
     }));
 
-    if (duplicateTableNames.length > 0 && checkDuplicateTableNames && duplicateEntityStrategy === 'forbidden') {
+    if (duplicateTableNames.length > 0 && checkDuplicateTableNames && checkDuplicateEntities) {
       throw MetadataError.duplicateEntityDiscovered(duplicateTableNames, 'table names');
     }
 

--- a/packages/core/src/metadata/MetadataValidator.ts
+++ b/packages/core/src/metadata/MetadataValidator.ts
@@ -70,7 +70,7 @@ export class MetadataValidator {
       return (meta.schema ? '.' + meta.schema : '') + tableName;
     }));
 
-    if (duplicateTableNames.length > 0 && checkDuplicateTableNames) {
+    if (duplicateTableNames.length > 0 && checkDuplicateTableNames && duplicateEntityStrategy === 'forbidden') {
       throw MetadataError.duplicateEntityDiscovered(duplicateTableNames, 'table names');
     }
 

--- a/packages/core/src/metadata/MetadataValidator.ts
+++ b/packages/core/src/metadata/MetadataValidator.ts
@@ -53,14 +53,14 @@ export class MetadataValidator {
     }
   }
 
-  validateDiscovered(discovered: EntityMetadata[], warnWhenNoEntities?: boolean, checkDuplicateTableNames?: boolean): void {
+  validateDiscovered(discovered: EntityMetadata[], warnWhenNoEntities?: boolean, checkDuplicateTableNames?: boolean, duplicateEntityStrategy: 'forbidden' | 'keep' | 'replace' = 'forbidden'): void {
     if (discovered.length === 0 && warnWhenNoEntities) {
       throw MetadataError.noEntityDiscovered();
     }
 
     const duplicates = Utils.findDuplicates(discovered.map(meta => meta.className));
 
-    if (duplicates.length > 0) {
+    if (duplicates.length > 0 && duplicateEntityStrategy === 'forbidden') {
       throw MetadataError.duplicateEntityDiscovered(duplicates);
     }
 

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -57,7 +57,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
       checkDuplicateTableNames: true,
       alwaysAnalyseProperties: true,
       disableDynamicFileAccess: false,
-      duplicateEntityStrategy: 'forbidden',
+      checkDuplicateEntities: true,
     },
     strict: false,
     validate: false,
@@ -492,8 +492,6 @@ export interface PoolConfig {
   Promise?: any;
 }
 
-export type DuplicateEntityStrategy = 'forbidden' | 'keep' | 'replace';
-
 export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> extends ConnectionOptions {
   entities: (string | EntityClass<AnyEntity> | EntityClassGroup<AnyEntity> | EntitySchema)[]; // `any` required here for some TS weirdness
   entitiesTs: (string | EntityClass<AnyEntity> | EntityClassGroup<AnyEntity> | EntitySchema)[]; // `any` required here for some TS weirdness
@@ -507,7 +505,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
     alwaysAnalyseProperties?: boolean;
     disableDynamicFileAccess?: boolean;
     getMappedType?: (type: string, platform: Platform) => Type<unknown> | undefined;
-    duplicateEntityStrategy?: DuplicateEntityStrategy;
+    checkDuplicateEntities?: boolean;
   };
   /** @deprecated type option will be removed in v6, use `defineConfig` exported from the driver package to define your ORM config */
   type?: keyof typeof Configuration.PLATFORMS;

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -41,6 +41,7 @@ import { EntityComparator } from './EntityComparator';
 import type { Type } from '../types/Type';
 import type { MikroORM } from '../MikroORM';
 
+
 export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
 
   static readonly DEFAULTS: MikroORMOptions = {
@@ -56,6 +57,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
       checkDuplicateTableNames: true,
       alwaysAnalyseProperties: true,
       disableDynamicFileAccess: false,
+      duplicateEntityStrategy: 'forbidden',
     },
     strict: false,
     validate: false,
@@ -490,6 +492,8 @@ export interface PoolConfig {
   Promise?: any;
 }
 
+export type DuplicateEntityStrategy = 'forbidden' | 'keep' | 'replace';
+
 export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> extends ConnectionOptions {
   entities: (string | EntityClass<AnyEntity> | EntityClassGroup<AnyEntity> | EntitySchema)[]; // `any` required here for some TS weirdness
   entitiesTs: (string | EntityClass<AnyEntity> | EntityClassGroup<AnyEntity> | EntitySchema)[]; // `any` required here for some TS weirdness
@@ -503,6 +507,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
     alwaysAnalyseProperties?: boolean;
     disableDynamicFileAccess?: boolean;
     getMappedType?: (type: string, platform: Platform) => Type<unknown> | undefined;
+    duplicateEntityStrategy?: DuplicateEntityStrategy;
   };
   /** @deprecated type option will be removed in v6, use `defineConfig` exported from the driver package to define your ORM config */
   type?: keyof typeof Configuration.PLATFORMS;

--- a/tests/MetadataValidator.test.ts
+++ b/tests/MetadataValidator.test.ts
@@ -165,7 +165,7 @@ describe('MetadataValidator', () => {
   });
 
   describe('Duplicate Entity Strategy', () => {
-    test('allows duplicate entity when strategy is "keep"', async () => {
+    test('allows duplicate classNames when "checkDuplicateEntities" is "false"', async () => {
       // Arrange
       const properties: Dictionary = {
         id: { reference: 'scalar', primary: true, name: 'id', type: 'number' },
@@ -184,13 +184,13 @@ describe('MetadataValidator', () => {
       } as any);
 
       // Act
-      const validateDiscoveryCommand = () => validator.validateDiscovered([schema1.meta, schema2.meta], true, true, 'keep');
+      const validateDiscoveryCommand = () => validator.validateDiscovered([schema1.meta, schema2.meta], true, true, false);
 
       // Assert
       expect(validateDiscoveryCommand).not.toThrowError();
     });
 
-    test('allows duplicate entity when strategy is "replace"', async () => {
+    test('allows duplicate tableNames when "checkDuplicateTableNames" is true but "checkDuplicateEntities" is false', async () => {
       // Arrange
       const properties: Dictionary = {
         id: { reference: 'scalar', primary: true, name: 'id', type: 'number' },
@@ -209,35 +209,10 @@ describe('MetadataValidator', () => {
       } as any);
 
       // Act
-      const validateDiscoveryCommand = () => validator.validateDiscovered([schema1.meta, schema2.meta], true, true, 'replace');
+      const validateDiscoveryCommand = () => validator.validateDiscovered([schema1.meta, schema2.meta], true, true, false);
 
       // Assert
       expect(validateDiscoveryCommand).not.toThrowError();
-    });
-
-    test('throws an error when duplicate entity when strategy is "forbidden"', async () => {
-      // Arrange
-      const properties: Dictionary = {
-        id: { reference: 'scalar', primary: true, name: 'id', type: 'number' },
-        name: { reference: 'scalar', name: 'name', type: 'string' },
-        age: { reference: 'scalar', name: 'age', type: 'string' },
-      };
-      const schema1 = EntitySchema.fromMetadata({
-        name: 'Foo1',
-        tableName: 'foo',
-        properties,
-      } as any);
-      const schema2 = EntitySchema.fromMetadata({
-        name: 'Foo1',
-        tableName: 'foo2',
-        properties,
-      } as any);
-
-      // Act
-      const validateDiscoveryCommand = () => validator.validateDiscovered([schema1.meta, schema2.meta], true, true, 'forbidden');
-
-      // Assert
-      expect(validateDiscoveryCommand).toThrowError('Duplicate entity names are not allowed: Foo1');
     });
 
     test('throws an error when duplicate entity is not provided', async () => {

--- a/tests/MetadataValidator.test.ts
+++ b/tests/MetadataValidator.test.ts
@@ -164,4 +164,105 @@ describe('MetadataValidator', () => {
     expect(() => storage.get('Test')).toThrowError('Metadata for entity Test not found');
   });
 
+  describe('Duplicate Entity Strategy', () => {
+    test('allows duplicate entity when strategy is "keep"', async () => {
+      // Arrange
+      const properties: Dictionary = {
+        id: { reference: 'scalar', primary: true, name: 'id', type: 'number' },
+        name: { reference: 'scalar', name: 'name', type: 'string' },
+        age: { reference: 'scalar', name: 'age', type: 'string' },
+      };
+      const schema1 = EntitySchema.fromMetadata({
+        name: 'Foo1',
+        tableName: 'foo',
+        properties,
+      } as any);
+      const schema2 = EntitySchema.fromMetadata({
+        name: 'Foo1',
+        tableName: 'foo2',
+        properties,
+      } as any);
+
+      // Act
+      const validateDiscoveryCommand = () => validator.validateDiscovered([schema1.meta, schema2.meta], true, true, 'keep');
+
+      // Assert
+      expect(validateDiscoveryCommand).not.toThrowError();
+    });
+
+    test('allows duplicate entity when strategy is "replace"', async () => {
+      // Arrange
+      const properties: Dictionary = {
+        id: { reference: 'scalar', primary: true, name: 'id', type: 'number' },
+        name: { reference: 'scalar', name: 'name', type: 'string' },
+        age: { reference: 'scalar', name: 'age', type: 'string' },
+      };
+      const schema1 = EntitySchema.fromMetadata({
+        name: 'Foo1',
+        tableName: 'foo',
+        properties,
+      } as any);
+      const schema2 = EntitySchema.fromMetadata({
+        name: 'Foo1',
+        tableName: 'foo2',
+        properties,
+      } as any);
+
+      // Act
+      const validateDiscoveryCommand = () => validator.validateDiscovered([schema1.meta, schema2.meta], true, true, 'replace');
+
+      // Assert
+      expect(validateDiscoveryCommand).not.toThrowError();
+    });
+
+    test('throws an error when duplicate entity when strategy is "forbidden"', async () => {
+      // Arrange
+      const properties: Dictionary = {
+        id: { reference: 'scalar', primary: true, name: 'id', type: 'number' },
+        name: { reference: 'scalar', name: 'name', type: 'string' },
+        age: { reference: 'scalar', name: 'age', type: 'string' },
+      };
+      const schema1 = EntitySchema.fromMetadata({
+        name: 'Foo1',
+        tableName: 'foo',
+        properties,
+      } as any);
+      const schema2 = EntitySchema.fromMetadata({
+        name: 'Foo1',
+        tableName: 'foo2',
+        properties,
+      } as any);
+
+      // Act
+      const validateDiscoveryCommand = () => validator.validateDiscovered([schema1.meta, schema2.meta], true, true, 'forbidden');
+
+      // Assert
+      expect(validateDiscoveryCommand).toThrowError('Duplicate entity names are not allowed: Foo1');
+    });
+
+    test('throws an error when duplicate entity is not provided', async () => {
+      // Arrange
+      const properties: Dictionary = {
+        id: { reference: 'scalar', primary: true, name: 'id', type: 'number' },
+        name: { reference: 'scalar', name: 'name', type: 'string' },
+        age: { reference: 'scalar', name: 'age', type: 'string' },
+      };
+      const schema1 = EntitySchema.fromMetadata({
+        name: 'Foo1',
+        tableName: 'foo',
+        properties,
+      } as any);
+      const schema2 = EntitySchema.fromMetadata({
+        name: 'Foo1',
+        tableName: 'foo2',
+        properties,
+      } as any);
+
+      // Act
+      const validateDiscoveryCommand = () => validator.validateDiscovered([schema1.meta, schema2.meta], true, true);
+
+      // Assert
+      expect(validateDiscoveryCommand).toThrowError('Duplicate entity names are not allowed: Foo1');
+    });
+  });
 });

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -58,6 +58,8 @@ describe('MikroORM', () => {
     const ormInitCommandPromise = MikroORM.init({ driver: MongoDriver, dbName: 'test', baseDir: BASE_DIR, entities: ['entities-1', 'entities-2'], discovery: { checkDuplicateEntities: false } });
 
     await expect(ormInitCommandPromise).resolves.toBeTruthy();
+
+    await ormInitCommandPromise.then(orm => orm.close());
   });
 
   test('should throw when only abstract entities were discovered', async () => {

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -11,7 +11,7 @@ jest.mock('knex', () => ({ knex }));
 
 (global as any).process.env.FORCE_COLOR = 0;
 
-import { Configuration, EntityManager, MikroORM, NullCacheAdapter, Utils } from '@mikro-orm/core';
+import { Configuration, Dictionary, EntityManager, EntitySchema, MikroORM, NullCacheAdapter, Utils } from '@mikro-orm/core';
 import fs from 'fs-extra';
 import { BASE_DIR } from './helpers';
 import { Author, Test } from './entities';
@@ -52,6 +52,12 @@ describe('MikroORM', () => {
 
   test('should throw when multiple entities with same file name discovered', async () => {
     await expect(MikroORM.init({ driver: MongoDriver, dbName: 'test', baseDir: BASE_DIR, entities: ['entities-1', 'entities-2'] })).rejects.toThrowError('Duplicate entity names are not allowed: Dup1, Dup2');
+  });
+
+  test('should NOT throw when multiple entities with same file name discovered ("keep" strategy)', async () => {
+    const ormInitCommandPromise = MikroORM.init({ driver: MongoDriver, dbName: 'test', baseDir: BASE_DIR, entities: ['entities-1', 'entities-2'], discovery: { duplicateEntityStrategy: 'keep' } });
+
+    await expect(ormInitCommandPromise).resolves.toBeTruthy();
   });
 
   test('should throw when only abstract entities were discovered', async () => {

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -54,8 +54,8 @@ describe('MikroORM', () => {
     await expect(MikroORM.init({ driver: MongoDriver, dbName: 'test', baseDir: BASE_DIR, entities: ['entities-1', 'entities-2'] })).rejects.toThrowError('Duplicate entity names are not allowed: Dup1, Dup2');
   });
 
-  test('should NOT throw when multiple entities with same file name discovered ("keep" strategy)', async () => {
-    const ormInitCommandPromise = MikroORM.init({ driver: MongoDriver, dbName: 'test', baseDir: BASE_DIR, entities: ['entities-1', 'entities-2'], discovery: { duplicateEntityStrategy: 'keep' } });
+  test('should NOT throw when multiple entities with same file name discovered ("checkDuplicateEntities" false)', async () => {
+    const ormInitCommandPromise = MikroORM.init({ driver: MongoDriver, dbName: 'test', baseDir: BASE_DIR, entities: ['entities-1', 'entities-2'], discovery: { checkDuplicateEntities: false } });
 
     await expect(ormInitCommandPromise).resolves.toBeTruthy();
   });


### PR DESCRIPTION
This PR adds a new option to the `discovery` object called `checkDuplicateEntities`. This new option aims to allow the client code to control the behavior regarding duplicated entities discovered. There might be situations where we just want to ignore the duplicates.

Closes https://github.com/mikro-orm/nestjs/issues/132