### PR TITLE
feat(core): add `Opt` type as an alternative to `OptionalProps` symbol

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -20,6 +20,8 @@
   --ifm-color-primary-light: rgb(70, 203, 174);
   --ifm-color-primary-lighter: rgb(102, 212, 189);
   --ifm-color-primary-lightest: rgb(146, 224, 208);
+  --prism-color: #393A34;
+  --prism-background-color: #f6f8fa;
 }
 
 html[data-theme="light"] {
@@ -28,6 +30,7 @@ html[data-theme="light"] {
   --ifm-alert-border-color: #ffeeba;
   --ifm-alert-color: #856404;
   --ra-admonition-icon-color: #856404;
+  --docusaurus-highlighted-code-line-bg: rgb(218, 221, 227);
 }
 
 html[data-theme="light"] .admonition-info {
@@ -240,16 +243,6 @@ html[data-theme="dark"] .navbar .navbar__link[href*=twitter]:before {
   .hero.hero--primary .button.button--outline {
     font-size: 0.8rem;
   }
-}
-
-html code {
-  color: #1c1e21;
-  background-color: #ebedf0;
-}
-
-html[data-theme="dark"] code {
-  color: #f5f6f7;
-  background-color: #444950;
 }
 
 html a code {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,7 @@ export {
   AnyEntity, EntityClass, EntityProperty, EntityMetadata, QBFilterQuery, PopulateOptions, Populate, Loaded, New, LoadedReference, LoadedCollection, IMigrator, IMigrationGenerator,
   GetRepository, EntityRepositoryType, MigrationObject, DeepPartial, PrimaryProperty, Cast, IsUnknown, EntityDictionary, EntityDTO, MigrationDiff, GenerateOptions, FilterObject,
   IEntityGenerator, ISeedManager, EntityClassGroup, OptionalProps, EagerProps, HiddenProps, RequiredEntityData, CheckCallback, SimpleColumnMeta, Rel, Ref, ISchemaGenerator,
-  UmzugMigration, MigrateOptions, MigrationResult, MigrationRow, EntityKey, EntityValue, FilterKey, EntityType, FromEntityType, Selected, IsSubset,
+  UmzugMigration, MigrateOptions, MigrationResult, MigrationRow, EntityKey, EntityValue, FilterKey, Opt, EntityType, FromEntityType, Selected, IsSubset,
 } from './typings';
 export * from './enums';
 export * from './errors';

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1,14 +1,21 @@
 import type { Transaction } from './connections';
-import { ReferenceKind, type Cascade, type EventType, type LoadStrategy, type LockMode, type QueryOrderMap } from './enums';
 import {
-  EntityHelper,
-  Reference,
+  type Cascade,
+  type EventType,
+  type LoadStrategy,
+  type LockMode,
+  type QueryOrderMap,
+  ReferenceKind,
+} from './enums';
+import {
   type AssignOptions,
   type Collection,
   type EntityFactory,
+  EntityHelper,
   type EntityIdentifier,
   type EntityLoaderOptions,
   type EntityRepository,
+  Reference,
   type ScalarReference,
 } from './entity';
 import type { SerializationContext, SerializeOptions } from './serialization';
@@ -47,6 +54,8 @@ export const PrimaryKeyProp = Symbol('PrimaryKeyProp');
 export const OptionalProps = Symbol('OptionalProps');
 export const EagerProps = Symbol('EagerProps');
 export const HiddenProps = Symbol('HiddenProps');
+
+export type Opt = { __optional?: 1 };
 
 export type UnwrapPrimary<T> = T extends Scalar
   ? T
@@ -186,9 +195,15 @@ export type EntityDataPropValue<T> = T | Primary<T>;
 type ExpandEntityProp<T> = T extends Record<string, any>
   ? { [K in keyof T as ExcludeFunctions<T, K>]?: EntityDataProp<ExpandProperty<T[K]>> | EntityDataPropValue<ExpandProperty<T[K]>> | null } | EntityDataPropValue<ExpandProperty<T>>
   : T;
-type ExpandRequiredEntityProp<T> = T extends Record<string, any>
-  ? { [K in keyof T as ExcludeFunctions<T, K>]: RequiredEntityDataProp<ExpandProperty<T[K]>, T> | EntityDataPropValue<ExpandProperty<T[K]>> } | EntityDataPropValue<ExpandProperty<T>>
+type ExpandRequiredEntityProp<T, I> = T extends Record<string, any>
+  ? ExpandRequiredEntityPropObject<T, I> | EntityDataPropValue<ExpandProperty<T>>
   : T;
+
+type ExpandRequiredEntityPropObject<T, I = never> = {
+  [K in keyof T as RequiredKeys<T, K, I>]: RequiredEntityDataProp<ExpandProperty<T[K]>, T> | EntityDataPropValue<ExpandProperty<T[K]>>;
+} & {
+  [K in keyof T as OptionalKeys<T, K, I>]?: RequiredEntityDataProp<ExpandProperty<T[K]>, T> | EntityDataPropValue<ExpandProperty<T[K]>> | null | undefined;
+};
 
 export type EntityDataProp<T> = T extends Date
   ? string | Date
@@ -196,11 +211,13 @@ export type EntityDataProp<T> = T extends Date
     ? T
     : T extends Reference<infer U>
       ? EntityDataNested<U>
-      : T extends Collection<infer U, any>
-          ? U | U[] | EntityDataNested<U> | EntityDataNested<U>[]
-          : T extends readonly (infer U)[]
-              ? U | U[] | EntityDataNested<U> | EntityDataNested<U>[]
-              : EntityDataNested<T>;
+      : T extends ScalarReference<infer U>
+        ? EntityDataProp<U>
+        : T extends Collection<infer U, any>
+            ? U | U[] | EntityDataNested<U> | EntityDataNested<U>[]
+            : T extends readonly (infer U)[]
+                ? U | U[] | EntityDataNested<U> | EntityDataNested<U>[]
+                : EntityDataNested<T>;
 
 export type RequiredEntityDataProp<T, O> = T extends Date
   ? string | Date
@@ -208,11 +225,13 @@ export type RequiredEntityDataProp<T, O> = T extends Date
     ? T
     : T extends Reference<infer U>
       ? RequiredEntityDataNested<U, O>
-      : T extends Collection<infer U, any>
-        ? U | U[] | RequiredEntityDataNested<U, O> | RequiredEntityDataNested<U, O>[]
-        : T extends readonly (infer U)[]
+      : T extends ScalarReference<infer U>
+        ? RequiredEntityDataProp<U, O>
+        : T extends Collection<infer U, any>
           ? U | U[] | RequiredEntityDataNested<U, O> | RequiredEntityDataNested<U, O>[]
-          : RequiredEntityDataNested<T, O>;
+          : T extends readonly (infer U)[]
+            ? U | U[] | RequiredEntityDataNested<U, O> | RequiredEntityDataNested<U, O>[]
+            : RequiredEntityDataNested<T, O>;
 
 export type EntityDataNested<T> = T extends undefined
   ? never
@@ -223,30 +242,26 @@ type EntityDataItem<T> = T | EntityDataProp<T> | null;
 
 export type RequiredEntityDataNested<T, O> = T extends any[]
     ? Readonly<T>
-    : RequiredEntityData<T, O> | ExpandRequiredEntityProp<T>;
+    : RequiredEntityData<T, O> | ExpandRequiredEntityProp<T, O>;
 
-type ExplicitlyOptionalProps<T> = T extends { [OptionalProps]?: infer PK } ? PK : never;
+type ExplicitlyOptionalProps<T> = (T extends { [OptionalProps]?: infer K } ? K : never) | ({ [K in keyof T]: T[K] extends Opt ? K : never }[keyof T] & {});
 type NullableKeys<T> = { [K in keyof T]: null extends T[K] ? K : never }[keyof T];
 type ProbablyOptionalProps<T> = ExplicitlyOptionalProps<T> | 'id' | '_id' | 'uuid' | Defined<NullableKeys<T>>;
 
 type IsOptional<T, K extends keyof T, I> = T[K] extends Collection<any, any>
   ? true
-  : T[K] extends Function
+  : ExtractType<T[K]> extends I
     ? true
-    : ExtractType<T[K]> extends I
+    : K extends ProbablyOptionalProps<T>
       ? true
-      : K extends symbol
-        ? never
-        : K extends ProbablyOptionalProps<T>
-          ? true
-          : false;
-type RequiredKeys<T, K extends keyof T, I> = IsOptional<T, K, I> extends false ? K : never;
-type OptionalKeys<T, K extends keyof T, I> = IsOptional<T, K, I> extends false ? never : K;
+      : false;
+type RequiredKeys<T, K extends keyof T, I> = IsOptional<T, K, I> extends false ? ExcludeFunctions<T, K> : never;
+type OptionalKeys<T, K extends keyof T, I> = IsOptional<T, K, I> extends false ? never : ExcludeFunctions<T, K>;
 export type EntityData<T> = { [K in EntityKey<T>]?: EntityDataItem<T[K]> };
 export type RequiredEntityData<T, I = never> = {
-  [K in keyof T as RequiredKeys<T, K, I>]: T[K] | RequiredEntityDataProp<T[K], T>
+  [K in keyof T as RequiredKeys<T, K, I>]: T[K] | RequiredEntityDataProp<T[K], T> | Primary<T[K]>
 } & {
-  [K in keyof T as OptionalKeys<T, K, I>]?: T[K] | RequiredEntityDataProp<T[K], T> | null
+  [K in keyof T as OptionalKeys<T, K, I>]?: T[K] | RequiredEntityDataProp<T[K], T> | Primary<T[K]> | null
 };
 export type EntityDictionary<T> = EntityData<T> & Record<any, any>;
 
@@ -272,15 +287,17 @@ export type EntityDTOProp<T> = T extends Scalar
     ? EntityDTONested<U>
     : T extends Reference<infer U>
       ? Primary<U>
-      : T extends { getItems(check?: boolean): infer U }
-        ? (U extends readonly (infer V)[] ? EntityDTONested<V>[] : EntityDTONested<U>)
-        : T extends { $: infer U }
+      : T extends ScalarReference<infer U>
+        ? U
+        : T extends { getItems(check?: boolean): infer U }
           ? (U extends readonly (infer V)[] ? EntityDTONested<V>[] : EntityDTONested<U>)
-          : T extends readonly (infer U)[]
-            ? (T extends readonly [infer U, ...infer V] ? T : U[])
-            : T extends Relation<T>
-              ? EntityDTONested<T>
-              : T;
+          : T extends { $: infer U }
+            ? (U extends readonly (infer V)[] ? EntityDTONested<V>[] : EntityDTONested<U>)
+            : T extends readonly (infer U)[]
+              ? (T extends readonly [infer U, ...infer V] ? T : U[])
+              : T extends Relation<T>
+                ? EntityDTONested<T>
+                : T;
 type ExtractHiddenProps<T> = T extends { [HiddenProps]?: infer Prop } ? Prop : never;
 type ExcludeHidden<T, K extends keyof T> = K extends ExtractHiddenProps<T> ? never : K;
 export type EntityDTO<T> = { [K in EntityKey<T> as ExcludeHidden<T, K>]: EntityDTOProp<T[K]> };

--- a/tests/entities-sql/Author2.ts
+++ b/tests/entities-sql/Author2.ts
@@ -21,7 +21,7 @@ import {
   EventArgs,
   t,
   OnLoad,
-  OptionalProps,
+  Opt,
   HiddenProps,
   Embeddable,
   Embedded,
@@ -60,16 +60,14 @@ export class Identity {
 @Unique({ properties: ['name', 'email'] })
 export class Author2 extends BaseEntity2 {
 
-  [OptionalProps]?: 'createdAt' | 'updatedAt' | 'termsAccepted' | 'version' | 'versionAsString' | 'code' | 'code2' | 'booksTotal' | 'hookParams' | 'hookTest' | 'onLoadCalled';
-
   static beforeDestroyCalled = 0;
   static afterDestroyCalled = 0;
 
   @Property({ length: 3, defaultRaw: 'current_timestamp(3)' })
-  createdAt = new Date();
+  createdAt: Date & Opt = new Date();
 
   @Property({ onUpdate: () => new Date(), length: 3, defaultRaw: 'current_timestamp(3)' })
-  updatedAt = new Date();
+  updatedAt: Date & Opt = new Date();
 
   @Property()
   name: string;
@@ -83,7 +81,7 @@ export class Author2 extends BaseEntity2 {
 
   @Index()
   @Property()
-  termsAccepted = false;
+  termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
   optional?: boolean;
@@ -125,18 +123,18 @@ export class Author2 extends BaseEntity2 {
   identity?: Identity;
 
   @Property({ persist: false })
-  version!: number;
+  version!: number & Opt;
 
   @Property({ persist: false })
-  versionAsString!: string;
+  versionAsString!: string & Opt;
 
   @Property({ persist: false })
-  code!: string;
+  code!: string & Opt;
 
   @Property({ persist: false })
-  booksTotal!: number;
+  booksTotal!: number & Opt;
 
-  hookParams: any[] = [];
+  hookParams: any[] & Opt = [];
   onLoadCalled?: number;
 
   constructor(name: string, email: string) {
@@ -191,12 +189,12 @@ export class Author2 extends BaseEntity2 {
   }
 
   @Property({ name: 'code' })
-  getCode() {
+  getCode(): string & Opt {
     return `${this.email} - ${this.name}`;
   }
 
   @Property({ persist: false })
-  get code2() {
+  get code2(): string & Opt {
     return `${this.email} - ${this.name}`;
   }
 

--- a/tests/entities-sql/BaseEntity2.ts
+++ b/tests/entities-sql/BaseEntity2.ts
@@ -1,4 +1,4 @@
-import { BeforeCreate, PrimaryKey, Property } from '@mikro-orm/core';
+import { BeforeCreate, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 export abstract class BaseEntity2 {
 
@@ -6,7 +6,7 @@ export abstract class BaseEntity2 {
   id!: number;
 
   @Property({ persist: false })
-  hookTest = false;
+  hookTest: boolean & Opt = false;
 
   @BeforeCreate()
   baseBeforeCreate() {

--- a/tests/entities-sql/Publisher2.ts
+++ b/tests/entities-sql/Publisher2.ts
@@ -26,7 +26,7 @@ export enum Enum2 {
 @Entity()
 export class Publisher2 extends BaseEntity2 {
 
-  [OptionalProps]?: 'type' | 'type2' | 'hookTest';
+  [OptionalProps]?: 'type' | 'type2';
 
   @Property({ fieldName: 'name' })
   name: string;

--- a/tests/features/composite-keys/GH1079.test.ts
+++ b/tests/features/composite-keys/GH1079.test.ts
@@ -7,7 +7,7 @@ import {
   Property,
   BigIntType,
   wrap,
-  OptionalProps,
+  Opt,
   PrimaryKeyProp,
 } from '@mikro-orm/core';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
@@ -38,9 +38,7 @@ class Wallet {
 
 }
 
-class AbstractDeposit<Optional> {
-
-  [OptionalProps]?: 'createdAt' | 'updatedAt' | Optional;
+class AbstractDeposit {
 
   @Property({ type: String, nullable: false })
   amount!: string;
@@ -49,10 +47,10 @@ class AbstractDeposit<Optional> {
   gatewayKey!: string;
 
   @Property()
-  createdAt: Date = new Date();
+  createdAt: Opt & Date = new Date();
 
   @Property({ onUpdate: () => new Date() })
-  updatedAt: Date = new Date();
+  updatedAt: Opt & Date = new Date();
 
 }
 
@@ -65,7 +63,7 @@ enum DepositStatus {
 
 
 @Entity()
-export class Deposit extends AbstractDeposit<'status'> {
+export class Deposit extends AbstractDeposit {
 
   [PrimaryKeyProp]?: ['txRef', 'wallet'];
 
@@ -79,7 +77,7 @@ export class Deposit extends AbstractDeposit<'status'> {
     nullable: false,
     items: () => DepositStatus,
   })
-  status: DepositStatus = DepositStatus.UNPAID;
+  status: Opt & DepositStatus = DepositStatus.UNPAID;
 
 }
 


### PR DESCRIPTION
```ts
import { Opt, Entity, PrimaryKey, Property } from '@mikro-orm/core';

@Entity()
class User {

  @PrimaryKey()
  id!: number;

  @Property()
  firstName!: string;

  @Property()
  middleName: string & Opt = '';

  @Property()
  lastName!: string;

  @Property({ persist: false })
  get fullName(): string & Opt {
    return `${this.firstName} ${this.middleName} ${this.lastName}`;
  }

}
```