### PR TITLE
feat(query-builder): respect `EntityManager` schema

### DIFF
--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -999,7 +999,7 @@ export class QueryBuilder<T extends object = AnyEntity> {
     const qb = this.getKnex();
     const schema = this.getSchema(this.mainAlias);
     // Joined tables doesn't need to belong to the same schema as the main table
-    const joinSchema = this._schema ?? this.em?.schema ?? schema;
+    const joinSchema = this._schema ?? this.em?.schema ?? this.em?.config.get('schema');
 
     if (schema) {
       qb.withSchema(schema);

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -999,7 +999,7 @@ export class QueryBuilder<T extends object = AnyEntity> {
     const qb = this.getKnex();
     const schema = this.getSchema(this.mainAlias);
     // Joined tables doesn't need to belong to the same schema as the main table
-    const joinSchema = this._schema ?? this.em?.schema ?? this.em?.config.get('schema');
+    const joinSchema = this._schema ?? this.em?.schema ?? schema;
 
     if (schema) {
       qb.withSchema(schema);

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -149,6 +149,7 @@ export class QueryBuilderHelper {
   joinOneToReference(prop: EntityProperty, ownerAlias: string, alias: string, type: 'leftJoin' | 'innerJoin' | 'pivotJoin', cond: Dictionary = {}): JoinOptions {
     const prop2 = prop.targetMeta!.properties[prop.mappedBy || prop.inversedBy];
     const table = this.getTableName(prop.type);
+    // Should * be handled the same as undefined?
     const schema = prop.targetMeta?.schema === '*' ? '*' : this.driver.getSchemaName(prop.targetMeta);
     const joinColumns = prop.owner ? prop.referencedColumnNames : prop2.joinColumns;
     const inverseJoinColumns = prop.referencedColumnNames;
@@ -164,7 +165,8 @@ export class QueryBuilderHelper {
     return {
       prop, type, cond, ownerAlias, alias,
       table: this.getTableName(prop.type),
-      schema: this.driver.getSchemaName(prop.targetMeta),
+      // Should * be handled the same as undefined?
+      schema: prop.targetMeta?.schema === '*' ? '*' : this.driver.getSchemaName(prop.targetMeta),
       joinColumns: prop.referencedColumnNames,
       primaryKeys: prop.fieldNames,
     };
@@ -182,7 +184,8 @@ export class QueryBuilderHelper {
         primaryKeys: prop.referencedColumnNames,
         cond: {},
         table: pivotMeta.tableName,
-        schema: this.driver.getSchemaName(pivotMeta),
+        // Should * be handled the same as undefined?
+        schema: prop.targetMeta?.schema === '*' ? '*' : this.driver.getSchemaName(pivotMeta),
         path: path.endsWith('[pivot]') ? path : `${path}[pivot]`,
       } as JoinOptions,
     };

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -149,7 +149,6 @@ export class QueryBuilderHelper {
   joinOneToReference(prop: EntityProperty, ownerAlias: string, alias: string, type: 'leftJoin' | 'innerJoin' | 'pivotJoin', cond: Dictionary = {}): JoinOptions {
     const prop2 = prop.targetMeta!.properties[prop.mappedBy || prop.inversedBy];
     const table = this.getTableName(prop.type);
-    // Should * be handled the same as undefined?
     const schema = prop.targetMeta?.schema === '*' ? '*' : this.driver.getSchemaName(prop.targetMeta);
     const joinColumns = prop.owner ? prop.referencedColumnNames : prop2.joinColumns;
     const inverseJoinColumns = prop.referencedColumnNames;
@@ -165,7 +164,6 @@ export class QueryBuilderHelper {
     return {
       prop, type, cond, ownerAlias, alias,
       table: this.getTableName(prop.type),
-      // Should * be handled the same as undefined?
       schema: prop.targetMeta?.schema === '*' ? '*' : this.driver.getSchemaName(prop.targetMeta),
       joinColumns: prop.referencedColumnNames,
       primaryKeys: prop.fieldNames,
@@ -184,7 +182,6 @@ export class QueryBuilderHelper {
         primaryKeys: prop.referencedColumnNames,
         cond: {},
         table: pivotMeta.tableName,
-        // Should * be handled the same as undefined?
         schema: prop.targetMeta?.schema === '*' ? '*' : this.driver.getSchemaName(pivotMeta),
         path: path.endsWith('[pivot]') ? path : `${path}[pivot]`,
       } as JoinOptions,

--- a/tests/features/multiple-schemas-entity-manager/multiple-schemas-e-manager-q-builder.test.ts
+++ b/tests/features/multiple-schemas-entity-manager/multiple-schemas-e-manager-q-builder.test.ts
@@ -1,7 +1,7 @@
 import {
   Collection,
   Entity,
-    LoadStrategy,
+  LoadStrategy,
   ManyToOne,
   MikroORM,
   OneToMany,
@@ -114,7 +114,6 @@ describe('multiple connected schemas in postgres', () => {
 
     const fork = orm.em.fork({ schema: 'n5' });
 
-
     await fork
       .getRepository(Category)
       .createQueryBuilder('category')
@@ -135,7 +134,6 @@ describe('multiple connected schemas in postgres', () => {
       strategy: LoadStrategy.JOINED,
       disableIdentityMap: true,
     });
-
 
     await fork.findOne(Topic, {
       id: 1,
@@ -162,6 +160,7 @@ describe('multiple connected schemas in postgres', () => {
     expect(mock.mock.calls[2][0]).toMatch(
       'select "d0"."id", "d0"."scope", "s1"."id" as "s1__id", "s1"."name" as "s1__name", "s1"."domain_id" as "s1__domain_id" from "n2"."domain" as "d0" left join "n2"."sub_domain" as "s1" on "d0"."id" = "s1"."domain_id" where "d0"."id" = 1',
     );
+
     /**
      * Main table topic(*) will join Domain(n2)
      */

--- a/tests/features/multiple-schemas-entity-manager/multiple-schemas-e-manager-q-builder.test.ts
+++ b/tests/features/multiple-schemas-entity-manager/multiple-schemas-e-manager-q-builder.test.ts
@@ -128,7 +128,7 @@ describe('multiple connected schemas in postgres', () => {
 
     /**
      * All * entities should use schema set in EntityManager
-     * All entities will set schema(domain) should use the set schema
+     * All entities with defined schema(domain) should use the defined schema
      */
     expect(mock.mock.calls[0][0]).toMatch(
       'select "category".*, "topic"."id" as "topic__id", "topic"."name" as "topic__name", "topic"."domain_id" as "topic__domain_id" from "n5"."category" as "category" left join "n5"."topic" as "topic" on "category"."topic_id" = "topic"."id"',
@@ -171,7 +171,7 @@ describe('multiple connected schemas in postgres', () => {
     );
   });
 
-  test('should default schema on not define schema', async () => {
+  test('should default schema on not defined schema', async () => {
     const mock = mockLogger(orm);
     mock.mockReset();
 

--- a/tests/features/multiple-schemas-entity-manager/multiple-schemas-e-manager-q-builder.test.ts
+++ b/tests/features/multiple-schemas-entity-manager/multiple-schemas-e-manager-q-builder.test.ts
@@ -1,0 +1,238 @@
+import {
+  Collection,
+  Entity,
+  ManyToOne,
+  MikroORM,
+  OneToMany,
+  OneToOne,
+  PrimaryKey,
+  Property,
+} from '@mikro-orm/core';
+import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { mockLogger } from '../../helpers';
+
+@Entity({ schema: 'n2' })
+class Domain {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  scope!: string;
+
+  @OneToMany(() => SubDomain, e => e.domain)
+  subDomain = new Collection<SubDomain>(this);
+
+}
+@Entity({ schema: '*' })
+class SubDomain {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @ManyToOne(() => Domain, { nullable: true })
+  domain?: Domain;
+
+}
+
+
+@Entity({ schema: '*' })
+class Topic {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(() => Category, e => e.topic)
+  category = new Collection<Category>(this);
+
+  @OneToOne(() => Domain, { nullable: true })
+  domain?: Domain;
+
+}
+
+@Entity({ schema: '*' })
+class Category {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Topic, { nullable: true })
+  topic?: Topic;
+
+}
+
+describe('multiple connected schemas in postgres', () => {
+  let orm: MikroORM<PostgreSqlDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Domain, Topic, Category, SubDomain],
+      dbName: `mikro_orm_test_multi_schemas`,
+      driver: PostgreSqlDriver,
+    });
+    await orm.schema.ensureDatabase();
+
+    for (const ns of ['n2', 'n5']) {
+      await orm.schema.execute(`drop schema if exists ${ns} cascade`);
+    }
+
+    // `*` schema will be ignored
+    await orm.schema.updateSchema();
+
+    // we need to pass schema for book
+    await orm.schema.updateSchema({ schema: 'n2' });
+    await orm.schema.updateSchema({ schema: 'n5' });
+    orm.config.set('schema', 'n2'); // set the schema so we can work with book entities without options param
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    await orm.em.createQueryBuilder(Topic).truncate().execute(); // current schema from config
+    await orm.em.createQueryBuilder(Topic).withSchema('n2').truncate().execute();
+    await orm.em.createQueryBuilder(Topic).withSchema('n5').truncate().execute();
+    await orm.em.createQueryBuilder(Category).truncate().execute(); // current schema from config
+    await orm.em.createQueryBuilder(Category).withSchema('n2').truncate().execute();
+    await orm.em.createQueryBuilder(Category).withSchema('n5').truncate().execute();
+    await orm.em.createQueryBuilder(Domain).truncate().execute(); // current schema from config
+    await orm.em.createQueryBuilder(Domain).withSchema('n2').truncate().execute();
+    orm.em.clear();
+  });
+
+  test('with fork schema', async () => {
+    const mock = mockLogger(orm);
+    mock.mockReset();
+
+    const fork = orm.em.fork({ schema: 'n5' });
+
+    await fork
+      .getRepository(Category)
+      .createQueryBuilder('category')
+      .leftJoinAndSelect('category.topic', 'topic')
+      .execute();
+
+    await fork
+      .getRepository(Topic)
+      .createQueryBuilder('topic')
+      .leftJoinAndSelect('topic.category', 'category')
+      .leftJoinAndSelect('topic.domain', 'domain')
+      .execute();
+
+    /**
+     * All * entities should use schema set in EntityManager
+     * All entities will set schema(domain) should use the set schema
+     */
+    expect(mock.mock.calls[0][0]).toMatch(
+      'select "category".*, "topic"."id" as "topic__id", "topic"."name" as "topic__name", "topic"."domain_id" as "topic__domain_id" from "n5"."category" as "category" left join "n5"."topic" as "topic" on "category"."topic_id" = "topic"."id"',
+    );
+    expect(mock.mock.calls[1][0]).toMatch(
+      'select "topic".*, "category"."id" as "category__id", "category"."topic_id" as "category__topic_id", "domain"."id" as "domain__id", "domain"."scope" as "domain__scope" from "n5"."topic" as "topic" left join "n5"."category" as "category" on "topic"."id" = "category"."topic_id" left join "n2"."domain" as "domain" on "topic"."domain_id" = "domain"."id"',
+    );
+  });
+
+  test('with schema differ from fork schema', async () => {
+    const mock = mockLogger(orm);
+    mock.mockReset();
+
+    const fork = orm.em.fork({ schema: 'n5' });
+
+    await fork
+      .getRepository(Category)
+      .createQueryBuilder('category')
+      .withSchema('n2')
+      .leftJoinAndSelect('category.topic', 'topic')
+      .execute();
+
+    await fork
+      .getRepository(Topic)
+      .createQueryBuilder('topic')
+      .withSchema('n2')
+      .leftJoinAndSelect('topic.category', 'category')
+      .leftJoinAndSelect('topic.domain', 'domain')
+      .execute();
+
+    /**
+     * withSchema triumphs all
+     * n2 should be used for all entities
+     */
+    expect(mock.mock.calls[0][0]).toMatch(
+      'select "category".*, "topic"."id" as "topic__id", "topic"."name" as "topic__name", "topic"."domain_id" as "topic__domain_id" from "n2"."category" as "category" left join "n2"."topic" as "topic" on "category"."topic_id" = "topic"."id"',
+    );
+    expect(mock.mock.calls[1][0]).toMatch(
+      'select "topic".*, "category"."id" as "category__id", "category"."topic_id" as "category__topic_id", "domain"."id" as "domain__id", "domain"."scope" as "domain__scope" from "n2"."topic" as "topic" left join "n2"."category" as "category" on "topic"."id" = "category"."topic_id" left join "n2"."domain" as "domain" on "topic"."domain_id" = "domain"."id"',
+    );
+  });
+
+  test('should default schema on not define schema', async () => {
+    const mock = mockLogger(orm);
+    mock.mockReset();
+
+    const fork = orm.em.fork();
+
+    await fork
+      .getRepository(Category)
+      .createQueryBuilder('category')
+      .leftJoinAndSelect('category.topic', 'topic')
+      .execute();
+
+    await fork
+      .getRepository(Topic)
+      .createQueryBuilder('topic')
+      .leftJoinAndSelect('topic.category', 'category')
+      .leftJoinAndSelect('topic.domain', 'domain')
+      .execute();
+
+    /**
+     * Nothing set, should default to entities.schema or if * is used, to schema set on orm
+     */
+    expect(mock.mock.calls[0][0]).toMatch(
+      'select "category".*, "topic"."id" as "topic__id", "topic"."name" as "topic__name", "topic"."domain_id" as "topic__domain_id" from "n2"."category" as "category" left join "n2"."topic" as "topic" on "category"."topic_id" = "topic"."id"',
+    );
+    expect(mock.mock.calls[1][0]).toMatch(
+      'select "topic".*, "category"."id" as "category__id", "category"."topic_id" as "category__topic_id", "domain"."id" as "domain__id", "domain"."scope" as "domain__scope" from "n2"."topic" as "topic" left join "n2"."category" as "category" on "topic"."id" = "category"."topic_id" left join "n2"."domain" as "domain" on "topic"."domain_id" = "domain"."id"',
+    );
+  });
+
+  test('join table in different schema', async () => {
+    const mock = mockLogger(orm);
+    mock.mockReset();
+
+    await orm.em.fork({ schema: 'n5' })
+      .getRepository(Domain)
+      .createQueryBuilder('domain')
+      .leftJoinAndSelect('domain.subDomain', 'subDomain')
+      .execute();
+
+    /**
+     * Domain is set to n2 and should join to n2
+     * SubDomain is set to * and should default to entityManager.schema (n5)
+     */
+    expect(mock.mock.calls[0][0]).toMatch(
+      'select "domain".*, "subDomain"."id" as "subDomain__id", "subDomain"."name" as "subDomain__name", "subDomain"."domain_id" as "subDomain__domain_id" from "n2"."domain" as "domain" left join "n5"."sub_domain" as "subDomain" on "domain"."id" = "subDomain"."domain_id"',
+    );
+
+    orm.config.set('schema', 'n5');
+    const fork = orm.em.fork();
+    await fork
+      .getRepository(Domain)
+      .createQueryBuilder('domain')
+      .leftJoinAndSelect('domain.subDomain', 'subDomain')
+      .execute();
+
+    /**
+     * Domain is set to n2 and should join to n2
+     * SubDomain is set to * and should default to orm schema (n5)
+     */
+    expect(mock.mock.calls[1][0]).toMatch(
+      'select "domain".*, "subDomain"."id" as "subDomain__id", "subDomain"."name" as "subDomain__name", "subDomain"."domain_id" as "subDomain__domain_id" from "n2"."domain" as "domain" left join "n5"."sub_domain" as "subDomain" on "domain"."id" = "subDomain"."domain_id"',
+    );
+  });
+});


### PR DESCRIPTION
- QueryBuilder will inherit schema from EntityManager (if set)
- QueryBuilder can now join entities that belong in a different schema than the main entity.


Previously if you had an entity that belongs to schema n2 which have a FK to an entity that does not exist in n2 the query will fail since it will use `n2.SubDomain`. If you used `withSchema('n5')`, then it will fail since `n5.Domain` does not exist.

```
@Entity({ schema: 'n2' })
class Domain {

  @PrimaryKey()
  id!: number;

  @OneToMany(() => SubDomain, e => e.domain)
  subDomain = new Collection<SubDomain>(this);
}

@Entity({ schema: '*' })
class SubDomain {

  @PrimaryKey()
  id!: number;

  @ManyToOne(() => Domain, { nullable: true })
  domain?: Domain;
}
```

Im wondering what you think about this approach. One thing I'm a bit divided about is the fallback for `joinSchema` should it be 

```
const joinSchema = this._schema ?? this.em?.schema ?? this.em?.config.get('schema');
// OR
// This approach will be a minor change since the only time it will differ from `schema` is if `this.em.schema` is set.
const joinSchema = this._schema ?? this.em?.schema ?? schema;
```

### v6 questions?

Should `schema: '*'` be treated the same way as `schema: undefined`?

I've kept the QueryBuilder.WithSchema logic that will make sure it will triumph all other schema settings. But I think it will be problematic to use, since it will not handle cases when entities are placed in different schemas.