### PR TITLE
feat(core): add entity to identity map on `em.persist()`

### DIFF
--- a/tests/features/multiple-schemas/GH3177.test.ts
+++ b/tests/features/multiple-schemas/GH3177.test.ts
@@ -70,13 +70,13 @@ afterAll(async () => {
 });
 
 test(`GH issue 3177`, async () => {
+  const mock = mockLogger(orm);
+
   const user = new User();
   user.id = 1;
   user.accessProfile = new UserAccessProfile();
   user.accessProfile.permissions.add(new Permission(), new Permission(), new Permission());
-  orm.em.persist(user);
-
-  const mock = mockLogger(orm);
+  await orm.em.persist(user).flush();
 
   const u1 = await orm.em.findOneOrFail(User, 1, { populate: ['accessProfile'] });
   const permissions = await u1.accessProfile.permissions.init();
@@ -93,9 +93,8 @@ test(`GH issue 3177`, async () => {
   expect(mock.mock.calls[3][0]).toMatch(`insert into "public"."permission" ("id") values (default), (default), (default) returning "id"`);
   expect(mock.mock.calls[4][0]).toMatch(`insert into "tenant_01"."access_profile_permission" ("permission_id", "access_profile_id") values (1, 1), (2, 1), (3, 1)`);
   expect(mock.mock.calls[5][0]).toMatch(`commit`);
-  expect(mock.mock.calls[6][0]).toMatch(`select "u0".* from "tenant_01"."user" as "u0" where "u0"."id" = 1 limit 1`);
-  expect(mock.mock.calls[7][0]).toMatch(`select "p1".*, "a0"."permission_id" as "fk__permission_id", "a0"."access_profile_id" as "fk__access_profile_id" from "tenant_01"."access_profile_permission" as "a0" inner join "public"."permission" as "p1" on "a0"."permission_id" = "p1"."id" where "a0"."access_profile_id" in (1)`);
-  expect(mock.mock.calls[8][0]).toMatch(`select "u0".* from "tenant_01"."user" as "u0" where "u0"."id" = 1 limit 1`);
-  expect(mock.mock.calls[9][0]).toMatch(`select "u0".* from "tenant_01"."user_access_profile" as "u0" where "u0"."id" in (1)`);
-  expect(mock.mock.calls[10][0]).toMatch(`select "p1".*, "a0"."permission_id" as "fk__permission_id", "a0"."access_profile_id" as "fk__access_profile_id" from "tenant_01"."access_profile_permission" as "a0" inner join "public"."permission" as "p1" on "a0"."permission_id" = "p1"."id" where "a0"."access_profile_id" in (1)`);
+  expect(mock.mock.calls[6][0]).toMatch(`select "p1".*, "a0"."permission_id" as "fk__permission_id", "a0"."access_profile_id" as "fk__access_profile_id" from "tenant_01"."access_profile_permission" as "a0" inner join "public"."permission" as "p1" on "a0"."permission_id" = "p1"."id" where "a0"."access_profile_id" in (1)`);
+  expect(mock.mock.calls[7][0]).toMatch(`select "u0".* from "tenant_01"."user" as "u0" where "u0"."id" = 1 limit 1`);
+  expect(mock.mock.calls[8][0]).toMatch(`select "u0".* from "tenant_01"."user_access_profile" as "u0" where "u0"."id" in (1)`);
+  expect(mock.mock.calls[9][0]).toMatch(`select "p1".*, "a0"."permission_id" as "fk__permission_id", "a0"."access_profile_id" as "fk__access_profile_id" from "tenant_01"."access_profile_permission" as "a0" inner join "public"."permission" as "p1" on "a0"."permission_id" = "p1"."id" where "a0"."access_profile_id" in (1)`);
 });

--- a/tests/features/unit-of-work/GH4905.test.ts
+++ b/tests/features/unit-of-work/GH4905.test.ts
@@ -1,0 +1,61 @@
+import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/sqlite';
+import { mockLogger } from '../../helpers';
+
+@Entity()
+class Book {
+
+  @PrimaryKey()
+  id!: string;
+
+  @Property()
+  title: string;
+
+  constructor(id: string, title: string) {
+    this.id = id;
+    this.title = title;
+  }
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Book],
+    dbName: ':memory:',
+  });
+
+  await orm.schema.createSchema();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('entity with known primary key is added to the identity map as early as on persist call (1/2)', async () => {
+  const mock = mockLogger(orm);
+  const e1 = new Book('abc', 'title: abc');
+  const e2 = new Book('def', 'title: def');
+
+  orm.em.persist(e1);
+  orm.em.persist(e2);
+
+  orm.em.remove(e1);
+  orm.em.remove(orm.em.getReference(Book, 'def'));
+
+  await orm.em.flush();
+  expect(mock).not.toHaveBeenCalled();
+});
+
+test('entity with known primary key is added to the identity map as early as on persist call (2/2)', async () => {
+  const mock = mockLogger(orm);
+  const e1 = new Book('abc', 'title: abc');
+  orm.em.persist(e1);
+
+  const e2 = await orm.em.findOneOrFail(Book, 'abc');
+  orm.em.remove(e2);
+
+  await orm.em.flush();
+  expect(mock).not.toHaveBeenCalled();
+});

--- a/tests/features/unit-of-work/UnitOfWork.test.ts
+++ b/tests/features/unit-of-work/UnitOfWork.test.ts
@@ -1,6 +1,6 @@
 import { Author } from '../../entities';
 import type { ChangeSet, ChangeSetComputer, EventSubscriber, FlushEventArgs, MikroORM } from '@mikro-orm/core';
-import { ChangeSetType, EntityValidator, IdentityMap, UnitOfWork } from '@mikro-orm/core';
+import { ChangeSetType, EntityValidator, IdentityMap, UnitOfWork, wrap } from '@mikro-orm/core';
 import { initORMMongo, mockLogger } from '../../bootstrap';
 import FooBar from '../../entities/FooBar';
 import { FooBaz } from '../../entities/FooBaz';
@@ -115,6 +115,9 @@ describe('UnitOfWork', () => {
     expect(uow.getPersistStack().size).toBe(1);
     uow.remove(author);
     expect(uow.getPersistStack().size).toBe(0);
+    expect(uow.getRemoveStack().size).toBe(0); // not managed entity won't be added to the remove stack
+    wrap(author, true).__managed = true;
+    uow.remove(author);
     expect(uow.getRemoveStack().size).toBe(1);
     uow.remove(author);
     expect(uow.getRemoveStack().size).toBe(1);

--- a/tests/issues/GH811.test.ts
+++ b/tests/issues/GH811.test.ts
@@ -88,7 +88,7 @@ describe('GH issue 811', () => {
     const employee = await orm.em.findOneOrFail(Employee, employeeCreate.id);
 
     // previously the `Employee.contact.address` was accidentally cascade merged
-    expect(orm.em.getUnitOfWork().getIdentityMap().values().map(e => helper(e).__originalEntityData)).toEqual([
+    expect(orm.em.getUnitOfWork().getIdentityMap().values().map(e => helper(e).__originalEntityData).filter(Boolean)).toEqual([
       { id: contact.id, name: 'My Contact', address: null },
       { id: employee.id, contact: contact.id, name: 'My Employee' },
     ]);


### PR DESCRIPTION
When you `em.persist()` a new entity which has the primary key value, it will be automatically added to the identity map. This means that a following call to `em.findOne()` based on its primary key will just return the same unmanaged entity instance instead of querying the database.

> Such entity is added to the identity map, but still remains unmanaged - it does not have a reference to the `EntityManager` yet.

```ts
// primary key value provided, will be added to the identity map
const jon = em.create(Author, {
  id: 1,
  name: 'Jon',
  email: 'foo@bar.com',
});

// this will not query the database
const jon2 = await em.findOne(Author, 1);
console.log(jon === jon2); // true
await em.flush(); // this inserts the entity
```

If you called `em.persist()` an entity without the primary key value, the `em.findOne()` call would detect it as well and flush automatically to get the value first.

```ts
// primary key value not provided
const jon = em.create(Author, {
  name: 'Jon',
  email: 'foo@bar.com',
});

// this will trigger auto flush and insert the entity, then query for it
const jon2 = await em.findOne(Author, 1);
console.log(jon === jon2); // true
await em.flush(); // this is a no-op
```

Closes #4905