### PR TITLE
test: all tests can now run on Windows

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,7 +44,7 @@ module.exports = {
     '@typescript-eslint/no-empty-function': 'error',
     '@typescript-eslint/no-inferrable-types': 'error',
     '@typescript-eslint/no-misused-new': 'error',
-    '@typescript-eslint/no-namespace': 'error',
+    '@typescript-eslint/no-namespace': ['error', { allowDeclarations: true }],
     '@typescript-eslint/no-this-alias': 'error',
     '@typescript-eslint/no-use-before-define': 'error',
     '@typescript-eslint/no-var-requires': 'error',

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,7 +53,7 @@
     "node": ">= 18.12.0"
   },
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn copy && cp src/esm.cmd dist/esm.cmd && yarn run -T gen-esm-wrapper dist/index.js dist/index.mjs",
+    "build": "yarn clean && yarn compile && yarn copy && yarn run -T gen-esm-wrapper dist/index.js dist/index.mjs",
     "clean": "yarn run -T rimraf ./dist",
     "compile": "yarn run -T tsc -p tsconfig.build.json",
     "copy": "node ../../scripts/copy.mjs"

--- a/scripts/copy.mjs
+++ b/scripts/copy.mjs
@@ -143,6 +143,9 @@ if (options['pin-versions']) {
 copy('README.md', root, target);
 copy('LICENSE',  root, target);
 copy('package.json', process.cwd(), target);
+if (resolve(process.cwd()) === resolve(root, 'packages/cli')) {
+  copy('esm.cmd', resolve(process.cwd(), 'src'), target);
+}
 rewrite(resolve(target, 'package.json'), pkg => {
   return pkg.replace(/dist\//g, '').replace(/src\/(.*)\.ts/g, '$1.js');
 });

--- a/scripts/copy.mjs
+++ b/scripts/copy.mjs
@@ -143,9 +143,11 @@ if (options['pin-versions']) {
 copy('README.md', root, target);
 copy('LICENSE',  root, target);
 copy('package.json', process.cwd(), target);
+
 if (resolve(process.cwd()) === resolve(root, 'packages/cli')) {
   copy('esm.cmd', resolve(process.cwd(), 'src'), target);
 }
+
 rewrite(resolve(target, 'package.json'), pkg => {
   return pkg.replace(/dist\//g, '').replace(/src\/(.*)\.ts/g, '$1.js');
 });

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -92,9 +92,10 @@ describe('MikroORM', () => {
     const pathExistsMock = jest.spyOn(fs as any, 'pathExists');
     pathExistsMock.mockImplementation(async path => {
       const str = path as string;
-      return str.endsWith('.json') || (str.includes('/mikro-orm.config.ts') && !str.includes('/src/mikro-orm.config.ts'));
+      return str.endsWith('.json') || (str.endsWith('/mikro-orm.config.ts') && !str.endsWith('/src/mikro-orm.config.ts'));
     });
     jest.mock('../mikro-orm.config.ts', () => options, { virtual: true });
+    jest.mock(Utils.normalizePath(process.cwd()) + '/mikro-orm.config.ts', () => options, { virtual: true });
     const pkg = { 'mikro-orm': { useTsNode: true } } as any;
     jest.mock('../package.json', () => pkg, { virtual: true });
 

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -8,28 +8,37 @@ import { resolve } from 'node:path';
 import type * as pathModule from 'node:path';
 import type * as mikroOrmCoreModule from '@mikro-orm/core';
 
-jest.mock(jest.requireActual<typeof mikroOrmCoreModule>('@mikro-orm/core').Utils.normalizePath(process.cwd()) + '/mikro-orm.config.js', () => ({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] }), { virtual: true });
-jest.mock(jest.requireActual<typeof mikroOrmCoreModule>('@mikro-orm/core').Utils.normalizePath(process.cwd()) + '/mikro-orm.config.ts', () => ({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] }), { virtual: true });
-jest.mock(jest.requireActual<typeof mikroOrmCoreModule>('@mikro-orm/core').Utils.normalizePath(process.cwd()) + '/mikro-orm-async.config.js', () => (Promise.resolve({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] })), { virtual: true });
-jest.mock(jest.requireActual<typeof mikroOrmCoreModule>('@mikro-orm/core').Utils.normalizePath(process.cwd()) + '/mikro-orm-async-catch.config.js', () => (Promise.reject('FooError')), { virtual: true });
+declare module global {
+  let normalizedCwd: string;
+  let resolvedCwd: string;
+}
+
+jest.mock((global.normalizedCwd = jest.requireActual<typeof mikroOrmCoreModule>('@mikro-orm/core').Utils.normalizePath(process.cwd())) + '/mikro-orm.config.js', () => ({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] }), { virtual: true });
+jest.mock(global.normalizedCwd + '/mikro-orm.config.ts', () => ({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] }), { virtual: true });
+jest.mock(global.normalizedCwd + '/mikro-orm-async.config.js', () => (Promise.resolve({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] })), { virtual: true });
+jest.mock(global.normalizedCwd + '/mikro-orm-async-catch.config.js', () => (Promise.reject('FooError')), { virtual: true });
 
 const pkg = { 'mikro-orm': {} } as any;
-jest.mock(jest.requireActual<typeof pathModule>('node:path').resolve(process.cwd(), './package.json'), () => pkg, { virtual: true });
+jest.mock(
+  (global.resolvedCwd = (() => {
+    const path = jest.requireActual<typeof pathModule>('node:path');
+    return path.resolve(process.cwd()) + path.sep;
+  })()) + 'package.json', () => pkg, { virtual: true });
 
 const tscBase = { compilerOptions: { baseUrl: '.', paths: { '@some-path/some': './libs/paths' } } } as any;
-jest.mock(jest.requireActual<typeof pathModule>('node:path').resolve(process.cwd(), './tsconfig.base.json'), () => tscBase, { virtual: true });
+jest.mock(global.resolvedCwd + 'tsconfig.base.json', () => tscBase, { virtual: true });
 
 const tscExtendedAbs = { extends: process.cwd() + '/tsconfig.base.json', compilerOptions: { module: 'commonjs' } } as any;
-jest.mock(jest.requireActual<typeof pathModule>('node:path').resolve(process.cwd(), './tsconfig.extended-abs.json'), () => tscExtendedAbs, { virtual: true });
+jest.mock(global.resolvedCwd + 'tsconfig.extended-abs.json', () => tscExtendedAbs, { virtual: true });
 
 const tscExtended = { extends: './tsconfig.extended-abs.json', compilerOptions: { module: 'commonjs' } } as any;
-jest.mock(jest.requireActual<typeof pathModule>('node:path').resolve(process.cwd(), './tsconfig.extended.json'), () => tscExtended, { virtual: true });
+jest.mock(global.resolvedCwd + 'tsconfig.extended.json', () => tscExtended, { virtual: true });
 
 const tscWithoutBaseUrl = { compilerOptions: { paths: { '@some-path/some': './libs/paths' } } };
-jest.mock(jest.requireActual<typeof pathModule>('node:path').resolve(process.cwd(), './tsconfig.without-baseurl.json'), () => tscWithoutBaseUrl, { virtual: true });
+jest.mock(global.resolvedCwd + 'tsconfig.without-baseurl.json', () => tscWithoutBaseUrl, { virtual: true });
 
 const tsc = { compilerOptions: { } } as any;
-jest.mock(jest.requireActual<typeof pathModule>('node:path').resolve(process.cwd(), './tsconfig.json'), () => tsc, { virtual: true });
+jest.mock(global.resolvedCwd + 'tsconfig.json', () => tsc, { virtual: true });
 
 process.env.FORCE_COLOR = '0';
 

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -5,39 +5,31 @@ import { SchemaCommandFactory } from '../../../packages/cli/src/commands/SchemaC
 import { MongoDriver } from '@mikro-orm/mongodb';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 import { resolve } from 'node:path';
+import type * as pathModule from 'node:path';
+import type * as mikroOrmCoreModule from '@mikro-orm/core';
 
-jest.mock(process.cwd() + '/mikro-orm.config.js', () => ({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] }), { virtual: true });
-jest.mock(process.cwd().replaceAll('\\', '/') + '/mikro-orm.config.js', () => ({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] }), { virtual: true });
-jest.mock(process.cwd() + '/mikro-orm.config.ts', () => ({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] }), { virtual: true });
-jest.mock(process.cwd().replaceAll('\\', '/') + '/mikro-orm.config.ts', () => ({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] }), { virtual: true });
-jest.mock(process.cwd() + '/mikro-orm-async.config.js', () => (Promise.resolve({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] })), { virtual: true });
-jest.mock(process.cwd().replaceAll('\\', '/') + '/mikro-orm-async.config.js', () => (Promise.resolve({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] })), { virtual: true });
-jest.mock(process.cwd() + '/mikro-orm-async-catch.config.js', () => (Promise.reject('FooError')), { virtual: true });
-jest.mock(process.cwd().replaceAll('\\', '/') + '/mikro-orm-async-catch.config.js', () => (Promise.reject('FooError')), { virtual: true });
+jest.mock(jest.requireActual<typeof mikroOrmCoreModule>('@mikro-orm/core').Utils.normalizePath(process.cwd()) + '/mikro-orm.config.js', () => ({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] }), { virtual: true });
+jest.mock(jest.requireActual<typeof mikroOrmCoreModule>('@mikro-orm/core').Utils.normalizePath(process.cwd()) + '/mikro-orm.config.ts', () => ({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] }), { virtual: true });
+jest.mock(jest.requireActual<typeof mikroOrmCoreModule>('@mikro-orm/core').Utils.normalizePath(process.cwd()) + '/mikro-orm-async.config.js', () => (Promise.resolve({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] })), { virtual: true });
+jest.mock(jest.requireActual<typeof mikroOrmCoreModule>('@mikro-orm/core').Utils.normalizePath(process.cwd()) + '/mikro-orm-async-catch.config.js', () => (Promise.reject('FooError')), { virtual: true });
 
 const pkg = { 'mikro-orm': {} } as any;
-jest.mock(process.cwd() + '/package.json', () => pkg, { virtual: true });
-jest.mock(process.cwd() + '\\package.json', () => pkg, { virtual: true });
+jest.mock(jest.requireActual<typeof pathModule>('node:path').resolve(process.cwd(), './package.json'), () => pkg, { virtual: true });
 
 const tscBase = { compilerOptions: { baseUrl: '.', paths: { '@some-path/some': './libs/paths' } } } as any;
-jest.mock(process.cwd() + '/tsconfig.base.json', () => tscBase, { virtual: true });
-jest.mock(process.cwd() + '\\tsconfig.base.json', () => tscBase, { virtual: true });
+jest.mock(jest.requireActual<typeof pathModule>('node:path').resolve(process.cwd(), './tsconfig.base.json'), () => tscBase, { virtual: true });
 
 const tscExtendedAbs = { extends: process.cwd() + '/tsconfig.base.json', compilerOptions: { module: 'commonjs' } } as any;
-jest.mock(process.cwd() + '/tsconfig.extended-abs.json', () => tscExtendedAbs, { virtual: true });
-jest.mock(process.cwd() + '\\tsconfig.extended-abs.json', () => tscExtendedAbs, { virtual: true });
+jest.mock(jest.requireActual<typeof pathModule>('node:path').resolve(process.cwd(), './tsconfig.extended-abs.json'), () => tscExtendedAbs, { virtual: true });
 
 const tscExtended = { extends: './tsconfig.extended-abs.json', compilerOptions: { module: 'commonjs' } } as any;
-jest.mock(process.cwd() + '/tsconfig.extended.json', () => tscExtended, { virtual: true });
-jest.mock(process.cwd() + '\\tsconfig.extended.json', () => tscExtended, { virtual: true });
+jest.mock(jest.requireActual<typeof pathModule>('node:path').resolve(process.cwd(), './tsconfig.extended.json'), () => tscExtended, { virtual: true });
 
 const tscWithoutBaseUrl = { compilerOptions: { paths: { '@some-path/some': './libs/paths' } } };
-jest.mock(process.cwd() + '/tsconfig.without-baseurl.json', () => tscWithoutBaseUrl, { virtual: true });
-jest.mock(process.cwd() + '\\tsconfig.without-baseurl.json', () => tscWithoutBaseUrl, { virtual: true });
+jest.mock(jest.requireActual<typeof pathModule>('node:path').resolve(process.cwd(), './tsconfig.without-baseurl.json'), () => tscWithoutBaseUrl, { virtual: true });
 
 const tsc = { compilerOptions: { } } as any;
-jest.mock(process.cwd() + '/tsconfig.json', () => tsc, { virtual: true });
-jest.mock(process.cwd() + '\\tsconfig.json', () => tsc, { virtual: true });
+jest.mock(jest.requireActual<typeof pathModule>('node:path').resolve(process.cwd(), './tsconfig.json'), () => tsc, { virtual: true });
 
 process.env.FORCE_COLOR = '0';
 

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -4,28 +4,40 @@ import { CLIConfigurator, CLIHelper } from '@mikro-orm/cli';
 import { SchemaCommandFactory } from '../../../packages/cli/src/commands/SchemaCommandFactory';
 import { MongoDriver } from '@mikro-orm/mongodb';
 import { SqliteDriver } from '@mikro-orm/sqlite';
+import { resolve } from 'node:path';
 
 jest.mock(process.cwd() + '/mikro-orm.config.js', () => ({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] }), { virtual: true });
+jest.mock(process.cwd().replaceAll('\\', '/') + '/mikro-orm.config.js', () => ({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] }), { virtual: true });
 jest.mock(process.cwd() + '/mikro-orm.config.ts', () => ({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] }), { virtual: true });
+jest.mock(process.cwd().replaceAll('\\', '/') + '/mikro-orm.config.ts', () => ({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] }), { virtual: true });
 jest.mock(process.cwd() + '/mikro-orm-async.config.js', () => (Promise.resolve({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] })), { virtual: true });
+jest.mock(process.cwd().replaceAll('\\', '/') + '/mikro-orm-async.config.js', () => (Promise.resolve({ driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] })), { virtual: true });
 jest.mock(process.cwd() + '/mikro-orm-async-catch.config.js', () => (Promise.reject('FooError')), { virtual: true });
+jest.mock(process.cwd().replaceAll('\\', '/') + '/mikro-orm-async-catch.config.js', () => (Promise.reject('FooError')), { virtual: true });
+
 const pkg = { 'mikro-orm': {} } as any;
 jest.mock(process.cwd() + '/package.json', () => pkg, { virtual: true });
+jest.mock(process.cwd() + '\\package.json', () => pkg, { virtual: true });
 
 const tscBase = { compilerOptions: { baseUrl: '.', paths: { '@some-path/some': './libs/paths' } } } as any;
 jest.mock(process.cwd() + '/tsconfig.base.json', () => tscBase, { virtual: true });
+jest.mock(process.cwd() + '\\tsconfig.base.json', () => tscBase, { virtual: true });
 
 const tscExtendedAbs = { extends: process.cwd() + '/tsconfig.base.json', compilerOptions: { module: 'commonjs' } } as any;
 jest.mock(process.cwd() + '/tsconfig.extended-abs.json', () => tscExtendedAbs, { virtual: true });
+jest.mock(process.cwd() + '\\tsconfig.extended-abs.json', () => tscExtendedAbs, { virtual: true });
 
 const tscExtended = { extends: './tsconfig.extended-abs.json', compilerOptions: { module: 'commonjs' } } as any;
 jest.mock(process.cwd() + '/tsconfig.extended.json', () => tscExtended, { virtual: true });
+jest.mock(process.cwd() + '\\tsconfig.extended.json', () => tscExtended, { virtual: true });
 
 const tscWithoutBaseUrl = { compilerOptions: { paths: { '@some-path/some': './libs/paths' } } };
 jest.mock(process.cwd() + '/tsconfig.without-baseurl.json', () => tscWithoutBaseUrl, { virtual: true });
+jest.mock(process.cwd() + '\\tsconfig.without-baseurl.json', () => tscWithoutBaseUrl, { virtual: true });
 
 const tsc = { compilerOptions: { } } as any;
 jest.mock(process.cwd() + '/tsconfig.json', () => tsc, { virtual: true });
+jest.mock(process.cwd() + '\\tsconfig.json', () => tsc, { virtual: true });
 
 process.env.FORCE_COLOR = '0';
 
@@ -79,7 +91,7 @@ describe('CLIHelper', () => {
     pkg['mikro-orm'].useTsNode = true;
     const cli = await CLIConfigurator.configure() as any;
     expect(cli.$0).toBe('mikro-orm');
-    expect(requireFromMock).toHaveBeenCalledWith('ts-node', process.cwd() + '/tsconfig.json');
+    expect(requireFromMock).toHaveBeenCalledWith('ts-node', resolve(process.cwd(), './tsconfig.json'));
   });
 
   test('configures yargs instance [ts-node] without paths', async () => {
@@ -89,8 +101,8 @@ describe('CLIHelper', () => {
     const registerSpy = jest.spyOn(require('ts-node'), 'register');
     const cli = await CLIConfigurator.configure() as any;
     expect(cli.$0).toBe('mikro-orm');
-    expect(requireFromMock).toHaveBeenCalledWith('ts-node', process.cwd() + '/tsconfig.json');
-    expect(requireFromMock).toHaveBeenCalledWith('tsconfig-paths', process.cwd() + '/tsconfig.json');
+    expect(requireFromMock).toHaveBeenCalledWith('ts-node', resolve(process.cwd(), './tsconfig.json'));
+    expect(requireFromMock).toHaveBeenCalledWith('tsconfig-paths', resolve(process.cwd(), './tsconfig.json'));
     expect(registerSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -124,8 +136,8 @@ describe('CLIHelper', () => {
     const cli = await CLIConfigurator.configure() as any;
     expect(cli.$0).toBe('mikro-orm');
     expect(requireFromMock).toHaveBeenCalledTimes(2);
-    expect(requireFromMock).toHaveBeenCalledWith('ts-node', process.cwd() + '/tsconfig.extended-abs.json');
-    expect(requireFromMock).toHaveBeenCalledWith('tsconfig-paths', process.cwd() + '/tsconfig.extended-abs.json');
+    expect(requireFromMock).toHaveBeenCalledWith('ts-node', resolve(process.cwd(), './tsconfig.extended-abs.json'));
+    expect(requireFromMock).toHaveBeenCalledWith('tsconfig-paths', resolve(process.cwd(), './tsconfig.extended-abs.json'));
     expect(registerPathsMock).toHaveBeenCalledWith({
       baseUrl: '.',
       paths: { '@some-path/some': './libs/paths' },
@@ -163,8 +175,8 @@ describe('CLIHelper', () => {
     const cli = await CLIConfigurator.configure() as any;
     expect(cli.$0).toBe('mikro-orm');
     expect(requireFromMock).toHaveBeenCalledTimes(2);
-    expect(requireFromMock).toHaveBeenCalledWith('ts-node', process.cwd() + '/tsconfig.without-baseurl.json');
-    expect(requireFromMock).toHaveBeenCalledWith('tsconfig-paths', process.cwd() + '/tsconfig.without-baseurl.json');
+    expect(requireFromMock).toHaveBeenCalledWith('ts-node', resolve(process.cwd(), './tsconfig.without-baseurl.json'));
+    expect(requireFromMock).toHaveBeenCalledWith('tsconfig-paths', resolve(process.cwd(), './tsconfig.without-baseurl.json'));
     expect(registerPathsMock).toHaveBeenCalledWith({
       baseUrl: '.',
       paths: { '@some-path/some': './libs/paths' },
@@ -235,7 +247,7 @@ Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
 
   test('gets ORM configuration [from package.json] with promise', async () => {
     pathExistsMock.mockResolvedValue(true);
-    pkg['mikro-orm'].configPaths = [`${process.cwd()}/mikro-orm-async.config.js`];
+    pkg['mikro-orm'].configPaths = [`${Utils.normalizePath(process.cwd())}/mikro-orm-async.config.js`];
     const conf = await CLIHelper.getConfiguration();
     expect(conf).toBeInstanceOf(Configuration);
     expect(conf.get('dbName')).toBe('foo_bar');
@@ -246,7 +258,7 @@ Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
   test('gets ORM configuration [from package.json] with rejected promise', async () => {
     expect.assertions(1);
     pathExistsMock.mockResolvedValue(true);
-    pkg['mikro-orm'].configPaths = [`${process.cwd()}/mikro-orm-async-catch.config.js`];
+    pkg['mikro-orm'].configPaths = [`${Utils.normalizePath(process.cwd())}/mikro-orm-async-catch.config.js`];
     await expect(CLIHelper.getConfiguration()).rejects.toEqual('FooError');
     delete pkg['mikro-orm'].configPaths;
   });
@@ -282,7 +294,7 @@ Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
         return true;
       }
 
-      return (path as string).endsWith(process.cwd() + '/mikro-orm.config.ts');
+      return (path as string).endsWith(Utils.normalizePath(process.cwd() + '/mikro-orm.config.ts'));
     });
     pkg['mikro-orm'].useTsNode = true;
     await expect(CLIHelper.getORM()).rejects.toThrowError('No entities were discovered');


### PR DESCRIPTION
In order to do so without breaking Unix compatibility, and still respect Jest's mock rules (namely, no imports for mocked module names), additional mocks are added where the path's slashes are replaced.

Utils.normalizePath() or path.resolve() is used in other places, based on the expected value.

Also fixed building on Windows, by making copy.mjs be responsible for copying esm.cmd.