### PR TITLE
fix(core): detect `ts-node` when using esm loader

### DIFF
--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -764,6 +764,7 @@ export class Utils {
       || !!process.env.TS_JEST // check if ts-jest is used (works only with v27.0.4+)
       || !!process.env.VITEST // check if vitest is used
       || process.argv.slice(1).some(arg => arg.includes('ts-node')) // registering ts-node runner
+      || process.execArgv.some(arg => arg === 'ts-node/esm') // check for ts-node/esm module loader
       || (require.extensions && !!require.extensions['.ts']); // check if the extension is registered
   }
 


### PR DESCRIPTION
### The problem
When using mikroorm in typescript ESM project and using cli, `.ts` config and `entitiesTs` are not taken into account. This is because ts-node is not detected for node > 16.20 when using `ts-node/esm` loader as node option https://github.com/TypeStrong/ts-node?tab=readme-ov-file#node-flags-and-other-tools (directly or using `mikro-orm-esm` binary).

If we have the orm script in `package.json` and defined `configPaths`:

```package.json
  "scripts": {
    "orm-node-loader": "cross-env \"NODE_OPTIONS='--loader ts-node/esm --no-warnings'\" mikro-orm",
    "orm-esm-binary": "mikro-orm-esm"
  },
  "mikro-orm": {
    "configPaths": [
      "./src/db/orm.config.ts",
      "./src/db/orm.config.js"
    ]
  },
```
And run `npm run orm-esm-binary debug` or `npm run orm-node-loader debug` in development, you will see the message

```
 - searched config paths:
   - /home/ruby/workspace/server/src/db/orm.config.js (not found)
   - /home/ruby/workspace/server/dist/mikro-orm.config.js (not found)
   - /home/ruby/workspace/server/mikro-orm.config.js (not found)
- configuration not found (MikroORM config file not found in ['./src/db/orm.config.js', './dist/mikro-orm.config.js', './mikro-orm.config.js'])
```
For node 16 this works as ts-node is detected because it will install internal ts-node symbol in process.

### Description of the solution
Adding the check for `ts-node/esm` in `process.execArgv` (args passed to nodejs runtime: https://nodejs.org/api/process.html#processexecargv) in this case `--loader` option is passed as nodejs option, will correctly detect ts-node and ts config is used when using cli.

### Alternative solutions

- Forcing to register ts-node using env - this works but is redundant bacause we already use loader

```
cross-env "NODE_OPTIONS='--loader ts-node/esm --no-warnings'" MIKRO_ORM_CLI_USE_TS_NODE=true mikro-orm
cross-env MIKRO_ORM_CLI_USE_TS_NODE=true mikro-orm-esm
```

- Add useTsNode to options in package.json - not ideal bacause it will require ts-node also in production
