### PR TITLE
feat(postgres): allow defining deferred FK constraints

### DIFF
--- a/packages/core/src/decorators/ManyToOne.ts
+++ b/packages/core/src/decorators/ManyToOne.ts
@@ -1,7 +1,7 @@
 import type { ReferenceOptions } from './Property';
 import { MetadataStorage, MetadataValidator } from '../metadata';
 import { Utils } from '../utils';
-import { ReferenceKind } from '../enums';
+import { type DeferMode, ReferenceKind } from '../enums';
 import type { AnyEntity, AnyString, EntityKey, EntityName, EntityProperty } from '../typings';
 
 export function ManyToOne<T extends object, O>(
@@ -30,4 +30,5 @@ export interface ManyToOneOptions<Owner, Target> extends ReferenceOptions<Owner,
   referencedColumnNames?: string[];
   deleteRule?: 'cascade' | 'no action' | 'set null' | 'set default' | AnyString;
   updateRule?: 'cascade' | 'no action' | 'set null' | 'set default' | AnyString;
+  deferMode?: DeferMode;
 }

--- a/packages/core/src/decorators/OneToOne.ts
+++ b/packages/core/src/decorators/OneToOne.ts
@@ -1,4 +1,4 @@
-import { ReferenceKind } from '../enums';
+import { type DeferMode, ReferenceKind } from '../enums';
 import { createOneToDecorator, type OneToManyOptions } from './OneToMany';
 import type { AnyString, EntityName } from '../typings';
 
@@ -20,4 +20,5 @@ export interface OneToOneOptions<Owner, Target> extends Partial<Omit<OneToManyOp
   mapToPk?: boolean;
   deleteRule?: 'cascade' | 'no action' | 'set null' | 'set default' | AnyString;
   updateRule?: 'cascade' | 'no action' | 'set null' | 'set default' | AnyString;
+  deferMode?: DeferMode;
 }

--- a/packages/core/src/enums.ts
+++ b/packages/core/src/enums.ts
@@ -205,3 +205,9 @@ export interface TransactionOptions {
 
 export abstract class PlainObject {
 }
+
+export enum DeferMode {
+  NOT_DEFERRABLE = 'not deferrable',
+  INITIALLY_IMMEDIATE = 'immediate',
+  INITIALLY_DEFERRED = 'deferred',
+}

--- a/packages/core/src/enums.ts
+++ b/packages/core/src/enums.ts
@@ -207,7 +207,6 @@ export abstract class PlainObject {
 }
 
 export enum DeferMode {
-  NOT_DEFERRABLE = 'not deferrable',
   INITIALLY_IMMEDIATE = 'immediate',
   INITIALLY_DEFERRED = 'deferred',
 }

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1,5 +1,12 @@
 import type { Transaction } from './connections';
-import { type Cascade, type EventType, type LoadStrategy, type QueryOrderMap, ReferenceKind } from './enums';
+import {
+  type DeferMode,
+  type Cascade,
+  type EventType,
+  type LoadStrategy,
+  type QueryOrderMap,
+  ReferenceKind,
+} from './enums';
 import {
   type AssignOptions,
   type Collection,
@@ -483,6 +490,7 @@ export interface EntityProperty<Owner = any, Target = any> {
   userDefined?: boolean;
   optional?: boolean; // for ts-morph
   ignoreSchemaChanges?: ('type' | 'extra')[];
+  deferMode?: DeferMode;
 }
 
 export class EntityMetadata<T = any> {

--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -158,6 +158,10 @@ export class DatabaseTable {
       if (prop.updateRule || prop.cascade.includes(Cascade.PERSIST) || prop.cascade.includes(Cascade.ALL)) {
         this.foreignKeys[constraintName].updateRule = prop.updateRule || 'cascade';
       }
+
+      if (prop.deferMode) {
+        this.foreignKeys[constraintName].deferMode = prop.deferMode;
+      }
     }
 
     if (prop.index) {
@@ -599,6 +603,7 @@ export class DatabaseTable {
     fkOptions.referencedColumnNames = fk.referencedColumnNames;
     fkOptions.updateRule = fk.updateRule?.toLowerCase();
     fkOptions.deleteRule = fk.deleteRule?.toLowerCase();
+    fkOptions.deferMode = fk.deferMode;
     fkOptions.columnTypes = fk.columnNames.map(c => this.getColumn(c)!.type);
 
     const columnOptions: Partial<EntityProperty> = {};
@@ -662,6 +667,7 @@ export class DatabaseTable {
       fkOptions.referencedColumnNames = fk.referencedColumnNames;
       fkOptions.updateRule = fk.updateRule?.toLowerCase();
       fkOptions.deleteRule = fk.deleteRule?.toLowerCase();
+      fkOptions.deferMode = fk.deferMode;
     }
 
     return {

--- a/packages/knex/src/schema/SchemaComparator.ts
+++ b/packages/knex/src/schema/SchemaComparator.ts
@@ -9,7 +9,6 @@ import {
   type Dictionary,
   type EntityProperty,
   type Logger,
-  DeferMode,
 } from '@mikro-orm/core';
 import type { Column, ForeignKey, IndexDef, SchemaDifference, TableDifference } from '../typings';
 import type { DatabaseSchema } from './DatabaseSchema';
@@ -435,7 +434,7 @@ export class SchemaComparator {
       return true;
     }
 
-    if ((key1.deferMode ?? DeferMode.NOT_DEFERRABLE) !== (key2.deferMode ?? DeferMode.NOT_DEFERRABLE)) {
+    if (key1.deferMode !== key2.deferMode) {
       return true;
     }
 

--- a/packages/knex/src/schema/SchemaComparator.ts
+++ b/packages/knex/src/schema/SchemaComparator.ts
@@ -9,6 +9,7 @@ import {
   type Dictionary,
   type EntityProperty,
   type Logger,
+  DeferMode,
 } from '@mikro-orm/core';
 import type { Column, ForeignKey, IndexDef, SchemaDifference, TableDifference } from '../typings';
 import type { DatabaseSchema } from './DatabaseSchema';
@@ -431,6 +432,10 @@ export class SchemaComparator {
     }
 
     if (key1.referencedTableName !== key2.referencedTableName) {
+      return true;
+    }
+
+    if ((key1.deferMode ?? DeferMode.NOT_DEFERRABLE) !== (key2.deferMode ?? DeferMode.NOT_DEFERRABLE)) {
       return true;
     }
 

--- a/packages/knex/src/schema/SchemaHelper.ts
+++ b/packages/knex/src/schema/SchemaHelper.ts
@@ -256,6 +256,7 @@ export abstract class SchemaHelper {
           referencedColumnNames: [fk.referenced_column_name],
           updateRule: fk.update_rule.toLowerCase(),
           deleteRule: fk.delete_rule.toLowerCase(),
+          deferMode: fk.defer_mode,
         };
       }
 

--- a/packages/knex/src/schema/SqlSchemaGenerator.ts
+++ b/packages/knex/src/schema/SqlSchemaGenerator.ts
@@ -352,6 +352,10 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
     if (foreignKey.deleteRule) {
       builder.onDelete(foreignKey.deleteRule);
     }
+
+    if (foreignKey.deferMode) {
+      builder.deferrable(foreignKey.deferMode);
+    }
   }
 
   /**

--- a/packages/knex/src/typings.ts
+++ b/packages/knex/src/typings.ts
@@ -1,5 +1,5 @@
-import type { Knex } from 'knex';
 import type {
+  DeferMode,
   CheckCallback,
   Dictionary,
   EntityProperty,
@@ -12,6 +12,7 @@ import type {
   AnyEntity,
   EntityName,
 } from '@mikro-orm/core';
+import type { Knex } from 'knex';
 import type { JoinType, QueryType } from './query/enums';
 import type { DatabaseSchema, DatabaseTable } from './schema';
 
@@ -78,6 +79,7 @@ export interface ForeignKey {
   referencedColumnNames: string[];
   updateRule?: string;
   deleteRule?: string;
+  deferMode?: DeferMode;
 }
 
 export interface IndexDef {

--- a/tests/features/deferrable-constraints/deferrable-constraints.postgres.test.ts
+++ b/tests/features/deferrable-constraints/deferrable-constraints.postgres.test.ts
@@ -21,13 +21,12 @@ class Child {
 
 describe('deferrable constraints in postgres', () => {
 
-  let orm: MikroORM<PostgreSqlDriver>;
+  let orm: MikroORM;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Parent, Child],
       dbName: `mikro_orm_test_deferrable`,
-      driver: PostgreSqlDriver,
     });
     await orm.schema.refreshDatabase();
   });

--- a/tests/features/deferrable-constraints/deferrable-constraints.postgres.test.ts
+++ b/tests/features/deferrable-constraints/deferrable-constraints.postgres.test.ts
@@ -1,6 +1,4 @@
-import { MikroORM, Ref, Reference } from '@mikro-orm/core';
-import { DeferMode, Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { DeferMode, Entity, ManyToOne, PrimaryKey, MikroORM, Ref, Reference } from '@mikro-orm/postgresql';
 
 @Entity()
 class Parent {

--- a/tests/features/deferrable-constraints/deferrable-constraints.postgres.test.ts
+++ b/tests/features/deferrable-constraints/deferrable-constraints.postgres.test.ts
@@ -1,0 +1,58 @@
+import { MikroORM, Ref, Reference } from '@mikro-orm/core';
+import { DeferMode, Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+
+@Entity()
+class Parent {
+
+  @PrimaryKey()
+  id!: number;
+
+}
+
+@Entity()
+class Child {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Parent, { ref: true, deferMode: DeferMode.INITIALLY_DEFERRED })
+  parent!: Ref<Parent>;
+
+}
+
+describe('deferrable constraints in postgres', () => {
+
+  let orm: MikroORM<PostgreSqlDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Parent, Child],
+      dbName: `mikro_orm_test_deferrable`,
+      driver: PostgreSqlDriver,
+    });
+    await orm.schema.ensureDatabase();
+    await orm.schema.execute('drop table if exists child');
+    await orm.schema.execute('drop table if exists parent');
+    await orm.schema.createSchema();
+  });
+  beforeEach(async () => orm.schema.clearDatabase());
+  afterAll(async () => {
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+  test('insert deferred', async () => {
+    await orm.em.transactional(async em => {
+      const parent = new Parent();
+      parent.id = 1;
+      const child = new Child();
+      child.id = 1;
+      child.parent = Reference.createFromPK(Parent, 1);
+
+      await em.persistAndFlush(child);
+      await em.persistAndFlush(parent);
+    });
+  });
+
+});

--- a/tests/features/deferrable-constraints/deferrable-constraints.postgres.test.ts
+++ b/tests/features/deferrable-constraints/deferrable-constraints.postgres.test.ts
@@ -31,10 +31,7 @@ describe('deferrable constraints in postgres', () => {
       dbName: `mikro_orm_test_deferrable`,
       driver: PostgreSqlDriver,
     });
-    await orm.schema.ensureDatabase();
-    await orm.schema.execute('drop table if exists child');
-    await orm.schema.execute('drop table if exists parent');
-    await orm.schema.createSchema();
+    await orm.schema.refreshDatabase();
   });
   beforeEach(async () => orm.schema.clearDatabase());
   afterAll(async () => {

--- a/tests/features/schema-generator/__snapshots__/fk-diffing.postgres.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/fk-diffing.postgres.test.ts.snap
@@ -53,3 +53,27 @@ alter table "book" drop column "based_on_id";
 
 "
 `;
+
+exports[`updating tables with FKs in postgres schema generator updates foreign keys on deferrable change 1`] = `
+"alter table "book" drop constraint "book_author1_pk_foreign";
+
+alter table "book" add constraint "book_author1_pk_foreign" foreign key ("author1_pk") references "author" ("pk") on update cascade deferrable initially deferred ;
+
+"
+`;
+
+exports[`updating tables with FKs in postgres schema generator updates foreign keys on deferrable change 2`] = `
+"alter table "book" drop constraint "book_author1_pk_foreign";
+
+alter table "book" add constraint "book_author1_pk_foreign" foreign key ("author1_pk") references "author" ("pk") on update cascade deferrable initially immediate ;
+
+"
+`;
+
+exports[`updating tables with FKs in postgres schema generator updates foreign keys on deferrable change 3`] = `
+"alter table "book" drop constraint "book_author1_pk_foreign";
+
+alter table "book" add constraint "book_author1_pk_foreign" foreign key ("author1_pk") references "author" ("pk") on update cascade;
+
+"
+`;

--- a/tests/features/schema-generator/fk-diffing.postgres.test.ts
+++ b/tests/features/schema-generator/fk-diffing.postgres.test.ts
@@ -206,21 +206,21 @@ describe('updating tables with FKs in postgres', () => {
     const diff1 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
     expect(diff1).toMatchSnapshot();
     await orm.schema.execute(diff1);
-    expect(await orm.schema.getUpdateSchemaSQL({ wrap: false })).toBe('');
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
 
     orm.getMetadata().reset('Book41');
     orm.discoverEntity([Book42]);
     const diff2 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
     expect(diff2).toMatchSnapshot();
     await orm.schema.execute(diff2);
-    expect(await orm.schema.getUpdateSchemaSQL({ wrap: false })).toBe('');
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
 
     orm.getMetadata().reset('Book42');
     orm.discoverEntity([Book4]);
     const diff3 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
     expect(diff3).toMatchSnapshot();
     await orm.schema.execute(diff3);
-    expect(await orm.schema.getUpdateSchemaSQL({ wrap: false })).toBe('');
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
 
     await orm.close(true);
   });

--- a/tests/features/schema-generator/fk-diffing.postgres.test.ts
+++ b/tests/features/schema-generator/fk-diffing.postgres.test.ts
@@ -206,18 +206,21 @@ describe('updating tables with FKs in postgres', () => {
     const diff1 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
     expect(diff1).toMatchSnapshot();
     await orm.schema.execute(diff1);
+    expect(await orm.schema.getUpdateSchemaSQL({ wrap: false })).toBe('');
 
     orm.getMetadata().reset('Book41');
     orm.discoverEntity([Book42]);
     const diff2 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
     expect(diff2).toMatchSnapshot();
     await orm.schema.execute(diff2);
+    expect(await orm.schema.getUpdateSchemaSQL({ wrap: false })).toBe('');
 
     orm.getMetadata().reset('Book42');
     orm.discoverEntity([Book4]);
     const diff3 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
     expect(diff3).toMatchSnapshot();
     await orm.schema.execute(diff3);
+    expect(await orm.schema.getUpdateSchemaSQL({ wrap: false })).toBe('');
 
     await orm.close(true);
   });


### PR DESCRIPTION
This PR adds the option to specify constraints as deferrable for relations.

On OneToOne and ManyToOne relations you can now specify a `deferMode` property, which can be either `not deferrable` (default), `immediate` or `deferred`. Those are also covered by a new `DeferMode` enum.

Closes #5306