### PR TITLE
refactor: rename `MIKRO_ORM_CLI` to `MIKRO_ORM_CLI_CONFIG`

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -513,15 +513,13 @@ MikroORM.init({
 
 ## Persist created entities automatically
 
-> Since v5.5 `persistOnCreate` defaults to `true`.
+When you create new entity instance via `em.create()`, it will be automatically marked for future persistence (`em.persist()` will be called on it before its returned to you). In case you want to disable this behavior, you can set `persistOnCreate: false` globally or override this locally via `em.create(Type, data, { persist: false })`.
 
-If we create new entity via `em.create()`, we still need to mark it via `em.persist()` to make the `EntityManager` aware of it. Alternatively we can enable `persistOnCreate` flag, which will make this work automatically.
-
-> This flag affects only `em.create()`, entities created via constructors still need explicit `em.persist()` call or they need to be part of entity graph of some already managed entity.
+> This flag affects only `em.create()`, entities created manually via constructor still need an explicit `em.persist()` call, or they need to be part of the entity graph of some already managed entity.
 
 ```ts
 MikroORM.init({
-  persistOnCreate: true,
+  persistOnCreate: false, // defaults to true since v5.5
 });
 ```
 
@@ -560,7 +558,7 @@ MIKRO_ORM_FORCE_UNDEFINED = true
 Full list of supported options:
 
 | env variable                                                | config key                               |
-| ----------------------------------------------------------- | ---------------------------------------- |
+|-------------------------------------------------------------|------------------------------------------|
 | `MIKRO_ORM_BASE_DIR`                                        | `baseDir`                                |
 | `MIKRO_ORM_TYPE`                                            | `type`                                   |
 | `MIKRO_ORM_ENTITIES`                                        | `entities`                               |
@@ -588,7 +586,6 @@ Full list of supported options:
 | `MIKRO_ORM_ENSURE_INDEXES`                                  | `ensureIndexes`                          |
 | `MIKRO_ORM_IMPLICIT_TRANSACTIONS`                           | `implicitTransactions`                   |
 | `MIKRO_ORM_DEBUG`                                           | `debug`                                  |
-| `MIKRO_ORM_VERBOSE`                                         | `verbose`                                |
 | `MIKRO_ORM_DISCOVERY_WARN_WHEN_NO_ENTITIES`                 | `discovery.warnWhenNoEntities`           |
 | `MIKRO_ORM_DISCOVERY_REQUIRE_ENTITIES_ARRAY`                | `discovery.requireEntitiesArray`         |
 | `MIKRO_ORM_DISCOVERY_ALWAYS_ANALYSE_PROPERTIES`             | `discovery.alwaysAnalyseProperties`      |
@@ -610,3 +607,13 @@ Full list of supported options:
 | `MIKRO_ORM_SEEDER_GLOB`                                     | `seeder.glob`                            |
 | `MIKRO_ORM_SEEDER_EMIT`                                     | `seeder.emit`                            |
 | `MIKRO_ORM_SEEDER_DEFAULT_SEEDER`                           | `seeder.defaultSeeder`                   |
+
+There are also env vars you can use to control the CLI settings (those you can set in your `package.json`):
+
+| env variable                    | config key |
+|---------------------------------|------------|
+| `MIKRO_ORM_CLI_CONFIG`          | (CLI only) |
+| `MIKRO_ORM_CLI_TS_CONFIG_PATH`  | (CLI only) |
+| `MIKRO_ORM_CLI_ALWAYS_ALLOW_TS` | (CLI only) |
+| `MIKRO_ORM_CLI_USE_TS_NODE`     | (CLI only) |
+| `MIKRO_ORM_CLI_VERBOSE`         | (CLI only) |

--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -370,3 +370,13 @@ There is no way to rollback DDL changes in MySQL. An implicit commit is forced f
 - no nested transaction support
 - no schema diffing
 - only blank migrations are generated
+
+## Debugging
+
+Sometimes the schema diffing might not work as expected and will produce unwanted queries. Often this is a problem with how you set up the `columnType` or `default/defaultRaw` options of your properties. You can use `MIKRO_ORM_CLI_VERBOSE` env var to enable verbose logging of the CLI, which in turn enables both the underlying queries used to extract the current schema, as well as logs in the `SchemaComparator` which should help you understand why the ORM sees two columns as different (and what particular options are different).
+
+> Debugging issues with migrations is easier when you use `schema:update`, as you skip the Migrator layer on top of it and test the actual layer where those problems occur.
+
+```bash
+$ MIKRO_ORM_CLI_VERBOSE=1 npx mikro-orm schema:update --dump
+```

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -280,12 +280,13 @@ You can also set up array of possible paths to `mikro-orm.config.*` file in the 
 }
 ```
 
-Another way to control these CLI related settings is with the environment variables:
+Another way to control these CLI-related settings is with the environment variables:
 
-- `MIKRO_ORM_CLI`: the path to ORM config file
-- `MIKRO_ORM_CLI_USE_TS_NODE`: register ts-node
+- `MIKRO_ORM_CLI_CONFIG`: the path to ORM config file
+- `MIKRO_ORM_CLI_USE_TS_NODE`: register `ts-node` for TypeScript support
 - `MIKRO_ORM_CLI_TS_CONFIG_PATH`: path to the tsconfig.json (for ts-node)
 - `MIKRO_ORM_CLI_ALWAYS_ALLOW_TS`: enable `.ts` files to use without ts-node
+- `MIKRO_ORM_CLI_VERBOSE`: enable verbose logging (e.g. print queries used in seeder or schema diffing)
 
 Alternatively, you can also specify the config path via `--config` option:
 

--- a/docs/docs/schema-generator.md
+++ b/docs/docs/schema-generator.md
@@ -118,3 +118,11 @@ There are limitations of SQLite database because of which it behaves differently
 - alter column requires nullability
 
 Because of this, you can end up with different schema with SQLite, so it is not suggested to use SQLite for integration tests of your application.
+
+## Debugging
+
+Sometimes the schema diffing might not work as expected and will produce unwanted queries. Often this is a problem with how you set up the `columnType` or `default/defaultRaw` options of your properties. You can use `MIKRO_ORM_CLI_VERBOSE` env var to enable verbose logging of the CLI, which in turn enables both the underlying queries used to extract the current schema, as well as logs in the `SchemaComparator` which should help you understand why the ORM sees two columns as different (and what particular options are different).
+
+```bash
+$ MIKRO_ORM_CLI_VERBOSE=1 npx mikro-orm schema:update --dump
+```

--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -268,6 +268,7 @@ The method was only forwarding the call to `BaseEntity.toObject`, so use that in
 - `Options.cache` -> `Options.metadataCache`
 - `UnitOfWork.registerManaged` -> `UnitOfWork.register`
 - `baseDir` -> `path` option in `EntityGenerator.generate()`
+- `MIKRO_ORM_CLI` env var -> `MIKRO_ORM_CLI_CONFIG`
 
 ## Removed dependency on `faker` in seeder package
 

--- a/packages/cli/src/CLIHelper.ts
+++ b/packages/cli/src/CLIHelper.ts
@@ -20,7 +20,7 @@ export class CLIHelper {
   static async getORM(warnWhenNoEntities?: boolean, opts: Partial<Options> = {}): Promise<MikroORM> {
     const options = await CLIHelper.getConfiguration(warnWhenNoEntities, opts);
     options.set('allowGlobalContext', true);
-    options.set('debug', !!process.env.MIKRO_ORM_VERBOSE);
+    options.set('debug', !!process.env.MIKRO_ORM_CLI_VERBOSE);
     const settings = await ConfigurationLoader.getSettings();
     options.getLogger().setDebugMode(false);
 

--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -77,8 +77,9 @@ export class ConfigurationLoader {
     settings.useTsNode = process.env.MIKRO_ORM_CLI_USE_TS_NODE != null ? bool(process.env.MIKRO_ORM_CLI_USE_TS_NODE) : settings.useTsNode;
     settings.tsConfigPath = process.env.MIKRO_ORM_CLI_TS_CONFIG_PATH ?? settings.tsConfigPath;
     settings.alwaysAllowTs = process.env.MIKRO_ORM_CLI_ALWAYS_ALLOW_TS != null ? bool(process.env.MIKRO_ORM_CLI_ALWAYS_ALLOW_TS) : settings.alwaysAllowTs;
+    settings.verbose = process.env.MIKRO_ORM_CLI_VERBOSE != null ? bool(process.env.MIKRO_ORM_CLI_VERBOSE) : settings.verbose;
 
-    if (process.env.MIKRO_ORM_CLI?.endsWith('.ts')) {
+    if (process.env.MIKRO_ORM_CLI_CONFIG?.endsWith('.ts')) {
       settings.useTsNode = true;
     }
 
@@ -95,8 +96,8 @@ export class ConfigurationLoader {
     const paths: string[] = [];
     const settings = await ConfigurationLoader.getSettings();
 
-    if (process.env.MIKRO_ORM_CLI) {
-      paths.push(process.env.MIKRO_ORM_CLI);
+    if (process.env.MIKRO_ORM_CLI_CONFIG) {
+      paths.push(process.env.MIKRO_ORM_CLI_CONFIG);
     }
 
     paths.push(...(settings.configPaths || []));
@@ -216,7 +217,6 @@ export class ConfigurationLoader {
     read(ret, 'MIKRO_ORM_ENSURE_INDEXES', 'ensureIndexes', bool);
     read(ret, 'MIKRO_ORM_IMPLICIT_TRANSACTIONS', 'implicitTransactions', bool);
     read(ret, 'MIKRO_ORM_DEBUG', 'debug', bool);
-    read(ret, 'MIKRO_ORM_VERBOSE', 'verbose', bool);
 
     ret.discovery = {};
     read(ret.discovery, 'MIKRO_ORM_DISCOVERY_WARN_WHEN_NO_ENTITIES', 'warnWhenNoEntities', bool);
@@ -326,6 +326,7 @@ export class ConfigurationLoader {
 
 export interface Settings {
   alwaysAllowTs?: boolean;
+  verbose?: boolean;
   useTsNode?: boolean;
   tsConfigPath?: string;
   configPaths?: string[];

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -120,14 +120,14 @@ describe('MikroORM', () => {
   });
 
   test('CLI config can export async function', async () => {
-    process.env.MIKRO_ORM_CLI = __dirname + '/cli-config.ts';
+    process.env.MIKRO_ORM_CLI_CONFIG = __dirname + '/cli-config.ts';
     const orm = await MikroORM.init();
 
     expect(orm).toBeInstanceOf(MikroORM);
     expect(orm.em).toBeInstanceOf(EntityManager);
     expect(Object.keys(orm.getMetadata().getAll()).sort()).toEqual(['Test3']);
 
-    delete process.env.MIKRO_ORM_CLI;
+    delete process.env.MIKRO_ORM_CLI_CONFIG;
   });
 
   test('should prefer environment variables', async () => {

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -458,9 +458,9 @@ Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
     (global as any).process.argv = ['npx', 'mikro-orm', 'debug', '--config', './override3/orm-config.ts'];
     await expect(CLIHelper.getConfigPaths()).resolves.toEqual(['./override3/orm-config.ts']);
     (global as any).process.argv = ['node', 'start.js'];
-    (global as any).process.env.MIKRO_ORM_CLI = './override/orm-config.ts';
+    (global as any).process.env.MIKRO_ORM_CLI_CONFIG = './override/orm-config.ts';
     await expect(CLIHelper.getConfigPaths()).resolves.toEqual(['./override/orm-config.ts', './src/mikro-orm.config.ts', './mikro-orm.config.ts', './src/mikro-orm.config.js', './mikro-orm.config.js']);
-    delete (global as any).process.env.MIKRO_ORM_CLI;
+    delete (global as any).process.env.MIKRO_ORM_CLI_CONFIG;
     await expect(CLIHelper.getConfigPaths()).resolves.toEqual(['./src/mikro-orm.config.js', './mikro-orm.config.js']);
 
     (global as any).process.env.MIKRO_ORM_CLI_ALWAYS_ALLOW_TS = '1';


### PR DESCRIPTION
Also renames `MIKRO_ORM_VERBOSE` to `MIKRO_ORM_CLI_VERBOSE` and adds it to the CLI settings interface so it can be set in the package.json settings.

BREAKING CHANGE