### PR TITLE
docs: add @mikro-orm/mssql to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,6 +32,7 @@ body:
         - "@mikro-orm/mysql"
         - "@mikro-orm/postgresql"
         - "@mikro-orm/sqlite"
+        - "@mikro-orm/libsql"
         - "@mikro-orm/mssql"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,6 +32,7 @@ body:
         - "@mikro-orm/mysql"
         - "@mikro-orm/postgresql"
         - "@mikro-orm/sqlite"
+        - "@mikro-orm/mssql"
     validations:
       required: false
 


### PR DESCRIPTION
Allows selection of `@mikro-orm/mssql` package in the bug template.