### PR TITLE
feat(core): add `sql.now()`, `sql.lower()` and `sql.upper()` functions

### DIFF
--- a/docs/docs/raw-queries.md
+++ b/docs/docs/raw-queries.md
@@ -56,6 +56,25 @@ When you want to refer to a column, you can use the `sql.ref()` function:
 await em.find(User, { foo: sql`bar` });
 ```
 
+### `sql.now()`
+
+When you want to define a default value for a datetime column, you can use the `sql.now()` function. It resolves to `current_timestamp` SQL function, and accepts a `length` parameter.
+
+```ts
+@Property({ default: sql.now() })
+createdAt: Date & Opt;
+```
+
+### `sql.lower()` and `sql.upper()`
+
+To convert a key to lowercase or uppercase, you can use the `sql.lower()` and `sql.upper()` functions
+
+```ts
+const books = await orm.em.find(Book, {
+  [sql.upper('title')]: 'TITLE',
+});
+```
+
 ### Aliasing
 
 To select a raw fragment, we need to alias it. For that, we can use ```sql`(select 1 + 1)`.as('<alias>')```.

--- a/packages/core/src/utils/RawQueryFragment.ts
+++ b/packages/core/src/utils/RawQueryFragment.ts
@@ -1,6 +1,6 @@
 import { inspect } from 'util';
 import { Utils } from './Utils';
-import type { Dictionary, EntityKey, AnyString } from '../typings';
+import type { AnyString, Dictionary, EntityKey } from '../typings';
 
 export class RawQueryFragment {
 
@@ -178,4 +178,15 @@ export function sql(sql: readonly string[], ...values: unknown[]) {
   }, ''), values);
 }
 
+export function createSqlFunction<T extends object, R = string>(func: string, key: string | ((alias: string) => string)): R {
+  if (typeof key === 'string') {
+    return raw<T, R>(`${func}(${key})`);
+  }
+
+  return raw<T, R>(a => `${func}(${(key(a))})`);
+}
+
 sql.ref = <T extends object>(...keys: string[]) => raw<T, RawQueryFragment>('??', [keys.join('.')]);
+sql.now = (length?: number) => raw<Date, string>('current_timestamp' + (length == null ? '' : `(${length})`));
+sql.lower = <T extends object>(key: string | ((alias: string) => string)) => createSqlFunction('lower', key);
+sql.upper = <T extends object>(key: string | ((alias: string) => string)) => createSqlFunction('upper', key);

--- a/packages/knex/src/AbstractSqlPlatform.ts
+++ b/packages/knex/src/AbstractSqlPlatform.ts
@@ -52,49 +52,6 @@ export abstract class AbstractSqlPlatform extends Platform {
     return escape(value, true, this.timezone);
   }
 
-  formatQuery(sql: string, params: readonly any[]): string {
-    if (params.length === 0) {
-      return sql;
-    }
-
-    // fast string replace without regexps
-    let j = 0;
-    let pos = 0;
-    let ret = '';
-
-    if (sql[0] === '?') {
-      if (sql[1] === '?') {
-        ret += this.quoteIdentifier(params[j++]);
-        pos = 2;
-      } else {
-        ret += this.quoteValue(params[j++]);
-        pos = 1;
-      }
-    }
-
-    while (pos < sql.length) {
-      const idx = sql.indexOf('?', pos + 1);
-
-      if (idx === -1) {
-        ret += sql.substring(pos, sql.length);
-        break;
-      }
-
-      if (sql.substring(idx - 1, idx + 1) === '\\?') {
-        ret += sql.substring(pos, idx - 1) + '?';
-        pos = idx + 1;
-      } else if (sql.substring(idx, idx + 2) === '??') {
-        ret += sql.substring(pos, idx) + this.quoteIdentifier(params[j++]);
-        pos = idx + 2;
-      } else {
-        ret += sql.substring(pos, idx) + this.quoteValue(params[j++]);
-        pos = idx + 1;
-      }
-    }
-
-    return ret;
-  }
-
   override getSearchJsonPropertySQL(path: string, type: string, aliased: boolean): string {
     return this.getSearchJsonPropertyKey(path.split('->'), type, aliased);
   }

--- a/packages/knex/src/schema/SchemaHelper.ts
+++ b/packages/knex/src/schema/SchemaHelper.ts
@@ -1,5 +1,5 @@
 import type { Knex } from 'knex';
-import { BigIntType, EnumType, Utils, type Connection, type Dictionary } from '@mikro-orm/core';
+import { BigIntType, EnumType, Utils, type Connection, type Dictionary, RawQueryFragment } from '@mikro-orm/core';
 import type { AbstractSqlConnection } from '../AbstractSqlConnection';
 import type { AbstractSqlPlatform } from '../AbstractSqlPlatform';
 import type { CheckDef, Column, IndexDef, Table, TableDifference } from '../typings';
@@ -257,6 +257,12 @@ export abstract class SchemaHelper {
   normalizeDefaultValue(defaultValue: string, length?: number, defaultValues: Dictionary<string[]> = {}): string | number {
     if (defaultValue == null) {
       return defaultValue;
+    }
+
+    const raw = RawQueryFragment.getKnownFragment(defaultValue);
+
+    if (raw) {
+      return this.platform.formatQuery(raw.sql, raw.params);
     }
 
     const genericValue = defaultValue.replace(/\(\d+\)/, '(?)').toLowerCase();

--- a/packages/postgresql/src/PostgreSqlSchemaHelper.ts
+++ b/packages/postgresql/src/PostgreSqlSchemaHelper.ts
@@ -395,8 +395,8 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
   }
 
   override normalizeDefaultValue(defaultValue: string, length: number) {
-    if (!defaultValue) {
-      return defaultValue;
+    if (!defaultValue || typeof defaultValue as unknown !== 'string') {
+      return super.normalizeDefaultValue(defaultValue, length, PostgreSqlSchemaHelper.DEFAULT_VALUES);
     }
 
     const match = defaultValue.match(/^'(.*)'::(.*)$/);

--- a/packages/reflection/src/TsMorphMetadataProvider.ts
+++ b/packages/reflection/src/TsMorphMetadataProvider.ts
@@ -59,8 +59,28 @@ export class TsMorphMetadataProvider extends MetadataProvider {
     return prop.type;
   }
 
+  private cleanUpTypeTags(type: string): string {
+    const genericTags = [/Opt<(.*?)>/, /Hidden<(.*?)>/];
+    const intersectionTags = [
+      '{ __optional?: 1 | undefined; }',
+      '{ __hidden?: 1 | undefined; }',
+    ];
+
+    for (const tag of genericTags) {
+      type = type.replace(tag, '$1');
+    }
+
+    for (const tag of intersectionTags) {
+      type = type.replace(' & ' + tag, '');
+      type = type.replace(tag + ' & ', '');
+    }
+
+    return type;
+  }
+
   private initPropertyType(meta: EntityMetadata, prop: EntityProperty): void {
-    const { type, optional } = this.readTypeFromSource(meta, prop);
+    const { type: typeRaw, optional } = this.readTypeFromSource(meta, prop);
+    const type = this.cleanUpTypeTags(typeRaw);
     prop.type = type;
     prop.runtimeType = type as 'string';
 

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -1784,7 +1784,7 @@ describe('EntityManagerPostgre', () => {
     const mock = mockLogger(orm, ['query', 'query-params']);
 
     const books1 = await orm.em.find(Book2, {
-      [raw('upper(title)')]: ['B1', 'B2'],
+      [sql.upper('title')]: ['B1', 'B2'],
       author: {
         [raw(a => `${a}.age::text`)]: { $ilike: '%2%' },
       },
@@ -1794,7 +1794,7 @@ describe('EntityManagerPostgre', () => {
     orm.em.clear();
 
     const books2 = await orm.em.find(Book2, {
-      [raw('upper(title)')]: raw('upper(?)', ['b2']),
+      [sql.upper('title')]: raw('upper(?)', ['b2']),
     }, { populate: ['perex'] });
     expect(books2).toHaveLength(1);
     expect(mock.mock.calls[1][0]).toMatch(`select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and upper(title) = upper('b2')`);
@@ -1843,7 +1843,7 @@ describe('EntityManagerPostgre', () => {
     const ref2 = await orm.em.findOneOrFail(Author2, 2);
 
     const mock = mockLogger(orm, ['query', 'query-params']);
-    ref1.age = raw(`age * 2`);
+    ref1.age = sql`age * 2`;
     expect(() => ref1.age!++).toThrow();
     expect(() => ref2.age = ref1.age).toThrow();
     expect(() => JSON.stringify(ref1)).toThrow();

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -394,7 +394,7 @@ describe('QueryBuilder', () => {
       .leftJoin('a.books', 'b', {
         [sql`json_contains(b.meta, ${{ 'b.foo': 'bar' }})`]: [],
         [raw('json_contains(`b`.`meta`, ?) = ?', [{ 'b.foo': 'bar' }, false])]: [],
-        [raw('lower(??)', ['b.title'])]: '321',
+        [sql.lower(a => `${a}.title`)]: '321',
       })
       .where({ 'b.title': 'test 123' });
     expect(qb.getQuery()).toEqual('select `a`.*, `b`.* from `author2` as `a` ' +
@@ -402,7 +402,7 @@ describe('QueryBuilder', () => {
       'on `a`.`id` = `b`.`author_id` ' +
       'and json_contains(b.meta, ?) ' +
       'and json_contains(`b`.`meta`, ?) = ? ' +
-      'and lower(`b`.`title`) = ? ' +
+      'and lower(b.title) = ? ' +
       'where `b`.`title` = ?');
     expect(qb.getParams()).toEqual([{ 'b.foo': 'bar' }, { 'b.foo': 'bar' }, false, '321', 'test 123']);
     expect(qb.getFormattedQuery()).toEqual('select `a`.*, `b`.* from `author2` as `a` ' +
@@ -410,7 +410,7 @@ describe('QueryBuilder', () => {
       'on `a`.`id` = `b`.`author_id` ' +
       'and json_contains(b.meta, \'{\\"b.foo\\":\\"bar\\"}\') ' +
       'and json_contains(`b`.`meta`, \'{\\"b.foo\\":\\"bar\\"}\') = false ' +
-      'and lower(`b`.`title`) = \'321\' ' +
+      'and lower(b.title) = \'321\' ' +
       "where `b`.`title` = 'test 123'");
   });
 

--- a/tests/entities-sql/Author2.ts
+++ b/tests/entities-sql/Author2.ts
@@ -24,7 +24,7 @@ import {
   Opt,
   Hidden,
   Embeddable,
-  Embedded,
+  Embedded, sql,
 } from '@mikro-orm/core';
 
 import { Book2 } from './Book2';
@@ -61,10 +61,10 @@ export class Author2 extends BaseEntity2 {
   static beforeDestroyCalled = 0;
   static afterDestroyCalled = 0;
 
-  @Property({ length: 3, defaultRaw: 'current_timestamp(3)' })
+  @Property({ length: 3, default: sql.now(3) })
   createdAt: Opt<Date> = new Date();
 
-  @Property({ onUpdate: () => new Date(), length: 3, defaultRaw: 'current_timestamp(3)' })
+  @Property({ onUpdate: () => new Date(), length: 3, default: sql.now(3) })
   updatedAt: Opt<Date> = new Date();
 
   @Property()

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -36,7 +36,7 @@ export class Book2 {
   @PrimaryKey({ name: 'uuid_pk', type: t.uuid })
   uuid = v4();
 
-  @Property({ defaultRaw: 'current_timestamp(3)', length: 3 })
+  @Property({ default: sql.now(3), length: 3 })
   createdAt = new Date();
 
   @Index({ type: 'fulltext' })

--- a/tests/features/custom-types/GH725.test.ts
+++ b/tests/features/custom-types/GH725.test.ts
@@ -1,4 +1,4 @@
-import { EntitySchema, MikroORM, Type, ValidationError } from '@mikro-orm/core';
+import { EntitySchema, MikroORM, sql, Type, ValidationError } from '@mikro-orm/core';
 import type { AbstractSqlDriver } from '@mikro-orm/knex';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
@@ -18,10 +18,6 @@ export class DateTime {
 }
 
 type Maybe<T> = T | null | undefined;
-
-export type TimestampTypeOptions = {
-  hasTimeZone: boolean;
-};
 
 export class DateTimeType extends Type<Maybe<DateTime>, Maybe<Date>> {
 
@@ -79,7 +75,7 @@ export const TestSchema = new EntitySchema<Test>({
       defaultRaw: 'uuid_generate_v4()',
     },
     createdAt: {
-      defaultRaw: 'now()',
+      default: sql.now(),
       type: DateTimeType,
     },
     updatedAt: {

--- a/tests/features/embeddables/GH3887.mysql.test.ts
+++ b/tests/features/embeddables/GH3887.mysql.test.ts
@@ -1,9 +1,9 @@
-import { Embeddable, Embedded, Entity, PrimaryKey, Property, MikroORM } from '@mikro-orm/mysql';
+import { Embeddable, Embedded, Entity, PrimaryKey, Property, MikroORM, sql } from '@mikro-orm/mysql';
 
 @Embeddable()
 class NestedTime {
 
-  @Property({ defaultRaw: 'current_timestamp' })
+  @Property({ default: sql.now() })
   timestamp!: Date;
 
 }
@@ -11,7 +11,7 @@ class NestedTime {
 @Embeddable()
 class Time {
 
-  @Property({ defaultRaw: 'current_timestamp' })
+  @Property({ default: sql.now() })
   timestamp!: Date;
 
   @Embedded(() => NestedTime)

--- a/tests/features/embeddables/GH3887.sqlite.test.ts
+++ b/tests/features/embeddables/GH3887.sqlite.test.ts
@@ -1,9 +1,9 @@
-import { Embeddable, Embedded, Entity, PrimaryKey, Property, MikroORM } from '@mikro-orm/better-sqlite';
+import { Embeddable, Embedded, Entity, PrimaryKey, Property, MikroORM, sql } from '@mikro-orm/better-sqlite';
 
 @Embeddable()
 class NestedTime {
 
-  @Property({ defaultRaw: 'current_timestamp' })
+  @Property({ default: sql.now() })
   timestamp!: Date;
 
 }
@@ -11,7 +11,7 @@ class NestedTime {
 @Embeddable()
 class Time {
 
-  @Property({ defaultRaw: 'current_timestamp' })
+  @Property({ default: sql.now() })
   timestamp!: Date;
 
   @Embedded(() => NestedTime)

--- a/tests/features/schema-generator/GH4782.test.ts
+++ b/tests/features/schema-generator/GH4782.test.ts
@@ -1,4 +1,4 @@
-import { MikroORM } from '@mikro-orm/mysql';
+import { MikroORM, sql } from '@mikro-orm/mysql';
 import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity({ tableName: 'user' })
@@ -15,7 +15,7 @@ class User1 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ defaultRaw: 'current_timestamp(3)', columnType: 'timestamp(3)' })
+  @Property({ default: sql.now(3), columnType: 'timestamp(3)' })
   bar!: Date;
 
 }
@@ -26,7 +26,7 @@ class User2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ defaultRaw: 'current_timestamp(3)', columnType: 'timestamp(3)' })
+  @Property({ default: sql.now(3), columnType: 'timestamp(3)' })
   bar!: Date;
 
 }
@@ -37,7 +37,7 @@ class User3 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ defaultRaw: 'current_timestamp(6)', columnType: 'timestamp(6)' })
+  @Property({ default: sql.now(6), columnType: 'timestamp(6)' })
   bar!: Date;
 
 }

--- a/tests/features/schema-generator/__snapshots__/diffing-default-values.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/diffing-default-values.test.ts.snap
@@ -4,7 +4,7 @@ exports[`diffing default values (GH #2385) string defaults do not produce additi
 "set names utf8mb4;
 set foreign_key_checks = 0;
 
-create table \`foo1\` (\`id\` int unsigned not null auto_increment primary key, \`bar0\` varchar(255) not null default 'test', \`bar1\` varchar(255) not null default 'test', \`bar2\` datetime not null default now(), \`bar3\` datetime(6) not null default now(6), \`metadata\` json not null default '{"value":42}') default character set utf8mb4 engine = InnoDB;
+create table \`foo1\` (\`id\` int unsigned not null auto_increment primary key, \`bar0\` varchar(255) not null default 'test', \`bar1\` varchar(255) not null default 'test', \`bar2\` datetime not null default current_timestamp, \`bar3\` datetime(6) not null default current_timestamp(6), \`metadata\` json not null default '{"value":42}') default character set utf8mb4 engine = InnoDB;
 
 set foreign_key_checks = 1;
 "
@@ -14,7 +14,7 @@ exports[`diffing default values (GH #2385) string defaults do not produce additi
 "set names utf8mb4;
 set foreign_key_checks = 0;
 
-create table \`foo0\` (\`id\` int unsigned not null auto_increment primary key, \`bar0\` varchar(255) not null default 'test', \`bar1\` varchar(255) not null default 'test', \`bar2\` datetime not null default now(), \`bar3\` datetime(6) not null default now(6)) default character set utf8mb4 engine = InnoDB;
+create table \`foo0\` (\`id\` int unsigned not null auto_increment primary key, \`bar0\` varchar(255) not null default 'test', \`bar1\` varchar(255) not null default 'test', \`bar2\` datetime not null default current_timestamp, \`bar3\` datetime(6) not null default current_timestamp(6)) default character set utf8mb4 engine = InnoDB;
 
 set foreign_key_checks = 1;
 "
@@ -24,7 +24,7 @@ exports[`diffing default values (GH #2385) string defaults do not produce additi
 "set names 'utf8';
 set session_replication_role = 'replica';
 
-create table "foo2" ("id" serial primary key, "bar0" varchar(255) not null default 'test', "bar1" varchar(255) not null default 'test', "bar2" timestamptz not null default now(), "bar3" timestamptz(6) not null default now(), "metadata" jsonb not null default '{"value":42}');
+create table "foo2" ("id" serial primary key, "bar0" varchar(255) not null default 'test', "bar1" varchar(255) not null default 'test', "bar2" timestamptz not null default current_timestamp, "bar3" timestamptz(6) not null default current_timestamp, "metadata" jsonb not null default '{"value":42}');
 
 set session_replication_role = 'origin';
 "
@@ -33,7 +33,7 @@ set session_replication_role = 'origin';
 exports[`diffing default values (GH #2385) string defaults do not produce additional diffs [sqlite] 1`] = `
 "pragma foreign_keys = off;
 
-create table \`foo3\` (\`id\` integer not null primary key autoincrement, \`bar0\` text not null default 'test', \`bar1\` text not null default 'test', \`bar2\` datetime not null default now, \`metadata\` json not null default '{"value":43}');
+create table \`foo3\` (\`id\` integer not null primary key autoincrement, \`bar0\` text not null default 'test', \`bar1\` text not null default 'test', \`bar2\` datetime not null default current_timestamp, \`metadata\` json not null default '{"value":43}');
 
 pragma foreign_keys = on;
 "

--- a/tests/features/schema-generator/__snapshots__/diffing-default-values.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/diffing-default-values.test.ts.snap
@@ -4,7 +4,7 @@ exports[`diffing default values (GH #2385) string defaults do not produce additi
 "set names utf8mb4;
 set foreign_key_checks = 0;
 
-create table \`foo1\` (\`id\` int unsigned not null auto_increment primary key, \`bar0\` varchar(255) not null default 'test', \`bar1\` varchar(255) not null default 'test', \`bar2\` datetime not null default current_timestamp, \`bar3\` datetime(6) not null default current_timestamp(6), \`metadata\` json not null default '{"value":42}') default character set utf8mb4 engine = InnoDB;
+create table \`foo1\` (\`id\` int unsigned not null auto_increment primary key, \`bar0\` varchar(255) not null default 'test', \`bar1\` varchar(255) not null default 'test', \`num\` int not null default 1, \`bool\` tinyint(1) not null default true, \`bar2\` datetime not null default current_timestamp, \`bar3\` datetime(6) not null default current_timestamp(6), \`metadata\` json not null default '{"value":42}') default character set utf8mb4 engine = InnoDB;
 
 set foreign_key_checks = 1;
 "
@@ -14,7 +14,7 @@ exports[`diffing default values (GH #2385) string defaults do not produce additi
 "set names utf8mb4;
 set foreign_key_checks = 0;
 
-create table \`foo0\` (\`id\` int unsigned not null auto_increment primary key, \`bar0\` varchar(255) not null default 'test', \`bar1\` varchar(255) not null default 'test', \`bar2\` datetime not null default current_timestamp, \`bar3\` datetime(6) not null default current_timestamp(6)) default character set utf8mb4 engine = InnoDB;
+create table \`foo0\` (\`id\` int unsigned not null auto_increment primary key, \`bar0\` varchar(255) not null default 'test', \`bar1\` varchar(255) not null default 'test', \`num\` int not null default 1, \`bool\` tinyint(1) not null default true, \`bar2\` datetime not null default current_timestamp, \`bar3\` datetime(6) not null default current_timestamp(6)) default character set utf8mb4 engine = InnoDB;
 
 set foreign_key_checks = 1;
 "
@@ -24,7 +24,7 @@ exports[`diffing default values (GH #2385) string defaults do not produce additi
 "set names 'utf8';
 set session_replication_role = 'replica';
 
-create table "foo2" ("id" serial primary key, "bar0" varchar(255) not null default 'test', "bar1" varchar(255) not null default 'test', "bar2" timestamptz not null default current_timestamp, "bar3" timestamptz(6) not null default current_timestamp, "metadata" jsonb not null default '{"value":42}');
+create table "foo2" ("id" serial primary key, "bar0" varchar(255) not null default 'test', "bar1" varchar(255) not null default 'test', "num" int not null default 1, "bool" boolean not null default true, "bar2" timestamptz not null default current_timestamp, "bar3" timestamptz(6) not null default current_timestamp, "metadata" jsonb not null default '{"value":42}');
 
 set session_replication_role = 'origin';
 "
@@ -33,7 +33,7 @@ set session_replication_role = 'origin';
 exports[`diffing default values (GH #2385) string defaults do not produce additional diffs [sqlite] 1`] = `
 "pragma foreign_keys = off;
 
-create table \`foo3\` (\`id\` integer not null primary key autoincrement, \`bar0\` text not null default 'test', \`bar1\` text not null default 'test', \`bar2\` datetime not null default current_timestamp, \`metadata\` json not null default '{"value":43}');
+create table \`foo3\` (\`id\` integer not null primary key autoincrement, \`bar0\` text not null default 'test', \`bar1\` text not null default 'test', \`num\` integer not null default 1, \`bool\` integer not null default true, \`bar2\` datetime not null default current_timestamp, \`metadata\` json not null default '{"value":43}');
 
 pragma foreign_keys = on;
 "

--- a/tests/features/schema-generator/diffing-default-values.test.ts
+++ b/tests/features/schema-generator/diffing-default-values.test.ts
@@ -1,54 +1,42 @@
-import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
+import { Entity, MikroORM, Opt, PrimaryKey, Property, sql } from '@mikro-orm/core';
 import { MySqlDriver } from '@mikro-orm/mysql';
 import { MariaDbDriver } from '@mikro-orm/mariadb';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 import { SqliteDriver } from '@mikro-orm/sqlite';
+import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
 
-export class Foo {
+class Foo {
 
   @PrimaryKey()
   id!: number;
 
   @Property({ defaultRaw: "'test'" })
-  bar0!: string;
+  bar0!: string & Opt;
 
   @Property({ default: 'test' })
-  bar1!: string;
+  bar1!: string & Opt;
 
 }
 
 @Entity()
-export class Foo0 extends Foo {
+class Foo0 extends Foo {
 
-  @Property({ defaultRaw: 'now()' })
-  bar2!: Date;
+  @Property({ default: sql.now() })
+  bar2!: Opt<Date>;
 
-  @Property({ defaultRaw: 'now(6)', length: 6 })
-  bar3!: Date;
-
-}
-
-@Entity()
-export class Foo1 extends Foo {
-
-  @Property({ defaultRaw: 'now()' })
-  bar2!: Date;
-
-  @Property({ defaultRaw: 'now(6)', length: 6 })
-  bar3!: Date;
-
-  @Property({ type: 'json', default: JSON.stringify({ value: 42 }) })
-  metadata!: any;
+  @Property({ default: sql.now(6), length: 6 })
+  bar3!: Date & Opt;
 
 }
 
 @Entity()
-export class Foo2 extends Foo {
+class Foo1 extends Foo {
 
-  @Property({ defaultRaw: 'now()' })
+  @Property({ default: sql.now() })
   bar2!: Date;
 
-  @Property({ defaultRaw: 'now()', length: 6 })
+  // test that we can infer the Date type from default here too
+  @Property({ default: sql.now(6), type: 'any', length: 6 })
   bar3!: Date;
 
   @Property({ type: 'json', default: JSON.stringify({ value: 42 }) })
@@ -57,9 +45,23 @@ export class Foo2 extends Foo {
 }
 
 @Entity()
-export class Foo3 extends Foo {
+class Foo2 extends Foo {
 
-  @Property({ defaultRaw: 'now' })
+  @Property({ default: sql.now() })
+  bar2!: Date;
+
+  @Property({ default: sql.now(), length: 6 })
+  bar3!: Date;
+
+  @Property({ type: 'json', default: JSON.stringify({ value: 42 }) })
+  metadata!: any;
+
+}
+
+@Entity()
+class Foo3 extends Foo {
+
+  @Property({ default: sql.now() })
   bar2!: Date;
 
   @Property({ type: 'json', default: JSON.stringify({ value: 43 }) })
@@ -75,6 +77,8 @@ describe('diffing default values (GH #2385)', () => {
       dbName: 'mikro_orm_test_gh_2385',
       driver: MySqlDriver,
       port: 3308,
+      metadataProvider: TsMorphMetadataProvider,
+      metadataCache: { enabled: false },
     });
     await orm.schema.refreshDatabase();
     expect(await orm.schema.getCreateSchemaSQL()).toMatchSnapshot();

--- a/tests/features/schema-generator/diffing-default-values.test.ts
+++ b/tests/features/schema-generator/diffing-default-values.test.ts
@@ -16,12 +16,18 @@ class Foo {
   @Property({ default: 'test' })
   bar1!: string & Opt;
 
+  @Property({ default: 1 })
+  num!: number & Opt;
+
+  @Property({ default: true })
+  bool!: boolean & Opt;
+
 }
 
 @Entity()
 class Foo0 extends Foo {
 
-  @Property({ default: sql.now() })
+  @Property({ defaultRaw: sql.now() })
   bar2!: Opt<Date>;
 
   @Property({ default: sql.now(6), length: 6 })

--- a/tests/features/upsert/GH4020.test.ts
+++ b/tests/features/upsert/GH4020.test.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryKey, Property, SimpleLogger } from '@mikro-orm/core';
+import { Entity, PrimaryKey, Property, SimpleLogger, sql } from '@mikro-orm/core';
 import { MikroORM } from '@mikro-orm/sqlite';
 import { mockLogger } from '../../helpers';
 
@@ -11,7 +11,7 @@ export class GuildEntity {
   @Property()
   name!: string;
 
-  @Property({ defaultRaw: 'current_timestamp', index: true })
+  @Property({ default: sql.now(), index: true })
   created_at: Date = new Date();
 
 }

--- a/tests/features/upsert/GH4242-2.test.ts
+++ b/tests/features/upsert/GH4242-2.test.ts
@@ -1,4 +1,4 @@
-import { Entity, ManyToOne, PrimaryKey, Property, Ref, Reference, SimpleLogger, Unique } from '@mikro-orm/core';
+import { Entity, ManyToOne, PrimaryKey, Property, Ref, Reference, SimpleLogger, sql, Unique } from '@mikro-orm/core';
 import { MikroORM } from '@mikro-orm/mysql';
 import { mockLogger } from '../../helpers';
 
@@ -14,7 +14,7 @@ class B {
   @Property({ unique: true })
   order!: number;
 
-  @Property({ defaultRaw: 'current_timestamp', onUpdate: () => new Date() })
+  @Property({ default: sql.now(), onUpdate: () => new Date() })
   updatedAt: Date = new Date();
 
 }
@@ -29,7 +29,7 @@ class D {
   @Property()
   tenantWorkflowId!: number;
 
-  @Property({ defaultRaw: 'current_timestamp', onUpdate: () => new Date() })
+  @Property({ default: sql.now(), onUpdate: () => new Date() })
   updatedAt: Date = new Date();
 
   @Property({ nullable: true })

--- a/tests/features/upsert/GH4242.test.ts
+++ b/tests/features/upsert/GH4242.test.ts
@@ -1,4 +1,4 @@
-import { Entity, ManyToOne, PrimaryKey, Property, Ref, Reference, SimpleLogger, Unique } from '@mikro-orm/core';
+import { Entity, ManyToOne, PrimaryKey, Property, Ref, Reference, SimpleLogger, sql, Unique } from '@mikro-orm/core';
 import { MikroORM } from '@mikro-orm/postgresql';
 import { mockLogger } from '../../helpers';
 
@@ -14,7 +14,7 @@ class B {
   @Property({ unique: true })
   order!: number;
 
-  @Property({ length: 6, defaultRaw: 'now()', onUpdate: () => new Date() })
+  @Property({ length: 6, default: sql.now(), onUpdate: () => new Date() })
   updatedAt: Date = new Date();
 
 }
@@ -29,7 +29,7 @@ class D {
   @Property()
   tenantWorkflowId!: number;
 
-  @Property({ length: 6, defaultRaw: 'now()', onUpdate: () => new Date() })
+  @Property({ length: 6, default: sql.now(), onUpdate: () => new Date() })
   updatedAt: Date = new Date();
 
   @Property({ nullable: true })

--- a/tests/features/upsert/GH4786.test.ts
+++ b/tests/features/upsert/GH4786.test.ts
@@ -6,7 +6,7 @@ import {
   OptionalProps,
   PrimaryKey,
   Property,
-  SimpleLogger,
+  SimpleLogger, sql,
   Unique,
 } from '@mikro-orm/core';
 import { MikroORM } from '@mikro-orm/sqlite';
@@ -20,10 +20,10 @@ abstract class ApplicationEntity<Optionals = never> {
   @PrimaryKey()
   id!: number;
 
-  @Property({ name: 'created_at', defaultRaw: 'current_timestamp' })
+  @Property({ name: 'created_at', default: sql.now() })
   createdAt!: Date;
 
-  @Property({ name: 'updated_at', defaultRaw: 'current_timestamp', onUpdate: () => new Date() })
+  @Property({ name: 'updated_at', default: sql.now(), onUpdate: () => new Date() })
   updatedAt!: Date;
 
 }

--- a/tests/issues/GH3965.test.ts
+++ b/tests/issues/GH3965.test.ts
@@ -7,7 +7,9 @@ import {
   PrimaryKey,
   Cascade,
   Ref,
-  PrimaryKeyProp, Primary,
+  PrimaryKeyProp,
+  Primary,
+  sql,
 } from '@mikro-orm/core';
 import { MikroORM } from '@mikro-orm/mysql';
 import { randomUUID } from 'crypto';
@@ -21,7 +23,8 @@ export class Category {
   id!: string;
 
   @Property({
-    defaultRaw: 'CURRENT_TIMESTAMP',
+    length: 3,
+    default: sql.now(3),
   })
   createdAt?: Date;
 
@@ -41,7 +44,8 @@ export class Article {
   id!: string;
 
   @Property({
-    defaultRaw: 'CURRENT_TIMESTAMP',
+    length: 3,
+    default: sql.now(3),
   })
   createdAt?: Date;
 
@@ -67,7 +71,8 @@ export class ArticleAttribute {
   id!: string;
 
   @Property({
-    defaultRaw: 'CURRENT_TIMESTAMP',
+    length: 3,
+    default: sql.now(3),
   })
   createdAt?: Date;
 

--- a/tests/issues/GH4062.test.ts
+++ b/tests/issues/GH4062.test.ts
@@ -1,4 +1,18 @@
-import { MikroORM, Cascade, Collection, Entity, EntityData, ManyToOne, OneToMany, PrimaryKey, PrimaryKeyProp, Property, Ref, SimpleLogger } from '@mikro-orm/mysql';
+import {
+  MikroORM,
+  Cascade,
+  Collection,
+  Entity,
+  EntityData,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  PrimaryKeyProp,
+  Property,
+  Ref,
+  SimpleLogger,
+  sql,
+} from '@mikro-orm/mysql';
 import { mockLogger } from '../helpers';
 
 @Entity()
@@ -13,7 +27,7 @@ class Category {
   })
   articles = new Collection<Article>(this);
 
-  @Property({ defaultRaw: 'CURRENT_TIMESTAMP' })
+  @Property({ default: sql.now() })
   createdAt?: Date;
 
 }
@@ -39,7 +53,7 @@ class Article {
   attributes = new Collection<ArticleAttribute>(this);
 
   @Property({
-    defaultRaw: 'CURRENT_TIMESTAMP',
+    default: sql.now(),
   })
   createdAt?: Date;
 
@@ -63,7 +77,7 @@ class ArticleAttribute {
   [PrimaryKeyProp]?: ['id', ['id', 'category']];
 
   @Property({
-    defaultRaw: 'CURRENT_TIMESTAMP',
+    default: sql.now(),
   })
   createdAt?: Date;
 

--- a/tests/issues/GH4377.test.ts
+++ b/tests/issues/GH4377.test.ts
@@ -1,4 +1,4 @@
-import { Cascade, Entity, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+import { Cascade, Entity, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Ref, sql } from '@mikro-orm/core';
 import { MikroORM } from '@mikro-orm/mysql';
 import { randomUUID } from 'crypto';
 
@@ -25,9 +25,7 @@ class Root {
   @PrimaryKey()
   id!: string;
 
-  @Property({
-    defaultRaw: 'CURRENT_TIMESTAMP',
-  })
+  @Property({ default: sql.now() })
   createdAt?: Date;
 
   @OneToOne(() => NonRoot, nonRoot => nonRoot.root, {

--- a/tests/issues/GH4988.test.ts
+++ b/tests/issues/GH4988.test.ts
@@ -1,4 +1,4 @@
-import { BigIntType, Collection, EntitySchema, Ref } from '@mikro-orm/core';
+import { BigIntType, Collection, EntitySchema, Ref, sql } from '@mikro-orm/core';
 import { MikroORM } from '@mikro-orm/postgresql';
 
 class ProductEntity {
@@ -90,12 +90,12 @@ const companyProductsSchema = new EntitySchema({
     createdAt: {
       type: 'timestamp',
       onCreate: () => new Date(),
-      defaultRaw: 'current_timestamp',
+      default: sql.now(),
     },
     updatedAt: {
       type: 'timestamp',
       onUpdate: () => new Date(),
-      defaultRaw: 'current_timestamp',
+      default: sql.now(),
     },
   },
 });


### PR DESCRIPTION
### `sql.now()`

When you want to define a default value for a datetime column, you can use the `sql.now()` function. It resolves to `current_timestamp` SQL function, and accepts a `length` parameter.

```ts
@Property({ default: sql.now() })
createdAt: Date & Opt;
```

### `sql.lower()` and `sql.upper()`

To convert a key to lowercase or uppercase, you can use the `sql.lower()` and `sql.upper()` functions

```ts
const books = await orm.em.find(Book, {
  [sql.upper('title')]: 'TITLE',
});
```