### PR TITLE
feat(entity-generator): support functions in extension hooks

### DIFF
--- a/packages/entity-generator/src/EntitySchemaSourceFile.ts
+++ b/packages/entity-generator/src/EntitySchemaSourceFile.ts
@@ -71,7 +71,7 @@ export class EntitySchemaSourceFile extends SourceFile {
     ret += `export const ${this.meta.className}Schema = new EntitySchema({\n`;
     ret += `  class: ${this.meta.className},\n`;
 
-    if (this.meta.tableName !== this.namingStrategy.classToTableName(this.meta.className)) {
+    if (this.meta.tableName && this.meta.tableName !== this.namingStrategy.classToTableName(this.meta.className)) {
       ret += `  tableName: ${this.quote(this.meta.tableName)},\n`;
     }
 
@@ -149,6 +149,10 @@ export class EntitySchemaSourceFile extends SourceFile {
     if (prop.enum) {
       options.enum = true;
       options.items = `() => ${prop.type}`;
+    }
+
+    if (prop.formula) {
+      options.formula = `${prop.formula}`;
     }
 
     this.getCommonDecoratorOptions(options, prop);

--- a/tests/features/entity-generator/MetadataHooks.mysql.test.ts
+++ b/tests/features/entity-generator/MetadataHooks.mysql.test.ts
@@ -1,5 +1,6 @@
 import { Cascade, EntityMetadata, GenerateOptions, Platform, ReferenceKind, MetadataProcessor } from '@mikro-orm/core';
 import { initORMMySql } from '../../bootstrap';
+import { Author2 } from '../../entities-sql';
 
 const initialMetadataProcessor: MetadataProcessor = (metadata, platform) => {
   expect(platform).toBeInstanceOf(Platform);
@@ -18,15 +19,24 @@ const initialMetadataProcessor: MetadataProcessor = (metadata, platform) => {
 
     if (entity.className === 'BaseUser2') {
       entity.abstract = true;
+      entity.extends = 'CustomBase2';
       entity.discriminatorColumn = 'type';
       entity.discriminatorMap = {
-        employee: "'Employee2'",
-        manager: "'Manager2'",
+        employee: 'Employee2',
+        manager: 'Manager2',
       };
     }
 
     if (entity.className === 'Author2') {
       entity.readonly = true;
+      entity.addProperty({
+        name: 'secondsSinceLastModified',
+        fieldNames: [platform.getConfig().getNamingStrategy().propertyToColumnName('secondsSinceLastModified')],
+        columnTypes: ['int'],
+        type: 'number',
+        lazy: true,
+        formula: alias => `TIMESTAMPDIFF(SECONDS, NOW(), ${alias}.updated_at)`,
+      });
       Object.entries(entity.properties).forEach(propEntry => {
         const [propName, propOptions] = propEntry;
         expect(propOptions.kind).not.toBe(ReferenceKind.MANY_TO_MANY);
@@ -64,14 +74,35 @@ const initialMetadataProcessor: MetadataProcessor = (metadata, platform) => {
     className: 'AuthorPartialView',
     collection: platform.getConfig().getNamingStrategy().classToTableName('AuthorPartialView'),
     virtual: true,
-    expression: '"SELECT name, email FROM author2"',
-    comment: "'test'",
+    expression: 'SELECT name, email FROM author2',
+    comment: 'test',
   });
   const nameProp = virtualEntityBase.props.find(prop => prop.name === 'name')!;
-  nameProp.comment = "'author name'";
+  nameProp.comment = 'author name';
   virtualEntityMeta.addProperty(nameProp);
   virtualEntityMeta.addProperty(virtualEntityBase.props.find(prop => prop.name === 'email')!);
   metadata.push(virtualEntityMeta);
+
+  const virtualEntityMeta2 = new EntityMetadata<any>({
+    className: 'AuthorPartialView2',
+    collection: platform.getConfig().getNamingStrategy().classToTableName('AuthorPartialView'),
+    virtual: true,
+    expression: (em: typeof orm.em) => em.createQueryBuilder<Author2>('Author2').select(['name', 'email']),
+    comment: 'test',
+  });
+  const nameProp2 = Object.assign({}, virtualEntityBase.props.find(prop => prop.name === 'name')!);
+  nameProp2.comment = 'author name also';
+  nameProp2.onUpdate = owner => { owner.name += ' also'; };
+  virtualEntityMeta2.addProperty(nameProp2);
+  const emailProp2 = Object.assign({}, virtualEntityBase.props.find(prop => prop.name === 'email')!);
+  emailProp2.serializer = (email: string) => {
+    const [localPart, hostnamePart] = email.split('@', 2);
+    return `${localPart[0]}${'*'.repeat(localPart.length - 2)}${localPart[localPart.length - 1]}@${hostnamePart}`;
+  };
+  emailProp2.hidden = false;
+  emailProp2.serializedName = 'anonymizedEmail';
+  virtualEntityMeta2.addProperty(emailProp2);
+  metadata.push(virtualEntityMeta2);
 
   const embeddableEntityMeta = new EntityMetadata({
     className: 'IdentitiesContainer',
@@ -122,12 +153,19 @@ const initialMetadataProcessor: MetadataProcessor = (metadata, platform) => {
     virtual: true,
     relations: [],
   });
-  metadata.push(companyOwner2def);
+
+  const customBase2 = new EntityMetadata({
+    className: 'CustomBase2',
+    abstract: true,
+    virtual: true,
+    relations: [],
+  });
+  metadata.push(customBase2);
 };
 
 const processedMetadataProcessor: GenerateOptions['onProcessedMetadata'] = (metadata, platform) => {
   metadata.forEach(entity => {
-    if (['AuthorPartialView', 'Employee2', 'Manager2', 'CompanyOwner2'].includes(entity.className)) {
+    if (['AuthorPartialView', 'AuthorPartialView2', 'CustomBase2', 'Employee2', 'Manager2', 'CompanyOwner2'].includes(entity.className)) {
       expect(entity.virtual).toBe(true);
     } else if (entity.className === 'IdentitiesContainer') {
       expect(entity.embeddable).toBe(true);

--- a/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
@@ -18,7 +18,7 @@ export class Address2 {
 
 }
 ",
-  "import { Cascade, Collection, EagerProps, Embedded, Entity, Hidden, Index, ManyToMany, ManyToOne, OneToMany, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Cascade, Collection, EagerProps, Embedded, Entity, Formula, Hidden, Index, ManyToMany, ManyToOne, OneToMany, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { IdentitiesContainer } from './IdentitiesContainer';
 
@@ -77,6 +77,9 @@ export class Author2 {
   @Embedded({ entity: () => IdentitiesContainer, array: true, object: true, prefix: false, nullable: true })
   identity?: IdentitiesContainer[];
 
+  @Formula(alias => \`TIMESTAMPDIFF(SECONDS, NOW(), \${alias}.updated_at)\`, { lazy: true })
+  secondsSinceLastModified!: number;
+
   @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id', hidden: true })
   authorToFriend: Collection<Author2> & Hidden = new Collection<Author2>(this);
 
@@ -98,9 +101,10 @@ export class Author2 {
 }
 ",
   "import { Collection, Entity, Enum, Index, ManyToOne, OneToMany, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+import { CustomBase2 } from './CustomBase2';
 
 @Entity({ abstract: true, discriminatorColumn: 'type', discriminatorMap: { employee: 'Employee2', manager: 'Manager2' } })
-export abstract class BaseUser2 {
+export abstract class BaseUser2 extends CustomBase2 {
 
   @PrimaryKey()
   id!: number;
@@ -587,7 +591,7 @@ export class User2 {
 ",
   "import { Entity, Hidden, Index, Property, Unique } from '@mikro-orm/core';
 
-@Entity({ expression: "SELECT name, email FROM author2", comment: 'test', virtual: true })
+@Entity({ expression: 'SELECT name, email FROM author2', comment: 'test', virtual: true })
 export class AuthorPartialView {
 
   @Index({ name: 'custom_idx_name_123' })
@@ -598,6 +602,25 @@ export class AuthorPartialView {
   @Unique({ name: 'custom_email_unique_name' })
   @Property({ length: 255, hidden: true })
   email!: string & Hidden;
+
+}
+",
+  "import { Entity, Index, Property, Unique } from '@mikro-orm/core';
+
+@Entity({ tableName: 'author_partial_view', expression: (em) => em.createQueryBuilder('Author2').select(['name', 'email']), comment: 'test', virtual: true })
+export class AuthorPartialView2 {
+
+  @Index({ name: 'custom_idx_name_123' })
+  @Property({ length: 255, onUpdate: owner => { owner.name += ' also'; }, comment: 'author name also' })
+  name!: string;
+
+  @Index({ name: 'custom_email_index_name' })
+  @Unique({ name: 'custom_email_unique_name' })
+  @Property({ length: 255, serializer: (email) => {
+        const [localPart, hostnamePart] = email.split('@', 2);
+        return \`\${localPart[0]}\${'*'.repeat(localPart.length - 2)}\${localPart[localPart.length - 1]}@\${hostnamePart}\`;
+    }, serializedName: 'anonymizedEmail' })
+  email!: string;
 
 }
 ",
@@ -628,11 +651,9 @@ import { BaseUser2 } from './BaseUser2';
 export class Manager2 extends BaseUser2 {
 }
 ",
-  "import { Entity } from '@mikro-orm/core';
-import { BaseUser2 } from './BaseUser2';
+  "
 
-@Entity({ virtual: true, discriminatorValue: 'owner' })
-export class CompanyOwner2 extends BaseUser2 {
+export abstract class CustomBase2 {
 }
 ",
 ]
@@ -681,6 +702,7 @@ export class Author2 {
   favouriteBook?: Book2;
   favouriteAuthor?: Author2;
   identity?: IdentitiesContainer[];
+  secondsSinceLastModified!: number;
   authorToFriend: Collection<Author2> & Hidden = new Collection<Author2>(this);
   following = new Collection<Author2>(this);
   authorInverse = new Collection<Book2>(this);
@@ -753,6 +775,10 @@ export const Author2Schema = new EntitySchema({
       prefix: false,
       nullable: true,
     },
+    secondsSinceLastModified: {
+      formula: alias => \`TIMESTAMPDIFF(SECONDS, NOW(), \${alias}.updated_at)\`,
+      lazy: true,
+    },
     authorToFriend: {
       kind: 'm:n',
       entity: () => Author2,
@@ -775,8 +801,9 @@ export const Author2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema } from '@mikro-orm/core';
+import { CustomBase2 } from './CustomBase2';
 
-export abstract class BaseUser2 {
+export abstract class BaseUser2 extends CustomBase2 {
   id!: number;
   firstName!: string;
   lastName!: string;
@@ -1322,6 +1349,38 @@ export const AuthorPartialViewSchema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 
+export class AuthorPartialView2 {
+  name!: string;
+  email!: string;
+}
+
+export const AuthorPartialView2Schema = new EntitySchema({
+  class: AuthorPartialView2,
+  tableName: 'author_partial_view',
+  properties: {
+    name: {
+      type: 'string',
+      length: 255,
+      onUpdate: owner => { owner.name += ' also'; },
+      comment: 'author name also',
+      index: 'custom_idx_name_123',
+    },
+    email: {
+      type: 'string',
+      length: 255,
+      serializer: (email) => {
+        const [localPart, hostnamePart] = email.split('@', 2);
+        return \`\${localPart[0]}\${'*'.repeat(localPart.length - 2)}\${localPart[localPart.length - 1]}@\${hostnamePart}\`;
+    },
+      serializedName: 'anonymizedEmail',
+      index: 'custom_email_index_name',
+      unique: 'custom_email_unique_name',
+    },
+  },
+});
+",
+  "import { EntitySchema } from '@mikro-orm/core';
+
 export class IdentitiesContainer {
   github!: string;
   local!: number;
@@ -1360,13 +1419,12 @@ export const Manager2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema } from '@mikro-orm/core';
-import { BaseUser2 } from './BaseUser2';
 
-export class CompanyOwner2 extends BaseUser2 {
+export abstract class CustomBase2 {
 }
 
-export const CompanyOwner2Schema = new EntitySchema({
-  class: CompanyOwner2,
+export const CustomBase2Schema = new EntitySchema({
+  class: CustomBase2,
   properties: {
   },
 });


### PR DESCRIPTION
If a function is provided, its toString() representation (its source) will be put in the generated file.
Support spots for functions include
- onCreate
- onUpdate
- serializer
- expression in virtual entities

Also added support for the `@Formula` decorator (used whenever a "formula" option is included).

Simplified meta data edits to not use quotes in places where only string types are expected, such as comment, expression (as string) and STI values.


----

btw, I tried to push this branch to this repo instead of my fork, but I got 403. Seems I have no permissions to push new branches (or at all?) 😕 