### PR TITLE
fix(postgres): escape array literal values containing backslash

### DIFF
--- a/packages/postgresql/src/PostgreSqlPlatform.ts
+++ b/packages/postgresql/src/PostgreSqlPlatform.ts
@@ -141,7 +141,7 @@ export class PostgreSqlPlatform extends AbstractSqlPlatform {
   }
 
   marshallArray(values: string[]): string {
-    const quote = (v: string) => v === '' || v.match(/["{},]/) ? JSON.stringify(v) : v;
+    const quote = (v: string) => v === '' || v.match(/["{},\\]/) ? JSON.stringify(v) : v;
     return `{${values.map(v => quote('' + v)).join(',')}}`;
   }
 

--- a/tests/issues/GH4796.test.ts
+++ b/tests/issues/GH4796.test.ts
@@ -1,0 +1,51 @@
+import {
+  Entity,
+  OptionalProps,
+  PrimaryKey,
+  Property,
+  SimpleLogger,
+} from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/postgresql';
+import { mockLogger } from '../helpers';
+
+@Entity()
+class User {
+
+  [OptionalProps]?: 'options';
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: 'string[]', default: ['foo'] })
+  options = ['foo'];
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [User],
+    dbName: 'mikro_orm_test_gh_4796',
+    loggerFactory: options => new SimpleLogger(options),
+  });
+  await orm.schema.refreshDatabase();
+});
+
+afterAll(async () => {
+  await orm.close();
+});
+
+test('4796', async () => {
+  const mock = mockLogger(orm, ['query', 'query-params']);
+  const u1 = orm.em.create(User, { options: ['\\'] });
+  await orm.em.flush();
+
+  expect(mock.mock.calls).toEqual([
+    ['[query] begin'],
+    [
+      '[query] insert into "user" ("options") values ( E\'{"\\\\\\\\"}\') returning "id", "options"',
+    ],
+    ['[query] commit'],
+  ]);
+});

--- a/tests/issues/GH4796.test.ts
+++ b/tests/issues/GH4796.test.ts
@@ -41,9 +41,6 @@ test('4796', async () => {
   const u1 = orm.em.create(User, { options: ['\\'] });
   await orm.em.flush();
 
-  const ud = await orm.em.findOne(User, { id: u1.id });
-
-  expect(ud).toEqual({ id: 1, options: ['\\'] });
   expect(mock.mock.calls).toEqual([
     ['[query] begin'],
     [
@@ -51,4 +48,8 @@ test('4796', async () => {
     ],
     ['[query] commit'],
   ]);
+
+  const ud = await orm.em.fork().findOne(User, { id: u1.id });
+
+  expect(ud).toEqual({ id: 1, options: ['\\'] });
 });

--- a/tests/issues/GH4796.test.ts
+++ b/tests/issues/GH4796.test.ts
@@ -41,6 +41,9 @@ test('4796', async () => {
   const u1 = orm.em.create(User, { options: ['\\'] });
   await orm.em.flush();
 
+  const ud = await orm.em.findOne(User, { id: u1.id });
+
+  expect(ud).toEqual({ id: 1, options: ['\\'] });
   expect(mock.mock.calls).toEqual([
     ['[query] begin'],
     [


### PR DESCRIPTION
Fixes #4796.