### PR TITLE
docs: update remaining `uuid_generate_v4()` calls to `gen_random_uuid()`

### DIFF
--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -1644,7 +1644,7 @@ values={[
 @Entity()
 export class Book {
 
-  @PrimaryKey({ type: 'uuid', defaultRaw: 'uuid_generate_v4()' })
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   uuid: string;
 
   @Property()
@@ -1663,7 +1663,7 @@ export class Book {
 @Entity()
 export class Book {
 
-  @PrimaryKey({ type: 'uuid', defaultRaw: 'uuid_generate_v4()' })
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   uuid: string;
 
   @Property()
@@ -1688,7 +1688,7 @@ export class Book {
 export const BookSchema = new EntitySchema<Book>({
   class: Book,
   properties: {
-    uuid: { type: 'uuid', defaultRaw: 'uuid_generate_v4()', primary: true },
+    uuid: { type: 'uuid', defaultRaw: 'gen_random_uuid()', primary: true },
     title: { type: 'string' },
     author: { entity: () => Author, kind: 'm:1' },
   },

--- a/docs/versioned_docs/version-4.5/defining-entities.md
+++ b/docs/versioned_docs/version-4.5/defining-entities.md
@@ -1287,7 +1287,7 @@ export const Book = new EntitySchema<IBook>({
 @Entity()
 export class Book {
 
-  @PrimaryKey({ type: 'uuid', defaultRaw: 'uuid_generate_v4()' })
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   uuid: string;
 
   @Property()
@@ -1306,7 +1306,7 @@ export class Book {
 @Entity()
 export class Book {
 
-  @PrimaryKey({ type: 'uuid', defaultRaw: 'uuid_generate_v4()' })
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   uuid: string;
 
   @Property()
@@ -1331,7 +1331,7 @@ export class Book {
 export const BookSchema = new EntitySchema<Book>({
   class: Book,
   properties: {
-    uuid: { type: 'uuid', defaultRaw: 'uuid_generate_v4()', primary: true },
+    uuid: { type: 'uuid', defaultRaw: 'gen_random_uuid()', primary: true },
     title: { type: 'string' },
     author: { entity: () => Author, reference: 'm:1' },
   },

--- a/docs/versioned_docs/version-5.9/defining-entities.md
+++ b/docs/versioned_docs/version-5.9/defining-entities.md
@@ -1471,7 +1471,7 @@ values={[
 @Entity()
 export class Book {
 
-  @PrimaryKey({ type: 'uuid', defaultRaw: 'uuid_generate_v4()' })
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   uuid: string;
 
   @Property()
@@ -1490,7 +1490,7 @@ export class Book {
 @Entity()
 export class Book {
 
-  @PrimaryKey({ type: 'uuid', defaultRaw: 'uuid_generate_v4()' })
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   uuid: string;
 
   @Property()
@@ -1515,7 +1515,7 @@ export class Book {
 export const BookSchema = new EntitySchema<Book>({
   class: Book,
   properties: {
-    uuid: { type: 'uuid', defaultRaw: 'uuid_generate_v4()', primary: true },
+    uuid: { type: 'uuid', defaultRaw: 'gen_random_uuid()', primary: true },
     title: { type: 'string' },
     author: { entity: () => Author, reference: 'm:1' },
   },

--- a/docs/versioned_docs/version-6.0/defining-entities.md
+++ b/docs/versioned_docs/version-6.0/defining-entities.md
@@ -1644,7 +1644,7 @@ values={[
 @Entity()
 export class Book {
 
-  @PrimaryKey({ type: 'uuid', defaultRaw: 'uuid_generate_v4()' })
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   uuid: string;
 
   @Property()
@@ -1663,7 +1663,7 @@ export class Book {
 @Entity()
 export class Book {
 
-  @PrimaryKey({ type: 'uuid', defaultRaw: 'uuid_generate_v4()' })
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   uuid: string;
 
   @Property()
@@ -1688,7 +1688,7 @@ export class Book {
 export const BookSchema = new EntitySchema<Book>({
   class: Book,
   properties: {
-    uuid: { type: 'uuid', defaultRaw: 'uuid_generate_v4()', primary: true },
+    uuid: { type: 'uuid', defaultRaw: 'gen_random_uuid()', primary: true },
     title: { type: 'string' },
     author: { entity: () => Author, kind: 'm:1' },
   },


### PR DESCRIPTION
Since https://github.com/mikro-orm/mikro-orm/pull/4408 the docs have been in a weird inconsistent state regarding the uuid functions, recommending one in the section header but then using another one in the example code.

`uuid_generate_v4()` is still used in a few tests but I am not updating that here.