### PR TITLE
fix(core): ensure propagation and change-tracking works with `useDefineForClassFields`

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -236,25 +236,6 @@ MikroORM.init({
 });
 ```
 
-## Propagation of 1:1 and m:1 owners
-
-MikroORM defines getter and setter for every owning side of m:1 and 1:1 relation. This is then used for propagation of changes to the inverse side of bi-directional relations.
-
-```ts
-const author = new Author('n', 'e');
-const book = new Book('t');
-book.author = author;
-console.log(author.books.contains(book)); // true
-```
-
-You can disable this behaviour via `propagateToOneOwner` option.
-
-```ts
-MikroORM.init({
-  propagateToOneOwner: false,
-});
-```
-
 ## Forcing UTC Timezone
 
 Use `forceUtcTimezone` option to force the `Date`s to be saved in UTC in datetime columns without timezone. It works for MySQL (`datetime` type) and PostgreSQL (`timestamp` type). SQLite does this by default.

--- a/docs/docs/propagation.md
+++ b/docs/docs/propagation.md
@@ -2,7 +2,7 @@
 title: Propagation
 ---
 
-By default, MikroORM will propagate all changes made to one side of bi-directional relations to the other side, keeping them in sync. This works for all relations, including M:1 and 1:1. As part of the discovery process, all M:1 and 1:1 properties are re-defined as getter/setter.
+By default, MikroORM will propagate all changes made to one side of bidirectional relations to the other side, keeping them in sync. This works for all relations, including M:1 and 1:1. As part of the discovery process, all M:1 and 1:1 properties are re-defined as getter/setter.
 
 ```ts
 const author = new Author(...);
@@ -11,7 +11,11 @@ book.author = author;
 console.log(author.books.contains(book)); // true
 ```
 
-> You can disable this behaviour via `propagateToOneOwner` option.
+:::caution Warning
+
+Propagation on new entities you create via constructor is supported too, by modifying the entity class prototype, but this technique fails when `useDefineForClassFields` TypeScript compiler flag is enabled (which is true when targeting `ES2022` or higher). You can get around this by using `declare` keyword in your entity definition, or by creating entity instances via `em.create()`, which will ensure the propagation is enabled.
+
+:::
 
 ## Propagation of Collection's add() and remove() operations
 

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -76,6 +76,7 @@ import type { Transaction } from './connections';
 import { EventManager, type FlushEventArgs, TransactionEventBroadcaster } from './events';
 import type { EntityComparator } from './utils/EntityComparator';
 import { OptimisticLockError, ValidationError } from './errors';
+import type { CacheAdapter } from './cache/CacheAdapter';
 
 /**
  * The EntityManager is the central access point to ORM functionality. It is a facade to all different ORM subsystems
@@ -87,18 +88,18 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   private static counter = 1;
   readonly _id = EntityManager.counter++;
   readonly global = false;
-  readonly name = this.config.get('contextName');
-  private readonly validator = new EntityValidator(this.config.get('strict'));
+  readonly name: string;
+  private readonly validator: EntityValidator;
   private readonly repositoryMap: Dictionary<EntityRepository<any>> = {};
-  private readonly entityLoader: EntityLoader = new EntityLoader(this);
-  private readonly comparator = this.config.getComparator(this.metadata);
-  private readonly entityFactory: EntityFactory = new EntityFactory(this);
-  private readonly unitOfWork: UnitOfWork = new UnitOfWork(this);
-  private readonly resultCache = this.config.getResultCacheAdapter();
+  private readonly entityLoader: EntityLoader;
+  protected readonly comparator: EntityComparator;
+  private readonly entityFactory: EntityFactory;
+  private readonly unitOfWork: UnitOfWork;
+  private readonly resultCache: CacheAdapter;
   private filters: Dictionary<FilterDef> = {};
   private filterParams: Dictionary<Dictionary> = {};
   private transactionContext?: Transaction;
-  private disableTransactions = this.config.get('disableTransactions');
+  private disableTransactions: boolean;
   private flushMode?: FlushMode;
 
   /**
@@ -108,7 +109,16 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
               protected readonly driver: D,
               protected readonly metadata: MetadataStorage,
               protected readonly useContext = true,
-              protected readonly eventManager = new EventManager(config.get('subscribers'))) { }
+              protected readonly eventManager = new EventManager(config.get('subscribers'))) {
+    this.entityLoader = new EntityLoader(this);
+    this.name = this.config.get('contextName');
+    this.validator = new EntityValidator(this.config.get('strict'));
+    this.comparator = this.config.getComparator(this.metadata);
+    this.resultCache = this.config.getResultCacheAdapter();
+    this.disableTransactions = this.config.get('disableTransactions');
+    this.entityFactory = new EntityFactory(this);
+    this.unitOfWork = new UnitOfWork(this);
+  }
 
   /**
    * Gets the Driver instance used by this EntityManager.

--- a/packages/core/src/connections/Connection.ts
+++ b/packages/core/src/connections/Connection.ts
@@ -1,6 +1,6 @@
 import { URL } from 'url';
 import type { Configuration, ConnectionOptions, DynamicPassword } from '../utils';
-import type { LogContext } from '../logging';
+import type { LogContext, Logger } from '../logging';
 import type { MetadataStorage } from '../metadata';
 import type { ConnectionType, Dictionary, MaybePromise, Primary } from '../typings';
 import type { Platform } from '../platforms/Platform';
@@ -12,12 +12,14 @@ export abstract class Connection {
   protected metadata!: MetadataStorage;
   protected platform!: Platform;
   protected readonly options: ConnectionOptions;
-  protected readonly logger = this.config.getLogger();
+  protected readonly logger: Logger;
   protected connected = false;
 
   constructor(protected readonly config: Configuration,
               options?: ConnectionOptions,
               protected readonly type: ConnectionType = 'write') {
+    this.logger = this.config.getLogger();
+
     if (options) {
       this.options = options;
     } else {

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -34,6 +34,7 @@ import { EntityManager } from '../EntityManager';
 import { ValidationError } from '../errors';
 import { DriverException } from '../exceptions';
 import { helper } from '../entity/wrap';
+import type { Logger } from '../logging/Logger';
 
 export abstract class DatabaseDriver<C extends Connection> implements IDatabaseDriver<C> {
 
@@ -42,12 +43,14 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
   protected readonly connection!: C;
   protected readonly replicas: C[] = [];
   protected readonly platform!: Platform;
-  protected readonly logger = this.config.getLogger();
+  protected readonly logger: Logger;
   protected comparator!: EntityComparator;
   protected metadata!: MetadataStorage;
 
   protected constructor(readonly config: Configuration,
-                        protected readonly dependencies: string[]) { }
+                        protected readonly dependencies: string[]) {
+    this.logger = this.config.getLogger();
+  }
 
   async init(): Promise<void> {
     // do nothing on this level

--- a/packages/core/src/entity/ArrayCollection.ts
+++ b/packages/core/src/entity/ArrayCollection.ts
@@ -432,7 +432,7 @@ export class ArrayCollection<T extends object, O extends object> {
 
   [inspect.custom](depth: number) {
     const object = { ...this } as Dictionary;
-    const hidden = ['items', 'owner', '_property', '_count', 'snapshot', '_populated', '_lazyInitialized'];
+    const hidden = ['items', 'owner', '_property', '_count', 'snapshot', '_populated', '_lazyInitialized', '_em', 'readonly'];
     hidden.forEach(k => delete object[k]);
     const ret = inspect(object, { depth });
     const name = `${this.constructor.name}<${this.property?.type ?? 'unknown'}>`;

--- a/packages/core/src/entity/EntityHelper.ts
+++ b/packages/core/src/entity/EntityHelper.ts
@@ -1,7 +1,20 @@
 import { inspect } from 'util';
 
 import type { EntityManager } from '../EntityManager';
-import { EntityRepositoryType, OptionalProps, PrimaryKeyProp, type AnyEntity, type Dictionary, type EntityMetadata, type EntityProperty, type IHydrator, type EntityValue } from '../typings';
+import {
+  EntityRepositoryType,
+  OptionalProps,
+  PrimaryKeyProp,
+  EagerProps,
+  HiddenProps,
+  type AnyEntity,
+  type Dictionary,
+  type EntityMetadata,
+  type EntityProperty,
+  type IHydrator,
+  type EntityValue,
+  type EntityKey,
+} from '../typings';
 import { EntityTransformer } from '../serialization/EntityTransformer';
 import { Reference } from './Reference';
 import { Utils } from '../utils/Utils';
@@ -9,6 +22,9 @@ import { WrappedEntity } from './WrappedEntity';
 import { ReferenceKind } from '../enums';
 import { helper } from './wrap';
 
+/**
+ * @internal
+ */
 export class EntityHelper {
 
   static decorate<T extends object>(meta: EntityMetadata<T>, em: EntityManager): void {
@@ -27,8 +43,9 @@ export class EntityHelper {
     }
 
     EntityHelper.defineBaseProperties(meta, meta.prototype, fork);
+    EntityHelper.defineCustomInspect(meta);
 
-    if (!meta.embeddable && !meta.virtual) {
+    if (em.config.get('propagationOnPrototype') && !meta.embeddable && !meta.virtual) {
       EntityHelper.defineProperties(meta, fork);
     }
 
@@ -116,12 +133,17 @@ export class EntityHelper {
           },
         });
       });
+  }
 
+  static defineCustomInspect<T extends object>(meta: EntityMetadata<T>): void {
     // @ts-ignore
     meta.prototype[inspect.custom] ??= function (this: T, depth: number) {
       const object = { ...this } as any;
       // ensure we dont have internal symbols in the POJO
-      [OptionalProps, EntityRepositoryType, PrimaryKeyProp].forEach(sym => delete object[sym]);
+      [OptionalProps, EntityRepositoryType, PrimaryKeyProp, EagerProps, HiddenProps].forEach(sym => delete object[sym]);
+      meta.props
+        .filter(prop => object[prop.name] === undefined)
+        .forEach(prop => delete object[prop.name]);
       const ret = inspect(object, { depth });
       let name = (this).constructor.name;
 
@@ -223,6 +245,49 @@ export class EntityHelper {
     if (old?.[prop2.name] != null) {
       delete helper(old).__data[prop2.name];
     }
+  }
+
+  static ensurePropagation<T>(entity: T) {
+    if ((entity as Dictionary).__gettersDefined) {
+      return;
+    }
+
+    const wrapped = helper(entity);
+    const meta = wrapped.__meta;
+    const platform = wrapped.__platform;
+    const serializedPrimaryKey = meta.props.find(p => p.serializedPrimaryKey);
+
+    const values: [string, unknown][] = [];
+
+    if (serializedPrimaryKey) {
+      const pk = meta.getPrimaryProps()[0];
+      const val = entity[serializedPrimaryKey.name];
+      delete entity[serializedPrimaryKey.name];
+      Object.defineProperty(entity, serializedPrimaryKey.name, {
+        get(): string | null {
+          return this[pk.name] ? platform.normalizePrimaryKey<string>(this[pk.name]) : null;
+        },
+        set(id: string): void {
+          this[pk.name] = id ? platform.denormalizePrimaryKey(id) : null;
+        },
+      });
+
+      if (entity[pk.name] == null && val != null) {
+        values.push([serializedPrimaryKey.name, val]);
+      }
+    }
+
+    meta.trackingProps.forEach(prop => {
+      if (entity[prop.name] !== undefined) {
+        values.push([prop.name, entity[prop.name]]);
+      }
+    });
+
+    meta.trackingProps.forEach(prop => {
+      delete entity[prop.name];
+    });
+    Object.defineProperties(entity, meta.definedProperties);
+    values.forEach(val => entity[val[0] as EntityKey<T>] = val[1] as EntityValue<T>);
   }
 
 }

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -15,9 +15,9 @@ import { QueryHelper } from '../utils/QueryHelper';
 import { Utils } from '../utils/Utils';
 import { ValidationError } from '../errors';
 import type { Collection } from './Collection';
-import { LoadStrategy, QueryOrder, ReferenceKind, type LockMode, type PopulateHint, type QueryOrderMap } from '../enums';
+import { LoadStrategy, ReferenceKind, type LockMode, type PopulateHint, type QueryOrderMap } from '../enums';
 import { Reference, type ScalarReference } from './Reference';
-import type { EntityField, FindOptions } from '../drivers/IDatabaseDriver';
+import type { EntityField, FindOptions, IDatabaseDriver } from '../drivers/IDatabaseDriver';
 import type { MetadataStorage } from '../metadata/MetadataStorage';
 import type { Platform } from '../platforms/Platform';
 import { helper } from './wrap';
@@ -43,10 +43,13 @@ export type EntityLoaderOptions<Entity, Hint extends string = never, Fields exte
 
 export class EntityLoader {
 
-  private readonly metadata = this.em.getMetadata();
-  private readonly driver = this.em.getDriver();
+  private readonly metadata: MetadataStorage;
+  private readonly driver: IDatabaseDriver;
 
-  constructor(private readonly em: EntityManager) { }
+  constructor(private readonly em: EntityManager) {
+    this.metadata = this.em.getMetadata();
+    this.driver = this.em.getDriver();
+  }
 
   /**
    * Loads specified relations in batch. This will execute one query for each relation, that will populate it on all of the specified entities.

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -35,35 +35,55 @@ import { EntitySerializer, type SerializeOptions } from '../serialization/Entity
 
 export class WrappedEntity<Entity extends object> {
 
-  __initialized = true;
-  __touched = false;
-  __populated?: boolean;
-  __managed?: boolean;
-  __onLoadFired?: boolean;
-  __schema?: string;
-  __em?: EntityManager;
-  __serializationContext: { root?: SerializationContext<Entity>; populate?: PopulateOptions<Entity>[]; fields?: string[] } = {};
-  __loadedProperties = new Set<string>();
-  __data: Dictionary = {};
-  __processing = false;
+  declare __initialized: boolean;
+  declare __touched: boolean;
+  declare __populated?: boolean;
+  declare __managed?: boolean;
+  declare __onLoadFired?: boolean;
+  declare __schema?: string;
+  declare __em?: EntityManager;
+  declare __serializationContext: { root?: SerializationContext<Entity>; populate?: PopulateOptions<Entity>[]; fields?: string[] };
+  declare __loadedProperties: Set<string>;
+  declare __data: Dictionary;
+  declare __processing: boolean;
 
   /** stores last known primary key, as its current state might be broken due to propagation/orphan removal, but we need to know the PK to be able t remove the entity */
-  __pk?: Primary<Entity>;
+  declare __pk?: Primary<Entity>;
 
   /** holds the reference wrapper instance (if created), so we can maintain the identity on reference wrappers too */
-  __reference?: Reference<Entity>;
+  declare __reference?: Reference<Entity>;
 
   /** holds last entity data snapshot, so we can compute changes when persisting managed entities */
-  __originalEntityData?: EntityData<Entity>;
+  declare __originalEntityData?: EntityData<Entity>;
 
   /** holds wrapped primary key, so we can compute change set without eager commit */
-  __identifier?: EntityIdentifier;
+  declare __identifier?: EntityIdentifier;
 
-  constructor(private readonly entity: Entity,
-              private readonly hydrator: IHydrator,
-              private readonly pkGetter?: (e: Entity) => Primary<Entity>,
-              private readonly pkSerializer?: (e: Entity) => string,
-              private readonly pkGetterConverted?: (e: Entity) => Primary<Entity>) { }
+  declare private readonly entity: Entity;
+  declare private readonly hydrator: IHydrator;
+  declare private readonly pkGetter?: (e: Entity) => Primary<Entity>;
+  declare private readonly pkSerializer?: (e: Entity) => string;
+  declare private readonly pkGetterConverted?: (e: Entity) => Primary<Entity>;
+
+  constructor(
+    entity: Entity,
+    hydrator: IHydrator,
+    pkGetter?: (e: Entity) => Primary<Entity>,
+    pkSerializer?: (e: Entity) => string,
+    pkGetterConverted?: (e: Entity) => Primary<Entity>,
+  ) {
+    this.entity = entity;
+    this.hydrator = hydrator;
+    this.pkGetter = pkGetter;
+    this.pkSerializer = pkSerializer;
+    this.pkGetterConverted = pkGetterConverted;
+    this.__initialized = true;
+    this.__touched = false;
+    this.__serializationContext = {};
+    this.__loadedProperties = new Set<string>();
+    this.__data = {};
+    this.__processing = false;
+  }
 
   isInitialized(): boolean {
     return this.__initialized;

--- a/packages/core/src/events/TransactionEventBroadcaster.ts
+++ b/packages/core/src/events/TransactionEventBroadcaster.ts
@@ -2,13 +2,16 @@ import type { Transaction } from '../connections';
 import type { EntityManager } from '../EntityManager';
 import type { TransactionEventType } from '../enums';
 import type { UnitOfWork } from '../unit-of-work';
+import type { EventManager } from './EventManager';
 
 export class TransactionEventBroadcaster {
 
-  private readonly eventManager = this.em.getEventManager();
+  private readonly eventManager: EventManager;
 
   constructor(private readonly em: EntityManager,
-              private readonly uow?: UnitOfWork) {}
+              private readonly uow?: UnitOfWork) {
+    this.eventManager = this.em.getEventManager();
+  }
 
   async dispatchEvent(event: TransactionEventType, transaction?: Transaction) {
     await this.eventManager.dispatchEvent(event, { em: this.em, transaction, uow: this.uow });

--- a/packages/core/src/logging/DefaultLogger.ts
+++ b/packages/core/src/logging/DefaultLogger.ts
@@ -1,14 +1,20 @@
 import type { Logger, LoggerNamespace, LogContext, LoggerOptions } from './Logger';
 import { colors } from './colors';
+import type { Highlighter } from '../typings';
 
 export class DefaultLogger implements Logger {
 
-  public debugMode = this.options.debugMode ?? false;
-  readonly writer = this.options.writer;
-  private readonly usesReplicas = this.options.usesReplicas;
-  private readonly highlighter = this.options.highlighter;
+  debugMode: boolean | LoggerNamespace[];
+  readonly writer: (message: string) => void;
+  private readonly usesReplicas?: boolean;
+  private readonly highlighter?: Highlighter;
 
-  constructor(private readonly options: LoggerOptions) {}
+  constructor(private readonly options: LoggerOptions) {
+    this.debugMode = this.options.debugMode ?? false;
+    this.writer = this.options.writer;
+    this.usesReplicas = this.options.usesReplicas;
+    this.highlighter = this.options.highlighter;
+  }
 
   /**
    * @inheritDoc

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -5,6 +5,9 @@ import { EntityMetadata, type AnyEntity, type Constructor, type Dictionary, type
 import { Utils } from '../utils/Utils';
 import type { Configuration } from '../utils/Configuration';
 import { MetadataValidator } from './MetadataValidator';
+import type { MetadataProvider } from './MetadataProvider';
+import type { NamingStrategy } from '../naming-strategy/NamingStrategy';
+import type { SyncCacheAdapter } from '../cache/CacheAdapter';
 import { MetadataStorage } from './MetadataStorage';
 import { EntitySchema } from './EntitySchema';
 import { Cascade, ReferenceKind, type EventType } from '../enums';
@@ -13,20 +16,27 @@ import type { Platform } from '../platforms';
 import { ArrayType, BigIntType, BlobType, EnumArrayType, JsonType, t, Type, Uint8ArrayType } from '../types';
 import { colors } from '../logging/colors';
 import { raw } from '../utils/RawQueryFragment';
+import type { Logger } from '../logging/Logger';
 
 export class MetadataDiscovery {
 
-  private readonly namingStrategy = this.config.getNamingStrategy();
-  private readonly metadataProvider = this.config.getMetadataProvider();
-  private readonly cache = this.config.getMetadataCacheAdapter();
-  private readonly logger = this.config.getLogger();
-  private readonly schemaHelper = this.platform.getSchemaHelper();
+  private readonly namingStrategy: NamingStrategy;
+  private readonly metadataProvider: MetadataProvider;
+  private readonly cache: SyncCacheAdapter;
+  private readonly logger: Logger;
+  private readonly schemaHelper: unknown;
   private readonly validator = new MetadataValidator();
   private readonly discovered: EntityMetadata[] = [];
 
   constructor(private readonly metadata: MetadataStorage,
               private readonly platform: Platform,
-              private readonly config: Configuration) { }
+              private readonly config: Configuration) {
+    this.namingStrategy = this.config.getNamingStrategy();
+    this.metadataProvider = this.config.getMetadataProvider();
+    this.cache = this.config.getMetadataCacheAdapter();
+    this.logger = this.config.getLogger();
+    this.schemaHelper = this.platform.getSchemaHelper();
+  }
 
   async discover(preferTsNode = true): Promise<MetadataStorage> {
     const startTime = Date.now();

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -410,14 +410,18 @@ export class EntityMetadata<T = any> {
     this.relations = this.props.filter(prop => prop.kind !== ReferenceKind.SCALAR && prop.kind !== ReferenceKind.EMBEDDED);
     this.bidirectionalRelations = this.relations.filter(prop => prop.mappedBy || prop.inversedBy);
     this.uniqueProps = this.props.filter(prop => prop.unique);
-    this.comparableProps = this.props.filter(prop => EntityComparator.isComparable(prop, this.root));
+    this.comparableProps = this.props.filter(prop => EntityComparator.isComparable(prop, this));
     this.hydrateProps = this.props.filter(prop => {
       // `prop.userDefined` is either `undefined` or `false`
       const discriminator = this.root.discriminatorColumn === prop.name && prop.userDefined === false;
       // even if we don't have a setter, do not ignore value from database!
-      const onlyGetter = prop.getter && !prop.setter && prop.persist === false;
+      const onlyGetter = prop.getter && !prop.setter;
       return !prop.inherited && prop.hydrate !== false && !discriminator && !prop.embedded && !onlyGetter;
     });
+    this.trackingProps = this.hydrateProps
+      .filter(prop => !prop.getter && !prop.setter)
+      .filter(prop => ![ReferenceKind.ONE_TO_MANY, ReferenceKind.MANY_TO_MANY].includes(prop.kind))
+      .filter(prop => !prop.serializedPrimaryKey);
     this.selfReferencing = this.relations.some(prop => [this.className, this.root.className].includes(prop.type));
     this.hasUniqueProps = this.uniques.length + this.uniqueProps.length > 0;
     this.virtual = !!this.expression;
@@ -430,7 +434,7 @@ export class EntityMetadata<T = any> {
       this.props.forEach(prop => this.initIndexes(prop));
     }
 
-    this.definedProperties = this.props.reduce((o, prop) => {
+    this.definedProperties = this.trackingProps.reduce((o, prop) => {
       const isCollection = [ReferenceKind.ONE_TO_MANY, ReferenceKind.MANY_TO_MANY].includes(prop.kind);
       const isReference = [ReferenceKind.ONE_TO_ONE, ReferenceKind.MANY_TO_ONE].includes(prop.kind) && (prop.inversedBy || prop.mappedBy) && !prop.mapToPk;
 
@@ -558,6 +562,7 @@ export interface EntityMetadata<T = any> {
   relations: EntityProperty<T>[];
   bidirectionalRelations: EntityProperty<T>[];
   comparableProps: EntityProperty<T>[]; // for EntityComparator
+  trackingProps: EntityProperty<T>[]; // for change-tracking and propagation
   hydrateProps: EntityProperty<T>[]; // for Hydrator
   uniqueProps: EntityProperty<T>[];
   indexes: { properties: (EntityKey<T>) | (EntityKey<T>)[]; name?: string; type?: string; options?: Dictionary; expression?: string }[];

--- a/packages/core/src/unit-of-work/ChangeSetComputer.ts
+++ b/packages/core/src/unit-of-work/ChangeSetComputer.ts
@@ -1,4 +1,4 @@
-import { Utils, type Configuration } from '../utils';
+import { Utils, type Configuration, type EntityComparator } from '../utils';
 import type { MetadataStorage } from '../metadata';
 import type { AnyEntity, EntityData, EntityKey, EntityProperty, EntityValue } from '../typings';
 import { ChangeSet, ChangeSetType } from './ChangeSet';
@@ -8,13 +8,15 @@ import { ReferenceKind } from '../enums';
 
 export class ChangeSetComputer {
 
-  private readonly comparator = this.config.getComparator(this.metadata);
+  private readonly comparator: EntityComparator;
 
   constructor(private readonly validator: EntityValidator,
               private readonly collectionUpdates: Set<Collection<AnyEntity>>,
               private readonly metadata: MetadataStorage,
               private readonly platform: Platform,
-              private readonly config: Configuration) { }
+              private readonly config: Configuration) {
+    this.comparator = this.config.getComparator(this.metadata);
+  }
 
   computeChangeSet<T extends object>(entity: T): ChangeSet<T> | null {
     const meta = this.metadata.get((entity as AnyEntity).constructor.name);

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -3,22 +3,26 @@ import type { AnyEntity, Dictionary, EntityData, EntityDictionary, EntityMetadat
 import { EntityIdentifier, helper, type EntityFactory, type EntityValidator, type Collection } from '../entity';
 import { ChangeSetType, type ChangeSet } from './ChangeSet';
 import type { QueryResult } from '../connections';
-import { Utils, type Configuration } from '../utils';
+import { Utils, type Configuration, type EntityComparator } from '../utils';
 import type { DriverMethodOptions, IDatabaseDriver } from '../drivers';
 import { OptimisticLockError } from '../errors';
 import { ReferenceKind } from '../enums';
+import type { Platform } from '../platforms/Platform';
 
 export class ChangeSetPersister {
 
-  private readonly platform = this.driver.getPlatform();
-  private readonly comparator = this.config.getComparator(this.metadata);
+  private readonly platform: Platform;
+  private readonly comparator: EntityComparator;
 
   constructor(private readonly driver: IDatabaseDriver,
               private readonly metadata: MetadataStorage,
               private readonly hydrator: IHydrator,
               private readonly factory: EntityFactory,
               private readonly validator: EntityValidator,
-              private readonly config: Configuration) { }
+              private readonly config: Configuration) {
+    this.platform = this.driver.getPlatform();
+    this.comparator = this.config.getComparator(this.metadata);
+  }
 
   async executeInserts<T extends object>(changeSets: ChangeSet<T>[], options?: DriverMethodOptions, withSchema?: boolean): Promise<void> {
     if (!withSchema) {

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -10,7 +10,7 @@ import type {
   IPrimaryKeyValue,
   Primary,
 } from '../typings';
-import { Collection, EntityIdentifier, helper, Reference } from '../entity';
+import { Collection, EntityHelper, EntityIdentifier, helper, Reference } from '../entity';
 import { ChangeSet, ChangeSetType } from './ChangeSet';
 import { ChangeSetComputer } from './ChangeSetComputer';
 import { ChangeSetPersister } from './ChangeSetPersister';
@@ -20,9 +20,10 @@ import type { EntityManager } from '../EntityManager';
 import { Cascade, EventType, LockMode, ReferenceKind } from '../enums';
 import { OptimisticLockError, ValidationError } from '../errors';
 import type { Transaction } from '../connections';
-import { TransactionEventBroadcaster } from '../events';
+import { type EventManager, TransactionEventBroadcaster } from '../events';
 import { IdentityMap } from './IdentityMap';
 import type { LockOptions } from '../drivers/IDatabaseDriver';
+import type { EntityComparator, MetadataStorage, Platform } from '@mikro-orm/core';
 
 // to deal with validation for flush inside flush hooks and `Promise.all`
 const insideFlush = new AsyncLocalStorage<boolean>();
@@ -38,19 +39,25 @@ export class UnitOfWork {
   private readonly changeSets = new Map<AnyEntity, ChangeSet<any>>();
   private readonly collectionUpdates = new Set<Collection<AnyEntity>>();
   private readonly extraUpdates = new Set<[AnyEntity, string | string[], AnyEntity | AnyEntity[] | Reference<any> | Collection<any>, ChangeSet<any> | undefined]>();
-  private readonly metadata = this.em.getMetadata();
-  private readonly platform = this.em.getPlatform();
-  private readonly eventManager = this.em.getEventManager();
-  private readonly comparator = this.em.getComparator();
-  private readonly changeSetComputer = new ChangeSetComputer(this.em.getValidator(), this.collectionUpdates, this.metadata, this.platform, this.em.config);
-  private readonly changeSetPersister = new ChangeSetPersister(this.em.getDriver(), this.metadata, this.em.config.getHydrator(this.metadata), this.em.getEntityFactory(), this.em.getValidator(), this.em.config);
+  private readonly metadata: MetadataStorage;
+  private readonly platform: Platform;
+  private readonly eventManager: EventManager;
+  private readonly comparator: EntityComparator;
+  private readonly changeSetComputer: ChangeSetComputer;
+  private readonly changeSetPersister: ChangeSetPersister;
   private readonly queuedActions = new Set<string>();
   private readonly loadedEntities = new Set<AnyEntity>();
   private readonly flushQueue: (() => Promise<void>)[] = [];
   private working = false;
-  private insideHooks = false;
 
-  constructor(private readonly em: EntityManager) { }
+  constructor(private readonly em: EntityManager) {
+    this.metadata = this.em.getMetadata();
+    this.platform = this.em.getPlatform();
+    this.eventManager = this.em.getEventManager();
+    this.comparator = this.em.getComparator();
+    this.changeSetComputer = new ChangeSetComputer(this.em.getValidator(), this.collectionUpdates, this.metadata, this.platform, this.em.config);
+    this.changeSetPersister = new ChangeSetPersister(this.em.getDriver(), this.metadata, this.em.config.getHydrator(this.metadata), this.em.getEntityFactory(), this.em.getValidator(), this.em.config);
+  }
 
   merge<T extends object>(entity: T, visited?: Set<AnyEntity>): void {
     const wrapped = helper(entity);
@@ -83,6 +90,7 @@ export class UnitOfWork {
    */
   registerManaged<T extends object>(entity: T, data?: EntityData<T>, options?: RegisterManagedOptions): T {
     this.identityMap.store(entity);
+    EntityHelper.ensurePropagation(entity);
 
     if (options?.newEntity) {
       return entity;
@@ -282,6 +290,8 @@ export class UnitOfWork {
   }
 
   persist<T extends object>(entity: T, visited?: Set<AnyEntity>, options: { checkRemoveStack?: boolean; cascade?: boolean } = {}): void {
+    EntityHelper.ensurePropagation(entity);
+
     if (options.checkRemoveStack && this.removeStack.has(entity)) {
       return;
     }
@@ -690,11 +700,8 @@ export class UnitOfWork {
       return;
     }
 
-    this.insideHooks = true;
-
     if (!sync) {
       await this.eventManager.dispatchEvent(type, { entity: changeSet.entity, meta, em: this.em, changeSet });
-      this.insideHooks = false;
       return;
     }
 
@@ -708,8 +715,6 @@ export class UnitOfWork {
     if (wrapped.__identifier && diff[wrapped.__meta.primaryKeys[0]]) {
       wrapped.__identifier.setValue(diff[wrapped.__meta.primaryKeys[0]] as IPrimaryKeyValue);
     }
-
-    this.insideHooks = false;
   }
 
   private postCommitCleanup(): void {
@@ -726,7 +731,6 @@ export class UnitOfWork {
     this.extraUpdates.clear();
     this.queuedActions.clear();
     this.working = false;
-    this.insideHooks = false;
   }
 
   private cascade<T extends object>(entity: T, type: Cascade, visited = new Set<AnyEntity>(), options: { checkRemoveStack?: boolean; cascade?: boolean } = {}): void {

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -73,7 +73,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     populateWhere: PopulateHint.ALL,
     connect: true,
     autoJoinOneToOneOwner: true,
-    propagateToOneOwner: true,
+    propagationOnPrototype: true,
     populateAfterFlush: true,
     serialization: {
       includePrimaryKeys: true,
@@ -509,7 +509,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
   connect: boolean;
   verbose: boolean;
   autoJoinOneToOneOwner: boolean;
-  propagateToOneOwner: boolean;
+  propagationOnPrototype: boolean;
   populateAfterFlush: boolean;
   serialization: {
     includePrimaryKeys: boolean;

--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -208,7 +208,6 @@ export class ConfigurationLoader {
     read(ret, 'MIKRO_ORM_VALIDATE', 'validate', bool);
     read(ret, 'MIKRO_ORM_ALLOW_GLOBAL_CONTEXT', 'allowGlobalContext', bool);
     read(ret, 'MIKRO_ORM_AUTO_JOIN_ONE_TO_ONE_OWNER', 'autoJoinOneToOneOwner', bool);
-    read(ret, 'MIKRO_ORM_PROPAGATE_TO_ONE_OWNER', 'propagateToOneOwner', bool);
     read(ret, 'MIKRO_ORM_POPULATE_AFTER_FLUSH', 'populateAfterFlush', bool);
     read(ret, 'MIKRO_ORM_FORCE_ENTITY_CONSTRUCTOR', 'forceEntityConstructor', bool);
     read(ret, 'MIKRO_ORM_FORCE_UNDEFINED', 'forceUndefined', bool);

--- a/packages/core/src/utils/TransactionContext.ts
+++ b/packages/core/src/utils/TransactionContext.ts
@@ -4,9 +4,11 @@ import type { EntityManager } from '../EntityManager';
 export class TransactionContext {
 
   private static storage = new AsyncLocalStorage<TransactionContext>();
-  readonly id = this.em._id;
+  readonly id: number;
 
-  constructor(readonly em: EntityManager) { }
+  constructor(readonly em: EntityManager) {
+    this.id = this.em._id;
+  }
 
   /**
    * Creates new TransactionContext instance and runs the code inside its domain.

--- a/packages/entity-generator/src/EntityGenerator.ts
+++ b/packages/entity-generator/src/EntityGenerator.ts
@@ -1,20 +1,43 @@
 import { ensureDir, writeFile } from 'fs-extra';
-import { ReferenceKind, Utils, type EntityMetadata, type EntityProperty, type GenerateOptions, type MikroORM } from '@mikro-orm/core';
-import { DatabaseSchema, type EntityManager } from '@mikro-orm/knex';
+import {
+  ReferenceKind,
+  Utils,
+  type EntityMetadata,
+  type EntityProperty,
+  type GenerateOptions,
+  type MikroORM,
+  type NamingStrategy,
+} from '@mikro-orm/core';
+import {
+  type AbstractSqlConnection,
+  type AbstractSqlDriver,
+  type AbstractSqlPlatform,
+  type Configuration,
+  DatabaseSchema,
+  type EntityManager,
+  type SchemaHelper,
+} from '@mikro-orm/knex';
 import { SourceFile } from './SourceFile';
 import { EntitySchemaSourceFile } from './EntitySchemaSourceFile';
 
 export class EntityGenerator {
 
-  private readonly config = this.em.config;
-  private readonly driver = this.em.getDriver();
-  private readonly platform = this.driver.getPlatform();
-  private readonly helper = this.platform.getSchemaHelper()!;
-  private readonly connection = this.driver.getConnection();
-  private readonly namingStrategy = this.config.getNamingStrategy();
+  private readonly config: Configuration;
+  private readonly driver: AbstractSqlDriver;
+  private readonly platform: AbstractSqlPlatform;
+  private readonly helper: SchemaHelper;
+  private readonly connection: AbstractSqlConnection;
+  private readonly namingStrategy: NamingStrategy;
   private readonly sources: SourceFile[] = [];
 
-  constructor(private readonly em: EntityManager) { }
+  constructor(private readonly em: EntityManager) {
+    this.config = this.em.config;
+    this.driver = this.em.getDriver();
+    this.platform = this.driver.getPlatform();
+    this.helper = this.platform.getSchemaHelper()!;
+    this.connection = this.driver.getConnection();
+    this.namingStrategy = this.config.getNamingStrategy();
+  }
 
   static register(orm: MikroORM): void {
     orm.config.registerExtension('@mikro-orm/entity-generator', () => new EntityGenerator(orm.em as EntityManager));

--- a/packages/knex/src/AbstractSqlConnection.ts
+++ b/packages/knex/src/AbstractSqlConnection.ts
@@ -27,7 +27,7 @@ function isRootTransaction<T>(trx: Transaction<T>) {
 export abstract class AbstractSqlConnection extends Connection {
 
   private static __patched = false;
-  protected override platform!: AbstractSqlPlatform;
+  declare protected platform: AbstractSqlPlatform;
   protected client!: Knex;
 
   constructor(config: Configuration, options?: ConnectionOptions, type?: 'read' | 'write') {

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -41,6 +41,7 @@ import { QueryBuilderHelper, type Alias } from './QueryBuilderHelper';
 import type { SqlEntityManager } from '../SqlEntityManager';
 import { CriteriaNodeFactory } from './CriteriaNodeFactory';
 import type { Field, JoinOptions } from '../typings';
+import type { AbstractSqlPlatform } from '../AbstractSqlPlatform';
 
 /**
  * SQL query builder with fluent interface.
@@ -116,8 +117,8 @@ export class QueryBuilder<T extends object = AnyEntity> {
   private _mainAlias?: Alias<T>;
   private _aliases: Dictionary<Alias<any>> = {};
   private _helper?: QueryBuilderHelper;
-  private readonly platform = this.driver.getPlatform();
-  private readonly knex = this.driver.getConnection(this.connectionType).getKnex();
+  private readonly platform: AbstractSqlPlatform;
+  private readonly knex: Knex;
 
   /**
    * @internal
@@ -130,6 +131,9 @@ export class QueryBuilder<T extends object = AnyEntity> {
               private connectionType?: ConnectionType,
               private readonly em?: SqlEntityManager,
               private readonly logging?: LoggingOptions) {
+    this.platform = this.driver.getPlatform();
+    this.knex = this.driver.getConnection(this.connectionType).getKnex();
+
     if (alias) {
       this.aliasCounter++;
       this._explicitAlias = true;

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -18,25 +18,30 @@ import {
   type EntityProperty,
   type FlatQueryOrderMap,
   type QBFilterQuery,
+  type MetadataStorage,
 } from '@mikro-orm/core';
 import { QueryType } from './enums';
 import type { Field, JoinOptions } from '../typings';
 import type { AbstractSqlDriver } from '../AbstractSqlDriver';
+import type { AbstractSqlPlatform } from '../AbstractSqlPlatform';
 
 /**
  * @internal
  */
 export class QueryBuilderHelper {
 
-  private readonly platform = this.driver.getPlatform();
-  private readonly metadata = this.driver.getMetadata();
+  private readonly platform: AbstractSqlPlatform;
+  private readonly metadata: MetadataStorage;
 
   constructor(private readonly entityName: string,
               private readonly alias: string,
               private readonly aliasMap: Dictionary<Alias<any>>,
               private readonly subQueries: Dictionary<string>,
               private readonly knex: Knex,
-              private readonly driver: AbstractSqlDriver) { }
+              private readonly driver: AbstractSqlDriver) {
+    this.platform = this.driver.getPlatform();
+    this.metadata = this.driver.getMetadata();
+  }
 
   mapper(field: string | Knex.Raw, type?: QueryType): string;
   mapper(field: string | Knex.Raw, type?: QueryType, value?: any, alias?: string | null): string;
@@ -498,7 +503,8 @@ export class QueryBuilderHelper {
     const fields = Utils.splitPrimaryKeys(key);
 
     if (fields.length > 1 && Array.isArray(value[op]) && !value[op].every((v: unknown) => Array.isArray(v))) {
-      value[op] = this.knex.raw(`(${fields.map(() => '?').join(', ')})`, value[op]);
+      const tmp = value[op].length === 1 && Utils.isPlainObject(value[op][0]) ? fields.map(f => value[op][0][f]) : value[op];
+      value[op] = this.knex.raw(`(${fields.map(() => '?').join(', ')})`, tmp);
     }
 
     if (this.subQueries[key]) {

--- a/packages/knex/src/schema/SchemaComparator.ts
+++ b/packages/knex/src/schema/SchemaComparator.ts
@@ -1,19 +1,23 @@
 import { inspect } from 'util';
-import { BooleanType, DateTimeType, JsonType, parseJsonSafe, Utils, type Dictionary, type EntityProperty } from '@mikro-orm/core';
+import { BooleanType, DateTimeType, JsonType, parseJsonSafe, Utils, type Dictionary, type EntityProperty, type Logger } from '@mikro-orm/core';
 import type { CheckDef, Column, ForeignKey, IndexDef, SchemaDifference, TableDifference } from '../typings';
 import type { DatabaseSchema } from './DatabaseSchema';
 import type { DatabaseTable } from './DatabaseTable';
 import type { AbstractSqlPlatform } from '../AbstractSqlPlatform';
+import type { SchemaHelper } from './SchemaHelper';
 
 /**
  * Compares two Schemas and return an instance of SchemaDifference.
  */
 export class SchemaComparator {
 
-  private readonly helper = this.platform.getSchemaHelper()!;
-  private readonly logger = this.platform.getConfig().getLogger();
+  private readonly helper: SchemaHelper;
+  private readonly logger: Logger;
 
-  constructor(private readonly platform: AbstractSqlPlatform) { }
+  constructor(private readonly platform: AbstractSqlPlatform) {
+    this.helper = this.platform.getSchemaHelper()!;
+    this.logger = this.platform.getConfig().getLogger();
+  }
 
   /**
    * Returns a SchemaDifference object containing the differences between the schemas fromSchema and toSchema.

--- a/packages/migrations-mongodb/src/MigrationRunner.ts
+++ b/packages/migrations-mongodb/src/MigrationRunner.ts
@@ -1,14 +1,16 @@
 import type { MigrationsOptions, Transaction } from '@mikro-orm/core';
-import type { MongoDriver } from '@mikro-orm/mongodb';
+import type { MongoDriver, MongoConnection } from '@mikro-orm/mongodb';
 import type { Migration } from './Migration';
 
 export class MigrationRunner {
 
-  private readonly connection = this.driver.getConnection();
+  private readonly connection: MongoConnection;
   private masterTransaction?: Transaction;
 
   constructor(protected readonly driver: MongoDriver,
-              protected readonly options: MigrationsOptions) { }
+              protected readonly options: MigrationsOptions) {
+    this.connection = this.driver.getConnection();
+  }
 
   async run(migration: Migration, method: 'up' | 'down'): Promise<void> {
     migration.reset();

--- a/packages/migrations-mongodb/src/Migrator.ts
+++ b/packages/migrations-mongodb/src/Migrator.ts
@@ -1,8 +1,17 @@
 import { Umzug, type InputMigrations, type MigrateDownOptions, type MigrateUpOptions, type MigrationParams, type RunnableMigration } from 'umzug';
 import { join } from 'path';
 import { ensureDir } from 'fs-extra';
-import { Utils, type Constructor, type IMigrationGenerator, type IMigrator, type MikroORM, type Transaction } from '@mikro-orm/core';
-import type { EntityManager } from '@mikro-orm/mongodb';
+import {
+  Utils,
+  type Constructor,
+  type Configuration,
+  type IMigrationGenerator,
+  type IMigrator,
+  type MikroORM,
+  type Transaction,
+  type MigrationsOptions,
+} from '@mikro-orm/core';
+import type { EntityManager, MongoDriver } from '@mikro-orm/mongodb';
 import type { Migration } from './Migration';
 import { MigrationRunner } from './MigrationRunner';
 import { MigrationStorage } from './MigrationStorage';
@@ -16,12 +25,16 @@ export class Migrator implements IMigrator {
   private runner!: MigrationRunner;
   private storage!: MigrationStorage;
   private generator!: IMigrationGenerator;
-  private readonly driver = this.em.getDriver();
-  private readonly config = this.em.config;
-  private readonly options = this.config.get('migrations');
+  private readonly driver: MongoDriver;
+  private readonly config: Configuration;
+  private readonly options: MigrationsOptions;
   private readonly absolutePath: string;
 
   constructor(private readonly em: EntityManager) {
+    this.driver = this.em.getDriver();
+    this.config = this.em.config;
+    this.options = this.config.get('migrations');
+
     /* istanbul ignore next */
     const key = (this.config.get('tsNode', Utils.detectTsNode()) && this.options.pathTs) ? 'pathTs' : 'path';
     this.absolutePath = Utils.absolutePath(this.options[key]!, this.config.get('baseDir'));

--- a/packages/migrations/src/MigrationRunner.ts
+++ b/packages/migrations/src/MigrationRunner.ts
@@ -1,16 +1,19 @@
 import { Utils, type Configuration, type MigrationsOptions, type Transaction } from '@mikro-orm/core';
-import type { AbstractSqlDriver } from '@mikro-orm/knex';
+import type { AbstractSqlDriver, AbstractSqlConnection, SchemaHelper } from '@mikro-orm/knex';
 import type { Migration } from './Migration';
 
 export class MigrationRunner {
 
-  private readonly connection = this.driver.getConnection();
-  private readonly helper = this.driver.getPlatform().getSchemaHelper()!;
+  private readonly connection: AbstractSqlConnection;
+  private readonly helper: SchemaHelper;
   private masterTransaction?: Transaction;
 
   constructor(protected readonly driver: AbstractSqlDriver,
               protected readonly options: MigrationsOptions,
-              protected readonly config: Configuration) { }
+              protected readonly config: Configuration) {
+    this.connection = this.driver.getConnection();
+    this.helper = this.driver.getPlatform().getSchemaHelper()!;
+  }
 
   async run(migration: Migration, method: 'up' | 'down'): Promise<void> {
     migration.reset();

--- a/packages/migrations/src/MigrationStorage.ts
+++ b/packages/migrations/src/MigrationStorage.ts
@@ -1,17 +1,20 @@
 import type { MigrationsOptions, Transaction } from '@mikro-orm/core';
-import type { AbstractSqlDriver, Table } from '@mikro-orm/knex';
+import type { AbstractSqlDriver, Table, AbstractSqlConnection, SchemaHelper } from '@mikro-orm/knex';
 import type { MigrationParams, UmzugStorage } from 'umzug';
 import * as path from 'path';
 import type { MigrationRow } from './typings';
 
 export class MigrationStorage implements UmzugStorage {
 
-  private readonly connection = this.driver.getConnection();
-  private readonly helper = this.driver.getPlatform().getSchemaHelper()!;
+  private readonly connection: AbstractSqlConnection;
+  private readonly helper: SchemaHelper;
   private masterTransaction?: Transaction;
 
   constructor(protected readonly driver: AbstractSqlDriver,
-              protected readonly options: MigrationsOptions) { }
+              protected readonly options: MigrationsOptions) {
+    this.connection = this.driver.getConnection();
+    this.helper = this.driver.getPlatform().getSchemaHelper()!;
+  }
 
   async executed(): Promise<string[]> {
     const migrations = await this.getExecutedMigrations();

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -1,8 +1,27 @@
 import { Umzug, type InputMigrations, type MigrateDownOptions, type MigrateUpOptions, type MigrationParams, type RunnableMigration } from 'umzug';
 import { basename, join } from 'path';
 import { ensureDir, pathExists, writeJSON } from 'fs-extra';
-import { t, Type, UnknownType, Utils, type Constructor, type Dictionary, type IMigrationGenerator, type IMigrator, type MikroORM, type Transaction } from '@mikro-orm/core';
-import { DatabaseSchema, DatabaseTable, SqlSchemaGenerator, type EntityManager } from '@mikro-orm/knex';
+import {
+  t,
+  Type,
+  UnknownType,
+  Utils,
+  type Constructor,
+  type Dictionary,
+  type IMigrationGenerator,
+  type IMigrator,
+  type MikroORM,
+  type Transaction,
+  type Configuration,
+  type MigrationsOptions,
+} from '@mikro-orm/core';
+import {
+  DatabaseSchema,
+  DatabaseTable,
+  SqlSchemaGenerator,
+  type EntityManager,
+  type AbstractSqlDriver,
+} from '@mikro-orm/knex';
 import type { Migration } from './Migration';
 import { MigrationRunner } from './MigrationRunner';
 import { MigrationStorage } from './MigrationStorage';
@@ -16,14 +35,19 @@ export class Migrator implements IMigrator {
   private runner!: MigrationRunner;
   private storage!: MigrationStorage;
   private generator!: IMigrationGenerator;
-  private readonly driver = this.em.getDriver();
-  private readonly schemaGenerator = new SqlSchemaGenerator(this.em);
-  private readonly config = this.em.config;
-  private readonly options = this.config.get('migrations');
+  private readonly driver: AbstractSqlDriver;
+  private readonly schemaGenerator: SqlSchemaGenerator;
+  private readonly config: Configuration;
+  private readonly options: MigrationsOptions;
   private readonly absolutePath: string;
   private readonly snapshotPath: string;
 
   constructor(private readonly em: EntityManager) {
+    this.driver = this.em.getDriver();
+    this.schemaGenerator = new SqlSchemaGenerator(this.em);
+    this.config = this.em.config;
+    this.options = this.config.get('migrations');
+
     /* istanbul ignore next */
     const key = (this.config.get('tsNode', Utils.detectTsNode()) && this.options.pathTs) ? 'pathTs' : 'path';
     this.absolutePath = Utils.absolutePath(this.options[key]!, this.config.get('baseDir'));

--- a/packages/seeder/src/SeedManager.ts
+++ b/packages/seeder/src/SeedManager.ts
@@ -1,15 +1,25 @@
 import globby from 'globby';
-import { Utils, type Constructor, type EntityManager, type ISeedManager, type MikroORM } from '@mikro-orm/core';
+import {
+  Utils,
+  type Constructor,
+  type EntityManager,
+  type ISeedManager,
+  type MikroORM,
+  type Configuration,
+  type SeederOptions,
+} from '@mikro-orm/core';
 import type { Seeder } from './Seeder';
 import { ensureDir, writeFile } from 'fs-extra';
 
 export class SeedManager implements ISeedManager {
 
-  private readonly config = this.em.config;
-  private readonly options = this.config.get('seeder');
+  private readonly config: Configuration;
+  private readonly options: SeederOptions;
   private readonly absolutePath: string;
 
   constructor(private readonly em: EntityManager) {
+    this.config = this.em.config;
+    this.options = this.config.get('seeder');
     this.em = this.em.fork();
     this.config.set('persistOnCreate', true);
     /* istanbul ignore next */

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -59,7 +59,7 @@ describe('EntityManagerMongo', () => {
     const book3 = new Book('My Life on The Wall, part 3', author);
     book3.publisher = publisherRef;
 
-    await orm.em.persist(publisher).flush();
+    await orm.em.persist([book1, book2, book3]).flush();
     orm.em.clear();
 
     const publisher7k = (await orm.em.getRepository(Publisher).findOne({ name: '7K publisher' }))!;
@@ -1359,7 +1359,7 @@ describe('EntityManagerMongo', () => {
     Author.afterDestroyCalled = 0;
     const repo = orm.em.getRepository(Author);
     const author = new Author('Jon Snow', 'snow@wall.st');
-    expect(author.id).toBeNull();
+    expect(author.id).toBeUndefined(); // with useDefineForClassFields: true we dont get getter value before flushing
     expect(author.version).toBeUndefined();
     expect(author.versionAsString).toBeUndefined();
     expect(author.hookTest).toBe(false);
@@ -1835,7 +1835,7 @@ describe('EntityManagerMongo', () => {
   test('automatically map raw results to entities when setting collection items', async () => {
     const god = new Author('God', 'hello@heaven.god');
     const bookData = { title: 'Bible', author: god.id };
-    expect(() => god.books.add(bookData as any)).toThrowError(`Entity of type Book expected for property Author.books, { title: 'Bible', author: null } of type object given.`);
+    expect(() => god.books.add(bookData as any)).toThrowError(`Entity of type Book expected for property Author.books, { title: 'Bible', author: undefined } of type object given.`);
   });
 
   test('allow undefined value in nullable properties', async () => {

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -1057,7 +1057,7 @@ describe('EntityManagerMySql', () => {
     b4.tags.add(tag2, tag4, tag5);
     b5.tags.add(tag5);
 
-    await orm.em.persistAndFlush(author);
+    await orm.em.persistAndFlush([b1, b2, b3, b4, b5]);
     orm.em.clear();
 
     const a1 = await orm.em.find(Author2, author, {
@@ -2184,9 +2184,10 @@ describe('EntityManagerMySql', () => {
     for (let i = 1; i <= 10; i++) {
       const num = `${i}`.padStart(2, '0');
       const god = new Author2(`God ${num}`, `hello${num}@heaven.god`);
-      new Book2(`Bible ${num}.1`, god);
-      new Book2(`Bible ${num}.2`, god);
-      new Book2(`Bible ${num}.3`, god);
+      const b1 = new Book2(`Bible ${num}.1`, god);
+      const b2 = new Book2(`Bible ${num}.2`, god);
+      const b3 = new Book2(`Bible ${num}.3`, god);
+      await orm.em.persistAndFlush([b1, b2, b3]);
       orm.em.persist(god);
     }
 

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -1782,10 +1782,10 @@ describe('EntityManagerPostgre', () => {
     for (let i = 1; i <= 10; i++) {
       const num = `${i}`.padStart(2, '0');
       const god = new Author2(`God ${num}`, `hello${num}@heaven.god`);
-      new Book2(`Bible ${num}.1`, god);
-      new Book2(`Bible ${num}.2`, god);
-      new Book2(`Bible ${num}.3`, god);
-      orm.em.persist(god);
+      const b1 = new Book2(`Bible ${num}.1`, god);
+      const b2 = new Book2(`Bible ${num}.2`, god);
+      const b3 = new Book2(`Bible ${num}.3`, god);
+      orm.em.persist([b1, b2, b3]);
     }
 
     await orm.em.flush();
@@ -2142,7 +2142,7 @@ describe('EntityManagerPostgre', () => {
   });
 
   test('creating unmanaged entity reference', async () => {
-    await orm.em.getDriver().nativeInsertMany(Publisher2.name, [
+    await orm.em.insertMany(Publisher2, [
       { id: 1, name: 'p 1', type: PublisherType.LOCAL, type2: PublisherType2.LOCAL },
       { id: 2, name: 'p 2', type: PublisherType.GLOBAL, type2: PublisherType2.GLOBAL },
     ]);
@@ -2154,7 +2154,7 @@ describe('EntityManagerPostgre', () => {
 
     // not managed reference
     expect(wrap(b.publisher, true).__em).toBeUndefined();
-    await orm.em.persistAndFlush(a);
+    await orm.em.persistAndFlush(b);
     // after flush it will become managed
     expect(wrap(b.publisher, true).__em).toBe(orm.em);
 

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -191,7 +191,6 @@ export async function initORMSqlite2(type: 'sqlite' | 'better-sqlite' = 'sqlite'
     baseDir: BASE_DIR,
     driver: type === 'sqlite' ? SqliteDriver : BetterSqliteDriver,
     debug: ['query'],
-    propagateToOneOwner: false,
     forceUndefined: true,
     logger: i => i,
     migrations: { path: BASE_DIR + '/../temp/migrations-2', snapshot: false },

--- a/tests/features/auto-flush.postgre.test.ts
+++ b/tests/features/auto-flush.postgre.test.ts
@@ -34,7 +34,7 @@ describe('automatic flushing when querying for overlapping entities via em.find/
     const b3 = new Book2('Bible 3', god);
     b3.perex = ref('b3 perex');
     b3.price = 789;
-    await orm.em.fork().persistAndFlush(god);
+    await orm.em.fork().persistAndFlush([b1, b2, b3]);
 
     return { god };
   }
@@ -66,9 +66,15 @@ describe('automatic flushing when querying for overlapping entities via em.find/
   });
 
   test('em.find() triggers auto-flush for newly flushed entities too', async () => {
-    const god = new Author2('God', 'hello@heaven.god');
-    god.favouriteAuthor = new Author2('God 2', 'hello2@heaven.god');
-    god.favouriteAuthor.age = 21;
+    const god = orm.em.create(Author2, {
+      name: 'God',
+      email: 'hello@heaven.god',
+      favouriteAuthor: {
+        name: 'God 2',
+        email: 'hello2@heaven.god',
+      },
+    });
+    god.favouriteAuthor!.age = 21;
     god.age = 999;
 
     expect(wrap(god, true).__touched).toBe(true);
@@ -215,7 +221,7 @@ describe('automatic flushing when querying for overlapping entities via em.find/
       const b3 = new Book2(`Bible 3-${i}`, god);
       b3.perex = ref(`b3-${i} perex`);
       b3.price = 789;
-      fork.persist(god);
+      fork.persist([b1, b2, b3]);
     }
 
     await fork.flush();

--- a/tests/features/auto-refreshing.postgre.test.ts
+++ b/tests/features/auto-refreshing.postgre.test.ts
@@ -31,7 +31,7 @@ describe('automatic refreshing of already loaded entities', () => {
     const b3 = new Book2('Bible 3', god);
     b3.perex = ref('b3 perex');
     b3.price = 789;
-    await orm.em.fork().persistAndFlush(god);
+    await orm.em.fork().persistAndFlush([b1, b2, b3]);
 
     return { god };
   }

--- a/tests/features/composite-keys/custom-pivot-entity-fixed-order.sqlite.test.ts
+++ b/tests/features/composite-keys/custom-pivot-entity-fixed-order.sqlite.test.ts
@@ -122,7 +122,7 @@ describe('custom pivot entity for m:n with additional properties (unidirectional
     const item33 = new OrderItem(order3, product5);
     item33.offeredPrice = 5123;
 
-    await orm.em.fork().persistAndFlush([order1, order2, order3]);
+    await orm.em.fork().persistAndFlush([item11, item12, item21, item22, item23, item31, item32, item33]);
     return { order1, order2, product1, product2, product3, product4, product5 };
   }
 

--- a/tests/features/composite-keys/custom-pivot-entity-uni.sqlite.test.ts
+++ b/tests/features/composite-keys/custom-pivot-entity-uni.sqlite.test.ts
@@ -127,7 +127,7 @@ describe('custom pivot entity for m:n with additional properties (unidirectional
     const item33 = new OrderItem(order3, product5);
     item33.offeredPrice = 5123;
 
-    await orm.em.fork().persistAndFlush([order1, order2, order3]);
+    await orm.em.fork().persistAndFlush([item11, item12, item21, item22, item23, item31, item32, item33]);
     return { order1, order2, product1, product2, product3, product4, product5 };
   }
 

--- a/tests/features/composite-keys/custom-pivot-entity-wrong-order.sqlite.test.ts
+++ b/tests/features/composite-keys/custom-pivot-entity-wrong-order.sqlite.test.ts
@@ -130,7 +130,7 @@ describe('custom pivot entity for m:n with additional properties (bidirectional,
     const item33 = new OrderItem(order3, product5);
     item33.offeredPrice = 5123;
 
-    await orm.em.fork().persistAndFlush([order1, order2, order3]);
+    await orm.em.fork().persistAndFlush([item11, item12, item21, item22, item23, item31, item32, item33]);
     return { order1, order2, product1, product2, product3, product4, product5 };
   }
 

--- a/tests/features/composite-keys/custom-pivot-entity.sqlite.test.ts
+++ b/tests/features/composite-keys/custom-pivot-entity.sqlite.test.ts
@@ -9,6 +9,7 @@ import {
   Collection,
   ManyToMany,
   PrimaryKeyProp,
+  OptionalProps,
 } from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
@@ -59,6 +60,8 @@ export class Product {
 
 @Entity()
 export class OrderItem {
+
+  [OptionalProps]?: 'amount' | 'offeredPrice';
 
   @ManyToOne({ primary: true })
   order: Order;
@@ -113,22 +116,14 @@ describe('custom pivot entity for m:n with additional properties (bidirectional)
     const product3 = new Product('p3', 333);
     const product4 = new Product('p4', 444);
     const product5 = new Product('p5', 555);
-    const item11 = new OrderItem(order1, product1);
-    item11.offeredPrice = 123;
-    const item12 = new OrderItem(order1, product2);
-    item12.offeredPrice = 3123;
-    const item21 = new OrderItem(order2, product1);
-    item21.offeredPrice = 4123;
-    const item22 = new OrderItem(order2, product2);
-    item22.offeredPrice = 1123;
-    const item23 = new OrderItem(order2, product5);
-    item23.offeredPrice = 1263;
-    const item31 = new OrderItem(order3, product3);
-    item31.offeredPrice = 7123;
-    const item32 = new OrderItem(order3, product4);
-    item32.offeredPrice = 9123;
-    const item33 = new OrderItem(order3, product5);
-    item33.offeredPrice = 5123;
+    const item11 = orm.em.create(OrderItem, { order: order1, product: product1, offeredPrice: 123 });
+    const item12 = orm.em.create(OrderItem, { order: order1, product: product2, offeredPrice: 3123 });
+    const item21 = orm.em.create(OrderItem, { order: order2, product: product1, offeredPrice: 4123 });
+    const item22 = orm.em.create(OrderItem, { order: order2, product: product2, offeredPrice: 1123 });
+    const item23 = orm.em.create(OrderItem, { order: order2, product: product5, offeredPrice: 1263 });
+    const item31 = orm.em.create(OrderItem, { order: order3, product: product3, offeredPrice: 7123 });
+    const item32 = orm.em.create(OrderItem, { order: order3, product: product4, offeredPrice: 9123 });
+    const item33 = orm.em.create(OrderItem, { order: order3, product: product5, offeredPrice: 5123 });
 
     await orm.em.fork().persistAndFlush([order1, order2, order3]);
     return { order1, order2, product1, product2, product3, product4, product5 };

--- a/tests/features/events/events.mysql.test.ts
+++ b/tests/features/events/events.mysql.test.ts
@@ -51,7 +51,7 @@ describe('events (mysql)', () => {
     book1.tags.add(tag1, tag3);
     book2.tags.add(tag1, tag2, tag5);
     book3.tags.add(tag2, tag4, tag5);
-    await orm.em.persistAndFlush(author);
+    await orm.em.persistAndFlush([book1, book2, book3]);
     expect(wrap(author, true).__onLoadFired).toBeUndefined();
     orm.em.clear();
   }

--- a/tests/features/partial-loading/partial-loading.mongo.test.ts
+++ b/tests/features/partial-loading/partial-loading.mongo.test.ts
@@ -27,11 +27,11 @@ describe('partial loading (mongo)', () => {
 
   test('partial nested loading (1:m)', async () => {
     const god = new Author(`God `, `hello@heaven.god`);
-    const b1 = new Book(`Bible 1`, god);
+    const b1 = orm.em.create(Book, { title: `Bible 1`, author: god });
     b1.tenant = 123;
-    const b2 = new Book(`Bible 2`, god);
+    const b2 = orm.em.create(Book, { title: `Bible 2`, author: god });
     b2.tenant = 456;
-    const b3 = new Book(`Bible 3`, god);
+    const b3 = orm.em.create(Book, { title: `Bible 3`, author: god });
     b3.tenant = 789;
     await orm.em.persistAndFlush(god);
     orm.em.clear();
@@ -72,11 +72,11 @@ describe('partial loading (mongo)', () => {
 
   test('partial nested loading (m:1)', async () => {
     const god = new Author(`God `, `hello@heaven.god`);
-    const b1 = new Book(`Bible 1`, god);
+    const b1 = orm.em.create(Book, { title: `Bible 1`, author: god });
     b1.tenant = 123;
-    const b2 = new Book(`Bible 2`, god);
+    const b2 = orm.em.create(Book, { title: `Bible 2`, author: god });
     b2.tenant = 456;
-    const b3 = new Book(`Bible 3`, god);
+    const b3 = orm.em.create(Book, { title: `Bible 3`, author: god });
     b3.tenant = 789;
     await orm.em.persistAndFlush(god);
     orm.em.clear();
@@ -124,14 +124,14 @@ describe('partial loading (mongo)', () => {
 
   test('partial nested loading (m:n)', async () => {
     const god = new Author(`God `, `hello@heaven.god`);
-    const b1 = new Book(`Bible 1`, god);
+    const b1 = orm.em.create(Book, { title: `Bible 1`, author: god });
     b1.tenant = 123;
     const t1 = new BookTag('t1');
     b1.tags.add(t1, new BookTag('t2'));
-    const b2 = new Book(`Bible 2`, god);
+    const b2 = orm.em.create(Book, { title: `Bible 2`, author: god });
     b2.tenant = 456;
     b2.tags.add(new BookTag('t3'), new BookTag('t4'), t1);
-    const b3 = new Book(`Bible 3`, god);
+    const b3 = orm.em.create(Book, { title: `Bible 3`, author: god });
     b3.tenant = 789;
     b3.tags.add(new BookTag('t5'), new BookTag('t6'), t1);
     await orm.em.persistAndFlush(god);
@@ -174,13 +174,13 @@ describe('partial loading (mongo)', () => {
 
   test('partial nested loading (mixed)', async () => {
     const god = new Author(`God `, `hello@heaven.god`);
-    const b1 = new Book(`Bible 1`, god);
+    const b1 = orm.em.create(Book, { title: `Bible 1`, author: god });
     b1.tenant = 123;
     b1.tags.add(new BookTag('t1'), new BookTag('t2'));
-    const b2 = new Book(`Bible 2`, god);
+    const b2 = orm.em.create(Book, { title: `Bible 2`, author: god });
     b2.tenant = 456;
     b2.tags.add(new BookTag('t3'), new BookTag('t4'));
-    const b3 = new Book(`Bible 3`, god);
+    const b3 = orm.em.create(Book, { title: `Bible 3`, author: god });
     b3.tenant = 789;
     b3.tags.add(new BookTag('t5'), new BookTag('t6'));
     await orm.em.persistAndFlush(god);

--- a/tests/features/partial-loading/partial-loading.mysql.test.ts
+++ b/tests/features/partial-loading/partial-loading.mysql.test.ts
@@ -14,13 +14,13 @@ describe('partial loading (mysql)', () => {
 
   async function createEntities() {
     const god = new Author2(`God `, `hello@heaven.god`);
-    const b1 = new Book2(`Bible 1`, god);
+    const b1 = orm.em.create(Book2, { title: `Bible 1`, author: god });
     b1.price = 123;
     b1.tags.add(new BookTag2('t1'), new BookTag2('t2'));
-    const b2 = new Book2(`Bible 2`, god);
+    const b2 = orm.em.create(Book2, { title: `Bible 2`, author: god });
     b2.price = 456;
     b2.tags.add(new BookTag2('t3'), new BookTag2('t4'));
-    const b3 = new Book2(`Bible 3`, god);
+    const b3 = orm.em.create(Book2, { title: `Bible 3`, author: god });
     b3.price = 789;
     b3.tags.add(new BookTag2('t5'), new BookTag2('t6'));
     await orm.em.persistAndFlush(god);

--- a/tests/features/result-cache/result-cache.mongo.test.ts
+++ b/tests/features/result-cache/result-cache.mongo.test.ts
@@ -25,7 +25,7 @@ describe('result cache (mongo)', () => {
     book1.tags.add(tag1, tag3);
     book2.tags.add(tag1, tag2, tag5);
     book3.tags.add(tag2, tag4, tag5);
-    await orm.em.persistAndFlush(author);
+    await orm.em.persistAndFlush([book1, book2, book3]);
     orm.em.clear();
 
     return author;

--- a/tests/features/result-cache/result-cache.postgre.test.ts
+++ b/tests/features/result-cache/result-cache.postgre.test.ts
@@ -25,7 +25,7 @@ describe('result cache (postgres)', () => {
     book1.tags.add(tag1, tag3);
     book2.tags.add(tag1, tag2, tag5);
     book3.tags.add(tag2, tag4, tag5);
-    await orm.em.persistAndFlush(author);
+    await orm.em.persistAndFlush([book1, book2, book3]);
     orm.em.clear();
   }
 

--- a/tests/features/schema-generator/SchemaGenerator.mysql2.test.ts
+++ b/tests/features/schema-generator/SchemaGenerator.mysql2.test.ts
@@ -21,7 +21,7 @@ describe('SchemaGenerator (no FKs)', () => {
   test('create/drop database [mysql]', async () => {
     const orm = await MikroORM.init({
       entities: [FooBar2, FooBaz2, Test2, Book2, Author2, Configuration2, Publisher2, BookTag2, Address2, BaseEntity2, BaseEntity22],
-      dbName: `mikro_orm_test_${Date.now()}`,
+      dbName: `mikro_orm_test_${Utils.randomInt(1, 10000)}`,
       port: 3308,
       baseDir: BASE_DIR,
       driver: MySqlDriver,
@@ -35,7 +35,7 @@ describe('SchemaGenerator (no FKs)', () => {
   });
 
   test('create schema also creates the database if not exists [mysql]', async () => {
-    const dbName = `mikro_orm_test_${Date.now()}`;
+    const dbName = `mikro_orm_test_${Utils.randomInt(1, 10000)}`;
     const orm = await MikroORM.init({
       entities: [FooBar2, FooBaz2, Test2, Book2, Author2, Configuration2, Publisher2, BookTag2, Address2, BaseEntity2, BaseEntity22],
       dbName,

--- a/tests/features/serialization/GH3788.test.ts
+++ b/tests/features/serialization/GH3788.test.ts
@@ -30,18 +30,15 @@ class MainItem {
 }
 
 test('serialization of not managed relations (#3788)', async () => {
-  await MikroORM.init({
+  const { em } = await MikroORM.init({
     driver: BetterSqliteDriver,
     dbName: ':memory:',
     entities: [ImageInfo],
     connect: false,
   });
 
-  const image = new ImageInfo();
-  image.url = 'xxxx';
-  const mainItem = new MainItem();
-  mainItem.name = 'yyyy';
-  mainItem.coverImage = image;
+  const image = em.create(ImageInfo, { url: 'xxxx' });
+  const mainItem = em.create(MainItem, { name: 'yyyy', coverImage: image });
   expect(mainItem).toMatchObject({
     name: 'yyyy',
     coverImage: {

--- a/tests/features/serialization/explicit-serialization.test.ts
+++ b/tests/features/serialization/explicit-serialization.test.ts
@@ -26,7 +26,7 @@ async function createEntities() {
   book2.publisher = wrap(publisher).toReference();
   const book3 = new Book2('My Life on The Wall, part 3', author);
   book3.publisher = wrap(publisher).toReference();
-  await orm.em.persist(author).flush();
+  await orm.em.persist([book1, book2, book3]).flush();
   orm.em.clear();
 
   return { god, author, publisher, book1, book2, book3 };

--- a/tests/features/single-table-inheritance/single-table-inheritance.mysql.test.ts
+++ b/tests/features/single-table-inheritance/single-table-inheritance.mysql.test.ts
@@ -126,10 +126,10 @@ describe('single table inheritance in mysql', () => {
       favouriteManager: users[2],
       type: Type.Owner,
     });
-    expect(Object.keys(users[0])).toEqual(['id', 'firstName', 'lastName', 'type', 'employeeProp']);
-    expect(Object.keys(users[1])).toEqual(['id', 'firstName', 'lastName', 'type', 'employeeProp']);
-    expect(Object.keys(users[2])).toEqual(['id', 'firstName', 'lastName', 'type', 'managerProp']);
-    expect(Object.keys(users[3])).toEqual(['id', 'firstName', 'lastName', 'type', 'ownerProp', 'favouriteEmployee', 'favouriteManager', 'managerProp']);
+    expect(Object.keys(users[0])).toEqual(['firstName', 'lastName', 'type', 'employeeProp', 'id']);
+    expect(Object.keys(users[1])).toEqual(['firstName', 'lastName', 'type', 'employeeProp', 'id']);
+    expect(Object.keys(users[2])).toEqual(['firstName', 'lastName', 'type', 'managerProp', 'id']);
+    expect(Object.keys(users[3])).toEqual(['firstName', 'lastName', 'type', 'ownerProp', 'favouriteEmployee', 'favouriteManager', 'managerProp', 'id']);
 
     expect([...orm.em.getUnitOfWork().getIdentityMap().keys()]).toEqual(['BaseUser2-4', 'BaseUser2-1', 'BaseUser2-2', 'BaseUser2-3']);
 

--- a/tests/features/unit-of-work/GH4216.test.ts
+++ b/tests/features/unit-of-work/GH4216.test.ts
@@ -1,0 +1,169 @@
+import {
+  Collection,
+  Entity,
+  LoadStrategy,
+  ManyToOne,
+  OneToMany,
+  PopulateHint,
+  PrimaryKey,
+  Property,
+  Ref,
+  Rel,
+} from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/sqlite';
+import { v4 } from 'uuid';
+
+@Entity()
+class Shipment {
+
+  @PrimaryKey({ type: 'uuid' })
+  id: string = v4();
+
+  @Property()
+  createdAt!: Date;
+
+  @Property({ onUpdate: () => new Date() })
+  updatedAt!: Date;
+
+  @OneToMany({
+    entity: 'LineItem',
+    mappedBy: 'shipment',
+  })
+  lineItems = new Collection<LineItem>(this);
+
+  @ManyToOne(() => Order, { hidden: true, deleteRule: 'cascade' })
+  order!: Rel<Order>;
+
+}
+
+@Entity()
+class LineItem {
+
+  @PrimaryKey()
+  id!: string;
+
+  @Property()
+  sku!: string;
+
+  @Property()
+  name!: string;
+
+  @Property()
+  createdAt!: Date;
+
+  @Property({ onUpdate: () => new Date() })
+  updatedAt!: Date;
+
+  // Relationships
+  @ManyToOne(() => Order, { hidden: true })
+  order!: Ref<Order>;
+
+  @ManyToOne(() => Shipment, { hidden: true })
+  shipment!: Ref<Shipment>;
+
+}
+
+@Entity()
+class Order {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  number!: string;
+
+  @Property()
+  createdAt!: Date;
+
+  @Property({ onUpdate: () => new Date() })
+  updatedAt!: Date;
+
+  @OneToMany({
+    entity: 'LineItem',
+    mappedBy: 'order',
+  })
+  lineItems = new Collection<LineItem>(this);
+
+  @OneToMany({ entity: 'Shipment', mappedBy: 'order' })
+  shipments = new Collection<Shipment>(this);
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    loadStrategy: LoadStrategy.JOINED,
+    populateWhere: PopulateHint.ALL,
+    entities: [Order, Shipment, LineItem],
+  });
+  await orm.schema.createSchema();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test(`GH issue 4219`, async () => {
+  orm.em.create(Order, {
+    id: 1234,
+    number: '6789567833435',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+
+  const shipments = [
+    orm.em.create(Shipment, {
+      id: '67e24192-4454-41d5-af5f-25940b63b759',
+      order: orm.em.getReference(Order, 1234),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }),
+    orm.em.create(Shipment, {
+      id: '8d466cb1-8abc-4423-a1a8-5081ec43d26e',
+      order: orm.em.getReference(Order, 1234),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }),
+  ];
+
+  const lineItems = [
+    orm.em.create(LineItem, {
+      id: v4(),
+      shipment: orm.em.getReference(
+        Shipment,
+        '67e24192-4454-41d5-af5f-25940b63b759',
+      ),
+      order: orm.em.getReference(Order, 1234),
+      sku: 'TEST_SKU',
+      name: 'Test Product',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }),
+    orm.em.create(LineItem, {
+      id: v4(),
+      shipment: orm.em.getReference(
+        Shipment,
+        '8d466cb1-8abc-4423-a1a8-5081ec43d26e',
+      ),
+      order: orm.em.getReference(Order, 1234),
+      sku: 'TEST_SKU_2',
+      name: 'Test Product 2',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }),
+  ];
+
+  shipments.forEach(shipment => orm.em?.persist(shipment));
+  lineItems.forEach(lineItem => orm.em?.persist(lineItem));
+
+  await orm.em.flush();
+
+  const order = await orm.em.findOne(Order, 1234, {
+    populate: ['lineItems', 'shipments', 'shipments.lineItems'],
+    refresh: true,
+  });
+
+  expect(order?.id).toBe(1234);
+});

--- a/tests/issues/GH2059.test.ts
+++ b/tests/issues/GH2059.test.ts
@@ -47,7 +47,7 @@ describe('GH issue 2059', () => {
     const b = new Category('B');
     const b1 = new Category('B1', b);
     const b2 = new Category('B2', b);
-    await orm.em.fork().persistAndFlush([a, b]);
+    await orm.em.fork().persistAndFlush([a, a1, a11, a111, a2, b, b1, b2]);
 
     /* Current tree structure is:
         - CAT A
@@ -70,7 +70,7 @@ describe('GH issue 2059', () => {
     expect(categories[0].children[0].children[0].name).toBe('A11');
     await categories[0].children[0].children[0].children.init();
     expect(categories[0].children[0].children[0].children[0].name).toBe('A111');
-    expect(wrap(categories[0]).toObject().children[0].children[0].children).toEqual([5]);
+    expect(wrap(categories[0]).toObject().children[0].children[0].children).toEqual([4]);
     expect(wrap(categories[0]).toObject()).toMatchObject({
       name: 'A',
       children: [

--- a/tests/issues/GH2760.test.ts
+++ b/tests/issues/GH2760.test.ts
@@ -9,7 +9,7 @@ export class User {
   @Property()
   name!: string;
 
-  @Property()
+  @Property({ persist: false })
   get lowerName() {
     return this.name.toLowerCase();
   }

--- a/tests/issues/GH2777.test.ts
+++ b/tests/issues/GH2777.test.ts
@@ -83,9 +83,11 @@ describe('GH issue 2777', () => {
     const c = new Customer();
     c.comment = new Comment();
     c.comment.title = 'c';
+    c.comment.customer = c;
     c.product = new Product();
     c.product.title = 't';
     c.product.image = new Image();
+    c.product.customer = c;
     c.product.image.customer = c;
     c.name = 'f';
     await orm.em.fork().persistAndFlush(c);

--- a/tests/issues/GH3271.test.ts
+++ b/tests/issues/GH3271.test.ts
@@ -17,7 +17,7 @@ test('test nested find with repository', async () => {
 
   const author = new Author2('Bartleby', 'bartelby@writer.org');
   const book = new Book2('My Life on The Wall, part 1', author);
-  await orm.em.persistAndFlush(author);
+  await orm.em.persistAndFlush(book);
 
   orm.em.clear();
 
@@ -47,7 +47,7 @@ test('test nested find with EM 1', async () => {
 
   const author = new Author2('Bartleby', 'bartelby@writer.org');
   const book = new Book2('My Life on The Wall, part 1', author);
-  await orm.em.persistAndFlush(author);
+  await orm.em.persistAndFlush(book);
 
   orm.em.clear();
 
@@ -77,7 +77,7 @@ test('test nested find with EM 2', async () => {
 
   const author = new Author2('Bartleby', 'bartelby@writer.org');
   const book = new Book2('My Life on The Wall, part 1', author);
-  await orm.em.fork().persistAndFlush(author);
+  await orm.em.fork().persistAndFlush(book);
 
   async function requestCommonService() {
     const [b] = await orm.em.find(Book2, {});
@@ -103,7 +103,7 @@ test('test nested find with EM 3', async () => {
 
   const author = new Author2('Bartleby', 'bartelby@writer.org');
   const book = new Book2('My Life on The Wall, part 1', author);
-  await orm.em.fork().persistAndFlush(author);
+  await orm.em.fork().persistAndFlush(book);
 
   async function requestCommonService() {
     const b = await orm.em.findOne(Book2, book);

--- a/tests/issues/GH3292.test.ts
+++ b/tests/issues/GH3292.test.ts
@@ -5,32 +5,25 @@ import { Author2, Book2 } from '../entities-sql';
 let orm: MikroORM;
 
 beforeAll(async () => orm = await initORMPostgreSql());
-beforeEach(async () => orm.schema.clearDatabase());
+beforeEach(async () => {
+  await orm.schema.clearDatabase();
+  const author = new Author2('Bartleby', 'bartelby@writer.org');
+  const book = new Book2('My Life on The Wall, part 1', author);
+  const book2 = new Book2('My Life on The Wall, part 2', author);
+  author.books.add([book, book2]);
+  await orm.em.fork().persistAndFlush(author);
+});
 afterAll(async () => {
   await orm.schema.dropDatabase();
   await orm.close(true);
 });
 
 test('test findOne without a offset', async () => {
-  const author = new Author2('Bartleby', 'bartelby@writer.org');
-  const book = new Book2('My Life on The Wall, part 1', author);
-  new Book2('My Life on The Wall, part 2', author);
-
-  await orm.em.fork().persistAndFlush(author);
-
-  const myBook = await orm.em.findOne(Book2, {});
-
-  expect(myBook?.title).toEqual(book.title);
+  const myBook = await orm.em.findOne(Book2, {}, { orderBy: { title: 1 } });
+  expect(myBook?.title).toEqual('My Life on The Wall, part 1');
 });
 
 test('test findOne but with a offset', async () => {
-  const author = new Author2('Bartleby', 'bartelby@writer.org');
-  new Book2('My Life on The Wall, part 1', author);
-  const book2 = new Book2('My Life on The Wall, part 2', author);
-
-  await orm.em.fork().persistAndFlush(author);
-
-  const myBook = await orm.em.findOne(Book2, {}, { offset: 1 });
-
-  expect(myBook?.title).toEqual(book2.title);
+  const myBook = await orm.em.findOne(Book2, {}, { orderBy: { title: 1 }, offset: 1 });
+  expect(myBook?.title).toEqual('My Life on The Wall, part 2');
 });

--- a/tests/issues/GH4061.test.ts
+++ b/tests/issues/GH4061.test.ts
@@ -51,7 +51,7 @@ test('4061', async () => {
   const thirdCategory = new Category();
   thirdCategory.name = 'TEST3';
   thirdCategory.parent = secondCategory;
-  await orm.em.persistAndFlush(firstCategory1);
+  await orm.em.persistAndFlush([firstCategory1, secondCategory, thirdCategory]);
   orm.em.clear();
 
   const firstCategory = await orm.em.findOneOrFail(Category, { parent: null });

--- a/tests/issues/GH535.test.ts
+++ b/tests/issues/GH535.test.ts
@@ -52,7 +52,6 @@ describe('GH issue 535', () => {
   });
 
   test(`GH issue 535`, async () => {
-
     const a = new A();
     const b = new B();
     a.b = wrap(b).toReference();

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,7 +7,6 @@
     "sourceMap": false,
     "strict": true,
     "esModuleInterop": true,
-    "useDefineForClassFields": false,
     "preserveConstEnums": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
Propagation failed when `useDefineForClassFields` TypeScript compiler flag was enabled (which is true when targeting `ES2022` or higher).

This PR ensures the propagation works regardless of the flag, by ensuring the getters are set up when registering entity as managed (and on few other places) via the new `EntityHelper.ensurePropagation()` method.

Moreover, this PR also enables the `useDefineForClassFields` flag, and since v6 is targeting es2022, we get no transpilation for class properties thanks to this.

Closes #4216