### PR TITLE
fix(core): fix query processing when PK is falsy

### DIFF
--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -95,11 +95,7 @@ export class QueryHelper {
       QueryHelper.inlinePrimaryKeyObjects(where as Dictionary, meta, metadata);
     }
 
-    where = QueryHelper.processParams(where);
-
-    if (where == null) {
-      where = {};
-    }
+    where = QueryHelper.processParams(where) ?? {};
 
     /* istanbul ignore next */
     if (!root && Utils.isPrimaryKey<T>(where)) {

--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -97,7 +97,7 @@ export class QueryHelper {
 
     where = QueryHelper.processParams(where);
 
-    if (!where && typeof where !== 'number') {
+    if (where == null) {
       where = {};
     }
 

--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -95,7 +95,11 @@ export class QueryHelper {
       QueryHelper.inlinePrimaryKeyObjects(where as Dictionary, meta, metadata);
     }
 
-    where = QueryHelper.processParams(where) || {};
+    where = QueryHelper.processParams(where);
+
+    if (!where && typeof where !== 'number') {
+      where = {};
+    }
 
     /* istanbul ignore next */
     if (!root && Utils.isPrimaryKey<T>(where)) {

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -464,7 +464,6 @@ describe('EntityManagerMongo', () => {
   });
 
   test('findOne with empty where will throw', async () => {
-    await expect(orm.em.findOne(Author, '')).rejects.toThrowError(`You cannot call 'EntityManager.findOne()' with empty 'where' parameter`);
     await expect(orm.em.findOne(Author, {})).rejects.toThrowError(`You cannot call 'EntityManager.findOne()' with empty 'where' parameter`);
     await expect(orm.em.findOne(Author, undefined!)).rejects.toThrowError(`You cannot call 'EntityManager.findOne()' with empty 'where' parameter`);
     await expect(orm.em.findOne(Author, null!)).rejects.toThrowError(`You cannot call 'EntityManager.findOne()' with empty 'where' parameter`);

--- a/tests/SmartQueryHelper.test.ts
+++ b/tests/SmartQueryHelper.test.ts
@@ -85,10 +85,10 @@ describe('QueryHelper', () => {
     expect(QueryHelper.processWhere({ where: undefined as any, entityName: 'id', metadata: orm.getMetadata(), platform: orm.em.getDriver().getPlatform() })).toEqual({});
   });
 
-  test('processWhere returns empty object for entity pk as empty string condition', async () => {
+  test('processWhere returns pk when pk is empty string and condition is entity', async () => {
     const test = new BookTag2('Test');
     test.id = '';
-    expect(QueryHelper.processWhere({ where: test, entityName: 'id', metadata: orm.getMetadata(), platform: orm.em.getDriver().getPlatform() })).toEqual({});
+    expect(QueryHelper.processWhere({ where: test, entityName: 'id', metadata: orm.getMetadata(), platform: orm.em.getDriver().getPlatform() })).toEqual('');
   });
 
   test('processWhere returns pk when pk is 0 and condition is entity', async () => {

--- a/tests/SmartQueryHelper.test.ts
+++ b/tests/SmartQueryHelper.test.ts
@@ -1,7 +1,7 @@
 import type { MikroORM } from '@mikro-orm/core';
 import { Reference, QueryHelper } from '@mikro-orm/core';
 import { initORMMySql } from './bootstrap';
-import { Author2, Book2, FooBar2, FooBaz2, Test2 } from './entities-sql';
+import { Author2, Book2, BookTag2, FooBar2, FooBaz2, Test2 } from './entities-sql';
 import { FooParam2 } from './entities-sql/FooParam2';
 
 describe('QueryHelper', () => {
@@ -83,6 +83,17 @@ describe('QueryHelper', () => {
 
   test('processWhere returns empty object for undefined condition', async () => {
     expect(QueryHelper.processWhere({ where: undefined as any, entityName: 'id', metadata: orm.getMetadata(), platform: orm.em.getDriver().getPlatform() })).toEqual({});
+  });
+
+  test('processWhere returns empty object for entity pk as empty string condition', async () => {
+    const test = new BookTag2('Test');
+    test.id = '';
+    expect(QueryHelper.processWhere({ where: test, entityName: 'id', metadata: orm.getMetadata(), platform: orm.em.getDriver().getPlatform() })).toEqual({});
+  });
+
+  test('processWhere returns pk when pk is 0 and condition is entity', async () => {
+    const test = new Test2({ id: 0 });
+    expect(QueryHelper.processWhere({ where: test, entityName: 'id', metadata: orm.getMetadata(), platform: orm.em.getDriver().getPlatform() })).toEqual(0);
   });
 
   test('test entity conversion to PK', async () => {


### PR DESCRIPTION
Fix case of `processWhere` returning empty object when the where clause is an entity with an int pk of 0