### PR TITLE
docs: fix table formatting in `query-conditions.md`

### DIFF
--- a/docs/docs/query-conditions.md
+++ b/docs/docs/query-conditions.md
@@ -69,7 +69,7 @@ const res = await orm.em.find(Author, [1, 2, 7]);
 | `$contains`    | @>               | (postgres only)                                                                             |
 | `$contained`   | \<@              | (postgres only)                                                                             |
 | `$hasKey`      | ?                | (postgres only)                                                                             |
-| `$hasSomeKeys` | ?|               | (postgres only)                                                                             |
+| `$hasSomeKeys` | ?&#x7c;               | (postgres only)                                                                             |
 | `$hasKeys`     | ?&               | (postgres only)                                                                             |
 
 ### Logical

--- a/docs/docs/query-conditions.md
+++ b/docs/docs/query-conditions.md
@@ -69,7 +69,7 @@ const res = await orm.em.find(Author, [1, 2, 7]);
 | `$contains`    | @>               | (postgres only)                                                                             |
 | `$contained`   | \<@              | (postgres only)                                                                             |
 | `$hasKey`      | ?                | (postgres only)                                                                             |
-| `$hasSomeKeys` | ?&#x7c;               | (postgres only)                                                                             |
+| `$hasSomeKeys` | ?&#x7c;          | (postgres only)                                                                             |
 | `$hasKeys`     | ?&               | (postgres only)                                                                             |
 
 ### Logical


### PR DESCRIPTION
Pipes as values in Markdown tables need to be written as an HTML entity, e.g. `&|` should be written as `&&#x7c;`.