### PR TITLE
fix(core): use join on conditions for `populateWhere`

### DIFF
--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -1088,6 +1088,8 @@ export class QueryBuilder<T extends object = AnyEntity> {
         .forEach(field => this.addSelect(field));
     }
 
+    this.processPopulateWhere();
+
     QueryHelper.processObjectParams(this._data);
     QueryHelper.processObjectParams(this._cond);
     QueryHelper.processObjectParams(this._having);
@@ -1108,6 +1110,46 @@ export class QueryBuilder<T extends object = AnyEntity> {
     this.finalized = true;
   }
 
+  private processPopulateWhere() {
+    if (this._populateWhere == null || this._populateWhere === PopulateHint.ALL) {
+      return;
+    }
+
+    const joins = Object.values(this._joins);
+    joins.forEach(join => {
+      join.cond_ = join.cond;
+      join.cond = {};
+    });
+
+    const replaceOnConditions = (cond: Dictionary) => {
+      Object.keys(cond).forEach(k => {
+        if (Utils.isOperator(k)) {
+          if (Array.isArray(cond[k])) {
+            return cond[k].forEach((c: Dictionary) => replaceOnConditions(c));
+          }
+
+          return replaceOnConditions(cond[k]);
+        }
+
+        const [a] = this.helper.splitField(k);
+        const join = joins.find(j => j.alias === a);
+
+        if (join) {
+          join.cond = { ...join.cond, [k]: cond[k] };
+        }
+      });
+    };
+
+    if (this._populateWhere === PopulateHint.INFER) {
+      replaceOnConditions(this._cond);
+    } else if (typeof this._populateWhere === 'object') {
+      const cond = CriteriaNodeFactory
+          .createNode(this.metadata, this.mainAlias.entityName, this._populateWhere)
+          .process(this);
+      replaceOnConditions(cond);
+    }
+  }
+
   private hasToManyJoins(): boolean {
     return Object.values(this._joins).some(join => {
       return [ReferenceType.ONE_TO_MANY, ReferenceType.MANY_TO_MANY].includes(join.prop.reference);
@@ -1117,6 +1159,8 @@ export class QueryBuilder<T extends object = AnyEntity> {
   private wrapPaginateSubQuery(meta: EntityMetadata): void {
     const pks = this.prepareFields(meta.primaryKeys, 'sub-query') as string[];
     const subQuery = this.clone().select(pks).groupBy(pks).limit(this._limit!);
+    // revert the on conditions added via populateWhere, we want to apply those only once
+    Object.values(subQuery._joins).forEach(join => join.cond = join.cond_ ?? {});
 
     if (this._offset) {
       subQuery.offset(this._offset);
@@ -1171,14 +1215,7 @@ export class QueryBuilder<T extends object = AnyEntity> {
     (subSubQuery as Dictionary).__raw = true; // tag it as there is now way to check via `instanceof`
     this._limit = undefined;
     this._offset = undefined;
-    const cond = this._cond;
     this.select(this._fields!).where({ [Utils.getPrimaryKeyHash(meta.primaryKeys)]: { $in: subSubQuery } });
-
-    if (this._populateWhere === PopulateHint.INFER) {
-      this.andWhere(cond);
-    } else if (typeof this._populateWhere === 'object') {
-      this.andWhere(this._populateWhere);
-    }
   }
 
   private wrapModifySubQuery(meta: EntityMetadata): void {

--- a/packages/knex/src/typings.ts
+++ b/packages/knex/src/typings.ts
@@ -31,6 +31,9 @@ export interface JoinOptions {
   path?: string;
   prop: EntityProperty;
   cond: Dictionary;
+  // used as cache when overriding the on condition via `populateWhere` as we need
+  // to revert the change when wrapping queries when pagination is triggered.
+  cond_?: Dictionary;
 }
 
 export interface Column {

--- a/tests/features/paginate-flag.postgres.test.ts
+++ b/tests/features/paginate-flag.postgres.test.ts
@@ -359,6 +359,7 @@ describe('GH issue 2095', () => {
     );
     expect(users5).toHaveLength(2);
     expect(users5[0].id).toBe('id-user-03');
+    expect(users5[0].groups).toHaveLength(0);
     expect(users5[1].id).toBe('id-user-02');
     expect(users5[1].groups).toHaveLength(1);
     expect(users5[1].groups[0].name).toBe('Group #1');
@@ -374,11 +375,13 @@ describe('GH issue 2095', () => {
         populateWhere: { groups: { name: ['Group #1'] } },
       },
     );
-    // with joined strategy the populateWhere condition is AND-ed with the base query
-    expect(users6).toHaveLength(1);
-    expect(users6[0].id).toBe('id-user-02');
-    expect(users6[0].groups).toHaveLength(1);
-    expect(users6[0].groups[0].name).toBe('Group #1');
+
+    expect(users6).toHaveLength(2);
+    expect(users6[0].id).toBe('id-user-03');
+    expect(users6[0].groups).toHaveLength(0);
+    expect(users6[1].id).toBe('id-user-02');
+    expect(users6[1].groups).toHaveLength(1);
+    expect(users6[1].groups[0].name).toBe('Group #1');
   });
 
   test('getting users with limit 2, offset 1. must be: [id-user-02, id-user-01]', async () => {

--- a/tests/issues/GH3871.test.ts
+++ b/tests/issues/GH3871.test.ts
@@ -1,0 +1,232 @@
+import {
+    Collection,
+    Entity,
+    LoadStrategy,
+    ManyToOne,
+    OneToMany,
+    PrimaryKey,
+    Property,
+    ref,
+    Ref,
+} from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/sqlite';
+
+@Entity()
+class User {
+
+    @PrimaryKey()
+    id!: number;
+
+    @OneToMany(() => Pet, p => p.user)
+    pets = new Collection<Pet>(this);
+
+}
+
+@Entity()
+class Pet {
+
+    @PrimaryKey()
+    id!: number;
+
+    @Property({ type: 'text', default: 'yo' })
+    name: string;
+
+    @ManyToOne(() => User, {
+        ref: true,
+        nullable: true,
+    })
+    user: Ref<User> | null = null;
+
+    @ManyToOne(() => Action, {
+        ref: true,
+        nullable: true,
+    })
+    action: Ref<Action> | null = null;
+
+    constructor(name: string) {
+        this.name = name;
+    }
+
+}
+
+@Entity()
+class Action {
+
+    @PrimaryKey()
+    id!: number;
+
+    @Property({ type: 'text' })
+    name: string;
+
+    @OneToMany(() => Pet, p => p.action)
+    pets = new Collection<Pet>(this);
+
+    constructor(name: string) {
+        this.name = name;
+    }
+
+}
+
+describe('GH issue 3871', () => {
+
+    let orm: MikroORM;
+
+    beforeAll(async () => {
+        orm = await MikroORM.init({
+            entities: [User, Action, Pet],
+            loadStrategy: LoadStrategy.JOINED,
+            dbName: ':memory:',
+        });
+        await orm.schema.refreshDatabase();
+        await createEntities();
+    });
+
+    beforeEach(() => orm.em.clear());
+    afterAll(() => orm.close(true));
+
+    async function createEntities() {
+        for (let i = 0; i < 10; i++) {
+            const user = new User();
+
+            for (let j = 0; j < 10; j++) {
+                const pet = new Pet('name - ' + Math.random().toString());
+                pet.user = ref(user);
+
+                if (i === 3 && j === 3) {
+                    pet.name = 'yoyo';
+                }
+
+                for (let i = 0; i < 10; i++) {
+                    const action = new Action('name - ' + Math.random().toString());
+                    pet.action = ref(action);
+                    orm.em.persist(action);
+                }
+
+                orm.em.persist(pet);
+            }
+
+            orm.em.persist(user);
+        }
+
+        await orm.em.flush();
+        orm.em.clear();
+    }
+
+    test('joined with populateWhere', async () => {
+        const res = await orm.em.find(User, {}, {
+            populate: ['pets'],
+            populateWhere: {
+                pets: {
+                    name: 'yoyo',
+                },
+            },
+            strategy: LoadStrategy.JOINED,
+        });
+
+        expect(res).toHaveLength(10);
+        expect(res[0].pets).toHaveLength(0);
+        expect(res[1].pets).toHaveLength(0);
+        expect(res[2].pets).toHaveLength(0);
+        expect(res[3].pets).toHaveLength(1);
+        expect(res[3].pets[0]).toMatchObject({ name: 'yoyo' });
+        expect(res[4].pets).toHaveLength(0);
+        expect(res[5].pets).toHaveLength(0);
+        expect(res[6].pets).toHaveLength(0);
+        expect(res[7].pets).toHaveLength(0);
+        expect(res[8].pets).toHaveLength(0);
+        expect(res[9].pets).toHaveLength(0);
+    });
+
+    test('select in with populateWhere', async () => {
+        const res = await orm.em.find(User, {}, {
+            populate: ['pets'],
+            populateWhere: {
+                pets: {
+                    name: 'yoyo',
+                },
+            },
+            strategy: LoadStrategy.SELECT_IN,
+        });
+
+        expect(res).toHaveLength(10);
+        expect(res[0].pets).toHaveLength(0);
+        expect(res[1].pets).toHaveLength(0);
+        expect(res[2].pets).toHaveLength(0);
+        expect(res[3].pets).toHaveLength(1);
+        expect(res[3].pets[0]).toMatchObject({ name: 'yoyo' });
+        expect(res[4].pets).toHaveLength(0);
+        expect(res[5].pets).toHaveLength(0);
+        expect(res[6].pets).toHaveLength(0);
+        expect(res[7].pets).toHaveLength(0);
+        expect(res[8].pets).toHaveLength(0);
+        expect(res[9].pets).toHaveLength(0);
+    });
+
+    test('pagination with joined strategy and populateWhere', async () => {
+        const [res, total] = await orm.em.findAndCount(User, {}, {
+            populate: ['pets'],
+            populateWhere: {
+                pets: {
+                    name: 'yoyo',
+                },
+            },
+            strategy: LoadStrategy.JOINED,
+            limit: 5,
+        });
+
+        expect(total).toBe(10);
+        expect(res).toHaveLength(5);
+        expect(res[0].pets).toHaveLength(0);
+        expect(res[1].pets).toHaveLength(0);
+        expect(res[2].pets).toHaveLength(0);
+        expect(res[3].pets).toHaveLength(1);
+        expect(res[3].pets[0]).toMatchObject({ name: 'yoyo' });
+        expect(res[4].pets).toHaveLength(0);
+    });
+
+    test('pagination with select in strategy and populateWhere', async () => {
+        const [res, total] = await orm.em.findAndCount(User, {}, {
+            populate: ['pets'],
+            populateWhere: {
+                pets: {
+                    name: 'yoyo',
+                },
+            },
+            strategy: LoadStrategy.SELECT_IN,
+            limit: 5,
+        });
+
+        expect(total).toBe(10);
+        expect(res).toHaveLength(5);
+        expect(res[0].pets).toHaveLength(0);
+        expect(res[1].pets).toHaveLength(0);
+        expect(res[2].pets).toHaveLength(0);
+        expect(res[3].pets).toHaveLength(1);
+        expect(res[3].pets[0]).toMatchObject({ name: 'yoyo' });
+        expect(res[4].pets).toHaveLength(0);
+    });
+
+    test('pagination with joined strategy and populateWhere with group operators', async () => {
+        const [res, total] = await orm.em.findAndCount(User, {}, {
+            populate: ['pets'],
+            populateWhere: {
+                pets: {
+                    name: 'yoyo',
+                    action: { $ne: null },
+                },
+            },
+            strategy: LoadStrategy.JOINED,
+            limit: 5,
+        });
+
+        expect(total).toBe(10);
+        expect(res).toHaveLength(5);
+        expect(res[0].pets).toHaveLength(0);
+        expect(res[1].pets).toHaveLength(0);
+        expect(res[2].pets).toHaveLength(0);
+        expect(res[3].pets).toHaveLength(1);
+        expect(res[3].pets[0]).toMatchObject({ name: 'yoyo' });
+        expect(res[4].pets).toHaveLength(0);
+    });
+
+});


### PR DESCRIPTION
When using joined strategy, the `populateWhere` condition is now applied to the joins via `on` conditions instead of using a `where` condition. This aligns how the two loading strategies work, as the `populateWhere` will affect only what gets joined, but not the root entity query.

Closes #3871