### PR TITLE
fix(core): default baseUrl value to '.' when registering ts-node

### DIFF
--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -142,7 +142,7 @@ export class ConfigurationLoader {
 
     if (Object.entries(options?.paths ?? {}).length > 0) {
       Utils.requireFrom('tsconfig-paths', tsConfigPath).register({
-        baseUrl: options.baseUrl,
+        baseUrl: options.baseUrl ?? '.',
         paths: options.paths,
       });
     }


### PR DESCRIPTION
Fixes #4679. See the linked issue for the full context of this PR.