### PR TITLE
feat(core): add onlyOwnProperties option to assign (#5327)

### DIFF
--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -71,6 +71,10 @@ export class EntityAssigner {
     let value = data[propName];
     const prop = { ...props[propName], name: propName } as EntityProperty<T>;
 
+    if (options.onlyOwnProperties && prop.entity && !Utils.isPrimaryKey(value)) {
+      return;
+    }
+
     if (propName in props && !prop.nullable && value == null) {
       throw new Error(`You must pass a non-${value} value to the property ${propName} of entity ${(entity as Dictionary).constructor.name}.`);
     }
@@ -294,6 +298,7 @@ export interface AssignOptions {
   updateNestedEntities?: boolean;
   updateByPrimaryKey?: boolean;
   onlyProperties?: boolean;
+  onlyOwnProperties?: boolean;
   convertCustomTypes?: boolean;
   mergeObjectProperties?: boolean;
   merge?: boolean;

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -391,7 +391,7 @@ export type AnyString = string & {};
 
 export interface EntityProperty<Owner = any, Target = any> {
   name: EntityKey<Owner>;
-  entity: () => EntityName<Owner>;
+  entity?: () => EntityName<Owner>;
   type: keyof typeof types | AnyString;
   runtimeType: 'number' | 'string' | 'boolean' | 'bigint' | 'Buffer' | 'Date';
   targetMeta?: EntityMetadata<Target>;


### PR DESCRIPTION
add onlyOwnProperties option, ignore entities but allow primary keys

Closes #5327