### PR TITLE
feat(core): allow extending `EntityManager`

### DIFF
--- a/docs/docs/entity-manager.md
+++ b/docs/docs/entity-manager.md
@@ -634,3 +634,28 @@ for (const t of tasks) {
 }
 // Logs A, B, C
 ```
+
+## Extending `EntityManager`
+
+To extend the EntityManager with your own custom methods, you can use the `entityManager` ORM option:
+
+```ts
+import { MikroORM, EntityManager } from '@mikro-orm/sqlite';
+
+class MyEntityManager extends EntityManager {
+
+  myCustomMethod(base: number): number {
+    return base * Math.random();
+  }
+
+}
+
+const orm = await MikroORM.init({
+  entities: [...],
+  dbName: ':memory:',
+  // highlight-next-line
+  entityManager: MyEntityManager,
+});
+console.log(orm.em instanceof MyEntityManager); // true
+const res = orm.em.myCustomMethod(123);
+```

--- a/packages/better-sqlite/src/BetterSqliteMikroORM.ts
+++ b/packages/better-sqlite/src/BetterSqliteMikroORM.ts
@@ -1,24 +1,32 @@
-import { defineConfig, MikroORM, type Options, type IDatabaseDriver } from '@mikro-orm/core';
+import {
+  defineConfig,
+  MikroORM,
+  type Options,
+  type IDatabaseDriver,
+  type EntityManager,
+  type EntityManagerType,
+} from '@mikro-orm/core';
 import { BetterSqliteDriver } from './BetterSqliteDriver';
+import type { SqlEntityManager } from '@mikro-orm/knex';
 
 /**
  * @inheritDoc
  */
-export class BetterSqliteMikroORM extends MikroORM<BetterSqliteDriver> {
+export class BetterSqliteMikroORM<EM extends EntityManager = SqlEntityManager> extends MikroORM<BetterSqliteDriver, EM> {
 
   private static DRIVER = BetterSqliteDriver;
 
   /**
    * @inheritDoc
    */
-  static override async init<D extends IDatabaseDriver = BetterSqliteDriver>(options?: Options<D>): Promise<MikroORM<D>> {
+  static override async init<D extends IDatabaseDriver = BetterSqliteDriver, EM extends EntityManager = D[typeof EntityManagerType] & EntityManager>(options?: Options<D, EM>): Promise<MikroORM<D, EM>> {
     return super.init(options);
   }
 
   /**
    * @inheritDoc
    */
-  static override initSync<D extends IDatabaseDriver = BetterSqliteDriver>(options: Options<D>): MikroORM<D> {
+  static override initSync<D extends IDatabaseDriver = BetterSqliteDriver, EM extends EntityManager = D[typeof EntityManagerType] & EntityManager>(options: Options<D, EM>): MikroORM<D, EM> {
     return super.initSync(options);
   }
 

--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -9,10 +9,10 @@ import type { Constructor, EntityMetadata, EntityName, IEntityGenerator, IMigrat
 /**
  * Helper class for bootstrapping the MikroORM.
  */
-export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
+export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver, EM extends EntityManager = D[typeof EntityManagerType] & EntityManager> {
 
   /** The global EntityManager instance. If you are using `RequestContext` helper, it will automatically pick the request specific context under the hood */
-  em!: D[typeof EntityManagerType] & EntityManager;
+  em!: EM;
   readonly config: Configuration<D>;
   private metadata!: MetadataStorage;
   private readonly driver: D;
@@ -23,13 +23,13 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
    * Initialize the ORM, load entity metadata, create EntityManager and connect to the database.
    * If you omit the `options` parameter, your CLI config will be used.
    */
-  static async init<D extends IDatabaseDriver = IDatabaseDriver>(options?: Options<D>): Promise<MikroORM<D>> {
+  static async init<D extends IDatabaseDriver = IDatabaseDriver, EM extends EntityManager = D[typeof EntityManagerType] & EntityManager>(options?: Options<D, EM>): Promise<MikroORM<D, EM>> {
     ConfigurationLoader.registerDotenv(options);
     const coreVersion = await ConfigurationLoader.checkPackageVersion();
     const env = ConfigurationLoader.loadEnvironmentVars<D>();
 
     if (!options) {
-      options = (await ConfigurationLoader.getConfiguration<D>()).getAll();
+      options = (await ConfigurationLoader.getConfiguration<D, EM>()).getAll();
     }
 
     options = Utils.mergeConfig(options, env);
@@ -71,7 +71,7 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
    * - no support for folder based discovery
    * - no check for mismatched package versions
    */
-  static initSync<D extends IDatabaseDriver = IDatabaseDriver>(options: Options<D>): MikroORM<D> {
+  static initSync<D extends IDatabaseDriver = IDatabaseDriver, EM extends EntityManager = D[typeof EntityManagerType] & EntityManager>(options: Options<D, EM>): MikroORM<D, EM> {
     ConfigurationLoader.registerDotenv(options);
     const env = ConfigurationLoader.loadEnvironmentVars<D>();
     options = Utils.merge(options, env);
@@ -96,7 +96,7 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
     return orm;
   }
 
-  constructor(options: Options<D> | Configuration<D>) {
+  constructor(options: Options<D, EM> | Configuration<D, EM>) {
     if (options instanceof Configuration) {
       this.config = options;
     } else {
@@ -216,7 +216,7 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver> {
 
   private createEntityManager(): void {
     this.driver.setMetadata(this.metadata);
-    this.em = this.driver.createEntityManager<D>();
+    this.em = this.driver.createEntityManager() as EM;
     (this.em as { global: boolean }).global = true;
     this.metadata.decorate(this.em);
     this.driver.setMetadata(this.metadata);

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -71,7 +71,8 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
   abstract count<T extends object, P extends string = never>(entityName: string, where: FilterQuery<T>, options?: CountOptions<T, P>): Promise<number>;
 
   createEntityManager<D extends IDatabaseDriver = IDatabaseDriver>(useContext?: boolean): D[typeof EntityManagerType] {
-    return new EntityManager(this.config, this, this.metadata, useContext) as unknown as EntityManager<D>;
+    const EntityManagerClass = this.config.get('entityManager', EntityManager);
+    return new EntityManagerClass(this.config, this, this.metadata, useContext) as unknown as EntityManager<D>;
   }
 
   /* istanbul ignore next */

--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -3,18 +3,19 @@ import { pathExists, pathExistsSync, realpath } from 'fs-extra';
 import { isAbsolute, join } from 'path';
 import { platform } from 'os';
 import { fileURLToPath } from 'url';
-import type { IDatabaseDriver } from '../drivers';
+import type { EntityManagerType, IDatabaseDriver } from '../drivers';
 import { Configuration, type Options } from './Configuration';
 import { Utils } from './Utils';
 import type { Dictionary } from '../typings';
 import { colors } from '../logging/colors';
+import type { EntityManager } from '../EntityManager';
 
 /**
  * @internal
  */
 export class ConfigurationLoader {
 
-  static async getConfiguration<D extends IDatabaseDriver = IDatabaseDriver>(validate = true, options: Partial<Options> = {}): Promise<Configuration<D>> {
+  static async getConfiguration<D extends IDatabaseDriver = IDatabaseDriver, EM extends D[typeof EntityManagerType] & EntityManager = EntityManager>(validate = true, options: Partial<Options> = {}): Promise<Configuration<D, EM>> {
     await this.commonJSCompat(options);
     this.registerDotenv(options);
     const paths = await this.getConfigPaths();

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -79,7 +79,8 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
   }
 
   override createEntityManager<D extends IDatabaseDriver = IDatabaseDriver>(useContext?: boolean): D[typeof EntityManagerType] {
-    return new SqlEntityManager(this.config, this, this.metadata, useContext) as unknown as EntityManager<D>;
+    const EntityManagerClass = this.config.get('entityManager', SqlEntityManager);
+    return new EntityManagerClass(this.config, this, this.metadata, useContext) as unknown as EntityManager<D>;
   }
 
   async find<T extends object, P extends string = never, F extends string = '*', E extends string = never>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, P, F, E> = {}): Promise<EntityData<T>[]> {

--- a/packages/mariadb/src/MariaDbMikroORM.ts
+++ b/packages/mariadb/src/MariaDbMikroORM.ts
@@ -1,24 +1,32 @@
-import { defineConfig, MikroORM, type Options, type IDatabaseDriver } from '@mikro-orm/core';
+import {
+  defineConfig,
+  MikroORM,
+  type Options,
+  type IDatabaseDriver,
+  type EntityManager,
+  type EntityManagerType,
+} from '@mikro-orm/core';
 import { MariaDbDriver } from './MariaDbDriver';
+import type { SqlEntityManager } from '@mikro-orm/knex';
 
 /**
  * @inheritDoc
  */
-export class MariaDbMikroORM extends MikroORM<MariaDbDriver> {
+export class MariaDbMikroORM<EM extends EntityManager = SqlEntityManager> extends MikroORM<MariaDbDriver, EM> {
 
   private static DRIVER = MariaDbDriver;
 
   /**
    * @inheritDoc
    */
-  static override async init<D extends IDatabaseDriver = MariaDbDriver>(options?: Options<D>): Promise<MikroORM<D>> {
+  static override async init<D extends IDatabaseDriver = MariaDbDriver, EM extends EntityManager = D[typeof EntityManagerType] & EntityManager>(options?: Options<D, EM>): Promise<MikroORM<D, EM>> {
     return super.init(options);
   }
 
   /**
    * @inheritDoc
    */
-  static override initSync<D extends IDatabaseDriver = MariaDbDriver>(options: Options<D>): MikroORM<D> {
+  static override initSync<D extends IDatabaseDriver = MariaDbDriver, EM extends EntityManager = D[typeof EntityManagerType] & EntityManager>(options: Options<D, EM>): MikroORM<D, EM> {
     return super.initSync(options);
   }
 

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -42,7 +42,8 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
   }
 
   override createEntityManager<D extends IDatabaseDriver = IDatabaseDriver>(useContext?: boolean): D[typeof EntityManagerType] {
-    return new MongoEntityManager(this.config, this, this.metadata, useContext) as unknown as EntityManager<D>;
+    const EntityManagerClass = this.config.get('entityManager', MongoEntityManager);
+    return new EntityManagerClass(this.config, this, this.metadata, useContext) as unknown as EntityManager<D>;
   }
 
   async find<T extends object, P extends string = never, F extends string = '*', E extends string = never>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, P, F, E> = {}): Promise<EntityData<T>[]> {

--- a/packages/mongodb/src/MongoMikroORM.ts
+++ b/packages/mongodb/src/MongoMikroORM.ts
@@ -1,24 +1,32 @@
-import { defineConfig, MikroORM, type Options, type IDatabaseDriver } from '@mikro-orm/core';
+import {
+  defineConfig,
+  MikroORM,
+  type Options,
+  type IDatabaseDriver,
+  type EntityManager,
+  type EntityManagerType,
+} from '@mikro-orm/core';
 import { MongoDriver } from './MongoDriver';
+import type { MongoEntityManager } from './MongoEntityManager';
 
 /**
  * @inheritDoc
  */
-export class MongoMikroORM extends MikroORM<MongoDriver> {
+export class MongoMikroORM<EM extends EntityManager = MongoEntityManager> extends MikroORM<MongoDriver, EM> {
 
   private static DRIVER = MongoDriver;
 
   /**
    * @inheritDoc
    */
-  static override async init<D extends IDatabaseDriver = MongoDriver>(options?: Options<D>): Promise<MikroORM<D>> {
+  static override async init<D extends IDatabaseDriver = MongoDriver, EM extends EntityManager = D[typeof EntityManagerType] & EntityManager>(options?: Options<D, EM>): Promise<MikroORM<D, EM>> {
     return super.init(options);
   }
 
   /**
    * @inheritDoc
    */
-  static override initSync<D extends IDatabaseDriver = MongoDriver>(options: Options<D>): MikroORM<D> {
+  static override initSync<D extends IDatabaseDriver = MongoDriver, EM extends EntityManager = D[typeof EntityManagerType] & EntityManager>(options: Options<D, EM>): MikroORM<D, EM> {
     return super.initSync(options);
   }
 

--- a/packages/mysql/src/MySqlMikroORM.ts
+++ b/packages/mysql/src/MySqlMikroORM.ts
@@ -1,24 +1,32 @@
-import { defineConfig, MikroORM, type Options, type IDatabaseDriver } from '@mikro-orm/core';
+import {
+  defineConfig,
+  MikroORM,
+  type Options,
+  type IDatabaseDriver,
+  type EntityManager,
+  type EntityManagerType,
+} from '@mikro-orm/core';
 import { MySqlDriver } from './MySqlDriver';
+import type { SqlEntityManager } from '@mikro-orm/knex';
 
 /**
  * @inheritDoc
  */
-export class MySqlMikroORM extends MikroORM<MySqlDriver> {
+export class MySqlMikroORM<EM extends EntityManager = SqlEntityManager> extends MikroORM<MySqlDriver, EM> {
 
   private static DRIVER = MySqlDriver;
 
   /**
    * @inheritDoc
    */
-  static override async init<D extends IDatabaseDriver = MySqlDriver>(options?: Options<D>): Promise<MikroORM<D>> {
+  static override async init<D extends IDatabaseDriver = MySqlDriver, EM extends EntityManager = D[typeof EntityManagerType] & EntityManager>(options?: Options<D, EM>): Promise<MikroORM<D, EM>> {
     return super.init(options);
   }
 
   /**
    * @inheritDoc
    */
-  static override initSync<D extends IDatabaseDriver = MySqlDriver>(options: Options<D>): MikroORM<D> {
+  static override initSync<D extends IDatabaseDriver = MySqlDriver, EM extends EntityManager = D[typeof EntityManagerType] & EntityManager>(options: Options<D, EM>): MikroORM<D, EM> {
     return super.initSync(options);
   }
 

--- a/packages/postgresql/src/PostgreSqlMikroORM.ts
+++ b/packages/postgresql/src/PostgreSqlMikroORM.ts
@@ -1,24 +1,32 @@
-import { defineConfig, MikroORM, type Options, type IDatabaseDriver } from '@mikro-orm/core';
+import {
+  defineConfig,
+  MikroORM,
+  type Options,
+  type IDatabaseDriver,
+  type EntityManager,
+  type EntityManagerType,
+} from '@mikro-orm/core';
 import { PostgreSqlDriver } from './PostgreSqlDriver';
+import type { SqlEntityManager } from '@mikro-orm/knex';
 
 /**
  * @inheritDoc
  */
-export class PostgreSqlMikroORM extends MikroORM<PostgreSqlDriver> {
+export class PostgreSqlMikroORM<EM extends EntityManager = SqlEntityManager> extends MikroORM<PostgreSqlDriver, EM> {
 
   private static DRIVER = PostgreSqlDriver;
 
   /**
    * @inheritDoc
    */
-  static override async init<D extends IDatabaseDriver = PostgreSqlDriver>(options?: Options<D>): Promise<MikroORM<D>> {
+  static override async init<D extends IDatabaseDriver = PostgreSqlDriver, EM extends EntityManager = D[typeof EntityManagerType] & EntityManager>(options?: Options<D, EM>): Promise<MikroORM<D, EM>> {
     return super.init(options);
   }
 
   /**
    * @inheritDoc
    */
-  static override initSync<D extends IDatabaseDriver = PostgreSqlDriver>(options: Options<D>): MikroORM<D> {
+  static override initSync<D extends IDatabaseDriver = PostgreSqlDriver, EM extends EntityManager = D[typeof EntityManagerType] & EntityManager>(options: Options<D, EM>): MikroORM<D, EM> {
     return super.initSync(options);
   }
 

--- a/packages/sqlite/src/SqliteMikroORM.ts
+++ b/packages/sqlite/src/SqliteMikroORM.ts
@@ -1,24 +1,32 @@
-import { defineConfig, MikroORM, type Options, type IDatabaseDriver } from '@mikro-orm/core';
+import {
+  defineConfig,
+  MikroORM,
+  type Options,
+  type IDatabaseDriver,
+  type EntityManager,
+  type EntityManagerType,
+} from '@mikro-orm/core';
 import { SqliteDriver } from './SqliteDriver';
+import type { SqlEntityManager } from '@mikro-orm/knex';
 
 /**
  * @inheritDoc
  */
-export class SqliteMikroORM extends MikroORM<SqliteDriver> {
+export class SqliteMikroORM<EM extends EntityManager = SqlEntityManager> extends MikroORM<SqliteDriver, EM> {
 
   private static DRIVER = SqliteDriver;
 
   /**
    * @inheritDoc
    */
-  static override async init<D extends IDatabaseDriver = SqliteDriver>(options?: Options<D>): Promise<MikroORM<D>> {
+  static override async init<D extends IDatabaseDriver = SqliteDriver, EM extends EntityManager = D[typeof EntityManagerType] & EntityManager>(options?: Options<D, EM>): Promise<MikroORM<D, EM>> {
     return super.init(options);
   }
 
   /**
    * @inheritDoc
    */
-  static override initSync<D extends IDatabaseDriver = SqliteDriver>(options: Options<D>): MikroORM<D> {
+  static override initSync<D extends IDatabaseDriver = SqliteDriver, EM extends EntityManager = D[typeof EntityManagerType] & EntityManager>(options: Options<D, EM>): MikroORM<D, EM> {
     return super.initSync(options);
   }
 

--- a/tests/features/custom-entity-manager.test.ts
+++ b/tests/features/custom-entity-manager.test.ts
@@ -1,0 +1,31 @@
+import { Entity, PrimaryKey } from '@mikro-orm/core';
+import { MikroORM, SqlEntityManager } from '@mikro-orm/sqlite';
+
+@Entity()
+class Author {
+
+  @PrimaryKey()
+  id!: number;
+
+}
+
+class MyEntityManager extends SqlEntityManager {
+
+  myCustomMethod(base: number): number {
+    return base * Math.random();
+  }
+
+}
+
+test('using custom EM class', async () => {
+  const orm = await MikroORM.init({
+    entities: [Author],
+    dbName: ':memory:',
+    entityManager: MyEntityManager,
+  });
+  await orm.schema.createSchema();
+  expect(orm.em).toBeInstanceOf(MyEntityManager);
+  const res = orm.em.myCustomMethod(123);
+  expect(typeof res).toBe('number');
+  await orm.close();
+});


### PR DESCRIPTION
To extend the EntityManager with your own custom methods, you can use the `entityManager` ORM option:

```ts
import { MikroORM, EntityManager } from '@mikro-orm/sqlite';

class MyEntityManager extends EntityManager {

  myCustomMethod(base: number): number {
    return base * Math.random();
  }

}

const orm = await MikroORM.init({
  entities: [...],
  dbName: ':memory:',
  entityManager: MyEntityManager,
});
console.log(orm.em instanceof MyEntityManager); // true
const res = orm.em.myCustomMethod(123);
```