### PR TITLE
fix(entity-generator): fix generation of entities with identifiers that overlap with core

### DIFF
--- a/packages/entity-generator/package.json
+++ b/packages/entity-generator/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@mikro-orm/knex": "6.2.9",
-    "fs-extra": "11.2.0"
+    "ts-morph": "22.0.0"
   },
   "devDependencies": {
     "@mikro-orm/core": "^6.2.9"

--- a/packages/entity-generator/src/CoreImportsHelper.ts
+++ b/packages/entity-generator/src/CoreImportsHelper.ts
@@ -1,3 +1,47 @@
+import {
+  BaseEntity,
+  Collection,
+  Config,
+  EagerProps,
+  Embeddable,
+  Embedded,
+  Entity,
+  EntitySchema,
+  Enum,
+  Formula,
+  Index,
+  ManyToMany,
+  ManyToOne,
+  OneToMany,
+  OneToOne,
+  PrimaryKey,
+  PrimaryKeyProp,
+  Property,
+  Unique,
+} from '@mikro-orm/core';
+
+export const POSSIBLE_IMPORTS = [
+  BaseEntity.name,
+  Collection.name,
+  Config.description!,
+  EagerProps.description!,
+  Embeddable.name,
+  Embedded.name,
+  Entity.name,
+  EntitySchema.name,
+  Enum.name,
+  Formula.name,
+  Index.name,
+  ManyToMany.name,
+  ManyToOne.name,
+  OneToMany.name,
+  OneToOne.name,
+  PrimaryKey.name,
+  PrimaryKeyProp.description!,
+  Property.name,
+  Unique.name,
+] as const;
+
 export const POSSIBLE_TYPE_IMPORTS = [
   'DefineConfig',
   'Hidden',
@@ -8,3 +52,12 @@ export const POSSIBLE_TYPE_IMPORTS = [
   'ScalarRef',
   'Rel',
 ] as const;
+
+export const POSSIBLY_GENERATED_CORE_IMPORTS = [
+  ...POSSIBLE_TYPE_IMPORTS,
+  ...POSSIBLE_IMPORTS,
+] as const;
+
+export const ESCAPE_PREFIX = 'U$';
+
+export const RESOLVE_PREFIX = 'Mikro';

--- a/packages/entity-generator/src/EntitySchemaSourceFile.ts
+++ b/packages/entity-generator/src/EntitySchemaSourceFile.ts
@@ -70,8 +70,8 @@ export class EntitySchemaSourceFile extends SourceFile {
     }
 
     ret += `\n`;
-    ret += `export const ${this.meta.className}Schema = new EntitySchema({\n`;
-    ret += `  class: ${this.meta.className},\n`;
+    ret += `export const ${this.getValidIdentifierName(`${this.meta.className}Schema`)} = new EntitySchema({\n`;
+    ret += `  class: ${this.getValidIdentifierName(this.meta.className)},\n`;
 
     if (this.meta.tableName && this.meta.tableName !== this.namingStrategy.classToTableName(this.meta.className)) {
       ret += `  tableName: ${this.quote(this.meta.tableName)},\n`;
@@ -162,7 +162,7 @@ export class EntitySchemaSourceFile extends SourceFile {
 
     if (prop.enum) {
       options.enum = true;
-      options.items = `() => ${prop.runtimeType}`;
+      options.items = `() => ${this.getValidIdentifierName(prop.runtimeType)}`;
     }
 
     if (prop.formula) {

--- a/packages/knex/src/schema/DatabaseSchema.ts
+++ b/packages/knex/src/schema/DatabaseSchema.ts
@@ -74,10 +74,13 @@ export class DatabaseSchema {
 
   static async create(connection: AbstractSqlConnection, platform: AbstractSqlPlatform, config: Configuration, schemaName?: string, schemas?: string[]): Promise<DatabaseSchema> {
     const schema = new DatabaseSchema(platform, schemaName ?? config.get('schema') ?? platform.getDefaultSchemaName());
-    const allTables = await connection.execute<Table[]>(platform.getSchemaHelper()!.getListTablesSQL());
+    let allTables = await connection.execute<Table[]>(platform.getSchemaHelper()!.getListTablesSQL());
     const parts = config.get('migrations').tableName!.split('.');
     const migrationsTableName = parts[1] ?? parts[0];
     const migrationsSchemaName = parts.length > 1 ? parts[0] : config.get('schema', platform.getDefaultSchemaName());
+    if (schemaName) {
+      allTables = allTables.filter(t => t.schema_name === schemaName);
+    }
     const tables = allTables.filter(t => t.table_name !== migrationsTableName || (t.schema_name && t.schema_name !== migrationsSchemaName));
     await platform.getSchemaHelper()!.loadInformationSchema(schema, connection, tables, schemas && schemas.length > 0 ? schemas : undefined);
 

--- a/tests/features/entity-generator/ConflictingEntityNames.mysql.test.ts
+++ b/tests/features/entity-generator/ConflictingEntityNames.mysql.test.ts
@@ -1,0 +1,132 @@
+import { EntityGenerator } from '@mikro-orm/entity-generator';
+import { MikroORM, ReferenceKind } from '@mikro-orm/mysql';
+
+let orm: MikroORM;
+
+const schemaName = 'conflicting_entity_names_example';
+const schema = `
+CREATE TABLE IF NOT EXISTS \`entity\` (
+  \`id\` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  \`type\` ENUM('legal', 'physical') NOT NULL,
+  PRIMARY KEY (\`id\`))
+ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS \`enum\` (
+  \`id\` SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  \`opt\` VARCHAR(255) NOT NULL,
+  PRIMARY KEY (\`id\`))
+ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS \`property\` (
+  \`id\` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  \`one_to_many\` SMALLINT UNSIGNED NOT NULL,
+  PRIMARY KEY (\`id\`),
+  INDEX \`fk_property_enum_idx\` (\`one_to_many\` ASC) VISIBLE,
+  CONSTRAINT \`fk_property_enum\`
+    FOREIGN KEY (\`one_to_many\`)
+    REFERENCES \`enum\` (\`id\`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS \`config\` (
+  \`id\` SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  \`name\` VARCHAR(255) NOT NULL,
+  \`settings\` JSON NOT NULL,
+  PRIMARY KEY (\`id\`),
+  UNIQUE INDEX \`name_UNIQUE\` (\`name\` ASC) VISIBLE)
+ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS \`many_to_many\` (
+  \`entity_id\` INT UNSIGNED NOT NULL,
+  \`property_id\` INT UNSIGNED NOT NULL,
+  \`creation_order\` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  \`owner_since\` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (\`entity_id\`, \`property_id\`),
+  INDEX \`fk_many_to_many_property1_idx\` (\`property_id\` ASC) VISIBLE,
+  UNIQUE INDEX \`creation_order_UNIQUE\` (\`creation_order\` ASC) VISIBLE,
+  CONSTRAINT \`fk_many_to_many_entity1\`
+    FOREIGN KEY (\`entity_id\`)
+    REFERENCES \`entity\` (\`id\`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT \`fk_many_to_many_property1\`
+    FOREIGN KEY (\`property_id\`)
+    REFERENCES \`property\` (\`id\`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+ENGINE = InnoDB;
+  `;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: schemaName,
+    port: 3308,
+    discovery: { warnWhenNoEntities: false },
+    extensions: [EntityGenerator],
+    multipleStatements: true,
+    ensureDatabase: false,
+  });
+
+  if (await orm.schema.ensureDatabase({ create: true })) {
+    await orm.schema.execute(schema);
+  }
+
+  await orm.close(true);
+});
+
+beforeEach(async () => {
+  orm = await MikroORM.init({
+    dbName: schemaName,
+    port: 3308,
+    discovery: { warnWhenNoEntities: false },
+    extensions: [EntityGenerator],
+    multipleStatements: true,
+  });
+});
+
+afterEach(async () => {
+  await orm.close(true);
+});
+
+describe(schemaName, () => {
+
+  test.each([true, false])('entitySchema=%s', async entitySchema => {
+    orm.config.get('entityGenerator').entitySchema = entitySchema;
+    orm.config.get('entityGenerator').bidirectionalRelations = true;
+    orm.config.get('entityGenerator').readOnlyPivotTables = true;
+
+    const dump = await orm.entityGenerator.generate(
+      {
+        onInitialMetadata: (metadata, platform) => {
+          metadata[0].addProperty({
+            type: 'MyUnknownClass',
+            kind: ReferenceKind.EMBEDDED,
+            name: 'test',
+            fieldNames: ['test'],
+            persist: false,
+            hydrate: false,
+          });
+          metadata[0].addProperty({
+            type: 'Entity',
+            kind: ReferenceKind.EMBEDDED,
+            name: 'test2',
+            fieldNames: ['test2'],
+            persist: false,
+            hydrate: false,
+          });
+          metadata[0].addProperty({
+            type: 'EntitySchema',
+            kind: ReferenceKind.EMBEDDED,
+            name: 'test3',
+            fieldNames: ['test3'],
+            persist: false,
+            hydrate: false,
+          });
+        },
+      },
+    );
+    expect(dump).toMatchSnapshot('dump');
+  });
+
+});

--- a/tests/features/entity-generator/__snapshots__/ConflictingEntityNames.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/ConflictingEntityNames.mysql.test.ts.snap
@@ -1,0 +1,277 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`conflicting_entity_names_example entitySchema=false: dump 1`] = `
+[
+  "import { Embedded, Entity as MikroEntity, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+import { Entity } from './Entity';
+import { EntitySchema } from './EntitySchema';
+import { MyUnknownClass } from './MyUnknownClass';
+
+@MikroEntity()
+export class Config {
+
+  @PrimaryKey({ type: 'smallint' })
+  id!: number;
+
+  @Unique({ name: 'name_UNIQUE' })
+  @Property({ length: 255 })
+  name!: string;
+
+  @Property({ type: 'json' })
+  settings!: any;
+
+  @Embedded({ entity: () => MyUnknownClass, persist: false, hydrate: false })
+  test!: MyUnknownClass;
+
+  @Embedded({ entity: () => Entity, persist: false, hydrate: false })
+  test2!: Entity;
+
+  @Embedded({ entity: () => EntitySchema, persist: false, hydrate: false })
+  test3!: EntitySchema;
+
+}
+",
+  "import { Collection, Entity as MikroEntity, Enum, ManyToMany as MikroManyToMany, OneToMany, PrimaryKey } from '@mikro-orm/core';
+import { ManyToMany } from './ManyToMany';
+import { Property } from './Property';
+
+@MikroEntity()
+export class Entity {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Enum({ items: () => EntityType })
+  type!: EntityType;
+
+  @MikroManyToMany({ entity: () => Property, pivotTable: 'many_to_many', pivotEntity: () => ManyToMany, joinColumn: 'entity_id', inverseJoinColumn: 'property_id', fixedOrder: true, fixedOrderColumn: 'creation_order' })
+  manyToMany = new Collection<Property>(this);
+
+  @OneToMany({ entity: () => ManyToMany, mappedBy: 'entity' })
+  entityInverse = new Collection<ManyToMany>(this);
+
+}
+
+export enum EntityType {
+  LEGAL = 'legal',
+  PHYSICAL = 'physical',
+}
+",
+  "import { Collection, Entity, OneToMany, PrimaryKey, Property as MikroProperty } from '@mikro-orm/core';
+import { Property } from './Property';
+
+@Entity()
+export class Enum {
+
+  @PrimaryKey({ type: 'smallint' })
+  id!: number;
+
+  @MikroProperty({ length: 255 })
+  opt!: string;
+
+  @OneToMany({ entity: () => Property, mappedBy: 'oneToMany' })
+  oneToManyInverse = new Collection<Property>(this);
+
+}
+",
+  "import { Entity as MikroEntity, ManyToOne, type Opt, PrimaryKeyProp, Property as MikroProperty, Unique } from '@mikro-orm/core';
+import { Entity } from './Entity';
+import { Property } from './Property';
+
+@MikroEntity()
+export class ManyToMany {
+
+  [PrimaryKeyProp]?: ['entity', 'property'];
+
+  @ManyToOne({ entity: () => Entity, primary: true })
+  entity!: Entity;
+
+  @ManyToOne({ entity: () => Property, primary: true, index: 'fk_many_to_many_property1_idx' })
+  property!: Property;
+
+  @Unique({ name: 'creation_order_UNIQUE' })
+  @MikroProperty({ unsigned: true, autoincrement: true })
+  creationOrder!: number;
+
+  @MikroProperty({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  ownerSince!: Date & Opt;
+
+}
+",
+  "import { Collection, Entity as MikroEntity, ManyToMany as MikroManyToMany, ManyToOne, OneToMany, PrimaryKey } from '@mikro-orm/core';
+import { Entity } from './Entity';
+import { Enum } from './Enum';
+import { ManyToMany } from './ManyToMany';
+
+@MikroEntity()
+export class Property {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne({ entity: () => Enum, fieldName: 'one_to_many', index: 'fk_property_enum_idx' })
+  oneToMany!: Enum;
+
+  @MikroManyToMany({ entity: () => Entity, mappedBy: 'manyToMany' })
+  manyToManyInverse = new Collection<Entity>(this);
+
+  @OneToMany({ entity: () => ManyToMany, mappedBy: 'property' })
+  propertyInverse = new Collection<ManyToMany>(this);
+
+}
+",
+]
+`;
+
+exports[`conflicting_entity_names_example entitySchema=true: dump 1`] = `
+[
+  "import { EntitySchema as MikroEntitySchema } from '@mikro-orm/core';
+import { Entity } from './Entity';
+import { EntitySchema } from './EntitySchema';
+import { MyUnknownClass } from './MyUnknownClass';
+
+export class Config {
+  id!: number;
+  name!: string;
+  settings!: any;
+  test!: MyUnknownClass;
+  test2!: Entity;
+  test3!: MikroEntitySchema;
+}
+
+export const ConfigSchema = new MikroEntitySchema({
+  class: Config,
+  properties: {
+    id: { primary: true, type: 'smallint' },
+    name: { type: 'string', length: 255, unique: 'name_UNIQUE' },
+    settings: { type: 'json' },
+    test: {
+      kind: 'embedded',
+      entity: () => MyUnknownClass,
+      persist: false,
+      hydrate: false,
+    },
+    test2: { kind: 'embedded', entity: () => Entity, persist: false, hydrate: false },
+    test3: {
+      kind: 'embedded',
+      entity: () => EntitySchema,
+      persist: false,
+      hydrate: false,
+    },
+  },
+});
+",
+  "import { Collection, EntitySchema as MikroEntitySchema } from '@mikro-orm/core';
+import { ManyToMany } from './ManyToMany';
+import { Property } from './Property';
+
+export class Entity {
+  id!: number;
+  type!: EntityType;
+  manyToMany = new Collection<Property>(this);
+  entityInverse = new Collection<ManyToMany>(this);
+}
+
+export enum EntityType {
+  LEGAL = 'legal',
+  PHYSICAL = 'physical',
+}
+
+export const EntitySchema = new MikroEntitySchema({
+  class: Entity,
+  properties: {
+    id: { primary: true, type: 'integer' },
+    type: { enum: true, items: () => EntityType },
+    manyToMany: {
+      kind: 'm:n',
+      entity: () => Property,
+      pivotTable: 'many_to_many',
+      pivotEntity: () => ManyToMany,
+      joinColumn: 'entity_id',
+      inverseJoinColumn: 'property_id',
+      fixedOrder: true,
+      fixedOrderColumn: 'creation_order',
+    },
+    entityInverse: { kind: '1:m', entity: () => ManyToMany, mappedBy: 'entity' },
+  },
+});
+",
+  "import { Collection, EntitySchema } from '@mikro-orm/core';
+import { Property } from './Property';
+
+export class Enum {
+  id!: number;
+  opt!: string;
+  oneToManyInverse = new Collection<Property>(this);
+}
+
+export const EnumSchema = new EntitySchema({
+  class: Enum,
+  properties: {
+    id: { primary: true, type: 'smallint' },
+    opt: { type: 'string', length: 255 },
+    oneToManyInverse: { kind: '1:m', entity: () => Property, mappedBy: 'oneToMany' },
+  },
+});
+",
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Entity } from './Entity';
+import { Property } from './Property';
+
+export class ManyToMany {
+  [PrimaryKeyProp]?: ['entity', 'property'];
+  entity!: Entity;
+  property!: Property;
+  creationOrder!: number;
+  ownerSince!: Date & Opt;
+}
+
+export const ManyToManySchema = new EntitySchema({
+  class: ManyToMany,
+  properties: {
+    entity: { primary: true, kind: 'm:1', entity: () => Entity },
+    property: {
+      primary: true,
+      kind: 'm:1',
+      entity: () => Property,
+      index: 'fk_many_to_many_property1_idx',
+    },
+    creationOrder: {
+      type: 'integer',
+      unsigned: true,
+      autoincrement: true,
+      unique: 'creation_order_UNIQUE',
+    },
+    ownerSince: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+  },
+});
+",
+  "import { Collection, EntitySchema } from '@mikro-orm/core';
+import { Entity } from './Entity';
+import { Enum } from './Enum';
+import { ManyToMany } from './ManyToMany';
+
+export class Property {
+  id!: number;
+  oneToMany!: Enum;
+  manyToManyInverse = new Collection<Entity>(this);
+  propertyInverse = new Collection<ManyToMany>(this);
+}
+
+export const PropertySchema = new EntitySchema({
+  class: Property,
+  properties: {
+    id: { primary: true, type: 'integer' },
+    oneToMany: {
+      kind: 'm:1',
+      entity: () => Enum,
+      fieldName: 'one_to_many',
+      index: 'fk_property_enum_idx',
+    },
+    manyToManyInverse: { kind: 'm:n', entity: () => Entity, mappedBy: 'manyToMany' },
+    propertyInverse: { kind: '1:m', entity: () => ManyToMany, mappedBy: 'property' },
+  },
+});
+",
+]
+`;

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
@@ -586,8 +586,7 @@ export class Book2Tags {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
-import { Test2 } from './Test2';
+  "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Configuration2 {
@@ -597,8 +596,8 @@ export class Configuration2 {
   @PrimaryKey({ length: 255 })
   property!: string;
 
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', primary: true })
-  test!: Test2;
+  @PrimaryKey({ fieldName: 'test_id' })
+  test!: number;
 
   @Property({ length: 255 })
   value!: string;
@@ -696,9 +695,8 @@ export class Label2 {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { Label2 } from './Label2';
-import { Test2 } from './Test2';
 
 @Entity({ tableName: 'label2_tests', schema: 'label_schema' })
 export class Label2Tests {
@@ -709,8 +707,8 @@ export class Label2Tests {
   @ManyToOne({ entity: () => Label2, updateRule: 'cascade', deleteRule: 'cascade' })
   label2!: Label2;
 
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
-  test2!: Test2;
+  @Property({ fieldName: 'test2_id' })
+  test2!: number;
 
 }
 ",
@@ -768,9 +766,8 @@ export enum Publisher2Enum5 {
   A = 'a',
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
-import { Test2 } from './Test2';
 
 @Entity({ tableName: 'publisher2_tests' })
 export class Publisher2Tests {
@@ -781,8 +778,8 @@ export class Publisher2Tests {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade' })
   publisher2!: Publisher2;
 
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
-  test2!: Test2;
+  @Property({ fieldName: 'test2_id' })
+  test2!: number;
 
 }
 ",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1393,7 +1393,7 @@ __metadata:
   dependencies:
     "@mikro-orm/core": "npm:^6.2.9"
     "@mikro-orm/knex": "npm:6.2.9"
-    fs-extra: "npm:11.2.0"
+    ts-morph: "npm:22.0.0"
   peerDependencies:
     "@mikro-orm/core": ^6.0.0
   languageName: unknown
@@ -2456,16 +2456,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=18, @types/node@npm:^20.11.17":
-  version: 20.12.13
-  resolution: "@types/node@npm:20.12.13"
-  dependencies:
-    undici-types: "npm:~5.26.4"
-  checksum: 10/c9f02cfe342bce4aa9221f389115c1f9e3bd9abc87d45e3b2c3a5b92d99523c02b72dd67f50cbbc5edddbaf7dd458cf61dd3289d7a8c14fde80c998df10fee82
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:20.14.0":
+"@types/node@npm:*, @types/node@npm:20.14.0, @types/node@npm:>=18, @types/node@npm:^20.11.17":
   version: 20.14.0
   resolution: "@types/node@npm:20.14.0"
   dependencies:


### PR DESCRIPTION
Accomplished by adding ts-morph as a dependency, and using it to post process the generated sources. On a possible conflict, user identifiers now include a marker ("U$"), to disambiguate them in the input to ts-morph.

On conflict, the prefix "Mikro" is added to MikroORM's imports as an alias, and if even that is not enough, the same prefix will keep being added until the conflict is resolved. Previously, there was a special case for the BaseEntity class. This is now removed in favor of this more general purpose conflict resolution, allowing an entity being named like "Entity" or "Property".

Fixed erroneously included skipped tables.

Ensured that tables that start with a number can also be referenced properly, not merely defined, by moving the "E" prefix addition into the naming strategy.