### PR TITLE
fix(core): fix folder-based discovery for multiple entities in single file

### DIFF
--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -52,6 +52,17 @@ describe('MikroORM', () => {
     await expect(MikroORM.init({ driver: MongoDriver, dbName: 'test', baseDir: BASE_DIR, entities: ['entities-1', 'entities-2'] })).rejects.toThrow('Duplicate entity names are not allowed: Dup1, Dup2');
   });
 
+  test('should NOT throw when multiple entities in same file were discovered', async () => {
+    const orm = await MikroORM.init({
+      driver: SqliteDriver,
+      dbName: ':memory:',
+      baseDir: BASE_DIR,
+      connect: false,
+      entities: ['complex-entities/**/*.entity.js'],
+      entitiesTs: ['complex-entities/**/*.entity.ts'],
+     });
+  });
+
   test('should NOT throw when multiple entities with same file name discovered ("checkDuplicateEntities" false)', async () => {
     const ormInitCommandPromise = MikroORM.init({ driver: MongoDriver, dbName: 'test', baseDir: BASE_DIR, entities: ['entities-1', 'entities-2'], discovery: { checkDuplicateEntities: false } });
 

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -53,14 +53,17 @@ describe('MikroORM', () => {
   });
 
   test('should NOT throw when multiple entities in same file were discovered', async () => {
-    await expect(MikroORM.init({
+    const orm = await MikroORM.init({
       driver: SqliteDriver,
       dbName: ':memory:',
       baseDir: BASE_DIR,
       connect: false,
       entities: ['complex-entities/**/*.entity.js'],
       entitiesTs: ['complex-entities/**/*.entity.ts'],
-     })).resolves.not.toBeUndefined();
+    });
+
+    expect(orm).toBeInstanceOf(MikroORM);
+    expect(Object.keys(orm.getMetadata().getAll()).sort()).toEqual(['AbstractClass', 'ClassA', 'ClassB']);
   });
 
   test('should NOT throw when multiple entities with same file name discovered ("checkDuplicateEntities" false)', async () => {

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -53,14 +53,14 @@ describe('MikroORM', () => {
   });
 
   test('should NOT throw when multiple entities in same file were discovered', async () => {
-    const orm = await MikroORM.init({
+    await expect(MikroORM.init({
       driver: SqliteDriver,
       dbName: ':memory:',
       baseDir: BASE_DIR,
       connect: false,
       entities: ['complex-entities/**/*.entity.js'],
       entitiesTs: ['complex-entities/**/*.entity.ts'],
-     });
+     })).resolves.not.toBeUndefined();
   });
 
   test('should NOT throw when multiple entities with same file name discovered ("checkDuplicateEntities" false)', async () => {

--- a/tests/complex-entities/abstract-class.entity.ts
+++ b/tests/complex-entities/abstract-class.entity.ts
@@ -1,0 +1,26 @@
+import {
+  Entity,
+  Enum, BaseEntity, PrimaryKey,
+} from '@mikro-orm/postgresql';
+
+export enum SomeEnum {
+  CLASS_A = 'class-a',
+  CLASS_B = 'class-b',
+}
+
+@Entity({ discriminatorColumn: 'type', abstract: true })
+export class AbstractClass extends BaseEntity {
+
+  @PrimaryKey()
+  id!: string;
+
+  @Enum(() => SomeEnum)
+  type!: SomeEnum;
+
+}
+
+@Entity({ discriminatorValue: SomeEnum.CLASS_A })
+export class ClassA extends AbstractClass {}
+
+@Entity({ discriminatorValue: SomeEnum.CLASS_B })
+export class ClassB extends AbstractClass {}


### PR DESCRIPTION
### Describe the bug

After upgrading from `v5` to `v6`, initializing ORM doesn't work, throwing following stack trace:

```bash
TypeError: Cannot read properties of undefined (reading 'length')
    at MetadataDiscovery.defineBaseEntityProperties (.../node_modules/@mikro-orm/core/metadata/MetadataDiscovery.js:733:75)
    at .../node_modules/@mikro-orm/core/metadata/MetadataDiscovery.js:90:39
    at Array.forEach (<anonymous>)
    at MetadataDiscovery.processDiscoveredEntities (.../node_modules/@mikro-orm/core/metadata/MetadataDiscovery.js:90:18)
    at MetadataDiscovery.discover (.../node_modules/@mikro-orm/core/metadata/MetadataDiscovery.js:47:14)
    at async MikroORM.discoverEntities (.../node_modules/@mikro-orm/core/MikroORM.js:172:25)
    at async Function.init (.../node_modules/@mikro-orm/core/MikroORM.js:44:9)
    at async Function.handleMigrationCommand (.../node_modules/@mikro-orm/cli/commands/MigrationCommandFactory.js:83:21)
```
We went together with @Ruby184 through code and found out that that it was caused by `this.metadata.set(name, Utils.copy(MetadataStorage.getMetadata(name, path), false));` in `MetadataDiscovery.discoverDirectories` function.
- This is problematic when there are multiple entities in one file.
- As a key in local `this.metadata` is `const name = this.namingStrategy.getClassName(filename);` used, which overwrites local metadata, when iterating multiple entities in file.
  - Overriding applies if the name derived from the file name is the same as the name of the class entity.

**Resolution:**

Global metadata initialisation (`MetadataStorage.getMetadata(entity.meta.className, filepath)`) is important if the user uses `EntitySchema` and `TsMorphMetadataProvider ` for entities definition, so as a solution we moved this code to the `MetadataDiscovery.getSchema` function and refactored the `MetadataDiscovery.prepare` function to return `EntitySchema` even if it is located in `EntitySchema.REGISTRY`.
- **See the code for details**

However, we are not sure, that setting metadata locally is necessary

```ts
  private getSchema<T>(entity: Constructor<T> | EntitySchema<T>, filepath?: string): EntitySchema<T> {
    if (entity instanceof EntitySchema) {
      if (filepath) {
        const meta = Utils.copy(MetadataStorage.getMetadata(entity.meta.className, filepath), false);
        // Is following line neccessary?
        this.metadata.set(entity.meta.className, meta);
      }
      return entity;
    }
...
```
because they will be overwritten latter in the `MetadataDiscovery.discoverDirectories` function as follows:

```ts
...

const meta = schema.init().meta;
this.metadata.set(meta.className, meta);

...
```


### Reproduction

- We added clear test for reproduction

### What driver are you using?

None

### MikroORM version

6.2.1

### Node.js version

v20.11.1

### Operating system

Mac OS Sonoma 14.4.1 (23E224)

### Validations

- [X] Read the [Contributing Guidelines](https://github.com/mikro-orm/mikro-orm/blob/master/CONTRIBUTING.md).
- [X] Read the [docs](https://mikro-orm.io/docs).
- [X] Check that there isn't [already an issue](https://github.com/mikro-orm/mikro-orm/issues) that reports the same bug to avoid creating a duplicate.
- [X] Check that this is a concrete bug. For Q&A open a [GitHub Discussion](https://github.com/mikro-orm/mikro-orm/discussions) or join our [Slack](https://join.slack.com/t/mikroorm/shared_invite/enQtNTM1ODYzMzM4MDk3LWM4ZDExMjU5ZDhmNjA2MmM3MWMwZmExNjhhNDdiYTMwNWM0MGY5ZTE3ZjkyZTMzOWExNDgyYmMzNDE1NDI5NjA).
- [X] The provided reproduction is a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) of the bug.