### PR TITLE
feat(core): native `BigInt` support

### DIFF
--- a/docs/docs/custom-types.md
+++ b/docs/docs/custom-types.md
@@ -274,12 +274,27 @@ numericArray?: number[];
 
 ### BigIntType
 
-You can use `BigIntType` to support `bigint`s. By default, it will represent the value as a `string`.
+Since v6, `bigint`s are represented by the native `BigInt` type, and as such, they don't require explicit type in the decorator options:
 
 ```ts
-@PrimaryKey({ type: BigIntType })
-id: string;
+@PrimaryKey()
+id: bigint;
 ```
+
+You can also specify the target type you want your bigints to be mapped to:
+
+```ts
+@PrimaryKey({ type: new BigIntType('bigint') })
+id1: bigint;
+
+@PrimaryKey({ type: new BigIntType('string') })
+id2: string;
+
+@PrimaryKey({ type: new BigIntType('number') })
+id3: number;
+```
+
+> JavaScript cannot represent all the possible values of a `bigint` when mapping to the `number` type - only values up to `Number.MAX_SAFE_INTEGER` (2^53 - 1) are safely supported.
 
 ### BlobType
 

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -1620,7 +1620,27 @@ export const BookSchema = new EntitySchema<Book>({
 
 ### Using BigInt as primary key (MySQL and PostgreSQL)
 
-We can use `BigIntType` to support `bigint`s. By default, it will represent the value as a `string`.
+Since v6, `bigint`s are represented by the native `BigInt` type, and as such, they don't require explicit type in the decorator options:
+
+```ts
+@PrimaryKey()
+id: bigint;
+```
+
+You can also specify the target type you want your bigints to be mapped to:
+
+```ts
+@PrimaryKey({ type: new BigIntType('bigint') })
+id1: bigint;
+
+@PrimaryKey({ type: new BigIntType('string') })
+id2: string;
+
+@PrimaryKey({ type: new BigIntType('number') })
+id3: number;
+```
+
+> JavaScript cannot represent all the possible values of a `bigint` when mapping to the `number` type - only values up to `Number.MAX_SAFE_INTEGER` (2^53 - 1) are safely supported.
 
 <Tabs
 groupId="entity-def"
@@ -1637,8 +1657,8 @@ values={[
 @Entity()
 export class Book {
 
-  @PrimaryKey({ type: BigIntType })
-  id: string;
+  @PrimaryKey()
+  id: bigint;
 
 }
 ```
@@ -1650,8 +1670,8 @@ export class Book {
 @Entity()
 export class Book {
 
-  @PrimaryKey({ type: BigIntType })
-  id: string;
+  @PrimaryKey()
+  id: bigint;
 
 }
 ```
@@ -1661,7 +1681,7 @@ export class Book {
 
 ```ts title="./entities/CustomBaseEntity.ts"
 properties: {
-  id: { type: BigIntType },
+  id: { type: 'bigint' },
 },
 ```
 

--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -367,3 +367,21 @@ const dto = wrap(user).toObject();
 Previously, mapping of datetime columns to JS `Date` objects was dependent on the driver, while SQLite didn't have this out of box support and required manual conversion on various places. All drivers now have disabled `Date` conversion and this is now handled explicitly, in the same way for all of them.
 
 Moreover, the `date` type was previously seen as a `datetime`, while now only `Date` (with uppercase `D`) will be considered as `datetime`, while `date` is just a `date`.
+
+## Native BigInt support
+
+The default mapping of `bigint` columns is now using the native JavaScript `BigInt`, and is configurable, so it can also map to numbers or strings:
+
+```ts
+@PrimaryKey()
+id0: bigint; // type is inferred
+
+@PrimaryKey({ type: new BigIntType('bigint') })
+id1: bigint; // same as `id0`
+
+@PrimaryKey({ type: new BigIntType('string') })
+id2: string;
+
+@PrimaryKey({ type: new BigIntType('number') })
+id3: number;
+```

--- a/docs/docs/using-bigint-pks.md
+++ b/docs/docs/using-bigint-pks.md
@@ -2,40 +2,24 @@
 title: Using native BigInt PKs (MySQL and PostgreSQL)
 ---
 
-We can use `BigIntType` to support `bigint`s. By default, it will represent the value as a `string`.
+Since v6, `bigint`s are represented by the native `BigInt` type, and as such, they don't require explicit type in the decorator options:
 
 ```ts
-import { Entity, PrimaryKey, t } from '@mikro-orm/core';
-
-@Entity()
-export class Book {
-
-  @PrimaryKey({ type: t.bigint })
-  id: string;
-
-}
+@PrimaryKey()
+id: bigint;
 ```
 
-`bigint` can fit larger numbers than JavaScript number, for this reason it is mapped to a string. If we want to map it to a number anyway, we can implement [custom type](custom-types.md) that will do so. Similarly, we can define one to use the native `bigint` type:
+You can also specify the target type you want your bigints to be mapped to:
 
 ```ts
-export class NativeBigIntType extends BigIntType {
+@PrimaryKey({ type: new BigIntType('bigint') })
+id1: bigint;
 
-  convertToJSValue(value: any): any {
-    if (!value) {
-      return value;
-    }
+@PrimaryKey({ type: new BigIntType('string') })
+id2: string;
 
-    return BigInt(value);
-  }
-
-}
-
-@Entity()
-export class Book {
-
-  @PrimaryKey({ type: NativeBigIntType })
-  id: bigint;
-
-}
+@PrimaryKey({ type: new BigIntType('number') })
+id3: number;
 ```
+
+> JavaScript cannot represent all the possible values of a `bigint` when mapping to the `number` type - only values up to `Number.MAX_SAFE_INTEGER` (2^53 - 1) are safely supported.

--- a/packages/core/src/serialization/EntityTransformer.ts
+++ b/packages/core/src/serialization/EntityTransformer.ts
@@ -157,7 +157,11 @@ export class EntityTransformer {
       return customType.toJSON(value, wrapped.__platform);
     }
 
-    return wrapped.__platform.normalizePrimaryKey(value as unknown as IPrimaryKey) as unknown as EntityValue<Entity>;
+    if (property?.primary) {
+      return wrapped.__platform.normalizePrimaryKey(value as unknown as IPrimaryKey) as unknown as EntityValue<Entity>;
+    }
+
+    return value;
   }
 
   private static processEntity<Entity extends object>(prop: keyof Entity, entity: Entity, platform: Platform, raw: boolean, populated: boolean): EntityValue<Entity> | undefined {
@@ -184,7 +188,7 @@ export class EntityTransformer {
       return wrap(child).toJSON() as EntityValue<Entity>;
     }
 
-    return platform.normalizePrimaryKey(wrapped.getPrimaryKey() as IPrimaryKey) as unknown as EntityValue<Entity>;
+    return platform.normalizePrimaryKey(wrapped.getPrimaryKey(true) as IPrimaryKey) as unknown as EntityValue<Entity>;
   }
 
   private static processCollection<Entity>(prop: keyof Entity, entity: Entity, raw: boolean, populated: boolean): EntityValue<Entity> | undefined {

--- a/packages/core/src/types/BigIntType.ts
+++ b/packages/core/src/types/BigIntType.ts
@@ -3,9 +3,14 @@ import type { Platform } from '../platforms';
 import type { EntityProperty } from '../typings';
 
 /**
- * This type will automatically convert string values returned from the database to native JS bigints.
+ * This type will automatically convert string values returned from the database to native JS bigints (default)
+ * or numbers (safe only for values up to `Number.MAX_SAFE_INTEGER`), or strings, depending on the `mode`.
  */
-export class BigIntType extends Type<string | bigint | null | undefined, string | null | undefined> {
+export class BigIntType extends Type<string | bigint | number | null | undefined, string | null | undefined> {
+
+  constructor(readonly mode: 'bigint' | 'number' | 'string' = 'bigint') {
+    super();
+  }
 
   override convertToDatabaseValue(value: string | bigint | null | undefined): string | null | undefined {
     if (value == null) {
@@ -15,12 +20,24 @@ export class BigIntType extends Type<string | bigint | null | undefined, string 
     return '' + value;
   }
 
-  override convertToJSValue(value: string | bigint | null | undefined): string | null | undefined {
+  override convertToJSValue(value: string | bigint | null | undefined): bigint | number | string | null | undefined {
     if (value == null) {
       return value as null | undefined;
     }
 
-    return '' + value;
+    switch (this.mode) {
+      case 'bigint':
+        return BigInt(value);
+      case 'number':
+        return Number(value);
+      case 'string':
+      default:
+        return String(value);
+    }
+  }
+
+  override toJSON(value: string | bigint | null | undefined): string | bigint | null | undefined {
+    return this.convertToDatabaseValue(value);
   }
 
   override getColumnType(prop: EntityProperty, platform: Platform) {
@@ -28,7 +45,7 @@ export class BigIntType extends Type<string | bigint | null | undefined, string 
   }
 
   override compareAsType(): string {
-    return 'string';
+    return 'bigint';
   }
 
 }

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -78,7 +78,9 @@ export type ExpandScalar<T> = null | (T extends string
   ? T | RegExp
   : T extends Date
     ? Date | string
-    : T);
+    : T extends bigint
+      ? bigint | string | number
+      : T);
 
 export type OperatorMap<T> = {
   $and?: Query<T>[];

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -481,7 +481,7 @@ export class EntityComparator {
         const convertorKey = this.safeKey(childProp.name);
         context.set(`convertToDatabaseValue_${convertorKey}`, (val: any) => childProp.customType.convertToDatabaseValue(val, this.platform, { mode: 'serialization' }));
 
-        if (['number', 'string', 'boolean'].includes(childProp.customType.compareAsType().toLowerCase())) {
+        if (['number', 'string', 'boolean', 'bigint'].includes(childProp.customType.compareAsType().toLowerCase())) {
           return `${padding}  if (${childCond}) ret${childDataKey} = convertToDatabaseValue_${convertorKey}(entity${childEntityKey});`;
         }
 
@@ -546,7 +546,7 @@ export class EntityComparator {
     if (prop.customType) {
       context.set(`convertToDatabaseValue_${convertorKey}`, (val: any) => prop.customType.convertToDatabaseValue(val, this.platform, { mode: 'serialization' }));
 
-      if (['number', 'string', 'boolean'].includes(prop.customType.compareAsType().toLowerCase())) {
+      if (['number', 'string', 'boolean', 'bigint'].includes(prop.customType.compareAsType().toLowerCase())) {
         return ret + `    ret${dataKey} = convertToDatabaseValue_${convertorKey}(entity${entityKey}${unwrap});\n  }\n`;
       }
 
@@ -622,7 +622,7 @@ export class EntityComparator {
       type = 'array';
     }
 
-    if (['string', 'number'].includes(type)) {
+    if (['string', 'number', 'bigint'].includes(type)) {
       return this.getGenericComparator(this.wrap(prop.name), `last${this.wrap(prop.name)} !== current${this.wrap(prop.name)}`);
     }
 

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -226,7 +226,7 @@ describe('EntityManagerMySql', () => {
       created_at: '2019-06-09T07:50:25.722Z',
       author_id: 123,
       publisher_id: 321,
-      tags: ['1', '2', '3'],
+      tags: [1n, 2n, 3n],
     })!;
     expect(book.uuid).toBe('123-dsa');
     expect(book.title).toBe('name');
@@ -238,9 +238,9 @@ describe('EntityManagerMySql', () => {
     expect(book.publisher!.id).toBe(321);
     expect(book.tags.length).toBe(3);
     expect(book.tags[0]).toBeInstanceOf(BookTag2);
-    expect(book.tags[0].id).toBe('1'); // bigint as string
-    expect(book.tags[1].id).toBe('2');
-    expect(book.tags[2].id).toBe('3');
+    expect(book.tags[0].id).toBe(1n);
+    expect(book.tags[1].id).toBe(2n);
+    expect(book.tags[2].id).toBe(3n);
     expect(repo.getReference(book.uuid)).toBe(book);
   });
 
@@ -1133,11 +1133,11 @@ describe('EntityManagerMySql', () => {
     orm.em.persist(book2);
     await orm.em.persistAndFlush(book3);
 
-    expect(typeof tag1.id).toBe('string');
-    expect(typeof tag2.id).toBe('string');
-    expect(typeof tag3.id).toBe('string');
-    expect(typeof tag4.id).toBe('string');
-    expect(typeof tag5.id).toBe('string');
+    expect(typeof tag1.id).toBe('bigint');
+    expect(typeof tag2.id).toBe('bigint');
+    expect(typeof tag3.id).toBe('bigint');
+    expect(typeof tag4.id).toBe('bigint');
+    expect(typeof tag5.id).toBe('bigint');
 
     // test inverse side
     const tagRepository = orm.em.getRepository(BookTag2);
@@ -1231,13 +1231,13 @@ describe('EntityManagerMySql', () => {
 
   test('bigint support', async () => {
     const t = new BookTag2('test');
-    t.id = '9223372036854775807';
+    t.id = 9223372036854775807n;
     await orm.em.persistAndFlush(t);
-    expect(t.id).toBe('9223372036854775807');
+    expect(t.id).toBe(9223372036854775807n);
     orm.em.clear();
 
     const t2 = await orm.em.findOneOrFail(BookTag2, t.id);
-    expect(t2.id).toBe('9223372036854775807');
+    expect(t2.id).toBe(9223372036854775807n);
   });
 
   test('many to many working with inverse side', async () => {

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -1101,11 +1101,11 @@ describe('EntityManagerPostgre', () => {
     await orm.em.persist(book2);
     await orm.em.persistAndFlush(book3);
 
-    expect(typeof tag1.id).toBe('string');
-    expect(typeof tag2.id).toBe('string');
-    expect(typeof tag3.id).toBe('string');
-    expect(typeof tag4.id).toBe('string');
-    expect(typeof tag5.id).toBe('string');
+    expect(typeof tag1.id).toBe('bigint');
+    expect(typeof tag2.id).toBe('bigint');
+    expect(typeof tag3.id).toBe('bigint');
+    expect(typeof tag4.id).toBe('bigint');
+    expect(typeof tag5.id).toBe('bigint');
 
     // test inverse side
     const tagRepository = orm.em.getRepository(BookTag2);
@@ -1211,13 +1211,13 @@ describe('EntityManagerPostgre', () => {
 
   test('bigint support', async () => {
     const t = new BookTag2('test');
-    t.id = '9223372036854775807';
+    t.id = 9223372036854775807n;
     await orm.em.persistAndFlush(t);
-    expect(t.id).toBe('9223372036854775807');
+    expect(t.id).toBe(9223372036854775807n);
     orm.em.clear();
 
     const t2 = await orm.em.findOneOrFail(BookTag2, t.id);
-    expect(t2.id).toBe('9223372036854775807');
+    expect(t2.id).toBe(9223372036854775807n);
   });
 
   test('populating many to many relation', async () => {

--- a/tests/entities-sql/BookTag2.ts
+++ b/tests/entities-sql/BookTag2.ts
@@ -1,11 +1,11 @@
-import { BigIntType, Collection, Entity, ManyToMany, PrimaryKey, Property } from '@mikro-orm/core';
+import { Collection, Entity, ManyToMany, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
 export class BookTag2 {
 
-  @PrimaryKey({ type: BigIntType })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @Property({ length: 50 })
   name: string;

--- a/tests/features/custom-types/GH4249.test.ts
+++ b/tests/features/custom-types/GH4249.test.ts
@@ -1,12 +1,12 @@
-import { BigIntType, Entity, ManyToOne, PrimaryKey, wrap } from '@mikro-orm/core';
+import { Entity, ManyToOne, PrimaryKey, wrap } from '@mikro-orm/core';
 import { MikroORM } from '@mikro-orm/mysql';
 import { mockLogger } from '../../helpers';
 
 @Entity()
 class Author {
 
-  @PrimaryKey({ type: BigIntType })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
 }
 

--- a/tests/features/embeddables/nested-embeddables-order-of-discovery.test.ts
+++ b/tests/features/embeddables/nested-embeddables-order-of-discovery.test.ts
@@ -1,4 +1,4 @@
-import { ArrayType, BigIntType, Embeddable, Embedded, Entity, Enum, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
+import { ArrayType, Embeddable, Embedded, Entity, Enum, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
 export enum RestrictionMode {
@@ -20,8 +20,8 @@ export class RestrictionItem {
 @Embeddable()
 export class Restriction {
 
-  @Property({ type: BigIntType })
-  permissions!: string;
+  @Property()
+  permissions!: bigint;
 
   @Embedded(() => RestrictionItem)
   role!: RestrictionItem;
@@ -34,8 +34,8 @@ export class Restriction {
 @Entity({ abstract: true })
 export class PluginSettings {
 
-  @PrimaryKey({ type: BigIntType })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @Embedded(() => Restriction, { nullable: true })
   restriction?: Restriction;
@@ -59,12 +59,12 @@ describe('GH issue 2242', () => {
     await orm.schema.createSchema();
 
     const item = orm.em.create(PluginTestSettings, {
-      id: '771309736129200140',
+      id: 771309736129200140n,
       enabled: true,
     });
 
     expect(item).toBeInstanceOf(PluginTestSettings);
-    expect(item.id).toBe('771309736129200140');
+    expect(item.id).toBe(771309736129200140n);
     expect(item.enabled).toBe(true);
     await orm.close();
   });
@@ -78,12 +78,12 @@ describe('GH issue 2242', () => {
     await orm.schema.createSchema();
 
     const item = orm.em.create(PluginTestSettings, {
-      id: '771309736129200140',
+      id: 771309736129200140n,
       enabled: true,
     });
 
     expect(item).toBeInstanceOf(PluginTestSettings);
-    expect(item.id).toBe('771309736129200140');
+    expect(item.id).toBe(771309736129200140n);
     expect(item.enabled).toBe(true);
     await orm.close();
   });
@@ -97,12 +97,12 @@ describe('GH issue 2242', () => {
     await orm.schema.createSchema();
 
     const item = orm.em.create(PluginTestSettings, {
-      id: '771309736129200140',
+      id: 771309736129200140n,
       enabled: true,
     });
 
     expect(item).toBeInstanceOf(PluginTestSettings);
-    expect(item.id).toBe('771309736129200140');
+    expect(item.id).toBe(771309736129200140n);
     expect(item.enabled).toBe(true);
     await orm.close();
   });
@@ -116,12 +116,12 @@ describe('GH issue 2242', () => {
     await orm.schema.createSchema();
 
     const item = orm.em.create(PluginTestSettings, {
-      id: '771309736129200140',
+      id: 771309736129200140n,
       enabled: true,
     });
 
     expect(item).toBeInstanceOf(PluginTestSettings);
-    expect(item.id).toBe('771309736129200140');
+    expect(item.id).toBe(771309736129200140n);
     expect(item.enabled).toBe(true);
     await orm.close();
   });
@@ -135,12 +135,12 @@ describe('GH issue 2242', () => {
     await orm.schema.createSchema();
 
     const item = orm.em.create(PluginTestSettings, {
-      id: '771309736129200140',
+      id: 771309736129200140n,
       enabled: true,
     });
 
     expect(item).toBeInstanceOf(PluginTestSettings);
-    expect(item.id).toBe('771309736129200140');
+    expect(item.id).toBe(771309736129200140n);
     expect(item.enabled).toBe(true);
     await orm.close();
   });
@@ -154,12 +154,12 @@ describe('GH issue 2242', () => {
     await orm.schema.createSchema();
 
     const item = orm.em.create(PluginTestSettings, {
-      id: '771309736129200140',
+      id: 771309736129200140n,
       enabled: true,
     });
 
     expect(item).toBeInstanceOf(PluginTestSettings);
-    expect(item.id).toBe('771309736129200140');
+    expect(item.id).toBe(771309736129200140n);
     expect(item.enabled).toBe(true);
     await orm.close();
   });
@@ -173,12 +173,12 @@ describe('GH issue 2242', () => {
     await orm.schema.createSchema();
 
     const item = orm.em.create(PluginTestSettings, {
-      id: '771309736129200140',
+      id: 771309736129200140n,
       enabled: true,
     });
 
     expect(item).toBeInstanceOf(PluginTestSettings);
-    expect(item.id).toBe('771309736129200140');
+    expect(item.id).toBe(771309736129200140n);
     expect(item.enabled).toBe(true);
     await orm.close();
   });
@@ -192,12 +192,12 @@ describe('GH issue 2242', () => {
     await orm.schema.createSchema();
 
     const item = orm.em.create(PluginTestSettings, {
-      id: '771309736129200140',
+      id: 771309736129200140n,
       enabled: true,
     });
 
     expect(item).toBeInstanceOf(PluginTestSettings);
-    expect(item.id).toBe('771309736129200140');
+    expect(item.id).toBe(771309736129200140n);
     expect(item.enabled).toBe(true);
     await orm.close();
   });
@@ -211,12 +211,12 @@ describe('GH issue 2242', () => {
     await orm.schema.createSchema();
 
     const item = orm.em.create(PluginTestSettings, {
-      id: '771309736129200140',
+      id: 771309736129200140n,
       enabled: true,
     });
 
     expect(item).toBeInstanceOf(PluginTestSettings);
-    expect(item.id).toBe('771309736129200140');
+    expect(item.id).toBe(771309736129200140n);
     expect(item.enabled).toBe(true);
     await orm.close();
   });
@@ -230,12 +230,12 @@ describe('GH issue 2242', () => {
     await orm.schema.createSchema();
 
     const item = orm.em.create(PluginTestSettings, {
-      id: '771309736129200140',
+      id: 771309736129200140n,
       enabled: true,
     });
 
     expect(item).toBeInstanceOf(PluginTestSettings);
-    expect(item.id).toBe('771309736129200140');
+    expect(item.id).toBe(771309736129200140n);
     expect(item.enabled).toBe(true);
     await orm.close();
   });

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
@@ -255,7 +255,7 @@ import { Book2 } from './Book2';
 import { Book2Tags } from './Book2Tags';
 
 export class BookTag2 {
-  id!: string;
+  id!: bigint;
   name!: string;
   bookToTagUnorderedInverse = new Collection<Book2>(this);
   bookTag2Inverse = new Collection<Book2Tags>(this);
@@ -264,7 +264,7 @@ export class BookTag2 {
 export const BookTag2Schema = new EntitySchema({
   class: BookTag2,
   properties: {
-    id: { primary: true, type: 'string', columnType: 'bigint' },
+    id: { primary: true, type: 'bigint' },
     name: { type: 'string', length: 50 },
     bookToTagUnorderedInverse: { kind: 'm:n', entity: () => Book2, mappedBy: 'bookToTagUnordered' },
     bookTag2Inverse: { kind: '1:m', entity: () => Book2Tags, mappedBy: 'bookTag2' },
@@ -789,8 +789,8 @@ export class Account {
 
   [OptionalProps]?: 'active' | 'receiveEmailNotifications';
 
-  @PrimaryKey({ columnType: 'bigint' })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @Property({ default: false })
   active: boolean = false;
@@ -935,8 +935,8 @@ export enum BaseUser2Type {
 @Entity()
 export class BookTag2 {
 
-  @PrimaryKey({ columnType: 'bigint' })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @Property({ length: 50 })
   name!: string;
@@ -1420,8 +1420,8 @@ export class Author2 {
 @Entity()
 export class BookTag2 {
 
-  @PrimaryKey({ columnType: 'bigint' })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @Property({ length: 50 })
   name!: string;
@@ -2062,8 +2062,8 @@ import { Book2Tags } from './Book2Tags';
 @Entity()
 export class BookTag2 {
 
-  @PrimaryKey({ columnType: 'bigint' })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @Property({ length: 50 })
   name!: string;
@@ -2674,8 +2674,8 @@ import { Book2Tags } from './Book2Tags';
 @Entity()
 export class BookTag2 {
 
-  @PrimaryKey({ columnType: 'bigint' })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @Property({ length: 50 })
   name!: string;
@@ -3266,8 +3266,8 @@ export enum BaseUser2Type {
 @Entity()
 export class BookTag2 {
 
-  @PrimaryKey({ columnType: 'bigint' })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @Property({ length: 50 })
   name!: string;
@@ -3846,8 +3846,8 @@ export enum BaseUser2Type {
 @Entity()
 export class BookTag2 {
 
-  @PrimaryKey({ columnType: 'bigint' })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @Property({ length: 50 })
   name!: string;
@@ -4293,8 +4293,8 @@ export class Author2 {
 @Entity()
 export class BookTag2 {
 
-  @PrimaryKey({ columnType: 'bigint' })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @Property({ length: 50 })
   name!: string;

--- a/tests/features/find-one-or-fail-strict.test.ts
+++ b/tests/features/find-one-or-fail-strict.test.ts
@@ -1,11 +1,11 @@
-import { BigIntType, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
 @Entity()
 class Author {
 
-  @PrimaryKey({ type: BigIntType })
-  id?: string;
+  @PrimaryKey()
+  id?: bigint;
 
   @Property()
   name!: string;
@@ -18,8 +18,8 @@ class Author {
 @Entity()
 class Book {
 
-  @PrimaryKey({ type: BigIntType })
-  id?: string;
+  @PrimaryKey()
+  id?: bigint;
 
   @Property()
   title!: string;
@@ -56,7 +56,7 @@ describe('GH issue 3051', () => {
 
     expect(jonSnow).not.toBeNull();
 
-    await expect(orm.em.findOneOrFail(Book, { author: jonSnow }, { strict: true })).rejects.toThrowError(`Wrong number of Book entities found for query { author: '${jonSnow.id}' }, expected exactly one`);
+    await expect(orm.em.findOneOrFail(Book, { author: jonSnow }, { strict: true })).rejects.toThrowError(`Wrong number of Book entities found for query { author: ${jonSnow.id}n }, expected exactly one`);
     await expect(orm.em.findOneOrFail(Book, { title: 'b4' })).rejects.toThrowError('Book not found ({ title: \'b4\' })');
     await expect(orm.em.findOneOrFail(Book, { author: jonSnow }, { strict: true, failHandler: () => new Error('Test') })).rejects.toThrowError('Test');
     await expect(orm.em.findOneOrFail(Book, { author: jonSnow }, { strict: true, failHandler: (entityName: string) => new Error(`Failed: ${entityName}`) })).rejects.toThrowError('Failed: Book');

--- a/tests/features/single-table-inheritance/GH2364.test.ts
+++ b/tests/features/single-table-inheritance/GH2364.test.ts
@@ -1,4 +1,4 @@
-import { BigIntType, Entity, Enum, Ref, ManyToOne, MikroORM, PrimaryKey, QueryOrder } from '@mikro-orm/core';
+import { Entity, Enum, Ref, ManyToOne, MikroORM, PrimaryKey, QueryOrder } from '@mikro-orm/core';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 
 export enum EntityType {
@@ -9,8 +9,8 @@ export enum EntityType {
 @Entity({ discriminatorColumn: 'type', abstract: true })
 abstract class BaseEntity {
 
-  @PrimaryKey({ type: BigIntType })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @ManyToOne(() => BaseEntity, { ref: true, nullable: true })
   parent?: Ref<BaseEntity>;

--- a/tests/features/virtual-entities/virtual-entities.postgres.test.ts
+++ b/tests/features/virtual-entities/virtual-entities.postgres.test.ts
@@ -249,13 +249,14 @@ describe('virtual entities (sqlite)', () => {
       'inner join "book2_tags" as "b1" on "b"."uuid_pk" = "b1"."book2_uuid_pk" ' +
       'inner join "book_tag2" as "t" on "b1"."book_tag2_id" = "t"."id" ' +
       'group by "b"."uuid_pk"';
-    expect(mock.mock.calls).toHaveLength(6);
-    expect(mock.mock.calls[0][0]).toMatch(`select count(*) as count from (${sql}) as "b0"`);
-    expect(mock.mock.calls[1][0]).toMatch(`select * from (${sql}) as "b0"`);
-    expect(mock.mock.calls[2][0]).toMatch(`select * from (${sql}) as "b0" order by "b0"."title" asc limit 2 offset 1`);
-    expect(mock.mock.calls[3][0]).toMatch(`select * from (${sql}) as "b0" order by "b0"."title" asc limit 2`);
-    expect(mock.mock.calls[4][0]).toMatch(`select * from (${sql}) as "b0" where "b0"."title" like 'My Life%' and "b0"."author_name" is not null order by "b0"."title" asc limit 2`);
-    expect(mock.mock.calls[5][0]).toMatch(`select * from (${sql}) as "b0" where "b0"."title" in ('My Life on the Wall, part 1/2', 'My Life on the Wall, part 1/3')`);
+    const queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toHaveLength(6);
+    expect(queries[0]).toMatch(`select * from (${sql}) as "b0"`);
+    expect(queries[1]).toMatch(`select * from (${sql}) as "b0" order by "b0"."title" asc limit 2`);
+    expect(queries[2]).toMatch(`select * from (${sql}) as "b0" order by "b0"."title" asc limit 2 offset 1`);
+    expect(queries[3]).toMatch(`select * from (${sql}) as "b0" where "b0"."title" in ('My Life on the Wall, part 1/2', 'My Life on the Wall, part 1/3')`);
+    expect(queries[4]).toMatch(`select * from (${sql}) as "b0" where "b0"."title" like 'My Life%' and "b0"."author_name" is not null order by "b0"."title" asc limit 2`);
+    expect(queries[5]).toMatch(`select count(*) as count from (${sql}) as "b0"`);
 
     expect(orm.em.getUnitOfWork().getIdentityMap().keys()).toHaveLength(0);
     expect(mock.mock.calls[0][0]).toMatch(sql);

--- a/tests/issues/GH1038.test.ts
+++ b/tests/issues/GH1038.test.ts
@@ -1,10 +1,10 @@
-import { BigIntType, Entity, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity({ abstract: true })
 abstract class BaseEntity {
 
-  @PrimaryKey({ type: BigIntType })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @Property({ onUpdate: () => new Date() })
   modifiedAt: Date = new Date();

--- a/tests/issues/GH1538.test.ts
+++ b/tests/issues/GH1538.test.ts
@@ -1,10 +1,10 @@
-import { BigIntType, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 export class Author {
 
-  @PrimaryKey({ type: BigIntType, comment: 'PK' })
-  id!: string;
+  @PrimaryKey({ comment: 'PK' })
+  id!: bigint;
 
   @Property({ nullable: true })
   name!: string;
@@ -22,8 +22,8 @@ export class Author {
 @Entity()
 export class Post {
 
-  @PrimaryKey({ type: BigIntType, comment: 'PK' })
-  id!: string;
+  @PrimaryKey({ comment: 'PK' })
+  id!: bigint;
 
   @Property({ nullable: true })
   title!: string;

--- a/tests/issues/GH1882.test.ts
+++ b/tests/issues/GH1882.test.ts
@@ -1,11 +1,11 @@
-import { BigIntType, Collection, Entity, ManyToOne, MikroORM, OneToMany, PopulateHint, PrimaryKey, Property } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PopulateHint, PrimaryKey, Property } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 @Entity()
 export class Foo {
 
-  @PrimaryKey({ type: BigIntType })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @OneToMany(() => Bar, bar => bar.foo)
   barItems = new Collection<Bar>(this);
@@ -18,8 +18,8 @@ export class Foo {
 @Entity()
 export class Bar {
 
-  @PrimaryKey({ type: BigIntType })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @ManyToOne(() => Foo)
   foo!: Foo;
@@ -45,11 +45,11 @@ describe('GH issue 1882', () => {
 
   test(`GH issue 1882-1`, async () => {
     const fooItem = new Foo();
-    fooItem.id = '1234';
+    fooItem.id = 1234n;
     fooItem.name = 'fooName';
 
     const barItem = new Bar();
-    barItem.id = '5678';
+    barItem.id = 5678n;
     barItem.name = 'barName1';
     barItem.foo = fooItem;
 
@@ -71,11 +71,11 @@ describe('GH issue 1882', () => {
 
   test(`GH issue 1882-2`, async () => {
     const fooItem = new Foo();
-    fooItem.id = '9012';
+    fooItem.id = 9012n;
     fooItem.name = 'fooName';
 
     const barItem = new Bar();
-    barItem.id = '3456';
+    barItem.id = 3456n;
     barItem.name = 'barName';
     barItem.foo = fooItem;
 

--- a/tests/issues/GH1968.test.ts
+++ b/tests/issues/GH1968.test.ts
@@ -1,10 +1,10 @@
-import { BigIntType, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 class Author {
 
-  @PrimaryKey({ type: BigIntType })
-  id?: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @Property()
   name!: string;
@@ -17,8 +17,8 @@ class Author {
 @Entity()
 class Book {
 
-  @PrimaryKey({ type: BigIntType })
-  id?: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @Property()
   name!: string;

--- a/tests/issues/GH2379.test.ts
+++ b/tests/issues/GH2379.test.ts
@@ -1,4 +1,4 @@
-import { BigIntType, Collection, Entity, Ref, ManyToOne, MikroORM, OneToMany, OptionalProps, PrimaryKey, Property } from '@mikro-orm/sqlite';
+import { Collection, Entity, Ref, ManyToOne, MikroORM, OneToMany, OptionalProps, PrimaryKey, Property } from '@mikro-orm/sqlite';
 import { performance } from 'perf_hooks';
 
 @Entity()
@@ -6,8 +6,8 @@ export class VendorBuyerRelationship {
 
   [OptionalProps]?: 'created';
 
-  @PrimaryKey({ type: BigIntType })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @Property({ onCreate: () => new Date() })
   created!: Date;
@@ -28,8 +28,8 @@ export class Member {
 
   [OptionalProps]?: 'created';
 
-  @PrimaryKey({ type: BigIntType })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @Property({ onCreate: () => new Date() })
   created!: Date;
@@ -53,8 +53,8 @@ export class Job {
 
   [OptionalProps]?: 'rejected';
 
-  @PrimaryKey({ type: BigIntType })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @ManyToOne(() => Member, { ref: true, nullable: true })
   member?: Ref<Member>;
@@ -87,8 +87,8 @@ export class Order {
 
   [OptionalProps]?: 'created';
 
-  @PrimaryKey({ type: BigIntType })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @Property({ onCreate: () => new Date() })
   created!: Date;

--- a/tests/issues/GH3739.test.ts
+++ b/tests/issues/GH3739.test.ts
@@ -49,11 +49,11 @@ test('bigint in mysql 1/3', async () => {
     name: 'foo',
   });
   await orm.em.flush();
-  expect(typeof a1.id).toBe('string');
+  expect(typeof a1.id).toBe('bigint');
   const a3 = await orm.em.fork().findOneOrFail(Asset1, a1);
-  expect(typeof a3.id).toBe('string');
+  expect(typeof a3.id).toBe('bigint');
   const a4 = await orm.em.fork().findOneOrFail(Asset1, a2);
-  expect(typeof a4.id).toBe('string');
+  expect(typeof a4.id).toBe('bigint');
 
   await orm.close(true);
 });
@@ -70,9 +70,9 @@ test('bigint in mysql 2/3', async () => {
     name: 'foo',
   });
   await orm.em.flush();
-  expect(typeof a1.id).toBe('string');
+  expect(typeof a1.id).toBe('bigint');
   const a2 = await orm.em.fork().findOneOrFail(Asset2, a1);
-  expect(typeof a2.id).toBe('string');
+  expect(typeof a2.id).toBe('bigint');
 
   await orm.close(true);
 });
@@ -89,9 +89,9 @@ test('bigint in mysql 3/3', async () => {
     name: 'foo',
   });
   await orm.em.flush();
-  expect(typeof a1.id).toBe('string');
+  expect(typeof a1.id).toBe('bigint');
   const a2 = await orm.em.fork().findOneOrFail(Asset3, a1);
-  expect(typeof a2.id).toBe('string');
+  expect(typeof a2.id).toBe('bigint');
 
   await orm.close(true);
 });

--- a/tests/issues/GH4227.test.ts
+++ b/tests/issues/GH4227.test.ts
@@ -4,8 +4,8 @@ import { MikroORM } from '@mikro-orm/postgresql';
 @Entity()
 class BidEntity {
 
-  @PrimaryKey({ type: BigIntType })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @ManyToOne('ItemEntity', {
     serializer: value => value.id,
@@ -18,8 +18,8 @@ class BidEntity {
 @Entity()
 class ItemEntity {
 
-  @PrimaryKey({ type: BigIntType })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @OneToMany('BidEntity', 'item', {
     orphanRemoval: true,

--- a/tests/issues/GH482.test.ts
+++ b/tests/issues/GH482.test.ts
@@ -14,11 +14,11 @@ export enum NumLevelType {
 @Entity()
 class Job {
 
-  @PrimaryKey({ type: BigIntType })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @Property({ type: BigIntType, nullable: true })
-  optional?: string | null; // GH issue 631
+  optional?: bigint | null; // GH issue 631
 
   @OneToMany('Level', 'job', { orphanRemoval: true })
   levels = new Collection<Level>(this);
@@ -62,7 +62,7 @@ describe('GH issue 482', () => {
 
   test(`orphan removal with composite keys`, async () => {
     const job = new Job();
-    job.id = '1';
+    job.id = 1n;
     job.levels.add(new Level(LevelType.A));
     job.levels.add(new Level(LevelType.B));
     await orm.em.persistAndFlush(job);
@@ -84,13 +84,13 @@ describe('GH issue 482', () => {
     orm.config.set('debug', ['query', 'query-params']);
 
     const job = new Job();
-    job.id = '2';
+    job.id = 2n;
     orm.em.persist(job);
-    job.optional = '1';
+    job.optional = 1n;
     await orm.em.flush();
     job.optional = null;
     await orm.em.flush();
-    job.optional = '1';
+    job.optional = 1n;
     await orm.em.flush();
     job.optional = undefined;
     await orm.em.flush();
@@ -115,7 +115,7 @@ describe('GH issue 482', () => {
   test(`GH issue 476 - enum arrays`, async () => {
     const a = new Level(LevelType.A);
     a.job = new Job();
-    a.job.id = '3';
+    a.job.id = 3n;
     await orm.em.persistAndFlush(a);
     expect(a.types).toEqual([LevelType.A]);
     expect(a.numTypes).toEqual([NumLevelType.A]);

--- a/tests/issues/GH940.test.ts
+++ b/tests/issues/GH940.test.ts
@@ -1,11 +1,11 @@
-import { BigIntType, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
 @Entity()
 class User {
 
-  @PrimaryKey({ type: BigIntType })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @OneToMany('UserOrganization', 'user')
   organizations = new Collection<UserOrganization>(this);
@@ -15,8 +15,8 @@ class User {
 @Entity()
 class UserOrganization {
 
-  @PrimaryKey({ type: BigIntType })
-  id!: string;
+  @PrimaryKey()
+  id!: bigint;
 
   @ManyToOne(() => User, { nullable: true })
   user?: User;

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -30,7 +30,7 @@ describe('check typings', () => {
     assert<IsExact<Primary<Author>, number>>(false);
 
     // bigint support
-    assert<IsExact<Primary<BookTag2>, string>>(true);
+    assert<IsExact<Primary<BookTag2>, bigint>>(true);
     assert<IsExact<Primary<BookTag2>, number>>(false);
   });
 
@@ -248,7 +248,10 @@ describe('check typings', () => {
     assert<IsAssignable<FilterQuery<Book2>, { author: { favouriteBook: { tags: string[] } } }>>(true);
     assert<IsAssignable<FilterQuery<Book2>, { tags: string[] }>>(true);
     assert<IsAssignable<FilterQuery<Book2>, { tags: string }>>(true);
-    assert<IsAssignable<FilterQuery<Author2>, { books: { tags: bigint[] } }>>(false);
+    assert<IsAssignable<FilterQuery<Author2>, { books: { tags: number[] } }>>(true);
+    assert<IsAssignable<FilterQuery<Author2>, { books: { tags: bigint[] } }>>(true);
+    assert<IsAssignable<FilterQuery<Author2>, { books: { tags: string[] } }>>(true);
+    assert<IsAssignable<FilterQuery<Author2>, { books: { tags: boolean[] } }>>(false);
   });
 
   test('assignment to naked relation, generic reference and identified reference', async () => {
@@ -428,6 +431,8 @@ describe('check typings', () => {
     ok01 = { books: { author: { born: '2020-01-01' } }, favouriteBook: {} as Book2 };
     ok01 = { books: { tags: { name: 'asd' } } };
     ok01 = { books: { tags: '1' } };
+    ok01 = { books: { tags: 1 } };
+    ok01 = { books: { tags: 1n } };
     ok01 = { books: { tags: { books: { title: 'asd' } } } };
     ok01 = { name: 'asd' };
     ok01 = { $or: [{ name: 'asd' }, { age: 18 }] };


### PR DESCRIPTION
The default mapping of `bigint` columns is now using the native JavaScript `BigInt`, and is configurable, so it can also map to numbers or strings:

```ts
@PrimaryKey()
id0: bigint; // type is inferred

@PrimaryKey({ type: new BigIntType('bigint') })
id1: bigint; // same as `id0`

@PrimaryKey({ type: new BigIntType('string') })
id2: string;

@PrimaryKey({ type: new BigIntType('number') })
id3: number;
```