### PR TITLE
feat(core): auto-join M:1 and 1:1 relations with filters

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -270,6 +270,16 @@ MikroORM.init({
 });
 ```
 
+## Auto-join of M:1 and 1:1 relations with filters
+
+Since v6, filters are applied to the relations too, as part of `JOIN ON` condition. If a filter exists on a M:1 or 1:1 relation target, such an entity will be automatically joined, and when the foreign key is defined as `NOT NULL`, it will result in an `INNER JOIN` rather than `LEFT JOIN`. This is especially important for implementing soft deletes via filters, as the foreign key might point to a soft-deleted entity. When this happens, the automatic `INNER JOIN` will result in such a record not being returned at all. You can disable this behavior via `autoJoinRefsForFilters` ORM option.
+
+```ts
+MikroORM.init({
+  autoJoinRefsForFilters: false,
+});
+```
+
 ## Forcing UTC Timezone
 
 Use `forceUtcTimezone` option to force the `Date`s to be saved in UTC in datetime columns without timezone. It works for MySQL (`datetime` type) and PostgreSQL (`timestamp` type). SQLite does this by default.

--- a/docs/docs/filters.md
+++ b/docs/docs/filters.md
@@ -126,9 +126,9 @@ em.find(Book, {}, { filters: { tenant: false } }); // disabled tenant filter, so
 em.find(Book, {}, { filters: false }); // disabled all filters, so truly `{}`
 ```
 
-## Filters and populating of relationships
+## Filters and relationships
 
-When populating relationships, filters will be applied only to the root entity of given query, but not to those that are auto-joined. On the other hand, this means that when you use the default loading strategy - `LoadStrategy.SELECT_IN` - filters will be applied to every entity populated this way, as the child entities will become root entities in their respective load calls.
+Since v6, filters are applied to the relations too, as part of `JOIN ON` condition. If a filter exists on a M:1 or 1:1 relation target, such an entity will be automatically joined, and when the foreign key is defined as `NOT NULL`, it will result in an `INNER JOIN` rather than `LEFT JOIN`. This is especially important for implementing soft deletes via filters, as the foreign key might point to a soft-deleted entity. When this happens, the automatic `INNER JOIN` will result in such a record not being returned at all. You can disable this behavior via `autoJoinRefsForFilters` ORM option.
 
 ## Naming of filters
 

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -572,7 +572,7 @@ export class EntityLoader {
     } else if (prop.kind === ReferenceKind.MANY_TO_MANY) { // inverse side
       children.push(...filtered as AnyEntity[]);
     } else { // MANY_TO_ONE or ONE_TO_ONE
-      children.push(...this.filterReferences(entities, prop.name, options) as AnyEntity[]);
+      children.push(...this.filterReferences(entities, prop.name, options, ref) as AnyEntity[]);
     }
 
     return children;
@@ -586,7 +586,11 @@ export class EntityLoader {
     return entities.filter(e => Utils.isCollection(e[field]) && !(e[field] as unknown as Collection<AnyEntity>).isInitialized(!ref));
   }
 
-  private filterReferences<Entity extends object>(entities: Entity[], field: keyof Entity & string, options: Required<EntityLoaderOptions<Entity>>): Entity[keyof Entity][] {
+  private filterReferences<Entity extends object>(entities: Entity[], field: keyof Entity & string, options: Required<EntityLoaderOptions<Entity>>, ref: boolean): Entity[keyof Entity][] {
+    if (ref) {
+      return [];
+    }
+
     const children = entities.filter(e => Utils.isEntity(e[field], true));
 
     if (options.refresh) {

--- a/packages/core/src/entity/Reference.ts
+++ b/packages/core/src/entity/Reference.ts
@@ -152,8 +152,8 @@ export class Reference<T extends object> {
     return this.getEntity()[prop];
   }
 
-  async loadProperty<TT extends T, P extends string = never, K extends keyof TT = keyof TT>(prop: K, options?: LoadReferenceOptions<TT, P>): Promise<Loaded<TT, P>[K]> {
-    await this.load(options);
+  async loadProperty<TT extends T, P extends string = never, K extends keyof TT = keyof TT>(prop: K, options?: LoadReferenceOrFailOptions<TT, P>): Promise<Loaded<TT, P>[K]> {
+    await this.loadOrFail(options);
     return (this.getEntity() as TT)[prop] as Loaded<TT, P>[K];
   }
 

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -858,6 +858,7 @@ export type PopulateOptions<T> = {
   field: EntityKey<T>;
   strategy?: LoadStrategy;
   all?: boolean;
+  filter?: boolean;
   children?: PopulateOptions<T[keyof T]>[];
 };
 

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -78,6 +78,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver> {
     connect: true,
     ignoreUndefinedInQuery: false,
     autoJoinOneToOneOwner: true,
+    autoJoinRefsForFilters: true,
     propagationOnPrototype: true,
     populateAfterFlush: true,
     serialization: {
@@ -532,6 +533,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver> ex
   verbose: boolean;
   ignoreUndefinedInQuery?: boolean;
   autoJoinOneToOneOwner: boolean;
+  autoJoinRefsForFilters: boolean;
   propagationOnPrototype: boolean;
   populateAfterFlush: boolean;
   serialization: {

--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -375,9 +375,10 @@ export class QueryBuilderHelper {
   }
 
   mapJoinColumns(type: QueryType, join: JoinOptions): (string | Knex.Raw)[] {
-    if (join.prop && join.prop.kind === ReferenceKind.ONE_TO_ONE && !join.prop.owner) {
+    if (join.prop && [ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(join.prop.kind)) {
       return join.prop.fieldNames.map((fieldName, idx) => {
-        return this.mapper(`${join.alias}.${join.inverseJoinColumns![idx]}`, type, undefined, fieldName);
+        const columns = join.prop.owner ? join.joinColumns : join.inverseJoinColumns;
+        return this.mapper(`${join.alias}.${columns![idx]}`, type, undefined, fieldName);
       });
     }
 

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -1767,14 +1767,12 @@ describe('EntityManagerMySql', () => {
       orderBy: { title: QueryOrder.DESC },
       strategy: 'joined',
     });
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name`, `t5`.`id` as `test_id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name`, `t3`.`id` as `test_id` ' +
       'from `book2` as `b0` ' +
       'left join `book_to_tag_unordered` as `b2` on `b0`.`uuid_pk` = `b2`.`book2_uuid_pk` ' +
       'left join `book_tag2` as `t1` on `b2`.`book_tag2_id` = `t1`.`id` and `t1`.`name` != ? ' +
-      'left join `book_to_tag_unordered` as `b4` on `b0`.`uuid_pk` = `b4`.`book2_uuid_pk` ' +
-      'left join `book_tag2` as `b3` on `b4`.`book_tag2_id` = `b3`.`id` ' +
-      'left join `test2` as `t5` on `b0`.`uuid_pk` = `t5`.`book_uuid_pk` ' +
-      'where `b0`.`author_id` is not null and `b3`.`name` != ? ' +
+      'left join `test2` as `t3` on `b0`.`uuid_pk` = `t3`.`book_uuid_pk` ' +
+      'where `b0`.`author_id` is not null and `t1`.`name` != ? ' +
       'order by `b0`.`title` desc, `t1`.`name` asc');
 
     expect(books4.length).toBe(3);

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -120,6 +120,7 @@ export async function initORMMySql<D extends MySqlDriver | MariaDbDriver = MySql
     charset: 'utf8mb4',
     logger: (i: any) => i,
     multipleStatements: true,
+    autoJoinRefsForFilters: false,
     populateAfterFlush: false,
     entityRepository: SqlEntityRepository,
     driver: type === 'mysql' ? MySqlDriver : MariaDbDriver,

--- a/tests/features/__snapshots__/dataloader.test.ts.snap
+++ b/tests/features/__snapshots__/dataloader.test.ts.snap
@@ -12,34 +12,34 @@ exports[`Dataloader Collection dataloader can be disabled per-query 1`] = `
     "[query] select \`a1\`.*, \`a0\`.\`author_2_id\` as \`fk__author_2_id\`, \`a0\`.\`author_1_id\` as \`fk__author_1_id\` from \`author_buddies\` as \`a0\` inner join \`author\` as \`a1\` on \`a0\`.\`author_2_id\` = \`a1\`.\`id\` where \`a1\`.\`age\` < 80 and \`a0\`.\`author_1_id\` in (3)",
   ],
   [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`author_id\` in (1)",
-  ],
-  [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`author_id\` in (2)",
-  ],
-  [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`author_id\` in (3)",
-  ],
-  [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`publisher_id\` in (1)",
-  ],
-  [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`publisher_id\` in (2)",
-  ],
-  [
-    "[query] select \`c0\`.* from \`chat\` as \`c0\` where \`c0\`.\`owner_id\` in (1)",
-  ],
-  [
-    "[query] select \`c0\`.* from \`chat\` as \`c0\` where \`c0\`.\`owner_id\` in (2)",
-  ],
-  [
-    "[query] select \`c0\`.* from \`chat\` as \`c0\` where \`c0\`.\`owner_id\` in (3)",
-  ],
-  [
     "[query] select \`m0\`.* from \`message\` as \`m0\` where (\`m0\`.\`chat_owner_id\`, \`m0\`.\`chat_recipient_id\`) in ( values (1, 2))",
   ],
   [
     "[query] select \`m0\`.* from \`message\` as \`m0\` where (\`m0\`.\`chat_owner_id\`, \`m0\`.\`chat_recipient_id\`) in ( values (1, 3))",
+  ],
+  [
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`author_id\` in (1)",
+  ],
+  [
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`author_id\` in (2)",
+  ],
+  [
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`author_id\` in (3)",
+  ],
+  [
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`publisher_id\` in (1)",
+  ],
+  [
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`publisher_id\` in (2)",
+  ],
+  [
+    "[query] select \`c0\`.*, \`o1\`.\`id\` as \`owner_id\`, \`r2\`.\`id\` as \`recipient_id\` from \`chat\` as \`c0\` inner join \`author\` as \`o1\` on \`c0\`.\`owner_id\` = \`o1\`.\`id\` and \`o1\`.\`age\` < 80 inner join \`author\` as \`r2\` on \`c0\`.\`recipient_id\` = \`r2\`.\`id\` and \`r2\`.\`age\` < 80 where \`c0\`.\`owner_id\` in (1)",
+  ],
+  [
+    "[query] select \`c0\`.*, \`o1\`.\`id\` as \`owner_id\`, \`r2\`.\`id\` as \`recipient_id\` from \`chat\` as \`c0\` inner join \`author\` as \`o1\` on \`c0\`.\`owner_id\` = \`o1\`.\`id\` and \`o1\`.\`age\` < 80 inner join \`author\` as \`r2\` on \`c0\`.\`recipient_id\` = \`r2\`.\`id\` and \`r2\`.\`age\` < 80 where \`c0\`.\`owner_id\` in (2)",
+  ],
+  [
+    "[query] select \`c0\`.*, \`o1\`.\`id\` as \`owner_id\`, \`r2\`.\`id\` as \`recipient_id\` from \`chat\` as \`c0\` inner join \`author\` as \`o1\` on \`c0\`.\`owner_id\` = \`o1\`.\`id\` and \`o1\`.\`age\` < 80 inner join \`author\` as \`r2\` on \`c0\`.\`recipient_id\` = \`r2\`.\`id\` and \`r2\`.\`age\` < 80 where \`c0\`.\`owner_id\` in (3)",
   ],
 ]
 `;
@@ -47,16 +47,16 @@ exports[`Dataloader Collection dataloader can be disabled per-query 1`] = `
 exports[`Dataloader Collection.load 1`] = `
 [
   [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where (\`b0\`.\`author_id\` in (1, 2, 3) or \`b0\`.\`publisher_id\` in (1, 2))",
-  ],
-  [
-    "[query] select \`c0\`.* from \`chat\` as \`c0\` where \`c0\`.\`owner_id\` in (1, 2, 3)",
-  ],
-  [
     "[query] select \`m0\`.* from \`message\` as \`m0\` where (\`m0\`.\`chat_owner_id\`, \`m0\`.\`chat_recipient_id\`) in ( values (1, 2), (1, 3))",
   ],
   [
     "[query] select \`a0\`.*, \`b1\`.\`id\` as \`b1__id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`email\` as \`b1__email\` from \`author\` as \`a0\` left join \`author_buddies\` as \`a2\` on \`a0\`.\`id\` = \`a2\`.\`author_2_id\` left join \`author\` as \`b1\` on \`a2\`.\`author_1_id\` = \`b1\`.\`id\` and \`b1\`.\`age\` < 80 left join \`author_buddies\` as \`a3\` on \`a0\`.\`id\` = \`a3\`.\`author_2_id\` where \`a0\`.\`age\` < 80 and \`a3\`.\`author_1_id\` in (1, 2, 3)",
+  ],
+  [
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where (\`b0\`.\`author_id\` in (1, 2, 3) or \`b0\`.\`publisher_id\` in (1, 2))",
+  ],
+  [
+    "[query] select \`c0\`.*, \`o1\`.\`id\` as \`owner_id\`, \`r2\`.\`id\` as \`recipient_id\` from \`chat\` as \`c0\` inner join \`author\` as \`o1\` on \`c0\`.\`owner_id\` = \`o1\`.\`id\` and \`o1\`.\`age\` < 80 inner join \`author\` as \`r2\` on \`c0\`.\`recipient_id\` = \`r2\`.\`id\` and \`r2\`.\`age\` < 80 where \`c0\`.\`owner_id\` in (1, 2, 3)",
   ],
 ]
 `;
@@ -64,7 +64,7 @@ exports[`Dataloader Collection.load 1`] = `
 exports[`Dataloader Collection.load with orderBy 1`] = `
 [
   [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`author_id\` in (1, 2, 3) order by \`b0\`.\`title\` asc",
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`author_id\` in (1, 2, 3) order by \`b0\`.\`title\` asc",
   ],
 ]
 `;
@@ -72,7 +72,7 @@ exports[`Dataloader Collection.load with orderBy 1`] = `
 exports[`Dataloader Collection.load with populate 1`] = `
 [
   [
-    "[query] select \`b0\`.*, \`p1\`.\`id\` as \`p1__id\`, \`p1\`.\`name\` as \`p1__name\`, \`p1\`.\`type\` as \`p1__type\` from \`book\` as \`b0\` left join \`publisher\` as \`p1\` on \`b0\`.\`publisher_id\` = \`p1\`.\`id\` where \`b0\`.\`author_id\` in (1, 2, 3)",
+    "[query] select \`b0\`.*, \`p1\`.\`id\` as \`p1__id\`, \`p1\`.\`name\` as \`p1__name\`, \`p1\`.\`type\` as \`p1__type\`, \`a2\`.\`id\` as \`author_id\` from \`book\` as \`b0\` left join \`publisher\` as \`p1\` on \`b0\`.\`publisher_id\` = \`p1\`.\`id\` inner join \`author\` as \`a2\` on \`b0\`.\`author_id\` = \`a2\`.\`id\` and \`a2\`.\`age\` < 80 where \`b0\`.\`author_id\` in (1, 2, 3)",
   ],
 ]
 `;
@@ -80,7 +80,7 @@ exports[`Dataloader Collection.load with populate 1`] = `
 exports[`Dataloader Collection.load with where 1`] = `
 [
   [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`author_id\` in (1, 2, 3) and \`b0\`.\`title\` in ('One', 'Two', 'Six')",
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`author_id\` in (1, 2, 3) and \`b0\`.\`title\` in ('One', 'Two', 'Six')",
   ],
 ]
 `;
@@ -99,38 +99,38 @@ exports[`Dataloader Collection.load with wildcard populate 1`] = `
 ]
 `;
 
-exports[`Dataloader Dataloader can be globally enabled for Collections with true, Dataloader.ALL, Dataloader.COLLECTION 1`] = `
+exports[`Dataloader Dataloader can be globally enabled for Collections with true, DataloaderType.ALL, DataloaderType.COLLECTION 1`] = `
 [
-  [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where (\`b0\`.\`author_id\` in (1, 2, 3) or \`b0\`.\`publisher_id\` in (1, 2))",
-  ],
-  [
-    "[query] select \`c0\`.* from \`chat\` as \`c0\` where \`c0\`.\`owner_id\` in (1, 2, 3)",
-  ],
   [
     "[query] select \`m0\`.* from \`message\` as \`m0\` where (\`m0\`.\`chat_owner_id\`, \`m0\`.\`chat_recipient_id\`) in ( values (1, 2), (1, 3))",
   ],
   [
     "[query] select \`a0\`.*, \`b1\`.\`id\` as \`b1__id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`email\` as \`b1__email\` from \`author\` as \`a0\` left join \`author_buddies\` as \`a2\` on \`a0\`.\`id\` = \`a2\`.\`author_2_id\` left join \`author\` as \`b1\` on \`a2\`.\`author_1_id\` = \`b1\`.\`id\` and \`b1\`.\`age\` < 80 left join \`author_buddies\` as \`a3\` on \`a0\`.\`id\` = \`a3\`.\`author_2_id\` where \`a0\`.\`age\` < 80 and \`a3\`.\`author_1_id\` in (1, 2, 3)",
   ],
+  [
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where (\`b0\`.\`author_id\` in (1, 2, 3) or \`b0\`.\`publisher_id\` in (1, 2))",
+  ],
+  [
+    "[query] select \`c0\`.*, \`o1\`.\`id\` as \`owner_id\`, \`r2\`.\`id\` as \`recipient_id\` from \`chat\` as \`c0\` inner join \`author\` as \`o1\` on \`c0\`.\`owner_id\` = \`o1\`.\`id\` and \`o1\`.\`age\` < 80 inner join \`author\` as \`r2\` on \`c0\`.\`recipient_id\` = \`r2\`.\`id\` and \`r2\`.\`age\` < 80 where \`c0\`.\`owner_id\` in (1, 2, 3)",
+  ],
 ]
 `;
 
-exports[`Dataloader Dataloader can be globally enabled for References with true, Dataloader.ALL, Dataloader.REFERENCE 1`] = `
+exports[`Dataloader Dataloader can be globally enabled for References with true, DataloaderType.ALL, DataloaderType.REFERENCE 1`] = `
 [
   [
     "[query] select \`a0\`.* from \`author\` as \`a0\` where \`a0\`.\`age\` < 80 and \`a0\`.\`id\` in (1, 2)",
   ],
   [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`id\` in (5, 3, 4)",
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`id\` in (5, 3, 4)",
   ],
   [
-    "[query] select \`c0\`.* from \`chat\` as \`c0\` where ((\`c0\`.\`owner_id\` = 1 and \`c0\`.\`recipient_id\` = 2) or (\`c0\`.\`owner_id\` = 1 and \`c0\`.\`recipient_id\` = 3) or (\`c0\`.\`owner_id\` = 3 and \`c0\`.\`recipient_id\` = 1))",
+    "[query] select \`c0\`.*, \`o1\`.\`id\` as \`owner_id\`, \`r2\`.\`id\` as \`recipient_id\` from \`chat\` as \`c0\` inner join \`author\` as \`o1\` on \`c0\`.\`owner_id\` = \`o1\`.\`id\` and \`o1\`.\`age\` < 80 inner join \`author\` as \`r2\` on \`c0\`.\`recipient_id\` = \`r2\`.\`id\` and \`r2\`.\`age\` < 80 where ((\`c0\`.\`owner_id\` = 1 and \`c0\`.\`recipient_id\` = 2) or (\`c0\`.\`owner_id\` = 1 and \`c0\`.\`recipient_id\` = 3) or (\`c0\`.\`owner_id\` = 3 and \`c0\`.\`recipient_id\` = 1))",
   ],
 ]
 `;
 
-exports[`Dataloader Dataloader should not be globally enabled for Collections with false, Dataloader.OFF, Dataloader.REFERENCE 1`] = `
+exports[`Dataloader Dataloader should not be globally enabled for Collections with false, DataloaderType.NONE, DataloaderType.REFERENCE 1`] = `
 [
   [
     "[query] select \`a1\`.*, \`a0\`.\`author_2_id\` as \`fk__author_2_id\`, \`a0\`.\`author_1_id\` as \`fk__author_1_id\` from \`author_buddies\` as \`a0\` inner join \`author\` as \`a1\` on \`a0\`.\`author_2_id\` = \`a1\`.\`id\` where \`a1\`.\`age\` < 80 and \`a0\`.\`author_1_id\` in (1)",
@@ -142,39 +142,39 @@ exports[`Dataloader Dataloader should not be globally enabled for Collections wi
     "[query] select \`a1\`.*, \`a0\`.\`author_2_id\` as \`fk__author_2_id\`, \`a0\`.\`author_1_id\` as \`fk__author_1_id\` from \`author_buddies\` as \`a0\` inner join \`author\` as \`a1\` on \`a0\`.\`author_2_id\` = \`a1\`.\`id\` where \`a1\`.\`age\` < 80 and \`a0\`.\`author_1_id\` in (3)",
   ],
   [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`author_id\` in (1)",
-  ],
-  [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`author_id\` in (2)",
-  ],
-  [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`author_id\` in (3)",
-  ],
-  [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`publisher_id\` in (1)",
-  ],
-  [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`publisher_id\` in (2)",
-  ],
-  [
-    "[query] select \`c0\`.* from \`chat\` as \`c0\` where \`c0\`.\`owner_id\` in (1)",
-  ],
-  [
-    "[query] select \`c0\`.* from \`chat\` as \`c0\` where \`c0\`.\`owner_id\` in (2)",
-  ],
-  [
-    "[query] select \`c0\`.* from \`chat\` as \`c0\` where \`c0\`.\`owner_id\` in (3)",
-  ],
-  [
     "[query] select \`m0\`.* from \`message\` as \`m0\` where (\`m0\`.\`chat_owner_id\`, \`m0\`.\`chat_recipient_id\`) in ( values (1, 2))",
   ],
   [
     "[query] select \`m0\`.* from \`message\` as \`m0\` where (\`m0\`.\`chat_owner_id\`, \`m0\`.\`chat_recipient_id\`) in ( values (1, 3))",
   ],
+  [
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`author_id\` in (1)",
+  ],
+  [
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`author_id\` in (2)",
+  ],
+  [
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`author_id\` in (3)",
+  ],
+  [
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`publisher_id\` in (1)",
+  ],
+  [
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`publisher_id\` in (2)",
+  ],
+  [
+    "[query] select \`c0\`.*, \`o1\`.\`id\` as \`owner_id\`, \`r2\`.\`id\` as \`recipient_id\` from \`chat\` as \`c0\` inner join \`author\` as \`o1\` on \`c0\`.\`owner_id\` = \`o1\`.\`id\` and \`o1\`.\`age\` < 80 inner join \`author\` as \`r2\` on \`c0\`.\`recipient_id\` = \`r2\`.\`id\` and \`r2\`.\`age\` < 80 where \`c0\`.\`owner_id\` in (1)",
+  ],
+  [
+    "[query] select \`c0\`.*, \`o1\`.\`id\` as \`owner_id\`, \`r2\`.\`id\` as \`recipient_id\` from \`chat\` as \`c0\` inner join \`author\` as \`o1\` on \`c0\`.\`owner_id\` = \`o1\`.\`id\` and \`o1\`.\`age\` < 80 inner join \`author\` as \`r2\` on \`c0\`.\`recipient_id\` = \`r2\`.\`id\` and \`r2\`.\`age\` < 80 where \`c0\`.\`owner_id\` in (2)",
+  ],
+  [
+    "[query] select \`c0\`.*, \`o1\`.\`id\` as \`owner_id\`, \`r2\`.\`id\` as \`recipient_id\` from \`chat\` as \`c0\` inner join \`author\` as \`o1\` on \`c0\`.\`owner_id\` = \`o1\`.\`id\` and \`o1\`.\`age\` < 80 inner join \`author\` as \`r2\` on \`c0\`.\`recipient_id\` = \`r2\`.\`id\` and \`r2\`.\`age\` < 80 where \`c0\`.\`owner_id\` in (3)",
+  ],
 ]
 `;
 
-exports[`Dataloader Dataloader should not be globally enabled for References with false, Dataloader.OFF, Dataloader.COLLECTION 1`] = `
+exports[`Dataloader Dataloader should not be globally enabled for References with false, DataloaderType.NONE, DataloaderType.COLLECTION 1`] = `
 [
   [
     "[query] select \`a0\`.* from \`author\` as \`a0\` where \`a0\`.\`age\` < 80 and \`a0\`.\`id\` = 1 limit 1",
@@ -183,22 +183,22 @@ exports[`Dataloader Dataloader should not be globally enabled for References wit
     "[query] select \`a0\`.* from \`author\` as \`a0\` where \`a0\`.\`age\` < 80 and \`a0\`.\`id\` = 2 limit 1",
   ],
   [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`id\` = 5 limit 1",
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`id\` = 5 limit 1",
   ],
   [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`id\` = 3 limit 1",
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`id\` = 3 limit 1",
   ],
   [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`id\` = 4 limit 1",
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`id\` = 4 limit 1",
   ],
   [
-    "[query] select \`c0\`.* from \`chat\` as \`c0\` where (\`c0\`.\`owner_id\`, \`c0\`.\`recipient_id\`) in ((1, 2)) limit 1",
+    "[query] select \`c0\`.*, \`o1\`.\`id\` as \`owner_id\`, \`r2\`.\`id\` as \`recipient_id\` from \`chat\` as \`c0\` inner join \`author\` as \`o1\` on \`c0\`.\`owner_id\` = \`o1\`.\`id\` and \`o1\`.\`age\` < 80 inner join \`author\` as \`r2\` on \`c0\`.\`recipient_id\` = \`r2\`.\`id\` and \`r2\`.\`age\` < 80 where (\`c0\`.\`owner_id\`, \`c0\`.\`recipient_id\`) in ((1, 2)) limit 1",
   ],
   [
-    "[query] select \`c0\`.* from \`chat\` as \`c0\` where (\`c0\`.\`owner_id\`, \`c0\`.\`recipient_id\`) in ((1, 3)) limit 1",
+    "[query] select \`c0\`.*, \`o1\`.\`id\` as \`owner_id\`, \`r2\`.\`id\` as \`recipient_id\` from \`chat\` as \`c0\` inner join \`author\` as \`o1\` on \`c0\`.\`owner_id\` = \`o1\`.\`id\` and \`o1\`.\`age\` < 80 inner join \`author\` as \`r2\` on \`c0\`.\`recipient_id\` = \`r2\`.\`id\` and \`r2\`.\`age\` < 80 where (\`c0\`.\`owner_id\`, \`c0\`.\`recipient_id\`) in ((1, 3)) limit 1",
   ],
   [
-    "[query] select \`c0\`.* from \`chat\` as \`c0\` where (\`c0\`.\`owner_id\`, \`c0\`.\`recipient_id\`) in ((3, 1)) limit 1",
+    "[query] select \`c0\`.*, \`o1\`.\`id\` as \`owner_id\`, \`r2\`.\`id\` as \`recipient_id\` from \`chat\` as \`c0\` inner join \`author\` as \`o1\` on \`c0\`.\`owner_id\` = \`o1\`.\`id\` and \`o1\`.\`age\` < 80 inner join \`author\` as \`r2\` on \`c0\`.\`recipient_id\` = \`r2\`.\`id\` and \`r2\`.\`age\` < 80 where (\`c0\`.\`owner_id\`, \`c0\`.\`recipient_id\`) in ((3, 1)) limit 1",
   ],
 ]
 `;
@@ -212,22 +212,22 @@ exports[`Dataloader Reference dataloader can be disabled per-query 1`] = `
     "[query] select \`a0\`.* from \`author\` as \`a0\` where \`a0\`.\`age\` < 80 and \`a0\`.\`id\` = 2 limit 1",
   ],
   [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`id\` = 5 limit 1",
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`id\` = 5 limit 1",
   ],
   [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`id\` = 3 limit 1",
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`id\` = 3 limit 1",
   ],
   [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`id\` = 4 limit 1",
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`id\` = 4 limit 1",
   ],
   [
-    "[query] select \`c0\`.* from \`chat\` as \`c0\` where (\`c0\`.\`owner_id\`, \`c0\`.\`recipient_id\`) in ((1, 2)) limit 1",
+    "[query] select \`c0\`.*, \`o1\`.\`id\` as \`owner_id\`, \`r2\`.\`id\` as \`recipient_id\` from \`chat\` as \`c0\` inner join \`author\` as \`o1\` on \`c0\`.\`owner_id\` = \`o1\`.\`id\` and \`o1\`.\`age\` < 80 inner join \`author\` as \`r2\` on \`c0\`.\`recipient_id\` = \`r2\`.\`id\` and \`r2\`.\`age\` < 80 where (\`c0\`.\`owner_id\`, \`c0\`.\`recipient_id\`) in ((1, 2)) limit 1",
   ],
   [
-    "[query] select \`c0\`.* from \`chat\` as \`c0\` where (\`c0\`.\`owner_id\`, \`c0\`.\`recipient_id\`) in ((1, 3)) limit 1",
+    "[query] select \`c0\`.*, \`o1\`.\`id\` as \`owner_id\`, \`r2\`.\`id\` as \`recipient_id\` from \`chat\` as \`c0\` inner join \`author\` as \`o1\` on \`c0\`.\`owner_id\` = \`o1\`.\`id\` and \`o1\`.\`age\` < 80 inner join \`author\` as \`r2\` on \`c0\`.\`recipient_id\` = \`r2\`.\`id\` and \`r2\`.\`age\` < 80 where (\`c0\`.\`owner_id\`, \`c0\`.\`recipient_id\`) in ((1, 3)) limit 1",
   ],
   [
-    "[query] select \`c0\`.* from \`chat\` as \`c0\` where (\`c0\`.\`owner_id\`, \`c0\`.\`recipient_id\`) in ((3, 1)) limit 1",
+    "[query] select \`c0\`.*, \`o1\`.\`id\` as \`owner_id\`, \`r2\`.\`id\` as \`recipient_id\` from \`chat\` as \`c0\` inner join \`author\` as \`o1\` on \`c0\`.\`owner_id\` = \`o1\`.\`id\` and \`o1\`.\`age\` < 80 inner join \`author\` as \`r2\` on \`c0\`.\`recipient_id\` = \`r2\`.\`id\` and \`r2\`.\`age\` < 80 where (\`c0\`.\`owner_id\`, \`c0\`.\`recipient_id\`) in ((3, 1)) limit 1",
   ],
 ]
 `;
@@ -238,10 +238,10 @@ exports[`Dataloader Reference.load 1`] = `
     "[query] select \`a0\`.* from \`author\` as \`a0\` where \`a0\`.\`age\` < 80 and \`a0\`.\`id\` in (1, 2)",
   ],
   [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`id\` in (5, 3, 4)",
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`id\` in (5, 3, 4)",
   ],
   [
-    "[query] select \`c0\`.* from \`chat\` as \`c0\` where ((\`c0\`.\`owner_id\` = 1 and \`c0\`.\`recipient_id\` = 2) or (\`c0\`.\`owner_id\` = 1 and \`c0\`.\`recipient_id\` = 3) or (\`c0\`.\`owner_id\` = 3 and \`c0\`.\`recipient_id\` = 1))",
+    "[query] select \`c0\`.*, \`o1\`.\`id\` as \`owner_id\`, \`r2\`.\`id\` as \`recipient_id\` from \`chat\` as \`c0\` inner join \`author\` as \`o1\` on \`c0\`.\`owner_id\` = \`o1\`.\`id\` and \`o1\`.\`age\` < 80 inner join \`author\` as \`r2\` on \`c0\`.\`recipient_id\` = \`r2\`.\`id\` and \`r2\`.\`age\` < 80 where ((\`c0\`.\`owner_id\` = 1 and \`c0\`.\`recipient_id\` = 2) or (\`c0\`.\`owner_id\` = 1 and \`c0\`.\`recipient_id\` = 3) or (\`c0\`.\`owner_id\` = 3 and \`c0\`.\`recipient_id\` = 1))",
   ],
 ]
 `;
@@ -249,16 +249,16 @@ exports[`Dataloader Reference.load 1`] = `
 exports[`Dataloader getColBatchLoadFn 1`] = `
 [
   [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where (\`b0\`.\`author_id\` in (1, 2, 3) or \`b0\`.\`publisher_id\` in (1, 2))",
-  ],
-  [
-    "[query] select \`c0\`.* from \`chat\` as \`c0\` where \`c0\`.\`owner_id\` in (1, 2, 3)",
-  ],
-  [
     "[query] select \`m0\`.* from \`message\` as \`m0\` where (\`m0\`.\`chat_owner_id\`, \`m0\`.\`chat_recipient_id\`) in ( values (1, 2), (1, 3))",
   ],
   [
     "[query] select \`a0\`.*, \`b1\`.\`id\` as \`b1__id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`email\` as \`b1__email\` from \`author\` as \`a0\` left join \`author_buddies\` as \`a2\` on \`a0\`.\`id\` = \`a2\`.\`author_2_id\` left join \`author\` as \`b1\` on \`a2\`.\`author_1_id\` = \`b1\`.\`id\` and \`b1\`.\`age\` < 80 left join \`author_buddies\` as \`a3\` on \`a0\`.\`id\` = \`a3\`.\`author_2_id\` where \`a0\`.\`age\` < 80 and \`a3\`.\`author_1_id\` in (1, 2, 3)",
+  ],
+  [
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where (\`b0\`.\`author_id\` in (1, 2, 3) or \`b0\`.\`publisher_id\` in (1, 2))",
+  ],
+  [
+    "[query] select \`c0\`.*, \`o1\`.\`id\` as \`owner_id\`, \`r2\`.\`id\` as \`recipient_id\` from \`chat\` as \`c0\` inner join \`author\` as \`o1\` on \`c0\`.\`owner_id\` = \`o1\`.\`id\` and \`o1\`.\`age\` < 80 inner join \`author\` as \`r2\` on \`c0\`.\`recipient_id\` = \`r2\`.\`id\` and \`r2\`.\`age\` < 80 where \`c0\`.\`owner_id\` in (1, 2, 3)",
   ],
 ]
 `;
@@ -269,10 +269,10 @@ exports[`Dataloader getRefBatchLoadFn 1`] = `
     "[query] select \`a0\`.* from \`author\` as \`a0\` where \`a0\`.\`age\` < 80 and \`a0\`.\`id\` in (1, 2)",
   ],
   [
-    "[query] select \`b0\`.* from \`book\` as \`b0\` where \`b0\`.\`id\` in (5, 3, 4)",
+    "[query] select \`b0\`.*, \`a1\`.\`id\` as \`author_id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where \`b0\`.\`id\` in (5, 3, 4)",
   ],
   [
-    "[query] select \`c0\`.* from \`chat\` as \`c0\` where ((\`c0\`.\`owner_id\` = 1 and \`c0\`.\`recipient_id\` = 2) or (\`c0\`.\`owner_id\` = 1 and \`c0\`.\`recipient_id\` = 3) or (\`c0\`.\`owner_id\` = 3 and \`c0\`.\`recipient_id\` = 1))",
+    "[query] select \`c0\`.*, \`o1\`.\`id\` as \`owner_id\`, \`r2\`.\`id\` as \`recipient_id\` from \`chat\` as \`c0\` inner join \`author\` as \`o1\` on \`c0\`.\`owner_id\` = \`o1\`.\`id\` and \`o1\`.\`age\` < 80 inner join \`author\` as \`r2\` on \`c0\`.\`recipient_id\` = \`r2\`.\`id\` and \`r2\`.\`age\` < 80 where ((\`c0\`.\`owner_id\` = 1 and \`c0\`.\`recipient_id\` = 2) or (\`c0\`.\`owner_id\` = 1 and \`c0\`.\`recipient_id\` = 3) or (\`c0\`.\`owner_id\` = 3 and \`c0\`.\`recipient_id\` = 1))",
   ],
 ]
 `;

--- a/tests/features/dataloader.test.ts
+++ b/tests/features/dataloader.test.ts
@@ -340,7 +340,7 @@ describe('Dataloader', () => {
     expect(serialize(resA)).toEqual(serialize(resB));
   });
 
-  test('Dataloader can be globally enabled for References with true, Dataloader.ALL, Dataloader.REFERENCE', async () => {
+  test('Dataloader can be globally enabled for References with true, DataloaderType.ALL, DataloaderType.REFERENCE', async () => {
     async function getRefs(dataloader: DataloaderType | boolean) {
       const orm = await MikroORM.init({
         dbName: ':memory:',
@@ -364,7 +364,7 @@ describe('Dataloader', () => {
     expect(await getRefs(DataloaderType.REFERENCE)).toEqual(res);
   });
 
-  test('Dataloader should not be globally enabled for References with false, Dataloader.OFF, Dataloader.COLLECTION', async () => {
+  test('Dataloader should not be globally enabled for References with false, DataloaderType.NONE, DataloaderType.COLLECTION', async () => {
     async function getRefs(dataloader: DataloaderType | boolean) {
       const orm = await MikroORM.init({
         dbName: ':memory:',
@@ -580,7 +580,7 @@ describe('Dataloader', () => {
     }
   });
 
-  test('Dataloader can be globally enabled for Collections with true, Dataloader.ALL, Dataloader.COLLECTION', async () => {
+  test('Dataloader can be globally enabled for Collections with true, DataloaderType.ALL, DataloaderType.COLLECTION', async () => {
     async function getCols(dataloader: DataloaderType | boolean) {
       const orm = await MikroORM.init({
         dbName: ':memory:',
@@ -604,7 +604,7 @@ describe('Dataloader', () => {
     expect(await getCols(DataloaderType.COLLECTION)).toEqual(res);
   });
 
-  test('Dataloader should not be globally enabled for Collections with false, Dataloader.OFF, Dataloader.REFERENCE', async () => {
+  test('Dataloader should not be globally enabled for Collections with false, DataloaderType.NONE, DataloaderType.REFERENCE', async () => {
     async function getCols(dataloader: DataloaderType | boolean) {
       const orm = await MikroORM.init({
         dbName: ':memory:',

--- a/tests/features/filters/filters.postgres.test.ts
+++ b/tests/features/filters/filters.postgres.test.ts
@@ -185,7 +185,7 @@ describe('filters [postgres]', () => {
     const e1 = await orm.em.findOneOrFail(Employee, employee.id, { populate: ['benefits.details'], strategy: 'select-in' });
     expect(mock.mock.calls[0][0]).toMatch(`select "e0".* from "employee" as "e0" where "e0"."id" = $1 limit $2`);
     expect(mock.mock.calls[1][0]).toMatch(`select "b1".*, "e0"."benefit_id" as "fk__benefit_id", "e0"."employee_id" as "fk__employee_id" from "employee_benefits" as "e0" inner join "public"."benefit" as "b1" on "e0"."benefit_id" = "b1"."id" where "b1"."benefit_status" = $1 and "e0"."employee_id" in ($2)`);
-    expect(mock.mock.calls[2][0]).toMatch(`select "b0".* from "benefit_detail" as "b0" where "b0"."active" = $1 and "b0"."benefit_id" in ($2)`);
+    expect(mock.mock.calls[2][0]).toMatch(`select "b0".*, "b1"."id" as "benefit_id" from "benefit_detail" as "b0" inner join "benefit" as "b1" on "b0"."benefit_id" = "b1"."id" and "b1"."benefit_status" = $1 where "b0"."active" = $2 and "b0"."benefit_id" in ($3)`);
     expect(e1.benefits).toHaveLength(1);
     expect(e1.benefits[0].details).toHaveLength(1);
 
@@ -222,7 +222,7 @@ describe('filters [postgres]', () => {
     }, { filters: false });
 
     expect(mock.mock.calls[0][0]).toMatch(`select "u0".* from "user" as "u0" where ("u0"."age" = $1 or "u0"."age" = $2) and ("u0"."first_name" = $3 or "u0"."last_name" = $4)`);
-    expect(mock.mock.calls[1][0]).toMatch(`select "m0".* from "membership" as "m0" left join "user" as "u1" on "m0"."user_id" = "u1"."id" where ("u1"."first_name" = $1 or "u1"."last_name" = $2 or "u1"."age" = (select $3 + $4)) and ("m0"."role" = $5 or "m0"."role" = $6)`);
+    expect(mock.mock.calls[1][0]).toMatch(`select "m0".*, "u1"."id" as "user_id" from "membership" as "m0" inner join "user" as "u1" on "m0"."user_id" = "u1"."id" and ("u1"."age" = $1 or "u1"."age" = $2) where ("u1"."first_name" = $3 or "u1"."last_name" = $4 or "u1"."age" = (select $5 + $6)) and ("m0"."role" = $7 or "m0"."role" = $8)`);
     expect(mock.mock.calls[2][0]).toMatch(`select "m0".* from "membership" as "m0" left join "user" as "u1" on "m0"."user_id" = "u1"."id" where ("m0"."role" = $1 or "m0"."role" = $2) and ("u1"."first_name" = $3 or "u1"."last_name" = $4)`);
   });
 
@@ -246,6 +246,42 @@ describe('filters [postgres]', () => {
     });
   });
 
+  test('eager joined filter on relation', async () => {
+    await createEntities();
+
+    const mock = mockLogger(orm, ['query']);
+    const details1 = await orm.em.findAll(BenefitDetail, { strategy: 'select-in' });
+    expect(mock.mock.calls[0][0]).toMatch(`select "b0".*, "b1"."id" as "benefit_id" from "benefit_detail" as "b0" inner join "benefit" as "b1" on "b0"."benefit_id" = "b1"."id" and "b1"."benefit_status" = $1 where "b0"."active" = $2`);
+    expect(details1).toHaveLength(1);
+    await expect(details1[0].benefit.load()).resolves.toMatchObject({
+      id: details1[0].benefit.id,
+      benefitStatus: 'A',
+      name: 'b2',
+    });
+
+    mock.mockReset();
+    const details2 = await orm.em.findAll(BenefitDetail);
+    expect(mock.mock.calls[0][0]).toMatch(`select "b0".*, "b1"."id" as "benefit_id" from "benefit_detail" as "b0" inner join "benefit" as "b1" on "b0"."benefit_id" = "b1"."id" and "b1"."benefit_status" = $1 where "b0"."active" = $2`);
+    expect(details2).toHaveLength(1);
+    await expect(details2[0].benefit.load()).resolves.toMatchObject({
+      id: details2[0].benefit.id,
+      benefitStatus: 'A',
+      name: 'b2',
+    });
+
+    mock.mockReset();
+    const details3 = await orm.em.findAll(BenefitDetail, { filters: false });
+    expect(mock.mock.calls[0][0]).toMatch(`select "b0".* from "benefit_detail" as "b0"`);
+    expect(details3).toHaveLength(6);
+    expect(details3[0].benefit.id).toBe(1);
+    await expect(details3[0].benefit.load()).resolves.toBe(null);
+    await expect(details3[0].benefit.load({ filters: false })).resolves.toMatchObject({
+      id: details3[0].benefit.id,
+      benefitStatus: 'IA',
+      name: 'b1',
+    });
+  });
+
   test('Collection.load() allows controlling filters', async () => {
     await createEntities(false);
 
@@ -258,7 +294,7 @@ describe('filters [postgres]', () => {
     expect(mock.mock.calls[0][0]).toMatch(`select "b0".* from "benefit" as "b0" left join "benefit_detail" as "b1" on "b0"."id" = "b1"."benefit_id" where "b1"."active" = $1`);
     expect(benefits[0].details.isInitialized()).toBe(false);
     await expect(benefits[0].details.loadItems()).resolves.toHaveLength(0);
-    expect(mock.mock.calls[1][0]).toMatch(`select "b0".* from "benefit_detail" as "b0" where "b0"."active" = $1 and "b0"."benefit_id" in ($2)`);
+    expect(mock.mock.calls[1][0]).toMatch(`select "b0".*, "b1"."id" as "benefit_id" from "benefit_detail" as "b0" inner join "benefit" as "b1" on "b0"."benefit_id" = "b1"."id" and "b1"."benefit_status" = $1 where "b0"."active" = $2 and "b0"."benefit_id" in ($3)`);
     await expect(benefits[0].details.loadItems({ filters: false, refresh: true })).resolves.toHaveLength(3);
     expect(mock.mock.calls[2][0]).toMatch(`select "b0".* from "benefit_detail" as "b0" where "b0"."benefit_id" in ($1)`);
   });

--- a/tests/features/joined-strategy.postgre.test.ts
+++ b/tests/features/joined-strategy.postgre.test.ts
@@ -113,21 +113,26 @@ describe('Joined loading strategy', () => {
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books2.perex'] });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"f2"."uuid_pk" as "favourite_book_uuid_pk" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
+      'left join "book2" as "f2" on "a0"."favourite_book_uuid_pk" = "f2"."uuid_pk" and "f2"."author_id" is not null ' +
       'where "a0"."id" = $1 ' +
-      'order by "b1"."title"');
+      'order by "b1"."title" asc');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books2'] });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"f2"."uuid_pk" as "favourite_book_uuid_pk" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
-      'where "a0"."id" = $1');
+      'left join "book2" as "f2" on "a0"."favourite_book_uuid_pk" = "f2"."uuid_pk" and "f2"."author_id" is not null ' +
+      'where "a0"."id" = $1 ' +
+      'order by "b1"."title" asc');
 
     orm.em.clear();
     mock.mock.calls.length = 0;
@@ -144,9 +149,11 @@ describe('Joined loading strategy', () => {
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books.perex'] });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"f2"."uuid_pk" as "favourite_book_uuid_pk" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
+      'left join "book2" as "f2" on "a0"."favourite_book_uuid_pk" = "f2"."uuid_pk" and "f2"."author_id" is not null ' +
       'where "a0"."id" = $1');
   });
 
@@ -178,9 +185,11 @@ describe('Joined loading strategy', () => {
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books2'] });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"f2"."uuid_pk" as "favourite_book_uuid_pk" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
+      'left join "book2" as "f2" on "a0"."favourite_book_uuid_pk" = "f2"."uuid_pk" and "f2"."author_id" is not null ' +
       'where "a0"."id" = $1');
 
     orm.em.clear();
@@ -188,9 +197,11 @@ describe('Joined loading strategy', () => {
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books'], strategy: LoadStrategy.JOINED });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"f2"."uuid_pk" as "favourite_book_uuid_pk" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
+      'left join "book2" as "f2" on "a0"."favourite_book_uuid_pk" = "f2"."uuid_pk" and "f2"."author_id" is not null ' +
       'where "a0"."id" = $1');
 
     orm.em.clear();
@@ -198,9 +209,11 @@ describe('Joined loading strategy', () => {
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books.perex'] });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"f2"."uuid_pk" as "favourite_book_uuid_pk" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
+      'left join "book2" as "f2" on "a0"."favourite_book_uuid_pk" = "f2"."uuid_pk" and "f2"."author_id" is not null ' +
       'where "a0"."id" = $1');
   });
 

--- a/tests/features/virtual-entities/virtual-entities.postgres.test.ts
+++ b/tests/features/virtual-entities/virtual-entities.postgres.test.ts
@@ -274,7 +274,7 @@ describe('virtual entities (sqlite)', () => {
       'group by "b"."uuid_pk"';
     const queries = mock.mock.calls.map(call => call[0]).sort();
     expect(queries).toHaveLength(7);
-    expect(queries[0]).toMatch(`select "a0".*, "a1"."author_id" as "address_author_id" from "author2" as "a0" left join "address2" as "a1" on "a0"."id" = "a1"."author_id" where "a0"."id" in (1, 2, 3)`);
+    expect(queries[0]).toMatch(`select "a0".*, "f1"."uuid_pk" as "favourite_book_uuid_pk", "a2"."author_id" as "address_author_id" from "author2" as "a0" left join "book2" as "f1" on "a0"."favourite_book_uuid_pk" = "f1"."uuid_pk" and "f1"."author_id" is not null left join "address2" as "a2" on "a0"."id" = "a2"."author_id" where "a0"."id" in (1, 2, 3)`);
     expect(queries[1]).toMatch(`select * from (${sql}) as "b0"`);
     expect(queries[2]).toMatch(`select * from (${sql}) as "b0" order by "b0"."title" asc limit 2`);
     expect(queries[3]).toMatch(`select * from (${sql}) as "b0" order by "b0"."title" asc limit 2 offset 1`);


### PR DESCRIPTION
Filters are applied to the relations too, as part of `JOIN ON` condition. If a filter exists on a M:1 or 1:1 relation target, such an entity will be automatically joined, and when the foreign key is defined as `NOT NULL`, it will result in an `INNER JOIN` rather than `LEFT JOIN`. This is especially important for implementing soft deletes via filters, as the foreign key might point to a soft-deleted entity. When this happens, the automatic `INNER JOIN` will result in such a record not being returned at all.

You can disable this behavior via `autoJoinRefsForFilters` ORM option.

Related: #4975