### PR TITLE
fix(core): make `em.create` strictly typed for relations too

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1204,7 +1204,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
 
     data = QueryHelper.processObjectParams(data);
     em.validator.validateParams(data, 'insert data');
-    const res = await em.driver.nativeInsert<Entity>(entityName, data, { ctx: em.transactionContext, ...options });
+    const res = await em.driver.nativeInsert<Entity>(entityName, data as EntityData<Entity>, { ctx: em.transactionContext, ...options });
 
     return res.insertId!;
   }
@@ -1248,7 +1248,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
 
     data = data.map(row => QueryHelper.processObjectParams(row));
     data.forEach(row => em.validator.validateParams(row, 'insert data'));
-    const res = await em.driver.nativeInsertMany<Entity>(entityName, data, { ctx: em.transactionContext, ...options });
+    const res = await em.driver.nativeInsertMany<Entity>(entityName, data as EntityData<Entity>[], { ctx: em.transactionContext, ...options });
 
     return res.insertedIds!;
   }
@@ -1356,7 +1356,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    */
   create<Entity extends object>(entityName: EntityName<Entity>, data: RequiredEntityData<Entity>, options: CreateOptions = {}): Entity {
     const em = this.getContext();
-    const entity = em.entityFactory.create(entityName, data, {
+    const entity = em.entityFactory.create(entityName, data as EntityData<Entity>, {
       ...options,
       newEntity: !options.managed,
       merge: options.managed,

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -239,7 +239,7 @@ export class EntityRepository<Entity extends object> {
    * the whole `data` parameter will be passed. This means we can also define `constructor(data: Partial<Entity>)` and
    * `em.create()` will pass the data into it (unless we have a property named `data` too).
    */
-  create<Hint = never>(data: RequiredEntityData<Entity>, options?: CreateOptions): Entity {
+  create(data: RequiredEntityData<Entity>, options?: CreateOptions): Entity {
     return this.getEntityManager().create(this.entityName, data, options);
   }
 

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -564,9 +564,9 @@ describe('EntityManagerPostgre', () => {
   test('order by json properties', async () => {
     await orm.em.insert(Author2, { name: 'n', email: 'e', id: 1 });
     await orm.em.insertMany(Book2, [
-      { uuid: '123e4567-e89b-12d3-a456-426614174001', title: 't1', author: 1, meta: { nested: { foo: '3', deep: { str: 'c', baz: 3 } } } },
-      { uuid: '123e4567-e89b-12d3-a456-426614174002', title: 't2', author: 1, meta: { nested: { foo: '2', deep: { str: 'b', baz: 1 } } } },
-      { uuid: '123e4567-e89b-12d3-a456-426614174003', title: 't3', author: 1, meta: { nested: { foo: '1', deep: { str: 'a', baz: 2 } } } },
+      { uuid: '123e4567-e89b-12d3-a456-426614174001', title: 't1', author: 1, meta: { nested: { foo: '3', deep: { str: 'c', qux: false, baz: 3 } } } },
+      { uuid: '123e4567-e89b-12d3-a456-426614174002', title: 't2', author: 1, meta: { nested: { foo: '2', deep: { str: 'b', qux: false, baz: 1 } } } },
+      { uuid: '123e4567-e89b-12d3-a456-426614174003', title: 't3', author: 1, meta: { nested: { foo: '1', deep: { str: 'a', qux: false, baz: 2 } } } },
     ]);
 
     const res14 = await orm.em.fork().find(Book2, {}, { orderBy: { meta: { nested: { foo: 'asc' } } } });

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -86,8 +86,8 @@ export class Book2 {
 }
 
 export interface Book2Meta {
-  category: string;
-  items: number;
+  category?: string;
+  items?: number;
   valid?: boolean;
   nested?: {
     foo: string;

--- a/tests/features/optimistic-lock/GH3209.test.ts
+++ b/tests/features/optimistic-lock/GH3209.test.ts
@@ -70,6 +70,10 @@ export class Author {
 @Entity()
 export class Book {
 
+  [PrimaryKeyProp]?: 'bookId';
+
+  [OptionalProps]?: 'bookId';
+
   @PrimaryKey()
   bookId!: number;
 

--- a/tests/issues/GH1592.test.ts
+++ b/tests/issues/GH1592.test.ts
@@ -1,7 +1,9 @@
-import { Entity, MikroORM, PrimaryKey, Property, Ref, LoadStrategy, OneToOne } from '@mikro-orm/sqlite';
+import { Entity, MikroORM, PrimaryKey, Property, Ref, LoadStrategy, OneToOne, OptionalProps } from '@mikro-orm/sqlite';
 
 @Entity()
 export class RadioOption {
+
+  [OptionalProps]?: 'createdAt';
 
   @PrimaryKey()
   id!: number;

--- a/tests/issues/GH3429.test.ts
+++ b/tests/issues/GH3429.test.ts
@@ -1,9 +1,10 @@
-import { MikroORM, Embeddable, Embedded, Entity, PrimaryKey, Property, HiddenProps, wrap } from '@mikro-orm/sqlite';
+import { MikroORM, Embeddable, Embedded, Entity, PrimaryKey, Property, HiddenProps, OptionalProps, wrap } from '@mikro-orm/sqlite';
 
 @Embeddable()
 class Address {
 
   [HiddenProps]?: 'addressLine1' | 'addressLine2';
+  [OptionalProps]?: 'address';
 
   @Property({ hidden: true })
   addressLine1!: string;

--- a/tests/issues/GH3738.test.ts
+++ b/tests/issues/GH3738.test.ts
@@ -33,7 +33,7 @@ export class Question {
 @Entity()
 export class Answer {
 
-  [OptionalProps]?: 'createdAt';
+  [OptionalProps]?: 'createdAt' | 'question';
 
   @PrimaryKey({ type: 'uuid' })
   id: string = randomUUID();

--- a/tests/issues/GH3812.test.ts
+++ b/tests/issues/GH3812.test.ts
@@ -73,7 +73,7 @@ export class Log extends BaseEntity {
   step?: Step;
 
   @Property({ type: 'date', nullable: true })
-  operationDate?: string;
+  operationDate?: string | null;
 
   @Property({ default: false })
   current: boolean = false;

--- a/tests/issues/GH3941.test.ts
+++ b/tests/issues/GH3941.test.ts
@@ -1,4 +1,15 @@
-import { Collection, Entity, helper, ManyToOne, OneToMany, OneToOne, PrimaryKey, Property, Ref } from '@mikro-orm/core';
+import {
+  Collection,
+  Entity,
+  helper,
+  ManyToOne,
+  OneToMany,
+  OneToOne,
+  OptionalProps,
+  PrimaryKey,
+  Property,
+  Ref,
+} from '@mikro-orm/core';
 import { MikroORM } from '@mikro-orm/sqlite';
 
 @Entity()
@@ -24,6 +35,8 @@ class Organization {
 @Entity()
 class License {
 
+  [OptionalProps]?: 'organization';
+
   @PrimaryKey()
   id!: number;
 
@@ -37,6 +50,8 @@ class License {
 
 @Entity()
 class Workspace {
+
+  [OptionalProps]?: 'organization';
 
   @PrimaryKey()
   id!: number;

--- a/tests/issues/GH4323.test.ts
+++ b/tests/issues/GH4323.test.ts
@@ -19,7 +19,7 @@ class Blog {
 @Entity()
 class User {
 
-  [OptionalProps]!: 'name' | 'balance';
+  [OptionalProps]?: 'name' | 'balance';
 
   @PrimaryKey()
   id!: number;

--- a/tests/perf/creating-large-collections.test.ts
+++ b/tests/perf/creating-large-collections.test.ts
@@ -1,4 +1,13 @@
-import { Collection, Entity, ManyToOne, OneToMany, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
+import {
+  Collection,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  MikroORM,
+  PrimaryKey,
+  Property,
+  OptionalProps,
+} from '@mikro-orm/core';
 import { BetterSqliteDriver } from '@mikro-orm/better-sqlite';
 
 @Entity()
@@ -14,6 +23,8 @@ class TestRunEntity {
 
 @Entity()
 class TestCaseEntity {
+
+  [OptionalProps]?: 'testRun';
 
   @PrimaryKey()
   id!: number;


### PR DESCRIPTION
When using `em.create()`, we can create the entity graph in one step, including relations. This commit makes the typing strict for the relations too, requiring their mandatory props to be present

There is one common issue with this - the `em.create` automatically propagates things to inverse sides, in other words, doing this is completely fine, as the author will be propagated to the new books:

```ts
em.create(Author, {
  name: '...',
  books: [{ title: 'foo' }], // Book.author is required, but will be propagated from the upper scope
});
```

To get around it, the child properties matching their parent type are automatically considered as optional - in other words, since we are processing contents of `Author.books`, we will make all properties of type `Author` in the `Author.books` as optional. It's not perfect, as it will mark every `Author` property as optional, not just the one that is an inverse of `Author.books`, but I feel like it's the tradeoff we need to make.

Closes #4748