### PR TITLE
fix(postgres): removed erroneous duplicates in FK discovery query

### DIFF
--- a/packages/knex/src/schema/SchemaHelper.ts
+++ b/packages/knex/src/schema/SchemaHelper.ts
@@ -1,14 +1,14 @@
+import { BigIntType, EnumType, RawQueryFragment, Utils, type Connection, type Dictionary } from '@mikro-orm/core';
 import type { Knex } from 'knex';
-import { BigIntType, EnumType, Utils, type Connection, type Dictionary, RawQueryFragment } from '@mikro-orm/core';
 import type { AbstractSqlConnection } from '../AbstractSqlConnection';
 import type { AbstractSqlPlatform } from '../AbstractSqlPlatform';
 import type { CheckDef, Column, IndexDef, Table, TableDifference } from '../typings';
-import type { DatabaseTable } from './DatabaseTable';
 import type { DatabaseSchema } from './DatabaseSchema';
+import type { DatabaseTable } from './DatabaseTable';
 
 export abstract class SchemaHelper {
 
-  constructor(protected readonly platform: AbstractSqlPlatform) {}
+  constructor(protected readonly platform: AbstractSqlPlatform) { }
 
   getSchemaBeginning(charset: string): string {
     return `${this.disableForeignKeysSQL()}\n\n`;
@@ -245,13 +245,8 @@ export abstract class SchemaHelper {
   mapForeignKeys(fks: any[], tableName: string, schemaName?: string): Dictionary {
     return fks.reduce((ret, fk: any) => {
       if (ret[fk.constraint_name]) {
-        if (!ret[fk.constraint_name].columnNames.includes(fk.column_name)) {
-          ret[fk.constraint_name].columnNames.push(fk.column_name);
-        }
-
-        if (!ret[fk.constraint_name].referencedColumnNames.includes(fk.referenced_column_name)) {
-          ret[fk.constraint_name].referencedColumnNames.push(fk.referenced_column_name);
-        }
+        ret[fk.constraint_name].columnNames.push(fk.column_name);
+        ret[fk.constraint_name].referencedColumnNames.push(fk.referenced_column_name);
       } else {
         ret[fk.constraint_name] = {
           columnNames: [fk.column_name],


### PR DESCRIPTION
This PR fixes an issue introduced in v6.1.12 ([2dff96b](https://github.com/mikro-orm/mikro-orm/commit/2dff96bc48c6a84bc1fc213e8044b0ac722d4792)).

The query used to discover foreign keys was returning erroneous duplicate rows. The fixed query removes the duplicates and ensures FK columns are returned in the correct order.

This PR also reverses changes to the SchemaHelper, which are no longer needed.

