### PR TITLE
feat(core): add `onlyOwnProperties` option to `assign` helper

### DIFF
--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -71,10 +71,12 @@ export class EntityAssigner {
     let value = data[propName];
     const prop = { ...props[propName], name: propName } as EntityProperty<T>;
 
-    if (options.onlyOwnProperties) {
-      if ([ReferenceKind.MANY_TO_MANY, ReferenceKind.ONE_TO_MANY].includes(prop?.kind)) {
+    if (prop && options.onlyOwnProperties) {
+      if ([ReferenceKind.MANY_TO_MANY, ReferenceKind.ONE_TO_MANY].includes(prop.kind)) {
         return;
-      } else if ([ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop?.kind)) {
+      }
+
+      if ([ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind)) {
         value = Utils.extractPK(value, prop.targetMeta);
       }
     }

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -71,8 +71,12 @@ export class EntityAssigner {
     let value = data[propName];
     const prop = { ...props[propName], name: propName } as EntityProperty<T>;
 
-    if (options.onlyOwnProperties && (prop as any).entity && !Utils.isPrimaryKey(value)) {
-      return;
+    if (options.onlyOwnProperties) {
+      if ([ReferenceKind.MANY_TO_MANY, ReferenceKind.ONE_TO_MANY].includes(prop?.kind)) {
+        return;
+      } else if ([ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop?.kind)) {
+        value = Utils.extractPK(value, prop.targetMeta);
+      }
     }
 
     if (propName in props && !prop.nullable && value == null) {

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -71,6 +71,10 @@ export class EntityAssigner {
     let value = data[propName];
     const prop = { ...props[propName], name: propName } as EntityProperty<T>;
 
+    if (options.onlyOwnProperties && (prop as any).entity && !Utils.isPrimaryKey(value)) {
+      return;
+    }
+
     if (propName in props && !prop.nullable && value == null) {
       throw new Error(`You must pass a non-${value} value to the property ${propName} of entity ${(entity as Dictionary).constructor.name}.`);
     }
@@ -294,6 +298,7 @@ export interface AssignOptions {
   updateNestedEntities?: boolean;
   updateByPrimaryKey?: boolean;
   onlyProperties?: boolean;
+  onlyOwnProperties?: boolean;
   convertCustomTypes?: boolean;
   mergeObjectProperties?: boolean;
   merge?: boolean;


### PR DESCRIPTION
add option, ignore entities but allow primary keys

Closes #5327