### PR TITLE
feat(postgres): add `?`, `?|` and `?&` json operators

### DIFF
--- a/docs/docs/query-conditions.md
+++ b/docs/docs/query-conditions.md
@@ -51,23 +51,26 @@ const res = await orm.em.find(Author, [1, 2, 7]);
 
 ### Comparison
 
-| operator     | name             | description                                                                                 |
-| ------------ | ---------------- | ------------------------------------------------------------------------------------------- |
-| `$eq`        | equals           | Matches values that are equal to a specified value.                                         |
-| `$gt`        | greater          | Matches values that are greater than a specified value.                                     |
-| `$gte`       | greater or equal | Matches values that are greater than or equal to a specified value.                         |
-| `$in`        | contains         | Matches any of the values specified in an array.                                            |
-| `$lt`        | lower            | Matches values that are less than a specified value.                                        |
-| `$lte`       | lower or equal   | Matches values that are less than or equal to a specified value.                            |
-| `$ne`        | not equal        | Matches all values that are not equal to a specified value.                                 |
-| `$nin`       | not contains     | Matches none of the values specified in an array.                                           |
-| `$like`      | like             | Uses LIKE operator                                                                          |
-| `$re`        | regexp           | Uses REGEXP operator. See info [below](#regular-expressions)                                |
-| `$fulltext`  | full text        | A driver specific full text search function. See requirements [below](#full-text-searching) |
-| `$ilike`     | ilike            | (postgres only)                                                                             |
-| `$overlap`   | &&               | (postgres only)                                                                             |
-| `$contains`  | @>               | (postgres only)                                                                             |
-| `$contained` | \<@              | (postgres only)                                                                             |
+| operator       | name             | description                                                                                 |
+| -------------- | ---------------- | ------------------------------------------------------------------------------------------- |
+| `$eq`          | equals           | Matches values that are equal to a specified value.                                         |
+| `$gt`          | greater          | Matches values that are greater than a specified value.                                     |
+| `$gte`         | greater or equal | Matches values that are greater than or equal to a specified value.                         |
+| `$in`          | contains         | Matches any of the values specified in an array.                                            |
+| `$lt`          | lower            | Matches values that are less than a specified value.                                        |
+| `$lte`         | lower or equal   | Matches values that are less than or equal to a specified value.                            |
+| `$ne`          | not equal        | Matches all values that are not equal to a specified value.                                 |
+| `$nin`         | not contains     | Matches none of the values specified in an array.                                           |
+| `$like`        | like             | Uses LIKE operator                                                                          |
+| `$re`          | regexp           | Uses REGEXP operator. See info [below](#regular-expressions)                                |
+| `$fulltext`    | full text        | A driver specific full text search function. See requirements [below](#full-text-searching) |
+| `$ilike`       | ilike            | (postgres only)                                                                             |
+| `$overlap`     | &&               | (postgres only)                                                                             |
+| `$contains`    | @>               | (postgres only)                                                                             |
+| `$contained`   | \<@              | (postgres only)                                                                             |
+| `$haskey`      | ?                | (postgres only)                                                                             |
+| `$hassomekeys` | ?|               | (postgres only)                                                                             |
+| `$haskeys`     | ?&               | (postgres only)                                                                             |
 
 ### Logical
 

--- a/docs/docs/query-conditions.md
+++ b/docs/docs/query-conditions.md
@@ -68,9 +68,9 @@ const res = await orm.em.find(Author, [1, 2, 7]);
 | `$overlap`     | &&               | (postgres only)                                                                             |
 | `$contains`    | @>               | (postgres only)                                                                             |
 | `$contained`   | \<@              | (postgres only)                                                                             |
-| `$haskey`      | ?                | (postgres only)                                                                             |
-| `$hassomekeys` | ?|               | (postgres only)                                                                             |
-| `$haskeys`     | ?&               | (postgres only)                                                                             |
+| `$hasKey`      | ?                | (postgres only)                                                                             |
+| `$hasSomeKeys` | ?|               | (postgres only)                                                                             |
+| `$hasKeys`     | ?&               | (postgres only)                                                                             |
 
 ### Logical
 

--- a/packages/core/src/enums.ts
+++ b/packages/core/src/enums.ts
@@ -42,9 +42,9 @@ export enum QueryOperator {
   $none = 'none', // collection operators, sql only
   $some = 'some', // collection operators, sql only
   $every = 'every', // collection operators, sql only
-  $haskey = '?', // postgres only, json
-  $haskeys = '?&', // postgres only, json
-  $hassomekeys = '?|', // postgres only, json
+  $hasKey = '?', // postgres only, json
+  $hasKeys = '?&', // postgres only, json
+  $hasSomeKeys = '?|', // postgres only, json
 }
 
 export const ARRAY_OPERATORS = [
@@ -60,9 +60,9 @@ export const ARRAY_OPERATORS = [
 ];
 
 export const JSON_KEY_OPERATORS = [
-  '$haskey',
-  '$haskeys',
-  '$hassomekeys',
+  '$hasKey',
+  '$hasKeys',
+  '$hasSomeKeys',
 ];
 
 export enum QueryOrder {

--- a/packages/core/src/enums.ts
+++ b/packages/core/src/enums.ts
@@ -42,6 +42,9 @@ export enum QueryOperator {
   $none = 'none', // collection operators, sql only
   $some = 'some', // collection operators, sql only
   $every = 'every', // collection operators, sql only
+  $haskey = '?', // postgres only, json
+  $haskeys = '?&', // postgres only, json
+  $hassomekeys = '?|', // postgres only, json
 }
 
 export const ARRAY_OPERATORS = [
@@ -54,6 +57,12 @@ export const ARRAY_OPERATORS = [
   '$overlap',
   '$contains',
   '$contained',
+];
+
+export const JSON_KEY_OPERATORS = [
+  '$haskey',
+  '$haskeys',
+  '$hassomekeys',
 ];
 
 export enum QueryOrder {

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -135,6 +135,9 @@ export type OperatorMap<T> = {
   $contains?: string[] | object;
   $contained?: string[] | object;
   $exists?: boolean;
+  $haskey?: string;
+  $haskeys?: string[];
+  $hassomekeys?: string[];
 };
 
 export type FilterItemValue<T> = T | ExpandScalar<T> | Primary<T>;

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -135,9 +135,9 @@ export type OperatorMap<T> = {
   $contains?: string[] | object;
   $contained?: string[] | object;
   $exists?: boolean;
-  $haskey?: string;
-  $haskeys?: string[];
-  $hassomekeys?: string[];
+  $hasKey?: string;
+  $hasKeys?: string[];
+  $hasSomeKeys?: string[];
 };
 
 export type FilterItemValue<T> = T | ExpandScalar<T> | Primary<T>;

--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -241,6 +241,12 @@ export class QueryHelper {
       }, {} as FilterQuery<T>);
     }
 
+    if (key && Utils.isJsonKeyOperator(key)) {
+      return Array.isArray(cond)
+        ? (platform.marshallArray(cond) as unknown as FilterQuery<T>)
+        : cond;
+    }
+
     if (Array.isArray(cond) && !(key && Utils.isArrayOperator(key))) {
       return (cond as FilterQuery<T>[]).map(v => QueryHelper.processCustomType(prop, v, platform, key, fromQuery)) as unknown as FilterQuery<T>;
     }

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -18,7 +18,7 @@ import type {
   IMetadataStorage,
   Primary,
 } from '../typings';
-import { ARRAY_OPERATORS, GroupOperator, PlainObject, QueryOperator, ReferenceKind } from '../enums';
+import { ARRAY_OPERATORS, JSON_KEY_OPERATORS, GroupOperator, PlainObject, QueryOperator, ReferenceKind } from '../enums';
 import type { Collection } from '../entity/Collection';
 import type { Platform } from '../platforms';
 import { helper } from '../entity/wrap';
@@ -1010,6 +1010,10 @@ export class Utils {
 
   static isArrayOperator(key: PropertyKey): boolean {
     return ARRAY_OPERATORS.includes(key as string);
+  }
+
+  static isJsonKeyOperator(key: PropertyKey): boolean {
+    return JSON_KEY_OPERATORS.includes(key as string);
   }
 
   static hasNestedKey(object: unknown, key: string): boolean {

--- a/tests/issues/GH4678.test.ts
+++ b/tests/issues/GH4678.test.ts
@@ -56,14 +56,14 @@ beforeAll(async () => {
 afterAll(() => orm.close(true));
 
 
-test('GH #4678 ($haskey operator)', async () => {
+test('GH #4678 ($hasKey operator)', async () => {
   const mock = mockLogger(orm);
   await orm.em.findAll(Book, {
-    where: { parameters: { $haskey: 'seasons' } },
+    where: { parameters: { $hasKey: 'seasons' } },
   });
   await orm.em.findAll(User, {
     where: {
-      books: { parameters: { $haskey: 'seasons' } },
+      books: { parameters: { $hasKey: 'seasons' } },
     },
     populate: ['books'],
     strategy: 'select-in',
@@ -77,14 +77,14 @@ test('GH #4678 ($haskey operator)', async () => {
   );
 });
 
-test('GH #4678 ($hassomekeys operator)', async () => {
+test('GH #4678 ($hasSomeKeys operator)', async () => {
   const mock = mockLogger(orm);
   await orm.em.findAll(Book, {
-    where: { parameters: { $hassomekeys: ['seasons', 'pages'] } },
+    where: { parameters: { $hasSomeKeys: ['seasons', 'pages'] } },
   });
   await orm.em.findAll(User, {
     where: {
-      books: { parameters: { $hassomekeys: ['seasons', 'pages'] } },
+      books: { parameters: { $hasSomeKeys: ['seasons', 'pages'] } },
     },
     populate: ['books'],
     strategy: 'select-in',
@@ -97,14 +97,14 @@ test('GH #4678 ($hassomekeys operator)', async () => {
   );
 });
 
-test('GH #4678 ($haskeys operator)', async () => {
+test('GH #4678 ($hasKeys operator)', async () => {
   const mock = mockLogger(orm);
   await orm.em.findAll(Book, {
-    where: { parameters: { $haskeys: ['seasons', 'pages'] } },
+    where: { parameters: { $hasKeys: ['seasons', 'pages'] } },
   });
   await orm.em.findAll(User, {
     where: {
-      books: { parameters: { $haskeys: ['seasons', 'pages'] } },
+      books: { parameters: { $hasKeys: ['seasons', 'pages'] } },
     },
     populate: ['books'],
     strategy: 'select-in',

--- a/tests/issues/GH4678.test.ts
+++ b/tests/issues/GH4678.test.ts
@@ -30,7 +30,7 @@ class Book {
   parameters!: BooksParameters;
 
   @Property({ type: 'jsonb' })
-  authors: string[];
+  authors!: string[];
 
   @ManyToOne(() => User)
   user!: User;

--- a/tests/issues/GH4678.test.ts
+++ b/tests/issues/GH4678.test.ts
@@ -1,0 +1,118 @@
+import {
+  Collection,
+  Entity,
+  OneToMany,
+  MikroORM,
+  PrimaryKey,
+  Property,
+  ManyToOne,
+} from '@mikro-orm/postgresql';
+import { mockLogger } from '../helpers';
+
+@Entity()
+class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @OneToMany(() => Book, book => book.user)
+  books = new Collection<Book>(this);
+
+}
+
+@Entity()
+class Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: 'jsonb' })
+  parameters!: BooksParameters;
+
+  @ManyToOne(() => User)
+  user!: User;
+
+}
+
+interface BooksParameters {
+  pages: number;
+  seasons: SeasonType[];
+}
+
+interface SeasonType {
+  name: string;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [User, Book],
+    dbName: '4678',
+  });
+  await orm.schema.refreshDatabase();
+});
+
+afterAll(() => orm.close(true));
+
+
+test('GH #4678 ($haskey operator)', async () => {
+  const mock = mockLogger(orm);
+  await orm.em.findAll(Book, {
+    where: { parameters: { $haskey: 'seasons' } },
+  });
+  await orm.em.findAll(User, {
+    where: {
+      books: { parameters: { $haskey: 'seasons' } },
+    },
+    populate: ['books'],
+    strategy: 'select-in',
+  });
+
+  expect(mock.mock.calls[0][0]).toMatch(
+    `select "b0".* from "book" as "b0" where "b0"."parameters" ? 'seasons'`,
+  );
+  expect(mock.mock.calls[1][0]).toMatch(
+    `select "u0".* from "user" as "u0" left join "book" as "b1" on "u0"."id" = "b1"."user_id" where "b1"."parameters" ? 'seasons'`,
+  );
+});
+
+test('GH #4678 ($hassomekeys operator)', async () => {
+  const mock = mockLogger(orm);
+  await orm.em.findAll(Book, {
+    where: { parameters: { $hassomekeys: ['seasons', 'pages'] } },
+  });
+  await orm.em.findAll(User, {
+    where: {
+      books: { parameters: { $hassomekeys: ['seasons', 'pages'] } },
+    },
+    populate: ['books'],
+    strategy: 'select-in',
+  });
+  expect(mock.mock.calls[0][0]).toMatch(
+    `select "b0".* from "book" as "b0" where "b0"."parameters" ?| '{seasons,pages}'`,
+  );
+  expect(mock.mock.calls[1][0]).toMatch(
+    `select "u0".* from "user" as "u0" left join "book" as "b1" on "u0"."id" = "b1"."user_id" where "b1"."parameters" ?| '{seasons,pages}'`,
+  );
+});
+
+test('GH #4678 ($haskeys operator)', async () => {
+  const mock = mockLogger(orm);
+  await orm.em.findAll(Book, {
+    where: { parameters: { $haskeys: ['seasons', 'pages'] } },
+  });
+  await orm.em.findAll(User, {
+    where: {
+      books: { parameters: { $haskeys: ['seasons', 'pages'] } },
+    },
+    populate: ['books'],
+    strategy: 'select-in',
+  });
+  expect(mock.mock.calls[0][0]).toMatch(
+    `select "b0".* from "book" as "b0" where "b0"."parameters" ?& '{seasons,pages}'`,
+  );
+  expect(mock.mock.calls[1][0]).toMatch(
+    `select "u0".* from "user" as "u0" left join "book" as "b1" on "u0"."id" = "b1"."user_id" where "b1"."parameters" ?& '{seasons,pages}'`,
+  );
+});


### PR DESCRIPTION
This PR will introduce few missing PostgreSQL [JSON operators](https://www.postgresql.org/docs/10/functions-json.html) In response to https://github.com/mikro-orm/mikro-orm/issues/4678
`?` - Does the string exist as a top-level key within the JSON value?
`?|` - Do any of array strings exist as top-level keys?
`?&`- Do all of array strings exist as top-level keys?

```ts
  // ? operator
  await orm.em.findAll(User, {
    where: {
      books: { parameters: { $hasKey: 'seasons' } },
    },
  });
```
```ts
  // ?& operator
  await orm.em.findAll(User, {
    where: { books: { parameters: { $hasKeys: ['seasons', 'pages'] } } },
  });
```
```ts
  // ?| operator
  await orm.em.findAll(User, {
    where: { books: { parameters: { $hasSomeKeys: ['seasons', 'pages'] } } },
  });
```

Related: #4678