### PR TITLE
refactor(reflection): removed the defense inside initProject() in favor of check outside

### DIFF
--- a/packages/reflection/src/TsMorphMetadataProvider.ts
+++ b/packages/reflection/src/TsMorphMetadataProvider.ts
@@ -193,10 +193,6 @@ export class TsMorphMetadataProvider extends MetadataProvider {
   }
 
   private initProject(): void {
-    if (this.project) {
-      return;
-    }
-
     const settings = ConfigurationLoader.getSettings();
     const tsConfigFilePath = this.config.get('discovery').tsConfigPath ?? settings.tsConfigPath ?? './tsconfig.json';
 
@@ -220,7 +216,9 @@ export class TsMorphMetadataProvider extends MetadataProvider {
   }
 
   private initSourceFiles(): void {
-    this.initProject();
+    if (!this.project) {
+      this.initProject();
+    }
 
     // All entity files are first required during the discovery, before we reach here, so it is safe to get the parts from the global
     // metadata storage. We know the path thanks the decorators being executed. In case we are running via ts-node, the extension


### PR DESCRIPTION
This makes the project init consistent with source files init, while also eliminating the otherwise unreachable path from project re-init that initProject() defended from.

This removal in turn increases coverage of TsMorphMetadataProvider.ts to 100%.