### PR TITLE
feat(core): add `FindOptions.exclude`

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -580,7 +580,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     Hint extends string = never,
     Fields extends string = '*',
     Excludes extends string = never,
-  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindByCursorOptions<Entity, Hint, Fields, Excludes> = {}): Promise<Cursor<Entity, Hint, Fields, Excludes>> {
+  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindByCursorOptions<Entity, Hint, Fields, Excludes>): Promise<Cursor<Entity, Hint, Fields, Excludes>> {
     const em = this.getContext(false);
     entityName = Utils.className(entityName);
     options.overfetch ??= true;

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -26,6 +26,7 @@ import type {
   DeleteOptions,
   EntityField,
   EntityManagerType,
+  FindAllOptions,
   FindByCursorOptions,
   FindOneOptions,
   FindOneOrFailOptions,
@@ -37,7 +38,6 @@ import type {
   UpdateOptions,
   UpsertManyOptions,
   UpsertOptions,
-  FindAllOptions,
 } from './drivers';
 import type {
   AnyEntity,
@@ -198,11 +198,12 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     Entity extends object,
     Hint extends string = never,
     Fields extends string = '*',
-  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint, Fields> = {}): Promise<Loaded<Entity, Hint, Fields>[]> {
+    Excludes extends string = never,
+  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint, Fields, Excludes> = {}): Promise<Loaded<Entity, Hint, Fields, Excludes>[]> {
     if (options.disableIdentityMap ?? this.config.get('disableIdentityMap')) {
       const em = this.getContext(false);
       const fork = em.fork();
-      const ret = await fork.find<Entity, Hint, Fields>(entityName, where, { ...options, disableIdentityMap: false });
+      const ret = await fork.find(entityName, where, { ...options, disableIdentityMap: false });
       fork.clear();
 
       return ret;
@@ -218,7 +219,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     options.populate = em.preparePopulate(entityName, options) as any;
     const populate = options.populate as unknown as PopulateOptions<Entity>[];
     const cacheKey = em.cacheKey(entityName, options, 'em.find', where);
-    const cached = await em.tryCache<Entity, Loaded<Entity, Hint, Fields>[]>(entityName, options.cache, cacheKey, options.refresh, true);
+    const cached = await em.tryCache<Entity, Loaded<Entity, Hint, Fields, Excludes>[]>(entityName, options.cache, cacheKey, options.refresh, true);
 
     if (cached?.data) {
       await em.entityLoader.populate<Entity>(entityName, cached.data as Entity[], populate, {
@@ -237,14 +238,14 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     // save the original hint value so we know it was infer/all
     (options as Dictionary)._populateWhere = options.populateWhere ?? this.config.get('populateWhere');
     options.populateWhere = await this.applyJoinedFilters(meta, { ...where } as ObjectQuery<Entity>, options);
-    const results = await em.driver.find<Entity, Hint, Fields>(entityName, where, { ctx: em.transactionContext, ...options });
+    const results = await em.driver.find(entityName, where, { ctx: em.transactionContext, ...options });
 
     if (results.length === 0) {
       await em.storeCache(options.cache, cached!, []);
       return [];
     }
 
-    const ret: Loaded<Entity, Hint, Fields>[] = [];
+    const ret: Loaded<Entity, Hint, Fields, Excludes>[] = [];
 
     for (const data of results) {
       const entity = em.entityFactory.create(entityName, data as EntityData<Entity>, {
@@ -252,7 +253,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
         refresh: options.refresh,
         schema: options.schema,
         convertCustomTypes: true,
-      }) as Loaded<Entity, Hint, Fields>;
+      }) as Loaded<Entity, Hint, Fields, Excludes>;
 
       ret.push(entity);
     }
@@ -283,8 +284,9 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     Entity extends object,
     Hint extends string = never,
     Fields extends string = '*',
-  >(entityName: EntityName<Entity>, options?: FindAllOptions<Entity, Hint, Fields>): Promise<Loaded<Entity, Hint, Fields>[]> {
-    return this.find<Entity, Hint, Fields>(entityName, options?.where ?? {}, options);
+    Excludes extends string = never,
+  >(entityName: EntityName<Entity>, options?: FindAllOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes>[]> {
+    return this.find(entityName, options?.where ?? {}, options);
   }
 
   private getPopulateWhere<
@@ -358,7 +360,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     Entity extends object,
     Hint extends string = never,
     Fields extends string = '*',
-  >(entityName: string, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint, Fields> | FindOneOptions<Entity, Hint, Fields>, type: 'read' | 'update' | 'delete'): Promise<FilterQuery<Entity>> {
+    Excludes extends string = never,
+  >(entityName: string, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint, Fields, Excludes> | FindOneOptions<Entity, Hint, Fields, Excludes>, type: 'read' | 'update' | 'delete'): Promise<FilterQuery<Entity>> {
     where = QueryHelper.processWhere({
       where,
       entityName,
@@ -396,7 +399,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     return where;
   }
 
-  protected async applyJoinedFilters<Entity extends object>(meta: EntityMetadata<Entity>, cond: ObjectQuery<Entity>, options: FindOptions<Entity, any, any> | FindOneOptions<Entity, any, any>): Promise<ObjectQuery<Entity>> {
+  protected async applyJoinedFilters<Entity extends object>(meta: EntityMetadata<Entity>, cond: ObjectQuery<Entity>, options: FindOptions<Entity, any, any, any> | FindOneOptions<Entity, any, any, any>): Promise<ObjectQuery<Entity>> {
     const ret = {} as ObjectQuery<Entity>;
     const populateWhere = options.populateWhere ?? this.config.get('populateWhere');
 
@@ -439,7 +442,13 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * @internal
    */
-  async applyFilters<Entity extends object>(entityName: string, where: FilterQuery<Entity> | undefined, options: Dictionary<boolean | Dictionary> | string[] | boolean, type: 'read' | 'update' | 'delete', findOptions?: FindOptions<any, any, any> | FindOneOptions<any, any, any>): Promise<FilterQuery<Entity> | undefined> {
+  async applyFilters<Entity extends object>(
+    entityName: string,
+    where: FilterQuery<Entity> | undefined,
+    options: Dictionary<boolean | Dictionary> | string[] | boolean,
+    type: 'read' | 'update' | 'delete',
+    findOptions?: FindOptions<any, any, any, any> | FindOneOptions<any, any, any, any>,
+  ): Promise<FilterQuery<Entity> | undefined> {
     const meta = this.metadata.find<Entity>(entityName);
     const filters: FilterDef[] = [];
     const ret: Dictionary[] = [];
@@ -496,18 +505,19 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
 
   /**
    * Calls `em.find()` and `em.count()` with the same arguments (where applicable) and returns the results as tuple
-   * where first element is the array of entities and the second is the count.
+   * where the first element is the array of entities, and the second is the count.
    */
   async findAndCount<
     Entity extends object,
     Hint extends string = never,
     Fields extends string = '*',
-  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint, Fields> = {}): Promise<[Loaded<Entity, Hint, Fields>[], number]> {
+    Excludes extends string = never,
+  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint, Fields, Excludes> = {}): Promise<[Loaded<Entity, Hint, Fields, Excludes>[], number]> {
     const em = this.getContext(false);
     const copy = Utils.copy(where);
     const [entities, count] = await Promise.all([
-      em.find<Entity, Hint, Fields>(entityName, where, options),
-      em.count<Entity, Hint>(entityName, copy, options as any),
+      em.find(entityName, where, options),
+      em.count(entityName, copy, options as CountOptions<Entity, Hint>),
     ]);
 
     return [entities, count];
@@ -548,7 +558,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * });
    * ```
    *
-   * The `Cursor` object provides following interface:
+   * The `Cursor` object provides the following interface:
    *
    * ```ts
    * Cursor<User> {
@@ -569,7 +579,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     Entity extends object,
     Hint extends string = never,
     Fields extends string = '*',
-  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindByCursorOptions<Entity, Hint, Fields> = {}): Promise<Cursor<Entity, Hint, Fields>> {
+    Excludes extends string = never,
+  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindByCursorOptions<Entity, Hint, Fields, Excludes> = {}): Promise<Cursor<Entity, Hint, Fields, Excludes>> {
     const em = this.getContext(false);
     entityName = Utils.className(entityName);
     options.overfetch ??= true;
@@ -578,9 +589,33 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       throw new Error('Explicit `orderBy` option required');
     }
 
-    const [entities, count] = await em.findAndCount<Entity, Hint, Fields>(entityName, where, options);
+    const [entities, count] = await em.findAndCount(entityName, where, options);
 
-    return new Cursor<Entity, Hint, Fields>(entities, count, options, this.metadata.get(entityName));
+    return new Cursor(entities, count, options, this.metadata.get(entityName));
+  }
+
+  /**
+   * Refreshes the persistent state of an entity from the database, overriding any local changes that have not yet been
+   * persisted. Returns the same entity instance (same object reference), but re-hydrated. If the entity is no longer
+   * in database, the method throws an error just like `em.findOneOrFail()` (and respects the same config options).
+   */
+  async refreshOrFail<
+    Entity extends object,
+    Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(entity: Entity, options: FindOneOrFailOptions<Entity, Hint, Fields, Excludes> = {}): Promise<MergeLoaded<Entity, Naked, Hint, Fields, Excludes, true>> {
+    const ret = await this.refresh(entity, options);
+
+    if (!ret) {
+      options.failHandler ??= this.config.get('findOneOrFailHandler');
+      const entityName = entity.constructor.name;
+      const where = helper(entity).getPrimaryKey() as any;
+      throw options.failHandler!(entityName, where);
+    }
+
+    return ret as any;
   }
 
   /**
@@ -590,12 +625,14 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    */
   async refresh<
     Entity extends object,
+    Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
     Hint extends string = never,
     Fields extends string = '*',
-  >(entity: Entity, options: FindOneOptions<Entity, Hint, Fields> = {}): Promise<Loaded<Entity, Hint, Fields> | null> {
+    Excludes extends string = never,
+  >(entity: Entity, options: FindOneOptions<Entity, Hint, Fields, Excludes> = {}): Promise<MergeLoaded<Entity, Naked, Hint, Fields, Excludes, true> | null> {
     const fork = this.fork();
     const entityName = entity.constructor.name;
-    const reloaded = await fork.findOne<Entity, Hint, Fields>(entityName, entity, {
+    const reloaded = await fork.findOne(entityName, entity, {
       schema: helper(entity).__schema,
       ...options,
       flushMode: FlushMode.COMMIT,
@@ -623,11 +660,12 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     Entity extends object,
     Hint extends string = never,
     Fields extends string = '*',
-  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOneOptions<Entity, Hint, Fields> = {}): Promise<Loaded<Entity, Hint, Fields> | null> {
+    Excludes extends string = never,
+  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOneOptions<Entity, Hint, Fields, Excludes> = {}): Promise<Loaded<Entity, Hint, Fields, Excludes> | null> {
     if (options.disableIdentityMap ?? this.config.get('disableIdentityMap')) {
       const em = this.getContext(false);
       const fork = em.fork();
-      const ret = await fork.findOne<Entity, Hint, Fields>(entityName, where, { ...options, disableIdentityMap: false });
+      const ret = await fork.findOne(entityName, where, { ...options, disableIdentityMap: false });
       fork.clear();
 
       return ret;
@@ -642,7 +680,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     // was provided with a PK this entity does not exist in the db, there can't
     // be any relations to it, so no need to deal with the populate hint
     if (entity && !helper(entity).__managed) {
-      return entity as Loaded<Entity, Hint, Fields>;
+      return entity as Loaded<Entity, Hint, Fields, Excludes>;
     }
 
     await em.tryFlush(entityName, options);
@@ -660,7 +698,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     em.validator.validateParams(where);
     options.populate = em.preparePopulate(entityName, options) as any;
     const cacheKey = em.cacheKey(entityName, options, 'em.findOne', where);
-    const cached = await em.tryCache<Entity, Loaded<Entity, Hint, Fields>>(entityName, options.cache, cacheKey, options.refresh, true);
+    const cached = await em.tryCache<Entity, Loaded<Entity, Hint, Fields, Excludes>>(entityName, options.cache, cacheKey, options.refresh, true);
 
     if (cached?.data) {
       await em.entityLoader.populate<Entity, Fields>(entityName, [cached.data as Entity], options.populate as unknown as PopulateOptions<Entity>[], {
@@ -678,7 +716,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     // save the original hint value so we know it was infer/all
     (options as Dictionary)._populateWhere = options.populateWhere ?? this.config.get('populateWhere');
     options.populateWhere = await this.applyJoinedFilters(meta, { ...where } as ObjectQuery<Entity>, options);
-    const data = await em.driver.findOne<Entity, Hint, Fields>(entityName, where, {
+    const data = await em.driver.findOne<Entity, Hint, Fields, Excludes>(entityName, where, {
       ctx: em.transactionContext,
       ...options,
     });
@@ -699,7 +737,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     await em.unitOfWork.dispatchOnLoadEvent();
     await em.storeCache(options.cache, cached!, () => helper(entity!).toPOJO());
 
-    return entity as Loaded<Entity, Hint, Fields>;
+    return entity as Loaded<Entity, Hint, Fields, Excludes>;
   }
 
   /**
@@ -712,16 +750,17 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     Entity extends object,
     Hint extends string = never,
     Fields extends string = '*',
-  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOneOrFailOptions<Entity, Hint, Fields> = {}): Promise<Loaded<Entity, Hint, Fields>> {
-    let entity: Loaded<Entity, Hint, Fields> | null;
+    Excludes extends string = never,
+  >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOneOrFailOptions<Entity, Hint, Fields, Excludes> = {}): Promise<Loaded<Entity, Hint, Fields, Excludes>> {
+    let entity: Loaded<Entity, Hint, Fields, Excludes> | null;
     let isStrictViolation = false;
 
     if (options.strict) {
-      const ret = await this.find(entityName, where, { ...options, limit: 2 } as FindOptions<Entity, Hint, Fields>);
+      const ret = await this.find(entityName, where, { ...options, limit: 2 } as FindOptions<Entity, Hint, Fields, Excludes>);
       isStrictViolation = ret.length !== 1;
       entity = ret[0];
     } else {
-      entity = await this.findOne<Entity, Hint, Fields>(entityName, where, options);
+      entity = await this.findOne<Entity, Hint, Fields, Excludes>(entityName, where, options);
     }
 
     if (!entity || isStrictViolation) {
@@ -732,7 +771,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       throw options.failHandler!(entityName, where);
     }
 
-    return entity as Loaded<Entity, Hint, Fields>;
+    return entity as Loaded<Entity, Hint, Fields, Excludes>;
   }
 
   /**
@@ -1711,7 +1750,8 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
     Hint extends string = never,
     Fields extends string = '*',
-  >(entities: Entity, populate: AutoPath<UnboxArray<Entity>, Hint, '*'>[] | false, options: EntityLoaderOptions<UnboxArray<Entity>, Fields> = {}): Promise<Entity extends object[] ? MergeLoaded<ArrayElement<Entity>, Naked, Hint, Fields>[] : MergeLoaded<Entity, Naked, Hint, Fields>> {
+    Excludes extends string = never,
+  >(entities: Entity, populate: AutoPath<UnboxArray<Entity>, Hint, '*'>[] | false, options: EntityLoaderOptions<UnboxArray<Entity>, Fields, Excludes> = {}): Promise<Entity extends object[] ? MergeLoaded<ArrayElement<Entity>, Naked, Hint, Fields, Excludes>[] : MergeLoaded<Entity, Naked, Hint, Fields, Excludes>> {
     const arr = Utils.asArray(entities);
 
     if (arr.length === 0) {
@@ -1894,7 +1934,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     }
   }
 
-  private async lockAndPopulate<T extends object, P extends string = never, F extends string = '*'>(meta: EntityMetadata<T>, entity: T, where: FilterQuery<T>, options: FindOneOptions<T, P, F>): Promise<Loaded<T, P, F>> {
+  private async lockAndPopulate<T extends object, P extends string = never, F extends string = '*', E extends string = never>(meta: EntityMetadata<T>, entity: T, where: FilterQuery<T>, options: FindOneOptions<T, P, F, E>): Promise<Loaded<T, P, F, E>> {
     if (!meta.virtual && options.lockMode === LockMode.OPTIMISTIC) {
       await this.lock(entity, options.lockMode, {
         lockVersion: options.lockVersion,
@@ -1911,7 +1951,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       lookup: false,
     });
 
-    return entity as Loaded<T, P, F>;
+    return entity as Loaded<T, P, F, E>;
   }
 
   private buildFields<T extends object, P extends string>(fields: readonly EntityField<T, P>[]): string[] {
@@ -2011,7 +2051,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    * when the entity is found in identity map, we check if it was partially loaded or we are trying to populate
    * some additional lazy properties, if so, we reload and merge the data from database
    */
-  protected shouldRefresh<T extends object, P extends string = never, F extends string = '*'>(meta: EntityMetadata<T>, entity: T, options: FindOneOptions<T, P, F>) {
+  protected shouldRefresh<T extends object, P extends string = never, F extends string = '*', E extends string = never>(meta: EntityMetadata<T>, entity: T, options: FindOneOptions<T, P, F, E>) {
     if (!helper(entity).__initialized || options.refresh) {
       return true;
     }
@@ -2038,7 +2078,11 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
     return !!options.populate;
   }
 
-  protected prepareOptions(options: FindOptions<any, any, any> | FindOneOptions<any, any, any>, em: this): void {
+  protected prepareOptions(options: FindOptions<any, any, any, any> | FindOneOptions<any, any, any, any>, em: this): void {
+    if (!Utils.isEmpty(options.fields) && !Utils.isEmpty(options.exclude)) {
+      throw new ValidationError(`Cannot combine 'fields' and 'exclude' option.`);
+    }
+
     options.schema ??= em._schema;
     options.logging = Utils.merge(
       { id: this.id },
@@ -2053,7 +2097,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
    */
   cacheKey<T extends object>(
     entityName: string,
-    options: FindOptions<T, any, any> | FindOneOptions<T, any, any> | CountOptions<T, any>,
+    options: FindOptions<T, any, any, any> | FindOneOptions<T, any, any, any> | CountOptions<T, any>,
     method: string,
     where: FilterQuery<T>,
   ): unknown[] {

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -767,6 +767,7 @@ export class EntityManager<D extends IDatabaseDriver = IDatabaseDriver> {
       const key = options.strict ? 'findExactlyOneOrFailHandler' : 'findOneOrFailHandler';
       options.failHandler ??= this.config.get(key);
       entityName = Utils.className(entityName);
+      /* istanbul ignore next */
       where = Utils.isEntity(where) ? helper(where).getPrimaryKey() as any : where;
       throw options.failHandler!(entityName, where);
     }

--- a/packages/core/src/decorators/Entity.ts
+++ b/packages/core/src/decorators/Entity.ts
@@ -31,6 +31,6 @@ export type EntityOptions<T> = {
   virtual?: boolean;
   // we need to use `em: any` here otherwise an expression would not be assignable with more narrow type like `SqlEntityManager`
   // also return type is unknown as it can be either QB instance (which we cannot type here) or array of POJOs (e.g. for mongodb)
-  expression?: string | ((em: any, where: FilterQuery<T>, options: FindOptions<T, any, any>) => object);
+  expression?: string | ((em: any, where: FilterQuery<T>, options: FindOptions<T, any, any, any>) => object);
   repository?: () => Constructor;
 };

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -52,9 +52,9 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     this.logger = this.config.getLogger();
   }
 
-  abstract find<T extends object, P extends string = never, F extends string = '*'>(entityName: string, where: FilterQuery<T>, options?: FindOptions<T, P, F>): Promise<EntityData<T>[]>;
+  abstract find<T extends object, P extends string = never, F extends string = '*', E extends string = never>(entityName: string, where: FilterQuery<T>, options?: FindOptions<T, P, F, E>): Promise<EntityData<T>[]>;
 
-  abstract findOne<T extends object, P extends string = never, F extends string = '*'>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T, P, F>): Promise<EntityData<T> | null>;
+  abstract findOne<T extends object, P extends string = never, F extends string = '*', E extends string = never>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T, P, F, E>): Promise<EntityData<T> | null>;
 
   abstract nativeInsert<T extends object>(entityName: string, data: EntityDictionary<T>, options?: NativeInsertUpdateOptions<T>): Promise<QueryResult<T>>;
 
@@ -75,7 +75,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
   }
 
   /* istanbul ignore next */
-  async findVirtual<T extends object>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, any, any>): Promise<EntityData<T>[]> {
+  async findVirtual<T extends object>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, any, any, any>): Promise<EntityData<T>[]> {
     throw new Error(`Virtual entities are not supported by ${this.constructor.name} driver.`);
   }
 
@@ -88,7 +88,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     throw new Error(`Aggregations are not supported by ${this.constructor.name} driver`);
   }
 
-  async loadFromPivotTable<T extends object, O extends object>(prop: EntityProperty, owners: Primary<O>[][], where?: FilterQuery<any>, orderBy?: OrderDefinition<T>, ctx?: Transaction, options?: FindOptions<T, any, any>, pivotJoin?: boolean): Promise<Dictionary<T[]>> {
+  async loadFromPivotTable<T extends object, O extends object>(prop: EntityProperty, owners: Primary<O>[][], where?: FilterQuery<any>, orderBy?: OrderDefinition<T>, ctx?: Transaction, options?: FindOptions<T, any, any, any>, pivotJoin?: boolean): Promise<Dictionary<T[]>> {
     throw new Error(`${this.constructor.name} does not use pivot tables`);
   }
 
@@ -171,7 +171,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     return this.dependencies;
   }
 
-  protected processCursorOptions<T extends object, P extends string>(meta: EntityMetadata<T>, options: FindOptions<T, P, any>, orderBy: OrderDefinition<T>): { orderBy: OrderDefinition<T>[]; where: FilterQuery<T> } {
+  protected processCursorOptions<T extends object, P extends string>(meta: EntityMetadata<T>, options: FindOptions<T, P, any, any>, orderBy: OrderDefinition<T>): { orderBy: OrderDefinition<T>[]; where: FilterQuery<T> } {
     const { first, last, before, after, overfetch } = options;
     const limit = first || last;
     const isLast = !first && !!last;

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -32,14 +32,14 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   /**
    * Finds selection of entities
    */
-  find<T extends object, P extends string = never, F extends string = '*'>(entityName: string, where: FilterQuery<T>, options?: FindOptions<T, P, F>): Promise<EntityData<T>[]>;
+  find<T extends object, P extends string = never, F extends string = '*', E extends string = never>(entityName: string, where: FilterQuery<T>, options?: FindOptions<T, P, F, E>): Promise<EntityData<T>[]>;
 
   /**
    * Finds single entity (table row, document)
    */
-  findOne<T extends object, P extends string = never, F extends string = '*'>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T, P, F>): Promise<EntityData<T> | null>;
+  findOne<T extends object, P extends string = never, F extends string = '*', E extends string = never>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T, P, F, E>): Promise<EntityData<T> | null>;
 
-  findVirtual<T extends object>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, any, any>): Promise<EntityData<T>[]>;
+  findVirtual<T extends object>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, any, any, any>): Promise<EntityData<T>[]>;
 
   nativeInsert<T extends object>(entityName: string, data: EntityDictionary<T>, options?: NativeInsertUpdateOptions<T>): Promise<QueryResult<T>>;
 
@@ -62,7 +62,7 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   /**
    * When driver uses pivot tables for M:N, this method will load identifiers for given collections from them
    */
-  loadFromPivotTable<T extends object, O extends object>(prop: EntityProperty, owners: Primary<O>[][], where?: FilterQuery<T>, orderBy?: OrderDefinition<T>, ctx?: Transaction, options?: FindOptions<T, any, any>, pivotJoin?: boolean): Promise<Dictionary<T[]>>;
+  loadFromPivotTable<T extends object, O extends object>(prop: EntityProperty, owners: Primary<O>[][], where?: FilterQuery<T>, orderBy?: OrderDefinition<T>, ctx?: Transaction, options?: FindOptions<T, any, any, any>, pivotJoin?: boolean): Promise<Dictionary<T[]>>;
 
   getPlatform(): Platform;
 
@@ -94,25 +94,31 @@ export type EntityField<T, P extends string = '*'> = keyof T | '*' | AutoPath<T,
 
 export type OrderDefinition<T> = (QueryOrderMap<T> & { 0?: never }) | QueryOrderMap<T>[];
 
-export interface FindAllOptions<T, P extends string = never, F extends string = '*'> extends FindOptions<T, P, F> {
+export interface FindAllOptions<T, P extends string = never, F extends string = '*', E extends string = never> extends FindOptions<T, P, F, E> {
   where?: FilterQuery<T>;
 }
 
 export type FilterOptions = Dictionary<boolean | Dictionary> | string[] | boolean;
 
-export interface FindOptions<T, P extends string = never, F extends string = '*'> {
-  populate?: Populate<T, P>;
-  populateWhere?: ObjectQuery<T> | PopulateHint | `${PopulateHint}`;
-  populateOrderBy?: OrderDefinition<T>;
-  fields?: readonly AutoPath<T, F, '*'>[];
-  orderBy?: OrderDefinition<T>;
+export interface FindOptions<
+  Entity,
+  Hint extends string = never,
+  Fields extends string = '*',
+  Excludes extends string = never,
+> {
+  populate?: Populate<Entity, Hint>;
+  populateWhere?: ObjectQuery<Entity> | PopulateHint | `${PopulateHint}`;
+  populateOrderBy?: OrderDefinition<Entity>;
+  fields?: readonly AutoPath<Entity, Fields, '*'>[];
+  exclude?: readonly AutoPath<Entity, Excludes>[];
+  orderBy?: OrderDefinition<Entity>;
   cache?: boolean | number | [string, number];
   limit?: number;
   offset?: number;
   /** Fetch items `before` this cursor. */
-  before?: string | { startCursor: string | null } | FilterObject<T>;
+  before?: string | { startCursor: string | null } | FilterObject<Entity>;
   /** Fetch items `after` this cursor. */
-  after?: string | { endCursor: string | null } | FilterObject<T>;
+  after?: string | { endCursor: string | null } | FilterObject<Entity>;
   /** Fetch `first` N items. */
   first?: number;
   /** Fetch `last` N items. */
@@ -126,7 +132,7 @@ export interface FindOptions<T, P extends string = never, F extends string = '*'
   flags?: QueryFlag[];
   /** sql only */
   groupBy?: string | string[];
-  having?: QBFilterQuery<T>;
+  having?: QBFilterQuery<Entity>;
   /** sql only */
   strategy?: LoadStrategy | `${LoadStrategy}`;
   flushMode?: FlushMode | `${FlushMode}`;
@@ -147,15 +153,15 @@ export interface FindOptions<T, P extends string = never, F extends string = '*'
   logging?: LoggingOptions;
 }
 
-export interface FindByCursorOptions<T extends object, P extends string = never, F extends string = '*'> extends Omit<FindOptions<T, P, F>, 'limit' | 'offset'> {
+export interface FindByCursorOptions<T extends object, P extends string = never, F extends string = '*', E extends string = never> extends Omit<FindOptions<T, P, F, E>, 'limit' | 'offset'> {
 }
 
-export interface FindOneOptions<T extends object, P extends string = never, F extends string = '*'> extends Omit<FindOptions<T, P, F>, 'limit' | 'lockMode'> {
+export interface FindOneOptions<T extends object, P extends string = never, F extends string = '*', E extends string = never> extends Omit<FindOptions<T, P, F, E>, 'limit' | 'lockMode'> {
   lockMode?: LockMode;
   lockVersion?: number | Date;
 }
 
-export interface FindOneOrFailOptions<T extends object, P extends string = never, F extends string = '*'> extends FindOneOptions<T, P, F> {
+export interface FindOneOrFailOptions<T extends object, P extends string = never, F extends string = '*', E extends string = never> extends FindOneOptions<T, P, F, E> {
   failHandler?: (entityName: string, where: Dictionary | IPrimaryKey | any) => Error;
   strict?: boolean;
 }

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -150,7 +150,7 @@ export class EntityRepository<Entity extends object> {
     Hint extends string = never,
     Fields extends string = '*',
     Excludes extends string = never,
-  >(where: FilterQuery<Entity>, options?: FindByCursorOptions<Entity, Hint, Fields, Excludes>): Promise<Cursor<Entity, Hint, Fields, Excludes>> {
+  >(where: FilterQuery<Entity>, options: FindByCursorOptions<Entity, Hint, Fields, Excludes>): Promise<Cursor<Entity, Hint, Fields, Excludes>> {
     return this.getEntityManager().findByCursor(this.entityName, where, options);
   }
 

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -47,20 +47,22 @@ export class EntityRepository<Entity extends object> {
   async findOne<
     Hint extends string = never,
     Fields extends string = '*',
-  >(where: FilterQuery<Entity>, options?: FindOneOptions<Entity, Hint, Fields>): Promise<Loaded<Entity, Hint, Fields> | null> {
-    return this.getEntityManager().findOne<Entity, Hint, Fields>(this.entityName, where, options);
+    Excludes extends string = never,
+  >(where: FilterQuery<Entity>, options?: FindOneOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes> | null> {
+    return this.getEntityManager().findOne<Entity, Hint, Fields, Excludes>(this.entityName, where, options);
   }
 
   /**
-   * Finds first entity matching your `where` query. If nothing found, it will throw an error.
+   * Finds first entity matching your `where` query. If nothing is found, it will throw an error.
    * You can override the factory for creating this method via `options.failHandler` locally
    * or via `Configuration.findOneOrFailHandler` globally.
    */
   async findOneOrFail<
     Hint extends string = never,
     Fields extends string = '*',
-  >(where: FilterQuery<Entity>, options?: FindOneOrFailOptions<Entity, Hint, Fields>): Promise<Loaded<Entity, Hint, Fields>> {
-    return this.getEntityManager().findOneOrFail<Entity, Hint, Fields>(this.entityName, where, options);
+    Excludes extends string = never,
+  >(where: FilterQuery<Entity>, options?: FindOneOrFailOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes>> {
+    return this.getEntityManager().findOneOrFail<Entity, Hint, Fields, Excludes>(this.entityName, where, options);
   }
 
   /**
@@ -124,18 +126,20 @@ export class EntityRepository<Entity extends object> {
   async find<
     Hint extends string = never,
     Fields extends string = '*',
-  >(where: FilterQuery<Entity>, options?: FindOptions<Entity, Hint, Fields>): Promise<Loaded<Entity, Hint, Fields>[]> {
+    Excludes extends string = never,
+  >(where: FilterQuery<Entity>, options?: FindOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes>[]> {
     return this.getEntityManager().find(this.entityName, where as FilterQuery<Entity>, options);
   }
 
   /**
    * Calls `em.find()` and `em.count()` with the same arguments (where applicable) and returns the results as tuple
-   * where first element is the array of entities and the second is the count.
+   * where first element is the array of entities, and the second is the count.
    */
   async findAndCount<
     Hint extends string = never,
     Fields extends string = '*',
-  >(where: FilterQuery<Entity>, options?: FindOptions<Entity, Hint, Fields>): Promise<[Loaded<Entity, Hint, Fields>[], number]> {
+    Excludes extends string = never,
+  >(where: FilterQuery<Entity>, options?: FindOptions<Entity, Hint, Fields, Excludes>): Promise<[Loaded<Entity, Hint, Fields, Excludes>[], number]> {
     return this.getEntityManager().findAndCount(this.entityName, where, options);
   }
 
@@ -145,7 +149,8 @@ export class EntityRepository<Entity extends object> {
   async findByCursor<
     Hint extends string = never,
     Fields extends string = '*',
-  >(where: FilterQuery<Entity>, options?: FindByCursorOptions<Entity, Hint, Fields>): Promise<Cursor<Entity, Hint, Fields>> {
+    Excludes extends string = never,
+  >(where: FilterQuery<Entity>, options?: FindByCursorOptions<Entity, Hint, Fields, Excludes>): Promise<Cursor<Entity, Hint, Fields, Excludes>> {
     return this.getEntityManager().findByCursor(this.entityName, where, options);
   }
 
@@ -155,7 +160,8 @@ export class EntityRepository<Entity extends object> {
   async findAll<
     Hint extends string = never,
     Fields extends string = '*',
-  >(options?: FindAllOptions<Entity, Hint, Fields>): Promise<Loaded<Entity, Hint, Fields>[]> {
+    Excludes extends string = never,
+  >(options?: FindAllOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes>[]> {
     return this.getEntityManager().findAll(this.entityName, options);
   }
 
@@ -231,7 +237,8 @@ export class EntityRepository<Entity extends object> {
     Hint extends string = never,
     Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
     Fields extends string = '*',
-  >(entities: Ent, populate: AutoPath<Entity, Hint, '*'>[] | false, options?: EntityLoaderOptions<Entity, Fields>): Promise<Ent extends object[] ? MergeLoaded<ArrayElement<Ent>, Naked, Hint, Fields>[] : MergeLoaded<Ent, Naked, Hint, Fields>> {
+    Excludes extends string = never,
+  >(entities: Ent, populate: AutoPath<Entity, Hint, '*'>[] | false, options?: EntityLoaderOptions<Entity, Fields, Excludes>): Promise<Ent extends object[] ? MergeLoaded<ArrayElement<Ent>, Naked, Hint, Fields, Excludes>[] : MergeLoaded<Ent, Naked, Hint, Fields, Excludes>> {
     this.validateRepositoryType(entities, 'populate');
     // @ts-ignore hard to type
     return this.getEntityManager().populate(entities, populate, options);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,7 @@ export {
   GetRepository, EntityRepositoryType, MigrationObject, DeepPartial, PrimaryProperty, Cast, IsUnknown, EntityDictionary, EntityDTO, MigrationDiff, GenerateOptions, FilterObject,
   IEntityGenerator, ISeedManager, EntityClassGroup, OptionalProps, EagerProps, HiddenProps, RequiredEntityData, CheckCallback, SimpleColumnMeta, Rel, Ref, ScalarRef, EntityRef, ISchemaGenerator,
   UmzugMigration, MigrateOptions, MigrationResult, MigrationRow, EntityKey, EntityValue, FilterKey, Opt, EntityType, FromEntityType, Selected, IsSubset,
-  EntityProps, ExpandProperty, ExpandScalar, FilterItemValue, ExpandQuery, Scalar, ExpandHint, Hidden, FilterValue,
+  EntityProps, ExpandProperty, ExpandScalar, FilterItemValue, ExpandQuery, Scalar, ExpandHint, Hidden, FilterValue, MergeLoaded, MergeSelected,
 } from './typings';
 export * from './enums';
 export * from './errors';

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -431,9 +431,21 @@ export abstract class Platform {
     return false;
   }
 
-  shouldHaveColumn<T>(prop: EntityProperty<T>, populate: PopulateOptions<T>[] | boolean, includeFormulas = true): boolean {
+  isPopulated<T>(key: string, populate: PopulateOptions<T>[] | boolean): boolean {
+    return populate === true || (populate !== false && populate.some(p => p.field === key || p.all));
+  }
+
+  shouldHaveColumn<T>(prop: EntityProperty<T>, populate: PopulateOptions<T>[] | boolean, exclude?: string[], includeFormulas = true): boolean {
+    if (exclude?.includes(prop.name)) {
+      return false;
+    }
+
+    if (exclude?.find(k => k.startsWith(`${prop.name}.`) && !this.isPopulated(prop.name, populate))) {
+      return false;
+    }
+
     if (prop.formula) {
-      return includeFormulas && (!prop.lazy || populate === true || (populate !== false && populate.some(p => p.field === prop.name || p.all)));
+      return includeFormulas && (!prop.lazy || this.isPopulated(prop.name, populate));
     }
 
     if (prop.persist === false) {

--- a/packages/core/src/serialization/EntitySerializer.ts
+++ b/packages/core/src/serialization/EntitySerializer.ts
@@ -187,16 +187,10 @@ export class EntitySerializer {
   }
 
   private static extractChildOptions<T extends object, U extends object>(options: SerializeOptions<T, any, any>, prop: EntityKey<T>): SerializeOptions<U, any> {
-    const extractChildElements = (items: string[], allSymbol?: string) => {
-      return items
-        .filter(field => field === allSymbol || field.startsWith(`${prop}.`))
-        .map(field => field === allSymbol ? allSymbol : field.substring(prop.length + 1));
-    };
-
     return {
       ...options,
-      populate: Array.isArray(options.populate) ? extractChildElements(options.populate, '*') : options.populate,
-      exclude: Array.isArray(options.exclude) ? extractChildElements(options.exclude) : options.exclude,
+      populate: Array.isArray(options.populate) ? Utils.extractChildElements(options.populate, prop, '*') : options.populate,
+      exclude: Array.isArray(options.exclude) ? Utils.extractChildElements(options.exclude, prop) : options.exclude,
     } as SerializeOptions<U, any>;
   }
 

--- a/packages/core/src/serialization/EntityTransformer.ts
+++ b/packages/core/src/serialization/EntityTransformer.ts
@@ -26,7 +26,12 @@ export class EntityTransformer {
     let contextCreated = false;
 
     if (!wrapped.__serializationContext.root) {
-      const root = new SerializationContext<Entity>(wrapped.__config, wrapped.__serializationContext.populate, wrapped.__serializationContext.fields);
+      const root = new SerializationContext<Entity>(
+        wrapped.__config,
+        wrapped.__serializationContext.populate,
+        wrapped.__serializationContext.fields,
+        wrapped.__serializationContext.exclude,
+      );
       SerializationContext.propagate(root, entity, isVisible);
       contextCreated = true;
     }

--- a/packages/core/src/serialization/SerializationContext.ts
+++ b/packages/core/src/serialization/SerializationContext.ts
@@ -17,7 +17,8 @@ export class SerializationContext<T> {
 
   constructor(private readonly config: Configuration,
               private readonly populate: PopulateOptions<T>[] = [],
-              private readonly fields?: string[]) {}
+              private readonly fields?: string[],
+              private readonly exclude?: string[]) {}
 
   /**
    * Returns true when there is a cycle detected.

--- a/packages/core/src/utils/Cursor.ts
+++ b/packages/core/src/utils/Cursor.ts
@@ -6,8 +6,8 @@ import { ReferenceKind, type QueryOrder, type QueryOrderKeys } from '../enums';
 import { Reference } from '../entity/Reference';
 
 /**
- * As an alternative to the offset based pagination with `limit` and `offset`, we can paginate based on a cursor.
- * A cursor is an opaque string that defines specific place in ordered entity graph. You can use `em.findByCursor()`
+ * As an alternative to the offset-based pagination with `limit` and `offset`, we can paginate based on a cursor.
+ * A cursor is an opaque string that defines a specific place in ordered entity graph. You can use `em.findByCursor()`
  * to access those options. Under the hood, it will call `em.find()` and `em.count()` just like the `em.findAndCount()`
  * method, but will use the cursor options instead.
  *
@@ -33,7 +33,7 @@ import { Reference } from '../entity/Reference';
  * });
  * ```
  *
- * The `Cursor` object provides following interface:
+ * The `Cursor` object provides the following interface:
  *
  * ```ts
  * Cursor<User> {
@@ -52,7 +52,12 @@ import { Reference } from '../entity/Reference';
  * }
  * ```
  */
-export class Cursor<Entity extends object, Hint extends string = never, Fields extends string = '*'> {
+export class Cursor<
+  Entity extends object,
+  Hint extends string = never,
+  Fields extends string = '*',
+  Excludes extends string = never,
+> {
 
   readonly hasPrevPage: boolean;
   readonly hasNextPage: boolean;
@@ -60,9 +65,9 @@ export class Cursor<Entity extends object, Hint extends string = never, Fields e
   private readonly definition: (readonly [EntityKey<Entity>, QueryOrder])[];
 
   constructor(
-    readonly items: Loaded<Entity, Hint, Fields>[],
+    readonly items: Loaded<Entity, Hint, Fields, Excludes>[],
     readonly totalCount: number,
-    options: FindByCursorOptions<Entity, Hint, Fields>,
+    options: FindByCursorOptions<Entity, Hint, Fields, Excludes>,
     meta: EntityMetadata<Entity>,
   ) {
     const { first, last, before, after, orderBy, overfetch } = options;
@@ -100,9 +105,9 @@ export class Cursor<Entity extends object, Hint extends string = never, Fields e
   }
 
   /**
-   * Computes the cursor value for given entity.
+   * Computes the cursor value for a given entity.
    */
-  from(entity: Entity | Loaded<Entity, Hint, Fields>) {
+  from(entity: Entity | Loaded<Entity, Hint, Fields, Excludes>) {
     const processEntity = <T extends object> (entity: T, prop: EntityKey<T>, direction: QueryOrderKeys<T>, object = false) => {
       if (Utils.isPlainObject(direction)) {
         const value = Utils.keys(direction).reduce((o, key) => {
@@ -122,7 +127,7 @@ export class Cursor<Entity extends object, Hint extends string = never, Fields e
     return Cursor.encode(value);
   }
 
-  * [Symbol.iterator](): IterableIterator<Loaded<Entity, Hint, Fields>> {
+  * [Symbol.iterator](): IterableIterator<Loaded<Entity, Hint, Fields, Excludes>> {
     for (const item of this.items) {
       yield item;
     }

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -730,6 +730,12 @@ export class Utils {
     return classOrName.name as string;
   }
 
+  static extractChildElements(items: string[], prefix: string, allSymbol?: string) {
+    return items
+      .filter(field => field === allSymbol || field.startsWith(`${prefix}.`))
+      .map(field => field === allSymbol ? allSymbol : field.substring(prefix.length + 1));
+  }
+
   /**
    * Tries to detect `ts-node` runtime.
    */

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -83,8 +83,8 @@ export class MongoPlatform extends Platform {
     return ret;
   }
 
-  override shouldHaveColumn<T>(prop: EntityProperty<T>, populate: PopulateOptions<T>[]): boolean {
-    if (super.shouldHaveColumn(prop, populate)) {
+  override shouldHaveColumn<T>(prop: EntityProperty<T>, populate: PopulateOptions<T>[], exclude?: string[]): boolean {
+    if (super.shouldHaveColumn(prop, populate, exclude)) {
       return true;
     }
 

--- a/tests/DatabaseDriver.test.ts
+++ b/tests/DatabaseDriver.test.ts
@@ -38,11 +38,11 @@ class Driver extends DatabaseDriver<Connection> implements IDatabaseDriver {
     return 0;
   }
 
-  async find<T extends object, P extends string = never, F extends string = '*'>(entityName: string, where: ObjectQuery<T>, options: FindOptions<T, P, F> | undefined): Promise<EntityData<T>[]> {
+  async find<T extends object, P extends string = never, F extends string = '*', E extends string = never>(entityName: string, where: ObjectQuery<T>, options: FindOptions<T, P, F, E> | undefined): Promise<EntityData<T>[]> {
     return [];
   }
 
-  async findOne<T extends object, P extends string = never, F extends string = '*'>(entityName: string, where: ObjectQuery<T>, options: FindOneOptions<T, P, F> | undefined): Promise<EntityData<T> | null> {
+  async findOne<T extends object, P extends string = never, F extends string = '*', E extends string = never>(entityName: string, where: ObjectQuery<T>, options: FindOneOptions<T, P, F, E> | undefined): Promise<EntityData<T> | null> {
     return null;
   }
 

--- a/tests/EntityManager.sqlite2.test.ts
+++ b/tests/EntityManager.sqlite2.test.ts
@@ -1157,6 +1157,9 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
     expect(e2.name).toBe('123');
     await orm.em.refresh(e2);
     expect(e2.name).toBe('lalala');
+
+    await orm.em.nativeDelete(Author4, e2);
+    await expect(orm.em.refreshOrFail(e2)).rejects.toThrow(`Author4 not found (${e2.id})`);
   });
 
   test('qb.getCount()`', async () => {

--- a/tests/features/cursor-based-pagination/simple-cursor.test.ts
+++ b/tests/features/cursor-based-pagination/simple-cursor.test.ts
@@ -59,6 +59,9 @@ describe.each(['sqlite', 'better-sqlite', 'mysql', 'postgresql', 'mongo'] as con
   afterAll(() => orm.close(true));
 
   test('using `first` and `after` (id asc)', async () => {
+    const cursor0 = await orm.em.findByCursor(User, {});
+    expect(cursor0).toBeInstanceOf(Cursor);
+
     const mock = mockLogger(orm, ['query', 'query-params']);
 
     // 1. page

--- a/tests/features/cursor-based-pagination/simple-cursor.test.ts
+++ b/tests/features/cursor-based-pagination/simple-cursor.test.ts
@@ -59,9 +59,6 @@ describe.each(['sqlite', 'better-sqlite', 'mysql', 'postgresql', 'mongo'] as con
   afterAll(() => orm.close(true));
 
   test('using `first` and `after` (id asc)', async () => {
-    const cursor0 = await orm.em.findByCursor(User, {});
-    expect(cursor0).toBeInstanceOf(Cursor);
-
     const mock = mockLogger(orm, ['query', 'query-params']);
 
     // 1. page

--- a/tests/features/partial-loading/partial-loading-exclude.mysql.test.ts
+++ b/tests/features/partial-loading/partial-loading-exclude.mysql.test.ts
@@ -1,0 +1,329 @@
+import type { MikroORM } from '@mikro-orm/core';
+import { LoadStrategy } from '@mikro-orm/core';
+import { MySqlDriver } from '@mikro-orm/mysql';
+import { Author2, Book2, BookTag2 } from '../../entities-sql';
+import { initORMMySql, mockLogger } from '../../bootstrap';
+
+describe('partial loading via `exclude` (mysql)', () => {
+
+  let orm: MikroORM<MySqlDriver>;
+
+  beforeAll(async () => orm = await initORMMySql('mysql', { dbName: 'partial_loading2' }, true));
+  beforeEach(async () => orm.schema.clearDatabase());
+  afterAll(async () => await orm.close(true));
+
+  async function createEntities() {
+    const god = new Author2(`God `, `hello@heaven.god`);
+    const b1 = orm.em.create(Book2, { title: `Bible 1`, author: god });
+    b1.price = 123;
+    b1.tags.add(new BookTag2('t1'), new BookTag2('t2'));
+    const b2 = orm.em.create(Book2, { title: `Bible 2`, author: god });
+    b2.price = 456;
+    b2.tags.add(new BookTag2('t3'), new BookTag2('t4'));
+    const b3 = orm.em.create(Book2, { title: `Bible 3`, author: god });
+    b3.price = 789;
+    b3.tags.add(new BookTag2('t5'), new BookTag2('t6'));
+    await orm.em.persistAndFlush(god);
+    orm.em.clear();
+
+    return god;
+  }
+
+  test('exclude option', async () => {
+    const author = new Author2('Jon Snow', 'snow@wall.st');
+    author.born = '1990-03-23';
+    await orm.em.persistAndFlush(author);
+    orm.em.clear();
+
+    const a = (await orm.em.findOne(Author2, author, { exclude: ['email', 'born', 'termsAccepted'] }))!;
+    expect(a.name).toBe('Jon Snow');
+    // @ts-expect-error
+    expect(a.email).toBeUndefined();
+    // @ts-expect-error
+    expect(a.born).toBeUndefined();
+    // @ts-expect-error
+    expect(a.termsAccepted).toBeUndefined();
+
+    const a1 = orm.em.assign(a, { email: 'e1' });
+    expect(a1.name).toBe('Jon Snow');
+    expect(a1.email).toBe('e1');
+    // @ts-expect-error
+    expect(a1.termsAccepted).toBeUndefined();
+
+    const a2 = orm.em.repo(Author2).assign(a, { email: 'e1' });
+    expect(a2.name).toBe('Jon Snow');
+    expect(a2.email).toBe('e1');
+    // @ts-expect-error
+    expect(a2.termsAccepted).toBeUndefined();
+
+    const a3 = orm.em.assign(a1, { born: '1990-03-24' });
+    expect(a3.name).toBe('Jon Snow');
+    expect(a3.email).toBe('e1');
+    expect(a3.born).toBe('1990-03-24');
+    // @ts-expect-error
+    expect(a3.termsAccepted).toBeUndefined();
+
+    // @ts-expect-error
+    const a4 = orm.em.repo(Author2).assign(a2, { born: '1990-03-24', asd: true });
+    expect(a4.name).toBe('Jon Snow');
+    expect(a4.email).toBe('e1');
+    expect(a4.born).toBe('1990-03-24');
+    // @ts-expect-error
+    expect(a4.asd).toBe(true);
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const a5 = (await orm.em.findOne(Author2, author, { exclude: ['email'] }))!;
+    expect(a5.name).toBe('Jon Snow');
+    // @ts-expect-error
+    expect(a5.email).toBeUndefined();
+    expect(a5.born).toEqual('1990-03-24');
+
+    const a6 = await orm.em.refresh(a5);
+    expect(a6?.email).toBe('e1');
+    orm.em.clear();
+  });
+
+  test('partial nested loading (1:m)', async () => {
+    const god = await createEntities();
+
+    const rr = await orm.em.findOneOrFail(Author2, god, {
+      populate: ['books.publisher'],
+      exclude: ['email', 'favouriteBook.author', 'favouriteBook.publisher', 'books.title', 'books.publisher.type'],
+      disableIdentityMap: true,
+    });
+
+    // @ts-expect-error
+    rr.favouriteBook?.author;
+    rr.favouriteBook?.title;
+    rr.favouriteBook?.double;
+    rr.favouriteBook?.
+      // @ts-expect-error
+      publisher?.$.name;
+
+    // @ts-expect-error
+    rr.books.$[0].title;
+    rr.books.$[0].publisher?.$.name;
+    // @ts-expect-error
+    rr.books.$[0].publisher?.$.type;
+
+    // test working with scalars
+    expect(`This is User #${rr.id.toFixed()} with name '${rr.name.substring(0, 3)}'`).toBe(`This is User #1 with name 'God'`);
+
+    const mock = mockLogger(orm, ['query']);
+
+    const r1 = await orm.em.find(Author2, god, { populate: ['books'], exclude: ['name', 'books.price'], strategy: 'select-in' });
+    expect(r1).toHaveLength(1);
+    expect(r1[0].id).toBe(god.id);
+    // @ts-expect-error
+    expect(r1[0].name).toBeUndefined();
+    expect(r1[0].books[0].uuid).toBe(god.books[0].uuid);
+    expect(r1[0].books[0].title).toBe('Bible 1');
+    // @ts-expect-error
+    expect(r1[0].books[0].price).toBeUndefined();
+    expect(r1[0].books[0].author).toBeDefined();
+    expect(mock.mock.calls).toHaveLength(2);
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `a0`.`created_at`, `a0`.`updated_at`, `a0`.`email`, `a0`.`age`, `a0`.`terms_accepted`, `a0`.`optional`, `a0`.`identities`, `a0`.`born`, `a0`.`born_time`, `a0`.`favourite_book_uuid_pk`, `a0`.`favourite_author_id`, `a0`.`identity`, `a1`.`author_id` as `address_author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id` where `a0`.`id` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `test_id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`author_id` is not null and `b0`.`author_id` in (?) order by `b0`.`title` asc');
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const r0 = await orm.em.find(Author2, god, { populate: ['books'], exclude: ['name', 'books.price'], strategy: 'joined' });
+    expect(r0).toHaveLength(1);
+    expect(r0[0].id).toBe(god.id);
+    // @ts-expect-error
+    expect(r0[0].name).toBeUndefined();
+    expect(r0[0].books[0].uuid).toBe(god.books[0].uuid);
+    expect(r0[0].books[0].title).toBe('Bible 1');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `a0`.`created_at`, `a0`.`updated_at`, `a0`.`email`, `a0`.`age`, `a0`.`terms_accepted`, `a0`.`optional`, `a0`.`identities`, `a0`.`born`, `a0`.`born_time`, `a0`.`favourite_book_uuid_pk`, `a0`.`favourite_author_id`, `a0`.`identity`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`title` as `b1__title`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `address_author_id` from `author2` as `a0` left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` where `a0`.`id` = ? order by `b1`.`title` asc');
+    // @ts-expect-error
+    expect(r0[0].books[0].price).toBeUndefined();
+    expect(r0[0].books[0].author).toBeDefined();
+    expect(mock.mock.calls).toHaveLength(1);
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    // partial loading with query builder
+    const r3 = await orm.em.qb(Author2, 'a')
+      .select('id')
+      .innerJoinAndSelect('a.books', 'b', {}, ['author', 'title'])
+      .where({ id: god.id })
+      .orderBy({ 'b.title': 1 });
+    expect(r3).toHaveLength(1);
+    expect(r3[0].id).toBe(god.id);
+    expect(r3[0].name).toBeUndefined();
+    expect(r3[0].books[0].uuid).toBe(god.books[0].uuid);
+    expect(r3[0].books[0].title).toBe('Bible 1');
+    expect(r3[0].books[0].price).toBeUndefined();
+    expect(r3[0].books[0].author).toBeDefined();
+    expect(mock.mock.calls[0][0]).toMatch('select `a`.`id`, `b`.`uuid_pk` as `b__uuid_pk`, `b`.`title` as `b__title`, `b`.`author_id` as `b__author_id` from `author2` as `a` inner join `book2` as `b` on `a`.`id` = `b`.`author_id` where `a`.`id` = ? order by `b`.`title` asc');
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+  });
+
+  test('partial nested loading (m:1)', async () => {
+    const god = await createEntities();
+    const b1 = god.books[0];
+    const mock = mockLogger(orm, ['query']);
+
+    const r1 = await orm.em.find(Book2, b1, {
+      exclude: ['price', 'author.name'],
+      populate: ['author'],
+      filters: false,
+      strategy: LoadStrategy.JOINED,
+    });
+    expect(r1).toHaveLength(1);
+    expect(r1[0].uuid).toBe(b1.uuid);
+    expect(r1[0].title).toBe('Bible 1');
+    // @ts-expect-error
+    expect(r1[0].price).toBeUndefined();
+    expect(r1[0].author).toBeDefined();
+    expect(r1[0].author.id).toBe(god.id);
+    // @ts-expect-error
+    expect(r1[0].author.name).toBeUndefined();
+    expect(r1[0].author.email).toBeDefined();
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `a1`.`id` as `a1__id`, `a1`.`created_at` as `a1__created_at`, `a1`.`updated_at` as `a1__updated_at`, `a1`.`email` as `a1__email`, `a1`.`age` as `a1__age`, `a1`.`terms_accepted` as `a1__terms_accepted`, `a1`.`optional` as `a1__optional`, `a1`.`identities` as `a1__identities`, `a1`.`born` as `a1__born`, `a1`.`born_time` as `a1__born_time`, `a1`.`favourite_book_uuid_pk` as `a1__favourite_book_uuid_pk`, `a1`.`favourite_author_id` as `a1__favourite_author_id`, `a1`.`identity` as `a1__identity`, `t2`.`id` as `test_id` from `book2` as `b0` left join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` where `b0`.`uuid_pk` = ?');
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const r2 = await orm.em.find(Book2, b1, {
+      exclude: ['price', 'author.name'],
+      populate: ['author'],
+      filters: false,
+      strategy: LoadStrategy.SELECT_IN,
+    });
+    expect(r2).toHaveLength(1);
+    expect(r2[0].uuid).toBe(b1.uuid);
+    expect(r2[0].title).toBe('Bible 1');
+    // @ts-expect-error
+    expect(r2[0].price).toBeUndefined();
+    expect(r2[0].author).toBeDefined();
+    expect(r2[0].author.id).toBe(god.id);
+    // @ts-expect-error
+    expect(r2[0].author.name).toBeUndefined();
+    expect(r2[0].author.email).toBeDefined();
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `test_id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`uuid_pk` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select `a0`.`id`, `a0`.`created_at`, `a0`.`updated_at`, `a0`.`email`, `a0`.`age`, `a0`.`terms_accepted`, `a0`.`optional`, `a0`.`identities`, `a0`.`born`, `a0`.`born_time`, `a0`.`favourite_book_uuid_pk`, `a0`.`favourite_author_id`, `a0`.`identity`, `a1`.`author_id` as `address_author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id` where `a0`.`id` in (?)');
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+  });
+
+  test('partial nested loading (m:n)', async () => {
+    await createEntities();
+    const mock = mockLogger(orm, ['query']);
+
+    const r1 = await orm.em.find(BookTag2, {}, {
+      exclude: ['books.author', 'books.price'],
+      populate: ['books'],
+      filters: false,
+      strategy: 'joined',
+    });
+    expect(r1).toHaveLength(6);
+    expect(r1[0].name).toBe('t1');
+    expect(r1[0].books[0].title).toBe('Bible 1');
+    // @ts-expect-error
+    expect(r1[0].books[0].price).toBeUndefined();
+    // @ts-expect-error
+    expect(r1[0].books[0].author).toBeUndefined();
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`title` as `b1__title`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`publisher_id` as `b1__publisher_id` from `book_tag2` as `b0` left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` order by `b2`.`order` asc');
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const r2 = await orm.em.find(BookTag2, { name: 't1' }, {
+      exclude: ['books.author', 'books.price'],
+      populate: ['books'],
+      filters: false,
+      strategy: 'select-in',
+    });
+    expect(r2).toHaveLength(1);
+    expect(r2[0].name).toBe('t1');
+    expect(r2[0].books[0].title).toBe('Bible 1');
+    // @ts-expect-error
+    expect(r2[0].books[0].price).toBeUndefined();
+    // @ts-expect-error
+    expect(r2[0].books[0].author).toBeUndefined();
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name` from `book_tag2` as `b0` where `b0`.`name` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select `b1`.price * 1.19 as `price_taxed`, `b1`.`publisher_id`, `b1`.`meta`, `b1`.`double`, `b1`.`title`, `b1`.`created_at`, `b1`.`uuid_pk`, `b0`.`book_tag2_id` as `fk__book_tag2_id`, `b0`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `b2`.`id` as `test_id` from `book2_tags` as `b0` inner join `book2` as `b1` on `b0`.`book2_uuid_pk` = `b1`.`uuid_pk` left join `test2` as `b2` on `b1`.`uuid_pk` = `b2`.`book_uuid_pk` where `b0`.`book_tag2_id` in (?) order by `b0`.`order` asc');
+  });
+
+  test('partial nested loading (m:n -> m:1)', async () => {
+    const god = await createEntities();
+    const mock = mockLogger(orm, ['query']);
+
+    const r1 = await orm.em.find(BookTag2, {}, {
+      exclude: ['books.price', 'books.author.name'],
+      populate: ['books.author'],
+      filters: false,
+      strategy: LoadStrategy.SELECT_IN,
+    });
+    expect(r1).toHaveLength(6);
+    expect(r1[0].name).toBe('t1');
+    expect(r1[0].books[0].title).toBe('Bible 1');
+    // @ts-expect-error
+    expect(r1[0].books[0].price).toBeUndefined();
+    expect(r1[0].books[0].author).toBeDefined();
+    expect(r1[0].books[0].author.id).toBeDefined();
+    // @ts-expect-error
+    expect(r1[0].books[0].author.name).toBeUndefined();
+    expect(r1[0].books[0].author.email).toBe(god.email);
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name` from `book_tag2` as `b0`');
+    expect(mock.mock.calls[1][0]).toMatch('select `b1`.price * 1.19 as `price_taxed`, `b1`.`publisher_id`, `b1`.`author_id`, `b1`.`meta`, `b1`.`double`, `b1`.`title`, `b1`.`created_at`, `b1`.`uuid_pk`, `b0`.`book_tag2_id` as `fk__book_tag2_id`, `b0`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `b2`.`id` as `test_id` from `book2_tags` as `b0` inner join `book2` as `b1` on `b0`.`book2_uuid_pk` = `b1`.`uuid_pk` left join `test2` as `b2` on `b1`.`uuid_pk` = `b2`.`book_uuid_pk` where `b0`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) order by `b0`.`order` asc');
+    expect(mock.mock.calls[2][0]).toMatch('select `a0`.`id`, `a0`.`created_at`, `a0`.`updated_at`, `a0`.`email`, `a0`.`age`, `a0`.`terms_accepted`, `a0`.`optional`, `a0`.`identities`, `a0`.`born`, `a0`.`born_time`, `a0`.`favourite_book_uuid_pk`, `a0`.`favourite_author_id`, `a0`.`identity`, `a1`.`author_id` as `address_author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id` where `a0`.`id` in (?)');
+    orm.em.clear();
+    mock.mock.calls.length = 0;
+
+    const r2 = await orm.em.findAll(BookTag2, {
+      exclude: ['books.price', 'books.author.name'],
+      populate: ['books.author'],
+      filters: false,
+      strategy: LoadStrategy.JOINED,
+    });
+    expect(r2).toHaveLength(6);
+    expect(r2[0].name).toBe('t1');
+    expect(r2[0].books[0].title).toBe('Bible 1');
+    // @ts-expect-error
+    expect(r2[0].books[0].price).toBeUndefined();
+    expect(r2[0].books[0].author).toBeDefined();
+    expect(r2[0].books[0].author.id).toBeDefined();
+    // @ts-expect-error
+    expect(r2[0].books[0].author.name).toBeUndefined();
+    expect(r2[0].books[0].author.email).toBe(god.email);
+    expect(mock.mock.calls).toHaveLength(1);
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`title` as `b1__title`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a3`.`id` as `a3__id`, `a3`.`created_at` as `a3__created_at`, `a3`.`updated_at` as `a3__updated_at`, `a3`.`email` as `a3__email`, `a3`.`age` as `a3__age`, `a3`.`terms_accepted` as `a3__terms_accepted`, `a3`.`optional` as `a3__optional`, `a3`.`identities` as `a3__identities`, `a3`.`born` as `a3__born`, `a3`.`born_time` as `a3__born_time`, `a3`.`favourite_book_uuid_pk` as `a3__favourite_book_uuid_pk`, `a3`.`favourite_author_id` as `a3__favourite_author_id`, `a3`.`identity` as `a3__identity` ' +
+      'from `book_tag2` as `b0` ' +
+      'left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` ' +
+      'left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` ' +
+      'left join `author2` as `a3` on `b1`.`author_id` = `a3`.`id` ' +
+      'order by `b2`.`order` asc');
+  });
+
+  test('populate partial (joined)', async () => {
+    const god = await createEntities();
+
+    const r1 = await orm.em.findOneOrFail(BookTag2, 1, {
+      exclude: ['books.price', 'books.author.name'],
+      populate: ['books.author'],
+      strategy: LoadStrategy.JOINED,
+    });
+    expect(r1.name).toBe('t1');
+    expect(r1.books[0].title).toBe('Bible 1');
+    // @ts-expect-error
+    expect(r1.books[0].price).toBeUndefined();
+    expect(r1.books[0].author).toBeDefined();
+    expect(r1.books[0].author.id).toBeDefined();
+    // @ts-expect-error
+    expect(r1.books[0].author.name).toBeUndefined();
+    expect(r1.books[0].author.email).toBe(god.email);
+
+    const r2 = await orm.em.refreshOrFail(r1, { populate: ['*'] });
+    expect(r2.name).toBe('t1');
+    expect(r2.books[0].title).toBe('Bible 1');
+    expect(r2.books[0].price).toBe('123.00');
+    expect(r2.books[0].author).toBeDefined();
+    expect(r2.books[0].author.id).toBeDefined();
+    expect(r2.books[0].author.name).toBe(god.name);
+    expect(r2.books[0].author.email).toBe(god.email);
+  });
+
+});

--- a/tests/features/partial-loading/partial-loading-exclude.mysql.test.ts
+++ b/tests/features/partial-loading/partial-loading-exclude.mysql.test.ts
@@ -324,6 +324,8 @@ describe('partial loading via `exclude` (mysql)', () => {
     expect(r2.books[0].author.id).toBeDefined();
     expect(r2.books[0].author.name).toBe(god.name);
     expect(r2.books[0].author.email).toBe(god.email);
+
+    await expect(orm.em.findAll(BookTag2, { fields: ['books.title'], exclude: ['name'] })).rejects.toThrow(`Cannot combine 'fields' and 'exclude' option.`);
   });
 
 });

--- a/tests/repositories/AuthorRepository.ts
+++ b/tests/repositories/AuthorRepository.ts
@@ -8,7 +8,7 @@ export class AuthorRepository extends EntityRepository<Author> {
     return `111 ${data} 222`;
   }
 
-  override async find<P extends string = never, F extends string = '*'>(where: FilterQuery<Author> = {}, options?: FindOptions<Author, P, F>): Promise<Loaded<Author, P, F>[]> {
+  override async find<P extends string = never, F extends string = '*', E extends string = never>(where: FilterQuery<Author> = {}, options?: FindOptions<Author, P, F, E>): Promise<Loaded<Author, P, F, E>[]> {
     return super.find(where, options);
   }
 


### PR DESCRIPTION
Adds the `exclude` option, which will omit the provided properties and select everything else:

```ts
const author = await em.findOne(Author, '...', {
  exclude: ['email', 'books.price'],
  populate: ['books'], // unlike with `fields`, you need to explicitly populate the relation here
});
```