### PR TITLE
feat(core): allow M:1 and 1:1 relations in virtual entities

### DIFF
--- a/docs/docs/virtual-entities.md
+++ b/docs/docs/virtual-entities.md
@@ -5,11 +5,13 @@ title: Virtual Entities
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Virtual entities don't represent any database table. Instead, they dynamically resolve to an SQL query (or an aggregation in MongoDB), allowing to map any kind of results onto an entity. Such entities are meant for read purposes, they don't have a primary key and therefore cannot be tracked for changes. In a sense they are similar to (currently unsupported) database views.
+Virtual entities don't represent any database table. Instead, they dynamically resolve to an SQL query (or an aggregation in MongoDB), allowing to map any kind of results onto an entity. Such entities are meant for read purposes, they don't have a primary key and therefore cannot be tracked for changes. In a way they are similar to (currently unsupported) database views, and you can use them to proxy your native views already.
+
+> Virtual entities can contain scalar properties as well as to-one relations (M:1 and 1:1 owners). Such relations are always populated via `select-in` strategy.
 
 To define a virtual entity, provide an `expression`, either as a string (SQL query):
 
-> We need to use the virtual column names based on current naming strategy. Note the `authorName` property being represented as `author_name` column.
+> You need to use the virtual column names based on current naming strategy. Note the `authorName` property being represented as `author_name` column.
 
 <Tabs
   groupId="entity-def"
@@ -200,7 +202,7 @@ export const BookWithAuthor = new EntitySchema<IBookWithAuthor>({
   </TabItem>
 </Tabs>
 
-In MongoDB, we can use aggregations, although it is not very ergonomic due to their nature. Following example is a rough equivalent of the previous SQL ones.
+In MongoDB, you can use aggregations, although it is not very ergonomic due to their nature. Following example is a rough equivalent of the previous SQL ones.
 
 > The `where` query as well as the options like `orderBy`, `limit` and `offset` needs to be explicitly handled in your pipeline.
 

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -248,13 +248,6 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       ret.push(entity);
     }
 
-    if (meta.virtual) {
-      await em.unitOfWork.dispatchOnLoadEvent();
-      await em.storeCache(options.cache, cached!, () => ret);
-
-      return ret;
-    }
-
     const unique = Utils.unique(ret);
     await em.entityLoader.populate<Entity, Fields>(entityName, unique as Entity[], populate, {
       ...options as Dictionary,
@@ -264,7 +257,12 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       lookup: false,
     });
     await em.unitOfWork.dispatchOnLoadEvent();
-    await em.storeCache(options.cache, cached!, () => unique.map(e => helper(e).toPOJO()));
+
+    if (meta.virtual) {
+      await em.storeCache(options.cache, cached!, () => ret);
+    } else {
+      await em.storeCache(options.cache, cached!, () => unique.map(e => helper(e).toPOJO()));
+    }
 
     return unique;
   }

--- a/packages/core/src/metadata/MetadataValidator.ts
+++ b/packages/core/src/metadata/MetadataValidator.ts
@@ -25,8 +25,8 @@ export class MetadataValidator {
 
     if (meta.virtual || meta.expression) {
       for (const prop of Utils.values(meta.properties)) {
-        if (![ReferenceKind.SCALAR, ReferenceKind.EMBEDDED].includes(prop.kind)) {
-          throw new MetadataError(`Only scalar and embedded properties are allowed inside virtual entity. Found '${prop.kind}' in ${meta.className}.${prop.name}`);
+        if (![ReferenceKind.SCALAR, ReferenceKind.EMBEDDED, ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind)) {
+          throw new MetadataError(`Only scalars, embedded properties and to-many relations are allowed inside virtual entity. Found '${prop.kind}' in ${meta.className}.${prop.name}`);
         }
 
         if (prop.primary) {

--- a/tests/MetadataValidator.test.ts
+++ b/tests/MetadataValidator.test.ts
@@ -134,7 +134,7 @@ describe('MetadataValidator', () => {
     meta.AuthorProfile.root = meta.AuthorProfile;
     expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'AuthorProfile')).toThrowError(`Virtual entity AuthorProfile cannot have primary key AuthorProfile.id`);
     delete properties.id.primary;
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'AuthorProfile')).toThrowError(`Only scalar and embedded properties are allowed inside virtual entity. Found '1:m' in AuthorProfile.invalid1`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'AuthorProfile')).toThrowError(`Only scalars, embedded properties and to-many relations are allowed inside virtual entity. Found '1:m' in AuthorProfile.invalid1`);
     delete properties.invalid1;
     expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'AuthorProfile')).not.toThrowError();
   });

--- a/tests/features/virtual-entities/virtual-entities.postgres.test.ts
+++ b/tests/features/virtual-entities/virtual-entities.postgres.test.ts
@@ -1,9 +1,9 @@
-import { Embedded, Entity, EntitySchema, Property, raw, sql } from '@mikro-orm/core';
+import { Embedded, Entity, EntitySchema, ManyToOne, Property, raw, sql, wrap } from '@mikro-orm/core';
 import { EntityManager, MikroORM } from '@mikro-orm/postgresql';
 import { mockLogger } from '../../bootstrap';
 import { Author2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, Identity } from '../../entities-sql';
 
-const authorProfilesSQL = 'select min(name) as name, min(age) as age, identity, ' +
+const authorProfilesSQL = 'select min(name) as name, favourite_book_uuid_pk, min(age) as age, identity, ' +
   '(select count(*) from book2 b where b.author_id = a.id)::int as total_books, ' +
   // this subquery is wrong, it returns the tags in wrong order, but that is not relevant to the actual test which is about mapping any query results
   '(select array_agg(t.name) from book2 b join book2_tags bt on bt.book2_uuid_pk = b.uuid_pk join book_tag2 t on t.id = bt.book_tag2_id where b.author_id = a.id group by b.author_id order by min(bt.order)) as used_tags ' +
@@ -22,6 +22,9 @@ class AuthorProfile {
   @Property()
   totalBooks!: number;
 
+  @ManyToOne(() => Book2, { nullable: true })
+  favouriteBook?: Book2;
+
   @Property()
   usedTags!: string[];
 
@@ -33,6 +36,7 @@ class AuthorProfile {
 interface IBookWithAuthor{
   title: string;
   authorName: string;
+  author: Author2;
   tags: string[];
 }
 
@@ -40,7 +44,7 @@ const BookWithAuthor = new EntitySchema<IBookWithAuthor>({
   name: 'BookWithAuthor',
   expression: (em: EntityManager) => {
     return em.createQueryBuilder(Book2, 'b')
-      .select([sql`min(b.title)`.as('title'), sql`min(a.name)`.as('author_name'), raw('array_agg(t.name) as tags')])
+      .select([sql`min(b.title)`.as('title'), 'author', sql`min(a.name)`.as('author_name'), raw('array_agg(t.name) as tags')])
       .join('b.author', 'a')
       .join('b.tags', 't')
       .groupBy('b.uuid_pk');
@@ -48,6 +52,7 @@ const BookWithAuthor = new EntitySchema<IBookWithAuthor>({
   properties: {
     title: { type: 'string' },
     authorName: { type: 'string' },
+    author: { type: 'Author2', kind: 'm:1' },
     tags: { type: 'string[]' },
   },
 });
@@ -72,6 +77,7 @@ describe('virtual entities (sqlite)', () => {
     const book1 = orm.em.create(Book2, { title: 'My Life on the Wall, part 1/' + index, author });
     const book2 = orm.em.create(Book2, { title: 'My Life on the Wall, part 2/' + index, author });
     const book3 = orm.em.create(Book2, { title: 'My Life on the Wall, part 3/' + index, author });
+    author.favouriteBook = book3;
     const tag1 = orm.em.create(BookTag2, { name: 'silly-' + index });
     const tag2 = orm.em.create(BookTag2, { name: 'funny-' + index });
     const tag3 = orm.em.create(BookTag2, { name: 'sick-' + index });
@@ -114,24 +120,27 @@ describe('virtual entities (sqlite)', () => {
         name: 'Jon Snow 1',
         identity: { foo: 'foo', bar: 123 },
         age: expect.any(Number),
+        favouriteBook: { uuid: expect.any(String) },
         totalBooks: 3,
-        usedTags: ['silly-1', 'sick-1', 'silly-1', 'funny-1', 'sexy-1', 'funny-1', 'strange-1', 'sexy-1'],
+        usedTags: ['funny-1', 'strange-1', 'sexy-1', 'silly-1', 'sick-1', 'silly-1', 'funny-1', 'sexy-1'],
         // usedTags: ['silly-1', 'sick-1', 'funny-1', 'sexy-1', 'strange-1'],
       },
       {
         name: 'Jon Snow 2',
         identity: { foo: 'foo', bar: 123 },
         age: expect.any(Number),
+        favouriteBook: { uuid: expect.any(String) },
         totalBooks: 3,
-        usedTags: ['silly-2', 'sick-2', 'silly-2', 'funny-2', 'sexy-2', 'funny-2', 'strange-2', 'sexy-2'],
+        usedTags: ['funny-2', 'strange-2', 'sexy-2', 'silly-2', 'sick-2', 'silly-2', 'funny-2', 'sexy-2'],
         // usedTags: ['silly-2', 'sick-2', 'funny-2', 'sexy-2', 'strange-2'],
       },
       {
         name: 'Jon Snow 3',
         identity: { foo: 'foo', bar: 123 },
         age: expect.any(Number),
+        favouriteBook: { uuid: expect.any(String) },
         totalBooks: 3,
-        usedTags: ['silly-3', 'sick-3', 'silly-3', 'funny-3', 'sexy-3', 'funny-3', 'strange-3', 'sexy-3'],
+        usedTags: ['funny-3', 'strange-3', 'sexy-3', 'silly-3', 'sick-3', 'silly-3', 'funny-3', 'sexy-3'],
         // usedTags: ['silly-3', 'sick-3', 'funny-3', 'sexy-3', 'strange-3'],
       },
     ]);
@@ -164,7 +173,7 @@ describe('virtual entities (sqlite)', () => {
     expect(mock.mock.calls[3][0]).toMatch(`select * from (${authorProfilesSQL}) as "a0" order by "a0"."name" asc limit 2`);
     expect(mock.mock.calls[4][0]).toMatch(`select * from (${authorProfilesSQL}) as "a0" where "a0"."name" like 'Jon%' and "a0"."age" >= 0 order by "a0"."name" asc limit 2`);
     expect(mock.mock.calls[5][0]).toMatch(`select * from (${authorProfilesSQL}) as "a0" where "a0"."name" in ('Jon Snow 2', 'Jon Snow 3')`);
-    expect(orm.em.getUnitOfWork().getIdentityMap().keys()).toHaveLength(0);
+    expect(orm.em.getUnitOfWork().getIdentityMap().keys()).toHaveLength(3);
   });
 
   test('with callback', async () => {
@@ -173,58 +182,72 @@ describe('virtual entities (sqlite)', () => {
     await createEntities(3);
 
     const mock = mockLogger(orm);
-    const [books, total] = await orm.em.findAndCount(BookWithAuthor, {}, { orderBy: { authorName: 1, title: 1 } });
+    const [books, total] = await orm.em.findAndCount(BookWithAuthor, {}, {
+      populate: ['author'],
+      orderBy: { authorName: 1, title: 1 },
+    });
     expect(total).toBe(9);
-    expect(books).toEqual([
+    expect(books).toMatchObject([
       {
         title: 'My Life on the Wall, part 1/1',
         authorName: 'Jon Snow 1',
+        author: { name: 'Jon Snow 1' },
         tags: ['silly-1', 'sick-1'],
       },
       {
         title: 'My Life on the Wall, part 2/1',
         authorName: 'Jon Snow 1',
+        author: { name: 'Jon Snow 1' },
         tags: ['silly-1', 'funny-1', 'sexy-1'],
       },
       {
         title: 'My Life on the Wall, part 3/1',
         authorName: 'Jon Snow 1',
+        author: { name: 'Jon Snow 1' },
         tags: ['funny-1', 'strange-1', 'sexy-1'],
       },
       {
         title: 'My Life on the Wall, part 1/2',
         authorName: 'Jon Snow 2',
+        author: { name: 'Jon Snow 2' },
         tags: ['silly-2', 'sick-2'],
       },
       {
         title: 'My Life on the Wall, part 2/2',
         authorName: 'Jon Snow 2',
+        author: { name: 'Jon Snow 2' },
         tags: ['silly-2', 'funny-2', 'sexy-2'],
       },
       {
         title: 'My Life on the Wall, part 3/2',
         authorName: 'Jon Snow 2',
+        author: { name: 'Jon Snow 2' },
         tags: ['funny-2', 'strange-2', 'sexy-2'],
       },
       {
         title: 'My Life on the Wall, part 1/3',
         authorName: 'Jon Snow 3',
+        author: { name: 'Jon Snow 3' },
         tags: ['silly-3', 'sick-3'],
       },
       {
         title: 'My Life on the Wall, part 2/3',
         authorName: 'Jon Snow 3',
+        author: { name: 'Jon Snow 3' },
         tags: ['silly-3', 'funny-3', 'sexy-3'],
       },
       {
         title: 'My Life on the Wall, part 3/3',
         authorName: 'Jon Snow 3',
+        author: { name: 'Jon Snow 3' },
         tags: ['funny-3', 'strange-3', 'sexy-3'],
       },
     ]);
 
     for (const book of books) {
       expect(book.constructor.name).toBe('BookWithAuthor');
+      expect(book.author).toBeInstanceOf(Author2);
+      expect(wrap(book.author).isInitialized()).toBe(true);
     }
 
     const someBooks1 = await orm.em.find(BookWithAuthor, {}, { limit: 2, offset: 1, orderBy: { title: 'asc' } });
@@ -243,24 +266,77 @@ describe('virtual entities (sqlite)', () => {
     expect(someBooks4).toHaveLength(2);
     expect(someBooks4.map(p => p.title)).toEqual(['My Life on the Wall, part 1/2', 'My Life on the Wall, part 1/3']);
 
-    const sql = 'select min(b.title) as title, min(a.name) as author_name, array_agg(t.name) as tags ' +
+    const sql = 'select min(b.title) as title, "b"."author_id", min(a.name) as author_name, array_agg(t.name) as tags ' +
       'from "book2" as "b" ' +
       'inner join "author2" as "a" on "b"."author_id" = "a"."id" ' +
       'inner join "book2_tags" as "b1" on "b"."uuid_pk" = "b1"."book2_uuid_pk" ' +
       'inner join "public"."book_tag2" as "t" on "b1"."book_tag2_id" = "t"."id" ' +
       'group by "b"."uuid_pk"';
     const queries = mock.mock.calls.map(call => call[0]).sort();
-    expect(queries).toHaveLength(6);
-    expect(queries[0]).toMatch(`select * from (${sql}) as "b0"`);
-    expect(queries[1]).toMatch(`select * from (${sql}) as "b0" order by "b0"."title" asc limit 2`);
-    expect(queries[2]).toMatch(`select * from (${sql}) as "b0" order by "b0"."title" asc limit 2 offset 1`);
-    expect(queries[3]).toMatch(`select * from (${sql}) as "b0" where "b0"."title" in ('My Life on the Wall, part 1/2', 'My Life on the Wall, part 1/3')`);
-    expect(queries[4]).toMatch(`select * from (${sql}) as "b0" where "b0"."title" like 'My Life%' and "b0"."author_name" is not null order by "b0"."title" asc limit 2`);
-    expect(queries[5]).toMatch(`select count(*) as count from (${sql}) as "b0"`);
+    expect(queries).toHaveLength(7);
+    expect(queries[0]).toMatch(`select "a0".*, "a1"."author_id" as "address_author_id" from "author2" as "a0" left join "address2" as "a1" on "a0"."id" = "a1"."author_id" where "a0"."id" in (1, 2, 3)`);
+    expect(queries[1]).toMatch(`select * from (${sql}) as "b0"`);
+    expect(queries[2]).toMatch(`select * from (${sql}) as "b0" order by "b0"."title" asc limit 2`);
+    expect(queries[3]).toMatch(`select * from (${sql}) as "b0" order by "b0"."title" asc limit 2 offset 1`);
+    expect(queries[4]).toMatch(`select * from (${sql}) as "b0" where "b0"."title" in ('My Life on the Wall, part 1/2', 'My Life on the Wall, part 1/3')`);
+    expect(queries[5]).toMatch(`select * from (${sql}) as "b0" where "b0"."title" like 'My Life%' and "b0"."author_name" is not null order by "b0"."title" asc limit 2`);
+    expect(queries[6]).toMatch(`select count(*) as count from (${sql}) as "b0"`);
 
-    expect(orm.em.getUnitOfWork().getIdentityMap().keys()).toHaveLength(0);
+    expect(orm.em.getUnitOfWork().getIdentityMap().keys().map(k => k.split('-')[0])).toEqual([
+      'Author2',
+      'Author2',
+      'Author2',
+      'Book2',
+      'Book2',
+      'Book2',
+    ]);
     expect(mock.mock.calls[0][0]).toMatch(sql);
-    expect(orm.em.getUnitOfWork().getIdentityMap().keys()).toHaveLength(0);
+  });
+
+  test('em.populate', async () => {
+    await createEntities(1);
+
+    const mock = mockLogger(orm);
+    const [books, total] = await orm.em.findAndCount(BookWithAuthor, {}, {
+      orderBy: { authorName: 1, title: 1 },
+    });
+    expect(total).toBe(3);
+    expect(books).toMatchObject([
+      {
+        title: 'My Life on the Wall, part 1/1',
+        authorName: 'Jon Snow 1',
+        author: { id: 1 },
+        tags: ['silly-1', 'sick-1'],
+      },
+      {
+        title: 'My Life on the Wall, part 2/1',
+        authorName: 'Jon Snow 1',
+        author: { id: 1 },
+        tags: ['silly-1', 'funny-1', 'sexy-1'],
+      },
+      {
+        title: 'My Life on the Wall, part 3/1',
+        authorName: 'Jon Snow 1',
+        author: { id: 1 },
+        tags: ['funny-1', 'strange-1', 'sexy-1'],
+      },
+    ]);
+
+    for (const book of books) {
+      expect(book.constructor.name).toBe('BookWithAuthor');
+      expect(book.author).toBeInstanceOf(Author2);
+      expect(wrap(book.author).isInitialized()).toBe(false);
+      expect(book.author.name).toBeUndefined();
+    }
+
+    await orm.em.populate(books, ['author']);
+
+    for (const book of books) {
+      expect(book.constructor.name).toBe('BookWithAuthor');
+      expect(book.author).toBeInstanceOf(Author2);
+      expect(wrap(book.author).isInitialized()).toBe(true);
+      expect(book.author.name).toBe('Jon Snow 1');
+    }
   });
 
 });


### PR DESCRIPTION
Virtual entities can now contain also to-one relations (M:1 and 1:1 owners).

Such relations are always populated via `select-in` strategy.