### PR TITLE
fix(entity-generator): optional and hidden properties get type option + string defaults

### DIFF
--- a/packages/mariadb/src/MariaDbSchemaHelper.ts
+++ b/packages/mariadb/src/MariaDbSchemaHelper.ts
@@ -105,7 +105,12 @@ export class MariaDbSchemaHelper extends SchemaHelper {
 
     for (const col of allColumns) {
       const mappedType = this.platform.getMappedType(col.column_type);
-      const tmp = this.normalizeDefaultValue(col.column_default, col.length);
+      const tmp = this.normalizeDefaultValue(
+        (mappedType.compareAsType() === 'boolean' && ['0', '1'].includes(col.column_default))
+          ? ['false', 'true'][+col.column_default]
+          : col.column_default,
+        col.length,
+      );
       const defaultValue = str(tmp === 'NULL' && col.is_nullable === 'YES' ? null : tmp);
       const key = this.getTableKey(col);
       const generated = col.generation_expression ? `${col.generation_expression} ${col.extra.match(/stored generated/i) ? 'stored' : 'virtual'}` : undefined;

--- a/packages/mysql/src/MySqlSchemaHelper.ts
+++ b/packages/mysql/src/MySqlSchemaHelper.ts
@@ -113,7 +113,12 @@ export class MySqlSchemaHelper extends SchemaHelper {
 
     for (const col of allColumns) {
       const mappedType = this.platform.getMappedType(col.column_type);
-      const defaultValue = str(this.normalizeDefaultValue(col.column_default, col.length));
+      const defaultValue = str(this.normalizeDefaultValue(
+        (mappedType.compareAsType() === 'boolean' && ['0', '1'].includes(col.column_default))
+          ? ['false', 'true'][+col.column_default]
+          : col.column_default,
+        col.length,
+      ));
       const key = this.getTableKey(col);
       const generated = col.generation_expression ? `${col.generation_expression} ${col.extra.match(/stored generated/i) ? 'stored' : 'virtual'}` : undefined;
       ret[key] ??= [];

--- a/tests/features/entity-generator/EntityGenerator.postgres.test.ts
+++ b/tests/features/entity-generator/EntityGenerator.postgres.test.ts
@@ -26,7 +26,7 @@ describe('EntityGenerator', () => {
           type: 'varchar(50)',
           maxLength: 50,
           nullable: true,
-          default: 'foo',
+          default: `'foo'`,
           indexes: [],
         },
       },
@@ -35,9 +35,11 @@ describe('EntityGenerator', () => {
     const helper = orm.em.getDriver().getPlatform().getSchemaHelper()!;
     const meta = table.getEntityDeclaration(orm.config.getNamingStrategy(), helper, orm.config.get('entityGenerator').scalarPropertiesForRelations!);
     expect(meta.properties.name.default).toBeUndefined();
+    expect(meta.properties.name.defaultRaw).toBeUndefined();
     expect(meta.properties.name.nullable).toBe(true);
     expect(meta.properties.name.columnTypes[0]).toBe('varchar(50)');
     expect(meta.properties.test.default).toBe('foo');
+    expect(meta.properties.test.defaultRaw).toBe(`'foo'`);
     expect(meta.properties.test.nullable).toBe(true);
     expect(meta.properties.test.columnTypes[0]).toBe('varchar(50)');
 

--- a/tests/features/entity-generator/__snapshots__/CustomBase.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/CustomBase.mysql.test.ts.snap
@@ -29,10 +29,10 @@ export class Author2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -48,7 +48,7 @@ export class Author2 {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -150,7 +150,7 @@ export class Book2 {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -175,8 +175,8 @@ export class Book2 {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -290,7 +290,7 @@ export class FooBar2 {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -318,7 +318,7 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -341,7 +341,7 @@ export class FooParam2 {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -354,13 +354,13 @@ export class Publisher2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -453,7 +453,7 @@ export class Test2 {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -564,7 +564,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true },
-    termsAccepted: { type: 'boolean', default: false, index: 'author2_terms_accepted_index' },
+    termsAccepted: { type: 'boolean', index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -675,7 +675,7 @@ export class Book2 {
   meta?: any;
   author!: Author2;
   publisher?: Publisher2;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
 }
 
@@ -697,7 +697,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -887,7 +887,7 @@ export const FooParam2Schema = new EntitySchema({
 
 export class Publisher2 {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -921,9 +921,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -1004,7 +1004,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', default: 1 },
+    version: { type: 'number' },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,
@@ -1099,10 +1099,10 @@ export class Author2 extends BaseEntity {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -1118,7 +1118,7 @@ export class Author2 extends BaseEntity {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -1223,7 +1223,7 @@ export class Book2 extends BaseEntity {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -1248,8 +1248,8 @@ export class Book2 extends BaseEntity {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -1369,7 +1369,7 @@ export class FooBar2 extends BaseEntity {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -1398,7 +1398,7 @@ export class FooBaz2 extends BaseEntity {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -1422,7 +1422,7 @@ export class FooParam2 extends BaseEntity {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -1436,13 +1436,13 @@ export class Publisher2 extends BaseEntity {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -1538,7 +1538,7 @@ export class Test2 extends BaseEntity {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -1660,7 +1660,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true },
-    termsAccepted: { type: 'boolean', default: false, index: 'author2_terms_accepted_index' },
+    termsAccepted: { type: 'boolean', index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -1774,7 +1774,7 @@ export class Book2 extends BaseEntity {
   meta?: any;
   author!: Author2;
   publisher?: Publisher2;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
 }
 
@@ -1796,7 +1796,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -1995,7 +1995,7 @@ import { BaseEntity } from './BaseEntity';
 
 export class Publisher2 extends BaseEntity {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -2029,9 +2029,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -2115,7 +2115,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', default: 1 },
+    version: { type: 'number' },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,
@@ -2223,10 +2223,10 @@ export class Author2 extends BaseUser2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -2242,7 +2242,7 @@ export class Author2 extends BaseUser2 {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -2349,7 +2349,7 @@ export class Book2 extends BaseUser2 {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -2374,8 +2374,8 @@ export class Book2 extends BaseUser2 {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -2495,7 +2495,7 @@ export class FooBar2 extends BaseUser2 {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -2524,7 +2524,7 @@ export class FooBaz2 extends BaseUser2 {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -2548,7 +2548,7 @@ export class FooParam2 extends BaseUser2 {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -2562,13 +2562,13 @@ export class Publisher2 extends BaseUser2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -2664,7 +2664,7 @@ export class Test2 extends BaseUser2 {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -2778,7 +2778,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true },
-    termsAccepted: { type: 'boolean', default: false, index: 'author2_terms_accepted_index' },
+    termsAccepted: { type: 'boolean', index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -2892,7 +2892,7 @@ export class Book2 extends BaseUser2 {
   meta?: any;
   author!: Author2;
   publisher?: Publisher2;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
 }
 
@@ -2914,7 +2914,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -3113,7 +3113,7 @@ import { BaseUser2 } from './BaseUser2';
 
 export class Publisher2 extends BaseUser2 {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -3147,9 +3147,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -3233,7 +3233,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', default: 1 },
+    version: { type: 'number' },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,
@@ -3329,10 +3329,10 @@ export class Author2 extends CustomBase {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -3348,7 +3348,7 @@ export class Author2 extends CustomBase {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -3453,7 +3453,7 @@ export class Book2 extends CustomBase {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -3478,8 +3478,8 @@ export class Book2 extends CustomBase {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -3599,7 +3599,7 @@ export class FooBar2 extends CustomBase {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -3628,7 +3628,7 @@ export class FooBaz2 extends CustomBase {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -3652,7 +3652,7 @@ export class FooParam2 extends CustomBase {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -3666,13 +3666,13 @@ export class Publisher2 extends CustomBase {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -3768,7 +3768,7 @@ export class Test2 extends CustomBase {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -3890,7 +3890,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true },
-    termsAccepted: { type: 'boolean', default: false, index: 'author2_terms_accepted_index' },
+    termsAccepted: { type: 'boolean', index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -4004,7 +4004,7 @@ export class Book2 extends CustomBase {
   meta?: any;
   author!: Author2;
   publisher?: Publisher2;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
 }
 
@@ -4026,7 +4026,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -4225,7 +4225,7 @@ import { CustomBase } from './CustomBase';
 
 export class Publisher2 extends CustomBase {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -4259,9 +4259,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -4345,7 +4345,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', default: 1 },
+    version: { type: 'number' },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,
@@ -4451,10 +4451,10 @@ export class Author2 extends BaseEntity {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -4470,7 +4470,7 @@ export class Author2 extends BaseEntity {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -4572,7 +4572,7 @@ export class Book2 extends BaseEntity {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -4597,8 +4597,8 @@ export class Book2 extends BaseEntity {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -4712,7 +4712,7 @@ export class FooBar2 extends BaseEntity {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -4740,7 +4740,7 @@ export class FooBaz2 extends BaseEntity {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -4763,7 +4763,7 @@ export class FooParam2 extends BaseEntity {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -4776,13 +4776,13 @@ export class Publisher2 extends BaseEntity {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -4875,7 +4875,7 @@ export class Test2 extends BaseEntity {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -4986,7 +4986,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true },
-    termsAccepted: { type: 'boolean', default: false, index: 'author2_terms_accepted_index' },
+    termsAccepted: { type: 'boolean', index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -5097,7 +5097,7 @@ export class Book2 extends BaseEntity {
   meta?: any;
   author!: Author2;
   publisher?: Publisher2;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
 }
 
@@ -5119,7 +5119,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -5309,7 +5309,7 @@ export const FooParam2Schema = new EntitySchema({
 
 export class Publisher2 extends BaseEntity {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -5343,9 +5343,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -5426,7 +5426,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', default: 1 },
+    version: { type: 'number' },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,
@@ -5521,10 +5521,10 @@ export class Author2 extends BaseEntity {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -5540,7 +5540,7 @@ export class Author2 extends BaseEntity {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -5645,7 +5645,7 @@ export class Book2 extends BaseEntity {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -5670,8 +5670,8 @@ export class Book2 extends BaseEntity {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -5791,7 +5791,7 @@ export class FooBar2 extends BaseEntity {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -5820,7 +5820,7 @@ export class FooBaz2 extends BaseEntity {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -5844,7 +5844,7 @@ export class FooParam2 extends BaseEntity {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -5858,13 +5858,13 @@ export class Publisher2 extends BaseEntity {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -5960,7 +5960,7 @@ export class Test2 extends BaseEntity {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -6082,7 +6082,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true },
-    termsAccepted: { type: 'boolean', default: false, index: 'author2_terms_accepted_index' },
+    termsAccepted: { type: 'boolean', index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -6196,7 +6196,7 @@ export class Book2 extends BaseEntity {
   meta?: any;
   author!: Author2;
   publisher?: Publisher2;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
 }
 
@@ -6218,7 +6218,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -6417,7 +6417,7 @@ import { BaseEntity } from './BaseEntity';
 
 export class Publisher2 extends BaseEntity {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -6451,9 +6451,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -6537,7 +6537,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', default: 1 },
+    version: { type: 'number' },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,
@@ -6645,10 +6645,10 @@ export class Author2 extends BaseUser2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -6664,7 +6664,7 @@ export class Author2 extends BaseUser2 {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -6771,7 +6771,7 @@ export class Book2 extends BaseUser2 {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -6796,8 +6796,8 @@ export class Book2 extends BaseUser2 {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -6917,7 +6917,7 @@ export class FooBar2 extends BaseUser2 {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -6946,7 +6946,7 @@ export class FooBaz2 extends BaseUser2 {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -6970,7 +6970,7 @@ export class FooParam2 extends BaseUser2 {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -6984,13 +6984,13 @@ export class Publisher2 extends BaseUser2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -7086,7 +7086,7 @@ export class Test2 extends BaseUser2 {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -7200,7 +7200,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true },
-    termsAccepted: { type: 'boolean', default: false, index: 'author2_terms_accepted_index' },
+    termsAccepted: { type: 'boolean', index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -7314,7 +7314,7 @@ export class Book2 extends BaseUser2 {
   meta?: any;
   author!: Author2;
   publisher?: Publisher2;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
 }
 
@@ -7336,7 +7336,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -7535,7 +7535,7 @@ import { BaseUser2 } from './BaseUser2';
 
 export class Publisher2 extends BaseUser2 {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -7569,9 +7569,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -7655,7 +7655,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', default: 1 },
+    version: { type: 'number' },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,
@@ -7751,10 +7751,10 @@ export class Author2 extends CustomBase {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -7770,7 +7770,7 @@ export class Author2 extends CustomBase {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -7875,7 +7875,7 @@ export class Book2 extends CustomBase {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -7900,8 +7900,8 @@ export class Book2 extends CustomBase {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -8021,7 +8021,7 @@ export class FooBar2 extends CustomBase {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -8050,7 +8050,7 @@ export class FooBaz2 extends CustomBase {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -8074,7 +8074,7 @@ export class FooParam2 extends CustomBase {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -8088,13 +8088,13 @@ export class Publisher2 extends CustomBase {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -8190,7 +8190,7 @@ export class Test2 extends CustomBase {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -8312,7 +8312,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true },
-    termsAccepted: { type: 'boolean', default: false, index: 'author2_terms_accepted_index' },
+    termsAccepted: { type: 'boolean', index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -8426,7 +8426,7 @@ export class Book2 extends CustomBase {
   meta?: any;
   author!: Author2;
   publisher?: Publisher2;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
 }
 
@@ -8448,7 +8448,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -8647,7 +8647,7 @@ import { CustomBase } from './CustomBase';
 
 export class Publisher2 extends CustomBase {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -8681,9 +8681,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -8767,7 +8767,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', default: 1 },
+    version: { type: 'number' },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,
@@ -8873,10 +8873,10 @@ export class Author2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -8892,7 +8892,7 @@ export class Author2 {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -8994,7 +8994,7 @@ export class Book2 {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -9019,8 +9019,8 @@ export class Book2 {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -9134,7 +9134,7 @@ export class FooBar2 {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -9162,7 +9162,7 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -9185,7 +9185,7 @@ export class FooParam2 {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -9198,13 +9198,13 @@ export class Publisher2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -9297,7 +9297,7 @@ export class Test2 {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -9408,7 +9408,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true },
-    termsAccepted: { type: 'boolean', default: false, index: 'author2_terms_accepted_index' },
+    termsAccepted: { type: 'boolean', index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -9519,7 +9519,7 @@ export class Book2 {
   meta?: any;
   author!: Author2;
   publisher?: Publisher2;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
 }
 
@@ -9541,7 +9541,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -9731,7 +9731,7 @@ export const FooParam2Schema = new EntitySchema({
 
 export class Publisher2 {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -9765,9 +9765,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -9848,7 +9848,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', default: 1 },
+    version: { type: 'number' },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,
@@ -9943,10 +9943,10 @@ export class Author2 extends BaseEntity {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -9962,7 +9962,7 @@ export class Author2 extends BaseEntity {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -10067,7 +10067,7 @@ export class Book2 extends BaseEntity {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -10092,8 +10092,8 @@ export class Book2 extends BaseEntity {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -10213,7 +10213,7 @@ export class FooBar2 extends BaseEntity {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -10242,7 +10242,7 @@ export class FooBaz2 extends BaseEntity {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -10266,7 +10266,7 @@ export class FooParam2 extends BaseEntity {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -10280,13 +10280,13 @@ export class Publisher2 extends BaseEntity {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -10382,7 +10382,7 @@ export class Test2 extends BaseEntity {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -10504,7 +10504,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true },
-    termsAccepted: { type: 'boolean', default: false, index: 'author2_terms_accepted_index' },
+    termsAccepted: { type: 'boolean', index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -10618,7 +10618,7 @@ export class Book2 extends BaseEntity {
   meta?: any;
   author!: Author2;
   publisher?: Publisher2;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
 }
 
@@ -10640,7 +10640,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -10839,7 +10839,7 @@ import { BaseEntity } from './BaseEntity';
 
 export class Publisher2 extends BaseEntity {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -10873,9 +10873,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -10959,7 +10959,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', default: 1 },
+    version: { type: 'number' },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,
@@ -11067,10 +11067,10 @@ export class Author2 extends BaseUser2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -11086,7 +11086,7 @@ export class Author2 extends BaseUser2 {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -11193,7 +11193,7 @@ export class Book2 extends BaseUser2 {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -11218,8 +11218,8 @@ export class Book2 extends BaseUser2 {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -11339,7 +11339,7 @@ export class FooBar2 extends BaseUser2 {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -11368,7 +11368,7 @@ export class FooBaz2 extends BaseUser2 {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -11392,7 +11392,7 @@ export class FooParam2 extends BaseUser2 {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -11406,13 +11406,13 @@ export class Publisher2 extends BaseUser2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -11508,7 +11508,7 @@ export class Test2 extends BaseUser2 {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -11622,7 +11622,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true },
-    termsAccepted: { type: 'boolean', default: false, index: 'author2_terms_accepted_index' },
+    termsAccepted: { type: 'boolean', index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -11736,7 +11736,7 @@ export class Book2 extends BaseUser2 {
   meta?: any;
   author!: Author2;
   publisher?: Publisher2;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
 }
 
@@ -11758,7 +11758,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -11957,7 +11957,7 @@ import { BaseUser2 } from './BaseUser2';
 
 export class Publisher2 extends BaseUser2 {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -11991,9 +11991,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -12077,7 +12077,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', default: 1 },
+    version: { type: 'number' },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,
@@ -12173,10 +12173,10 @@ export class Author2 extends CustomBase {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -12192,7 +12192,7 @@ export class Author2 extends CustomBase {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -12297,7 +12297,7 @@ export class Book2 extends CustomBase {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -12322,8 +12322,8 @@ export class Book2 extends CustomBase {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -12443,7 +12443,7 @@ export class FooBar2 extends CustomBase {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -12472,7 +12472,7 @@ export class FooBaz2 extends CustomBase {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -12496,7 +12496,7 @@ export class FooParam2 extends CustomBase {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -12510,13 +12510,13 @@ export class Publisher2 extends CustomBase {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -12612,7 +12612,7 @@ export class Test2 extends CustomBase {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -12734,7 +12734,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true },
-    termsAccepted: { type: 'boolean', default: false, index: 'author2_terms_accepted_index' },
+    termsAccepted: { type: 'boolean', index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -12848,7 +12848,7 @@ export class Book2 extends CustomBase {
   meta?: any;
   author!: Author2;
   publisher?: Publisher2;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
 }
 
@@ -12870,7 +12870,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -13069,7 +13069,7 @@ import { CustomBase } from './CustomBase';
 
 export class Publisher2 extends CustomBase {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -13103,9 +13103,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -13189,7 +13189,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', default: 1 },
+    version: { type: 'number' },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,
@@ -13295,10 +13295,10 @@ export class Author2 extends BaseEntity {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -13314,7 +13314,7 @@ export class Author2 extends BaseEntity {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -13416,7 +13416,7 @@ export class Book2 extends BaseEntity {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -13441,8 +13441,8 @@ export class Book2 extends BaseEntity {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -13556,7 +13556,7 @@ export class FooBar2 extends BaseEntity {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -13584,7 +13584,7 @@ export class FooBaz2 extends BaseEntity {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -13607,7 +13607,7 @@ export class FooParam2 extends BaseEntity {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -13620,13 +13620,13 @@ export class Publisher2 extends BaseEntity {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -13719,7 +13719,7 @@ export class Test2 extends BaseEntity {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -13830,7 +13830,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true },
-    termsAccepted: { type: 'boolean', default: false, index: 'author2_terms_accepted_index' },
+    termsAccepted: { type: 'boolean', index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -13941,7 +13941,7 @@ export class Book2 extends BaseEntity {
   meta?: any;
   author!: Author2;
   publisher?: Publisher2;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
 }
 
@@ -13963,7 +13963,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -14153,7 +14153,7 @@ export const FooParam2Schema = new EntitySchema({
 
 export class Publisher2 extends BaseEntity {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -14187,9 +14187,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -14270,7 +14270,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', default: 1 },
+    version: { type: 'number' },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,
@@ -14365,10 +14365,10 @@ export class Author2 extends BaseEntity {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -14384,7 +14384,7 @@ export class Author2 extends BaseEntity {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -14489,7 +14489,7 @@ export class Book2 extends BaseEntity {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -14514,8 +14514,8 @@ export class Book2 extends BaseEntity {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -14635,7 +14635,7 @@ export class FooBar2 extends BaseEntity {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -14664,7 +14664,7 @@ export class FooBaz2 extends BaseEntity {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -14688,7 +14688,7 @@ export class FooParam2 extends BaseEntity {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -14702,13 +14702,13 @@ export class Publisher2 extends BaseEntity {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -14804,7 +14804,7 @@ export class Test2 extends BaseEntity {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -14926,7 +14926,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true },
-    termsAccepted: { type: 'boolean', default: false, index: 'author2_terms_accepted_index' },
+    termsAccepted: { type: 'boolean', index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -15040,7 +15040,7 @@ export class Book2 extends BaseEntity {
   meta?: any;
   author!: Author2;
   publisher?: Publisher2;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
 }
 
@@ -15062,7 +15062,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -15261,7 +15261,7 @@ import { BaseEntity } from './BaseEntity';
 
 export class Publisher2 extends BaseEntity {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -15295,9 +15295,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -15381,7 +15381,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', default: 1 },
+    version: { type: 'number' },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,
@@ -15489,10 +15489,10 @@ export class Author2 extends BaseUser2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -15508,7 +15508,7 @@ export class Author2 extends BaseUser2 {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -15615,7 +15615,7 @@ export class Book2 extends BaseUser2 {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -15640,8 +15640,8 @@ export class Book2 extends BaseUser2 {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -15761,7 +15761,7 @@ export class FooBar2 extends BaseUser2 {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -15790,7 +15790,7 @@ export class FooBaz2 extends BaseUser2 {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -15814,7 +15814,7 @@ export class FooParam2 extends BaseUser2 {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -15828,13 +15828,13 @@ export class Publisher2 extends BaseUser2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -15930,7 +15930,7 @@ export class Test2 extends BaseUser2 {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -16044,7 +16044,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true },
-    termsAccepted: { type: 'boolean', default: false, index: 'author2_terms_accepted_index' },
+    termsAccepted: { type: 'boolean', index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -16158,7 +16158,7 @@ export class Book2 extends BaseUser2 {
   meta?: any;
   author!: Author2;
   publisher?: Publisher2;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
 }
 
@@ -16180,7 +16180,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -16379,7 +16379,7 @@ import { BaseUser2 } from './BaseUser2';
 
 export class Publisher2 extends BaseUser2 {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -16413,9 +16413,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -16499,7 +16499,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', default: 1 },
+    version: { type: 'number' },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,
@@ -16595,10 +16595,10 @@ export class Author2 extends CustomBase {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -16614,7 +16614,7 @@ export class Author2 extends CustomBase {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -16719,7 +16719,7 @@ export class Book2 extends CustomBase {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -16744,8 +16744,8 @@ export class Book2 extends CustomBase {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -16865,7 +16865,7 @@ export class FooBar2 extends CustomBase {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -16894,7 +16894,7 @@ export class FooBaz2 extends CustomBase {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -16918,7 +16918,7 @@ export class FooParam2 extends CustomBase {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -16932,13 +16932,13 @@ export class Publisher2 extends CustomBase {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -17034,7 +17034,7 @@ export class Test2 extends CustomBase {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -17156,7 +17156,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true },
-    termsAccepted: { type: 'boolean', default: false, index: 'author2_terms_accepted_index' },
+    termsAccepted: { type: 'boolean', index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -17270,7 +17270,7 @@ export class Book2 extends CustomBase {
   meta?: any;
   author!: Author2;
   publisher?: Publisher2;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
 }
 
@@ -17292,7 +17292,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -17491,7 +17491,7 @@ import { CustomBase } from './CustomBase';
 
 export class Publisher2 extends CustomBase {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -17525,9 +17525,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -17611,7 +17611,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', default: 1 },
+    version: { type: 'number' },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.mysql.test.ts.snap
@@ -10,13 +10,13 @@ export class Publisher2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 100, nullable: true, default: '123' })
-  test?: string;
+  @Property({ type: 'string', length: 100, nullable: true })
+  test?: string & Opt = '123';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, nullable: true, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2, nullable: true })
   type2?: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
 }
@@ -106,7 +106,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true },
-    termsAccepted: { type: 'boolean', default: false, index: 'author2_terms_accepted_index' },
+    termsAccepted: { type: 'boolean', index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -249,7 +249,7 @@ export class Book2 {
   meta?: any;
   author!: Ref<Author2>;
   publisher?: Ref<Publisher2>;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
   favouriteBookInverse = new Collection<Author2>(this);
   book2Inverse = new Collection<Book2Tags>(this);
@@ -275,7 +275,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -518,7 +518,7 @@ import { Publisher2Tests } from './Publisher2Tests';
 
 export class Publisher2 {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -554,9 +554,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -659,7 +659,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', default: 1 },
+    version: { type: 'number' },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,
@@ -796,7 +796,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true },
-    termsAccepted: { type: 'boolean', default: false, index: 'author2_terms_accepted_index' },
+    termsAccepted: { type: 'boolean', index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -918,7 +918,7 @@ export class Book2 {
   meta?: any;
   author!: Ref<Author2>;
   publisher?: Ref<Publisher2>;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
 }
 
@@ -941,7 +941,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -1160,7 +1160,7 @@ export const FooParam2Schema = new EntitySchema({
 
 export class Publisher2 {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -1194,9 +1194,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -1289,7 +1289,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', default: 1 },
+    version: { type: 'number' },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,
@@ -1365,10 +1365,10 @@ export class Account {
   @PrimaryKey()
   id!: bigint;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   active: boolean & Opt = false;
 
-  @Property({ default: true })
+  @Property({ type: 'boolean' })
   receiveEmailNotifications: boolean & Opt = true;
 
 }
@@ -1405,10 +1405,10 @@ export class Author2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -1424,7 +1424,7 @@ export class Author2 {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -1526,7 +1526,7 @@ export class Book2 {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -1551,8 +1551,8 @@ export class Book2 {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -1666,7 +1666,7 @@ export class FooBar2 {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -1694,7 +1694,7 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -1717,7 +1717,7 @@ export class FooParam2 {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -1730,13 +1730,13 @@ export class Publisher2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -1829,7 +1829,7 @@ export class Test2 {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -1904,10 +1904,10 @@ export class Author2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -1923,7 +1923,7 @@ export class Author2 {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -2053,7 +2053,7 @@ export class Book2 {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -2078,8 +2078,8 @@ export class Book2 {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -2215,7 +2215,7 @@ export class FooBar2 {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -2253,7 +2253,7 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
   @OneToMany({ entity: () => FooParam2, mappedBy: 'baz' })
@@ -2279,7 +2279,7 @@ export class FooParam2 {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -2294,13 +2294,13 @@ export class Publisher2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -2405,7 +2405,7 @@ export class Test2 {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -2489,10 +2489,10 @@ export class Author2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -2508,7 +2508,7 @@ export class Author2 {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -2638,7 +2638,7 @@ export class Book2 {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -2663,8 +2663,8 @@ export class Book2 {
   @ManyToOne({ entity: () => Publisher2, ref: true, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Ref<Publisher2>;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -2800,7 +2800,7 @@ export class FooBar2 {
   @OneToOne({ entity: () => FooBar2, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: Ref<FooBar2>;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -2838,7 +2838,7 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
   @OneToMany({ entity: () => FooParam2, mappedBy: 'baz' })
@@ -2864,7 +2864,7 @@ export class FooParam2 {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -2879,13 +2879,13 @@ export class Publisher2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -2990,7 +2990,7 @@ export class Test2 {
   @ManyToOne({ entity: () => Test2, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Ref<Test2>;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, ref: true, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -3074,10 +3074,10 @@ export class Author2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -3093,7 +3093,7 @@ export class Author2 {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -3195,7 +3195,7 @@ export class Book2 {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -3220,8 +3220,8 @@ export class Book2 {
   @ManyToOne({ entity: () => Publisher2, ref: true, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Ref<Publisher2>;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -3335,7 +3335,7 @@ export class FooBar2 {
   @OneToOne({ entity: () => FooBar2, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: Ref<FooBar2>;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -3363,7 +3363,7 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -3386,7 +3386,7 @@ export class FooParam2 {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -3399,13 +3399,13 @@ export class Publisher2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -3498,7 +3498,7 @@ export class Test2 {
   @ManyToOne({ entity: () => Test2, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Ref<Test2>;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, ref: true, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -3627,10 +3627,10 @@ export class Author2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -3646,7 +3646,7 @@ export class Author2 {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -3748,7 +3748,7 @@ export class Book2 {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -3770,8 +3770,8 @@ export class Book2 {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -3885,7 +3885,7 @@ export class FooBar2 {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -3913,7 +3913,7 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -3936,7 +3936,7 @@ export class FooParam2 {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -3949,13 +3949,13 @@ export class Publisher2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
@@ -10,13 +10,13 @@ export class Publisher2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ nullable: true, default: '123' })
-  test?: string;
+  @Property({ type: 'string', nullable: true })
+  test?: string & Opt = '123';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, nullable: true, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2, nullable: true })
   type2?: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
 }
@@ -63,10 +63,10 @@ export class Author2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -82,7 +82,7 @@ export class Author2 {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -142,11 +142,11 @@ export class Book2 {
   @PrimaryKey({ columnType: 'uuid' })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 255, nullable: true, default: '' })
-  title?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  title?: string & Opt = '';
 
   @Property({ columnType: 'text', nullable: true })
   perex?: string;
@@ -166,8 +166,8 @@ export class Book2 {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -234,7 +234,7 @@ export class FooBar2 {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`current_timestamp(0)\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`current_timestamp(0)\` })
   version!: Date & Opt;
 
   @Property({ nullable: true })
@@ -262,7 +262,7 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -285,7 +285,7 @@ export class FooParam2 {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -412,7 +412,7 @@ export class Test2 {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @Property({ columnType: 'polygon', nullable: true })
@@ -455,10 +455,10 @@ export class Author2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -474,7 +474,7 @@ export class Author2 {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -534,11 +534,11 @@ export class Book2 {
   @PrimaryKey({ columnType: 'uuid' })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 255, nullable: true, default: '' })
-  title?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  title?: string & Opt = '';
 
   @Property({ columnType: 'text', nullable: true })
   perex?: string;
@@ -555,8 +555,8 @@ export class Book2 {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -623,7 +623,7 @@ export class FooBar2 {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`current_timestamp(0)\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`current_timestamp(0)\` })
   version!: Date & Opt;
 
   @Property({ nullable: true })
@@ -651,7 +651,7 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -674,7 +674,7 @@ export class FooParam2 {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
@@ -28,7 +28,7 @@ export class Author3 {
   @Property({ nullable: true })
   age?: number;
 
-  @Property({ default: 0 })
+  @Property({ type: 'number' })
   termsAccepted: number & Opt = 0;
 
   @Property({ nullable: true })
@@ -56,7 +56,7 @@ export class BookTag3 {
   @Property()
   name!: string;
 
-  @Property({ defaultRaw: \`current_timestamp\` })
+  @Property({ type: 'Date', defaultRaw: \`current_timestamp\` })
   version!: Date & Opt;
 
 }
@@ -77,8 +77,8 @@ export class Book3 {
   @Property({ nullable: true })
   updatedAt?: Date;
 
-  @Property({ default: '' })
-  title!: string & Opt;
+  @Property({ type: 'string' })
+  title: string & Opt = '';
 
   @ManyToOne({ entity: () => Author3, updateRule: 'cascade' })
   author!: Author3;
@@ -151,7 +151,7 @@ export class Test3 {
   @Property({ nullable: true })
   name?: string;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
 }

--- a/tests/features/entity-generator/__snapshots__/GeneratedColumns.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/GeneratedColumns.mysql.test.ts.snap
@@ -29,10 +29,10 @@ export class Users {
   @Property({ length: 100 })
   lastName!: string;
 
-  @Property({ length: 200, generated: () => "concat(\`first_name\`,_utf8mb4\\\\' \\\\',\`last_name\`) virtual" })
+  @Property({ type: 'string', length: 200, generated: () => "concat(\`first_name\`,_utf8mb4\\\\' \\\\',\`last_name\`) virtual" })
   fullName!: string & Opt;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt!: Date & Opt;
 
   @Property({ columnType: 'date' })
@@ -75,10 +75,10 @@ export class Users {
   @Property({ length: 100 })
   lastName!: string;
 
-  @Property({ length: 200, generated: 'concat(\`first_name\`,_utf8mb4\\' \\',\`last_name\`) virtual' })
+  @Property({ type: 'string', length: 200, generated: 'concat(\`first_name\`,_utf8mb4\\' \\',\`last_name\`) virtual' })
   fullName!: string & Opt;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt!: Date & Opt;
 
   @Property({ columnType: 'date' })

--- a/tests/features/entity-generator/__snapshots__/GeneratedColumns.postgresql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/GeneratedColumns.postgresql.test.ts.snap
@@ -29,10 +29,10 @@ export class Users {
   @Property({ length: 100 })
   lastName!: string;
 
-  @Property({ length: 200, generated: () => "(((first_name)::text || ' '::text) || (last_name)::text) stored" })
+  @Property({ type: 'string', length: 200, generated: () => "(((first_name)::text || ' '::text) || (last_name)::text) stored" })
   fullName!: string & Opt;
 
-  @Property({ length: 6, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 6, defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt!: Date & Opt;
 
   @Property({ columnType: 'date' })
@@ -75,10 +75,10 @@ export class Users {
   @Property({ length: 100 })
   lastName!: string;
 
-  @Property({ length: 200, generated: '(((first_name)::text || ' '::text) || (last_name)::text) stored' })
+  @Property({ type: 'string', length: 200, generated: '(((first_name)::text || ' '::text) || (last_name)::text) stored' })
   fullName!: string & Opt;
 
-  @Property({ length: 6, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 6, defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt!: Date & Opt;
 
   @Property({ columnType: 'date' })

--- a/tests/features/entity-generator/__snapshots__/ManyToManyRelations.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/ManyToManyRelations.mysql.test.ts.snap
@@ -145,14 +145,16 @@ export class UserEmails {
   @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
   email!: Emails;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
 
 }
 ",
   "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Orders } from './Orders';
+import { UserEmails } from './UserEmails';
 
 @Entity()
 export class Users {
@@ -165,6 +167,9 @@ export class Users {
   @Unique({ name: 'name_UNIQUE' })
   @Property({ length: 255 })
   name!: string;
+
+  @ManyToMany({ entity: () => Emails, pivotTable: 'user_emails', pivotEntity: () => UserEmails, joinColumn: 'user_id', inverseJoinColumn: 'email_id' })
+  userEmails = new Collection<Emails>(this);
 
   @ManyToMany({ entity: () => Flags, pivotTable: 'user_flags', joinColumn: 'user_id', inverseJoinColumn: 'flag_id' })
   userFlags = new Collection<Flags>(this);
@@ -377,11 +382,12 @@ export const UserEmailsSchema = new EntitySchema({
       deleteRule: 'cascade',
       index: 'fk_user_emails_emails1_idx',
     },
-    isVerified: { type: 'boolean', default: false },
+    isVerified: { type: 'boolean' },
   },
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Orders } from './Orders';
 
@@ -389,6 +395,7 @@ export class Users {
   [PrimaryKeyProp]?: 'userId';
   userId!: number;
   name!: string;
+  userEmails = new Collection<Emails>(this);
   userFlags = new Collection<Flags>(this);
   userOrders = new Collection<Orders>(this);
 }
@@ -398,6 +405,14 @@ export const UsersSchema = new EntitySchema({
   properties: {
     userId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
+    userEmails: {
+      kind: 'm:n',
+      entity: () => Emails,
+      pivotTable: 'user_emails',
+      pivotEntity: () => UserEmails,
+      joinColumn: 'user_id',
+      inverseJoinColumn: 'email_id',
+    },
     userFlags: {
       kind: 'm:n',
       entity: () => Flags,
@@ -565,7 +580,7 @@ export class UserEmails {
   @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
   email!: Emails;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
 
 }
@@ -600,7 +615,7 @@ export class Users {
   @ManyToMany({ entity: () => Emails, pivotTable: 'user_email_orders', pivotEntity: () => UserEmailOrders, joinColumn: 'user_id', inverseJoinColumn: 'email_id', persist: false })
   userEmailOrders = new Collection<Emails>(this);
 
-  @ManyToMany({ entity: () => Emails, pivotTable: 'user_emails', pivotEntity: () => UserEmails, joinColumn: 'user_id', inverseJoinColumn: 'email_id', persist: false })
+  @ManyToMany({ entity: () => Emails, pivotTable: 'user_emails', pivotEntity: () => UserEmails, joinColumn: 'user_id', inverseJoinColumn: 'email_id' })
   userEmails = new Collection<Emails>(this);
 
   @ManyToMany({ entity: () => Flags, pivotTable: 'user_flags', joinColumn: 'user_id', inverseJoinColumn: 'flag_id' })
@@ -814,7 +829,7 @@ export const UserEmailsSchema = new EntitySchema({
       deleteRule: 'cascade',
       index: 'fk_user_emails_emails1_idx',
     },
-    isVerified: { type: 'boolean', default: false },
+    isVerified: { type: 'boolean' },
   },
 });
 ",
@@ -874,7 +889,6 @@ export const UsersSchema = new EntitySchema({
       pivotEntity: () => UserEmails,
       joinColumn: 'user_id',
       inverseJoinColumn: 'email_id',
-      persist: false,
     },
     userFlags: {
       kind: 'm:n',
@@ -1043,7 +1057,7 @@ export class UserEmails {
   @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
   email!: Emails;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
 
 }
@@ -1292,7 +1306,7 @@ export const UserEmailsSchema = new EntitySchema({
       deleteRule: 'cascade',
       index: 'fk_user_emails_emails1_idx',
     },
-    isVerified: { type: 'boolean', default: false },
+    isVerified: { type: 'boolean' },
   },
 });
 ",
@@ -1500,7 +1514,7 @@ export class UserEmails {
   @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
   email!: Emails;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
 
 }
@@ -1749,7 +1763,7 @@ export const UserEmailsSchema = new EntitySchema({
       deleteRule: 'cascade',
       index: 'fk_user_emails_emails1_idx',
     },
-    isVerified: { type: 'boolean', default: false },
+    isVerified: { type: 'boolean' },
   },
 });
 ",
@@ -1833,8 +1847,9 @@ export class CompletedOrders {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { UserEmails } from './UserEmails';
+import { Users } from './Users';
 
 @Entity()
 export class Emails {
@@ -1850,6 +1865,9 @@ export class Emails {
 
   @OneToMany({ entity: () => UserEmails, mappedBy: 'email' })
   emailInverse = new Collection<UserEmails>(this);
+
+  @ManyToMany({ entity: () => Users, mappedBy: 'userEmails' })
+  userEmailsInverse = new Collection<Users>(this);
 
 }
 ",
@@ -1977,12 +1995,13 @@ export class UserEmails {
   @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
   email!: Emails;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
 
 }
 ",
   "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Orders } from './Orders';
 import { UserEmails } from './UserEmails';
@@ -1998,6 +2017,9 @@ export class Users {
   @Unique({ name: 'name_UNIQUE' })
   @Property({ length: 255 })
   name!: string;
+
+  @ManyToMany({ entity: () => Emails, pivotTable: 'user_emails', pivotEntity: () => UserEmails, joinColumn: 'user_id', inverseJoinColumn: 'email_id' })
+  userEmails = new Collection<Emails>(this);
 
   @ManyToMany({ entity: () => Flags, pivotTable: 'user_flags', joinColumn: 'user_id', inverseJoinColumn: 'flag_id' })
   userFlags = new Collection<Flags>(this);
@@ -2047,12 +2069,14 @@ export const CompletedOrdersSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { UserEmails } from './UserEmails';
+import { Users } from './Users';
 
 export class Emails {
   [PrimaryKeyProp]?: 'emailId';
   emailId!: number;
   address!: string;
   emailInverse = new Collection<UserEmails>(this);
+  userEmailsInverse = new Collection<Users>(this);
 }
 
 export const EmailsSchema = new EntitySchema({
@@ -2061,6 +2085,7 @@ export const EmailsSchema = new EntitySchema({
     emailId: { primary: true, type: 'number' },
     address: { type: 'string', length: 255, unique: 'address_UNIQUE' },
     emailInverse: { kind: '1:m', entity: () => UserEmails, mappedBy: 'email' },
+    userEmailsInverse: { kind: 'm:n', entity: () => Users, mappedBy: 'userEmails' },
   },
 });
 ",
@@ -2227,11 +2252,12 @@ export const UserEmailsSchema = new EntitySchema({
       deleteRule: 'cascade',
       index: 'fk_user_emails_emails1_idx',
     },
-    isVerified: { type: 'boolean', default: false },
+    isVerified: { type: 'boolean' },
   },
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Orders } from './Orders';
 import { UserEmails } from './UserEmails';
@@ -2240,6 +2266,7 @@ export class Users {
   [PrimaryKeyProp]?: 'userId';
   userId!: number;
   name!: string;
+  userEmails = new Collection<Emails>(this);
   userFlags = new Collection<Flags>(this);
   userOrders = new Collection<Orders>(this);
   userInverse = new Collection<UserEmails>(this);
@@ -2250,6 +2277,14 @@ export const UsersSchema = new EntitySchema({
   properties: {
     userId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
+    userEmails: {
+      kind: 'm:n',
+      entity: () => Emails,
+      pivotTable: 'user_emails',
+      pivotEntity: () => UserEmails,
+      joinColumn: 'user_id',
+      inverseJoinColumn: 'email_id',
+    },
     userFlags: {
       kind: 'm:n',
       entity: () => Flags,
@@ -2322,7 +2357,7 @@ export class Emails {
   @ManyToMany({ entity: () => Users, mappedBy: 'userEmailOrders', persist: false })
   userEmailOrdersInverse = new Collection<Users>(this);
 
-  @ManyToMany({ entity: () => Users, mappedBy: 'userEmails', persist: false })
+  @ManyToMany({ entity: () => Users, mappedBy: 'userEmails' })
   userEmailsInverse = new Collection<Users>(this);
 
 }
@@ -2451,7 +2486,7 @@ export class UserEmails {
   @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
   email!: Emails;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
 
 }
@@ -2486,7 +2521,7 @@ export class Users {
   @ManyToMany({ entity: () => Emails, pivotTable: 'user_email_orders', pivotEntity: () => UserEmailOrders, joinColumn: 'user_id', inverseJoinColumn: 'email_id', persist: false })
   userEmailOrders = new Collection<Emails>(this);
 
-  @ManyToMany({ entity: () => Emails, pivotTable: 'user_emails', pivotEntity: () => UserEmails, joinColumn: 'user_id', inverseJoinColumn: 'email_id', persist: false })
+  @ManyToMany({ entity: () => Emails, pivotTable: 'user_emails', pivotEntity: () => UserEmails, joinColumn: 'user_id', inverseJoinColumn: 'email_id' })
   userEmails = new Collection<Emails>(this);
 
   @ManyToMany({ entity: () => Flags, pivotTable: 'user_flags', joinColumn: 'user_id', inverseJoinColumn: 'flag_id' })
@@ -2569,7 +2604,7 @@ export const EmailsSchema = new EntitySchema({
       mappedBy: 'userEmailOrders',
       persist: false,
     },
-    userEmailsInverse: { kind: 'm:n', entity: () => Users, mappedBy: 'userEmails', persist: false },
+    userEmailsInverse: { kind: 'm:n', entity: () => Users, mappedBy: 'userEmails' },
   },
 });
 ",
@@ -2736,7 +2771,7 @@ export const UserEmailsSchema = new EntitySchema({
       deleteRule: 'cascade',
       index: 'fk_user_emails_emails1_idx',
     },
-    isVerified: { type: 'boolean', default: false },
+    isVerified: { type: 'boolean' },
   },
 });
 ",
@@ -2798,7 +2833,6 @@ export const UsersSchema = new EntitySchema({
       pivotEntity: () => UserEmails,
       joinColumn: 'user_id',
       inverseJoinColumn: 'email_id',
-      persist: false,
     },
     userFlags: {
       kind: 'm:n',
@@ -2984,7 +3018,7 @@ export class UserEmails {
   @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
   email!: Emails;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
 
 }
@@ -3248,7 +3282,7 @@ export const UserEmailsSchema = new EntitySchema({
       deleteRule: 'cascade',
       index: 'fk_user_emails_emails1_idx',
     },
-    isVerified: { type: 'boolean', default: false },
+    isVerified: { type: 'boolean' },
   },
 });
 ",
@@ -3475,7 +3509,7 @@ export class UserEmails {
   @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
   email!: Emails;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
 
 }
@@ -3739,7 +3773,7 @@ export const UserEmailsSchema = new EntitySchema({
       deleteRule: 'cascade',
       index: 'fk_user_emails_emails1_idx',
     },
-    isVerified: { type: 'boolean', default: false },
+    isVerified: { type: 'boolean' },
   },
 });
 ",

--- a/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
@@ -32,10 +32,10 @@ export class Author2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, hidden: true, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, hidden: true, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Hidden & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -44,14 +44,14 @@ export class Author2 {
 
   @Index({ name: 'custom_email_index_name' })
   @Unique({ name: 'custom_email_unique_name' })
-  @Property({ length: 255, hidden: true })
+  @Property({ type: 'string', length: 255, hidden: true })
   email!: string & Hidden;
 
   @Property({ nullable: true, concurrencyCheck: true })
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ lazy: true, default: false })
+  @Property({ type: 'boolean', lazy: true })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -185,7 +185,7 @@ export class Book2 {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -210,8 +210,8 @@ export class Book2 {
   @ManyToOne({ entity: () => Publisher2, mapToPk: true, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: number;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -347,7 +347,7 @@ export class FooBar2 {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -385,7 +385,7 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
   @OneToMany({ entity: () => FooParam2, mappedBy: 'baz' })
@@ -411,7 +411,7 @@ export class FooParam2 {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -426,13 +426,13 @@ export class Publisher2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -537,7 +537,7 @@ export class Test2 {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ version: true, default: 1 })
+  @Property({ type: 'number', version: true })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -600,7 +600,7 @@ export class AuthorPartialView {
 
   @Index({ name: 'custom_email_index_name' })
   @Unique({ name: 'custom_email_unique_name' })
-  @Property({ length: 255, hidden: true })
+  @Property({ type: 'string', length: 255, hidden: true })
   email!: string & Hidden;
 
 }
@@ -744,12 +744,7 @@ export const Author2Schema = new EntitySchema({
       unique: 'custom_email_unique_name',
     },
     age: { type: 'number', nullable: true, concurrencyCheck: true },
-    termsAccepted: {
-      type: 'boolean',
-      lazy: true,
-      default: false,
-      index: 'author2_terms_accepted_index',
-    },
+    termsAccepted: { type: 'boolean', lazy: true, index: 'author2_terms_accepted_index' },
     optional: { type: 'boolean', nullable: true },
     identities: { type: 'string', columnType: 'text', nullable: true },
     born: {
@@ -896,7 +891,7 @@ export class Book2 {
   meta?: any;
   author!: Author2;
   publisher?: number;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
   favouriteBookInverse = new Collection<Author2>(this);
   book2Inverse = new Collection<Book2Tags>(this);
@@ -922,7 +917,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -1136,7 +1131,7 @@ import { Publisher2Tests } from './Publisher2Tests';
 
 export class Publisher2 {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -1172,9 +1167,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -1265,7 +1260,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', version: true, default: 1 },
+    version: { type: 'number', version: true },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,
@@ -1485,10 +1480,10 @@ export class Author2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, hidden: true, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, hidden: true, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Hidden & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -1497,14 +1492,14 @@ export class Author2 {
 
   @Index({ name: 'custom_email_index_name' })
   @Unique({ name: 'custom_email_unique_name' })
-  @Property({ length: 255, hidden: true })
+  @Property({ type: 'string', length: 255, hidden: true })
   email!: string & Hidden;
 
   @Property({ nullable: true, concurrencyCheck: true })
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ lazy: true, default: false })
+  @Property({ type: 'boolean', lazy: true, default: false })
   termsAccepted: Ref<boolean>;
 
   @Property({ nullable: true })
@@ -1639,7 +1634,7 @@ export class Book2 {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -1664,8 +1659,8 @@ export class Book2 {
   @ManyToOne({ entity: () => Publisher2, ref: true, mapToPk: true, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Ref<number>;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -1801,7 +1796,7 @@ export class FooBar2 {
   @OneToOne({ entity: () => FooBar2, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: Ref<FooBar2>;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -1839,7 +1834,7 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
   @OneToMany({ entity: () => FooParam2, mappedBy: 'baz' })
@@ -1865,7 +1860,7 @@ export class FooParam2 {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -1880,13 +1875,13 @@ export class Publisher2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -1991,7 +1986,7 @@ export class Test2 {
   @ManyToOne({ entity: () => Test2, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Ref<Test2>;
 
-  @Property({ version: true, default: 1 })
+  @Property({ type: 'number', version: true })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, ref: true, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -2055,7 +2050,7 @@ export class AuthorPartialView {
 
   @Index({ name: 'custom_email_index_name' })
   @Unique({ name: 'custom_email_unique_name' })
-  @Property({ length: 255, hidden: true })
+  @Property({ type: 'string', length: 255, hidden: true })
   email!: string & Hidden;
 
 }
@@ -2364,7 +2359,7 @@ export class Book2 {
   meta?: any;
   author!: Ref<Author2>;
   publisher?: Ref<number>;
-  foo?: string;
+  foo?: string & Opt = 'lol';
   bookToTagUnordered = new Collection<BookTag2>(this);
   favouriteBookInverse = new Collection<Author2>(this);
   book2Inverse = new Collection<Book2Tags>(this);
@@ -2391,7 +2386,7 @@ export const Book2Schema = new EntitySchema({
       deleteRule: 'cascade',
       nullable: true,
     },
-    foo: { type: 'string', length: 255, nullable: true, default: 'lol' },
+    foo: { type: 'string', length: 255, nullable: true },
     bookToTagUnordered: {
       kind: 'm:n',
       entity: () => BookTag2,
@@ -2634,7 +2629,7 @@ import { Publisher2Tests } from './Publisher2Tests';
 
 export class Publisher2 {
   id!: number;
-  name!: string & Opt;
+  name: string & Opt = 'asd';
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
@@ -2670,9 +2665,9 @@ export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
   properties: {
     id: { primary: true, type: 'number' },
-    name: { type: 'string', length: 255, default: 'asd' },
-    type: { enum: true, items: () => Publisher2Type, default: 'local' },
-    type2: { enum: true, items: () => Publisher2Type2, default: 'LOCAL' },
+    name: { type: 'string', length: 255 },
+    type: { enum: true, items: () => Publisher2Type },
+    type2: { enum: true, items: () => Publisher2Type2 },
     enum1: { type: 'number', columnType: 'tinyint', nullable: true },
     enum2: { type: 'number', columnType: 'tinyint', nullable: true },
     enum3: { type: 'number', columnType: 'tinyint', nullable: true },
@@ -2775,7 +2770,7 @@ export const Test2Schema = new EntitySchema({
       deleteRule: 'set null',
       nullable: true,
     },
-    version: { type: 'number', version: true, default: 1 },
+    version: { type: 'number', version: true },
     fooBar: {
       kind: '1:1',
       entity: () => FooBar2,

--- a/tests/features/entity-generator/__snapshots__/NullableFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/NullableFks.mysql.test.ts.snap
@@ -38,7 +38,7 @@ export class EmailSendingLogs {
   @Property({ nullable: true, persist: false })
   replyEmailId?: number;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt!: Date & Opt;
 
 }
@@ -375,7 +375,7 @@ export class EmailSendingLogs {
   @Property({ nullable: true, persist: false })
   replyEmailId?: number;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt!: Date & Opt;
 
 }
@@ -730,7 +730,7 @@ export class EmailSendingLogs {
   @Property({ nullable: true, persist: false })
   replyEmailId?: number;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt!: Date & Opt;
 
 }
@@ -1119,7 +1119,7 @@ export class EmailSendingLogs {
   @Property({ nullable: true, persist: false })
   replyEmailId?: number;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt!: Date & Opt;
 
 }
@@ -1511,7 +1511,7 @@ export class EmailSendingLogs {
   @ManyToOne({ entity: () => SenderEmails, fieldNames: ['sender_id', 'reply_email_id'], nullable: true, index: 'fk_email_sending_logs_sender_emails2_idx' })
   reply?: SenderEmails;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt!: Date & Opt;
 
 }
@@ -1801,7 +1801,7 @@ export class EmailSendingLogs {
   @ManyToOne({ entity: () => SenderEmails, ref: true, fieldNames: ['sender_id', 'reply_email_id'], nullable: true, index: 'fk_email_sending_logs_sender_emails2_idx' })
   reply?: Ref<SenderEmails>;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt!: Date & Opt;
 
 }
@@ -2109,7 +2109,7 @@ export class EmailSendingLogs {
   @ManyToOne({ entity: () => SenderEmails, fieldNames: ['sender_id', 'reply_email_id'], nullable: true, index: 'fk_email_sending_logs_sender_emails2_idx' })
   reply?: SenderEmails;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt!: Date & Opt;
 
 }
@@ -2451,7 +2451,7 @@ export class EmailSendingLogs {
   @ManyToOne({ entity: () => SenderEmails, ref: true, fieldNames: ['sender_id', 'reply_email_id'], nullable: true, index: 'fk_email_sending_logs_sender_emails2_idx' })
   reply?: Ref<SenderEmails>;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt!: Date & Opt;
 
 }
@@ -2811,7 +2811,7 @@ export class EmailSendingLogs {
   @ManyToOne({ entity: () => SenderEmails, fieldNames: ['sender_id', 'reply_email_id'], nullable: true, index: 'fk_email_sending_logs_sender_emails2_idx' })
   reply?: SenderEmails;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt!: Date & Opt;
 
 }
@@ -3101,7 +3101,7 @@ export class EmailSendingLogs {
   @ManyToOne({ entity: () => SenderEmails, ref: true, fieldNames: ['sender_id', 'reply_email_id'], nullable: true, index: 'fk_email_sending_logs_sender_emails2_idx' })
   reply?: Ref<SenderEmails>;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt!: Date & Opt;
 
 }
@@ -3409,7 +3409,7 @@ export class EmailSendingLogs {
   @ManyToOne({ entity: () => SenderEmails, fieldNames: ['sender_id', 'reply_email_id'], nullable: true, index: 'fk_email_sending_logs_sender_emails2_idx' })
   reply?: SenderEmails;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt!: Date & Opt;
 
 }
@@ -3751,7 +3751,7 @@ export class EmailSendingLogs {
   @ManyToOne({ entity: () => SenderEmails, ref: true, fieldNames: ['sender_id', 'reply_email_id'], nullable: true, index: 'fk_email_sending_logs_sender_emails2_idx' })
   reply?: Ref<SenderEmails>;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt!: Date & Opt;
 
 }

--- a/tests/features/entity-generator/__snapshots__/OverlapFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OverlapFks.mysql.test.ts.snap
@@ -35,7 +35,7 @@ export class ProductCountryMap {
   @Property({ persist: false })
   productId!: number;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
   @ManyToOne({ entity: () => Countries, fieldName: 'country', primary: true })
@@ -65,12 +65,14 @@ export class ProductSellers {
   @Property({ persist: false })
   productId!: number;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { ProductCountryMap } from './ProductCountryMap';
 
 @Entity()
 export class Products {
@@ -87,8 +89,11 @@ export class Products {
   @Property({ columnType: 'numeric(10,2)' })
   currentPrice!: string;
 
-  @Property({ default: 0 })
+  @Property({ type: 'number' })
   currentQuantity: number & Opt = 0;
+
+  @ManyToMany({ entity: () => Countries, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'product_id', inverseJoinColumn: 'country' })
+  productCountryMap = new Collection<Countries>(this);
 
 }
 ",
@@ -120,7 +125,7 @@ export class Sales {
   @Property({ columnType: 'numeric(10,2)' })
   singularPrice!: string;
 
-  @Property({ unsigned: true, default: 1 })
+  @Property({ type: 'number', unsigned: true })
   quantitySold: number & Opt = 1;
 
   @ManyToOne({ entity: () => ProductCountryMap, fieldNames: ['country', 'product_id'], updateRule: 'cascade', index: 'fk_sales_product_country_map1_idx' })
@@ -128,7 +133,9 @@ export class Sales {
 
 }
 ",
-  "import { Entity, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+import { ProductSellers } from './ProductSellers';
+import { Products } from './Products';
 
 @Entity()
 export class Sellers {
@@ -141,6 +148,9 @@ export class Sellers {
   @Unique({ name: 'name_UNIQUE' })
   @Property({ length: 255 })
   name!: string;
+
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_sellers', pivotEntity: () => ProductSellers, joinColumn: 'seller_id', inverseJoinColumn: 'product_id' })
+  productSellers = new Collection<Products>(this);
 
 }
 ",
@@ -190,7 +200,7 @@ export const ProductCountryMapSchema = new EntitySchema({
       index: 'fk_product_country_map_products1',
     },
     productId: { type: 'number', persist: false, index: 'fk_product_country_map_products1' },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
     countries: { primary: true, kind: 'm:1', entity: () => Countries, fieldName: 'country' },
   },
 });
@@ -228,11 +238,12 @@ export const ProductSellersSchema = new EntitySchema({
       index: 'fk_product_sellers_products1',
     },
     productId: { type: 'number', persist: false, index: 'fk_product_sellers_products1' },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
@@ -240,6 +251,7 @@ export class Products {
   name!: string;
   currentPrice!: string;
   currentQuantity: number & Opt = 0;
+  productCountryMap = new Collection<Countries>(this);
 }
 
 export const ProductsSchema = new EntitySchema({
@@ -248,7 +260,15 @@ export const ProductsSchema = new EntitySchema({
     productId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
     currentPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    currentQuantity: { type: 'number', default: 0 },
+    currentQuantity: { type: 'number' },
+    productCountryMap: {
+      kind: 'm:n',
+      entity: () => Countries,
+      pivotTable: 'product_country_map',
+      pivotEntity: () => ProductCountryMap,
+      joinColumn: 'product_id',
+      inverseJoinColumn: 'country',
+    },
   },
 });
 ",
@@ -284,7 +304,7 @@ export const SalesSchema = new EntitySchema({
     sellerId: { type: 'number', persist: false },
     productId: { type: 'number', persist: false, index: 'product_id_idx' },
     singularPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    quantitySold: { type: 'number', unsigned: true, default: 1 },
+    quantitySold: { type: 'number', unsigned: true },
     productCountryMap: {
       kind: 'm:1',
       entity: () => ProductCountryMap,
@@ -298,12 +318,14 @@ export const SalesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 
 export class Sellers {
   [PrimaryKeyProp]?: 'sellerId';
   sellerId!: number;
   name!: string;
+  productSellers = new Collection<Products>(this);
 }
 
 export const SellersSchema = new EntitySchema({
@@ -311,6 +333,14 @@ export const SellersSchema = new EntitySchema({
   properties: {
     sellerId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
+    productSellers: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_sellers',
+      pivotEntity: () => ProductSellers,
+      joinColumn: 'seller_id',
+      inverseJoinColumn: 'product_id',
+    },
   },
 });
 ",
@@ -352,7 +382,7 @@ export class ProductCountryMap {
   @Property({ persist: false })
   productId!: number;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
   @ManyToOne({ entity: () => Countries, ref: true, fieldName: 'country', primary: true })
@@ -382,12 +412,14 @@ export class ProductSellers {
   @Property({ persist: false })
   productId!: number;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { ProductCountryMap } from './ProductCountryMap';
 
 @Entity()
 export class Products {
@@ -404,8 +436,11 @@ export class Products {
   @Property({ columnType: 'numeric(10,2)' })
   currentPrice!: string;
 
-  @Property({ default: 0 })
+  @Property({ type: 'number' })
   currentQuantity: number & Opt = 0;
+
+  @ManyToMany({ entity: () => Countries, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'product_id', inverseJoinColumn: 'country' })
+  productCountryMap = new Collection<Countries>(this);
 
 }
 ",
@@ -437,7 +472,7 @@ export class Sales {
   @Property({ columnType: 'numeric(10,2)' })
   singularPrice!: string;
 
-  @Property({ unsigned: true, default: 1 })
+  @Property({ type: 'number', unsigned: true })
   quantitySold: number & Opt = 1;
 
   @ManyToOne({ entity: () => ProductCountryMap, ref: true, fieldNames: ['country', 'product_id'], updateRule: 'cascade', index: 'fk_sales_product_country_map1_idx' })
@@ -445,7 +480,9 @@ export class Sales {
 
 }
 ",
-  "import { Entity, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+import { ProductSellers } from './ProductSellers';
+import { Products } from './Products';
 
 @Entity()
 export class Sellers {
@@ -458,6 +495,9 @@ export class Sellers {
   @Unique({ name: 'name_UNIQUE' })
   @Property({ length: 255 })
   name!: string;
+
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_sellers', pivotEntity: () => ProductSellers, joinColumn: 'seller_id', inverseJoinColumn: 'product_id' })
+  productSellers = new Collection<Products>(this);
 
 }
 ",
@@ -510,7 +550,7 @@ export const ProductCountryMapSchema = new EntitySchema({
       index: 'fk_product_country_map_products1',
     },
     productId: { type: 'number', persist: false, index: 'fk_product_country_map_products1' },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
     countries: {
       primary: true,
       kind: 'm:1',
@@ -558,11 +598,12 @@ export const ProductSellersSchema = new EntitySchema({
       index: 'fk_product_sellers_products1',
     },
     productId: { type: 'number', persist: false, index: 'fk_product_sellers_products1' },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
@@ -570,6 +611,7 @@ export class Products {
   name!: string;
   currentPrice!: string;
   currentQuantity: number & Opt = 0;
+  productCountryMap = new Collection<Countries>(this);
 }
 
 export const ProductsSchema = new EntitySchema({
@@ -578,7 +620,15 @@ export const ProductsSchema = new EntitySchema({
     productId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
     currentPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    currentQuantity: { type: 'number', default: 0 },
+    currentQuantity: { type: 'number' },
+    productCountryMap: {
+      kind: 'm:n',
+      entity: () => Countries,
+      pivotTable: 'product_country_map',
+      pivotEntity: () => ProductCountryMap,
+      joinColumn: 'product_id',
+      inverseJoinColumn: 'country',
+    },
   },
 });
 ",
@@ -617,7 +667,7 @@ export const SalesSchema = new EntitySchema({
     sellerId: { type: 'number', persist: false },
     productId: { type: 'number', persist: false, index: 'product_id_idx' },
     singularPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    quantitySold: { type: 'number', unsigned: true, default: 1 },
+    quantitySold: { type: 'number', unsigned: true },
     productCountryMap: {
       kind: 'm:1',
       entity: () => ProductCountryMap,
@@ -632,12 +682,14 @@ export const SalesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 
 export class Sellers {
   [PrimaryKeyProp]?: 'sellerId';
   sellerId!: number;
   name!: string;
+  productSellers = new Collection<Products>(this);
 }
 
 export const SellersSchema = new EntitySchema({
@@ -645,6 +697,14 @@ export const SellersSchema = new EntitySchema({
   properties: {
     sellerId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
+    productSellers: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_sellers',
+      pivotEntity: () => ProductSellers,
+      joinColumn: 'seller_id',
+      inverseJoinColumn: 'product_id',
+    },
   },
 });
 ",
@@ -653,8 +713,9 @@ export const SellersSchema = new EntitySchema({
 
 exports[`overlap_fk_example scalarPropertiesForRelations=always bidirectionalRelations=true identifiedReferences=false entitySchema=false: dump 1`] = `
 [
-  "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
+import { Products } from './Products';
 
 @Entity()
 export class Countries {
@@ -666,6 +727,9 @@ export class Countries {
 
   @OneToMany({ entity: () => ProductCountryMap, mappedBy: 'countries' })
   countriesInverse = new Collection<ProductCountryMap>(this);
+
+  @ManyToMany({ entity: () => Products, mappedBy: 'productCountryMap' })
+  productCountryMapInverse = new Collection<Products>(this);
 
 }
 ",
@@ -691,7 +755,7 @@ export class ProductCountryMap {
   @Property({ persist: false })
   productId!: number;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
   @ManyToOne({ entity: () => Countries, fieldName: 'country', primary: true })
@@ -725,7 +789,7 @@ export class ProductSellers {
   @Property({ persist: false })
   productId!: number;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'seller' })
@@ -733,8 +797,11 @@ export class ProductSellers {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
+import { Sellers } from './Sellers';
 
 @Entity()
 export class Products {
@@ -751,11 +818,17 @@ export class Products {
   @Property({ columnType: 'numeric(10,2)' })
   currentPrice!: string;
 
-  @Property({ default: 0 })
+  @Property({ type: 'number' })
   currentQuantity: number & Opt = 0;
+
+  @ManyToMany({ entity: () => Countries, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'product_id', inverseJoinColumn: 'country' })
+  productCountryMap = new Collection<Countries>(this);
 
   @OneToMany({ entity: () => ProductSellers, mappedBy: 'product' })
   productInverse = new Collection<ProductSellers>(this);
+
+  @ManyToMany({ entity: () => Sellers, mappedBy: 'productSellers' })
+  productSellersInverse = new Collection<Sellers>(this);
 
 }
 ",
@@ -787,7 +860,7 @@ export class Sales {
   @Property({ columnType: 'numeric(10,2)' })
   singularPrice!: string;
 
-  @Property({ unsigned: true, default: 1 })
+  @Property({ type: 'number', unsigned: true })
   quantitySold: number & Opt = 1;
 
   @ManyToOne({ entity: () => ProductCountryMap, fieldNames: ['country', 'product_id'], updateRule: 'cascade', index: 'fk_sales_product_country_map1_idx' })
@@ -795,8 +868,9 @@ export class Sales {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
+import { Products } from './Products';
 
 @Entity()
 export class Sellers {
@@ -810,6 +884,9 @@ export class Sellers {
   @Property({ length: 255 })
   name!: string;
 
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_sellers', pivotEntity: () => ProductSellers, joinColumn: 'seller_id', inverseJoinColumn: 'product_id' })
+  productSellers = new Collection<Products>(this);
+
   @OneToMany({ entity: () => ProductSellers, mappedBy: 'seller' })
   sellerInverse = new Collection<ProductSellers>(this);
 
@@ -822,11 +899,13 @@ exports[`overlap_fk_example scalarPropertiesForRelations=always bidirectionalRel
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
+import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
   code!: unknown;
   countriesInverse = new Collection<ProductCountryMap>(this);
+  productCountryMapInverse = new Collection<Products>(this);
 }
 
 export const CountriesSchema = new EntitySchema({
@@ -834,6 +913,7 @@ export const CountriesSchema = new EntitySchema({
   properties: {
     code: { primary: true, type: 'unknown', columnType: 'char(2)' },
     countriesInverse: { kind: '1:m', entity: () => ProductCountryMap, mappedBy: 'countries' },
+    productCountryMapInverse: { kind: 'm:n', entity: () => Products, mappedBy: 'productCountryMap' },
   },
 });
 ",
@@ -866,7 +946,7 @@ export const ProductCountryMapSchema = new EntitySchema({
       index: 'fk_product_country_map_products1',
     },
     productId: { type: 'number', persist: false, index: 'fk_product_country_map_products1' },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
     countries: { primary: true, kind: 'm:1', entity: () => Countries, fieldName: 'country' },
     productCountryMapInverse: { kind: '1:m', entity: () => Sales, mappedBy: 'productCountryMap' },
   },
@@ -907,13 +987,15 @@ export const ProductSellersSchema = new EntitySchema({
       index: 'fk_product_sellers_products1',
     },
     productId: { type: 'number', persist: false, index: 'fk_product_sellers_products1' },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
     sellerInverse: { kind: '1:m', entity: () => Sales, mappedBy: 'seller' },
   },
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
 import { ProductSellers } from './ProductSellers';
+import { Sellers } from './Sellers';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
@@ -921,7 +1003,9 @@ export class Products {
   name!: string;
   currentPrice!: string;
   currentQuantity: number & Opt = 0;
+  productCountryMap = new Collection<Countries>(this);
   productInverse = new Collection<ProductSellers>(this);
+  productSellersInverse = new Collection<Sellers>(this);
 }
 
 export const ProductsSchema = new EntitySchema({
@@ -930,8 +1014,17 @@ export const ProductsSchema = new EntitySchema({
     productId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
     currentPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    currentQuantity: { type: 'number', default: 0 },
+    currentQuantity: { type: 'number' },
+    productCountryMap: {
+      kind: 'm:n',
+      entity: () => Countries,
+      pivotTable: 'product_country_map',
+      pivotEntity: () => ProductCountryMap,
+      joinColumn: 'product_id',
+      inverseJoinColumn: 'country',
+    },
     productInverse: { kind: '1:m', entity: () => ProductSellers, mappedBy: 'product' },
+    productSellersInverse: { kind: 'm:n', entity: () => Sellers, mappedBy: 'productSellers' },
   },
 });
 ",
@@ -967,7 +1060,7 @@ export const SalesSchema = new EntitySchema({
     sellerId: { type: 'number', persist: false },
     productId: { type: 'number', persist: false, index: 'product_id_idx' },
     singularPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    quantitySold: { type: 'number', unsigned: true, default: 1 },
+    quantitySold: { type: 'number', unsigned: true },
     productCountryMap: {
       kind: 'm:1',
       entity: () => ProductCountryMap,
@@ -983,11 +1076,13 @@ export const SalesSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
+import { Products } from './Products';
 
 export class Sellers {
   [PrimaryKeyProp]?: 'sellerId';
   sellerId!: number;
   name!: string;
+  productSellers = new Collection<Products>(this);
   sellerInverse = new Collection<ProductSellers>(this);
 }
 
@@ -996,6 +1091,14 @@ export const SellersSchema = new EntitySchema({
   properties: {
     sellerId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
+    productSellers: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_sellers',
+      pivotEntity: () => ProductSellers,
+      joinColumn: 'seller_id',
+      inverseJoinColumn: 'product_id',
+    },
     sellerInverse: { kind: '1:m', entity: () => ProductSellers, mappedBy: 'seller' },
   },
 });
@@ -1005,8 +1108,9 @@ export const SellersSchema = new EntitySchema({
 
 exports[`overlap_fk_example scalarPropertiesForRelations=always bidirectionalRelations=true identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
+import { Products } from './Products';
 
 @Entity()
 export class Countries {
@@ -1018,6 +1122,9 @@ export class Countries {
 
   @OneToMany({ entity: () => ProductCountryMap, mappedBy: 'countries' })
   countriesInverse = new Collection<ProductCountryMap>(this);
+
+  @ManyToMany({ entity: () => Products, mappedBy: 'productCountryMap' })
+  productCountryMapInverse = new Collection<Products>(this);
 
 }
 ",
@@ -1043,7 +1150,7 @@ export class ProductCountryMap {
   @Property({ persist: false })
   productId!: number;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
   @ManyToOne({ entity: () => Countries, ref: true, fieldName: 'country', primary: true })
@@ -1077,7 +1184,7 @@ export class ProductSellers {
   @Property({ persist: false })
   productId!: number;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'seller' })
@@ -1085,8 +1192,11 @@ export class ProductSellers {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
+import { Sellers } from './Sellers';
 
 @Entity()
 export class Products {
@@ -1103,11 +1213,17 @@ export class Products {
   @Property({ columnType: 'numeric(10,2)' })
   currentPrice!: string;
 
-  @Property({ default: 0 })
+  @Property({ type: 'number' })
   currentQuantity: number & Opt = 0;
+
+  @ManyToMany({ entity: () => Countries, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'product_id', inverseJoinColumn: 'country' })
+  productCountryMap = new Collection<Countries>(this);
 
   @OneToMany({ entity: () => ProductSellers, mappedBy: 'product' })
   productInverse = new Collection<ProductSellers>(this);
+
+  @ManyToMany({ entity: () => Sellers, mappedBy: 'productSellers' })
+  productSellersInverse = new Collection<Sellers>(this);
 
 }
 ",
@@ -1139,7 +1255,7 @@ export class Sales {
   @Property({ columnType: 'numeric(10,2)' })
   singularPrice!: string;
 
-  @Property({ unsigned: true, default: 1 })
+  @Property({ type: 'number', unsigned: true })
   quantitySold: number & Opt = 1;
 
   @ManyToOne({ entity: () => ProductCountryMap, ref: true, fieldNames: ['country', 'product_id'], updateRule: 'cascade', index: 'fk_sales_product_country_map1_idx' })
@@ -1147,8 +1263,9 @@ export class Sales {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
+import { Products } from './Products';
 
 @Entity()
 export class Sellers {
@@ -1162,6 +1279,9 @@ export class Sellers {
   @Property({ length: 255 })
   name!: string;
 
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_sellers', pivotEntity: () => ProductSellers, joinColumn: 'seller_id', inverseJoinColumn: 'product_id' })
+  productSellers = new Collection<Products>(this);
+
   @OneToMany({ entity: () => ProductSellers, mappedBy: 'seller' })
   sellerInverse = new Collection<ProductSellers>(this);
 
@@ -1174,11 +1294,13 @@ exports[`overlap_fk_example scalarPropertiesForRelations=always bidirectionalRel
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
+import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
   code!: unknown;
   countriesInverse = new Collection<ProductCountryMap>(this);
+  productCountryMapInverse = new Collection<Products>(this);
 }
 
 export const CountriesSchema = new EntitySchema({
@@ -1186,6 +1308,7 @@ export const CountriesSchema = new EntitySchema({
   properties: {
     code: { primary: true, type: 'unknown', columnType: 'char(2)' },
     countriesInverse: { kind: '1:m', entity: () => ProductCountryMap, mappedBy: 'countries' },
+    productCountryMapInverse: { kind: 'm:n', entity: () => Products, mappedBy: 'productCountryMap' },
   },
 });
 ",
@@ -1221,7 +1344,7 @@ export const ProductCountryMapSchema = new EntitySchema({
       index: 'fk_product_country_map_products1',
     },
     productId: { type: 'number', persist: false, index: 'fk_product_country_map_products1' },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
     countries: {
       primary: true,
       kind: 'm:1',
@@ -1272,13 +1395,15 @@ export const ProductSellersSchema = new EntitySchema({
       index: 'fk_product_sellers_products1',
     },
     productId: { type: 'number', persist: false, index: 'fk_product_sellers_products1' },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
     sellerInverse: { kind: '1:m', entity: () => Sales, mappedBy: 'seller' },
   },
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
 import { ProductSellers } from './ProductSellers';
+import { Sellers } from './Sellers';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
@@ -1286,7 +1411,9 @@ export class Products {
   name!: string;
   currentPrice!: string;
   currentQuantity: number & Opt = 0;
+  productCountryMap = new Collection<Countries>(this);
   productInverse = new Collection<ProductSellers>(this);
+  productSellersInverse = new Collection<Sellers>(this);
 }
 
 export const ProductsSchema = new EntitySchema({
@@ -1295,8 +1422,17 @@ export const ProductsSchema = new EntitySchema({
     productId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
     currentPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    currentQuantity: { type: 'number', default: 0 },
+    currentQuantity: { type: 'number' },
+    productCountryMap: {
+      kind: 'm:n',
+      entity: () => Countries,
+      pivotTable: 'product_country_map',
+      pivotEntity: () => ProductCountryMap,
+      joinColumn: 'product_id',
+      inverseJoinColumn: 'country',
+    },
     productInverse: { kind: '1:m', entity: () => ProductSellers, mappedBy: 'product' },
+    productSellersInverse: { kind: 'm:n', entity: () => Sellers, mappedBy: 'productSellers' },
   },
 });
 ",
@@ -1335,7 +1471,7 @@ export const SalesSchema = new EntitySchema({
     sellerId: { type: 'number', persist: false },
     productId: { type: 'number', persist: false, index: 'product_id_idx' },
     singularPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    quantitySold: { type: 'number', unsigned: true, default: 1 },
+    quantitySold: { type: 'number', unsigned: true },
     productCountryMap: {
       kind: 'm:1',
       entity: () => ProductCountryMap,
@@ -1352,11 +1488,13 @@ export const SalesSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
+import { Products } from './Products';
 
 export class Sellers {
   [PrimaryKeyProp]?: 'sellerId';
   sellerId!: number;
   name!: string;
+  productSellers = new Collection<Products>(this);
   sellerInverse = new Collection<ProductSellers>(this);
 }
 
@@ -1365,6 +1503,14 @@ export const SellersSchema = new EntitySchema({
   properties: {
     sellerId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
+    productSellers: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_sellers',
+      pivotEntity: () => ProductSellers,
+      joinColumn: 'seller_id',
+      inverseJoinColumn: 'product_id',
+    },
     sellerInverse: { kind: '1:m', entity: () => ProductSellers, mappedBy: 'seller' },
   },
 });
@@ -1374,7 +1520,9 @@ export const SellersSchema = new EntitySchema({
 
 exports[`overlap_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=false entitySchema=false: dump 1`] = `
 [
-  "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountryMap } from './ProductCountryMap';
+import { Products } from './Products';
 
 @Entity()
 export class Countries {
@@ -1383,6 +1531,9 @@ export class Countries {
 
   @PrimaryKey({ columnType: 'char(2)' })
   code!: unknown;
+
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'country', inverseJoinColumn: 'product_id' })
+  productCountryMap = new Collection<Products>(this);
 
 }
 ",
@@ -1403,7 +1554,7 @@ export class ProductCountryMap {
   @ManyToOne({ entity: () => Products, fieldName: 'product_id', primary: true, index: 'fk_product_country_map_products1' })
   product!: Products;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
 }
@@ -1423,7 +1574,7 @@ export class ProductSellers {
   @ManyToOne({ entity: () => Products, fieldName: 'product_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_product_sellers_products1' })
   product!: Products;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
 }
@@ -1445,7 +1596,7 @@ export class Products {
   @Property({ columnType: 'numeric(10,2)' })
   currentPrice!: string;
 
-  @Property({ default: 0 })
+  @Property({ type: 'number' })
   currentQuantity: number & Opt = 0;
 
 }
@@ -1472,12 +1623,14 @@ export class Sales {
   @Property({ columnType: 'numeric(10,2)' })
   singularPrice!: string;
 
-  @Property({ unsigned: true, default: 1 })
+  @Property({ type: 'number', unsigned: true })
   quantitySold: number & Opt = 1;
 
 }
 ",
-  "import { Entity, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+import { ProductSellers } from './ProductSellers';
+import { Products } from './Products';
 
 @Entity()
 export class Sellers {
@@ -1491,6 +1644,9 @@ export class Sellers {
   @Property({ length: 255 })
   name!: string;
 
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_sellers', pivotEntity: () => ProductSellers, joinColumn: 'seller_id', inverseJoinColumn: 'product_id' })
+  productSellers = new Collection<Products>(this);
+
 }
 ",
 ]
@@ -1498,17 +1654,27 @@ export class Sellers {
 
 exports[`overlap_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
   code!: unknown;
+  productCountryMap = new Collection<Products>(this);
 }
 
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
     code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    productCountryMap: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_country_map',
+      pivotEntity: () => ProductCountryMap,
+      joinColumn: 'country',
+      inverseJoinColumn: 'product_id',
+    },
   },
 });
 ",
@@ -1536,7 +1702,7 @@ export const ProductCountryMapSchema = new EntitySchema({
       fieldName: 'product_id',
       index: 'fk_product_country_map_products1',
     },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
   },
 });
 ",
@@ -1569,7 +1735,7 @@ export const ProductSellersSchema = new EntitySchema({
       deleteRule: 'cascade',
       index: 'fk_product_sellers_products1',
     },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
   },
 });
 ",
@@ -1589,7 +1755,7 @@ export const ProductsSchema = new EntitySchema({
     productId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
     currentPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    currentQuantity: { type: 'number', default: 0 },
+    currentQuantity: { type: 'number' },
   },
 });
 ",
@@ -1632,16 +1798,18 @@ export const SalesSchema = new EntitySchema({
       index: 'fk_sales_product_sellers1_idx',
     },
     singularPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    quantitySold: { type: 'number', unsigned: true, default: 1 },
+    quantitySold: { type: 'number', unsigned: true },
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 
 export class Sellers {
   [PrimaryKeyProp]?: 'sellerId';
   sellerId!: number;
   name!: string;
+  productSellers = new Collection<Products>(this);
 }
 
 export const SellersSchema = new EntitySchema({
@@ -1649,6 +1817,14 @@ export const SellersSchema = new EntitySchema({
   properties: {
     sellerId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
+    productSellers: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_sellers',
+      pivotEntity: () => ProductSellers,
+      joinColumn: 'seller_id',
+      inverseJoinColumn: 'product_id',
+    },
   },
 });
 ",
@@ -1657,7 +1833,9 @@ export const SellersSchema = new EntitySchema({
 
 exports[`overlap_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountryMap } from './ProductCountryMap';
+import { Products } from './Products';
 
 @Entity()
 export class Countries {
@@ -1666,6 +1844,9 @@ export class Countries {
 
   @PrimaryKey({ columnType: 'char(2)' })
   code!: unknown;
+
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'country', inverseJoinColumn: 'product_id' })
+  productCountryMap = new Collection<Products>(this);
 
 }
 ",
@@ -1686,7 +1867,7 @@ export class ProductCountryMap {
   @ManyToOne({ entity: () => Products, ref: true, fieldName: 'product_id', primary: true, index: 'fk_product_country_map_products1' })
   product!: Ref<Products>;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
 }
@@ -1706,7 +1887,7 @@ export class ProductSellers {
   @ManyToOne({ entity: () => Products, ref: true, fieldName: 'product_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_product_sellers_products1' })
   product!: Ref<Products>;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
 }
@@ -1728,7 +1909,7 @@ export class Products {
   @Property({ columnType: 'numeric(10,2)' })
   currentPrice!: string;
 
-  @Property({ default: 0 })
+  @Property({ type: 'number' })
   currentQuantity: number & Opt = 0;
 
 }
@@ -1755,12 +1936,14 @@ export class Sales {
   @Property({ columnType: 'numeric(10,2)' })
   singularPrice!: string;
 
-  @Property({ unsigned: true, default: 1 })
+  @Property({ type: 'number', unsigned: true })
   quantitySold: number & Opt = 1;
 
 }
 ",
-  "import { Entity, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+import { ProductSellers } from './ProductSellers';
+import { Products } from './Products';
 
 @Entity()
 export class Sellers {
@@ -1774,6 +1957,9 @@ export class Sellers {
   @Property({ length: 255 })
   name!: string;
 
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_sellers', pivotEntity: () => ProductSellers, joinColumn: 'seller_id', inverseJoinColumn: 'product_id' })
+  productSellers = new Collection<Products>(this);
+
 }
 ",
 ]
@@ -1781,17 +1967,27 @@ export class Sellers {
 
 exports[`overlap_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
   code!: unknown;
+  productCountryMap = new Collection<Products>(this);
 }
 
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
     code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    productCountryMap: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_country_map',
+      pivotEntity: () => ProductCountryMap,
+      joinColumn: 'country',
+      inverseJoinColumn: 'product_id',
+    },
   },
 });
 ",
@@ -1828,7 +2024,7 @@ export const ProductCountryMapSchema = new EntitySchema({
       fieldName: 'product_id',
       index: 'fk_product_country_map_products1',
     },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
   },
 });
 ",
@@ -1865,7 +2061,7 @@ export const ProductSellersSchema = new EntitySchema({
       deleteRule: 'cascade',
       index: 'fk_product_sellers_products1',
     },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
   },
 });
 ",
@@ -1885,7 +2081,7 @@ export const ProductsSchema = new EntitySchema({
     productId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
     currentPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    currentQuantity: { type: 'number', default: 0 },
+    currentQuantity: { type: 'number' },
   },
 });
 ",
@@ -1932,16 +2128,18 @@ export const SalesSchema = new EntitySchema({
       index: 'fk_sales_product_sellers1_idx',
     },
     singularPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    quantitySold: { type: 'number', unsigned: true, default: 1 },
+    quantitySold: { type: 'number', unsigned: true },
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 
 export class Sellers {
   [PrimaryKeyProp]?: 'sellerId';
   sellerId!: number;
   name!: string;
+  productSellers = new Collection<Products>(this);
 }
 
 export const SellersSchema = new EntitySchema({
@@ -1949,6 +2147,14 @@ export const SellersSchema = new EntitySchema({
   properties: {
     sellerId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
+    productSellers: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_sellers',
+      pivotEntity: () => ProductSellers,
+      joinColumn: 'seller_id',
+      inverseJoinColumn: 'product_id',
+    },
   },
 });
 ",
@@ -1957,8 +2163,9 @@ export const SellersSchema = new EntitySchema({
 
 exports[`overlap_fk_example scalarPropertiesForRelations=never bidirectionalRelations=true identifiedReferences=false entitySchema=false: dump 1`] = `
 [
-  "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
+import { Products } from './Products';
 
 @Entity()
 export class Countries {
@@ -1967,6 +2174,9 @@ export class Countries {
 
   @PrimaryKey({ columnType: 'char(2)' })
   code!: unknown;
+
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'country', inverseJoinColumn: 'product_id' })
+  productCountryMap = new Collection<Products>(this);
 
   @OneToMany({ entity: () => ProductCountryMap, mappedBy: 'country' })
   countryInverse = new Collection<ProductCountryMap>(this);
@@ -1991,7 +2201,7 @@ export class ProductCountryMap {
   @ManyToOne({ entity: () => Products, fieldName: 'product_id', primary: true, index: 'fk_product_country_map_products1' })
   product!: Products;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'country' })
@@ -2015,7 +2225,7 @@ export class ProductSellers {
   @ManyToOne({ entity: () => Products, fieldName: 'product_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_product_sellers_products1' })
   product!: Products;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'seller' })
@@ -2023,8 +2233,10 @@ export class ProductSellers {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+import { Countries } from './Countries';
 import { ProductSellers } from './ProductSellers';
+import { Sellers } from './Sellers';
 
 @Entity()
 export class Products {
@@ -2041,11 +2253,17 @@ export class Products {
   @Property({ columnType: 'numeric(10,2)' })
   currentPrice!: string;
 
-  @Property({ default: 0 })
+  @Property({ type: 'number' })
   currentQuantity: number & Opt = 0;
+
+  @ManyToMany({ entity: () => Countries, mappedBy: 'productCountryMap' })
+  productCountryMapInverse = new Collection<Countries>(this);
 
   @OneToMany({ entity: () => ProductSellers, mappedBy: 'product' })
   productInverse = new Collection<ProductSellers>(this);
+
+  @ManyToMany({ entity: () => Sellers, mappedBy: 'productSellers' })
+  productSellersInverse = new Collection<Sellers>(this);
 
 }
 ",
@@ -2071,13 +2289,14 @@ export class Sales {
   @Property({ columnType: 'numeric(10,2)' })
   singularPrice!: string;
 
-  @Property({ unsigned: true, default: 1 })
+  @Property({ type: 'number', unsigned: true })
   quantitySold: number & Opt = 1;
 
 }
 ",
-  "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
+import { Products } from './Products';
 
 @Entity()
 export class Sellers {
@@ -2090,6 +2309,9 @@ export class Sellers {
   @Unique({ name: 'name_UNIQUE' })
   @Property({ length: 255 })
   name!: string;
+
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_sellers', pivotEntity: () => ProductSellers, joinColumn: 'seller_id', inverseJoinColumn: 'product_id' })
+  productSellers = new Collection<Products>(this);
 
   @OneToMany({ entity: () => ProductSellers, mappedBy: 'seller' })
   sellerInverse = new Collection<ProductSellers>(this);
@@ -2103,10 +2325,12 @@ exports[`overlap_fk_example scalarPropertiesForRelations=never bidirectionalRela
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
+import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
   code!: unknown;
+  productCountryMap = new Collection<Products>(this);
   countryInverse = new Collection<ProductCountryMap>(this);
 }
 
@@ -2114,6 +2338,14 @@ export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
     code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    productCountryMap: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_country_map',
+      pivotEntity: () => ProductCountryMap,
+      joinColumn: 'country',
+      inverseJoinColumn: 'product_id',
+    },
     countryInverse: { kind: '1:m', entity: () => ProductCountryMap, mappedBy: 'country' },
   },
 });
@@ -2144,7 +2376,7 @@ export const ProductCountryMapSchema = new EntitySchema({
       fieldName: 'product_id',
       index: 'fk_product_country_map_products1',
     },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
     countryInverse: { kind: '1:m', entity: () => Sales, mappedBy: 'country' },
   },
 });
@@ -2180,13 +2412,15 @@ export const ProductSellersSchema = new EntitySchema({
       deleteRule: 'cascade',
       index: 'fk_product_sellers_products1',
     },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
     sellerInverse: { kind: '1:m', entity: () => Sales, mappedBy: 'seller' },
   },
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
 import { ProductSellers } from './ProductSellers';
+import { Sellers } from './Sellers';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
@@ -2194,7 +2428,9 @@ export class Products {
   name!: string;
   currentPrice!: string;
   currentQuantity: number & Opt = 0;
+  productCountryMapInverse = new Collection<Countries>(this);
   productInverse = new Collection<ProductSellers>(this);
+  productSellersInverse = new Collection<Sellers>(this);
 }
 
 export const ProductsSchema = new EntitySchema({
@@ -2203,8 +2439,10 @@ export const ProductsSchema = new EntitySchema({
     productId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
     currentPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    currentQuantity: { type: 'number', default: 0 },
+    currentQuantity: { type: 'number' },
+    productCountryMapInverse: { kind: 'm:n', entity: () => Countries, mappedBy: 'productCountryMap' },
     productInverse: { kind: '1:m', entity: () => ProductSellers, mappedBy: 'product' },
+    productSellersInverse: { kind: 'm:n', entity: () => Sellers, mappedBy: 'productSellers' },
   },
 });
 ",
@@ -2247,17 +2485,19 @@ export const SalesSchema = new EntitySchema({
       index: 'fk_sales_product_sellers1_idx',
     },
     singularPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    quantitySold: { type: 'number', unsigned: true, default: 1 },
+    quantitySold: { type: 'number', unsigned: true },
   },
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
+import { Products } from './Products';
 
 export class Sellers {
   [PrimaryKeyProp]?: 'sellerId';
   sellerId!: number;
   name!: string;
+  productSellers = new Collection<Products>(this);
   sellerInverse = new Collection<ProductSellers>(this);
 }
 
@@ -2266,6 +2506,14 @@ export const SellersSchema = new EntitySchema({
   properties: {
     sellerId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
+    productSellers: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_sellers',
+      pivotEntity: () => ProductSellers,
+      joinColumn: 'seller_id',
+      inverseJoinColumn: 'product_id',
+    },
     sellerInverse: { kind: '1:m', entity: () => ProductSellers, mappedBy: 'seller' },
   },
 });
@@ -2275,8 +2523,9 @@ export const SellersSchema = new EntitySchema({
 
 exports[`overlap_fk_example scalarPropertiesForRelations=never bidirectionalRelations=true identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
+import { Products } from './Products';
 
 @Entity()
 export class Countries {
@@ -2285,6 +2534,9 @@ export class Countries {
 
   @PrimaryKey({ columnType: 'char(2)' })
   code!: unknown;
+
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'country', inverseJoinColumn: 'product_id' })
+  productCountryMap = new Collection<Products>(this);
 
   @OneToMany({ entity: () => ProductCountryMap, mappedBy: 'country' })
   countryInverse = new Collection<ProductCountryMap>(this);
@@ -2309,7 +2561,7 @@ export class ProductCountryMap {
   @ManyToOne({ entity: () => Products, ref: true, fieldName: 'product_id', primary: true, index: 'fk_product_country_map_products1' })
   product!: Ref<Products>;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'country' })
@@ -2333,7 +2585,7 @@ export class ProductSellers {
   @ManyToOne({ entity: () => Products, ref: true, fieldName: 'product_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_product_sellers_products1' })
   product!: Ref<Products>;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'seller' })
@@ -2341,8 +2593,10 @@ export class ProductSellers {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+import { Countries } from './Countries';
 import { ProductSellers } from './ProductSellers';
+import { Sellers } from './Sellers';
 
 @Entity()
 export class Products {
@@ -2359,11 +2613,17 @@ export class Products {
   @Property({ columnType: 'numeric(10,2)' })
   currentPrice!: string;
 
-  @Property({ default: 0 })
+  @Property({ type: 'number' })
   currentQuantity: number & Opt = 0;
+
+  @ManyToMany({ entity: () => Countries, mappedBy: 'productCountryMap' })
+  productCountryMapInverse = new Collection<Countries>(this);
 
   @OneToMany({ entity: () => ProductSellers, mappedBy: 'product' })
   productInverse = new Collection<ProductSellers>(this);
+
+  @ManyToMany({ entity: () => Sellers, mappedBy: 'productSellers' })
+  productSellersInverse = new Collection<Sellers>(this);
 
 }
 ",
@@ -2389,13 +2649,14 @@ export class Sales {
   @Property({ columnType: 'numeric(10,2)' })
   singularPrice!: string;
 
-  @Property({ unsigned: true, default: 1 })
+  @Property({ type: 'number', unsigned: true })
   quantitySold: number & Opt = 1;
 
 }
 ",
-  "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
+import { Products } from './Products';
 
 @Entity()
 export class Sellers {
@@ -2409,6 +2670,9 @@ export class Sellers {
   @Property({ length: 255 })
   name!: string;
 
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_sellers', pivotEntity: () => ProductSellers, joinColumn: 'seller_id', inverseJoinColumn: 'product_id' })
+  productSellers = new Collection<Products>(this);
+
   @OneToMany({ entity: () => ProductSellers, mappedBy: 'seller' })
   sellerInverse = new Collection<ProductSellers>(this);
 
@@ -2421,10 +2685,12 @@ exports[`overlap_fk_example scalarPropertiesForRelations=never bidirectionalRela
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
+import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
   code!: unknown;
+  productCountryMap = new Collection<Products>(this);
   countryInverse = new Collection<ProductCountryMap>(this);
 }
 
@@ -2432,6 +2698,14 @@ export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
     code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    productCountryMap: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_country_map',
+      pivotEntity: () => ProductCountryMap,
+      joinColumn: 'country',
+      inverseJoinColumn: 'product_id',
+    },
     countryInverse: { kind: '1:m', entity: () => ProductCountryMap, mappedBy: 'country' },
   },
 });
@@ -2471,7 +2745,7 @@ export const ProductCountryMapSchema = new EntitySchema({
       fieldName: 'product_id',
       index: 'fk_product_country_map_products1',
     },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
     countryInverse: { kind: '1:m', entity: () => Sales, mappedBy: 'country' },
   },
 });
@@ -2511,13 +2785,15 @@ export const ProductSellersSchema = new EntitySchema({
       deleteRule: 'cascade',
       index: 'fk_product_sellers_products1',
     },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
     sellerInverse: { kind: '1:m', entity: () => Sales, mappedBy: 'seller' },
   },
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
 import { ProductSellers } from './ProductSellers';
+import { Sellers } from './Sellers';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
@@ -2525,7 +2801,9 @@ export class Products {
   name!: string;
   currentPrice!: string;
   currentQuantity: number & Opt = 0;
+  productCountryMapInverse = new Collection<Countries>(this);
   productInverse = new Collection<ProductSellers>(this);
+  productSellersInverse = new Collection<Sellers>(this);
 }
 
 export const ProductsSchema = new EntitySchema({
@@ -2534,8 +2812,10 @@ export const ProductsSchema = new EntitySchema({
     productId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
     currentPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    currentQuantity: { type: 'number', default: 0 },
+    currentQuantity: { type: 'number' },
+    productCountryMapInverse: { kind: 'm:n', entity: () => Countries, mappedBy: 'productCountryMap' },
     productInverse: { kind: '1:m', entity: () => ProductSellers, mappedBy: 'product' },
+    productSellersInverse: { kind: 'm:n', entity: () => Sellers, mappedBy: 'productSellers' },
   },
 });
 ",
@@ -2582,17 +2862,19 @@ export const SalesSchema = new EntitySchema({
       index: 'fk_sales_product_sellers1_idx',
     },
     singularPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    quantitySold: { type: 'number', unsigned: true, default: 1 },
+    quantitySold: { type: 'number', unsigned: true },
   },
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
+import { Products } from './Products';
 
 export class Sellers {
   [PrimaryKeyProp]?: 'sellerId';
   sellerId!: number;
   name!: string;
+  productSellers = new Collection<Products>(this);
   sellerInverse = new Collection<ProductSellers>(this);
 }
 
@@ -2601,6 +2883,14 @@ export const SellersSchema = new EntitySchema({
   properties: {
     sellerId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
+    productSellers: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_sellers',
+      pivotEntity: () => ProductSellers,
+      joinColumn: 'seller_id',
+      inverseJoinColumn: 'product_id',
+    },
     sellerInverse: { kind: '1:m', entity: () => ProductSellers, mappedBy: 'seller' },
   },
 });
@@ -2610,7 +2900,9 @@ export const SellersSchema = new EntitySchema({
 
 exports[`overlap_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=false entitySchema=false: dump 1`] = `
 [
-  "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountryMap } from './ProductCountryMap';
+import { Products } from './Products';
 
 @Entity()
 export class Countries {
@@ -2619,6 +2911,9 @@ export class Countries {
 
   @PrimaryKey({ columnType: 'char(2)' })
   code!: unknown;
+
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'country', inverseJoinColumn: 'product_id' })
+  productCountryMap = new Collection<Products>(this);
 
 }
 ",
@@ -2639,7 +2934,7 @@ export class ProductCountryMap {
   @ManyToOne({ entity: () => Products, fieldName: 'product_id', primary: true, index: 'fk_product_country_map_products1' })
   product!: Products;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
 }
@@ -2659,7 +2954,7 @@ export class ProductSellers {
   @ManyToOne({ entity: () => Products, fieldName: 'product_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_product_sellers_products1' })
   product!: Products;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
 }
@@ -2681,7 +2976,7 @@ export class Products {
   @Property({ columnType: 'numeric(10,2)' })
   currentPrice!: string;
 
-  @Property({ default: 0 })
+  @Property({ type: 'number' })
   currentQuantity: number & Opt = 0;
 
 }
@@ -2708,12 +3003,14 @@ export class Sales {
   @Property({ columnType: 'numeric(10,2)' })
   singularPrice!: string;
 
-  @Property({ unsigned: true, default: 1 })
+  @Property({ type: 'number', unsigned: true })
   quantitySold: number & Opt = 1;
 
 }
 ",
-  "import { Entity, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+import { ProductSellers } from './ProductSellers';
+import { Products } from './Products';
 
 @Entity()
 export class Sellers {
@@ -2727,6 +3024,9 @@ export class Sellers {
   @Property({ length: 255 })
   name!: string;
 
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_sellers', pivotEntity: () => ProductSellers, joinColumn: 'seller_id', inverseJoinColumn: 'product_id' })
+  productSellers = new Collection<Products>(this);
+
 }
 ",
 ]
@@ -2734,17 +3034,27 @@ export class Sellers {
 
 exports[`overlap_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
   code!: unknown;
+  productCountryMap = new Collection<Products>(this);
 }
 
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
     code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    productCountryMap: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_country_map',
+      pivotEntity: () => ProductCountryMap,
+      joinColumn: 'country',
+      inverseJoinColumn: 'product_id',
+    },
   },
 });
 ",
@@ -2772,7 +3082,7 @@ export const ProductCountryMapSchema = new EntitySchema({
       fieldName: 'product_id',
       index: 'fk_product_country_map_products1',
     },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
   },
 });
 ",
@@ -2805,7 +3115,7 @@ export const ProductSellersSchema = new EntitySchema({
       deleteRule: 'cascade',
       index: 'fk_product_sellers_products1',
     },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
   },
 });
 ",
@@ -2825,7 +3135,7 @@ export const ProductsSchema = new EntitySchema({
     productId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
     currentPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    currentQuantity: { type: 'number', default: 0 },
+    currentQuantity: { type: 'number' },
   },
 });
 ",
@@ -2868,16 +3178,18 @@ export const SalesSchema = new EntitySchema({
       index: 'fk_sales_product_sellers1_idx',
     },
     singularPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    quantitySold: { type: 'number', unsigned: true, default: 1 },
+    quantitySold: { type: 'number', unsigned: true },
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 
 export class Sellers {
   [PrimaryKeyProp]?: 'sellerId';
   sellerId!: number;
   name!: string;
+  productSellers = new Collection<Products>(this);
 }
 
 export const SellersSchema = new EntitySchema({
@@ -2885,6 +3197,14 @@ export const SellersSchema = new EntitySchema({
   properties: {
     sellerId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
+    productSellers: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_sellers',
+      pivotEntity: () => ProductSellers,
+      joinColumn: 'seller_id',
+      inverseJoinColumn: 'product_id',
+    },
   },
 });
 ",
@@ -2893,7 +3213,9 @@ export const SellersSchema = new EntitySchema({
 
 exports[`overlap_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountryMap } from './ProductCountryMap';
+import { Products } from './Products';
 
 @Entity()
 export class Countries {
@@ -2902,6 +3224,9 @@ export class Countries {
 
   @PrimaryKey({ columnType: 'char(2)' })
   code!: unknown;
+
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'country', inverseJoinColumn: 'product_id' })
+  productCountryMap = new Collection<Products>(this);
 
 }
 ",
@@ -2922,7 +3247,7 @@ export class ProductCountryMap {
   @ManyToOne({ entity: () => Products, ref: true, fieldName: 'product_id', primary: true, index: 'fk_product_country_map_products1' })
   product!: Ref<Products>;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
 }
@@ -2942,7 +3267,7 @@ export class ProductSellers {
   @ManyToOne({ entity: () => Products, ref: true, fieldName: 'product_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_product_sellers_products1' })
   product!: Ref<Products>;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
 }
@@ -2964,7 +3289,7 @@ export class Products {
   @Property({ columnType: 'numeric(10,2)' })
   currentPrice!: string;
 
-  @Property({ default: 0 })
+  @Property({ type: 'number' })
   currentQuantity: number & Opt = 0;
 
 }
@@ -2991,12 +3316,14 @@ export class Sales {
   @Property({ columnType: 'numeric(10,2)' })
   singularPrice!: string;
 
-  @Property({ unsigned: true, default: 1 })
+  @Property({ type: 'number', unsigned: true })
   quantitySold: number & Opt = 1;
 
 }
 ",
-  "import { Entity, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+import { ProductSellers } from './ProductSellers';
+import { Products } from './Products';
 
 @Entity()
 export class Sellers {
@@ -3010,6 +3337,9 @@ export class Sellers {
   @Property({ length: 255 })
   name!: string;
 
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_sellers', pivotEntity: () => ProductSellers, joinColumn: 'seller_id', inverseJoinColumn: 'product_id' })
+  productSellers = new Collection<Products>(this);
+
 }
 ",
 ]
@@ -3017,17 +3347,27 @@ export class Sellers {
 
 exports[`overlap_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
   code!: unknown;
+  productCountryMap = new Collection<Products>(this);
 }
 
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
     code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    productCountryMap: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_country_map',
+      pivotEntity: () => ProductCountryMap,
+      joinColumn: 'country',
+      inverseJoinColumn: 'product_id',
+    },
   },
 });
 ",
@@ -3064,7 +3404,7 @@ export const ProductCountryMapSchema = new EntitySchema({
       fieldName: 'product_id',
       index: 'fk_product_country_map_products1',
     },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
   },
 });
 ",
@@ -3101,7 +3441,7 @@ export const ProductSellersSchema = new EntitySchema({
       deleteRule: 'cascade',
       index: 'fk_product_sellers_products1',
     },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
   },
 });
 ",
@@ -3121,7 +3461,7 @@ export const ProductsSchema = new EntitySchema({
     productId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
     currentPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    currentQuantity: { type: 'number', default: 0 },
+    currentQuantity: { type: 'number' },
   },
 });
 ",
@@ -3168,16 +3508,18 @@ export const SalesSchema = new EntitySchema({
       index: 'fk_sales_product_sellers1_idx',
     },
     singularPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    quantitySold: { type: 'number', unsigned: true, default: 1 },
+    quantitySold: { type: 'number', unsigned: true },
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 
 export class Sellers {
   [PrimaryKeyProp]?: 'sellerId';
   sellerId!: number;
   name!: string;
+  productSellers = new Collection<Products>(this);
 }
 
 export const SellersSchema = new EntitySchema({
@@ -3185,6 +3527,14 @@ export const SellersSchema = new EntitySchema({
   properties: {
     sellerId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
+    productSellers: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_sellers',
+      pivotEntity: () => ProductSellers,
+      joinColumn: 'seller_id',
+      inverseJoinColumn: 'product_id',
+    },
   },
 });
 ",
@@ -3193,8 +3543,9 @@ export const SellersSchema = new EntitySchema({
 
 exports[`overlap_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=true identifiedReferences=false entitySchema=false: dump 1`] = `
 [
-  "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
+import { Products } from './Products';
 
 @Entity()
 export class Countries {
@@ -3203,6 +3554,9 @@ export class Countries {
 
   @PrimaryKey({ columnType: 'char(2)' })
   code!: unknown;
+
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'country', inverseJoinColumn: 'product_id' })
+  productCountryMap = new Collection<Products>(this);
 
   @OneToMany({ entity: () => ProductCountryMap, mappedBy: 'country' })
   countryInverse = new Collection<ProductCountryMap>(this);
@@ -3227,7 +3581,7 @@ export class ProductCountryMap {
   @ManyToOne({ entity: () => Products, fieldName: 'product_id', primary: true, index: 'fk_product_country_map_products1' })
   product!: Products;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'country' })
@@ -3251,7 +3605,7 @@ export class ProductSellers {
   @ManyToOne({ entity: () => Products, fieldName: 'product_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_product_sellers_products1' })
   product!: Products;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'seller' })
@@ -3259,8 +3613,10 @@ export class ProductSellers {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+import { Countries } from './Countries';
 import { ProductSellers } from './ProductSellers';
+import { Sellers } from './Sellers';
 
 @Entity()
 export class Products {
@@ -3277,11 +3633,17 @@ export class Products {
   @Property({ columnType: 'numeric(10,2)' })
   currentPrice!: string;
 
-  @Property({ default: 0 })
+  @Property({ type: 'number' })
   currentQuantity: number & Opt = 0;
+
+  @ManyToMany({ entity: () => Countries, mappedBy: 'productCountryMap' })
+  productCountryMapInverse = new Collection<Countries>(this);
 
   @OneToMany({ entity: () => ProductSellers, mappedBy: 'product' })
   productInverse = new Collection<ProductSellers>(this);
+
+  @ManyToMany({ entity: () => Sellers, mappedBy: 'productSellers' })
+  productSellersInverse = new Collection<Sellers>(this);
 
 }
 ",
@@ -3307,13 +3669,14 @@ export class Sales {
   @Property({ columnType: 'numeric(10,2)' })
   singularPrice!: string;
 
-  @Property({ unsigned: true, default: 1 })
+  @Property({ type: 'number', unsigned: true })
   quantitySold: number & Opt = 1;
 
 }
 ",
-  "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
+import { Products } from './Products';
 
 @Entity()
 export class Sellers {
@@ -3327,6 +3690,9 @@ export class Sellers {
   @Property({ length: 255 })
   name!: string;
 
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_sellers', pivotEntity: () => ProductSellers, joinColumn: 'seller_id', inverseJoinColumn: 'product_id' })
+  productSellers = new Collection<Products>(this);
+
   @OneToMany({ entity: () => ProductSellers, mappedBy: 'seller' })
   sellerInverse = new Collection<ProductSellers>(this);
 
@@ -3339,10 +3705,12 @@ exports[`overlap_fk_example scalarPropertiesForRelations=smart bidirectionalRela
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
+import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
   code!: unknown;
+  productCountryMap = new Collection<Products>(this);
   countryInverse = new Collection<ProductCountryMap>(this);
 }
 
@@ -3350,6 +3718,14 @@ export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
     code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    productCountryMap: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_country_map',
+      pivotEntity: () => ProductCountryMap,
+      joinColumn: 'country',
+      inverseJoinColumn: 'product_id',
+    },
     countryInverse: { kind: '1:m', entity: () => ProductCountryMap, mappedBy: 'country' },
   },
 });
@@ -3380,7 +3756,7 @@ export const ProductCountryMapSchema = new EntitySchema({
       fieldName: 'product_id',
       index: 'fk_product_country_map_products1',
     },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
     countryInverse: { kind: '1:m', entity: () => Sales, mappedBy: 'country' },
   },
 });
@@ -3416,13 +3792,15 @@ export const ProductSellersSchema = new EntitySchema({
       deleteRule: 'cascade',
       index: 'fk_product_sellers_products1',
     },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
     sellerInverse: { kind: '1:m', entity: () => Sales, mappedBy: 'seller' },
   },
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
 import { ProductSellers } from './ProductSellers';
+import { Sellers } from './Sellers';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
@@ -3430,7 +3808,9 @@ export class Products {
   name!: string;
   currentPrice!: string;
   currentQuantity: number & Opt = 0;
+  productCountryMapInverse = new Collection<Countries>(this);
   productInverse = new Collection<ProductSellers>(this);
+  productSellersInverse = new Collection<Sellers>(this);
 }
 
 export const ProductsSchema = new EntitySchema({
@@ -3439,8 +3819,10 @@ export const ProductsSchema = new EntitySchema({
     productId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
     currentPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    currentQuantity: { type: 'number', default: 0 },
+    currentQuantity: { type: 'number' },
+    productCountryMapInverse: { kind: 'm:n', entity: () => Countries, mappedBy: 'productCountryMap' },
     productInverse: { kind: '1:m', entity: () => ProductSellers, mappedBy: 'product' },
+    productSellersInverse: { kind: 'm:n', entity: () => Sellers, mappedBy: 'productSellers' },
   },
 });
 ",
@@ -3483,17 +3865,19 @@ export const SalesSchema = new EntitySchema({
       index: 'fk_sales_product_sellers1_idx',
     },
     singularPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    quantitySold: { type: 'number', unsigned: true, default: 1 },
+    quantitySold: { type: 'number', unsigned: true },
   },
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
+import { Products } from './Products';
 
 export class Sellers {
   [PrimaryKeyProp]?: 'sellerId';
   sellerId!: number;
   name!: string;
+  productSellers = new Collection<Products>(this);
   sellerInverse = new Collection<ProductSellers>(this);
 }
 
@@ -3502,6 +3886,14 @@ export const SellersSchema = new EntitySchema({
   properties: {
     sellerId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
+    productSellers: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_sellers',
+      pivotEntity: () => ProductSellers,
+      joinColumn: 'seller_id',
+      inverseJoinColumn: 'product_id',
+    },
     sellerInverse: { kind: '1:m', entity: () => ProductSellers, mappedBy: 'seller' },
   },
 });
@@ -3511,8 +3903,9 @@ export const SellersSchema = new EntitySchema({
 
 exports[`overlap_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=true identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
+import { Products } from './Products';
 
 @Entity()
 export class Countries {
@@ -3521,6 +3914,9 @@ export class Countries {
 
   @PrimaryKey({ columnType: 'char(2)' })
   code!: unknown;
+
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'country', inverseJoinColumn: 'product_id' })
+  productCountryMap = new Collection<Products>(this);
 
   @OneToMany({ entity: () => ProductCountryMap, mappedBy: 'country' })
   countryInverse = new Collection<ProductCountryMap>(this);
@@ -3545,7 +3941,7 @@ export class ProductCountryMap {
   @ManyToOne({ entity: () => Products, ref: true, fieldName: 'product_id', primary: true, index: 'fk_product_country_map_products1' })
   product!: Ref<Products>;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'country' })
@@ -3569,7 +3965,7 @@ export class ProductSellers {
   @ManyToOne({ entity: () => Products, ref: true, fieldName: 'product_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_product_sellers_products1' })
   product!: Ref<Products>;
 
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   isCurrentlyAllowed: boolean & Opt = false;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'seller' })
@@ -3577,8 +3973,10 @@ export class ProductSellers {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+import { Countries } from './Countries';
 import { ProductSellers } from './ProductSellers';
+import { Sellers } from './Sellers';
 
 @Entity()
 export class Products {
@@ -3595,11 +3993,17 @@ export class Products {
   @Property({ columnType: 'numeric(10,2)' })
   currentPrice!: string;
 
-  @Property({ default: 0 })
+  @Property({ type: 'number' })
   currentQuantity: number & Opt = 0;
+
+  @ManyToMany({ entity: () => Countries, mappedBy: 'productCountryMap' })
+  productCountryMapInverse = new Collection<Countries>(this);
 
   @OneToMany({ entity: () => ProductSellers, mappedBy: 'product' })
   productInverse = new Collection<ProductSellers>(this);
+
+  @ManyToMany({ entity: () => Sellers, mappedBy: 'productSellers' })
+  productSellersInverse = new Collection<Sellers>(this);
 
 }
 ",
@@ -3625,13 +4029,14 @@ export class Sales {
   @Property({ columnType: 'numeric(10,2)' })
   singularPrice!: string;
 
-  @Property({ unsigned: true, default: 1 })
+  @Property({ type: 'number', unsigned: true })
   quantitySold: number & Opt = 1;
 
 }
 ",
-  "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
+import { Products } from './Products';
 
 @Entity()
 export class Sellers {
@@ -3645,6 +4050,9 @@ export class Sellers {
   @Property({ length: 255 })
   name!: string;
 
+  @ManyToMany({ entity: () => Products, pivotTable: 'product_sellers', pivotEntity: () => ProductSellers, joinColumn: 'seller_id', inverseJoinColumn: 'product_id' })
+  productSellers = new Collection<Products>(this);
+
   @OneToMany({ entity: () => ProductSellers, mappedBy: 'seller' })
   sellerInverse = new Collection<ProductSellers>(this);
 
@@ -3657,10 +4065,12 @@ exports[`overlap_fk_example scalarPropertiesForRelations=smart bidirectionalRela
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
+import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
   code!: unknown;
+  productCountryMap = new Collection<Products>(this);
   countryInverse = new Collection<ProductCountryMap>(this);
 }
 
@@ -3668,6 +4078,14 @@ export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
     code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    productCountryMap: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_country_map',
+      pivotEntity: () => ProductCountryMap,
+      joinColumn: 'country',
+      inverseJoinColumn: 'product_id',
+    },
     countryInverse: { kind: '1:m', entity: () => ProductCountryMap, mappedBy: 'country' },
   },
 });
@@ -3707,7 +4125,7 @@ export const ProductCountryMapSchema = new EntitySchema({
       fieldName: 'product_id',
       index: 'fk_product_country_map_products1',
     },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
     countryInverse: { kind: '1:m', entity: () => Sales, mappedBy: 'country' },
   },
 });
@@ -3747,13 +4165,15 @@ export const ProductSellersSchema = new EntitySchema({
       deleteRule: 'cascade',
       index: 'fk_product_sellers_products1',
     },
-    isCurrentlyAllowed: { type: 'boolean', default: false },
+    isCurrentlyAllowed: { type: 'boolean' },
     sellerInverse: { kind: '1:m', entity: () => Sales, mappedBy: 'seller' },
   },
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
 import { ProductSellers } from './ProductSellers';
+import { Sellers } from './Sellers';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
@@ -3761,7 +4181,9 @@ export class Products {
   name!: string;
   currentPrice!: string;
   currentQuantity: number & Opt = 0;
+  productCountryMapInverse = new Collection<Countries>(this);
   productInverse = new Collection<ProductSellers>(this);
+  productSellersInverse = new Collection<Sellers>(this);
 }
 
 export const ProductsSchema = new EntitySchema({
@@ -3770,8 +4192,10 @@ export const ProductsSchema = new EntitySchema({
     productId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
     currentPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    currentQuantity: { type: 'number', default: 0 },
+    currentQuantity: { type: 'number' },
+    productCountryMapInverse: { kind: 'm:n', entity: () => Countries, mappedBy: 'productCountryMap' },
     productInverse: { kind: '1:m', entity: () => ProductSellers, mappedBy: 'product' },
+    productSellersInverse: { kind: 'm:n', entity: () => Sellers, mappedBy: 'productSellers' },
   },
 });
 ",
@@ -3818,17 +4242,19 @@ export const SalesSchema = new EntitySchema({
       index: 'fk_sales_product_sellers1_idx',
     },
     singularPrice: { type: 'string', columnType: 'numeric(10,2)' },
-    quantitySold: { type: 'number', unsigned: true, default: 1 },
+    quantitySold: { type: 'number', unsigned: true },
   },
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductSellers } from './ProductSellers';
+import { Products } from './Products';
 
 export class Sellers {
   [PrimaryKeyProp]?: 'sellerId';
   sellerId!: number;
   name!: string;
+  productSellers = new Collection<Products>(this);
   sellerInverse = new Collection<ProductSellers>(this);
 }
 
@@ -3837,6 +4263,14 @@ export const SellersSchema = new EntitySchema({
   properties: {
     sellerId: { primary: true, type: 'number' },
     name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
+    productSellers: {
+      kind: 'm:n',
+      entity: () => Products,
+      pivotTable: 'product_sellers',
+      pivotEntity: () => ProductSellers,
+      joinColumn: 'seller_id',
+      inverseJoinColumn: 'product_id',
+    },
     sellerInverse: { kind: '1:m', entity: () => ProductSellers, mappedBy: 'seller' },
   },
 });

--- a/tests/features/entity-generator/__snapshots__/ScalarPropsForFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/ScalarPropsForFks.mysql.test.ts.snap
@@ -32,10 +32,10 @@ export class Author2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -51,7 +51,7 @@ export class Author2 {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -169,7 +169,7 @@ export class Book2 {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -202,8 +202,8 @@ export class Book2 {
   @Property({ nullable: true, persist: false })
   publisherId?: number;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -343,7 +343,7 @@ export class FooBar2 {
   @Property({ nullable: true, persist: false })
   fooBarId?: number;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -371,7 +371,7 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -402,7 +402,7 @@ export class FooParam2 {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -415,13 +415,13 @@ export class Publisher2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -530,7 +530,7 @@ export class Test2 {
   @Property({ nullable: true, persist: false })
   parentId?: number;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @Unique({ name: 'test2_foo___bar_unique' })
@@ -615,10 +615,10 @@ export class Author2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
@@ -634,7 +634,7 @@ export class Author2 {
   age?: number;
 
   @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ default: false })
+  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
 
   @Property({ nullable: true })
@@ -736,7 +736,7 @@ export class Book2 {
   @PrimaryKey({ length: 36 })
   uuidPk!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
 
   @Index({ name: 'book2_title_index' })
@@ -761,8 +761,8 @@ export class Book2 {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
-  @Property({ length: 255, nullable: true, default: 'lol' })
-  foo?: string;
+  @Property({ type: 'string', length: 255, nullable: true })
+  foo?: string & Opt = 'lol';
 
   @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
@@ -876,7 +876,7 @@ export class FooBar2 {
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
-  @Property({ length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
 
   @Property({ length: 65535, nullable: true })
@@ -904,7 +904,7 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -927,7 +927,7 @@ export class FooParam2 {
   @Property({ length: 255 })
   value!: string;
 
-  @Property({ length: 3, defaultRaw: \`current_timestamp(3)\` })
+  @Property({ type: 'Date', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
 }
@@ -940,13 +940,13 @@ export class Publisher2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, default: 'asd' })
-  name!: string & Opt;
+  @Property({ type: 'string', length: 255 })
+  name: string & Opt = 'asd';
 
-  @Enum({ items: () => Publisher2Type, default: 'local' })
+  @Enum({ items: () => Publisher2Type })
   type: Publisher2Type & Opt = Publisher2Type.LOCAL;
 
-  @Enum({ items: () => Publisher2Type2, default: 'LOCAL' })
+  @Enum({ items: () => Publisher2Type2 })
   type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ columnType: 'tinyint', nullable: true })
@@ -1039,7 +1039,7 @@ export class Test2 {
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
-  @Property({ default: 1 })
+  @Property({ type: 'number' })
   version: number & Opt = 1;
 
   @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })

--- a/tests/features/entity-generator/__snapshots__/TypesForScalarDecorators.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/TypesForScalarDecorators.mysql.test.ts.snap
@@ -12,16 +12,16 @@ export class Users {
   @PrimaryKey({ type: 'number' })
   userId!: number;
 
-  @Property({ length: 255, type: 'string' })
+  @Property({ type: 'string', length: 255 })
   username!: string;
 
-  @Property({ unsigned: true, type: 'bigint' })
+  @Property({ type: 'bigint', unsigned: true })
   views!: bigint;
 
   @Property({ type: 'boolean' })
   enabled!: boolean;
 
-  @Property({ length: 0, type: 'Date', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt!: Date & Opt;
 
 }


### PR DESCRIPTION
The "default" option is no longer emitted into the decorator, in favor of it being specified in the property's declaration at the entity class. The "defaultRaw" option is still used in cases where the SQL expression does not unambiguously map to the "default" option's value.

The MySQL schema helper translates TINYINT(1) with a value of 0 to "false". This ensures behavior consistent with other drivers. And if this value accidentally finds its way back in a query, it is also OK, as MySQL treats this literal as "0".

The "optional" option is now added early, in the DatabaseTable stage. This has also unlocked some ManyToMany relations that were previously not detected.

Closes #5260