### PR TITLE
@CreateRequestContext() decorator should support callback returns an EntityManager

### DIFF
--- a/packages/core/src/decorators/CreateRequestContext.ts
+++ b/packages/core/src/decorators/CreateRequestContext.ts
@@ -18,6 +18,7 @@ export function CreateRequestContext<T>(getContext?: MikroORM | Promise<MikroORM
 
       if (typeof getContext === 'function') {
         orm = await (getContext(this) ?? (this as any).orm);
+        em = await (getContext(this) ?? (this any).em);
       } else if (getContext) {
         orm = await getContext;
       } else {


### PR DESCRIPTION
If I define services like this (though there is some inversify, but I think it doesn't affect the result). I will got **runtime error** .

```typescript
@injectable()
export class DbService extends BasicDatabaseServiceImpl {
    private _em: EntityManager;
    private emWithoutContext: EntityManager;
    constructor(private configManager: ConfigManager){}

    public getEntityManager(useContext: boolean): EntityManager {
        if (useContext) {
            return this._em;
        } else {
            if (!this.emWithoutContext) {
                this.emWithoutContext = this._em.fork({useContext: false});
            }
            return this.emWithoutContext
        }
    }
    public async start(): Promise<void> {
        this._ormHelper = await MikroORM.init<PostgreSqlDriver>(this.configManager.databaseConfig());
        this._em = this._ormHelper.em;
    }
}

@injectable()
export class BookShelfService {

    constructor(private dbService: DbService) {
    }

    @CreateRequestContext<BookShelfService>(t => t.dbService.getEntityManager(true))
    public async listBooks(): Promise<Book[]> {
        const bookRepo = this.dbService.getBookRepo();
        return await bookRepo.findAll();
    }
}
```

```
Error: @CreateRequestContext() decorator can only be applied to methods of classes with `orm: MikroORM` property, `em: EntityManager` property, or with a callback parameter like `@CreateRequestContext(() => orm)` that returns one of those types. The parameter will contain a reference to current `this`. Returning an EntityRepository from it is also supported.
    at BookShelfService.descriptor.value (/home/everett/iroha/everett/mira-shared/node_modules/@mikro-orm/core/decorators/CreateRequestContext.js:41:23)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

The issue is though the type definition for the decorator claims it support callbacks that returns an EntityManager, but the decorator are expecting an MikroORM or something like that object return from callback.
