### PR TITLE
test: try to fix flaky `Promise.all()` test

### DIFF
--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -2544,21 +2544,27 @@ describe('EntityManagerPostgre', () => {
       (async () => {
         const a = new Author2('a4', 'e4');
         const b = new Book2('t4', a, 123);
-        await new Promise(r => setTimeout(r, 100));
+        while (!orm.em.getReference(Author2, 5, { wrapped: true }).isInitialized()) {
+          await new Promise(r => setTimeout(r, 0));
+        }
         await orm.em.persistAndFlush(b);
         return b;
       })(),
       (async () => {
         const a = new Author2('a5', 'e5');
         const b = new Book2('t5', a, 456);
-        await new Promise(r => setTimeout(r, 20));
+        while (!orm.em.getReference(Author2, 3, { wrapped: true }).isInitialized()) {
+          await new Promise(r => setTimeout(r, 0));
+        }
         await orm.em.persistAndFlush(b);
         return b;
       })(),
       (async () => {
         const a = new Author2('a6', 'e6');
         const b = new Book2('t6', a, 789);
-        await new Promise(r => setTimeout(r, 70));
+        while (!orm.em.getReference(Author2, 4, { wrapped: true }).isInitialized()) {
+          await new Promise(r => setTimeout(r, 0));
+        }
         await orm.em.persistAndFlush(b);
         return b;
       })(),


### PR DESCRIPTION
Fix by explicitly checking on every tick if the entity with the previous ID is loaded into the entity manager.
Thus, while the promises are technically all started at the same time, they are resolved in a forced order, making the actual output of the query log consistent.

---

A potential solution to the situation described [here](https://github.com/mikro-orm/mikro-orm/pull/5113#issuecomment-1890953639).