### PR TITLE
feat(core): allow type-safe populate all via `populate: ['*']`

### DIFF
--- a/docs/docs/nested-populate.md
+++ b/docs/docs/nested-populate.md
@@ -21,7 +21,7 @@ console.log(tags[0].books[0].author.name); // prints name of nested author
 4. Load all `Test`s associated with previously loaded `Publisher`s
 5. Load all `Author`s associated with previously loaded `Book`s
 
-> You can also populate all relationships by passing `populate: true`.
+> You can also populate all relationships by passing `populate: ['*']`.
 
 For SQL drivers with pivot tables this means:
 

--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -430,3 +430,18 @@ for (const book of author.books) {
   // ...
 }
 ```
+
+## Type-safe `populate: ['*']` and removed `populate: true` support
+
+When populating all relations, the `Loaded` type will now respect `*` in the populate hint. The old boolean variant is now removed in favor of new `populate: ['*']`.
+
+> This also applies to the `serialize()` helper and its `populate` parameter.
+
+```diff
+const users = await em.find(User, {}, {
+-  populate: true,
++  populate: ['*'],
+});
+```
+
+`populate: false` is still allowed and serves as a way to disable eager loaded properties.

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -1,6 +1,6 @@
 import type {
   ConnectionType, EntityData, EntityMetadata, EntityProperty, FilterQuery, Primary, Dictionary, QBFilterQuery,
-  IPrimaryKey, PopulateOptions, EntityDictionary, AutoPath, ObjectQuery, FilterObject,
+  IPrimaryKey, PopulateOptions, EntityDictionary, AutoPath, ObjectQuery, FilterObject, Populate,
 } from '../typings';
 import type { Connection, QueryResult, Transaction } from '../connections';
 import type { FlushMode, LockMode, QueryOrderMap, QueryFlag, LoadStrategy, PopulateHint } from '../enums';
@@ -96,7 +96,7 @@ export type OrderDefinition<T> = (QueryOrderMap<T> & { 0?: never }) | QueryOrder
 
 export interface FindOptions<T, P extends string = never, F extends string = never> {
   where?: FilterQuery<T>;
-  populate?: readonly AutoPath<T, P>[] | boolean;
+  populate?: Populate<T, P>;
   populateWhere?: ObjectQuery<T> | PopulateHint | `${PopulateHint}`;
   fields?: readonly AutoPath<T, F, '*'>[];
   orderBy?: OrderDefinition<T>;
@@ -183,7 +183,7 @@ export interface CountOptions<T extends object, P extends string = never>  {
   groupBy?: string | readonly string[];
   having?: QBFilterQuery<T>;
   cache?: boolean | number | [string, number];
-  populate?: readonly AutoPath<T, P>[] | boolean;
+  populate?: Populate<T, P>;
   ctx?: Transaction;
   connectionType?: ConnectionType;
   /** sql only */
@@ -194,7 +194,7 @@ export interface CountOptions<T extends object, P extends string = never>  {
   hintComments?: string | string[];
 }
 
-export interface UpdateOptions<T>  {
+export interface UpdateOptions<T> {
   filters?: Dictionary<boolean | Dictionary> | string[] | boolean;
   schema?: string;
   ctx?: Transaction;

--- a/packages/core/src/entity/BaseEntity.ts
+++ b/packages/core/src/entity/BaseEntity.ts
@@ -1,5 +1,5 @@
 import { Reference, type Ref } from './Reference';
-import type { AutoPath, EntityData, EntityDTO, Loaded, LoadedReference, AddEager, EntityKey, EntityType, FromEntityType, IsSubset, MergeSelected } from '../typings';
+import type { AutoPath, EntityData, EntityDTO, Loaded, LoadedReference, AddEager, EntityKey, FromEntityType, IsSubset, MergeSelected } from '../typings';
 import { EntityAssigner, type AssignOptions } from './EntityAssigner';
 import type { EntityLoaderOptions } from './EntityLoader';
 import { EntitySerializer, type SerializeOptions } from '../serialization/EntitySerializer';
@@ -20,8 +20,8 @@ export abstract class BaseEntity {
   }
 
   async populate<Entity extends this = this, Hint extends string = never>(
-    populate: AutoPath<Entity, Hint>[] | boolean,
-    options: EntityLoaderOptions<Entity, Hint> = {},
+    populate: AutoPath<Entity, Hint>[] | false,
+    options: EntityLoaderOptions<Entity> = {},
   ): Promise<Loaded<Entity, Hint>> {
     return helper(this as Entity).populate(populate, options);
   }
@@ -46,11 +46,11 @@ export abstract class BaseEntity {
   }
 
   assign<
-    Ent extends EntityType<this>,
-    Naked extends FromEntityType<Ent> = FromEntityType<Ent>,
+    Entity extends this,
+    Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
     Data extends EntityData<Naked> | Partial<EntityDTO<Naked>> = EntityData<Naked> | Partial<EntityDTO<Naked>>,
-  >(data: Data & IsSubset<EntityData<Naked>, Data>, options: AssignOptions = {}): MergeSelected<Ent, Naked, keyof Data & string> {
-    return EntityAssigner.assign(this as Ent, data as any, options) as any;
+  >(data: Data & IsSubset<EntityData<Naked>, Data>, options: AssignOptions = {}): MergeSelected<Entity, Naked, keyof Data & string> {
+    return EntityAssigner.assign(this as Entity, data as any, options) as any;
   }
 
   init<Entity extends this = this, Populate extends string = never>(populated = true): Promise<Loaded<Entity, Populate>> {

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -226,7 +226,7 @@ export class EntityRepository<Entity extends object> {
   async populate<
     Hint extends string = never,
     Fields extends string = never,
-  >(entities: Entity | Entity[], populate: AutoPath<Entity, Hint>[] | boolean, options?: EntityLoaderOptions<Entity, Hint, Fields>): Promise<Loaded<Entity, Hint, Fields>[]> {
+  >(entities: Entity | Entity[], populate: AutoPath<Entity, Hint>[] | false, options?: EntityLoaderOptions<Entity, Fields>): Promise<Loaded<Entity, Hint, Fields>[]> {
     this.validateRepositoryType(entities, 'populate');
     return this.getEntityManager().populate(entities as Entity, populate, options);
   }
@@ -250,7 +250,7 @@ export class EntityRepository<Entity extends object> {
     Ent extends EntityType<Entity>,
     Naked extends FromEntityType<Ent> = FromEntityType<Ent>,
     Data extends EntityData<Naked> | Partial<EntityDTO<Naked>> = EntityData<Naked> | Partial<EntityDTO<Naked>>,
-  >(entity: Ent, data: Data & IsSubset<EntityData<Naked>, Data>, options?: AssignOptions): MergeSelected<Ent, Naked, keyof Data & string> {
+  >(entity: Ent | Partial<Ent>, data: Data & IsSubset<EntityData<Naked>, Data>, options?: AssignOptions): MergeSelected<Ent, Naked, keyof Data & string> {
     this.validateRepositoryType(entity as Entity, 'assign');
     return this.getEntityManager().assign(entity, data as any, options) as any;
   }

--- a/packages/core/src/entity/Reference.ts
+++ b/packages/core/src/entity/Reference.ts
@@ -1,6 +1,7 @@
 import { inspect } from 'util';
 import type {
   AddEager,
+  AutoPath,
   ConnectionType,
   Dictionary,
   EntityClass,
@@ -8,7 +9,6 @@ import type {
   EntityProperty,
   Loaded,
   LoadedReference,
-  Populate,
   Primary,
   Ref,
 } from '../typings';
@@ -248,7 +248,7 @@ Object.defineProperties(ScalarReference.prototype, {
 });
 
 export interface LoadReferenceOptions<T, P extends string = never> {
-  populate?: Populate<T, P>;
+  populate?: readonly AutoPath<T, P>[] | AutoPath<T, P>;
   lockMode?: Exclude<LockMode, LockMode.OPTIMISTIC>;
   connectionType?: ConnectionType;
   refresh?: boolean;

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -144,8 +144,8 @@ export class WrappedEntity<Entity extends object> {
   }
 
   async populate<Hint extends string = never>(
-    populate: AutoPath<Entity, Hint>[] | boolean,
-    options: EntityLoaderOptions<Entity, Hint> = {},
+    populate: AutoPath<Entity, Hint>[] | false,
+    options: EntityLoaderOptions<Entity> = {},
   ): Promise<Loaded<Entity, Hint>> {
     if (!this.__em) {
       throw ValidationError.entityNotManaged(this.entity);

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -432,7 +432,7 @@ export abstract class Platform {
 
   shouldHaveColumn<T>(prop: EntityProperty<T>, populate: PopulateOptions<T>[] | boolean, includeFormulas = true): boolean {
     if (prop.formula) {
-      return includeFormulas && (!prop.lazy || populate === true || (populate !== false && populate.some(p => p.field === prop.name)));
+      return includeFormulas && (!prop.lazy || populate === true || (populate !== false && populate.some(p => p.field === prop.name || p.all)));
     }
 
     if (prop.persist === false) {

--- a/tests/EntityHelper.mongo.test.ts
+++ b/tests/EntityHelper.mongo.test.ts
@@ -279,8 +279,8 @@ describe('EntityHelperMongo', () => {
     await orm.em.persistAndFlush(bible);
     orm.em.clear();
 
-    const jon = await orm.em.findOneOrFail(Author, god, { populate: true });
-    const o = serialize(jon, { populate: true });
+    const jon = await orm.em.findOneOrFail(Author, god, { populate: ['*'] });
+    const o = serialize(jon, { populate: ['*'] });
     expect(o).toMatchObject({
       id: jon.id,
       createdAt: jon.createdAt,

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -1,5 +1,5 @@
 import { ObjectId } from 'bson';
-import type { EntityProperty } from '@mikro-orm/core';
+import type { EntityProperty, Selected } from '@mikro-orm/core';
 import {
   Collection,
   Configuration,
@@ -945,7 +945,7 @@ describe('EntityManagerMongo', () => {
     expect(wrap(publishers4[1].tests[0]).isInitialized()).toBe(false);
 
     orm.em.clear();
-    const publishers5 = await repo.findAll({ orderBy: { id: 1 }, populate: false });
+    const publishers5 = await repo.findAll({ orderBy: { id: 1 } });
     await publishers5[0].tests.init({ ref: true });
     await publishers5[1].tests.init({ ref: true });
     expect(publishers5).toBeInstanceOf(Array);
@@ -1369,7 +1369,7 @@ describe('EntityManagerMongo', () => {
     const repo = orm.em.getRepository(BookTag);
 
     orm.em.clear();
-    const tags = await repo.findAll({ populate: true });
+    const tags = await repo.findAll({ populate: ['*'] });
     expect(tags.length).toBe(5);
     expect(tags[0]).toBeInstanceOf(BookTag);
     expect(tags[0].books.isInitialized()).toBe(true);

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -1307,7 +1307,7 @@ describe('EntityManagerMySql', () => {
     await orm.em.flush();
     orm.em.clear();
 
-    tag = await orm.em.findOneOrFail(BookTag2, tag1.id, { populate: ['books'] });
+    tag = await orm.em.findOneOrFail(BookTag2, tag1.id, { populate: ['books'] as const });
     expect(tag.books.count()).toBe(0);
   });
 

--- a/tests/features/composite-keys/GH4478.test.ts
+++ b/tests/features/composite-keys/GH4478.test.ts
@@ -75,7 +75,7 @@ test(`GH issue 4478`, async () => {
   expect(mock.mock.calls).toMatchSnapshot();
   orm.em.clear();
 
-  const sa = await orm.em.find(StudentAllocation, { academicYear: '2023' }, { populate: true });
+  const sa = await orm.em.find(StudentAllocation, { academicYear: '2023' }, { populate: ['*'] });
   expect(wrap(sa[0]).toObject()).toEqual({
     academicYear: '2023',
     school: {

--- a/tests/features/composite-keys/custom-pivot-entity-auto-discovery.sqlite.test.ts
+++ b/tests/features/composite-keys/custom-pivot-entity-auto-discovery.sqlite.test.ts
@@ -130,7 +130,7 @@ describe('custom pivot entity for m:n with additional properties (auto-discovere
   test(`should work`, async () => {
     const { order1, order2, product1, product2, product3, product4, product5 } = await createEntities();
 
-    const orders = await orm.em.find(Order, {}, { populate: true });
+    const orders = await orm.em.find(Order, {}, { populate: ['*'] });
     expect(orders).toHaveLength(3);
 
     // test inverse side

--- a/tests/features/composite-keys/custom-pivot-entity-fixed-order.sqlite.test.ts
+++ b/tests/features/composite-keys/custom-pivot-entity-fixed-order.sqlite.test.ts
@@ -130,7 +130,7 @@ describe('custom pivot entity for m:n with additional properties (unidirectional
     const { product1, product2, product3, product4, product5 } = await createEntities();
     const productRepository = orm.em.getRepository(Product);
 
-    const orders = await orm.em.find(Order, {}, { populate: true });
+    const orders = await orm.em.find(Order, {}, { populate: ['*'] });
     expect(orders).toHaveLength(3);
 
     // test M:N lazy load

--- a/tests/features/composite-keys/custom-pivot-entity-uni.sqlite.test.ts
+++ b/tests/features/composite-keys/custom-pivot-entity-uni.sqlite.test.ts
@@ -135,7 +135,7 @@ describe('custom pivot entity for m:n with additional properties (unidirectional
     const { product1, product2, product3, product4, product5 } = await createEntities();
     const productRepository = orm.em.getRepository(Product);
 
-    const orders = await orm.em.find(Order, {}, { populate: true });
+    const orders = await orm.em.find(Order, {}, { populate: ['*'] });
     expect(orders).toHaveLength(3);
 
     // test M:N lazy load

--- a/tests/features/composite-keys/custom-pivot-entity-wrong-order.sqlite.test.ts
+++ b/tests/features/composite-keys/custom-pivot-entity-wrong-order.sqlite.test.ts
@@ -137,7 +137,7 @@ describe('custom pivot entity for m:n with additional properties (bidirectional,
   test(`should work`, async () => {
     const { order1, order2, product1, product2, product3, product4, product5 } = await createEntities();
 
-    const orders = await orm.em.find(Order, {}, { populate: true });
+    const orders = await orm.em.find(Order, {}, { populate: ['*'] });
     expect(orders).toHaveLength(3);
 
     // test inverse side

--- a/tests/features/composite-keys/custom-pivot-entity.sqlite.test.ts
+++ b/tests/features/composite-keys/custom-pivot-entity.sqlite.test.ts
@@ -144,7 +144,7 @@ describe('custom pivot entity for m:n with additional properties (bidirectional)
   test(`should work`, async () => {
     const { order1, order2, product1, product2, product3, product4, product5 } = await createEntities();
 
-    const orders = await orm.em.find(Order, {}, { populate: true });
+    const orders = await orm.em.find(Order, {}, { populate: ['*'] });
     expect(orders).toHaveLength(3);
 
     // test inverse side

--- a/tests/features/custom-types/json-hydration.postgres.test.ts
+++ b/tests/features/custom-types/json-hydration.postgres.test.ts
@@ -89,7 +89,7 @@ test('json property hydration 1/2', async () => {
   orm.em.clear();
 
   Page.log = [];
-  const results = await orm.em.find(Course, {}, { populate: true });
+  const results = await orm.em.find(Course, {}, { populate: ['*'] });
   expect(results[0].published?.page.attestations).toEqual(['attestation1', 'attestation2']);
   expect(Page.log).toEqual([
     ['attestation1', 'attestation2'],
@@ -115,7 +115,7 @@ test('json property hydration 2/2', async () => {
   await orm.em.persistAndFlush(cr1);
   orm.em.clear();
 
-  const results = await orm.em.find(Course, {}, { populate: true });
+  const results = await orm.em.find(Course, {}, { populate: ['*'] });
   expect(results[0].published?.page2.attestations).toEqual(['attestation1', 'attestation2']);
 
   const mock = mockLogger(orm);

--- a/tests/features/embeddables/GH2948.test.ts
+++ b/tests/features/embeddables/GH2948.test.ts
@@ -120,7 +120,7 @@ describe('GH issue 2948', () => {
     ]);
     await orm.em.fork().persist(foo).flush();
 
-    const [foo2] = await orm.em.find(FooEntity, {}, { populate: true });
+    const [foo2] = await orm.em.find(FooEntity, {}, { populate: ['*'] });
     expect(foo2._bar[0]._fiz[0]._baz.name).toBeDefined();
     expect(foo2._bar[0]._fiz[1]._baz.name).toBeDefined();
     expect(foo2._bar[1]._fiz[0]._baz.name).toBeDefined();

--- a/tests/features/entity-assigner/GH1811.test.ts
+++ b/tests/features/entity-assigner/GH1811.test.ts
@@ -4,7 +4,7 @@ import { v4 } from 'uuid';
 import { mockLogger } from '../../helpers';
 
 @Entity()
-export class Recipe {
+class Recipe {
 
   @PrimaryKey({ type: t.uuid })
   id: string = v4();
@@ -21,7 +21,7 @@ export class Recipe {
 }
 
 @Entity()
-export class Ingredient {
+class Ingredient {
 
   @PrimaryKey({ type: t.uuid })
   id: string = v4();
@@ -35,7 +35,7 @@ export class Ingredient {
 }
 
 @Entity()
-export class User {
+class User {
 
   @PrimaryKey({ type: t.uuid })
   id: string = v4();

--- a/tests/features/events/events.mysql.test.ts
+++ b/tests/features/events/events.mysql.test.ts
@@ -217,7 +217,7 @@ describe('events (mysql)', () => {
     ]);
     EverythingSubscriber.log.length = 0;
 
-    const authors3 = await orm.em.fork().find(Author2, {}, { populate: true });
+    const authors3 = await orm.em.fork().find(Author2, {}, { populate: ['*'] });
     expect(authors3).toHaveLength(1);
     expect(EverythingSubscriber.log.map(l => [l[0], l[1].entity.constructor.name]).filter(a => a[0] === EventType.onLoad)).toEqual([
       ['onLoad', 'Author2'],

--- a/tests/features/joined-strategy.postgre.test.ts
+++ b/tests/features/joined-strategy.postgre.test.ts
@@ -253,7 +253,7 @@ describe('Joined loading strategy', () => {
     await orm.em.persistAndFlush(author2);
     orm.em.clear();
 
-    const a2 = await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: true, strategy: LoadStrategy.SELECT_IN });
+    const a2 = await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['*'], strategy: LoadStrategy.SELECT_IN });
     expect(a2.books2).toHaveLength(2);
     expect(a2.books).toHaveLength(2);
   });

--- a/tests/features/multiple-schemas-entity-manager/multiple-schemas-entity-manager.postgres.test.ts
+++ b/tests/features/multiple-schemas-entity-manager/multiple-schemas-entity-manager.postgres.test.ts
@@ -127,7 +127,7 @@ describe('multiple connected schemas in postgres', () => {
     expect(wrap(author.books[2].tags[0]).getSchema()).toBe('n2');
 
     fork.clear();
-    author = await fork.findOneOrFail(Author, author, { populate: true });
+    author = await fork.findOneOrFail(Author, author, { populate: ['*'] });
 
     expect(fork.getUnitOfWork().getIdentityMap().keys()).toEqual([
       'Author-n1:1',
@@ -231,7 +231,7 @@ describe('multiple connected schemas in postgres', () => {
     expect(wrap(author.books[2].tags[0]).getSchema()).toBe('n2');
 
     fork.clear();
-    author = await fork.findOneOrFail(Author, author, { populate: true });
+    author = await fork.findOneOrFail(Author, author, { populate: ['*'] });
 
     expect(fork.getUnitOfWork().getIdentityMap().keys()).toEqual([
       'Author-n1:1',
@@ -334,7 +334,7 @@ describe('multiple connected schemas in postgres', () => {
     expect(wrap(author.books[2].tags[0]).getSchema()).toBe('n2');
 
     fork.clear();
-    author = await fork.findOneOrFail(Author, author, { populate: true });
+    author = await fork.findOneOrFail(Author, author, { populate: ['*'] });
 
     expect(fork.getUnitOfWork().getIdentityMap().keys()).toEqual([
       'Author-n1:1',
@@ -509,7 +509,7 @@ describe('multiple connected schemas in postgres', () => {
     mock.mockReset();
 
     const fork = mainForkN4.fork();
-    await fork.findOneOrFail(Author, author, { populate: true, schema: 'n5' });
+    await fork.findOneOrFail(Author, author, { populate: ['*'], schema: 'n5' });
 
     expect(mock.mock.calls[0][0]).toMatch(`select "a0".* from "n1"."author" as "a0" where "a0"."id" = 1 limit 1`);
     expect(mock.mock.calls[1][0]).toMatch(`select "b0".* from "n5"."book" as "b0" where "b0"."author_id" in (1)`);

--- a/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
+++ b/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
@@ -123,7 +123,7 @@ describe('multiple connected schemas in postgres', () => {
     expect(wrap(author.books[2].tags[0]).getSchema()).toBe('n2');
 
     orm.em.clear();
-    author = await orm.em.findOneOrFail(Author, author, { populate: true });
+    author = await orm.em.findOneOrFail(Author, author, { populate: ['*'] });
 
     expect(orm.em.getUnitOfWork().getIdentityMap().keys()).toEqual([
       'Author-n1:1',
@@ -293,7 +293,7 @@ describe('multiple connected schemas in postgres', () => {
     mock.mockReset();
 
     const fork = orm.em.fork();
-    await fork.findOneOrFail(Author, author, { populate: true, schema: 'n5' });
+    await fork.findOneOrFail(Author, author, { populate: ['*'], schema: 'n5' });
 
     expect(mock.mock.calls[0][0]).toMatch(`select "a0".* from "n1"."author" as "a0" where "a0"."id" = 1 limit 1`);
     expect(mock.mock.calls[1][0]).toMatch(`select "b0".* from "n5"."book" as "b0" where "b0"."author_id" in (1)`);

--- a/tests/features/partial-loading/GH4433.test.ts
+++ b/tests/features/partial-loading/GH4433.test.ts
@@ -130,7 +130,7 @@ test(`GH issue 4433 (select-in) - only id`, async () => {
     A,
     { },
     {
-      populate: true,
+      populate: ['*'],
       fields: ['*', 'b.id'],
       strategy: LoadStrategy.SELECT_IN,
     },

--- a/tests/features/partial-loading/partial-loading.mysql.test.ts
+++ b/tests/features/partial-loading/partial-loading.mysql.test.ts
@@ -191,7 +191,7 @@ describe('partial loading (mysql)', () => {
     const mock = mockLogger(orm, ['query']);
 
     const r1 = await orm.em.find(Book2, b1, {
-      fields: ['uuid', 'title', 'author', 'author.email'],
+      fields: ['uuid', 'title', 'author.email'],
       populate: ['author'],
       filters: false,
     });

--- a/tests/features/serialization/explicit-serialization.test.ts
+++ b/tests/features/serialization/explicit-serialization.test.ts
@@ -45,7 +45,7 @@ test('explicit serialization with ORM BaseEntity', async () => {
 
 test('explicit serialization', async () => {
   const { god, author, publisher, book1, book2, book3 } = await createEntities();
-  const jon = await orm.em.findOneOrFail(Author2, author, { populate: true })!;
+  const jon = await orm.em.findOneOrFail(Author2, author, { populate: ['*'] })!;
 
   const o1 = wrap(jon).serialize();
   expect(o1).toMatchObject({
@@ -179,9 +179,9 @@ test('explicit serialization', async () => {
 
 test('explicit serialization with populate: true', async () => {
   const { god, author, publisher } = await createEntities();
-  const jon = await orm.em.findOneOrFail(Author2, author, { populate: true })!;
+  const jon = await orm.em.findOneOrFail(Author2, author, { populate: ['*'] })!;
 
-  const o8 = serialize(jon, { populate: true });
+  const o8 = serialize(jon, { populate: ['*'] });
   expect(o8).toMatchObject({
     id: jon.id,
     createdAt: jon.createdAt,
@@ -202,7 +202,7 @@ test('explicit serialization with not initialized properties', async () => {
   const { author } = await createEntities();
   const jon = await orm.em.findOneOrFail(Author2, author)!;
 
-  const o = serialize(jon, { populate: true });
+  const o = serialize(jon, { populate: ['*'] });
   expect(o).toMatchObject({
     id: jon.id,
     createdAt: jon.createdAt,
@@ -213,7 +213,7 @@ test('explicit serialization with not initialized properties', async () => {
     name: 'Jon Snow',
   });
 
-  const o2 = serialize(jon.favouriteBook!, { populate: true });
+  const o2 = serialize(jon.favouriteBook!, { populate: ['*'] });
   expect(o2).toEqual({
     uuid: jon.favouriteBook!.uuid,
   });

--- a/tests/issues/GH1115.test.ts
+++ b/tests/issues/GH1115.test.ts
@@ -42,7 +42,7 @@ describe('GH issue 1115', () => {
     await orm.em.persistAndFlush(a);
     orm.em.clear();
 
-    const user = await orm.em.findOne(A, { id: 1 }, { populate: true });
+    const user = await orm.em.findOne(A, { id: 1 }, { populate: ['*'] });
     const data = JSON.parse(JSON.stringify(user));
     await expect(data.property).toEqual({ id: 1, property: 'foo' });
   });

--- a/tests/issues/GH1128.test.ts
+++ b/tests/issues/GH1128.test.ts
@@ -46,7 +46,7 @@ describe('GH issue 1128', () => {
     });
     orm.em.clear();
 
-    const entity = await orm.em.findOneOrFail(A, { id: 1 }, { populate: true });
+    const entity = await orm.em.findOneOrFail(A, { id: 1 }, { populate: ['*'] });
     expect(entity.entities).toHaveLength(2);
     expect(entity.entities[0].entity).toBe(entity.id);
     expect(entity.entities[1].entity).toBe(entity.id);

--- a/tests/issues/GH1134.test.ts
+++ b/tests/issues/GH1134.test.ts
@@ -127,7 +127,7 @@ describe('GH issue 1134', () => {
   afterAll(() => orm.close(true));
 
   test('Load nested data with smart populate (select-in strategy)', async () => {
-    const entity = await orm.em.getRepository(N).findAll({ populate: true });
+    const entity = await orm.em.getRepository(N).findAll({ populate: ['*'] });
     const json = JSON.parse(JSON.stringify(entity));
 
     // check both entity and DTO
@@ -149,25 +149,25 @@ describe('GH issue 1134', () => {
   });
 
   test('Load nested data with smart populate (select-in strategy will be forced due to `populate: true`)', async () => {
-    const entity = await orm.em.getRepository(N).findAll({ populate: true, strategy: LoadStrategy.JOINED });
+    const entity = await orm.em.getRepository(N).findAll({ populate: ['*'], strategy: LoadStrategy.JOINED });
     const json = JSON.parse(JSON.stringify(entity));
 
     // check both entity and DTO
-    [entity, json].forEach(item => {
-      expect(item[0].m[0].e).toMatchObject({
-        a: {
-          value: 'A2',
+    const expected = {
+      a: {
+        value: 'A2',
+      },
+      t: {
+        value: 'T2',
+      },
+      v: {
+        i: {
+          value: 6,
         },
-        t: {
-          value: 'T2',
-        },
-        v: {
-          i: {
-            value: 6,
-          },
-        },
-      });
-    });
+      },
+    };
+    expect(entity[0].m[0].e).toMatchObject(expected);
+    expect(json[0].m[0].e).toMatchObject(expected);
   });
 });
 

--- a/tests/issues/GH228.test.ts
+++ b/tests/issues/GH228.test.ts
@@ -52,7 +52,7 @@ describe('GH issue 228', () => {
     const mock = mockLogger(orm, ['query']);
     await orm.em.findAndCount(A, {}, {
       orderBy: { type: 'asc' },
-      populate: true,
+      populate: ['*'],
     });
 
     const queries: string[] = mock.mock.calls.map(c => c[0]).sort();

--- a/tests/issues/GH3543.test.ts
+++ b/tests/issues/GH3543.test.ts
@@ -78,7 +78,7 @@ test('GH issue 3543', async () => {
     customerId: '456',
     companyId: '789',
     orderId: order.orderId,
-  }, { populate: true });
+  }, { populate: ['*'] });
 
   order.events.removeAll();
   await orm.em.flush();
@@ -88,7 +88,7 @@ test('GH issue 3543', async () => {
     customerId: '456',
     companyId: '789',
     orderId: order.orderId,
-  }, { populate: true });
+  }, { populate: ['*'] });
 
   expect(order.events).toHaveLength(0);
 });
@@ -110,7 +110,7 @@ test('GH issue 3543 without orphan removal builds correct query', async () => {
     customerId: '456',
     companyId: '789',
     orderId: order.orderId,
-  }, { populate: true });
+  }, { populate: ['*'] });
 
   // disconnecting the relation without orphan removal throws, as it means nulling it on the owning side, which would fail as it is a non-null PK column
   expect(() => order.events.removeAll()).toThrowError(

--- a/tests/issues/GH3548.test.ts
+++ b/tests/issues/GH3548.test.ts
@@ -51,7 +51,7 @@ test('GH issue 3548', async () => {
   author.authorDetail = authorDetail;
   await orm.em.fork().persist(author).flush();
 
-  const r1 = await orm.em.fork().find(AuthorDetail, {}, { populate: true });
+  const r1 = await orm.em.fork().find(AuthorDetail, {}, { populate: ['*'] });
   expect(r1[0]).toMatchObject({
     _id: expect.any(ObjectId),
     name: 'name',
@@ -64,7 +64,7 @@ test('GH issue 3548', async () => {
     },
   });
 
-  const r2 = await orm.em.fork().find(Author, {}, { populate: true });
+  const r2 = await orm.em.fork().find(Author, {}, { populate: ['*'] });
   expect(r2[0]).toMatchObject({
     _id: expect.any(ObjectId),
     authorDetail: {

--- a/tests/issues/GH3564.test.ts
+++ b/tests/issues/GH3564.test.ts
@@ -88,7 +88,7 @@ describe(`GH issue 3564`, () => {
     car.parts[0].parts.add(electrolyte); // add part 'Electrolyte' to part 'Battery'
     await orm.em.flush();
 
-    await orm.em.refresh(car, { populate: true });
+    await orm.em.refresh(car, { populate: ['*'] });
 
     expect(car.parts.count()).toBe(1); // should be one, since we removed the 'Electrolyte'
     expect(car.parts[0].parts.count()).toBe(2); // the part 'Battery' has 2 parts now
@@ -103,7 +103,7 @@ describe(`GH issue 3564`, () => {
     battery.parts.set([electrolyte, electrode]); // add part 'Electrolyte' to part 'Battery'
     await orm.em.flush();
 
-    await orm.em.refresh(car, { populate: true });
+    await orm.em.refresh(car, { populate: ['*'] });
 
     expect(car.parts.count()).toBe(1); // should be one, since we removed the 'Electrolyte'
     expect(car.parts[0].parts.count()).toBe(2); // the part 'Battery' has 2 parts now
@@ -130,7 +130,7 @@ describe(`GH issue 3564`, () => {
       }],
     });
     await orm.em.flush();
-    await orm.em.refresh(car, { populate: true });
+    await orm.em.refresh(car, { populate: ['*'] });
 
     expect(car.parts.count()).toBe(1); // should be one, since we removed the 'Electrolyte'
     expect(car.parts[0].parts.count()).toBe(2); // the part 'Battery' has 2 parts now

--- a/tests/issues/GH4062.test.ts
+++ b/tests/issues/GH4062.test.ts
@@ -130,8 +130,11 @@ test('4062', async () => {
   const loaded = await orm.em.findOneOrFail(
     Category,
     { id: category.id },
-    { populate: true },
+    { populate: ['*'] },
   );
+  // type-safe populate: ['*']
+  const a = loaded.articles.$[0].category.$.articles.$[0].category.$.articles.$[0].category.$.articles.$[0].category.$;
+  expect(a).toBe(loaded);
 
   orm.em.assign(loaded, plainUpdate);
 

--- a/tests/issues/GH560.test.ts
+++ b/tests/issues/GH560.test.ts
@@ -68,7 +68,7 @@ describe('GH issue 560', () => {
     await expect(orm.em.flush()).resolves.not.toThrow();
     orm.em.clear();
 
-    const fetchedParent = await orm.em.findOneOrFail(A, { type: 'parent' }, { populate: true });
+    const fetchedParent = await orm.em.findOneOrFail(A, { type: 'parent' }, { populate: ['*'] });
     expect(fetchedParent.childrenA).toBeTruthy();
   });
 });

--- a/tests/issues/GHx3.test.ts
+++ b/tests/issues/GHx3.test.ts
@@ -73,7 +73,7 @@ beforeAll(async () => {
 afterAll(() => orm.close(true));
 
 test('json property hydration', async () => {
-  await orm.em.find(Course, {}, { populate: true });
+  await orm.em.find(Course, {}, { populate: ['*'] });
   const mock = mockLogger(orm);
   await orm.em.flush();
   expect(mock).not.toBeCalled();

--- a/tests/perf/serializing-nested-entities/serializing-nested-entities.test.ts
+++ b/tests/perf/serializing-nested-entities/serializing-nested-entities.test.ts
@@ -18,7 +18,7 @@ beforeAll(async () => {
 afterAll(() => orm.close(true));
 
 test('perf: serialize nested entities', async () => {
-  const risks = await orm.em.find(Risk, {}, { populate: true });
+  const risks = await orm.em.find(Risk, {}, { populate: ['*'] });
   const project = await orm.em.findOneOrFail(Project, { id: 1 });
 
   // Serialize a collection of 150 entities

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -3,7 +3,17 @@ import type { BaseEntity, Ref, Reference, Collection, EntityManager, EntityName,
 import type { Has, IsExact } from 'conditional-type-checks';
 import { assert } from 'conditional-type-checks';
 import type { ObjectId } from 'bson';
-import type { EntityData, EntityDTO, FilterQuery, FilterValue, Loaded, OperatorMap, Primary, PrimaryKeyProp, Query } from '../packages/core/src/typings';
+import type {
+  EntityData,
+  EntityDTO,
+  FilterQuery,
+  FilterValue,
+  Loaded,
+  OperatorMap,
+  Primary,
+  PrimaryKeyProp,
+  Query,
+} from '../packages/core/src/typings';
 import type { Author2, Book2, BookTag2, Car2, FooBar2, FooParam2, Publisher2, User2 } from './entities-sql';
 import type { Author, Book } from './entities';
 


### PR DESCRIPTION
When populating all relations, the `Loaded` type will now respect `*` in the populate hint. The old boolean variant is now removed in favor of new `populate: ['*']`.

> This also applies to the `serialize()` helper and its `populate` parameter.

```diff
const users = await em.find(User, {}, {
-  populate: true,
+  populate: ['*'],
});
```

`populate: false` is still allowed and serves as a way to disable eager loaded properties.

Closes #4920