### PR TITLE
feat(core): allow defining `serialization.forceObject: true` on type level

### DIFF
--- a/docs/docs/serializing.md
+++ b/docs/docs/serializing.md
@@ -148,14 +148,39 @@ const dto = wrap(user).toObject();
 // `{ id: 1, books: [{ id: 2, publisher: { id: 3, name: '...' } }] }`
 ```
 
+**This also works for embeddables, including nesting and object mode.**
+
 Primary keys are automatically included. If you want to hide them, you have two options:
 
 - use `hidden: true` in the property options
 - use `serialization: { includePrimaryKeys: false }` in the ORM config
 
-Unpopulated relations are serialized as foreign key values, e.g. `{ author: 1 }`, if you want to enforce objects, e.g. `{ author: { id: 1 } }`, use `serialization: { forceObject: false }` in your ORM config. 
+### Foreign keys are `forceObject`
 
-**This also works for embeddables, including nesting and object mode.**
+Unpopulated relations are serialized as foreign key values, e.g. `{ author: 1 }`, if you want to enforce objects, e.g. `{ author: { id: 1 } }`, use `serialization: { forceObject: false }` in your ORM config.
+
+For strict typings to respect the global config option, you need to define it on your entity class via `Config` symbol:
+
+```ts
+import { Config, Entity, ManyToOne, PrimaryKey, Ref, wrap } from '@mikro-orm/core';
+
+@Entity()
+class Book {
+
+  [Config]?: DefineConfig<{ forceObject: true }>;
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => User, { ref: true })
+  author!: Ref<User>;
+
+}
+
+const book = await em.findOneOrFail(Book, 1);
+const dto = wrap(book).toObject();
+const identityId = dto.author.id; // without the Config symbol, `dto.identity` would resolve to number
+```
 
 ## Explicit serialization
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,7 @@ export {
   GetRepository, EntityRepositoryType, MigrationObject, DeepPartial, PrimaryProperty, Cast, IsUnknown, EntityDictionary, EntityDTO, MigrationDiff, GenerateOptions, FilterObject,
   IEntityGenerator, ISeedManager, EntityClassGroup, OptionalProps, EagerProps, HiddenProps, RequiredEntityData, CheckCallback, SimpleColumnMeta, Rel, Ref, ScalarRef, EntityRef, ISchemaGenerator,
   UmzugMigration, MigrateOptions, MigrationResult, MigrationRow, EntityKey, EntityValue, FilterKey, Opt, EntityType, FromEntityType, Selected, IsSubset,
-  EntityProps, ExpandProperty, ExpandScalar, FilterItemValue, ExpandQuery, Scalar, ExpandHint, Hidden, FilterValue, MergeLoaded, MergeSelected,
+  EntityProps, ExpandProperty, ExpandScalar, FilterItemValue, ExpandQuery, Scalar, ExpandHint, Hidden, FilterValue, MergeLoaded, MergeSelected, Config, DefineConfig, TypeConfig,
 } from './typings';
 export * from './enums';
 export * from './errors';

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -71,7 +71,7 @@ export class Book extends BaseEntity3 {
     this.author = author!;
   }
 
-  toJSON<Ignored extends EntityKey<this>>(strict = true, strip: Ignored[] = ['metaObject', 'metaArray', 'metaArrayOfStrings'] as Ignored[]): Omit<EntityDTO<this>, Ignored> {
+  toJSON<Ignored extends EntityKey<this>>(strict = true, strip: Ignored[] = ['metaObject', 'metaArray', 'metaArrayOfStrings'] as Ignored[]): Omit<EntityDTO<this>, Ignored> | EntityDTO<this> {
     if (strict) {
       return wrap(this).toObject(strip);
     }

--- a/tests/features/serialization/explicit-serialization.test.ts
+++ b/tests/features/serialization/explicit-serialization.test.ts
@@ -123,6 +123,8 @@ test('explicit serialization', async () => {
   });
 
   const o5 = serialize(jon, { populate: ['books.author', 'favouriteBook'], forceObject: true });
+  const pub = o5.books[0].publisher!.id;
+  expect(pub).toBe(1);
   expect(o5).toMatchObject({
     id: jon.id,
     createdAt: jon.createdAt,


### PR DESCRIPTION
For strict typings to respect the global config option, you need to define it on your entity class via `Config` symbol:

```ts
import { Config, Entity, ManyToOne, PrimaryKey, Ref, wrap } from '@mikro-orm/core';

@Entity()
class Book {

  [Config]?: DefineConfig<{ forceObject: true }>;

  @PrimaryKey()
  id!: number;

  @ManyToOne(() => User, { ref: true })
  author!: Ref<User>;

}

const book = await em.findOneOrFail(Book, 1);
const dto = wrap(book).toObject();
const identityId = dto.author.id; // without the Config symbol, `dto.identity` would resolve to number
```