### PR TITLE
fix(entity-generator): allow arbitrary class and prop names as identifiers

### DIFF
--- a/packages/knex/src/dialects/mysql/MySqlSchemaHelper.ts
+++ b/packages/knex/src/dialects/mysql/MySqlSchemaHelper.ts
@@ -78,7 +78,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
         constraint: !index.non_unique,
       };
 
-      if (!index.column_name || index.column_name.match(/[(): ,"'`]/) || index.expression?.match(/ where /i)) {
+      if (!index.column_name || index.expression?.match(/ where /i)) {
         indexDef.expression = index.expression; // required for the `getCreateIndexSQL()` call
         indexDef.expression = this.getCreateIndexSQL(index.table_name, indexDef, !!index.expression);
       }
@@ -125,7 +125,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
         col.length,
       ));
       const key = this.getTableKey(col);
-      const generated = col.generation_expression ? `${col.generation_expression} ${col.extra.match(/stored generated/i) ? 'stored' : 'virtual'}` : undefined;
+      const generated = col.generation_expression ? `(${col.generation_expression.replaceAll(`\\'`, `'`)}) ${col.extra.match(/stored generated/i) ? 'stored' : 'virtual'}` : undefined;
       ret[key] ??= [];
       ret[key].push({
         name: col.column_name,

--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -225,8 +225,7 @@ export class DatabaseTable {
       skippedColumnNames,
     } = this.foreignKeysToProps(namingStrategy, scalarPropertiesForRelations);
 
-    let name = namingStrategy.getEntityName(this.name, this.schema);
-    name = name.match(/^\d/) ? 'E' + name : name;
+    const name = namingStrategy.getEntityName(this.name, this.schema);
     const schema = new EntitySchema({ name, collection: this.name, schema: this.schema });
 
     const compositeFkIndexes: Dictionary<{ keyName: string }> = {};

--- a/packages/knex/src/schema/SchemaComparator.ts
+++ b/packages/knex/src/schema/SchemaComparator.ts
@@ -603,7 +603,7 @@ export class SchemaComparator {
   diffExpression(expr1: string, expr2: string): boolean {
     // expressions like check constraints might be normalized by the driver,
     // e.g. quotes might be added (https://github.com/mikro-orm/mikro-orm/issues/3827)
-    const simplify = (str?: string) => str?.replace(/_\w+\\'(.*?)\\'/g, '$1').replace(/['"`()]|::\w+| +/g, '').toLowerCase();
+    const simplify = (str?: string) => str?.replace(/_\w+'(.*?)'/g, '$1').replace(/['"`()]|::\w+| +/g, '').toLowerCase();
     return simplify(expr1) !== simplify(expr2);
   }
 

--- a/packages/mariadb/src/MariaDbSchemaHelper.ts
+++ b/packages/mariadb/src/MariaDbSchemaHelper.ts
@@ -90,7 +90,7 @@ export class MariaDbSchemaHelper extends MySqlSchemaHelper {
       );
       const defaultValue = str(tmp === 'NULL' && col.is_nullable === 'YES' ? null : tmp);
       const key = this.getTableKey(col);
-      const generated = col.generation_expression ? `${col.generation_expression} ${col.extra.match(/stored generated/i) ? 'stored' : 'virtual'}` : undefined;
+      const generated = col.generation_expression ? `${col.generation_expression.replaceAll(`\\'`, `'`)} ${col.extra.match(/stored generated/i) ? 'stored' : 'virtual'}` : undefined;
       ret[key] ??= [];
       ret[key].push({
         name: col.column_name,

--- a/tests/features/entity-generator/OddTableNames.mysql.test.ts
+++ b/tests/features/entity-generator/OddTableNames.mysql.test.ts
@@ -1,0 +1,127 @@
+import { MikroORM } from '@mikro-orm/mysql';
+import { EntityGenerator } from '@mikro-orm/entity-generator';
+import { pathExists, remove } from 'fs-extra';
+
+let orm: MikroORM;
+
+const schemaName = 'odd_table_names_example:100%';
+const schema = `CREATE SCHEMA IF NOT EXISTS \`odd identifier's_example's_second\` DEFAULT CHARACTER SET utf8mb4 ;
+CREATE SCHEMA IF NOT EXISTS \`odd_table_names_example:100%\` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci ;
+
+CREATE TABLE IF NOT EXISTS \`odd_table_names_example:100%\`.\`50% of stuff\` (
+  \`+-20%\` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  \`my@odd.column\` VARCHAR(45) NOT NULL,
+  \`column with apostrophe in it's name\` VARCHAR(45) NOT NULL,
+  \`column with backtick in it\`\`s name\` VARCHAR(45) NOT NULL,
+  UNIQUE INDEX \`odd columns' unique index\` (\`column with apostrophe in it's name\` ASC, \`column with backtick in it\`\`s name\` ASC) VISIBLE,
+  PRIMARY KEY (\`+-20%\`))
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = utf8mb4
+COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS \`odd_table_names_example:100%\`.\`*misc\` (
+  \`@ref\` INT UNSIGNED NOT NULL,
+  PRIMARY KEY (\`@ref\`),
+  CONSTRAINT \`fk_*misc_50% of stuff\`
+    FOREIGN KEY (\`@ref\`)
+    REFERENCES \`odd_table_names_example:100%\`.\`50% of stuff\` (\`+-20%\`))
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = utf8mb4
+COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS \`odd identifier's_example's_second\`.\`table's name has apostrophe, also \`\` this\` (
+  \`!cool\` INT UNSIGNED NOT NULL,
+  \`'derive\` VARCHAR(45) NULL,
+  \`__proto__\` VARCHAR(45) NULL,
+  PRIMARY KEY (\`!cool\`),
+  UNIQUE INDEX \`__proto___UNIQUE\` (\`__proto__\` ASC) VISIBLE,
+  CONSTRAINT \`fk_table's name has apostrophe, also \`\` this_*misc\`
+    FOREIGN KEY (\`!cool\`)
+    REFERENCES \`odd_table_names_example:100%\`.\`*misc\` (\`@ref\`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS \`odd_table_names_example:100%\`.\`this+that\` (
+  \`80% of stuff\` INT UNSIGNED NOT NULL,
+  PRIMARY KEY (\`80% of stuff\`),
+  CONSTRAINT \`fk_this+that_*misc1\`
+    FOREIGN KEY (\`80% of stuff\`)
+    REFERENCES \`odd_table_names_example:100%\`.\`*misc\` (\`@ref\`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = utf8mb4
+COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS \`odd_table_names_example:100%\`.\`ns___subns__the_name\` (
+  \`id\` INT UNSIGNED NOT NULL,
+  \`r_n_b\` VARCHAR(45) NOT NULL,
+  \`*\` VARCHAR(45) NOT NULL,
+  \`$*\` VARCHAR(35) NOT NULL,
+  PRIMARY KEY (\`id\`)
+)
+ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS \`odd_table_names_example:100%\`.\`123_table_name\` (
+  \`$\` INT NOT NULL,
+  \`$$\` BIGINT NOT NULL,
+  \`prototype\` VARCHAR(45) NOT NULL,
+  \`oh_captain__my___captain\` VARCHAR(255) NOT NULL DEFAULT 'test',
+  \`infer\` VARCHAR(255) NOT NULL,
+  \`$infer\` VARCHAR(200) NOT NULL,
+  \`$$infer\` VARCHAR(100) NOT NULL,
+  PRIMARY KEY (\`$\`),
+  INDEX \`fk_123_table_name_table's name has apostrophe, also\`\` this_idx\` (\`prototype\` ASC) VISIBLE,
+  INDEX \`dollar's index\` (\`$$\` ASC, \`$infer\` ASC) VISIBLE,
+  CONSTRAINT \`fk_123_table_name_table's name has apostrophe, also \`\` this1\`
+    FOREIGN KEY (\`prototype\`)
+    REFERENCES \`odd identifier's_example's_second\`.\`table's name has apostrophe, also \`\` this\` (\`__proto__\`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+ENGINE = InnoDB;
+`;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: schemaName,
+    port: 3308,
+    discovery: { warnWhenNoEntities: false },
+    extensions: [EntityGenerator],
+    multipleStatements: true,
+    ensureDatabase: false,
+  });
+
+  if (await orm.schema.ensureDatabase()) {
+    await orm.schema.execute(schema);
+  }
+
+  await orm.close(true);
+});
+
+beforeEach(async () => {
+  orm = await MikroORM.init({
+    dbName: schemaName,
+    port: 3308,
+    discovery: { warnWhenNoEntities: false },
+    extensions: [EntityGenerator],
+    multipleStatements: true,
+  });
+});
+
+afterEach(async () => {
+  await orm.close(true);
+});
+
+describe(schemaName, () => {
+  test.each([true, false])('entitySchema=%s', async entitySchema => {
+    orm.config.get('entityGenerator').entitySchema = entitySchema;
+    const dump = await orm.entityGenerator.generate({
+      save: true,
+      path: './temp/entities',
+    });
+    expect(dump).toMatchSnapshot('mysql');
+    await expect(pathExists('./temp/entities/E123TableName.ts')).resolves.toBe(true);
+    await remove('./temp/entities');
+  });
+});

--- a/tests/features/entity-generator/OddTableNames.postgres.test.ts
+++ b/tests/features/entity-generator/OddTableNames.postgres.test.ts
@@ -1,0 +1,105 @@
+import { MikroORM } from '@mikro-orm/postgresql';
+import { EntityGenerator } from '@mikro-orm/entity-generator';
+import { pathExists, remove } from 'fs-extra';
+
+let orm: MikroORM;
+
+const dbName = 'odd_db_name100';
+const schema = `CREATE SCHEMA IF NOT EXISTS "odd_identifier's_example's_second";
+CREATE SCHEMA IF NOT EXISTS "odd table_names_example:100%";
+
+SET search_path TO "odd table_names_example:100%";
+
+CREATE TABLE IF NOT EXISTS "50% of stuff" (
+  "+-20%" SERIAL PRIMARY KEY,
+  "my@odd.column" VARCHAR(45) NOT NULL,
+  "column with apostrophe in it's name" VARCHAR(45) NOT NULL,
+  "column with backtick in it\`\`s name" VARCHAR(45) NOT NULL,
+  CONSTRAINT "odd columns' unique index" UNIQUE ("column with apostrophe in it's name", "column with backtick in it\`\`s name")
+);
+
+CREATE TABLE IF NOT EXISTS "*misc" (
+  "@ref" SERIAL PRIMARY KEY,
+  CONSTRAINT "fk_*misc_50% of stuff"
+    FOREIGN KEY ("@ref")
+    REFERENCES "50% of stuff" ("+-20%")
+);
+
+CREATE TABLE IF NOT EXISTS "this+that" (
+  "80 of stuff" SERIAL PRIMARY KEY,
+  CONSTRAINT "fk_this+that_*misc1"
+    FOREIGN KEY ("80 of stuff")
+    REFERENCES "*misc" ("@ref")
+);
+
+CREATE TABLE IF NOT EXISTS "odd_identifier's_example's_second"."ns___subns__the_name" (
+  "id" SERIAL PRIMARY KEY,
+  "r_n_b" VARCHAR(45) NOT NULL,
+  "*" VARCHAR(45) NOT NULL,
+  "$*" VARCHAR(35) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "odd_identifier's_example's_second"."table's name has apostrophe, Also \`\` this" (
+  "!cool" SERIAL PRIMARY KEY,
+  "'derive" VARCHAR(45),
+  "__proto__" VARCHAR(45),
+  CONSTRAINT "proto_unique" UNIQUE ("__proto__"),
+  CONSTRAINT "fk_table's name has apostrophe, Also \`\` this_*misc"
+    FOREIGN KEY ("!cool")
+    REFERENCES "odd table_names_example:100%"."*misc" ("@ref")
+);
+
+CREATE TABLE IF NOT EXISTS "odd table_names_example:100%"."123_table_name" (
+  "$" INT NOT NULL,
+  "prototype" VARCHAR(45) NOT NULL,
+  "oh_captain__my___captain" VARCHAR(255) NOT NULL DEFAULT 'test',
+  "infer" VARCHAR(255) NOT NULL,
+  "$infer" VARCHAR(200) NOT NULL,
+  "$$infer" VARCHAR(200) NOT NULL,
+  PRIMARY KEY ("$"),
+  CONSTRAINT "fk_123_table_name_table's name has apostrophe, Also \`\` this1"
+    FOREIGN KEY ("prototype")
+    REFERENCES "odd_identifier's_example's_second"."table's name has apostrophe, Also \`\` this" ("__proto__")
+);`;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName,
+    discovery: { warnWhenNoEntities: false },
+    extensions: [EntityGenerator],
+    multipleStatements: true,
+    ensureDatabase: false,
+  });
+
+  if (await orm.schema.ensureDatabase()) {
+    await orm.schema.execute(schema);
+  }
+
+  await orm.close(true);
+});
+
+beforeEach(async () => {
+  orm = await MikroORM.init({
+    dbName,
+    discovery: { warnWhenNoEntities: false },
+    extensions: [EntityGenerator],
+    multipleStatements: true,
+  });
+});
+
+afterEach(async () => {
+  await orm.close(true);
+});
+
+describe(dbName, () => {
+  test.each([true, false])('entitySchema=%s', async entitySchema => {
+    orm.config.get('entityGenerator').entitySchema = entitySchema;
+    const dump = await orm.entityGenerator.generate({
+      save: true,
+      path: './temp/entities',
+    });
+    expect(dump).toMatchSnapshot('postgre');
+    await expect(pathExists('./temp/entities/E123TableName.ts')).resolves.toBe(true);
+    await remove('./temp/entities');
+  });
+});

--- a/tests/features/entity-generator/__snapshots__/GeneratedColumns.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/GeneratedColumns.mysql.test.ts.snap
@@ -29,7 +29,7 @@ export class Users {
   @Property({ length: 100 })
   lastName!: string;
 
-  @Property({ type: 'string', length: 200, generated: () => "concat(\`first_name\`,_utf8mb4\\\\' \\\\',\`last_name\`) virtual" })
+  @Property({ type: 'string', length: 200, generated: () => "(concat(\`first_name\`,_utf8mb4' ',\`last_name\`)) virtual" })
   fullName!: string & Opt;
 
   @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
@@ -38,7 +38,7 @@ export class Users {
   @Property({ columnType: 'date' })
   dateOfBirth!: string;
 
-  @ManyToOne({ entity: () => AllowedAgesAtCreation, fieldName: 'age_at_creation', deleteRule: 'cascade', generated: () => "timestampdiff(YEAR,\`date_of_birth\`,\`created_at\`) stored", nullable: true, index: 'fk_users_allowed_ages_at_creation_idx' })
+  @ManyToOne({ entity: () => AllowedAgesAtCreation, fieldName: 'age_at_creation', deleteRule: 'cascade', generated: () => "(timestampdiff(YEAR,\`date_of_birth\`,\`created_at\`)) stored", nullable: true, index: 'fk_users_allowed_ages_at_creation_idx' })
   ageAtCreation?: AllowedAgesAtCreation;
 
 }
@@ -75,7 +75,7 @@ export class Users {
   @Property({ length: 100 })
   lastName!: string;
 
-  @Property({ type: 'string', length: 200, generated: 'concat(\`first_name\`,_utf8mb4\\' \\',\`last_name\`) virtual' })
+  @Property({ type: 'string', length: 200, generated: '(concat(\`first_name\`,_utf8mb4\\' \\',\`last_name\`)) virtual' })
   fullName!: string & Opt;
 
   @Property({ type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` })
@@ -84,7 +84,7 @@ export class Users {
   @Property({ columnType: 'date' })
   dateOfBirth!: string;
 
-  @ManyToOne({ entity: () => AllowedAgesAtCreation, fieldName: 'age_at_creation', deleteRule: 'cascade', generated: 'timestampdiff(YEAR,\`date_of_birth\`,\`created_at\`) stored', nullable: true, index: 'fk_users_allowed_ages_at_creation_idx' })
+  @ManyToOne({ entity: () => AllowedAgesAtCreation, fieldName: 'age_at_creation', deleteRule: 'cascade', generated: '(timestampdiff(YEAR,\`date_of_birth\`,\`created_at\`)) stored', nullable: true, index: 'fk_users_allowed_ages_at_creation_idx' })
   ageAtCreation?: AllowedAgesAtCreation;
 
 }
@@ -130,7 +130,7 @@ export const UsersSchema = new EntitySchema({
     fullName: {
       type: 'string',
       length: 200,
-      generated: () => "concat(\`first_name\`,_utf8mb4\\\\' \\\\',\`last_name\`) virtual",
+      generated: () => "(concat(\`first_name\`,_utf8mb4' ',\`last_name\`)) virtual",
     },
     createdAt: { type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` },
     dateOfBirth: { type: 'string', columnType: 'date' },
@@ -139,7 +139,7 @@ export const UsersSchema = new EntitySchema({
       entity: () => AllowedAgesAtCreation,
       fieldName: 'age_at_creation',
       deleteRule: 'cascade',
-      generated: () => "timestampdiff(YEAR,\`date_of_birth\`,\`created_at\`) stored",
+      generated: () => "(timestampdiff(YEAR,\`date_of_birth\`,\`created_at\`)) stored",
       nullable: true,
       index: 'fk_users_allowed_ages_at_creation_idx',
     },
@@ -187,7 +187,7 @@ export const UsersSchema = new EntitySchema({
     fullName: {
       type: 'string',
       length: 200,
-      generated: 'concat(\`first_name\`,_utf8mb4\\' \\',\`last_name\`) virtual',
+      generated: '(concat(\`first_name\`,_utf8mb4\\' \\',\`last_name\`)) virtual',
     },
     createdAt: { type: 'Date', length: 0, defaultRaw: \`CURRENT_TIMESTAMP\` },
     dateOfBirth: { type: 'string', columnType: 'date' },
@@ -196,7 +196,7 @@ export const UsersSchema = new EntitySchema({
       entity: () => AllowedAgesAtCreation,
       fieldName: 'age_at_creation',
       deleteRule: 'cascade',
-      generated: 'timestampdiff(YEAR,\`date_of_birth\`,\`created_at\`) stored',
+      generated: '(timestampdiff(YEAR,\`date_of_birth\`,\`created_at\`)) stored',
       nullable: true,
       index: 'fk_users_allowed_ages_at_creation_idx',
     },

--- a/tests/features/entity-generator/__snapshots__/GeneratedColumns.postgresql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/GeneratedColumns.postgresql.test.ts.snap
@@ -75,7 +75,7 @@ export class Users {
   @Property({ length: 100 })
   lastName!: string;
 
-  @Property({ type: 'string', length: 200, generated: '(((first_name)::text || ' '::text) || (last_name)::text) stored' })
+  @Property({ type: 'string', length: 200, generated: '(((first_name)::text || \\' \\'::text) || (last_name)::text) stored' })
   fullName!: string & Opt;
 
   @Property({ type: 'Date', length: 6, defaultRaw: \`CURRENT_TIMESTAMP\` })
@@ -186,7 +186,7 @@ export const UsersSchema = new EntitySchema({
     fullName: {
       type: 'string',
       length: 200,
-      generated: '(((first_name)::text || ' '::text) || (last_name)::text) stored',
+      generated: '(((first_name)::text || \\' \\'::text) || (last_name)::text) stored',
     },
     createdAt: { type: 'Date', length: 6, defaultRaw: \`CURRENT_TIMESTAMP\` },
     dateOfBirth: { type: 'string', columnType: 'date' },

--- a/tests/features/entity-generator/__snapshots__/OddTableNames.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OddTableNames.mysql.test.ts.snap
@@ -1,0 +1,236 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`odd_table_names_example:100% entitySchema=false: mysql 1`] = `
+[
+  "import { Entity, OneToOne, PrimaryKeyProp } from '@mikro-orm/core';
+import { E50$37$32of$32stuff } from './E50$37$32of$32stuff';
+
+@Entity({ tableName: '*misc' })
+export class E_$42misc {
+
+  [PrimaryKeyProp]?: '@ref';
+
+  @OneToOne({ entity: () => E50$37$32of$32stuff, fieldName: '@ref', primary: true })
+  '@ref'!: E50$37$32of$32stuff;
+
+}
+",
+  "import { Entity, Index, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+import { Table$39s$32name$32has$32apostrophe$44$32also$32$96$32this } from './Table$39s$32name$32has$32apostrophe$44$32also$32$96$32this';
+
+@Entity({ tableName: '123_table_name' })
+@Index({ name: 'dollar\\'s index', properties: ['$$', '$$infer'] })
+export class E123TableName {
+
+  [PrimaryKeyProp]?: '$';
+
+  @PrimaryKey({ unsigned: false, autoincrement: false })
+  $!: number;
+
+  @Property()
+  $$!: bigint;
+
+  @ManyToOne({ entity: () => Table$39s$32name$32has$32apostrophe$44$32also$32$96$32this, fieldName: 'prototype', index: 'fk_123_table_name_table\\'s name has apostrophe, also\` this_idx' })
+  prototype!: Table$39s$32name$32has$32apostrophe$44$32also$32$96$32this;
+
+  @Property({ fieldName: 'oh_captain__my___captain', type: 'string', length: 255 })
+  ohCaptainMyCaptain: string & Opt = 'test';
+
+  @Property({ length: 255 })
+  infer!: string;
+
+  @Property({ fieldName: '$infer', length: 200 })
+  $$infer!: string;
+
+  @Property({ fieldName: '$$infer', length: 100 })
+  $$$infer!: string;
+
+}
+",
+  "import { Entity, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+
+@Entity({ tableName: '50% of stuff' })
+@Unique({ name: 'odd columns\\' unique index', properties: ['columnWithApostropheInIt\\'sName', 'columnWithBacktickInIt\`sName'] })
+export class E50$37$32of$32stuff {
+
+  [PrimaryKeyProp]?: '+20%';
+
+  @PrimaryKey({ fieldName: '+-20%' })
+  '+20%'!: number;
+
+  @Property({ length: 45 })
+  'my@odd.column'!: string;
+
+  @Property({ fieldName: 'column with apostrophe in it\\'s name', length: 45 })
+  'columnWithApostropheInIt\\'sName'!: string;
+
+  @Property({ fieldName: 'column with backtick in it\`s name', length: 45 })
+  'columnWithBacktickInIt\`sName'!: string;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'ns___subns__the_name' })
+export class NsSubnsTheName {
+
+  @PrimaryKey({ autoincrement: false })
+  id!: number;
+
+  @Property({ fieldName: 'r_n_b', length: 45 })
+  rNB!: string;
+
+  @Property({ fieldName: '*', length: 45 })
+  '$*'!: string;
+
+  @Property({ fieldName: '$*', length: 35 })
+  '$$*'!: string;
+
+}
+",
+  "import { Entity, OneToOne, PrimaryKeyProp } from '@mikro-orm/core';
+import { E_$42misc } from './E_$42misc';
+
+@Entity({ tableName: 'this+that' })
+export class This$43that {
+
+  [PrimaryKeyProp]?: '80%OfStuff';
+
+  @OneToOne({ entity: () => E_$42misc, fieldName: '80% of stuff', primary: true })
+  '80%OfStuff'!: E_$42misc;
+
+}
+",
+]
+`;
+
+exports[`odd_table_names_example:100% entitySchema=true: mysql 1`] = `
+[
+  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { E50$37$32of$32stuff } from './E50$37$32of$32stuff';
+
+export class E_$42misc {
+  [PrimaryKeyProp]?: '@ref';
+  '@ref'!: E50$37$32of$32stuff;
+}
+
+export const E_$42miscSchema = new EntitySchema({
+  class: E_$42misc,
+  tableName: '*misc',
+  properties: {
+    '@ref': {
+      primary: true,
+      kind: '1:1',
+      entity: () => E50$37$32of$32stuff,
+      fieldName: '@ref',
+    },
+  },
+});
+",
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Table$39s$32name$32has$32apostrophe$44$32also$32$96$32this } from './Table$39s$32name$32has$32apostrophe$44$32also$32$96$32this';
+
+export class E123TableName {
+  [PrimaryKeyProp]?: '$';
+  $!: number;
+  $$!: bigint;
+  prototype!: Table$39s$32name$32has$32apostrophe$44$32also$32$96$32this;
+  ohCaptainMyCaptain: string & Opt = 'test';
+  infer!: string;
+  $$infer!: string;
+  $$$infer!: string;
+}
+
+export const E123TableNameSchema = new EntitySchema({
+  class: E123TableName,
+  tableName: '123_table_name',
+  indexes: [
+    { name: 'dollar\\'s index', properties: ['$$', '$$infer'] },
+  ],
+  properties: {
+    $: { primary: true, type: 'number', unsigned: false, autoincrement: false },
+    $$: { type: 'bigint' },
+    prototype: {
+      kind: 'm:1',
+      entity: () => Table$39s$32name$32has$32apostrophe$44$32also$32$96$32this,
+      fieldName: 'prototype',
+      index: 'fk_123_table_name_table\\'s name has apostrophe, also\` this_idx',
+    },
+    ohCaptainMyCaptain: { type: 'string', fieldName: 'oh_captain__my___captain', length: 255 },
+    infer: { type: 'string', length: 255 },
+    $$infer: { type: 'string', fieldName: '$infer', length: 200 },
+    $$$infer: { type: 'string', fieldName: '$$infer', length: 100 },
+  },
+});
+",
+  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+
+export class E50$37$32of$32stuff {
+  [PrimaryKeyProp]?: '+20%';
+  '+20%'!: number;
+  'my@odd.column'!: string;
+  'columnWithApostropheInIt\\'sName'!: string;
+  'columnWithBacktickInIt\`sName'!: string;
+}
+
+export const E50$37$32of$32stuffSchema = new EntitySchema({
+  class: E50$37$32of$32stuff,
+  tableName: '50% of stuff',
+  uniques: [
+    { name: 'odd columns\\' unique index', properties: ['columnWithApostropheInIt\\'sName', 'columnWithBacktickInIt\`sName'] },
+  ],
+  properties: {
+    '+20%': { primary: true, type: 'number', fieldName: '+-20%' },
+    'my@odd.column': { type: 'string', length: 45 },
+    'columnWithApostropheInIt\\'sName': {
+      type: 'string',
+      fieldName: 'column with apostrophe in it\\'s name',
+      length: 45,
+    },
+    'columnWithBacktickInIt\`sName': { type: 'string', fieldName: 'column with backtick in it\`s name', length: 45 },
+  },
+});
+",
+  "import { EntitySchema } from '@mikro-orm/core';
+
+export class NsSubnsTheName {
+  id!: number;
+  rNB!: string;
+  '$*'!: string;
+  '$$*'!: string;
+}
+
+export const NsSubnsTheNameSchema = new EntitySchema({
+  class: NsSubnsTheName,
+  tableName: 'ns___subns__the_name',
+  properties: {
+    id: { primary: true, type: 'number', autoincrement: false },
+    rNB: { type: 'string', fieldName: 'r_n_b', length: 45 },
+    '$*': { type: 'string', fieldName: '*', length: 45 },
+    '$$*': { type: 'string', fieldName: '$*', length: 35 },
+  },
+});
+",
+  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { E_$42misc } from './E_$42misc';
+
+export class This$43that {
+  [PrimaryKeyProp]?: '80%OfStuff';
+  '80%OfStuff'!: E_$42misc;
+}
+
+export const This$43thatSchema = new EntitySchema({
+  class: This$43that,
+  tableName: 'this+that',
+  properties: {
+    '80%OfStuff': {
+      primary: true,
+      kind: '1:1',
+      entity: () => E_$42misc,
+      fieldName: '80% of stuff',
+    },
+  },
+});
+",
+]
+`;

--- a/tests/features/entity-generator/__snapshots__/OddTableNames.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OddTableNames.postgres.test.ts.snap
@@ -1,0 +1,266 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`odd_db_name100 entitySchema=false: postgre 1`] = `
+[
+  "import { Entity, OneToOne, PrimaryKeyProp } from '@mikro-orm/core';
+import { E50$37$32of$32stuff } from './E50$37$32of$32stuff';
+
+@Entity({ tableName: '*misc', schema: 'odd table_names_example:100%' })
+export class E_$42misc {
+
+  [PrimaryKeyProp]?: '@ref';
+
+  @OneToOne({ entity: () => E50$37$32of$32stuff, fieldName: '@ref', primary: true })
+  '@ref'!: E50$37$32of$32stuff;
+
+}
+",
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+import { Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this } from './Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this';
+
+@Entity({ tableName: '123_table_name', schema: 'odd table_names_example:100%' })
+export class E123TableName {
+
+  [PrimaryKeyProp]?: '$';
+
+  @PrimaryKey({ autoincrement: false })
+  $!: number;
+
+  @ManyToOne({ entity: () => Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this, fieldName: 'prototype' })
+  prototype!: Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this;
+
+  @Property({ fieldName: 'oh_captain__my___captain', type: 'string', length: 255 })
+  ohCaptainMyCaptain: string & Opt = 'test';
+
+  @Property({ length: 255 })
+  infer!: string;
+
+  @Property({ fieldName: '$infer', length: 200 })
+  $$infer!: string;
+
+  @Property({ fieldName: '$$infer', length: 200 })
+  $$$infer!: string;
+
+}
+",
+  "import { Entity, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+
+@Entity({ tableName: '50% of stuff', schema: 'odd table_names_example:100%' })
+@Unique({ name: 'odd columns\\' unique index', expression: 'CREATE UNIQUE INDEX "odd columns\\' unique index" ON "odd table_names_example:100%"."50% of stuff" USING btree ("column with apostrophe in it\\'s name", "column with backtick in it\`\`s name")' })
+export class E50$37$32of$32stuff {
+
+  [PrimaryKeyProp]?: '+20%';
+
+  @PrimaryKey({ fieldName: '+-20%' })
+  '+20%'!: number;
+
+  @Property({ length: 45 })
+  'my@odd.column'!: string;
+
+  @Property({ fieldName: 'column with apostrophe in it\\'s name', length: 45 })
+  'columnWithApostropheInIt\\'sName'!: string;
+
+  @Property({ fieldName: 'column with backtick in it\`\`s name', length: 45 })
+  'columnWithBacktickInIt\`\`sName'!: string;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'ns___subns__the_name', schema: 'odd_identifier\\'s_example\\'s_second' })
+export class NsSubnsTheName {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ fieldName: 'r_n_b', length: 45 })
+  rNB!: string;
+
+  @Property({ fieldName: '*', length: 45 })
+  '$*'!: string;
+
+  @Property({ fieldName: '$*', length: 35 })
+  '$$*'!: string;
+
+}
+",
+  "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+import { E_$42misc } from './E_$42misc';
+
+@Entity({ tableName: 'table\\'s name has apostrophe, Also \`\` this', schema: 'odd_identifier\\'s_example\\'s_second' })
+export class Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this {
+
+  [PrimaryKeyProp]?: '!cool';
+
+  @OneToOne({ entity: () => E_$42misc, fieldName: '!cool', primary: true })
+  '!cool'!: E_$42misc;
+
+  @Property({ length: 45, nullable: true })
+  \`'derive\`?: string;
+
+}
+",
+  "import { Entity, OneToOne, PrimaryKeyProp } from '@mikro-orm/core';
+import { E_$42misc } from './E_$42misc';
+
+@Entity({ tableName: 'this+that', schema: 'odd table_names_example:100%' })
+export class This$43that {
+
+  [PrimaryKeyProp]?: '80OfStuff';
+
+  @OneToOne({ entity: () => E_$42misc, fieldName: '80 of stuff', primary: true })
+  '80OfStuff'!: E_$42misc;
+
+}
+",
+]
+`;
+
+exports[`odd_db_name100 entitySchema=true: postgre 1`] = `
+[
+  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { E50$37$32of$32stuff } from './E50$37$32of$32stuff';
+
+export class E_$42misc {
+  [PrimaryKeyProp]?: '@ref';
+  '@ref'!: E50$37$32of$32stuff;
+}
+
+export const E_$42miscSchema = new EntitySchema({
+  class: E_$42misc,
+  tableName: '*misc',
+  schema: 'odd table_names_example:100%',
+  properties: {
+    '@ref': {
+      primary: true,
+      kind: '1:1',
+      entity: () => E50$37$32of$32stuff,
+      fieldName: '@ref',
+    },
+  },
+});
+",
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this } from './Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this';
+
+export class E123TableName {
+  [PrimaryKeyProp]?: '$';
+  $!: number;
+  prototype!: Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this;
+  ohCaptainMyCaptain: string & Opt = 'test';
+  infer!: string;
+  $$infer!: string;
+  $$$infer!: string;
+}
+
+export const E123TableNameSchema = new EntitySchema({
+  class: E123TableName,
+  tableName: '123_table_name',
+  schema: 'odd table_names_example:100%',
+  properties: {
+    $: { primary: true, type: 'number', autoincrement: false },
+    prototype: {
+      kind: 'm:1',
+      entity: () => Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this,
+      fieldName: 'prototype',
+    },
+    ohCaptainMyCaptain: { type: 'string', fieldName: 'oh_captain__my___captain', length: 255 },
+    infer: { type: 'string', length: 255 },
+    $$infer: { type: 'string', fieldName: '$infer', length: 200 },
+    $$$infer: { type: 'string', fieldName: '$$infer', length: 200 },
+  },
+});
+",
+  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+
+export class E50$37$32of$32stuff {
+  [PrimaryKeyProp]?: '+20%';
+  '+20%'!: number;
+  'my@odd.column'!: string;
+  'columnWithApostropheInIt\\'sName'!: string;
+  'columnWithBacktickInIt\`\`sName'!: string;
+}
+
+export const E50$37$32of$32stuffSchema = new EntitySchema({
+  class: E50$37$32of$32stuff,
+  tableName: '50% of stuff',
+  schema: 'odd table_names_example:100%',
+  uniques: [
+    { name: 'odd columns\\' unique index', expression: 'CREATE UNIQUE INDEX "odd columns\\' unique index" ON "odd table_names_example:100%"."50% of stuff" USING btree ("column with apostrophe in it\\'s name", "column with backtick in it\`\`s name")' },
+  ],
+  properties: {
+    '+20%': { primary: true, type: 'number', fieldName: '+-20%' },
+    'my@odd.column': { type: 'string', length: 45 },
+    'columnWithApostropheInIt\\'sName': {
+      type: 'string',
+      fieldName: 'column with apostrophe in it\\'s name',
+      length: 45,
+    },
+    'columnWithBacktickInIt\`\`sName': { type: 'string', fieldName: 'column with backtick in it\`\`s name', length: 45 },
+  },
+});
+",
+  "import { EntitySchema } from '@mikro-orm/core';
+
+export class NsSubnsTheName {
+  id!: number;
+  rNB!: string;
+  '$*'!: string;
+  '$$*'!: string;
+}
+
+export const NsSubnsTheNameSchema = new EntitySchema({
+  class: NsSubnsTheName,
+  tableName: 'ns___subns__the_name',
+  schema: 'odd_identifier\\'s_example\\'s_second',
+  properties: {
+    id: { primary: true, type: 'number' },
+    rNB: { type: 'string', fieldName: 'r_n_b', length: 45 },
+    '$*': { type: 'string', fieldName: '*', length: 45 },
+    '$$*': { type: 'string', fieldName: '$*', length: 35 },
+  },
+});
+",
+  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { E_$42misc } from './E_$42misc';
+
+export class Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this {
+  [PrimaryKeyProp]?: '!cool';
+  '!cool'!: E_$42misc;
+  \`'derive\`?: string;
+}
+
+export const Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32thisSchema = new EntitySchema({
+  class: Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this,
+  tableName: 'table\\'s name has apostrophe, Also \`\` this',
+  schema: 'odd_identifier\\'s_example\\'s_second',
+  properties: {
+    '!cool': { primary: true, kind: '1:1', entity: () => E_$42misc, fieldName: '!cool' },
+    \`'derive\`: { type: 'string', length: 45, nullable: true },
+  },
+});
+",
+  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { E_$42misc } from './E_$42misc';
+
+export class This$43that {
+  [PrimaryKeyProp]?: '80OfStuff';
+  '80OfStuff'!: E_$42misc;
+}
+
+export const This$43thatSchema = new EntitySchema({
+  class: This$43that,
+  tableName: 'this+that',
+  schema: 'odd table_names_example:100%',
+  properties: {
+    '80OfStuff': {
+      primary: true,
+      kind: '1:1',
+      entity: () => E_$42misc,
+      fieldName: '80 of stuff',
+    },
+  },
+});
+",
+]
+`;


### PR DESCRIPTION
fix(entity-generator): allow arbitrary class and prop names as identifiers

AbstractNamingStrategy is updated to handle class conflicts, and inherently,
any naming strategy that inherits from it.

The "word boundary" character in entity and property names is now correctly replaced,
even in cases where multiple sequential separators are present.

Any table that starts with a character that is invalid as a JS start character (not just digits)
gets prefixed with "E".
Characters that are not valid in any position as a class identifier (or the character "$")
get turned into code points, prefixed with $, making them valid (though inconvenient to type)
identifiers and file names.

In AbstractNamingStrategy.columnNameToProperty(),
prop names that would be in conflict with PopulatePath values get prefixed with "$".

Prop names that are not valid identifiers get string quoted.
This is a SourceFile/EntitySchemaSourceFile feature, not a naming strategy feature,
so it will get applied regardless of naming strategy.

The MySqlSchemaHelper doesn't special case index expression based on column name.
Lack of column name or presence of an "expression" column with "where" is still considered.

The PostgreSqlSchemaHelper properly escapes all identifiers when looking them up.
Due to the relative complexity of PostgreSQL's expressions vs column names,
index properties are still not picked up for odd identifiers,
though an index expression is generated.

Also made the imports of types tied to the "entity" prop option, rather than the prop declaration.
This ensures proper imports when using mapToPk in extension hooks.

Also moved the schema de-duplication code to happen before bi-directional and many-to-many
detection, to ensure less work and error prone-ness for the other stages in updating references.

Also fixed quoting of strings in generated columns.
