### PR TITLE
feat(core): Allow to use `.ts` files as configuration without `ts-node`

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -186,13 +186,14 @@ For CLI to be able to access our database, we will need to create `mikro-orm.con
 
 > ORM configuration file can export the Promise, like: `export default Promise.resolve({...});`.
 
-TypeScript is also supported, just enable `useTsNode` flag in our `package.json` file. There we can also set up array of possible paths to `mikro-orm.config` file, as well as use different file name. The `package.json` file can be located in the current working directory, or in one of its parent folders.
+TypeScript is also supported, just enable `useTsNode` flag in our `package.json` file. By default, when `useTsNode` is not enabled, CLI will ignore `.ts` files, so if you want to out-out of this behaviour, enable the `alwaysAllowTs` option. This would be useful if you want to use MikroORM with [Bun](https://bun.sh), which has TypeScript support out of the box. There we can also set up array of possible paths to `mikro-orm.config` file, as well as use different file name. The `package.json` file can be located in the current working directory, or in one of its parent folders.
 
 We can use these environment variables to override CLI settings:
 
 - `MIKRO_ORM_CLI`: the path to ORM config file
 - `MIKRO_ORM_CLI_USE_TS_NODE`: register ts-node
 - `MIKRO_ORM_CLI_TS_CONFIG_PATH`: path to the tsconfig.json (for ts-node)
+- `MIKRO_ORM_CLI_ALWAYS_ALLOW_TS`: enable `.ts` files to use without ts-node
 
 > Do not forget to install `ts-node` when enabling `useTsNode` flag.
 

--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -76,7 +76,7 @@ export class ConfigurationLoader {
     const bool = (v: string) => ['true', 't', '1'].includes(v.toLowerCase());
     settings.useTsNode = process.env.MIKRO_ORM_CLI_USE_TS_NODE != null ? bool(process.env.MIKRO_ORM_CLI_USE_TS_NODE) : settings.useTsNode;
     settings.tsConfigPath = process.env.MIKRO_ORM_CLI_TS_CONFIG_PATH ?? settings.tsConfigPath;
-    settings.alwaysAllowTs = process.env.MIKRO_ORM_CLI_ALWAYS_ALLOW_TS ? bool(process.env.MIKRO_ORM_CLI_ALWAYS_ALLOW_TS) : settings.alwaysAllowTs;
+    settings.alwaysAllowTs = process.env.MIKRO_ORM_CLI_ALWAYS_ALLOW_TS != null ? bool(process.env.MIKRO_ORM_CLI_ALWAYS_ALLOW_TS) : settings.alwaysAllowTs;
 
     if (process.env.MIKRO_ORM_CLI?.endsWith('.ts')) {
       settings.useTsNode = true;

--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -76,6 +76,7 @@ export class ConfigurationLoader {
     const bool = (v: string) => ['true', 't', '1'].includes(v.toLowerCase());
     settings.useTsNode = process.env.MIKRO_ORM_CLI_USE_TS_NODE != null ? bool(process.env.MIKRO_ORM_CLI_USE_TS_NODE) : settings.useTsNode;
     settings.tsConfigPath = process.env.MIKRO_ORM_CLI_TS_CONFIG_PATH ?? settings.tsConfigPath;
+    settings.alwaysAllowTs = process.env.MIKRO_ORM_CLI_ALWAYS_ALLOW_TS ? bool(process.env.MIKRO_ORM_CLI_ALWAYS_ALLOW_TS) : settings.alwaysAllowTs;
 
     if (process.env.MIKRO_ORM_CLI?.endsWith('.ts')) {
       settings.useTsNode = true;
@@ -107,7 +108,7 @@ export class ConfigurationLoader {
     paths.push('./mikro-orm.config.js');
     const tsNode = Utils.detectTsNode();
 
-    return Utils.unique(paths).filter(p => p.endsWith('.js') || tsNode);
+    return Utils.unique(paths).filter(p => p.endsWith('.js') || tsNode || settings.alwaysAllowTs);
   }
 
   static async isESM(): Promise<boolean> {
@@ -307,6 +308,7 @@ export class ConfigurationLoader {
 }
 
 export interface Settings {
+  alwaysAllowTs?: boolean;
   useTsNode?: boolean;
   tsConfigPath?: string;
   configPaths?: string[];

--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -95,7 +95,7 @@ export class ConfigurationLoader {
 
     paths.push(...(settings.configPaths || []));
 
-    if (settings.useTsNode) {
+    if (settings.useTsNode || settings.alwaysAllowTs) {
       paths.push('./src/mikro-orm.config.ts');
       paths.push('./mikro-orm.config.ts');
     }

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -426,12 +426,15 @@ Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
 
     process.env.MIKRO_ORM_CLI_USE_TS_NODE = '1';
     process.env.MIKRO_ORM_CLI_TS_CONFIG_PATH = 'foo/tsconfig.json';
+    process.env.MIKRO_ORM_CLI_ALWAYS_ALLOW_TS = '1';
     await expect(ConfigurationLoader.getSettings()).resolves.toEqual({
       useTsNode: true,
+      alwaysAllowTs: true,
       tsConfigPath: 'foo/tsconfig.json',
     });
     delete process.env.MIKRO_ORM_CLI_USE_TS_NODE;
     delete process.env.MIKRO_ORM_CLI_TS_CONFIG_PATH;
+    delete process.env.MIKRO_ORM_CLI_ALWAYS_ALLOW_TS;
 
     pathExistsMock.mockRestore();
   });
@@ -455,6 +458,14 @@ Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
     await expect(CLIHelper.getConfigPaths()).resolves.toEqual(['./override/orm-config.ts', './src/mikro-orm.config.ts', './mikro-orm.config.ts', './src/mikro-orm.config.js', './mikro-orm.config.js']);
     delete (global as any).process.env.MIKRO_ORM_CLI;
     await expect(CLIHelper.getConfigPaths()).resolves.toEqual(['./src/mikro-orm.config.js', './mikro-orm.config.js']);
+
+    (global as any).process.env.MIKRO_ORM_CLI_ALWAYS_ALLOW_TS = '1';
+    await expect(CLIHelper.getConfigPaths()).resolves.toEqual(['./src/mikro-orm.config.ts', './mikro-orm.config.ts', './src/mikro-orm.config.js', './mikro-orm.config.js']);
+    delete (global as any).process.env.MIKRO_ORM_CLI_ALWAYS_ALLOW_TS;
+
+    pkg['mikro-orm'] = { alwaysAllowTs: true };
+    await expect(CLIHelper.getConfigPaths()).resolves.toEqual(['./src/mikro-orm.config.ts', './mikro-orm.config.ts', './src/mikro-orm.config.js', './mikro-orm.config.js']);
+    pkg['mikro-orm'] = undefined;
 
     const pathExistsMock = jest.spyOn(require('fs-extra'), 'pathExists');
     pathExistsMock.mockResolvedValue(true);


### PR DESCRIPTION
### Details

This PR introduces two new options to allow `.ts` files as configs when `ts-node` is not enabled:

- `alwaysAllowTs` flag in `mikro-orm` section of `package.json`
- `MIKRO_ORM_CLI_ALWAYS_ALLOW_TS` environment variable

### Changes

- [x] Add optional `alwaysAllowTs` field on `Settings` interface in `ConfigurationLoader`;
- [x] Return `.ts` configs files from `ConfigurationLoader.getConfigPaths()` when `alwaysAllowTs` option is enabled;
- [x] Add tests;
- [x] Add documentation for these new options

Fixes #4701