### PR TITLE
feat(core): allow mapping array columns to arrays of objects via `ArrayType`

### DIFF
--- a/docs/docs/custom-types.md
+++ b/docs/docs/custom-types.md
@@ -276,6 +276,36 @@ stringArray?: string[];
 numericArray?: number[];
 ```
 
+#### Extending `ArrayType`
+
+You can also map the array items to more complex types like objects. Consider the following example of mapping a `date[]` column to array of objects with `date` string property:
+
+```ts
+import { ArrayType } from '@mikro-orm/core';
+
+export interface CalendarDate {
+  date: string;
+}
+
+export class CalendarDateArrayType extends ArrayType<CalendarDate> {
+
+  constructor() {
+    super(
+      date => ({ date }), // to JS
+      d => d.date, // to DB
+    );
+  }
+
+  getColumnType(): string {
+    return 'date[]';
+  }
+
+}
+
+@Property({ type: CalendarDateArrayType })
+favoriteDays!: CalendarDate[];
+```
+
 ### BigIntType
 
 Since v6, `bigint`s are represented by the native `BigInt` type, and as such, they don't require explicit type in the decorator options:

--- a/docs/versioned_docs/version-6.0/custom-types.md
+++ b/docs/versioned_docs/version-6.0/custom-types.md
@@ -276,6 +276,36 @@ stringArray?: string[];
 numericArray?: number[];
 ```
 
+#### Extending `ArrayType`
+
+You can also map the array items to more complex types like objects. Consider the following example of mapping a `date[]` column to array of objects with `date` string property:
+
+```ts
+import { ArrayType } from '@mikro-orm/core';
+
+export interface CalendarDate {
+  date: string;
+}
+
+export class CalendarDateArrayType extends ArrayType<CalendarDate> {
+
+  constructor() {
+    super(
+            date => ({ date }), // to JS
+            d => d.date, // to DB
+    );
+  }
+
+  getColumnType(): string {
+    return 'date[]';
+  }
+
+}
+
+@Property({ type: CalendarDateArrayType })
+favoriteDays!: CalendarDate[];
+```
+
 ### BigIntType
 
 Since v6, `bigint`s are represented by the native `BigInt` type, and as such, they don't require explicit type in the decorator options:

--- a/packages/core/src/types/ArrayType.ts
+++ b/packages/core/src/types/ArrayType.ts
@@ -4,9 +4,12 @@ import type { EntityProperty } from '../typings';
 import type { Platform } from '../platforms';
 import { ValidationError } from '../errors';
 
-export class ArrayType<T extends string | number = string> extends Type<T[] | null, string | null> {
+export class ArrayType<T = string> extends Type<T[] | null, string | null> {
 
-  constructor(private readonly hydrate: (i: string) => T = i => i as T) {
+  constructor(
+    private readonly toJsValue: (i: string) => T = i => i as T,
+    private readonly toDbValue: (i: T) => string = i => i as string,
+  ) {
     super();
   }
 
@@ -16,7 +19,7 @@ export class ArrayType<T extends string | number = string> extends Type<T[] | nu
     }
 
     if (Array.isArray(value)) {
-      return platform.marshallArray(value as string[]);
+      return platform.marshallArray(value.map(i => this.toDbValue(i)));
     }
 
     /* istanbul ignore next */
@@ -36,7 +39,7 @@ export class ArrayType<T extends string | number = string> extends Type<T[] | nu
       value = platform.unmarshallArray(value) as T[];
     }
 
-    return value.map(i => this.hydrate(i as string));
+    return value.map(i => this.toJsValue(i as string));
   }
 
   override compareAsType(): string {

--- a/packages/postgresql/src/PostgreSqlConnection.ts
+++ b/packages/postgresql/src/PostgreSqlConnection.ts
@@ -1,4 +1,5 @@
 import TypeOverrides from 'pg/lib/type-overrides';
+import array from 'postgres-array';
 import type { Dictionary } from '@mikro-orm/core';
 import { AbstractSqlConnection, MonkeyPatchable, type Knex } from '@mikro-orm/knex';
 
@@ -16,9 +17,20 @@ export class PostgreSqlConnection extends AbstractSqlConnection {
 
   override getConnectionOptions(): Knex.PgConnectionConfig {
     const ret = super.getConnectionOptions() as Knex.PgConnectionConfig;
+    // use `select typname, oid, typarray from pg_type order by oid` to get the list of OIDs
     const types = new TypeOverrides();
-    // date, timestamp, timestamptz, interval type
-    [1082, 1114, 1184, 1186].forEach(oid => types.setTypeParser(oid, str => str));
+    [
+      1082, // date
+      1114, // timestamp
+      1184, // timestamptz
+      1186, // interval
+    ].forEach(oid => types.setTypeParser(oid, str => str));
+    [
+      1182, // date[]
+      1115, // timestamp[]
+      1185, // timestamptz[]
+      1187, // interval[]
+    ].forEach(oid => types.setTypeParser(oid, str => array.parse(str)));
     ret.types = types as any;
 
     return ret;

--- a/tests/features/custom-types/GH5188.test.ts
+++ b/tests/features/custom-types/GH5188.test.ts
@@ -1,0 +1,82 @@
+import {
+  ArrayType,
+  Entity,
+  MikroORM,
+  PrimaryKey,
+  Property,
+} from '@mikro-orm/postgresql';
+import { mockLogger } from '../../helpers';
+
+interface CalendarDate {
+  date: string;
+}
+
+class CalendarDateArrayType extends ArrayType<CalendarDate> {
+
+  constructor() {
+    super(
+      date => ({ date }),
+      d => d.date,
+    );
+  }
+
+  getColumnType(): string {
+    return 'date[]';
+  }
+
+}
+
+@Entity()
+class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: CalendarDateArrayType })
+  favoriteDays!: CalendarDate[];
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [User],
+    dbName: '5188',
+  });
+
+  await orm.schema.refreshDatabase();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('array of date is not converted to array of Date objects', async () => {
+  const mock = mockLogger(orm);
+
+  const u = orm.em.create(User, {
+    favoriteDays: [
+      { date: '1990-03-23' },
+      { date: '2023-03-23' },
+    ],
+  });
+  await orm.em.persistAndFlush(u);
+  orm.em.clear();
+
+  const u2 = await orm.em.findOneOrFail(User, { favoriteDays: { $contains: [{ date: '2023-03-23' }] } });
+  expect(u2.favoriteDays).toEqual([
+    { date: '1990-03-23' },
+    { date: '2023-03-23' },
+  ]);
+  u2.favoriteDays[1].date = '1234-01-01';
+  await orm.em.flush();
+
+  expect(mock.mock.calls[0][0]).toMatch(`begin`);
+  expect(mock.mock.calls[1][0]).toMatch(`insert into "user" ("favorite_days") values ('{1990-03-23,2023-03-23}') returning "id"`);
+  expect(mock.mock.calls[2][0]).toMatch(`commit`);
+  expect(mock.mock.calls[3][0]).toMatch(`select "u0".* from "user" as "u0" where "u0"."favorite_days" @> '{2023-03-23}' limit 1`);
+  expect(mock.mock.calls[4][0]).toMatch(`begin`);
+  expect(mock.mock.calls[5][0]).toMatch(`update "user" set "favorite_days" = '{1990-03-23,1234-01-01}' where "id" = 1`);
+  expect(mock.mock.calls[6][0]).toMatch(`commit`);
+});


### PR DESCRIPTION
`ArrayType` can be now also used to map the array items to more complex types like objects. Consider the following example of mapping a `date[]` column to array of objects with `date` string property:

```ts
import { ArrayType } from '@mikro-orm/core';

export class CalendarDateArrayType extends ArrayType<CalendarDate> {

  constructor() {
    super(
      date => ({ date }), // to JS
      d => d.date, // to DB
    );
  }

  getColumnType(): string {
    return 'date[]';
  }

}
```

This PR also disables the automatic conversion of arrays of datetime values (and similar, e.g. date or interval) to arrays of Date objects. This was disabled only for the scalar types, but it had to be disabled explicitly for their array variants to get consistent behavior.

Closes #5188