### PR TITLE
refactor: use `flush` option with `writeFile`

### DIFF
--- a/packages/entity-generator/src/EntityGenerator.ts
+++ b/packages/entity-generator/src/EntityGenerator.ts
@@ -1,4 +1,3 @@
-import { ensureDir, writeFile } from 'fs-extra';
 import {
   type EntityMetadata,
   type EntityProperty,
@@ -17,8 +16,9 @@ import {
   type EntityManager,
   type SchemaHelper,
 } from '@mikro-orm/knex';
-import { SourceFile } from './SourceFile';
+import { ensureDir, writeFile } from 'fs-extra';
 import { EntitySchemaSourceFile } from './EntitySchemaSourceFile';
+import { SourceFile } from './SourceFile';
 
 export class EntityGenerator {
 
@@ -63,7 +63,7 @@ export class EntityGenerator {
 
     if (options.save) {
       await ensureDir(baseDir);
-      await Promise.all(this.sources.map(file => writeFile(baseDir + '/' + file.getBaseName(), file.generate())));
+      await Promise.all(this.sources.map(file => writeFile(baseDir + '/' + file.getBaseName(), file.generate(), { flush: true })));
     }
 
     return this.sources.map(file => file.generate());

--- a/packages/migrations-mongodb/src/MigrationGenerator.ts
+++ b/packages/migrations-mongodb/src/MigrationGenerator.ts
@@ -1,6 +1,6 @@
-import { ensureDir, writeFile } from 'fs-extra';
-import { Utils, type IMigrationGenerator, type MigrationsOptions, type NamingStrategy } from '@mikro-orm/core';
+import { type IMigrationGenerator, type MigrationsOptions, type NamingStrategy, Utils } from '@mikro-orm/core';
 import type { MongoDriver } from '@mikro-orm/mongodb';
+import { ensureDir, writeFile } from 'fs-extra';
 
 /* istanbul ignore next */
 export abstract class MigrationGenerator implements IMigrationGenerator {
@@ -21,7 +21,7 @@ export abstract class MigrationGenerator implements IMigrationGenerator {
     const className = this.namingStrategy.classToMigrationName(timestamp, name);
     const fileName = `${this.options.fileName!(timestamp, name)}.${this.options.emit}`;
     const ret = this.generateMigrationFile(className, diff);
-    await writeFile(path + '/' + fileName, ret);
+    await writeFile(path + '/' + fileName, ret, { flush: true });
 
     return [ret, fileName];
   }

--- a/packages/migrations/src/MigrationGenerator.ts
+++ b/packages/migrations/src/MigrationGenerator.ts
@@ -1,6 +1,6 @@
-import { ensureDir, writeFile } from 'fs-extra';
-import { Utils, type IMigrationGenerator, type MigrationsOptions, type NamingStrategy } from '@mikro-orm/core';
+import { type IMigrationGenerator, type MigrationsOptions, type NamingStrategy, Utils } from '@mikro-orm/core';
 import type { AbstractSqlDriver } from '@mikro-orm/knex';
+import { ensureDir, writeFile } from 'fs-extra';
 
 export abstract class MigrationGenerator implements IMigrationGenerator {
 
@@ -20,7 +20,7 @@ export abstract class MigrationGenerator implements IMigrationGenerator {
     const className = this.namingStrategy.classToMigrationName(timestamp, name);
     const fileName = `${this.options.fileName!(timestamp, name)}.${this.options.emit}`;
     const ret = this.generateMigrationFile(className, diff);
-    await writeFile(path + '/' + fileName, ret);
+    await writeFile(path + '/' + fileName, ret, { flush: true });
 
     return [ret, fileName];
   }

--- a/packages/seeder/src/SeedManager.ts
+++ b/packages/seeder/src/SeedManager.ts
@@ -1,15 +1,15 @@
-import globby from 'globby';
 import {
-  Utils,
+  type Configuration,
   type Constructor,
   type EntityManager,
   type ISeedManager,
   type MikroORM,
-  type Configuration,
   type SeederOptions,
+  Utils,
 } from '@mikro-orm/core';
-import type { Seeder } from './Seeder';
 import { ensureDir, writeFile } from 'fs-extra';
+import globby from 'globby';
+import type { Seeder } from './Seeder';
 
 export class SeedManager implements ISeedManager {
 
@@ -97,7 +97,7 @@ export class SeedManager implements ISeedManager {
       ret += `exports.${className} = ${className};\n`;
     }
 
-    await writeFile(filePath, ret);
+    await writeFile(filePath, ret, { flush: true });
 
     return filePath;
   }

--- a/scripts/copy.mjs
+++ b/scripts/copy.mjs
@@ -26,7 +26,7 @@ function rewrite(path, replacer) {
   try {
     const file = readFileSync(path).toString();
     const replaced = replacer(file);
-    writeFileSync(path, replaced);
+    writeFileSync(path, replaced, { flush: true });
   } catch {
     // not found
   }
@@ -121,7 +121,7 @@ if (options.canary) {
   // eslint-disable-next-line no-console
   console.info(`canary: setting version to ${nextVersion}`);
 
-  writeFileSync(pkgPath, `${JSON.stringify(pkgJson, null, 2)}\n`);
+  writeFileSync(pkgPath, `${JSON.stringify(pkgJson, null, 2)}\n`, { flush: true });
 }
 
 if (options['pin-versions']) {
@@ -137,7 +137,7 @@ if (options['pin-versions']) {
   // eslint-disable-next-line no-console
   console.info(`pin-versions: version ${version}`, pkgJson.dependencies);
 
-  writeFileSync(pkgPath, `${JSON.stringify(pkgJson, null, 2)}\n`);
+  writeFileSync(pkgPath, `${JSON.stringify(pkgJson, null, 2)}\n`,{ flush: true });
 }
 
 copy('README.md', root, target);

--- a/scripts/copy.mjs
+++ b/scripts/copy.mjs
@@ -137,7 +137,7 @@ if (options['pin-versions']) {
   // eslint-disable-next-line no-console
   console.info(`pin-versions: version ${version}`, pkgJson.dependencies);
 
-  writeFileSync(pkgPath, `${JSON.stringify(pkgJson, null, 2)}\n`,{ flush: true });
+  writeFileSync(pkgPath, `${JSON.stringify(pkgJson, null, 2)}\n`, { flush: true });
 }
 
 copy('README.md', root, target);


### PR DESCRIPTION
In all places of the code, fs-extra's writeFile is used. This package however is actually a re-export of the callback version of node:fs' writeFile.
Meanwhile, all packages seem to assume this is the version from node:fs/promises.

This fix in turn fixes tests that can sometimes be flaky, due to assuming file operations are done, when that isn't necessarily true.

Also reordered imports in the affected files alphabetically.


---

I noticed this while running tests locally. Random tests sometimes fail, and all they had in common was the fact that they were checking for a file's existence. I thought it's maybe an fs-extra specific issue with Windows, but then discovered it's not re-exporting the promise, hence this PR.