### PR TITLE
fix(entity-generator): output type import statements for type only core imports

### DIFF
--- a/packages/entity-generator/src/CoreImportsHelper.ts
+++ b/packages/entity-generator/src/CoreImportsHelper.ts
@@ -1,0 +1,6 @@
+export const POSSIBLE_TYPE_IMPORTS = [
+  'DefineConfig',
+  'Hidden',
+  'Opt',
+  'Ref',
+] as const;

--- a/packages/entity-generator/src/CoreImportsHelper.ts
+++ b/packages/entity-generator/src/CoreImportsHelper.ts
@@ -3,4 +3,7 @@ export const POSSIBLE_TYPE_IMPORTS = [
   'Hidden',
   'Opt',
   'Ref',
+  'EntityRef',
+  'ScalarRef',
+  'Rel',
 ] as const;

--- a/packages/entity-generator/src/SourceFile.ts
+++ b/packages/entity-generator/src/SourceFile.ts
@@ -16,6 +16,7 @@ import {
   UnknownType,
   Utils,
 } from '@mikro-orm/core';
+import { POSSIBLE_TYPE_IMPORTS } from './CoreImportsHelper';
 
 /**
  * @see https://github.com/tc39/proposal-regexp-unicode-property-escapes#other-examples
@@ -134,7 +135,7 @@ export class SourceFile {
   protected generateImports() {
     const imports = [];
     if (this.coreImports.size > 0) {
-      imports.push(`import { ${([...this.coreImports].sort().join(', '))} } from '@mikro-orm/core';`);
+      imports.push(`import { ${([...this.coreImports].sort().map(t => POSSIBLE_TYPE_IMPORTS.includes(t as typeof POSSIBLE_TYPE_IMPORTS[number]) ? `type ${t}` : t).join(', '))} } from '@mikro-orm/core';`);
     }
     const entityImportExtension = this.options.esmImport ? '.js' : '';
     const entityImports = [...this.entityImports].filter(e => e !== this.meta.className);

--- a/tests/features/entity-generator/__snapshots__/AmbiguousFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/AmbiguousFks.mysql.test.ts.snap
@@ -637,7 +637,7 @@ export class Countries {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Colors } from './Colors';
 import { Products } from './Products';
 
@@ -661,7 +661,7 @@ export class ProductColors {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSizes } from './ProductSizes';
 
@@ -685,7 +685,7 @@ export class ProductCountries {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKeyProp, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountries } from './ProductCountries';
 import { Products } from './Products';
@@ -726,7 +726,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
 import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
@@ -781,7 +781,7 @@ export class Sales {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Sellers } from './Sellers';
 
@@ -805,7 +805,7 @@ export class SellerCountries {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -901,7 +901,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Colors } from './Colors';
 import { Products } from './Products';
 
@@ -936,7 +936,7 @@ export const ProductColorsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSizes } from './ProductSizes';
 
@@ -975,7 +975,7 @@ export const ProductCountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountries } from './ProductCountries';
 import { Products } from './Products';
@@ -1030,7 +1030,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
 import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
@@ -1133,7 +1133,7 @@ export const SalesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Sellers } from './Sellers';
 
@@ -1168,7 +1168,7 @@ export const SellerCountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -1993,7 +1993,7 @@ export class Countries {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Colors } from './Colors';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -2021,7 +2021,7 @@ export class ProductColors {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSizes } from './ProductSizes';
 import { Sales } from './Sales';
@@ -2049,7 +2049,7 @@ export class ProductCountries {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, PrimaryKeyProp, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountries } from './ProductCountries';
 import { Products } from './Products';
@@ -2109,7 +2109,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
 import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
@@ -2164,7 +2164,7 @@ export class Sales {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -2192,7 +2192,7 @@ export class SellerCountries {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -2309,7 +2309,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Colors } from './Colors';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -2347,7 +2347,7 @@ export const ProductColorsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSizes } from './ProductSizes';
 import { Sales } from './Sales';
@@ -2389,7 +2389,7 @@ export const ProductCountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountries } from './ProductCountries';
 import { Products } from './Products';
@@ -2458,7 +2458,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
 import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
@@ -2561,7 +2561,7 @@ export const SalesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -2599,7 +2599,7 @@ export const SellerCountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -3249,7 +3249,7 @@ export class Countries {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Colors } from './Colors';
 import { Products } from './Products';
 
@@ -3266,7 +3266,7 @@ export class ProductColors {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSizes } from './ProductSizes';
 
@@ -3283,7 +3283,7 @@ export class ProductCountries {
 
 }
 ",
-  "import { Entity, OneToOne, PrimaryKeyProp, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
 import { Products } from './Products';
 
 @Entity()
@@ -3316,7 +3316,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Ref, Unique } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, type Ref, Unique } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
 import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
@@ -3353,7 +3353,7 @@ export class Sales {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Sellers } from './Sellers';
 
@@ -3370,7 +3370,7 @@ export class SellerCountries {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -3476,7 +3476,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Colors } from './Colors';
 import { Products } from './Products';
 
@@ -3507,7 +3507,7 @@ export const ProductColorsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSizes } from './ProductSizes';
 
@@ -3538,7 +3538,7 @@ export const ProductCountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 
 export class ProductSizes {
@@ -3580,7 +3580,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
 import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
@@ -3674,7 +3674,7 @@ export const SalesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Sellers } from './Sellers';
 
@@ -3705,7 +3705,7 @@ export const SellerCountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -4436,7 +4436,7 @@ export class Countries {
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Colors } from './Colors';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -4457,7 +4457,7 @@ export class ProductColors {
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSizes } from './ProductSizes';
 import { Sales } from './Sales';
@@ -4478,7 +4478,7 @@ export class ProductCountries {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, PrimaryKeyProp, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountries } from './ProductCountries';
 import { Products } from './Products';
@@ -4535,7 +4535,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Ref, Unique } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, type Ref, Unique } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
 import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
@@ -4572,7 +4572,7 @@ export class Sales {
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -4593,7 +4593,7 @@ export class SellerCountries {
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -4717,7 +4717,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Colors } from './Colors';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -4751,7 +4751,7 @@ export const ProductColorsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSizes } from './ProductSizes';
 import { Sales } from './Sales';
@@ -4785,7 +4785,7 @@ export const ProductCountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountries } from './ProductCountries';
 import { Products } from './Products';
@@ -4845,7 +4845,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
 import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
@@ -4939,7 +4939,7 @@ export const SalesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -4973,7 +4973,7 @@ export const SellerCountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -5611,7 +5611,7 @@ export class Countries {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Colors } from './Colors';
 import { Products } from './Products';
 
@@ -5628,7 +5628,7 @@ export class ProductColors {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSizes } from './ProductSizes';
 
@@ -5645,7 +5645,7 @@ export class ProductCountries {
 
 }
 ",
-  "import { Entity, OneToOne, PrimaryKeyProp, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
 import { Products } from './Products';
 
 @Entity()
@@ -5678,7 +5678,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Ref, Unique } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, type Ref, Unique } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
 import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
@@ -5715,7 +5715,7 @@ export class Sales {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Sellers } from './Sellers';
 
@@ -5732,7 +5732,7 @@ export class SellerCountries {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -5838,7 +5838,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Colors } from './Colors';
 import { Products } from './Products';
 
@@ -5869,7 +5869,7 @@ export const ProductColorsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSizes } from './ProductSizes';
 
@@ -5900,7 +5900,7 @@ export const ProductCountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 
 export class ProductSizes {
@@ -5942,7 +5942,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
 import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
@@ -6036,7 +6036,7 @@ export const SalesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Sellers } from './Sellers';
 
@@ -6067,7 +6067,7 @@ export const SellerCountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -6798,7 +6798,7 @@ export class Countries {
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Colors } from './Colors';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -6819,7 +6819,7 @@ export class ProductColors {
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSizes } from './ProductSizes';
 import { Sales } from './Sales';
@@ -6840,7 +6840,7 @@ export class ProductCountries {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, PrimaryKeyProp, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountries } from './ProductCountries';
 import { Products } from './Products';
@@ -6897,7 +6897,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Ref, Unique } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, type Ref, Unique } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
 import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
@@ -6934,7 +6934,7 @@ export class Sales {
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -6955,7 +6955,7 @@ export class SellerCountries {
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -7079,7 +7079,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Colors } from './Colors';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -7113,7 +7113,7 @@ export const ProductColorsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSizes } from './ProductSizes';
 import { Sales } from './Sales';
@@ -7147,7 +7147,7 @@ export const ProductCountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountries } from './ProductCountries';
 import { Products } from './Products';
@@ -7207,7 +7207,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
 import { ProductCountries } from './ProductCountries';
 import { ProductSizes } from './ProductSizes';
@@ -7301,7 +7301,7 @@ export const SalesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -7335,7 +7335,7 @@ export const SellerCountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';

--- a/tests/features/entity-generator/__snapshots__/CustomBase.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/CustomBase.mysql.test.ts.snap
@@ -18,7 +18,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -137,7 +137,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -269,7 +269,7 @@ export class Dummy2 {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 @Entity()
@@ -307,7 +307,7 @@ export class FooBar2 {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class FooBaz2 {
@@ -323,7 +323,7 @@ export class FooBaz2 {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -346,7 +346,7 @@ export class FooParam2 {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Publisher2 {
@@ -434,7 +434,7 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
@@ -524,7 +524,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 export class Author2 {
@@ -663,7 +663,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -811,7 +811,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 {
@@ -855,7 +855,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 
 export class FooBaz2 {
   id!: number;
@@ -872,7 +872,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -894,7 +894,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 
 export class Publisher2 {
   id!: number;
@@ -990,7 +990,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
@@ -1101,7 +1101,7 @@ export class Address2 extends BaseEntity {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book2 } from './Book2';
 
@@ -1223,7 +1223,7 @@ export class BookTag2 extends BaseEntity {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BaseEntity } from './BaseEntity';
 import { BookTag2 } from './BookTag2';
@@ -1361,7 +1361,7 @@ export class Dummy2 extends BaseEntity {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBaz2 } from './FooBaz2';
 
@@ -1400,7 +1400,7 @@ export class FooBar2 extends BaseEntity {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 
 @Entity()
@@ -1417,7 +1417,7 @@ export class FooBaz2 extends BaseEntity {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -1441,7 +1441,7 @@ export class FooParam2 extends BaseEntity {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 
 @Entity()
@@ -1532,7 +1532,7 @@ export class Sandwich extends BaseEntity {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
@@ -1596,7 +1596,7 @@ export class User2 extends BaseEntity {
 
 }
 ",
-  "import { Config, DefineConfig } from '@mikro-orm/core';
+  "import { Config, type DefineConfig } from '@mikro-orm/core';
 
 export abstract class BaseEntity {
 
@@ -1633,7 +1633,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book2 } from './Book2';
 
@@ -1775,7 +1775,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BaseEntity } from './BaseEntity';
 import { BookTag2 } from './BookTag2';
@@ -1929,7 +1929,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBaz2 } from './FooBaz2';
 
@@ -1974,7 +1974,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 
 export class FooBaz2 extends BaseEntity {
@@ -1992,7 +1992,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -2015,7 +2015,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 
 export class Publisher2 extends BaseEntity {
@@ -2114,7 +2114,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
@@ -2205,7 +2205,7 @@ export const User2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Config, DefineConfig, EntitySchema } from '@mikro-orm/core';
+  "import { Config, type DefineConfig, EntitySchema } from '@mikro-orm/core';
 
 export abstract class BaseEntity {
   [Config]?: DefineConfig<{ forceObject: false }>;
@@ -2239,7 +2239,7 @@ export class Address2 extends BaseUser2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { Book2 } from './Book2';
 
@@ -2304,7 +2304,7 @@ export class Author2 extends BaseUser2 {
 
 }
 ",
-  "import { Config, DefineConfig, Entity, Enum, Index, ManyToOne, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Config, type DefineConfig, Entity, Enum, Index, ManyToOne, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 
 @Entity()
 export class BaseUser2 {
@@ -2363,7 +2363,7 @@ export class BookTag2 extends BaseUser2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BaseUser2 } from './BaseUser2';
 import { BookTag2 } from './BookTag2';
@@ -2501,7 +2501,7 @@ export class Dummy2 extends BaseUser2 {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -2540,7 +2540,7 @@ export class FooBar2 extends BaseUser2 {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 
 @Entity()
@@ -2557,7 +2557,7 @@ export class FooBaz2 extends BaseUser2 {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -2581,7 +2581,7 @@ export class FooParam2 extends BaseUser2 {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 
 @Entity()
@@ -2672,7 +2672,7 @@ export class Sandwich extends BaseUser2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
@@ -2765,7 +2765,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { Book2 } from './Book2';
 
@@ -2843,7 +2843,7 @@ export const Author2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Config, DefineConfig, EntitySchema } from '@mikro-orm/core';
+  "import { Config, type DefineConfig, EntitySchema } from '@mikro-orm/core';
 
 export class BaseUser2 {
   [Config]?: DefineConfig<{ forceObject: false }>;
@@ -2907,7 +2907,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BaseUser2 } from './BaseUser2';
 import { BookTag2 } from './BookTag2';
@@ -3061,7 +3061,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -3106,7 +3106,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 
 export class FooBaz2 extends BaseUser2 {
@@ -3124,7 +3124,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -3147,7 +3147,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 
 export class Publisher2 extends BaseUser2 {
@@ -3246,7 +3246,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
@@ -3359,7 +3359,7 @@ export class Address2 extends CustomBase {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 
@@ -3481,7 +3481,7 @@ export class BookTag2 extends CustomBase {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { CustomBase } from './CustomBase';
@@ -3619,7 +3619,7 @@ export class Dummy2 extends CustomBase {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBaz2 } from './FooBaz2';
 
@@ -3658,7 +3658,7 @@ export class FooBar2 extends CustomBase {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 
 @Entity()
@@ -3675,7 +3675,7 @@ export class FooBaz2 extends CustomBase {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -3699,7 +3699,7 @@ export class FooParam2 extends CustomBase {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 
 @Entity()
@@ -3790,7 +3790,7 @@ export class Sandwich extends CustomBase {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
@@ -3854,7 +3854,7 @@ export class User2 extends CustomBase {
 
 }
 ",
-  "import { Config, DefineConfig } from '@mikro-orm/core';
+  "import { Config, type DefineConfig } from '@mikro-orm/core';
 
 export abstract class CustomBase {
 
@@ -3891,7 +3891,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 
@@ -4033,7 +4033,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { CustomBase } from './CustomBase';
@@ -4187,7 +4187,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBaz2 } from './FooBaz2';
 
@@ -4232,7 +4232,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 
 export class FooBaz2 extends CustomBase {
@@ -4250,7 +4250,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -4273,7 +4273,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 
 export class Publisher2 extends CustomBase {
@@ -4372,7 +4372,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
@@ -4463,7 +4463,7 @@ export const User2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Config, DefineConfig, EntitySchema } from '@mikro-orm/core';
+  "import { Config, type DefineConfig, EntitySchema } from '@mikro-orm/core';
 
 export abstract class CustomBase {
   [Config]?: DefineConfig<{ forceObject: false }>;
@@ -4496,7 +4496,7 @@ export class Address2 extends BaseEntity {
 
 }
 ",
-  "import { BaseEntity, Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { BaseEntity, Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -4615,7 +4615,7 @@ export class BookTag2 extends BaseEntity {
 
 }
 ",
-  "import { BaseEntity, Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { BaseEntity, Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -4747,7 +4747,7 @@ export class Dummy2 extends BaseEntity {
 
 }
 ",
-  "import { BaseEntity, Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { BaseEntity, Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 @Entity()
@@ -4785,7 +4785,7 @@ export class FooBar2 extends BaseEntity {
 
 }
 ",
-  "import { BaseEntity, Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { BaseEntity, Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class FooBaz2 extends BaseEntity {
@@ -4801,7 +4801,7 @@ export class FooBaz2 extends BaseEntity {
 
 }
 ",
-  "import { BaseEntity, Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { BaseEntity, Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -4824,7 +4824,7 @@ export class FooParam2 extends BaseEntity {
 
 }
 ",
-  "import { BaseEntity, Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { BaseEntity, Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Publisher2 extends BaseEntity {
@@ -4912,7 +4912,7 @@ export class Sandwich extends BaseEntity {
 
 }
 ",
-  "import { BaseEntity, Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { BaseEntity, Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
@@ -5002,7 +5002,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity, Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { BaseEntity, Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 export class Author2 extends BaseEntity {
@@ -5141,7 +5141,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity, Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { BaseEntity, Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -5289,7 +5289,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { BaseEntity, EntitySchema, type Opt } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 extends BaseEntity {
@@ -5333,7 +5333,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { BaseEntity, EntitySchema, type Opt } from '@mikro-orm/core';
 
 export class FooBaz2 extends BaseEntity {
   id!: number;
@@ -5350,7 +5350,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { BaseEntity, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -5372,7 +5372,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { BaseEntity, EntitySchema, type Opt } from '@mikro-orm/core';
 
 export class Publisher2 extends BaseEntity {
   id!: number;
@@ -5468,7 +5468,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity, Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { BaseEntity, Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
@@ -5579,7 +5579,7 @@ export class Address2 extends BaseEntity {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book2 } from './Book2';
 
@@ -5701,7 +5701,7 @@ export class BookTag2 extends BaseEntity {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BaseEntity } from './BaseEntity';
 import { BookTag2 } from './BookTag2';
@@ -5839,7 +5839,7 @@ export class Dummy2 extends BaseEntity {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBaz2 } from './FooBaz2';
 
@@ -5878,7 +5878,7 @@ export class FooBar2 extends BaseEntity {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 
 @Entity()
@@ -5895,7 +5895,7 @@ export class FooBaz2 extends BaseEntity {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -5919,7 +5919,7 @@ export class FooParam2 extends BaseEntity {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 
 @Entity()
@@ -6010,7 +6010,7 @@ export class Sandwich extends BaseEntity {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
@@ -6074,7 +6074,7 @@ export class User2 extends BaseEntity {
 
 }
 ",
-  "import { BaseEntity as MikroBaseEntity, Config, DefineConfig } from '@mikro-orm/core';
+  "import { BaseEntity as MikroBaseEntity, Config, type DefineConfig } from '@mikro-orm/core';
 
 export abstract class BaseEntity extends MikroBaseEntity {
 
@@ -6111,7 +6111,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book2 } from './Book2';
 
@@ -6253,7 +6253,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BaseEntity } from './BaseEntity';
 import { BookTag2 } from './BookTag2';
@@ -6407,7 +6407,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBaz2 } from './FooBaz2';
 
@@ -6452,7 +6452,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 
 export class FooBaz2 extends BaseEntity {
@@ -6470,7 +6470,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -6493,7 +6493,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 
 export class Publisher2 extends BaseEntity {
@@ -6592,7 +6592,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
@@ -6683,7 +6683,7 @@ export const User2Schema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity as MikroBaseEntity, Config, DefineConfig, EntitySchema } from '@mikro-orm/core';
+  "import { BaseEntity as MikroBaseEntity, Config, type DefineConfig, EntitySchema } from '@mikro-orm/core';
 
 export abstract class BaseEntity extends MikroBaseEntity {
   [Config]?: DefineConfig<{ forceObject: false }>;
@@ -6717,7 +6717,7 @@ export class Address2 extends BaseUser2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { Book2 } from './Book2';
 
@@ -6782,7 +6782,7 @@ export class Author2 extends BaseUser2 {
 
 }
 ",
-  "import { BaseEntity, Config, DefineConfig, Entity, Enum, Index, ManyToOne, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { BaseEntity, Config, type DefineConfig, Entity, Enum, Index, ManyToOne, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 
 @Entity()
 export class BaseUser2 extends BaseEntity {
@@ -6841,7 +6841,7 @@ export class BookTag2 extends BaseUser2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BaseUser2 } from './BaseUser2';
 import { BookTag2 } from './BookTag2';
@@ -6979,7 +6979,7 @@ export class Dummy2 extends BaseUser2 {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -7018,7 +7018,7 @@ export class FooBar2 extends BaseUser2 {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 
 @Entity()
@@ -7035,7 +7035,7 @@ export class FooBaz2 extends BaseUser2 {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -7059,7 +7059,7 @@ export class FooParam2 extends BaseUser2 {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 
 @Entity()
@@ -7150,7 +7150,7 @@ export class Sandwich extends BaseUser2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
@@ -7243,7 +7243,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { Book2 } from './Book2';
 
@@ -7321,7 +7321,7 @@ export const Author2Schema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity, Config, DefineConfig, EntitySchema } from '@mikro-orm/core';
+  "import { BaseEntity, Config, type DefineConfig, EntitySchema } from '@mikro-orm/core';
 
 export class BaseUser2 extends BaseEntity {
   [Config]?: DefineConfig<{ forceObject: false }>;
@@ -7385,7 +7385,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BaseUser2 } from './BaseUser2';
 import { BookTag2 } from './BookTag2';
@@ -7539,7 +7539,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -7584,7 +7584,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 
 export class FooBaz2 extends BaseUser2 {
@@ -7602,7 +7602,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -7625,7 +7625,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 
 export class Publisher2 extends BaseUser2 {
@@ -7724,7 +7724,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
@@ -7837,7 +7837,7 @@ export class Address2 extends CustomBase {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 
@@ -7959,7 +7959,7 @@ export class BookTag2 extends CustomBase {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { CustomBase } from './CustomBase';
@@ -8097,7 +8097,7 @@ export class Dummy2 extends CustomBase {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBaz2 } from './FooBaz2';
 
@@ -8136,7 +8136,7 @@ export class FooBar2 extends CustomBase {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 
 @Entity()
@@ -8153,7 +8153,7 @@ export class FooBaz2 extends CustomBase {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -8177,7 +8177,7 @@ export class FooParam2 extends CustomBase {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 
 @Entity()
@@ -8268,7 +8268,7 @@ export class Sandwich extends CustomBase {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
@@ -8332,7 +8332,7 @@ export class User2 extends CustomBase {
 
 }
 ",
-  "import { BaseEntity, Config, DefineConfig } from '@mikro-orm/core';
+  "import { BaseEntity, Config, type DefineConfig } from '@mikro-orm/core';
 
 export abstract class CustomBase extends BaseEntity {
 
@@ -8369,7 +8369,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 
@@ -8511,7 +8511,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { CustomBase } from './CustomBase';
@@ -8665,7 +8665,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBaz2 } from './FooBaz2';
 
@@ -8710,7 +8710,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 
 export class FooBaz2 extends CustomBase {
@@ -8728,7 +8728,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -8751,7 +8751,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 
 export class Publisher2 extends CustomBase {
@@ -8850,7 +8850,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
@@ -8941,7 +8941,7 @@ export const User2Schema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity, Config, DefineConfig, EntitySchema } from '@mikro-orm/core';
+  "import { BaseEntity, Config, type DefineConfig, EntitySchema } from '@mikro-orm/core';
 
 export abstract class CustomBase extends BaseEntity {
   [Config]?: DefineConfig<{ forceObject: false }>;
@@ -8974,7 +8974,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -9093,7 +9093,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -9225,7 +9225,7 @@ export class Dummy2 {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 @Entity()
@@ -9263,7 +9263,7 @@ export class FooBar2 {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class FooBaz2 {
@@ -9279,7 +9279,7 @@ export class FooBaz2 {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -9302,7 +9302,7 @@ export class FooParam2 {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Publisher2 {
@@ -9390,7 +9390,7 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
@@ -9480,7 +9480,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 export class Author2 {
@@ -9619,7 +9619,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -9767,7 +9767,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 {
@@ -9811,7 +9811,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 
 export class FooBaz2 {
   id!: number;
@@ -9828,7 +9828,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -9850,7 +9850,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 
 export class Publisher2 {
   id!: number;
@@ -9946,7 +9946,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
@@ -10057,7 +10057,7 @@ export class Address2 extends BaseEntity {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book2 } from './Book2';
 
@@ -10179,7 +10179,7 @@ export class BookTag2 extends BaseEntity {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BaseEntity } from './BaseEntity';
 import { BookTag2 } from './BookTag2';
@@ -10317,7 +10317,7 @@ export class Dummy2 extends BaseEntity {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBaz2 } from './FooBaz2';
 
@@ -10356,7 +10356,7 @@ export class FooBar2 extends BaseEntity {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 
 @Entity()
@@ -10373,7 +10373,7 @@ export class FooBaz2 extends BaseEntity {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -10397,7 +10397,7 @@ export class FooParam2 extends BaseEntity {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 
 @Entity()
@@ -10488,7 +10488,7 @@ export class Sandwich extends BaseEntity {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
@@ -10552,7 +10552,7 @@ export class User2 extends BaseEntity {
 
 }
 ",
-  "import { Config, DefineConfig } from '@mikro-orm/core';
+  "import { Config, type DefineConfig } from '@mikro-orm/core';
 
 export abstract class BaseEntity {
 
@@ -10589,7 +10589,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book2 } from './Book2';
 
@@ -10731,7 +10731,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BaseEntity } from './BaseEntity';
 import { BookTag2 } from './BookTag2';
@@ -10885,7 +10885,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBaz2 } from './FooBaz2';
 
@@ -10930,7 +10930,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 
 export class FooBaz2 extends BaseEntity {
@@ -10948,7 +10948,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -10971,7 +10971,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 
 export class Publisher2 extends BaseEntity {
@@ -11070,7 +11070,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
@@ -11161,7 +11161,7 @@ export const User2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Config, DefineConfig, EntitySchema } from '@mikro-orm/core';
+  "import { Config, type DefineConfig, EntitySchema } from '@mikro-orm/core';
 
 export abstract class BaseEntity {
   [Config]?: DefineConfig<{ forceObject: true }>;
@@ -11195,7 +11195,7 @@ export class Address2 extends BaseUser2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { Book2 } from './Book2';
 
@@ -11260,7 +11260,7 @@ export class Author2 extends BaseUser2 {
 
 }
 ",
-  "import { Config, DefineConfig, Entity, Enum, Index, ManyToOne, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Config, type DefineConfig, Entity, Enum, Index, ManyToOne, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 
 @Entity()
 export class BaseUser2 {
@@ -11319,7 +11319,7 @@ export class BookTag2 extends BaseUser2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BaseUser2 } from './BaseUser2';
 import { BookTag2 } from './BookTag2';
@@ -11457,7 +11457,7 @@ export class Dummy2 extends BaseUser2 {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -11496,7 +11496,7 @@ export class FooBar2 extends BaseUser2 {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 
 @Entity()
@@ -11513,7 +11513,7 @@ export class FooBaz2 extends BaseUser2 {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -11537,7 +11537,7 @@ export class FooParam2 extends BaseUser2 {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 
 @Entity()
@@ -11628,7 +11628,7 @@ export class Sandwich extends BaseUser2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
@@ -11721,7 +11721,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { Book2 } from './Book2';
 
@@ -11799,7 +11799,7 @@ export const Author2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Config, DefineConfig, EntitySchema } from '@mikro-orm/core';
+  "import { Config, type DefineConfig, EntitySchema } from '@mikro-orm/core';
 
 export class BaseUser2 {
   [Config]?: DefineConfig<{ forceObject: true }>;
@@ -11863,7 +11863,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BaseUser2 } from './BaseUser2';
 import { BookTag2 } from './BookTag2';
@@ -12017,7 +12017,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -12062,7 +12062,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 
 export class FooBaz2 extends BaseUser2 {
@@ -12080,7 +12080,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -12103,7 +12103,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 
 export class Publisher2 extends BaseUser2 {
@@ -12202,7 +12202,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
@@ -12315,7 +12315,7 @@ export class Address2 extends CustomBase {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 
@@ -12437,7 +12437,7 @@ export class BookTag2 extends CustomBase {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { CustomBase } from './CustomBase';
@@ -12575,7 +12575,7 @@ export class Dummy2 extends CustomBase {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBaz2 } from './FooBaz2';
 
@@ -12614,7 +12614,7 @@ export class FooBar2 extends CustomBase {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 
 @Entity()
@@ -12631,7 +12631,7 @@ export class FooBaz2 extends CustomBase {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -12655,7 +12655,7 @@ export class FooParam2 extends CustomBase {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 
 @Entity()
@@ -12746,7 +12746,7 @@ export class Sandwich extends CustomBase {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
@@ -12810,7 +12810,7 @@ export class User2 extends CustomBase {
 
 }
 ",
-  "import { Config, DefineConfig } from '@mikro-orm/core';
+  "import { Config, type DefineConfig } from '@mikro-orm/core';
 
 export abstract class CustomBase {
 
@@ -12847,7 +12847,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 
@@ -12989,7 +12989,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { CustomBase } from './CustomBase';
@@ -13143,7 +13143,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBaz2 } from './FooBaz2';
 
@@ -13188,7 +13188,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 
 export class FooBaz2 extends CustomBase {
@@ -13206,7 +13206,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -13229,7 +13229,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 
 export class Publisher2 extends CustomBase {
@@ -13328,7 +13328,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
@@ -13419,7 +13419,7 @@ export const User2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Config, DefineConfig, EntitySchema } from '@mikro-orm/core';
+  "import { Config, type DefineConfig, EntitySchema } from '@mikro-orm/core';
 
 export abstract class CustomBase {
   [Config]?: DefineConfig<{ forceObject: true }>;
@@ -13452,7 +13452,7 @@ export class Address2 extends BaseEntity {
 
 }
 ",
-  "import { BaseEntity, Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { BaseEntity, Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -13571,7 +13571,7 @@ export class BookTag2 extends BaseEntity {
 
 }
 ",
-  "import { BaseEntity, Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { BaseEntity, Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -13703,7 +13703,7 @@ export class Dummy2 extends BaseEntity {
 
 }
 ",
-  "import { BaseEntity, Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { BaseEntity, Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 @Entity()
@@ -13741,7 +13741,7 @@ export class FooBar2 extends BaseEntity {
 
 }
 ",
-  "import { BaseEntity, Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { BaseEntity, Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class FooBaz2 extends BaseEntity {
@@ -13757,7 +13757,7 @@ export class FooBaz2 extends BaseEntity {
 
 }
 ",
-  "import { BaseEntity, Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { BaseEntity, Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -13780,7 +13780,7 @@ export class FooParam2 extends BaseEntity {
 
 }
 ",
-  "import { BaseEntity, Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { BaseEntity, Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Publisher2 extends BaseEntity {
@@ -13868,7 +13868,7 @@ export class Sandwich extends BaseEntity {
 
 }
 ",
-  "import { BaseEntity, Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { BaseEntity, Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
@@ -13958,7 +13958,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity, Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { BaseEntity, Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 export class Author2 extends BaseEntity {
@@ -14097,7 +14097,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity, Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { BaseEntity, Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -14245,7 +14245,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { BaseEntity, EntitySchema, type Opt } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 export class FooBar2 extends BaseEntity {
@@ -14289,7 +14289,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { BaseEntity, EntitySchema, type Opt } from '@mikro-orm/core';
 
 export class FooBaz2 extends BaseEntity {
   id!: number;
@@ -14306,7 +14306,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { BaseEntity, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -14328,7 +14328,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { BaseEntity, EntitySchema, type Opt } from '@mikro-orm/core';
 
 export class Publisher2 extends BaseEntity {
   id!: number;
@@ -14424,7 +14424,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity, Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { BaseEntity, Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
@@ -14535,7 +14535,7 @@ export class Address2 extends BaseEntity {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book2 } from './Book2';
 
@@ -14657,7 +14657,7 @@ export class BookTag2 extends BaseEntity {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BaseEntity } from './BaseEntity';
 import { BookTag2 } from './BookTag2';
@@ -14795,7 +14795,7 @@ export class Dummy2 extends BaseEntity {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBaz2 } from './FooBaz2';
 
@@ -14834,7 +14834,7 @@ export class FooBar2 extends BaseEntity {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 
 @Entity()
@@ -14851,7 +14851,7 @@ export class FooBaz2 extends BaseEntity {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -14875,7 +14875,7 @@ export class FooParam2 extends BaseEntity {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 
 @Entity()
@@ -14966,7 +14966,7 @@ export class Sandwich extends BaseEntity {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
@@ -15030,7 +15030,7 @@ export class User2 extends BaseEntity {
 
 }
 ",
-  "import { BaseEntity as MikroBaseEntity, Config, DefineConfig } from '@mikro-orm/core';
+  "import { BaseEntity as MikroBaseEntity, Config, type DefineConfig } from '@mikro-orm/core';
 
 export abstract class BaseEntity extends MikroBaseEntity {
 
@@ -15067,7 +15067,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book2 } from './Book2';
 
@@ -15209,7 +15209,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BaseEntity } from './BaseEntity';
 import { BookTag2 } from './BookTag2';
@@ -15363,7 +15363,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBaz2 } from './FooBaz2';
 
@@ -15408,7 +15408,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 
 export class FooBaz2 extends BaseEntity {
@@ -15426,7 +15426,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -15449,7 +15449,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 
 export class Publisher2 extends BaseEntity {
@@ -15548,7 +15548,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
@@ -15639,7 +15639,7 @@ export const User2Schema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity as MikroBaseEntity, Config, DefineConfig, EntitySchema } from '@mikro-orm/core';
+  "import { BaseEntity as MikroBaseEntity, Config, type DefineConfig, EntitySchema } from '@mikro-orm/core';
 
 export abstract class BaseEntity extends MikroBaseEntity {
   [Config]?: DefineConfig<{ forceObject: true }>;
@@ -15673,7 +15673,7 @@ export class Address2 extends BaseUser2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { Book2 } from './Book2';
 
@@ -15738,7 +15738,7 @@ export class Author2 extends BaseUser2 {
 
 }
 ",
-  "import { BaseEntity, Config, DefineConfig, Entity, Enum, Index, ManyToOne, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { BaseEntity, Config, type DefineConfig, Entity, Enum, Index, ManyToOne, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 
 @Entity()
 export class BaseUser2 extends BaseEntity {
@@ -15797,7 +15797,7 @@ export class BookTag2 extends BaseUser2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BaseUser2 } from './BaseUser2';
 import { BookTag2 } from './BookTag2';
@@ -15935,7 +15935,7 @@ export class Dummy2 extends BaseUser2 {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -15974,7 +15974,7 @@ export class FooBar2 extends BaseUser2 {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 
 @Entity()
@@ -15991,7 +15991,7 @@ export class FooBaz2 extends BaseUser2 {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -16015,7 +16015,7 @@ export class FooParam2 extends BaseUser2 {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 
 @Entity()
@@ -16106,7 +16106,7 @@ export class Sandwich extends BaseUser2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
@@ -16199,7 +16199,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { Book2 } from './Book2';
 
@@ -16277,7 +16277,7 @@ export const Author2Schema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity, Config, DefineConfig, EntitySchema } from '@mikro-orm/core';
+  "import { BaseEntity, Config, type DefineConfig, EntitySchema } from '@mikro-orm/core';
 
 export class BaseUser2 extends BaseEntity {
   [Config]?: DefineConfig<{ forceObject: true }>;
@@ -16341,7 +16341,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BaseUser2 } from './BaseUser2';
 import { BookTag2 } from './BookTag2';
@@ -16495,7 +16495,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -16540,7 +16540,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 
 export class FooBaz2 extends BaseUser2 {
@@ -16558,7 +16558,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -16581,7 +16581,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 
 export class Publisher2 extends BaseUser2 {
@@ -16680,7 +16680,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { BaseUser2 } from './BaseUser2';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
@@ -16793,7 +16793,7 @@ export class Address2 extends CustomBase {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 
@@ -16915,7 +16915,7 @@ export class BookTag2 extends CustomBase {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { CustomBase } from './CustomBase';
@@ -17053,7 +17053,7 @@ export class Dummy2 extends CustomBase {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBaz2 } from './FooBaz2';
 
@@ -17092,7 +17092,7 @@ export class FooBar2 extends CustomBase {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 
 @Entity()
@@ -17109,7 +17109,7 @@ export class FooBaz2 extends CustomBase {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -17133,7 +17133,7 @@ export class FooParam2 extends CustomBase {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 
 @Entity()
@@ -17224,7 +17224,7 @@ export class Sandwich extends CustomBase {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
@@ -17288,7 +17288,7 @@ export class User2 extends CustomBase {
 
 }
 ",
-  "import { BaseEntity, Config, DefineConfig } from '@mikro-orm/core';
+  "import { BaseEntity, Config, type DefineConfig } from '@mikro-orm/core';
 
 export abstract class CustomBase extends BaseEntity {
 
@@ -17325,7 +17325,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 
@@ -17467,7 +17467,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { CustomBase } from './CustomBase';
@@ -17621,7 +17621,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBaz2 } from './FooBaz2';
 
@@ -17666,7 +17666,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 
 export class FooBaz2 extends CustomBase {
@@ -17684,7 +17684,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
@@ -17707,7 +17707,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 
 export class Publisher2 extends CustomBase {
@@ -17806,7 +17806,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { CustomBase } from './CustomBase';
 import { FooBar2 } from './FooBar2';
@@ -17897,7 +17897,7 @@ export const User2Schema = new EntitySchema({
   },
 });
 ",
-  "import { BaseEntity, Config, DefineConfig, EntitySchema } from '@mikro-orm/core';
+  "import { BaseEntity, Config, type DefineConfig, EntitySchema } from '@mikro-orm/core';
 
 export abstract class CustomBase extends BaseEntity {
   [Config]?: DefineConfig<{ forceObject: true }>;

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.mysql.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`EntityGenerator enum with default value [mysql]: mysql-entity-dump-enum-default-value 1`] = `
 [
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Publisher2 {
@@ -36,7 +36,7 @@ export enum Publisher2Type2 {
 
 exports[`EntityGenerator generate EntitySchema with bidirectional relations and reference wrappers [mysql]: mysql-entity-schema-bidirectional-dump 1`] = `
 [
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
 export class Address2 {
@@ -60,7 +60,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, type Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 export class Author2 {
@@ -152,7 +152,7 @@ export const Author2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Ref } from '@mikro-orm/core';
 
 export class BaseUser2 {
   id!: number;
@@ -231,7 +231,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
@@ -289,7 +289,7 @@ export const Book2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { BookTag2 } from './BookTag2';
 
@@ -322,7 +322,7 @@ export const Book2TagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 
 export class CarOwner2 {
@@ -340,7 +340,7 @@ export const CarOwner2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { CarOwner2 } from './CarOwner2';
 import { User2 } from './User2';
 
@@ -366,7 +366,7 @@ export const Car2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Test2 } from './Test2';
 
 export class Configuration2 {
@@ -404,7 +404,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, type Ref } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
 import { Test2 } from './Test2';
@@ -458,7 +458,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { FooParam2 } from './FooParam2';
 
 export class FooBaz2 {
@@ -478,7 +478,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -512,7 +512,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
 
@@ -567,7 +567,7 @@ export const Publisher2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
 
@@ -619,7 +619,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, type Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
@@ -682,7 +682,7 @@ export const Test2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './Sandwich';
 
@@ -730,7 +730,7 @@ export const User2Schema = new EntitySchema({
 
 exports[`EntityGenerator generate EntitySchema with reference wrappers and named import [mysql]: mysql-entityschema-named-dump 1`] = `
 [
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2.js';
 
 export class Address2 {
@@ -754,7 +754,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, type Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2.js';
 
 export class Author2 {
@@ -838,7 +838,7 @@ export const Author2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 
 export class BaseUser2 {
   id!: number;
@@ -902,7 +902,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2.js';
 import { BookTag2 } from './BookTag2.js';
 import { Publisher2 } from './Publisher2.js';
@@ -952,7 +952,7 @@ export const Book2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2.js';
 import { BookTag2 } from './BookTag2.js';
 
@@ -985,7 +985,7 @@ export const Book2TagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2.js';
 
 export class CarOwner2 {
@@ -1021,7 +1021,7 @@ export const Car2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Test2 } from './Test2.js';
 
 export class Configuration2 {
@@ -1059,7 +1059,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, type Ref } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2.js';
 
 export class FooBar2 {
@@ -1105,7 +1105,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 
 export class FooBaz2 {
   id!: number;
@@ -1122,7 +1122,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2.js';
 import { FooBaz2 } from './FooBaz2.js';
 
@@ -1156,7 +1156,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 
 export class Publisher2 {
   id!: number;
@@ -1205,7 +1205,7 @@ export const Publisher2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2.js';
 import { Test2 } from './Test2.js';
 
@@ -1254,7 +1254,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, type Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2.js';
 import { FooBar2 } from './FooBar2.js';
 
@@ -1309,7 +1309,7 @@ export const Test2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2.js';
 import { Sandwich } from './Sandwich.js';
 
@@ -1357,7 +1357,7 @@ export const User2Schema = new EntitySchema({
 
 exports[`EntityGenerator generate OptionalProps and include properties for columns that are not nullable, but have defaults: generate-OptionalProps 1`] = `
 [
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Account {
@@ -1394,7 +1394,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -1513,7 +1513,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -1645,7 +1645,7 @@ export class Dummy2 {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 @Entity()
@@ -1683,7 +1683,7 @@ export class FooBar2 {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class FooBaz2 {
@@ -1699,7 +1699,7 @@ export class FooBaz2 {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -1722,7 +1722,7 @@ export class FooParam2 {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Publisher2 {
@@ -1810,7 +1810,7 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
@@ -1893,7 +1893,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -2038,7 +2038,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
@@ -2192,7 +2192,7 @@ export class Dummy2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
 import { Test2 } from './Test2';
@@ -2241,7 +2241,7 @@ export class FooBar2 {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooParam2 } from './FooParam2';
 
 @Entity()
@@ -2261,7 +2261,7 @@ export class FooBaz2 {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -2284,7 +2284,7 @@ export class FooParam2 {
 
 }
 ",
-  "import { Collection, Entity, Enum, OneToMany, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
 
@@ -2384,7 +2384,7 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToMany, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
@@ -2462,7 +2462,7 @@ export class User2 {
 
 exports[`EntityGenerator generate entities with bidirectional relations and reference wrappers [mysql]: mysql-entity-bidirectional-dump 1`] = `
 [
-  "import { Entity, OneToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
 @Entity()
@@ -2478,7 +2478,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, Opt, PrimaryKey, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, type Opt, PrimaryKey, Property, type Ref, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -2554,7 +2554,7 @@ export class Author2 {
 
 }
 ",
-  "import { Collection, Entity, Enum, Index, ManyToOne, OneToMany, OneToOne, PrimaryKey, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Enum, Index, ManyToOne, OneToMany, OneToOne, PrimaryKey, Property, type Ref, Unique } from '@mikro-orm/core';
 
 @Entity()
 export class BaseUser2 {
@@ -2623,7 +2623,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
@@ -2680,7 +2680,7 @@ export class Book2 {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { BookTag2 } from './BookTag2';
 
@@ -2700,7 +2700,7 @@ export class Book2Tags {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, Property, type Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 
 @Entity()
@@ -2717,7 +2717,7 @@ export class CarOwner2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { CarOwner2 } from './CarOwner2';
 import { User2 } from './User2';
 
@@ -2748,7 +2748,7 @@ export class Car2 {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Test2 } from './Test2';
 
 @Entity()
@@ -2777,7 +2777,7 @@ export class Dummy2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, Opt, PrimaryKey, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, type Opt, PrimaryKey, Property, type Ref } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
 import { Test2 } from './Test2';
@@ -2826,7 +2826,7 @@ export class FooBar2 {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooParam2 } from './FooParam2';
 
 @Entity()
@@ -2846,7 +2846,7 @@ export class FooBaz2 {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -2869,7 +2869,7 @@ export class FooParam2 {
 
 }
 ",
-  "import { Collection, Entity, Enum, OneToMany, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
 
@@ -2931,7 +2931,7 @@ export enum Publisher2Enum5 {
   A = 'a',
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
 
@@ -2969,7 +2969,7 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToMany, OneToOne, Opt, PrimaryKey, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, Property, type Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
@@ -3013,7 +3013,7 @@ export class Test2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './Sandwich';
 
@@ -3047,7 +3047,7 @@ export class User2 {
 
 exports[`EntityGenerator generate entities with reference wrappers and named import [mysql]: mysql-entity-named-dump 1`] = `
 [
-  "import { Entity, OneToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2.js';
 
 @Entity()
@@ -3063,7 +3063,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, type Ref, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2.js';
 
 @Entity()
@@ -3127,7 +3127,7 @@ export class Author2 {
 
 }
 ",
-  "import { Entity, Enum, Index, ManyToOne, OneToOne, PrimaryKey, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Entity, Enum, Index, ManyToOne, OneToOne, PrimaryKey, Property, type Ref, Unique } from '@mikro-orm/core';
 
 @Entity()
 export class BaseUser2 {
@@ -3182,7 +3182,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2.js';
 import { BookTag2 } from './BookTag2.js';
 import { Publisher2 } from './Publisher2.js';
@@ -3228,7 +3228,7 @@ export class Book2 {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2.js';
 import { BookTag2 } from './BookTag2.js';
 
@@ -3248,7 +3248,7 @@ export class Book2Tags {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, Property, type Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2.js';
 
 @Entity()
@@ -3285,7 +3285,7 @@ export class Car2 {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Test2 } from './Test2.js';
 
 @Entity()
@@ -3314,7 +3314,7 @@ export class Dummy2 {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property, type Ref } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2.js';
 
 @Entity()
@@ -3352,7 +3352,7 @@ export class FooBar2 {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class FooBaz2 {
@@ -3368,7 +3368,7 @@ export class FooBaz2 {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2.js';
 import { FooBaz2 } from './FooBaz2.js';
 
@@ -3391,7 +3391,7 @@ export class FooParam2 {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Publisher2 {
@@ -3445,7 +3445,7 @@ export enum Publisher2Enum5 {
   A = 'a',
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2.js';
 import { Test2 } from './Test2.js';
 
@@ -3479,7 +3479,7 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property, type Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2.js';
 import { FooBar2 } from './FooBar2.js';
 
@@ -3512,7 +3512,7 @@ export class Test2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2.js';
 import { Sandwich } from './Sandwich.js';
 
@@ -3616,7 +3616,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -3735,7 +3735,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -3864,7 +3864,7 @@ export class Dummy2 {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 @Entity()
@@ -3902,7 +3902,7 @@ export class FooBar2 {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class FooBaz2 {
@@ -3918,7 +3918,7 @@ export class FooBaz2 {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -3941,7 +3941,7 @@ export class FooParam2 {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Publisher2 {

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`EntityGenerator enum with default value [postgres]: postgres-entity-dump-enum-default-value 1`] = `
 [
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Publisher2 {
@@ -52,7 +52,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -129,7 +129,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -213,7 +213,7 @@ export class Configuration2 {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 @Entity()
@@ -251,7 +251,7 @@ export class FooBar2 {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class FooBaz2 {
@@ -267,7 +267,7 @@ export class FooBaz2 {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -393,7 +393,7 @@ export class Publisher2Tests {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
@@ -444,7 +444,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -521,7 +521,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -602,7 +602,7 @@ export class Configuration2 {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 @Entity()
@@ -640,7 +640,7 @@ export class FooBar2 {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class FooBaz2 {
@@ -656,7 +656,7 @@ export class FooBaz2 {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`EntityGenerator generate entities from schema [sqlite]: sqlite-entity-dump 1`] = `
 [
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book3 } from './book3';
 
 @Entity()
@@ -45,7 +45,7 @@ export class Author3 {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class BookTag3 {
@@ -61,7 +61,7 @@ export class BookTag3 {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Author3 } from './author3';
 import { Publisher3 } from './publisher3';
 
@@ -140,7 +140,7 @@ export class Publisher3Tests {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Test3 {

--- a/tests/features/entity-generator/__snapshots__/FkIndexSelection.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/FkIndexSelection.mysql.test.ts.snap
@@ -174,7 +174,7 @@ export class FashionableColors {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
 import { FashionableColors } from './FashionableColors';
 
 @Entity()
@@ -241,7 +241,7 @@ export const FashionableColorsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { FashionableColors } from './FashionableColors';
 
 export class Users {
@@ -470,7 +470,7 @@ export class FashionableColors {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
 import { FashionableColors } from './FashionableColors';
 
 @Entity()
@@ -540,7 +540,7 @@ export const FashionableColorsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { FashionableColors } from './FashionableColors';
 
 export class Users {
@@ -743,7 +743,7 @@ export class FashionableColors {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
 import { FashionableColors } from './FashionableColors';
 
 @Entity()
@@ -801,7 +801,7 @@ export const FashionableColorsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { FashionableColors } from './FashionableColors';
 
 export class Users {
@@ -1009,7 +1009,7 @@ export class FashionableColors {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
 import { FashionableColors } from './FashionableColors';
 
 @Entity()
@@ -1070,7 +1070,7 @@ export const FashionableColorsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { FashionableColors } from './FashionableColors';
 
 export class Users {
@@ -1272,7 +1272,7 @@ export class FashionableColors {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
 import { FashionableColors } from './FashionableColors';
 
 @Entity()
@@ -1333,7 +1333,7 @@ export const FashionableColorsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { FashionableColors } from './FashionableColors';
 
 export class Users {
@@ -1548,7 +1548,7 @@ export class FashionableColors {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
 import { FashionableColors } from './FashionableColors';
 
 @Entity()
@@ -1612,7 +1612,7 @@ export const FashionableColorsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { FashionableColors } from './FashionableColors';
 
 export class Users {

--- a/tests/features/entity-generator/__snapshots__/FkSharedWithColumn.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/FkSharedWithColumn.mysql.test.ts.snap
@@ -157,7 +157,7 @@ export class Countries {
 
 }
 ",
-  "import { Entity, OneToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 
 @Entity()
@@ -173,7 +173,7 @@ export class LegalUserCountries {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { LegalUserCountries } from './LegalUserCountries';
 
@@ -223,7 +223,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 
 export class LegalUserCountries {
@@ -246,7 +246,7 @@ export const LegalUserCountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { LegalUserCountries } from './LegalUserCountries';
 
@@ -466,7 +466,7 @@ export const UsersSchema = new EntitySchema({
 
 exports[`fk_shared_with_column_example scalarPropertiesForRelations=always bidirectionalRelations=true identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { LegalUserCountries } from './LegalUserCountries';
 import { Users } from './Users';
 
@@ -489,7 +489,7 @@ export class Countries {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Users } from './Users';
 
@@ -509,7 +509,7 @@ export class LegalUserCountries {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { LegalUserCountries } from './LegalUserCountries';
 
@@ -545,7 +545,7 @@ export class Users {
 
 exports[`fk_shared_with_column_example scalarPropertiesForRelations=always bidirectionalRelations=true identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { LegalUserCountries } from './LegalUserCountries';
 import { Users } from './Users';
 
@@ -572,7 +572,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Users } from './Users';
 
@@ -598,7 +598,7 @@ export const LegalUserCountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { LegalUserCountries } from './LegalUserCountries';
 
@@ -787,7 +787,7 @@ export class Countries {
 
 }
 ",
-  "import { Entity, OneToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 
 @Entity()
@@ -800,7 +800,7 @@ export class LegalUserCountries {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { LegalUserCountries } from './LegalUserCountries';
 
@@ -842,7 +842,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 
 export class LegalUserCountries {
@@ -863,7 +863,7 @@ export const LegalUserCountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { LegalUserCountries } from './LegalUserCountries';
 
@@ -1062,7 +1062,7 @@ export const UsersSchema = new EntitySchema({
 
 exports[`fk_shared_with_column_example scalarPropertiesForRelations=never bidirectionalRelations=true identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { LegalUserCountries } from './LegalUserCountries';
 import { Users } from './Users';
 
@@ -1085,7 +1085,7 @@ export class Countries {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Users } from './Users';
 
@@ -1102,7 +1102,7 @@ export class LegalUserCountries {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { LegalUserCountries } from './LegalUserCountries';
 
@@ -1130,7 +1130,7 @@ export class Users {
 
 exports[`fk_shared_with_column_example scalarPropertiesForRelations=never bidirectionalRelations=true identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { LegalUserCountries } from './LegalUserCountries';
 import { Users } from './Users';
 
@@ -1157,7 +1157,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Users } from './Users';
 
@@ -1181,7 +1181,7 @@ export const LegalUserCountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { LegalUserCountries } from './LegalUserCountries';
 
@@ -1366,7 +1366,7 @@ export class Countries {
 
 }
 ",
-  "import { Entity, OneToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 
 @Entity()
@@ -1379,7 +1379,7 @@ export class LegalUserCountries {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { LegalUserCountries } from './LegalUserCountries';
 
@@ -1421,7 +1421,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 
 export class LegalUserCountries {
@@ -1442,7 +1442,7 @@ export const LegalUserCountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { LegalUserCountries } from './LegalUserCountries';
 
@@ -1641,7 +1641,7 @@ export const UsersSchema = new EntitySchema({
 
 exports[`fk_shared_with_column_example scalarPropertiesForRelations=smart bidirectionalRelations=true identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { LegalUserCountries } from './LegalUserCountries';
 import { Users } from './Users';
 
@@ -1664,7 +1664,7 @@ export class Countries {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Users } from './Users';
 
@@ -1681,7 +1681,7 @@ export class LegalUserCountries {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { LegalUserCountries } from './LegalUserCountries';
 
@@ -1709,7 +1709,7 @@ export class Users {
 
 exports[`fk_shared_with_column_example scalarPropertiesForRelations=smart bidirectionalRelations=true identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { LegalUserCountries } from './LegalUserCountries';
 import { Users } from './Users';
 
@@ -1736,7 +1736,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Users } from './Users';
 
@@ -1760,7 +1760,7 @@ export const LegalUserCountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { LegalUserCountries } from './LegalUserCountries';
 

--- a/tests/features/entity-generator/__snapshots__/GeneratedColumns.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/GeneratedColumns.mysql.test.ts.snap
@@ -14,7 +14,7 @@ export class AllowedAgesAtCreation {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 @Entity()
@@ -60,7 +60,7 @@ export class AllowedAgesAtCreation {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 @Entity()
@@ -108,7 +108,7 @@ export const AllowedAgesAtCreationSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 export class Users {
@@ -165,7 +165,7 @@ export const AllowedAgesAtCreationSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 export class Users {

--- a/tests/features/entity-generator/__snapshots__/GeneratedColumns.postgresql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/GeneratedColumns.postgresql.test.ts.snap
@@ -14,7 +14,7 @@ export class AllowedAgesAtCreation {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 @Entity()
@@ -60,7 +60,7 @@ export class AllowedAgesAtCreation {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 @Entity()
@@ -108,7 +108,7 @@ export const AllowedAgesAtCreationSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 export class Users {
@@ -164,7 +164,7 @@ export const AllowedAgesAtCreationSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt } from '@mikro-orm/core';
 import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 export class Users {

--- a/tests/features/entity-generator/__snapshots__/ManyToManyRelations.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/ManyToManyRelations.mysql.test.ts.snap
@@ -88,7 +88,7 @@ export class UserEmailAvatars {
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -130,7 +130,7 @@ export class UserEmailOrders {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -297,7 +297,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -363,7 +363,7 @@ export const UserEmailOrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -536,7 +536,7 @@ export class UserEmailAvatars {
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -578,7 +578,7 @@ export class UserEmailOrders {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -757,7 +757,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -823,7 +823,7 @@ export const UserEmailOrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -1029,7 +1029,7 @@ export class UserEmailAvatars {
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -1071,7 +1071,7 @@ export class UserEmailOrders {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -1250,7 +1250,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -1316,7 +1316,7 @@ export const UserEmailOrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -1500,7 +1500,7 @@ export class UserEmailAvatars {
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -1542,7 +1542,7 @@ export class UserEmailOrders {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -1721,7 +1721,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -1787,7 +1787,7 @@ export const UserEmailOrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -1995,7 +1995,7 @@ export class UserEmailAvatars {
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -2037,7 +2037,7 @@ export class UserEmailOrders {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -2225,7 +2225,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -2291,7 +2291,7 @@ export const UserEmailOrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -2499,7 +2499,7 @@ export class UserEmailAvatars {
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -2541,7 +2541,7 @@ export class UserEmailOrders {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -2757,7 +2757,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -2823,7 +2823,7 @@ export const UserEmailOrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -3047,7 +3047,7 @@ export class UserEmailAvatars {
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -3089,7 +3089,7 @@ export class UserEmailOrders {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -3284,7 +3284,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -3350,7 +3350,7 @@ export const UserEmailOrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -3553,7 +3553,7 @@ export class UserEmailAvatars {
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -3595,7 +3595,7 @@ export class UserEmailOrders {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -3790,7 +3790,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -3856,7 +3856,7 @@ export const UserEmailOrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 

--- a/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
@@ -18,7 +18,7 @@ export class Address2 {
 
 }
 ",
-  "import { Cascade, Collection, EagerProps, Embedded, Entity, Formula, Hidden, Index, ManyToMany, ManyToOne, OneToMany, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Cascade, Collection, EagerProps, Embedded, Entity, Formula, type Hidden, Index, ManyToMany, ManyToOne, OneToMany, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { IdentitiesContainer } from './IdentitiesContainer';
 
@@ -170,7 +170,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
@@ -324,7 +324,7 @@ export class Dummy2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
 import { Test2 } from './Test2';
@@ -373,7 +373,7 @@ export class FooBar2 {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooParam2 } from './FooParam2';
 
 @Entity()
@@ -393,7 +393,7 @@ export class FooBaz2 {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -416,7 +416,7 @@ export class FooParam2 {
 
 }
 ",
-  "import { Collection, Entity, Enum, OneToMany, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
 
@@ -516,7 +516,7 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToMany, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
@@ -589,7 +589,7 @@ export class User2 {
 
 }
 ",
-  "import { Entity, Hidden, Index, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, type Hidden, Index, Property, Unique } from '@mikro-orm/core';
 
 @Entity({ expression: 'SELECT name, email FROM author2', comment: 'test', virtual: true })
 export class AuthorPartialView {
@@ -691,7 +691,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Cascade, Collection, EagerProps, Embedded, EntitySchema, Hidden, Opt } from '@mikro-orm/core';
+  "import { Cascade, Collection, EagerProps, Embedded, EntitySchema, type Hidden, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { IdentitiesContainer } from './IdentitiesContainer';
 
@@ -877,7 +877,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
@@ -1042,7 +1042,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
 import { Test2 } from './Test2';
@@ -1094,7 +1094,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { FooParam2 } from './FooParam2';
 
 export class FooBaz2 {
@@ -1114,7 +1114,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -1136,7 +1136,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
 
@@ -1241,7 +1241,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
@@ -1339,7 +1339,7 @@ export const User2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Hidden } from '@mikro-orm/core';
+  "import { EntitySchema, type Hidden } from '@mikro-orm/core';
 
 export class AuthorPartialView {
   name!: string;
@@ -1464,7 +1464,7 @@ export const CustomBase2Schema = new EntitySchema({
 
 exports[`MetadataHooks [mysql] identifiedReferences=true metadata hooks with decorators: mysql-defaults-dump 1`] = `
 [
-  "import { Entity, OneToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
 @Entity()
@@ -1480,7 +1480,7 @@ export class Address2 {
 
 }
 ",
-  "import { Cascade, Collection, EagerProps, Embedded, Entity, Formula, Hidden, Index, ManyToMany, ManyToOne, OneToMany, Opt, PrimaryKey, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Cascade, Collection, EagerProps, Embedded, Entity, Formula, type Hidden, Index, ManyToMany, ManyToOne, OneToMany, type Opt, PrimaryKey, Property, type Ref, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { IdentitiesContainer } from './IdentitiesContainer';
 
@@ -1562,7 +1562,7 @@ export class Author2 {
 
 }
 ",
-  "import { Collection, Entity, Enum, Index, ManyToOne, OneToMany, OneToOne, PrimaryKey, Property, Ref, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Enum, Index, ManyToOne, OneToMany, OneToOne, PrimaryKey, Property, type Ref, Unique } from '@mikro-orm/core';
 import { CustomBase2 } from './CustomBase2';
 
 @Entity({ abstract: true, discriminatorColumn: 'type', discriminatorMap: { employee: 'Employee2', manager: 'Manager2' } })
@@ -1632,7 +1632,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
@@ -1689,7 +1689,7 @@ export class Book2 {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { BookTag2 } from './BookTag2';
 
@@ -1709,7 +1709,7 @@ export class Book2Tags {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, Property, type Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 
 @Entity()
@@ -1726,7 +1726,7 @@ export class CarOwner2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { CarOwner2 } from './CarOwner2';
 import { User2 } from './User2';
 
@@ -1757,7 +1757,7 @@ export class Car2 {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Test2 } from './Test2';
 
 @Entity()
@@ -1786,7 +1786,7 @@ export class Dummy2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, Opt, PrimaryKey, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, type Opt, PrimaryKey, Property, type Ref } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
 import { Test2 } from './Test2';
@@ -1835,7 +1835,7 @@ export class FooBar2 {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooParam2 } from './FooParam2';
 
 @Entity()
@@ -1855,7 +1855,7 @@ export class FooBaz2 {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -1878,7 +1878,7 @@ export class FooParam2 {
 
 }
 ",
-  "import { Collection, Entity, Enum, OneToMany, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
 
@@ -1940,7 +1940,7 @@ export enum Publisher2Enum5 {
   A = 'a',
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
 
@@ -1978,7 +1978,7 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToMany, OneToOne, Opt, PrimaryKey, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, Property, type Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
@@ -2022,7 +2022,7 @@ export class Test2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './Sandwich';
 
@@ -2051,7 +2051,7 @@ export class User2 {
 
 }
 ",
-  "import { Entity, Hidden, Index, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, type Hidden, Index, Property, Unique } from '@mikro-orm/core';
 
 @Entity({ expression: 'SELECT name, email FROM author2', comment: 'test', virtual: true })
 export class AuthorPartialView {
@@ -2130,7 +2130,7 @@ export abstract class CustomBase2 {
 
 exports[`MetadataHooks [mysql] identifiedReferences=true metadata hooks with entity schema: mysql-EntitySchema-dump 1`] = `
 [
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
 export class Address2 {
@@ -2154,7 +2154,7 @@ export const Address2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Cascade, Collection, EagerProps, Embedded, EntitySchema, Hidden, Opt, Ref } from '@mikro-orm/core';
+  "import { Cascade, Collection, EagerProps, Embedded, EntitySchema, type Hidden, type Opt, type Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { IdentitiesContainer } from './IdentitiesContainer';
 
@@ -2274,7 +2274,7 @@ export const Author2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Ref } from '@mikro-orm/core';
 import { CustomBase2 } from './CustomBase2';
 
 export abstract class BaseUser2 extends CustomBase2 {
@@ -2354,7 +2354,7 @@ export const BookTag2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
@@ -2413,7 +2413,7 @@ export const Book2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { BookTag2 } from './BookTag2';
 
@@ -2446,7 +2446,7 @@ export const Book2TagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 
 export class CarOwner2 {
@@ -2464,7 +2464,7 @@ export const CarOwner2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { CarOwner2 } from './CarOwner2';
 import { User2 } from './User2';
 
@@ -2490,7 +2490,7 @@ export const Car2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Test2 } from './Test2';
 
 export class Configuration2 {
@@ -2528,7 +2528,7 @@ export const Dummy2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, type Ref } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
 import { Test2 } from './Test2';
@@ -2582,7 +2582,7 @@ export const FooBar2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { FooParam2 } from './FooParam2';
 
 export class FooBaz2 {
@@ -2602,7 +2602,7 @@ export const FooBaz2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -2636,7 +2636,7 @@ export const FooParam2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
 
@@ -2691,7 +2691,7 @@ export const Publisher2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
 
@@ -2743,7 +2743,7 @@ export const SandwichSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, type Ref } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
@@ -2806,7 +2806,7 @@ export const Test2Schema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './Sandwich';
 
@@ -2850,7 +2850,7 @@ export const User2Schema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Hidden } from '@mikro-orm/core';
+  "import { EntitySchema, type Hidden } from '@mikro-orm/core';
 
 export class AuthorPartialView {
   name!: string;

--- a/tests/features/entity-generator/__snapshots__/NonCompositeAmbiguousFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/NonCompositeAmbiguousFks.mysql.test.ts.snap
@@ -233,7 +233,7 @@ export const ShippableProductsSchema = new EntitySchema({
 
 exports[`non_composite_ambiguous_fk_example scalarPropertiesForRelations=always bidirectionalRelations=false identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Entity, OneToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 
 @Entity()
@@ -268,7 +268,7 @@ export class Destinations {
 
 }
 ",
-  "import { Entity, OneToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 
 @Entity()
@@ -302,7 +302,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { DeliverableProducts } from './DeliverableProducts';
 import { Destinations } from './Destinations';
 import { ManufacturedProducts } from './ManufacturedProducts';
@@ -338,7 +338,7 @@ export class ShippableProducts {
 
 exports[`non_composite_ambiguous_fk_example scalarPropertiesForRelations=always bidirectionalRelations=false identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 
 export class DeliverableProducts {
@@ -379,7 +379,7 @@ export const DestinationsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 
 export class ManufacturedProducts {
@@ -420,7 +420,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { DeliverableProducts } from './DeliverableProducts';
 import { Destinations } from './Destinations';
 import { ManufacturedProducts } from './ManufacturedProducts';
@@ -756,7 +756,7 @@ export const ShippableProductsSchema = new EntitySchema({
 
 exports[`non_composite_ambiguous_fk_example scalarPropertiesForRelations=always bidirectionalRelations=true identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { ShippableProducts } from './ShippableProducts';
 
@@ -799,7 +799,7 @@ export class Destinations {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { ShippableProducts } from './ShippableProducts';
 
@@ -825,7 +825,7 @@ export class ManufacturedProducts {
 
 }
 ",
-  "import { Entity, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { ManufacturedProducts } from './ManufacturedProducts';
 
 @Entity()
@@ -844,7 +844,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { DeliverableProducts } from './DeliverableProducts';
 import { Destinations } from './Destinations';
 import { ManufacturedProducts } from './ManufacturedProducts';
@@ -880,7 +880,7 @@ export class ShippableProducts {
 
 exports[`non_composite_ambiguous_fk_example scalarPropertiesForRelations=always bidirectionalRelations=true identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { ShippableProducts } from './ShippableProducts';
 
@@ -931,7 +931,7 @@ export const DestinationsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { ShippableProducts } from './ShippableProducts';
 
@@ -969,7 +969,7 @@ export const ManufacturedProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { ManufacturedProducts } from './ManufacturedProducts';
 
 export class Products {
@@ -993,7 +993,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { DeliverableProducts } from './DeliverableProducts';
 import { Destinations } from './Destinations';
 import { ManufacturedProducts } from './ManufacturedProducts';
@@ -1259,7 +1259,7 @@ export const ShippableProductsSchema = new EntitySchema({
 
 exports[`non_composite_ambiguous_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Entity, OneToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 
 @Entity()
@@ -1291,7 +1291,7 @@ export class Destinations {
 
 }
 ",
-  "import { Entity, OneToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 
 @Entity()
@@ -1322,7 +1322,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { DeliverableProducts } from './DeliverableProducts';
 import { Destinations } from './Destinations';
 import { ManufacturedProducts } from './ManufacturedProducts';
@@ -1351,7 +1351,7 @@ export class ShippableProducts {
 
 exports[`non_composite_ambiguous_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 
 export class DeliverableProducts {
@@ -1390,7 +1390,7 @@ export const DestinationsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 
 export class ManufacturedProducts {
@@ -1429,7 +1429,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { DeliverableProducts } from './DeliverableProducts';
 import { Destinations } from './Destinations';
 import { ManufacturedProducts } from './ManufacturedProducts';
@@ -1732,7 +1732,7 @@ export const ShippableProductsSchema = new EntitySchema({
 
 exports[`non_composite_ambiguous_fk_example scalarPropertiesForRelations=never bidirectionalRelations=true identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { ShippableProducts } from './ShippableProducts';
 
@@ -1772,7 +1772,7 @@ export class Destinations {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { ShippableProducts } from './ShippableProducts';
 
@@ -1795,7 +1795,7 @@ export class ManufacturedProducts {
 
 }
 ",
-  "import { Entity, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { ManufacturedProducts } from './ManufacturedProducts';
 
 @Entity()
@@ -1814,7 +1814,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { DeliverableProducts } from './DeliverableProducts';
 import { Destinations } from './Destinations';
 import { ManufacturedProducts } from './ManufacturedProducts';
@@ -1843,7 +1843,7 @@ export class ShippableProducts {
 
 exports[`non_composite_ambiguous_fk_example scalarPropertiesForRelations=never bidirectionalRelations=true identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { ShippableProducts } from './ShippableProducts';
 
@@ -1892,7 +1892,7 @@ export const DestinationsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { ShippableProducts } from './ShippableProducts';
 
@@ -1928,7 +1928,7 @@ export const ManufacturedProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { ManufacturedProducts } from './ManufacturedProducts';
 
 export class Products {
@@ -1952,7 +1952,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { DeliverableProducts } from './DeliverableProducts';
 import { Destinations } from './Destinations';
 import { ManufacturedProducts } from './ManufacturedProducts';
@@ -2210,7 +2210,7 @@ export const ShippableProductsSchema = new EntitySchema({
 
 exports[`non_composite_ambiguous_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Entity, OneToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 
 @Entity()
@@ -2242,7 +2242,7 @@ export class Destinations {
 
 }
 ",
-  "import { Entity, OneToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 
 @Entity()
@@ -2273,7 +2273,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { DeliverableProducts } from './DeliverableProducts';
 import { Destinations } from './Destinations';
 import { ManufacturedProducts } from './ManufacturedProducts';
@@ -2302,7 +2302,7 @@ export class ShippableProducts {
 
 exports[`non_composite_ambiguous_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 
 export class DeliverableProducts {
@@ -2341,7 +2341,7 @@ export const DestinationsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 
 export class ManufacturedProducts {
@@ -2380,7 +2380,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { DeliverableProducts } from './DeliverableProducts';
 import { Destinations } from './Destinations';
 import { ManufacturedProducts } from './ManufacturedProducts';
@@ -2683,7 +2683,7 @@ export const ShippableProductsSchema = new EntitySchema({
 
 exports[`non_composite_ambiguous_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=true identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { ShippableProducts } from './ShippableProducts';
 
@@ -2723,7 +2723,7 @@ export class Destinations {
 
 }
 ",
-  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { ShippableProducts } from './ShippableProducts';
 
@@ -2746,7 +2746,7 @@ export class ManufacturedProducts {
 
 }
 ",
-  "import { Entity, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { ManufacturedProducts } from './ManufacturedProducts';
 
 @Entity()
@@ -2765,7 +2765,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { DeliverableProducts } from './DeliverableProducts';
 import { Destinations } from './Destinations';
 import { ManufacturedProducts } from './ManufacturedProducts';
@@ -2794,7 +2794,7 @@ export class ShippableProducts {
 
 exports[`non_composite_ambiguous_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=true identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { ShippableProducts } from './ShippableProducts';
 
@@ -2843,7 +2843,7 @@ export const DestinationsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { ShippableProducts } from './ShippableProducts';
 
@@ -2879,7 +2879,7 @@ export const ManufacturedProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { ManufacturedProducts } from './ManufacturedProducts';
 
 export class Products {
@@ -2903,7 +2903,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { DeliverableProducts } from './DeliverableProducts';
 import { Destinations } from './Destinations';
 import { ManufacturedProducts } from './ManufacturedProducts';

--- a/tests/features/entity-generator/__snapshots__/NullableFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/NullableFks.mysql.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`nullable_fk_example scalarPropertiesForRelations=always bidirectionalRelations=false identifiedReferences=false entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -152,7 +152,7 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=always bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -347,7 +347,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=always bidirectionalRelations=false identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -404,7 +404,7 @@ export class Emails {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Recepients } from './Recepients';
 
@@ -448,7 +448,7 @@ export class Recepients {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Senders } from './Senders';
 
@@ -497,7 +497,7 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=always bidirectionalRelations=false identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -575,7 +575,7 @@ export const EmailsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Recepients } from './Recepients';
 
@@ -637,7 +637,7 @@ export const RecepientsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Senders } from './Senders';
 
@@ -704,7 +704,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=always bidirectionalRelations=true identifiedReferences=false entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -883,7 +883,7 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=always bidirectionalRelations=true identifiedReferences=false entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -1099,7 +1099,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=always bidirectionalRelations=true identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -1168,7 +1168,7 @@ export class Emails {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { EmailSendingLogs } from './EmailSendingLogs';
 import { Emails } from './Emails';
 import { Recepients } from './Recepients';
@@ -1219,7 +1219,7 @@ export class Recepients {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { EmailSendingLogs } from './EmailSendingLogs';
 import { Emails } from './Emails';
 import { Senders } from './Senders';
@@ -1278,7 +1278,7 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=always bidirectionalRelations=true identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -1365,7 +1365,7 @@ export const EmailsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { EmailSendingLogs } from './EmailSendingLogs';
 import { Emails } from './Emails';
 import { Recepients } from './Recepients';
@@ -1432,7 +1432,7 @@ export const RecepientsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { EmailSendingLogs } from './EmailSendingLogs';
 import { Emails } from './Emails';
 import { Senders } from './Senders';
@@ -1506,7 +1506,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=false entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -1627,7 +1627,7 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -1804,7 +1804,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -1846,7 +1846,7 @@ export class Emails {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Recepients } from './Recepients';
 
@@ -1883,7 +1883,7 @@ export class Recepients {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Senders } from './Senders';
 
@@ -1925,7 +1925,7 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=never bidirectionalRelations=false identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -1993,7 +1993,7 @@ export const EmailsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Recepients } from './Recepients';
 
@@ -2051,7 +2051,7 @@ export const RecepientsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Senders } from './Senders';
 
@@ -2114,7 +2114,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=never bidirectionalRelations=true identifiedReferences=false entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -2264,7 +2264,7 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=never bidirectionalRelations=true identifiedReferences=false entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -2462,7 +2462,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=never bidirectionalRelations=true identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -2516,7 +2516,7 @@ export class Emails {
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { EmailSendingLogs } from './EmailSendingLogs';
 import { Emails } from './Emails';
 import { Recepients } from './Recepients';
@@ -2560,7 +2560,7 @@ export class Recepients {
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { EmailSendingLogs } from './EmailSendingLogs';
 import { Emails } from './Emails';
 import { Senders } from './Senders';
@@ -2612,7 +2612,7 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=never bidirectionalRelations=true identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -2689,7 +2689,7 @@ export const EmailsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { EmailSendingLogs } from './EmailSendingLogs';
 import { Emails } from './Emails';
 import { Recepients } from './Recepients';
@@ -2752,7 +2752,7 @@ export const RecepientsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { EmailSendingLogs } from './EmailSendingLogs';
 import { Emails } from './Emails';
 import { Senders } from './Senders';
@@ -2822,7 +2822,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=false entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -2943,7 +2943,7 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=false entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -3120,7 +3120,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -3162,7 +3162,7 @@ export class Emails {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Recepients } from './Recepients';
 
@@ -3199,7 +3199,7 @@ export class Recepients {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Senders } from './Senders';
 
@@ -3241,7 +3241,7 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=false identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -3309,7 +3309,7 @@ export const EmailsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Recepients } from './Recepients';
 
@@ -3367,7 +3367,7 @@ export const RecepientsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Senders } from './Senders';
 
@@ -3430,7 +3430,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=true identifiedReferences=false entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -3580,7 +3580,7 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=true identifiedReferences=false entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -3778,7 +3778,7 @@ export const SendersSchema = new EntitySchema({
 
 exports[`nullable_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=true identifiedReferences=true entitySchema=false: dump 1`] = `
 [
-  "import { Entity, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -3832,7 +3832,7 @@ export class Emails {
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { EmailSendingLogs } from './EmailSendingLogs';
 import { Emails } from './Emails';
 import { Recepients } from './Recepients';
@@ -3876,7 +3876,7 @@ export class Recepients {
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { EmailSendingLogs } from './EmailSendingLogs';
 import { Emails } from './Emails';
 import { Senders } from './Senders';
@@ -3928,7 +3928,7 @@ export class Senders {
 
 exports[`nullable_fk_example scalarPropertiesForRelations=smart bidirectionalRelations=true identifiedReferences=true entitySchema=true: dump 1`] = `
 [
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
 import { SenderEmails } from './SenderEmails';
 
@@ -4005,7 +4005,7 @@ export const EmailsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { EmailSendingLogs } from './EmailSendingLogs';
 import { Emails } from './Emails';
 import { Recepients } from './Recepients';
@@ -4068,7 +4068,7 @@ export const RecepientsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { EmailSendingLogs } from './EmailSendingLogs';
 import { Emails } from './Emails';
 import { Senders } from './Senders';

--- a/tests/features/entity-generator/__snapshots__/OverlapFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OverlapFks.mysql.test.ts.snap
@@ -14,7 +14,7 @@ export class Countries {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
@@ -43,7 +43,7 @@ export class ProductCountryMap {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -70,7 +70,7 @@ export class ProductSellers {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountryMap } from './ProductCountryMap';
 
@@ -97,7 +97,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -173,7 +173,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
@@ -207,7 +207,7 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -246,7 +246,7 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountryMap } from './ProductCountryMap';
 
@@ -277,7 +277,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -369,7 +369,7 @@ export class Countries {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
@@ -398,7 +398,7 @@ export class ProductCountryMap {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -425,7 +425,7 @@ export class ProductSellers {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountryMap } from './ProductCountryMap';
 
@@ -452,7 +452,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -528,7 +528,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
@@ -569,7 +569,7 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -610,7 +610,7 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountryMap } from './ProductCountryMap';
 
@@ -641,7 +641,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -743,7 +743,7 @@ export class Countries {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -776,7 +776,7 @@ export class ProductCountryMap {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -807,7 +807,7 @@ export class ProductSellers {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
@@ -842,7 +842,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -927,7 +927,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -964,7 +964,7 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -1006,7 +1006,7 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
@@ -1043,7 +1043,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -1145,7 +1145,7 @@ export class Countries {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -1178,7 +1178,7 @@ export class ProductCountryMap {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -1209,7 +1209,7 @@ export class ProductSellers {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
@@ -1244,7 +1244,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -1329,7 +1329,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -1373,7 +1373,7 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -1417,7 +1417,7 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
@@ -1454,7 +1454,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -1555,7 +1555,7 @@ export class Countries {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
@@ -1577,7 +1577,7 @@ export class ProductCountryMap {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -1597,7 +1597,7 @@ export class ProductSellers {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 
 @Entity()
 export class Products {
@@ -1619,7 +1619,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -1697,7 +1697,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
@@ -1727,7 +1727,7 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -1762,7 +1762,7 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
@@ -1782,7 +1782,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -1876,7 +1876,7 @@ export class Countries {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
@@ -1898,7 +1898,7 @@ export class ProductCountryMap {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -1918,7 +1918,7 @@ export class ProductSellers {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 
 @Entity()
 export class Products {
@@ -1940,7 +1940,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -2018,7 +2018,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
@@ -2055,7 +2055,7 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -2092,7 +2092,7 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
@@ -2112,7 +2112,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -2211,7 +2211,7 @@ export class Countries {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -2237,7 +2237,7 @@ export class ProductCountryMap {
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -2261,7 +2261,7 @@ export class ProductSellers {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSellers } from './ProductSellers';
 import { Sellers } from './Sellers';
@@ -2295,7 +2295,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -2378,7 +2378,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -2411,7 +2411,7 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -2449,7 +2449,7 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSellers } from './ProductSellers';
 import { Sellers } from './Sellers';
@@ -2478,7 +2478,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -2577,7 +2577,7 @@ export class Countries {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -2603,7 +2603,7 @@ export class ProductCountryMap {
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -2627,7 +2627,7 @@ export class ProductSellers {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSellers } from './ProductSellers';
 import { Sellers } from './Sellers';
@@ -2661,7 +2661,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -2744,7 +2744,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -2784,7 +2784,7 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -2824,7 +2824,7 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSellers } from './ProductSellers';
 import { Sellers } from './Sellers';
@@ -2853,7 +2853,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -2951,7 +2951,7 @@ export class Countries {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
@@ -2973,7 +2973,7 @@ export class ProductCountryMap {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -2993,7 +2993,7 @@ export class ProductSellers {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 
 @Entity()
 export class Products {
@@ -3015,7 +3015,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -3093,7 +3093,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
@@ -3123,7 +3123,7 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -3158,7 +3158,7 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
@@ -3178,7 +3178,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -3272,7 +3272,7 @@ export class Countries {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
@@ -3294,7 +3294,7 @@ export class ProductCountryMap {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -3314,7 +3314,7 @@ export class ProductSellers {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 
 @Entity()
 export class Products {
@@ -3336,7 +3336,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -3414,7 +3414,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 
@@ -3451,7 +3451,7 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sellers } from './Sellers';
 
@@ -3488,7 +3488,7 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 
 export class Products {
   [PrimaryKeyProp]?: 'productId';
@@ -3508,7 +3508,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -3607,7 +3607,7 @@ export class Countries {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -3633,7 +3633,7 @@ export class ProductCountryMap {
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -3657,7 +3657,7 @@ export class ProductSellers {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSellers } from './ProductSellers';
 import { Sellers } from './Sellers';
@@ -3691,7 +3691,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -3774,7 +3774,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -3807,7 +3807,7 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -3845,7 +3845,7 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSellers } from './ProductSellers';
 import { Sellers } from './Sellers';
@@ -3874,7 +3874,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -3973,7 +3973,7 @@ export class Countries {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToOne, OneToMany, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -3999,7 +3999,7 @@ export class ProductCountryMap {
 
 }
 ",
-  "import { Collection, Entity, ManyToOne, OneToMany, Opt, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToOne, OneToMany, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -4023,7 +4023,7 @@ export class ProductSellers {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSellers } from './ProductSellers';
 import { Sellers } from './Sellers';
@@ -4057,7 +4057,7 @@ export class Products {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property, Ref } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 
@@ -4140,7 +4140,7 @@ export const CountriesSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { Products } from './Products';
 import { Sales } from './Sales';
@@ -4180,7 +4180,7 @@ export const ProductCountryMapSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
 import { Sales } from './Sales';
 import { Sellers } from './Sellers';
@@ -4220,7 +4220,7 @@ export const ProductSellersSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { Countries } from './Countries';
 import { ProductSellers } from './ProductSellers';
 import { Sellers } from './Sellers';
@@ -4249,7 +4249,7 @@ export const ProductsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, Opt, PrimaryKeyProp, Ref } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
 import { ProductSellers } from './ProductSellers';
 

--- a/tests/features/entity-generator/__snapshots__/ScalarPropsForFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/ScalarPropsForFks.mysql.test.ts.snap
@@ -21,7 +21,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -156,7 +156,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -314,7 +314,7 @@ export class Dummy2 {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 @Entity()
@@ -360,7 +360,7 @@ export class FooBar2 {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class FooBaz2 {
@@ -376,7 +376,7 @@ export class FooBaz2 {
 
 }
 ",
-  "import { Entity, Index, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -407,7 +407,7 @@ export class FooParam2 {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Publisher2 {
@@ -503,7 +503,7 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 
@@ -604,7 +604,7 @@ export class Address2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 
 @Entity()
@@ -723,7 +723,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -855,7 +855,7 @@ export class Dummy2 {
 
 }
 ",
-  "import { Entity, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
 
 @Entity()
@@ -893,7 +893,7 @@ export class FooBar2 {
 
 }
 ",
-  "import { Entity, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class FooBaz2 {
@@ -909,7 +909,7 @@ export class FooBaz2 {
 
 }
 ",
-  "import { Entity, ManyToOne, Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
@@ -932,7 +932,7 @@ export class FooParam2 {
 
 }
 ",
-  "import { Entity, Enum, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Publisher2 {
@@ -1020,7 +1020,7 @@ export class Sandwich {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { FooBar2 } from './FooBar2';
 

--- a/tests/features/entity-generator/__snapshots__/TypesForScalarDecorators.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/TypesForScalarDecorators.mysql.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`TypesForScalarDecorators: dump 1`] = `
 [
-  "import { Entity, Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Users {


### PR DESCRIPTION
Helps transpilers and bundlers to more efficiently strip out types.