### PR TITLE
fix(entity-generator): emit missing imports in `EntitySchema` generated files

### DIFF
--- a/packages/entity-generator/src/EntitySchemaSourceFile.ts
+++ b/packages/entity-generator/src/EntitySchemaSourceFile.ts
@@ -55,9 +55,8 @@ export class EntitySchemaSourceFile extends SourceFile {
     }
 
     classBody += `${props.join('')}`;
-    const classDecl = this.getEntityClass(classBody);
 
-    let ret = `${this.generateImports()}\n\n${classDecl}`;
+    let ret = this.getEntityClass(classBody);
     if (enumDefinitions.length) {
       ret += '\n' + enumDefinitions.join('\n');
     }
@@ -114,6 +113,8 @@ export class EntitySchemaSourceFile extends SourceFile {
     });
     ret += `  },\n`;
     ret += `});\n`;
+
+    ret = `${this.generateImports()}\n\n${ret}`;
 
     return ret;
   }

--- a/packages/entity-generator/src/SourceFile.ts
+++ b/packages/entity-generator/src/SourceFile.ts
@@ -200,11 +200,12 @@ export class SourceFile {
     const useDefault = prop.default != null;
     const optional = prop.nullable ? '?' : (useDefault ? '' : '!');
 
+    if (!prop.mapToPk && typeof prop.kind === 'string' && prop.kind !== ReferenceKind.SCALAR) {
+      this.entityImports.add(propType);
+    }
+
     if (prop.ref) {
       this.coreImports.add('Ref');
-      if (typeof prop.kind === 'string' && prop.kind !== ReferenceKind.SCALAR) {
-        this.entityImports.add(propType);
-      }
       return `${padding}${prop.name}${optional}: Ref<${propType}>${hiddenType};\n`;
     }
 
@@ -581,10 +582,8 @@ export class SourceFile {
   }
 
   protected getForeignKeyDecoratorOptions(options: OneToOneOptions<any, any>, prop: EntityProperty) {
-    const parts = prop.referencedTableName.split('.', 2);
-    const className = this.namingStrategy.getEntityName(...parts.reverse() as [string, string]);
-    this.entityImports.add(className);
-    options.entity = `() => ${className}`;
+    this.entityImports.add(prop.type);
+    options.entity = `() => ${prop.type}`;
 
     if (prop.ref) {
       options.ref = true;

--- a/tests/features/entity-generator/__snapshots__/AmbiguousFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/AmbiguousFks.mysql.test.ts.snap
@@ -259,6 +259,7 @@ export class Sellers {
 exports[`ambiguous_fk_example scalarPropertiesForRelations=always bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductColors } from './ProductColors';
 import { Products } from './Products';
 
 export class Colors {
@@ -299,6 +300,8 @@ export const CountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Colors } from './Colors';
+import { Products } from './Products';
 
 export class ProductColors {
   [PrimaryKeyProp]?: ['color', 'product'];
@@ -325,6 +328,8 @@ export const ProductColorsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { ProductSizes } from './ProductSizes';
 
 export class ProductCountries {
   [PrimaryKeyProp]?: ['product', 'countries'];
@@ -356,6 +361,8 @@ export const ProductCountriesSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
+import { ProductCountries } from './ProductCountries';
+import { Products } from './Products';
 
 export class ProductSizes {
   [PrimaryKeyProp]?: 'product';
@@ -402,6 +409,11 @@ export const ProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductColors } from './ProductColors';
+import { ProductCountries } from './ProductCountries';
+import { ProductSizes } from './ProductSizes';
+import { SellerCountries } from './SellerCountries';
+import { SellerProducts } from './SellerProducts';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
@@ -494,6 +506,8 @@ export const SalesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { Sellers } from './Sellers';
 
 export class SellerCountries {
   [PrimaryKeyProp]?: ['seller', 'countries'];
@@ -520,6 +534,8 @@ export const SellerCountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
+import { Sellers } from './Sellers';
 
 export class SellerProducts {
   [PrimaryKeyProp]?: ['seller', 'product'];
@@ -548,6 +564,8 @@ export const SellerProductsSchema = new EntitySchema({
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
+import { SellerCountries } from './SellerCountries';
+import { SellerProducts } from './SellerProducts';
 
 export class Sellers {
   [PrimaryKeyProp]?: 'sellerId';
@@ -843,6 +861,7 @@ export class Sellers {
 exports[`ambiguous_fk_example scalarPropertiesForRelations=always bidirectionalRelations=false identifiedReferences=true entitySchema=true: dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductColors } from './ProductColors';
 import { Products } from './Products';
 
 export class Colors {
@@ -958,6 +977,7 @@ export const ProductCountriesSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
+import { ProductCountries } from './ProductCountries';
 import { Products } from './Products';
 
 export class ProductSizes {
@@ -1186,6 +1206,8 @@ export const SellerProductsSchema = new EntitySchema({
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
+import { SellerCountries } from './SellerCountries';
+import { SellerProducts } from './SellerProducts';
 
 export class Sellers {
   [PrimaryKeyProp]?: 'sellerId';
@@ -1589,6 +1611,8 @@ export const CountriesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Colors } from './Colors';
+import { Products } from './Products';
 import { Sales } from './Sales';
 
 export class ProductColors {
@@ -1618,6 +1642,8 @@ export const ProductColorsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { ProductSizes } from './ProductSizes';
 import { Sales } from './Sales';
 
 export class ProductCountries {
@@ -1653,6 +1679,7 @@ export const ProductCountriesSchema = new EntitySchema({
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountries } from './ProductCountries';
+import { Products } from './Products';
 import { Sales } from './Sales';
 
 export class ProductSizes {
@@ -1713,6 +1740,11 @@ export const ProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductColors } from './ProductColors';
+import { ProductCountries } from './ProductCountries';
+import { ProductSizes } from './ProductSizes';
+import { SellerCountries } from './SellerCountries';
+import { SellerProducts } from './SellerProducts';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
@@ -1805,7 +1837,9 @@ export const SalesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
 import { Sales } from './Sales';
+import { Sellers } from './Sellers';
 
 export class SellerCountries {
   [PrimaryKeyProp]?: ['seller', 'countries'];
@@ -1834,7 +1868,9 @@ export const SellerCountriesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 import { Sales } from './Sales';
+import { Sellers } from './Sellers';
 
 export class SellerProducts {
   [PrimaryKeyProp]?: ['seller', 'product'];
@@ -1867,6 +1903,7 @@ export const SellerProductsSchema = new EntitySchema({
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
+import { SellerCountries } from './SellerCountries';
 import { SellerProducts } from './SellerProducts';
 
 export class Sellers {
@@ -2605,6 +2642,7 @@ export const SellerProductsSchema = new EntitySchema({
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
+import { SellerCountries } from './SellerCountries';
 import { SellerProducts } from './SellerProducts';
 
 export class Sellers {
@@ -2854,6 +2892,7 @@ export class Sellers {
 exports[`ambiguous_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductColors } from './ProductColors';
 import { Products } from './Products';
 
 export class Colors {
@@ -2880,7 +2919,9 @@ export const ColorsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
+import { SellerCountries } from './SellerCountries';
 import { Sellers } from './Sellers';
 
 export class Countries {
@@ -2914,6 +2955,8 @@ export const CountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Colors } from './Colors';
+import { Products } from './Products';
 
 export class ProductColors {
   [PrimaryKeyProp]?: ['color', 'product'];
@@ -2936,6 +2979,8 @@ export const ProductColorsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { ProductSizes } from './ProductSizes';
 
 export class ProductCountries {
   [PrimaryKeyProp]?: ['country', 'product'];
@@ -2958,6 +3003,7 @@ export const ProductCountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 
 export class ProductSizes {
   [PrimaryKeyProp]?: 'product';
@@ -2993,6 +3039,11 @@ export const ProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductColors } from './ProductColors';
+import { ProductCountries } from './ProductCountries';
+import { ProductSizes } from './ProductSizes';
+import { SellerCountries } from './SellerCountries';
+import { SellerProducts } from './SellerProducts';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
@@ -3076,6 +3127,8 @@ export const SalesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { Sellers } from './Sellers';
 
 export class SellerCountries {
   [PrimaryKeyProp]?: ['country', 'seller'];
@@ -3098,6 +3151,8 @@ export const SellerCountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
+import { Sellers } from './Sellers';
 
 export class SellerProducts {
   [PrimaryKeyProp]?: ['seller', 'product'];
@@ -3121,6 +3176,7 @@ export const SellerProductsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Products } from './Products';
+import { SellerProducts } from './SellerProducts';
 
 export class Sellers {
   [PrimaryKeyProp]?: 'sellerId';
@@ -3358,6 +3414,7 @@ export class Sellers {
 exports[`ambiguous_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=true entitySchema=true: dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductColors } from './ProductColors';
 import { Products } from './Products';
 
 export class Colors {
@@ -3384,7 +3441,9 @@ export const ColorsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
+import { SellerCountries } from './SellerCountries';
 import { Sellers } from './Sellers';
 
 export class Countries {
@@ -3679,6 +3738,7 @@ export const SellerProductsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Products } from './Products';
+import { SellerProducts } from './SellerProducts';
 
 export class Sellers {
   [PrimaryKeyProp]?: 'sellerId';
@@ -4001,6 +4061,7 @@ export const ColorsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
 import { SellerCountries } from './SellerCountries';
 import { Sellers } from './Sellers';
@@ -4038,6 +4099,8 @@ export const CountriesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Colors } from './Colors';
+import { Products } from './Products';
 import { Sales } from './Sales';
 
 export class ProductColors {
@@ -4063,6 +4126,8 @@ export const ProductColorsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { ProductSizes } from './ProductSizes';
 import { Sales } from './Sales';
 
 export class ProductCountries {
@@ -4090,6 +4155,7 @@ export const ProductCountriesSchema = new EntitySchema({
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountries } from './ProductCountries';
+import { Products } from './Products';
 import { Sales } from './Sales';
 
 export class ProductSizes {
@@ -4141,6 +4207,11 @@ export const ProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductColors } from './ProductColors';
+import { ProductCountries } from './ProductCountries';
+import { ProductSizes } from './ProductSizes';
+import { SellerCountries } from './SellerCountries';
+import { SellerProducts } from './SellerProducts';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
@@ -4224,7 +4295,9 @@ export const SalesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
 import { Sales } from './Sales';
+import { Sellers } from './Sellers';
 
 export class SellerCountries {
   [PrimaryKeyProp]?: ['country', 'seller'];
@@ -4249,7 +4322,9 @@ export const SellerCountriesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 import { Sales } from './Sales';
+import { Sellers } from './Sellers';
 
 export class SellerProducts {
   [PrimaryKeyProp]?: ['seller', 'product'];
@@ -4605,6 +4680,7 @@ export const ColorsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
 import { SellerCountries } from './SellerCountries';
 import { Sellers } from './Sellers';
@@ -5178,6 +5254,7 @@ export class Sellers {
 exports[`ambiguous_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductColors } from './ProductColors';
 import { Products } from './Products';
 
 export class Colors {
@@ -5204,7 +5281,9 @@ export const ColorsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
+import { SellerCountries } from './SellerCountries';
 import { Sellers } from './Sellers';
 
 export class Countries {
@@ -5238,6 +5317,8 @@ export const CountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Colors } from './Colors';
+import { Products } from './Products';
 
 export class ProductColors {
   [PrimaryKeyProp]?: ['color', 'product'];
@@ -5260,6 +5341,8 @@ export const ProductColorsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { ProductSizes } from './ProductSizes';
 
 export class ProductCountries {
   [PrimaryKeyProp]?: ['country', 'product'];
@@ -5282,6 +5365,7 @@ export const ProductCountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 
 export class ProductSizes {
   [PrimaryKeyProp]?: 'product';
@@ -5317,6 +5401,11 @@ export const ProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductColors } from './ProductColors';
+import { ProductCountries } from './ProductCountries';
+import { ProductSizes } from './ProductSizes';
+import { SellerCountries } from './SellerCountries';
+import { SellerProducts } from './SellerProducts';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
@@ -5400,6 +5489,8 @@ export const SalesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { Sellers } from './Sellers';
 
 export class SellerCountries {
   [PrimaryKeyProp]?: ['country', 'seller'];
@@ -5422,6 +5513,8 @@ export const SellerCountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
+import { Sellers } from './Sellers';
 
 export class SellerProducts {
   [PrimaryKeyProp]?: ['seller', 'product'];
@@ -5445,6 +5538,7 @@ export const SellerProductsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Products } from './Products';
+import { SellerProducts } from './SellerProducts';
 
 export class Sellers {
   [PrimaryKeyProp]?: 'sellerId';
@@ -5682,6 +5776,7 @@ export class Sellers {
 exports[`ambiguous_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=true entitySchema=true: dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductColors } from './ProductColors';
 import { Products } from './Products';
 
 export class Colors {
@@ -5708,7 +5803,9 @@ export const ColorsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
+import { SellerCountries } from './SellerCountries';
 import { Sellers } from './Sellers';
 
 export class Countries {
@@ -6003,6 +6100,7 @@ export const SellerProductsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Products } from './Products';
+import { SellerProducts } from './SellerProducts';
 
 export class Sellers {
   [PrimaryKeyProp]?: 'sellerId';
@@ -6325,6 +6423,7 @@ export const ColorsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
 import { SellerCountries } from './SellerCountries';
 import { Sellers } from './Sellers';
@@ -6362,6 +6461,8 @@ export const CountriesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Colors } from './Colors';
+import { Products } from './Products';
 import { Sales } from './Sales';
 
 export class ProductColors {
@@ -6387,6 +6488,8 @@ export const ProductColorsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { ProductSizes } from './ProductSizes';
 import { Sales } from './Sales';
 
 export class ProductCountries {
@@ -6414,6 +6517,7 @@ export const ProductCountriesSchema = new EntitySchema({
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountries } from './ProductCountries';
+import { Products } from './Products';
 import { Sales } from './Sales';
 
 export class ProductSizes {
@@ -6465,6 +6569,11 @@ export const ProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductColors } from './ProductColors';
+import { ProductCountries } from './ProductCountries';
+import { ProductSizes } from './ProductSizes';
+import { SellerCountries } from './SellerCountries';
+import { SellerProducts } from './SellerProducts';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
@@ -6548,7 +6657,9 @@ export const SalesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
 import { Sales } from './Sales';
+import { Sellers } from './Sellers';
 
 export class SellerCountries {
   [PrimaryKeyProp]?: ['country', 'seller'];
@@ -6573,7 +6684,9 @@ export const SellerCountriesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 import { Sales } from './Sales';
+import { Sellers } from './Sellers';
 
 export class SellerProducts {
   [PrimaryKeyProp]?: ['seller', 'product'];
@@ -6929,6 +7042,7 @@ export const ColorsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
 import { SellerCountries } from './SellerCountries';
 import { Sellers } from './Sellers';

--- a/tests/features/entity-generator/__snapshots__/CustomBase.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/CustomBase.mysql.test.ts.snap
@@ -502,6 +502,7 @@ export class User2 {
 exports[`CustomBase forceObject=false useCoreBaseEntity=false customBaseEntityName= entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 
 export class Address2 {
   [PrimaryKeyProp]?: 'author';
@@ -524,6 +525,7 @@ export const Address2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+import { Book2 } from './Book2';
 
 export class Author2 {
   id!: number;
@@ -662,7 +664,9 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
+import { Publisher2 } from './Publisher2';
 
 export class Book2 {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -709,6 +713,8 @@ export const Book2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
 
 export class Book2Tags {
   [PrimaryKeyProp]?: 'order';
@@ -738,6 +744,7 @@ export const Book2TagsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema } from '@mikro-orm/core';
+import { Car2 } from './Car2';
 
 export class CarOwner2 {
   id!: number;
@@ -773,6 +780,7 @@ export const Car2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Test2 } from './Test2';
 
 export class Configuration2 {
   [PrimaryKeyProp]?: ['property', 'test'];
@@ -804,6 +812,7 @@ export const Dummy2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt } from '@mikro-orm/core';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 {
   id!: number;
@@ -864,6 +873,8 @@ export const FooBaz2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { FooBar2 } from './FooBar2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 {
   [PrimaryKeyProp]?: ['bar', 'baz'];
@@ -933,6 +944,8 @@ export const Publisher2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema } from '@mikro-orm/core';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
 export class Publisher2Tests {
   id!: number;
@@ -978,6 +991,7 @@ export const SandwichSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
 export class Test2 {
@@ -1596,6 +1610,7 @@ export abstract class BaseEntity {
 exports[`CustomBase forceObject=false useCoreBaseEntity=false customBaseEntityName=BaseEntity entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BaseEntity } from './BaseEntity';
 
 export class Address2 extends BaseEntity {
@@ -1620,6 +1635,7 @@ export const Address2Schema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book2 } from './Book2';
 
 export class Author2 extends BaseEntity {
   id!: number;
@@ -1760,8 +1776,10 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BaseEntity } from './BaseEntity';
 import { BookTag2 } from './BookTag2';
+import { Publisher2 } from './Publisher2';
 
 export class Book2 extends BaseEntity {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -1809,6 +1827,8 @@ export const Book2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
 
 export class Book2Tags extends BaseEntity {
   [PrimaryKeyProp]?: 'order';
@@ -1839,6 +1859,7 @@ export const Book2TagsSchema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Car2 } from './Car2';
 
 export class CarOwner2 extends BaseEntity {
   id!: number;
@@ -1876,6 +1897,7 @@ export const Car2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Test2 } from './Test2';
 
 export class Configuration2 extends BaseEntity {
   [PrimaryKeyProp]?: ['property', 'test'];
@@ -1909,6 +1931,7 @@ export const Dummy2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 extends BaseEntity {
   id!: number;
@@ -1971,6 +1994,8 @@ export const FooBaz2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { FooBar2 } from './FooBar2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 extends BaseEntity {
   [PrimaryKeyProp]?: ['bar', 'baz'];
@@ -2042,6 +2067,8 @@ export const Publisher2Schema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
 export class Publisher2Tests extends BaseEntity {
   id!: number;
@@ -2089,6 +2116,7 @@ export const SandwichSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
 export class Test2 extends BaseEntity {
@@ -2714,6 +2742,7 @@ export class User2 extends BaseUser2 {
 exports[`CustomBase forceObject=false useCoreBaseEntity=false customBaseEntityName=BaseUser2 entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BaseUser2 } from './BaseUser2';
 
 export class Address2 extends BaseUser2 {
@@ -2738,6 +2767,7 @@ export const Address2Schema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Book2 } from './Book2';
 
 export class Author2 extends BaseUser2 {
   id!: number;
@@ -2878,8 +2908,10 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BaseUser2 } from './BaseUser2';
 import { BookTag2 } from './BookTag2';
+import { Publisher2 } from './Publisher2';
 
 export class Book2 extends BaseUser2 {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -2927,6 +2959,8 @@ export const Book2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
 
 export class Book2Tags extends BaseUser2 {
   [PrimaryKeyProp]?: 'order';
@@ -2957,6 +2991,7 @@ export const Book2TagsSchema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Car2 } from './Car2';
 
 export class CarOwner2 extends BaseUser2 {
   id!: number;
@@ -2994,6 +3029,7 @@ export const Car2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Test2 } from './Test2';
 
 export class Configuration2 extends BaseUser2 {
   [PrimaryKeyProp]?: ['property', 'test'];
@@ -3027,6 +3063,7 @@ export const Dummy2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 extends BaseUser2 {
   id!: number;
@@ -3089,6 +3126,8 @@ export const FooBaz2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { FooBar2 } from './FooBar2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 extends BaseUser2 {
   [PrimaryKeyProp]?: ['bar', 'baz'];
@@ -3160,6 +3199,8 @@ export const Publisher2Schema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
 export class Publisher2Tests extends BaseUser2 {
   id!: number;
@@ -3207,6 +3248,7 @@ export const SandwichSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
 export class Test2 extends BaseUser2 {
@@ -3826,6 +3868,7 @@ export abstract class CustomBase {
 exports[`CustomBase forceObject=false useCoreBaseEntity=false customBaseEntityName=CustomBase entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { CustomBase } from './CustomBase';
 
 export class Address2 extends CustomBase {
@@ -3849,6 +3892,7 @@ export const Address2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 
 export class Author2 extends CustomBase {
@@ -3990,8 +4034,10 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { CustomBase } from './CustomBase';
+import { Publisher2 } from './Publisher2';
 
 export class Book2 extends CustomBase {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -4038,6 +4084,8 @@ export const Book2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
 import { CustomBase } from './CustomBase';
 
 export class Book2Tags extends CustomBase {
@@ -4068,6 +4116,7 @@ export const Book2TagsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema } from '@mikro-orm/core';
+import { Car2 } from './Car2';
 import { CustomBase } from './CustomBase';
 
 export class CarOwner2 extends CustomBase {
@@ -4106,6 +4155,7 @@ export const Car2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { Test2 } from './Test2';
 
 export class Configuration2 extends CustomBase {
   [PrimaryKeyProp]?: ['property', 'test'];
@@ -4139,6 +4189,7 @@ export const Dummy2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 extends CustomBase {
   id!: number;
@@ -4201,6 +4252,8 @@ export const FooBaz2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { FooBar2 } from './FooBar2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 extends CustomBase {
   [PrimaryKeyProp]?: ['bar', 'baz'];
@@ -4272,6 +4325,8 @@ export const Publisher2Schema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
 export class Publisher2Tests extends CustomBase {
   id!: number;
@@ -4318,6 +4373,7 @@ export const SandwichSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
 
@@ -4924,6 +4980,7 @@ export class User2 extends BaseEntity {
 exports[`CustomBase forceObject=false useCoreBaseEntity=true customBaseEntityName= entitySchema=true: dump 1`] = `
 [
   "import { BaseEntity, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 
 export class Address2 extends BaseEntity {
   [PrimaryKeyProp]?: 'author';
@@ -4946,6 +5003,7 @@ export const Address2Schema = new EntitySchema({
 });
 ",
   "import { BaseEntity, Collection, EntitySchema, Opt } from '@mikro-orm/core';
+import { Book2 } from './Book2';
 
 export class Author2 extends BaseEntity {
   id!: number;
@@ -5084,7 +5142,9 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { BaseEntity, Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
+import { Publisher2 } from './Publisher2';
 
 export class Book2 extends BaseEntity {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -5131,6 +5191,8 @@ export const Book2Schema = new EntitySchema({
 });
 ",
   "import { BaseEntity, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
 
 export class Book2Tags extends BaseEntity {
   [PrimaryKeyProp]?: 'order';
@@ -5160,6 +5222,7 @@ export const Book2TagsSchema = new EntitySchema({
 });
 ",
   "import { BaseEntity, EntitySchema } from '@mikro-orm/core';
+import { Car2 } from './Car2';
 
 export class CarOwner2 extends BaseEntity {
   id!: number;
@@ -5195,6 +5258,7 @@ export const Car2Schema = new EntitySchema({
 });
 ",
   "import { BaseEntity, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Test2 } from './Test2';
 
 export class Configuration2 extends BaseEntity {
   [PrimaryKeyProp]?: ['property', 'test'];
@@ -5226,6 +5290,7 @@ export const Dummy2Schema = new EntitySchema({
 });
 ",
   "import { BaseEntity, EntitySchema, Opt } from '@mikro-orm/core';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 extends BaseEntity {
   id!: number;
@@ -5286,6 +5351,8 @@ export const FooBaz2Schema = new EntitySchema({
 });
 ",
   "import { BaseEntity, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { FooBar2 } from './FooBar2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 extends BaseEntity {
   [PrimaryKeyProp]?: ['bar', 'baz'];
@@ -5355,6 +5422,8 @@ export const Publisher2Schema = new EntitySchema({
 });
 ",
   "import { BaseEntity, EntitySchema } from '@mikro-orm/core';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
 export class Publisher2Tests extends BaseEntity {
   id!: number;
@@ -5400,6 +5469,7 @@ export const SandwichSchema = new EntitySchema({
 });
 ",
   "import { BaseEntity, Collection, EntitySchema, Opt } from '@mikro-orm/core';
+import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
 export class Test2 extends BaseEntity {
@@ -6018,6 +6088,7 @@ export abstract class BaseEntity extends MikroBaseEntity {
 exports[`CustomBase forceObject=false useCoreBaseEntity=true customBaseEntityName=BaseEntity entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BaseEntity } from './BaseEntity';
 
 export class Address2 extends BaseEntity {
@@ -6042,6 +6113,7 @@ export const Address2Schema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book2 } from './Book2';
 
 export class Author2 extends BaseEntity {
   id!: number;
@@ -6182,8 +6254,10 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BaseEntity } from './BaseEntity';
 import { BookTag2 } from './BookTag2';
+import { Publisher2 } from './Publisher2';
 
 export class Book2 extends BaseEntity {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -6231,6 +6305,8 @@ export const Book2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
 
 export class Book2Tags extends BaseEntity {
   [PrimaryKeyProp]?: 'order';
@@ -6261,6 +6337,7 @@ export const Book2TagsSchema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Car2 } from './Car2';
 
 export class CarOwner2 extends BaseEntity {
   id!: number;
@@ -6298,6 +6375,7 @@ export const Car2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Test2 } from './Test2';
 
 export class Configuration2 extends BaseEntity {
   [PrimaryKeyProp]?: ['property', 'test'];
@@ -6331,6 +6409,7 @@ export const Dummy2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 extends BaseEntity {
   id!: number;
@@ -6393,6 +6472,8 @@ export const FooBaz2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { FooBar2 } from './FooBar2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 extends BaseEntity {
   [PrimaryKeyProp]?: ['bar', 'baz'];
@@ -6464,6 +6545,8 @@ export const Publisher2Schema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
 export class Publisher2Tests extends BaseEntity {
   id!: number;
@@ -6511,6 +6594,7 @@ export const SandwichSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
 export class Test2 extends BaseEntity {
@@ -7136,6 +7220,7 @@ export class User2 extends BaseUser2 {
 exports[`CustomBase forceObject=false useCoreBaseEntity=true customBaseEntityName=BaseUser2 entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BaseUser2 } from './BaseUser2';
 
 export class Address2 extends BaseUser2 {
@@ -7160,6 +7245,7 @@ export const Address2Schema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Book2 } from './Book2';
 
 export class Author2 extends BaseUser2 {
   id!: number;
@@ -7300,8 +7386,10 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BaseUser2 } from './BaseUser2';
 import { BookTag2 } from './BookTag2';
+import { Publisher2 } from './Publisher2';
 
 export class Book2 extends BaseUser2 {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -7349,6 +7437,8 @@ export const Book2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
 
 export class Book2Tags extends BaseUser2 {
   [PrimaryKeyProp]?: 'order';
@@ -7379,6 +7469,7 @@ export const Book2TagsSchema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Car2 } from './Car2';
 
 export class CarOwner2 extends BaseUser2 {
   id!: number;
@@ -7416,6 +7507,7 @@ export const Car2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Test2 } from './Test2';
 
 export class Configuration2 extends BaseUser2 {
   [PrimaryKeyProp]?: ['property', 'test'];
@@ -7449,6 +7541,7 @@ export const Dummy2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 extends BaseUser2 {
   id!: number;
@@ -7511,6 +7604,8 @@ export const FooBaz2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { FooBar2 } from './FooBar2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 extends BaseUser2 {
   [PrimaryKeyProp]?: ['bar', 'baz'];
@@ -7582,6 +7677,8 @@ export const Publisher2Schema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
 export class Publisher2Tests extends BaseUser2 {
   id!: number;
@@ -7629,6 +7726,7 @@ export const SandwichSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
 export class Test2 extends BaseUser2 {
@@ -8248,6 +8346,7 @@ export abstract class CustomBase extends BaseEntity {
 exports[`CustomBase forceObject=false useCoreBaseEntity=true customBaseEntityName=CustomBase entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { CustomBase } from './CustomBase';
 
 export class Address2 extends CustomBase {
@@ -8271,6 +8370,7 @@ export const Address2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 
 export class Author2 extends CustomBase {
@@ -8412,8 +8512,10 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { CustomBase } from './CustomBase';
+import { Publisher2 } from './Publisher2';
 
 export class Book2 extends CustomBase {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -8460,6 +8562,8 @@ export const Book2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
 import { CustomBase } from './CustomBase';
 
 export class Book2Tags extends CustomBase {
@@ -8490,6 +8594,7 @@ export const Book2TagsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema } from '@mikro-orm/core';
+import { Car2 } from './Car2';
 import { CustomBase } from './CustomBase';
 
 export class CarOwner2 extends CustomBase {
@@ -8528,6 +8633,7 @@ export const Car2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { Test2 } from './Test2';
 
 export class Configuration2 extends CustomBase {
   [PrimaryKeyProp]?: ['property', 'test'];
@@ -8561,6 +8667,7 @@ export const Dummy2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 extends CustomBase {
   id!: number;
@@ -8623,6 +8730,8 @@ export const FooBaz2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { FooBar2 } from './FooBar2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 extends CustomBase {
   [PrimaryKeyProp]?: ['bar', 'baz'];
@@ -8694,6 +8803,8 @@ export const Publisher2Schema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
 export class Publisher2Tests extends CustomBase {
   id!: number;
@@ -8740,6 +8851,7 @@ export const SandwichSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
 
@@ -9346,6 +9458,7 @@ export class User2 {
 exports[`CustomBase forceObject=true useCoreBaseEntity=false customBaseEntityName= entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 
 export class Address2 {
   [PrimaryKeyProp]?: 'author';
@@ -9368,6 +9481,7 @@ export const Address2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+import { Book2 } from './Book2';
 
 export class Author2 {
   id!: number;
@@ -9506,7 +9620,9 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
+import { Publisher2 } from './Publisher2';
 
 export class Book2 {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -9553,6 +9669,8 @@ export const Book2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
 
 export class Book2Tags {
   [PrimaryKeyProp]?: 'order';
@@ -9582,6 +9700,7 @@ export const Book2TagsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema } from '@mikro-orm/core';
+import { Car2 } from './Car2';
 
 export class CarOwner2 {
   id!: number;
@@ -9617,6 +9736,7 @@ export const Car2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Test2 } from './Test2';
 
 export class Configuration2 {
   [PrimaryKeyProp]?: ['property', 'test'];
@@ -9648,6 +9768,7 @@ export const Dummy2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt } from '@mikro-orm/core';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 {
   id!: number;
@@ -9708,6 +9829,8 @@ export const FooBaz2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { FooBar2 } from './FooBar2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 {
   [PrimaryKeyProp]?: ['bar', 'baz'];
@@ -9777,6 +9900,8 @@ export const Publisher2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema } from '@mikro-orm/core';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
 export class Publisher2Tests {
   id!: number;
@@ -9822,6 +9947,7 @@ export const SandwichSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
 export class Test2 {
@@ -10440,6 +10566,7 @@ export abstract class BaseEntity {
 exports[`CustomBase forceObject=true useCoreBaseEntity=false customBaseEntityName=BaseEntity entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BaseEntity } from './BaseEntity';
 
 export class Address2 extends BaseEntity {
@@ -10464,6 +10591,7 @@ export const Address2Schema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book2 } from './Book2';
 
 export class Author2 extends BaseEntity {
   id!: number;
@@ -10604,8 +10732,10 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BaseEntity } from './BaseEntity';
 import { BookTag2 } from './BookTag2';
+import { Publisher2 } from './Publisher2';
 
 export class Book2 extends BaseEntity {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -10653,6 +10783,8 @@ export const Book2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
 
 export class Book2Tags extends BaseEntity {
   [PrimaryKeyProp]?: 'order';
@@ -10683,6 +10815,7 @@ export const Book2TagsSchema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Car2 } from './Car2';
 
 export class CarOwner2 extends BaseEntity {
   id!: number;
@@ -10720,6 +10853,7 @@ export const Car2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Test2 } from './Test2';
 
 export class Configuration2 extends BaseEntity {
   [PrimaryKeyProp]?: ['property', 'test'];
@@ -10753,6 +10887,7 @@ export const Dummy2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 extends BaseEntity {
   id!: number;
@@ -10815,6 +10950,8 @@ export const FooBaz2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { FooBar2 } from './FooBar2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 extends BaseEntity {
   [PrimaryKeyProp]?: ['bar', 'baz'];
@@ -10886,6 +11023,8 @@ export const Publisher2Schema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
 export class Publisher2Tests extends BaseEntity {
   id!: number;
@@ -10933,6 +11072,7 @@ export const SandwichSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
 export class Test2 extends BaseEntity {
@@ -11558,6 +11698,7 @@ export class User2 extends BaseUser2 {
 exports[`CustomBase forceObject=true useCoreBaseEntity=false customBaseEntityName=BaseUser2 entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BaseUser2 } from './BaseUser2';
 
 export class Address2 extends BaseUser2 {
@@ -11582,6 +11723,7 @@ export const Address2Schema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Book2 } from './Book2';
 
 export class Author2 extends BaseUser2 {
   id!: number;
@@ -11722,8 +11864,10 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BaseUser2 } from './BaseUser2';
 import { BookTag2 } from './BookTag2';
+import { Publisher2 } from './Publisher2';
 
 export class Book2 extends BaseUser2 {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -11771,6 +11915,8 @@ export const Book2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
 
 export class Book2Tags extends BaseUser2 {
   [PrimaryKeyProp]?: 'order';
@@ -11801,6 +11947,7 @@ export const Book2TagsSchema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Car2 } from './Car2';
 
 export class CarOwner2 extends BaseUser2 {
   id!: number;
@@ -11838,6 +11985,7 @@ export const Car2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Test2 } from './Test2';
 
 export class Configuration2 extends BaseUser2 {
   [PrimaryKeyProp]?: ['property', 'test'];
@@ -11871,6 +12019,7 @@ export const Dummy2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 extends BaseUser2 {
   id!: number;
@@ -11933,6 +12082,8 @@ export const FooBaz2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { FooBar2 } from './FooBar2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 extends BaseUser2 {
   [PrimaryKeyProp]?: ['bar', 'baz'];
@@ -12004,6 +12155,8 @@ export const Publisher2Schema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
 export class Publisher2Tests extends BaseUser2 {
   id!: number;
@@ -12051,6 +12204,7 @@ export const SandwichSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
 export class Test2 extends BaseUser2 {
@@ -12670,6 +12824,7 @@ export abstract class CustomBase {
 exports[`CustomBase forceObject=true useCoreBaseEntity=false customBaseEntityName=CustomBase entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { CustomBase } from './CustomBase';
 
 export class Address2 extends CustomBase {
@@ -12693,6 +12848,7 @@ export const Address2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 
 export class Author2 extends CustomBase {
@@ -12834,8 +12990,10 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { CustomBase } from './CustomBase';
+import { Publisher2 } from './Publisher2';
 
 export class Book2 extends CustomBase {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -12882,6 +13040,8 @@ export const Book2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
 import { CustomBase } from './CustomBase';
 
 export class Book2Tags extends CustomBase {
@@ -12912,6 +13072,7 @@ export const Book2TagsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema } from '@mikro-orm/core';
+import { Car2 } from './Car2';
 import { CustomBase } from './CustomBase';
 
 export class CarOwner2 extends CustomBase {
@@ -12950,6 +13111,7 @@ export const Car2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { Test2 } from './Test2';
 
 export class Configuration2 extends CustomBase {
   [PrimaryKeyProp]?: ['property', 'test'];
@@ -12983,6 +13145,7 @@ export const Dummy2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 extends CustomBase {
   id!: number;
@@ -13045,6 +13208,8 @@ export const FooBaz2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { FooBar2 } from './FooBar2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 extends CustomBase {
   [PrimaryKeyProp]?: ['bar', 'baz'];
@@ -13116,6 +13281,8 @@ export const Publisher2Schema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
 export class Publisher2Tests extends CustomBase {
   id!: number;
@@ -13162,6 +13329,7 @@ export const SandwichSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
 
@@ -13768,6 +13936,7 @@ export class User2 extends BaseEntity {
 exports[`CustomBase forceObject=true useCoreBaseEntity=true customBaseEntityName= entitySchema=true: dump 1`] = `
 [
   "import { BaseEntity, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 
 export class Address2 extends BaseEntity {
   [PrimaryKeyProp]?: 'author';
@@ -13790,6 +13959,7 @@ export const Address2Schema = new EntitySchema({
 });
 ",
   "import { BaseEntity, Collection, EntitySchema, Opt } from '@mikro-orm/core';
+import { Book2 } from './Book2';
 
 export class Author2 extends BaseEntity {
   id!: number;
@@ -13928,7 +14098,9 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { BaseEntity, Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
+import { Publisher2 } from './Publisher2';
 
 export class Book2 extends BaseEntity {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -13975,6 +14147,8 @@ export const Book2Schema = new EntitySchema({
 });
 ",
   "import { BaseEntity, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
 
 export class Book2Tags extends BaseEntity {
   [PrimaryKeyProp]?: 'order';
@@ -14004,6 +14178,7 @@ export const Book2TagsSchema = new EntitySchema({
 });
 ",
   "import { BaseEntity, EntitySchema } from '@mikro-orm/core';
+import { Car2 } from './Car2';
 
 export class CarOwner2 extends BaseEntity {
   id!: number;
@@ -14039,6 +14214,7 @@ export const Car2Schema = new EntitySchema({
 });
 ",
   "import { BaseEntity, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Test2 } from './Test2';
 
 export class Configuration2 extends BaseEntity {
   [PrimaryKeyProp]?: ['property', 'test'];
@@ -14070,6 +14246,7 @@ export const Dummy2Schema = new EntitySchema({
 });
 ",
   "import { BaseEntity, EntitySchema, Opt } from '@mikro-orm/core';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 extends BaseEntity {
   id!: number;
@@ -14130,6 +14307,8 @@ export const FooBaz2Schema = new EntitySchema({
 });
 ",
   "import { BaseEntity, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { FooBar2 } from './FooBar2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 extends BaseEntity {
   [PrimaryKeyProp]?: ['bar', 'baz'];
@@ -14199,6 +14378,8 @@ export const Publisher2Schema = new EntitySchema({
 });
 ",
   "import { BaseEntity, EntitySchema } from '@mikro-orm/core';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
 export class Publisher2Tests extends BaseEntity {
   id!: number;
@@ -14244,6 +14425,7 @@ export const SandwichSchema = new EntitySchema({
 });
 ",
   "import { BaseEntity, Collection, EntitySchema, Opt } from '@mikro-orm/core';
+import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
 export class Test2 extends BaseEntity {
@@ -14862,6 +15044,7 @@ export abstract class BaseEntity extends MikroBaseEntity {
 exports[`CustomBase forceObject=true useCoreBaseEntity=true customBaseEntityName=BaseEntity entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BaseEntity } from './BaseEntity';
 
 export class Address2 extends BaseEntity {
@@ -14886,6 +15069,7 @@ export const Address2Schema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book2 } from './Book2';
 
 export class Author2 extends BaseEntity {
   id!: number;
@@ -15026,8 +15210,10 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BaseEntity } from './BaseEntity';
 import { BookTag2 } from './BookTag2';
+import { Publisher2 } from './Publisher2';
 
 export class Book2 extends BaseEntity {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -15075,6 +15261,8 @@ export const Book2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
 
 export class Book2Tags extends BaseEntity {
   [PrimaryKeyProp]?: 'order';
@@ -15105,6 +15293,7 @@ export const Book2TagsSchema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Car2 } from './Car2';
 
 export class CarOwner2 extends BaseEntity {
   id!: number;
@@ -15142,6 +15331,7 @@ export const Car2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Test2 } from './Test2';
 
 export class Configuration2 extends BaseEntity {
   [PrimaryKeyProp]?: ['property', 'test'];
@@ -15175,6 +15365,7 @@ export const Dummy2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 extends BaseEntity {
   id!: number;
@@ -15237,6 +15428,8 @@ export const FooBaz2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { FooBar2 } from './FooBar2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 extends BaseEntity {
   [PrimaryKeyProp]?: ['bar', 'baz'];
@@ -15308,6 +15501,8 @@ export const Publisher2Schema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
 export class Publisher2Tests extends BaseEntity {
   id!: number;
@@ -15355,6 +15550,7 @@ export const SandwichSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
 export class Test2 extends BaseEntity {
@@ -15980,6 +16176,7 @@ export class User2 extends BaseUser2 {
 exports[`CustomBase forceObject=true useCoreBaseEntity=true customBaseEntityName=BaseUser2 entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BaseUser2 } from './BaseUser2';
 
 export class Address2 extends BaseUser2 {
@@ -16004,6 +16201,7 @@ export const Address2Schema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Book2 } from './Book2';
 
 export class Author2 extends BaseUser2 {
   id!: number;
@@ -16144,8 +16342,10 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BaseUser2 } from './BaseUser2';
 import { BookTag2 } from './BookTag2';
+import { Publisher2 } from './Publisher2';
 
 export class Book2 extends BaseUser2 {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -16193,6 +16393,8 @@ export const Book2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
 
 export class Book2Tags extends BaseUser2 {
   [PrimaryKeyProp]?: 'order';
@@ -16223,6 +16425,7 @@ export const Book2TagsSchema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Car2 } from './Car2';
 
 export class CarOwner2 extends BaseUser2 {
   id!: number;
@@ -16260,6 +16463,7 @@ export const Car2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Test2 } from './Test2';
 
 export class Configuration2 extends BaseUser2 {
   [PrimaryKeyProp]?: ['property', 'test'];
@@ -16293,6 +16497,7 @@ export const Dummy2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 extends BaseUser2 {
   id!: number;
@@ -16355,6 +16560,8 @@ export const FooBaz2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { FooBar2 } from './FooBar2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 extends BaseUser2 {
   [PrimaryKeyProp]?: ['bar', 'baz'];
@@ -16426,6 +16633,8 @@ export const Publisher2Schema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
 export class Publisher2Tests extends BaseUser2 {
   id!: number;
@@ -16473,6 +16682,7 @@ export const SandwichSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
+import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
 export class Test2 extends BaseUser2 {
@@ -17092,6 +17302,7 @@ export abstract class CustomBase extends BaseEntity {
 exports[`CustomBase forceObject=true useCoreBaseEntity=true customBaseEntityName=CustomBase entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { CustomBase } from './CustomBase';
 
 export class Address2 extends CustomBase {
@@ -17115,6 +17326,7 @@ export const Address2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 
 export class Author2 extends CustomBase {
@@ -17256,8 +17468,10 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { CustomBase } from './CustomBase';
+import { Publisher2 } from './Publisher2';
 
 export class Book2 extends CustomBase {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -17304,6 +17518,8 @@ export const Book2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
 import { CustomBase } from './CustomBase';
 
 export class Book2Tags extends CustomBase {
@@ -17334,6 +17550,7 @@ export const Book2TagsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema } from '@mikro-orm/core';
+import { Car2 } from './Car2';
 import { CustomBase } from './CustomBase';
 
 export class CarOwner2 extends CustomBase {
@@ -17372,6 +17589,7 @@ export const Car2Schema = new EntitySchema({
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { Test2 } from './Test2';
 
 export class Configuration2 extends CustomBase {
   [PrimaryKeyProp]?: ['property', 'test'];
@@ -17405,6 +17623,7 @@ export const Dummy2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 extends CustomBase {
   id!: number;
@@ -17467,6 +17686,8 @@ export const FooBaz2Schema = new EntitySchema({
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { FooBar2 } from './FooBar2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 extends CustomBase {
   [PrimaryKeyProp]?: ['bar', 'baz'];
@@ -17538,6 +17759,8 @@ export const Publisher2Schema = new EntitySchema({
 ",
   "import { EntitySchema } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
 export class Publisher2Tests extends CustomBase {
   id!: number;
@@ -17584,6 +17807,7 @@ export const SandwichSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
 

--- a/tests/features/entity-generator/__snapshots__/FkIndexSelection.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/FkIndexSelection.mysql.test.ts.snap
@@ -100,6 +100,7 @@ export const FashionableColorsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { FashionableColors } from './FashionableColors';
 
 export class Users {
   [PrimaryKeyProp]?: 'userId';
@@ -391,6 +392,7 @@ export const FashionableColorsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { FashionableColors } from './FashionableColors';
 
 export class Users {
   [PrimaryKeyProp]?: 'userId';
@@ -673,6 +675,7 @@ export const FashionableColorsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { FashionableColors } from './FashionableColors';
 
 export class Users {
   [PrimaryKeyProp]?: 'userId';
@@ -934,6 +937,7 @@ export const FashionableColorsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { FashionableColors } from './FashionableColors';
 
 export class Users {
   [PrimaryKeyProp]?: 'userId';
@@ -1198,6 +1202,7 @@ export const FashionableColorsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { FashionableColors } from './FashionableColors';
 
 export class Users {
   [PrimaryKeyProp]?: 'userId';
@@ -1469,6 +1474,7 @@ export const FashionableColorsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { FashionableColors } from './FashionableColors';
 
 export class Users {
   [PrimaryKeyProp]?: 'userId';

--- a/tests/features/entity-generator/__snapshots__/FkSharedWithColumn.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/FkSharedWithColumn.mysql.test.ts.snap
@@ -81,6 +81,7 @@ export const CountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
 
 export class LegalUserCountries {
   [PrimaryKeyProp]?: 'countries';
@@ -97,6 +98,8 @@ export const LegalUserCountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { LegalUserCountries } from './LegalUserCountries';
 
 export class Users {
   [PrimaryKeyProp]?: 'userId';
@@ -374,6 +377,7 @@ export class Users {
 exports[`fk_shared_with_column_example scalarPropertiesForRelations=always bidirectionalRelations=true identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { LegalUserCountries } from './LegalUserCountries';
 import { Users } from './Users';
 
 export class Countries {
@@ -395,6 +399,7 @@ export const CountriesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
 import { Users } from './Users';
 
 export class LegalUserCountries {
@@ -414,6 +419,8 @@ export const LegalUserCountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { LegalUserCountries } from './LegalUserCountries';
 
 export class Users {
   [PrimaryKeyProp]?: 'userId';
@@ -710,6 +717,7 @@ export const CountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
 
 export class LegalUserCountries {
   [PrimaryKeyProp]?: 'country';
@@ -724,6 +732,8 @@ export const LegalUserCountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { LegalUserCountries } from './LegalUserCountries';
 
 export class Users {
   [PrimaryKeyProp]?: 'userId';
@@ -969,6 +979,7 @@ export class Users {
 exports[`fk_shared_with_column_example scalarPropertiesForRelations=never bidirectionalRelations=true identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { LegalUserCountries } from './LegalUserCountries';
 import { Users } from './Users';
 
 export class Countries {
@@ -990,6 +1001,7 @@ export const CountriesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
 import { Users } from './Users';
 
 export class LegalUserCountries {
@@ -1007,6 +1019,8 @@ export const LegalUserCountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { LegalUserCountries } from './LegalUserCountries';
 
 export class Users {
   [PrimaryKeyProp]?: 'userId';
@@ -1282,6 +1296,7 @@ export const CountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
 
 export class LegalUserCountries {
   [PrimaryKeyProp]?: 'country';
@@ -1296,6 +1311,8 @@ export const LegalUserCountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { LegalUserCountries } from './LegalUserCountries';
 
 export class Users {
   [PrimaryKeyProp]?: 'userId';
@@ -1541,6 +1558,7 @@ export class Users {
 exports[`fk_shared_with_column_example scalarPropertiesForRelations=smart bidirectionalRelations=true identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { LegalUserCountries } from './LegalUserCountries';
 import { Users } from './Users';
 
 export class Countries {
@@ -1562,6 +1580,7 @@ export const CountriesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
 import { Users } from './Users';
 
 export class LegalUserCountries {
@@ -1579,6 +1598,8 @@ export const LegalUserCountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { LegalUserCountries } from './LegalUserCountries';
 
 export class Users {
   [PrimaryKeyProp]?: 'userId';

--- a/tests/features/entity-generator/__snapshots__/GeneratedColumns.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/GeneratedColumns.mysql.test.ts.snap
@@ -109,6 +109,7 @@ export const AllowedAgesAtCreationSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt } from '@mikro-orm/core';
+import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 export class Users {
   id!: number;
@@ -165,6 +166,7 @@ export const AllowedAgesAtCreationSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt } from '@mikro-orm/core';
+import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 export class Users {
   id!: number;

--- a/tests/features/entity-generator/__snapshots__/GeneratedColumns.postgresql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/GeneratedColumns.postgresql.test.ts.snap
@@ -109,6 +109,7 @@ export const AllowedAgesAtCreationSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt } from '@mikro-orm/core';
+import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 export class Users {
   id!: number;
@@ -164,6 +165,7 @@ export const AllowedAgesAtCreationSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt } from '@mikro-orm/core';
+import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 export class Users {
   id!: number;

--- a/tests/features/entity-generator/__snapshots__/ManyToManyRelations.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/ManyToManyRelations.mysql.test.ts.snap
@@ -185,6 +185,8 @@ export class Users {
 exports[`many_to_many_variants bidirectionalRelations=false onlyPurePivotTables=false readOnlyPivotTables=false entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema } from '@mikro-orm/core';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
@@ -263,6 +265,8 @@ export const OrdersSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -294,6 +298,9 @@ export const UserEmailAvatarsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Flags } from './Flags';
+import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -325,6 +332,9 @@ export const UserEmailFlagsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -354,6 +364,8 @@ export const UserEmailOrdersSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -390,6 +402,7 @@ export const UserEmailsSchema = new EntitySchema({
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Orders } from './Orders';
+import { UserEmails } from './UserEmails';
 
 export class Users {
   [PrimaryKeyProp]?: 'userId';
@@ -632,6 +645,8 @@ export class Users {
 exports[`many_to_many_variants bidirectionalRelations=false onlyPurePivotTables=false readOnlyPivotTables=true entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema } from '@mikro-orm/core';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
@@ -710,6 +725,8 @@ export const OrdersSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -741,6 +758,9 @@ export const UserEmailAvatarsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Flags } from './Flags';
+import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -772,6 +792,9 @@ export const UserEmailFlagsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -801,6 +824,8 @@ export const UserEmailOrdersSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -837,6 +862,10 @@ export const UserEmailsSchema = new EntitySchema({
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Orders } from './Orders';
+import { UserEmailAvatars } from './UserEmailAvatars';
+import { UserEmailFlags } from './UserEmailFlags';
+import { UserEmailOrders } from './UserEmailOrders';
+import { UserEmails } from './UserEmails';
 
 export class Users {
   [PrimaryKeyProp]?: 'userId';
@@ -1109,6 +1138,8 @@ export class Users {
 exports[`many_to_many_variants bidirectionalRelations=false onlyPurePivotTables=true readOnlyPivotTables=false entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema } from '@mikro-orm/core';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
@@ -1187,6 +1218,8 @@ export const OrdersSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -1218,6 +1251,9 @@ export const UserEmailAvatarsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Flags } from './Flags';
+import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -1249,6 +1285,9 @@ export const UserEmailFlagsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -1278,6 +1317,8 @@ export const UserEmailOrdersSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -1311,6 +1352,8 @@ export const UserEmailsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class UserOrders {
   [PrimaryKeyProp]?: ['user', 'order'];
@@ -1566,6 +1609,8 @@ export class Users {
 exports[`many_to_many_variants bidirectionalRelations=false onlyPurePivotTables=true readOnlyPivotTables=true entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema } from '@mikro-orm/core';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
@@ -1644,6 +1689,8 @@ export const OrdersSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -1675,6 +1722,9 @@ export const UserEmailAvatarsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Flags } from './Flags';
+import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -1706,6 +1756,9 @@ export const UserEmailFlagsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -1735,6 +1788,8 @@ export const UserEmailOrdersSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -1768,6 +1823,8 @@ export const UserEmailsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class UserOrders {
   [PrimaryKeyProp]?: ['user', 'order'];
@@ -2038,6 +2095,8 @@ export class Users {
 exports[`many_to_many_variants bidirectionalRelations=true onlyPurePivotTables=false readOnlyPivotTables=false entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema } from '@mikro-orm/core';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
@@ -2090,6 +2149,7 @@ export const EmailsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { UserEmailFlags } from './UserEmailFlags';
 import { Users } from './Users';
 
 export class Flags {
@@ -2133,6 +2193,8 @@ export const OrdersSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -2164,6 +2226,9 @@ export const UserEmailAvatarsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Flags } from './Flags';
+import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -2195,6 +2260,9 @@ export const UserEmailFlagsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -2224,6 +2292,8 @@ export const UserEmailOrdersSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -2541,6 +2611,8 @@ export class Users {
 exports[`many_to_many_variants bidirectionalRelations=true onlyPurePivotTables=false readOnlyPivotTables=true entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema } from '@mikro-orm/core';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
@@ -2609,6 +2681,7 @@ export const EmailsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { UserEmailFlags } from './UserEmailFlags';
 import { Users } from './Users';
 
 export class Flags {
@@ -2652,6 +2725,8 @@ export const OrdersSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -2683,6 +2758,9 @@ export const UserEmailAvatarsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Flags } from './Flags';
+import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -2714,6 +2792,9 @@ export const UserEmailFlagsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -2743,6 +2824,8 @@ export const UserEmailOrdersSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -2779,6 +2862,9 @@ export const UserEmailsSchema = new EntitySchema({
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Orders } from './Orders';
+import { UserEmailAvatars } from './UserEmailAvatars';
+import { UserEmailFlags } from './UserEmailFlags';
+import { UserEmailOrders } from './UserEmailOrders';
 import { UserEmails } from './UserEmails';
 
 export class Users {
@@ -3074,6 +3160,8 @@ export class Users {
 exports[`many_to_many_variants bidirectionalRelations=true onlyPurePivotTables=true readOnlyPivotTables=false entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema } from '@mikro-orm/core';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
@@ -3123,6 +3211,7 @@ export const EmailsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { UserEmailFlags } from './UserEmailFlags';
 import { Users } from './Users';
 
 export class Flags {
@@ -3163,6 +3252,8 @@ export const OrdersSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -3194,6 +3285,9 @@ export const UserEmailAvatarsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Flags } from './Flags';
+import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -3225,6 +3319,9 @@ export const UserEmailFlagsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -3254,6 +3351,8 @@ export const UserEmailOrdersSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -3287,6 +3386,8 @@ export const UserEmailsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class UserOrders {
   [PrimaryKeyProp]?: ['user', 'order'];
@@ -3565,6 +3666,8 @@ export class Users {
 exports[`many_to_many_variants bidirectionalRelations=true onlyPurePivotTables=true readOnlyPivotTables=true entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema } from '@mikro-orm/core';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
@@ -3614,6 +3717,7 @@ export const EmailsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { UserEmailFlags } from './UserEmailFlags';
 import { Users } from './Users';
 
 export class Flags {
@@ -3654,6 +3758,8 @@ export const OrdersSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -3685,6 +3791,9 @@ export const UserEmailAvatarsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Flags } from './Flags';
+import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -3716,6 +3825,9 @@ export const UserEmailFlagsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -3745,6 +3857,8 @@ export const UserEmailOrdersSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
@@ -3778,6 +3892,8 @@ export const UserEmailsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Orders } from './Orders';
+import { Users } from './Users';
 
 export class UserOrders {
   [PrimaryKeyProp]?: ['user', 'order'];

--- a/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
@@ -669,6 +669,7 @@ export abstract class CustomBase2 {
 exports[`MetadataHooks [mysql] identifiedReferences=false metadata hooks with entity schema: mysql-EntitySchema-dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Author2 } from './Author2';
 
 export class Address2 {
   [PrimaryKeyProp]?: 'author';
@@ -690,8 +691,9 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EagerProps, EntitySchema, Hidden, Opt } from '@mikro-orm/core';
+  "import { Cascade, Collection, EagerProps, Embedded, EntitySchema, Hidden, Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
+import { IdentitiesContainer } from './IdentitiesContainer';
 
 export class Author2 {
   [EagerProps]?: 'favouriteBook';
@@ -879,6 +881,8 @@ export const BookTag2Schema = new EntitySchema({
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
 export class Book2 {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -932,6 +936,8 @@ export const Book2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
 
 export class Book2Tags {
   [PrimaryKeyProp]?: 'order';
@@ -961,6 +967,7 @@ export const Book2TagsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema } from '@mikro-orm/core';
+import { Car2 } from './Car2';
 
 export class CarOwner2 {
   id!: number;
@@ -1004,6 +1011,7 @@ export const Car2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Test2 } from './Test2';
 
 export class Configuration2 {
   [PrimaryKeyProp]?: ['property', 'test'];
@@ -1035,6 +1043,7 @@ export const Dummy2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
 import { Test2 } from './Test2';
 
@@ -1106,6 +1115,8 @@ export const FooBaz2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { FooBar2 } from './FooBar2';
+import { FooBaz2 } from './FooBaz2';
 
 export class FooParam2 {
   [PrimaryKeyProp]?: ['bar', 'baz'];
@@ -1181,6 +1192,8 @@ export const Publisher2Schema = new EntitySchema({
 });
 ",
   "import { EntitySchema } from '@mikro-orm/core';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
 export class Publisher2Tests {
   id!: number;
@@ -1229,6 +1242,7 @@ export const SandwichSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+import { Book2 } from './Book2';
 import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
 import { Publisher2Tests } from './Publisher2Tests';
@@ -1624,7 +1638,6 @@ import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
-import { number } from './number';
 
 @Entity()
 export class Book2 {
@@ -2012,7 +2025,6 @@ export class Test2 {
   "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './Sandwich';
-import { [string, number] } from './[string, number]';
 
 @Entity()
 export class User2 {
@@ -2142,8 +2154,9 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EagerProps, EntitySchema, Hidden, Opt, Ref } from '@mikro-orm/core';
+  "import { Cascade, Collection, EagerProps, Embedded, EntitySchema, Hidden, Opt, Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
+import { IdentitiesContainer } from './IdentitiesContainer';
 
 export class Author2 {
   [EagerProps]?: 'favouriteBook';
@@ -2345,8 +2358,8 @@ export const BookTag2Schema = new EntitySchema({
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
+import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
-import { number } from './number';
 
 export class Book2 {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -2796,7 +2809,6 @@ export const Test2Schema = new EntitySchema({
   "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './Sandwich';
-import { [string, number] } from './[string, number]';
 
 export class User2 {
   [PrimaryKeyProp]?: ['firstName', 'lastName'];

--- a/tests/features/entity-generator/__snapshots__/NonCompositeAmbiguousFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/NonCompositeAmbiguousFks.mysql.test.ts.snap
@@ -108,6 +108,7 @@ export class ShippableProducts {
 exports[`non_composite_ambiguous_fk_example scalarPropertiesForRelations=always bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 
 export class DeliverableProducts {
   [PrimaryKeyProp]?: 'product';
@@ -142,6 +143,7 @@ export const DestinationsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 
 export class ManufacturedProducts {
   [PrimaryKeyProp]?: 'product';
@@ -176,6 +178,9 @@ export const ProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { DeliverableProducts } from './DeliverableProducts';
+import { Destinations } from './Destinations';
+import { ManufacturedProducts } from './ManufacturedProducts';
 
 export class ShippableProducts {
   [PrimaryKeyProp]?: ['deliverableProducts', 'fkShippableProductsManufacturedProducts', 'fkShippableProductsManufacturedProducts1'];
@@ -600,6 +605,7 @@ export class ShippableProducts {
 exports[`non_composite_ambiguous_fk_example scalarPropertiesForRelations=always bidirectionalRelations=true identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 import { ShippableProducts } from './ShippableProducts';
 
 export class DeliverableProducts {
@@ -644,6 +650,7 @@ export const DestinationsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 import { ShippableProducts } from './ShippableProducts';
 
 export class ManufacturedProducts {
@@ -675,6 +682,7 @@ export const ManufacturedProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ManufacturedProducts } from './ManufacturedProducts';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
@@ -693,6 +701,9 @@ export const ProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { DeliverableProducts } from './DeliverableProducts';
+import { Destinations } from './Destinations';
+import { ManufacturedProducts } from './ManufacturedProducts';
 
 export class ShippableProducts {
   [PrimaryKeyProp]?: ['deliverableProducts', 'fkShippableProductsManufacturedProducts', 'fkShippableProductsManufacturedProducts1'];
@@ -1135,6 +1146,7 @@ export class ShippableProducts {
 exports[`non_composite_ambiguous_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 
 export class DeliverableProducts {
   [PrimaryKeyProp]?: 'product';
@@ -1167,6 +1179,7 @@ export const DestinationsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 
 export class ManufacturedProducts {
   [PrimaryKeyProp]?: 'product';
@@ -1199,6 +1212,9 @@ export const ProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { DeliverableProducts } from './DeliverableProducts';
+import { Destinations } from './Destinations';
+import { ManufacturedProducts } from './ManufacturedProducts';
 
 export class ShippableProducts {
   [PrimaryKeyProp]?: ['deliverableProducts', 'fkShippableProductsManufacturedProducts', 'fkShippableProductsManufacturedProducts1'];
@@ -1577,6 +1593,7 @@ export class ShippableProducts {
 exports[`non_composite_ambiguous_fk_example scalarPropertiesForRelations=never bidirectionalRelations=true identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 import { ShippableProducts } from './ShippableProducts';
 
 export class DeliverableProducts {
@@ -1619,6 +1636,7 @@ export const DestinationsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 import { ShippableProducts } from './ShippableProducts';
 
 export class ManufacturedProducts {
@@ -1648,6 +1666,7 @@ export const ManufacturedProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ManufacturedProducts } from './ManufacturedProducts';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
@@ -1666,6 +1685,9 @@ export const ProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { DeliverableProducts } from './DeliverableProducts';
+import { Destinations } from './Destinations';
+import { ManufacturedProducts } from './ManufacturedProducts';
 
 export class ShippableProducts {
   [PrimaryKeyProp]?: ['deliverableProducts', 'fkShippableProductsManufacturedProducts', 'fkShippableProductsManufacturedProducts1'];
@@ -2075,6 +2097,7 @@ export class ShippableProducts {
 exports[`non_composite_ambiguous_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 
 export class DeliverableProducts {
   [PrimaryKeyProp]?: 'product';
@@ -2107,6 +2130,7 @@ export const DestinationsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 
 export class ManufacturedProducts {
   [PrimaryKeyProp]?: 'product';
@@ -2139,6 +2163,9 @@ export const ProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { DeliverableProducts } from './DeliverableProducts';
+import { Destinations } from './Destinations';
+import { ManufacturedProducts } from './ManufacturedProducts';
 
 export class ShippableProducts {
   [PrimaryKeyProp]?: ['deliverableProducts', 'fkShippableProductsManufacturedProducts', 'fkShippableProductsManufacturedProducts1'];
@@ -2517,6 +2544,7 @@ export class ShippableProducts {
 exports[`non_composite_ambiguous_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=true identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 import { ShippableProducts } from './ShippableProducts';
 
 export class DeliverableProducts {
@@ -2559,6 +2587,7 @@ export const DestinationsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 import { ShippableProducts } from './ShippableProducts';
 
 export class ManufacturedProducts {
@@ -2588,6 +2617,7 @@ export const ManufacturedProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ManufacturedProducts } from './ManufacturedProducts';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
@@ -2606,6 +2636,9 @@ export const ProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { DeliverableProducts } from './DeliverableProducts';
+import { Destinations } from './Destinations';
+import { ManufacturedProducts } from './ManufacturedProducts';
 
 export class ShippableProducts {
   [PrimaryKeyProp]?: ['deliverableProducts', 'fkShippableProductsManufacturedProducts', 'fkShippableProductsManufacturedProducts1'];

--- a/tests/features/entity-generator/__snapshots__/NullableFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/NullableFks.mysql.test.ts.snap
@@ -153,6 +153,8 @@ export class Senders {
 exports[`nullable_fk_example scalarPropertiesForRelations=always bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { RecepientEmails } from './RecepientEmails';
+import { SenderEmails } from './SenderEmails';
 
 export class EmailSendingLogs {
   [PrimaryKeyProp]?: 'logId';
@@ -226,6 +228,8 @@ export const EmailsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Recepients } from './Recepients';
 
 export class RecepientEmails {
   [PrimaryKeyProp]?: ['recepient', 'email'];
@@ -258,6 +262,7 @@ export const RecepientEmailsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
+import { RecepientEmails } from './RecepientEmails';
 
 export class Recepients {
   [PrimaryKeyProp]?: 'recepientId';
@@ -283,6 +288,8 @@ export const RecepientsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Senders } from './Senders';
 
 export class SenderEmails {
   [PrimaryKeyProp]?: ['sender', 'email'];
@@ -310,6 +317,7 @@ export const SenderEmailsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
+import { SenderEmails } from './SenderEmails';
 
 export class Senders {
   [PrimaryKeyProp]?: 'senderId';
@@ -604,6 +612,7 @@ export const RecepientEmailsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
+import { RecepientEmails } from './RecepientEmails';
 
 export class Recepients {
   [PrimaryKeyProp]?: 'recepientId';
@@ -665,6 +674,7 @@ export const SenderEmailsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
+import { SenderEmails } from './SenderEmails';
 
 export class Senders {
   [PrimaryKeyProp]?: 'senderId';
@@ -874,6 +884,8 @@ export class Senders {
 exports[`nullable_fk_example scalarPropertiesForRelations=always bidirectionalRelations=true identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { RecepientEmails } from './RecepientEmails';
+import { SenderEmails } from './SenderEmails';
 
 export class EmailSendingLogs {
   [PrimaryKeyProp]?: 'logId';
@@ -957,6 +969,8 @@ export const EmailsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { EmailSendingLogs } from './EmailSendingLogs';
+import { Emails } from './Emails';
+import { Recepients } from './Recepients';
 
 export class RecepientEmails {
   [PrimaryKeyProp]?: ['recepient', 'email'];
@@ -1020,6 +1034,8 @@ export const RecepientsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { EmailSendingLogs } from './EmailSendingLogs';
+import { Emails } from './Emails';
+import { Senders } from './Senders';
 
 export class SenderEmails {
   [PrimaryKeyProp]?: ['sender', 'email'];
@@ -1612,6 +1628,8 @@ export class Senders {
 exports[`nullable_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { RecepientEmails } from './RecepientEmails';
+import { SenderEmails } from './SenderEmails';
 
 export class EmailSendingLogs {
   [PrimaryKeyProp]?: 'logId';
@@ -1675,6 +1693,8 @@ export const EmailsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Recepients } from './Recepients';
 
 export class RecepientEmails {
   [PrimaryKeyProp]?: ['recepient', 'email'];
@@ -1703,6 +1723,7 @@ export const RecepientEmailsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
+import { RecepientEmails } from './RecepientEmails';
 
 export class Recepients {
   [PrimaryKeyProp]?: 'recepientId';
@@ -1728,6 +1749,8 @@ export const RecepientsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Senders } from './Senders';
 
 export class SenderEmails {
   [PrimaryKeyProp]?: ['sender', 'email'];
@@ -1751,6 +1774,7 @@ export const SenderEmailsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
+import { SenderEmails } from './SenderEmails';
 
 export class Senders {
   [PrimaryKeyProp]?: 'senderId';
@@ -2002,6 +2026,7 @@ export const RecepientEmailsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
+import { RecepientEmails } from './RecepientEmails';
 
 export class Recepients {
   [PrimaryKeyProp]?: 'recepientId';
@@ -2059,6 +2084,7 @@ export const SenderEmailsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
+import { SenderEmails } from './SenderEmails';
 
 export class Senders {
   [PrimaryKeyProp]?: 'senderId';
@@ -2239,6 +2265,8 @@ export class Senders {
 exports[`nullable_fk_example scalarPropertiesForRelations=never bidirectionalRelations=true identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { RecepientEmails } from './RecepientEmails';
+import { SenderEmails } from './SenderEmails';
 
 export class EmailSendingLogs {
   [PrimaryKeyProp]?: 'logId';
@@ -2312,6 +2340,8 @@ export const EmailsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { EmailSendingLogs } from './EmailSendingLogs';
+import { Emails } from './Emails';
+import { Recepients } from './Recepients';
 
 export class RecepientEmails {
   [PrimaryKeyProp]?: ['recepient', 'email'];
@@ -2371,6 +2401,8 @@ export const RecepientsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { EmailSendingLogs } from './EmailSendingLogs';
+import { Emails } from './Emails';
+import { Senders } from './Senders';
 
 export class SenderEmails {
   [PrimaryKeyProp]?: ['sender', 'email'];
@@ -2912,6 +2944,8 @@ export class Senders {
 exports[`nullable_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { RecepientEmails } from './RecepientEmails';
+import { SenderEmails } from './SenderEmails';
 
 export class EmailSendingLogs {
   [PrimaryKeyProp]?: 'logId';
@@ -2975,6 +3009,8 @@ export const EmailsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Recepients } from './Recepients';
 
 export class RecepientEmails {
   [PrimaryKeyProp]?: ['recepient', 'email'];
@@ -3003,6 +3039,7 @@ export const RecepientEmailsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
+import { RecepientEmails } from './RecepientEmails';
 
 export class Recepients {
   [PrimaryKeyProp]?: 'recepientId';
@@ -3028,6 +3065,8 @@ export const RecepientsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Emails } from './Emails';
+import { Senders } from './Senders';
 
 export class SenderEmails {
   [PrimaryKeyProp]?: ['sender', 'email'];
@@ -3051,6 +3090,7 @@ export const SenderEmailsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
+import { SenderEmails } from './SenderEmails';
 
 export class Senders {
   [PrimaryKeyProp]?: 'senderId';
@@ -3302,6 +3342,7 @@ export const RecepientEmailsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
+import { RecepientEmails } from './RecepientEmails';
 
 export class Recepients {
   [PrimaryKeyProp]?: 'recepientId';
@@ -3359,6 +3400,7 @@ export const SenderEmailsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
+import { SenderEmails } from './SenderEmails';
 
 export class Senders {
   [PrimaryKeyProp]?: 'senderId';
@@ -3539,6 +3581,8 @@ export class Senders {
 exports[`nullable_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=true identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { RecepientEmails } from './RecepientEmails';
+import { SenderEmails } from './SenderEmails';
 
 export class EmailSendingLogs {
   [PrimaryKeyProp]?: 'logId';
@@ -3612,6 +3656,8 @@ export const EmailsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { EmailSendingLogs } from './EmailSendingLogs';
+import { Emails } from './Emails';
+import { Recepients } from './Recepients';
 
 export class RecepientEmails {
   [PrimaryKeyProp]?: ['recepient', 'email'];
@@ -3671,6 +3717,8 @@ export const RecepientsSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { EmailSendingLogs } from './EmailSendingLogs';
+import { Emails } from './Emails';
+import { Senders } from './Senders';
 
 export class SenderEmails {
   [PrimaryKeyProp]?: ['sender', 'email'];

--- a/tests/features/entity-generator/__snapshots__/OverlapFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OverlapFks.mysql.test.ts.snap
@@ -174,6 +174,8 @@ export const CountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { Products } from './Products';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['product', 'countries'];
@@ -206,6 +208,8 @@ export const ProductCountryMapSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
+import { Sellers } from './Sellers';
 
 export class ProductSellers {
   [PrimaryKeyProp]?: ['seller', 'product'];
@@ -244,6 +248,7 @@ export const ProductSellersSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
+import { ProductCountryMap } from './ProductCountryMap';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
@@ -273,6 +278,8 @@ export const ProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountryMap } from './ProductCountryMap';
+import { ProductSellers } from './ProductSellers';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
@@ -319,6 +326,7 @@ export const SalesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductSellers } from './ProductSellers';
 import { Products } from './Products';
 
 export class Sellers {
@@ -604,6 +612,7 @@ export const ProductSellersSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
+import { ProductCountryMap } from './ProductCountryMap';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
@@ -683,6 +692,7 @@ export const SalesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductSellers } from './ProductSellers';
 import { Products } from './Products';
 
 export class Sellers {
@@ -918,6 +928,8 @@ export const CountriesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { Products } from './Products';
 import { Sales } from './Sales';
 
 export class ProductCountryMap {
@@ -953,7 +965,9 @@ export const ProductCountryMapSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 import { Sales } from './Sales';
+import { Sellers } from './Sellers';
 
 export class ProductSellers {
   [PrimaryKeyProp]?: ['seller', 'product'];
@@ -994,6 +1008,7 @@ export const ProductSellersSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
+import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 import { Sellers } from './Sellers';
 
@@ -1029,6 +1044,8 @@ export const ProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountryMap } from './ProductCountryMap';
+import { ProductSellers } from './ProductSellers';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
@@ -1402,6 +1419,7 @@ export const ProductSellersSchema = new EntitySchema({
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
+import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 import { Sellers } from './Sellers';
 
@@ -1655,6 +1673,7 @@ export class Sellers {
 exports[`overlap_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountryMap } from './ProductCountryMap';
 import { Products } from './Products';
 
 export class Countries {
@@ -1679,6 +1698,8 @@ export const CountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { Products } from './Products';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['country', 'product'];
@@ -1707,6 +1728,8 @@ export const ProductCountryMapSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
+import { Sellers } from './Sellers';
 
 export class ProductSellers {
   [PrimaryKeyProp]?: ['seller', 'product'];
@@ -1760,6 +1783,8 @@ export const ProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountryMap } from './ProductCountryMap';
+import { ProductSellers } from './ProductSellers';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
@@ -1803,6 +1828,7 @@ export const SalesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductSellers } from './ProductSellers';
 import { Products } from './Products';
 
 export class Sellers {
@@ -1968,6 +1994,7 @@ export class Sellers {
 exports[`overlap_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=true entitySchema=true: dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountryMap } from './ProductCountryMap';
 import { Products } from './Products';
 
 export class Countries {
@@ -2133,6 +2160,7 @@ export const SalesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductSellers } from './ProductSellers';
 import { Products } from './Products';
 
 export class Sellers {
@@ -2351,6 +2379,8 @@ export const CountriesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { Products } from './Products';
 import { Sales } from './Sales';
 
 export class ProductCountryMap {
@@ -2382,7 +2412,9 @@ export const ProductCountryMapSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 import { Sales } from './Sales';
+import { Sellers } from './Sellers';
 
 export class ProductSellers {
   [PrimaryKeyProp]?: ['seller', 'product'];
@@ -2447,6 +2479,8 @@ export const ProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountryMap } from './ProductCountryMap';
+import { ProductSellers } from './ProductSellers';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
@@ -3035,6 +3069,7 @@ export class Sellers {
 exports[`overlap_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountryMap } from './ProductCountryMap';
 import { Products } from './Products';
 
 export class Countries {
@@ -3059,6 +3094,8 @@ export const CountriesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { Products } from './Products';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['country', 'product'];
@@ -3087,6 +3124,8 @@ export const ProductCountryMapSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
+import { Sellers } from './Sellers';
 
 export class ProductSellers {
   [PrimaryKeyProp]?: ['seller', 'product'];
@@ -3140,6 +3179,8 @@ export const ProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountryMap } from './ProductCountryMap';
+import { ProductSellers } from './ProductSellers';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
@@ -3183,6 +3224,7 @@ export const SalesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductSellers } from './ProductSellers';
 import { Products } from './Products';
 
 export class Sellers {
@@ -3348,6 +3390,7 @@ export class Sellers {
 exports[`overlap_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=true entitySchema=true: dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountryMap } from './ProductCountryMap';
 import { Products } from './Products';
 
 export class Countries {
@@ -3513,6 +3556,7 @@ export const SalesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductSellers } from './ProductSellers';
 import { Products } from './Products';
 
 export class Sellers {
@@ -3731,6 +3775,8 @@ export const CountriesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Countries } from './Countries';
+import { Products } from './Products';
 import { Sales } from './Sales';
 
 export class ProductCountryMap {
@@ -3762,7 +3808,9 @@ export const ProductCountryMapSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Products } from './Products';
 import { Sales } from './Sales';
+import { Sellers } from './Sellers';
 
 export class ProductSellers {
   [PrimaryKeyProp]?: ['seller', 'product'];
@@ -3827,6 +3875,8 @@ export const ProductsSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { ProductCountryMap } from './ProductCountryMap';
+import { ProductSellers } from './ProductSellers';
 
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';

--- a/tests/features/entity-generator/__snapshots__/multple-schemas.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/multple-schemas.postgres.test.ts.snap
@@ -65,7 +65,6 @@ export class Test {
 exports[`multiple schemas with same table name 2 1`] = `
 [
   "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import { Test } from './Test';
 
 @Entity({ tableName: 'test', schema: 'schema1' })
 export class Schema1Test {
@@ -79,13 +78,12 @@ export class Schema1Test {
   @Property({ length: 6, nullable: true })
   created?: Date;
 
-  @ManyToOne({ entity: () => Test, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  @ManyToOne({ entity: () => Schema1Test, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   test?: Schema1Test;
 
 }
 ",
   "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import { Test } from './Test';
 
 @Entity({ tableName: 'test', schema: 'schema2' })
 export class Schema2Test {
@@ -99,13 +97,12 @@ export class Schema2Test {
   @Property({ length: 6, nullable: true })
   created?: Date;
 
-  @ManyToOne({ entity: () => Test, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  @ManyToOne({ entity: () => Schema2Test, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   test?: Schema2Test;
 
 }
 ",
   "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import { Test } from './Test';
 
 @Entity({ tableName: 'test' })
 export class PublicTest {
@@ -119,7 +116,7 @@ export class PublicTest {
   @Property({ length: 6, nullable: true })
   created?: Date;
 
-  @ManyToOne({ entity: () => Test, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  @ManyToOne({ entity: () => PublicTest, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   test?: PublicTest;
 
 }


### PR DESCRIPTION
Also fixed extra imports when the mapToPk option is set.

Also removed the usage of getEntityName() in SourceFile, thus ensuring that adjustments made by the de-duplication are honored.