### PR TITLE
refactor: remove `Reference.load(prop: keyof T)` signature

### DIFF
--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -227,7 +227,7 @@ Note that if you used it for converting entity instance to reference wrapper, th
 
 ## Primary key inference
 
-Some methods allowed you to pass in the primary key property via second generic type argument, this is now removed in favour of the automatic inference. To set the PK type explicitly, use the `PrimaryKeyProp` symbol.
+Some methods allowed you to pass in the primary key property via second generic type argument, this is now removed in favor of the automatic inference. To set the PK type explicitly, use the `PrimaryKeyProp` symbol.
 
 `PrimaryKeyType` symbol has been removed, use `PrimaryKeyProp` instead if needed. Moreover, the value for composite PKs now has to be a tuple instead of a union to ensure we preserve the order of keys:
 
@@ -508,3 +508,12 @@ class User {
 ```
 
 > This validation can be disabled via `discovery.checkDuplicateFieldNames` ORM config option.
+
+## `Reference.load(prop: keyof T)` signature removed
+
+The `Reference.load()` method allowed two signatures, one to ensure the entity is loaded, and another to get a property value in one step. The latter is now removed in favor of a new method called `Reference.loadProperty(prop)`:
+
+```diff
+-const email = book.author.load('email');
++const email = book.author.loadProperty('email');
+```

--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -16,7 +16,7 @@ import type {
 import { ArrayCollection } from './ArrayCollection';
 import { DataloaderUtils, Utils } from '../utils';
 import { ValidationError } from '../errors';
-import { type LockMode, type QueryOrderMap, ReferenceKind, Dataloader } from '../enums';
+import { type LockMode, type QueryOrderMap, ReferenceKind, DataloaderType } from '../enums';
 import { Reference } from './Reference';
 import type { Transaction } from '../connections/Connection';
 import type { FindOptions, CountOptions } from '../drivers/IDatabaseDriver';
@@ -314,7 +314,7 @@ export class Collection<T extends object, O extends object = object> extends Arr
 
     const em = this.getEntityManager();
 
-    if (options.dataloader ?? [Dataloader.ALL, Dataloader.COLLECTION].includes(DataloaderUtils.getDataloaderType(em.config.get('dataloader')))) {
+    if (options.dataloader ?? [DataloaderType.ALL, DataloaderType.COLLECTION].includes(DataloaderUtils.getDataloaderType(em.config.get('dataloader')))) {
       const order = [...this.items]; // copy order of references
       const customOrder = !!options.orderBy;
       const items: TT[] = await em.colLoader.load([this, options]);

--- a/packages/core/src/enums.ts
+++ b/packages/core/src/enums.ts
@@ -128,8 +128,8 @@ export enum LoadStrategy {
   JOINED = 'joined'
 }
 
-export enum Dataloader {
-  OFF = 0,
+export enum DataloaderType {
+  NONE = 0,
   REFERENCE = 1,
   COLLECTION = 2,
   ALL = 3,

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -32,7 +32,7 @@ import type { EventSubscriber } from '../events';
 import type { IDatabaseDriver } from '../drivers/IDatabaseDriver';
 import { NotFoundError } from '../errors';
 import { RequestContext } from './RequestContext';
-import { Dataloader, FlushMode, LoadStrategy, PopulateHint } from '../enums';
+import { DataloaderType, FlushMode, LoadStrategy, PopulateHint } from '../enums';
 import { MemoryCacheAdapter } from '../cache/MemoryCacheAdapter';
 import { EntityComparator } from './EntityComparator';
 import type { Type } from '../types/Type';
@@ -72,7 +72,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     hydrator: ObjectHydrator,
     flushMode: FlushMode.AUTO,
     loadStrategy: LoadStrategy.JOINED,
-    dataloader: Dataloader.OFF,
+    dataloader: DataloaderType.NONE,
     populateWhere: PopulateHint.ALL,
     connect: true,
     ignoreUndefinedInQuery: false,
@@ -540,7 +540,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
   batchSize: number;
   hydrator: HydratorConstructor;
   loadStrategy: LoadStrategy | 'select-in' | 'joined';
-  dataloader: Dataloader | boolean;
+  dataloader: DataloaderType | boolean;
   populateWhere: PopulateHint;
   flushMode: FlushMode | 'commit' | 'auto' | 'always';
   entityRepository?: Constructor;

--- a/packages/core/src/utils/DataloaderUtils.ts
+++ b/packages/core/src/utils/DataloaderUtils.ts
@@ -7,7 +7,7 @@ import { Collection, type InitOptions } from '../entity/Collection';
 import { helper } from '../entity/wrap';
 import { type EntityManager } from '../EntityManager';
 import type DataLoader from 'dataloader';
-import { Dataloader } from '../enums';
+import { DataloaderType } from '../enums';
 import { type LoadReferenceOptions } from '../entity/Reference';
 
 export class DataloaderUtils {
@@ -200,12 +200,12 @@ export class DataloaderUtils {
     };
   }
 
-  static getDataloaderType(dataloaderCfg: Dataloader | boolean): Dataloader {
+  static getDataloaderType(dataloaderCfg: DataloaderType | boolean): DataloaderType {
     switch (dataloaderCfg) {
       case true:
-        return Dataloader.ALL;
+        return DataloaderType.ALL;
       case false:
-        return Dataloader.OFF;
+        return DataloaderType.NONE;
       default:
         return dataloaderCfg;
     }

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -1922,10 +1922,10 @@ describe('EntityManagerMongo', () => {
 
     const ref4 = orm.em.getReference(Author, author.id, { wrapped: true });
     expect(ref4.isInitialized()).toBe(false);
-    await expect(ref4.load('name')).resolves.toBe('God');
+    await expect(ref4.loadProperty('name')).resolves.toBe('God');
     expect(ref4.isInitialized()).toBe(true);
     expect(ref4.getProperty('name')).toBe('God');
-    await expect(ref4.load('email')).resolves.toBe('hello@heaven.god');
+    await expect(ref4.loadProperty('email')).resolves.toBe('hello@heaven.god');
     expect(wrap(ref4, true).__populated).toBeUndefined();
     ref4.populated(false);
     expect(wrap(ref4, true).__populated).toBe(false);

--- a/tests/features/dataloader.test.ts
+++ b/tests/features/dataloader.test.ts
@@ -16,7 +16,7 @@ import {
   helper,
   Primary,
   SimpleLogger,
-  Dataloader,
+  DataloaderType,
   serialize,
   Filter,
 } from '@mikro-orm/sqlite';
@@ -325,8 +325,8 @@ describe('Dataloader', () => {
   test('Reference.load with prop', async () => {
     const refsA = getReferences(orm.em).slice(0, 2);
     const refsB = getReferences(orm.em).slice(0, 2);
-    const resA = await Promise.all(refsA.map(ref => ref.load('age')));
-    const resB = await Promise.all(refsB.map(ref => ref.load('age', true)));
+    const resA = await Promise.all(refsA.map(ref => ref.loadProperty('age')));
+    const resB = await Promise.all(refsB.map(ref => ref.loadProperty('age', { dataloader: true })));
     await orm.em.flush();
     expect(resA).toEqual(resB);
   });
@@ -341,7 +341,7 @@ describe('Dataloader', () => {
   });
 
   test('Dataloader can be globally enabled for References with true, Dataloader.ALL, Dataloader.REFERENCE', async () => {
-    async function getRefs(dataloader: Dataloader | boolean) {
+    async function getRefs(dataloader: DataloaderType | boolean) {
       const orm = await MikroORM.init({
         dbName: ':memory:',
         dataloader,
@@ -358,14 +358,14 @@ describe('Dataloader', () => {
       return mock.mock.calls;
     }
 
-    const res = structuredClone(await getRefs(Dataloader.ALL));
+    const res = structuredClone(await getRefs(DataloaderType.ALL));
     expect(res).toMatchSnapshot();
     expect(await getRefs(true)).toEqual(res);
-    expect(await getRefs(Dataloader.REFERENCE)).toEqual(res);
+    expect(await getRefs(DataloaderType.REFERENCE)).toEqual(res);
   });
 
   test('Dataloader should not be globally enabled for References with false, Dataloader.OFF, Dataloader.COLLECTION', async () => {
-    async function getRefs(dataloader: Dataloader | boolean) {
+    async function getRefs(dataloader: DataloaderType | boolean) {
       const orm = await MikroORM.init({
         dbName: ':memory:',
         dataloader,
@@ -382,16 +382,16 @@ describe('Dataloader', () => {
       return mock.mock.calls;
     }
 
-    const res = structuredClone(await getRefs(Dataloader.OFF));
+    const res = structuredClone(await getRefs(DataloaderType.NONE));
     expect(res).toMatchSnapshot();
     expect(await getRefs(false)).toEqual(res);
-    expect(await getRefs(Dataloader.COLLECTION)).toEqual(res);
+    expect(await getRefs(DataloaderType.COLLECTION)).toEqual(res);
   });
 
   test('Reference dataloader can be disabled per-query', async () => {
     const orm = await MikroORM.init({
       dbName: ':memory:',
-      dataloader: Dataloader.ALL,
+      dataloader: DataloaderType.ALL,
       entities: [Author, Book, Chat, Message],
       loggerFactory: options => new SimpleLogger(options),
     });
@@ -581,7 +581,7 @@ describe('Dataloader', () => {
   });
 
   test('Dataloader can be globally enabled for Collections with true, Dataloader.ALL, Dataloader.COLLECTION', async () => {
-    async function getCols(dataloader: Dataloader | boolean) {
+    async function getCols(dataloader: DataloaderType | boolean) {
       const orm = await MikroORM.init({
         dbName: ':memory:',
         dataloader,
@@ -598,14 +598,14 @@ describe('Dataloader', () => {
       return mock.mock.calls;
     }
 
-    const res = structuredClone(await getCols(Dataloader.ALL));
+    const res = structuredClone(await getCols(DataloaderType.ALL));
     expect(res).toMatchSnapshot();
     expect(await getCols(true)).toEqual(res);
-    expect(await getCols(Dataloader.COLLECTION)).toEqual(res);
+    expect(await getCols(DataloaderType.COLLECTION)).toEqual(res);
   });
 
   test('Dataloader should not be globally enabled for Collections with false, Dataloader.OFF, Dataloader.REFERENCE', async () => {
-    async function getCols(dataloader: Dataloader | boolean) {
+    async function getCols(dataloader: DataloaderType | boolean) {
       const orm = await MikroORM.init({
         dbName: ':memory:',
         dataloader,
@@ -622,16 +622,16 @@ describe('Dataloader', () => {
       return mock.mock.calls;
     }
 
-    const res = structuredClone(await getCols(Dataloader.OFF));
+    const res = structuredClone(await getCols(DataloaderType.NONE));
     expect(res).toMatchSnapshot();
     expect(await getCols(false)).toEqual(res);
-    expect(await getCols(Dataloader.REFERENCE)).toEqual(res);
+    expect(await getCols(DataloaderType.REFERENCE)).toEqual(res);
   });
 
   test('Collection dataloader can be disabled per-query', async () => {
     const orm = await MikroORM.init({
       dbName: ':memory:',
-      dataloader: Dataloader.ALL,
+      dataloader: DataloaderType.ALL,
       entities: [Author, Book, Chat, Message],
       loggerFactory: options => new SimpleLogger(options),
     });
@@ -648,8 +648,8 @@ describe('Dataloader', () => {
   });
 
   test('getDataloaderType', async () => {
-    expect(DataloaderUtils.getDataloaderType(true)).toEqual(Dataloader.ALL);
-    expect(DataloaderUtils.getDataloaderType(false)).toEqual(Dataloader.OFF);
-    expect(DataloaderUtils.getDataloaderType(Dataloader.COLLECTION)).toEqual(Dataloader.COLLECTION);
+    expect(DataloaderUtils.getDataloaderType(true)).toEqual(DataloaderType.ALL);
+    expect(DataloaderUtils.getDataloaderType(false)).toEqual(DataloaderType.NONE);
+    expect(DataloaderUtils.getDataloaderType(DataloaderType.COLLECTION)).toEqual(DataloaderType.COLLECTION);
   });
 });


### PR DESCRIPTION
BREAKING CHANGE:

The `Reference.load()` method allowed two signatures, one to ensure the entity is loaded, and another to get a property value in one step. The latter is now removed in favor of a new method called `Reference.loadProperty(prop)`:

```diff
-const email = book.author.load('email');
+const email = book.author.loadProperty('email');
```