### PR TITLE
feat(entity-generator): allow local and global configuration of all options

### DIFF
--- a/docs/docs/entity-generator.md
+++ b/docs/docs/entity-generator.md
@@ -2,23 +2,27 @@
 title: Entity Generator
 ---
 
-To generate entities from existing database schema, you can use `EntityGenerator` helper.
+To generate entities from existing database schema, you can use the `EntityGenerator` helper. It lives in its own package called `@mikro-orm/entity-generator`:
 
-Install it with
-
-```sh
-yarn add @mikro-orm/entity-generator
-```
-
-or
-
-```sh
-npm i -s @mikro-orm/entity-generator
+```bash npm2yarn
+npm install @mikro-orm/entity-generator
 ```
 
 > The version needs to be aligned with the `@mikro-orm/core` package and the database driver package.
 
-You can use it via CLI:
+To use it, you need to register the `EntityGenerator` extension in your ORM config:
+
+```ts
+import { defineConfig } from '@mikro-orm/postgresql';
+import { EntityGenerator } from '@mikro-orm/entity-generator';
+
+export default defineConfig({
+  dbName: 'test',
+  extensions: [EntityGenerator],
+});
+```
+
+Then you can use it either via CLI:
 
 > To work with the CLI, first install `@mikro-orm/cli` package locally. The version needs to be aligned with the `@mikro-orm/core` package.
 
@@ -31,20 +35,21 @@ Or you can create simple script where you initialize MikroORM like this:
 
 ```ts title="./generate-entities.ts"
 import { MikroORM } from '@mikro-orm/core';
+import { EntityGenerator } from '@mikro-orm/entity-generator';
 
 (async () => {
   const orm = await MikroORM.init({
     discovery: {
       // we need to disable validation for no entities
       warnWhenNoEntities: false,
+      extensions: [EntityGenerator],
     },
     dbName: 'your-db-name',
     // ...
   });
-  const generator = orm.getEntityGenerator();
-  const dump = await generator.generate({
+  const dump = await orm.entityGenerator.generate({
     save: true,
-    baseDir: process.cwd() + '/my-entities',
+    path: process.cwd() + '/my-entities',
   });
   console.log(dump);
   await orm.close(true);
@@ -59,39 +64,34 @@ $ ts-node generate-entities
 
 ## Advanced configuration
 
-The behaviour of the entity generator can be adjusted via `entityGenerator` section in the ORM config. Available options:
+The behaviour of the entity generator can be adjusted either via `entityGenerator` section in the ORM config, or with the `GenerateOptions` object (parameter of the `generate` method), which takes precedence over the global configuration. 
 
-| Option                         | Type                             | Default   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-|--------------------------------|----------------------------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `bidirectionalRelations`       | `boolean`                        | `false`   | By default, the `EntityGenerator` generates only owning sides of relations (e.g. M:1). If set to true, generates also the inverse sides for them                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `identifiedReferences`         | `boolean`                        | `false`   | If set to `true`, generate M:1 and 1:1 relations as wrapped references.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `entitySchema`                 | `boolean`                        | `false`   | By default, generate entities using decorators. If `true`, generate the entities using `EntitySchema` instead.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| `esmImport`                    | `boolean`                        | `false`   | By default, import statements for entities without extensions are used. If set to `true`, uses ESM style import for imported entities, i.e. adds a ".js" suffix as extension.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `scalarTypeInDecorator`        | `boolean`                        | `false`   | If `true`, include the `type` option in scalar property decorators. This information is discovered at runtime, but the process of discovery can be skipped by including this option in the decorator. If using `EntitySchema`, this type information is always included.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `scalarPropertiesForRelations` | `'never' \| 'always' \| 'smart'` | `'never'` | <ul><li> `'never'` - Do not generate any scalar properties for columns covered by foreign key relations. This effectively forces the application to always provide the entire relation, or (if all columns in the relation are nullable) omit the entire relation.</li><li> `'always'` - Generate all scalar properties for all columns covered by foreign key relations. This enables the application to deal with code that disables foreign key checks.</li><li> `'smart'` - Only generate scalar properties for foreign key relations, where doing so is necessary to enable the management of rows where a composite foreign key is not enforced due to some columns being set to NULL. This enables the application to deal with all rows that could possibly be part of a table, even when foreign key checks are always enabled.</li></ul> |
+Available options:
 
-The call to `generate()` accepts the following options:
+| Option                                                         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+|----------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `schema: string`                                               | The target schema to generate entities for. Defaults to what the main config would use.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `skipTables: string[]`                                         | Ignore some database tables. Accepts array of table names. If there is a foreign key reference to a skipped table, the generated code will be as if that foreign key did not exist.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `skipColumns`                                                  | Ignore some database tables columns. Accepts an object, where keys are table names with schema prefix if available, values are arrays of column names. If a skipped column is the target of a foreign key reference, the generated code will look as if that foreign key did not exist.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |                 
+| `save: boolean`                                                | Whether to save the generated entities as files.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `path: string`                                                 | Folder to save the generated entities in, if saving is enabled. Defaults to a folder called `generated-entities` inside the `baseDir` of the main config.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `bidirectionalRelations: boolean`                              | By default, the `EntityGenerator` generates only owning sides of relations (e.g. M:1). If set to true, generates also the inverse sides for them                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `identifiedReferences: boolean`                                | If set to `true`, generate M:1 and 1:1 relations as wrapped references.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `entitySchema: boolean`                                        | By default, generate entities using decorators. If `true`, generate the entities using `EntitySchema` instead.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `esmImport: boolean`                                           | By default, import statements for entities without extensions are used. If set to `true`, uses ESM style import for imported entities, i.e. adds a `.js` suffix as extension.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `scalarTypeInDecorator: boolean`                               | If `true`, include the `type` option in scalar property decorators. This information is discovered at runtime, but the process of discovery can be skipped by including this option in the decorator. If using `EntitySchema`, this type information is always included.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `scalarPropertiesForRelations: 'never' \| 'always' \| 'smart'` | <ul><li> `'never'` (default) - Do not generate any scalar properties for columns covered by foreign key relations. This effectively forces the application to always provide the entire relation, or (if all columns in the relation are nullable) omit the entire relation.</li><li> `'always'` - Generate all scalar properties for all columns covered by foreign key relations. This enables the application to deal with code that disables foreign key checks.</li><li> `'smart'` - Only generate scalar properties for foreign key relations, where doing so is necessary to enable the management of rows where a composite foreign key is not enforced due to some columns being set to NULL. This enables the application to deal with all rows that could possibly be part of a table, even when foreign key checks are always enabled.</li></ul> |
 
-| Option        | Type                               | Default                                              | Description                                                                                                                                                                                                                                                                             |
-|---------------|------------------------------------|------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `schema`      | `string`                           | `this.config.get('dbName`)`                          | The target schema to generate entities for. Defaults to what the main config would use.                                                                                                                                                                                                 |
-| `skipTables`  | `string[]`                         | `[]`                                                 | Ignore some database tables. Accepts array of table names. If there is a foreign key reference to a skipped table, the generated code will be as if that foreign key did not exist.                                                                                                     |
-| `skipColumns` | `{[tableNames: string]: string[]}` | `{}`                                                 | Ignore some database tables columns. Accepts an object, where keys are table names with schema prefix if available, values are arrays of column names. If a skipped column is the target of a foreign key reference, the generated code will look as if that foreign key did not exist. |                 
-| `save`        | `boolean`                          | `false`                                              | Whether to save the generated entities as files.                                                                                                                                                                                                                                        |
-| `baseDir`     | `string`                           | `this.config.get('baseDir') + '/generated-entities'` | Folder to save the generated entities in, if saving is enabled. Defaults to a folder called `generated-entities` inside the `baseDir` of the main config.                                                                                                                               |
-
-Example configuration and run:
+Example configuration:
 
 ```ts
-orm.config.set('entityGenerator', {
-    entitySchema: true,
-    bidirectionalRelations: true,
-    identifiedReferences: true,
-    esmImport: true,
-});
 const dump = await orm.entityGenerator.generate({
+  entitySchema: true,
+  bidirectionalRelations: true,
+  identifiedReferences: true,
+  esmImport: true,
   save: true,
-  baseDir: process.cwd() + '/my-entities',
+  path: process.cwd() + '/my-entities',
   skipTables: ['book', 'author'],
   skipColumns: {
     'public.user': ['email', 'middle_name'],

--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -267,6 +267,7 @@ The method was only forwarding the call to `BaseEntity.toObject`, so use that in
 - `EntityOptions.customRepository` -> `EntityOptions.repository`
 - `Options.cache` -> `Options.metadataCache`
 - `UnitOfWork.registerManaged` -> `UnitOfWork.register`
+- `baseDir` -> `path` option in `EntityGenerator.generate()`
 
 ## Removed dependency on `faker` in seeder package
 

--- a/packages/cli/src/commands/GenerateEntitiesCommand.ts
+++ b/packages/cli/src/commands/GenerateEntitiesCommand.ts
@@ -46,7 +46,7 @@ export class GenerateEntitiesCommand<U extends Options = Options> implements Com
     const orm = await CLIHelper.getORM(false);
     const dump = await orm.entityGenerator.generate({
       save: args.save,
-      baseDir: args.path,
+      path: args.path,
       schema: args.schema,
     });
 

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -682,11 +682,17 @@ export interface ISchemaGenerator {
 }
 
 export interface GenerateOptions {
-  baseDir?: string;
+  path?: string;
   save?: boolean;
   schema?: string;
   skipTables?: string[];
   skipColumns?: Record<string, string[]>;
+  bidirectionalRelations?: boolean;
+  identifiedReferences?: boolean;
+  entitySchema?: boolean;
+  esmImport?: boolean;
+  scalarTypeInDecorator?: boolean;
+  scalarPropertiesForRelations?: 'always' | 'never' | 'smart';
 }
 
 export interface IEntityGenerator {

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -564,6 +564,11 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
     managementDbName?: string;
   };
   entityGenerator: {
+    baseDir?: string;
+    save?: boolean;
+    schema?: string;
+    skipTables?: string[];
+    skipColumns?: Record<string, string[]>;
     bidirectionalRelations?: boolean;
     identifiedReferences?: boolean;
     entitySchema?: boolean;

--- a/tests/features/entity-generator/EntityGenerator.postgres.test.ts
+++ b/tests/features/entity-generator/EntityGenerator.postgres.test.ts
@@ -1,9 +1,6 @@
 import { pathExists, remove } from 'fs-extra';
-import { MikroORM } from '@mikro-orm/core';
 import { DatabaseTable } from '@mikro-orm/knex';
-import { SqliteDriver } from '@mikro-orm/sqlite';
-import { MongoDriver } from '@mikro-orm/mongodb';
-import { initORMMySql, initORMPostgreSql, initORMSqlite } from '../../bootstrap';
+import { initORMPostgreSql } from '../../bootstrap';
 
 describe('EntityGenerator', () => {
 
@@ -51,7 +48,7 @@ describe('EntityGenerator', () => {
     const orm = await initORMPostgreSql();
     const dump = await orm.entityGenerator.generate({
       save: true,
-      baseDir: './temp/entities',
+      path: './temp/entities',
       skipTables: ['test2', 'test2_bars'],
       skipColumns: { 'public.book2': ['price'] },
     });
@@ -68,7 +65,7 @@ describe('EntityGenerator', () => {
     await orm.schema.dropSchema();
     const schema = `create table "publisher2" ("id" serial primary key, "test" varchar null default '123', "type" text check ("type" in ('local', 'global')) not null default 'local', "type2" text check ("type2" in ('LOCAL', 'GLOBAL')) default 'LOCAL')`;
     await orm.schema.execute(schema);
-    const dump = await orm.entityGenerator.generate({ save: false, baseDir: './temp/entities' });
+    const dump = await orm.entityGenerator.generate({ save: false, path: './temp/entities' });
     expect(dump).toMatchSnapshot('postgres-entity-dump-enum-default-value');
     await orm.schema.execute(`drop table if exists "publisher2"`);
     await orm.close(true);

--- a/tests/features/entity-generator/EntityGenerator.test.ts
+++ b/tests/features/entity-generator/EntityGenerator.test.ts
@@ -1,9 +1,7 @@
 import { pathExists, remove } from 'fs-extra';
 import { MikroORM } from '@mikro-orm/core';
-import { DatabaseTable } from '@mikro-orm/knex';
-import { SqliteDriver } from '@mikro-orm/sqlite';
 import { MongoDriver } from '@mikro-orm/mongodb';
-import { initORMMySql, initORMPostgreSql, initORMSqlite } from '../../bootstrap';
+import { initORMSqlite } from '../../bootstrap';
 
 describe('EntityGenerator', () => {
 

--- a/tests/features/entity-generator/ScalarPropsForFks.mysql.test.ts
+++ b/tests/features/entity-generator/ScalarPropsForFks.mysql.test.ts
@@ -5,7 +5,7 @@ describe('ScalarPropsForFks', () => {
 
   test('generate entities with columns for all foreign key properties [mysql]', async () => {
     const orm = await initORMMySql('mysql', { entityGenerator: { scalarPropertiesForRelations: 'always' } }, true);
-    const dump = await orm.entityGenerator.generate({ save: true, baseDir: './temp/entities' });
+    const dump = await orm.entityGenerator.generate({ save: true, path: './temp/entities' });
     expect(dump).toMatchSnapshot('mysql-entity-composite-fk-prop-always-dump');
     await expect(pathExists('./temp/entities/Author2.ts')).resolves.toBe(true);
     await remove('./temp/entities');
@@ -16,7 +16,7 @@ describe('ScalarPropsForFks', () => {
 
   test('generate entities with columns for some foreign key properties [mysql]', async () => {
     const orm = await initORMMySql('mysql', { entityGenerator: { scalarPropertiesForRelations: 'smart' } }, true);
-    const dump = await orm.entityGenerator.generate({ save: true, baseDir: './temp/entities' });
+    const dump = await orm.entityGenerator.generate({ save: true, path: './temp/entities' });
     expect(dump).toMatchSnapshot('mysql-entity-composite-fk-prop-smart-dump');
     await expect(pathExists('./temp/entities/Author2.ts')).resolves.toBe(true);
     await remove('./temp/entities');


### PR DESCRIPTION
Add support for all the options both via ORM config and `GenerateOptions`.

Also renames the `baseDir` option to `path` to match how it's called in the CLI command.