### PR TITLE
feat(core): allow better type-safety for custom types via `IType`

### DIFF
--- a/packages/core/src/entity/BaseEntity.ts
+++ b/packages/core/src/entity/BaseEntity.ts
@@ -49,8 +49,9 @@ export abstract class BaseEntity {
   assign<
     Entity extends this,
     Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
-    Data extends EntityData<Naked> | Partial<EntityDTO<Naked>> = EntityData<Naked> | Partial<EntityDTO<Naked>>,
-  >(data: Data & IsSubset<EntityData<Naked>, Data>, options: AssignOptions = {}): MergeSelected<Entity, Naked, keyof Data & string> {
+    Convert extends boolean = false,
+    Data extends EntityData<Naked, Convert> | Partial<EntityDTO<Naked>> = EntityData<Naked, Convert> | Partial<EntityDTO<Naked>>,
+  >(data: Data & IsSubset<EntityData<Naked>, Data>, options: AssignOptions<Convert> = {}): MergeSelected<Entity, Naked, keyof Data & string> {
     return EntityAssigner.assign(this as Entity, data as any, options) as any;
   }
 

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -254,7 +254,7 @@ export class EntityRepository<Entity extends object> {
    * the whole `data` parameter will be passed. This means we can also define `constructor(data: Partial<Entity>)` and
    * `em.create()` will pass the data into it (unless we have a property named `data` too).
    */
-  create(data: RequiredEntityData<Entity>, options?: CreateOptions): Entity {
+  create<Convert extends boolean = false>(data: RequiredEntityData<Entity, never, Convert>, options?: CreateOptions<Convert>): Entity {
     return this.getEntityManager().create(this.entityName, data, options);
   }
 
@@ -264,8 +264,9 @@ export class EntityRepository<Entity extends object> {
   assign<
     Ent extends EntityType<Entity>,
     Naked extends FromEntityType<Ent> = FromEntityType<Ent>,
-    Data extends EntityData<Naked> | Partial<EntityDTO<Naked>> = EntityData<Naked> | Partial<EntityDTO<Naked>>,
-  >(entity: Ent | Partial<Ent>, data: Data & IsSubset<EntityData<Naked>, Data>, options?: AssignOptions): MergeSelected<Ent, Naked, keyof Data & string> {
+    Convert extends boolean = false,
+    Data extends EntityData<Naked, Convert> | Partial<EntityDTO<Naked>> = EntityData<Naked, Convert> | Partial<EntityDTO<Naked>>,
+  >(entity: Ent | Partial<Ent>, data: Data & IsSubset<EntityData<Naked, Convert>, Data>, options?: AssignOptions<Convert>): MergeSelected<Ent, Naked, keyof Data & string> {
     this.validateRepositoryType(entity as Entity, 'assign');
     return this.getEntityManager().assign(entity, data as any, options) as any;
   }

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -126,8 +126,9 @@ export class WrappedEntity<Entity extends object> {
 
   assign<
     Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
-    Data extends EntityData<Naked> | Partial<EntityDTO<Naked>> = EntityData<Naked> | Partial<EntityDTO<Naked>>,
-  >(data: Data & IsSubset<EntityData<Naked>, Data>, options?: AssignOptions): MergeSelected<Entity, Naked, keyof Data & string> {
+    Convert extends boolean = false,
+    Data extends EntityData<Naked, Convert> | Partial<EntityDTO<Naked>> = EntityData<Naked, Convert> | Partial<EntityDTO<Naked>>,
+  >(data: Data & IsSubset<EntityData<Naked>, Data>, options?: AssignOptions<Convert>): MergeSelected<Entity, Naked, keyof Data & string> {
     if ('assign' in this.entity) {
       return (this.entity as Dictionary).assign(data, options);
     }

--- a/packages/core/src/types/Type.ts
+++ b/packages/core/src/types/Type.ts
@@ -8,6 +8,12 @@ export interface TransformContext {
   mode?: 'hydration' | 'query' | 'query-data' | 'discovery' | 'serialization';
 }
 
+export type IType<Runtime, Raw, Serialized = Raw> = Runtime & {
+  __raw?: Raw;
+  __runtime?: Runtime;
+  __serialized?: Serialized;
+};
+
 export abstract class Type<JSType = string, DBType = JSType> {
 
   private static readonly types = new Map();

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,4 +1,4 @@
-import { Type, TransformContext } from './Type';
+import { Type, TransformContext, IType } from './Type';
 import { DateType } from './DateType';
 import { TimeType } from './TimeType';
 import { DateTimeType } from './DateTimeType';
@@ -26,7 +26,7 @@ import { UnknownType } from './UnknownType';
 export {
   Type, DateType, TimeType, DateTimeType, BigIntType, BlobType, Uint8ArrayType, ArrayType, EnumArrayType, EnumType,
   JsonType, IntegerType, SmallIntType, TinyIntType, MediumIntType, FloatType, DoubleType, BooleanType, DecimalType,
-  StringType, UuidType, TextType, UnknownType, TransformContext, IntervalType,
+  StringType, UuidType, TextType, UnknownType, TransformContext, IntervalType, IType,
 };
 
 export const types = {

--- a/tests/issues/GH910.test.ts
+++ b/tests/issues/GH910.test.ts
@@ -1,4 +1,4 @@
-import type { Platform } from '@mikro-orm/sqlite';
+import type { IType, Platform } from '@mikro-orm/sqlite';
 import { Cascade, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, Type } from '@mikro-orm/sqlite';
 import { mockLogger } from '../helpers';
 
@@ -63,7 +63,7 @@ export class CartItem {
   readonly cart!: Cart;
 
   @PrimaryKey({ type: SkuType })
-  readonly sku: Sku;
+  readonly sku: IType<Sku, string>;
 
   @Property()
   quantity: number;
@@ -91,8 +91,8 @@ describe('GH issue 910', () => {
     const mock = mockLogger(orm, ['query', 'query-params']);
 
     const id = '123';
-    const item1 = new CartItem(Sku.create('sku1'), 10);
-    const item2 = new CartItem(Sku.create('sku2'), 10);
+    const item1 = orm.em.create(CartItem, { sku: 'sku1', quantity: 10 }, { partial: true, convertCustomTypes: true });
+    const item2 = orm.em.create(CartItem, { sku: Sku.create('sku2'), quantity: 10 }, { partial: true });
     const cart = new Cart(id, [item1, item2]);
     await orm.em.persistAndFlush(cart);
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,4 +1,4 @@
-import { Constructor, EntityRepository, EntitySchema, OptionalProps, ref, wrap } from '@mikro-orm/core';
+import { Constructor, EntityRepository, EntitySchema, OptionalProps, IType, ref, wrap } from '@mikro-orm/core';
 import type { BaseEntity, Ref, Reference, Collection, EntityManager, EntityName, RequiredEntityData } from '@mikro-orm/core';
 import type { Has, IsExact } from 'conditional-type-checks';
 import { assert } from 'conditional-type-checks';
@@ -810,7 +810,7 @@ describe('check typings', () => {
       status?: string;
     }
 
-    abstract class AbstractRepository<
+    class AbstractRepository<
       Entity extends AbstractEntity
     > extends EntityRepository<Entity> {
 
@@ -853,6 +853,36 @@ describe('check typings', () => {
     const dto1: UserDTO = { id: 1, name: null };
     // @ts-expect-error
     const dto2: UserDTO = { id: 1, name: undefined };
+  });
+
+  test('custom types with IType', async () => {
+    const myClassSymbol = Symbol('MyClass');
+
+    interface MyClass {
+      [myClassSymbol]: true;
+    }
+
+    class MyEntity {
+
+      myClass!: IType<MyClass, string>;
+
+    }
+
+    function create<T>(type: EntityName<T>, data: EntityData<T> | RequiredEntityData<T>) {
+      //
+    }
+
+    create(MyEntity, { myClass: {} as MyClass });
+    // @ts-expect-error
+    create(MyEntity, { myClass: '...' });
+    // @ts-expect-error
+    create(MyEntity, { myClass: 123 });
+    // @ts-expect-error
+    create(MyEntity, { myClass: true });
+
+    const o = {} as EntityDTO<MyEntity>;
+    const myClass = o.myClass;
+    assert<IsExact<typeof myClass, string>>(true);
   });
 
 });


### PR DESCRIPTION
When your custom type maps a value to an object, it might break the internal types like in `em.create()`, as there is no easy way to detect whether some object type is an entity or something else. In those cases, it can be handy to use `IType` to provide more information about your type on the type-level. It has three arguments, the first represents the runtime type, the second one is the raw value type, and the last optional argument allows overriding the serialized type (which defaults to the raw value type).

Consider the following custom type:

```ts
class MyClass {
  constructor(private value: string) {}
}

class MyType extends Type<MyClass, string> {

  convertToDatabaseValue(value: MyClass): string {
    return value.value;
  }

  convertToJSValue(value: string): MyClass {
    return new MyClass(value);
  }

}
```

Now let's use it together with the `IType`:

```ts
@Entity()
class MyEntity {

  @Property({ type: MyType })
  // highlight-next-line
  foo?: IType<MyClass, string>;

}
```

This will make the `em.create()` properly disallow values other than MyClass, as well as convert the value type to `string` when serializing. Without the `IType`, there would be no error with `em.create()` and the serialization would result in `MyClass` on type level (but would be a `string` value on runtime):

```ts
// this will fail but wouldn't without the `IType`
const entity = em.create(MyEntity, { foo: 'bar' });

// serialized value is now correctly typed to `string`
const object = wrap(e).toObject(); // `{ foo: string }`
```