### PR TITLE
feat(core): allow configuring filters in `Reference.load()` and `Collection.load()`

### DIFF
--- a/docs/docs/upgrading-v5-to-v6.md
+++ b/docs/docs/upgrading-v5-to-v6.md
@@ -269,6 +269,7 @@ The method was only forwarding the call to `BaseEntity.toObject`, so use that in
 - `UnitOfWork.registerManaged` -> `UnitOfWork.register`
 - `baseDir` -> `path` option in `EntityGenerator.generate()`
 - `MIKRO_ORM_CLI` env var -> `MIKRO_ORM_CLI_CONFIG`
+- `InitOptions` -> `InitCollectionOptions`
 
 ## Removed dependency on `faker` in seeder package
 
@@ -525,4 +526,13 @@ The `Reference.load()` method allowed two signatures, one to ensure the entity i
 ```diff
 -book.author.set(other);
 +book.author = ref(other);
+```
+
+## `Reference.load()` can return `null`
+
+`Reference.load()` (and other methods that are using `WrappedEntity.init()` under the hood) can now return `null` when the target entity is not found instead of resolving to unloaded entity. This can happen either because it was removed in the meantime, or it is not compatible with the currently enabled filters. A new method called `loadOrFail()` is added to the `Reference` class which always returns a value or throws otherwise, just like `em.findOneOrFail()`.
+
+```diff
+-const publisher = await book.publisher.load();
++const publisher = await book.publisher.loadOrFail();
 ```

--- a/packages/core/src/entity/BaseEntity.ts
+++ b/packages/core/src/entity/BaseEntity.ts
@@ -4,6 +4,7 @@ import { EntityAssigner, type AssignOptions } from './EntityAssigner';
 import type { EntityLoaderOptions } from './EntityLoader';
 import { EntitySerializer, type SerializeOptions } from '../serialization/EntitySerializer';
 import { helper } from './wrap';
+import type { FindOneOptions } from '../drivers/IDatabaseDriver';
 
 export abstract class BaseEntity {
 
@@ -53,8 +54,13 @@ export abstract class BaseEntity {
     return EntityAssigner.assign(this as Entity, data as any, options) as any;
   }
 
-  init<Entity extends this = this, Populate extends string = never>(populated = true): Promise<Loaded<Entity, Populate>> {
-    return helper(this as Entity).init<Populate>(populated);
+  init<
+    Entity extends this = this,
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(options?: FindOneOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes> | null> {
+    return helper(this as Entity).init(options);
   }
 
   getSchema(): string | undefined {

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -54,7 +54,7 @@ export class EntityFactory {
   }
 
   create<T extends object, P extends string = string>(entityName: EntityName<T>, data: EntityData<T>, options: FactoryOptions = {}): New<T, P> {
-    data = Reference.unwrapReference(data);
+    data = Reference.unwrapReference(data as T);
     options.initialized ??= true;
 
     if ((data as Dictionary).__entity) {

--- a/packages/core/src/entity/EntityHelper.ts
+++ b/packages/core/src/entity/EntityHelper.ts
@@ -251,7 +251,7 @@ export class EntityHelper {
     }
   }
 
-  static ensurePropagation<T>(entity: T) {
+  static ensurePropagation<T extends object>(entity: T) {
     if ((entity as Dictionary).__gettersDefined) {
       return;
     }

--- a/packages/core/src/entity/Reference.ts
+++ b/packages/core/src/entity/Reference.ts
@@ -1,8 +1,6 @@
 import { inspect } from 'util';
 import type {
   AddEager,
-  AutoPath,
-  ConnectionType,
   Dictionary,
   EntityClass,
   EntityKey,
@@ -13,11 +11,12 @@ import type {
   Ref,
 } from '../typings';
 import type { EntityFactory } from './EntityFactory';
-import { DataloaderType, type  LockMode  } from '../enums';
+import { DataloaderType } from '../enums';
 import { helper, wrap } from './wrap';
 import { DataloaderUtils, Utils } from '../utils';
+import type { FindOneOptions, FindOneOrFailOptions } from '../drivers/IDatabaseDriver';
 
-export class Reference<T> {
+export class Reference<T extends object> {
 
   constructor(private entity: T) {
     this.set(entity);
@@ -40,7 +39,7 @@ export class Reference<T> {
     }
   }
 
-  static create<T>(entity: T | Ref<T>): Ref<T> {
+  static create<T extends object>(entity: T | Ref<T>): Ref<T> {
     const unwrapped = Reference.unwrapReference(entity);
     const ref = helper(entity).toReference() as Reference<T>;
 
@@ -51,12 +50,12 @@ export class Reference<T> {
     return ref as Ref<T>;
   }
 
-  static createFromPK<T>(entityType: EntityClass<T>, pk: Primary<T>, options?: { schema?: string }): Ref<T> {
+  static createFromPK<T extends object>(entityType: EntityClass<T>, pk: Primary<T>, options?: { schema?: string }): Ref<T> {
     const ref = this.createNakedFromPK(entityType, pk, options);
     return helper(ref).toReference();
   }
 
-  static createNakedFromPK<T>(entityType: EntityClass<T>, pk: Primary<T>, options?: { schema?: string }): T {
+  static createNakedFromPK<T extends object>(entityType: EntityClass<T>, pk: Primary<T>, options?: { schema?: string }): T {
     const factory = entityType.prototype.__factory as EntityFactory;
     const entity = factory.createReference(entityType, pk, {
       merge: false,
@@ -74,7 +73,7 @@ export class Reference<T> {
   /**
    * Checks whether the argument is instance of `Reference` wrapper.
    */
-  static isReference<T>(data: any): data is Reference<T> {
+  static isReference<T extends object>(data: any): data is Reference<T> {
     return data && !!data.__reference;
   }
 
@@ -92,24 +91,44 @@ export class Reference<T> {
   /**
    * Returns wrapped entity.
    */
-  static unwrapReference<T>(ref: T | Reference<T> | ScalarReference<T>): T {
+  static unwrapReference<T extends object>(ref: T | Reference<T> | ScalarReference<T> | Ref<T>): T {
     return Reference.isReference<T>(ref) ? (ref as Reference<T>).unwrap() : ref as T;
   }
 
   /**
-   * Ensures the underlying entity is loaded first (without reloading it if it already is loaded).
-   * Returns the entity.
+   * Ensures the underlying entity is loaded first (without reloading it if it already is loaded). Returns the entity.
+   * If the entity is not found in the database (e.g. it was deleted in the meantime, or currently active filters disallow loading of it)
+   * the method returns `null`. Use `loadOrFail()` if you want an error to be thrown in such a case.
    */
-  async load<TT extends T, P extends string = never>(options: LoadReferenceOptions<TT, P> = {}): Promise<Loaded<TT, P>> {
+  async load<TT extends T, P extends string = never, F extends string = '*', E extends string = never>(options: LoadReferenceOptions<TT, P, F, E> = {}): Promise<Loaded<TT, P, F, E> | null> {
     if (!this.isInitialized() || options.refresh) {
-      if (options.dataloader ?? [DataloaderType.ALL, DataloaderType.REFERENCE].includes(DataloaderUtils.getDataloaderType(helper(this.entity).__em.config.get('dataloader')))) {
-        await helper(this.entity).__em.refLoader.load([this, options]);
-      } else {
-        await helper(this.entity).init(undefined, options.populate as any, options.lockMode, options.connectionType);
+      const wrapped = helper(this.entity as TT & object);
+      if (options.dataloader ?? [DataloaderType.ALL, DataloaderType.REFERENCE].includes(DataloaderUtils.getDataloaderType(wrapped.__em.config.get('dataloader')))) {
+        return wrapped.__em.refLoader.load([this, options]);
       }
+
+      return wrapped.init(options);
     }
 
-    return this.entity as Loaded<TT, P>;
+    return this.entity as Loaded<TT, P, F, E>;
+  }
+
+  /**
+   * Ensures the underlying entity is loaded first (without reloading it if it already is loaded).
+   * Returns the entity or throws an error just like `em.findOneOrFail()` (and respects the same config options).
+   */
+  async loadOrFail<TT extends T, P extends string = never, F extends string = '*', E extends string = never>(options: LoadReferenceOrFailOptions<TT, P, F, E> = {}): Promise<Loaded<TT, P, F, E>> {
+    const ret = await this.load(options);
+
+    if (!ret) {
+      const wrapped = helper(this.entity);
+      options.failHandler ??= wrapped.__em.config.get('findOneOrFailHandler');
+      const entityName = this.entity.constructor.name;
+      const where = wrapped.getPrimaryKey() as any;
+      throw options.failHandler!(entityName, where);
+    }
+
+    return ret;
   }
 
   private set<TT extends T>(entity: TT | Ref<TT>): void {
@@ -178,7 +197,7 @@ export class ScalarReference<Value> {
    * Ensures the underlying entity is loaded first (without reloading it if it already is loaded).
    * Returns either the whole entity, or the requested property.
    */
-  async load(options?: Omit<LoadReferenceOptions<any, any>, 'populate'>): Promise<Value | undefined> {
+  async load(options?: Omit<LoadReferenceOptions<any, any>, 'populate' | 'fields' | 'exclude'>): Promise<Value | undefined> {
     const opts: Dictionary = typeof options === 'object' ? options : { prop: options } as LoadReferenceOptions<any, any>;
 
     if (!this.initialized || opts.refresh) {
@@ -234,11 +253,11 @@ Object.defineProperties(ScalarReference.prototype, {
   get: { get() { return () => this.value; } },
 });
 
-export interface LoadReferenceOptions<T, P extends string = never> {
-  populate?: readonly AutoPath<T, P>[] | AutoPath<T, P>;
-  lockMode?: Exclude<LockMode, LockMode.OPTIMISTIC>;
-  connectionType?: ConnectionType;
-  refresh?: boolean;
+export interface LoadReferenceOptions<T extends object, P extends string = never, F extends string = '*', E extends string = never> extends FindOneOptions<T, P, F, E> {
+  dataloader?: boolean;
+}
+
+export interface LoadReferenceOrFailOptions<T extends object, P extends string = never, F extends string = '*', E extends string = never> extends FindOneOrFailOptions<T, P, F, E> {
   dataloader?: boolean;
 }
 
@@ -281,7 +300,7 @@ export function ref<T, PKV extends Primary<T> = Primary<T>>(entityOrType?: T | R
     return pk as null;
   }
 
-  return Reference.createFromPK<T>(entityOrType as EntityClass<T>, pk as PKV);
+  return Reference.createFromPK(entityOrType as EntityClass<T>, pk as PKV) as Ref<T>;
 }
 
 /**

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -2,7 +2,6 @@ import { inspect } from 'util';
 import type { EntityManager } from '../EntityManager';
 import type {
   AnyEntity,
-  ConnectionType,
   Dictionary,
   EntityData,
   EntityDictionary,
@@ -11,7 +10,6 @@ import type {
   EntityValue,
   EntityKey,
   IWrappedEntityInternal,
-  Populate,
   PopulateOptions,
   Primary,
   AutoPath,
@@ -29,12 +27,12 @@ import { EntityTransformer } from '../serialization/EntityTransformer';
 import { EntityAssigner, type AssignOptions } from './EntityAssigner';
 import type { EntityLoaderOptions } from './EntityLoader';
 import { Utils } from '../utils/Utils';
-import type { LockMode } from '../enums';
 import { ValidationError } from '../errors';
 import type { EntityIdentifier } from './EntityIdentifier';
 import { helper } from './wrap';
 import type { SerializationContext } from '../serialization/SerializationContext';
 import { EntitySerializer, type SerializeOptions } from '../serialization/EntitySerializer';
+import type { FindOneOptions } from '../drivers/IDatabaseDriver';
 
 export class WrappedEntity<Entity extends object> {
 
@@ -133,14 +131,16 @@ export class WrappedEntity<Entity extends object> {
     return EntityAssigner.assign(this.entity, data as any, options) as any;
   }
 
-  async init<P extends Populate<Entity> = Populate<Entity>>(populated = true, populate?: P, lockMode?: LockMode, connectionType?: ConnectionType): Promise<Entity> {
+  async init<
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(options?: FindOneOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes> | null> {
     if (!this.__em) {
       throw ValidationError.entityNotManaged(this.entity);
     }
 
-    await this.__em.findOne(this.entity.constructor.name, this.entity, { refresh: true, lockMode, populate, connectionType, schema: this.__schema });
-
-    return this.entity;
+    return this.__em.findOne(this.entity.constructor.name, this.entity, { ...options, refresh: true, schema: this.__schema });
   }
 
   async populate<Hint extends string = never>(

--- a/packages/core/src/entity/wrap.ts
+++ b/packages/core/src/entity/wrap.ts
@@ -31,6 +31,6 @@ export function wrap<T extends object>(entity: T & Dictionary, preferHelper = fa
  * use `preferHelper = true` to have access to the internal `__` properties like `__meta` or `__em`
  * @internal
  */
-export function helper<T>(entity: T): IWrappedEntityInternal<T> {
+export function helper<T extends object>(entity: T): IWrappedEntityInternal<T> {
   return (entity as Dictionary).__helper;
 }

--- a/packages/core/src/serialization/EntityTransformer.ts
+++ b/packages/core/src/serialization/EntityTransformer.ts
@@ -212,7 +212,7 @@ export class EntityTransformer {
     return platform.normalizePrimaryKey(wrapped.getPrimaryKey(true) as IPrimaryKey) as EntityValue<Entity>;
   }
 
-  private static processCollection<Entity>(prop: keyof Entity, entity: Entity, raw: boolean, populated: boolean): EntityValue<Entity> | undefined {
+  private static processCollection<Entity extends object>(prop: keyof Entity, entity: Entity, raw: boolean, populated: boolean): EntityValue<Entity> | undefined {
     const col = entity[prop] as Collection<AnyEntity>;
 
     if (raw && col.isInitialized(true)) {

--- a/tests/EntityHelper.mongo.test.ts
+++ b/tests/EntityHelper.mongo.test.ts
@@ -74,7 +74,7 @@ describe('EntityHelperMongo', () => {
     expect(json.favouriteAuthor).toBe(god.id); // self reference will be ignored even when explicitly populated
     expect(json.books![0]).toMatchObject({
       author: { name: bible.author.name },
-      publisher: { name: (await bible.publisher.load()).name },
+      publisher: { name: (await bible.publisher.loadOrFail()).name },
     });
     expect(json.books[0].author.books).toBeInstanceOf(Array); // even the cycle is there, as it is explicitly populated path
     expect(json.books[0].author.books).toHaveLength(1);

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -491,7 +491,7 @@ describe('EntityManagerMongo', () => {
 
     const newGod = (await orm.em.findOne(Author, god.id))!;
     const books = await orm.em.find(Book, {});
-    await wrap(newGod).init(false);
+    await wrap(newGod).init();
 
     for (const book of books) {
       expect(book.toJSON()).toMatchObject({
@@ -1916,7 +1916,7 @@ describe('EntityManagerMongo', () => {
     ref3['set'](Reference.create(author));
     expect(ref3.id).toBe(author.id);
 
-    const ent = await ref.load();
+    const ent = await ref.loadOrFail();
     expect(ent).toBeInstanceOf(Author);
     expect(wrap(ent).isInitialized()).toBe(true);
     orm.em.clear();

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -918,7 +918,7 @@ describe('EntityManagerMySql', () => {
     expect(books0).toHaveLength(0);
     const newGod = (await orm.em.findOne(Author2, god.id))!;
     const books = await orm.em.find(Book2, {});
-    await wrap(newGod).init(false);
+    await wrap(newGod).init();
 
     for (const book of books) {
       expect(wrap(book).toJSON()).toMatchObject({

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -370,7 +370,7 @@ describe('EntityManagerPostgre', () => {
     await em.begin();
 
     const book2 = await em.findOneOrFail(Book2, book.uuid);
-    const publisher2 = await book2.publisher!.load({ populate: ['tests'], lockMode: LockMode.PESSIMISTIC_WRITE });
+    const publisher2 = await book2.publisher!.loadOrFail({ populate: ['tests'], lockMode: LockMode.PESSIMISTIC_WRITE });
 
     await em.transactional(async () => {
       //
@@ -931,7 +931,7 @@ describe('EntityManagerPostgre', () => {
 
     const newGod = (await orm.em.findOne(Author2, god.id))!;
     const books = await orm.em.find(Book2, {});
-    await wrap(newGod).init(false);
+    await wrap(newGod).init();
 
     for (const book of books) {
       expect(wrap(book).toJSON()).toMatchObject({
@@ -1027,7 +1027,7 @@ describe('EntityManagerPostgre', () => {
     const bible2 = await em2.findOneOrFail(Book2, { uuid: bible.uuid });
     expect(wrap(bible2, true).__em!.id).toBe(em2.id);
     expect(wrap(bible2.publisher!, true).__em!.id).toBe(em2.id);
-    const publisher2 = await bible2.publisher!.load();
+    const publisher2 = await bible2.publisher!.loadOrFail();
     expect(wrap(publisher2, true).__em!.id).toBe(em2.id);
   });
 

--- a/tests/EntityManager.sqlite2.test.ts
+++ b/tests/EntityManager.sqlite2.test.ts
@@ -483,7 +483,7 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
 
     const newGod = (await orm.em.findOne(Author4, god.id))!;
     const books = await orm.em.find(Book4, {});
-    await wrap(newGod).init(false);
+    await wrap(newGod).init();
 
     for (const book of books) {
       expect(wrap(book).toJSON()).toMatchObject({

--- a/tests/features/dataloader.test.ts
+++ b/tests/features/dataloader.test.ts
@@ -334,8 +334,8 @@ describe('Dataloader', () => {
   test('Reference.load with populate', async () => {
     const refsA = getReferences(orm.em).slice(0, 2);
     const refsB = getReferences(orm.em).slice(0, 2);
-    const resA = await Promise.all(refsA.map(ref => ref.load({ populate: 'books' })));
-    const resB = await Promise.all(refsB.map(ref => ref.load({ populate: 'books', dataloader: true })));
+    const resA = await Promise.all(refsA.map(ref => ref.load({ populate: ['books'] })));
+    const resB = await Promise.all(refsB.map(ref => ref.load({ populate: ['books'], dataloader: true })));
     await orm.em.flush();
     expect(serialize(resA)).toEqual(serialize(resB));
   });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -609,7 +609,7 @@ describe('check typings', () => {
       parent: Ref<Parent>;
     }
 
-    const parent = { load: jest.fn() as any } as Ref<Parent>;
+    const parent = { loadOrFail: jest.fn() as any } as Ref<Parent>;
 
     // @ts-expect-error Loaded<Parent, never> is not assignable
     const populated01: Loaded<Parent, 'children'> = {} as Loaded<Ref<Parent>>;
@@ -618,18 +618,18 @@ describe('check typings', () => {
     function foo(e: Loaded<Parent, 'children'>) {
       //
     }
-    const e = await parent.load();
+    const e = await parent.loadOrFail();
     // @ts-expect-error Loaded<Parent, never> is not assignable
     foo(e);
-    const populated1: Loaded<Parent, 'children'> = await parent.load();
-    const populated22 = await parent.load({ populate: [] });
+    const populated1: Loaded<Parent, 'children'> = await parent.loadOrFail();
+    const populated22 = await parent.loadOrFail({ populate: [] });
     // @ts-expect-error Loaded<Parent, never> is not assignable
     const populated2: Loaded<Parent, 'children'> = populated22;
 
     // only this should pass
-    const populated3: Loaded<Parent, 'children'> = await parent.load({ populate: ['children'] });
-    const populated4: Loaded<Parent, 'children'> = await parent.load({ populate: ['children', 'id'] });
-    const populated5: Loaded<Parent, 'children'> = await parent.load({ populate: ['children.parent'] });
+    const populated3: Loaded<Parent, 'children'> = await parent.loadOrFail({ populate: ['children'] });
+    const populated4: Loaded<Parent, 'children'> = await parent.loadOrFail({ populate: ['children', 'id'] });
+    const populated5: Loaded<Parent, 'children'> = await parent.loadOrFail({ populate: ['children.parent'] });
   });
 
   test('assignability of Loaded<T> to Ref<T> via ref() helper', async () => {


### PR DESCRIPTION
`Reference.load()` (and other methods that are using `WrappedEntity.init()` under the hood) now return `null` when the target entity is not found instead of resolving to unloaded entity. This can happen either because it was removed in the meantime, or it is not compatible with the currently enabled filters. A new method called `loadOrFail()` is added to the `Reference` class which always returns a value or throws otherwise, just like `em.findOneOrFail`.

This PR also adds more options to both `Reference.load` and `Collection.load`, aligning them with the underlying methods used (`em.findOne` and `em.populate` respectively).

BREAKING CHANGE

Closes #4975