### PR TITLE
feat(core): allow setting default `schema` on `EntityManager`

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -311,7 +311,6 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     Entity extends object,
     Hint extends string = never,
   >(entityName: string, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint> | FindOneOptions<Entity, Hint>, type: 'read' | 'update' | 'delete'): Promise<FilterQuery<Entity>> {
-    options.schema ??= this._schema;
     where = QueryHelper.processWhere({
       where: where as FilterQuery<Entity>,
       entityName,
@@ -349,7 +348,6 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   }
 
   protected async applyJoinedFilters<Entity extends object>(meta: EntityMetadata<Entity>, cond: ObjectQuery<Entity>, options: FindOptions<Entity, any> | FindOneOptions<Entity, any>): Promise<ObjectQuery<Entity>> {
-    options.schema ??= this._schema;
     const ret = {} as ObjectQuery<Entity>;
     const populateWhere = options.populateWhere ?? this.config.get('populateWhere');
 
@@ -392,7 +390,6 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * @internal
    */
   async applyFilters<Entity extends object>(entityName: string, where: FilterQuery<Entity>, options: Dictionary<boolean | Dictionary> | string[] | boolean, type: 'read' | 'update' | 'delete', findOptions: FindOptions<any, any> | FindOneOptions<any, any> = {}): Promise<FilterQuery<Entity>> {
-    findOptions.schema ??= this._schema;
     const meta = this.metadata.find<Entity>(entityName);
     const filters: FilterDef[] = [];
     const ret: Dictionary[] = [];
@@ -1234,7 +1231,6 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   merge<Entity extends object>(entityName: EntityName<Entity> | Entity, data?: EntityData<Entity> | EntityDTO<Entity> | MergeOptions, options: MergeOptions = {}): Entity {
     const em = this.getContext();
 
-
     if (Utils.isEntity(entityName)) {
       return em.merge((entityName as Dictionary).constructor.name, entityName as unknown as EntityData<Entity>, data as MergeOptions);
     }
@@ -1287,7 +1283,6 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * Shortcut for `wrap(entity).assign(data, { em })`
    */
   assign<Entity extends object>(entity: Entity, data: EntityData<Entity> | Partial<EntityDTO<Entity>>, options: AssignOptions = {}): Entity {
-    options.schema ??= this._schema;
     return EntityAssigner.assign(entity, data, { em: this.getContext(), ...options });
   }
 
@@ -1708,7 +1703,6 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   }
 
   private async lockAndPopulate<T extends object, P extends string = never>(entityName: string, entity: T, where: FilterQuery<T>, options: FindOneOptions<T, P>): Promise<Loaded<T, P>> {
-    options.schema ??= this._schema;
     if (options.lockMode === LockMode.OPTIMISTIC) {
       await this.lock(entity, options.lockMode, {
         lockVersion: options.lockVersion,
@@ -1779,7 +1773,6 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * some additional lazy properties, if so, we reload and merge the data from database
    */
   protected shouldRefresh<T extends object, P extends string = never>(meta: EntityMetadata<T>, entity: T, options: FindOneOptions<T, P>) {
-    options.schema ??= this._schema;
     if (!helper(entity).__initialized || options.refresh) {
       return true;
     }

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -165,9 +165,9 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     Entity extends object,
     Hint extends string = never,
   >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint>[]> {
-    options.schema ??= this._schema;
     if (options.disableIdentityMap ?? this.config.get('disableIdentityMap')) {
       const em = this.getContext(false);
+      options.schema ??= em._schema;
       const fork = em.fork();
       const ret = await fork.find<Entity, Hint>(entityName, where, { ...options, disableIdentityMap: false });
       fork.clear();
@@ -176,6 +176,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     const em = this.getContext();
+    options.schema ??= em._schema;
     await em.tryFlush(entityName, options);
     entityName = Utils.className(entityName);
     where = await em.processWhere(entityName, where, options, 'read') as FilterQuery<Entity>;
@@ -451,7 +452,6 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     Entity extends object,
     Hint extends string = never,
   >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint> = {}): Promise<[Loaded<Entity, Hint>[], number]> {
-    options.schema ??= this._schema;
     const [entities, count] = await Promise.all([
       this.find<Entity, Hint>(entityName, where, options),
       this.count(entityName, where, options),
@@ -467,7 +467,6 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     Entity extends object,
     Hint extends string = never,
   >(entity: Entity, options: FindOneOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint> | null> {
-    options.schema ??= this._schema;
     const fork = this.fork();
     const entityName = entity.constructor.name;
     const reloaded = await fork.findOne(entityName, entity, {
@@ -492,10 +491,9 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     Entity extends object,
     Hint extends string = never,
   >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOneOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint> | null> {
-    options.schema ??= this._schema;
-
     if (options.disableIdentityMap ?? this.config.get('disableIdentityMap')) {
       const em = this.getContext(false);
+      options.schema ??= em._schema;
       const fork = em.fork();
       const ret = await fork.findOne<Entity, Hint>(entityName, where, { ...options, disableIdentityMap: false });
       fork.clear();
@@ -504,6 +502,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     const em = this.getContext();
+    options.schema ??= em._schema;
     await em.tryFlush(entityName, options);
     entityName = Utils.className(entityName);
     const meta = em.metadata.get<Entity>(entityName);
@@ -572,8 +571,6 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     Entity extends object,
     Hint extends string = never,
   >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOneOrFailOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint>> {
-    options.schema ??= this._schema;
-
     let entity: Loaded<Entity, Hint> | null;
     let isStrictViolation = false;
 
@@ -620,7 +617,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    */
   async upsert<Entity extends object>(entityNameOrEntity: EntityName<Entity> | Entity, data?: EntityData<Entity> | Entity, options: UpsertOptions<Entity> = {}): Promise<Entity> {
     const em = this.getContext(false);
-    options.schema ??= this._schema;
+    options.schema ??= em._schema;
 
     let entityName: EntityName<Entity>;
     let where: FilterQuery<Entity>;
@@ -757,7 +754,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    */
   async upsertMany<Entity extends object>(entityNameOrEntity: EntityName<Entity> | Entity[], data?: (EntityData<Entity> | Entity)[], options: UpsertManyOptions<Entity> = {}): Promise<Entity[]> {
     const em = this.getContext(false);
-    options.schema ??= this._schema;
+    options.schema ??= em._schema;
 
     let entityName: string;
     let propIndex: number;
@@ -1089,7 +1086,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    */
   async insert<Entity extends object>(entityNameOrEntity: EntityName<Entity> | Entity, data?: EntityData<Entity> | Entity, options: NativeInsertUpdateOptions<Entity> = {}): Promise<Primary<Entity>> {
     const em = this.getContext(false);
-    options.schema ??= this._schema;
+    options.schema ??= em._schema;
 
     let entityName;
 
@@ -1124,7 +1121,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    */
   async insertMany<Entity extends object>(entityNameOrEntities: EntityName<Entity> | Entity[], data?: EntityData<Entity>[] | Entity[], options: NativeInsertUpdateOptions<Entity> = {}): Promise<Primary<Entity>[]> {
     const em = this.getContext(false);
-    options.schema ??= this._schema;
+    options.schema ??= em._schema;
 
     let entityName;
 
@@ -1165,7 +1162,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    */
   async nativeUpdate<Entity extends object>(entityName: EntityName<Entity>, where: FilterQuery<Entity>, data: EntityData<Entity>, options: UpdateOptions<Entity> = {}): Promise<number> {
     const em = this.getContext(false);
-    options.schema ??= this._schema;
+    options.schema ??= em._schema;
 
     entityName = Utils.className(entityName);
     data = QueryHelper.processObjectParams(data);
@@ -1182,7 +1179,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    */
   async nativeDelete<Entity extends object>(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: DeleteOptions<Entity> = {}): Promise<number> {
     const em = this.getContext(false);
-    options.schema ??= this._schema;
+    options.schema ??= em._schema;
 
     entityName = Utils.className(entityName);
     where = await em.processWhere(entityName, where, options, 'delete');
@@ -1199,7 +1196,6 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     entityName = Utils.className(entityName);
     const meta = this.metadata.get(entityName);
     const data = this.driver.mapResult(result, meta) as Dictionary;
-    options.schema ??= this._schema;
 
     Object.keys(data).forEach(k => {
       const prop = meta.properties[k];
@@ -1235,7 +1231,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       return em.merge((entityName as Dictionary).constructor.name, entityName as unknown as EntityData<Entity>, data as MergeOptions);
     }
 
-    options.schema ??= this._schema;
+    options.schema ??= em._schema;
     entityName = Utils.className(entityName as string);
     em.validator.validatePrimaryKey(data as EntityData<Entity>, em.metadata.get(entityName));
     let entity = em.unitOfWork.tryGetById<Entity>(entityName, data as FilterQuery<Entity>, options.schema, false);
@@ -1264,7 +1260,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    */
   create<Entity extends object>(entityName: EntityName<Entity>, data: RequiredEntityData<Entity>, options: CreateOptions = {}): Entity {
     const em = this.getContext();
-    options.schema ??= this._schema;
+    options.schema ??= em._schema;
     const entity = em.entityFactory.create(entityName, data, {
       ...options,
       newEntity: !options.managed,
@@ -1310,7 +1306,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
   getReference<Entity extends object>(entityName: EntityName<Entity>, id: Primary<Entity>, options: GetReferenceOptions = {}): Entity | Reference<Entity> {
-    options.schema ??= this._schema;
+    options.schema ??= this.schema;
     options.convertCustomTypes ??= false;
     const meta = this.metadata.get(Utils.className(entityName));
 
@@ -1338,12 +1334,13 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     Entity extends object,
     Hint extends string = never,
   >(entityName: EntityName<Entity>, where: FilterQuery<Entity> = {} as FilterQuery<Entity>, options: CountOptions<Entity, Hint> = {}): Promise<number> {
+    const em = this.getContext(false);
+
     // Shallow copy options since the object will be modified when deleting orderBy
     options = {
-      schema: this._schema,
+      schema: em._schema,
       ...options,
     };
-    const em = this.getContext(false);
     entityName = Utils.className(entityName);
     where = await em.processWhere(entityName, where, options as FindOptions<Entity, Hint>, 'read') as FilterQuery<Entity>;
     options.populate = em.preparePopulate(entityName, options) as unknown as Populate<Entity>;
@@ -1528,7 +1525,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     const em = this.getContext();
-    options.schema ??= this._schema;
+    options.schema ??= em._schema;
     const entityName = (entities[0] as Dictionary).constructor.name;
     const preparedPopulate = em.preparePopulate<Entity>(entityName, { populate: populate as true });
     await em.entityLoader.populate(entityName, entities, preparedPopulate, options);

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -167,7 +167,6 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint>[]> {
     if (options.disableIdentityMap ?? this.config.get('disableIdentityMap')) {
       const em = this.getContext(false);
-      options.schema ??= em._schema;
       const fork = em.fork();
       const ret = await fork.find<Entity, Hint>(entityName, where, { ...options, disableIdentityMap: false });
       fork.clear();
@@ -493,7 +492,6 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOneOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint> | null> {
     if (options.disableIdentityMap ?? this.config.get('disableIdentityMap')) {
       const em = this.getContext(false);
-      options.schema ??= em._schema;
       const fork = em.fork();
       const ret = await fork.findOne<Entity, Hint>(entityName, where, { ...options, disableIdentityMap: false });
       fork.clear();

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1233,12 +1233,13 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    */
   merge<Entity extends object>(entityName: EntityName<Entity> | Entity, data?: EntityData<Entity> | EntityDTO<Entity> | MergeOptions, _options: MergeOptions = {}): Entity {
     const em = this.getContext();
-    const options = this.mergeOptions<MergeOptions>(_options);
+
 
     if (Utils.isEntity(entityName)) {
       return em.merge((entityName as Dictionary).constructor.name, entityName as unknown as EntityData<Entity>, data as MergeOptions);
     }
 
+    const options = this.mergeOptions<MergeOptions>(_options);
     entityName = Utils.className(entityName as string);
     em.validator.validatePrimaryKey(data as EntityData<Entity>, em.metadata.get(entityName));
     let entity = em.unitOfWork.tryGetById<Entity>(entityName, data as FilterQuery<Entity>, options.schema, false);

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1562,7 +1562,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
 
     fork.filters = { ...em.filters };
     fork.filterParams = Utils.copy(em.filterParams);
-    fork._schema = options.schema || em.schema;
+    fork._schema = options.schema ?? em.schema;
 
     if (!options.clear) {
       for (const entity of em.unitOfWork.getIdentityMap()) {

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -389,7 +389,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * @internal
    */
-  async applyFilters<Entity extends object>(entityName: string, where: FilterQuery<Entity>, options: Dictionary<boolean | Dictionary> | string[] | boolean, type: 'read' | 'update' | 'delete', findOptions: FindOptions<any, any> | FindOneOptions<any, any> = {}): Promise<FilterQuery<Entity>> {
+  async applyFilters<Entity extends object>(entityName: string, where: FilterQuery<Entity>, options: Dictionary<boolean | Dictionary> | string[] | boolean, type: 'read' | 'update' | 'delete', findOptions?: FindOptions<any, any> | FindOneOptions<any, any>): Promise<FilterQuery<Entity>> {
     const meta = this.metadata.find<Entity>(entityName);
     const filters: FilterDef[] = [];
     const ret: Dictionary[] = [];

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -90,6 +90,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   private transactionContext?: Transaction;
   private disableTransactions = this.config.get('disableTransactions');
   private flushMode?: FlushMode;
+  private _schema?: string;
 
   /**
    * @internal
@@ -163,7 +164,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   async find<
     Entity extends object,
     Hint extends string = never,
-  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint>[]> {
+  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, _options: FindOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint>[]> {
+    let options = this.mergeOptions<FindOptions<Entity, Hint>>(_options);
     if (options.disableIdentityMap ?? this.config.get('disableIdentityMap')) {
       const em = this.getContext(false);
       const fork = em.fork();
@@ -308,7 +310,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   protected async processWhere<
     Entity extends object,
     Hint extends string = never,
-  >(entityName: string, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint> | FindOneOptions<Entity, Hint>, type: 'read' | 'update' | 'delete'): Promise<FilterQuery<Entity>> {
+  >(entityName: string, where: FilterQuery<Entity>, _options: FindOptions<Entity, Hint> | FindOneOptions<Entity, Hint>, type: 'read' | 'update' | 'delete'): Promise<FilterQuery<Entity>> {
+    const options = this.mergeOptions<FindOptions<Entity, Hint>>(_options);
     where = QueryHelper.processWhere({
       where: where as FilterQuery<Entity>,
       entityName,
@@ -345,7 +348,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     return where;
   }
 
-  protected async applyJoinedFilters<Entity extends object>(meta: EntityMetadata<Entity>, cond: ObjectQuery<Entity>, options: FindOptions<Entity, any> | FindOneOptions<Entity, any>): Promise<ObjectQuery<Entity>> {
+  protected async applyJoinedFilters<Entity extends object>(meta: EntityMetadata<Entity>, cond: ObjectQuery<Entity>, _options: FindOptions<Entity, any> | FindOneOptions<Entity, any>): Promise<ObjectQuery<Entity>> {
+    const options = this.mergeOptions<FindOptions<Entity, any> | FindOneOptions<Entity, any>>(_options);
     const ret = {} as ObjectQuery<Entity>;
     const populateWhere = options.populateWhere ?? this.config.get('populateWhere');
 
@@ -387,7 +391,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * @internal
    */
-  async applyFilters<Entity extends object>(entityName: string, where: FilterQuery<Entity>, options: Dictionary<boolean | Dictionary> | string[] | boolean, type: 'read' | 'update' | 'delete', findOptions?: FindOptions<any, any> | FindOneOptions<any, any>): Promise<FilterQuery<Entity>> {
+  async applyFilters<Entity extends object>(entityName: string, where: FilterQuery<Entity>, options: Dictionary<boolean | Dictionary> | string[] | boolean, type: 'read' | 'update' | 'delete', _findOptions?: FindOptions<any, any> | FindOneOptions<any, any>): Promise<FilterQuery<Entity>> {
+    const findOptions = this.mergeOptions<FindOptions<any, any> | FindOneOptions<any, any>>(_findOptions);
     const meta = this.metadata.find<Entity>(entityName);
     const filters: FilterDef[] = [];
     const ret: Dictionary[] = [];
@@ -448,7 +453,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   async findAndCount<
     Entity extends object,
     Hint extends string = never,
-  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint> = {}): Promise<[Loaded<Entity, Hint>[], number]> {
+  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, _options: FindOptions<Entity, Hint> = {}): Promise<[Loaded<Entity, Hint>[], number]> {
+    const options = this.mergeOptions<FindOptions<Entity, Hint>>(_options);
     const [entities, count] = await Promise.all([
       this.find<Entity, Hint>(entityName, where, options),
       this.count(entityName, where, options),
@@ -463,7 +469,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   async refresh<
     Entity extends object,
     Hint extends string = never,
-  >(entity: Entity, options: FindOneOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint> | null> {
+  >(entity: Entity, _options: FindOneOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint> | null> {
+    const options = this.mergeOptions<FindOneOptions<Entity, Hint>>(_options);
     const fork = this.fork();
     const entityName = entity.constructor.name;
     const reloaded = await fork.findOne(entityName, entity, {
@@ -487,7 +494,9 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   async findOne<
     Entity extends object,
     Hint extends string = never,
-  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOneOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint> | null> {
+  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, _options: FindOneOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint> | null> {
+    let options = this.mergeOptions<FindOneOptions<Entity, Hint>>(_options);
+
     if (options.disableIdentityMap ?? this.config.get('disableIdentityMap')) {
       const em = this.getContext(false);
       const fork = em.fork();
@@ -565,7 +574,9 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   async findOneOrFail<
     Entity extends object,
     Hint extends string = never,
-  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOneOrFailOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint>> {
+  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, _options: FindOneOrFailOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint>> {
+    const options = this.mergeOptions<FindOneOrFailOptions<Entity, Hint>>(_options);
+
     let entity: Loaded<Entity, Hint> | null;
     let isStrictViolation = false;
 
@@ -610,8 +621,9 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    *
    * If the entity is already present in current context, there won't be any queries - instead, the entity data will be assigned and an explicit `flush` will be required for those changes to be persisted.
    */
-  async upsert<Entity extends object>(entityNameOrEntity: EntityName<Entity> | Entity, data?: EntityData<Entity> | Entity, options: UpsertOptions<Entity> = {}): Promise<Entity> {
+  async upsert<Entity extends object>(entityNameOrEntity: EntityName<Entity> | Entity, data?: EntityData<Entity> | Entity, _options: UpsertOptions<Entity> = {}): Promise<Entity> {
     const em = this.getContext(false);
+    const options = this.mergeOptions<UpsertOptions<Entity>>(_options);
 
     let entityName: EntityName<Entity>;
     let where: FilterQuery<Entity>;
@@ -746,8 +758,9 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    *
    * If the entity is already present in current context, there won't be any queries - instead, the entity data will be assigned and an explicit `flush` will be required for those changes to be persisted.
    */
-  async upsertMany<Entity extends object>(entityNameOrEntity: EntityName<Entity> | Entity[], data?: (EntityData<Entity> | Entity)[], options: UpsertManyOptions<Entity> = {}): Promise<Entity[]> {
+  async upsertMany<Entity extends object>(entityNameOrEntity: EntityName<Entity> | Entity[], data?: (EntityData<Entity> | Entity)[], _options: UpsertManyOptions<Entity> = {}): Promise<Entity[]> {
     const em = this.getContext(false);
+    const options = this.mergeOptions<UpsertManyOptions<Entity>>(_options);
 
     let entityName: string;
     let propIndex: number;
@@ -1077,8 +1090,9 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Fires native insert query. Calling this has no side effects on the context (identity map).
    */
-  async insert<Entity extends object>(entityNameOrEntity: EntityName<Entity> | Entity, data?: EntityData<Entity> | Entity, options: NativeInsertUpdateOptions<Entity> = {}): Promise<Primary<Entity>> {
+  async insert<Entity extends object>(entityNameOrEntity: EntityName<Entity> | Entity, data?: EntityData<Entity> | Entity, _options: NativeInsertUpdateOptions<Entity> = {}): Promise<Primary<Entity>> {
     const em = this.getContext(false);
+    const options = this.mergeOptions<NativeInsertUpdateOptions<Entity>>(_options);
 
     let entityName;
 
@@ -1111,8 +1125,9 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Fires native multi-insert query. Calling this has no side effects on the context (identity map).
    */
-  async insertMany<Entity extends object>(entityNameOrEntities: EntityName<Entity> | Entity[], data?: EntityData<Entity>[] | Entity[], options: NativeInsertUpdateOptions<Entity> = {}): Promise<Primary<Entity>[]> {
+  async insertMany<Entity extends object>(entityNameOrEntities: EntityName<Entity> | Entity[], data?: EntityData<Entity>[] | Entity[], _options: NativeInsertUpdateOptions<Entity> = {}): Promise<Primary<Entity>[]> {
     const em = this.getContext(false);
+    const options = this.mergeOptions<NativeInsertUpdateOptions<Entity>>(_options);
 
     let entityName;
 
@@ -1151,8 +1166,9 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Fires native update query. Calling this has no side effects on the context (identity map).
    */
-  async nativeUpdate<Entity extends object>(entityName: EntityName<Entity>, where: FilterQuery<Entity>, data: EntityData<Entity>, options: UpdateOptions<Entity> = {}): Promise<number> {
+  async nativeUpdate<Entity extends object>(entityName: EntityName<Entity>, where: FilterQuery<Entity>, data: EntityData<Entity>, _options: UpdateOptions<Entity> = {}): Promise<number> {
     const em = this.getContext(false);
+    const options = this.mergeOptions<UpdateOptions<Entity>>(_options);
 
     entityName = Utils.className(entityName);
     data = QueryHelper.processObjectParams(data);
@@ -1167,8 +1183,9 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Fires native delete query. Calling this has no side effects on the context (identity map).
    */
-  async nativeDelete<Entity extends object>(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: DeleteOptions<Entity> = {}): Promise<number> {
+  async nativeDelete<Entity extends object>(entityName: EntityName<Entity>, where: FilterQuery<Entity>, _options: DeleteOptions<Entity> = {}): Promise<number> {
     const em = this.getContext(false);
+    const options = this.mergeOptions<DeleteOptions<Entity>>(_options);
 
     entityName = Utils.className(entityName);
     where = await em.processWhere(entityName, where, options, 'delete');
@@ -1181,10 +1198,11 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Maps raw database result to an entity and merges it to this EntityManager.
    */
-  map<Entity extends object>(entityName: EntityName<Entity>, result: EntityDictionary<Entity>, options: { schema?: string } = {}): Entity {
+  map<Entity extends object>(entityName: EntityName<Entity>, result: EntityDictionary<Entity>, _options: { schema?: string } = {}): Entity {
     entityName = Utils.className(entityName);
     const meta = this.metadata.get(entityName);
     const data = this.driver.mapResult(result, meta) as Dictionary;
+    const options = this.mergeOptions(_options) as { schema?: string };
 
     Object.keys(data).forEach(k => {
       const prop = meta.properties[k];
@@ -1213,8 +1231,9 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * Merges given entity to this EntityManager so it becomes managed. You can force refreshing of existing entities
    * via second parameter. By default, it will return already loaded entities without modifying them.
    */
-  merge<Entity extends object>(entityName: EntityName<Entity> | Entity, data?: EntityData<Entity> | EntityDTO<Entity> | MergeOptions, options: MergeOptions = {}): Entity {
+  merge<Entity extends object>(entityName: EntityName<Entity> | Entity, data?: EntityData<Entity> | EntityDTO<Entity> | MergeOptions, _options: MergeOptions = {}): Entity {
     const em = this.getContext();
+    const options = this.mergeOptions<MergeOptions>(_options);
 
     if (Utils.isEntity(entityName)) {
       return em.merge((entityName as Dictionary).constructor.name, entityName as unknown as EntityData<Entity>, data as MergeOptions);
@@ -1246,8 +1265,9 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * the whole `data` parameter will be passed. This means we can also define `constructor(data: Partial<T>)` and
    * `em.create()` will pass the data into it (unless we have a property named `data` too).
    */
-  create<Entity extends object>(entityName: EntityName<Entity>, data: RequiredEntityData<Entity>, options: CreateOptions = {}): Entity {
+  create<Entity extends object>(entityName: EntityName<Entity>, data: RequiredEntityData<Entity>, _options: CreateOptions = {}): Entity {
     const em = this.getContext();
+    const options = this.mergeOptions<CreateOptions>(_options);
     const entity = em.entityFactory.create(entityName, data, {
       ...options,
       newEntity: !options.managed,
@@ -1265,7 +1285,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Shortcut for `wrap(entity).assign(data, { em })`
    */
-  assign<Entity extends object>(entity: Entity, data: EntityData<Entity> | Partial<EntityDTO<Entity>>, options: AssignOptions = {}): Entity {
+  assign<Entity extends object>(entity: Entity, data: EntityData<Entity> | Partial<EntityDTO<Entity>>, _options: AssignOptions = {}): Entity {
+    const options = this.mergeOptions<AssignOptions>(_options);
     return EntityAssigner.assign(entity, data, { em: this.getContext(), ...options });
   }
 
@@ -1292,7 +1313,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<Entity extends object>(entityName: EntityName<Entity>, id: Primary<Entity>, options: GetReferenceOptions = {}): Entity | Reference<Entity> {
+  getReference<Entity extends object>(entityName: EntityName<Entity>, id: Primary<Entity>, _options: GetReferenceOptions = {}): Entity | Reference<Entity> {
+    const options = this.mergeOptions<GetReferenceOptions>(_options);
     options.convertCustomTypes ??= false;
     const meta = this.metadata.get(Utils.className(entityName));
 
@@ -1319,8 +1341,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   async count<
     Entity extends object,
     Hint extends string = never,
-  >(entityName: EntityName<Entity>, where: FilterQuery<Entity> = {} as FilterQuery<Entity>, options: CountOptions<Entity, Hint> = {}): Promise<number> {
-    options = { ...options };
+  >(entityName: EntityName<Entity>, where: FilterQuery<Entity> = {} as FilterQuery<Entity>, _options: CountOptions<Entity, Hint> = {}): Promise<number> {
+    const options = this.mergeOptions<CountOptions<Entity, Hint>>(_options);
     const em = this.getContext(false);
     entityName = Utils.className(entityName);
     where = await em.processWhere(entityName, where, options as FindOptions<Entity, Hint>, 'read') as FilterQuery<Entity>;
@@ -1498,7 +1520,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   async populate<
     Entity extends object,
     Hint extends string = never,
-  >(entities: Entity | Entity[], populate: AutoPath<Entity, Hint>[] | boolean, options: EntityLoaderOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint>[]> {
+  >(entities: Entity | Entity[], populate: AutoPath<Entity, Hint>[] | boolean, _options: EntityLoaderOptions<Entity, Hint> = {}): Promise<Loaded<Entity, Hint>[]> {
     entities = Utils.asArray(entities);
 
     if (entities.length === 0) {
@@ -1506,11 +1528,23 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     const em = this.getContext();
+    const options = this.mergeOptions<EntityLoaderOptions<Entity, Hint>>(_options);
     const entityName = (entities[0] as Dictionary).constructor.name;
     const preparedPopulate = em.preparePopulate<Entity>(entityName, { populate: populate as true });
     await em.entityLoader.populate(entityName, entities, preparedPopulate, options);
 
     return entities as Loaded<Entity, Hint>[];
+  }
+
+  /**
+   *
+   * Merges options from entity manager default options with sent in options
+   */
+  mergeOptions<T>(options: { schema?: string }  = {}) {
+    return {
+      schema: this.schema,
+      ...options,
+    } as T;
   }
 
   /**
@@ -1539,6 +1573,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
 
     fork.filters = { ...em.filters };
     fork.filterParams = Utils.copy(em.filterParams);
+    fork._schema = options.schema || em.schema;
 
     if (!options.clear) {
       for (const entity of em.unitOfWork.getIdentityMap()) {
@@ -1678,7 +1713,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }
   }
 
-  private async lockAndPopulate<T extends object, P extends string = never>(entityName: string, entity: T, where: FilterQuery<T>, options: FindOneOptions<T, P>): Promise<Loaded<T, P>> {
+  private async lockAndPopulate<T extends object, P extends string = never>(entityName: string, entity: T, where: FilterQuery<T>, _options: FindOneOptions<T, P>): Promise<Loaded<T, P>> {
+    const options = this.mergeOptions<FindOneOptions<T, P>>(_options);
     if (options.lockMode === LockMode.OPTIMISTIC) {
       await this.lock(entity, options.lockMode, {
         lockVersion: options.lockVersion,
@@ -1748,7 +1784,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * when the entity is found in identity map, we check if it was partially loaded or we are trying to populate
    * some additional lazy properties, if so, we reload and merge the data from database
    */
-  protected shouldRefresh<T extends object, P extends string = never>(meta: EntityMetadata<T>, entity: T, options: FindOneOptions<T, P>) {
+  protected shouldRefresh<T extends object, P extends string = never>(meta: EntityMetadata<T>, entity: T, _options: FindOneOptions<T, P>) {
+    const options = this.mergeOptions<FindOneOptions<T, P>>(_options);
     if (!helper(entity).__initialized || options.refresh) {
       return true;
     }
@@ -1835,6 +1872,14 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   }
 
   /**
+   * Returns the default schema of this EntityManager. Respects the context, so global EM will give you the contextual schema
+   * if executed inside request context handler.
+   */
+  get schema(): string | undefined {
+    return this.getContext(false)._schema;
+  }
+
+  /**
    * Returns the ID of this EntityManager. Respects the context, so global EM will give you the contextual ID
    * if executed inside request context handler.
    */
@@ -1878,4 +1923,6 @@ export interface ForkOptions {
   flushMode?: FlushMode;
   /** disable transactions for this fork */
   disableTransactions?: boolean;
+  /** default schema to use for this fork */
+  schema?: string;
 }

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1867,6 +1867,14 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   }
 
   /**
+   * Sets the default schema of this EntityManager. Respects the context, so global EM will set the contextual schema
+   * if executed inside request context handler.
+   */
+  set schema(schema: string | null | undefined) {
+    this.getContext(false)._schema = schema ?? undefined;
+  }
+
+  /**
    * Returns the ID of this EntityManager. Respects the context, so global EM will give you the contextual ID
    * if executed inside request context handler.
    */

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -255,8 +255,6 @@ export class UnitOfWork {
 
   computeChangeSet<T extends object>(entity: T, type?: ChangeSetType): void {
     const wrapped = helper(entity);
-    // Set entityManager default schema
-    wrapped.__schema ??= this.em.schema;
 
     if (type) {
       this.changeSets.set(entity, new ChangeSet(entity, type, {}, wrapped.__meta));

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -255,6 +255,8 @@ export class UnitOfWork {
 
   computeChangeSet<T extends object>(entity: T, type?: ChangeSetType): void {
     const wrapped = helper(entity);
+    // Set entityManager default schema
+    wrapped.__schema ??= this.em.schema;
 
     if (type) {
       this.changeSets.set(entity, new ChangeSet(entity, type, {}, wrapped.__meta));
@@ -559,6 +561,8 @@ export class UnitOfWork {
       return;
     }
 
+    // Set entityManager default schema
+    wrapped.__schema ??= this.em.schema;
     this.initIdentifier(entity);
 
     for (const prop of helper(entity).__meta.relations) {

--- a/packages/core/src/utils/RequestContext.ts
+++ b/packages/core/src/utils/RequestContext.ts
@@ -22,8 +22,8 @@ export class RequestContext {
   /**
    * Creates new RequestContext instance and runs the code inside its domain.
    */
-  static create(em: EntityManager | EntityManager[], next: (...args: any[]) => void): void {
-    const ctx = this.createContext(em);
+  static create(em: EntityManager | EntityManager[], next: (...args: any[]) => void, options: CreateContextOptions = {}): void {
+    const ctx = this.createContext(em, options);
     this.storage.run(ctx, next);
   }
 
@@ -31,8 +31,8 @@ export class RequestContext {
    * Creates new RequestContext instance and runs the code inside its domain.
    * Async variant, when the `next` handler needs to be awaited (like in Koa).
    */
-  static async createAsync<T>(em: EntityManager | EntityManager[], next: (...args: any[]) => Promise<T>): Promise<T> {
-    const ctx = this.createContext(em);
+  static async createAsync<T>(em: EntityManager | EntityManager[], next: (...args: any[]) => Promise<T>, options: CreateContextOptions = {}): Promise<T> {
+    const ctx = this.createContext(em, options);
     return this.storage.run(ctx, next);
   }
 
@@ -51,16 +51,20 @@ export class RequestContext {
     return context ? context.map.get(name) : undefined;
   }
 
-  private static createContext(em: EntityManager | EntityManager[]): RequestContext {
+  private static createContext(em: EntityManager | EntityManager[], options: CreateContextOptions = {}): RequestContext {
     const forks = new Map<string, EntityManager>();
 
     if (Array.isArray(em)) {
-      em.forEach(em => forks.set(em.name, em.fork({ useContext: true })));
+      em.forEach(em => forks.set(em.name, em.fork({ useContext: true, schema: options.schema })));
     } else {
-      forks.set(em.name, em.fork({ useContext: true }));
+      forks.set(em.name, em.fork({ useContext: true, schema: options.schema }));
     }
 
     return new RequestContext(forks);
   }
 
+}
+
+export interface CreateContextOptions {
+  schema?: string;
 }

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -457,10 +457,10 @@ describe('EntityManagerMongo', () => {
 
     const spy = jest.spyOn(EntityManager.prototype, 'getContext');
     const fork2 = orm.em.fork({ disableContextResolution: true });
-    expect(spy).toBeCalledTimes(2);
+    expect(spy).toBeCalledTimes(3);
 
     const fork3 = orm.em.fork({ disableContextResolution: false });
-    expect(spy).toBeCalledTimes(5);
+    expect(spy).toBeCalledTimes(7);
   });
 
   test('findOne with empty where will throw', async () => {

--- a/tests/features/multiple-schemas-entity-manager/multiple-schemas-entity-manager.postgres.test.ts
+++ b/tests/features/multiple-schemas-entity-manager/multiple-schemas-entity-manager.postgres.test.ts
@@ -1,0 +1,357 @@
+import { BaseEntity, Cascade, Collection, Entity, LockMode, ManyToMany, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, Property, wrap } from '@mikro-orm/core';
+import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { mockLogger } from '../../helpers';
+
+@Entity({ schema: 'n1' })
+export class Author {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToOne(() => Author, undefined, { nullable: true })
+  mentor?: Author;
+
+  @OneToMany(() => Book, e => e.author, { cascade: [Cascade.REMOVE, Cascade.PERSIST] })
+  books = new Collection<Book>(this);
+
+}
+
+@Entity({ schema: '*' })
+export class BookTag extends BaseEntity<BookTag, 'id'> {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+}
+
+@Entity({ schema: '*' })
+export class Book extends BaseEntity<Book, 'id'> {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+  @ManyToOne(() => Author, { nullable: true, onDelete: 'cascade' })
+  author?: Author;
+
+  @ManyToOne(() => Book, { nullable: true })
+  basedOn?: Book;
+
+  @ManyToMany(() => BookTag, undefined, { cascade: [Cascade.ALL] })
+  tags = new Collection<BookTag>(this);
+
+}
+
+describe('multiple connected schemas in postgres', () => {
+
+  let orm: MikroORM<PostgreSqlDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Author, Book, BookTag],
+      dbName: `mikro_orm_test_multi_schemas_em`,
+      driver: PostgreSqlDriver,
+    });
+    await orm.schema.ensureDatabase();
+
+    for (const ns of ['n1', 'n2', 'n3', 'n4', 'n5']) {
+      await orm.schema.execute(`drop schema if exists ${ns} cascade`);
+    }
+
+    // `*` schema will be ignored
+    await orm.schema.updateSchema(); // `*` schema will be ignored
+
+    // we need to pass schema for book
+    await orm.schema.updateSchema({ schema: 'n2' });
+    await orm.schema.updateSchema({ schema: 'n3' });
+    await orm.schema.updateSchema({ schema: 'n4' });
+    await orm.schema.updateSchema({ schema: 'n5' });
+    orm.config.set('schema', 'n2'); // set the schema so we can work with book entities without options param
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    orm.config.set('schema', 'n2'); // set the schema so we can work with book entities without options param
+    await orm.em.createQueryBuilder(Author).truncate().execute(); // schema from metadata
+    await orm.em.createQueryBuilder(Book).truncate().execute(); // current schema from config
+    await orm.em.createQueryBuilder(Book).withSchema('n3').truncate().execute();
+    await orm.em.createQueryBuilder(Book).withSchema('n4').truncate().execute();
+    await orm.em.createQueryBuilder(Book).withSchema('n5').truncate().execute();
+    await orm.em.createQueryBuilder(BookTag).truncate().execute(); // current schema from config
+    await orm.em.createQueryBuilder(BookTag).withSchema('n3').truncate().execute();
+    await orm.em.createQueryBuilder(BookTag).withSchema('n4').truncate().execute();
+    await orm.em.createQueryBuilder(BookTag).withSchema('n5').truncate().execute();
+    orm.em.clear();
+  });
+
+  // if we have schema specified on entity level, it only exists in that schema
+  // if we have * schema on entity, it can exist in any schema, defined in forked EntityManager
+  // no schema on entity - default schema or from global orm config
+  test('should work. different schema on orm and fork', async () => {
+    orm.config.set('schema', 'n4'); // set the schema to a different schema than the fork
+
+    let author = new Author();
+    author.name = 'a1';
+    author.books.add(new Book(), new Book(), new Book());
+    author.books[0].tags.add(new BookTag(), new BookTag(), new BookTag());
+    author.books[1].basedOn = author.books[0];
+    author.books[1].tags.add(new BookTag(), new BookTag(), new BookTag());
+    author.books[2].basedOn = author.books[0];
+    author.books[2].tags.add(new BookTag(), new BookTag(), new BookTag());
+
+    // schema not specified yet, will be used from metadata
+    expect(wrap(author).getSchema()).toBeUndefined();
+    const fork = orm.em.fork({
+      schema: 'n2',
+    });
+
+    await fork.persistAndFlush(author);
+    // schema is saved after flush
+    expect(wrap(author).getSchema()).toBe('n1');
+    expect(wrap(author.books[0]).getSchema()).toBe('n2');
+    expect(wrap(author.books[0].tags[0]).getSchema()).toBe('n2');
+    expect(wrap(author.books[1]).getSchema()).toBe('n2');
+    expect(wrap(author.books[1].tags[0]).getSchema()).toBe('n2');
+    expect(wrap(author.books[2]).getSchema()).toBe('n2');
+    expect(wrap(author.books[2].tags[0]).getSchema()).toBe('n2');
+
+    fork.clear();
+    author = await fork.findOneOrFail(Author, author, { populate: true });
+
+    expect(fork.getUnitOfWork().getIdentityMap().keys()).toEqual([
+      'Author-n1:1',
+      'Book-n2:1',
+      'Book-n2:2',
+      'Book-n2:3',
+      'BookTag-n2:1',
+      'BookTag-n2:2',
+      'BookTag-n2:3',
+      'BookTag-n2:4',
+      'BookTag-n2:5',
+      'BookTag-n2:6',
+      'BookTag-n2:7',
+      'BookTag-n2:8',
+      'BookTag-n2:9',
+    ]);
+
+    expect(wrap(author).getSchema()).toBe('n1');
+    expect(wrap(author.books[0]).getSchema()).toBe('n2');
+    expect(wrap(author.books[0].tags[0]).getSchema()).toBe('n2');
+    expect(wrap(author.books[1]).getSchema()).toBe('n2');
+    expect(wrap(author.books[1].tags[0]).getSchema()).toBe('n2');
+    expect(wrap(author.books[2]).getSchema()).toBe('n2');
+    expect(wrap(author.books[2].tags[0]).getSchema()).toBe('n2');
+
+    // update entities and flush
+    author.name = 'new name';
+    author.books[0].name = 'new name 1';
+    author.books[0].tags[0].name = 'new name 1';
+    author.books[1].name = 'new name 2';
+    author.books[1].tags[0].name = 'new name 2';
+    author.books[2].name = 'new name 3';
+    author.books[2].tags[0].name = 'new name 3';
+
+    const mock = mockLogger(orm);
+    await fork.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch(`begin`);
+    expect(mock.mock.calls[1][0]).toMatch(`update "n2"."book_tag" set "name" = case when ("id" = 1) then 'new name 1' when ("id" = 4) then 'new name 2' when ("id" = 7) then 'new name 3' else "name" end where "id" in (1, 4, 7)`);
+    expect(mock.mock.calls[2][0]).toMatch(`update "n1"."author" set "name" = 'new name' where "id" = 1`);
+    expect(mock.mock.calls[3][0]).toMatch(`update "n2"."book" set "name" = case when ("id" = 1) then 'new name 1' when ("id" = 2) then 'new name 2' when ("id" = 3) then 'new name 3' else "name" end where "id" in (1, 2, 3)`);
+    expect(mock.mock.calls[4][0]).toMatch(`commit`);
+    mock.mockReset();
+
+    // remove entity
+    fork.remove(author);
+    await fork.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch(`begin`);
+    expect(mock.mock.calls[1][0]).toMatch(`delete from "n2"."book" where "id" in (1, 2, 3)`);
+    expect(mock.mock.calls[2][0]).toMatch(`delete from "n1"."author" where "id" in (1)`);
+    expect(mock.mock.calls[3][0]).toMatch(`delete from "n2"."book_tag" where "id" in (1, 2, 3, 4, 5, 6, 7, 8, 9)`);
+    expect(mock.mock.calls[4][0]).toMatch(`commit`);
+
+    fork.clear();
+
+    const n1 = await fork.find(Author, {});
+    const n3 = await fork.find(Book, {});
+    const n4 = await fork.find(Book, {});
+    const n5 = await fork.find(Book, {});
+    const n3tags = await fork.find(BookTag, {});
+    const n4tags = await fork.find(BookTag, {});
+    const n5tags = await fork.find(BookTag, {});
+    expect(n1).toHaveLength(0);
+    expect(n3).toHaveLength(0);
+    expect(n4).toHaveLength(0);
+    expect(n5).toHaveLength(0);
+    expect(n3tags).toHaveLength(0);
+    expect(n4tags).toHaveLength(0);
+    expect(n5tags).toHaveLength(0);
+  });
+
+  test('use different schema via options', async () => {
+    // author is always in schema `n1`
+    const author = new Author();
+    author.name = 'a1';
+
+    // Schema in orm config is n2
+    const mainForkN4 = orm.em.fork({
+      schema: 'n4',
+    });
+
+    // each book has different schema, such collection can be used for persisting, but it can't be loaded (as we can load only from single schema at a time)
+    const book51 = mainForkN4.create(Book, {});
+    book51.setSchema('n5');
+    const book52 = mainForkN4.create(Book, {});
+    wrap(book52).setSchema('n5');
+    author.books.add(
+      mainForkN4.create(Book, {}, { schema: 'n3' }),
+      mainForkN4.create(Book, {}),
+      book51,
+      book52,
+    );
+    author.books[0].tags.add(new BookTag(), new BookTag(), new BookTag());
+    author.books[1].basedOn = author.books[0];
+    author.books[1].tags.add(new BookTag(), new BookTag(), new BookTag());
+    author.books[2].basedOn = author.books[0];
+    author.books[2].tags.add(new BookTag(), new BookTag(), new BookTag());
+    author.books[3].tags.add(new BookTag(), new BookTag(), new BookTag());
+
+    // schema not specified yet, will be used from metadata
+    expect(wrap(author).getSchema()).toBeUndefined();
+    const mock = mockLogger(orm);
+    await mainForkN4.persistAndFlush(author);
+    expect(mainForkN4.getUnitOfWork().getIdentityMap().keys()).toEqual([
+      'BookTag-n3:1',
+      'BookTag-n3:2',
+      'BookTag-n3:3',
+      'BookTag-n5:1',
+      'BookTag-n5:2',
+      'BookTag-n5:3',
+      'BookTag-n5:4',
+      'BookTag-n5:5',
+      'BookTag-n5:6',
+      'BookTag-n4:1',
+      'BookTag-n4:2',
+      'BookTag-n4:3',
+      'Author-n1:1',
+      'Book-n3:1',
+      'Book-n5:1',
+      'Book-n5:2',
+      'Book-n4:1',
+    ]);
+    expect(mock.mock.calls[0][0]).toMatch(`begin`);
+    expect(mock.mock.calls[1][0]).toMatch(`insert into "n3"."book_tag" ("id") values (default), (default), (default) returning "id"`);
+    expect(mock.mock.calls[2][0]).toMatch(`insert into "n5"."book_tag" ("id") values (default), (default), (default), (default), (default), (default) returning "id"`);
+    expect(mock.mock.calls[3][0]).toMatch(`insert into "n4"."book_tag" ("id") values (default), (default), (default) returning "id"`);
+    expect(mock.mock.calls[4][0]).toMatch(`insert into "n1"."author" ("name") values ('a1') returning "id"`);
+    expect(mock.mock.calls[5][0]).toMatch(`insert into "n3"."book" ("author_id") values (1) returning "id"`);
+    expect(mock.mock.calls[6][0]).toMatch(`insert into "n5"."book" ("author_id") values (1), (1) returning "id"`);
+    expect(mock.mock.calls[7][0]).toMatch(`insert into "n4"."book" ("author_id") values (1) returning "id"`);
+    expect(mock.mock.calls[8][0]).toMatch(`update "n5"."book" set "based_on_id" = 1 where "id" = 1`);
+    expect(mock.mock.calls[9][0]).toMatch(`update "n4"."book" set "based_on_id" = 1 where "id" = 1`);
+    expect(mock.mock.calls[10][0]).toMatch(`insert into "n3"."book_tags" ("book_id", "book_tag_id") values (1, 1), (1, 2), (1, 3) returning "book_id", "book_tag_id"`);
+    expect(mock.mock.calls[11][0]).toMatch(`insert into "n5"."book_tags" ("book_id", "book_tag_id") values (1, 1), (1, 2), (1, 3) returning "book_id", "book_tag_id"`);
+    expect(mock.mock.calls[12][0]).toMatch(`insert into "n5"."book_tags" ("book_id", "book_tag_id") values (2, 4), (2, 5), (2, 6) returning "book_id", "book_tag_id"`);
+    expect(mock.mock.calls[13][0]).toMatch(`insert into "n4"."book_tags" ("book_id", "book_tag_id") values (1, 1), (1, 2), (1, 3) returning "book_id", "book_tag_id"`);
+    expect(mock.mock.calls[14][0]).toMatch(`commit`);
+    mock.mockReset();
+
+    // schema is saved after flush as if the entity was loaded from db
+    expect(wrap(author).getSchema()).toBe('n1');
+    expect(wrap(author.books[0]).getSchema()).toBe('n3');
+    expect(wrap(author.books[0].tags[0]).getSchema()).toBe('n3');
+    expect(wrap(author.books[1]).getSchema()).toBe('n4');
+    expect(wrap(author.books[1].tags[0]).getSchema()).toBe('n4');
+    expect(author.books[2].getSchema()).toBe('n5');
+    expect(author.books[2].tags[0].getSchema()).toBe('n5');
+    expect(author.books[3].getSchema()).toBe('n5');
+    expect(author.books[3].tags[0].getSchema()).toBe('n5');
+
+    // update entities and flush
+    author.name = 'new name';
+    author.books[0].name = 'new name 1';
+    author.books[0].tags[0].name = 'new name 1';
+    author.books[1].name = 'new name 2';
+    author.books[1].tags[0].name = 'new name 2';
+    author.books[2].name = 'new name 3';
+    author.books[2].tags[0].name = 'new name 3';
+    author.books[3].name = 'new name 4';
+    author.books[3].tags[0].name = 'new name 4';
+    await mainForkN4.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch(`begin`);
+    expect(mock.mock.calls[1][0]).toMatch(`update "n1"."author" set "name" = 'new name' where "id" = 1`);
+    expect(mock.mock.calls[2][0]).toMatch(`update "n3"."book" set "name" = 'new name 1' where "id" = 1`);
+    expect(mock.mock.calls[3][0]).toMatch(`update "n4"."book" set "name" = 'new name 2' where "id" = 1`);
+    expect(mock.mock.calls[4][0]).toMatch(`update "n5"."book" set "name" = case when ("id" = 1) then 'new name 3' when ("id" = 2) then 'new name 4' else "name" end where "id" in (1, 2)`);
+    expect(mock.mock.calls[5][0]).toMatch(`update "n3"."book_tag" set "name" = 'new name 1' where "id" = 1`);
+    expect(mock.mock.calls[6][0]).toMatch(`update "n5"."book_tag" set "name" = case when ("id" = 1) then 'new name 3' when ("id" = 4) then 'new name 4' else "name" end where "id" in (1, 4)`);
+    expect(mock.mock.calls[7][0]).toMatch(`update "n4"."book_tag" set "name" = 'new name 2' where "id" = 1`);
+    expect(mock.mock.calls[8][0]).toMatch(`commit`);
+    mock.mockReset();
+
+    const fork = mainForkN4.fork();
+    await fork.findOneOrFail(Author, author, { populate: true, schema: 'n5' });
+
+    expect(mock.mock.calls[0][0]).toMatch(`select "a0".* from "n1"."author" as "a0" where "a0"."id" = 1 limit 1`);
+    expect(mock.mock.calls[1][0]).toMatch(`select "b0".* from "n5"."book" as "b0" where "b0"."author_id" in (1) order by "b0"."author_id" asc`);
+    expect(mock.mock.calls[2][0]).toMatch(`select "b0".*, "b1"."book_tag_id" as "fk__book_tag_id", "b1"."book_id" as "fk__book_id" from "n5"."book_tag" as "b0" left join "n5"."book_tags" as "b1" on "b0"."id" = "b1"."book_tag_id" where "b1"."book_id" in (2, 1)`);
+    mock.mockReset();
+
+    expect(fork.getUnitOfWork().getIdentityMap().keys()).toEqual([
+      'Author-n1:1',
+      'Book-n5:2',
+      'Book-n5:1',
+      'BookTag-n5:5',
+      'BookTag-n5:6',
+      'BookTag-n5:4',
+      'BookTag-n5:2',
+      'BookTag-n5:3',
+      'BookTag-n5:1',
+    ]);
+
+    // remove entity
+    mainForkN4.remove(author);
+    await mainForkN4.flush();
+
+    expect(mock.mock.calls[0][0]).toMatch(`begin`);
+    expect(mock.mock.calls[1][0]).toMatch(`delete from "n3"."book" where "id" in (1)`);
+    expect(mock.mock.calls[2][0]).toMatch(`delete from "n4"."book" where "id" in (1)`);
+    expect(mock.mock.calls[3][0]).toMatch(`delete from "n5"."book" where "id" in (1, 2)`);
+    expect(mock.mock.calls[4][0]).toMatch(`delete from "n1"."author" where "id" in (1)`);
+    expect(mock.mock.calls[5][0]).toMatch(`delete from "n3"."book_tag" where "id" in (1, 2, 3)`);
+    expect(mock.mock.calls[6][0]).toMatch(`delete from "n4"."book_tag" where "id" in (1, 2, 3)`);
+    expect(mock.mock.calls[7][0]).toMatch(`delete from "n5"."book_tag" where "id" in (1, 2, 3, 4, 5, 6)`);
+    expect(mock.mock.calls[8][0]).toMatch(`commit`);
+
+    mainForkN4.clear();
+
+    const n1 = await mainForkN4.find(Author, {});
+    const n3 = await mainForkN4.find(Book, {}, { schema: 'n3' });
+    const n4 = await mainForkN4.find(Book, {});
+    const n5 = await mainForkN4.find(Book, {}, { schema: 'n5' });
+    const n3tags = await mainForkN4.find(BookTag, {}, { schema: 'n3' });
+    const n4tags = await mainForkN4.find(BookTag, {});
+    const n5tags = await mainForkN4.find(BookTag, {}, { schema: 'n5' });
+    expect(n1).toHaveLength(0);
+    expect(n3).toHaveLength(0);
+    expect(n4).toHaveLength(0);
+    expect(n5).toHaveLength(0);
+    expect(n3tags).toHaveLength(0);
+    expect(n4tags).toHaveLength(0);
+    expect(n5tags).toHaveLength(0);
+  });
+
+});

--- a/tests/features/multiple-schemas-entity-manager/multiple-schemas-entity-manager.postgres.test.ts
+++ b/tests/features/multiple-schemas-entity-manager/multiple-schemas-entity-manager.postgres.test.ts
@@ -173,7 +173,8 @@ describe('multiple connected schemas in postgres', () => {
     mock.mockReset();
 
     // remove entity
-    fork.remove(author);
+    const authorRef = fork.getReference(Author, 1);
+    fork.remove(authorRef);
     await fork.flush();
 
     expect(mock.mock.calls[0][0]).toMatch(`begin`);


### PR DESCRIPTION
Hi,

I want to start with thanking you all for this great ORM that is so actively maintained and offer so many great features. One thing that really catches my eye is the per request (shell)EntityManager that I think will make this ORM a winner when it comes to multi tenancy. Almost all of the other big ORM libraries are based on a global concept. 

My aim with this PR is to make a shoot at implementing schema based multi tenancy support with help of the per request EntityManager. With this PR it's possible to set a schema when forking the EntityManager. That schema will be applied as a default schema if no other schema is present. It makes use of the schema options introduced in: https://github.com/mikro-orm/mikro-orm/pull/2296 

If this seems like an approach to pursue there is some more work to do:
- Add a hook in the other packages like Nestjs to allow for setting schema / request
- Documentation
- More extensive tests

Some questions
- Should the number of `this.context()` calls be reduced?
- When `.fork()` an existing fork with schema, should schema be inherited and should it be possible to clear schema?