### PR TITLE
docs: Add note about allOrNothing for isTransactional migrations

### DIFF
--- a/docs/versioned_docs/version-5.8/migrations.md
+++ b/docs/versioned_docs/version-5.8/migrations.md
@@ -28,7 +28,7 @@ export class Migration20191019195930 extends Migration {
 
 To support undoing those changed, we can implement the `down` method, which throws an error by default.
 
-Migrations are by default wrapped in a transaction. You can override this behaviour on per migration basis by implementing the `isTransactional(): boolean` method.
+Migrations are by default wrapped in a transaction. You can override this behaviour on per migration basis by implementing the `isTransactional(): boolean` method - but note that your migration may still be wrapped in a master transaction, in accordance with `allOrNothing` option in your [configuration](#configuration).
 
 `Configuration` object and driver instance are available in the `Migration` class context.
 


### PR DESCRIPTION
Relating to #4775 - for a relative new-comer such as myself, I found the note about `isTransactional` easily enough, but missed the `allOrNothing` option in the config (which is important for instance in postgres (as per the example in #4775) - `CREATE INDEX CONCURRENTLY` must be run outside a transaction, so having a master transaction would cause it to fail)