### PR TITLE
fix(core): fix value of `hasPrev[/Next]Page` when paginating backwards

### DIFF
--- a/packages/core/src/utils/Cursor.ts
+++ b/packages/core/src/utils/Cursor.ts
@@ -77,8 +77,8 @@ export class Cursor<
     const limit = first || last;
     const isLast = !first && !!last;
     const hasMorePages = !!overfetch && limit != null && items.length > limit;
-    this.hasPrevPage = before || after ? true : (isLast && hasMorePages);
-    this.hasNextPage = !(isLast && !before && !after) && hasMorePages;
+    this.hasPrevPage = isLast ? hasMorePages : !!after;
+    this.hasNextPage = isLast ? !!before : hasMorePages;
 
     if (hasMorePages) {
       if (isLast) {

--- a/tests/features/cursor-based-pagination/__snapshots__/bidirectional-cursor.test.ts.snap
+++ b/tests/features/cursor-based-pagination/__snapshots__/bidirectional-cursor.test.ts.snap
@@ -1,0 +1,701 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 1`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 2`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 3 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 3`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 6 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 4`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 7 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 5`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 4 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 1`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 2`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 7 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 3`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 4 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 4`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 3 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 5`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 6 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 1`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 2`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 7 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 3`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 4 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 4`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 3 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 5`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 6 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 1`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 2`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 3 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 3`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 6 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 4`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 7 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (better-sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 5`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 4 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 1`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({}, {}).sort([ [ '_id', 1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 2`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({ _id: { '$gt': 3 } }, {}).sort([ [ '_id', 1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 3`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({ _id: { '$gt': 6 } }, {}).sort([ [ '_id', 1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 4`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({ _id: { '$lt': 7 } }, {}).sort([ [ '_id', -1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 5`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({ _id: { '$lt': 4 } }, {}).sort([ [ '_id', -1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 1`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({}, {}).sort([ [ '_id', -1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 2`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({ _id: { '$lt': 7 } }, {}).sort([ [ '_id', -1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 3`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({ _id: { '$lt': 4 } }, {}).sort([ [ '_id', -1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 4`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({ _id: { '$gt': 3 } }, {}).sort([ [ '_id', 1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 5`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({ _id: { '$gt': 6 } }, {}).sort([ [ '_id', 1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 1`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({}, {}).sort([ [ '_id', -1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 2`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({ _id: { '$lt': 7 } }, {}).sort([ [ '_id', -1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 3`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({ _id: { '$lt': 4 } }, {}).sort([ [ '_id', -1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 4`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({ _id: { '$gt': 3 } }, {}).sort([ [ '_id', 1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 5`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({ _id: { '$gt': 6 } }, {}).sort([ [ '_id', 1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 1`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({}, {}).sort([ [ '_id', 1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 2`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({ _id: { '$gt': 3 } }, {}).sort([ [ '_id', 1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 3`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({ _id: { '$gt': 6 } }, {}).sort([ [ '_id', 1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 4`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({ _id: { '$lt': 7 } }, {}).sort([ [ '_id', -1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mongo) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 5`] = `
+[
+  "[query] db.getCollection('user').countDocuments({}, {});",
+  "[query] db.getCollection('user').find({ _id: { '$lt': 4 } }, {}).sort([ [ '_id', -1 ] ]).limit(4).toArray();",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 1`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 2`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 3 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 3`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 6 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 4`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 7 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 5`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 4 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 1`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 2`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 7 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 3`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 4 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 4`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 3 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 5`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 6 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 1`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 2`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 7 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 3`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 4 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 4`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 3 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 5`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 6 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 1`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 2`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 3 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 3`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 6 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 4`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 7 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (mysql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 5`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 4 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 1`] = `
+[
+  "[query] select "u0".* from "user" as "u0" order by "u0"."_id" asc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 2`] = `
+[
+  "[query] select "u0".* from "user" as "u0" where "u0"."_id" > 3 order by "u0"."_id" asc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 3`] = `
+[
+  "[query] select "u0".* from "user" as "u0" where "u0"."_id" > 6 order by "u0"."_id" asc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 4`] = `
+[
+  "[query] select "u0".* from "user" as "u0" where "u0"."_id" < 7 order by "u0"."_id" desc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 5`] = `
+[
+  "[query] select "u0".* from "user" as "u0" where "u0"."_id" < 4 order by "u0"."_id" desc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 1`] = `
+[
+  "[query] select "u0".* from "user" as "u0" order by "u0"."_id" desc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 2`] = `
+[
+  "[query] select "u0".* from "user" as "u0" where "u0"."_id" < 7 order by "u0"."_id" desc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 3`] = `
+[
+  "[query] select "u0".* from "user" as "u0" where "u0"."_id" < 4 order by "u0"."_id" desc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 4`] = `
+[
+  "[query] select "u0".* from "user" as "u0" where "u0"."_id" > 3 order by "u0"."_id" asc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 5`] = `
+[
+  "[query] select "u0".* from "user" as "u0" where "u0"."_id" > 6 order by "u0"."_id" asc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 1`] = `
+[
+  "[query] select "u0".* from "user" as "u0" order by "u0"."_id" desc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 2`] = `
+[
+  "[query] select "u0".* from "user" as "u0" where "u0"."_id" < 7 order by "u0"."_id" desc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 3`] = `
+[
+  "[query] select "u0".* from "user" as "u0" where "u0"."_id" < 4 order by "u0"."_id" desc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 4`] = `
+[
+  "[query] select "u0".* from "user" as "u0" where "u0"."_id" > 3 order by "u0"."_id" asc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 5`] = `
+[
+  "[query] select "u0".* from "user" as "u0" where "u0"."_id" > 6 order by "u0"."_id" asc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 1`] = `
+[
+  "[query] select "u0".* from "user" as "u0" order by "u0"."_id" asc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 2`] = `
+[
+  "[query] select "u0".* from "user" as "u0" where "u0"."_id" > 3 order by "u0"."_id" asc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 3`] = `
+[
+  "[query] select "u0".* from "user" as "u0" where "u0"."_id" > 6 order by "u0"."_id" asc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 4`] = `
+[
+  "[query] select "u0".* from "user" as "u0" where "u0"."_id" < 7 order by "u0"."_id" desc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (postgresql) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 5`] = `
+[
+  "[query] select "u0".* from "user" as "u0" where "u0"."_id" < 4 order by "u0"."_id" desc limit 4",
+  "[query] select count(*) as "count" from "user" as "u0"",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 1`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 2`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 3 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 3`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 6 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 4`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 7 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id asc) 5`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 4 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 1`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 2`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 7 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 3`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 4 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 4`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 3 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`first\` and \`after\` then backward using \`last\` and \`before\` (id desc) 5`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 6 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 1`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 2`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 7 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 3`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 4 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 4`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 3 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id asc) 5`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 6 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 1`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 2`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 3 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 3`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` > 6 order by \`u0\`.\`_id\` asc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 4`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 7 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;
+
+exports[`bidrectional cursor based pagination (sqlite) using \`last\` and \`before\` then forward using \`first\` and \`after\` (id desc) 5`] = `
+[
+  "[query] select \`u0\`.* from \`user\` as \`u0\` where \`u0\`.\`_id\` < 4 order by \`u0\`.\`_id\` desc limit 4",
+  "[query] select count(*) as \`count\` from \`user\` as \`u0\`",
+]
+`;

--- a/tests/features/cursor-based-pagination/__snapshots__/complex-cursor.test.ts.snap
+++ b/tests/features/cursor-based-pagination/__snapshots__/complex-cursor.test.ts.snap
@@ -1,125 +1,125 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`simple cursor based pagination (better-sqlite) complex cursor based pagination using \`first\` and \`after\` (id asc) 1`] = `
+exports[`complex cursor based pagination (better-sqlite) complex cursor based pagination using \`first\` and \`after\` (id asc) 1`] = `
 [
   "[query] select \`u0\`.* from \`user\` as \`u0\` where (\`u0\`.\`terms_accepted\` = true or \`u0\`.\`name\` = 'User 1' or \`u0\`.\`age\` <= 30) and \`u0\`.\`name\` != 'User 2' order by \`u0\`.\`name\` desc, \`u0\`.\`age\` asc, \`u0\`.\`email\` asc limit 11",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` where (\`u0\`.\`terms_accepted\` = true or \`u0\`.\`name\` = 'User 1' or \`u0\`.\`age\` <= 30) and \`u0\`.\`name\` != 'User 2'",
 ]
 `;
 
-exports[`simple cursor based pagination (better-sqlite) complex cursor based pagination using \`first\` and \`after\` (id asc) 2`] = `
+exports[`complex cursor based pagination (better-sqlite) complex cursor based pagination using \`first\` and \`after\` (id asc) 2`] = `
 [
   "[query] select \`u0\`.* from \`user\` as \`u0\` where (\`u0\`.\`terms_accepted\` = true or \`u0\`.\`name\` = 'User 1' or \`u0\`.\`age\` <= 30) and \`u0\`.\`name\` != 'User 2' and \`u0\`.\`name\` <= 'User 1' and (\`u0\`.\`name\` < 'User 1' or (\`u0\`.\`age\` >= 28 and (\`u0\`.\`age\` > 28 or \`u0\`.\`email\` > 'email-55'))) order by \`u0\`.\`name\` desc, \`u0\`.\`age\` asc, \`u0\`.\`email\` asc limit 11",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` where (\`u0\`.\`terms_accepted\` = true or \`u0\`.\`name\` = 'User 1' or \`u0\`.\`age\` <= 30) and \`u0\`.\`name\` != 'User 2'",
 ]
 `;
 
-exports[`simple cursor based pagination (better-sqlite) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 1`] = `
+exports[`complex cursor based pagination (better-sqlite) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 1`] = `
 [
   "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` left join \`user\` as \`u2\` on \`u0\`.\`best_friend__id\` = \`u2\`.\`_id\` where \`u2\`.\`name\` = 'User 3' order by \`u2\`.\`email\` desc, \`u2\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3'",
 ]
 `;
 
-exports[`simple cursor based pagination (better-sqlite) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
+exports[`complex cursor based pagination (better-sqlite) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
 [
   "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` left join \`user\` as \`u2\` on \`u0\`.\`best_friend__id\` = \`u2\`.\`_id\` where \`u2\`.\`name\` = 'User 3' and \`u2\`.\`email\` <= 'email-96' and \`u2\`.\`name\` <= 'User 3' and ((\`u2\`.\`email\` < 'email-96' and \`u2\`.\`name\` < 'User 3') or (\`u0\`.\`name\` >= 'User 3' and (\`u0\`.\`name\` > 'User 3' or (\`u0\`.\`age\` <= 38 and (\`u0\`.\`age\` < 38 or \`u0\`.\`email\` < 'email-76'))))) order by \`u2\`.\`email\` desc, \`u2\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3'",
 ]
 `;
 
-exports[`simple cursor based pagination (mongo) complex cursor based pagination using \`first\` and \`after\` (id asc) 1`] = `
+exports[`complex cursor based pagination (mongo) complex cursor based pagination using \`first\` and \`after\` (id asc) 1`] = `
 [
   "[query] db.getCollection('user').countDocuments({ '$or': [ { termsAccepted: true }, { name: 'User 1' }, { age: { '$lte': 30 } } ], name: { '$ne': 'User 2' } }, {});",
   "[query] db.getCollection('user').find({ '$or': [ { termsAccepted: true }, { name: 'User 1' }, { age: { '$lte': 30 } } ], name: { '$ne': 'User 2' } }, {}).sort([ [ 'name', -1 ], [ 'age', 1 ], [ 'email', 1 ] ]).limit(11).toArray();",
 ]
 `;
 
-exports[`simple cursor based pagination (mongo) complex cursor based pagination using \`first\` and \`after\` (id asc) 2`] = `
+exports[`complex cursor based pagination (mongo) complex cursor based pagination using \`first\` and \`after\` (id asc) 2`] = `
 [
   "[query] db.getCollection('user').countDocuments({ '$or': [ { termsAccepted: true }, { name: 'User 1' }, { age: { '$lte': 30 } } ], name: { '$ne': 'User 2' } }, {});",
   "[query] db.getCollection('user').find({ '$and': [ { '$or': [ { termsAccepted: true }, { name: 'User 1' }, { age: { '$lte': 30 } } ], name: { '$ne': 'User 2' } }, { name: { '$lte': 'User 1' }, '$or': [ { name: { '$lt': 'User 1' } }, { age: { '$gte': 28 }, '$or': [ [Object], [Object] ] } ] } ] }, {}).sort([ [ 'name', -1 ], [ 'age', 1 ], [ 'email', 1 ] ]).limit(11).toArray();",
 ]
 `;
 
-exports[`simple cursor based pagination (mysql) complex cursor based pagination using \`first\` and \`after\` (id asc) 1`] = `
+exports[`complex cursor based pagination (mysql) complex cursor based pagination using \`first\` and \`after\` (id asc) 1`] = `
 [
   "[query] select \`u0\`.* from \`user\` as \`u0\` where (\`u0\`.\`terms_accepted\` = true or \`u0\`.\`name\` = 'User 1' or \`u0\`.\`age\` <= 30) and \`u0\`.\`name\` != 'User 2' order by \`u0\`.\`name\` desc, \`u0\`.\`age\` asc, \`u0\`.\`email\` asc limit 11",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` where (\`u0\`.\`terms_accepted\` = true or \`u0\`.\`name\` = 'User 1' or \`u0\`.\`age\` <= 30) and \`u0\`.\`name\` != 'User 2'",
 ]
 `;
 
-exports[`simple cursor based pagination (mysql) complex cursor based pagination using \`first\` and \`after\` (id asc) 2`] = `
+exports[`complex cursor based pagination (mysql) complex cursor based pagination using \`first\` and \`after\` (id asc) 2`] = `
 [
   "[query] select \`u0\`.* from \`user\` as \`u0\` where (\`u0\`.\`terms_accepted\` = true or \`u0\`.\`name\` = 'User 1' or \`u0\`.\`age\` <= 30) and \`u0\`.\`name\` != 'User 2' and \`u0\`.\`name\` <= 'User 1' and (\`u0\`.\`name\` < 'User 1' or (\`u0\`.\`age\` >= 28 and (\`u0\`.\`age\` > 28 or \`u0\`.\`email\` > 'email-55'))) order by \`u0\`.\`name\` desc, \`u0\`.\`age\` asc, \`u0\`.\`email\` asc limit 11",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` where (\`u0\`.\`terms_accepted\` = true or \`u0\`.\`name\` = 'User 1' or \`u0\`.\`age\` <= 30) and \`u0\`.\`name\` != 'User 2'",
 ]
 `;
 
-exports[`simple cursor based pagination (mysql) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 1`] = `
+exports[`complex cursor based pagination (mysql) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 1`] = `
 [
   "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` left join \`user\` as \`u2\` on \`u0\`.\`best_friend__id\` = \`u2\`.\`_id\` where \`u2\`.\`name\` = 'User 3' order by \`u2\`.\`email\` desc, \`u2\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3'",
 ]
 `;
 
-exports[`simple cursor based pagination (mysql) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
+exports[`complex cursor based pagination (mysql) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
 [
   "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` left join \`user\` as \`u2\` on \`u0\`.\`best_friend__id\` = \`u2\`.\`_id\` where \`u2\`.\`name\` = 'User 3' and \`u2\`.\`email\` <= 'email-96' and \`u2\`.\`name\` <= 'User 3' and ((\`u2\`.\`email\` < 'email-96' and \`u2\`.\`name\` < 'User 3') or (\`u0\`.\`name\` >= 'User 3' and (\`u0\`.\`name\` > 'User 3' or (\`u0\`.\`age\` <= 38 and (\`u0\`.\`age\` < 38 or \`u0\`.\`email\` < 'email-76'))))) order by \`u2\`.\`email\` desc, \`u2\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3'",
 ]
 `;
 
-exports[`simple cursor based pagination (postgresql) complex cursor based pagination using \`first\` and \`after\` (id asc) 1`] = `
+exports[`complex cursor based pagination (postgresql) complex cursor based pagination using \`first\` and \`after\` (id asc) 1`] = `
 [
   "[query] select "u0".* from "user" as "u0" where ("u0"."terms_accepted" = true or "u0"."name" = 'User 1' or "u0"."age" <= 30) and "u0"."name" != 'User 2' order by "u0"."name" desc, "u0"."age" asc, "u0"."email" asc limit 11",
   "[query] select count(*) as "count" from "user" as "u0" where ("u0"."terms_accepted" = true or "u0"."name" = 'User 1' or "u0"."age" <= 30) and "u0"."name" != 'User 2'",
 ]
 `;
 
-exports[`simple cursor based pagination (postgresql) complex cursor based pagination using \`first\` and \`after\` (id asc) 2`] = `
+exports[`complex cursor based pagination (postgresql) complex cursor based pagination using \`first\` and \`after\` (id asc) 2`] = `
 [
   "[query] select "u0".* from "user" as "u0" where ("u0"."terms_accepted" = true or "u0"."name" = 'User 1' or "u0"."age" <= 30) and "u0"."name" != 'User 2' and "u0"."name" <= 'User 1' and ("u0"."name" < 'User 1' or ("u0"."age" >= 28 and ("u0"."age" > 28 or "u0"."email" > 'email-55'))) order by "u0"."name" desc, "u0"."age" asc, "u0"."email" asc limit 11",
   "[query] select count(*) as "count" from "user" as "u0" where ("u0"."terms_accepted" = true or "u0"."name" = 'User 1' or "u0"."age" <= 30) and "u0"."name" != 'User 2'",
 ]
 `;
 
-exports[`simple cursor based pagination (postgresql) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 1`] = `
+exports[`complex cursor based pagination (postgresql) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 1`] = `
 [
   "[query] select "u0".*, "b1"."_id" as "b1___id", "b1"."name" as "b1__name", "b1"."email" as "b1__email", "b1"."age" as "b1__age", "b1"."terms_accepted" as "b1__terms_accepted", "b1"."best_friend__id" as "b1__best_friend__id" from "user" as "u0" left join "user" as "b1" on "u0"."best_friend__id" = "b1"."_id" left join "user" as "u2" on "u0"."best_friend__id" = "u2"."_id" where "u2"."name" = 'User 3' order by "u2"."email" desc, "u2"."name" desc, "u0"."name" asc, "u0"."age" desc, "u0"."email" desc limit 6",
   "[query] select count(*) as "count" from "user" as "u0" left join "user" as "u1" on "u0"."best_friend__id" = "u1"."_id" where "u1"."name" = 'User 3'",
 ]
 `;
 
-exports[`simple cursor based pagination (postgresql) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
+exports[`complex cursor based pagination (postgresql) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
 [
   "[query] select "u0".*, "b1"."_id" as "b1___id", "b1"."name" as "b1__name", "b1"."email" as "b1__email", "b1"."age" as "b1__age", "b1"."terms_accepted" as "b1__terms_accepted", "b1"."best_friend__id" as "b1__best_friend__id" from "user" as "u0" left join "user" as "b1" on "u0"."best_friend__id" = "b1"."_id" left join "user" as "u2" on "u0"."best_friend__id" = "u2"."_id" where "u2"."name" = 'User 3' and "u2"."email" <= 'email-96' and "u2"."name" <= 'User 3' and (("u2"."email" < 'email-96' and "u2"."name" < 'User 3') or ("u0"."name" >= 'User 3' and ("u0"."name" > 'User 3' or ("u0"."age" <= 38 and ("u0"."age" < 38 or "u0"."email" < 'email-76'))))) order by "u2"."email" desc, "u2"."name" desc, "u0"."name" asc, "u0"."age" desc, "u0"."email" desc limit 6",
   "[query] select count(*) as "count" from "user" as "u0" left join "user" as "u1" on "u0"."best_friend__id" = "u1"."_id" where "u1"."name" = 'User 3'",
 ]
 `;
 
-exports[`simple cursor based pagination (sqlite) complex cursor based pagination using \`first\` and \`after\` (id asc) 1`] = `
+exports[`complex cursor based pagination (sqlite) complex cursor based pagination using \`first\` and \`after\` (id asc) 1`] = `
 [
   "[query] select \`u0\`.* from \`user\` as \`u0\` where (\`u0\`.\`terms_accepted\` = true or \`u0\`.\`name\` = 'User 1' or \`u0\`.\`age\` <= 30) and \`u0\`.\`name\` != 'User 2' order by \`u0\`.\`name\` desc, \`u0\`.\`age\` asc, \`u0\`.\`email\` asc limit 11",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` where (\`u0\`.\`terms_accepted\` = true or \`u0\`.\`name\` = 'User 1' or \`u0\`.\`age\` <= 30) and \`u0\`.\`name\` != 'User 2'",
 ]
 `;
 
-exports[`simple cursor based pagination (sqlite) complex cursor based pagination using \`first\` and \`after\` (id asc) 2`] = `
+exports[`complex cursor based pagination (sqlite) complex cursor based pagination using \`first\` and \`after\` (id asc) 2`] = `
 [
   "[query] select \`u0\`.* from \`user\` as \`u0\` where (\`u0\`.\`terms_accepted\` = true or \`u0\`.\`name\` = 'User 1' or \`u0\`.\`age\` <= 30) and \`u0\`.\`name\` != 'User 2' and \`u0\`.\`name\` <= 'User 1' and (\`u0\`.\`name\` < 'User 1' or (\`u0\`.\`age\` >= 28 and (\`u0\`.\`age\` > 28 or \`u0\`.\`email\` > 'email-55'))) order by \`u0\`.\`name\` desc, \`u0\`.\`age\` asc, \`u0\`.\`email\` asc limit 11",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` where (\`u0\`.\`terms_accepted\` = true or \`u0\`.\`name\` = 'User 1' or \`u0\`.\`age\` <= 30) and \`u0\`.\`name\` != 'User 2'",
 ]
 `;
 
-exports[`simple cursor based pagination (sqlite) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 1`] = `
+exports[`complex cursor based pagination (sqlite) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 1`] = `
 [
   "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` left join \`user\` as \`u2\` on \`u0\`.\`best_friend__id\` = \`u2\`.\`_id\` where \`u2\`.\`name\` = 'User 3' order by \`u2\`.\`email\` desc, \`u2\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3'",
 ]
 `;
 
-exports[`simple cursor based pagination (sqlite) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
+exports[`complex cursor based pagination (sqlite) complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
 [
   "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` left join \`user\` as \`u2\` on \`u0\`.\`best_friend__id\` = \`u2\`.\`_id\` where \`u2\`.\`name\` = 'User 3' and \`u2\`.\`email\` <= 'email-96' and \`u2\`.\`name\` <= 'User 3' and ((\`u2\`.\`email\` < 'email-96' and \`u2\`.\`name\` < 'User 3') or (\`u0\`.\`name\` >= 'User 3' and (\`u0\`.\`name\` > 'User 3' or (\`u0\`.\`age\` <= 38 and (\`u0\`.\`age\` < 38 or \`u0\`.\`email\` < 'email-76'))))) order by \`u2\`.\`email\` desc, \`u2\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`u1\` on \`u0\`.\`best_friend__id\` = \`u1\`.\`_id\` where \`u1\`.\`name\` = 'User 3'",

--- a/tests/features/cursor-based-pagination/bidirectional-cursor.test.ts
+++ b/tests/features/cursor-based-pagination/bidirectional-cursor.test.ts
@@ -1,0 +1,513 @@
+import { Cursor, Entity, MikroORM, Options, PrimaryKey, Property, SimpleLogger } from '@mikro-orm/core';
+import { mockLogger } from '../../helpers';
+import { PLATFORMS } from '../../bootstrap';
+
+@Entity()
+class User {
+
+  @PrimaryKey({ name: '_id' })
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property()
+  email!: string;
+
+  @Property()
+  age!: number;
+
+  @Property()
+  termsAccepted!: boolean;
+
+}
+
+describe.each(['sqlite', 'better-sqlite', 'mysql', 'postgresql', 'mongo'] as const)('bidrectional cursor based pagination (%s)', type => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    const options: Options = {};
+
+    if (type === 'mysql') {
+      options.port = 3308;
+    }
+
+    orm = await MikroORM.init({
+      entities: [User],
+      dbName: type.includes('sqlite') ? ':memory:' : 'mikro_orm_cursor_bidirectional',
+      driver: PLATFORMS[type],
+      loggerFactory: options => new SimpleLogger(options),
+      ...options,
+    });
+    await orm.schema.refreshDatabase();
+
+    for (let i = 0; i < 9; i++) {
+      orm.em.create(User, {
+        id: i + 1,
+        name: `User ${i + 1}`,
+        email: `email-${100 - i}`,
+        termsAccepted: i % 5 === 0,
+        age: Math.round((100 - i) / 2),
+      });
+    }
+
+    await orm.em.flush();
+    orm.em.clear();
+  });
+
+  afterAll(() => orm.close(true));
+
+  test('using `first` and `after` then backward using `last` and `before` (id asc)', async () => {
+    const mock = mockLogger(orm, ['query', 'query-params']);
+
+    // 1. page (first / forward)
+    const cursor1 = await orm.em.findByCursor(User, {}, {
+      first: 3,
+      orderBy: { id: 'asc' },
+    });
+    expect(cursor1).toBeInstanceOf(Cursor);
+    expect(cursor1.items).toMatchObject([
+      { id: 1, name: 'User 1' },
+      { id: 2, name: 'User 2' },
+      { id: 3, name: 'User 3' },
+    ]);
+    expect(cursor1.totalCount).toBe(9);
+    expect(cursor1.startCursor).toBe('WzFd');
+    expect(cursor1.endCursor).toBe('WzNd');
+    expect(cursor1.hasNextPage).toBe(true);
+    expect(cursor1.hasPrevPage).toBe(false);
+    let queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+
+    // 2. page (mid / forward)
+    const cursor2 = await orm.em.findByCursor(User, {}, {
+      first: 3,
+      after: cursor1,
+      orderBy: { id: 'asc' },
+    });
+    expect(cursor2).toBeInstanceOf(Cursor);
+    expect(cursor2.items).toMatchObject([
+      { id: 4, name: 'User 4' },
+      { id: 5, name: 'User 5' },
+      { id: 6, name: 'User 6' },
+    ]);
+    expect(cursor2.totalCount).toBe(9);
+    expect(cursor2.startCursor).toBe('WzRd');
+    expect(cursor2.endCursor).toBe('WzZd');
+    expect(cursor2.hasNextPage).toBe(true);
+    expect(cursor2.hasPrevPage).toBe(true);
+    queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+
+    // 3. page (last / forward)
+    const cursor3 = await orm.em.findByCursor(User, {}, {
+      first: 3,
+      after: cursor2,
+      orderBy: { id: 'asc' },
+    });
+    expect(cursor3).toBeInstanceOf(Cursor);
+    expect(cursor3.items).toMatchObject([
+      { id: 7, name: 'User 7' },
+      { id: 8, name: 'User 8' },
+      { id: 9, name: 'User 9' },
+    ]);
+    expect(cursor3.totalCount).toBe(9);
+    expect(cursor3.startCursor).toBe('Wzdd');
+    expect(cursor3.endCursor).toBe('Wzld');
+    expect(cursor3.hasNextPage).toBe(false);
+    expect(cursor3.hasPrevPage).toBe(true);
+    queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+
+    // 4. page (mid / backward)
+    const cursor4 = await orm.em.findByCursor(User, {}, {
+      last: 3,
+      before: cursor3,
+      orderBy: { id: 'asc' },
+    });
+    expect(cursor4).toBeInstanceOf(Cursor);
+    expect(cursor4.items).toMatchObject([
+      { id: 4, name: 'User 4' },
+      { id: 5, name: 'User 5' },
+      { id: 6, name: 'User 6' },
+    ]);
+    expect(cursor4.totalCount).toBe(9);
+    expect(cursor4.startCursor).toBe('WzRd');
+    expect(cursor4.endCursor).toBe('WzZd');
+    expect(cursor4.hasNextPage).toBe(true);
+    expect(cursor4.hasPrevPage).toBe(true);
+    queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+
+    // 5. page (first / backward)
+    const cursor5 = await orm.em.findByCursor(User, {}, {
+      last: 3,
+      before: cursor4,
+      orderBy: { id: 'asc' },
+    });
+    expect(cursor5).toBeInstanceOf(Cursor);
+    expect(cursor5.items).toMatchObject([
+      { id: 1, name: 'User 1' },
+      { id: 2, name: 'User 2' },
+      { id: 3, name: 'User 3' },
+    ]);
+    expect(cursor5.totalCount).toBe(9);
+    expect(cursor5.startCursor).toBe('WzFd');
+    expect(cursor5.endCursor).toBe('WzNd');
+    expect(cursor5.hasNextPage).toBe(true);
+    expect(cursor5.hasPrevPage).toBe(false);
+    queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+  });
+
+  test('using `last` and `before` then forward using `first` and `after` (id asc)', async () => {
+    const mock = mockLogger(orm, ['query', 'query-params']);
+
+    // 1. page (last / backward)
+    const cursor1 = await orm.em.findByCursor(User, {}, {
+      last: 3,
+      orderBy: { id: 'asc' },
+    });
+    expect(cursor1).toBeInstanceOf(Cursor);
+    expect(cursor1.items).toMatchObject([
+      { id: 7, name: 'User 7' },
+      { id: 8, name: 'User 8' },
+      { id: 9, name: 'User 9' },
+    ]);
+    expect(cursor1.totalCount).toBe(9);
+    expect(cursor1.startCursor).toBe('Wzdd');
+    expect(cursor1.endCursor).toBe('Wzld');
+    expect(cursor1.hasNextPage).toBe(false);
+    expect(cursor1.hasPrevPage).toBe(true);
+    let queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+
+    // 2. page (mid / backward)
+    const cursor2 = await orm.em.findByCursor(User, {}, {
+      last: 3,
+      before: cursor1,
+      orderBy: { id: 'asc' },
+    });
+    expect(cursor2).toBeInstanceOf(Cursor);
+    expect(cursor2.items).toMatchObject([
+      { id: 4, name: 'User 4' },
+      { id: 5, name: 'User 5' },
+      { id: 6, name: 'User 6' },
+    ]);
+    expect(cursor2.totalCount).toBe(9);
+    expect(cursor2.startCursor).toBe('WzRd');
+    expect(cursor2.endCursor).toBe('WzZd');
+    expect(cursor2.hasNextPage).toBe(true);
+    expect(cursor2.hasPrevPage).toBe(true);
+    queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+
+    // 3. page (first / backward)
+    const cursor3 = await orm.em.findByCursor(User, {}, {
+      last: 3,
+      before: cursor2,
+      orderBy: { id: 'asc' },
+    });
+    expect(cursor3).toBeInstanceOf(Cursor);
+    expect(cursor3.items).toMatchObject([
+      { id: 1, name: 'User 1' },
+      { id: 2, name: 'User 2' },
+      { id: 3, name: 'User 3' },
+    ]);
+    expect(cursor3.totalCount).toBe(9);
+    expect(cursor3.startCursor).toBe('WzFd');
+    expect(cursor3.endCursor).toBe('WzNd');
+    expect(cursor3.hasNextPage).toBe(true);
+    expect(cursor3.hasPrevPage).toBe(false);
+    queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+
+    // 4. page (mid / forward)
+    const cursor4 = await orm.em.findByCursor(User, {}, {
+      first: 3,
+      after: cursor3,
+      orderBy: { id: 'asc' },
+    });
+    expect(cursor4).toBeInstanceOf(Cursor);
+    expect(cursor4.items).toMatchObject([
+      { id: 4, name: 'User 4' },
+      { id: 5, name: 'User 5' },
+      { id: 6, name: 'User 6' },
+    ]);
+    expect(cursor4.totalCount).toBe(9);
+    expect(cursor4.startCursor).toBe('WzRd');
+    expect(cursor4.endCursor).toBe('WzZd');
+    expect(cursor4.hasNextPage).toBe(true);
+    expect(cursor4.hasPrevPage).toBe(true);
+    queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+
+    // 5. page (last / forward)
+    const cursor5 = await orm.em.findByCursor(User, {}, {
+      first: 3,
+      after: cursor4,
+      orderBy: { id: 'asc' },
+    });
+    expect(cursor5).toBeInstanceOf(Cursor);
+    expect(cursor5.items).toMatchObject([
+      { id: 7, name: 'User 7' },
+      { id: 8, name: 'User 8' },
+      { id: 9, name: 'User 9' },
+    ]);
+    expect(cursor5.totalCount).toBe(9);
+    expect(cursor5.startCursor).toBe('Wzdd');
+    expect(cursor5.endCursor).toBe('Wzld');
+    expect(cursor5.hasNextPage).toBe(false);
+    expect(cursor5.hasPrevPage).toBe(true);
+    queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+  });
+
+  test('using `first` and `after` then backward using `last` and `before` (id desc)', async () => {
+    const mock = mockLogger(orm, ['query', 'query-params']);
+
+    // 1. page (first / forward)
+    const cursor1 = await orm.em.findByCursor(User, {}, {
+      first: 3,
+      orderBy: { id: 'desc' },
+    });
+    expect(cursor1).toBeInstanceOf(Cursor);
+    expect(cursor1.items).toMatchObject([
+      { id: 9, name: 'User 9' },
+      { id: 8, name: 'User 8' },
+      { id: 7, name: 'User 7' },
+    ]);
+    expect(cursor1.totalCount).toBe(9);
+    expect(cursor1.startCursor).toBe('Wzld');
+    expect(cursor1.endCursor).toBe('Wzdd');
+    expect(cursor1.hasNextPage).toBe(true);
+    expect(cursor1.hasPrevPage).toBe(false);
+    let queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+
+    // 2. page (mid / forward)
+    const cursor2 = await orm.em.findByCursor(User, {}, {
+      first: 3,
+      after: cursor1,
+      orderBy: { id: 'desc' },
+    });
+    expect(cursor2).toBeInstanceOf(Cursor);
+    expect(cursor2.items).toMatchObject([
+      { id: 6, name: 'User 6' },
+      { id: 5, name: 'User 5' },
+      { id: 4, name: 'User 4' },
+    ]);
+    expect(cursor2.totalCount).toBe(9);
+    expect(cursor2.startCursor).toBe('WzZd');
+    expect(cursor2.endCursor).toBe('WzRd');
+    expect(cursor2.hasNextPage).toBe(true);
+    expect(cursor2.hasPrevPage).toBe(true);
+    queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+
+    // 3. page (last / forward)
+    const cursor3 = await orm.em.findByCursor(User, {}, {
+      first: 3,
+      after: cursor2,
+      orderBy: { id: 'desc' },
+    });
+    expect(cursor3).toBeInstanceOf(Cursor);
+    expect(cursor3.items).toMatchObject([
+      { id: 3, name: 'User 3' },
+      { id: 2, name: 'User 2' },
+      { id: 1, name: 'User 1' },
+    ]);
+    expect(cursor3.totalCount).toBe(9);
+    expect(cursor3.startCursor).toBe('WzNd');
+    expect(cursor3.endCursor).toBe('WzFd');
+    expect(cursor3.hasNextPage).toBe(false);
+    expect(cursor3.hasPrevPage).toBe(true);
+    queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+
+    // 4. page (mid / backward)
+    const cursor4 = await orm.em.findByCursor(User, {}, {
+      last: 3,
+      before: cursor3,
+      orderBy: { id: 'desc' },
+    });
+    expect(cursor4).toBeInstanceOf(Cursor);
+    expect(cursor4.items).toMatchObject([
+      { id: 6, name: 'User 6' },
+      { id: 5, name: 'User 5' },
+      { id: 4, name: 'User 4' },
+    ]);
+    expect(cursor4.totalCount).toBe(9);
+    expect(cursor4.startCursor).toBe('WzZd');
+    expect(cursor4.endCursor).toBe('WzRd');
+    expect(cursor4.hasNextPage).toBe(true);
+    expect(cursor4.hasPrevPage).toBe(true);
+    queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+
+    // 5. page (first / backward)
+    const cursor5 = await orm.em.findByCursor(User, {}, {
+      last: 3,
+      before: cursor4,
+      orderBy: { id: 'desc' },
+    });
+    expect(cursor5).toBeInstanceOf(Cursor);
+    expect(cursor5.items).toMatchObject([
+      { id: 9, name: 'User 9' },
+      { id: 8, name: 'User 8' },
+      { id: 7, name: 'User 7' },
+    ]);
+    expect(cursor5.totalCount).toBe(9);
+    expect(cursor5.startCursor).toBe('Wzld');
+    expect(cursor5.endCursor).toBe('Wzdd');
+    expect(cursor5.hasNextPage).toBe(true);
+    expect(cursor5.hasPrevPage).toBe(false);
+    queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+  });
+
+  test('using `last` and `before` then forward using `first` and `after` (id desc)', async () => {
+    const mock = mockLogger(orm, ['query', 'query-params']);
+
+    // 1. page (last / backward)
+    const cursor1 = await orm.em.findByCursor(User, {}, {
+      last: 3,
+      orderBy: { id: 'desc' },
+    });
+    expect(cursor1).toBeInstanceOf(Cursor);
+    expect(cursor1.items).toMatchObject([
+      { id: 3, name: 'User 3' },
+      { id: 2, name: 'User 2' },
+      { id: 1, name: 'User 1' },
+    ]);
+    expect(cursor1.totalCount).toBe(9);
+    expect(cursor1.startCursor).toBe('WzNd');
+    expect(cursor1.endCursor).toBe('WzFd');
+    expect(cursor1.hasNextPage).toBe(false);
+    expect(cursor1.hasPrevPage).toBe(true);
+    let queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+
+    // 2. page (mid / backward)
+    const cursor2 = await orm.em.findByCursor(User, {}, {
+      last: 3,
+      before: cursor1,
+      orderBy: { id: 'desc' },
+    });
+    expect(cursor2).toBeInstanceOf(Cursor);
+    expect(cursor2.items).toMatchObject([
+      { id: 6, name: 'User 6' },
+      { id: 5, name: 'User 5' },
+      { id: 4, name: 'User 4' },
+    ]);
+    expect(cursor2.totalCount).toBe(9);
+    expect(cursor2.startCursor).toBe('WzZd');
+    expect(cursor2.endCursor).toBe('WzRd');
+    expect(cursor2.hasNextPage).toBe(true);
+    expect(cursor2.hasPrevPage).toBe(true);
+    queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+
+    // 3. page (first / backward)
+    const cursor3 = await orm.em.findByCursor(User, {}, {
+      last: 3,
+      before: cursor2,
+      orderBy: { id: 'desc' },
+    });
+    expect(cursor3).toBeInstanceOf(Cursor);
+    expect(cursor3.items).toMatchObject([
+      { id: 9, name: 'User 9' },
+      { id: 8, name: 'User 8' },
+      { id: 7, name: 'User 7' },
+    ]);
+    expect(cursor3.totalCount).toBe(9);
+    expect(cursor3.startCursor).toBe('Wzld');
+    expect(cursor3.endCursor).toBe('Wzdd');
+    expect(cursor3.hasNextPage).toBe(true);
+    expect(cursor3.hasPrevPage).toBe(false);
+    queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+
+    // 4. page (mid / forward)
+    const cursor4 = await orm.em.findByCursor(User, {}, {
+      first: 3,
+      after: cursor3,
+      orderBy: { id: 'desc' },
+    });
+    expect(cursor4).toBeInstanceOf(Cursor);
+    expect(cursor4.length).toBe(3);
+    expect(cursor4.items).toMatchObject([
+      { id: 6, name: 'User 6' },
+      { id: 5, name: 'User 5' },
+      { id: 4, name: 'User 4' },
+    ]);
+    expect(cursor4.totalCount).toBe(9);
+    expect(cursor4.startCursor).toBe('WzZd');
+    expect(cursor4.endCursor).toBe('WzRd');
+    expect(cursor4.hasNextPage).toBe(true);
+    expect(cursor4.hasPrevPage).toBe(true);
+    queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+
+    // 5. page (last / forward)
+    const cursor5 = await orm.em.findByCursor(User, {}, {
+      first: 3,
+      after: cursor4,
+      orderBy: { id: 'desc' },
+    });
+    expect(cursor5).toBeInstanceOf(Cursor);
+    expect(cursor5.items).toMatchObject([
+      { id: 3, name: 'User 3' },
+      { id: 2, name: 'User 2' },
+      { id: 1, name: 'User 1' },
+    ]);
+    expect(cursor5.totalCount).toBe(9);
+    expect(cursor5.startCursor).toBe('WzNd');
+    expect(cursor5.endCursor).toBe('WzFd');
+    expect(cursor5.hasNextPage).toBe(false);
+    expect(cursor5.hasPrevPage).toBe(true);
+    queries = mock.mock.calls.map(call => call[0]).sort();
+    expect(queries).toMatchSnapshot();
+    orm.em.clear();
+    mock.mockReset();
+  });
+});

--- a/tests/features/cursor-based-pagination/complex-cursor.test.ts
+++ b/tests/features/cursor-based-pagination/complex-cursor.test.ts
@@ -38,7 +38,7 @@ export class User {
 
 }
 
-describe.each(['sqlite', 'better-sqlite', 'mysql', 'postgresql', 'mongo'] as const)('simple cursor based pagination (%s)', type => {
+describe.each(['sqlite', 'better-sqlite', 'mysql', 'postgresql', 'mongo'] as const)('complex cursor based pagination (%s)', type => {
 
   let orm: MikroORM;
 
@@ -194,8 +194,8 @@ describe.each(['sqlite', 'better-sqlite', 'mysql', 'postgresql', 'mongo'] as con
     expect(cursor2.totalCount).toBe(10);
     expect(cursor2.startCursor).toBe('W3siYmVzdEZyaWVuZCI6eyJlbWFpbCI6ImVtYWlsLTk2IiwibmFtZSI6IlVzZXIgMyJ9fSwiVXNlciAzIiwyNiwiZW1haWwtNTEiXQ');
     expect(cursor2.endCursor).toBe('W3siYmVzdEZyaWVuZCI6eyJlbWFpbCI6ImVtYWlsLTk2IiwibmFtZSI6IlVzZXIgMyJ9fSwiVXNlciAzIiwzNiwiZW1haWwtNzEiXQ');
-    expect(cursor2.hasNextPage).toBe(false);
-    expect(cursor2.hasPrevPage).toBe(true);
+    expect(cursor2.hasNextPage).toBe(true);
+    expect(cursor2.hasPrevPage).toBe(false);
     queries = mock.mock.calls.map(call => call[0]).sort();
     expect(queries).toMatchSnapshot();
 

--- a/tests/features/cursor-based-pagination/simple-cursor.test.ts
+++ b/tests/features/cursor-based-pagination/simple-cursor.test.ts
@@ -408,8 +408,8 @@ describe.each(['sqlite', 'better-sqlite', 'mysql', 'postgresql', 'mongo'] as con
     expect(cursor5.totalCount).toBe(50);
     expect(cursor5.startCursor).toBe('WzFd');
     expect(cursor5.endCursor).toBe('WzFd');
-    expect(cursor5.hasNextPage).toBe(false);
-    expect(cursor5.hasPrevPage).toBe(true);
+    expect(cursor5.hasNextPage).toBe(true);
+    expect(cursor5.hasPrevPage).toBe(false);
     queries = mock.mock.calls.map(call => call[0]).sort();
     expect(queries).toMatchSnapshot();
     orm.em.clear();
@@ -426,8 +426,8 @@ describe.each(['sqlite', 'better-sqlite', 'mysql', 'postgresql', 'mongo'] as con
     expect(cursor6.totalCount).toBe(50);
     expect(cursor6.startCursor).toBeNull();
     expect(cursor6.endCursor).toBeNull();
-    expect(cursor6.hasNextPage).toBe(false);
-    expect(cursor6.hasPrevPage).toBe(true);
+    expect(cursor6.hasNextPage).toBe(true);
+    expect(cursor6.hasPrevPage).toBe(false);
     queries = mock.mock.calls.map(call => call[0]).sort();
     expect(queries).toMatchSnapshot();
     orm.em.clear();
@@ -533,8 +533,8 @@ describe.each(['sqlite', 'better-sqlite', 'mysql', 'postgresql', 'mongo'] as con
     expect(cursor5.totalCount).toBe(50);
     expect(cursor5.startCursor).toBe('WzUwXQ');
     expect(cursor5.endCursor).toBe('WzUwXQ');
-    expect(cursor5.hasNextPage).toBe(false);
-    expect(cursor5.hasPrevPage).toBe(true);
+    expect(cursor5.hasNextPage).toBe(true);
+    expect(cursor5.hasPrevPage).toBe(false);
     queries = mock.mock.calls.map(call => call[0]).sort();
     expect(queries).toMatchSnapshot();
     orm.em.clear();
@@ -551,8 +551,8 @@ describe.each(['sqlite', 'better-sqlite', 'mysql', 'postgresql', 'mongo'] as con
     expect(cursor6.totalCount).toBe(50);
     expect(cursor6.startCursor).toBeNull();
     expect(cursor6.endCursor).toBeNull();
-    expect(cursor6.hasNextPage).toBe(false);
-    expect(cursor6.hasPrevPage).toBe(true);
+    expect(cursor6.hasNextPage).toBe(true);
+    expect(cursor6.hasPrevPage).toBe(false);
     queries = mock.mock.calls.map(call => call[0]).sort();
     expect(queries).toMatchSnapshot();
     orm.em.clear();


### PR DESCRIPTION
When using cursor pagination, the `hasPrevPage` and `hasNextPage` has inconsistency behavior that display the wrong value when query to the last page of last/before (which is the first page of the first/after).

### Changes

```ts
const { first, last, before, after, orderBy, overfetch } = options;
const limit = first || last;
const isLast = !first && !!last;
const hasMorePages = !!overfetch && limit != null && items.length > limit;
// this.hasPrevPage = before || after ? true : (isLast && hasMorePages);
// this.hasNextPage = !(isLast && !before && !after) && hasMorePages;
this.hasPrevPage = isLast ? hasMorePages : !!after; 
this.hasNextPage = isLast ? !!before : hasMorePages;
```
The old `hasPrevPage` is true if either `before` or `after` exists, which is wrong because having `before` doesn't mean it wouldn't have more page beyond the result, `hasMorePages` decides that if a backward pagination has a previous page. 

Similar to `hasNextPage`, it fails when `isLast` is true and `before` exists because it relies on hasMorePages, in a backward pagination `hasMorePages` can not determine if it has the next page which is the page beyond the `before`.

### Fixing the test cases

You can see the inconsistency in the test cases here, I have fixed to be aligned with the changes.

```ts 
// These ones are correct with the following hasPrevPage/hasNextPage order: 
// true/false => true/true => false/true

// 1. page
const cursor1 = await orm.em.findByCursor(User, {}, {
  first: 3,
  orderBy: { id: 'asc' },
});
expect(cursor1.hasNextPage).toBe(true);
expect(cursor1.hasPrevPage).toBe(false);

// 2. page
const cursor2 = await orm.em.findByCursor(User, {}, {
  first: 3,
  after: cursor1,
  orderBy: { id: 'asc' },
});
expect(cursor2.hasNextPage).toBe(true);
expect(cursor2.hasPrevPage).toBe(true);

....

// 5. page (last)
const cursor5 = await orm.em.findByCursor(User, {}, {
  first: 40,
  after: cursor4,
  orderBy: { id: 'asc' },
});
expect(cursor5.hasNextPage).toBe(false);
expect(cursor5.hasPrevPage).toBe(true);
```

This is where I made the changes
```ts
// These ones are incorrect with the following hasPrevPage/hasNextPage order: 
// false/true => true/true => false/true
// I changed the last one into true/false

// 1. page
const cursor1 = await orm.em.findByCursor(User, {}, {
  last: 3,
  orderBy: { id: 'asc' },
});
expect(cursor1.hasNextPage).toBe(false);
expect(cursor1.hasPrevPage).toBe(true);

// 2. page
const cursor2 = await orm.em.findByCursor(User, {}, {
  last: 3,
  before: cursor1,
  orderBy: { id: 'asc' },
});
expect(cursor2.hasNextPage).toBe(true);
expect(cursor2.hasPrevPage).toBe(true);

// 5. page (last)
const cursor5 = await orm.em.findByCursor(User, {}, {
  last: 40,
  before: cursor4,
  orderBy: { id: 'asc' },
});
// expect(cursor5.hasNextPage).toBe(false);
// expect(cursor5.hasPrevPage).toBe(true);
expect(cursor5.hasNextPage).toBe(true); // new change
expect(cursor5.hasPrevPage).toBe(false); // new change
```

### Additional tests

I added a new `bidirectional-cursor.test.ts`, in which it will test the cursor moving forwards using `first/after` from the first page to the last page and then backward using `last/before` from the last cursor to the first page, and vice versa.

Also, fixing the word simple to complex in the `complex-cursor.test.ts`
