### PR TITLE
feat(core): add support for indexes on JSON properties

### DIFF
--- a/packages/better-sqlite/src/BetterSqliteSchemaHelper.ts
+++ b/packages/better-sqlite/src/BetterSqliteSchemaHelper.ts
@@ -80,6 +80,7 @@ export class BetterSqliteSchemaHelper extends SchemaHelper {
         columnNames: [col.name],
         keyName: 'primary',
         unique: true,
+        constraint: true,
         primary: true,
       });
     }
@@ -90,6 +91,7 @@ export class BetterSqliteSchemaHelper extends SchemaHelper {
         columnNames: [row.name],
         keyName: index.name,
         unique: !!index.unique,
+        constraint: !!index.unique,
         primary: false,
       })));
     }

--- a/packages/core/src/metadata/MetadataValidator.ts
+++ b/packages/core/src/metadata/MetadataValidator.ts
@@ -203,7 +203,8 @@ export class MetadataValidator {
   private validateIndexes(meta: EntityMetadata, indexes: { properties: string | string[] }[], type: 'index' | 'unique'): void {
     for (const index of indexes) {
       for (const prop of Utils.asArray(index.properties)) {
-        if (!(prop in meta.properties)) {
+        // if (!(prop in meta.properties)) {
+        if (!meta.props.some(p => prop === p.name || prop.startsWith(p.name + '.'))) {
           throw MetadataError.unknownIndexProperty(meta, prop, type);
         }
       }

--- a/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
+++ b/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
@@ -29,6 +29,8 @@ export abstract class AbstractNamingStrategy implements NamingStrategy {
       return `${tableName}_pkey`;
     }
 
+    columns = columns.map(col => col.replace(/\./g, '_'));
+
     if (type === 'sequence') {
       return `${tableName}_${columns.join('_')}_seq`;
     }

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -314,6 +314,11 @@ export abstract class Platform {
     return path.join('.');
   }
 
+  /* istanbul ignore next */
+  getJsonIndexDefinition(index: { columnNames: string[] }): string[] {
+    return index.columnNames;
+  }
+
   getFullTextWhereClause(prop: EntityProperty): string {
     throw new Error('Full text searching is not supported by this driver.');
   }

--- a/packages/knex/src/AbstractSqlPlatform.ts
+++ b/packages/knex/src/AbstractSqlPlatform.ts
@@ -2,6 +2,7 @@ import { escape } from 'sqlstring';
 import { raw, JsonProperty, Platform, Utils, type Constructor, type EntityManager, type EntityRepository, type IDatabaseDriver, type MikroORM } from '@mikro-orm/core';
 import { SqlEntityRepository } from './SqlEntityRepository';
 import { SqlSchemaGenerator, type SchemaHelper } from './schema';
+import type { IndexDef } from './typings';
 
 export abstract class AbstractSqlPlatform extends Platform {
 
@@ -107,6 +108,14 @@ export abstract class AbstractSqlPlatform extends Platform {
     }
 
     return raw(`json_extract(${this.quoteIdentifier(a)}, '$.${b.map(quoteKey).join('.')}')`);
+  }
+
+  override getJsonIndexDefinition(index: IndexDef): string[] {
+    return index.columnNames
+      .map(column => {
+        const [root, ...path] = column.split('.');
+        return `json_extract(${root}, '$.${path.join('.')}')`;
+      });
   }
 
   override isRaw(value: any): boolean {

--- a/packages/knex/src/typings.ts
+++ b/packages/knex/src/typings.ts
@@ -70,9 +70,11 @@ export interface IndexDef {
   columnNames: string[];
   keyName: string;
   unique: boolean;
+  constraint: boolean;
   primary: boolean;
   composite?: boolean;
   expression?: string; // allows using custom sql expressions
+  options?: Dictionary; // for driver specific options
   type?: string | Readonly<{ indexType?: string; storageEngineIndexType?: 'hash' | 'btree'; predicate?: Knex.QueryBuilder }>; // for back compatibility mainly, to allow using knex's `index.type` option (e.g. gin index)
 }
 

--- a/packages/mariadb/src/MariaDbSchemaHelper.ts
+++ b/packages/mariadb/src/MariaDbSchemaHelper.ts
@@ -69,6 +69,7 @@ export class MariaDbSchemaHelper extends SchemaHelper {
         keyName: index.index_name,
         unique: !index.non_unique,
         primary: index.index_name === 'PRIMARY',
+        constraint: !index.non_unique,
       });
     }
 

--- a/packages/mysql/src/MySqlPlatform.ts
+++ b/packages/mysql/src/MySqlPlatform.ts
@@ -1,4 +1,4 @@
-import { AbstractSqlPlatform } from '@mikro-orm/knex';
+import { AbstractSqlPlatform, type IndexDef } from '@mikro-orm/knex';
 import { MySqlSchemaHelper } from './MySqlSchemaHelper';
 import { MySqlExceptionConverter } from './MySqlExceptionConverter';
 import { Utils, type SimpleColumnMeta, type Dictionary, type Type, type TransformContext } from '@mikro-orm/core';
@@ -18,6 +18,14 @@ export class MySqlPlatform extends AbstractSqlPlatform {
     }
 
     return JSON.stringify(value);
+  }
+
+  override getJsonIndexDefinition(index: IndexDef): string[] {
+    return index.columnNames
+      .map(column => {
+        const [root, ...path] = column.split('.');
+        return `json_value(${this.quoteIdentifier(root)}, '$.${path.join('.')}' returning ${index.options?.returning ?? 'char(255)'})`;
+      });
   }
 
   override getBooleanTypeDeclarationSQL(): string {

--- a/packages/mysql/src/MySqlSchemaHelper.ts
+++ b/packages/mysql/src/MySqlSchemaHelper.ts
@@ -70,6 +70,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
         keyName: index.index_name,
         unique: !index.non_unique,
         primary: index.index_name === 'PRIMARY',
+        constraint: !index.non_unique,
       });
     }
 

--- a/packages/sqlite/src/SqliteSchemaHelper.ts
+++ b/packages/sqlite/src/SqliteSchemaHelper.ts
@@ -79,6 +79,7 @@ export class SqliteSchemaHelper extends SchemaHelper {
       ret.push({
         columnNames: [col.name],
         keyName: 'primary',
+        constraint: true,
         unique: true,
         primary: true,
       });
@@ -90,6 +91,7 @@ export class SqliteSchemaHelper extends SchemaHelper {
         columnNames: [row.name],
         keyName: index.name,
         unique: !!index.unique,
+        constraint: !!index.unique,
         primary: false,
       })));
     }

--- a/tests/features/schema-generator/__snapshots__/index-diffing.mysql.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/index-diffing.mysql.test.ts.snap
@@ -1,12 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`indexes on FKs in mysql (GH 1518) schema generator respect indexes on FKs on column update 1`] = `
-"create table \`book\` (\`id\` int unsigned not null auto_increment primary key, \`author1_id\` int unsigned not null, \`author2_id\` int unsigned not null, \`author3_id\` int unsigned not null, \`author4_id\` int unsigned not null, \`author5_id\` int unsigned not null, \`title\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+"create table \`book\` (\`id\` int unsigned not null auto_increment primary key, \`author1_id\` int unsigned not null, \`author2_id\` int unsigned not null, \`author3_id\` int unsigned not null, \`author4_id\` int unsigned not null, \`author5_id\` int unsigned not null, \`title\` varchar(255) not null, \`isbn\` varchar(255) not null, \`meta_data\` json not null) default character set utf8mb4 engine = InnoDB;
 alter table \`book\` add index \`book_author1_id_index\`(\`author1_id\`);
 alter table \`book\` add index \`book_author2_id_index\`(\`author2_id\`);
 alter table \`book\` add index \`book_author3_id_index\`(\`author3_id\`);
 alter table \`book\` add index \`book_author4_id_index\`(\`author4_id\`);
 alter table \`book\` add index \`book_author5_id_index\`(\`author5_id\`);
+alter table \`book\` add unique \`book_isbn_unique\`(\`isbn\`);
 
 alter table \`book\` add constraint \`book_author1_id_foreign\` foreign key (\`author1_id\`) references \`author\` (\`id\`) on update cascade;
 alter table \`book\` add constraint \`book_author2_id_foreign\` foreign key (\`author2_id\`) references \`author\` (\`id\`) on update cascade;
@@ -19,23 +20,37 @@ alter table \`book\` add constraint \`book_author5_id_foreign\` foreign key (\`a
 
 exports[`indexes on FKs in mysql (GH 1518) schema generator respect indexes on FKs on column update 2`] = `
 "alter table \`book\` add index \`custom_index_expr\`(\`title\`);
+alter table \`book\` add index \`book_meta_data_foo_bar_baz_index\`((json_value(\`meta_data\`, '$.foo.bar.baz' returning char(200))));
+alter table \`book\` add unique index \`book_meta_data_fooBar_email_unique\`((json_value(\`meta_data\`, '$.fooBar.email' returning char(255))));
+alter table \`book\` drop index \`book_isbn_unique\`;
+alter table \`book\` add unique \`isbn_unique_constr\`(\`isbn\`);
 
 "
 `;
 
 exports[`indexes on FKs in mysql (GH 1518) schema generator respect indexes on FKs on column update 3`] = `
-"alter table \`book\` drop index \`custom_index_expr\`;
+"alter table \`book\` drop index \`book_meta_data_foo_bar_baz_index\`;
+alter table \`book\` drop index \`book_meta_data_fooBar_email_unique\`;
+alter table \`book\` drop index \`custom_index_expr\`;
 alter table \`book\` add index \`custom_index_expr2\`(\`title\`);
+alter table \`book\` add index \`book_meta_data_foo_bar2_meta_data_foo_bar3_index\`((json_value(\`meta_data\`, '$.foo.bar2' returning char(255))), (json_value(\`meta_data\`, '$.foo.bar3' returning char(255))));
 alter table \`book\` add index \`lol41\`(\`author3_id\`);
 alter table \`book\` add index \`lol31\`(\`author3_id\`);
+alter table \`book\` add unique index \`book_meta_data_fooBar_bazBaz_meta_data_fooBar_lol123_unique\`((json_value(\`meta_data\`, '$.fooBar.bazBaz' returning char(255))), (json_value(\`meta_data\`, '$.fooBar.lol123' returning char(255))));
 alter table \`book\` rename index \`book_author5_id_index\` to \`auth_idx5\`;
+alter table \`book\` drop index \`isbn_unique_constr\`;
+alter table \`book\` add unique \`book_isbn_unique\`(\`isbn\`);
 
 "
 `;
 
 exports[`indexes on FKs in mysql (GH 1518) schema generator respect indexes on FKs on column update 4`] = `
-"alter table \`book\` add index \`lol32\`(\`author3_id\`);
-alter table \`book\` add index \`lol42\`(\`author3_id\`);
+"alter table \`book\` drop index \`book_meta_data_foo_bar2_meta_data_foo_bar3_index\`;
+alter table \`book\` drop index \`book_meta_data_fooBar_bazBaz_meta_data_fooBar_lol123_unique\`;
 alter table \`book\` drop index \`lol31\`;
-alter table \`book\` drop index \`lol41\`;"
+alter table \`book\` drop index \`lol41\`;
+alter table \`book\` add index \`lol42\`(\`author3_id\`);
+alter table \`book\` add index \`lol32\`(\`author3_id\`);
+
+"
 `;

--- a/tests/features/schema-generator/__snapshots__/index-diffing.postgres.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/index-diffing.postgres.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`indexes on FKs in postgres (GH 1518) schema generator respect indexes on FKs on column update 1`] = `
-"create table "book" ("id" serial primary key, "author1_id" int not null, "author2_id" int not null, "author3_id" int not null, "author4_id" int not null, "author5_id" int not null, "title" varchar(255) not null, "isbn" varchar(255) not null);
+"create table "book" ("id" serial primary key, "author1_id" int not null, "author2_id" int not null, "author3_id" int not null, "author4_id" int not null, "author5_id" int not null, "title" varchar(255) not null, "isbn" varchar(255) not null, "meta_data" jsonb not null);
 alter table "book" add constraint "book_isbn_unique" unique ("isbn");
 
 alter table "book" add constraint "book_author1_id_foreign" foreign key ("author1_id") references "author" ("id") on update cascade;
@@ -21,6 +21,8 @@ create index "book_author4_id_index" on "book" ("author4_id");
 create index "book_author5_id_index" on "book" ("author5_id");
 create index "custom_index_expr" on "book" ("title");
 create  index  "custom_index_expr123" on "book" ("isbn");
+create index "book_meta_data_foo_bar_baz_index" on "book" (("meta_data"->'foo'->'bar'->>'baz'));
+create unique index "book_meta_data_fooBar_email_unique" on "book" (("meta_data"->'fooBar'->>'email'));
 alter table "book" drop constraint "book_isbn_unique";
 alter table "book" add constraint "isbn_unique_constr" unique ("isbn");
 
@@ -28,9 +30,13 @@ alter table "book" add constraint "isbn_unique_constr" unique ("isbn");
 `;
 
 exports[`indexes on FKs in postgres (GH 1518) schema generator respect indexes on FKs on column update 3`] = `
-"drop index "custom_index_expr";
+"drop index "book_meta_data_fooBar_email_unique";
+drop index "book_meta_data_foo_bar_baz_index";
+drop index "custom_index_expr";
 create index "custom_index_expr2" on "book" ("title");
+create index "book_meta_data_foo_meta_data_foo_bar3_index" on "book" (("meta_data"->>'foo'), ("meta_data"->'foo'->>'bar3'));
 create index "lol31" on "book" ("author3_id");
+create unique index "book_meta_data_fooBar_bazBaz_meta_data_fooBar_lol123_unique" on "book" (("meta_data"->'fooBar'->>'bazBaz'), ("meta_data"->'fooBar'->>'lol123'));
 alter index "book_author3_id_index" rename to "lol41";
 alter index "book_author5_id_index" rename to "auth_idx5";
 alter table "book" drop constraint "isbn_unique_constr";
@@ -40,7 +46,9 @@ alter table "book" add constraint "book_isbn_unique" unique ("isbn");
 `;
 
 exports[`indexes on FKs in postgres (GH 1518) schema generator respect indexes on FKs on column update 4`] = `
-"drop index "custom_index_expr123";
+"drop index "book_meta_data_fooBar_bazBaz_meta_data_fooBar_lol123_unique";
+drop index "book_meta_data_foo_meta_data_foo_bar3_index";
+drop index "custom_index_expr123";
 drop index "custom_index_expr2";
 drop index "lol31";
 drop index "lol41";

--- a/tests/features/schema-generator/__snapshots__/index-diffing.sqlite.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/index-diffing.sqlite.test.ts.snap
@@ -1,30 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`indexes on FKs in postgres (GH 1518) schema generator respect indexes on FKs on column update 1`] = `
-"create table \`book\` (\`id\` integer not null primary key autoincrement, \`author1_id\` integer not null, \`author2_id\` integer not null, \`author3_id\` integer not null, \`author4_id\` integer not null, \`author5_id\` integer not null, constraint \`book_author1_id_foreign\` foreign key(\`author1_id\`) references \`author\`(\`id\`) on update cascade, constraint \`book_author2_id_foreign\` foreign key(\`author2_id\`) references \`author\`(\`id\`) on update cascade, constraint \`book_author3_id_foreign\` foreign key(\`author3_id\`) references \`author\`(\`id\`) on update cascade, constraint \`book_author4_id_foreign\` foreign key(\`author4_id\`) references \`author\`(\`id\`) on update cascade, constraint \`book_author5_id_foreign\` foreign key(\`author5_id\`) references \`author\`(\`id\`) on update cascade);
+"create table \`book\` (\`id\` integer not null primary key autoincrement, \`author1_id\` integer not null, \`author2_id\` integer not null, \`author3_id\` integer not null, \`author4_id\` integer not null, \`author5_id\` integer not null, \`title\` text not null, \`isbn\` text not null, \`meta_data\` json not null, constraint \`book_author1_id_foreign\` foreign key(\`author1_id\`) references \`author\`(\`id\`) on update cascade, constraint \`book_author2_id_foreign\` foreign key(\`author2_id\`) references \`author\`(\`id\`) on update cascade, constraint \`book_author3_id_foreign\` foreign key(\`author3_id\`) references \`author\`(\`id\`) on update cascade, constraint \`book_author4_id_foreign\` foreign key(\`author4_id\`) references \`author\`(\`id\`) on update cascade, constraint \`book_author5_id_foreign\` foreign key(\`author5_id\`) references \`author\`(\`id\`) on update cascade);
 create index \`book_author1_id_index\` on \`book\` (\`author1_id\`);
 create index \`book_author2_id_index\` on \`book\` (\`author2_id\`);
 create index \`book_author3_id_index\` on \`book\` (\`author3_id\`);
 create index \`book_author4_id_index\` on \`book\` (\`author4_id\`);
 create index \`book_author5_id_index\` on \`book\` (\`author5_id\`);
+create unique index \`book_isbn_unique\` on \`book\` (\`isbn\`);
 
 "
 `;
 
-exports[`indexes on FKs in postgres (GH 1518) schema generator respect indexes on FKs on column update 2`] = `""`;
+exports[`indexes on FKs in postgres (GH 1518) schema generator respect indexes on FKs on column update 2`] = `
+"create index \`book_meta_data_foo_bar_baz_index\` on \`book\` ((json_extract(meta_data, '$.foo.bar.baz')));
+create index \`book_meta_data_fooBar_email_unique\` on \`book\` ((json_extract(meta_data, '$.fooBar.email')));
+drop index \`book_isbn_unique\`;
+create unique index \`isbn_unique_constr\` on \`book\` (\`isbn\`);
+
+"
+`;
 
 exports[`indexes on FKs in postgres (GH 1518) schema generator respect indexes on FKs on column update 3`] = `
-"create index \`lol41\` on \`book\` (\`author3_id\`);
+"drop index \`book_meta_data_fooBar_email_unique\`;
+drop index \`book_meta_data_foo_bar_baz_index\`;
+create index \`book_meta_data_foo_bar2_meta_data_foo_bar3_index\` on \`book\` ((json_extract(meta_data, '$.foo.bar2')), (json_extract(meta_data, '$.foo.bar3')));
+create index \`lol41\` on \`book\` (\`author3_id\`);
 create index \`lol31\` on \`book\` (\`author3_id\`);
+create index \`book_meta_data_fooBar_bazBaz_meta_data_fooBar_lol123_unique\` on \`book\` ((json_extract(meta_data, '$.fooBar.bazBaz')), (json_extract(meta_data, '$.fooBar.lol123')));
 drop index \`book_author5_id_index\`;
 create index \`auth_idx5\` on \`book\` (\`author5_id\`);
+drop index \`isbn_unique_constr\`;
+create unique index \`book_isbn_unique\` on \`book\` (\`isbn\`);
 
 "
 `;
 
 exports[`indexes on FKs in postgres (GH 1518) schema generator respect indexes on FKs on column update 4`] = `
-"drop index \`lol31\`;
+"drop index \`book_meta_data_fooBar_bazBaz_meta_data_fooBar_lol123_unique\`;
+drop index \`lol31\`;
 drop index \`lol41\`;
+drop index \`book_meta_data_foo_bar2_meta_data_foo_bar3_index\`;
 create index \`lol42\` on \`book\` (\`author3_id\`);
 create index \`lol32\` on \`book\` (\`author3_id\`);
 

--- a/tests/features/schema-generator/index-diffing.postgres.test.ts
+++ b/tests/features/schema-generator/index-diffing.postgres.test.ts
@@ -39,11 +39,16 @@ export class Book1 {
   @Property({ unique: true })
   isbn!: string;
 
+  @Property({ type: 'json' })
+  metaData: any;
+
 }
 
 @Entity({ tableName: 'book' })
 @Index({ properties: 'author1' })
 @Index({ properties: 'author3' })
+@Index({ properties: 'metaData.foo.bar.baz' })
+@Unique({ properties: 'metaData.fooBar.email' })
 @Index({ name: 'custom_index_expr123', expression: 'create  index  "custom_index_expr123" on "book" ("isbn")' })
 export class Book2 {
 
@@ -74,12 +79,17 @@ export class Book2 {
   @Property({ unique: 'isbn_unique_constr' })
   isbn!: string;
 
+  @Property({ type: 'json' })
+  metaData: any;
+
 }
 
 @Entity({ tableName: 'book' })
 @Index({ properties: 'author1' })
 @Index({ properties: 'author3', name: 'lol31' })
 @Index({ properties: 'author3', name: 'lol41' })
+@Index({ properties: ['metaData.foo', 'metaData.foo.bar3'] })
+@Unique({ properties: ['metaData.fooBar.bazBaz', 'metaData.fooBar.lol123'] })
 @Index({ name: 'custom_index_expr123', expression: 'create  index  "custom_index_expr123" on "book" ("isbn")' })
 export class Book3 {
 
@@ -110,6 +120,9 @@ export class Book3 {
   @Property()
   @Unique()
   isbn!: string;
+
+  @Property({ type: 'json' })
+  metaData: any;
 
 }
 
@@ -146,6 +159,9 @@ export class Book4 {
   @Unique()
   isbn!: string;
 
+  @Property({ type: 'json' })
+  metaData: any;
+
 }
 
 describe('indexes on FKs in postgres (GH 1518)', () => {
@@ -158,6 +174,7 @@ describe('indexes on FKs in postgres (GH 1518)', () => {
       dbName: `mikro_orm_test_gh_1518`,
       driver: PostgreSqlDriver,
     });
+
     await orm.schema.ensureDatabase();
     await orm.schema.execute('drop table if exists author cascade');
     await orm.schema.execute('drop table if exists book cascade');

--- a/tests/features/schema-generator/index-diffing.sqlite.test.ts
+++ b/tests/features/schema-generator/index-diffing.sqlite.test.ts
@@ -1,5 +1,4 @@
-import { Entity, Ref, Index, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, Ref, Index, ManyToOne, MikroORM, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
 @Entity()
@@ -34,11 +33,22 @@ export class Book1 {
   @ManyToOne(() => Author)
   author5!: Author;
 
+  @Property()
+  title!: string;
+
+  @Property({ unique: true })
+  isbn!: string;
+
+  @Property({ type: 'json' })
+  metaData: any;
+
 }
 
 @Entity({ tableName: 'book' })
 @Index({ properties: 'author1' })
 @Index({ properties: 'author3' })
+@Index({ properties: 'metaData.foo.bar.baz', options: { returning: 'char(200)' } })
+@Unique({ properties: 'metaData.fooBar.email' })
 export class Book2 {
 
   @PrimaryKey()
@@ -61,12 +71,23 @@ export class Book2 {
   @ManyToOne(() => Author, { index: true })
   author5!: Author;
 
+  @Property()
+  title!: string;
+
+  @Property({ unique: 'isbn_unique_constr' })
+  isbn!: string;
+
+  @Property({ type: 'json' })
+  metaData: any;
+
 }
 
 @Entity({ tableName: 'book' })
 @Index({ properties: 'author1' })
 @Index({ properties: 'author3', name: 'lol31' })
 @Index({ properties: 'author3', name: 'lol41' })
+@Index({ properties: ['metaData.foo.bar2', 'metaData.foo.bar3'] })
+@Unique({ properties: ['metaData.fooBar.bazBaz', 'metaData.fooBar.lol123'] })
 export class Book3 {
 
   @PrimaryKey()
@@ -88,6 +109,16 @@ export class Book3 {
 
   @ManyToOne(() => Author, { index: 'auth_idx5' })
   author5!: Author;
+
+  @Property()
+  title!: string;
+
+  @Property()
+  @Unique()
+  isbn!: string;
+
+  @Property({ type: 'json' })
+  metaData: any;
 
 }
 
@@ -116,6 +147,16 @@ export class Book4 {
 
   @ManyToOne(() => Author, { index: 'auth_idx5' })
   author5!: Author;
+
+  @Property()
+  title!: string;
+
+  @Property()
+  @Unique()
+  isbn!: string;
+
+  @Property({ type: 'json' })
+  metaData: any;
 
 }
 


### PR DESCRIPTION
To create an index on a JSON property, use an entity-level `@Index()` decorator with a dot path:

```ts
@Entity()
@Index({ properties: 'metaData.foo' })
@Index({ properties: ['metaData.foo', 'metaData.bar'] }) // compound index
export class Book {

  @Property({ type: 'json', nullable: true })
  metaData?: { foo: string; bar: number };

}
```

In PostgreSQL, this will generate a query like the following:

```sql
create index "book_meta_data_foo_index" on "book" (("meta_data"->>'foo'));
```

To create a unique index, use the `@Unique()` decorator:

```ts
@Entity()
@Unique({ properties: 'metaData.foo' })
@Unique({ properties: ['metaData.foo', 'metaData.bar'] }) // compound unique index
export class Book {

  @Property({ type: 'json', nullable: true })
  metaData?: { foo: string; bar: number };

}
```

In MySQL, you can also set the type explicitly:

```ts
@Entity()
@Index({ properties: 'metaData.foo', options: { returning: 'char(200)' } })
export class Book {

  @Property({ type: 'json', nullable: true })
  metaData?: { foo: string; bar: number };

}
```

This will generate a query like the following:

```sql
alter table `book`
  add index `book_meta_data_foo_index`((json_value(`meta_data`, '$.foo' returning char(200))));
```

> MariaDB driver does not support this feature.

Closes #1230