### PR TITLE
docs: add Accounts.js example

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ You can find example integrations for some popular frameworks in the [`mikro-orm
 - [GraphQL + PostgreSQL](https://github.com/driescroons/mikro-orm-graphql-example)
 - [Inversify + PostgreSQL](https://github.com/PodaruDragos/inversify-example-app)
 - [NextJS + MySQL](https://github.com/jonahallibone/mikro-orm-nextjs)
+- [Accounts.js REST and GraphQL authentication + SQLite](https://github.com/darkbasic/mikro-orm-accounts-example)
 
 ### JavaScript Examples 
 


### PR DESCRIPTION
I've prepared a simple example which covers both REST and GraphQL authentication with Accounts.js. I would be glad if you could mention it in the blog post :)