### PR TITLE
fix(reflection): ensure complete stripping of relative paths with multiple leading slashes

### DIFF
--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -1162,7 +1162,7 @@ export class Utils {
   }
 
   static stripRelativePath(str: string): string {
-    return str.replace(/^(?:\.\.\/|\.\/)+/, '');
+    return str.replace(/^(?:\.\.\/|\.\/)+/, '/');
   }
 
 }

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -1161,4 +1161,8 @@ export class Utils {
 
   }
 
+  static stripRelativePath(str: string): string {
+    return str.replace(/^(?:\.\.\/|\.\/)+/, '');
+  }
+
 }

--- a/packages/reflection/src/TsMorphMetadataProvider.ts
+++ b/packages/reflection/src/TsMorphMetadataProvider.ts
@@ -136,9 +136,7 @@ export class TsMorphMetadataProvider extends MetadataProvider {
     if (!this.sources) {
       await this.initSourceFiles();
     }
-
-    const source = this.sources.find(s => s.getFilePath().endsWith(tsPath.replace(/^\.+/, '')));
-
+    const source = this.sources.find(s => s.getFilePath().endsWith(Utils.stripRelativePath(tsPath)));
     if (!source && validate) {
       throw new MetadataError(`Source file '${tsPath}' not found. Check your 'entitiesTs' option and verify you have 'compilerOptions.declaration' enabled in your 'tsconfig.json'. If you are using webpack, see https://bit.ly/35pPDNn`);
     }

--- a/packages/reflection/src/TsMorphMetadataProvider.ts
+++ b/packages/reflection/src/TsMorphMetadataProvider.ts
@@ -136,7 +136,9 @@ export class TsMorphMetadataProvider extends MetadataProvider {
     if (!this.sources) {
       await this.initSourceFiles();
     }
+
     const source = this.sources.find(s => s.getFilePath().endsWith(Utils.stripRelativePath(tsPath)));
+
     if (!source && validate) {
       throw new MetadataError(`Source file '${tsPath}' not found. Check your 'entitiesTs' option and verify you have 'compilerOptions.declaration' enabled in your 'tsconfig.json'. If you are using webpack, see https://bit.ly/35pPDNn`);
     }

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -154,16 +154,16 @@ describe('Utils', () => {
   describe('stripRelativePath', () => {
     test('Remove single leading dot (./)', () => {
       const path = './my/path';
-      expect(Utils.stripRelativePath(path)).toEqual('my/path');
+      expect(Utils.stripRelativePath(path)).toEqual('/my/path');
     });
     test('Remove multiple leading dots (../)', () => {
       const path = '../my/path';
-      expect(Utils.stripRelativePath(path)).toEqual('my/path');
+      expect(Utils.stripRelativePath(path)).toEqual('/my/path');
     });
 
     test('Remove multiple leading dots and slashes (../../)', () => {
       const path = '../../my/path';
-      expect(Utils.stripRelativePath(path)).toEqual('my/path');
+      expect(Utils.stripRelativePath(path)).toEqual('/my/path');
     });
 
   });

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -151,6 +151,22 @@ describe('Utils', () => {
     expect(c.inner.p).toBeInstanceOf(Promise);
   });
 
+  describe('stripRelativePath', () => {
+    test('Remove single leading dot (./)', () => {
+      const path = './my/path';
+      expect(Utils.stripRelativePath(path)).toEqual('my/path');
+    });
+    test('Remove multiple leading dots (../)', () => {
+      const path = '../my/path';
+      expect(Utils.stripRelativePath(path)).toEqual('my/path');
+    });
+
+    test('Remove multiple leading dots and slashes (../../)', () => {
+      const path = '../../my/path';
+      expect(Utils.stripRelativePath(path)).toEqual('my/path');
+    });
+
+  });
   /**
    * regression test for running code coverage with nyc, mocha and ts-node and entity has default constructor value as enum parameter
    */


### PR DESCRIPTION
This PR addresses an issue where relative paths with leading slashes and dots were not being stripped correctly. The problem arises when the 'path' contains multiple leading slashes like `../../`, as the current logic strips it to `/../`, which is incorrect and prevents the entity from being discovered.

This code modification ensures that any dots followed by slashes are stripped to provide the full path without any dots and slashes at the beginning.

**Please note:** that the current behavior is such that if you pass `./my/path` the result is `/my/path` However, with the updated code, the result will be `my/path` This change is made because, in the end, we use the resulting path to check if the `source` contains the path using `endsWith`, and the leading slash is unnecessary for this purpose.

## Update
I added a slash again after @B4nan clarified a case that we need it in this [thread](https://mikroorm.slack.com/archives/CFTFEK39D/p1697634946389959?thread_ts=1697550457.817269&cid=CFTFEK39D) 

so the result now for `./my/path` will be `/my/path`