### PR TITLE
feat(sql): rework joined strategy to support the default `populateWhere: 'all'`

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -228,6 +228,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
 
     const meta = this.metadata.get<Entity>(entityName);
     options = { ...options };
+    // save the original hint value so we know it was infer/all
+    (options as Dictionary)._populateWhere = options.populateWhere ?? this.config.get('populateWhere');
     options.populateWhere = await this.applyJoinedFilters(meta, { ...where } as ObjectQuery<Entity>, options);
     const results = await em.driver.find<Entity, Hint, Fields>(entityName, where, { ctx: em.transactionContext, ...options });
 
@@ -658,6 +660,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     options = { ...options };
+    // save the original hint value so we know it was infer/all
+    (options as Dictionary)._populateWhere = options.populateWhere ?? this.config.get('populateWhere');
     options.populateWhere = await this.applyJoinedFilters(meta, { ...where } as ObjectQuery<Entity>, options);
     const data = await em.driver.findOne<Entity, Hint, Fields>(entityName, where, {
       ctx: em.transactionContext,

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -102,6 +102,7 @@ export interface FindOptions<T, P extends string = never, F extends string = nev
   where?: FilterQuery<T>;
   populate?: Populate<T, P>;
   populateWhere?: ObjectQuery<T> | PopulateHint | `${PopulateHint}`;
+  populateOrderBy?: OrderDefinition<T>;
   fields?: readonly AutoPath<T, F, '*'>[];
   orderBy?: OrderDefinition<T>;
   cache?: boolean | number | [string, number];

--- a/packages/core/src/utils/Cursor.ts
+++ b/packages/core/src/utils/Cursor.ts
@@ -152,7 +152,7 @@ export class Cursor<Entity extends object, Hint extends string = never, Fields e
     return Utils.asArray(orderBy).flatMap(order => {
       return Utils.keys(order)
         .map(key => meta.properties[key as EntityKey<Entity>])
-        .filter(prop => [ReferenceKind.SCALAR, ReferenceKind.MANY_TO_ONE].includes(prop.kind) || (prop.kind === ReferenceKind.ONE_TO_ONE && prop.owner))
+        .filter(prop => prop && ([ReferenceKind.SCALAR, ReferenceKind.MANY_TO_ONE].includes(prop.kind) || (prop.kind === ReferenceKind.ONE_TO_ONE && prop.owner)))
         .map(prop => [prop.name, order[prop.name] as QueryOrder] as const);
     });
   }

--- a/packages/knex/src/query/ArrayCriteriaNode.ts
+++ b/packages/knex/src/query/ArrayCriteriaNode.ts
@@ -1,14 +1,14 @@
 import { CriteriaNode } from './CriteriaNode';
-import type { IQueryBuilder } from '../typings';
+import type { IQueryBuilder, ICriteriaNodeProcessOptions } from '../typings';
 
 /**
  * @internal
  */
 export class ArrayCriteriaNode<T extends object> extends CriteriaNode<T> {
 
-  override process(qb: IQueryBuilder<T>, alias?: string): any {
+  override process(qb: IQueryBuilder<T>, options?: ICriteriaNodeProcessOptions): any {
     return this.payload.map((node: CriteriaNode<T>) => {
-      return node.process(qb, alias);
+      return node.process(qb, options);
     });
   }
 

--- a/packages/knex/src/query/CriteriaNode.ts
+++ b/packages/knex/src/query/CriteriaNode.ts
@@ -1,6 +1,6 @@
 import { inspect } from 'util';
 import { ReferenceKind, Utils, type Dictionary, type EntityProperty, type MetadataStorage, type EntityKey } from '@mikro-orm/core';
-import type { ICriteriaNode, IQueryBuilder } from '../typings';
+import type { ICriteriaNode, ICriteriaNodeProcessOptions, IQueryBuilder } from '../typings';
 
 /**
  * Helper for working with deeply nested where/orderBy/having criteria. Uses composite pattern to build tree from the payload.
@@ -39,7 +39,7 @@ export class CriteriaNode<T extends object> implements ICriteriaNode<T> {
     }
   }
 
-  process(qb: IQueryBuilder<T>, alias?: string): any {
+  process(qb: IQueryBuilder<T>, options?: ICriteriaNodeProcessOptions): any {
     return this.payload;
   }
 

--- a/packages/knex/src/query/ScalarCriteriaNode.ts
+++ b/packages/knex/src/query/ScalarCriteriaNode.ts
@@ -1,6 +1,6 @@
 import { ReferenceKind } from '@mikro-orm/core';
 import { CriteriaNode } from './CriteriaNode';
-import type { IQueryBuilder } from '../typings';
+import type { IQueryBuilder, ICriteriaNodeProcessOptions } from '../typings';
 import { JoinType } from './enums';
 
 /**
@@ -8,17 +8,17 @@ import { JoinType } from './enums';
  */
 export class ScalarCriteriaNode<T extends object> extends CriteriaNode<T> {
 
-  override process(qb: IQueryBuilder<T>, alias?: string): any {
+  override process(qb: IQueryBuilder<T>, options?: ICriteriaNodeProcessOptions): any {
     if (this.shouldJoin()) {
       const path = this.getPath();
       const parentPath = this.parent!.getPath(); // the parent is always there, otherwise `shouldJoin` would return `false`
       const nestedAlias = qb.getAliasForJoinPath(path) || qb.getNextAlias(this.prop?.pivotTable ?? this.entityName);
-      const field = `${alias}.${this.prop!.name}`;
+      const field = `${options?.alias}.${this.prop!.name}`;
       const type = this.prop!.kind === ReferenceKind.MANY_TO_MANY ? JoinType.pivotJoin : JoinType.leftJoin;
       qb.join(field, nestedAlias, undefined, type, path);
 
       // select the owner as virtual property when joining from 1:1 inverse side, but only if the parent is root entity
-      if (this.prop!.kind === ReferenceKind.ONE_TO_ONE && !parentPath.includes('.')) {
+      if (this.prop!.kind === ReferenceKind.ONE_TO_ONE && !parentPath.includes('.') && !qb._fields?.includes(field)) {
         qb.addSelect(field);
       }
     }

--- a/packages/knex/src/typings.ts
+++ b/packages/knex/src/typings.ts
@@ -162,12 +162,20 @@ export interface IQueryBuilder<T> {
   orderBy(orderBy: QueryOrderMap<T>): this;
   groupBy(fields: (string | keyof T) | (string | keyof T)[]): this;
   having(cond?: QBFilterQuery | string, params?: any[]): this;
-  getAliasForJoinPath(path: string): string | undefined;
+  getAliasForJoinPath(path: string, options?: ICriteriaNodeProcessOptions): string | undefined;
+  getJoinForPath(path?: string, options?: ICriteriaNodeProcessOptions): JoinOptions | undefined;
   getNextAlias(entityName?: string): string;
   clone(reset?: boolean): IQueryBuilder<T>;
   setFlag(flag: QueryFlag): this;
   unsetFlag(flag: QueryFlag): this;
   hasFlag(flag: QueryFlag): boolean;
+}
+
+export interface ICriteriaNodeProcessOptions {
+  alias?: string;
+  matchPopulateJoins?: boolean;
+  ignoreBranching?: boolean;
+  preferNoBranch?: boolean;
 }
 
 export interface ICriteriaNode<T extends object> {
@@ -177,7 +185,7 @@ export interface ICriteriaNode<T extends object> {
   payload: any;
   prop?: EntityProperty;
   index?: number;
-  process(qb: IQueryBuilder<T>, alias?: string): any;
+  process(qb: IQueryBuilder<T>, options?: ICriteriaNodeProcessOptions): any;
   shouldInline(payload: any): boolean;
   willAutoJoin(qb: IQueryBuilder<T>, alias?: string): boolean;
   shouldRename(payload: any): boolean;

--- a/packages/sqlite/src/SqlitePlatform.ts
+++ b/packages/sqlite/src/SqlitePlatform.ts
@@ -31,6 +31,7 @@ export class SqlitePlatform extends AbstractSqlPlatform {
       return 'text';
     }
 
+    /* istanbul ignore next */
     return this.getTinyIntTypeDeclarationSQL(column);
   }
 

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -25,7 +25,7 @@ import {
   ref,
 } from '@mikro-orm/core';
 import { MySqlDriver, MySqlConnection, ScalarReference } from '@mikro-orm/mysql';
-import { Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, PublisherType, Test2 } from './entities-sql';
+import { Address2, Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, PublisherType, Test2 } from './entities-sql';
 import { initORMMySql, mockLogger } from './bootstrap';
 import { Author2Subscriber } from './subscribers/Author2Subscriber';
 import { EverythingSubscriber } from './subscribers/EverythingSubscriber';
@@ -36,7 +36,7 @@ describe('EntityManagerMySql', () => {
 
   let orm: MikroORM<MySqlDriver>;
 
-  beforeAll(async () => orm = await initORMMySql('mysql', {}, true));
+  beforeAll(async () => orm = await initORMMySql('mysql', { loadStrategy: 'joined' }, true));
   beforeEach(async () => orm.schema.clearDatabase());
   afterEach(() => {
     orm.config.set('debug', false);
@@ -330,7 +330,7 @@ describe('EntityManagerMySql', () => {
 
     const a1 = await orm.em.findOneOrFail(FooBaz2, bar.baz, {
       fields: ['name', 'bar'],
-      populate: [],
+      populate: [], // otherwise it would be inferred from `fields` and populate the `bar` automatically
     });
     expect(a1.name).toBe('fz');
     expect(a1.bar).toBeInstanceOf(FooBar2);
@@ -813,12 +813,12 @@ describe('EntityManagerMySql', () => {
     mock.mock.calls.length = 0;
 
     await orm.em.transactional(async em => {
-      await em.findOne(Author2, { email: 'foo' }, { lockMode: LockMode.PESSIMISTIC_READ });
+      await em.findOne(Author2, { email: 'foo' }, { lockMode: LockMode.PESSIMISTIC_READ, strategy: 'select-in' });
     });
 
     expect(mock.mock.calls.length).toBe(3);
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('select `a0`.*, `a1`.`author_id` as `address_author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id` where `a0`.`email` = ? limit ? lock in share mode');
+    expect(mock.mock.calls[1][0]).toMatch(' from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id` where `a0`.`email` = ? limit ? lock in share mode');
     expect(mock.mock.calls[2][0]).toMatch('commit');
   });
 
@@ -870,7 +870,7 @@ describe('EntityManagerMySql', () => {
     expect(res4.createdAt).toBeDefined();
     expect(res4.price).toBe('100.00');
     expect(res4.meta).toEqual({ category: 'foo', items: 1 });
-    expect(mock.mock.calls[0][0]).toMatch('where `b0`.`author_id` is not null and (`b0`.`price`, `b0`.`created_at`) <= (?, ?) limit ?');
+    expect(mock.mock.calls[0][0]).toMatch('where `b0`.`author_id` is not null and (`b0`.`price`, `b0`.`created_at`) <= (?, ?)');
   });
 
   test('query builder getResult() and getSingleResult() return entities', async () => {
@@ -1003,14 +1003,14 @@ describe('EntityManagerMySql', () => {
 
     const mock = mockLogger(orm, ['query']);
 
-    const b0 = (await orm.em.findOne(FooBaz2, { id: baz.id }))!;
+    const b0 = (await orm.em.findOne(FooBaz2, { id: baz.id }, { strategy: 'select-in' }))!;
     expect(mock.mock.calls[0][0]).toMatch('select `f0`.*, `f1`.`id` as `bar_id` from `foo_baz2` as `f0` left join `foo_bar2` as `f1` on `f0`.`id` = `f1`.`baz_id` where `f0`.`id` = ? limit ?');
     expect(b0.bar).toBeDefined();
     expect(b0.bar).toBeInstanceOf(FooBar2);
     expect(wrap(b0.bar!).isInitialized()).toBe(false);
     orm.em.clear();
 
-    const b1 = (await orm.em.findOne(FooBaz2, { id: baz.id }, { populate: ['bar'] }))!;
+    const b1 = (await orm.em.findOne(FooBaz2, { id: baz.id }, { populate: ['bar'], strategy: 'select-in' }))!;
     expect(mock.mock.calls[1][0]).toMatch('select `f0`.*, `f1`.`id` as `bar_id` from `foo_baz2` as `f0` left join `foo_bar2` as `f1` on `f0`.`id` = `f1`.`baz_id` where `f0`.`id` = ? limit ?');
     expect(mock.mock.calls[2][0]).toMatch('select `f0`.*, (select 123) as `random` from `foo_bar2` as `f0` where `f0`.`id` in (?)');
     expect(b1.bar).toBeInstanceOf(FooBar2);
@@ -1018,7 +1018,7 @@ describe('EntityManagerMySql', () => {
     expect(wrap(b1).toJSON()).toMatchObject({ bar: { id: bar.id, baz: baz.id, name: 'bar' } });
     orm.em.clear();
 
-    const b2 = (await orm.em.findOne(FooBaz2, { bar: bar.id }, { populate: ['bar'] }))!;
+    const b2 = (await orm.em.findOne(FooBaz2, { bar: bar.id }, { populate: ['bar'], strategy: 'select-in' }))!;
     expect(mock.mock.calls[3][0]).toMatch('select `f0`.*, `f1`.`id` as `bar_id` from `foo_baz2` as `f0` left join `foo_bar2` as `f1` on `f0`.`id` = `f1`.`baz_id` where `f1`.`id` = ? limit ?');
     expect(mock.mock.calls[4][0]).toMatch('select `f0`.*, (select 123) as `random` from `foo_bar2` as `f0` where `f0`.`id` in (?)');
     expect(b2.bar).toBeInstanceOf(FooBar2);
@@ -1060,18 +1060,25 @@ describe('EntityManagerMySql', () => {
     await orm.em.persistAndFlush([b1, b2, b3, b4, b5]);
     orm.em.clear();
 
+    const a0 = await orm.em.find(Author2, author, {
+      populate: ['books'],
+      orderBy: { books: { title: 'asc' } },
+    });
+    expect(a0[0].books.map(b => b.title)).toEqual(['b1', 'b2', 'b3', 'b4', 'b5']);
+    orm.em.clear();
+
     const a1 = await orm.em.find(Author2, author, {
       populate: ['books'],
       orderBy: { books: { title: QueryOrder.DESC } },
     });
-    expect(a1[0].books.getItems().map(b => b.title)).toEqual(['b5', 'b4', 'b3', 'b2', 'b1']);
+    expect(a1[0].books.map(b => b.title)).toEqual(['b5', 'b4', 'b3', 'b2', 'b1']);
     orm.em.clear();
 
     const a2 = await orm.em.findOneOrFail(Author2, author, {
       populate: ['books'],
       orderBy: [{ books: { title: QueryOrder.DESC } }],
     });
-    expect(a2.books.getItems().map(b => b.title)).toEqual(['b5', 'b4', 'b3', 'b2', 'b1']);
+    expect(a2.books.map(b => b.title)).toEqual(['b5', 'b4', 'b3', 'b2', 'b1']);
     orm.em.clear();
 
     const a3 = await orm.em.findOneOrFail(Author2, { books: { tags: { name: { $in: ['silly', 'strange'] } } } }, {
@@ -1079,7 +1086,7 @@ describe('EntityManagerMySql', () => {
       populateWhere: PopulateHint.INFER,
       orderBy: { books: { tags: { name: QueryOrder.DESC }, title: QueryOrder.ASC } },
     });
-    expect(a3.books.getItems().map(b => b.title)).toEqual(['b4', 'b1', 'b2']); // first strange tag (desc), then silly by name (asc)
+    expect(a3.books.map(b => b.title)).toEqual(['b4', 'b1', 'b2']); // first strange tag (desc), then silly by name (asc)
     orm.em.clear();
 
     const a4 = await orm.em.findOneOrFail(Author2, { books: { tags: { name: { $in: ['silly', 'strange'] } } } }, {
@@ -1090,7 +1097,7 @@ describe('EntityManagerMySql', () => {
         { books: { title: QueryOrder.ASC } },
       ],
     });
-    expect(a4.books.getItems().map(b => b.title)).toEqual(['b4', 'b1', 'b2']); // first strange tag (desc), then silly by name (asc)
+    expect(a4.books.map(b => b.title)).toEqual(['b4', 'b1', 'b2']); // first strange tag (desc), then silly by name (asc)
     orm.em.clear();
 
     const a5 = await orm.em.findOneOrFail(Author2, { books: { tags: { name: { $in: ['silly', 'strange'] } } } }, {
@@ -1101,7 +1108,7 @@ describe('EntityManagerMySql', () => {
         { books: { title: QueryOrder.ASC } },
       ],
     });
-    expect(a5.books.getItems().map(b => b.title)).toEqual(['b4', 'b1', 'b2', 'b3', 'b5']);
+    expect(a5.books.map(b => b.title)).toEqual(['b4', 'b1', 'b2', 'b3', 'b5']);
     orm.em.clear();
 
     const a6 = await orm.em.findOneOrFail(Author2, { books: { tags: { name: { $in: ['silly', 'strange'] } } } }, {
@@ -1112,7 +1119,7 @@ describe('EntityManagerMySql', () => {
         { books: { title: QueryOrder.ASC } },
       ],
     });
-    expect(a6.books.getItems().map(b => b.title)).toEqual(['b4', 'b1', 'b2', 'b3', 'b5']);
+    expect(a6.books.map(b => b.title)).toEqual(['b4', 'b1', 'b2', 'b3', 'b5']);
   });
 
   test('many to many relation', async () => {
@@ -1426,13 +1433,13 @@ describe('EntityManagerMySql', () => {
 
     // as we order by Book.createdAt when populating collection, we need to make sure values will be sequential
     book1.createdAt = new Date(Date.now() + 1);
-    book1.publisher = wrap(new Publisher2('B1 publisher')).toReference();
+    book1.publisher = ref(new Publisher2('B1 publisher'));
     book1.publisher.unwrap().tests.add(Test2.create('t11'), Test2.create('t12'));
     book2.createdAt = new Date(Date.now() + 2);
-    book2.publisher = wrap(new Publisher2('B2 publisher')).toReference();
+    book2.publisher = ref(new Publisher2('B2 publisher'));
     book2.publisher.unwrap().tests.add(Test2.create('t21'), Test2.create('t22'));
     book3.createdAt = new Date(Date.now() + 3);
-    book3.publisher = wrap(new Publisher2('B3 publisher')).toReference();
+    book3.publisher = ref(new Publisher2('B3 publisher'));
     book3.publisher.unwrap().tests.add(Test2.create('t31'), Test2.create('t32'));
 
     const tag1 = new BookTag2('silly');
@@ -1444,30 +1451,94 @@ describe('EntityManagerMySql', () => {
     book2.tags.add(tag1, tag2, tag5);
     book3.tags.add(tag2, tag4, tag5);
     await orm.em.persistAndFlush([book1, book2, book3]);
-    const repo = orm.em.getRepository(BookTag2);
-
     orm.em.clear();
-    const tags = await repo.findAll({ populate: ['books.publisher.tests', 'books.author'] });
-    expect(tags.length).toBe(5);
-    expect(tags[0]).toBeInstanceOf(BookTag2);
-    expect(tags[0].books.isInitialized()).toBe(true);
-    expect(tags[0].books.count()).toBe(2);
-    expect(wrap(tags[0].books[0]).isInitialized()).toBe(true);
-    expect(tags[0].books[0].author).toBeInstanceOf(Author2);
-    expect(wrap(tags[0].books[0].author).isInitialized()).toBe(true);
-    expect(tags[0].books[0].author.name).toBe('Jon Snow');
-    expect(tags[0].books[0].publisher).toBeInstanceOf(Reference);
-    expect(tags[0].books[0].publisher!.unwrap()).toBeInstanceOf(Publisher2);
-    expect(wrap(tags[0].books[0].publisher!).isInitialized()).toBe(true);
-    expect(tags[0].books[0].publisher!.unwrap().tests.isInitialized(true)).toBe(true);
-    expect(tags[0].books[0].publisher!.unwrap().tests.count()).toBe(2);
-    expect(tags[0].books[0].publisher!.unwrap().tests[0].name).toBe('t11');
-    expect(tags[0].books[0].publisher!.unwrap().tests[1].name).toBe('t12');
 
+    const tags0 = await orm.em.findAll(BookTag2, {
+      populate: ['books.publisher.tests', 'books.author'],
+    });
+    expect(tags0.length).toBe(5);
+    expect(tags0[0]).toBeInstanceOf(BookTag2);
+    expect(tags0[0].books.isInitialized()).toBe(true);
+    expect(tags0[0].books.count()).toBe(2);
+    expect(wrap(tags0[0].books[0]).isInitialized()).toBe(true);
+    expect(tags0[0].books[0].author).toBeInstanceOf(Author2);
+    expect(wrap(tags0[0].books[0].author).isInitialized()).toBe(true);
+    expect(tags0[0].books[0].author.name).toBe('Jon Snow');
+    expect(tags0[0].books[0].publisher).toBeInstanceOf(Reference);
+    expect(tags0[0].books[0].publisher!.unwrap()).toBeInstanceOf(Publisher2);
+    expect(wrap(tags0[0].books[0].publisher!).isInitialized()).toBe(true);
+    expect(tags0[0].books[0].publisher!.unwrap().tests.isInitialized(true)).toBe(true);
+    expect(tags0[0].books[0].publisher!.unwrap().tests.count()).toBe(2);
+    expect(tags0[0].books[0].publisher!.unwrap().tests[0].name).toBe('t11');
+    expect(tags0[0].books[0].publisher!.unwrap().tests[1].name).toBe('t12');
     orm.em.clear();
-    const books = await orm.em.find(Book2, {}, {
+
+    const tags1 = await orm.em.findAll(BookTag2, {
+      populate: ['books.publisher.tests', 'books.author'],
+      orderBy: { books: { publisher: { tests: -1 } } },
+    });
+    expect(tags1.length).toBe(5);
+    expect(tags1[0]).toBeInstanceOf(BookTag2);
+    expect(tags1[0].books.isInitialized()).toBe(true);
+    expect(tags1[0].books.count()).toBe(2);
+    expect(wrap(tags1[0].books[0]).isInitialized()).toBe(true);
+    expect(tags1[0].books[0].author).toBeInstanceOf(Author2);
+    expect(wrap(tags1[0].books[0].author).isInitialized()).toBe(true);
+    expect(tags1[0].books[0].author.name).toBe('Jon Snow');
+    expect(tags1[0].books[0].publisher).toBeInstanceOf(Reference);
+    expect(tags1[0].books[0].publisher!.unwrap()).toBeInstanceOf(Publisher2);
+    expect(wrap(tags1[0].books[0].publisher!).isInitialized()).toBe(true);
+    expect(tags1[0].books[0].publisher!.unwrap().tests.isInitialized(true)).toBe(true);
+    expect(tags1[0].books[0].publisher!.unwrap().tests.count()).toBe(2);
+    expect(tags1[0].books[0].publisher!.unwrap().tests[0].name).toBe('t32');
+    expect(tags1[0].books[0].publisher!.unwrap().tests[1].name).toBe('t31');
+    orm.em.clear();
+
+    const tags2 = await orm.em.findAll(BookTag2, {
+      populate: ['books.publisher.tests', 'books.author'],
+      orderBy: { books: { publisher: { tests: { name: -1 } } } },
+    });
+    expect(tags2.length).toBe(5);
+    expect(tags2[0]).toBeInstanceOf(BookTag2);
+    expect(tags2[0].books.isInitialized()).toBe(true);
+    expect(tags2[0].books.count()).toBe(2);
+    expect(wrap(tags2[0].books[0]).isInitialized()).toBe(true);
+    expect(tags2[0].books[0].author).toBeInstanceOf(Author2);
+    expect(wrap(tags2[0].books[0].author).isInitialized()).toBe(true);
+    expect(tags2[0].books[0].author.name).toBe('Jon Snow');
+    expect(tags2[0].books[0].publisher).toBeInstanceOf(Reference);
+    expect(tags2[0].books[0].publisher!.unwrap()).toBeInstanceOf(Publisher2);
+    expect(wrap(tags2[0].books[0].publisher!).isInitialized()).toBe(true);
+    expect(tags2[0].books[0].publisher!.unwrap().tests.isInitialized(true)).toBe(true);
+    expect(tags2[0].books[0].publisher!.unwrap().tests.count()).toBe(2);
+    expect(tags2[0].books[0].publisher!.unwrap().tests[0].name).toBe('t32');
+    expect(tags2[0].books[0].publisher!.unwrap().tests[1].name).toBe('t31');
+    orm.em.clear();
+
+    const tags3 = await orm.em.findAll(BookTag2, {
+      populate: ['books.publisher.tests', 'books.author'],
+      orderBy: { books: { publisher: { tests: { id: 1 } } } },
+    });
+    expect(tags3.length).toBe(5);
+    expect(tags3[0]).toBeInstanceOf(BookTag2);
+    expect(tags3[0].books.isInitialized()).toBe(true);
+    expect(tags3[0].books.count()).toBe(2);
+    expect(wrap(tags3[0].books[0]).isInitialized()).toBe(true);
+    expect(tags3[0].books[0].author).toBeInstanceOf(Author2);
+    expect(wrap(tags3[0].books[0].author).isInitialized()).toBe(true);
+    expect(tags3[0].books[0].author.name).toBe('Jon Snow');
+    expect(tags3[0].books[0].publisher).toBeInstanceOf(Reference);
+    expect(tags3[0].books[0].publisher!.unwrap()).toBeInstanceOf(Publisher2);
+    expect(wrap(tags3[0].books[0].publisher!).isInitialized()).toBe(true);
+    expect(tags3[0].books[0].publisher!.unwrap().tests.isInitialized(true)).toBe(true);
+    expect(tags3[0].books[0].publisher!.unwrap().tests.count()).toBe(2);
+    expect(tags3[0].books[0].publisher!.unwrap().tests[0].name).toBe('t11');
+    expect(tags3[0].books[0].publisher!.unwrap().tests[1].name).toBe('t12');
+    orm.em.clear();
+
+    const books = await orm.em.findAll(Book2, {
       populate: ['publisher.tests', 'author'],
-      orderBy: { title: QueryOrder.ASC },
+      orderBy: { title: 1, publisher: { tests: 1 } },
     });
     expect(books.length).toBe(3);
     expect(books[0]).toBeInstanceOf(Book2);
@@ -1539,17 +1610,17 @@ describe('EntityManagerMySql', () => {
     orm.em.clear();
     const ent1 = await orm.em.findOneOrFail(Book2, book.uuid);
     await ent1.tags.init();
-    expect(ent1.tags.getItems().map(t => t.name)).toEqual([tag1.name, tag2.name, tag3.name, tag4.name, tag5.name]);
+    expect(ent1.tags.map(t => t.name)).toEqual([tag1.name, tag2.name, tag3.name, tag4.name, tag5.name]);
 
     orm.em.clear();
     const ent2 = await orm.em.findOneOrFail(Book2, book.uuid);
     await ent2.tags.init({ orderBy: { name: QueryOrder.DESC } });
-    expect(ent2.tags.getItems().map(t => t.name)).toEqual([tag4.name, tag1.name, tag3.name, tag5.name, tag2.name]);
+    expect(ent2.tags.map(t => t.name)).toEqual([tag4.name, tag1.name, tag3.name, tag5.name, tag2.name]);
 
     orm.em.clear();
     const ent3 = await orm.em.findOneOrFail(Book2, book.uuid);
     await ent3.tags.init({ where: { name: { $ne: 'funny' } }, orderBy: { name: QueryOrder.DESC } });
-    expect(ent3.tags.getItems().map(t => t.name)).toEqual([tag4.name, tag1.name, tag3.name, tag5.name]);
+    expect(ent3.tags.map(t => t.name)).toEqual([tag4.name, tag1.name, tag3.name, tag5.name]);
 
     orm.em.clear();
     const ent4 = await orm.em.findOneOrFail(Author2, author.id);
@@ -1578,21 +1649,22 @@ describe('EntityManagerMySql', () => {
     await orm.em.persistAndFlush(author);
     orm.em.clear();
 
-    const books = await orm.em.find(Book2, { tags: { name: { $ne: 'funny' } } }, {
+    const books = await orm.em.findAll(Book2, {
+      where: { tags: { name: { $ne: 'funny' } } },
       populate: ['tags'],
       populateWhere: PopulateHint.INFER,
       orderBy: { title: QueryOrder.DESC, tags: { name: QueryOrder.ASC } },
     });
     expect(books.length).toBe(3);
     expect(books[0].title).toBe('My Life on The Wall, part 3');
-    expect(books[0].tags.getItems().map(t => t.name)).toEqual(['awkward', 'sexy', 'strange']);
+    expect(books[0].tags.map(t => t.name)).toEqual(['awkward', 'sexy', 'strange']);
     expect(books[1].title).toBe('My Life on The Wall, part 2');
-    expect(books[1].tags.getItems().map(t => t.name)).toEqual(['sexy', 'silly', 'zupa']);
+    expect(books[1].tags.map(t => t.name)).toEqual(['sexy', 'silly', 'zupa']);
     expect(books[2].title).toBe('My Life on The Wall, part 1');
-    expect(books[2].tags.getItems().map(t => t.name)).toEqual(['awkward', 'sick', 'silly', 'zupa']);
+    expect(books[2].tags.map(t => t.name)).toEqual(['awkward', 'sick', 'silly', 'zupa']);
   });
 
-  test('many to many with composite pk', async () => {
+  test('populateWhere: all/infer with different loading strategies', async () => {
     const author = new Author2('Jon Snow', 'snow@wall.st');
     const book1 = new Book2('My Life on The Wall, part 1', author);
     book1.perex = ref('asd 1');
@@ -1613,30 +1685,124 @@ describe('EntityManagerMySql', () => {
     author.books.add(book1, book2, book3);
     await orm.em.persistAndFlush(author);
 
-    const mock = mockLogger(orm, ['query']);
+    orm.em.clear();
+    const books1 = await orm.em.find(Book2, { tagsUnordered: { name: { $ne: 'funny' } } }, {
+      populate: ['tagsUnordered', 'perex'],
+      populateWhere: PopulateHint.ALL,
+      orderBy: { title: QueryOrder.DESC },
+      strategy: 'select-in',
+    });
+    expect(books1.length).toBe(3);
+    expect(books1[0].perex).toBeInstanceOf(ScalarReference);
+    expect(books1[0].perex?.$).toBe('asd 3');
+    expect(books1[0].title).toBe('My Life on The Wall, part 3');
+    expect(books1[0].tagsUnordered.getItems().map(t => t.name)).toEqual(['awkward', 'funny', 'sexy', 'strange']);
+    expect(books1[1].title).toBe('My Life on The Wall, part 2');
+    expect(books1[1].tagsUnordered.getItems().map(t => t.name)).toEqual(['funny', 'sexy', 'silly', 'zupa']);
+    expect(books1[2].title).toBe('My Life on The Wall, part 1');
+    expect(books1[2].tagsUnordered.getItems().map(t => t.name)).toEqual(['awkward', 'sick', 'silly', 'zupa']);
 
     orm.em.clear();
-    const books = await orm.em.find(Book2, { tagsUnordered: { name: { $ne: 'funny' } } }, {
+    const books2 = await orm.em.find(Book2, { tagsUnordered: { name: { $ne: 'funny' } } }, {
       populate: ['tagsUnordered', 'perex'],
       populateWhere: PopulateHint.INFER,
       orderBy: { title: QueryOrder.DESC },
+      strategy: 'select-in',
     });
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t3`.`id` as `test_id` from `book2` as `b0` ' +
-      'left join `book_to_tag_unordered` as `b2` on `b0`.`uuid_pk` = `b2`.`book2_uuid_pk` ' +
-      'left join `book_tag2` as `b1` on `b2`.`book_tag2_id` = `b1`.`id` ' +
-      'left join `test2` as `t3` on `b0`.`uuid_pk` = `t3`.`book_uuid_pk` ' +
-      'where `b0`.`author_id` is not null and `b1`.`name` != ? ' +
-      'order by `b0`.`title` desc');
+    expect(books2.length).toBe(3);
+    expect(books2[0].perex).toBeInstanceOf(ScalarReference);
+    expect(books2[0].perex?.$).toBe('asd 3');
+    expect(books2[0].title).toBe('My Life on The Wall, part 3');
+    expect(books2[0].tagsUnordered.getItems().map(t => t.name)).toEqual(['awkward', 'sexy', 'strange']);
+    expect(books2[1].title).toBe('My Life on The Wall, part 2');
+    expect(books2[1].tagsUnordered.getItems().map(t => t.name)).toEqual(['sexy', 'silly', 'zupa']);
+    expect(books2[2].title).toBe('My Life on The Wall, part 1');
+    expect(books2[2].tagsUnordered.getItems().map(t => t.name)).toEqual(['awkward', 'sick', 'silly', 'zupa']);
 
-    expect(books.length).toBe(3);
-    expect(books[0].perex).toBeInstanceOf(ScalarReference);
-    expect(books[0].perex?.$).toBe('asd 3');
-    expect(books[0].title).toBe('My Life on The Wall, part 3');
-    expect(books[0].tagsUnordered.getItems().map(t => t.name)).toEqual(['awkward', 'sexy', 'strange']);
-    expect(books[1].title).toBe('My Life on The Wall, part 2');
-    expect(books[1].tagsUnordered.getItems().map(t => t.name)).toEqual(['sexy', 'silly', 'zupa']);
-    expect(books[2].title).toBe('My Life on The Wall, part 1');
-    expect(books[2].tagsUnordered.getItems().map(t => t.name)).toEqual(['awkward', 'sick', 'silly', 'zupa']);
+    const mock = mockLogger(orm, ['query']);
+
+    orm.em.clear();
+    const books3 = await orm.em.find(Book2, { tagsUnordered: { name: { $ne: 'funny' } } }, {
+      populate: ['tagsUnordered', 'perex'],
+      populateWhere: PopulateHint.ALL,
+      orderBy: { title: QueryOrder.DESC },
+      strategy: 'joined',
+    });
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name`, `t3`.`id` as `test_id` ' +
+      'from `book2` as `b0` ' +
+      'left join `book_to_tag_unordered` as `b2` on `b0`.`uuid_pk` = `b2`.`book2_uuid_pk` ' +
+      'left join `book_tag2` as `t1` on `b2`.`book_tag2_id` = `t1`.`id` ' +
+      'left join `test2` as `t3` on `b0`.`uuid_pk` = `t3`.`book_uuid_pk` ' +
+      'left join `book_to_tag_unordered` as `b5` on `b0`.`uuid_pk` = `b5`.`book2_uuid_pk` ' +
+      'left join `book_tag2` as `b4` on `b5`.`book_tag2_id` = `b4`.`id` ' +
+      'where `b0`.`author_id` is not null and `b4`.`name` != ? ' +
+      'order by `b0`.`title` desc, `t1`.`name` asc');
+    expect(books3.length).toBe(3);
+    expect(books3[0].perex).toBeInstanceOf(ScalarReference);
+    expect(books3[0].perex?.$).toBe('asd 3');
+    expect(books3[0].title).toBe('My Life on The Wall, part 3');
+    expect(books3[0].tagsUnordered.getItems().map(t => t.name)).toEqual(['awkward', 'funny', 'sexy', 'strange']);
+    expect(books3[1].title).toBe('My Life on The Wall, part 2');
+    expect(books3[1].tagsUnordered.getItems().map(t => t.name)).toEqual(['funny', 'sexy', 'silly', 'zupa']);
+    expect(books3[2].title).toBe('My Life on The Wall, part 1');
+    expect(books3[2].tagsUnordered.getItems().map(t => t.name)).toEqual(['awkward', 'sick', 'silly', 'zupa']);
+
+    orm.em.clear();
+    mock.mockReset();
+    const books4 = await orm.em.find(Book2, { tagsUnordered: { name: { $ne: 'funny' } } }, {
+      populate: ['tagsUnordered', 'perex'],
+      populateWhere: PopulateHint.INFER,
+      orderBy: { title: QueryOrder.DESC },
+      strategy: 'joined',
+    });
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name`, `t3`.`id` as `test_id` ' +
+      'from `book2` as `b0` ' +
+      'left join `book_to_tag_unordered` as `b2` on `b0`.`uuid_pk` = `b2`.`book2_uuid_pk` ' +
+      'left join `book_tag2` as `t1` on `b2`.`book_tag2_id` = `t1`.`id` and `t1`.`name` != ? ' +
+      'left join `test2` as `t3` on `b0`.`uuid_pk` = `t3`.`book_uuid_pk` ' +
+      'left join `book_to_tag_unordered` as `b5` on `b0`.`uuid_pk` = `b5`.`book2_uuid_pk` ' +
+      'left join `book_tag2` as `b4` on `b5`.`book_tag2_id` = `b4`.`id` ' +
+      'where `b0`.`author_id` is not null and `b4`.`name` != ? ' +
+      'order by `b0`.`title` desc, `t1`.`name` asc');
+
+    expect(books4.length).toBe(3);
+    expect(books4[0].perex).toBeInstanceOf(ScalarReference);
+    expect(books4[0].perex?.$).toBe('asd 3');
+    expect(books4[0].title).toBe('My Life on The Wall, part 3');
+    expect(books4[0].tagsUnordered.getItems().map(t => t.name)).toEqual(['awkward', 'sexy', 'strange']);
+    expect(books4[1].title).toBe('My Life on The Wall, part 2');
+    expect(books4[1].tagsUnordered.getItems().map(t => t.name)).toEqual(['sexy', 'silly', 'zupa']);
+    expect(books4[2].title).toBe('My Life on The Wall, part 1');
+    expect(books4[2].tagsUnordered.getItems().map(t => t.name)).toEqual(['awkward', 'sick', 'silly', 'zupa']);
+
+    orm.em.clear();
+    mock.mockReset();
+    const books5 = await orm.em.find(Book2, { tagsUnordered: { name: { $ne: 'funny' } } }, {
+      populate: ['tagsUnordered', 'perex'],
+      populateWhere: { tagsUnordered: { name: { $ne: 'funny' } } },
+      orderBy: { title: QueryOrder.DESC },
+      strategy: 'joined',
+    });
+
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name`, `t3`.`id` as `test_id` ' +
+      'from `book2` as `b0` ' +
+      'left join `book_to_tag_unordered` as `b2` on `b0`.`uuid_pk` = `b2`.`book2_uuid_pk` ' +
+      'left join `book_tag2` as `t1` on `b2`.`book_tag2_id` = `t1`.`id` and `t1`.`name` != ? ' +
+      'left join `test2` as `t3` on `b0`.`uuid_pk` = `t3`.`book_uuid_pk` ' +
+      'left join `book_to_tag_unordered` as `b5` on `b0`.`uuid_pk` = `b5`.`book2_uuid_pk` ' +
+      'left join `book_tag2` as `b4` on `b5`.`book_tag2_id` = `b4`.`id` ' +
+      'where `b0`.`author_id` is not null and `b4`.`name` != ? ' +
+      'order by `b0`.`title` desc, `t1`.`name` asc');
+
+    expect(books5.length).toBe(3);
+    expect(books5[0].perex).toBeInstanceOf(ScalarReference);
+    expect(books5[0].perex?.$).toBe('asd 3');
+    expect(books5[0].title).toBe('My Life on The Wall, part 3');
+    expect(books5[0].tagsUnordered.getItems().map(t => t.name)).toEqual(['awkward', 'sexy', 'strange']);
+    expect(books5[1].title).toBe('My Life on The Wall, part 2');
+    expect(books5[1].tagsUnordered.getItems().map(t => t.name)).toEqual(['sexy', 'silly', 'zupa']);
+    expect(books5[2].title).toBe('My Life on The Wall, part 1');
+    expect(books5[2].tagsUnordered.getItems().map(t => t.name)).toEqual(['awkward', 'sick', 'silly', 'zupa']);
 
     orm.em.clear();
     mock.mock.calls.length = 0;
@@ -1645,10 +1811,6 @@ describe('EntityManagerMySql', () => {
       populateWhere: PopulateHint.INFER,
       orderBy: { name: QueryOrder.ASC },
     });
-    expect(mock.mock.calls[1][0]).toMatch('select `b1`.price * 1.19 as `price_taxed`, `b1`.*, `b0`.`book_tag2_id` as `fk__book_tag2_id`, `b0`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `b2`.`id` as `test_id` from `book_to_tag_unordered` as `b0` ' +
-      'inner join `book2` as `b1` on `b0`.`book2_uuid_pk` = `b1`.`uuid_pk` ' +
-      'left join `test2` as `b2` on `b1`.`uuid_pk` = `b2`.`book_uuid_pk` ' +
-      'where `b1`.`author_id` is not null and `b1`.`title` != ? and `b0`.`book_tag2_id` in (?, ?, ?, ?, ?, ?)');
     expect(tags.length).toBe(6);
     expect(tags.map(tag => tag.name)).toEqual(['awkward', 'funny', 'sexy', 'sick', 'silly', 'zupa']);
     expect(tags.map(tag => tag.booksUnordered.count())).toEqual([1, 1, 1, 1, 2, 2]);
@@ -1659,6 +1821,7 @@ describe('EntityManagerMySql', () => {
     const a2 = new Author2('A2', 'a2@wall.st');
     const a3 = new Author2('A3', 'a3@wall.st');
     const author = new Author2('Jon Snow', 'snow@wall.st');
+    a1.address = new Address2(a1, 'val');
     author.friends.add(a1, a2, a3, author);
     await orm.em.persistAndFlush(author);
     orm.em.clear();
@@ -1668,17 +1831,20 @@ describe('EntityManagerMySql', () => {
     const jon = await orm.em.findOneOrFail(Author2, author.id, {
       populate: ['friends'],
       orderBy: { friends: { name: QueryOrder.ASC } },
+      strategy: 'select-in',
     });
     expect(jon.friends.isInitialized(true)).toBe(true);
     expect(jon.friends.getIdentifiers()).toEqual([a1.id, a2.id, a3.id, author.id]);
+    expect(jon.friends[0].name).toBe('A1');
+    expect(jon.friends[0].address).not.toBeUndefined();
+    expect(wrap(jon.friends[0].address!).isInitialized()).toBe(false);
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `a3`.`author_id` as `address_author_id` ' +
       'from `author2` as `a0` ' +
       'left join `author_to_friend` as `a2` on `a0`.`id` = `a2`.`author2_1_id` ' +
       'left join `author2` as `a1` on `a2`.`author2_2_id` = `a1`.`id` ' +
       'left join `address2` as `a3` on `a0`.`id` = `a3`.`author_id` ' +
-      'where `a0`.`id` = ? ' +
-      'order by `a1`.`name` asc ' +
-      'limit ?');
+      'where `a0`.`id` = ? order by `a1`.`name` asc limit ?');
+
     expect(mock.mock.calls[1][0]).toMatch('select `a1`.*, `a0`.`author2_2_id` as `fk__author2_2_id`, `a0`.`author2_1_id` as `fk__author2_1_id`, `a2`.`author_id` as `address_author_id` ' +
       'from `author_to_friend` as `a0` ' +
       'inner join `author2` as `a1` on `a0`.`author2_2_id` = `a1`.`id` ' +
@@ -1690,14 +1856,14 @@ describe('EntityManagerMySql', () => {
     const jon2 = await orm.em.findOneOrFail(Author2, { friends: a2.id }, {
       populate: ['friends'],
       orderBy: { friends: { name: QueryOrder.ASC } },
+      strategy: 'select-in',
     });
     expect(mock.mock.calls[2][0]).toMatch('select `a0`.*, `a3`.`author_id` as `address_author_id` ' +
       'from `author2` as `a0` ' +
       'left join `author_to_friend` as `a1` on `a0`.`id` = `a1`.`author2_1_id` ' +
       'left join `author2` as `a2` on `a1`.`author2_2_id` = `a2`.`id` ' +
       'left join `address2` as `a3` on `a0`.`id` = `a3`.`author_id` ' +
-      'where `a1`.`author2_2_id` = ? ' +
-      'order by `a2`.`name` asc ' +
+      'where `a1`.`author2_2_id` = ? order by `a2`.`name` asc ' +
       'limit ?');
     expect(mock.mock.calls[3][0]).toMatch('select `a1`.*, `a0`.`author2_2_id` as `fk__author2_2_id`, `a0`.`author2_1_id` as `fk__author2_1_id`, `a2`.`author_id` as `address_author_id` ' +
       'from `author_to_friend` as `a0` ' +
@@ -1731,6 +1897,7 @@ describe('EntityManagerMySql', () => {
       populate: ['following'],
       orderBy: { following: { name: QueryOrder.ASC } },
     });
+
     expect(jon2.id).toBe(author.id);
     expect(jon2.following.isInitialized(true)).toBe(true);
     expect(jon2.following.getIdentifiers()).toEqual([a1.id, a2.id, a3.id, author.id]);
@@ -1859,7 +2026,7 @@ describe('EntityManagerMySql', () => {
     expect(mock.mock.calls[2][0]).toMatch('insert into `book2` (`uuid_pk`, `created_at`, `title`, `author_id`) values (?, ?, ?, ?), (?, ?, ?, ?), (?, ?, ?, ?)');
     expect(mock.mock.calls[3][0]).toMatch('update `author2` set `favourite_author_id` = ?, `updated_at` = ? where `id` = ?');
     expect(mock.mock.calls[4][0]).toMatch('commit');
-    expect(mock.mock.calls[5][0]).toMatch('select `a0`.*, `a1`.`author_id` as `address_author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id` where `a0`.`id` = ? limit ?');
+    expect(mock.mock.calls[5][0]).toMatch('select `a0`.*, `a1`.`author_id` as `address_author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id` where `a0`.`id` = ?');
   });
 
   test('self referencing 1:1 (1 step)', async () => {
@@ -1907,8 +2074,6 @@ describe('EntityManagerMySql', () => {
     author.books.add(book1, book2, book3);
     await orm.em.persistAndFlush(author);
     await expect(orm.em.count(Book2, [book1.uuid, book2.uuid, book3.uuid])).resolves.toBe(3);
-    // this test was causing TS recursion errors without the type argument
-    // see https://github.com/mikro-orm/mikro-orm/issues/124 and https://github.com/mikro-orm/mikro-orm/issues/208
     await expect(orm.em.count(Book2, [book1, book2, book3])).resolves.toBe(3);
     await expect(orm.em.count(Book2, [book1, book2, book3])).resolves.toBe(3);
     const a = await orm.em.find(Book2, [book1, book2, book3]) as Book2[];
@@ -1986,7 +2151,7 @@ describe('EntityManagerMySql', () => {
     orm.em.clear();
 
     const mock = mockLogger(orm, ['query']);
-    const res1 = await orm.em.find(Book2, { author: { name: 'Jon Snow' } }, { populate: ['perex'] });
+    const res1 = await orm.em.find(Book2, { author: { name: 'Jon Snow' } }, { populate: ['perex'], strategy: 'select-in' });
     expect(res1).toHaveLength(3);
     expect(res1[0].test).toBeInstanceOf(Test2);
     expect(wrap(res1[0].test!).isInitialized()).toBe(false);
@@ -1999,7 +2164,7 @@ describe('EntityManagerMySql', () => {
 
     orm.em.clear();
     mock.mock.calls.length = 0;
-    const res2 = await orm.em.find(Book2, { author: { favouriteBook: { author: { name: 'Jon Snow' } } } }, { populate: ['perex'] });
+    const res2 = await orm.em.find(Book2, { author: { favouriteBook: { author: { name: 'Jon Snow' } } } }, { populate: ['perex'], strategy: 'select-in' });
     expect(res2).toHaveLength(3);
     expect(res2[0].test).toBeInstanceOf(Test2);
     expect(wrap(res2[0].test!).isInitialized()).toBe(false);
@@ -2014,7 +2179,7 @@ describe('EntityManagerMySql', () => {
 
     orm.em.clear();
     mock.mock.calls.length = 0;
-    const res3 = await orm.em.find(Book2, { author: { favouriteBook: book3 } }, { populate: ['perex'] });
+    const res3 = await orm.em.find(Book2, { author: { favouriteBook: book3 } }, { populate: ['perex'], strategy: 'select-in' });
     expect(res3).toHaveLength(3);
     expect(res3[0].test).toBeInstanceOf(Test2);
     expect(wrap(res3[0].test!).isInitialized()).toBe(false);
@@ -2027,7 +2192,7 @@ describe('EntityManagerMySql', () => {
 
     orm.em.clear();
     mock.mock.calls.length = 0;
-    const res4 = await orm.em.find(Book2, { author: { favouriteBook: { $or: [{ author: { name: 'Jon Snow' } }] } } }, { populate: ['perex'] });
+    const res4 = await orm.em.find(Book2, { author: { favouriteBook: { $or: [{ author: { name: 'Jon Snow' } }] } } }, { populate: ['perex'], strategy: 'select-in' });
     expect(res4).toHaveLength(3);
     expect(res4[0].test).toBeInstanceOf(Test2);
     expect(wrap(res4[0].test!).isInitialized()).toBe(false);
@@ -2261,12 +2426,23 @@ describe('EntityManagerMySql', () => {
 
     const mock = mockLogger(orm, ['query']);
 
+    // select `a0`.*, `a1`.`author_id` as `address_author_id`
+    // from `author2` as `a0`
+    // left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id`
+    // left join `book2` as `b2` on `a0`.`id` = `b2`.`author_id`
+    // where `b2`.`title` like 'Bible%'
+    // group by `a0`.`id`, `a0`.`name`, `b1`.`title`
+    // having (`a0`.`age` > 0 or `a0`.`age` <= 0 or `a0`.`age` is null)
+    // order by `a0`.`name` asc, `b2`.`title` asc limit 5
+    // Unknown column 'b1.title' in 'group statement'
+
     // without paginate flag it fails to get only 2 records (we need to explicitly disable it)
     const res1 = await orm.em.find(Author2, { books: { title: /^Bible/ } }, {
       orderBy: { name: QueryOrder.ASC, books: { title: QueryOrder.ASC } },
       limit: 5,
       groupBy: ['id', 'name', 'b1.title'],
       having: { $or: [{ age: { $gt: 0 } }, { age: { $lte: 0 } }, { age: null }] }, // no-op just for testing purposes
+      strategy: 'select-in',
     });
 
     expect(res1).toHaveLength(2);
@@ -2278,7 +2454,8 @@ describe('EntityManagerMySql', () => {
       'where `b1`.`title` like ? ' +
       'group by `a0`.`id`, `a0`.`name`, `b1`.`title` ' +
       'having (`a0`.`age` > ? or `a0`.`age` <= ? or `a0`.`age` is null) ' +
-      'order by `a0`.`name` asc, `b1`.`title` asc limit ?');
+      'order by `a0`.`name` asc, `b1`.`title` asc ' +
+      'limit ?');
 
     // with paginate flag (and a bit of dark sql magic) we get what we want
     const res2 = await orm.em.find(Author2, { books: { title: /^Bible/ } }, {
@@ -2286,6 +2463,7 @@ describe('EntityManagerMySql', () => {
       offset: 3,
       limit: 5,
       flags: [QueryFlag.PAGINATE],
+      strategy: 'select-in',
     });
 
     expect(res2).toHaveLength(5);
@@ -2293,14 +2471,14 @@ describe('EntityManagerMySql', () => {
     expect(mock.mock.calls[1][0]).toMatch('select `a0`.*, `a2`.`author_id` as `address_author_id` ' +
       'from `author2` as `a0` ' +
       'left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` ' +
-      'left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` where `a0`.`id` in (select `a0`.`id` ' +
-      'from (select `a0`.`id` ' +
-      'from `author2` as `a0` ' +
+      'left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` ' +
+      'where `a0`.`id` in (select `a0`.`id` from (select `a0`.`id` from `author2` as `a0` ' +
       'left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` ' +
       'left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` ' +
-      'where `b1`.`title` like ? group by `a0`.`id` order by min(`a0`.`name`) asc, min(`b1`.`title`) asc limit ? offset ?' +
-      ') as `a0`' +
-      ') order by `a0`.`name` asc, `b1`.`title` asc');
+      'where `b1`.`title` like ? ' +
+      'group by `a0`.`id` ' +
+      'order by min(`a0`.`name`) asc, min(`b1`.`title`) asc limit ? offset ?) as `a0`) ' +
+      'order by `a0`.`name` asc, `b1`.`title` asc');
 
     // with paginate flag without offset
     const res3 = await orm.em.find(Author2, { books: { title: /^Bible/ } }, {
@@ -2322,17 +2500,18 @@ describe('EntityManagerMySql', () => {
 
     const mock = mockLogger(orm, ['query']);
 
-    const b = await orm.em.findOneOrFail(Book2, { author: { name: 'God' } });
+    const b = await orm.em.findOneOrFail(Book2, { author: { name: 'God' } }, { strategy: 'select-in' });
     expect(b.price).toBe('1000.00');
     expect(b.priceTaxed).toBe('1190.0000');
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `test_id` ' +
       'from `book2` as `b0` ' +
       'left join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
       'left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` ' +
-      'where `b0`.`author_id` is not null and `a1`.`name` = ? limit ?');
+      'where `b0`.`author_id` is not null and `a1`.`name` = ? ' +
+      'limit ?');
 
     // should trigger auto-flush
-    orm.em.create(FooBar2, { name: 'f' }, { persist: true });
+    orm.em.create(FooBar2, { name: 'f' });
     await orm.em.findOneOrFail(FooBar2, { random: { $gt: 0.5 } }, { having: { random: { $gt: 0.5 } } });
     expect(mock.mock.calls[1][0]).toMatch('begin');
     expect(mock.mock.calls[2][0]).toMatch('insert into `foo_bar2` (`name`) values (?)');
@@ -2372,7 +2551,7 @@ describe('EntityManagerMySql', () => {
 
     const mock = mockLogger(orm, ['query']);
 
-    const b = await orm.em.fork().findOneOrFail(Book2, { priceTaxed: '1190.0000' });
+    const b = await orm.em.fork().findOneOrFail(Book2, { priceTaxed: '1190.0000' }, { strategy: 'select-in' });
     expect(b.price).toBe('1000.00');
     expect(b.priceTaxed).toBe('1190.0000');
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `test_id` ' +
@@ -2380,7 +2559,7 @@ describe('EntityManagerMySql', () => {
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.price * 1.19 = ? limit ?');
 
-    const a1 = await orm.em.fork().find(Author2, { $or: [{ favouriteBook: { priceTaxed: '1190.0000' } }] }, { populate: ['books'] });
+    const a1 = await orm.em.fork().find(Author2, { $or: [{ favouriteBook: { priceTaxed: '1190.0000' } }] }, { populate: ['books'], strategy: 'select-in' });
     expect(a1[0].books[0].price).toBe('1000.00');
     expect(a1[0].books[0].priceTaxed).toBe('1190.0000');
     expect(mock.mock.calls[1][0]).toMatch('select `a0`.*, `a2`.`author_id` as `address_author_id` ' +
@@ -2394,7 +2573,7 @@ describe('EntityManagerMySql', () => {
       'where `b0`.`author_id` is not null and `b0`.`author_id` in (?) ' +
       'order by `b0`.`title` asc');
 
-    const a2 = await orm.em.fork().find(Author2, { favouriteBook: { $or: [{ priceTaxed: '1190.0000' }] } }, { populate: ['books'] });
+    const a2 = await orm.em.fork().find(Author2, { favouriteBook: { $or: [{ priceTaxed: '1190.0000' }] } }, { populate: ['books'], strategy: 'select-in' });
     expect(a2[0].books[0].price).toBe('1000.00');
     expect(a2[0].books[0].priceTaxed).toBe('1190.0000');
     expect(mock.mock.calls[3][0]).toMatch('select `a0`.*, `a2`.`author_id` as `address_author_id` ' +
@@ -2531,11 +2710,10 @@ describe('EntityManagerMySql', () => {
       hintComments: 'bar',
       indexHint: 'force index(custom_email_index_name)',
     });
-    expect(mock.mock.calls[0][0]).toMatch(
-      '/* foo */ select /*+ bar */ `a0`.*, `a1`.`author_id` as `address_author_id`' +
-      ' from `author2` as `a0` force index(custom_email_index_name)' +
-      ' left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id`',
-    );
+    expect(mock.mock.calls[0][0]).toMatch('/* foo */ select /*+ bar */ `a0`.*, ' +
+      '`a1`.`author_id` as `address_author_id` ' +
+      'from `author2` as `a0` force index(custom_email_index_name) ' +
+      'left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id`');
   });
 
   // this should run in ~800ms (when running single test locally)

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -2117,6 +2117,8 @@ describe('QueryBuilder', () => {
     node.payload = { foo: 123 };
     const qb = orm.em.createQueryBuilder(Author2, 'a');
     expect(qb.getAliasForJoinPath(node.getPath())).toBe('a');
+    expect(qb.getAliasForJoinPath(Author2.name)).toBe('a');
+    expect(qb.getAliasForJoinPath()).toBe('a');
   });
 
   test('pivot joining of m:n when target entity is null (GH issue 548)', async () => {

--- a/tests/features/composite-keys/composite-keys.mysql.test.ts
+++ b/tests/features/composite-keys/composite-keys.mysql.test.ts
@@ -8,7 +8,7 @@ describe('composite keys in mysql', () => {
 
   let orm: MikroORM<MySqlDriver>;
 
-  beforeAll(async () => orm = await initORMMySql('mysql', {}, true));
+  beforeAll(async () => orm = await initORMMySql('mysql', { loadStrategy: 'joined' }, true));
   beforeEach(async () => orm.schema.clearDatabase());
   afterAll(async () => {
     await orm.schema.dropDatabase();

--- a/tests/features/custom-types/custom-types.mysql.test.ts
+++ b/tests/features/custom-types/custom-types.mysql.test.ts
@@ -153,7 +153,7 @@ describe('custom types [mysql]', () => {
 
     // custom types with SQL fragments with joined strategy (GH #1594)
     const a2 = await orm.em.findOneOrFail(Address, addr, { populate: ['location'], strategy: LoadStrategy.JOINED });
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `a0`.`location_id`, `l1`.`id` as `l1__id`, `l1`.`rank` as `l1__rank`, ST_AsText(`l1`.`point`) as `l1__point`, ST_AsText(`l1`.`extended_point`) as `l1__extended_point` from `address` as `a0` left join `location` as `l1` on `a0`.`location_id` = `l1`.`id` where `a0`.`id` = 1');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `l1`.`id` as `l1__id`, `l1`.`rank` as `l1__rank`, ST_AsText(`l1`.`point`) as `l1__point`, ST_AsText(`l1`.`extended_point`) as `l1__extended_point` from `address` as `a0` left join `location` as `l1` on `a0`.`location_id` = `l1`.`id` where `a0`.`id` = 1');
     expect(a2.location.point).toBeInstanceOf(Point);
     expect(a2.location.point).toMatchObject({ latitude: 2.34, longitude: 9.87 });
     expect(a2.location.extendedPoint).toBeInstanceOf(Point);

--- a/tests/features/filters/filters.postgres.test.ts
+++ b/tests/features/filters/filters.postgres.test.ts
@@ -177,7 +177,7 @@ describe('filters [postgres]', () => {
     mock.mockReset();
 
     const e2 = await orm.em.findOneOrFail(Employee, employee.id, { populate: ['benefits.details'], strategy: LoadStrategy.JOINED });
-    expect(mock.mock.calls[0][0]).toMatch('select "e0"."id", "b1"."id" as "b1__id", "b1"."benefit_status" as "b1__benefit_status", "b1"."name" as "b1__name", "d3"."id" as "d3__id", "d3"."description" as "d3__description", "d3"."benefit_id" as "d3__benefit_id", "d3"."active" as "d3__active" ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "e0".*, "b1"."id" as "b1__id", "b1"."benefit_status" as "b1__benefit_status", "b1"."name" as "b1__name", "d3"."id" as "d3__id", "d3"."description" as "d3__description", "d3"."benefit_id" as "d3__benefit_id", "d3"."active" as "d3__active" ' +
       'from "employee" as "e0" ' +
       'left join "employee_benefits" as "e2" on "e0"."id" = "e2"."employee_id" ' +
       'left join "public"."benefit" as "b1" on "e2"."benefit_id" = "b1"."id" and "b1"."benefit_status" = $1 ' +

--- a/tests/features/joined-strategy.postgre.test.ts
+++ b/tests/features/joined-strategy.postgre.test.ts
@@ -112,17 +112,18 @@ describe('Joined loading strategy', () => {
 
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books2.perex'] });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "a0"."id", "a0"."created_at", "a0"."updated_at", "a0"."name", "a0"."email", "a0"."age", "a0"."terms_accepted", "a0"."optional", "a0"."identities", "a0"."born", "a0"."born_time", "a0"."favourite_book_uuid_pk", "a0"."favourite_author_id", "a0"."identity", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
       '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
-      'where "a0"."id" = $1');
+      'where "a0"."id" = $1 ' +
+      'order by "b1"."title"');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books2'] });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "a0"."id", "a0"."created_at", "a0"."updated_at", "a0"."name", "a0"."email", "a0"."age", "a0"."terms_accepted", "a0"."optional", "a0"."identities", "a0"."born", "a0"."born_time", "a0"."favourite_book_uuid_pk", "a0"."favourite_author_id", "a0"."identity", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
       '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
@@ -132,7 +133,7 @@ describe('Joined loading strategy', () => {
     mock.mock.calls.length = 0;
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books'], filters: false });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "a0"."id", "a0"."created_at", "a0"."updated_at", "a0"."name", "a0"."email", "a0"."age", "a0"."terms_accepted", "a0"."optional", "a0"."identities", "a0"."born", "a0"."born_time", "a0"."favourite_book_uuid_pk", "a0"."favourite_author_id", "a0"."identity", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
       '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" ' +
@@ -142,7 +143,7 @@ describe('Joined loading strategy', () => {
     mock.mock.calls.length = 0;
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books.perex'] });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "a0"."id", "a0"."created_at", "a0"."updated_at", "a0"."name", "a0"."email", "a0"."age", "a0"."terms_accepted", "a0"."optional", "a0"."identities", "a0"."born", "a0"."born_time", "a0"."favourite_book_uuid_pk", "a0"."favourite_author_id", "a0"."identity", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
       '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
@@ -166,7 +167,7 @@ describe('Joined loading strategy', () => {
 
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books2.perex'], filters: false });
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "a0"."id", "a0"."created_at", "a0"."updated_at", "a0"."name", "a0"."email", "a0"."age", "a0"."terms_accepted", "a0"."optional", "a0"."identities", "a0"."born", "a0"."born_time", "a0"."favourite_book_uuid_pk", "a0"."favourite_author_id", "a0"."identity", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
       '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" ' +
@@ -176,7 +177,7 @@ describe('Joined loading strategy', () => {
     mock.mock.calls.length = 0;
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books2'] });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "a0"."id", "a0"."created_at", "a0"."updated_at", "a0"."name", "a0"."email", "a0"."age", "a0"."terms_accepted", "a0"."optional", "a0"."identities", "a0"."born", "a0"."born_time", "a0"."favourite_book_uuid_pk", "a0"."favourite_author_id", "a0"."identity", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
       '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
@@ -186,7 +187,7 @@ describe('Joined loading strategy', () => {
     mock.mock.calls.length = 0;
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books'], strategy: LoadStrategy.JOINED });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "a0"."id", "a0"."created_at", "a0"."updated_at", "a0"."name", "a0"."email", "a0"."age", "a0"."terms_accepted", "a0"."optional", "a0"."identities", "a0"."born", "a0"."born_time", "a0"."favourite_book_uuid_pk", "a0"."favourite_author_id", "a0"."identity", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
       '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
@@ -196,7 +197,7 @@ describe('Joined loading strategy', () => {
     mock.mock.calls.length = 0;
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books.perex'] });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "a0"."id", "a0"."created_at", "a0"."updated_at", "a0"."name", "a0"."email", "a0"."age", "a0"."terms_accepted", "a0"."optional", "a0"."identities", "a0"."born", "a0"."born_time", "a0"."favourite_book_uuid_pk", "a0"."favourite_author_id", "a0"."identity", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
       '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
@@ -229,18 +230,18 @@ describe('Joined loading strategy', () => {
     mock.mock.calls.length = 0;
     const books = await orm.em.find(Book2, {}, { populate: ['tags'], strategy: LoadStrategy.JOINED, orderBy: { tags: { name: 'desc' } } });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."price", "b0".price * 1.19 as "price_taxed", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed", ' +
       '"t1"."id" as "t1__id", "t1"."name" as "t1__name" ' +
       'from "book2" as "b0" ' +
       'left join "book2_tags" as "b2" on "b0"."uuid_pk" = "b2"."book2_uuid_pk" ' +
       'left join "public"."book_tag2" as "t1" on "b2"."book_tag2_id" = "t1"."id" ' +
       'where "b0"."author_id" is not null ' +
-      'order by "t1"."name" desc');
+      'order by "t1"."name" desc, "b2"."order" asc');
 
-    expect(books.map(b => b.title)).toEqual(['b4', 'b2', 'b1', 'b5', 'b3']);
+    expect(books.map(b => b.title)).toEqual(['b4', 'b1', 'b2', 'b3', 'b5']);
     expect(books[0].tags.getItems().map(t => t.name)).toEqual(['strange', 'sexy', 'funny']);
-    expect(books[1].tags.getItems().map(t => t.name)).toEqual(['silly', 'sexy', 'funny']);
-    expect(books[2].tags.getItems().map(t => t.name)).toEqual(['silly', 'sick']);
+    expect(books[1].tags.getItems().map(t => t.name)).toEqual(['silly', 'sick']);
+    expect(books[2].tags.getItems().map(t => t.name)).toEqual(['silly', 'sexy', 'funny']);
     expect(books[3].tags.getItems().map(t => t.name)).toEqual(['sexy']);
     expect(books[4].tags.getItems().map(t => t.name)).toEqual(['sexy']);
   });
@@ -319,7 +320,7 @@ describe('Joined loading strategy', () => {
 
     const b1 = (await orm.em.findOne(FooBaz2, { id: baz.id }, { populate: ['bar'], strategy: LoadStrategy.JOINED }))!;
     expect(mock.mock.calls).toHaveLength(2);
-    expect(mock.mock.calls[1][0]).toMatch('select "f0"."id", "f0"."name", "f0"."version", ' +
+    expect(mock.mock.calls[1][0]).toMatch('select "f0".*, ' +
       '"b1"."id" as "b1__id", "b1"."name" as "b1__name", "b1"."name with space" as "b1__name with space", "b1"."baz_id" as "b1__baz_id", "b1"."foo_bar_id" as "b1__foo_bar_id", "b1"."version" as "b1__version", "b1"."blob" as "b1__blob", "b1"."blob2" as "b1__blob2", "b1"."array" as "b1__array", "b1"."object_property" as "b1__object_property", (select 123) as "b1__random", "b1"."id" as "bar_id" ' +
       'from "foo_baz2" as "f0" ' +
       'left join "foo_bar2" as "b1" on "f0"."id" = "b1"."baz_id" ' +
@@ -333,11 +334,12 @@ describe('Joined loading strategy', () => {
 
     const b2 = await orm.em.findOneOrFail(FooBaz2, { bar: bar.id }, { populate: ['bar'] });
     expect(mock.mock.calls).toHaveLength(3);
-    expect(mock.mock.calls[2][0]).toMatch('select "f0"."id", "f0"."name", "f0"."version", ' +
+    expect(mock.mock.calls[2][0]).toMatch('select "f0".*, ' +
       '"b1"."id" as "b1__id", "b1"."name" as "b1__name", "b1"."name with space" as "b1__name with space", "b1"."baz_id" as "b1__baz_id", "b1"."foo_bar_id" as "b1__foo_bar_id", "b1"."version" as "b1__version", "b1"."blob" as "b1__blob", "b1"."blob2" as "b1__blob2", "b1"."array" as "b1__array", "b1"."object_property" as "b1__object_property", (select 123) as "b1__random", "b1"."id" as "bar_id" ' +
       'from "foo_baz2" as "f0" ' +
-      'left join "foo_bar2" as "b1" on "f0"."id" = "b1"."baz_id" ' +
-      'where "b1"."id" = $1');
+      'left join "foo_bar2" as "b1" on "f0"."id" = "b1"."baz_id" ' + // for populate, only in select
+      'left join "foo_bar2" as "f2" on "f0"."id" = "f2"."baz_id" ' + // only for the where condition, as we populate items all by default
+      'where "f2"."id" = $1');
     expect(b2.bar).toBeInstanceOf(FooBar2);
     expect(b2.bar!.id).toBe(bar.id);
     expect(b2.bar!.random).toBe(123);
@@ -345,9 +347,9 @@ describe('Joined loading strategy', () => {
     expect(wrap(b2).toJSON()).toMatchObject({ bar: { id: bar.id, baz: baz.id, name: 'bar' } });
     orm.em.clear();
 
-    const b3 = await orm.em.findOneOrFail(FooBaz2, { bar: bar.id }, { populate: ['bar.lazyRandom'] });
+    const b3 = await orm.em.findOneOrFail(FooBaz2, { bar: bar.id }, { populate: ['bar.lazyRandom'], populateWhere: 'infer' });
     expect(mock.mock.calls).toHaveLength(4);
-    expect(mock.mock.calls[3][0]).toMatch('select "f0"."id", "f0"."name", "f0"."version", ' +
+    expect(mock.mock.calls[3][0]).toMatch('select "f0".*, ' +
       '"b1"."id" as "b1__id", "b1"."name" as "b1__name", "b1"."name with space" as "b1__name with space", "b1"."baz_id" as "b1__baz_id", "b1"."foo_bar_id" as "b1__foo_bar_id", "b1"."version" as "b1__version", "b1"."blob" as "b1__blob", "b1"."blob2" as "b1__blob2", "b1"."array" as "b1__array", "b1"."object_property" as "b1__object_property", (select 123) as "b1__random", (select 456) as "b1__lazy_random", "b1"."id" as "bar_id" ' +
       'from "foo_baz2" as "f0" ' +
       'left join "foo_bar2" as "b1" on "f0"."id" = "b1"."baz_id" ' +
@@ -361,7 +363,7 @@ describe('Joined loading strategy', () => {
     // paginate with joined loading strategy
     await orm.em.find(FooBaz2, { id: baz.id }, { populate: ['bar'], strategy: LoadStrategy.JOINED, flags: [QueryFlag.PAGINATE], limit: 3, offset: 10 });
     expect(mock.mock.calls).toHaveLength(5);
-    expect(mock.mock.calls[4][0]).toMatch('select "f0"."id", "f0"."name", "f0"."version", ' +
+    expect(mock.mock.calls[4][0]).toMatch('select "f0".*, ' +
       '"b1"."id" as "b1__id", "b1"."name" as "b1__name", "b1"."name with space" as "b1__name with space", "b1"."baz_id" as "b1__baz_id", "b1"."foo_bar_id" as "b1__foo_bar_id", "b1"."version" as "b1__version", "b1"."blob" as "b1__blob", "b1"."blob2" as "b1__blob2", "b1"."array" as "b1__array", "b1"."object_property" as "b1__object_property", (select 123) as "b1__random", "b1"."id" as "bar_id" ' +
       'from "foo_baz2" as "f0" ' +
       'left join "foo_bar2" as "b1" on "f0"."id" = "b1"."baz_id" ' +
@@ -392,19 +394,17 @@ describe('Joined loading strategy', () => {
     book2.tags.add(tag1, tag2, tag5);
     book3.tags.add(tag2, tag4, tag5);
     await orm.em.persistAndFlush([book1, book2, book3]);
-    const repo = orm.em.getRepository(BookTag2);
 
     orm.em.clear();
     const mock = mockLogger(orm, ['query']);
 
-    const tags = await repo.findAll({
+    const tags = await orm.em.findAll(BookTag2, {
       populate: ['books.author', 'books.publisher.tests'],
-      // TODO maybe this could be resolved too when we fix the ordering via em.populate?
-      orderBy: { name: 'asc', books: { publisher: { tests: { name: 'asc' } } } }, // TODO should be implicit as we have fixed order there
+      orderBy: { name: 'asc' },
       strategy: LoadStrategy.JOINED,
     });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "b0"."id", "b0"."name", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, ' +
       '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
       '"a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", "a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", "a3"."identity" as "a3__identity", ' +
       '"p4"."id" as "p4__id", "p4"."name" as "p4__name", "p4"."type" as "p4__type", "p4"."type2" as "p4__type2", "p4"."enum1" as "p4__enum1", "p4"."enum2" as "p4__enum2", "p4"."enum3" as "p4__enum3", "p4"."enum4" as "p4__enum4", "p4"."enum5" as "p4__enum5", ' +
@@ -416,7 +416,7 @@ describe('Joined loading strategy', () => {
       'left join "public"."publisher2" as "p4" on "b1"."publisher_id" = "p4"."id" ' +
       'left join "public"."publisher2_tests" as "p6" on "p4"."id" = "p6"."publisher2_id" ' +
       'left join "public"."test2" as "t5" on "p6"."test2_id" = "t5"."id" ' +
-      'order by "b0"."name" asc, "t5"."name" asc');
+      'order by "b0"."name" asc, "b2"."order" asc, "p6"."id" asc');
 
     expect(tags.length).toBe(5);
     expect(tags[0]).toBeInstanceOf(BookTag2);
@@ -472,30 +472,42 @@ describe('Joined loading strategy', () => {
     orm.em.clear();
 
     const mock = mockLogger(orm, ['query']);
-    const res1 = await orm.em.find(Book2, { author: { name: 'Jon Snow' } }, { populate: ['perex', 'author'] });
+    const res1 = await orm.em.findAll(Book2, {
+      where: { author: { name: 'Jon Snow' } },
+      populate: ['perex', 'author'],
+    });
     expect(res1).toHaveLength(3);
     expect(res1[0].test).toBeUndefined();
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."perex", "b0"."price", "b0".price * 1.19 as "price_taxed", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed", ' +
       '"a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "a1"."identity" as "a1__identity" ' +
       'from "book2" as "b0" ' +
-      'left join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
-      'where "b0"."author_id" is not null and "a1"."name" = $1');
+      'left join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' + // populate join
+      'left join "author2" as "a2" on "b0"."author_id" = "a2"."id" ' + // where join
+      'where "b0"."author_id" is not null and "a2"."name" = $1');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
-    const res2 = await orm.em.find(Book2, { author: { favouriteBook: { author: { name: 'Jon Snow' } } } }, { populate: ['perex', 'author.favouriteBook.author'] });
+    const res2 = await orm.em.findAll(Book2, {
+      where: { author: { favouriteBook: { author: { name: 'Jon Snow' } } } },
+      populate: ['perex', 'author.favouriteBook.author'],
+    });
     expect(res2).toHaveLength(3);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."perex", "b0"."price", "b0".price * 1.19 as "price_taxed", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed", ' +
       '"a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "a1"."identity" as "a1__identity", ' +
       '"f2"."uuid_pk" as "f2__uuid_pk", "f2"."created_at" as "f2__created_at", "f2"."title" as "f2__title", "f2"."price" as "f2__price", "f2".price * 1.19 as "f2__price_taxed", "f2"."double" as "f2__double", "f2"."meta" as "f2__meta", "f2"."author_id" as "f2__author_id", "f2"."publisher_id" as "f2__publisher_id", ' +
       '"a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", "a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", "a3"."identity" as "a3__identity" ' +
       'from "book2" as "b0" ' +
+      // populateHint: all
       'left join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
-      'left join "book2" as "f2" on "a1"."favourite_book_uuid_pk" = "f2"."uuid_pk" and "f2"."author_id" is not null ' +
+      'left join "book2" as "f2" on "a1"."favourite_book_uuid_pk" = "f2"."uuid_pk" and "f2"."author_id" is not null ' + // filter applied to populate join
       'left join "author2" as "a3" on "f2"."author_id" = "a3"."id" ' +
-      'where "b0"."author_id" is not null and "a3"."name" = $1');
+      // where joins
+      'left join "author2" as "a4" on "b0"."author_id" = "a4"."id" ' +
+      'left join "book2" as "b5" on "a4"."favourite_book_uuid_pk" = "b5"."uuid_pk" ' +
+      'left join "author2" as "a6" on "b5"."author_id" = "a6"."id" ' +
+      'where "b0"."author_id" is not null and "a6"."name" = $1');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
@@ -509,17 +521,21 @@ describe('Joined loading strategy', () => {
 
     orm.em.clear();
     mock.mock.calls.length = 0;
-    const res4 = await orm.em.find(Book2, { author: { favouriteBook: { $or: [{ author: { name: 'Jon Snow' } }] } } }, { populate: ['perex', 'author.favouriteBook.author'] });
+    const res4 = await orm.em.findAll(Book2, {
+      where: { author: { favouriteBook: { $or: [{ author: { name: 'Jon Snow' } }] } } },
+      populate: ['perex', 'author.favouriteBook.author'],
+      populateWhere: 'infer',
+    });
     expect(res4).toHaveLength(3);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."perex", "b0"."price", "b0".price * 1.19 as "price_taxed", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed", ' +
       '"a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "a1"."identity" as "a1__identity", ' +
       '"f2"."uuid_pk" as "f2__uuid_pk", "f2"."created_at" as "f2__created_at", "f2"."title" as "f2__title", "f2"."price" as "f2__price", "f2".price * 1.19 as "f2__price_taxed", "f2"."double" as "f2__double", "f2"."meta" as "f2__meta", "f2"."author_id" as "f2__author_id", "f2"."publisher_id" as "f2__publisher_id", ' +
       '"a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", "a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", "a3"."identity" as "a3__identity" ' +
       'from "book2" as "b0" left join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
       'left join "book2" as "f2" on "a1"."favourite_book_uuid_pk" = "f2"."uuid_pk" and "f2"."author_id" is not null ' +
-      'left join "author2" as "a3" on "f2"."author_id" = "a3"."id" ' +
-      'where "b0"."author_id" is not null and "a3"."name" = $1');
+      'left join "author2" as "a3" on "f2"."author_id" = "a3"."id" and "a3"."name" = $1 ' +
+      'where "b0"."author_id" is not null and "a3"."name" = $2');
   });
 
 });

--- a/tests/features/multiple-schemas-entity-manager/multiple-schemas-e-manager-q-builder.test.ts
+++ b/tests/features/multiple-schemas-entity-manager/multiple-schemas-e-manager-q-builder.test.ts
@@ -158,14 +158,14 @@ describe('multiple connected schemas in postgres', () => {
      * Main table Domain(n2) will make sure that the schema used for * joins will be n2 and ignore fork settings
      */
     expect(mock.mock.calls[2][0]).toMatch(
-      'select "d0"."id", "d0"."scope", "s1"."id" as "s1__id", "s1"."name" as "s1__name", "s1"."domain_id" as "s1__domain_id" from "n2"."domain" as "d0" left join "n2"."sub_domain" as "s1" on "d0"."id" = "s1"."domain_id" where "d0"."id" = 1',
+      'select "d0".*, "s1"."id" as "s1__id", "s1"."name" as "s1__name", "s1"."domain_id" as "s1__domain_id" from "n2"."domain" as "d0" left join "n2"."sub_domain" as "s1" on "d0"."id" = "s1"."domain_id" where "d0"."id" = 1',
     );
 
     /**
      * Main table topic(*) will join Domain(n2)
      */
     expect(mock.mock.calls[3][0]).toMatch(
-      'select "t0"."id", "t0"."name", "t0"."domain_id", "d1"."id" as "d1__id", "d1"."scope" as "d1__scope" from "n5"."topic" as "t0" left join "n2"."domain" as "d1" on "t0"."domain_id" = "d1"."id" where "t0"."id" = 1',
+      'select "t0".*, "d1"."id" as "d1__id", "d1"."scope" as "d1__scope" from "n5"."topic" as "t0" left join "n2"."domain" as "d1" on "t0"."domain_id" = "d1"."id" where "t0"."id" = 1',
     );
   });
 

--- a/tests/features/partial-loading/partial-loading.mysql.test.ts
+++ b/tests/features/partial-loading/partial-loading.mysql.test.ts
@@ -327,7 +327,8 @@ describe('partial loading (mysql)', () => {
       'from `book_tag2` as `b0` ' +
       'left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` ' +
       'left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` ' +
-      'left join `author2` as `a3` on `b1`.`author_id` = `a3`.`id`');
+      'left join `author2` as `a3` on `b1`.`author_id` = `a3`.`id` ' +
+      'order by `b2`.`order` asc');
   });
 
   test('partial nested loading (object notation)', async () => {

--- a/tests/issues/GH1041.test.ts
+++ b/tests/issues/GH1041.test.ts
@@ -93,7 +93,7 @@ describe('GH issue 1041, 1043', () => {
   test('joined strategy: find by many-to-many relation ID', async () => {
     const findPromise = orm.em.findOne(User, { apps: 1 }, { populate: ['apps'], strategy: LoadStrategy.JOINED });
     await expect(findPromise).resolves.toBeInstanceOf(User);
-    expect(log.mock.calls[0][0]).toMatch('select `u0`.`id`, `u0`.`name`, `a1`.`id` as `a1__id`, `a1`.`name` as `a1__name` from `user` as `u0` left join `user_apps` as `u2` on `u0`.`id` = `u2`.`user_id` left join `app` as `a1` on `u2`.`app_id` = `a1`.`id` where `u2`.`app_id` = 1');
+    expect(log.mock.calls[0][0]).toMatch('select `u0`.*, `a1`.`id` as `a1__id`, `a1`.`name` as `a1__name` from `user` as `u0` left join `user_apps` as `u2` on `u0`.`id` = `u2`.`user_id` left join `app` as `a1` on `u2`.`app_id` = `a1`.`id` left join `user_apps` as `u3` on `u0`.`id` = `u3`.`user_id` where `u3`.`app_id` = 1');
   });
 
   test('select-in strategy: find by many-to-many relation IDs (PopulateHint.INFER)', async () => {
@@ -101,6 +101,12 @@ describe('GH issue 1041, 1043', () => {
     await expect(findPromise).resolves.toBeInstanceOf(User);
     expect(log.mock.calls[0][0]).toMatch('select `u0`.* from `user` as `u0` left join `user_apps` as `u1` on `u0`.`id` = `u1`.`user_id` where `u1`.`app_id` in (1, 2, 3) limit 1');
     expect(log.mock.calls[1][0]).toMatch('select `a1`.*, `u0`.`app_id` as `fk__app_id`, `u0`.`user_id` as `fk__user_id` from `user_apps` as `u0` inner join `app` as `a1` on `u0`.`app_id` = `a1`.`id` where `a1`.`id` in (1, 2, 3) and `u0`.`user_id` in (123)');
+  });
+
+  test('joined strategy: find by many-to-many relation IDs (PopulateHint.INFER)', async () => {
+    const findPromise = orm.em.findOne(User, { apps: [1, 2, 3] }, { populate: ['apps'], strategy: LoadStrategy.JOINED, populateWhere: PopulateHint.INFER });
+    await expect(findPromise).resolves.toBeInstanceOf(User);
+    expect(log.mock.calls[0][0]).toMatch('select `u0`.*, `a1`.`id` as `a1__id`, `a1`.`name` as `a1__name` from `user` as `u0` left join `user_apps` as `u2` on `u0`.`id` = `u2`.`user_id` and `u2`.`app_id` in (1, 2, 3) left join `app` as `a1` on `u2`.`app_id` = `a1`.`id` where `u2`.`app_id` in (1, 2, 3)');
   });
 
   test('select-in strategy: find by many-to-many relation IDs', async () => {
@@ -113,7 +119,7 @@ describe('GH issue 1041, 1043', () => {
   test('joined strategy: find by many-to-many relation IDs', async () => {
     const findPromise = orm.em.findOne(User, { apps: [1, 2, 3] }, { populate: ['apps'], strategy: LoadStrategy.JOINED });
     await expect(findPromise).resolves.toBeInstanceOf(User);
-    expect(log.mock.calls[0][0]).toMatch('select `u0`.`id`, `u0`.`name`, `a1`.`id` as `a1__id`, `a1`.`name` as `a1__name` from `user` as `u0` left join `user_apps` as `u2` on `u0`.`id` = `u2`.`user_id` left join `app` as `a1` on `u2`.`app_id` = `a1`.`id` where `u2`.`app_id` in (1, 2, 3)');
+    expect(log.mock.calls[0][0]).toMatch('select `u0`.*, `a1`.`id` as `a1__id`, `a1`.`name` as `a1__name` from `user` as `u0` left join `user_apps` as `u2` on `u0`.`id` = `u2`.`user_id` left join `app` as `a1` on `u2`.`app_id` = `a1`.`id` left join `user_apps` as `u3` on `u0`.`id` = `u3`.`user_id` where `u3`.`app_id` in (1, 2, 3)');
   });
 
 });

--- a/tests/issues/GH1126.test.ts
+++ b/tests/issues/GH1126.test.ts
@@ -112,7 +112,7 @@ describe('GH issue 1126', () => {
       orm.em.clear();
     }
 
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `a0`.`name`, `b1`.`id` as `b1__id`, `b1`.`title` as `b1__title`, `b1`.`author_id` as `b1__author_id`, `p2`.`id` as `p2__id`, `p2`.`book_id` as `p2__book_id`, `p2`.`text` as `p2__text` from `author` as `a0` left join `book` as `b1` on `a0`.`id` = `b1`.`author_id` left join `page` as `p2` on `b1`.`id` = `p2`.`book_id` where `a0`.`id` = ?');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`id` as `b1__id`, `b1`.`title` as `b1__title`, `b1`.`author_id` as `b1__author_id`, `p2`.`id` as `p2__id`, `p2`.`book_id` as `p2__book_id`, `p2`.`text` as `p2__text` from `author` as `a0` left join `book` as `b1` on `a0`.`id` = `b1`.`author_id` left join `page` as `p2` on `b1`.`id` = `p2`.`book_id` where `a0`.`id` = ?');
     expect(mock.mock.calls[1][0]).toMatch('begin');
     expect(mock.mock.calls[2][0]).toMatch('insert into `book` (`title`, `author_id`) values (?, ?)');
     expect(mock.mock.calls[3][0]).toMatch('update `page` set `book_id` = ? where `id` = ?');
@@ -140,7 +140,7 @@ describe('GH issue 1126', () => {
       orm.em.clear();
     }
 
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `a0`.`name`, `b1`.`id` as `b1__id`, `b1`.`title` as `b1__title`, `b1`.`author_id` as `b1__author_id`, `p2`.`id` as `p2__id`, `p2`.`book_id` as `p2__book_id`, `p2`.`text` as `p2__text` from `author` as `a0` left join `book` as `b1` on `a0`.`id` = `b1`.`author_id` left join `page` as `p2` on `b1`.`id` = `p2`.`book_id` where `a0`.`id` = ?');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`id` as `b1__id`, `b1`.`title` as `b1__title`, `b1`.`author_id` as `b1__author_id`, `p2`.`id` as `p2__id`, `p2`.`book_id` as `p2__book_id`, `p2`.`text` as `p2__text` from `author` as `a0` left join `book` as `b1` on `a0`.`id` = `b1`.`author_id` left join `page` as `p2` on `b1`.`id` = `p2`.`book_id` where `a0`.`id` = ?');
     expect(mock.mock.calls[1][0]).toMatch('begin');
     expect(mock.mock.calls[2][0]).toMatch('insert into `book` (`title`, `author_id`) values (?, ?) returning `id`');
     expect(mock.mock.calls[3][0]).toMatch('insert into `page` (`book_id`, `text`) values (?, ?) returning `id`');
@@ -168,7 +168,7 @@ describe('GH issue 1126', () => {
       orm.em.clear();
     }
 
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `a0`.`name`, `b1`.`id` as `b1__id`, `b1`.`title` as `b1__title`, `b1`.`author_id` as `b1__author_id`, `p2`.`id` as `p2__id`, `p2`.`book_id` as `p2__book_id`, `p2`.`text` as `p2__text` from `author` as `a0` left join `book` as `b1` on `a0`.`id` = `b1`.`author_id` left join `page` as `p2` on `b1`.`id` = `p2`.`book_id` where `a0`.`id` = ?');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`id` as `b1__id`, `b1`.`title` as `b1__title`, `b1`.`author_id` as `b1__author_id`, `p2`.`id` as `p2__id`, `p2`.`book_id` as `p2__book_id`, `p2`.`text` as `p2__text` from `author` as `a0` left join `book` as `b1` on `a0`.`id` = `b1`.`author_id` left join `page` as `p2` on `b1`.`id` = `p2`.`book_id` where `a0`.`id` = ?');
     expect(mock.mock.calls[1][0]).toMatch('begin');
     expect(mock.mock.calls[2][0]).toMatch('insert into `book` (`title`, `author_id`) values (?, ?)');
     expect(mock.mock.calls[3][0]).toMatch('insert into `page` (`book_id`, `text`) values (?, ?)');

--- a/tests/issues/GH1657.test.ts
+++ b/tests/issues/GH1657.test.ts
@@ -77,7 +77,7 @@ describe('GH issue 1657', () => {
     expect(wrap(res1[1].order2!).isInitialized()).toBe(true);
 
     // first query loads item and joins the order2 relation (eager + joined strategy)
-    expect(mock.mock.calls[0][0]).toMatch('select `o0`.`id`, `o0`.`order1_id`, `o0`.`order2_id`, `o1`.`id` as `o1__id` from `order_item` as `o0` left join `order` as `o1` on `o0`.`order2_id` = `o1`.`id` where `o0`.`id` <= 100');
+    expect(mock.mock.calls[0][0]).toMatch('select `o0`.*, `o1`.`id` as `o1__id` from `order_item` as `o0` left join `order` as `o1` on `o0`.`order2_id` = `o1`.`id` where `o0`.`id` <= 100');
     // second query loads order1 relation (eager + select-in strategy)
     expect(mock.mock.calls[1][0]).toMatch('select `o0`.* from `order` as `o0` where `o0`.`id` in (1)');
 


### PR DESCRIPTION
The joined strategy now supports `populateWhere: 'all'`, which is the default behavior, and means "populate the full relations regardless of the where condition". This was previouly not working with the joined strategy, as it was reusing the same join clauses as the where clause. With this PR, the joined strategy will use a separate join branch for the populated relations.

**This aligns the behavior between the strategies.**

The `order by` clause is shared for both the join branches and a new `populateOrderBy` option is added to allow control of the order of populated relations separately.