### PR TITLE
feat(entity-generator): added ability to output type option in decorator

### DIFF
--- a/docs/docs/entity-generator.md
+++ b/docs/docs/entity-generator.md
@@ -53,6 +53,7 @@ By default, the `EntityGenerator` generates only owning sides of relations (e.g.
 - `esmImport` to use esm style import for imported entities e.x. when `esmImport=true`, generated entities include `import Author from './Author.js'`
 - `skipTables` to ignore some database tables (accepts array of table names)
 - `skipColumns` to ignore some database tables columns (accepts an object, keys are table names with schema prefix if available, values are arrays of column names)
+- `scalarTypeInDecorator` to include the `type` option in scalar property decorators. This information is discovered at runtime, but the process of discovery can be skipped by including this option in the decorator. If using `EntitySchema`, this type information is always included.
 - `scalarPropertiesForRelations` to control how scalar column properties are generated for foreign key relations. Possible values: 
   - `'never'` - (default) Do not generate any scalar properties for columns covered by foreign key relations. This effectively forces the application to always provide the entire relation, or (if all columns in the relation are nullable) omit the entire relation.
   - `'always'` - Generate all scalar properties for all columns covered by foreign key relations. This enables the application to deal with code that disables foreign key checks.

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -113,6 +113,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     entityGenerator: {
       bidirectionalRelations: false,
       identifiedReferences: false,
+      scalarTypeInDecorator: false,
       scalarPropertiesForRelations: 'never',
     },
     metadataCache: {
@@ -567,6 +568,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
     identifiedReferences?: boolean;
     entitySchema?: boolean;
     esmImport?: boolean;
+    scalarTypeInDecorator?: boolean;
     scalarPropertiesForRelations?: 'always' | 'never' | 'smart';
   };
   metadataCache: {

--- a/packages/entity-generator/src/EntityGenerator.ts
+++ b/packages/entity-generator/src/EntityGenerator.ts
@@ -92,9 +92,9 @@ export class EntityGenerator {
     for (const meta of metadata) {
       if (!meta.pivotTable || this.referencedEntities.has(meta)) {
         if (this.config.get('entityGenerator').entitySchema) {
-          this.sources.push(new EntitySchemaSourceFile(meta, this.namingStrategy, this.platform, esmImport));
+          this.sources.push(new EntitySchemaSourceFile(meta, this.namingStrategy, this.platform, esmImport, true));
         } else {
-          this.sources.push(new SourceFile(meta, this.namingStrategy, this.platform, esmImport));
+          this.sources.push(new SourceFile(meta, this.namingStrategy, this.platform, esmImport, this.config.get('entityGenerator').scalarTypeInDecorator!));
         }
       }
     }

--- a/packages/entity-generator/src/SourceFile.ts
+++ b/packages/entity-generator/src/SourceFile.ts
@@ -18,10 +18,13 @@ export class SourceFile {
   protected readonly coreImports = new Set<string>();
   protected readonly entityImports = new Set<string>();
 
-  constructor(protected readonly meta: EntityMetadata,
-              protected readonly namingStrategy: NamingStrategy,
-              protected readonly platform: Platform,
-              protected readonly esmImport: boolean) { }
+  constructor(
+    protected readonly meta: EntityMetadata,
+    protected readonly namingStrategy: NamingStrategy,
+    protected readonly platform: Platform,
+    protected readonly esmImport: boolean,
+    protected readonly scalarTypeInDecorator: boolean,
+  ) { }
 
   generate(): string {
     this.coreImports.add('Entity');
@@ -256,6 +259,9 @@ export class SourceFile {
   }
 
   protected getCommonDecoratorOptions(options: Dictionary, prop: EntityProperty): void {
+    if (this.scalarTypeInDecorator && prop.kind === ReferenceKind.SCALAR && !prop.enum) {
+      options.type = this.quote(prop.type);
+    }
     if (prop.nullable && !prop.mappedBy) {
       options.nullable = true;
     }

--- a/tests/features/entity-generator/TypesForScalarDecorators.test.ts
+++ b/tests/features/entity-generator/TypesForScalarDecorators.test.ts
@@ -1,0 +1,38 @@
+import { EntityGenerator } from '@mikro-orm/entity-generator';
+import { MikroORM } from '@mikro-orm/mysql';
+
+let orm: MikroORM;
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: 'types_for_scalar_decorators',
+    port: 3308,
+    discovery: { warnWhenNoEntities: false },
+    extensions: [EntityGenerator],
+    multipleStatements: true,
+  });
+  await orm.schema.ensureDatabase();
+});
+
+afterAll(async () => {
+  await orm.schema.dropDatabase();
+  await orm.close(true);
+});
+
+describe('TypesForScalarDecorators', () => {
+  test('generate entities from schema [mysql]', async () => {
+    await orm.schema.execute(`
+CREATE TABLE IF NOT EXISTS \`users\`
+(
+    \`user_id\` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    \`username\` VARCHAR(255) NOT NULL,
+    \`views\` BIGINT UNSIGNED NOT NULL,
+    \`enabled\` TINYINT(1) NOT NULL,
+    \`created_at\` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (\`user_id\`)
+)
+`);
+    orm.config.get('entityGenerator').scalarTypeInDecorator = true;
+    const dump = await orm.entityGenerator.generate();
+    expect(dump).toMatchSnapshot('dump');
+  });
+});

--- a/tests/features/entity-generator/__snapshots__/TypesForScalarDecorators.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/TypesForScalarDecorators.test.ts.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TypesForScalarDecorators generate entities from schema [mysql]: dump 1`] = `
+[
+  "import { Entity, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+
+@Entity()
+export class Users {
+
+  [PrimaryKeyProp]?: 'userId';
+
+  [OptionalProps]?: 'createdAt';
+
+  @PrimaryKey({ type: 'number' })
+  userId!: number;
+
+  @Property({ length: 255, type: 'string' })
+  username!: string;
+
+  @Property({ type: 'bigint' })
+  views!: bigint;
+
+  @Property({ type: 'boolean' })
+  enabled!: boolean;
+
+  @Property({ length: 0, type: 'Date', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  createdAt!: Date;
+
+}
+",
+]
+`;


### PR DESCRIPTION
I tried to run the tests with `@swc/jest` (yes, I did saw #3200, but I thought I take a fresh crack at it, since that branch is over a year old...), and an interesting error that popped up was the inability to discover the entity type.

Featuring the type is one way to avoid this... another way is to not use SWC or to use `EntitySchema` (which is the solution I intend to use for my projects personally...).

So... for users who intend to use SWC, and would like to use decorators, I think it would be very beneficial to be able to generate the "type" option. For everyone else, it would just provide a minor boost in startup performance of a project using generated entities with decorators.

Being a very limited option in scope, implementation was easy. Honestly, whether this should be an option and whether it should default to `true` or `false` is debatable... but I thought I just set it as an option defaulting to `false` for the sake of BC to avoid this debate... I mean, I think it's OK for it to not be an option and just always default to `true`... but that requires modification in existing tests if nothing else.

Side note: Because of the way SWC works, I fear the only way to possibly switch to it would be to support __BOTH__ `@swc/jest` and `ts-jest` in all tests but those that require reflection... and in CI, run those that require reflection separately with `ts-jest` while most others would run in `@swc/jest`.