### PR TITLE
docs: fix typo in getting started guide

### DIFF
--- a/docs/docs/guide/01-first-entity.md
+++ b/docs/docs/guide/01-first-entity.md
@@ -653,7 +653,7 @@ An alternative to the previous code snippet could be as well this:
 
 ```ts
 const userRef = em.getReference(User, 1);
-await em.remove(user).flush();
+await em.remove(userRef).flush();
 ```
 
 This concept is especially important for relationships and can be combined with the so-called `Reference` wrapper for added type safety, but we will get to that later.

--- a/docs/versioned_docs/version-6.0/guide/01-first-entity.md
+++ b/docs/versioned_docs/version-6.0/guide/01-first-entity.md
@@ -653,7 +653,7 @@ An alternative to the previous code snippet could be as well this:
 
 ```ts
 const userRef = em.getReference(User, 1);
-await em.remove(user).flush();
+await em.remove(userRef).flush();
 ```
 
 This concept is especially important for relationships and can be combined with the so-called `Reference` wrapper for added type safety, but we will get to that later.

--- a/docs/versioned_docs/version-6.1/guide/01-first-entity.md
+++ b/docs/versioned_docs/version-6.1/guide/01-first-entity.md
@@ -653,7 +653,7 @@ An alternative to the previous code snippet could be as well this:
 
 ```ts
 const userRef = em.getReference(User, 1);
-await em.remove(user).flush();
+await em.remove(userRef).flush();
 ```
 
 This concept is especially important for relationships and can be combined with the so-called `Reference` wrapper for added type safety, but we will get to that later.


### PR DESCRIPTION
Assuming this should read `userRef` instead of `user` based on previous const name.