### PR TITLE
refactor(core): added a PopulatePath enum, to contain the special prop names in populate

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -75,6 +75,7 @@ import {
   LoadStrategy,
   LockMode,
   PopulateHint,
+  PopulatePath,
   QueryFlag,
   ReferenceKind,
   SCALAR_TYPES,
@@ -196,7 +197,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   async find<
     Entity extends object,
     Hint extends string = never,
-    Fields extends string = '*',
+    Fields extends string = PopulatePath.ALL,
     Excludes extends string = never,
   >(entityName: EntityName<Entity>, where: FilterQuery<Entity>, options: FindOptions<Entity, Hint, Fields, Excludes> = {}): Promise<Loaded<Entity, Hint, Fields, Excludes>[]> {
     if (options.disableIdentityMap ?? this.config.get('disableIdentityMap')) {
@@ -1816,7 +1817,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     Hint extends string = never,
     Fields extends string = '*',
     Excludes extends string = never,
-  >(entities: Entity, populate: AutoPath<Naked, Hint, '*'>[] | false, options: EntityLoaderOptions<Naked, Fields, Excludes> = {}): Promise<Entity extends object[] ? MergeLoaded<ArrayElement<Entity>, Naked, Hint, Fields, Excludes>[] : MergeLoaded<Entity, Naked, Hint, Fields, Excludes>> {
+  >(entities: Entity, populate: AutoPath<Naked, Hint, PopulatePath.ALL>[] | false, options: EntityLoaderOptions<Naked, Fields, Excludes> = {}): Promise<Entity extends object[] ? MergeLoaded<ArrayElement<Entity>, Naked, Hint, Fields, Excludes>[] : MergeLoaded<Entity, Naked, Hint, Fields, Excludes>> {
     const arr = Utils.asArray(entities);
 
     if (arr.length === 0) {
@@ -2045,7 +2046,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
         const ret: string[] = [];
 
         for (const field of fields) {
-          if (field === '*' || field.startsWith('*.')) {
+          if (field === PopulatePath.ALL || field.startsWith(`${PopulatePath.ALL}.`)) {
             ret.push(...meta.props.filter(prop => prop.lazy || [ReferenceKind.SCALAR, ReferenceKind.EMBEDDED].includes(prop.kind)).map(prop => prop.name));
             continue;
           }
@@ -2086,12 +2087,12 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     if (typeof options.populate !== 'boolean') {
       options.populate = Utils.asArray(options.populate).map(field => {
         /* istanbul ignore next */
-        if (typeof field === 'boolean' || field === '*') {
+        if (typeof field === 'boolean' || field === PopulatePath.ALL) {
           return [{ field: meta.primaryKeys[0], strategy: options.strategy, all: !!field }]; //
         }
 
         // will be handled in QueryBuilder when processing the where condition via CriteriaNode
-        if (field === '$infer') {
+        if (field === PopulatePath.INFER) {
           options.flags ??= [];
           options.flags.push(QueryFlag.INFER_POPULATE);
 

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -3,7 +3,7 @@ import type {
   IPrimaryKey, PopulateOptions, EntityDictionary, AutoPath, ObjectQuery, FilterObject, Populate,
 } from '../typings';
 import type { Connection, QueryResult, Transaction } from '../connections';
-import type { FlushMode, LockMode, QueryOrderMap, QueryFlag, LoadStrategy, PopulateHint } from '../enums';
+import type { FlushMode, LockMode, QueryOrderMap, QueryFlag, LoadStrategy, PopulateHint, PopulatePath } from '../enums';
 import type { Platform } from '../platforms';
 import type { MetadataStorage } from '../metadata';
 import type { Collection } from '../entity/Collection';
@@ -90,7 +90,7 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
 
 }
 
-export type EntityField<T, P extends string = '*'> = keyof T | '*' | AutoPath<T, P, '*'>;
+export type EntityField<T, P extends string = PopulatePath.ALL> = keyof T | PopulatePath.ALL | AutoPath<T, P, `${PopulatePath.ALL}`>;
 
 export type OrderDefinition<T> = (QueryOrderMap<T> & { 0?: never }) | QueryOrderMap<T>[];
 
@@ -103,13 +103,13 @@ export type FilterOptions = Dictionary<boolean | Dictionary> | string[] | boolea
 export interface FindOptions<
   Entity,
   Hint extends string = never,
-  Fields extends string = '*',
+  Fields extends string = PopulatePath.ALL,
   Excludes extends string = never,
 > {
   populate?: Populate<Entity, Hint>;
   populateWhere?: ObjectQuery<Entity> | PopulateHint | `${PopulateHint}`;
   populateOrderBy?: OrderDefinition<Entity>;
-  fields?: readonly AutoPath<Entity, Fields, '*'>[];
+  fields?: readonly AutoPath<Entity, Fields, `${PopulatePath.ALL}`>[];
   exclude?: readonly AutoPath<Entity, Excludes>[];
   orderBy?: OrderDefinition<Entity>;
   cache?: boolean | number | [string, number];

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -1,3 +1,4 @@
+import type { PopulatePath } from '../enums';
 import type { CreateOptions, EntityManager, MergeOptions } from '../EntityManager';
 import type { AssignOptions } from './EntityAssigner';
 import type {
@@ -240,7 +241,7 @@ export class EntityRepository<Entity extends object> {
     Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
     Fields extends string = '*',
     Excludes extends string = never,
-  >(entities: Ent, populate: AutoPath<Naked, Hint, '*'>[] | false, options?: EntityLoaderOptions<Naked, Fields, Excludes>): Promise<Ent extends object[] ? MergeLoaded<ArrayElement<Ent>, Naked, Hint, Fields, Excludes>[] : MergeLoaded<Ent, Naked, Hint, Fields, Excludes>> {
+  >(entities: Ent, populate: AutoPath<Naked, Hint, PopulatePath.ALL>[] | false, options?: EntityLoaderOptions<Naked, Fields, Excludes>): Promise<Ent extends object[] ? MergeLoaded<ArrayElement<Ent>, Naked, Hint, Fields, Excludes>[] : MergeLoaded<Ent, Naked, Hint, Fields, Excludes>> {
     this.validateRepositoryType(entities, 'populate');
     // @ts-ignore hard to type
     return this.getEntityManager().populate(entities, populate, options);

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -1,3 +1,4 @@
+import type { PopulatePath } from '../enums';
 import { inspect } from 'util';
 import type { EntityManager } from '../EntityManager';
 import type {
@@ -149,7 +150,7 @@ export class WrappedEntity<Entity extends object> {
   }
 
   async populate<Hint extends string = never>(
-    populate: AutoPath<Entity, Hint, '*'>[] | false,
+    populate: AutoPath<Entity, Hint, PopulatePath.ALL>[] | false,
     options: EntityLoaderOptions<Entity> = {},
   ): Promise<Loaded<Entity, Hint>> {
     if (!this.__em) {

--- a/packages/core/src/enums.ts
+++ b/packages/core/src/enums.ts
@@ -16,6 +16,11 @@ export enum PopulateHint {
   ALL = 'all',
 }
 
+export enum PopulatePath {
+  INFER = '$infer',
+  ALL = '*',
+}
+
 export enum GroupOperator {
   $and = 'and',
   $or = 'or',

--- a/packages/core/src/serialization/EntitySerializer.ts
+++ b/packages/core/src/serialization/EntitySerializer.ts
@@ -18,7 +18,7 @@ import type {
 import { helper } from '../entity/wrap';
 import type { Platform } from '../platforms';
 import { Utils } from '../utils/Utils';
-import { ReferenceKind } from '../enums';
+import { type PopulatePath, ReferenceKind } from '../enums';
 import { Reference } from '../entity/Reference';
 import { SerializationContext } from './SerializationContext';
 import { RawQueryFragment } from '../utils/RawQueryFragment';
@@ -266,7 +266,7 @@ export class EntitySerializer {
 
 export interface SerializeOptions<T, P extends string = never, E extends string = never> {
   /** Specify which relation should be serialized as populated and which as a FK. */
-  populate?: readonly AutoPath<T, P, '*'>[];
+  populate?: readonly AutoPath<T, P, `${PopulatePath.ALL}`>[];
 
   /** Specify which properties should be omitted. */
   exclude?: readonly AutoPath<T, E>[];

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1,5 +1,6 @@
 import type { Transaction } from './connections';
 import {
+  type PopulatePath,
   type DeferMode,
   type Cascade,
   type EventType,
@@ -926,7 +927,7 @@ export type FilterDef = {
   args?: boolean;
 };
 
-export type Populate<T, P extends string = never> = readonly AutoPath<T, P, '*' | '$infer'>[] | false;
+export type Populate<T, P extends string = never> = readonly AutoPath<T, P, `${PopulatePath}`>[] | false;
 
 export type PopulateOptions<T> = {
   field: EntityKey<T>;

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -40,6 +40,7 @@ import {
   type OrderDefinition,
   parseJsonSafe,
   type PopulateOptions,
+  type PopulatePath,
   type Primary,
   QueryFlag,
   QueryHelper,
@@ -86,7 +87,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
     return new EntityManagerClass(this.config, this, this.metadata, useContext) as unknown as EntityManager<D>;
   }
 
-  async find<T extends object, P extends string = never, F extends string = '*', E extends string = never>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, P, F, E> = {}): Promise<EntityData<T>[]> {
+  async find<T extends object, P extends string = never, F extends string = PopulatePath.ALL, E extends string = never>(entityName: string, where: FilterQuery<T>, options: FindOptions<T, P, F, E> = {}): Promise<EntityData<T>[]> {
     options = { populate: [], orderBy: [], ...options };
     const meta = this.metadata.find<T>(entityName)!;
 
@@ -144,7 +145,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
     return result;
   }
 
-  async findOne<T extends object, P extends string = never, F extends string = '*', E extends string = never>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T, P, F, E>): Promise<EntityData<T> | null> {
+  async findOne<T extends object, P extends string = never, F extends string = PopulatePath.ALL, E extends string = never>(entityName: string, where: FilterQuery<T>, options?: FindOneOptions<T, P, F, E>): Promise<EntityData<T> | null> {
     const opts = { populate: [], ...options } as FindOptions<T>;
     const meta = this.metadata.find(entityName)!;
     const populate = this.autoJoinOneToOneOwner(meta, opts.populate as unknown as PopulateOptions<T>[], opts.fields);

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -19,6 +19,7 @@ import {
   type NativeInsertUpdateManyOptions,
   type NativeInsertUpdateOptions,
   type PopulateOptions,
+  type PopulatePath,
   type QueryResult,
   ReferenceKind,
   type Transaction,
@@ -89,7 +90,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     return res.map(r => this.mapResult<T>(r, this.metadata.find<T>(entityName))!);
   }
 
-  async findOne<T extends object, P extends string = never, F extends string = '*', E extends string = never>(entityName: string, where: FilterQuery<T>, options: FindOneOptions<T, P, F, E> = { populate: [], orderBy: {} }): Promise<EntityData<T> | null> {
+  async findOne<T extends object, P extends string = never, F extends string = PopulatePath.ALL, E extends string = never>(entityName: string, where: FilterQuery<T>, options: FindOneOptions<T, P, F, E> = { populate: [], orderBy: {} }): Promise<EntityData<T> | null> {
     if (this.metadata.find(entityName)?.virtual) {
       const [item] = await this.findVirtual(entityName, where, options as FindOptions<T, any, any, any>);
       /* istanbul ignore next */


### PR DESCRIPTION
Currently, this includes just `"*"` and `"$infer"`.
Places where `"*"` is used as an actual SQL query expression remain using the literal string `"*"`.