### PR TITLE
feat(core): allow fine-grained control over `em.upsert()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "lerna": "6.6.2",
     "lint-staged": "14.0.1",
     "mongodb": "5.8.1",
-    "mongodb-memory-server": "^8.12.2",
+    "mongodb-memory-server": "8.15.1",
     "node-gyp": "^9.3.1",
     "rimraf": "5.0.1",
     "ts-jest": "29.1.1",

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -152,6 +152,17 @@ export interface NativeInsertUpdateManyOptions<T> extends NativeInsertUpdateOpti
   processCollections?: boolean;
 }
 
+export interface UpsertOptions<Entity> extends Omit<NativeInsertUpdateOptions<Entity>, 'upsert'> {
+  onConflictFields?: (keyof Entity)[];
+  onConflictAction?: 'ignore' | 'merge';
+  onConflictMergeFields?: (keyof Entity)[];
+  onConflictExcludeFields?: (keyof Entity)[];
+}
+
+export interface UpsertManyOptions<Entity> extends UpsertOptions<Entity> {
+  batchSize?: number;
+}
+
 export interface CountOptions<T extends object, P extends string = never>  {
   filters?: Dictionary<boolean | Dictionary> | string[] | boolean;
   schema?: string;

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -378,10 +378,10 @@ export class ChangeSetPersister {
    * No need to handle composite keys here as they need to be set upfront.
    * We do need to map to the change set payload too, as it will be used in the originalEntityData for new entities.
    */
-  mapReturnedValues<T extends object>(entity: T, payload: EntityDictionary<T>, row: Dictionary | undefined, meta: EntityMetadata<T>): void {
+  mapReturnedValues<T extends object>(entity: T, payload: EntityDictionary<T>, row: Dictionary | undefined, meta: EntityMetadata<T>, override = false): void {
     if (this.platform.usesReturningStatement() && row && Utils.hasObjectKeys(row)) {
       const data = meta.props.reduce((ret, prop) => {
-        if (prop.fieldNames && row[prop.fieldNames[0]] != null && entity[prop.name] == null) {
+        if (prop.fieldNames && row[prop.fieldNames[0]] != null && (override || entity[prop.name] == null)) {
           ret[prop.name] = row[prop.fieldNames[0]];
         }
 

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -7,3 +7,4 @@ export * from './QueryHelper';
 export * from './NullHighlighter';
 export * from './EntityComparator';
 export * from './AbstractSchemaGenerator';
+export * from './upsert-utils';

--- a/packages/core/src/utils/upsert-utils.ts
+++ b/packages/core/src/utils/upsert-utils.ts
@@ -1,0 +1,40 @@
+import type { EntityData, EntityMetadata } from '../typings';
+import type { UpsertOptions } from '../drivers/IDatabaseDriver';
+
+/** @internal */
+export function getOnConflictFields<T>(data: EntityData<T>, uniqueFields: (keyof T)[], options: UpsertOptions<T>): (keyof T)[] {
+  if (options.onConflictMergeFields) {
+    return options.onConflictMergeFields;
+  }
+
+  const keys = Object.keys(data).filter(f => !uniqueFields.includes(f as keyof T)) as (keyof T)[];
+
+  if (options.onConflictExcludeFields) {
+    return keys.filter(f => !options.onConflictExcludeFields!.includes(f));
+  }
+
+  return keys;
+}
+
+/** @internal */
+export function getOnConflictReturningFields<T>(meta: EntityMetadata<T> | undefined, data: EntityData<T>, uniqueFields: (keyof T)[], options: UpsertOptions<T>): (keyof T)[] | '*' {
+  if (!meta) {
+    return '*';
+  }
+
+  const keys = meta.comparableProps.filter(p => !p.lazy && !p.embeddable && !uniqueFields.includes(p.name)).map(p => p.name) as (keyof T)[];
+
+  if (options.onConflictAction === 'ignore') {
+    return keys;
+  }
+
+  if (options.onConflictMergeFields) {
+    return keys.filter(key => !options.onConflictMergeFields!.includes(key));
+  }
+
+  if (options.onConflictExcludeFields) {
+    return [...new Set(keys.concat(...options.onConflictExcludeFields))];
+  }
+
+  return keys.filter(key => !(key in data));
+}

--- a/tests/features/upsert/GH4242-2.test.ts
+++ b/tests/features/upsert/GH4242-2.test.ts
@@ -72,7 +72,7 @@ test('4242 1/4', async () => {
   }]);
   expect(mock.mock.calls).toEqual([
     ["[query] insert into `d` (`optional`, `tenant_workflow_id`) values ('foo', 1) on duplicate key update `optional` = values(`optional`)"],
-    ['[query] select `d0`.`id`, `d0`.`tenant_workflow_id`, `d0`.`updated_at` from `d` as `d0` where `d0`.`tenant_workflow_id` = 1'],
+    ['[query] select `d0`.`id`, `d0`.`updated_at`, `d0`.`tenant_workflow_id` from `d` as `d0` where `d0`.`tenant_workflow_id` = 1'],
   ]);
   mock.mockReset();
 
@@ -87,7 +87,7 @@ test('4242 1/4', async () => {
   }]);
   expect(mock.mock.calls).toEqual([
     ['[query] insert ignore into `d` (`tenant_workflow_id`) values (1)'],
-    ['[query] select `d0`.`id`, `d0`.`tenant_workflow_id`, `d0`.`updated_at`, `d0`.`optional` from `d` as `d0` where `d0`.`tenant_workflow_id` = 1'],
+    ['[query] select `d0`.`id`, `d0`.`updated_at`, `d0`.`optional`, `d0`.`tenant_workflow_id` from `d` as `d0` where `d0`.`tenant_workflow_id` = 1'],
   ]);
   mock.mockReset();
 
@@ -103,7 +103,7 @@ test('4242 1/4', async () => {
   }]);
   expect(mock.mock.calls).toEqual([
     [`[query] insert into \`d\` (\`tenant_workflow_id\`, \`updated_at\`) values (1, '${date}') on duplicate key update \`updated_at\` = values(\`updated_at\`)`],
-    ['[query] select `d0`.`id`, `d0`.`tenant_workflow_id`, `d0`.`optional` from `d` as `d0` where `d0`.`tenant_workflow_id` = 1'],
+    ['[query] select `d0`.`id`, `d0`.`optional`, `d0`.`tenant_workflow_id` from `d` as `d0` where `d0`.`tenant_workflow_id` = 1'],
   ]);
   mock.mockReset();
 });
@@ -116,6 +116,7 @@ test('4242 2/4', async () => {
     id: expect.any(Number),
     updatedAt: expect.any(Date),
     tenantWorkflowId: 1,
+    optional: null,
   }]);
   await orm.em.flush();
 
@@ -182,6 +183,7 @@ test('4242 4/4', async () => {
   const loadedDs4 = await orm.em.upsert(D, { tenantWorkflowId: 1 });
   expect(loadedDs4).toEqual({
     id: expect.any(Number),
+    optional: null,
     updatedAt: expect.any(Date),
     tenantWorkflowId: 1,
   });

--- a/tests/features/upsert/GH4242.test.ts
+++ b/tests/features/upsert/GH4242.test.ts
@@ -87,7 +87,7 @@ test('4242 1/4', async () => {
   }]);
   expect(mock.mock.calls).toEqual([
     ['[query] insert into "d" ("tenant_workflow_id") values (1) on conflict ("tenant_workflow_id") do nothing returning "id", "updated_at", "optional"'],
-    ['[query] select "d0"."id", "d0"."tenant_workflow_id", "d0"."updated_at", "d0"."optional" from "d" as "d0" where "d0"."tenant_workflow_id" = 1'],
+    ['[query] select "d0"."id", "d0"."updated_at", "d0"."optional", "d0"."tenant_workflow_id" from "d" as "d0" where "d0"."tenant_workflow_id" = 1'],
   ]);
   mock.mockReset();
 

--- a/tests/features/upsert/__snapshots__/upsert.test.ts.snap
+++ b/tests/features/upsert/__snapshots__/upsert.test.ts.snap
@@ -3,13 +3,13 @@
 exports[`em.upsert [better-sqlite] em.upsert(Type, data) with PK 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`foo\`, \`bar\`",
   ],
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (2, 42, 'a2') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (2, 42, 'a2') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`foo\`, \`bar\`",
   ],
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (3, 43, 'a3') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (3, 43, 'a3') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`foo\`, \`bar\`",
   ],
 ]
 `;
@@ -48,13 +48,47 @@ exports[`em.upsert [better-sqlite] em.upsert(Type, data) with unique composite p
 exports[`em.upsert [better-sqlite] em.upsert(Type, data) with unique property 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (41, 'a1') on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (41, 'a1') on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`, \`foo\`, \`bar\`",
   ],
   [
-    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (42, 'a2') on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (42, 'a2') on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`, \`foo\`, \`bar\`",
   ],
   [
-    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (43, 'a3') on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (43, 'a3') on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`, \`foo\`, \`bar\`",
+  ],
+]
+`;
+
+exports[`em.upsert [better-sqlite] em.upsert(Type, data, options) with advanced options 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (1, 41, 'a1', true) on conflict (\`email\`) do nothing returning \`_id\`, \`current_age\`, \`foo\`, \`bar\`",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a1' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (2, 42, 'a2', true) on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`, \`foo\`, \`bar\`",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (5, 43, 'a3', true) on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\`, \`foo\` = excluded.\`foo\` returning \`_id\`, \`current_age\`, \`foo\`, \`bar\`",
+  ],
+]
+`;
+
+exports[`em.upsert [better-sqlite] em.upsert(Type, entity, options) with advanced options 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (1, 123, 41, 'a1', true) on conflict (\`email\`) do nothing returning \`_id\`, \`current_age\`, \`foo\`, \`bar\`",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a1' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (2, 123, 42, 'a2', true) on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`, \`foo\`, \`bar\`",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (5, 123, 43, 'a3', true) on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\`, \`foo\` = excluded.\`foo\`, \`bar\` = excluded.\`bar\` returning \`_id\`, \`current_age\`, \`foo\`, \`bar\`",
   ],
 ]
 `;
@@ -62,13 +96,13 @@ exports[`em.upsert [better-sqlite] em.upsert(Type, data) with unique property 1`
 exports[`em.upsert [better-sqlite] em.upsert(entity) 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (1, 123, 41, 'a1', false) on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`, \`foo\` = excluded.\`foo\`, \`bar\` = excluded.\`bar\` returning \`_id\`",
   ],
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (2, 42, 'a2') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (2, 123, 42, 'a2', false) on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`, \`foo\` = excluded.\`foo\`, \`bar\` = excluded.\`bar\` returning \`_id\`",
   ],
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (3, 43, 'a3') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (3, 123, 43, 'a3', false) on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`, \`foo\` = excluded.\`foo\`, \`bar\` = excluded.\`bar\` returning \`_id\`",
   ],
 ]
 `;
@@ -90,7 +124,7 @@ exports[`em.upsert [better-sqlite] em.upsert(entity) with unique composite prope
 exports[`em.upsert [better-sqlite] em.upsertMany([entity1, entity2, entity3]) with PK 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) select 1 as \`_id\`, 41 as \`current_age\`, 'a1' as \`email\` union all select 2 as \`_id\`, 42 as \`current_age\`, 'a2' as \`email\` union all select 3 as \`_id\`, 43 as \`current_age\`, 'a3' as \`email\` where true on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) select 1 as \`_id\`, 123 as \`bar\`, 41 as \`current_age\`, 'a1' as \`email\`, false as \`foo\` union all select 2 as \`_id\`, 123 as \`bar\`, 42 as \`current_age\`, 'a2' as \`email\`, false as \`foo\` union all select 3 as \`_id\`, 123 as \`bar\`, 43 as \`current_age\`, 'a3' as \`email\`, false as \`foo\` where true on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`, \`foo\` = excluded.\`foo\`, \`bar\` = excluded.\`bar\` returning \`_id\`, \`foo\`, \`bar\`",
   ],
 ]
 `;
@@ -98,7 +132,34 @@ exports[`em.upsert [better-sqlite] em.upsertMany([entity1, entity2, entity3]) wi
 exports[`em.upsert [better-sqlite] em.upsertMany([entity1, entity2, entity3]) with unique property 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`current_age\`, \`email\`) select 41 as \`current_age\`, 'a1' as \`email\` union all select 42 as \`current_age\`, 'a2' as \`email\` union all select 43 as \`current_age\`, 'a3' as \`email\` where true on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`bar\`, \`current_age\`, \`email\`, \`foo\`) select 123 as \`bar\`, 41 as \`current_age\`, 'a1' as \`email\`, false as \`foo\` union all select 123 as \`bar\`, 42 as \`current_age\`, 'a2' as \`email\`, false as \`foo\` union all select 123 as \`bar\`, 43 as \`current_age\`, 'a3' as \`email\`, false as \`foo\` where true on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\`, \`foo\` = excluded.\`foo\`, \`bar\` = excluded.\`bar\` returning \`_id\`",
+  ],
+]
+`;
+
+exports[`em.upsert [better-sqlite] em.upsertMany(Type, [data], options) with advanced options (ignore) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) select 1 as \`_id\`, 41 as \`current_age\`, 'a1' as \`email\`, true as \`foo\` union all select 2 as \`_id\`, 42 as \`current_age\`, 'a2' as \`email\`, true as \`foo\` union all select 5 as \`_id\`, 43 as \`current_age\`, 'a3' as \`email\`, true as \`foo\` where true on conflict (\`email\`) do nothing returning \`_id\`, \`current_age\`, \`foo\`, \`bar\`",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+  ],
+]
+`;
+
+exports[`em.upsert [better-sqlite] em.upsertMany(Type, [data], options) with advanced options (onConflictExcludeFields) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) select 1 as \`_id\`, 41 as \`current_age\`, 'a1' as \`email\`, true as \`foo\` union all select 2 as \`_id\`, 42 as \`current_age\`, 'a2' as \`email\`, true as \`foo\` union all select 5 as \`_id\`, 43 as \`current_age\`, 'a3' as \`email\`, true as \`foo\` where true on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\`, \`foo\` = excluded.\`foo\` returning \`_id\`, \`current_age\`, \`foo\`, \`bar\`",
+  ],
+]
+`;
+
+exports[`em.upsert [better-sqlite] em.upsertMany(Type, [data], options) with advanced options (onConflictMergeFields) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) select 1 as \`_id\`, 41 as \`current_age\`, 'a1' as \`email\`, true as \`foo\` union all select 2 as \`_id\`, 42 as \`current_age\`, 'a2' as \`email\`, true as \`foo\` union all select 5 as \`_id\`, 43 as \`current_age\`, 'a3' as \`email\`, true as \`foo\` where true on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`, \`foo\`, \`bar\`",
   ],
 ]
 `;
@@ -106,7 +167,7 @@ exports[`em.upsert [better-sqlite] em.upsertMany([entity1, entity2, entity3]) wi
 exports[`em.upsert [better-sqlite] em.upsertMany(Type, [data1, data2, data3]) with PK 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) select 1 as \`_id\`, 41 as \`current_age\`, 'a1' as \`email\` union all select 2 as \`_id\`, 42 as \`current_age\`, 'a2' as \`email\` union all select 3 as \`_id\`, 43 as \`current_age\`, 'a3' as \`email\` where true on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) select 1 as \`_id\`, 41 as \`current_age\`, 'a1' as \`email\` union all select 2 as \`_id\`, 42 as \`current_age\`, 'a2' as \`email\` union all select 3 as \`_id\`, 43 as \`current_age\`, 'a3' as \`email\` where true on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`foo\`, \`bar\`",
   ],
 ]
 `;
@@ -114,7 +175,34 @@ exports[`em.upsert [better-sqlite] em.upsertMany(Type, [data1, data2, data3]) wi
 exports[`em.upsert [better-sqlite] em.upsertMany(Type, [data1, data2, data3]) with unique property 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`current_age\`, \`email\`) select 41 as \`current_age\`, 'a1' as \`email\` union all select 42 as \`current_age\`, 'a2' as \`email\` union all select 43 as \`current_age\`, 'a3' as \`email\` where true on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) select 41 as \`current_age\`, 'a1' as \`email\` union all select 42 as \`current_age\`, 'a2' as \`email\` union all select 43 as \`current_age\`, 'a3' as \`email\` where true on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`, \`foo\`, \`bar\`",
+  ],
+]
+`;
+
+exports[`em.upsert [better-sqlite] em.upsertMany(Type, [entity], options) with advanced options (ignore) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) select 1 as \`_id\`, 123 as \`bar\`, 41 as \`current_age\`, 'a1' as \`email\`, true as \`foo\` union all select 2 as \`_id\`, 123 as \`bar\`, 42 as \`current_age\`, 'a2' as \`email\`, true as \`foo\` union all select 5 as \`_id\`, 123 as \`bar\`, 43 as \`current_age\`, 'a3' as \`email\`, true as \`foo\` where true on conflict (\`email\`) do nothing returning \`_id\`, \`current_age\`, \`foo\`, \`bar\`",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+  ],
+]
+`;
+
+exports[`em.upsert [better-sqlite] em.upsertMany(Type, [entity], options) with advanced options (onConflictExcludeFields) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) select 1 as \`_id\`, 123 as \`bar\`, 41 as \`current_age\`, 'a1' as \`email\`, true as \`foo\` union all select 2 as \`_id\`, 123 as \`bar\`, 42 as \`current_age\`, 'a2' as \`email\`, true as \`foo\` union all select 5 as \`_id\`, 123 as \`bar\`, 43 as \`current_age\`, 'a3' as \`email\`, true as \`foo\` where true on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\`, \`foo\` = excluded.\`foo\`, \`bar\` = excluded.\`bar\` returning \`_id\`, \`current_age\`, \`foo\`, \`bar\`",
+  ],
+]
+`;
+
+exports[`em.upsert [better-sqlite] em.upsertMany(Type, [entity], options) with advanced options (onConflictMergeFields) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) select 1 as \`_id\`, 123 as \`bar\`, 41 as \`current_age\`, 'a1' as \`email\`, true as \`foo\` union all select 2 as \`_id\`, 123 as \`bar\`, 42 as \`current_age\`, 'a2' as \`email\`, true as \`foo\` union all select 5 as \`_id\`, 123 as \`bar\`, 43 as \`current_age\`, 'a3' as \`email\`, true as \`foo\` where true on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`, \`foo\`, \`bar\`",
   ],
 ]
 `;
@@ -125,10 +213,19 @@ exports[`em.upsert [mariadb] em.upsert(Type, data) with PK 1`] = `
     "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
   ],
   [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`_id\` = 1 limit 1",
+  ],
+  [
     "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (2, 42, 'a2') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
   ],
   [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`_id\` = 2 limit 1",
+  ],
+  [
     "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (3, 43, 'a3') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`_id\` = 3 limit 1",
   ],
 ]
 `;
@@ -185,19 +282,65 @@ exports[`em.upsert [mariadb] em.upsert(Type, data) with unique property 1`] = `
     "[query] insert into \`author\` (\`current_age\`, \`email\`) values (41, 'a1') on duplicate key update \`current_age\` = values(\`current_age\`)",
   ],
   [
-    "[query] select \`a0\`.\`_id\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a1' limit 1",
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a1' limit 1",
   ],
   [
     "[query] insert into \`author\` (\`current_age\`, \`email\`) values (42, 'a2') on duplicate key update \`current_age\` = values(\`current_age\`)",
   ],
   [
-    "[query] select \`a0\`.\`_id\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
   ],
   [
     "[query] insert into \`author\` (\`current_age\`, \`email\`) values (43, 'a3') on duplicate key update \`current_age\` = values(\`current_age\`)",
   ],
   [
-    "[query] select \`a0\`.\`_id\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a3' limit 1",
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a3' limit 1",
+  ],
+]
+`;
+
+exports[`em.upsert [mariadb] em.upsert(Type, data, options) with advanced options 1`] = `
+[
+  [
+    "[query] insert ignore into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (1, 41, 'a1', true)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a1' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (2, 42, 'a2', true) on duplicate key update \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (5, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a3' limit 1",
+  ],
+]
+`;
+
+exports[`em.upsert [mariadb] em.upsert(Type, entity, options) with advanced options 1`] = `
+[
+  [
+    "[query] insert ignore into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (1, 123, 41, 'a1', true)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a1' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (2, 123, 42, 'a2', true) on duplicate key update \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (5, 123, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`), \`bar\` = values(\`bar\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a3' limit 1",
   ],
 ]
 `;
@@ -205,13 +348,13 @@ exports[`em.upsert [mariadb] em.upsert(Type, data) with unique property 1`] = `
 exports[`em.upsert [mariadb] em.upsert(entity) 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (1, 123, 41, 'a1', false) on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`), \`bar\` = values(\`bar\`)",
   ],
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (2, 42, 'a2') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (2, 123, 42, 'a2', false) on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`), \`bar\` = values(\`bar\`)",
   ],
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (3, 43, 'a3') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (3, 123, 43, 'a3', false) on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`), \`bar\` = values(\`bar\`)",
   ],
 ]
 `;
@@ -233,7 +376,7 @@ exports[`em.upsert [mariadb] em.upsert(entity) with unique composite property 1`
 exports[`em.upsert [mariadb] em.upsertMany([entity1, entity2, entity3]) with PK 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1'), (2, 42, 'a2'), (3, 43, 'a3') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (1, 123, 41, 'a1', false), (2, 123, 42, 'a2', false), (3, 123, 43, 'a3', false) on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`), \`bar\` = values(\`bar\`)",
   ],
 ]
 `;
@@ -241,10 +384,43 @@ exports[`em.upsert [mariadb] em.upsertMany([entity1, entity2, entity3]) with PK 
 exports[`em.upsert [mariadb] em.upsertMany([entity1, entity2, entity3]) with unique property 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (41, 'a1'), (42, 'a2'), (43, 'a3') on duplicate key update \`current_age\` = values(\`current_age\`)",
+    "[query] insert into \`author\` (\`bar\`, \`current_age\`, \`email\`, \`foo\`) values (123, 41, 'a1', false), (123, 42, 'a2', false), (123, 43, 'a3', false) on duplicate key update \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`), \`bar\` = values(\`bar\`)",
   ],
   [
     "[query] select \`a0\`.\`_id\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+  ],
+]
+`;
+
+exports[`em.upsert [mariadb] em.upsertMany(Type, [data], options) with advanced options (ignore) 1`] = `
+[
+  [
+    "[query] insert ignore into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (1, 41, 'a1', true), (2, 42, 'a2', true), (5, 43, 'a3', true)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+  ],
+]
+`;
+
+exports[`em.upsert [mariadb] em.upsertMany(Type, [data], options) with advanced options (onConflictExcludeFields) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (1, 41, 'a1', true), (2, 42, 'a2', true), (5, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+  ],
+]
+`;
+
+exports[`em.upsert [mariadb] em.upsertMany(Type, [data], options) with advanced options (onConflictMergeFields) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (1, 41, 'a1', true), (2, 42, 'a2', true), (5, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
   ],
 ]
 `;
@@ -253,6 +429,9 @@ exports[`em.upsert [mariadb] em.upsertMany(Type, [data1, data2, data3]) with PK 
 [
   [
     "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1'), (2, 42, 'a2'), (3, 43, 'a3') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`_id\` from \`author\` as \`a0\` where (\`a0\`.\`_id\` = 1 or \`a0\`.\`_id\` = 2 or \`a0\`.\`_id\` = 3)",
   ],
 ]
 `;
@@ -263,7 +442,40 @@ exports[`em.upsert [mariadb] em.upsertMany(Type, [data1, data2, data3]) with uni
     "[query] insert into \`author\` (\`current_age\`, \`email\`) values (41, 'a1'), (42, 'a2'), (43, 'a3') on duplicate key update \`current_age\` = values(\`current_age\`)",
   ],
   [
-    "[query] select \`a0\`.\`_id\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+  ],
+]
+`;
+
+exports[`em.upsert [mariadb] em.upsertMany(Type, [entity], options) with advanced options (ignore) 1`] = `
+[
+  [
+    "[query] insert ignore into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (1, 123, 41, 'a1', true), (2, 123, 42, 'a2', true), (5, 123, 43, 'a3', true)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+  ],
+]
+`;
+
+exports[`em.upsert [mariadb] em.upsertMany(Type, [entity], options) with advanced options (onConflictExcludeFields) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (1, 123, 41, 'a1', true), (2, 123, 42, 'a2', true), (5, 123, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`), \`bar\` = values(\`bar\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+  ],
+]
+`;
+
+exports[`em.upsert [mariadb] em.upsertMany(Type, [entity], options) with advanced options (onConflictMergeFields) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (1, 123, 41, 'a1', true), (2, 123, 42, 'a2', true), (5, 123, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
   ],
 ]
 `;
@@ -274,10 +486,19 @@ exports[`em.upsert [mongo] em.upsert(Type, data) with PK 1`] = `
     "[query] db.getCollection('author').updateMany({ _id: 1 }, { '$set': { _id: 1, email: 'a1', current_age: 41 } }, { upsert: true });",
   ],
   [
+    "[query] db.getCollection('author').find({ _id: 1 }, { projection: { id: 1, foo: 1, bar: 1 } }).limit(1).toArray();",
+  ],
+  [
     "[query] db.getCollection('author').updateMany({ _id: 2 }, { '$set': { _id: 2, email: 'a2', current_age: 42 } }, { upsert: true });",
   ],
   [
+    "[query] db.getCollection('author').find({ _id: 2 }, { projection: { id: 1, foo: 1, bar: 1 } }).limit(1).toArray();",
+  ],
+  [
     "[query] db.getCollection('author').updateMany({ _id: 3 }, { '$set': { _id: 3, email: 'a3', current_age: 43 } }, { upsert: true });",
+  ],
+  [
+    "[query] db.getCollection('author').find({ _id: 3 }, { projection: { id: 1, foo: 1, bar: 1 } }).limit(1).toArray();",
   ],
 ]
 `;
@@ -334,19 +555,65 @@ exports[`em.upsert [mongo] em.upsert(Type, data) with unique property 1`] = `
     "[query] db.getCollection('author').updateMany({ email: 'a1' }, { '$set': { email: 'a1', current_age: 41 } }, { upsert: true });",
   ],
   [
-    "[query] db.getCollection('author').find({ email: 'a1' }, { projection: { _id: 1 } }).limit(1).toArray();",
+    "[query] db.getCollection('author').find({ email: 'a1' }, { projection: { _id: 1, foo: 1, bar: 1 } }).limit(1).toArray();",
   ],
   [
     "[query] db.getCollection('author').updateMany({ email: 'a2' }, { '$set': { email: 'a2', current_age: 42 } }, { upsert: true });",
   ],
   [
-    "[query] db.getCollection('author').find({ email: 'a2' }, { projection: { _id: 1 } }).limit(1).toArray();",
+    "[query] db.getCollection('author').find({ email: 'a2' }, { projection: { _id: 1, foo: 1, bar: 1 } }).limit(1).toArray();",
   ],
   [
     "[query] db.getCollection('author').updateMany({ email: 'a3' }, { '$set': { email: 'a3', current_age: 43 } }, { upsert: true });",
   ],
   [
-    "[query] db.getCollection('author').find({ email: 'a3' }, { projection: { _id: 1 } }).limit(1).toArray();",
+    "[query] db.getCollection('author').find({ email: 'a3' }, { projection: { _id: 1, foo: 1, bar: 1 } }).limit(1).toArray();",
+  ],
+]
+`;
+
+exports[`em.upsert [mongo] em.upsert(Type, data, options) with advanced options 1`] = `
+[
+  [
+    "[query] db.getCollection('author').updateMany({ email: 'a1' }, { '$setOnInsert': { _id: 1, email: 'a1', current_age: 41, foo: true } }, { upsert: true });",
+  ],
+  [
+    "[query] db.getCollection('author').find({ email: 'a1' }, { projection: { _id: 1, current_age: 1, foo: 1, bar: 1 } }).limit(1).toArray();",
+  ],
+  [
+    "[query] db.getCollection('author').updateMany({ email: 'a2' }, { '$set': { current_age: 42 }, '$setOnInsert': { _id: 2, email: 'a2', foo: true } }, { upsert: true });",
+  ],
+  [
+    "[query] db.getCollection('author').find({ email: 'a2' }, { projection: { _id: 1, foo: 1, bar: 1 } }).limit(1).toArray();",
+  ],
+  [
+    "[query] db.getCollection('author').updateMany({ email: 'a3' }, { '$set': { email: 'a3', current_age: 43, foo: true }, '$setOnInsert': { _id: 5 } }, { upsert: true });",
+  ],
+  [
+    "[query] db.getCollection('author').find({ email: 'a3' }, { projection: { _id: 1, current_age: 1, foo: 1, bar: 1 } }).limit(1).toArray();",
+  ],
+]
+`;
+
+exports[`em.upsert [mongo] em.upsert(Type, entity, options) with advanced options 1`] = `
+[
+  [
+    "[query] db.getCollection('author').updateMany({ email: 'a1' }, { '$setOnInsert': { _id: 1, email: 'a1', current_age: 41, foo: true, bar: 123 } }, { upsert: true });",
+  ],
+  [
+    "[query] db.getCollection('author').find({ email: 'a1' }, { projection: { _id: 1, current_age: 1, foo: 1, bar: 1 } }).limit(1).toArray();",
+  ],
+  [
+    "[query] db.getCollection('author').updateMany({ email: 'a2' }, { '$set': { current_age: 42 }, '$setOnInsert': { _id: 2, email: 'a2', foo: true, bar: 123 } }, { upsert: true });",
+  ],
+  [
+    "[query] db.getCollection('author').find({ email: 'a2' }, { projection: { _id: 1, foo: 1, bar: 1 } }).limit(1).toArray();",
+  ],
+  [
+    "[query] db.getCollection('author').updateMany({ email: 'a3' }, { '$set': { email: 'a3', current_age: 43, foo: true, bar: 123 }, '$setOnInsert': { _id: 5 } }, { upsert: true });",
+  ],
+  [
+    "[query] db.getCollection('author').find({ email: 'a3' }, { projection: { _id: 1, current_age: 1, foo: 1, bar: 1 } }).limit(1).toArray();",
   ],
 ]
 `;
@@ -354,13 +621,13 @@ exports[`em.upsert [mongo] em.upsert(Type, data) with unique property 1`] = `
 exports[`em.upsert [mongo] em.upsert(entity) 1`] = `
 [
   [
-    "[query] db.getCollection('author').updateMany({ _id: 1 }, { '$set': { _id: 1, email: 'a1', current_age: 41 } }, { upsert: true });",
+    "[query] db.getCollection('author').updateMany({ _id: 1 }, { '$set': { _id: 1, email: 'a1', current_age: 41, foo: false, bar: 123 } }, { upsert: true });",
   ],
   [
-    "[query] db.getCollection('author').updateMany({ _id: 2 }, { '$set': { _id: 2, email: 'a2', current_age: 42 } }, { upsert: true });",
+    "[query] db.getCollection('author').updateMany({ _id: 2 }, { '$set': { _id: 2, email: 'a2', current_age: 42, foo: false, bar: 123 } }, { upsert: true });",
   ],
   [
-    "[query] db.getCollection('author').updateMany({ _id: 3 }, { '$set': { _id: 3, email: 'a3', current_age: 43 } }, { upsert: true });",
+    "[query] db.getCollection('author').updateMany({ _id: 3 }, { '$set': { _id: 3, email: 'a3', current_age: 43, foo: false, bar: 123 } }, { upsert: true });",
   ],
 ]
 `;
@@ -382,7 +649,7 @@ exports[`em.upsert [mongo] em.upsert(entity) with unique composite property 1`] 
 exports[`em.upsert [mongo] em.upsertMany([entity1, entity2, entity3]) with PK 1`] = `
 [
   [
-    "[query] bulk = db.getCollection('author').initializeUnorderedBulkOp({ upsert: true });bulk.find({ _id: 1 }).upsert().update({ '$set': { email: 'a1', current_age: 41 } });bulk.find({ _id: 2 }).upsert().update({ '$set': { email: 'a2', current_age: 42 } });bulk.find({ _id: 3 }).upsert().update({ '$set': { email: 'a3', current_age: 43 } });bulk.execute()",
+    "[query] bulk = db.getCollection('author').initializeUnorderedBulkOp({ upsert: true });bulk.find({ _id: 1 }).upsert().update({ '$set': { _id: 1, email: 'a1', current_age: 41, foo: false, bar: 123 } });bulk.find({ _id: 2 }).upsert().update({ '$set': { _id: 2, email: 'a2', current_age: 42, foo: false, bar: 123 } });bulk.find({ _id: 3 }).upsert().update({ '$set': { _id: 3, email: 'a3', current_age: 43, foo: false, bar: 123 } });bulk.execute()",
   ],
 ]
 `;
@@ -390,7 +657,7 @@ exports[`em.upsert [mongo] em.upsertMany([entity1, entity2, entity3]) with PK 1`
 exports[`em.upsert [mongo] em.upsertMany([entity1, entity2, entity3]) with unique property 1`] = `
 [
   [
-    "[query] bulk = db.getCollection('author').initializeUnorderedBulkOp({ upsert: true });bulk.find({ email: 'a1' }).upsert().update({ '$set': { email: 'a1', current_age: 41 } });bulk.find({ email: 'a2' }).upsert().update({ '$set': { email: 'a2', current_age: 42 } });bulk.find({ email: 'a3' }).upsert().update({ '$set': { email: 'a3', current_age: 43 } });bulk.execute()",
+    "[query] bulk = db.getCollection('author').initializeUnorderedBulkOp({ upsert: true });bulk.find({ email: 'a1' }).upsert().update({ '$set': { email: 'a1', current_age: 41, foo: false, bar: 123 } });bulk.find({ email: 'a2' }).upsert().update({ '$set': { email: 'a2', current_age: 42, foo: false, bar: 123 } });bulk.find({ email: 'a3' }).upsert().update({ '$set': { email: 'a3', current_age: 43, foo: false, bar: 123 } });bulk.execute()",
   ],
   [
     "[query] db.getCollection('author').find({ '$or': [ { email: 'a1' }, { email: 'a2' }, { email: 'a3' } ] }, { projection: { _id: 1, email: 1 } }).toArray();",
@@ -398,10 +665,46 @@ exports[`em.upsert [mongo] em.upsertMany([entity1, entity2, entity3]) with uniqu
 ]
 `;
 
+exports[`em.upsert [mongo] em.upsertMany(Type, [data], options) with advanced options (ignore) 1`] = `
+[
+  [
+    "[query] bulk = db.getCollection('author').initializeUnorderedBulkOp({ upsert: true });bulk.find({ email: 'a1' }).upsert().update({ '$setOnInsert': { _id: 1, email: 'a1', current_age: 41, foo: true } });bulk.find({ email: 'a2' }).upsert().update({ '$setOnInsert': { _id: 2, email: 'a2', current_age: 42, foo: true } });bulk.find({ email: 'a3' }).upsert().update({ '$setOnInsert': { _id: 5, email: 'a3', current_age: 43, foo: true } });bulk.execute()",
+  ],
+  [
+    "[query] db.getCollection('author').find({ '$or': [ { email: 'a1' }, { email: 'a2' }, { email: 'a3' } ] }, { projection: { _id: 1, current_age: 1, foo: 1, bar: 1, email: 1 } }).toArray();",
+  ],
+]
+`;
+
+exports[`em.upsert [mongo] em.upsertMany(Type, [data], options) with advanced options (onConflictExcludeFields) 1`] = `
+[
+  [
+    "[query] bulk = db.getCollection('author').initializeUnorderedBulkOp({ upsert: true });bulk.find({ email: 'a1' }).upsert().update({ '$set': { email: 'a1', current_age: 41, foo: true }, '$setOnInsert': { _id: 1 } });bulk.find({ email: 'a2' }).upsert().update({ '$set': { email: 'a2', current_age: 42, foo: true }, '$setOnInsert': { _id: 2 } });bulk.find({ email: 'a3' }).upsert().update({ '$set': { email: 'a3', current_age: 43, foo: true }, '$setOnInsert': { _id: 5 } });bulk.execute()",
+  ],
+  [
+    "[query] db.getCollection('author').find({ '$or': [ { email: 'a1' }, { email: 'a2' }, { email: 'a3' } ] }, { projection: { _id: 1, current_age: 1, foo: 1, bar: 1, email: 1 } }).toArray();",
+  ],
+]
+`;
+
+exports[`em.upsert [mongo] em.upsertMany(Type, [data], options) with advanced options (onConflictMergeFields) 1`] = `
+[
+  [
+    "[query] bulk = db.getCollection('author').initializeUnorderedBulkOp({ upsert: true });bulk.find({ email: 'a1' }).upsert().update({ '$set': { current_age: 41 }, '$setOnInsert': { _id: 1, email: 'a1', foo: true } });bulk.find({ email: 'a2' }).upsert().update({ '$set': { current_age: 42 }, '$setOnInsert': { _id: 2, email: 'a2', foo: true } });bulk.find({ email: 'a3' }).upsert().update({ '$set': { current_age: 43 }, '$setOnInsert': { _id: 5, email: 'a3', foo: true } });bulk.execute()",
+  ],
+  [
+    "[query] db.getCollection('author').find({ '$or': [ { email: 'a1' }, { email: 'a2' }, { email: 'a3' } ] }, { projection: { _id: 1, foo: 1, bar: 1, email: 1 } }).toArray();",
+  ],
+]
+`;
+
 exports[`em.upsert [mongo] em.upsertMany(Type, [data1, data2, data3]) with PK 1`] = `
 [
   [
-    "[query] bulk = db.getCollection('author').initializeUnorderedBulkOp({ upsert: true });bulk.find({ _id: 1 }).upsert().update({ '$set': { email: 'a1', current_age: 41 } });bulk.find({ _id: 2 }).upsert().update({ '$set': { email: 'a2', current_age: 42 } });bulk.find({ _id: 3 }).upsert().update({ '$set': { email: 'a3', current_age: 43 } });bulk.execute()",
+    "[query] bulk = db.getCollection('author').initializeUnorderedBulkOp({ upsert: true });bulk.find({ _id: 1 }).upsert().update({ '$set': { _id: 1, email: 'a1', current_age: 41 } });bulk.find({ _id: 2 }).upsert().update({ '$set': { _id: 2, email: 'a2', current_age: 42 } });bulk.find({ _id: 3 }).upsert().update({ '$set': { _id: 3, email: 'a3', current_age: 43 } });bulk.execute()",
+  ],
+  [
+    "[query] db.getCollection('author').find({ '$or': [ { _id: 1 }, { _id: 2 }, { _id: 3 } ] }, { projection: { foo: 1, bar: 1, _id: 1 } }).toArray();",
   ],
 ]
 `;
@@ -412,7 +715,40 @@ exports[`em.upsert [mongo] em.upsertMany(Type, [data1, data2, data3]) with uniqu
     "[query] bulk = db.getCollection('author').initializeUnorderedBulkOp({ upsert: true });bulk.find({ email: 'a1' }).upsert().update({ '$set': { email: 'a1', current_age: 41 } });bulk.find({ email: 'a2' }).upsert().update({ '$set': { email: 'a2', current_age: 42 } });bulk.find({ email: 'a3' }).upsert().update({ '$set': { email: 'a3', current_age: 43 } });bulk.execute()",
   ],
   [
-    "[query] db.getCollection('author').find({ '$or': [ { email: 'a1' }, { email: 'a2' }, { email: 'a3' } ] }, { projection: { _id: 1, email: 1 } }).toArray();",
+    "[query] db.getCollection('author').find({ '$or': [ { email: 'a1' }, { email: 'a2' }, { email: 'a3' } ] }, { projection: { _id: 1, foo: 1, bar: 1, email: 1 } }).toArray();",
+  ],
+]
+`;
+
+exports[`em.upsert [mongo] em.upsertMany(Type, [entity], options) with advanced options (ignore) 1`] = `
+[
+  [
+    "[query] bulk = db.getCollection('author').initializeUnorderedBulkOp({ upsert: true });bulk.find({ email: 'a1' }).upsert().update({ '$setOnInsert': { _id: 1, email: 'a1', current_age: 41, foo: true, bar: 123 } });bulk.find({ email: 'a2' }).upsert().update({ '$setOnInsert': { _id: 2, email: 'a2', current_age: 42, foo: true, bar: 123 } });bulk.find({ email: 'a3' }).upsert().update({ '$setOnInsert': { _id: 5, email: 'a3', current_age: 43, foo: true, bar: 123 } });bulk.execute()",
+  ],
+  [
+    "[query] db.getCollection('author').find({ '$or': [ { email: 'a1' }, { email: 'a2' }, { email: 'a3' } ] }, { projection: { _id: 1, current_age: 1, foo: 1, bar: 1, email: 1 } }).toArray();",
+  ],
+]
+`;
+
+exports[`em.upsert [mongo] em.upsertMany(Type, [entity], options) with advanced options (onConflictExcludeFields) 1`] = `
+[
+  [
+    "[query] bulk = db.getCollection('author').initializeUnorderedBulkOp({ upsert: true });bulk.find({ email: 'a1' }).upsert().update({ '$set': { email: 'a1', current_age: 41, foo: true, bar: 123 }, '$setOnInsert': { _id: 1 } });bulk.find({ email: 'a2' }).upsert().update({ '$set': { email: 'a2', current_age: 42, foo: true, bar: 123 }, '$setOnInsert': { _id: 2 } });bulk.find({ email: 'a3' }).upsert().update({ '$set': { email: 'a3', current_age: 43, foo: true, bar: 123 }, '$setOnInsert': { _id: 5 } });bulk.execute()",
+  ],
+  [
+    "[query] db.getCollection('author').find({ '$or': [ { email: 'a1' }, { email: 'a2' }, { email: 'a3' } ] }, { projection: { _id: 1, current_age: 1, foo: 1, bar: 1, email: 1 } }).toArray();",
+  ],
+]
+`;
+
+exports[`em.upsert [mongo] em.upsertMany(Type, [entity], options) with advanced options (onConflictMergeFields) 1`] = `
+[
+  [
+    "[query] bulk = db.getCollection('author').initializeUnorderedBulkOp({ upsert: true });bulk.find({ email: 'a1' }).upsert().update({ '$set': { current_age: 41 }, '$setOnInsert': { _id: 1, email: 'a1', foo: true, bar: 123 } });bulk.find({ email: 'a2' }).upsert().update({ '$set': { current_age: 42 }, '$setOnInsert': { _id: 2, email: 'a2', foo: true, bar: 123 } });bulk.find({ email: 'a3' }).upsert().update({ '$set': { current_age: 43 }, '$setOnInsert': { _id: 5, email: 'a3', foo: true, bar: 123 } });bulk.execute()",
+  ],
+  [
+    "[query] db.getCollection('author').find({ '$or': [ { email: 'a1' }, { email: 'a2' }, { email: 'a3' } ] }, { projection: { _id: 1, foo: 1, bar: 1, email: 1 } }).toArray();",
   ],
 ]
 `;
@@ -423,10 +759,19 @@ exports[`em.upsert [mysql] em.upsert(Type, data) with PK 1`] = `
     "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
   ],
   [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`_id\` = 1 limit 1",
+  ],
+  [
     "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (2, 42, 'a2') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
   ],
   [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`_id\` = 2 limit 1",
+  ],
+  [
     "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (3, 43, 'a3') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`_id\` = 3 limit 1",
   ],
 ]
 `;
@@ -483,19 +828,65 @@ exports[`em.upsert [mysql] em.upsert(Type, data) with unique property 1`] = `
     "[query] insert into \`author\` (\`current_age\`, \`email\`) values (41, 'a1') on duplicate key update \`current_age\` = values(\`current_age\`)",
   ],
   [
-    "[query] select \`a0\`.\`_id\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a1' limit 1",
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a1' limit 1",
   ],
   [
     "[query] insert into \`author\` (\`current_age\`, \`email\`) values (42, 'a2') on duplicate key update \`current_age\` = values(\`current_age\`)",
   ],
   [
-    "[query] select \`a0\`.\`_id\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
   ],
   [
     "[query] insert into \`author\` (\`current_age\`, \`email\`) values (43, 'a3') on duplicate key update \`current_age\` = values(\`current_age\`)",
   ],
   [
-    "[query] select \`a0\`.\`_id\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a3' limit 1",
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a3' limit 1",
+  ],
+]
+`;
+
+exports[`em.upsert [mysql] em.upsert(Type, data, options) with advanced options 1`] = `
+[
+  [
+    "[query] insert ignore into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (1, 41, 'a1', true)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a1' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (2, 42, 'a2', true) on duplicate key update \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (5, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a3' limit 1",
+  ],
+]
+`;
+
+exports[`em.upsert [mysql] em.upsert(Type, entity, options) with advanced options 1`] = `
+[
+  [
+    "[query] insert ignore into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (1, 123, 41, 'a1', true)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a1' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (2, 123, 42, 'a2', true) on duplicate key update \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (5, 123, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`), \`bar\` = values(\`bar\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a3' limit 1",
   ],
 ]
 `;
@@ -503,13 +894,13 @@ exports[`em.upsert [mysql] em.upsert(Type, data) with unique property 1`] = `
 exports[`em.upsert [mysql] em.upsert(entity) 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (1, 123, 41, 'a1', false) on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`), \`bar\` = values(\`bar\`)",
   ],
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (2, 42, 'a2') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (2, 123, 42, 'a2', false) on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`), \`bar\` = values(\`bar\`)",
   ],
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (3, 43, 'a3') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (3, 123, 43, 'a3', false) on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`), \`bar\` = values(\`bar\`)",
   ],
 ]
 `;
@@ -531,7 +922,7 @@ exports[`em.upsert [mysql] em.upsert(entity) with unique composite property 1`] 
 exports[`em.upsert [mysql] em.upsertMany([entity1, entity2, entity3]) with PK 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1'), (2, 42, 'a2'), (3, 43, 'a3') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (1, 123, 41, 'a1', false), (2, 123, 42, 'a2', false), (3, 123, 43, 'a3', false) on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`), \`bar\` = values(\`bar\`)",
   ],
 ]
 `;
@@ -539,10 +930,43 @@ exports[`em.upsert [mysql] em.upsertMany([entity1, entity2, entity3]) with PK 1`
 exports[`em.upsert [mysql] em.upsertMany([entity1, entity2, entity3]) with unique property 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (41, 'a1'), (42, 'a2'), (43, 'a3') on duplicate key update \`current_age\` = values(\`current_age\`)",
+    "[query] insert into \`author\` (\`bar\`, \`current_age\`, \`email\`, \`foo\`) values (123, 41, 'a1', false), (123, 42, 'a2', false), (123, 43, 'a3', false) on duplicate key update \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`), \`bar\` = values(\`bar\`)",
   ],
   [
     "[query] select \`a0\`.\`_id\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+  ],
+]
+`;
+
+exports[`em.upsert [mysql] em.upsertMany(Type, [data], options) with advanced options (ignore) 1`] = `
+[
+  [
+    "[query] insert ignore into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (1, 41, 'a1', true), (2, 42, 'a2', true), (5, 43, 'a3', true)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+  ],
+]
+`;
+
+exports[`em.upsert [mysql] em.upsertMany(Type, [data], options) with advanced options (onConflictExcludeFields) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (1, 41, 'a1', true), (2, 42, 'a2', true), (5, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+  ],
+]
+`;
+
+exports[`em.upsert [mysql] em.upsertMany(Type, [data], options) with advanced options (onConflictMergeFields) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (1, 41, 'a1', true), (2, 42, 'a2', true), (5, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
   ],
 ]
 `;
@@ -551,6 +975,9 @@ exports[`em.upsert [mysql] em.upsertMany(Type, [data1, data2, data3]) with PK 1`
 [
   [
     "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1'), (2, 42, 'a2'), (3, 43, 'a3') on duplicate key update \`email\` = values(\`email\`), \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`_id\` from \`author\` as \`a0\` where (\`a0\`.\`_id\` = 1 or \`a0\`.\`_id\` = 2 or \`a0\`.\`_id\` = 3)",
   ],
 ]
 `;
@@ -561,7 +988,40 @@ exports[`em.upsert [mysql] em.upsertMany(Type, [data1, data2, data3]) with uniqu
     "[query] insert into \`author\` (\`current_age\`, \`email\`) values (41, 'a1'), (42, 'a2'), (43, 'a3') on duplicate key update \`current_age\` = values(\`current_age\`)",
   ],
   [
-    "[query] select \`a0\`.\`_id\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+  ],
+]
+`;
+
+exports[`em.upsert [mysql] em.upsertMany(Type, [entity], options) with advanced options (ignore) 1`] = `
+[
+  [
+    "[query] insert ignore into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (1, 123, 41, 'a1', true), (2, 123, 42, 'a2', true), (5, 123, 43, 'a3', true)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+  ],
+]
+`;
+
+exports[`em.upsert [mysql] em.upsertMany(Type, [entity], options) with advanced options (onConflictExcludeFields) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (1, 123, 41, 'a1', true), (2, 123, 42, 'a2', true), (5, 123, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`), \`bar\` = values(\`bar\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+  ],
+]
+`;
+
+exports[`em.upsert [mysql] em.upsertMany(Type, [entity], options) with advanced options (onConflictMergeFields) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (1, 123, 41, 'a1', true), (2, 123, 42, 'a2', true), (5, 123, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`)",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
   ],
 ]
 `;
@@ -569,13 +1029,13 @@ exports[`em.upsert [mysql] em.upsertMany(Type, [data1, data2, data3]) with uniqu
 exports[`em.upsert [postgresql] em.upsert(Type, data) with PK 1`] = `
 [
   [
-    "[query] insert into "author" ("_id", "current_age", "email") values (1, 41, 'a1') on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age" returning "_id"",
+    "[query] insert into "author" ("_id", "current_age", "email") values (1, 41, 'a1') on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age" returning "foo", "bar"",
   ],
   [
-    "[query] insert into "author" ("_id", "current_age", "email") values (2, 42, 'a2') on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age" returning "_id"",
+    "[query] insert into "author" ("_id", "current_age", "email") values (2, 42, 'a2') on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age" returning "foo", "bar"",
   ],
   [
-    "[query] insert into "author" ("_id", "current_age", "email") values (3, 43, 'a3') on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age" returning "_id"",
+    "[query] insert into "author" ("_id", "current_age", "email") values (3, 43, 'a3') on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age" returning "foo", "bar"",
   ],
 ]
 `;
@@ -614,13 +1074,47 @@ exports[`em.upsert [postgresql] em.upsert(Type, data) with unique composite prop
 exports[`em.upsert [postgresql] em.upsert(Type, data) with unique property 1`] = `
 [
   [
-    "[query] insert into "author" ("current_age", "email") values (41, 'a1') on conflict ("email") do update set "current_age" = excluded."current_age" returning "_id"",
+    "[query] insert into "author" ("current_age", "email") values (41, 'a1') on conflict ("email") do update set "current_age" = excluded."current_age" returning "_id", "foo", "bar"",
   ],
   [
-    "[query] insert into "author" ("current_age", "email") values (42, 'a2') on conflict ("email") do update set "current_age" = excluded."current_age" returning "_id"",
+    "[query] insert into "author" ("current_age", "email") values (42, 'a2') on conflict ("email") do update set "current_age" = excluded."current_age" returning "_id", "foo", "bar"",
   ],
   [
-    "[query] insert into "author" ("current_age", "email") values (43, 'a3') on conflict ("email") do update set "current_age" = excluded."current_age" returning "_id"",
+    "[query] insert into "author" ("current_age", "email") values (43, 'a3') on conflict ("email") do update set "current_age" = excluded."current_age" returning "_id", "foo", "bar"",
+  ],
+]
+`;
+
+exports[`em.upsert [postgresql] em.upsert(Type, data, options) with advanced options 1`] = `
+[
+  [
+    "[query] insert into "author" ("_id", "current_age", "email", "foo") values (1, 41, 'a1', true) on conflict ("email") do nothing returning "_id", "current_age", "foo", "bar"",
+  ],
+  [
+    "[query] select "a0"."_id", "a0"."current_age", "a0"."foo", "a0"."bar" from "author" as "a0" where "a0"."email" = 'a1' limit 1",
+  ],
+  [
+    "[query] insert into "author" ("_id", "current_age", "email", "foo") values (2, 42, 'a2', true) on conflict ("email") do update set "current_age" = excluded."current_age" returning "_id", "foo", "bar"",
+  ],
+  [
+    "[query] insert into "author" ("_id", "current_age", "email", "foo") values (5, 43, 'a3', true) on conflict ("email") do update set "current_age" = excluded."current_age", "foo" = excluded."foo" returning "_id", "current_age", "foo", "bar"",
+  ],
+]
+`;
+
+exports[`em.upsert [postgresql] em.upsert(Type, entity, options) with advanced options 1`] = `
+[
+  [
+    "[query] insert into "author" ("_id", "bar", "current_age", "email", "foo") values (1, 123, 41, 'a1', true) on conflict ("email") do nothing returning "_id", "current_age", "foo", "bar"",
+  ],
+  [
+    "[query] select "a0"."_id", "a0"."current_age", "a0"."foo", "a0"."bar" from "author" as "a0" where "a0"."email" = 'a1' limit 1",
+  ],
+  [
+    "[query] insert into "author" ("_id", "bar", "current_age", "email", "foo") values (2, 123, 42, 'a2', true) on conflict ("email") do update set "current_age" = excluded."current_age" returning "_id", "foo", "bar"",
+  ],
+  [
+    "[query] insert into "author" ("_id", "bar", "current_age", "email", "foo") values (5, 123, 43, 'a3', true) on conflict ("email") do update set "current_age" = excluded."current_age", "foo" = excluded."foo", "bar" = excluded."bar" returning "_id", "current_age", "foo", "bar"",
   ],
 ]
 `;
@@ -628,13 +1122,13 @@ exports[`em.upsert [postgresql] em.upsert(Type, data) with unique property 1`] =
 exports[`em.upsert [postgresql] em.upsert(entity) 1`] = `
 [
   [
-    "[query] insert into "author" ("_id", "current_age", "email") values (1, 41, 'a1') on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age" returning "_id"",
+    "[query] insert into "author" ("_id", "bar", "current_age", "email", "foo") values (1, 123, 41, 'a1', false) on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age", "foo" = excluded."foo", "bar" = excluded."bar" returning "_id"",
   ],
   [
-    "[query] insert into "author" ("_id", "current_age", "email") values (2, 42, 'a2') on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age" returning "_id"",
+    "[query] insert into "author" ("_id", "bar", "current_age", "email", "foo") values (2, 123, 42, 'a2', false) on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age", "foo" = excluded."foo", "bar" = excluded."bar" returning "_id"",
   ],
   [
-    "[query] insert into "author" ("_id", "current_age", "email") values (3, 43, 'a3') on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age" returning "_id"",
+    "[query] insert into "author" ("_id", "bar", "current_age", "email", "foo") values (3, 123, 43, 'a3', false) on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age", "foo" = excluded."foo", "bar" = excluded."bar" returning "_id"",
   ],
 ]
 `;
@@ -656,7 +1150,7 @@ exports[`em.upsert [postgresql] em.upsert(entity) with unique composite property
 exports[`em.upsert [postgresql] em.upsertMany([entity1, entity2, entity3]) with PK 1`] = `
 [
   [
-    "[query] insert into "author" ("_id", "current_age", "email") values (1, 41, 'a1'), (2, 42, 'a2'), (3, 43, 'a3') on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age" returning "_id"",
+    "[query] insert into "author" ("_id", "bar", "current_age", "email", "foo") values (1, 123, 41, 'a1', false), (2, 123, 42, 'a2', false), (3, 123, 43, 'a3', false) on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age", "foo" = excluded."foo", "bar" = excluded."bar" returning "_id", "foo", "bar"",
   ],
 ]
 `;
@@ -664,7 +1158,34 @@ exports[`em.upsert [postgresql] em.upsertMany([entity1, entity2, entity3]) with 
 exports[`em.upsert [postgresql] em.upsertMany([entity1, entity2, entity3]) with unique property 1`] = `
 [
   [
-    "[query] insert into "author" ("current_age", "email") values (41, 'a1'), (42, 'a2'), (43, 'a3') on conflict ("email") do update set "current_age" = excluded."current_age" returning "_id"",
+    "[query] insert into "author" ("bar", "current_age", "email", "foo") values (123, 41, 'a1', false), (123, 42, 'a2', false), (123, 43, 'a3', false) on conflict ("email") do update set "current_age" = excluded."current_age", "foo" = excluded."foo", "bar" = excluded."bar" returning "_id"",
+  ],
+]
+`;
+
+exports[`em.upsert [postgresql] em.upsertMany(Type, [data], options) with advanced options (ignore) 1`] = `
+[
+  [
+    "[query] insert into "author" ("_id", "current_age", "email", "foo") values (1, 41, 'a1', true), (2, 42, 'a2', true), (5, 43, 'a3', true) on conflict ("email") do nothing returning "_id", "current_age", "foo", "bar"",
+  ],
+  [
+    "[query] select "a0"."_id", "a0"."current_age", "a0"."foo", "a0"."bar", "a0"."email" from "author" as "a0" where ("a0"."email" = 'a1' or "a0"."email" = 'a2' or "a0"."email" = 'a3')",
+  ],
+]
+`;
+
+exports[`em.upsert [postgresql] em.upsertMany(Type, [data], options) with advanced options (onConflictExcludeFields) 1`] = `
+[
+  [
+    "[query] insert into "author" ("_id", "current_age", "email", "foo") values (1, 41, 'a1', true), (2, 42, 'a2', true), (5, 43, 'a3', true) on conflict ("email") do update set "current_age" = excluded."current_age", "foo" = excluded."foo" returning "_id", "current_age", "foo", "bar"",
+  ],
+]
+`;
+
+exports[`em.upsert [postgresql] em.upsertMany(Type, [data], options) with advanced options (onConflictMergeFields) 1`] = `
+[
+  [
+    "[query] insert into "author" ("_id", "current_age", "email", "foo") values (1, 41, 'a1', true), (2, 42, 'a2', true), (5, 43, 'a3', true) on conflict ("email") do update set "current_age" = excluded."current_age" returning "_id", "foo", "bar"",
   ],
 ]
 `;
@@ -672,7 +1193,7 @@ exports[`em.upsert [postgresql] em.upsertMany([entity1, entity2, entity3]) with 
 exports[`em.upsert [postgresql] em.upsertMany(Type, [data1, data2, data3]) with PK 1`] = `
 [
   [
-    "[query] insert into "author" ("_id", "current_age", "email") values (1, 41, 'a1'), (2, 42, 'a2'), (3, 43, 'a3') on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age" returning "_id"",
+    "[query] insert into "author" ("_id", "current_age", "email") values (1, 41, 'a1'), (2, 42, 'a2'), (3, 43, 'a3') on conflict ("_id") do update set "email" = excluded."email", "current_age" = excluded."current_age" returning "foo", "bar"",
   ],
 ]
 `;
@@ -680,7 +1201,34 @@ exports[`em.upsert [postgresql] em.upsertMany(Type, [data1, data2, data3]) with 
 exports[`em.upsert [postgresql] em.upsertMany(Type, [data1, data2, data3]) with unique property 1`] = `
 [
   [
-    "[query] insert into "author" ("current_age", "email") values (41, 'a1'), (42, 'a2'), (43, 'a3') on conflict ("email") do update set "current_age" = excluded."current_age" returning "_id"",
+    "[query] insert into "author" ("current_age", "email") values (41, 'a1'), (42, 'a2'), (43, 'a3') on conflict ("email") do update set "current_age" = excluded."current_age" returning "_id", "foo", "bar"",
+  ],
+]
+`;
+
+exports[`em.upsert [postgresql] em.upsertMany(Type, [entity], options) with advanced options (ignore) 1`] = `
+[
+  [
+    "[query] insert into "author" ("_id", "bar", "current_age", "email", "foo") values (1, 123, 41, 'a1', true), (2, 123, 42, 'a2', true), (5, 123, 43, 'a3', true) on conflict ("email") do nothing returning "_id", "current_age", "foo", "bar"",
+  ],
+  [
+    "[query] select "a0"."_id", "a0"."current_age", "a0"."foo", "a0"."bar", "a0"."email" from "author" as "a0" where ("a0"."email" = 'a1' or "a0"."email" = 'a2' or "a0"."email" = 'a3')",
+  ],
+]
+`;
+
+exports[`em.upsert [postgresql] em.upsertMany(Type, [entity], options) with advanced options (onConflictExcludeFields) 1`] = `
+[
+  [
+    "[query] insert into "author" ("_id", "bar", "current_age", "email", "foo") values (1, 123, 41, 'a1', true), (2, 123, 42, 'a2', true), (5, 123, 43, 'a3', true) on conflict ("email") do update set "current_age" = excluded."current_age", "foo" = excluded."foo", "bar" = excluded."bar" returning "_id", "current_age", "foo", "bar"",
+  ],
+]
+`;
+
+exports[`em.upsert [postgresql] em.upsertMany(Type, [entity], options) with advanced options (onConflictMergeFields) 1`] = `
+[
+  [
+    "[query] insert into "author" ("_id", "bar", "current_age", "email", "foo") values (1, 123, 41, 'a1', true), (2, 123, 42, 'a2', true), (5, 123, 43, 'a3', true) on conflict ("email") do update set "current_age" = excluded."current_age" returning "_id", "foo", "bar"",
   ],
 ]
 `;
@@ -688,13 +1236,13 @@ exports[`em.upsert [postgresql] em.upsertMany(Type, [data1, data2, data3]) with 
 exports[`em.upsert [sqlite] em.upsert(Type, data) with PK 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`foo\`, \`bar\`",
   ],
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (2, 42, 'a2') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (2, 42, 'a2') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`foo\`, \`bar\`",
   ],
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (3, 43, 'a3') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (3, 43, 'a3') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`foo\`, \`bar\`",
   ],
 ]
 `;
@@ -733,13 +1281,47 @@ exports[`em.upsert [sqlite] em.upsert(Type, data) with unique composite property
 exports[`em.upsert [sqlite] em.upsert(Type, data) with unique property 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (41, 'a1') on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (41, 'a1') on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`, \`foo\`, \`bar\`",
   ],
   [
-    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (42, 'a2') on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (42, 'a2') on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`, \`foo\`, \`bar\`",
   ],
   [
-    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (43, 'a3') on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) values (43, 'a3') on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`, \`foo\`, \`bar\`",
+  ],
+]
+`;
+
+exports[`em.upsert [sqlite] em.upsert(Type, data, options) with advanced options 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (1, 41, 'a1', true) on conflict (\`email\`) do nothing returning \`_id\`, \`current_age\`, \`foo\`, \`bar\`",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a1' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (2, 42, 'a2', true) on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`, \`foo\`, \`bar\`",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (5, 43, 'a3', true) on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\`, \`foo\` = excluded.\`foo\` returning \`_id\`, \`current_age\`, \`foo\`, \`bar\`",
+  ],
+]
+`;
+
+exports[`em.upsert [sqlite] em.upsert(Type, entity, options) with advanced options 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (1, 123, 41, 'a1', true) on conflict (\`email\`) do nothing returning \`_id\`, \`current_age\`, \`foo\`, \`bar\`",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a1' limit 1",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (2, 123, 42, 'a2', true) on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`, \`foo\`, \`bar\`",
+  ],
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (5, 123, 43, 'a3', true) on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\`, \`foo\` = excluded.\`foo\`, \`bar\` = excluded.\`bar\` returning \`_id\`, \`current_age\`, \`foo\`, \`bar\`",
   ],
 ]
 `;
@@ -747,13 +1329,13 @@ exports[`em.upsert [sqlite] em.upsert(Type, data) with unique property 1`] = `
 exports[`em.upsert [sqlite] em.upsert(entity) 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (1, 41, 'a1') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (1, 123, 41, 'a1', false) on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`, \`foo\` = excluded.\`foo\`, \`bar\` = excluded.\`bar\` returning \`_id\`",
   ],
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (2, 42, 'a2') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (2, 123, 42, 'a2', false) on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`, \`foo\` = excluded.\`foo\`, \`bar\` = excluded.\`bar\` returning \`_id\`",
   ],
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) values (3, 43, 'a3') on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (3, 123, 43, 'a3', false) on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`, \`foo\` = excluded.\`foo\`, \`bar\` = excluded.\`bar\` returning \`_id\`",
   ],
 ]
 `;
@@ -775,7 +1357,7 @@ exports[`em.upsert [sqlite] em.upsert(entity) with unique composite property 1`]
 exports[`em.upsert [sqlite] em.upsertMany([entity1, entity2, entity3]) with PK 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) select 1 as \`_id\`, 41 as \`current_age\`, 'a1' as \`email\` union all select 2 as \`_id\`, 42 as \`current_age\`, 'a2' as \`email\` union all select 3 as \`_id\`, 43 as \`current_age\`, 'a3' as \`email\` where true on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) select 1 as \`_id\`, 123 as \`bar\`, 41 as \`current_age\`, 'a1' as \`email\`, false as \`foo\` union all select 2 as \`_id\`, 123 as \`bar\`, 42 as \`current_age\`, 'a2' as \`email\`, false as \`foo\` union all select 3 as \`_id\`, 123 as \`bar\`, 43 as \`current_age\`, 'a3' as \`email\`, false as \`foo\` where true on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\`, \`foo\` = excluded.\`foo\`, \`bar\` = excluded.\`bar\` returning \`_id\`, \`foo\`, \`bar\`",
   ],
 ]
 `;
@@ -783,7 +1365,34 @@ exports[`em.upsert [sqlite] em.upsertMany([entity1, entity2, entity3]) with PK 1
 exports[`em.upsert [sqlite] em.upsertMany([entity1, entity2, entity3]) with unique property 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`current_age\`, \`email\`) select 41 as \`current_age\`, 'a1' as \`email\` union all select 42 as \`current_age\`, 'a2' as \`email\` union all select 43 as \`current_age\`, 'a3' as \`email\` where true on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`bar\`, \`current_age\`, \`email\`, \`foo\`) select 123 as \`bar\`, 41 as \`current_age\`, 'a1' as \`email\`, false as \`foo\` union all select 123 as \`bar\`, 42 as \`current_age\`, 'a2' as \`email\`, false as \`foo\` union all select 123 as \`bar\`, 43 as \`current_age\`, 'a3' as \`email\`, false as \`foo\` where true on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\`, \`foo\` = excluded.\`foo\`, \`bar\` = excluded.\`bar\` returning \`_id\`",
+  ],
+]
+`;
+
+exports[`em.upsert [sqlite] em.upsertMany(Type, [data], options) with advanced options (ignore) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) select 1 as \`_id\`, 41 as \`current_age\`, 'a1' as \`email\`, true as \`foo\` union all select 2 as \`_id\`, 42 as \`current_age\`, 'a2' as \`email\`, true as \`foo\` union all select 5 as \`_id\`, 43 as \`current_age\`, 'a3' as \`email\`, true as \`foo\` where true on conflict (\`email\`) do nothing returning \`_id\`, \`current_age\`, \`foo\`, \`bar\`",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+  ],
+]
+`;
+
+exports[`em.upsert [sqlite] em.upsertMany(Type, [data], options) with advanced options (onConflictExcludeFields) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) select 1 as \`_id\`, 41 as \`current_age\`, 'a1' as \`email\`, true as \`foo\` union all select 2 as \`_id\`, 42 as \`current_age\`, 'a2' as \`email\`, true as \`foo\` union all select 5 as \`_id\`, 43 as \`current_age\`, 'a3' as \`email\`, true as \`foo\` where true on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\`, \`foo\` = excluded.\`foo\` returning \`_id\`, \`current_age\`, \`foo\`, \`bar\`",
+  ],
+]
+`;
+
+exports[`em.upsert [sqlite] em.upsertMany(Type, [data], options) with advanced options (onConflictMergeFields) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) select 1 as \`_id\`, 41 as \`current_age\`, 'a1' as \`email\`, true as \`foo\` union all select 2 as \`_id\`, 42 as \`current_age\`, 'a2' as \`email\`, true as \`foo\` union all select 5 as \`_id\`, 43 as \`current_age\`, 'a3' as \`email\`, true as \`foo\` where true on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`, \`foo\`, \`bar\`",
   ],
 ]
 `;
@@ -791,7 +1400,7 @@ exports[`em.upsert [sqlite] em.upsertMany([entity1, entity2, entity3]) with uniq
 exports[`em.upsert [sqlite] em.upsertMany(Type, [data1, data2, data3]) with PK 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) select 1 as \`_id\`, 41 as \`current_age\`, 'a1' as \`email\` union all select 2 as \`_id\`, 42 as \`current_age\`, 'a2' as \`email\` union all select 3 as \`_id\`, 43 as \`current_age\`, 'a3' as \`email\` where true on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`) select 1 as \`_id\`, 41 as \`current_age\`, 'a1' as \`email\` union all select 2 as \`_id\`, 42 as \`current_age\`, 'a2' as \`email\` union all select 3 as \`_id\`, 43 as \`current_age\`, 'a3' as \`email\` where true on conflict (\`_id\`) do update set \`email\` = excluded.\`email\`, \`current_age\` = excluded.\`current_age\` returning \`foo\`, \`bar\`",
   ],
 ]
 `;
@@ -799,7 +1408,34 @@ exports[`em.upsert [sqlite] em.upsertMany(Type, [data1, data2, data3]) with PK 1
 exports[`em.upsert [sqlite] em.upsertMany(Type, [data1, data2, data3]) with unique property 1`] = `
 [
   [
-    "[query] insert into \`author\` (\`current_age\`, \`email\`) select 41 as \`current_age\`, 'a1' as \`email\` union all select 42 as \`current_age\`, 'a2' as \`email\` union all select 43 as \`current_age\`, 'a3' as \`email\` where true on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`",
+    "[query] insert into \`author\` (\`current_age\`, \`email\`) select 41 as \`current_age\`, 'a1' as \`email\` union all select 42 as \`current_age\`, 'a2' as \`email\` union all select 43 as \`current_age\`, 'a3' as \`email\` where true on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`, \`foo\`, \`bar\`",
+  ],
+]
+`;
+
+exports[`em.upsert [sqlite] em.upsertMany(Type, [entity], options) with advanced options (ignore) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) select 1 as \`_id\`, 123 as \`bar\`, 41 as \`current_age\`, 'a1' as \`email\`, true as \`foo\` union all select 2 as \`_id\`, 123 as \`bar\`, 42 as \`current_age\`, 'a2' as \`email\`, true as \`foo\` union all select 5 as \`_id\`, 123 as \`bar\`, 43 as \`current_age\`, 'a3' as \`email\`, true as \`foo\` where true on conflict (\`email\`) do nothing returning \`_id\`, \`current_age\`, \`foo\`, \`bar\`",
+  ],
+  [
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`current_age\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+  ],
+]
+`;
+
+exports[`em.upsert [sqlite] em.upsertMany(Type, [entity], options) with advanced options (onConflictExcludeFields) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) select 1 as \`_id\`, 123 as \`bar\`, 41 as \`current_age\`, 'a1' as \`email\`, true as \`foo\` union all select 2 as \`_id\`, 123 as \`bar\`, 42 as \`current_age\`, 'a2' as \`email\`, true as \`foo\` union all select 5 as \`_id\`, 123 as \`bar\`, 43 as \`current_age\`, 'a3' as \`email\`, true as \`foo\` where true on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\`, \`foo\` = excluded.\`foo\`, \`bar\` = excluded.\`bar\` returning \`_id\`, \`current_age\`, \`foo\`, \`bar\`",
+  ],
+]
+`;
+
+exports[`em.upsert [sqlite] em.upsertMany(Type, [entity], options) with advanced options (onConflictMergeFields) 1`] = `
+[
+  [
+    "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) select 1 as \`_id\`, 123 as \`bar\`, 41 as \`current_age\`, 'a1' as \`email\`, true as \`foo\` union all select 2 as \`_id\`, 123 as \`bar\`, 42 as \`current_age\`, 'a2' as \`email\`, true as \`foo\` union all select 5 as \`_id\`, 123 as \`bar\`, 43 as \`current_age\`, 'a3' as \`email\`, true as \`foo\` where true on conflict (\`email\`) do update set \`current_age\` = excluded.\`current_age\` returning \`_id\`, \`foo\`, \`bar\`",
   ],
 ]
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2421,7 +2421,7 @@ __metadata:
     lerna: 6.6.2
     lint-staged: 14.0.1
     mongodb: 5.8.1
-    mongodb-memory-server: ^8.12.2
+    mongodb-memory-server: 8.15.1
     node-gyp: ^9.3.1
     rimraf: 5.0.1
     ts-jest: 29.1.1
@@ -6142,7 +6142,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.0":
+"follow-redirects@npm:^1.15.0, follow-redirects@npm:^1.15.2":
   version: 1.15.2
   resolution: "follow-redirects@npm:1.15.2"
   peerDependenciesMeta:
@@ -9261,16 +9261,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mongodb-connection-string-url@npm:^2.5.4":
-  version: 2.5.4
-  resolution: "mongodb-connection-string-url@npm:2.5.4"
-  dependencies:
-    "@types/whatwg-url": ^8.2.1
-    whatwg-url: ^11.0.0
-  checksum: 9f431826b229488808e4a8a9e6bdde0162be3e6d5cad40867b69b2199ce009f568b67dc1bf587a43367904d8184f1c68689f7ea6574ed40b396726abde9485e1
-  languageName: node
-  linkType: hard
-
 "mongodb-connection-string-url@npm:^2.6.0":
   version: 2.6.0
   resolution: "mongodb-connection-string-url@npm:2.6.0"
@@ -9281,35 +9271,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mongodb-memory-server-core@npm:8.12.2":
-  version: 8.12.2
-  resolution: "mongodb-memory-server-core@npm:8.12.2"
+"mongodb-memory-server-core@npm:8.15.1":
+  version: 8.15.1
+  resolution: "mongodb-memory-server-core@npm:8.15.1"
   dependencies:
     async-mutex: ^0.3.2
     camelcase: ^6.3.0
     debug: ^4.3.4
     find-cache-dir: ^3.3.2
+    follow-redirects: ^1.15.2
     get-port: ^5.1.1
     https-proxy-agent: ^5.0.1
     md5-file: ^5.0.0
-    mongodb: ^4.13.0
+    mongodb: ^4.16.0
     new-find-package-json: ^2.0.0
-    semver: ^7.3.8
+    semver: ^7.5.4
     tar-stream: ^2.1.4
-    tslib: ^2.5.0
+    tslib: ^2.6.1
     uuid: ^9.0.0
     yauzl: ^2.10.0
-  checksum: 5224ab18da6b09f784331f5397552e83de343bac716e54f221e963d3a6113aa108b60964f2b4814c32cbd6e3ab907dbfebb08b13f44e8c3bb6ea41ab04640342
+  checksum: 2e47663a65575f4d067f8acf47a00aa7f2cfd8040854034f72e2ca35ab3d708fbe45feff556eff9d9d8fce5a9618a57c4d01c8a9c267b810470962fd5e126823
   languageName: node
   linkType: hard
 
-"mongodb-memory-server@npm:^8.12.2":
-  version: 8.12.2
-  resolution: "mongodb-memory-server@npm:8.12.2"
+"mongodb-memory-server@npm:8.15.1":
+  version: 8.15.1
+  resolution: "mongodb-memory-server@npm:8.15.1"
   dependencies:
-    mongodb-memory-server-core: 8.12.2
-    tslib: ^2.5.0
-  checksum: 4ece74c4cd2991aaedf0c184cf0d785388585303ce80fe3a044edf2bb2a1245cf84f0660f3d68fcc833a5e15104bfdcef87f00edcf04e17cf48c231d182cd61f
+    mongodb-memory-server-core: 8.15.1
+    tslib: ^2.6.1
+  checksum: ad1f1cba52925556274786414c9267056dac6a7463789a13ebb3722a840fdbe45131a50d964ec5ee215460518dc0966050c8f118b70ea97d8de5d4276da44c6b
   languageName: node
   linkType: hard
 
@@ -9345,21 +9336,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mongodb@npm:^4.13.0":
-  version: 4.16.0
-  resolution: "mongodb@npm:4.16.0"
+"mongodb@npm:^4.16.0":
+  version: 4.17.1
+  resolution: "mongodb@npm:4.17.1"
   dependencies:
     "@aws-sdk/credential-providers": ^3.186.0
+    "@mongodb-js/saslprep": ^1.1.0
     bson: ^4.7.2
-    mongodb-connection-string-url: ^2.5.4
-    saslprep: ^1.0.3
+    mongodb-connection-string-url: ^2.6.0
     socks: ^2.7.1
   dependenciesMeta:
     "@aws-sdk/credential-providers":
       optional: true
-    saslprep:
+    "@mongodb-js/saslprep":
       optional: true
-  checksum: f0b1347739cc362b82b3aabc7e7d4d74bc7a344ed1bbafd6f92681bcab440f6cc618ffa0438d41d2789cb34818f3b09d4c78f517b42160ebae55bf2c96f13953
+  checksum: e7f280570d0f23d60c308b2a484ed55762ec8e523946c0de1a0b3b398f24efcf1916a745e5407f32cd1c105b2f19d8ac75474c92f73cdf651affe3430a963f54
   languageName: node
   linkType: hard
 
@@ -11385,15 +11376,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"saslprep@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "saslprep@npm:1.0.3"
-  dependencies:
-    sparse-bitfield: ^3.0.3
-  checksum: 4fdc0b70fb5e523f977de405e12cca111f1f10dd68a0cfae0ca52c1a7919a94d1556598ba2d35f447655c3b32879846c77f9274c90806f6673248ae3cea6ee43
-  languageName: node
-  linkType: hard
-
 "semver-compare@npm:^1.0.0":
   version: 1.0.0
   resolution: "semver-compare@npm:1.0.0"
@@ -12388,10 +12370,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.5.0":
-  version: 2.5.0
-  resolution: "tslib@npm:2.5.0"
-  checksum: ae3ed5f9ce29932d049908ebfdf21b3a003a85653a9a140d614da6b767a93ef94f460e52c3d787f0e4f383546981713f165037dc2274df212ea9f8a4541004e1
+"tslib@npm:^2.6.1":
+  version: 2.6.2
+  resolution: "tslib@npm:2.6.2"
+  checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds 4 new options to `em.upsert()`:

- `onConflictFields?: (keyof T)[]` to control the conflict clause
- `onConflictAction?: 'ignore' | 'merge'` used ignore and merge as that is how the QB methods are called
- `onConflictMergeFields?: (keyof T)[]` to control the merge clause
- `onConflictExcludeFields?: (keyof T)[]` to omit fields from the merge clause

Closes #4325
Closes #4602