### PR TITLE
fix(query-builder): merge raw join results in `qb.execute()`

### DIFF
--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -1049,48 +1049,6 @@ export class Utils {
     }
   }
 
-  private static processValue(obj: Dictionary, k: keyof typeof obj, v: unknown, meta: EntityMetadata, seen: Set<unknown>, idx?: number) {
-    const targetMeta = meta.properties[k]?.targetMeta;
-
-    if (typeof v !== 'object' || !v || !targetMeta) {
-      return;
-    }
-
-    if (Array.isArray(v)) {
-      let i = 0;
-
-      for (const el of v) {
-        this.processValue(obj, k, el, meta, seen, i++);
-      }
-
-      return;
-    }
-
-    if (!seen.has(v)) {
-      this.removeCycles(v, targetMeta, seen);
-      return;
-    }
-
-    const pk = Utils.getPrimaryKeyValues(v, targetMeta.primaryKeys, true);
-
-    if (idx != null) {
-      obj[k][idx] = pk;
-    } else {
-      obj[k] = pk;
-    }
-  }
-
-  /**
-   * Removes cycles from an entity graph, replacing the entity with its primary key value.
-   */
-  static removeCycles(obj: Dictionary, meta: EntityMetadata, seen = new Set()) {
-    seen.add(obj);
-
-    for (const [k, v] of Object.entries(obj)) {
-      this.processValue(obj, k, v, meta, seen);
-    }
-  }
-
   static unwrapProperty<T>(entity: T, meta: EntityMetadata<T>, prop: EntityProperty<T>, payload = false): [unknown, number[]][] {
     let p = prop;
     const path: string[] = [];

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -1481,13 +1481,13 @@ describe('EntityManagerMySql', () => {
       populateWhere: PopulateHint.INFER,
       orderBy: { title: QueryOrder.DESC, tags: { name: QueryOrder.ASC } },
     });
-    await expect(books.length).toBe(3);
-    await expect(books[0].title).toBe('My Life on The Wall, part 3');
-    await expect(books[0].tags.getItems().map(t => t.name)).toEqual(['awkward', 'sexy', 'strange']);
-    await expect(books[1].title).toBe('My Life on The Wall, part 2');
-    await expect(books[1].tags.getItems().map(t => t.name)).toEqual(['sexy', 'silly', 'zupa']);
-    await expect(books[2].title).toBe('My Life on The Wall, part 1');
-    await expect(books[2].tags.getItems().map(t => t.name)).toEqual(['awkward', 'sick', 'silly', 'zupa']);
+    expect(books.length).toBe(3);
+    expect(books[0].title).toBe('My Life on The Wall, part 3');
+    expect(books[0].tags.getItems().map(t => t.name)).toEqual(['awkward', 'sexy', 'strange']);
+    expect(books[1].title).toBe('My Life on The Wall, part 2');
+    expect(books[1].tags.getItems().map(t => t.name)).toEqual(['sexy', 'silly', 'zupa']);
+    expect(books[2].title).toBe('My Life on The Wall, part 1');
+    expect(books[2].tags.getItems().map(t => t.name)).toEqual(['awkward', 'sick', 'silly', 'zupa']);
   });
 
   test('many to many with composite pk', async () => {
@@ -1525,13 +1525,13 @@ describe('EntityManagerMySql', () => {
       'left join `test2` as `t3` on `b0`.`uuid_pk` = `t3`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b1`.`name` != ? ' +
       'order by `b0`.`title` desc');
-    await expect(books.length).toBe(3);
-    await expect(books[0].title).toBe('My Life on The Wall, part 3');
-    await expect(books[0].tagsUnordered.getItems().map(t => t.name)).toEqual(['awkward', 'sexy', 'strange']);
-    await expect(books[1].title).toBe('My Life on The Wall, part 2');
-    await expect(books[1].tagsUnordered.getItems().map(t => t.name)).toEqual(['sexy', 'silly', 'zupa']);
-    await expect(books[2].title).toBe('My Life on The Wall, part 1');
-    await expect(books[2].tagsUnordered.getItems().map(t => t.name)).toEqual(['awkward', 'sick', 'silly', 'zupa']);
+    expect(books.length).toBe(3);
+    expect(books[0].title).toBe('My Life on The Wall, part 3');
+    expect(books[0].tagsUnordered.getItems().map(t => t.name)).toEqual(['awkward', 'sexy', 'strange']);
+    expect(books[1].title).toBe('My Life on The Wall, part 2');
+    expect(books[1].tagsUnordered.getItems().map(t => t.name)).toEqual(['sexy', 'silly', 'zupa']);
+    expect(books[2].title).toBe('My Life on The Wall, part 1');
+    expect(books[2].tagsUnordered.getItems().map(t => t.name)).toEqual(['awkward', 'sick', 'silly', 'zupa']);
 
     orm.em.clear();
     mock.mock.calls.length = 0;
@@ -1544,9 +1544,9 @@ describe('EntityManagerMySql', () => {
       'left join `book_to_tag_unordered` as `b1` on `b0`.`uuid_pk` = `b1`.`book2_uuid_pk` ' +
       'left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`title` != ? and `b1`.`book_tag2_id` in (?, ?, ?, ?, ?, ?)');
-    await expect(tags.length).toBe(6);
-    await expect(tags.map(tag => tag.name)).toEqual(['awkward', 'funny', 'sexy', 'sick', 'silly', 'zupa']);
-    await expect(tags.map(tag => tag.booksUnordered.count())).toEqual([1, 1, 1, 1, 2, 2]);
+    expect(tags.length).toBe(6);
+    expect(tags.map(tag => tag.name)).toEqual(['awkward', 'funny', 'sexy', 'sick', 'silly', 'zupa']);
+    expect(tags.map(tag => tag.booksUnordered.count())).toEqual([1, 1, 1, 1, 2, 2]);
   });
 
   test('self referencing M:N (unidirectional)', async () => {

--- a/tests/issues/GH4741.test.ts
+++ b/tests/issues/GH4741.test.ts
@@ -102,7 +102,6 @@ beforeEach(async () => {
 
 // Outer --> active Division --> [Inners] --> Geometry
 test(`GH4741 issue (1/3)`, async () => {
-
   const em = orm.em.fork();
   const qb = em.createQueryBuilder(Outer, 'o');
 
@@ -135,7 +134,6 @@ test(`GH4741 issue (1/3)`, async () => {
     expect(geom).toBeInstanceOf(Geometry);
     expect(wrap(geom).isInitialized()).toBeTruthy();	// Succeeds
   }
-  em.clear();
 });
 
 // Outer --> active Division --> [Inners] --> Geometry
@@ -175,7 +173,6 @@ test(`GH4741 issue (2/3)`, async () => {
     expect(geom).toBeInstanceOf(Geometry);
     expect(wrap(geom).isInitialized()).toBeTruthy();	// Succeeds
   }
-  em.clear();
 });
 
 // Outer --> active Division --> [Inners] --> Geometry
@@ -215,5 +212,4 @@ test(`GH4741 issue (3/3)`, async () => {
     expect(geom).toBeInstanceOf(Geometry);
     expect(wrap(geom).isInitialized()).toBeTruthy();	// Fails
   }
-  em.clear();
 });

--- a/tests/issues/GH4816.test.ts
+++ b/tests/issues/GH4816.test.ts
@@ -1,0 +1,169 @@
+import {
+  Collection,
+  Entity,
+  EntityCaseNamingStrategy,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  Unique,
+} from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/mysql';
+
+enum UserRoleEnum {
+  Admin = 'Admin',
+  DataManager = 'Data Manager',
+  DataEntry = 'Data Entry'
+}
+
+@Entity({ tableName: 'user' })
+class User {
+
+  @PrimaryKey({
+    defaultRaw: '(UUID())',
+    length: 38,
+    name: 'idUser',
+  })
+  id!: string;
+
+  @Unique()
+  @Property({
+    length: 255,
+  })
+  Email!: string;
+
+  @OneToMany({ entity: () => WorkspaceUser, mappedBy: 'user' })
+  workspaceRoles = new Collection<WorkspaceUser>(this);
+
+}
+
+@Entity({ tableName: 'workspace' })
+class Workspace {
+
+  @PrimaryKey({
+    fieldName: 'idWorkspace',
+    length: 38,
+    defaultRaw: '(UUID())',
+    type: 'string',
+  })
+  id!: string;
+
+  @Unique()
+  @Property({
+    length: 45,
+    type: 'string',
+  })
+  orgName!: string;
+
+}
+
+@Entity({ tableName: 'userroles' })
+class UserRole {
+
+  @PrimaryKey({
+    name: 'UserRole',
+    fieldName: 'userRole',
+    length: 45,
+  })
+  UserRole!: UserRoleEnum;
+
+  @Property({
+    fieldName: 'level',
+    columnType: 'TINYINT',
+  })
+  Level!: number;
+
+}
+
+@Entity({ tableName: 'workspaceuser' })
+class WorkspaceUser {
+
+  @ManyToOne({
+    entity: () => User,
+    primary: true,
+    fieldName: 'idUser',
+  })
+  user!: User;
+
+  @ManyToOne({
+    entity: () => Workspace,
+    primary: true,
+    fieldName: 'idWorkspace',
+  })
+  workspace!: Workspace;
+
+  @ManyToOne({
+    entity: () => UserRole,
+    fieldName: 'userRole',
+  })
+  userRole!: UserRole;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [UserRole, Workspace, WorkspaceUser, User],
+    namingStrategy: EntityCaseNamingStrategy,
+    dbName: '4816',
+    port: 3308,
+  });
+  await orm.getSchemaGenerator().refreshDatabase();
+
+  await orm.em.execute("INSERT INTO `userroles` VALUES ('Admin', '1');");
+  await orm.em.execute("INSERT INTO `userroles` VALUES ('Data Manager', '2');");
+  await orm.em.execute("INSERT INTO `userroles` VALUES ('Data Entry', '3');");
+
+  await orm.em.execute("INSERT INTO `user` VALUES ('445bff08-0258-45c4-98b8-a1b1b3997de5', 'test@test.com');");
+
+  await orm.em.execute("INSERT INTO `workspace` VALUES ('8724b13e-9472-462f-b4be-927dc06f11fe', 'Test');");
+  await orm.em.execute("INSERT INTO `workspace` VALUES ('d278edec-97fc-4a7c-9999-df0b28967dba', 'Test2');");
+
+  await orm.em.execute("INSERT INTO `workspaceuser` VALUES ('445bff08-0258-45c4-98b8-a1b1b3997de5', '8724b13e-9472-462f-b4be-927dc06f11fe', 'Admin');");
+  await orm.em.execute("INSERT INTO `workspaceuser` VALUES ('445bff08-0258-45c4-98b8-a1b1b3997de5', 'd278edec-97fc-4a7c-9999-df0b28967dba', 'Admin');");
+});
+
+afterAll(() => orm.close(true));
+
+test('GH #4816', async () => {
+  const users = await orm.em
+    .createQueryBuilder(User)
+    .select('*')
+    .leftJoinAndSelect('workspaceRoles', 'wsr')
+    .leftJoinAndSelect('wsr.workspace', 'ws')
+    .leftJoinAndSelect('wsr.userRole', 'role')
+    .where({ id: '445bff08-0258-45c4-98b8-a1b1b3997de5' })
+    .execute();
+
+  expect(JSON.stringify(users, null, 2)).toEqual(`[
+  {
+    "id": "445bff08-0258-45c4-98b8-a1b1b3997de5",
+    "Email": "test@test.com",
+    "workspaceRoles": [
+      {
+        "user": "445bff08-0258-45c4-98b8-a1b1b3997de5",
+        "workspace": {
+          "id": "8724b13e-9472-462f-b4be-927dc06f11fe",
+          "orgName": "Test"
+        },
+        "userRole": {
+          "UserRole": "Admin",
+          "Level": 1
+        }
+      },
+      {
+        "user": "445bff08-0258-45c4-98b8-a1b1b3997de5",
+        "workspace": {
+          "id": "d278edec-97fc-4a7c-9999-df0b28967dba",
+          "orgName": "Test2"
+        },
+        "userRole": {
+          "UserRole": "Admin",
+          "Level": 1
+        }
+      }
+    ]
+  }
+]`);
+});


### PR DESCRIPTION
Previously, the `qb.execute()` method returned cartesian product when joining to-many relations. Now the results will be automatically merged, as if you would map the results via `qb.getResult()`.

Closes #4816
Related #4741