### PR TITLE
feat(core): allow ignoring `undefined` values in `em.find` queries

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -275,6 +275,19 @@ MikroORM.init({
 });
 ```
 
+## Ignoring `undefined` values in Find Queries
+
+The ORM will treat explicitly defined `undefined` values in your `em.find()` queries as `null`s. If you want to ignore them instead, use `ignoreUndefinedInQuery` option:
+
+```ts
+MikroORM.init({
+  ignoreUndefinedInQuery: true,
+});
+
+// resolves to `em.find(User, {})`
+await em.find(User, { email: undefined, { profiles: { foo: undefined } } });
+```
+
 ## Serialization of new entities
 
 After flushing a new entity, all relations are marked as populated, just like if the entity was loaded from the db. This aligns the serialized output of `e.toJSON()` of a loaded entity and just-inserted one.

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -73,6 +73,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     loadStrategy: LoadStrategy.SELECT_IN,
     populateWhere: PopulateHint.ALL,
     connect: true,
+    ignoreUndefinedInQuery: false,
     autoJoinOneToOneOwner: true,
     propagateToOneOwner: true,
     populateAfterFlush: true,
@@ -514,6 +515,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
   disableTransactions?: boolean;
   connect: boolean;
   verbose: boolean;
+  ignoreUndefinedInQuery?: boolean;
   autoJoinOneToOneOwner: boolean;
   propagateToOneOwner: boolean;
   populateAfterFlush: boolean;

--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -95,6 +95,10 @@ export class QueryHelper {
       QueryHelper.inlinePrimaryKeyObjects(where as Dictionary, meta, metadata);
     }
 
+    if (options.platform.getConfig().get('ignoreUndefinedInQuery') && where && typeof where === 'object') {
+      Utils.dropUndefinedProperties(where);
+    }
+
     where = QueryHelper.processParams(where) ?? {};
 
     /* istanbul ignore next */

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -226,14 +226,16 @@ export class Utils {
   /**
    * Removes `undefined` properties (recursively) so they are not saved as nulls
    */
-  static dropUndefinedProperties<T = Dictionary | unknown[]>(o: any, value?: undefined | null): void {
+  static dropUndefinedProperties<T = Dictionary | unknown[]>(o: any, value?: undefined | null, visited = new Set()): void {
     if (Array.isArray(o)) {
-      return o.forEach((item: unknown) => Utils.dropUndefinedProperties(item, value));
+      return o.forEach((item: unknown) => Utils.dropUndefinedProperties(item, value, visited));
     }
 
-    if (!Utils.isObject(o)) {
+    if (!Utils.isObject(o) || visited.has(o)) {
       return;
     }
+
+    visited.add(o);
 
     Object.keys(o).forEach(key => {
       if (o[key] === value) {
@@ -241,7 +243,7 @@ export class Utils {
         return;
       }
 
-      Utils.dropUndefinedProperties(o[key], value);
+      Utils.dropUndefinedProperties(o[key], value, visited);
     });
   }
 

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -507,8 +507,13 @@ export class QueryBuilderHelper {
   private processObjectSubCondition(cond: any, key: string, qb: Knex.QueryBuilder, method: 'where' | 'having', m: 'where' | 'orWhere' | 'having', type: QueryType): void {
     // grouped condition for one field
     let value = cond[key];
+    const size = Utils.getObjectKeysSize(value);
 
-    if (Utils.getObjectKeysSize(value) > 1) {
+    if (Utils.isPlainObject(value) && size === 0) {
+      return;
+    }
+
+    if (size > 1) {
       const subCondition = Object.entries(value).map(([subKey, subValue]) => ({ [key]: { [subKey]: subValue } }));
       return subCondition.forEach(sub => this.appendQueryCondition(type, sub, qb, '$and', method));
     }
@@ -520,6 +525,7 @@ export class QueryBuilderHelper {
     // operators
     const op = Object.keys(QueryOperator).find(op => op in value);
 
+    /* istanbul ignore next */
     if (!op) {
       throw new Error(`Invalid query condition: ${inspect(cond)}`);
     }

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -1345,12 +1345,6 @@ describe('QueryBuilder', () => {
     expect(() => qb0.select('*').where({ author: { undefinedName: 'Jon Snow' } }).getQuery()).toThrowError(err);
   });
 
-  test('select with invalid query condition throws error', async () => {
-    const qb0 = orm.em.createQueryBuilder(Book2);
-    const err = `Invalid query condition: { 'e0.author': {} }`;
-    expect(() => qb0.select('*').where({ author: {} }).getQuery()).toThrowError(err);
-  });
-
   test('pessimistic locking requires active transaction', async () => {
     const qb = orm.em.createQueryBuilder(Author2);
     qb.select('*').where({ name: '...' });

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
 import { MongoMemoryReplSet } from 'mongodb-memory-server';
 import type { Options } from '@mikro-orm/core';
-import { JavaScriptMetadataProvider, LoadStrategy, MikroORM, ReflectMetadataProvider, Utils } from '@mikro-orm/core';
+import { JavaScriptMetadataProvider, LoadStrategy, MikroORM, ReflectMetadataProvider, Utils, SimpleLogger } from '@mikro-orm/core';
 import type { AbstractSqlDriver } from '@mikro-orm/knex';
 import { SqlEntityRepository } from '@mikro-orm/knex';
 import { SqliteDriver } from '@mikro-orm/sqlite';
@@ -155,9 +155,11 @@ export async function initORMSqlite() {
     debug: ['query'],
     forceUtcTimezone: true,
     logger: i => i,
+    loggerFactory: options => new SimpleLogger(options),
     metadataProvider: JavaScriptMetadataProvider,
     cache: { enabled: true, pretty: true },
     persistOnCreate: false,
+    ignoreUndefinedInQuery: true,
   });
 
   const connection = orm.em.getConnection();


### PR DESCRIPTION
The ORM will treat explicitly defined `undefined` values in your `em.find()` queries as `null`s. If you want to ignore them instead, use `ignoreUndefinedInQuery` option:

```ts
MikroORM.init({
  ignoreUndefinedInQuery: true,
});

// resolves to `em.find(User, {})`
await em.find(User, { email: undefined, { profiles: { foo: undefined } } });
```

Closes #4873