### PR TITLE
feat(sql): use joined strategy as default for SQL drivers

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -404,7 +404,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       for (const hint of (options.populate as unknown as PopulateOptions<Entity>[])) {
         const field = hint.field.split(':')[0] as EntityKey<Entity>;
         const prop = meta.properties[field];
-        const joined = (options.strategy || hint.strategy || prop.strategy || this.config.get('loadStrategy')) === LoadStrategy.JOINED && prop.kind !== ReferenceKind.SCALAR;
+        const joined = (prop.strategy || options.strategy || hint.strategy || this.config.get('loadStrategy')) === LoadStrategy.JOINED && prop.kind !== ReferenceKind.SCALAR;
 
         if (!joined) {
           continue;

--- a/packages/core/src/entity/ArrayCollection.ts
+++ b/packages/core/src/entity/ArrayCollection.ts
@@ -39,7 +39,7 @@ export class ArrayCollection<T extends object, O extends object> {
     const meta = this.property.targetMeta!;
     const args = [...meta.toJsonParams.map(() => undefined)];
 
-    return this.getItems().map(item => wrap(item as TT).toJSON(...args));
+    return this.map(item => wrap(item as TT).toJSON(...args));
   }
 
   toJSON(): EntityDTO<T>[] {

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -210,7 +210,6 @@ export class EntityFactory {
     }
 
     const pks = Utils.getOrderedPrimaryKeys<T>(id, meta);
-
     const exists = this.unitOfWork.getById<T>(entityName, pks as Primary<T>, schema);
 
     if (exists) {
@@ -305,7 +304,7 @@ export class EntityFactory {
       return this.unitOfWork.getById<T>(meta.name!, data[meta.primaryKeys[0]] as Primary<T>, schema);
     }
 
-    if (meta.primaryKeys.some(pk => data[pk] == null)) {
+    if (!Array.isArray(data) && meta.primaryKeys.some(pk => data[pk] == null)) {
       return undefined;
     }
 

--- a/packages/core/src/hydration/ObjectHydrator.ts
+++ b/packages/core/src/hydration/ObjectHydrator.ts
@@ -137,6 +137,7 @@ export class ObjectHydrator extends Hydrator {
     const hydrateToOne = (prop: EntityProperty, dataKey: string, entityKey: string) => {
       const ret: string[] = [];
 
+      const method = type === 'reference' ? 'createReference' : 'create';
       const nullVal = this.config.get('forceUndefined') ? 'undefined' : 'null';
       ret.push(`  if (data${dataKey} === null) {\n    entity${entityKey} = ${nullVal};`);
       ret.push(`  } else if (typeof data${dataKey} !== 'undefined') {`);
@@ -151,9 +152,9 @@ export class ObjectHydrator extends Hydrator {
       ret.push(`    } else if (data${dataKey} && typeof data${dataKey} === 'object') {`);
 
       if (prop.ref) {
-        ret.push(`      entity${entityKey} = Reference.create(factory.create('${prop.type}', data${dataKey}, { initialized: true, merge: true, newEntity, convertCustomTypes, schema }));`);
+        ret.push(`      entity${entityKey} = Reference.create(factory.${method}('${prop.type}', data${dataKey}, { initialized: true, merge: true, newEntity, convertCustomTypes, schema }));`);
       } else {
-        ret.push(`      entity${entityKey} = factory.create('${prop.type}', data${dataKey}, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });`);
+        ret.push(`      entity${entityKey} = factory.${method}('${prop.type}', data${dataKey}, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });`);
       }
 
       ret.push(`    }`);

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -70,7 +70,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     baseDir: process.cwd(),
     hydrator: ObjectHydrator,
     flushMode: FlushMode.AUTO,
-    loadStrategy: LoadStrategy.SELECT_IN,
+    loadStrategy: LoadStrategy.JOINED,
     dataloader: Dataloader.OFF,
     populateWhere: PopulateHint.ALL,
     connect: true,

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -632,6 +632,28 @@ export class Utils {
     return cond;
   }
 
+  /**
+   * Maps nested FKs from `[1, 2, 3]` to `[1, [2, 3]]`.
+   */
+  static mapFlatCompositePrimaryKey(fk: Primary<any>[], prop: EntityProperty, fieldNames = prop.fieldNames, idx = 0): Primary<any> | Primary<any>[] {
+    if (!prop.targetMeta) {
+      return fk[idx++];
+    }
+
+    const parts: Primary<any>[] = [];
+
+    for (const pk of prop.targetMeta.getPrimaryProps()) {
+      parts.push(this.mapFlatCompositePrimaryKey(fk, pk, fieldNames, idx));
+      idx += pk.fieldNames.length;
+    }
+
+    if (parts.length < 2) {
+      return parts[0];
+    }
+
+    return parts;
+  }
+
   static getPrimaryKeyCondFromArray<T extends object>(pks: Primary<T>[], meta: EntityMetadata<T>): Record<string, Primary<T>> {
     return meta.getPrimaryProps().reduce((o, pk, idx) => {
       if (Array.isArray(pks[idx]) && pk.targetMeta) {

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -13,6 +13,7 @@ export class MongoPlatform extends Platform {
 
   override setConfig(config: Configuration) {
     config.set('autoJoinOneToOneOwner', false);
+    config.set('loadStrategy', 'select-in');
     config.get('discovery').inferDefaultValues = false;
     super.setConfig(config);
   }

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -36,7 +36,7 @@ describe('EntityManagerMySql', () => {
 
   let orm: MikroORM<MySqlDriver>;
 
-  beforeAll(async () => orm = await initORMMySql('mysql', { loadStrategy: 'joined' }, true));
+  beforeAll(async () => orm = await initORMMySql('mysql', {}, true));
   beforeEach(async () => orm.schema.clearDatabase());
   afterEach(() => {
     orm.config.set('debug', false);
@@ -1728,14 +1728,14 @@ describe('EntityManagerMySql', () => {
       orderBy: { title: QueryOrder.DESC },
       strategy: 'joined',
     });
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name`, `t3`.`id` as `test_id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name`, `t5`.`id` as `test_id` ' +
       'from `book2` as `b0` ' +
       'left join `book_to_tag_unordered` as `b2` on `b0`.`uuid_pk` = `b2`.`book2_uuid_pk` ' +
       'left join `book_tag2` as `t1` on `b2`.`book_tag2_id` = `t1`.`id` ' +
-      'left join `test2` as `t3` on `b0`.`uuid_pk` = `t3`.`book_uuid_pk` ' +
-      'left join `book_to_tag_unordered` as `b5` on `b0`.`uuid_pk` = `b5`.`book2_uuid_pk` ' +
-      'left join `book_tag2` as `b4` on `b5`.`book_tag2_id` = `b4`.`id` ' +
-      'where `b0`.`author_id` is not null and `b4`.`name` != ? ' +
+      'left join `book_to_tag_unordered` as `b4` on `b0`.`uuid_pk` = `b4`.`book2_uuid_pk` ' +
+      'left join `book_tag2` as `b3` on `b4`.`book_tag2_id` = `b3`.`id` ' +
+      'left join `test2` as `t5` on `b0`.`uuid_pk` = `t5`.`book_uuid_pk` ' +
+      'where `b0`.`author_id` is not null and `b3`.`name` != ? ' +
       'order by `b0`.`title` desc, `t1`.`name` asc');
     expect(books3.length).toBe(3);
     expect(books3[0].perex).toBeInstanceOf(ScalarReference);
@@ -1755,14 +1755,14 @@ describe('EntityManagerMySql', () => {
       orderBy: { title: QueryOrder.DESC },
       strategy: 'joined',
     });
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name`, `t3`.`id` as `test_id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name`, `t5`.`id` as `test_id` ' +
       'from `book2` as `b0` ' +
       'left join `book_to_tag_unordered` as `b2` on `b0`.`uuid_pk` = `b2`.`book2_uuid_pk` ' +
       'left join `book_tag2` as `t1` on `b2`.`book_tag2_id` = `t1`.`id` and `t1`.`name` != ? ' +
-      'left join `test2` as `t3` on `b0`.`uuid_pk` = `t3`.`book_uuid_pk` ' +
-      'left join `book_to_tag_unordered` as `b5` on `b0`.`uuid_pk` = `b5`.`book2_uuid_pk` ' +
-      'left join `book_tag2` as `b4` on `b5`.`book_tag2_id` = `b4`.`id` ' +
-      'where `b0`.`author_id` is not null and `b4`.`name` != ? ' +
+      'left join `book_to_tag_unordered` as `b4` on `b0`.`uuid_pk` = `b4`.`book2_uuid_pk` ' +
+      'left join `book_tag2` as `b3` on `b4`.`book_tag2_id` = `b3`.`id` ' +
+      'left join `test2` as `t5` on `b0`.`uuid_pk` = `t5`.`book_uuid_pk` ' +
+      'where `b0`.`author_id` is not null and `b3`.`name` != ? ' +
       'order by `b0`.`title` desc, `t1`.`name` asc');
 
     expect(books4.length).toBe(3);
@@ -1784,14 +1784,14 @@ describe('EntityManagerMySql', () => {
       strategy: 'joined',
     });
 
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name`, `t3`.`id` as `test_id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name`, `t5`.`id` as `test_id` ' +
       'from `book2` as `b0` ' +
       'left join `book_to_tag_unordered` as `b2` on `b0`.`uuid_pk` = `b2`.`book2_uuid_pk` ' +
       'left join `book_tag2` as `t1` on `b2`.`book_tag2_id` = `t1`.`id` and `t1`.`name` != ? ' +
-      'left join `test2` as `t3` on `b0`.`uuid_pk` = `t3`.`book_uuid_pk` ' +
-      'left join `book_to_tag_unordered` as `b5` on `b0`.`uuid_pk` = `b5`.`book2_uuid_pk` ' +
-      'left join `book_tag2` as `b4` on `b5`.`book_tag2_id` = `b4`.`id` ' +
-      'where `b0`.`author_id` is not null and `b4`.`name` != ? ' +
+      'left join `book_to_tag_unordered` as `b4` on `b0`.`uuid_pk` = `b4`.`book2_uuid_pk` ' +
+      'left join `book_tag2` as `b3` on `b4`.`book_tag2_id` = `b3`.`id` ' +
+      'left join `test2` as `t5` on `b0`.`uuid_pk` = `t5`.`book_uuid_pk` ' +
+      'where `b0`.`author_id` is not null and `b3`.`name` != ? ' +
       'order by `b0`.`title` desc, `t1`.`name` asc');
 
     expect(books5.length).toBe(3);

--- a/tests/features/__snapshots__/dataloader.test.ts.snap
+++ b/tests/features/__snapshots__/dataloader.test.ts.snap
@@ -50,16 +50,13 @@ exports[`Dataloader Collection.load 1`] = `
     "[query] select \`b0\`.* from \`book\` as \`b0\` where (\`b0\`.\`author_id\` in (1, 2, 3) or \`b0\`.\`publisher_id\` in (1, 2))",
   ],
   [
-    "[query] select \`a0\`.* from \`author\` as \`a0\` left join \`author_buddies\` as \`a1\` on \`a0\`.\`id\` = \`a1\`.\`author_2_id\` where \`a1\`.\`author_1_id\` in (1, 2, 3)",
-  ],
-  [
     "[query] select \`c0\`.* from \`chat\` as \`c0\` where \`c0\`.\`owner_id\` in (1, 2, 3)",
   ],
   [
     "[query] select \`m0\`.* from \`message\` as \`m0\` where (\`m0\`.\`chat_owner_id\`, \`m0\`.\`chat_recipient_id\`) in ( values (1, 2), (1, 3))",
   ],
   [
-    "[query] select \`a1\`.*, \`a0\`.\`author_2_id\` as \`fk__author_2_id\`, \`a0\`.\`author_1_id\` as \`fk__author_1_id\` from \`author_buddies\` as \`a0\` inner join \`author\` as \`a1\` on \`a0\`.\`author_1_id\` = \`a1\`.\`id\` where \`a0\`.\`author_2_id\` in (1, 2, 4, 5)",
+    "[query] select \`a0\`.*, \`b1\`.\`id\` as \`b1__id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\` from \`author\` as \`a0\` left join \`author_buddies\` as \`a2\` on \`a0\`.\`id\` = \`a2\`.\`author_2_id\` left join \`author\` as \`b1\` on \`a2\`.\`author_1_id\` = \`b1\`.\`id\` left join \`author_buddies\` as \`a3\` on \`a0\`.\`id\` = \`a3\`.\`author_2_id\` where \`a3\`.\`author_1_id\` in (1, 2, 3)",
   ],
 ]
 `;
@@ -70,16 +67,13 @@ exports[`Dataloader Dataloader can be globally enabled for Collections 1`] = `
     "[query] select \`b0\`.* from \`book\` as \`b0\` where (\`b0\`.\`author_id\` in (1, 2, 3) or \`b0\`.\`publisher_id\` in (1, 2))",
   ],
   [
-    "[query] select \`a0\`.* from \`author\` as \`a0\` left join \`author_buddies\` as \`a1\` on \`a0\`.\`id\` = \`a1\`.\`author_2_id\` where \`a1\`.\`author_1_id\` in (1, 2, 3)",
-  ],
-  [
     "[query] select \`c0\`.* from \`chat\` as \`c0\` where \`c0\`.\`owner_id\` in (1, 2, 3)",
   ],
   [
     "[query] select \`m0\`.* from \`message\` as \`m0\` where (\`m0\`.\`chat_owner_id\`, \`m0\`.\`chat_recipient_id\`) in ( values (1, 2), (1, 3))",
   ],
   [
-    "[query] select \`a1\`.*, \`a0\`.\`author_2_id\` as \`fk__author_2_id\`, \`a0\`.\`author_1_id\` as \`fk__author_1_id\` from \`author_buddies\` as \`a0\` inner join \`author\` as \`a1\` on \`a0\`.\`author_1_id\` = \`a1\`.\`id\` where \`a0\`.\`author_2_id\` in (1, 2, 4, 5)",
+    "[query] select \`a0\`.*, \`b1\`.\`id\` as \`b1__id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\` from \`author\` as \`a0\` left join \`author_buddies\` as \`a2\` on \`a0\`.\`id\` = \`a2\`.\`author_2_id\` left join \`author\` as \`b1\` on \`a2\`.\`author_1_id\` = \`b1\`.\`id\` left join \`author_buddies\` as \`a3\` on \`a0\`.\`id\` = \`a3\`.\`author_2_id\` where \`a3\`.\`author_1_id\` in (1, 2, 3)",
   ],
 ]
 `;
@@ -147,16 +141,13 @@ exports[`Dataloader getColBatchLoadFn 1`] = `
     "[query] select \`b0\`.* from \`book\` as \`b0\` where (\`b0\`.\`author_id\` in (1, 2, 3) or \`b0\`.\`publisher_id\` in (1, 2))",
   ],
   [
-    "[query] select \`a0\`.* from \`author\` as \`a0\` left join \`author_buddies\` as \`a1\` on \`a0\`.\`id\` = \`a1\`.\`author_2_id\` where \`a1\`.\`author_1_id\` in (1, 2, 3)",
-  ],
-  [
     "[query] select \`c0\`.* from \`chat\` as \`c0\` where \`c0\`.\`owner_id\` in (1, 2, 3)",
   ],
   [
     "[query] select \`m0\`.* from \`message\` as \`m0\` where (\`m0\`.\`chat_owner_id\`, \`m0\`.\`chat_recipient_id\`) in ( values (1, 2), (1, 3))",
   ],
   [
-    "[query] select \`a1\`.*, \`a0\`.\`author_2_id\` as \`fk__author_2_id\`, \`a0\`.\`author_1_id\` as \`fk__author_1_id\` from \`author_buddies\` as \`a0\` inner join \`author\` as \`a1\` on \`a0\`.\`author_1_id\` = \`a1\`.\`id\` where \`a0\`.\`author_2_id\` in (1, 2, 4, 5)",
+    "[query] select \`a0\`.*, \`b1\`.\`id\` as \`b1__id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\` from \`author\` as \`a0\` left join \`author_buddies\` as \`a2\` on \`a0\`.\`id\` = \`a2\`.\`author_2_id\` left join \`author\` as \`b1\` on \`a2\`.\`author_1_id\` = \`b1\`.\`id\` left join \`author_buddies\` as \`a3\` on \`a0\`.\`id\` = \`a3\`.\`author_2_id\` where \`a3\`.\`author_1_id\` in (1, 2, 3)",
   ],
 ]
 `;

--- a/tests/features/cursor-based-pagination/__snapshots__/complex-cursor.test.ts.snap
+++ b/tests/features/cursor-based-pagination/__snapshots__/complex-cursor.test.ts.snap
@@ -16,15 +16,14 @@ exports[`simple cursor based pagination (better-sqlite) complex cursor based pag
 
 exports[`simple cursor based pagination (better-sqlite) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 1`] = `
 [
-  "[query] select \`u0\`.* from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3' order by \`u1\`.\`email\` desc, \`u1\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
+  "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` left join \`user\` as \`u2\` on \`u0\`.\`best_friend__id\` = \`u2\`.\`_id\` where \`u2\`.\`name\` = 'User 3' order by \`u2\`.\`email\` desc, \`u2\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3'",
 ]
 `;
 
 exports[`simple cursor based pagination (better-sqlite) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
 [
-  "[query] select \`u0\`.* from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3' and \`u1\`.\`email\` <= 'email-96' and \`u1\`.\`name\` <= 'User 3' and ((\`u1\`.\`email\` < 'email-96' and \`u1\`.\`name\` < 'User 3') or (\`u0\`.\`name\` >= 'User 3' and (\`u0\`.\`name\` > 'User 3' or (\`u0\`.\`age\` <= 38 and (\`u0\`.\`age\` < 38 or \`u0\`.\`email\` < 'email-76'))))) order by \`u1\`.\`email\` desc, \`u1\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
-  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` in (5) order by \`u0\`.\`email\` asc, \`u0\`.\`name\` asc",
+  "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` left join \`user\` as \`u2\` on \`u0\`.\`best_friend__id\` = \`u2\`.\`_id\` where \`u2\`.\`name\` = 'User 3' and \`u2\`.\`email\` <= 'email-96' and \`u2\`.\`name\` <= 'User 3' and ((\`u2\`.\`email\` < 'email-96' and \`u2\`.\`name\` < 'User 3') or (\`u0\`.\`name\` >= 'User 3' and (\`u0\`.\`name\` > 'User 3' or (\`u0\`.\`age\` <= 38 and (\`u0\`.\`age\` < 38 or \`u0\`.\`email\` < 'email-76'))))) order by \`u2\`.\`email\` desc, \`u2\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3'",
 ]
 `;
@@ -59,15 +58,14 @@ exports[`simple cursor based pagination (mysql) complex cursor based pagination 
 
 exports[`simple cursor based pagination (mysql) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 1`] = `
 [
-  "[query] select \`u0\`.* from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3' order by \`u1\`.\`email\` desc, \`u1\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
+  "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` left join \`user\` as \`u2\` on \`u0\`.\`best_friend__id\` = \`u2\`.\`_id\` where \`u2\`.\`name\` = 'User 3' order by \`u2\`.\`email\` desc, \`u2\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3'",
 ]
 `;
 
 exports[`simple cursor based pagination (mysql) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
 [
-  "[query] select \`u0\`.* from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3' and \`u1\`.\`email\` <= 'email-96' and \`u1\`.\`name\` <= 'User 3' and ((\`u1\`.\`email\` < 'email-96' and \`u1\`.\`name\` < 'User 3') or (\`u0\`.\`name\` >= 'User 3' and (\`u0\`.\`name\` > 'User 3' or (\`u0\`.\`age\` <= 38 and (\`u0\`.\`age\` < 38 or \`u0\`.\`email\` < 'email-76'))))) order by \`u1\`.\`email\` desc, \`u1\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
-  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` in (5) order by \`u0\`.\`email\` asc, \`u0\`.\`name\` asc",
+  "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` left join \`user\` as \`u2\` on \`u0\`.\`best_friend__id\` = \`u2\`.\`_id\` where \`u2\`.\`name\` = 'User 3' and \`u2\`.\`email\` <= 'email-96' and \`u2\`.\`name\` <= 'User 3' and ((\`u2\`.\`email\` < 'email-96' and \`u2\`.\`name\` < 'User 3') or (\`u0\`.\`name\` >= 'User 3' and (\`u0\`.\`name\` > 'User 3' or (\`u0\`.\`age\` <= 38 and (\`u0\`.\`age\` < 38 or \`u0\`.\`email\` < 'email-76'))))) order by \`u2\`.\`email\` desc, \`u2\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3'",
 ]
 `;
@@ -88,15 +86,14 @@ exports[`simple cursor based pagination (postgresql) complex cursor based pagina
 
 exports[`simple cursor based pagination (postgresql) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 1`] = `
 [
-  "[query] select "u0".* from "user" as "u0" left join "user" as "u1" on "u0"."best_friend__id" = "u1"."_id" where "u1"."name" = 'User 3' order by "u1"."email" desc, "u1"."name" desc, "u0"."name" asc, "u0"."age" desc, "u0"."email" desc limit 6",
+  "[query] select "u0".*, "b1"."_id" as "b1___id", "b1"."name" as "b1__name", "b1"."email" as "b1__email", "b1"."age" as "b1__age", "b1"."terms_accepted" as "b1__terms_accepted", "b1"."best_friend__id" as "b1__best_friend__id" from "user" as "u0" left join "user" as "b1" on "u0"."best_friend__id" = "b1"."_id" left join "user" as "u2" on "u0"."best_friend__id" = "u2"."_id" where "u2"."name" = 'User 3' order by "u2"."email" desc, "u2"."name" desc, "u0"."name" asc, "u0"."age" desc, "u0"."email" desc limit 6",
   "[query] select count(*) as "count" from "user" as "u0" left join "user" as "u1" on "u0"."best_friend__id" = "u1"."_id" where "u1"."name" = 'User 3'",
 ]
 `;
 
 exports[`simple cursor based pagination (postgresql) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
 [
-  "[query] select "u0".* from "user" as "u0" left join "user" as "u1" on "u0"."best_friend__id" = "u1"."_id" where "u1"."name" = 'User 3' and "u1"."email" <= 'email-96' and "u1"."name" <= 'User 3' and (("u1"."email" < 'email-96' and "u1"."name" < 'User 3') or ("u0"."name" >= 'User 3' and ("u0"."name" > 'User 3' or ("u0"."age" <= 38 and ("u0"."age" < 38 or "u0"."email" < 'email-76'))))) order by "u1"."email" desc, "u1"."name" desc, "u0"."name" asc, "u0"."age" desc, "u0"."email" desc limit 6",
-  "[query] select "u0".* from "user" as "u0" where "u0"."_id" in (5) order by "u0"."email" asc, "u0"."name" asc",
+  "[query] select "u0".*, "b1"."_id" as "b1___id", "b1"."name" as "b1__name", "b1"."email" as "b1__email", "b1"."age" as "b1__age", "b1"."terms_accepted" as "b1__terms_accepted", "b1"."best_friend__id" as "b1__best_friend__id" from "user" as "u0" left join "user" as "b1" on "u0"."best_friend__id" = "b1"."_id" left join "user" as "u2" on "u0"."best_friend__id" = "u2"."_id" where "u2"."name" = 'User 3' and "u2"."email" <= 'email-96' and "u2"."name" <= 'User 3' and (("u2"."email" < 'email-96' and "u2"."name" < 'User 3') or ("u0"."name" >= 'User 3' and ("u0"."name" > 'User 3' or ("u0"."age" <= 38 and ("u0"."age" < 38 or "u0"."email" < 'email-76'))))) order by "u2"."email" desc, "u2"."name" desc, "u0"."name" asc, "u0"."age" desc, "u0"."email" desc limit 6",
   "[query] select count(*) as "count" from "user" as "u0" left join "user" as "u1" on "u0"."best_friend__id" = "u1"."_id" where "u1"."name" = 'User 3'",
 ]
 `;
@@ -117,15 +114,14 @@ exports[`simple cursor based pagination (sqlite) complex cursor based pagination
 
 exports[`simple cursor based pagination (sqlite) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 1`] = `
 [
-  "[query] select \`u0\`.* from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3' order by \`u1\`.\`email\` desc, \`u1\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
+  "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` left join \`user\` as \`u2\` on \`u0\`.\`best_friend__id\` = \`u2\`.\`_id\` where \`u2\`.\`name\` = 'User 3' order by \`u2\`.\`email\` desc, \`u2\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3'",
 ]
 `;
 
 exports[`simple cursor based pagination (sqlite) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
 [
-  "[query] select \`u0\`.* from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3' and \`u1\`.\`email\` <= 'email-96' and \`u1\`.\`name\` <= 'User 3' and ((\`u1\`.\`email\` < 'email-96' and \`u1\`.\`name\` < 'User 3') or (\`u0\`.\`name\` >= 'User 3' and (\`u0\`.\`name\` > 'User 3' or (\`u0\`.\`age\` <= 38 and (\`u0\`.\`age\` < 38 or \`u0\`.\`email\` < 'email-76'))))) order by \`u1\`.\`email\` desc, \`u1\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
-  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` in (5) order by \`u0\`.\`email\` asc, \`u0\`.\`name\` asc",
+  "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` left join \`user\` as \`u2\` on \`u0\`.\`best_friend__id\` = \`u2\`.\`_id\` where \`u2\`.\`name\` = 'User 3' and \`u2\`.\`email\` <= 'email-96' and \`u2\`.\`name\` <= 'User 3' and ((\`u2\`.\`email\` < 'email-96' and \`u2\`.\`name\` < 'User 3') or (\`u0\`.\`name\` >= 'User 3' and (\`u0\`.\`name\` > 'User 3' or (\`u0\`.\`age\` <= 38 and (\`u0\`.\`age\` < 38 or \`u0\`.\`email\` < 'email-76'))))) order by \`u2\`.\`email\` desc, \`u2\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3'",
 ]
 `;

--- a/tests/features/custom-order/custom-order.mysql.test.ts
+++ b/tests/features/custom-order/custom-order.mysql.test.ts
@@ -238,6 +238,7 @@ describe('custom order [mysql]', () => {
     em.clear();
 
     const users = await em.find(User, {}, {
+      strategy: 'select-in',
       populate: ['tasks'],
       orderBy: {
         name: QueryOrder.ASC,
@@ -251,5 +252,19 @@ describe('custom order [mysql]', () => {
     expect(ret).toEqual(['u1-1c', 'u1-1b', 'u1-1a', 'u2-2b', 'u2-2a', 'u2-2c']);
     expect(mock.mock.calls[4][0]).toMatch('select `u0`.* from `user` as `u0` left join `task` as `t1` on `u0`.`id` = `t1`.`owner_id` order by `u0`.`name` asc, (case when `t1`.`priority` = \'low\' then 0 when `t1`.`priority` = \'medium\' then 1 when `t1`.`priority` = \'high\' then 2 else null end) asc');
     expect(mock.mock.calls[5][0]).toMatch('select `t0`.* from `task` as `t0` where `t0`.`owner_id` in (1, 2) order by (case when `t0`.`priority` = \'low\' then 0 when `t0`.`priority` = \'medium\' then 1 when `t0`.`priority` = \'high\' then 2 else null end) asc');
+
+    const users2 = await em.find(User, {}, {
+      populate: ['tasks'],
+      orderBy: {
+        name: QueryOrder.ASC,
+        tasks: {
+          priority: QueryOrder.ASC,
+        },
+      },
+    });
+
+    const ret2 = users2.flatMap(u => u.tasks.getItems()).map(({ owner, label }) => `${owner?.name}-${label}`);
+    expect(ret2).toEqual(['u1-1c', 'u1-1b', 'u1-1a', 'u2-2b', 'u2-2a', 'u2-2c']);
+    expect(mock.mock.calls[6][0]).toMatch("select `u0`.*, `t1`.`id` as `t1__id`, `t1`.`label` as `t1__label`, `t1`.`owner_id` as `t1__owner_id`, `t1`.`priority` as `t1__priority`, `t1`.`rating` as `t1__rating`, `t1`.`difficulty` as `t1__difficulty` from `user` as `u0` left join `task` as `t1` on `u0`.`id` = `t1`.`owner_id` order by `u0`.`name` asc, (case when `t1`.`priority` = 'low' then 0 when `t1`.`priority` = 'medium' then 1 when `t1`.`priority` = 'high' then 2 else null end) asc");
   });
 });

--- a/tests/features/custom-order/custom-order.postgres.test.ts
+++ b/tests/features/custom-order/custom-order.postgres.test.ts
@@ -239,7 +239,8 @@ describe('custom order [postgres]', () => {
     await em.persistAndFlush([user1, user2]);
     em.clear();
 
-    const users = await em.find(User, {}, {
+    const users1 = await em.find(User, {}, {
+      strategy: 'select-in',
       populate: ['tasks'],
       orderBy: {
         name: QueryOrder.ASC,
@@ -249,9 +250,23 @@ describe('custom order [postgres]', () => {
       },
     });
 
-    const ret = users.flatMap(u => u.tasks.getItems()).map(({ owner, label }) => `${owner?.name}-${label}`);
-    expect(ret).toEqual(['u1-1c', 'u1-1b', 'u1-1a', 'u2-2b', 'u2-2a', 'u2-2c']);
+    const ret1 = users1.flatMap(u => u.tasks.getItems()).map(({ owner, label }) => `${owner?.name}-${label}`);
+    expect(ret1).toEqual(['u1-1c', 'u1-1b', 'u1-1a', 'u2-2b', 'u2-2a', 'u2-2c']);
     expect(mock.mock.calls[4][0]).toMatch(`select "u0".* from "user" as "u0" left join "task" as "t1" on "u0"."id" = "t1"."owner_id" order by "u0"."name" asc, (case when "t1"."priority" = 'low' then 0 when "t1"."priority" = 'medium' then 1 when "t1"."priority" = 'high' then 2 else null end) asc`);
     expect(mock.mock.calls[5][0]).toMatch(`select "t0".* from "task" as "t0" where "t0"."owner_id" in (1, 2) order by (case when "t0"."priority" = 'low' then 0 when "t0"."priority" = 'medium' then 1 when "t0"."priority" = 'high' then 2 else null end) asc`);
+
+    const users2 = await em.find(User, {}, {
+      populate: ['tasks'],
+      orderBy: {
+        name: QueryOrder.ASC,
+        tasks: {
+          priority: QueryOrder.ASC,
+        },
+      },
+    });
+
+    const ret2 = users2.flatMap(u => u.tasks.getItems()).map(({ owner, label }) => `${owner?.name}-${label}`);
+    expect(ret2).toEqual(['u1-1c', 'u1-1b', 'u1-1a', 'u2-2b', 'u2-2a', 'u2-2c']);
+    expect(mock.mock.calls[6][0]).toMatch(`select "u0".*, "t1"."id" as "t1__id", "t1"."label" as "t1__label", "t1"."owner_id" as "t1__owner_id", "t1"."priority" as "t1__priority", "t1"."rating" as "t1__rating", "t1"."difficulty" as "t1__difficulty" from "user" as "u0" left join "task" as "t1" on "u0"."id" = "t1"."owner_id" order by "u0"."name" asc, (case when "t1"."priority" = 'low' then 0 when "t1"."priority" = 'medium' then 1 when "t1"."priority" = 'high' then 2 else null end) asc`);
   });
 });

--- a/tests/features/embeddables/GH4824.test.ts
+++ b/tests/features/embeddables/GH4824.test.ts
@@ -1,5 +1,6 @@
 import { Embeddable, Embedded, Entity, PrimaryKey, Property, Type } from '@mikro-orm/core';
 import { MikroORM } from '@mikro-orm/sqlite';
+import { mockLogger } from '../../helpers';
 
 class Point {
 
@@ -84,8 +85,10 @@ afterAll(async () => {
 });
 
 test('GH #4824', async () => {
+  const mock = mockLogger(orm);
   const user = await orm.em.findOne(User, {
     id: 1,
   });
   expect(user).toBeNull();
+  expect(mock.mock.calls[0][0]).toMatch('select `u0`.* from `user` as `u0` where `u0`.`id` = 1 limit 1');
 });

--- a/tests/features/events/events.mysql.test.ts
+++ b/tests/features/events/events.mysql.test.ts
@@ -210,20 +210,20 @@ describe('events (mysql)', () => {
     const authors2 = await orm.em.fork().find(Author2, {}, { populate: ['books'] });
     expect(authors2).toHaveLength(1);
     expect(EverythingSubscriber.log.map(l => [l[0], l[1].entity.constructor.name]).filter(a => a[0] === EventType.onLoad)).toEqual([
+      ['onLoad', 'Book2'],
+      ['onLoad', 'Book2'],
+      ['onLoad', 'Book2'],
       ['onLoad', 'Author2'],
-      ['onLoad', 'Book2'],
-      ['onLoad', 'Book2'],
-      ['onLoad', 'Book2'],
     ]);
     EverythingSubscriber.log.length = 0;
 
     const authors3 = await orm.em.fork().find(Author2, {}, { populate: ['*'] });
     expect(authors3).toHaveLength(1);
     expect(EverythingSubscriber.log.map(l => [l[0], l[1].entity.constructor.name]).filter(a => a[0] === EventType.onLoad)).toEqual([
+      ['onLoad', 'Book2'],
+      ['onLoad', 'Book2'],
+      ['onLoad', 'Book2'],
       ['onLoad', 'Author2'],
-      ['onLoad', 'Book2'],
-      ['onLoad', 'Book2'],
-      ['onLoad', 'Book2'],
       ['onLoad', 'Publisher2'],
       ['onLoad', 'BookTag2'],
       ['onLoad', 'BookTag2'],

--- a/tests/features/filters/filters.mysql.test.ts
+++ b/tests/features/filters/filters.mysql.test.ts
@@ -15,7 +15,9 @@ describe('filters [mysql]', () => {
     await orm.close(true);
   });
 
-  test('filters', async () => {
+  test('filters (select-in)', async () => {
+    orm.config.set('loadStrategy', 'select-in');
+
     const author = new Author2('Jon Snow', 'snow@wall.st');
     const book1 = new Book2('My Life on The Wall, part 1', author);
     const book2 = new Book2('My Life on The Wall, part 2', author);
@@ -107,6 +109,104 @@ describe('filters [mysql]', () => {
     expect(mock.mock.calls[9][0]).toMatch('delete from `book2` where length(perex) > 10000 and `uuid_pk` = \'321\'');
 
     // wut, name: 'god' should not be here?
+    await expect(orm.em.find(Book2, {}, {
+      filters: { hasAuthor: false, long: true, writtenBy: true },
+    })).rejects.toThrow(`No arguments provided for filter 'writtenBy'`);
+  });
+
+  test('filters (joined)', async () => {
+    orm.config.set('loadStrategy', 'joined');
+    const author = new Author2('Jon Snow', 'snow@wall.st');
+    const book1 = new Book2('My Life on The Wall, part 1', author);
+    const book2 = new Book2('My Life on The Wall, part 2', author);
+    const book3 = new Book2('My Life on The Wall, part 3', author);
+    author.books.add(book1, book2, book3);
+    const god = new Author2('God', 'hello@heaven.god');
+    const bible1 = new Book2('Bible', god);
+    const bible2 = new Book2('Bible pt. 2', god);
+    const bible3 = new Book2('Bible pt. 3', new Author2('Lol', 'lol@lol.lol'));
+    god.books.add(bible1, bible2, bible3);
+    await orm.em.persistAndFlush([author, god]);
+    orm.em.clear();
+
+    const mock = mockLogger(orm);
+    const books1 = await orm.em.find(Book2, { title: '123' }, {
+      populate: ['perex'],
+      orderBy: { title: QueryOrder.DESC },
+      filters: ['long', 'expensive'],
+    });
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `test_id` ' +
+      'from `book2` as `b0` ' +
+      'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
+      'where `b0`.`author_id` is not null and length(perex) > 10000 and `b0`.`price` > 1000 and `b0`.`title` = \'123\' ' +
+      'order by `b0`.`title` desc');
+
+    const books2 = await orm.em.find(Book2, { title: '123' }, {
+      filters: { hasAuthor: false, long: true, writtenBy: { name: 'God' } },
+    });
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `test_id` ' +
+      'from `book2` as `b0` ' +
+      'left join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
+      'left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` ' +
+      "where `a1`.`name` = 'God' and length(perex) > 10000 and `b0`.`title` = '123'");
+
+    const books3 = await orm.em.find(Book2, { title: '123' }, {
+      filters: false,
+    });
+    expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `test_id` ' +
+      'from `book2` as `b0` ' +
+      'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
+      'where `b0`.`title` = \'123\'');
+
+    const books4 = await orm.em.find(Book2, { title: '123' }, {
+      filters: true,
+    });
+    expect(mock.mock.calls[3][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `test_id` ' +
+      'from `book2` as `b0` ' +
+      'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
+      'where `b0`.`author_id` is not null and `b0`.`title` = \'123\'');
+
+    const b1 = await orm.em.findOne(Book2, '123', {
+      filters: { long: true },
+    });
+    expect(mock.mock.calls[4][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `test_id` ' +
+      'from `book2` as `b0` ' +
+      'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
+      'where `b0`.`author_id` is not null and length(perex) > 10000 and `b0`.`uuid_pk` = \'123\' limit 1');
+
+    const b2 = await orm.em.findOne(Book2, { author: { name: 'Jon' } }, {
+      filters: { hasAuthor: false, long: true },
+    });
+    expect(mock.mock.calls[5][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `test_id` ' +
+      'from `book2` as `b0` ' +
+      'left join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
+      'left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` ' +
+      "where length(perex) > 10000 and `a1`.`name` = 'Jon' " +
+      'limit 1');
+
+    await orm.em.count(Book2, { author: { name: 'Jon' } }, {
+      filters: { hasAuthor: false, long: true },
+    });
+    expect(mock.mock.calls[6][0]).toMatch('select count(*) as `count` ' +
+      'from `book2` as `b0` ' +
+      'left join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
+      'where length(perex) > 10000 and `a1`.`name` = \'Jon\'');
+
+    await orm.em.nativeUpdate(Book2, '123', { title: 'b123' }, {
+      filters: { hasAuthor: false, long: true },
+    });
+    expect(mock.mock.calls[7][0]).toMatch('update `book2` set `title` = \'b123\'');
+
+    await orm.em.nativeUpdate(Book2, '123', { title: 'b123' }, {
+      filters: { hasAuthor: false, long: true },
+    });
+    expect(mock.mock.calls[8][0]).toMatch('update `book2` set `title` = \'b123\' where length(perex) > 10000 and `uuid_pk` = \'123\'');
+
+    await orm.em.nativeDelete(Book2, '321', {
+      filters: { hasAuthor: false, long: true },
+    });
+    expect(mock.mock.calls[9][0]).toMatch('delete from `book2` where length(perex) > 10000 and `uuid_pk` = \'321\'');
+
     await expect(orm.em.find(Book2, {}, {
       filters: { hasAuthor: false, long: true, writtenBy: true },
     })).rejects.toThrow(`No arguments provided for filter 'writtenBy'`);

--- a/tests/features/filters/filters.postgres.test.ts
+++ b/tests/features/filters/filters.postgres.test.ts
@@ -166,7 +166,7 @@ describe('filters [postgres]', () => {
     orm.em.clear();
     mock.mockReset();
 
-    const e1 = await orm.em.findOneOrFail(Employee, employee.id, { populate: ['benefits.details'] });
+    const e1 = await orm.em.findOneOrFail(Employee, employee.id, { populate: ['benefits.details'], strategy: 'select-in' });
     expect(mock.mock.calls[0][0]).toMatch(`select "e0".* from "employee" as "e0" where "e0"."id" = $1 limit $2`);
     expect(mock.mock.calls[1][0]).toMatch(`select "b1".*, "e0"."benefit_id" as "fk__benefit_id", "e0"."employee_id" as "fk__employee_id" from "employee_benefits" as "e0" inner join "public"."benefit" as "b1" on "e0"."benefit_id" = "b1"."id" where "b1"."benefit_status" = $1 and "e0"."employee_id" in ($2)`);
     expect(mock.mock.calls[2][0]).toMatch(`select "b0".* from "benefit_detail" as "b0" where "b0"."active" = $1 and "b0"."benefit_id" in ($2)`);
@@ -176,7 +176,7 @@ describe('filters [postgres]', () => {
     orm.em.clear();
     mock.mockReset();
 
-    const e2 = await orm.em.findOneOrFail(Employee, employee.id, { populate: ['benefits.details'], strategy: LoadStrategy.JOINED });
+    const e2 = await orm.em.findOneOrFail(Employee, employee.id, { populate: ['benefits.details'], strategy: 'joined' });
     expect(mock.mock.calls[0][0]).toMatch('select "e0".*, "b1"."id" as "b1__id", "b1"."benefit_status" as "b1__benefit_status", "b1"."name" as "b1__name", "d3"."id" as "d3__id", "d3"."description" as "d3__description", "d3"."benefit_id" as "d3__benefit_id", "d3"."active" as "d3__active" ' +
       'from "employee" as "e0" ' +
       'left join "employee_benefits" as "e2" on "e0"."id" = "e2"."employee_id" ' +

--- a/tests/features/multiple-schemas/GH3177.test.ts
+++ b/tests/features/multiple-schemas/GH3177.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, ManyToMany, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, Reference, t } from '@mikro-orm/core';
+import { Collection, Entity, ManyToMany, ManyToOne, MikroORM, OneToMany, PrimaryKey } from '@mikro-orm/core';
 import { mockLogger } from '../../helpers';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 
@@ -87,6 +87,7 @@ test(`GH issue 3177`, async () => {
   const u2 = await orm.em.findOneOrFail(User, 1, { populate: ['accessProfile.permissions'] });
   expect(u2.accessProfile.permissions.getItems()).toHaveLength(3);
 
+  expect(mock).toHaveBeenCalledTimes(8);
   expect(mock.mock.calls[0][0]).toMatch(`begin`);
   expect(mock.mock.calls[1][0]).toMatch(`insert into "tenant_01"."user_access_profile" ("id") values (default) returning "id"`);
   expect(mock.mock.calls[2][0]).toMatch(`insert into "tenant_01"."user" ("id", "access_profile_id") values (1, 1)`);
@@ -94,7 +95,5 @@ test(`GH issue 3177`, async () => {
   expect(mock.mock.calls[4][0]).toMatch(`insert into "tenant_01"."access_profile_permission" ("permission_id", "access_profile_id") values (1, 1), (2, 1), (3, 1)`);
   expect(mock.mock.calls[5][0]).toMatch(`commit`);
   expect(mock.mock.calls[6][0]).toMatch(`select "p1".*, "a0"."permission_id" as "fk__permission_id", "a0"."access_profile_id" as "fk__access_profile_id" from "tenant_01"."access_profile_permission" as "a0" inner join "public"."permission" as "p1" on "a0"."permission_id" = "p1"."id" where "a0"."access_profile_id" in (1)`);
-  expect(mock.mock.calls[7][0]).toMatch(`select "u0".* from "tenant_01"."user" as "u0" where "u0"."id" = 1 limit 1`);
-  expect(mock.mock.calls[8][0]).toMatch(`select "u0".* from "tenant_01"."user_access_profile" as "u0" where "u0"."id" in (1)`);
-  expect(mock.mock.calls[9][0]).toMatch(`select "p1".*, "a0"."permission_id" as "fk__permission_id", "a0"."access_profile_id" as "fk__access_profile_id" from "tenant_01"."access_profile_permission" as "a0" inner join "public"."permission" as "p1" on "a0"."permission_id" = "p1"."id" where "a0"."access_profile_id" in (1)`);
+  expect(mock.mock.calls[7][0]).toMatch(`select "u0".*, "a1"."id" as "a1__id", "p2"."id" as "p2__id" from "tenant_01"."user" as "u0" left join "tenant_01"."user_access_profile" as "a1" on "u0"."access_profile_id" = "a1"."id" left join "tenant_01"."access_profile_permission" as "a3" on "a1"."id" = "a3"."access_profile_id" left join "public"."permission" as "p2" on "a3"."permission_id" = "p2"."id" where "u0"."id" = 1`);
 });

--- a/tests/features/partial-loading/partial-loading.mysql.test.ts
+++ b/tests/features/partial-loading/partial-loading.mysql.test.ts
@@ -115,8 +115,7 @@ describe('partial loading (mysql)', () => {
     // @ts-expect-error
     expect(r1[0].books[0].price).toBeUndefined();
     expect(r1[0].books[0].author).toBeDefined();
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id` from `author2` as `a0` where `a0`.`id` = ?');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`author_id`, `b0`.`title` from `book2` as `b0` where `b0`.`author_id` is not null and `b0`.`author_id` in (?) order by `b0`.`title` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`title` as `b1__title`, `b1`.`author_id` as `b1__author_id` from `author2` as `a0` left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null where `a0`.`id` = ? order by `b1`.`title` asc');
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -131,8 +130,7 @@ describe('partial loading (mysql)', () => {
     // @ts-expect-error
     expect(r2[0].books[0].price).toBeUndefined();
     expect(r2[0].books[0].author).toBeDefined();
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id` from `author2` as `a0` where `a0`.`id` = ?');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`author_id`, `b0`.`title` from `book2` as `b0` where `b0`.`author_id` is not null and `b0`.`author_id` in (?) order by `b0`.`title` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`title` as `b1__title`, `b1`.`author_id` as `b1__author_id` from `author2` as `a0` left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null where `a0`.`id` = ? order by `b1`.`title` asc');
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -147,8 +145,7 @@ describe('partial loading (mysql)', () => {
     // @ts-expect-error
     expect(r0[0].books[0].price).toBeUndefined();
     expect(r0[0].books[0].author).toBeDefined();
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id` from `author2` as `a0` where `a0`.`id` = ?');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`author_id`, `b0`.`title` from `book2` as `b0` where `b0`.`author_id` is not null and `b0`.`author_id` in (?) order by `b0`.`title` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`title` as `b1__title`, `b1`.`author_id` as `b1__author_id` from `author2` as `a0` left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null where `a0`.`id` = ? order by `b1`.`title` asc');
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -181,8 +178,7 @@ describe('partial loading (mysql)', () => {
     expect(r00[0].books[0].price).toBeUndefined();
     // @ts-expect-error
     expect(r00[0].books[0].author).toBeDefined();
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id` from `author2` as `a0` where `a0`.`id` = ?');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`title`, `b0`.`author_id` from `book2` as `b0` where `b0`.`author_id` is not null and `b0`.`author_id` in (?) order by `b0`.`title` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`title` as `b1__title` from `author2` as `a0` left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null where `a0`.`id` = ? order by `b1`.`title` asc');
   });
 
   test('partial nested loading (m:1)', async () => {
@@ -194,6 +190,7 @@ describe('partial loading (mysql)', () => {
       fields: ['uuid', 'title', 'author.email'],
       populate: ['author'],
       filters: false,
+      strategy: LoadStrategy.SELECT_IN,
     });
     expect(r1).toHaveLength(1);
     expect(r1[0].uuid).toBe(b1.uuid);
@@ -214,6 +211,7 @@ describe('partial loading (mysql)', () => {
       fields: ['uuid', 'title', 'author.email'],
       populate: ['author'],
       filters: false,
+      strategy: LoadStrategy.SELECT_IN,
     });
     expect(r2).toHaveLength(1);
     expect(r2[0].uuid).toBe(b1.uuid);
@@ -241,8 +239,7 @@ describe('partial loading (mysql)', () => {
     expect(r1[0].books[0].price).toBeUndefined();
     // @ts-expect-error
     expect(r1[0].books[0].author).toBeUndefined();
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name` from `book_tag2` as `b0`');
-    expect(mock.mock.calls[1][0]).toMatch('select `b1`.`title`, `b1`.`uuid_pk`, `b0`.`book_tag2_id` as `fk__book_tag2_id`, `b0`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `b2`.`id` as `test_id` from `book2_tags` as `b0` inner join `book2` as `b1` on `b0`.`book2_uuid_pk` = `b1`.`uuid_pk` left join `test2` as `b2` on `b1`.`uuid_pk` = `b2`.`book_uuid_pk` where `b0`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) order by `b0`.`order` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`title` as `b1__title` from `book_tag2` as `b0` left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` order by `b2`.`order` asc');
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -254,11 +251,10 @@ describe('partial loading (mysql)', () => {
     expect(r2[0].books[0].price).toBeUndefined();
     // @ts-expect-error
     expect(r2[0].books[0].author).toBeUndefined();
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name` from `book_tag2` as `b0` where `b0`.`name` = ?');
-    expect(mock.mock.calls[1][0]).toMatch('select `b1`.`title`, `b1`.`uuid_pk`, `b0`.`book_tag2_id` as `fk__book_tag2_id`, `b0`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `b2`.`id` as `test_id` from `book2_tags` as `b0` inner join `book2` as `b1` on `b0`.`book2_uuid_pk` = `b1`.`uuid_pk` left join `test2` as `b2` on `b1`.`uuid_pk` = `b2`.`book_uuid_pk` where `b0`.`book_tag2_id` in (?) order by `b0`.`order` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`title` as `b1__title` from `book_tag2` as `b0` left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` where `b0`.`name` = ? order by `b2`.`order` asc');
   });
 
-  test('partial nested loading (dot notation)', async () => {
+  test('partial nested loading (dot notation, select-in)', async () => {
     const god = await createEntities();
     const mock = mockLogger(orm, ['query']);
 
@@ -266,6 +262,7 @@ describe('partial loading (mysql)', () => {
       fields: ['name', 'books.title', 'books.author', 'books.author.email'],
       populate: ['books.author'],
       filters: false,
+      strategy: LoadStrategy.SELECT_IN,
     });
     expect(r1).toHaveLength(6);
     expect(r1[0].name).toBe('t1');
@@ -290,7 +287,6 @@ describe('partial loading (mysql)', () => {
       fields: ['name', 'books.title', 'books.author', 'books.author.email'],
       populate: ['books.author'],
       filters: false,
-      strategy: LoadStrategy.JOINED,
     });
     expect(r3).toHaveLength(6);
     expect(r3[0].name).toBe('t1');
@@ -317,7 +313,6 @@ describe('partial loading (mysql)', () => {
       fields: ['*', 'books.title', 'books.author', 'books.author.email'],
       populate: ['books.author'],
       filters: false,
-      strategy: LoadStrategy.JOINED,
     });
     expect(r2).toHaveLength(6);
     expect(mock.mock.calls).toHaveLength(1);
@@ -331,13 +326,14 @@ describe('partial loading (mysql)', () => {
       'order by `b2`.`order` asc');
   });
 
-  test('partial nested loading (object notation)', async () => {
+  test('partial nested loading (object notation, select-in)', async () => {
     const god = await createEntities();
     const mock = mockLogger(orm, ['query']);
 
     const r2 = await orm.em.find(BookTag2, {}, {
       fields: ['name', 'books.title', 'books.author', 'books.author.email'],
       filters: false,
+      strategy: LoadStrategy.SELECT_IN,
     });
     expect(r2).toHaveLength(6);
     expect(r2[0].name).toBe('t1');
@@ -361,7 +357,6 @@ describe('partial loading (mysql)', () => {
     const r3 = await orm.em.find(BookTag2, {}, {
       fields: ['name', 'books.title', 'books.author.email'],
       filters: false,
-      strategy: LoadStrategy.JOINED,
     });
     expect(r3).toHaveLength(6);
     expect(r3[0].name).toBe('t1');
@@ -381,11 +376,6 @@ describe('partial loading (mysql)', () => {
       'left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` ' +
       'left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` ' +
       'left join `author2` as `a3` on `b1`.`author_id` = `a3`.`id`');
-
-    // Expected substring: "
-    // select `b0`.`id`, `b0`.`name`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`title` as `b1__title`, `b1`.`author_id` as `b1__author_id`, `a3`.`id` as `a3__id`, `a3`.`email` as `a3__email` from `book_tag2` as `b0` left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` left join `author2` as `a3` on `b1`.`author_id` = `a3`.`id`"
-    // Received string:    "
-    // select `b0`.`id`, `b0`.`name`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`title` as `b1__title`, `a3`.`id` as `a3__id`, `a3`.`email` as `a3__email` from `book_tag2` as `b0` left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` left join `author2` as `a3` on `b1`.`author_id` = `a3`.`id` [took 7 ms] (via read connection 'read-1')"
   });
 
 });

--- a/tests/features/sharing-column-in-composite-pk-fk.test.ts
+++ b/tests/features/sharing-column-in-composite-pk-fk.test.ts
@@ -233,8 +233,7 @@ test('shared column as composite PK and FK in M:N', async () => {
   await orm.em.flush();
 
   expect(mock.mock.calls).toEqual([
-    [`[query] select "o0".* from "order" as "o0" where "o0"."id" = 'd09f1159-c5b0-4336-bfed-2543b5422ba7' limit 1`],
-    [`[query] select "p1".*, "o0"."product_id" as "fk__product_id", "o0"."organization_id" as "fk__organization_id", "o0"."order_id" as "fk__order_id", "o0"."organization_id" as "fk__organization_id" from "order_item" as "o0" inner join "public"."product" as "p1" on "o0"."product_id" = "p1"."id" and "o0"."organization_id" = "p1"."organization_id" where ("o0"."order_id", "o0"."organization_id") in (('d09f1159-c5b0-4336-bfed-2543b5422ba7', 'a900a4da-c464-4bd4-88a3-e41e1d33dc2e'))`],
+    [`[query] select "o0".*, "p1"."id" as "p1__id", "p1"."organization_id" as "p1__organization_id" from "order" as "o0" left join "order_item" as "o2" on "o0"."id" = "o2"."order_id" and "o0"."organization_id" = "o2"."organization_id" left join "product" as "p1" on "o2"."product_id" = "p1"."id" and "o2"."organization_id" = "p1"."organization_id" where "o0"."id" = 'd09f1159-c5b0-4336-bfed-2543b5422ba7'`],
     ['[query] begin'],
     [`[query] insert into "product" ("id", "organization_id") values ('ffffffff-7c23-421c-9ae2-9d989630159a', 'a900a4da-c464-4bd4-88a3-e41e1d33dc2e')`],
     [`[query] update "order" set "number" = 321 where "id" = 'd09f1159-c5b0-4336-bfed-2543b5422ba7' and "organization_id" = 'a900a4da-c464-4bd4-88a3-e41e1d33dc2e'`],

--- a/tests/features/single-table-inheritance/GH4423.test.ts
+++ b/tests/features/single-table-inheritance/GH4423.test.ts
@@ -83,30 +83,18 @@ describe('GH issue 4423', () => {
 
   test('The owning side is in the main entity, This one chooses the wrong column of the pivot table', async () => {
     const mock = mockLogger(orm);
-    await orm.em.find(
-      Task,
-      {},
-      {
-        populate: ['managers'],
-      },
-    );
-    expect(mock.mock.calls[1][0]).toMatch(
-      "select `u1`.*, `t0`.`manager_id` as `fk__manager_id`, `t0`.`task_id` as `fk__task_id` from `task_managers` as `t0` inner join `user` as `u1` on `t0`.`manager_id` = `u1`.`id` and `u1`.`type` = 'manager' where `t0`.`task_id` in (1)",
-    );
+    await orm.em.findAll(Task, {
+      populate: ['managers'],
+    });
+    expect(mock.mock.calls[0][0]).toMatch("select `t0`.*, `m1`.`id` as `m1__id`, `m1`.`name` as `m1__name`, `m1`.`type` as `m1__type`, `m1`.`favorite_task_id` as `m1__favorite_task_id` from `task` as `t0` left join `task_managers` as `t2` on `t0`.`id` = `t2`.`task_id` left join `user` as `m1` on `t2`.`manager_id` = `m1`.`id` and `m1`.`type` = 'manager'");
   });
 
   test('The owning side is in the relation, This one works normally', async () => {
     const mock = mockLogger(orm);
-    await orm.em.find(
-      Manager,
-      {},
-      {
-        populate: ['tasks'],
-      },
-    );
+    await orm.em.findAll(Manager, {
+      populate: ['tasks'],
+    });
 
-    expect(mock.mock.calls[1][0]).toMatch(
-      'select `t1`.*, `t0`.`manager_id` as `fk__manager_id`, `t0`.`task_id` as `fk__task_id` from `task_managers` as `t0` inner join `task` as `t1` on `t0`.`task_id` = `t1`.`id` where `t0`.`manager_id` in (1)',
-    );
+    expect(mock.mock.calls[0][0]).toMatch("select `m0`.*, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name` from `user` as `m0` left join `task_managers` as `t2` on `m0`.`id` = `t2`.`manager_id` left join `task` as `t1` on `t2`.`task_id` = `t1`.`id` where `m0`.`type` = 'manager'");
   });
 });

--- a/tests/issues/GH1657.test.ts
+++ b/tests/issues/GH1657.test.ts
@@ -27,6 +27,7 @@ class OrderItem {
 
   @ManyToOne({
     entity: () => Order,
+    strategy: LoadStrategy.SELECT_IN,
     eager: true,
     nullable: true,
   })
@@ -34,7 +35,6 @@ class OrderItem {
 
   @ManyToOne({
     entity: () => Order,
-    strategy: LoadStrategy.JOINED,
     eager: true,
     nullable: true,
   })

--- a/tests/issues/GH1882.test.ts
+++ b/tests/issues/GH1882.test.ts
@@ -59,12 +59,12 @@ describe('GH issue 1882', () => {
     const mock = mockLogger(orm, ['query']);
     const cond =  { $or: [{ barItems: '5678' }, { name: 'fooName' }] };
 
-    await orm.em.fork().find(Foo, cond, { populate: ['barItems'], populateWhere: PopulateHint.INFER });
+    await orm.em.fork().find(Foo, cond, { populate: ['barItems'], populateWhere: PopulateHint.INFER, strategy: 'select-in' });
     expect(mock.mock.calls[0][0]).toMatch('select `f0`.* from `foo` as `f0` left join `bar` as `b1` on `f0`.`id` = `b1`.`foo_id` where (`b1`.`id` = ? or `f0`.`name` = ?)');
     expect(mock.mock.calls[1][0]).toMatch('select `b0`.* from `bar` as `b0` where `b0`.`foo_id` in (?) and `b0`.`id` = ?');
     mock.mockReset();
 
-    await orm.em.fork().find(Foo, cond, { populate: ['barItems'] });
+    await orm.em.fork().find(Foo, cond, { populate: ['barItems'], strategy: 'select-in' });
     expect(mock.mock.calls[0][0]).toMatch('select `f0`.* from `foo` as `f0` left join `bar` as `b1` on `f0`.`id` = `b1`.`foo_id` where (`b1`.`id` = ? or `f0`.`name` = ?)');
     expect(mock.mock.calls[1][0]).toMatch('select `b0`.* from `bar` as `b0` where `b0`.`foo_id` in (?)');
   });
@@ -85,18 +85,88 @@ describe('GH issue 1882', () => {
     const mock = mockLogger(orm, ['query']);
     const cond =  { $and: [{ barItems: '3456' }] };
 
-    await orm.em.find(Foo, cond, { populate: ['barItems'], populateWhere: PopulateHint.INFER });
+    await orm.em.find(Foo, cond, { populate: ['barItems'], populateWhere: PopulateHint.INFER, strategy: 'select-in' });
     orm.em.clear();
 
     expect(mock.mock.calls[0][0]).toMatch('select `f0`.* from `foo` as `f0` left join `bar` as `b1` on `f0`.`id` = `b1`.`foo_id` where `b1`.`id` = ?');
     expect(mock.mock.calls[1][0]).toMatch('select `b0`.* from `bar` as `b0` where `b0`.`foo_id` in (?) and `b0`.`id` = ?');
     mock.mockReset();
 
-    await orm.em.find(Foo, cond, { populate: ['barItems'] });
+    await orm.em.find(Foo, cond, { populate: ['barItems'], strategy: 'select-in' });
     orm.em.clear();
 
     expect(mock.mock.calls[0][0]).toMatch('select `f0`.* from `foo` as `f0` left join `bar` as `b1` on `f0`.`id` = `b1`.`foo_id` where `b1`.`id` = ?');
     expect(mock.mock.calls[1][0]).toMatch('select `b0`.* from `bar` as `b0` where `b0`.`foo_id` in (?)');
+  });
+
+  test(`GH issue 1882-3`, async () => {
+    const fooItem = new Foo();
+    fooItem.id = 12345n;
+    fooItem.name = 'fooName';
+
+    const barItem = new Bar();
+    barItem.id = 56789n;
+    barItem.name = 'barName1';
+    barItem.foo = fooItem;
+
+    await orm.em.persistAndFlush([barItem]);
+    orm.em.clear();
+
+    const mock = mockLogger(orm, ['query']);
+    const cond =  { $or: [{ barItems: '5678' }, { name: 'fooName' }] };
+
+    await orm.em.fork().find(Foo, cond, { populate: ['barItems'], populateWhere: PopulateHint.INFER, strategy: 'joined' });
+    expect(mock.mock.calls[0][0]).toMatch('select `f0`.*, ' +
+      '`b1`.`id` as `b1__id`, `b1`.`foo_id` as `b1__foo_id`, `b1`.`name` as `b1__name` ' +
+      'from `foo` as `f0` ' +
+      'left join `bar` as `b1` on `f0`.`id` = `b1`.`foo_id` ' +
+      'where (`b1`.`id` = ? or `f0`.`name` = ?)');
+    mock.mockReset();
+
+    await orm.em.fork().find(Foo, cond, { populate: ['barItems'], strategy: 'joined' });
+    expect(mock.mock.calls[0][0]).toMatch('select `f0`.*, ' +
+      '`b1`.`id` as `b1__id`, `b1`.`foo_id` as `b1__foo_id`, `b1`.`name` as `b1__name` ' +
+      'from `foo` as `f0` ' +
+      'left join `bar` as `b1` on `f0`.`id` = `b1`.`foo_id` ' +
+      'left join `bar` as `b2` on `f0`.`id` = `b2`.`foo_id` ' +
+      'where (`b2`.`id` = ? or `f0`.`name` = ?)');
+  });
+
+  test(`GH issue 1882-4`, async () => {
+    const fooItem = new Foo();
+    fooItem.id = 90121n;
+    fooItem.name = 'fooName';
+
+    const barItem = new Bar();
+    barItem.id = 34561n;
+    barItem.name = 'barName';
+    barItem.foo = fooItem;
+
+    await orm.em.persistAndFlush([barItem]);
+    orm.em.clear();
+
+    const mock = mockLogger(orm, ['query']);
+    const cond =  { $and: [{ barItems: '3456' }] };
+
+    await orm.em.find(Foo, cond, { populate: ['barItems'], populateWhere: PopulateHint.INFER, strategy: 'joined' });
+    orm.em.clear();
+
+    expect(mock.mock.calls[0][0]).toMatch('select `f0`.*, ' +
+      '`b1`.`id` as `b1__id`, `b1`.`foo_id` as `b1__foo_id`, `b1`.`name` as `b1__name` ' +
+      'from `foo` as `f0` ' +
+      'left join `bar` as `b1` on `f0`.`id` = `b1`.`foo_id` ' +
+      'where `b1`.`id` = ?');
+    mock.mockReset();
+
+    await orm.em.find(Foo, cond, { populate: ['barItems'], strategy: 'joined' });
+    orm.em.clear();
+
+    expect(mock.mock.calls[0][0]).toMatch('select `f0`.*, ' +
+      '`b1`.`id` as `b1__id`, `b1`.`foo_id` as `b1__foo_id`, `b1`.`name` as `b1__name` ' +
+      'from `foo` as `f0` ' +
+      'left join `bar` as `b1` on `f0`.`id` = `b1`.`foo_id` ' +
+      'left join `bar` as `b2` on `f0`.`id` = `b2`.`foo_id` ' +
+      'where `b2`.`id` = ?');
   });
 
 });

--- a/tests/issues/GH234.test.ts
+++ b/tests/issues/GH234.test.ts
@@ -38,51 +38,80 @@ describe('GH issue 234', () => {
       entities: [A, B],
       dbName: ':memory:',
     });
-    await orm.schema.dropSchema();
     await orm.schema.createSchema();
+
+    const a1 = new A();
+    a1.id = 1;
+    a1.name = 'a1';
+    const a2 = new A();
+    a2.id = 2;
+    a2.name = 'a2';
+    const a3 = new A();
+    a3.id = 3;
+    a3.name = 'a3';
+    const b = new B();
+    b.id = 1;
+    b.name = 'b';
+    b.aCollection.add(a1, a2, a3);
+    await orm.em.fork().persistAndFlush(b);
   });
 
   afterAll(() => orm.close(true));
 
-  test('search by m:n', async () => {
-    const a1 = new A();
-    a1.name = 'a1';
-    const a2 = new A();
-    a2.name = 'a2';
-    const a3 = new A();
-    a3.name = 'a3';
-    const b = new B();
-    b.name = 'b';
-    b.aCollection.add(a1, a2, a3);
-    await orm.em.persistAndFlush(b);
-    orm.em.clear();
-
+  test('search by m:n (select-in)', async () => {
     const mock = mockLogger(orm, ['query']);
-    const res1 = await orm.em.find(B, { aCollection: [1, 2, 3] }, { populate: ['aCollection'], populateWhere: PopulateHint.INFER });
+    const res1 = await orm.em.find(B, { aCollection: [1, 2, 3] }, { populate: ['aCollection'], strategy: 'select-in', populateWhere: PopulateHint.INFER });
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.* from `b` as `b0` left join `b_a_collection` as `b1` on `b0`.`id` = `b1`.`b_id` where `b1`.`a_id` in (?, ?, ?)');
     expect(mock.mock.calls[1][0]).toMatch('select `a1`.*, `b0`.`a_id` as `fk__a_id`, `b0`.`b_id` as `fk__b_id` from `b_a_collection` as `b0` inner join `a` as `a1` on `b0`.`a_id` = `a1`.`id` where `a1`.`id` in (?, ?, ?) and `b0`.`b_id` in (?) order by `b0`.`id` asc');
-    expect(res1.map(b => b.id)).toEqual([b.id]);
+    expect(res1.map(b => b.id)).toEqual([1]);
+
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+    const res2 = await orm.em.find(A, { bCollection: [1, 2, 3] }, { populate: ['bCollection'], strategy: 'select-in', populateWhere: PopulateHint.INFER });
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.* from `a` as `a0` left join `b_a_collection` as `b1` on `a0`.`id` = `b1`.`a_id` where `b1`.`b_id` in (?, ?, ?)');
+    expect(mock.mock.calls[1][0]).toMatch('select `b1`.*, `b0`.`a_id` as `fk__a_id`, `b0`.`b_id` as `fk__b_id` from `b_a_collection` as `b0` inner join `b` as `b1` on `b0`.`b_id` = `b1`.`id` where `b1`.`id` in (?, ?, ?) and `b0`.`a_id` in (?, ?, ?) order by `b0`.`id` asc');
+    expect(res2.map(a => a.id)).toEqual([1, 2, 3]);
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const res3 = await orm.em.find(B, { aCollection: [1, 2, 3] }, { populate: ['aCollection'], strategy: 'select-in' });
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.* from `b` as `b0` left join `b_a_collection` as `b1` on `b0`.`id` = `b1`.`b_id` where `b1`.`a_id` in (?, ?, ?)');
+    expect(mock.mock.calls[1][0]).toMatch('select `a1`.*, `b0`.`a_id` as `fk__a_id`, `b0`.`b_id` as `fk__b_id` from `b_a_collection` as `b0` inner join `a` as `a1` on `b0`.`a_id` = `a1`.`id` where `b0`.`b_id` in (?) order by `b0`.`id` asc');
+    expect(res3.map(b => b.id)).toEqual([1]);
+
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+    const res4 = await orm.em.find(A, { bCollection: [1, 2, 3] }, { populate: ['bCollection'], strategy: 'select-in' });
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.* from `a` as `a0` left join `b_a_collection` as `b1` on `a0`.`id` = `b1`.`a_id` where `b1`.`b_id` in (?, ?, ?)');
+    expect(mock.mock.calls[1][0]).toMatch('select `b1`.*, `b0`.`a_id` as `fk__a_id`, `b0`.`b_id` as `fk__b_id` from `b_a_collection` as `b0` inner join `b` as `b1` on `b0`.`b_id` = `b1`.`id` where `b0`.`a_id` in (?, ?, ?) order by `b0`.`id` asc');
+    expect(res4.map(a => a.id)).toEqual([1, 2, 3]);
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+  });
+
+  test('search by m:n (joined)', async () => {
+    const mock = mockLogger(orm, ['query']);
+    const res1 = await orm.em.find(B, { aCollection: [1, 2, 3] }, { populate: ['aCollection'], populateWhere: PopulateHint.INFER });
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `a1`.`id` as `a1__id`, `a1`.`name` as `a1__name` from `b` as `b0` left join `b_a_collection` as `b2` on `b0`.`id` = `b2`.`b_id` and `b2`.`a_id` in (?, ?, ?) left join `a` as `a1` on `b2`.`a_id` = `a1`.`id` where `b2`.`a_id` in (?, ?, ?) order by `b2`.`id` asc');
+    expect(res1.map(b => b.id)).toEqual([1]);
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     const res2 = await orm.em.find(A, { bCollection: [1, 2, 3] }, { populate: ['bCollection'], populateWhere: PopulateHint.INFER });
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.* from `a` as `a0` left join `b_a_collection` as `b1` on `a0`.`id` = `b1`.`a_id` where `b1`.`b_id` in (?, ?, ?)');
-    expect(mock.mock.calls[1][0]).toMatch('select `b1`.*, `b0`.`a_id` as `fk__a_id`, `b0`.`b_id` as `fk__b_id` from `b_a_collection` as `b0` inner join `b` as `b1` on `b0`.`b_id` = `b1`.`id` where `b1`.`id` in (?, ?, ?) and `b0`.`a_id` in (?, ?, ?) order by `b0`.`id` asc');
-    expect(res2.map(a => a.id)).toEqual([a1.id, a2.id, a3.id]);
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`id` as `b1__id`, `b1`.`name` as `b1__name` from `a` as `a0` left join `b_a_collection` as `b2` on `a0`.`id` = `b2`.`a_id` and `b2`.`b_id` in (?, ?, ?) left join `b` as `b1` on `b2`.`b_id` = `b1`.`id` where `b2`.`b_id` in (?, ?, ?) order by `b2`.`id` asc');
+    expect(res2.map(a => a.id)).toEqual([1, 2, 3]);
     orm.em.clear();
     mock.mock.calls.length = 0;
 
-    const res3 = await orm.em.find(B, { aCollection: [1, 2, 3] }, { populate: ['aCollection'] });
+    const res3 = await orm.em.find(B, { aCollection: [1, 2, 3] }, { populate: ['aCollection'], strategy: 'select-in' });
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.* from `b` as `b0` left join `b_a_collection` as `b1` on `b0`.`id` = `b1`.`b_id` where `b1`.`a_id` in (?, ?, ?)');
-    expect(mock.mock.calls[1][0]).toMatch('select `a1`.*, `b0`.`a_id` as `fk__a_id`, `b0`.`b_id` as `fk__b_id` from `b_a_collection` as `b0` inner join `a` as `a1` on `b0`.`a_id` = `a1`.`id` where `b0`.`b_id` in (?) order by `b0`.`id` asc');
-    expect(res3.map(b => b.id)).toEqual([b.id]);
+    expect(res3.map(b => b.id)).toEqual([1]);
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     const res4 = await orm.em.find(A, { bCollection: [1, 2, 3] }, { populate: ['bCollection'] });
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.* from `a` as `a0` left join `b_a_collection` as `b1` on `a0`.`id` = `b1`.`a_id` where `b1`.`b_id` in (?, ?, ?)');
-    expect(mock.mock.calls[1][0]).toMatch('select `b1`.*, `b0`.`a_id` as `fk__a_id`, `b0`.`b_id` as `fk__b_id` from `b_a_collection` as `b0` inner join `b` as `b1` on `b0`.`b_id` = `b1`.`id` where `b0`.`a_id` in (?, ?, ?) order by `b0`.`id` asc');
-    expect(res4.map(a => a.id)).toEqual([a1.id, a2.id, a3.id]);
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`id` as `b1__id`, `b1`.`name` as `b1__name` from `a` as `a0` left join `b_a_collection` as `b2` on `a0`.`id` = `b2`.`a_id` left join `b` as `b1` on `b2`.`b_id` = `b1`.`id` left join `b_a_collection` as `b3` on `a0`.`id` = `b3`.`a_id` where `b3`.`b_id` in (?, ?, ?) order by `b2`.`id` asc');
+    expect(res4.map(a => a.id)).toEqual([1, 2, 3]);
     orm.em.clear();
     mock.mock.calls.length = 0;
   });

--- a/tests/issues/GH4843.test.ts
+++ b/tests/issues/GH4843.test.ts
@@ -92,7 +92,23 @@ describe('populate with citext', () => {
 
   afterAll(() => orm.close());
 
-  test('composite FK', async () => {
+  test('composite FK (select-in)', async () => {
+    const a1 = await orm.em.fork().find(A, ['test1', 'test2'], { populate: ['c'], strategy: 'select-in' });
+    expect(a1[0].c.$.toArray()).toEqual([{ id: 1, a: { id1: 'test1', id2: 'test2' }, b: 'test3' }]);
+
+    const a2 = await orm.em.fork().find(A, ['asdf', 'test'], { populate: ['c'], strategy: 'select-in' });
+    expect(a2[0].c.$.toArray()).toEqual([{ id: 2, a: { id1: 'asdf', id2: 'test' }, b: 'test' }]);
+  });
+
+  test('simple FK (select-in)', async () => {
+    const b1 = await orm.em.fork().find(B, 'test3', { populate: ['c'], strategy: 'select-in' });
+    expect(b1[0].c.$.toArray()).toEqual([{ id: 1, a: { id1: 'test1', id2: 'test2' }, b: 'test3' }]);
+
+    const b2 = await orm.em.fork().find(B, 'test', { populate: ['c'], strategy: 'select-in' });
+    expect(b2[0].c.$.toArray()).toEqual([{ id: 2, a: { id1: 'asdf', id2: 'test' }, b: 'test' }]);
+  });
+
+  test('composite FK (joined)', async () => {
     const a1 = await orm.em.fork().find(A, ['test1', 'test2'], { populate: ['c'] });
     expect(a1[0].c.$.toArray()).toEqual([{ id: 1, a: { id1: 'test1', id2: 'test2' }, b: 'test3' }]);
 
@@ -100,7 +116,7 @@ describe('populate with citext', () => {
     expect(a2[0].c.$.toArray()).toEqual([{ id: 2, a: { id1: 'asdf', id2: 'test' }, b: 'test' }]);
   });
 
-  test('simple FK', async () => {
+  test('simple FK (joined)', async () => {
     const b1 = await orm.em.fork().find(B, 'test3', { populate: ['c'] });
     expect(b1[0].c.$.toArray()).toEqual([{ id: 1, a: { id1: 'test1', id2: 'test2' }, b: 'test3' }]);
 

--- a/tests/issues/GH572.test.ts
+++ b/tests/issues/GH572.test.ts
@@ -35,7 +35,6 @@ describe('GH issue 572', () => {
       entities: [A, B],
       dbName: ':memory:',
     });
-    await orm.schema.dropSchema();
     await orm.schema.createSchema();
   });
 
@@ -47,7 +46,7 @@ describe('GH issue 572', () => {
       orderBy: { b: { camelCaseField: QueryOrder.ASC } },
       populate: ['b'],
     });
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`id` as `b_id` from `a` as `a0` left join `b` as `b1` on `a0`.`id` = `b1`.`a_id` order by `b1`.`camel_case_field` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`id` as `b1__id`, `b1`.`camel_case_field` as `b1__camel_case_field`, `b1`.`a_id` as `b1__a_id`, `b1`.`id` as `b_id` from `a` as `a0` left join `b` as `b1` on `a0`.`id` = `b1`.`a_id` order by `b1`.`camel_case_field` asc');
     expect(res1).toHaveLength(0);
     const qb1 = orm.em.createQueryBuilder(A, 'a').select('a.*').orderBy({ b: { camelCaseField: QueryOrder.ASC } });
     expect(qb1.getQuery()).toMatch('select `a`.* from `a` as `a` left join `b` as `b1` on `a`.`id` = `b1`.`a_id` order by `b1`.`camel_case_field` asc');


### PR DESCRIPTION
This builds on the foundation of #4957, which resolved the biggest difference of the strategies. As part of the switch, few other smaller bugs were also fixed, as most of the test suite is now using the joined strategy too, so it uncovered some bugs that were fixed only with the select-in.

To keep the old behaviour, you can override the default loading strategy in your ORM config.