### PR TITLE
feat: allow to select fields for upsert

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -666,10 +666,10 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       }
     }
 
-    const unique = meta.props.filter(p => p.unique).map(p => p.name);
+    const unique = options.onConflictFields || meta.props.filter(p => p.unique).map(p => p.name);
     const propIndex = unique.findIndex(p => data![p] != null);
 
-    if (where == null) {
+    if (where == null || options.onConflictFields) {
       if (propIndex >= 0) {
         where = { [unique[propIndex]]: data[unique[propIndex]] } as FilterQuery<Entity>;
       } else if (meta.uniques.length > 0) {

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -151,6 +151,7 @@ export interface NativeInsertUpdateOptions<T> {
   schema?: string;
   /** `nativeUpdate()` only option */
   upsert?: boolean;
+  onConflictFields?: string[];
 }
 
 export interface NativeInsertUpdateManyOptions<T> extends NativeInsertUpdateOptions<T> {

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -488,6 +488,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
       if (options.upsert) {
         /* istanbul ignore next */
         const uniqueFields = Utils.isPlainObject(where) ? Utils.keys(where) as EntityKey<T>[] : meta!.primaryKeys;
+
         /* istanbul ignore next */
         qb.insert(data as T)
           .onConflict(uniqueFields.map(p => meta?.properties[p]?.fieldNames[0] ?? p))

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -488,7 +488,6 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
       if (options.upsert) {
         /* istanbul ignore next */
         const uniqueFields = Utils.isPlainObject(where) ? Utils.keys(where) as EntityKey<T>[] : meta!.primaryKeys;
-
         /* istanbul ignore next */
         qb.insert(data as T)
           .onConflict(uniqueFields.map(p => meta?.properties[p]?.fieldNames[0] ?? p))

--- a/tests/features/upsert/GH4602.test.ts
+++ b/tests/features/upsert/GH4602.test.ts
@@ -42,7 +42,7 @@ test('GH issue 4602', async () => {
   await orm.em.upsert(User, user2, { onConflictFields: ['email'] });
 
   expect(mock.mock.calls).toEqual([
-    ['[query] insert into `user` (`email`, `id`) values (\'test@test.com\', 123) on conflict (`email`) do update set `id` = excluded.`id`'],
-    ['[query] insert into `user` (`email`, `id`) values (\'test@test.com\', 456) on conflict (`email`) do update set `id` = excluded.`id`'],
+    ['[query] insert into `user` (`email`, `id`) values (\'test@test.com\', 123) on conflict (`email`) do nothing'],
+    ['[query] insert into `user` (`email`, `id`) values (\'test@test.com\', 456) on conflict (`email`) do nothing'],
   ]);
 });

--- a/tests/features/upsert/GH4602.test.ts
+++ b/tests/features/upsert/GH4602.test.ts
@@ -1,0 +1,48 @@
+import { Entity, PrimaryKey, Property, SimpleLogger } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/sqlite';
+import { mockLogger } from '../../helpers';
+
+@Entity()
+class User {
+
+  @PrimaryKey()
+  id: number;
+
+  @Property({ unique: true })
+  email: string;
+
+  constructor(id: number, email: string) {
+   this.id = id;
+   this.email = email;
+  }
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [User],
+    loggerFactory: options => new SimpleLogger(options),
+  });
+  await orm.schema.createSchema();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('GH issue 4602', async () => {
+  const mock = mockLogger(orm);
+  const user1 = new User(123, 'test@test.com');
+  await orm.em.upsert(User, user1, { onConflictFields: ['email'] });
+
+  const user2 = new User(456, 'test@test.com');
+  await orm.em.upsert(User, user2, { onConflictFields: ['email'] });
+
+  expect(mock.mock.calls).toEqual([
+    ['[query] insert into `user` (`email`, `id`) values (\'test@test.com\', 123) on conflict (`email`) do update set `id` = excluded.`id`'],
+    ['[query] insert into `user` (`email`, `id`) values (\'test@test.com\', 456) on conflict (`email`) do update set `id` = excluded.`id`'],
+  ]);
+});


### PR DESCRIPTION
This PR attempts to solve #4602 by allowing passing specific columns on which the upsert condition is done. This allows to use entities and generate an ID server-side.

I'm not 100% sure about the approach here, but the change I did is that if you select a different column to act as the on conflict column _and_ that the PK is also present, then it won't update any field on conflict.