### PR TITLE
refactor(entity-generator): emit `Opt` and `Hidden` prop types instead of the symbols

### DIFF
--- a/packages/entity-generator/src/EntitySchemaSourceFile.ts
+++ b/packages/entity-generator/src/EntitySchemaSourceFile.ts
@@ -17,8 +17,6 @@ export class EntitySchemaSourceFile extends SourceFile {
     ret += ' {\n';
     const enumDefinitions: string[] = [];
     const eagerProperties: EntityProperty<any>[] = [];
-    const hiddenProperties: EntityProperty<any>[] = [];
-    const optionalProperties: EntityProperty<any>[] = [];
     const primaryProps: EntityProperty<any>[] = [];
     const props: string[] = [];
 
@@ -32,14 +30,6 @@ export class EntitySchemaSourceFile extends SourceFile {
 
       if (prop.eager) {
         eagerProperties.push(prop);
-      }
-
-      if (prop.hidden) {
-        hiddenProperties.push(prop);
-      }
-
-      if (!prop.nullable && typeof prop.default !== 'undefined') {
-        optionalProperties.push(prop);
       }
 
       if (prop.primary && (!['id', '_id', 'uuid'].includes(prop.name) || this.meta.compositePK)) {
@@ -62,18 +52,6 @@ export class EntitySchemaSourceFile extends SourceFile {
       this.coreImports.add('EagerProps');
       const eagerPropertyNames = eagerProperties.map(prop => `'${prop.name}'`).sort();
       ret += `${' '.repeat(2)}[EagerProps]?: ${eagerPropertyNames.join(' | ')};\n`;
-    }
-
-    if (hiddenProperties.length > 0) {
-      this.coreImports.add('HiddenProps');
-      const hiddenPropertyNames = hiddenProperties.map(prop => `'${prop.name}'`).sort();
-      ret += `${' '.repeat(2)}[HiddenProps]?: ${hiddenPropertyNames.join(' | ')};\n`;
-    }
-
-    if (optionalProperties.length > 0) {
-      this.coreImports.add('OptionalProps');
-      const optionalPropertyNames = optionalProperties.map(prop => `'${prop.name}'`).sort();
-      ret += `${' '.repeat(2)}[OptionalProps]?: ${optionalPropertyNames.join(' | ')};\n`;
     }
 
     ret += `${props.join('')}}\n`;

--- a/tests/features/entity-generator/MetadataHooks.mysql.test.ts
+++ b/tests/features/entity-generator/MetadataHooks.mysql.test.ts
@@ -31,6 +31,9 @@ const initialMetadataProcessor: MetadataProcessor = (metadata, platform) => {
         const [propName, propOptions] = propEntry;
         expect(propOptions.kind).not.toBe(ReferenceKind.MANY_TO_MANY);
 
+        if (propName === 'createdAt') {
+          propOptions.hidden = true;
+        }
         if (propName === 'email') {
           propOptions.hidden = true;
         }

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.mysql.test.ts.snap
@@ -2,12 +2,10 @@
 
 exports[`EntityGenerator enum with default value [mysql]: mysql-entity-dump-enum-default-value 1`] = `
 [
-  "import { Entity, Enum, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Publisher2 {
-
-  [OptionalProps]?: 'type';
 
   @PrimaryKey()
   id!: number;
@@ -16,10 +14,10 @@ export class Publisher2 {
   test?: string;
 
   @Enum({ items: () => Publisher2Type, default: 'local' })
-  type: Publisher2Type = Publisher2Type.LOCAL;
+  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
   @Enum({ items: () => Publisher2Type2, nullable: true, default: 'LOCAL' })
-  type2?: Publisher2Type2 = Publisher2Type2.LOCAL;
+  type2?: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
 }
 
@@ -62,18 +60,17 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 export class Author2 {
-  [OptionalProps]?: 'createdAt' | 'termsAccepted' | 'updatedAt';
   id!: number;
-  createdAt!: Date;
-  updatedAt!: Date;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
   name!: string;
   email!: string;
   age?: number;
-  termsAccepted: boolean = false;
+  termsAccepted: boolean & Opt = false;
   optional?: boolean;
   identities?: string;
   born?: string;
@@ -234,7 +231,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
@@ -243,9 +240,8 @@ import { Test2 } from './Test2';
 
 export class Book2 {
   [PrimaryKeyProp]?: 'uuidPk';
-  [OptionalProps]?: 'createdAt';
   uuidPk!: string;
-  createdAt!: Date;
+  createdAt!: Date & Opt;
   title?: string;
   perex?: string;
   price?: string;
@@ -408,19 +404,18 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, Ref } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
 import { Test2 } from './Test2';
 
 export class FooBar2 {
-  [OptionalProps]?: 'version';
   id!: number;
   name!: string;
   nameWithSpace?: string;
   baz?: Ref<FooBaz2>;
   fooBar?: Ref<FooBar2>;
-  version!: Date;
+  version!: Date & Opt;
   blob?: Buffer;
   blob2?: Buffer;
   array?: string;
@@ -463,14 +458,13 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { FooParam2 } from './FooParam2';
 
 export class FooBaz2 {
-  [OptionalProps]?: 'version';
   id!: number;
   name!: string;
-  version!: Date;
+  version!: Date & Opt;
   bazInverse = new Collection<FooParam2>(this);
 }
 
@@ -484,17 +478,16 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 {
   [PrimaryKeyProp]?: ['bar', 'baz'];
-  [OptionalProps]?: 'version';
   bar!: Ref<FooBar2>;
   baz!: Ref<FooBaz2>;
   value!: string;
-  version!: Date;
+  version!: Date & Opt;
 }
 
 export const FooParam2Schema = new EntitySchema({
@@ -519,16 +512,15 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
 
 export class Publisher2 {
-  [OptionalProps]?: 'name' | 'type' | 'type2';
   id!: number;
-  name!: string;
-  type: Publisher2Type = Publisher2Type.LOCAL;
-  type2: Publisher2Type2 = Publisher2Type2.LOCAL;
+  name!: string & Opt;
+  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
+  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
   enum2?: number;
   enum3?: number;
@@ -627,19 +619,18 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
 import { Publisher2Tests } from './Publisher2Tests';
 
 export class Test2 {
-  [OptionalProps]?: 'version';
   id!: number;
   name?: string;
   book?: Ref<Book2>;
   parent?: Ref<Test2>;
-  version: number = 1;
+  version: number & Opt = 1;
   fooBar?: Ref<FooBar2>;
   fooBaz?: number;
   bars = new Collection<FooBar2>(this);
@@ -739,21 +730,19 @@ export const User2Schema = new EntitySchema({
 
 exports[`EntityGenerator generate OptionalProps and include properties for columns that are not nullable, but have defaults: generate-OptionalProps 1`] = `
 [
-  "import { Entity, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Account {
-
-  [OptionalProps]?: 'active' | 'receiveEmailNotifications';
 
   @PrimaryKey()
   id!: bigint;
 
   @Property({ default: false })
-  active: boolean = false;
+  active: boolean & Opt = false;
 
   @Property({ default: true })
-  receiveEmailNotifications: boolean = true;
+  receiveEmailNotifications: boolean & Opt = true;
 
 }
 ",
@@ -778,7 +767,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -786,16 +775,14 @@ import { Book2 } from './Book2';
 @Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
 export class Author2 {
 
-  [OptionalProps]?: 'createdAt' | 'termsAccepted' | 'updatedAt';
-
   @PrimaryKey()
   id!: number;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  updatedAt!: Date;
+  updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
   @Property({ length: 255 })
@@ -811,7 +798,7 @@ export class Author2 {
 
   @Index({ name: 'author2_terms_accepted_index' })
   @Property({ default: false })
-  termsAccepted: boolean = false;
+  termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
   optional?: boolean;
@@ -899,7 +886,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -909,13 +896,11 @@ export class Book2 {
 
   [PrimaryKeyProp]?: 'uuidPk';
 
-  [OptionalProps]?: 'createdAt';
-
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
   @Property({ length: 255, nullable: true })
@@ -1033,13 +1018,11 @@ export class Dummy2 {
 
 }
 ",
-  "import { Entity, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 @Entity()
 export class FooBar2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -1057,7 +1040,7 @@ export class FooBar2 {
   fooBar?: FooBar2;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  version!: Date;
+  version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
   blob?: Buffer;
@@ -1073,12 +1056,10 @@ export class FooBar2 {
 
 }
 ",
-  "import { Entity, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class FooBaz2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -1087,11 +1068,11 @@ export class FooBaz2 {
   name!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -1099,8 +1080,6 @@ import { FooBaz2 } from './FooBaz2';
 export class FooParam2 {
 
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  [OptionalProps]?: 'version';
 
   @ManyToOne({ entity: () => FooBar2, updateRule: 'cascade', primary: true })
   bar!: FooBar2;
@@ -1112,28 +1091,26 @@ export class FooParam2 {
   value!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
 }
 ",
-  "import { Entity, Enum, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Publisher2 {
-
-  [OptionalProps]?: 'name' | 'type' | 'type2';
 
   @PrimaryKey()
   id!: number;
 
   @Property({ length: 255, default: 'asd' })
-  name!: string;
+  name!: string & Opt;
 
   @Enum({ items: () => Publisher2Type, default: 'local' })
-  type: Publisher2Type = Publisher2Type.LOCAL;
+  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
   @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
-  type2: Publisher2Type2 = Publisher2Type2.LOCAL;
+  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
   enum1?: number;
@@ -1206,14 +1183,12 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
 @Entity()
 export class Test2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -1228,7 +1203,7 @@ export class Test2 {
   parent?: Test2;
 
   @Property({ default: 1 })
-  version: number = 1;
+  version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
@@ -1291,7 +1266,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OptionalProps, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -1299,16 +1274,14 @@ import { Book2 } from './Book2';
 @Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
 export class Author2 {
 
-  [OptionalProps]?: 'createdAt' | 'termsAccepted' | 'updatedAt';
-
   @PrimaryKey()
   id!: number;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  updatedAt!: Date;
+  updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
   @Property({ length: 255 })
@@ -1324,7 +1297,7 @@ export class Author2 {
 
   @Index({ name: 'author2_terms_accepted_index' })
   @Property({ default: false })
-  termsAccepted: boolean = false;
+  termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
   optional?: boolean;
@@ -1438,7 +1411,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
@@ -1450,13 +1423,11 @@ export class Book2 {
 
   [PrimaryKeyProp]?: 'uuidPk';
 
-  [OptionalProps]?: 'createdAt';
-
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
   @Property({ length: 255, nullable: true })
@@ -1594,15 +1565,13 @@ export class Dummy2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
 import { Test2 } from './Test2';
 
 @Entity()
 export class FooBar2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -1620,7 +1589,7 @@ export class FooBar2 {
   fooBar?: FooBar2;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  version!: Date;
+  version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
   blob?: Buffer;
@@ -1645,13 +1614,11 @@ export class FooBar2 {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooParam2 } from './FooParam2';
 
 @Entity()
 export class FooBaz2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -1660,14 +1627,14 @@ export class FooBaz2 {
   name!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
   @OneToMany({ entity: () => FooParam2, mappedBy: 'baz' })
   bazInverse = new Collection<FooParam2>(this);
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -1675,8 +1642,6 @@ import { FooBaz2 } from './FooBaz2';
 export class FooParam2 {
 
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  [OptionalProps]?: 'version';
 
   @ManyToOne({ entity: () => FooBar2, updateRule: 'cascade', primary: true })
   bar!: FooBar2;
@@ -1688,30 +1653,28 @@ export class FooParam2 {
   value!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
 }
 ",
-  "import { Collection, Entity, Enum, OneToMany, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Enum, OneToMany, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
 
 @Entity()
 export class Publisher2 {
 
-  [OptionalProps]?: 'name' | 'type' | 'type2';
-
   @PrimaryKey()
   id!: number;
 
   @Property({ length: 255, default: 'asd' })
-  name!: string;
+  name!: string & Opt;
 
   @Enum({ items: () => Publisher2Type, default: 'local' })
-  type: Publisher2Type = Publisher2Type.LOCAL;
+  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
   @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
-  type2: Publisher2Type2 = Publisher2Type2.LOCAL;
+  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
   enum1?: number;
@@ -1794,7 +1757,7 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToMany, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToMany, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
@@ -1802,8 +1765,6 @@ import { Publisher2Tests } from './Publisher2Tests';
 
 @Entity()
 export class Test2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -1818,7 +1779,7 @@ export class Test2 {
   parent?: Test2;
 
   @Property({ default: 1 })
-  version: number = 1;
+  version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
@@ -1890,7 +1851,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OptionalProps, PrimaryKey, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, Opt, PrimaryKey, Property, Ref, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -1898,16 +1859,14 @@ import { Book2 } from './Book2';
 @Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
 export class Author2 {
 
-  [OptionalProps]?: 'createdAt' | 'termsAccepted' | 'updatedAt';
-
   @PrimaryKey()
   id!: number;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  updatedAt!: Date;
+  updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
   @Property({ length: 255 })
@@ -1923,7 +1882,7 @@ export class Author2 {
 
   @Index({ name: 'author2_terms_accepted_index' })
   @Property({ default: false })
-  termsAccepted: boolean = false;
+  termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
   optional?: boolean;
@@ -2037,7 +1996,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
@@ -2049,13 +2008,11 @@ export class Book2 {
 
   [PrimaryKeyProp]?: 'uuidPk';
 
-  [OptionalProps]?: 'createdAt';
-
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
   @Property({ length: 255, nullable: true })
@@ -2193,15 +2150,13 @@ export class Dummy2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, OptionalProps, PrimaryKey, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, Opt, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
 import { Test2 } from './Test2';
 
 @Entity()
 export class FooBar2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -2219,7 +2174,7 @@ export class FooBar2 {
   fooBar?: Ref<FooBar2>;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  version!: Date;
+  version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
   blob?: Buffer;
@@ -2244,13 +2199,11 @@ export class FooBar2 {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooParam2 } from './FooParam2';
 
 @Entity()
 export class FooBaz2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -2259,14 +2212,14 @@ export class FooBaz2 {
   name!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
   @OneToMany({ entity: () => FooParam2, mappedBy: 'baz' })
   bazInverse = new Collection<FooParam2>(this);
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -2274,8 +2227,6 @@ import { FooBaz2 } from './FooBaz2';
 export class FooParam2 {
 
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  [OptionalProps]?: 'version';
 
   @ManyToOne({ entity: () => FooBar2, ref: true, updateRule: 'cascade', primary: true })
   bar!: Ref<FooBar2>;
@@ -2287,30 +2238,28 @@ export class FooParam2 {
   value!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
 }
 ",
-  "import { Collection, Entity, Enum, OneToMany, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Enum, OneToMany, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
 
 @Entity()
 export class Publisher2 {
 
-  [OptionalProps]?: 'name' | 'type' | 'type2';
-
   @PrimaryKey()
   id!: number;
 
   @Property({ length: 255, default: 'asd' })
-  name!: string;
+  name!: string & Opt;
 
   @Enum({ items: () => Publisher2Type, default: 'local' })
-  type: Publisher2Type = Publisher2Type.LOCAL;
+  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
   @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
-  type2: Publisher2Type2 = Publisher2Type2.LOCAL;
+  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
   enum1?: number;
@@ -2393,7 +2342,7 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToMany, OneToOne, OptionalProps, PrimaryKey, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToMany, OneToOne, Opt, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
@@ -2401,8 +2350,6 @@ import { Publisher2Tests } from './Publisher2Tests';
 
 @Entity()
 export class Test2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -2417,7 +2364,7 @@ export class Test2 {
   parent?: Ref<Test2>;
 
   @Property({ default: 1 })
-  version: number = 1;
+  version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, ref: true, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: Ref<FooBar2>;
@@ -2489,7 +2436,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Ref, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2.js';
 
 @Entity()
@@ -2497,16 +2444,14 @@ import { Book2 } from './Book2.js';
 @Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
 export class Author2 {
 
-  [OptionalProps]?: 'createdAt' | 'termsAccepted' | 'updatedAt';
-
   @PrimaryKey()
   id!: number;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  updatedAt!: Date;
+  updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
   @Property({ length: 255 })
@@ -2522,7 +2467,7 @@ export class Author2 {
 
   @Index({ name: 'author2_terms_accepted_index' })
   @Property({ default: false })
-  termsAccepted: boolean = false;
+  termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
   optional?: boolean;
@@ -2610,7 +2555,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2.js';
 import { BookTag2 } from './BookTag2.js';
 import { Publisher2 } from './Publisher2.js';
@@ -2620,13 +2565,11 @@ export class Book2 {
 
   [PrimaryKeyProp]?: 'uuidPk';
 
-  [OptionalProps]?: 'createdAt';
-
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
   @Property({ length: 255, nullable: true })
@@ -2744,13 +2687,11 @@ export class Dummy2 {
 
 }
 ",
-  "import { Entity, OneToOne, OptionalProps, PrimaryKey, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, OneToOne, Opt, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2.js';
 
 @Entity()
 export class FooBar2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -2768,7 +2709,7 @@ export class FooBar2 {
   fooBar?: Ref<FooBar2>;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  version!: Date;
+  version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
   blob?: Buffer;
@@ -2784,12 +2725,10 @@ export class FooBar2 {
 
 }
 ",
-  "import { Entity, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class FooBaz2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -2798,11 +2737,11 @@ export class FooBaz2 {
   name!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2.js';
 import { FooBaz2 } from './FooBaz2.js';
 
@@ -2810,8 +2749,6 @@ import { FooBaz2 } from './FooBaz2.js';
 export class FooParam2 {
 
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  [OptionalProps]?: 'version';
 
   @ManyToOne({ entity: () => FooBar2, ref: true, updateRule: 'cascade', primary: true })
   bar!: Ref<FooBar2>;
@@ -2823,28 +2760,26 @@ export class FooParam2 {
   value!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
 }
 ",
-  "import { Entity, Enum, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Publisher2 {
-
-  [OptionalProps]?: 'name' | 'type' | 'type2';
 
   @PrimaryKey()
   id!: number;
 
   @Property({ length: 255, default: 'asd' })
-  name!: string;
+  name!: string & Opt;
 
   @Enum({ items: () => Publisher2Type, default: 'local' })
-  type: Publisher2Type = Publisher2Type.LOCAL;
+  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
   @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
-  type2: Publisher2Type2 = Publisher2Type2.LOCAL;
+  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
   enum1?: number;
@@ -2917,14 +2852,12 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, OptionalProps, PrimaryKey, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property, Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2.js';
 import { FooBar2 } from './FooBar2.js';
 
 @Entity()
 export class Test2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -2939,7 +2872,7 @@ export class Test2 {
   parent?: Ref<Test2>;
 
   @Property({ default: 1 })
-  version: number = 1;
+  version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, ref: true, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: Ref<FooBar2>;
@@ -3056,7 +2989,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -3064,16 +2997,14 @@ import { Book2 } from './Book2';
 @Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
 export class Author2 {
 
-  [OptionalProps]?: 'createdAt' | 'termsAccepted' | 'updatedAt';
-
   @PrimaryKey()
   id!: number;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  updatedAt!: Date;
+  updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
   @Property({ length: 255 })
@@ -3089,7 +3020,7 @@ export class Author2 {
 
   @Index({ name: 'author2_terms_accepted_index' })
   @Property({ default: false })
-  termsAccepted: boolean = false;
+  termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
   optional?: boolean;
@@ -3177,7 +3108,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -3187,13 +3118,11 @@ export class Book2 {
 
   [PrimaryKeyProp]?: 'uuidPk';
 
-  [OptionalProps]?: 'createdAt';
-
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
   @Property({ length: 255, nullable: true })
@@ -3308,13 +3237,11 @@ export class Dummy2 {
 
 }
 ",
-  "import { Entity, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 @Entity()
 export class FooBar2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -3332,7 +3259,7 @@ export class FooBar2 {
   fooBar?: FooBar2;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  version!: Date;
+  version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
   blob?: Buffer;
@@ -3348,12 +3275,10 @@ export class FooBar2 {
 
 }
 ",
-  "import { Entity, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class FooBaz2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -3362,11 +3287,11 @@ export class FooBaz2 {
   name!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -3374,8 +3299,6 @@ import { FooBaz2 } from './FooBaz2';
 export class FooParam2 {
 
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  [OptionalProps]?: 'version';
 
   @ManyToOne({ entity: () => FooBar2, updateRule: 'cascade', primary: true })
   bar!: FooBar2;
@@ -3387,28 +3310,26 @@ export class FooParam2 {
   value!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
 }
 ",
-  "import { Entity, Enum, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Publisher2 {
-
-  [OptionalProps]?: 'name' | 'type' | 'type2';
 
   @PrimaryKey()
   id!: number;
 
   @Property({ length: 255, default: 'asd' })
-  name!: string;
+  name!: string & Opt;
 
   @Enum({ items: () => Publisher2Type, default: 'local' })
-  type: Publisher2Type = Publisher2Type.LOCAL;
+  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
   @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
-  type2: Publisher2Type2 = Publisher2Type2.LOCAL;
+  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
   enum1?: number;

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
@@ -2,12 +2,10 @@
 
 exports[`EntityGenerator enum with default value [postgres]: postgres-entity-dump-enum-default-value 1`] = `
 [
-  "import { Entity, Enum, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Publisher2 {
-
-  [OptionalProps]?: 'type';
 
   @PrimaryKey()
   id!: number;
@@ -16,10 +14,10 @@ export class Publisher2 {
   test?: string;
 
   @Enum({ items: () => Publisher2Type, default: 'local' })
-  type: Publisher2Type = Publisher2Type.LOCAL;
+  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
   @Enum({ items: () => Publisher2Type2, nullable: true, default: 'LOCAL' })
-  type2?: Publisher2Type2 = Publisher2Type2.LOCAL;
+  type2?: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
 }
 
@@ -54,7 +52,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -62,16 +60,14 @@ import { Book2 } from './Book2';
 @Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
 export class Author2 {
 
-  [OptionalProps]?: 'createdAt' | 'termsAccepted' | 'updatedAt';
-
   @PrimaryKey()
   id!: number;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  updatedAt!: Date;
+  updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
   @Property({ length: 255 })
@@ -87,7 +83,7 @@ export class Author2 {
 
   @Index({ name: 'author2_terms_accepted_index' })
   @Property({ default: false })
-  termsAccepted: boolean = false;
+  termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
   optional?: boolean;
@@ -133,7 +129,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -143,13 +139,11 @@ export class Book2 {
 
   [PrimaryKeyProp]?: 'uuidPk';
 
-  [OptionalProps]?: 'createdAt';
-
   @PrimaryKey({ columnType: 'uuid' })
   uuidPk!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Property({ length: 255, nullable: true, default: '' })
   title?: string;
@@ -219,13 +213,11 @@ export class Configuration2 {
 
 }
 ",
-  "import { Entity, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 @Entity()
 export class FooBar2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -243,7 +235,7 @@ export class FooBar2 {
   fooBar?: FooBar2;
 
   @Property({ length: 0, defaultRaw: \`current_timestamp(0)\` })
-  version!: Date;
+  version!: Date & Opt;
 
   @Property({ nullable: true })
   blob?: Buffer;
@@ -259,12 +251,10 @@ export class FooBar2 {
 
 }
 ",
-  "import { Entity, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class FooBaz2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -273,11 +263,11 @@ export class FooBaz2 {
   name!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -285,8 +275,6 @@ import { FooBaz2 } from './FooBaz2';
 export class FooParam2 {
 
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  [OptionalProps]?: 'version';
 
   @ManyToOne({ entity: () => FooBar2, updateRule: 'cascade', primary: true })
   bar!: FooBar2;
@@ -298,7 +286,7 @@ export class FooParam2 {
   value!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
 }
 ",
@@ -405,14 +393,12 @@ export class Publisher2Tests {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
 @Entity()
 export class Test2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -427,7 +413,7 @@ export class Test2 {
   parent?: Test2;
 
   @Property({ default: 1 })
-  version: number = 1;
+  version: number & Opt = 1;
 
   @Property({ columnType: 'polygon', nullable: true })
   path?: unknown;
@@ -458,7 +444,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -466,16 +452,14 @@ import { Book2 } from './Book2';
 @Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
 export class Author2 {
 
-  [OptionalProps]?: 'createdAt' | 'termsAccepted' | 'updatedAt';
-
   @PrimaryKey()
   id!: number;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  updatedAt!: Date;
+  updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
   @Property({ length: 255 })
@@ -491,7 +475,7 @@ export class Author2 {
 
   @Index({ name: 'author2_terms_accepted_index' })
   @Property({ default: false })
-  termsAccepted: boolean = false;
+  termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
   optional?: boolean;
@@ -537,7 +521,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -547,13 +531,11 @@ export class Book2 {
 
   [PrimaryKeyProp]?: 'uuidPk';
 
-  [OptionalProps]?: 'createdAt';
-
   @PrimaryKey({ columnType: 'uuid' })
   uuidPk!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Property({ length: 255, nullable: true, default: '' })
   title?: string;
@@ -620,13 +602,11 @@ export class Configuration2 {
 
 }
 ",
-  "import { Entity, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 @Entity()
 export class FooBar2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -644,7 +624,7 @@ export class FooBar2 {
   fooBar?: FooBar2;
 
   @Property({ length: 0, defaultRaw: \`current_timestamp(0)\` })
-  version!: Date;
+  version!: Date & Opt;
 
   @Property({ nullable: true })
   blob?: Buffer;
@@ -660,12 +640,10 @@ export class FooBar2 {
 
 }
 ",
-  "import { Entity, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class FooBaz2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -674,11 +652,11 @@ export class FooBaz2 {
   name!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -686,8 +664,6 @@ import { FooBaz2 } from './FooBaz2';
 export class FooParam2 {
 
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  [OptionalProps]?: 'version';
 
   @ManyToOne({ entity: () => FooBar2, updateRule: 'cascade', primary: true })
   bar!: FooBar2;
@@ -699,7 +675,7 @@ export class FooParam2 {
   value!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
 }
 ",

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
@@ -2,14 +2,12 @@
 
 exports[`EntityGenerator generate entities from schema [sqlite]: sqlite-entity-dump 1`] = `
 [
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book3 } from './book3';
 
 @Entity()
 @Index({ name: 'author3_name_favourite_book_id_index', properties: ['name', 'favouriteBook'] })
 export class Author3 {
-
-  [OptionalProps]?: 'termsAccepted';
 
   @PrimaryKey()
   id!: number;
@@ -31,7 +29,7 @@ export class Author3 {
   age?: number;
 
   @Property({ default: 0 })
-  termsAccepted: number = 0;
+  termsAccepted: number & Opt = 0;
 
   @Property({ nullable: true })
   identities?: string;
@@ -47,12 +45,10 @@ export class Author3 {
 
 }
 ",
-  "import { Entity, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class BookTag3 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -61,18 +57,16 @@ export class BookTag3 {
   name!: string;
 
   @Property({ defaultRaw: \`current_timestamp\` })
-  version!: Date;
+  version!: Date & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Author3 } from './author3';
 import { Publisher3 } from './publisher3';
 
 @Entity()
 export class Book3 {
-
-  [OptionalProps]?: 'title';
 
   @PrimaryKey()
   id!: number;
@@ -84,7 +78,7 @@ export class Book3 {
   updatedAt?: Date;
 
   @Property({ default: '' })
-  title!: string;
+  title!: string & Opt;
 
   @ManyToOne({ entity: () => Author3, updateRule: 'cascade' })
   author!: Author3;
@@ -146,12 +140,10 @@ export class Publisher3Tests {
 
 }
 ",
-  "import { Entity, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Test3 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -160,7 +152,7 @@ export class Test3 {
   name?: string;
 
   @Property({ default: 1 })
-  version: number = 1;
+  version: number & Opt = 1;
 
 }
 ",

--- a/tests/features/entity-generator/__snapshots__/ManyToManyRelations.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/ManyToManyRelations.mysql.test.ts.snap
@@ -88,7 +88,7 @@ export class UserEmailAvatars {
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -98,8 +98,6 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  [OptionalProps]?: 'flag';
-
   @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
   user!: Users;
 
@@ -107,7 +105,7 @@ export class UserEmailFlags {
   email!: Emails;
 
   @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags;
+  flag!: Flags & Opt;
 
 }
 ",
@@ -132,7 +130,7 @@ export class UserEmailOrders {
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -141,8 +139,6 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  [OptionalProps]?: 'isVerified';
-
   @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   user!: Users;
 
@@ -150,7 +146,7 @@ export class UserEmails {
   email!: Emails;
 
   @Property({ default: false })
-  isVerified: boolean = false;
+  isVerified: boolean & Opt = false;
 
 }
 ",
@@ -292,14 +288,13 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  [OptionalProps]?: 'flag';
   user!: Users;
   email!: Emails;
-  flag!: Flags;
+  flag!: Flags & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -353,14 +348,13 @@ export const UserEmailOrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  [OptionalProps]?: 'isVerified';
   user!: Users;
   email!: Emails;
-  isVerified: boolean = false;
+  isVerified: boolean & Opt = false;
 }
 
 export const UserEmailsSchema = new EntitySchema({
@@ -514,7 +508,7 @@ export class UserEmailAvatars {
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -524,8 +518,6 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  [OptionalProps]?: 'flag';
-
   @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
   user!: Users;
 
@@ -533,7 +525,7 @@ export class UserEmailFlags {
   email!: Emails;
 
   @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags;
+  flag!: Flags & Opt;
 
 }
 ",
@@ -558,7 +550,7 @@ export class UserEmailOrders {
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -567,8 +559,6 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  [OptionalProps]?: 'isVerified';
-
   @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   user!: Users;
 
@@ -576,7 +566,7 @@ export class UserEmails {
   email!: Emails;
 
   @Property({ default: false })
-  isVerified: boolean = false;
+  isVerified: boolean & Opt = false;
 
 }
 ",
@@ -735,14 +725,13 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  [OptionalProps]?: 'flag';
   user!: Users;
   email!: Emails;
-  flag!: Flags;
+  flag!: Flags & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -796,14 +785,13 @@ export const UserEmailOrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  [OptionalProps]?: 'isVerified';
   user!: Users;
   email!: Emails;
-  isVerified: boolean = false;
+  isVerified: boolean & Opt = false;
 }
 
 export const UserEmailsSchema = new EntitySchema({
@@ -998,7 +986,7 @@ export class UserEmailAvatars {
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -1008,8 +996,6 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  [OptionalProps]?: 'flag';
-
   @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
   user!: Users;
 
@@ -1017,7 +1003,7 @@ export class UserEmailFlags {
   email!: Emails;
 
   @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags;
+  flag!: Flags & Opt;
 
 }
 ",
@@ -1042,7 +1028,7 @@ export class UserEmailOrders {
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -1051,8 +1037,6 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  [OptionalProps]?: 'isVerified';
-
   @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   user!: Users;
 
@@ -1060,7 +1044,7 @@ export class UserEmails {
   email!: Emails;
 
   @Property({ default: false })
-  isVerified: boolean = false;
+  isVerified: boolean & Opt = false;
 
 }
 ",
@@ -1219,14 +1203,13 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  [OptionalProps]?: 'flag';
   user!: Users;
   email!: Emails;
-  flag!: Flags;
+  flag!: Flags & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -1280,14 +1263,13 @@ export const UserEmailOrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  [OptionalProps]?: 'isVerified';
   user!: Users;
   email!: Emails;
-  isVerified: boolean = false;
+  isVerified: boolean & Opt = false;
 }
 
 export const UserEmailsSchema = new EntitySchema({
@@ -1456,7 +1438,7 @@ export class UserEmailAvatars {
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -1466,8 +1448,6 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  [OptionalProps]?: 'flag';
-
   @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
   user!: Users;
 
@@ -1475,7 +1455,7 @@ export class UserEmailFlags {
   email!: Emails;
 
   @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags;
+  flag!: Flags & Opt;
 
 }
 ",
@@ -1500,7 +1480,7 @@ export class UserEmailOrders {
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -1509,8 +1489,6 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  [OptionalProps]?: 'isVerified';
-
   @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   user!: Users;
 
@@ -1518,7 +1496,7 @@ export class UserEmails {
   email!: Emails;
 
   @Property({ default: false })
-  isVerified: boolean = false;
+  isVerified: boolean & Opt = false;
 
 }
 ",
@@ -1677,14 +1655,13 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  [OptionalProps]?: 'flag';
   user!: Users;
   email!: Emails;
-  flag!: Flags;
+  flag!: Flags & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -1738,14 +1715,13 @@ export const UserEmailOrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  [OptionalProps]?: 'isVerified';
   user!: Users;
   email!: Emails;
-  isVerified: boolean = false;
+  isVerified: boolean & Opt = false;
 }
 
 export const UserEmailsSchema = new EntitySchema({
@@ -1934,7 +1910,7 @@ export class UserEmailAvatars {
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -1944,8 +1920,6 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  [OptionalProps]?: 'flag';
-
   @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
   user!: Users;
 
@@ -1953,7 +1927,7 @@ export class UserEmailFlags {
   email!: Emails;
 
   @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags;
+  flag!: Flags & Opt;
 
 }
 ",
@@ -1978,7 +1952,7 @@ export class UserEmailOrders {
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -1987,8 +1961,6 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  [OptionalProps]?: 'isVerified';
-
   @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   user!: Users;
 
@@ -1996,7 +1968,7 @@ export class UserEmails {
   email!: Emails;
 
   @Property({ default: false })
-  isVerified: boolean = false;
+  isVerified: boolean & Opt = false;
 
 }
 ",
@@ -2156,14 +2128,13 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  [OptionalProps]?: 'flag';
   user!: Users;
   email!: Emails;
-  flag!: Flags;
+  flag!: Flags & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -2217,14 +2188,13 @@ export const UserEmailOrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  [OptionalProps]?: 'isVerified';
   user!: Users;
   email!: Emails;
-  isVerified: boolean = false;
+  isVerified: boolean & Opt = false;
 }
 
 export const UserEmailsSchema = new EntitySchema({
@@ -2414,7 +2384,7 @@ export class UserEmailAvatars {
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -2424,8 +2394,6 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  [OptionalProps]?: 'flag';
-
   @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
   user!: Users;
 
@@ -2433,7 +2401,7 @@ export class UserEmailFlags {
   email!: Emails;
 
   @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags;
+  flag!: Flags & Opt;
 
 }
 ",
@@ -2458,7 +2426,7 @@ export class UserEmailOrders {
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -2467,8 +2435,6 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  [OptionalProps]?: 'isVerified';
-
   @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   user!: Users;
 
@@ -2476,7 +2442,7 @@ export class UserEmails {
   email!: Emails;
 
   @Property({ default: false })
-  isVerified: boolean = false;
+  isVerified: boolean & Opt = false;
 
 }
 ",
@@ -2671,14 +2637,13 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  [OptionalProps]?: 'flag';
   user!: Users;
   email!: Emails;
-  flag!: Flags;
+  flag!: Flags & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -2732,14 +2697,13 @@ export const UserEmailOrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  [OptionalProps]?: 'isVerified';
   user!: Users;
   email!: Emails;
-  isVerified: boolean = false;
+  isVerified: boolean & Opt = false;
 }
 
 export const UserEmailsSchema = new EntitySchema({
@@ -2953,7 +2917,7 @@ export class UserEmailAvatars {
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -2963,8 +2927,6 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  [OptionalProps]?: 'flag';
-
   @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
   user!: Users;
 
@@ -2972,7 +2934,7 @@ export class UserEmailFlags {
   email!: Emails;
 
   @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags;
+  flag!: Flags & Opt;
 
 }
 ",
@@ -2997,7 +2959,7 @@ export class UserEmailOrders {
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -3006,8 +2968,6 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  [OptionalProps]?: 'isVerified';
-
   @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   user!: Users;
 
@@ -3015,7 +2975,7 @@ export class UserEmails {
   email!: Emails;
 
   @Property({ default: false })
-  isVerified: boolean = false;
+  isVerified: boolean & Opt = false;
 
 }
 ",
@@ -3189,14 +3149,13 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  [OptionalProps]?: 'flag';
   user!: Users;
   email!: Emails;
-  flag!: Flags;
+  flag!: Flags & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -3250,14 +3209,13 @@ export const UserEmailOrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  [OptionalProps]?: 'isVerified';
   user!: Users;
   email!: Emails;
-  isVerified: boolean = false;
+  isVerified: boolean & Opt = false;
 }
 
 export const UserEmailsSchema = new EntitySchema({
@@ -3445,7 +3403,7 @@ export class UserEmailAvatars {
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -3455,8 +3413,6 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  [OptionalProps]?: 'flag';
-
   @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
   user!: Users;
 
@@ -3464,7 +3420,7 @@ export class UserEmailFlags {
   email!: Emails;
 
   @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags;
+  flag!: Flags & Opt;
 
 }
 ",
@@ -3489,7 +3445,7 @@ export class UserEmailOrders {
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -3498,8 +3454,6 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  [OptionalProps]?: 'isVerified';
-
   @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   user!: Users;
 
@@ -3507,7 +3461,7 @@ export class UserEmails {
   email!: Emails;
 
   @Property({ default: false })
-  isVerified: boolean = false;
+  isVerified: boolean & Opt = false;
 
 }
 ",
@@ -3681,14 +3635,13 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  [OptionalProps]?: 'flag';
   user!: Users;
   email!: Emails;
-  flag!: Flags;
+  flag!: Flags & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -3742,14 +3695,13 @@ export const UserEmailOrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  [OptionalProps]?: 'isVerified';
   user!: Users;
   email!: Emails;
-  isVerified: boolean = false;
+  isVerified: boolean & Opt = false;
 }
 
 export const UserEmailsSchema = new EntitySchema({

--- a/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
@@ -18,7 +18,7 @@ export class Address2 {
 
 }
 ",
-  "import { Cascade, Collection, EagerProps, Embedded, Entity, HiddenProps, Index, ManyToMany, ManyToOne, OneToMany, OptionalProps, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Cascade, Collection, EagerProps, Embedded, Entity, Hidden, Index, ManyToMany, ManyToOne, OneToMany, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { IdentitiesContainer } from './IdentitiesContainer';
 
@@ -29,18 +29,14 @@ export class Author2 {
 
   [EagerProps]?: 'favouriteBook';
 
-  [HiddenProps]?: 'authorToFriend' | 'email';
-
-  [OptionalProps]?: 'createdAt' | 'termsAccepted' | 'updatedAt';
-
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  @Property({ length: 3, hidden: true, defaultRaw: \`current_timestamp(3)\` })
+  createdAt!: Date & Hidden & Opt;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  updatedAt!: Date;
+  updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
   @Property({ length: 255, comment: 'author name' })
@@ -49,14 +45,14 @@ export class Author2 {
   @Index({ name: 'custom_email_index_name' })
   @Unique({ name: 'custom_email_unique_name' })
   @Property({ length: 255, hidden: true })
-  email!: string;
+  email!: string & Hidden;
 
   @Property({ nullable: true, concurrencyCheck: true })
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
   @Property({ lazy: true, default: false })
-  termsAccepted: boolean = false;
+  termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
   optional?: boolean;
@@ -82,7 +78,7 @@ export class Author2 {
   identity?: IdentitiesContainer[];
 
   @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id', hidden: true })
-  authorToFriend = new Collection<Author2>(this);
+  authorToFriend: Collection<Author2> & Hidden = new Collection<Author2>(this);
 
   @ManyToMany({ entity: () => Author2, joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
   following = new Collection<Author2>(this);
@@ -170,7 +166,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
@@ -182,13 +178,11 @@ export class Book2 {
 
   [PrimaryKeyProp]?: 'uuidPk';
 
-  [OptionalProps]?: 'createdAt';
-
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
   @Property({ length: 255, nullable: true })
@@ -326,15 +320,13 @@ export class Dummy2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
 import { Test2 } from './Test2';
 
 @Entity()
 export class FooBar2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -352,7 +344,7 @@ export class FooBar2 {
   fooBar?: FooBar2;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  version!: Date;
+  version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
   blob?: Buffer;
@@ -377,13 +369,11 @@ export class FooBar2 {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooParam2 } from './FooParam2';
 
 @Entity()
 export class FooBaz2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -392,14 +382,14 @@ export class FooBaz2 {
   name!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
   @OneToMany({ entity: () => FooParam2, mappedBy: 'baz' })
   bazInverse = new Collection<FooParam2>(this);
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -407,8 +397,6 @@ import { FooBaz2 } from './FooBaz2';
 export class FooParam2 {
 
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  [OptionalProps]?: 'version';
 
   @ManyToOne({ entity: () => FooBar2, updateRule: 'cascade', primary: true })
   bar!: FooBar2;
@@ -420,30 +408,28 @@ export class FooParam2 {
   value!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
 }
 ",
-  "import { Collection, Entity, Enum, OneToMany, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Enum, OneToMany, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
 
 @Entity()
 export class Publisher2 {
 
-  [OptionalProps]?: 'name' | 'type' | 'type2';
-
   @PrimaryKey()
   id!: number;
 
   @Property({ length: 255, default: 'asd' })
-  name!: string;
+  name!: string & Opt;
 
   @Enum({ items: () => Publisher2Type, default: 'local' })
-  type: Publisher2Type = Publisher2Type.LOCAL;
+  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
   @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
-  type2: Publisher2Type2 = Publisher2Type2.LOCAL;
+  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
   enum1?: number;
@@ -526,7 +512,7 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToMany, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToMany, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
@@ -534,8 +520,6 @@ import { Publisher2Tests } from './Publisher2Tests';
 
 @Entity()
 export class Test2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -550,7 +534,7 @@ export class Test2 {
   parent?: Test2;
 
   @Property({ version: true, default: 1 })
-  version: number = 1;
+  version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
@@ -601,12 +585,10 @@ export class User2 {
 
 }
 ",
-  "import { Entity, HiddenProps, Index, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, Hidden, Index, Property, Unique } from '@mikro-orm/core';
 
 @Entity({ expression: "SELECT name, email FROM author2", comment: 'test', virtual: true })
 export class AuthorPartialView {
-
-  [HiddenProps]?: 'email';
 
   @Index({ name: 'custom_idx_name_123' })
   @Property({ length: 255, comment: 'author name' })
@@ -615,7 +597,7 @@ export class AuthorPartialView {
   @Index({ name: 'custom_email_index_name' })
   @Unique({ name: 'custom_email_unique_name' })
   @Property({ length: 255, hidden: true })
-  email!: string;
+  email!: string & Hidden;
 
 }
 ",
@@ -680,20 +662,18 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EagerProps, EntitySchema, HiddenProps, OptionalProps } from '@mikro-orm/core';
+  "import { Collection, EagerProps, EntitySchema, Hidden, Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 export class Author2 {
   [EagerProps]?: 'favouriteBook';
-  [HiddenProps]?: 'authorToFriend' | 'email';
-  [OptionalProps]?: 'createdAt' | 'termsAccepted' | 'updatedAt';
   id!: number;
-  createdAt!: Date;
-  updatedAt!: Date;
+  createdAt!: Date & Hidden & Opt;
+  updatedAt!: Date & Opt;
   name!: string;
-  email!: string;
+  email!: string & Hidden;
   age?: number;
-  termsAccepted: boolean = false;
+  termsAccepted: boolean & Opt = false;
   optional?: boolean;
   identities?: string;
   born?: string;
@@ -701,7 +681,7 @@ export class Author2 {
   favouriteBook?: Book2;
   favouriteAuthor?: Author2;
   identity?: IdentitiesContainer[];
-  authorToFriend = new Collection<Author2>(this);
+  authorToFriend: Collection<Author2> & Hidden = new Collection<Author2>(this);
   following = new Collection<Author2>(this);
   authorInverse = new Collection<Book2>(this);
   favouriteAuthorInverse = new Collection<Author2>(this);
@@ -719,7 +699,7 @@ export const Author2Schema = new EntitySchema({
   ],
   properties: {
     id: { primary: true, type: 'number' },
-    createdAt: { type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` },
+    createdAt: { type: 'Date', length: 3, hidden: true, defaultRaw: \`current_timestamp(3)\` },
     updatedAt: { type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` },
     name: {
       type: 'string',
@@ -866,16 +846,15 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 
 export class Book2 {
   [PrimaryKeyProp]?: 'uuidPk';
-  [OptionalProps]?: 'createdAt';
   uuidPk!: string;
-  createdAt!: Date;
+  createdAt!: Date & Opt;
   title?: string;
   perex?: string;
   price?: string;
@@ -1025,18 +1004,17 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { FooParam2 } from './FooParam2';
 import { Test2 } from './Test2';
 
 export class FooBar2 {
-  [OptionalProps]?: 'version';
   id!: number;
   name!: string;
   nameWithSpace?: string;
   baz?: FooBaz2;
   fooBar?: FooBar2;
-  version!: Date;
+  version!: Date & Opt;
   blob?: Buffer;
   blob2?: Buffer;
   array?: string;
@@ -1077,14 +1055,13 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { FooParam2 } from './FooParam2';
 
 export class FooBaz2 {
-  [OptionalProps]?: 'version';
   id!: number;
   name!: string;
-  version!: Date;
+  version!: Date & Opt;
   bazInverse = new Collection<FooParam2>(this);
 }
 
@@ -1098,15 +1075,14 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class FooParam2 {
   [PrimaryKeyProp]?: ['bar', 'baz'];
-  [OptionalProps]?: 'version';
   bar!: FooBar2;
   baz!: FooBaz2;
   value!: string;
-  version!: Date;
+  version!: Date & Opt;
 }
 
 export const FooParam2Schema = new EntitySchema({
@@ -1119,16 +1095,15 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
 
 export class Publisher2 {
-  [OptionalProps]?: 'name' | 'type' | 'type2';
   id!: number;
-  name!: string;
-  type: Publisher2Type = Publisher2Type.LOCAL;
-  type2: Publisher2Type2 = Publisher2Type2.LOCAL;
+  name!: string & Opt;
+  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
+  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
   enum2?: number;
   enum3?: number;
@@ -1223,18 +1198,17 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
 import { Publisher2Tests } from './Publisher2Tests';
 
 export class Test2 {
-  [OptionalProps]?: 'version';
   id!: number;
   name?: string;
   book?: Book2;
   parent?: Test2;
-  version: number = 1;
+  version: number & Opt = 1;
   fooBar?: FooBar2;
   fooBaz?: number;
   bars = new Collection<FooBar2>(this);
@@ -1320,12 +1294,11 @@ export const User2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, HiddenProps } from '@mikro-orm/core';
+  "import { EntitySchema, Hidden } from '@mikro-orm/core';
 
 export class AuthorPartialView {
-  [HiddenProps]?: 'email';
   name!: string;
-  email!: string;
+  email!: string & Hidden;
 }
 
 export const AuthorPartialViewSchema = new EntitySchema({

--- a/tests/features/entity-generator/__snapshots__/NullableFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/NullableFks.mysql.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`nullable_fk_example scalarPropertiesForRelations=always bidirectionalRelations=false identifiedReferences=false entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -10,8 +10,6 @@ import { SenderEmails } from './SenderEmails';
 export class EmailSendingLogs {
 
   [PrimaryKeyProp]?: 'logId';
-
-  [OptionalProps]?: 'createdAt';
 
   @PrimaryKey()
   logId!: number;
@@ -41,7 +39,7 @@ export class EmailSendingLogs {
   replyEmailId?: number;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
 }
 ",
@@ -154,11 +152,10 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=always bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class EmailSendingLogs {
   [PrimaryKeyProp]?: 'logId';
-  [OptionalProps]?: 'createdAt';
   logId!: number;
   senderId!: number;
   recepient!: RecepientEmails;
@@ -168,7 +165,7 @@ export class EmailSendingLogs {
   recepientEmailId!: number;
   reply?: SenderEmails;
   replyEmailId?: number;
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 }
 
 export const EmailSendingLogsSchema = new EntitySchema({
@@ -342,7 +339,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=always bidirectionalRelations=false identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -350,8 +347,6 @@ import { SenderEmails } from './SenderEmails';
 export class EmailSendingLogs {
 
   [PrimaryKeyProp]?: 'logId';
-
-  [OptionalProps]?: 'createdAt';
 
   @PrimaryKey()
   logId!: number;
@@ -381,7 +376,7 @@ export class EmailSendingLogs {
   replyEmailId?: number;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
 }
 ",
@@ -494,13 +489,12 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=always bidirectionalRelations=false identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
 export class EmailSendingLogs {
   [PrimaryKeyProp]?: 'logId';
-  [OptionalProps]?: 'createdAt';
   logId!: number;
   senderId!: number;
   recepient!: Ref<RecepientEmails>;
@@ -510,7 +504,7 @@ export class EmailSendingLogs {
   recepientEmailId!: number;
   reply?: Ref<SenderEmails>;
   replyEmailId?: number;
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 }
 
 export const EmailSendingLogsSchema = new EntitySchema({
@@ -700,7 +694,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=always bidirectionalRelations=true identifiedReferences=false entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -708,8 +702,6 @@ import { SenderEmails } from './SenderEmails';
 export class EmailSendingLogs {
 
   [PrimaryKeyProp]?: 'logId';
-
-  [OptionalProps]?: 'createdAt';
 
   @PrimaryKey()
   logId!: number;
@@ -739,7 +731,7 @@ export class EmailSendingLogs {
   replyEmailId?: number;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
 }
 ",
@@ -881,11 +873,10 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=always bidirectionalRelations=true identifiedReferences=false entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class EmailSendingLogs {
   [PrimaryKeyProp]?: 'logId';
-  [OptionalProps]?: 'createdAt';
   logId!: number;
   senderId!: number;
   recepient!: RecepientEmails;
@@ -895,7 +886,7 @@ export class EmailSendingLogs {
   recepientEmailId!: number;
   reply?: SenderEmails;
   replyEmailId?: number;
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 }
 
 export const EmailSendingLogsSchema = new EntitySchema({
@@ -1092,7 +1083,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=always bidirectionalRelations=true identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -1100,8 +1091,6 @@ import { SenderEmails } from './SenderEmails';
 export class EmailSendingLogs {
 
   [PrimaryKeyProp]?: 'logId';
-
-  [OptionalProps]?: 'createdAt';
 
   @PrimaryKey()
   logId!: number;
@@ -1131,7 +1120,7 @@ export class EmailSendingLogs {
   replyEmailId?: number;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
 }
 ",
@@ -1273,13 +1262,12 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=always bidirectionalRelations=true identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
 export class EmailSendingLogs {
   [PrimaryKeyProp]?: 'logId';
-  [OptionalProps]?: 'createdAt';
   logId!: number;
   senderId!: number;
   recepient!: Ref<RecepientEmails>;
@@ -1289,7 +1277,7 @@ export class EmailSendingLogs {
   recepientEmailId!: number;
   reply?: Ref<SenderEmails>;
   replyEmailId?: number;
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 }
 
 export const EmailSendingLogsSchema = new EntitySchema({
@@ -1502,7 +1490,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=false entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -1510,8 +1498,6 @@ import { SenderEmails } from './SenderEmails';
 export class EmailSendingLogs {
 
   [PrimaryKeyProp]?: 'logId';
-
-  [OptionalProps]?: 'createdAt';
 
   @PrimaryKey()
   logId!: number;
@@ -1526,7 +1512,7 @@ export class EmailSendingLogs {
   reply?: SenderEmails;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
 }
 ",
@@ -1625,16 +1611,15 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class EmailSendingLogs {
   [PrimaryKeyProp]?: 'logId';
-  [OptionalProps]?: 'createdAt';
   logId!: number;
   recepient!: RecepientEmails;
   sender!: SenderEmails;
   reply?: SenderEmails;
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 }
 
 export const EmailSendingLogsSchema = new EntitySchema({
@@ -1795,7 +1780,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -1803,8 +1788,6 @@ import { SenderEmails } from './SenderEmails';
 export class EmailSendingLogs {
 
   [PrimaryKeyProp]?: 'logId';
-
-  [OptionalProps]?: 'createdAt';
 
   @PrimaryKey()
   logId!: number;
@@ -1819,7 +1802,7 @@ export class EmailSendingLogs {
   reply?: Ref<SenderEmails>;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
 }
 ",
@@ -1918,18 +1901,17 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
 export class EmailSendingLogs {
   [PrimaryKeyProp]?: 'logId';
-  [OptionalProps]?: 'createdAt';
   logId!: number;
   recepient!: Ref<RecepientEmails>;
   sender!: Ref<SenderEmails>;
   reply?: Ref<SenderEmails>;
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 }
 
 export const EmailSendingLogsSchema = new EntitySchema({
@@ -2106,7 +2088,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=never bidirectionalRelations=true identifiedReferences=false entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -2114,8 +2096,6 @@ import { SenderEmails } from './SenderEmails';
 export class EmailSendingLogs {
 
   [PrimaryKeyProp]?: 'logId';
-
-  [OptionalProps]?: 'createdAt';
 
   @PrimaryKey()
   logId!: number;
@@ -2130,7 +2110,7 @@ export class EmailSendingLogs {
   reply?: SenderEmails;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
 }
 ",
@@ -2258,16 +2238,15 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=never bidirectionalRelations=true identifiedReferences=false entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class EmailSendingLogs {
   [PrimaryKeyProp]?: 'logId';
-  [OptionalProps]?: 'createdAt';
   logId!: number;
   recepient!: RecepientEmails;
   sender!: SenderEmails;
   reply?: SenderEmails;
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 }
 
 export const EmailSendingLogsSchema = new EntitySchema({
@@ -2451,7 +2430,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=never bidirectionalRelations=true identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -2459,8 +2438,6 @@ import { SenderEmails } from './SenderEmails';
 export class EmailSendingLogs {
 
   [PrimaryKeyProp]?: 'logId';
-
-  [OptionalProps]?: 'createdAt';
 
   @PrimaryKey()
   logId!: number;
@@ -2475,7 +2452,7 @@ export class EmailSendingLogs {
   reply?: Ref<SenderEmails>;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
 }
 ",
@@ -2603,18 +2580,17 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=never bidirectionalRelations=true identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
 export class EmailSendingLogs {
   [PrimaryKeyProp]?: 'logId';
-  [OptionalProps]?: 'createdAt';
   logId!: number;
   recepient!: Ref<RecepientEmails>;
   sender!: Ref<SenderEmails>;
   reply?: Ref<SenderEmails>;
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 }
 
 export const EmailSendingLogsSchema = new EntitySchema({
@@ -2814,7 +2790,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=false entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -2822,8 +2798,6 @@ import { SenderEmails } from './SenderEmails';
 export class EmailSendingLogs {
 
   [PrimaryKeyProp]?: 'logId';
-
-  [OptionalProps]?: 'createdAt';
 
   @PrimaryKey()
   logId!: number;
@@ -2838,7 +2812,7 @@ export class EmailSendingLogs {
   reply?: SenderEmails;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
 }
 ",
@@ -2937,16 +2911,15 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class EmailSendingLogs {
   [PrimaryKeyProp]?: 'logId';
-  [OptionalProps]?: 'createdAt';
   logId!: number;
   recepient!: RecepientEmails;
   sender!: SenderEmails;
   reply?: SenderEmails;
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 }
 
 export const EmailSendingLogsSchema = new EntitySchema({
@@ -3107,7 +3080,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -3115,8 +3088,6 @@ import { SenderEmails } from './SenderEmails';
 export class EmailSendingLogs {
 
   [PrimaryKeyProp]?: 'logId';
-
-  [OptionalProps]?: 'createdAt';
 
   @PrimaryKey()
   logId!: number;
@@ -3131,7 +3102,7 @@ export class EmailSendingLogs {
   reply?: Ref<SenderEmails>;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
 }
 ",
@@ -3230,18 +3201,17 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
 export class EmailSendingLogs {
   [PrimaryKeyProp]?: 'logId';
-  [OptionalProps]?: 'createdAt';
   logId!: number;
   recepient!: Ref<RecepientEmails>;
   sender!: Ref<SenderEmails>;
   reply?: Ref<SenderEmails>;
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 }
 
 export const EmailSendingLogsSchema = new EntitySchema({
@@ -3418,7 +3388,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=true identifiedReferences=false entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -3426,8 +3396,6 @@ import { SenderEmails } from './SenderEmails';
 export class EmailSendingLogs {
 
   [PrimaryKeyProp]?: 'logId';
-
-  [OptionalProps]?: 'createdAt';
 
   @PrimaryKey()
   logId!: number;
@@ -3442,7 +3410,7 @@ export class EmailSendingLogs {
   reply?: SenderEmails;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
 }
 ",
@@ -3570,16 +3538,15 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=true identifiedReferences=false entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class EmailSendingLogs {
   [PrimaryKeyProp]?: 'logId';
-  [OptionalProps]?: 'createdAt';
   logId!: number;
   recepient!: RecepientEmails;
   sender!: SenderEmails;
   reply?: SenderEmails;
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 }
 
 export const EmailSendingLogsSchema = new EntitySchema({
@@ -3763,7 +3730,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=true identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -3771,8 +3738,6 @@ import { SenderEmails } from './SenderEmails';
 export class EmailSendingLogs {
 
   [PrimaryKeyProp]?: 'logId';
-
-  [OptionalProps]?: 'createdAt';
 
   @PrimaryKey()
   logId!: number;
@@ -3787,7 +3752,7 @@ export class EmailSendingLogs {
   reply?: Ref<SenderEmails>;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
 }
 ",
@@ -3915,18 +3880,17 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=true identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
 export class EmailSendingLogs {
   [PrimaryKeyProp]?: 'logId';
-  [OptionalProps]?: 'createdAt';
   logId!: number;
   recepient!: Ref<RecepientEmails>;
   sender!: Ref<SenderEmails>;
   reply?: Ref<SenderEmails>;
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 }
 
 export const EmailSendingLogsSchema = new EntitySchema({

--- a/tests/features/entity-generator/__snapshots__/OverlapFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OverlapFks.mysql.test.ts.snap
@@ -14,7 +14,7 @@ export class Countries {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
@@ -24,8 +24,6 @@ import { Products } from './Products';
 export class ProductCountryMap {
 
   [PrimaryKeyProp]?: ['product', 'countries'];
-
-  [OptionalProps]?: 'isCurrentlyAllowed';
 
   @Property({ columnType: 'char(2)', persist: false })
   country!: unknown;
@@ -38,14 +36,14 @@ export class ProductCountryMap {
   productId!: number;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
   @ManyToOne({ entity: () => Countries, fieldName: 'country', primary: true })
   countries!: Countries;
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -53,8 +51,6 @@ import { Sellers } from './Sellers';
 export class ProductSellers {
 
   [PrimaryKeyProp]?: ['seller', 'product'];
-
-  [OptionalProps]?: 'isCurrentlyAllowed';
 
   @ManyToOne({ entity: () => Sellers, fieldName: 'seller_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   seller!: Sellers;
@@ -70,18 +66,16 @@ export class ProductSellers {
   productId!: number;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
 }
 ",
-  "import { Entity, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 
 @Entity()
 export class Products {
 
   [PrimaryKeyProp]?: 'productId';
-
-  [OptionalProps]?: 'currentQuantity';
 
   @PrimaryKey()
   productId!: number;
@@ -94,11 +88,11 @@ export class Products {
   currentPrice!: string;
 
   @Property({ default: 0 })
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -106,8 +100,6 @@ import { ProductSellers } from './ProductSellers';
 export class Sales {
 
   [PrimaryKeyProp]?: 'saleId';
-
-  [OptionalProps]?: 'quantitySold';
 
   @PrimaryKey()
   saleId!: number;
@@ -129,7 +121,7 @@ export class Sales {
   singularPrice!: string;
 
   @Property({ default: 1 })
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 
   @ManyToOne({ entity: () => ProductCountryMap, fieldNames: ['country', 'product_id'], updateRule: 'cascade', index: 'fk_sales_product_country_map1_idx' })
   productCountryMap!: ProductCountryMap;
@@ -171,15 +163,14 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['product', 'countries'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   country!: unknown;
   product!: Products;
   productId!: number;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
   countries!: Countries;
 }
 
@@ -204,16 +195,15 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class ProductSellers {
   [PrimaryKeyProp]?: ['seller', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   seller!: Sellers;
   sellerId!: number;
   product!: Products;
   productId!: number;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 }
 
 export const ProductSellersSchema = new EntitySchema({
@@ -242,15 +232,14 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
-  [OptionalProps]?: 'currentQuantity';
   productId!: number;
   name!: string;
   currentPrice!: string;
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
 }
 
 export const ProductsSchema = new EntitySchema({
@@ -263,18 +252,17 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
-  [OptionalProps]?: 'quantitySold';
   saleId!: number;
   country!: unknown;
   seller!: ProductSellers;
   sellerId!: number;
   productId!: number;
   singularPrice!: string;
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
   productCountryMap!: ProductCountryMap;
 }
 
@@ -343,7 +331,7 @@ export class Countries {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
@@ -353,8 +341,6 @@ import { Products } from './Products';
 export class ProductCountryMap {
 
   [PrimaryKeyProp]?: ['product', 'countries'];
-
-  [OptionalProps]?: 'isCurrentlyAllowed';
 
   @Property({ columnType: 'char(2)', persist: false })
   country!: unknown;
@@ -367,14 +353,14 @@ export class ProductCountryMap {
   productId!: number;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
   @ManyToOne({ entity: () => Countries, ref: true, fieldName: 'country', primary: true })
   countries!: Ref<Countries>;
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -382,8 +368,6 @@ import { Sellers } from './Sellers';
 export class ProductSellers {
 
   [PrimaryKeyProp]?: ['seller', 'product'];
-
-  [OptionalProps]?: 'isCurrentlyAllowed';
 
   @ManyToOne({ entity: () => Sellers, ref: true, fieldName: 'seller_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   seller!: Ref<Sellers>;
@@ -399,18 +383,16 @@ export class ProductSellers {
   productId!: number;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
 }
 ",
-  "import { Entity, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 
 @Entity()
 export class Products {
 
   [PrimaryKeyProp]?: 'productId';
-
-  [OptionalProps]?: 'currentQuantity';
 
   @PrimaryKey()
   productId!: number;
@@ -423,11 +405,11 @@ export class Products {
   currentPrice!: string;
 
   @Property({ default: 0 })
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -435,8 +417,6 @@ import { ProductSellers } from './ProductSellers';
 export class Sales {
 
   [PrimaryKeyProp]?: 'saleId';
-
-  [OptionalProps]?: 'quantitySold';
 
   @PrimaryKey()
   saleId!: number;
@@ -458,7 +438,7 @@ export class Sales {
   singularPrice!: string;
 
   @Property({ default: 1 })
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 
   @ManyToOne({ entity: () => ProductCountryMap, ref: true, fieldNames: ['country', 'product_id'], updateRule: 'cascade', index: 'fk_sales_product_country_map1_idx' })
   productCountryMap!: Ref<ProductCountryMap>;
@@ -500,17 +480,16 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['product', 'countries'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   country!: unknown;
   product!: Ref<Products>;
   productId!: number;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
   countries!: Ref<Countries>;
 }
 
@@ -542,18 +521,17 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
 export class ProductSellers {
   [PrimaryKeyProp]?: ['seller', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   seller!: Ref<Sellers>;
   sellerId!: number;
   product!: Ref<Products>;
   productId!: number;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 }
 
 export const ProductSellersSchema = new EntitySchema({
@@ -584,15 +562,14 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
-  [OptionalProps]?: 'currentQuantity';
   productId!: number;
   name!: string;
   currentPrice!: string;
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
 }
 
 export const ProductsSchema = new EntitySchema({
@@ -605,20 +582,19 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
-  [OptionalProps]?: 'quantitySold';
   saleId!: number;
   country!: unknown;
   seller!: Ref<ProductSellers>;
   sellerId!: number;
   productId!: number;
   singularPrice!: string;
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
   productCountryMap!: Ref<ProductCountryMap>;
 }
 
@@ -693,7 +669,7 @@ export class Countries {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -704,8 +680,6 @@ import { Sales } from './Sales';
 export class ProductCountryMap {
 
   [PrimaryKeyProp]?: ['product', 'countries'];
-
-  [OptionalProps]?: 'isCurrentlyAllowed';
 
   @Property({ columnType: 'char(2)', persist: false })
   country!: unknown;
@@ -718,7 +692,7 @@ export class ProductCountryMap {
   productId!: number;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
   @ManyToOne({ entity: () => Countries, fieldName: 'country', primary: true })
   countries!: Countries;
@@ -728,7 +702,7 @@ export class ProductCountryMap {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -737,8 +711,6 @@ import { Sellers } from './Sellers';
 export class ProductSellers {
 
   [PrimaryKeyProp]?: ['seller', 'product'];
-
-  [OptionalProps]?: 'isCurrentlyAllowed';
 
   @ManyToOne({ entity: () => Sellers, fieldName: 'seller_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   seller!: Sellers;
@@ -754,22 +726,20 @@ export class ProductSellers {
   productId!: number;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'seller' })
   sellerInverse = new Collection<Sales>(this);
 
 }
 ",
-  "import { Collection, Entity, OneToMany, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
 
 @Entity()
 export class Products {
 
   [PrimaryKeyProp]?: 'productId';
-
-  [OptionalProps]?: 'currentQuantity';
 
   @PrimaryKey()
   productId!: number;
@@ -782,14 +752,14 @@ export class Products {
   currentPrice!: string;
 
   @Property({ default: 0 })
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
 
   @OneToMany({ entity: () => ProductSellers, mappedBy: 'product' })
   productInverse = new Collection<ProductSellers>(this);
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -797,8 +767,6 @@ import { ProductSellers } from './ProductSellers';
 export class Sales {
 
   [PrimaryKeyProp]?: 'saleId';
-
-  [OptionalProps]?: 'quantitySold';
 
   @PrimaryKey()
   saleId!: number;
@@ -820,7 +788,7 @@ export class Sales {
   singularPrice!: string;
 
   @Property({ default: 1 })
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 
   @ManyToOne({ entity: () => ProductCountryMap, fieldNames: ['country', 'product_id'], updateRule: 'cascade', index: 'fk_sales_product_country_map1_idx' })
   productCountryMap!: ProductCountryMap;
@@ -869,16 +837,15 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Sales } from './Sales';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['product', 'countries'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   country!: unknown;
   product!: Products;
   productId!: number;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
   countries!: Countries;
   productCountryMapInverse = new Collection<Sales>(this);
 }
@@ -905,17 +872,16 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Sales } from './Sales';
 
 export class ProductSellers {
   [PrimaryKeyProp]?: ['seller', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   seller!: Sellers;
   sellerId!: number;
   product!: Products;
   productId!: number;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
   sellerInverse = new Collection<Sales>(this);
 }
 
@@ -946,16 +912,15 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
-  [OptionalProps]?: 'currentQuantity';
   productId!: number;
   name!: string;
   currentPrice!: string;
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
   productInverse = new Collection<ProductSellers>(this);
 }
 
@@ -970,18 +935,17 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
-  [OptionalProps]?: 'quantitySold';
   saleId!: number;
   country!: unknown;
   seller!: ProductSellers;
   sellerId!: number;
   productId!: number;
   singularPrice!: string;
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
   productCountryMap!: ProductCountryMap;
 }
 
@@ -1057,7 +1021,7 @@ export class Countries {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, OptionalProps, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -1068,8 +1032,6 @@ import { Sales } from './Sales';
 export class ProductCountryMap {
 
   [PrimaryKeyProp]?: ['product', 'countries'];
-
-  [OptionalProps]?: 'isCurrentlyAllowed';
 
   @Property({ columnType: 'char(2)', persist: false })
   country!: unknown;
@@ -1082,7 +1044,7 @@ export class ProductCountryMap {
   productId!: number;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
   @ManyToOne({ entity: () => Countries, ref: true, fieldName: 'country', primary: true })
   countries!: Ref<Countries>;
@@ -1092,7 +1054,7 @@ export class ProductCountryMap {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, OptionalProps, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -1101,8 +1063,6 @@ import { Sellers } from './Sellers';
 export class ProductSellers {
 
   [PrimaryKeyProp]?: ['seller', 'product'];
-
-  [OptionalProps]?: 'isCurrentlyAllowed';
 
   @ManyToOne({ entity: () => Sellers, ref: true, fieldName: 'seller_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   seller!: Ref<Sellers>;
@@ -1118,22 +1078,20 @@ export class ProductSellers {
   productId!: number;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'seller' })
   sellerInverse = new Collection<Sales>(this);
 
 }
 ",
-  "import { Collection, Entity, OneToMany, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
 
 @Entity()
 export class Products {
 
   [PrimaryKeyProp]?: 'productId';
-
-  [OptionalProps]?: 'currentQuantity';
 
   @PrimaryKey()
   productId!: number;
@@ -1146,14 +1104,14 @@ export class Products {
   currentPrice!: string;
 
   @Property({ default: 0 })
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
 
   @OneToMany({ entity: () => ProductSellers, mappedBy: 'product' })
   productInverse = new Collection<ProductSellers>(this);
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -1161,8 +1119,6 @@ import { ProductSellers } from './ProductSellers';
 export class Sales {
 
   [PrimaryKeyProp]?: 'saleId';
-
-  [OptionalProps]?: 'quantitySold';
 
   @PrimaryKey()
   saleId!: number;
@@ -1184,7 +1140,7 @@ export class Sales {
   singularPrice!: string;
 
   @Property({ default: 1 })
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 
   @ManyToOne({ entity: () => ProductCountryMap, ref: true, fieldNames: ['country', 'product_id'], updateRule: 'cascade', index: 'fk_sales_product_country_map1_idx' })
   productCountryMap!: Ref<ProductCountryMap>;
@@ -1233,18 +1189,17 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['product', 'countries'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   country!: unknown;
   product!: Ref<Products>;
   productId!: number;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
   countries!: Ref<Countries>;
   productCountryMapInverse = new Collection<Sales>(this);
 }
@@ -1278,19 +1233,18 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
 
 export class ProductSellers {
   [PrimaryKeyProp]?: ['seller', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   seller!: Ref<Sellers>;
   sellerId!: number;
   product!: Ref<Products>;
   productId!: number;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
   sellerInverse = new Collection<Sales>(this);
 }
 
@@ -1323,16 +1277,15 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
-  [OptionalProps]?: 'currentQuantity';
   productId!: number;
   name!: string;
   currentPrice!: string;
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
   productInverse = new Collection<ProductSellers>(this);
 }
 
@@ -1347,20 +1300,19 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
-  [OptionalProps]?: 'quantitySold';
   saleId!: number;
   country!: unknown;
   seller!: Ref<ProductSellers>;
   sellerId!: number;
   productId!: number;
   singularPrice!: string;
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
   productCountryMap!: Ref<ProductCountryMap>;
 }
 
@@ -1434,7 +1386,7 @@ export class Countries {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
@@ -1445,8 +1397,6 @@ export class ProductCountryMap {
 
   [PrimaryKeyProp]?: ['country', 'product'];
 
-  [OptionalProps]?: 'isCurrentlyAllowed';
-
   @ManyToOne({ entity: () => Countries, fieldName: 'country', primary: true })
   country!: Countries;
 
@@ -1454,11 +1404,11 @@ export class ProductCountryMap {
   product!: Products;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -1467,8 +1417,6 @@ export class ProductSellers {
 
   [PrimaryKeyProp]?: ['seller', 'product'];
 
-  [OptionalProps]?: 'isCurrentlyAllowed';
-
   @ManyToOne({ entity: () => Sellers, fieldName: 'seller_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   seller!: Sellers;
 
@@ -1476,18 +1424,16 @@ export class ProductSellers {
   product!: Products;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
 }
 ",
-  "import { Entity, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 
 @Entity()
 export class Products {
 
   [PrimaryKeyProp]?: 'productId';
-
-  [OptionalProps]?: 'currentQuantity';
 
   @PrimaryKey()
   productId!: number;
@@ -1500,11 +1446,11 @@ export class Products {
   currentPrice!: string;
 
   @Property({ default: 0 })
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -1513,8 +1459,6 @@ import { ProductSellers } from './ProductSellers';
 export class Sales {
 
   [PrimaryKeyProp]?: 'saleId';
-
-  [OptionalProps]?: 'quantitySold';
 
   @PrimaryKey()
   saleId!: number;
@@ -1529,7 +1473,7 @@ export class Sales {
   singularPrice!: string;
 
   @Property({ default: 1 })
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 
 }
 ",
@@ -1568,14 +1512,13 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['country', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   country!: Countries;
   product!: Products;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 }
 
 export const ProductCountryMapSchema = new EntitySchema({
@@ -1597,14 +1540,13 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class ProductSellers {
   [PrimaryKeyProp]?: ['seller', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   seller!: Sellers;
   product!: Products;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 }
 
 export const ProductSellersSchema = new EntitySchema({
@@ -1631,15 +1573,14 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
-  [OptionalProps]?: 'currentQuantity';
   productId!: number;
   name!: string;
   currentPrice!: string;
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
 }
 
 export const ProductsSchema = new EntitySchema({
@@ -1652,16 +1593,15 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
-  [OptionalProps]?: 'quantitySold';
   saleId!: number;
   country!: ProductCountryMap;
   seller!: ProductSellers;
   singularPrice!: string;
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 }
 
 export const SalesSchema = new EntitySchema({
@@ -1729,7 +1669,7 @@ export class Countries {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
@@ -1740,8 +1680,6 @@ export class ProductCountryMap {
 
   [PrimaryKeyProp]?: ['country', 'product'];
 
-  [OptionalProps]?: 'isCurrentlyAllowed';
-
   @ManyToOne({ entity: () => Countries, ref: true, fieldName: 'country', primary: true })
   country!: Ref<Countries>;
 
@@ -1749,11 +1687,11 @@ export class ProductCountryMap {
   product!: Ref<Products>;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -1762,8 +1700,6 @@ export class ProductSellers {
 
   [PrimaryKeyProp]?: ['seller', 'product'];
 
-  [OptionalProps]?: 'isCurrentlyAllowed';
-
   @ManyToOne({ entity: () => Sellers, ref: true, fieldName: 'seller_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   seller!: Ref<Sellers>;
 
@@ -1771,18 +1707,16 @@ export class ProductSellers {
   product!: Ref<Products>;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
 }
 ",
-  "import { Entity, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 
 @Entity()
 export class Products {
 
   [PrimaryKeyProp]?: 'productId';
-
-  [OptionalProps]?: 'currentQuantity';
 
   @PrimaryKey()
   productId!: number;
@@ -1795,11 +1729,11 @@ export class Products {
   currentPrice!: string;
 
   @Property({ default: 0 })
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -1808,8 +1742,6 @@ import { ProductSellers } from './ProductSellers';
 export class Sales {
 
   [PrimaryKeyProp]?: 'saleId';
-
-  [OptionalProps]?: 'quantitySold';
 
   @PrimaryKey()
   saleId!: number;
@@ -1824,7 +1756,7 @@ export class Sales {
   singularPrice!: string;
 
   @Property({ default: 1 })
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 
 }
 ",
@@ -1863,16 +1795,15 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['country', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   country!: Ref<Countries>;
   product!: Ref<Products>;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 }
 
 export const ProductCountryMapSchema = new EntitySchema({
@@ -1901,16 +1832,15 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
 export class ProductSellers {
   [PrimaryKeyProp]?: ['seller', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   seller!: Ref<Sellers>;
   product!: Ref<Products>;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 }
 
 export const ProductSellersSchema = new EntitySchema({
@@ -1939,15 +1869,14 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
-  [OptionalProps]?: 'currentQuantity';
   productId!: number;
   name!: string;
   currentPrice!: string;
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
 }
 
 export const ProductsSchema = new EntitySchema({
@@ -1960,18 +1889,17 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
-  [OptionalProps]?: 'quantitySold';
   saleId!: number;
   country!: Ref<ProductCountryMap>;
   seller!: Ref<ProductSellers>;
   singularPrice!: string;
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 }
 
 export const SalesSchema = new EntitySchema({
@@ -2045,7 +1973,7 @@ export class Countries {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -2057,8 +1985,6 @@ export class ProductCountryMap {
 
   [PrimaryKeyProp]?: ['country', 'product'];
 
-  [OptionalProps]?: 'isCurrentlyAllowed';
-
   @ManyToOne({ entity: () => Countries, fieldName: 'country', primary: true })
   country!: Countries;
 
@@ -2066,14 +1992,14 @@ export class ProductCountryMap {
   product!: Products;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'country' })
   countryInverse = new Collection<Sales>(this);
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -2083,8 +2009,6 @@ export class ProductSellers {
 
   [PrimaryKeyProp]?: ['seller', 'product'];
 
-  [OptionalProps]?: 'isCurrentlyAllowed';
-
   @ManyToOne({ entity: () => Sellers, fieldName: 'seller_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   seller!: Sellers;
 
@@ -2092,22 +2016,20 @@ export class ProductSellers {
   product!: Products;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'seller' })
   sellerInverse = new Collection<Sales>(this);
 
 }
 ",
-  "import { Collection, Entity, OneToMany, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
 
 @Entity()
 export class Products {
 
   [PrimaryKeyProp]?: 'productId';
-
-  [OptionalProps]?: 'currentQuantity';
 
   @PrimaryKey()
   productId!: number;
@@ -2120,14 +2042,14 @@ export class Products {
   currentPrice!: string;
 
   @Property({ default: 0 })
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
 
   @OneToMany({ entity: () => ProductSellers, mappedBy: 'product' })
   productInverse = new Collection<ProductSellers>(this);
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -2136,8 +2058,6 @@ import { ProductSellers } from './ProductSellers';
 export class Sales {
 
   [PrimaryKeyProp]?: 'saleId';
-
-  [OptionalProps]?: 'quantitySold';
 
   @PrimaryKey()
   saleId!: number;
@@ -2152,7 +2072,7 @@ export class Sales {
   singularPrice!: string;
 
   @Property({ default: 1 })
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 
 }
 ",
@@ -2198,15 +2118,14 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Sales } from './Sales';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['country', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   country!: Countries;
   product!: Products;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
   countryInverse = new Collection<Sales>(this);
 }
 
@@ -2230,15 +2149,14 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Sales } from './Sales';
 
 export class ProductSellers {
   [PrimaryKeyProp]?: ['seller', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   seller!: Sellers;
   product!: Products;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
   sellerInverse = new Collection<Sales>(this);
 }
 
@@ -2267,16 +2185,15 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
-  [OptionalProps]?: 'currentQuantity';
   productId!: number;
   name!: string;
   currentPrice!: string;
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
   productInverse = new Collection<ProductSellers>(this);
 }
 
@@ -2291,16 +2208,15 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
-  [OptionalProps]?: 'quantitySold';
   saleId!: number;
   country!: ProductCountryMap;
   seller!: ProductSellers;
   singularPrice!: string;
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 }
 
 export const SalesSchema = new EntitySchema({
@@ -2375,7 +2291,7 @@ export class Countries {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, OptionalProps, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -2387,8 +2303,6 @@ export class ProductCountryMap {
 
   [PrimaryKeyProp]?: ['country', 'product'];
 
-  [OptionalProps]?: 'isCurrentlyAllowed';
-
   @ManyToOne({ entity: () => Countries, ref: true, fieldName: 'country', primary: true })
   country!: Ref<Countries>;
 
@@ -2396,14 +2310,14 @@ export class ProductCountryMap {
   product!: Ref<Products>;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'country' })
   countryInverse = new Collection<Sales>(this);
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, OptionalProps, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -2413,8 +2327,6 @@ export class ProductSellers {
 
   [PrimaryKeyProp]?: ['seller', 'product'];
 
-  [OptionalProps]?: 'isCurrentlyAllowed';
-
   @ManyToOne({ entity: () => Sellers, ref: true, fieldName: 'seller_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   seller!: Ref<Sellers>;
 
@@ -2422,22 +2334,20 @@ export class ProductSellers {
   product!: Ref<Products>;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'seller' })
   sellerInverse = new Collection<Sales>(this);
 
 }
 ",
-  "import { Collection, Entity, OneToMany, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
 
 @Entity()
 export class Products {
 
   [PrimaryKeyProp]?: 'productId';
-
-  [OptionalProps]?: 'currentQuantity';
 
   @PrimaryKey()
   productId!: number;
@@ -2450,14 +2360,14 @@ export class Products {
   currentPrice!: string;
 
   @Property({ default: 0 })
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
 
   @OneToMany({ entity: () => ProductSellers, mappedBy: 'product' })
   productInverse = new Collection<ProductSellers>(this);
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -2466,8 +2376,6 @@ import { ProductSellers } from './ProductSellers';
 export class Sales {
 
   [PrimaryKeyProp]?: 'saleId';
-
-  [OptionalProps]?: 'quantitySold';
 
   @PrimaryKey()
   saleId!: number;
@@ -2482,7 +2390,7 @@ export class Sales {
   singularPrice!: string;
 
   @Property({ default: 1 })
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 
 }
 ",
@@ -2528,17 +2436,16 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['country', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   country!: Ref<Countries>;
   product!: Ref<Products>;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
   countryInverse = new Collection<Sales>(this);
 }
 
@@ -2569,17 +2476,16 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
 
 export class ProductSellers {
   [PrimaryKeyProp]?: ['seller', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   seller!: Ref<Sellers>;
   product!: Ref<Products>;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
   sellerInverse = new Collection<Sales>(this);
 }
 
@@ -2610,16 +2516,15 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
-  [OptionalProps]?: 'currentQuantity';
   productId!: number;
   name!: string;
   currentPrice!: string;
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
   productInverse = new Collection<ProductSellers>(this);
 }
 
@@ -2634,18 +2539,17 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
-  [OptionalProps]?: 'quantitySold';
   saleId!: number;
   country!: Ref<ProductCountryMap>;
   seller!: Ref<ProductSellers>;
   singularPrice!: string;
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 }
 
 export const SalesSchema = new EntitySchema({
@@ -2718,7 +2622,7 @@ export class Countries {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
@@ -2729,8 +2633,6 @@ export class ProductCountryMap {
 
   [PrimaryKeyProp]?: ['country', 'product'];
 
-  [OptionalProps]?: 'isCurrentlyAllowed';
-
   @ManyToOne({ entity: () => Countries, fieldName: 'country', primary: true })
   country!: Countries;
 
@@ -2738,11 +2640,11 @@ export class ProductCountryMap {
   product!: Products;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -2751,8 +2653,6 @@ export class ProductSellers {
 
   [PrimaryKeyProp]?: ['seller', 'product'];
 
-  [OptionalProps]?: 'isCurrentlyAllowed';
-
   @ManyToOne({ entity: () => Sellers, fieldName: 'seller_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   seller!: Sellers;
 
@@ -2760,18 +2660,16 @@ export class ProductSellers {
   product!: Products;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
 }
 ",
-  "import { Entity, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 
 @Entity()
 export class Products {
 
   [PrimaryKeyProp]?: 'productId';
-
-  [OptionalProps]?: 'currentQuantity';
 
   @PrimaryKey()
   productId!: number;
@@ -2784,11 +2682,11 @@ export class Products {
   currentPrice!: string;
 
   @Property({ default: 0 })
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -2797,8 +2695,6 @@ import { ProductSellers } from './ProductSellers';
 export class Sales {
 
   [PrimaryKeyProp]?: 'saleId';
-
-  [OptionalProps]?: 'quantitySold';
 
   @PrimaryKey()
   saleId!: number;
@@ -2813,7 +2709,7 @@ export class Sales {
   singularPrice!: string;
 
   @Property({ default: 1 })
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 
 }
 ",
@@ -2852,14 +2748,13 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['country', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   country!: Countries;
   product!: Products;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 }
 
 export const ProductCountryMapSchema = new EntitySchema({
@@ -2881,14 +2776,13 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class ProductSellers {
   [PrimaryKeyProp]?: ['seller', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   seller!: Sellers;
   product!: Products;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 }
 
 export const ProductSellersSchema = new EntitySchema({
@@ -2915,15 +2809,14 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
-  [OptionalProps]?: 'currentQuantity';
   productId!: number;
   name!: string;
   currentPrice!: string;
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
 }
 
 export const ProductsSchema = new EntitySchema({
@@ -2936,16 +2829,15 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
-  [OptionalProps]?: 'quantitySold';
   saleId!: number;
   country!: ProductCountryMap;
   seller!: ProductSellers;
   singularPrice!: string;
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 }
 
 export const SalesSchema = new EntitySchema({
@@ -3013,7 +2905,7 @@ export class Countries {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
@@ -3024,8 +2916,6 @@ export class ProductCountryMap {
 
   [PrimaryKeyProp]?: ['country', 'product'];
 
-  [OptionalProps]?: 'isCurrentlyAllowed';
-
   @ManyToOne({ entity: () => Countries, ref: true, fieldName: 'country', primary: true })
   country!: Ref<Countries>;
 
@@ -3033,11 +2923,11 @@ export class ProductCountryMap {
   product!: Ref<Products>;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -3046,8 +2936,6 @@ export class ProductSellers {
 
   [PrimaryKeyProp]?: ['seller', 'product'];
 
-  [OptionalProps]?: 'isCurrentlyAllowed';
-
   @ManyToOne({ entity: () => Sellers, ref: true, fieldName: 'seller_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   seller!: Ref<Sellers>;
 
@@ -3055,18 +2943,16 @@ export class ProductSellers {
   product!: Ref<Products>;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
 }
 ",
-  "import { Entity, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 
 @Entity()
 export class Products {
 
   [PrimaryKeyProp]?: 'productId';
-
-  [OptionalProps]?: 'currentQuantity';
 
   @PrimaryKey()
   productId!: number;
@@ -3079,11 +2965,11 @@ export class Products {
   currentPrice!: string;
 
   @Property({ default: 0 })
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -3092,8 +2978,6 @@ import { ProductSellers } from './ProductSellers';
 export class Sales {
 
   [PrimaryKeyProp]?: 'saleId';
-
-  [OptionalProps]?: 'quantitySold';
 
   @PrimaryKey()
   saleId!: number;
@@ -3108,7 +2992,7 @@ export class Sales {
   singularPrice!: string;
 
   @Property({ default: 1 })
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 
 }
 ",
@@ -3147,16 +3031,15 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['country', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   country!: Ref<Countries>;
   product!: Ref<Products>;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 }
 
 export const ProductCountryMapSchema = new EntitySchema({
@@ -3185,16 +3068,15 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
 export class ProductSellers {
   [PrimaryKeyProp]?: ['seller', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   seller!: Ref<Sellers>;
   product!: Ref<Products>;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 }
 
 export const ProductSellersSchema = new EntitySchema({
@@ -3223,15 +3105,14 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
-  [OptionalProps]?: 'currentQuantity';
   productId!: number;
   name!: string;
   currentPrice!: string;
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
 }
 
 export const ProductsSchema = new EntitySchema({
@@ -3244,18 +3125,17 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
-  [OptionalProps]?: 'quantitySold';
   saleId!: number;
   country!: Ref<ProductCountryMap>;
   seller!: Ref<ProductSellers>;
   singularPrice!: string;
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 }
 
 export const SalesSchema = new EntitySchema({
@@ -3329,7 +3209,7 @@ export class Countries {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -3341,8 +3221,6 @@ export class ProductCountryMap {
 
   [PrimaryKeyProp]?: ['country', 'product'];
 
-  [OptionalProps]?: 'isCurrentlyAllowed';
-
   @ManyToOne({ entity: () => Countries, fieldName: 'country', primary: true })
   country!: Countries;
 
@@ -3350,14 +3228,14 @@ export class ProductCountryMap {
   product!: Products;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'country' })
   countryInverse = new Collection<Sales>(this);
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -3367,8 +3245,6 @@ export class ProductSellers {
 
   [PrimaryKeyProp]?: ['seller', 'product'];
 
-  [OptionalProps]?: 'isCurrentlyAllowed';
-
   @ManyToOne({ entity: () => Sellers, fieldName: 'seller_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   seller!: Sellers;
 
@@ -3376,22 +3252,20 @@ export class ProductSellers {
   product!: Products;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'seller' })
   sellerInverse = new Collection<Sales>(this);
 
 }
 ",
-  "import { Collection, Entity, OneToMany, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
 
 @Entity()
 export class Products {
 
   [PrimaryKeyProp]?: 'productId';
-
-  [OptionalProps]?: 'currentQuantity';
 
   @PrimaryKey()
   productId!: number;
@@ -3404,14 +3278,14 @@ export class Products {
   currentPrice!: string;
 
   @Property({ default: 0 })
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
 
   @OneToMany({ entity: () => ProductSellers, mappedBy: 'product' })
   productInverse = new Collection<ProductSellers>(this);
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -3420,8 +3294,6 @@ import { ProductSellers } from './ProductSellers';
 export class Sales {
 
   [PrimaryKeyProp]?: 'saleId';
-
-  [OptionalProps]?: 'quantitySold';
 
   @PrimaryKey()
   saleId!: number;
@@ -3436,7 +3308,7 @@ export class Sales {
   singularPrice!: string;
 
   @Property({ default: 1 })
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 
 }
 ",
@@ -3482,15 +3354,14 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Sales } from './Sales';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['country', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   country!: Countries;
   product!: Products;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
   countryInverse = new Collection<Sales>(this);
 }
 
@@ -3514,15 +3385,14 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Sales } from './Sales';
 
 export class ProductSellers {
   [PrimaryKeyProp]?: ['seller', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   seller!: Sellers;
   product!: Products;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
   sellerInverse = new Collection<Sales>(this);
 }
 
@@ -3551,16 +3421,15 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
-  [OptionalProps]?: 'currentQuantity';
   productId!: number;
   name!: string;
   currentPrice!: string;
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
   productInverse = new Collection<ProductSellers>(this);
 }
 
@@ -3575,16 +3444,15 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
-  [OptionalProps]?: 'quantitySold';
   saleId!: number;
   country!: ProductCountryMap;
   seller!: ProductSellers;
   singularPrice!: string;
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 }
 
 export const SalesSchema = new EntitySchema({
@@ -3659,7 +3527,7 @@ export class Countries {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, OptionalProps, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -3671,8 +3539,6 @@ export class ProductCountryMap {
 
   [PrimaryKeyProp]?: ['country', 'product'];
 
-  [OptionalProps]?: 'isCurrentlyAllowed';
-
   @ManyToOne({ entity: () => Countries, ref: true, fieldName: 'country', primary: true })
   country!: Ref<Countries>;
 
@@ -3680,14 +3546,14 @@ export class ProductCountryMap {
   product!: Ref<Products>;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'country' })
   countryInverse = new Collection<Sales>(this);
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, OptionalProps, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -3697,8 +3563,6 @@ export class ProductSellers {
 
   [PrimaryKeyProp]?: ['seller', 'product'];
 
-  [OptionalProps]?: 'isCurrentlyAllowed';
-
   @ManyToOne({ entity: () => Sellers, ref: true, fieldName: 'seller_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   seller!: Ref<Sellers>;
 
@@ -3706,22 +3570,20 @@ export class ProductSellers {
   product!: Ref<Products>;
 
   @Property({ default: false })
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'seller' })
   sellerInverse = new Collection<Sales>(this);
 
 }
 ",
-  "import { Collection, Entity, OneToMany, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
 
 @Entity()
 export class Products {
 
   [PrimaryKeyProp]?: 'productId';
-
-  [OptionalProps]?: 'currentQuantity';
 
   @PrimaryKey()
   productId!: number;
@@ -3734,14 +3596,14 @@ export class Products {
   currentPrice!: string;
 
   @Property({ default: 0 })
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
 
   @OneToMany({ entity: () => ProductSellers, mappedBy: 'product' })
   productInverse = new Collection<ProductSellers>(this);
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -3750,8 +3612,6 @@ import { ProductSellers } from './ProductSellers';
 export class Sales {
 
   [PrimaryKeyProp]?: 'saleId';
-
-  [OptionalProps]?: 'quantitySold';
 
   @PrimaryKey()
   saleId!: number;
@@ -3766,7 +3626,7 @@ export class Sales {
   singularPrice!: string;
 
   @Property({ default: 1 })
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 
 }
 ",
@@ -3812,17 +3672,16 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['country', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   country!: Ref<Countries>;
   product!: Ref<Products>;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
   countryInverse = new Collection<Sales>(this);
 }
 
@@ -3853,17 +3712,16 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
 
 export class ProductSellers {
   [PrimaryKeyProp]?: ['seller', 'product'];
-  [OptionalProps]?: 'isCurrentlyAllowed';
   seller!: Ref<Sellers>;
   product!: Ref<Products>;
-  isCurrentlyAllowed: boolean = false;
+  isCurrentlyAllowed: boolean & Opt = false;
   sellerInverse = new Collection<Sales>(this);
 }
 
@@ -3894,16 +3752,15 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, OptionalProps, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
-  [OptionalProps]?: 'currentQuantity';
   productId!: number;
   name!: string;
   currentPrice!: string;
-  currentQuantity: number = 0;
+  currentQuantity: number & Opt = 0;
   productInverse = new Collection<ProductSellers>(this);
 }
 
@@ -3918,18 +3775,17 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, OptionalProps, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
-  [OptionalProps]?: 'quantitySold';
   saleId!: number;
   country!: Ref<ProductCountryMap>;
   seller!: Ref<ProductSellers>;
   singularPrice!: string;
-  quantitySold: number = 1;
+  quantitySold: number & Opt = 1;
 }
 
 export const SalesSchema = new EntitySchema({

--- a/tests/features/entity-generator/__snapshots__/ScalarPropsForFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/ScalarPropsForFks.mysql.test.ts.snap
@@ -21,7 +21,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -29,16 +29,14 @@ import { Book2 } from './Book2';
 @Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
 export class Author2 {
 
-  [OptionalProps]?: 'createdAt' | 'termsAccepted' | 'updatedAt';
-
   @PrimaryKey()
   id!: number;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  updatedAt!: Date;
+  updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
   @Property({ length: 255 })
@@ -54,7 +52,7 @@ export class Author2 {
 
   @Index({ name: 'author2_terms_accepted_index' })
   @Property({ default: false })
-  termsAccepted: boolean = false;
+  termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
   optional?: boolean;
@@ -158,7 +156,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -168,13 +166,11 @@ export class Book2 {
 
   [PrimaryKeyProp]?: 'uuidPk';
 
-  [OptionalProps]?: 'createdAt';
-
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
   @Property({ length: 255, nullable: true })
@@ -318,13 +314,11 @@ export class Dummy2 {
 
 }
 ",
-  "import { Entity, OneToOne, OptionalProps, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, OneToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 @Entity()
 export class FooBar2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -350,7 +344,7 @@ export class FooBar2 {
   fooBarId?: number;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  version!: Date;
+  version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
   blob?: Buffer;
@@ -366,12 +360,10 @@ export class FooBar2 {
 
 }
 ",
-  "import { Entity, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class FooBaz2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -380,11 +372,11 @@ export class FooBaz2 {
   name!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
 }
 ",
-  "import { Entity, Index, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -392,8 +384,6 @@ import { FooBaz2 } from './FooBaz2';
 export class FooParam2 {
 
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  [OptionalProps]?: 'version';
 
   @ManyToOne({ entity: () => FooBar2, updateRule: 'cascade', primary: true })
   bar!: FooBar2;
@@ -413,28 +403,26 @@ export class FooParam2 {
   value!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
 }
 ",
-  "import { Entity, Enum, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Publisher2 {
-
-  [OptionalProps]?: 'name' | 'type' | 'type2';
 
   @PrimaryKey()
   id!: number;
 
   @Property({ length: 255, default: 'asd' })
-  name!: string;
+  name!: string & Opt;
 
   @Enum({ items: () => Publisher2Type, default: 'local' })
-  type: Publisher2Type = Publisher2Type.LOCAL;
+  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
   @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
-  type2: Publisher2Type2 = Publisher2Type2.LOCAL;
+  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
   enum1?: number;
@@ -515,14 +503,12 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToOne, OptionalProps, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
 @Entity()
 export class Test2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -545,7 +531,7 @@ export class Test2 {
   parentId?: number;
 
   @Property({ default: 1 })
-  version: number = 1;
+  version: number & Opt = 1;
 
   @Unique({ name: 'test2_foo___bar_unique' })
   @Property({ fieldName: 'foo___bar', nullable: true, persist: false })
@@ -618,7 +604,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -626,16 +612,14 @@ import { Book2 } from './Book2';
 @Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
 export class Author2 {
 
-  [OptionalProps]?: 'createdAt' | 'termsAccepted' | 'updatedAt';
-
   @PrimaryKey()
   id!: number;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  updatedAt!: Date;
+  updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
   @Property({ length: 255 })
@@ -651,7 +635,7 @@ export class Author2 {
 
   @Index({ name: 'author2_terms_accepted_index' })
   @Property({ default: false })
-  termsAccepted: boolean = false;
+  termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
   optional?: boolean;
@@ -739,7 +723,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -749,13 +733,11 @@ export class Book2 {
 
   [PrimaryKeyProp]?: 'uuidPk';
 
-  [OptionalProps]?: 'createdAt';
-
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
   @Property({ length: 255, nullable: true })
@@ -873,13 +855,11 @@ export class Dummy2 {
 
 }
 ",
-  "import { Entity, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 @Entity()
 export class FooBar2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -897,7 +877,7 @@ export class FooBar2 {
   fooBar?: FooBar2;
 
   @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
-  version!: Date;
+  version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
   blob?: Buffer;
@@ -913,12 +893,10 @@ export class FooBar2 {
 
 }
 ",
-  "import { Entity, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class FooBaz2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -927,11 +905,11 @@ export class FooBaz2 {
   name!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, OptionalProps, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -939,8 +917,6 @@ import { FooBaz2 } from './FooBaz2';
 export class FooParam2 {
 
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  [OptionalProps]?: 'version';
 
   @ManyToOne({ entity: () => FooBar2, updateRule: 'cascade', primary: true })
   bar!: FooBar2;
@@ -952,28 +928,26 @@ export class FooParam2 {
   value!: string;
 
   @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
-  version!: Date;
+  version!: Date & Opt;
 
 }
 ",
-  "import { Entity, Enum, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Publisher2 {
-
-  [OptionalProps]?: 'name' | 'type' | 'type2';
 
   @PrimaryKey()
   id!: number;
 
   @Property({ length: 255, default: 'asd' })
-  name!: string;
+  name!: string & Opt;
 
   @Enum({ items: () => Publisher2Type, default: 'local' })
-  type: Publisher2Type = Publisher2Type.LOCAL;
+  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
   @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
-  type2: Publisher2Type2 = Publisher2Type2.LOCAL;
+  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
   enum1?: number;
@@ -1046,14 +1020,12 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, OptionalProps, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
 @Entity()
 export class Test2 {
-
-  [OptionalProps]?: 'version';
 
   @PrimaryKey()
   id!: number;
@@ -1068,7 +1040,7 @@ export class Test2 {
   parent?: Test2;
 
   @Property({ default: 1 })
-  version: number = 1;
+  version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;

--- a/tests/features/entity-generator/__snapshots__/TypesForScalarDecorators.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/TypesForScalarDecorators.mysql.test.ts.snap
@@ -2,14 +2,12 @@
 
 exports[`TypesForScalarDecorators: dump 1`] = `
 [
-  "import { Entity, OptionalProps, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Users {
 
   [PrimaryKeyProp]?: 'userId';
-
-  [OptionalProps]?: 'createdAt';
 
   @PrimaryKey({ type: 'number' })
   userId!: number;
@@ -24,7 +22,7 @@ export class Users {
   enabled!: boolean;
 
   @Property({ length: 0, type: 'Date', defaultRaw: \`CURRENT_TIMESTAMP\` })
-  createdAt!: Date;
+  createdAt!: Date & Opt;
 
 }
 ",


### PR DESCRIPTION
As mentioned we should do in #5113 , but left it for a separate PR due to the increase in scope.

Pretty much all entity generator snapshots are affected, since most schemas have some form of an optional property involved.

I also adjusted the meta data post processing test to have one property that is both hidden and optional, to ensure the combination of the two is outputted fine too.