### PR TITLE
fix(query-builder): add alias to embedded property only if embedded is not prefixed

### DIFF
--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -903,7 +903,8 @@ export class QueryBuilder<T extends object = AnyEntity> {
       }
 
       if (prop?.embedded) {
-        const name = this._aliases[a] ? `${a}.${prop.fieldNames[0]}` : prop.fieldNames[0];
+        const hasPrefix = prop.name.startsWith(`${prop.embedded[0]}_`);
+        const name = this._aliases[a] && !hasPrefix ? `${a}.${prop.fieldNames[0]}` : prop.fieldNames[0];
         const fieldName = this.helper.mapper(name, this.type) as string;
         ret.push(fieldName);
         return;


### PR DESCRIPTION
When querying an entity that has prefixed Embedded, `TableNotFoundException` is thrown due to wrong generated query syntax.

Here is the reproduction and contextualization of the bug:
[mlsm-trl/mikro-orm-bug-virtual-properties-required-when-seeding](https://github.com/mlsm-trl/mikro-orm-bug-alias-embedded)

The idea would be to check if property not comes from a prefixed Embedded, and then add the alias. 

I don't know if we have a better/reliable way to do this than the string comparison I made.