### PR TITLE
fix(core): ignore nullable composite references in the upsert (#4945)

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -599,7 +599,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     const copy: Dictionary = {};
 
     for (const [key, value] of Object.entries(row)) {
-      const prop = meta.props.find(p => p.fieldNames[0] === key);
+      const prop = meta.props.find(p => p.fieldNames && p.fieldNames[0] === key);
 
       // ignore composite foreign keys with default value that are not null
       if (prop && prop.reference !== ReferenceType.SCALAR && prop.fieldNames.length > 1 && prop.defaultRaw && value != null) {

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -599,7 +599,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     const copy: Dictionary = {};
 
     for (const [key, value] of Object.entries(row)) {
-      const prop = meta.hydrateProps.find(p => p.fieldNames[0] === key);
+      const prop = meta.props.find(p => p.fieldNames[0] === key);
 
       // ignore composite foreign keys with default value that are not null
       if (prop && prop.reference !== ReferenceType.SCALAR && prop.fieldNames.length > 1 && prop.defaultRaw && value != null) {

--- a/tests/features/upsert/GH4945.test.ts
+++ b/tests/features/upsert/GH4945.test.ts
@@ -1,0 +1,89 @@
+import { Entity, IDatabaseDriver, MikroORM, PrimaryKey, Property, ManyToOne, Ref, ref, PrimaryKeyType } from '@mikro-orm/core';
+
+
+@Entity()
+class EntityA {
+
+  @PrimaryKey()
+  id!: string;
+
+  @PrimaryKey({ name: 'env_id' })
+  envID!: string;
+
+  @Property({ defaultRaw: `CURRENT_TIMESTAMP` })
+  createdAt?: Date;
+
+  [PrimaryKeyType]?: [string, string];
+
+}
+
+@Entity()
+class EntityB {
+
+  @PrimaryKey()
+  id!: string;
+
+  @PrimaryKey({ name: 'env_id', nullable: false })
+  envID!: string;
+
+  @Property({ type: 'text' })
+  name!: string;
+
+  @ManyToOne(() => EntityA, {
+    name: 'entity_a_id',
+    default: null,
+    onDelete: 'set default',
+    nullable: true,
+    fieldNames: ['entity_a_id', 'env_id'],
+  })
+  entityA: Ref<EntityA> | null = null;
+
+  [PrimaryKeyType]?: [string, string];
+
+}
+
+const options = {
+  'sqlite': { dbName: ':memory:' },
+  'better-sqlite': { dbName: ':memory:' },
+  'postgresql': { dbName: 'mikro_orm_upsert' },
+};
+
+describe.each(Object.keys(options))('GH #4945 [%s]',  type => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init<IDatabaseDriver>({
+      entities: [EntityA, EntityB],
+      type,
+      ...options[type],
+    });
+    await orm.schema.refreshDatabase();
+  });
+
+  beforeEach(async () => {
+    await orm.schema.clearDatabase();
+  });
+
+  afterAll(() => orm.close());
+
+  test('GH #4945 em.upsert()', async () => {
+    const entityA = await orm.em.upsert(EntityA, { id: 'entity-a-1', envID: 'env-1' });
+    const entityB = await orm.em.upsert(EntityB, { id: 'entity-b-1', envID: 'env-1', name: 'entity-b-1', entityA: ref(EntityA, ['entity-a-1', 'env-1']) });
+
+    await orm.em.flush();
+
+    expect(entityA).toBeInstanceOf(EntityA);
+    expect(entityB).toBeInstanceOf(EntityB);
+  });
+
+  test('GH #4945 em.upsertMany()', async () => {
+    const entitiesA = await orm.em.upsertMany(EntityA, [{ id: 'entity-a-1', envID: 'env-1' }, { id: 'entity-a-2', envID: 'env-1' }]);
+    const entitiesB = await orm.em.upsertMany(EntityB, [{ id: 'entity-b-1', envID: 'env-1', name: 'entity-b-1', entityA: ref(EntityA, ['entity-a-1', 'env-1']) }, { id: 'entity-b-2', envID: 'env-1', name: 'entity-b-2', entityA: ref(EntityA, ['entity-a-2', 'env-1']) }]);
+
+    await orm.em.flush();
+
+    expect(entitiesA).toHaveLength(2);
+    expect(entitiesB).toHaveLength(2);
+  });
+
+});


### PR DESCRIPTION
The PR implements the `cleanupUpsertRow` helper to ignore composite foreign keys. More info on this issue: https://github.com/mikro-orm/mikro-orm/issues/4945.

Btw, I've also found out that `MySQL` and `MariaDB` drivers (could be for others as well) generate incorrect create table SQLs for the entities from the test. In the test `entity_a_id` is a composite foreign key, it's nullable, and `null` is a default value. The generated SQL for `MySQL` and `MariaDB` looks like this:

```sql
create table `entity_b` (`id` varchar(255) not null, `env_id` varchar(255) not null default null, `name` text not null, `entity_a_id` varchar(255) null default null, primary key (`id`, `env_id`)) default character set utf8mb4 engine = InnoDB
```

As you can see, `default null` is used for the `env_id` field as well, even if it's a required field. Not sure if it's an issue with drivers/knex scheme generation...