### PR TITLE
test(docs): made the tests workflow build a more restricted set of versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,6 +78,7 @@ jobs:
         run: |
           cd docs
           yarn
+          export MIKRO_ORM_DOCS_TESTING=1
           yarn build
 
   lint:

--- a/docs/src/pages/versions.js
+++ b/docs/src/pages/versions.js
@@ -20,7 +20,11 @@ function Version() {
   const context = useDocusaurusContext();
   const { siteConfig = {} } = context;
   const latestVersion = [versions[0], pkg.version];
-  const pastVersions = versions.filter(version => version !== versions[0]).map(v => [v, v + '.0']);
+  /** @type {string[]|undefined} */
+  const includedVersions = siteConfig.presets[0][1].docs.onlyIncludeVersions;
+  const pastVersions = versions
+    .filter(version => version !== versions[0] && (!includedVersions || includedVersions.includes(version)))
+    .map(v => [v, v + '.0']);
   const repoUrl = `https://github.com/${siteConfig.organizationName}/${siteConfig.projectName}`;
   const link = (to, version) => {
     const useQuickStart = ['next', 'latest'].includes(version) || +version >= 6;


### PR DESCRIPTION
Only build the earliest and latest versions, plus the current docs, and any version mentioned in the footer (currently 5.9).

This shaves off around 2 minutes from any build,
while still ensuring that no breaking changes are accidentally introduced.

Full deploys of the docs (the docs workflow) still builds all versions, as would any local build without the newly introduced "MIKRO_ORM_DOCS_TESTING" environment variable.

---

I wasn't sure whether to include this in my last PR, so here it is separately. IMO, the trade off of not building all versions is worth it.