### PR TITLE
test(timers): replaced all timeouts with fake timers, or remove them as appropriate

### DIFF
--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -2545,7 +2545,7 @@ describe('EntityManagerPostgre', () => {
         const a = new Author2('a4', 'e4');
         const b = new Book2('t4', a, 123);
         while (!orm.em.getReference(Author2, 5, { wrapped: true }).isInitialized()) {
-          await new Promise(r => setTimeout(r, 0));
+          await new Promise(r => setImmediate(r));
         }
         await orm.em.persistAndFlush(b);
         return b;
@@ -2554,7 +2554,7 @@ describe('EntityManagerPostgre', () => {
         const a = new Author2('a5', 'e5');
         const b = new Book2('t5', a, 456);
         while (!orm.em.getReference(Author2, 3, { wrapped: true }).isInitialized()) {
-          await new Promise(r => setTimeout(r, 0));
+          await new Promise(r => setImmediate(r));
         }
         await orm.em.persistAndFlush(b);
         return b;
@@ -2563,7 +2563,7 @@ describe('EntityManagerPostgre', () => {
         const a = new Author2('a6', 'e6');
         const b = new Book2('t6', a, 789);
         while (!orm.em.getReference(Author2, 4, { wrapped: true }).isInitialized()) {
-          await new Promise(r => setTimeout(r, 0));
+          await new Promise(r => setImmediate(r));
         }
         await orm.em.persistAndFlush(b);
         return b;

--- a/tests/EntityManager.sqlite2.test.ts
+++ b/tests/EntityManager.sqlite2.test.ts
@@ -885,28 +885,37 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
   });
 
   test('property onUpdate hook (updatedAt field)', async () => {
+    jest.useFakeTimers();
+
     const repo = orm.em.getRepository(Author4);
     const author = orm.em.create(Author4, { name: 'name', email: 'email' });
     await orm.em.persistAndFlush(author);
     expect(author.createdAt).toBeDefined();
     expect(author.updatedAt).toBeDefined();
-    // allow 1 ms difference as updated time is recalculated when persisting
-    expect(+author.updatedAt - +author.createdAt).toBeLessThanOrEqual(1);
+    expect(+author.updatedAt - +author.createdAt).toBe(0);
 
     author.name = 'name1';
-    await new Promise(resolve => setTimeout(resolve, 10));
+
+    jest.advanceTimersByTime(10);
+
     await orm.em.persistAndFlush(author);
-    await expect(author.createdAt).toBeDefined();
-    await expect(author.updatedAt).toBeDefined();
-    await expect(author.updatedAt).not.toEqual(author.createdAt);
-    await expect(author.updatedAt > author.createdAt).toBe(true);
+    expect(author.createdAt).toBeDefined();
+    expect(author.updatedAt).toBeDefined();
+    expect(author.updatedAt).not.toEqual(author.createdAt);
+    expect(author.updatedAt > author.createdAt).toBe(true);
+    expect(+author.updatedAt).toBe(+author.createdAt + 10);
+
+    jest.advanceTimersByTime(10);
 
     orm.em.clear();
     const ent = (await repo.findOne(author.id))!;
-    await expect(ent.createdAt).toBeDefined();
-    await expect(ent.updatedAt).toBeDefined();
-    await expect(ent.updatedAt).not.toEqual(ent.createdAt);
-    await expect(ent.updatedAt > ent.createdAt).toBe(true);
+    expect(ent.createdAt).toBeDefined();
+    expect(ent.updatedAt).toBeDefined();
+    expect(ent.updatedAt).not.toEqual(ent.createdAt);
+    expect(ent.updatedAt > ent.createdAt).toBe(true);
+    expect(+author.updatedAt).toBe(+author.createdAt + 10);
+
+    jest.useRealTimers();
   });
 
   test('EM supports native insert/update/delete', async () => {
@@ -1024,7 +1033,6 @@ describe.each(['sqlite', 'better-sqlite'] as const)('EntityManager (%s)', driver
 
     const mock = mockLogger(orm, ['query']);
 
-    await new Promise(resolve => setTimeout(resolve, 10));
     await orm.em.flush();
 
     expect(mock.mock.calls[0][0]).toMatch('begin');

--- a/tests/entities-js/Author3.js
+++ b/tests/entities-js/Author3.js
@@ -28,7 +28,7 @@ class Author3 extends BaseEntity4 {
     this.name = name;
     this.email = email;
     this.createdAt = new Date();
-    this.updatedAt = new Date();
+    this.updatedAt = new Date(this.createdAt);
     this.termsAccepted = false;
   }
 

--- a/tests/entities-schema/BaseEntity5.ts
+++ b/tests/entities-schema/BaseEntity5.ts
@@ -13,7 +13,7 @@ export const BaseEntity5 = new EntitySchema<IBaseEntity5>({
   abstract: true,
   properties: {
     id: { type: 'number', primary: true },
-    createdAt: { type: 'Date', onCreate: () => new Date(), nullable: true },
-    updatedAt: { type: 'Date', onCreate: () => new Date(), onUpdate: () => new Date(), nullable: true },
+    createdAt: { type: 'Date', onCreate: owner => (owner.updatedAt ? new Date(owner.updatedAt) : new Date()), nullable: true },
+    updatedAt: { type: 'Date', onCreate: owner => (owner.createdAt ? new Date(owner.createdAt) : new Date()), onUpdate: () => new Date(), nullable: true },
   },
 });

--- a/tests/features/cache-adapters/FileCacheAdapter.test.ts
+++ b/tests/features/cache-adapters/FileCacheAdapter.test.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from 'fs';
+import { writeFileSync } from 'node:fs';
 import { FileCacheAdapter } from '@mikro-orm/core';
 import { TEMP_DIR } from '../../helpers';
 
@@ -7,18 +7,17 @@ describe('FileCacheAdapter', () => {
   test('should ignore old cache', async () => {
     const origin = TEMP_DIR + '/.origin';
     const cache = new FileCacheAdapter({ cacheDir: TEMP_DIR }, TEMP_DIR);
-    writeFileSync(origin, '123');
+    writeFileSync(origin, '123', { flush: true });
     cache.set('cache-test-handle-1', 123, origin);
-    await expect(cache.get('cache-test-handle-1')).toBe(123);
+    expect(cache.get('cache-test-handle-1')).toBe(123);
 
-    await new Promise(resolve => setTimeout(resolve, 10));
-    writeFileSync(origin, '321');
-    await expect(cache.get('cache-test-handle-1')).toBeNull();
+    writeFileSync(origin, '321', { flush: true });
+    expect(cache.get('cache-test-handle-1')).toBeNull();
 
     cache.set('cache-test-handle-1', 123, origin);
-    await expect(cache.get('cache-test-handle-1')).toBe(123);
+    expect(cache.get('cache-test-handle-1')).toBe(123);
     cache.remove('cache-test-handle-1');
-    await expect(cache.get('cache-test-handle-1')).toBeNull();
+    expect(cache.get('cache-test-handle-1')).toBeNull();
 
     cache.clear();
   });

--- a/tests/features/cache-adapters/MemoryCacheAdapter.test.ts
+++ b/tests/features/cache-adapters/MemoryCacheAdapter.test.ts
@@ -3,13 +3,20 @@ import { MemoryCacheAdapter } from '@mikro-orm/core';
 describe('MemoryCacheAdapter', () => {
 
   test('should ignore old cache', async () => {
+    jest.useFakeTimers();
+
     const cache = new MemoryCacheAdapter({ expiration: 10 });
     cache.set('cache-test-handle-1', 123, '');
     expect(cache.get('cache-test-handle-1')).toBe(123);
+    jest.advanceTimersByTime(10);
+    expect(cache.get('cache-test-handle-1')).toBe(123);
 
-    await new Promise(resolve => setTimeout(resolve, 20));
+    jest.advanceTimersByTime(1);
+
     expect(cache.get('cache-test-handle-1')).toBeUndefined();
     cache.clear();
+
+    jest.useRealTimers();
   });
 
 });

--- a/tests/features/embeddables/GH2391-2.test.ts
+++ b/tests/features/embeddables/GH2391-2.test.ts
@@ -138,6 +138,8 @@ describe('onCreate and onUpdate in embeddables (GH 2283 and 2391)', () => {
     expect(line2.fooAudit1.archived).toEqual(tmp1);
     expect(line2.barAudit2.archived).toEqual(tmp2);
     expect(line2.barAudit2.nestedAudit1.archived).toEqual(tmp3);
+
+    jest.useRealTimers();
   });
 
 });

--- a/tests/features/result-cache/result-cache.mongo.test.ts
+++ b/tests/features/result-cache/result-cache.mongo.test.ts
@@ -72,6 +72,8 @@ describe('result cache (mongo)', () => {
     const a = await createBooksWithTags();
 
     const mock = mockLogger(orm, ['query']);
+    jest.useFakeTimers({ doNotFake: ['nextTick'] });
+
     const call = () => orm.em.findOneOrFail(Book, {
       author: a.id,
     }, {
@@ -83,56 +85,78 @@ describe('result cache (mongo)', () => {
     expect(mock.mock.calls).toHaveLength(3);
     orm.em.clear();
 
+    jest.advanceTimersByTime(25);
+
     const res2 = await call();
     expect(mock.mock.calls).toHaveLength(3); // cache hit, no new query fired
     expect(wrap(res1).toObject()).toEqual(wrap(res2).toObject());
     orm.em.clear();
+
+    jest.advanceTimersByTime(25);
 
     const res3 = await call();
     expect(mock.mock.calls).toHaveLength(3); // cache hit, no new query fired
     expect(wrap(res1).toObject()).toEqual(wrap(res3).toObject());
     orm.em.clear();
 
-    await new Promise(r => setTimeout(r, 100)); // wait for cache to expire
+    jest.advanceTimersByTime(1); // wait for cache to expire
+
     const res4 = await call();
     expect(mock.mock.calls).toHaveLength(6); // cache miss, new query fired
     expect(wrap(res1).toObject()).toEqual(wrap(res4).toObject());
+
+    jest.advanceTimersByTime(10);
 
     const res5 = await call();
     expect(mock.mock.calls).toHaveLength(6); // cache hit
     expect(wrap(res1).toObject()).toEqual(wrap(res5).toObject());
 
+    jest.advanceTimersByTime(10);
+
     // clear key
     await orm.em.clearCache('abc');
     orm.em.clear();
+
+    jest.advanceTimersByTime(10);
+
     const res6 = await call();
     expect(mock.mock.calls).toHaveLength(9); // cache miss as we just cleared the key
     expect(wrap(res1).toObject()).toEqual(wrap(res6).toObject());
+
+    jest.useRealTimers();
   });
 
   test('result caching (count)', async () => {
     const a = await createBooksWithTags();
 
     const mock = mockLogger(orm, ['query']);
+    jest.useFakeTimers({ doNotFake: ['nextTick'] });
 
     const res1 = await orm.em.count(Book, { author: a.id }, { cache: 50 });
     expect(mock.mock.calls).toHaveLength(1);
     orm.em.clear();
+
+    jest.advanceTimersByTime(25);
 
     const res2 = await orm.em.count(Book, { author: a.id }, { cache: 50 });
     expect(mock.mock.calls).toHaveLength(1); // cache hit, no new query fired
     expect(res1).toEqual(res2);
     orm.em.clear();
 
+    jest.advanceTimersByTime(25);
+
     const res3 = await orm.em.count(Book, { author: a.id }, { cache: 50 });
     expect(mock.mock.calls).toHaveLength(1); // cache hit, no new query fired
     expect(res1).toEqual(res3);
     orm.em.clear();
 
-    await new Promise(r => setTimeout(r, 100)); // wait for cache to expire
+    jest.advanceTimersByTime(1);
+
     const res4 = await orm.em.count(Book, { author: a.id }, { cache: 50 });
     expect(mock.mock.calls).toHaveLength(2); // cache miss, new query fired
     expect(res1).toEqual(res4);
+
+    jest.useRealTimers();
   });
 
 });


### PR DESCRIPTION
Also tweaked the test entities-js/Author3.js and entities-schema/BaseEntity5.ts to derive the update out of the create or (in the case of the entity schema) vice-versa. This refactor, combined with fake timers in the affected tests, means that no tolerance is required for those columns - they start off as equal, always.