### PR TITLE
feat(core): validate duplicate field names

### DIFF
--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -456,3 +456,43 @@ const users = await em.find(User, {}, {
 ```
 
 `populate: false` is still allowed and serves as a way to disable eager loaded properties.
+
+## Duplicate field names are now validated
+
+When you use the same `fieldName` for two properties in one entity, error will be thrown:
+
+```ts
+@Entity()
+class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ name: 'custom_name' })
+  name!: number;
+
+  @Property({ name: 'custom_name' })
+  age!: number;
+
+}
+```
+
+This does not apply to virtual properties:
+
+```ts
+@Entity()
+class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => User, { name: 'parent_id' })
+  parent!: User;
+
+  @Property({ name: 'parent_id',  })
+  parentId!: number;
+
+}
+```
+
+> This validation can be disabled via `discovery.checkDuplicateFieldNames` ORM config option.

--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -229,7 +229,7 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
     entities = Utils.asArray(entities);
     const tmp = this.discovery.discoverReferences(entities);
     const options = this.config.get('discovery');
-    new MetadataValidator().validateDiscovered([...Object.values(this.metadata.getAll()), ...tmp], options.warnWhenNoEntities, options.checkDuplicateTableNames);
+    new MetadataValidator().validateDiscovered([...Object.values(this.metadata.getAll()), ...tmp], options);
     const metadata = this.discovery.processDiscoveredEntities(tmp);
     metadata.forEach(meta => this.metadata.set(meta.className, meta));
     this.metadata.decorate(this.em);

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -224,6 +224,10 @@ export class MetadataError<T extends AnyEntity = AnyEntity> extends ValidationEr
     return new MetadataError(`Duplicate ${subject} are not allowed: ${paths.join(', ')}`);
   }
 
+  static duplicateFieldName(className: string, names: [string, string][]): MetadataError {
+    return new MetadataError(`Duplicate fieldNames are not allowed: ${names.map(n => `${className}.${n[0]} (fieldName: '${n[0]}')`).join(', ')}`);
+  }
+
   static multipleDecorators(entityName: string, propertyName: string): MetadataError {
     return new MetadataError(`Multiple property decorators used on '${entityName}.${propertyName}' property`);
   }

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -167,7 +167,7 @@ export class MetadataDiscovery {
       return this.discoverDirectories(paths).then(() => {
         this.discoverReferences(refs);
         this.discoverMissingTargets();
-        this.validator.validateDiscovered(this.discovered, options.warnWhenNoEntities, options.checkDuplicateTableNames, options.checkDuplicateEntities);
+        this.validator.validateDiscovered(this.discovered, options);
 
         return this.discovered;
       });
@@ -175,7 +175,7 @@ export class MetadataDiscovery {
 
     this.discoverReferences(refs);
     this.discoverMissingTargets();
-    this.validator.validateDiscovered(this.discovered, this.config.get('discovery').warnWhenNoEntities!);
+    this.validator.validateDiscovered(this.discovered, options);
 
     return this.discovered;
   }
@@ -562,7 +562,7 @@ export class MetadataDiscovery {
     }
 
     meta.forceConstructor = this.shouldForceConstructorUsage(meta);
-    this.validator.validateEntityDefinition(this.metadata, meta.name!);
+    this.validator.validateEntityDefinition(this.metadata, meta.name!, this.config.get('discovery'));
 
     for (const prop of Object.values(meta.properties)) {
       this.initNullability(prop);

--- a/packages/core/src/metadata/MetadataValidator.ts
+++ b/packages/core/src/metadata/MetadataValidator.ts
@@ -1,5 +1,5 @@
 import type { EntityMetadata, EntityName, EntityProperty } from '../typings';
-import { Utils } from '../utils';
+import { type MetadataDiscoveryOptions, Utils } from '../utils';
 import { MetadataError } from '../errors';
 import { ReferenceKind } from '../enums';
 import type { MetadataStorage } from './MetadataStorage';
@@ -20,7 +20,7 @@ export class MetadataValidator {
     }
   }
 
-  validateEntityDefinition<T>(metadata: MetadataStorage, name: string): void {
+  validateEntityDefinition<T>(metadata: MetadataStorage, name: string, options: MetadataDiscoveryOptions): void {
     const meta = metadata.get<T>(name);
 
     if (meta.virtual || meta.expression) {
@@ -43,6 +43,7 @@ export class MetadataValidator {
     }
 
     this.validateVersionField(meta);
+    this.validateDuplicateFieldNames(meta, options);
     this.validateIndexes(meta, meta.indexes ?? [], 'index');
     this.validateIndexes(meta, meta.uniques ?? [], 'unique');
 
@@ -56,14 +57,14 @@ export class MetadataValidator {
     }
   }
 
-  validateDiscovered(discovered: EntityMetadata[], warnWhenNoEntities?: boolean, checkDuplicateTableNames?: boolean, checkDuplicateEntities = true): void {
-    if (discovered.length === 0 && warnWhenNoEntities) {
+  validateDiscovered(discovered: EntityMetadata[], options: MetadataDiscoveryOptions): void {
+    if (discovered.length === 0 && options.warnWhenNoEntities) {
       throw MetadataError.noEntityDiscovered();
     }
 
     const duplicates = Utils.findDuplicates(discovered.map(meta => meta.className));
 
-    if (duplicates.length > 0 && checkDuplicateEntities) {
+    if (duplicates.length > 0 && options.checkDuplicateEntities) {
       throw MetadataError.duplicateEntityDiscovered(duplicates);
     }
 
@@ -73,12 +74,12 @@ export class MetadataValidator {
       return (meta.schema ? '.' + meta.schema : '') + tableName;
     }));
 
-    if (duplicateTableNames.length > 0 && checkDuplicateTableNames && checkDuplicateEntities) {
+    if (duplicateTableNames.length > 0 && options.checkDuplicateTableNames && options.checkDuplicateEntities) {
       throw MetadataError.duplicateEntityDiscovered(duplicateTableNames, 'table names');
     }
 
     // validate we found at least one entity (not just abstract/base entities)
-    if (discovered.filter(meta => meta.name).length === 0 && warnWhenNoEntities) {
+    if (discovered.filter(meta => meta.name).length === 0 && options.warnWhenNoEntities) {
       throw MetadataError.onlyAbstractEntitiesDiscovered();
     }
 
@@ -203,10 +204,27 @@ export class MetadataValidator {
   private validateIndexes(meta: EntityMetadata, indexes: { properties: string | string[] }[], type: 'index' | 'unique'): void {
     for (const index of indexes) {
       for (const prop of Utils.asArray(index.properties)) {
-        if (!meta.properties[prop] && !meta.props.some(p => prop.startsWith(p.name + '.'))) {
+        if (!meta.properties[prop] && !Object.values(meta.properties).some(p => prop.startsWith(p.name + '.'))) {
           throw MetadataError.unknownIndexProperty(meta, prop, type);
         }
       }
+    }
+  }
+
+  private validateDuplicateFieldNames(meta: EntityMetadata, options: MetadataDiscoveryOptions): void {
+    const candidates = Object.values(meta.properties)
+      .filter(prop => prop.persist !== false && !prop.inherited && prop.fieldNames?.length === 1)
+      .map(prop => prop.fieldNames[0]);
+    const duplicates = Utils.findDuplicates(candidates);
+
+    if (duplicates.length > 0 && options.checkDuplicateFieldNames) {
+      const pairs = duplicates.flatMap(name => {
+        return Object.values(meta.properties)
+          .filter(p => p.fieldNames[0] === name)
+          .map(prop => [prop.name, prop.fieldNames[0]] as [string, string]);
+      });
+
+      throw MetadataError.duplicateFieldName(meta.className, pairs);
     }
   }
 

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -52,6 +52,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
       warnWhenNoEntities: true,
       requireEntitiesArray: false,
       checkDuplicateTableNames: true,
+      checkDuplicateFieldNames: true,
       alwaysAnalyseProperties: true,
       disableDynamicFileAccess: false,
       checkDuplicateEntities: true,
@@ -490,24 +491,27 @@ export interface PoolConfig {
   Promise?: any;
 }
 
+export interface MetadataDiscoveryOptions {
+  warnWhenNoEntities?: boolean;
+  requireEntitiesArray?: boolean;
+  checkDuplicateTableNames?: boolean;
+  checkDuplicateFieldNames?: boolean;
+  alwaysAnalyseProperties?: boolean;
+  disableDynamicFileAccess?: boolean;
+  inferDefaultValues?: boolean;
+  getMappedType?: (type: string, platform: Platform) => Type<unknown> | undefined;
+  checkDuplicateEntities?: boolean;
+  onMetadata?: (meta: EntityMetadata, platform: Platform) => MaybePromise<void>;
+  afterDiscovered?: (storage: MetadataStorage, platform: Platform) => MaybePromise<void>;
+}
+
 export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> extends ConnectionOptions {
   entities: (string | EntityClass<AnyEntity> | EntityClassGroup<AnyEntity> | EntitySchema)[]; // `any` required here for some TS weirdness
   entitiesTs: (string | EntityClass<AnyEntity> | EntityClassGroup<AnyEntity> | EntitySchema)[]; // `any` required here for some TS weirdness
   extensions: { register: (orm: MikroORM) => void }[];
   subscribers: (EventSubscriber | Constructor<EventSubscriber>)[];
   filters: Dictionary<{ name?: string } & Omit<FilterDef, 'name'>>;
-  discovery: {
-    warnWhenNoEntities?: boolean;
-    requireEntitiesArray?: boolean;
-    checkDuplicateTableNames?: boolean;
-    alwaysAnalyseProperties?: boolean;
-    disableDynamicFileAccess?: boolean;
-    inferDefaultValues?: boolean;
-    getMappedType?: (type: string, platform: Platform) => Type<unknown> | undefined;
-    checkDuplicateEntities?: boolean;
-    onMetadata?: (meta: EntityMetadata, platform: Platform) => MaybePromise<void>;
-    afterDiscovered?: (storage: MetadataStorage, platform: Platform) => MaybePromise<void>;
-  };
+  discovery: MetadataDiscoveryOptions;
   driver?: { new(config: Configuration): D };
   driverOptions: Dictionary;
   namingStrategy?: { new(): NamingStrategy };

--- a/tests/MetadataValidator.test.ts
+++ b/tests/MetadataValidator.test.ts
@@ -4,121 +4,131 @@ import { ReferenceKind, MetadataStorage, MetadataValidator, EntitySchema } from 
 describe('MetadataValidator', () => {
 
   const validator = new MetadataValidator();
+  const options = {
+    warnWhenNoEntities: true,
+    requireEntitiesArray: false,
+    checkDuplicateTableNames: true,
+    checkDuplicateFieldNames: true,
+    alwaysAnalyseProperties: true,
+    disableDynamicFileAccess: false,
+    checkDuplicateEntities: true,
+    inferDefaultValues: true,
+  };
 
   test('validates entity definition', async () => {
     const meta = { Author: { name: 'Author', className: 'Author', properties: {} } } as any;
     meta.Author.root = meta.Author;
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrow('Author entity is missing @PrimaryKey()');
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).toThrow('Author entity is missing @PrimaryKey()');
 
     // many to one
     meta.Author.primaryKeys = ['_id'];
     meta.Author.properties.test = { name: 'test', kind: ReferenceKind.MANY_TO_ONE };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrow('Author.test is missing type definition');
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).toThrow('Author.test is missing type definition');
 
     meta.Author.properties.test.type = 'Test';
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrow('Author.test has unknown type: Test');
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).toThrow('Author.test has unknown type: Test');
 
     // one to many
     meta.Test = { name: 'Test', className: 'Test', properties: {} };
     meta.Test.root = meta.Test;
     meta.Author.properties.tests = { name: 'tests', kind: ReferenceKind.ONE_TO_MANY, type: 'Test' };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrow(`Author.tests is missing 'mappedBy' option`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).toThrow(`Author.tests is missing 'mappedBy' option`);
     meta.Author.properties.tests.mappedBy = 'foo';
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrow(`Author.tests has unknown 'mappedBy' reference: Test.foo`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).toThrow(`Author.tests has unknown 'mappedBy' reference: Test.foo`);
 
     meta.Test.properties.foo = { name: 'foo', kind: ReferenceKind.ONE_TO_ONE, type: 'Author' };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrow(`Author.tests is of type 1:m which is incompatible with its owning side Test.foo of type 1:1`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).toThrow(`Author.tests is of type 1:m which is incompatible with its owning side Test.foo of type 1:1`);
 
     meta.Test.properties.foo = { name: 'foo', kind: ReferenceKind.MANY_TO_ONE, type: 'Author', inversedBy: 'tests' };
     meta.Author.properties.tests.kind = ReferenceKind.MANY_TO_MANY;
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrow(`Author.tests is of type m:n which is incompatible with its owning side Test.foo of type m:1`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).toThrow(`Author.tests is of type m:n which is incompatible with its owning side Test.foo of type m:1`);
 
     meta.Author.properties.tests.kind = ReferenceKind.ONE_TO_MANY;
     meta.Test.properties.foo = { name: 'foo', kind: ReferenceKind.MANY_TO_ONE, type: 'Wrong', mappedBy: 'foo' };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrow(`Author.tests has wrong 'mappedBy' reference type: Wrong instead of Author`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).toThrow(`Author.tests has wrong 'mappedBy' reference type: Wrong instead of Author`);
 
     meta.Test.properties.foo.type = 'Author';
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrow(`Both Author.tests and Test.foo are defined as inverse sides, use 'inversedBy' on one of them`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).toThrow(`Both Author.tests and Test.foo are defined as inverse sides, use 'inversedBy' on one of them`);
     delete meta.Test.properties.foo.mappedBy;
     meta.Test.properties.foo.inversedBy = 'tests';
 
     // many to many
     meta.Author.properties.books = { name: 'books', kind: ReferenceKind.MANY_TO_MANY, type: 'Book' };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrow('Author.books has unknown type: Book');
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).toThrow('Author.books has unknown type: Book');
 
     // many to many inversedBy
     meta.Book = { name: 'Book', className: 'Book', properties: {} };
     meta.Book.root = meta.Book;
     meta.Author.properties.books = { name: 'books', kind: ReferenceKind.MANY_TO_MANY, type: 'Book', inversedBy: 'bar' };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrow(`Author.books has unknown 'inversedBy' reference: Book.bar`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).toThrow(`Author.books has unknown 'inversedBy' reference: Book.bar`);
 
     meta.Author.properties.books.inversedBy = 'authors';
     meta.Book.properties.authors = { name: 'authors', kind: ReferenceKind.MANY_TO_MANY, type: 'Foo', inversedBy: 'bar' };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrow(`Author.books has wrong 'inversedBy' reference type: Foo instead of Author`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).toThrow(`Author.books has wrong 'inversedBy' reference type: Foo instead of Author`);
 
     meta.Book.properties.authors = { name: 'authors', kind: ReferenceKind.MANY_TO_MANY, type: 'Author', inversedBy: 'books' };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrow(`Both Author.books and Book.authors are defined as owning sides, use 'mappedBy' on one of them`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).toThrow(`Both Author.books and Book.authors are defined as owning sides, use 'mappedBy' on one of them`);
     meta.Author.properties.books = { name: 'books', kind: ReferenceKind.MANY_TO_MANY, type: 'Book', mappedBy: 'bar' };
 
     // many to many mappedBy
     meta.Book = { name: 'Book', className: 'Book', properties: {} };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrow(`Author.books has unknown 'mappedBy' reference: Book.bar`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).toThrow(`Author.books has unknown 'mappedBy' reference: Book.bar`);
 
     meta.Author.properties.books.mappedBy = 'authors';
     meta.Book.properties.authors = { name: 'authors', kind: ReferenceKind.MANY_TO_MANY, type: 'Foo', mappedBy: 'bar' };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrow(`Author.books has wrong 'mappedBy' reference type: Foo instead of Author`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).toThrow(`Author.books has wrong 'mappedBy' reference type: Foo instead of Author`);
 
     meta.Book.properties.authors = { name: 'authors', kind: ReferenceKind.MANY_TO_MANY, type: 'Author', mappedBy: 'books' };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrow(`Both Author.books and Book.authors are defined as inverse sides, use 'inversedBy' on one of them`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).toThrow(`Both Author.books and Book.authors are defined as inverse sides, use 'inversedBy' on one of them`);
     meta.Book.properties.authors = { name: 'authors', kind: ReferenceKind.MANY_TO_MANY, type: 'Author', inversedBy: 'books' };
 
     // one to one
     meta.Foo = { name: 'Foo', className: 'Foo', properties: {}, primaryKeys: ['_id'] };
     meta.Foo.properties.bar = { name: 'bar', kind: ReferenceKind.ONE_TO_ONE, type: 'Bar' };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Foo')).toThrow('Foo.bar has unknown type: Bar');
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Foo', options)).toThrow('Foo.bar has unknown type: Bar');
 
     // one to one inversedBy
     meta.Bar = { name: 'Bar', className: 'Bar', properties: {} };
     meta.Bar.root = meta.Bar;
     meta.Foo.properties.bar = { name: 'bar', kind: ReferenceKind.ONE_TO_ONE, type: 'Bar', inversedBy: 'bar' };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Foo')).toThrow(`Foo.bar has unknown 'inversedBy' reference: Bar.bar`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Foo', options)).toThrow(`Foo.bar has unknown 'inversedBy' reference: Bar.bar`);
 
     meta.Foo.properties.bar.inversedBy = 'foo';
     meta.Foo.root = meta.Foo;
     meta.Bar.properties.foo = { name: 'foo', kind: ReferenceKind.ONE_TO_ONE, type: 'FooBar', inversedBy: 'bar' };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Foo')).toThrow(`Foo.bar has wrong 'inversedBy' reference type: FooBar instead of Foo`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Foo', options)).toThrow(`Foo.bar has wrong 'inversedBy' reference type: FooBar instead of Foo`);
 
     meta.Bar.properties.foo = { name: 'foo', kind: ReferenceKind.ONE_TO_ONE, type: 'Foo', inversedBy: 'bar' };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Foo')).toThrow(`Both Foo.bar and Bar.foo are defined as owning sides, use 'mappedBy' on one of them`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Foo', options)).toThrow(`Both Foo.bar and Bar.foo are defined as owning sides, use 'mappedBy' on one of them`);
 
     // one to one mappedBy
     meta.Foo.properties.bar = { name: 'bar', kind: ReferenceKind.ONE_TO_ONE, type: 'Bar', mappedBy: 'bar' };
     meta.Bar = { name: 'Bar', className: 'Bar', properties: {} };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Foo')).toThrow(`Foo.bar has unknown 'mappedBy' reference: Bar.bar`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Foo', options)).toThrow(`Foo.bar has unknown 'mappedBy' reference: Bar.bar`);
 
     meta.Foo.properties.bar.mappedBy = 'foo';
     meta.Bar.properties.foo = { name: 'foo', kind: ReferenceKind.ONE_TO_ONE, type: 'FooBar', mappedBy: 'bar' };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Foo')).toThrow(`Foo.bar has wrong 'mappedBy' reference type: FooBar instead of Foo`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Foo', options)).toThrow(`Foo.bar has wrong 'mappedBy' reference type: FooBar instead of Foo`);
 
     meta.Bar.properties.foo = { name: 'foo', kind: ReferenceKind.ONE_TO_ONE, type: 'Foo', mappedBy: 'bar' };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Foo')).toThrow(`Both Foo.bar and Bar.foo are defined as inverse sides, use 'inversedBy' on one of them`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Foo', options)).toThrow(`Both Foo.bar and Bar.foo are defined as inverse sides, use 'inversedBy' on one of them`);
 
     // version field
     meta.Author.properties.version = { name: 'version', kind: ReferenceKind.SCALAR, type: 'Test', version: true };
     meta.Author.versionProperty = 'version';
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrow(`Version property Author.version has unsupported type 'Test'. Only 'number' and 'Date' are allowed.`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).toThrow(`Version property Author.version has unsupported type 'Test'. Only 'number' and 'Date' are allowed.`);
     meta.Author.properties.version.type = 'number';
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).not.toThrow();
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).not.toThrow();
     meta.Author.properties.version.type = 'Date';
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).not.toThrow();
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).not.toThrow();
     meta.Author.properties.version.type = 'timestamp(3)';
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).not.toThrow();
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).not.toThrow();
     meta.Author.properties.version.type = 'datetime(3)';
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).not.toThrow();
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).not.toThrow();
     meta.Author.properties.version2 = { name: 'version2', kind: ReferenceKind.SCALAR, type: 'number', version: true };
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrow(`Entity Author has multiple version properties defined: 'version', 'version2'. Only one version property is allowed per entity.`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).toThrow(`Entity Author has multiple version properties defined: 'version', 'version2'. Only one version property is allowed per entity.`);
     delete meta.Author.properties.version2;
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).not.toThrow();
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author', options)).not.toThrow();
   });
 
   test('validates virtual entity definition', async () => {
@@ -132,11 +142,11 @@ describe('MetadataValidator', () => {
     };
     const meta = { AuthorProfile: { expression: '...', name: 'AuthorProfile', className: 'AuthorProfile', properties } } as any;
     meta.AuthorProfile.root = meta.AuthorProfile;
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'AuthorProfile')).toThrow(`Virtual entity AuthorProfile cannot have primary key AuthorProfile.id`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'AuthorProfile', options)).toThrow(`Virtual entity AuthorProfile cannot have primary key AuthorProfile.id`);
     delete properties.id.primary;
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'AuthorProfile')).toThrow(`Only scalars, embedded properties and to-many relations are allowed inside virtual entity. Found '1:m' in AuthorProfile.invalid1`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'AuthorProfile', options)).toThrow(`Only scalars, embedded properties and to-many relations are allowed inside virtual entity. Found '1:m' in AuthorProfile.invalid1`);
     delete properties.invalid1;
-    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'AuthorProfile')).not.toThrow();
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'AuthorProfile', options)).not.toThrow();
   });
 
   test('validates duplicities in tableName', async () => {
@@ -156,9 +166,24 @@ describe('MetadataValidator', () => {
       tableName: 'foo',
       properties,
     } as any);
-    expect(() => validator.validateDiscovered([schema1.meta, schema2.meta], true, true)).not.toThrow();
+    expect(() => validator.validateDiscovered([schema1.meta, schema2.meta], { ...options, warnWhenNoEntities: true, checkDuplicateTableNames: true })).not.toThrow();
     schema2.meta.schema = '';
-    expect(() => validator.validateDiscovered([schema1.meta, schema2.meta], true, true)).toThrow(`Duplicate table names are not allowed: foo`);
+    expect(() => validator.validateDiscovered([schema1.meta, schema2.meta], { ...options, warnWhenNoEntities: true, checkDuplicateTableNames: true })).toThrow(`Duplicate table names are not allowed: foo`);
+  });
+
+  test('validates duplicities in fieldName', async () => {
+    const schema1 = EntitySchema.fromMetadata({
+      name: 'Foo1',
+      tableName: 'foo',
+      properties: {
+        id: { kind: 'scalar', primary: true, name: 'id', fieldNames: ['id'], type: 'number' },
+        name: { kind: 'scalar', name: 'name', fieldNames: ['name'], type: 'string' },
+        age: { kind: 'scalar', name: 'age', fieldNames: ['name'], type: 'string' },
+      },
+    } as any).init();
+    expect(() => validator.validateEntityDefinition(new MetadataStorage({ Foo1: schema1.meta }), 'Foo1', options)).toThrow("Duplicate fieldNames are not allowed: Foo1.name (fieldName: 'name'), Foo1.age (fieldName: 'age')");
+    schema1.meta.properties.age.fieldNames[0] = 'age';
+    expect(() => validator.validateDiscovered([schema1.meta], options)).not.toThrow();
   });
 
   test('MetadataStorage.get throws when no metadata found', async () => {
@@ -186,7 +211,7 @@ describe('MetadataValidator', () => {
       } as any);
 
       // Act
-      const validateDiscoveryCommand = () => validator.validateDiscovered([schema1.meta, schema2.meta], true, true, false);
+      const validateDiscoveryCommand = () => validator.validateDiscovered([schema1.meta, schema2.meta], { ...options, warnWhenNoEntities: true, checkDuplicateTableNames: true, checkDuplicateEntities: false });
 
       // Assert
       expect(validateDiscoveryCommand).not.toThrow();
@@ -211,7 +236,7 @@ describe('MetadataValidator', () => {
       } as any);
 
       // Act
-      const validateDiscoveryCommand = () => validator.validateDiscovered([schema1.meta, schema2.meta], true, true, false);
+      const validateDiscoveryCommand = () => validator.validateDiscovered([schema1.meta, schema2.meta], { ...options, warnWhenNoEntities: true, checkDuplicateTableNames: true, checkDuplicateEntities: false });
 
       // Assert
       expect(validateDiscoveryCommand).not.toThrow();
@@ -236,7 +261,7 @@ describe('MetadataValidator', () => {
       } as any);
 
       // Act
-      const validateDiscoveryCommand = () => validator.validateDiscovered([schema1.meta, schema2.meta], true, true);
+      const validateDiscoveryCommand = () => validator.validateDiscovered([schema1.meta, schema2.meta], { ...options, warnWhenNoEntities: true, checkDuplicateTableNames: true });
 
       // Assert
       expect(validateDiscoveryCommand).toThrow('Duplicate entity names are not allowed: Foo1');


### PR DESCRIPTION
When you use the same `fieldName` for two properties in one entity, error will be thrown:

```ts
@Entity()
class User {

  @PrimaryKey()
  id!: number;

  @Property({ name: 'custom_name' })
  name!: number;

  @Property({ name: 'custom_name' })
  age!: number;

}
```

This does not apply to virtual properties:

```ts
@Entity()
class User {

  @PrimaryKey()
  id!: number;

  @ManyToOne(() => User, { name: 'parent_id' })
  parent!: User;

  @Property({ name: 'parent_id',  })
  parentId!: number;

}
```

> This validation can be disabled via `discovery.checkDuplicateFieldNames` ORM config option.

Closes #4359