### PR TITLE
fix(postgres): parse timestamp dates less than year 1000

### DIFF
--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -59,7 +59,8 @@
   },
   "dependencies": {
     "@mikro-orm/knex": "5.9.7",
-    "pg": "8.11.3"
+    "pg": "8.11.3",
+    "postgres-date": "2.1.0"
   },
   "devDependencies": {
     "@mikro-orm/core": "^5.9.7"

--- a/packages/postgresql/src/PostgreSqlConnection.ts
+++ b/packages/postgresql/src/PostgreSqlConnection.ts
@@ -1,4 +1,5 @@
 import TypeOverrides from 'pg/lib/type-overrides';
+import parseDate from 'postgres-date';
 import type { Dictionary } from '@mikro-orm/core';
 import { AbstractSqlConnection, MonkeyPatchable, type Knex } from '@mikro-orm/knex';
 
@@ -20,7 +21,7 @@ export class PostgreSqlConnection extends AbstractSqlConnection {
     ret.types = types as any;
 
     if (this.config.get('forceUtcTimezone')) {
-      [1114].forEach(oid => types.setTypeParser(oid, str => new Date(str + 'Z'))); // timestamp w/o TZ type
+      [1114].forEach(oid => types.setTypeParser(oid, str => parseDate(str + 'Z'))); // timestamp w/o TZ type
       ret.parseInputDatesAsUTC = true;
     }
 

--- a/tests/features/schema-generator/timestamp.postgres.test.ts
+++ b/tests/features/schema-generator/timestamp.postgres.test.ts
@@ -18,9 +18,9 @@ beforeAll(async () => {
   orm = await MikroORM.init({
     entities: [TimestampTest],
     dbName: '5071',
-    ensureDatabase: { create: true, clear: true },
     forceUtcTimezone: true,
   });
+  await orm.schema.refreshDatabase();
 });
 afterAll(async () => await orm.close(true));
 

--- a/tests/features/schema-generator/timestamp.postgres.test.ts
+++ b/tests/features/schema-generator/timestamp.postgres.test.ts
@@ -1,0 +1,38 @@
+import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
+import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+
+@Entity()
+export class TimestampTest {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ columnType: 'timestamp' })
+  createdAtTimestamp!: Date;
+
+}
+
+test('postgres timestamp is correctly parsed', async () => {
+  const orm = await MikroORM.init({
+    entities: [TimestampTest],
+    dbName: `mikro_orm_test_timestamp`,
+    driver: PostgreSqlDriver,
+    forceUtcTimezone: true,
+  });
+
+  await orm.schema.ensureDatabase();
+  await orm.schema.execute('drop table if exists timestamp_test');
+  await orm.schema.createSchema();
+
+  const createdAt = new Date('0022-01-01T00:00:00Z');
+
+  const something = orm.em.create(TimestampTest, { createdAtTimestamp: createdAt });
+  await orm.em.persistAndFlush(something);
+
+  const res = await orm.em.find(TimestampTest, something.id);
+
+  expect(isNaN(res[0]!.createdAtTimestamp.getTime())).toBe(false);
+  expect(res[0]!.createdAtTimestamp.getTime()).toEqual(createdAt.getTime());
+
+  await orm.close(true);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,6 +1643,7 @@ __metadata:
     "@mikro-orm/core": ^5.9.7
     "@mikro-orm/knex": 5.9.7
     pg: 8.11.3
+    postgres-date: 2.1.0
   peerDependencies:
     "@mikro-orm/core": ^5.0.0
     "@mikro-orm/entity-generator": ^5.0.0
@@ -10005,6 +10006,13 @@ __metadata:
   dependencies:
     obuf: ~1.1.2
   checksum: 5f917a003fcaa0df7f285e1c37108ad474ce91193466b9bd4bcaecef2cdea98ca069c00aa6a8dbe6d2e7192336cadc3c9b36ae48d1555a299521918e00e2936b
+  languageName: node
+  linkType: hard
+
+"postgres-date@npm:2.1.0":
+  version: 2.1.0
+  resolution: "postgres-date@npm:2.1.0"
+  checksum: 5c573b0602e17c6134fd8bc8ac7689ac0302e1b199f15dd3578fc45186f206dbd0609f97bf0e4bd1db62234d7a37f29c04f4df525f7efebb9304363b2efca272
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Bug
Parsing a timestamp column in postgresql with a date less than year 1000 will create an invalid Date when using the `forceUtcTimezone` set to `true`.
### Reproduction
Created test for reproduction, run without the fix to `PostgresSqlConnection.ts`.
### Fix
Use the date parsing function from `postgres-date` that is used by default in `pg` for parsing dates but add the `Z` to force the utc timezone. `new Date('0022-01-01 09:17:58.000Z')` when parsing the timestamp column str creates an invalid date in js.