### PR TITLE
feat(query-builder): infer `Loaded` hint based on `joinAndSelect` calls

### DIFF
--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -32,13 +32,22 @@ import type { FindOneOptions, FindOptions } from './drivers';
 
 export type Constructor<T = unknown> = new (...args: any[]) => T;
 export type Dictionary<T = any> = { [k: string]: T };
-export type EntityKey<T = unknown> = string & keyof { [K in keyof T as CleanKeys<T, K>]?: unknown };
+// `EntityKey<T, true>` will skip scalar properties (and some other scalar like types like Date or Buffer)
+export type EntityKey<T = unknown, B extends boolean = false> = string & keyof { [K in keyof T as CleanKeys<T, K, B>]?: unknown };
 export type EntityValue<T> = T[EntityKey<T>];
 export type FilterKey<T> = keyof FilterQuery<T>;
 export type AsyncFunction<R = any, T = Dictionary> = (args: T) => Promise<T>;
 export type Compute<T> = { [K in keyof T]: T[K] } & {};
 type InternalKeys = 'EntityRepositoryType' | 'PrimaryKeyProp' | 'OptionalProps' | 'EagerProps' | 'HiddenProps' | '__selectedType' | '__loadedType';
-export type CleanKeys<T, K extends keyof T> = (T[K] & {}) extends Function ? never : (K extends symbol | InternalKeys ? never : K);
+export type CleanKeys<T, K extends keyof T, B extends boolean = false> = (T[K] & {}) extends Function
+  ? never
+  : K extends symbol | InternalKeys
+    ? never
+    : B extends true
+      ? (T[K] & {}) extends Scalar
+        ? never
+        : K
+      : K;
 export type FunctionKeys<T, K extends keyof T> = T[K] extends Function ? K : never;
 export type Cast<T, R> = T extends R ? T : R;
 export type IsUnknown<T> = T extends unknown ? unknown extends T ? true : never : never;

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -371,12 +371,12 @@ export type EntityDTOProp<E, T, C extends TypeConfig = never> = T extends Scalar
         ? PrimaryOrObject<E, U, C>
         : T extends ScalarReference<infer U>
           ? U
-          : T extends { getItems(check?: boolean): infer U }
-            ? (U extends readonly (infer V)[] ? EntityDTO<V, C>[] : EntityDTO<U, C>)
-            : T extends { $: infer U }
-              ? (U extends readonly (infer V)[] ? EntityDTO<V, C>[] : EntityDTO<U, C>)
+          : T extends LoadedCollection<infer U>
+            ? EntityDTO<U, C>[]
+            : T extends Collection<infer U>
+              ? PrimaryOrObject<E, U, C>[]
               : T extends readonly (infer U)[]
-                ? (T extends readonly [infer U, ...infer V] ? T : U[])
+                ? (T extends readonly any[] ? T : U[])
                 : T extends Relation<T>
                   ? EntityDTO<T, C>
                   : T;

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -257,7 +257,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
     return res.map(row => this.mapResult(row, meta) as T);
   }
 
-  override mapResult<T extends object>(result: EntityData<T>, meta: EntityMetadata<T>, populate: PopulateOptions<T>[] = [], qb?: QueryBuilder<T>, map: Dictionary = {}): EntityData<T> | null {
+  override mapResult<T extends object>(result: EntityData<T>, meta: EntityMetadata<T>, populate: PopulateOptions<T>[] = [], qb?: QueryBuilder<T, any, any, any>, map: Dictionary = {}): EntityData<T> | null {
     const ret = super.mapResult(result, meta);
 
     /* istanbul ignore if */
@@ -273,7 +273,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
     return ret;
   }
 
-  private mapJoinedProps<T extends object>(result: EntityData<T>, meta: EntityMetadata<T>, populate: PopulateOptions<T>[], qb: QueryBuilder<T>, root: EntityData<T>, map: Dictionary, parentJoinPath?: string) {
+  private mapJoinedProps<T extends object>(result: EntityData<T>, meta: EntityMetadata<T>, populate: PopulateOptions<T>[], qb: QueryBuilder<T, any, any, any>, root: EntityData<T>, map: Dictionary, parentJoinPath?: string) {
     const joinedProps = this.joinedProps(meta, populate);
 
     joinedProps.forEach(hint => {
@@ -1137,7 +1137,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
     return res;
   }
 
-  protected getFieldsForJoinedLoad<T extends object>(qb: QueryBuilder<T>, meta: EntityMetadata<T>, explicitFields?: Field<T>[], exclude?: Field<T>[], populate: PopulateOptions<T>[] = [], options?: { strategy?: Options['loadStrategy']; populateWhere?: FindOptions<any>['populateWhere'] }, parentTableAlias?: string, parentJoinPath?: string): Field<T>[] {
+  protected getFieldsForJoinedLoad<T extends object>(qb: QueryBuilder<T, any, any, any>, meta: EntityMetadata<T>, explicitFields?: Field<T>[], exclude?: Field<T>[], populate: PopulateOptions<T>[] = [], options?: { strategy?: Options['loadStrategy']; populateWhere?: FindOptions<any>['populateWhere'] }, parentTableAlias?: string, parentJoinPath?: string): Field<T>[] {
     const fields: Field<T>[] = [];
     const joinedProps = this.joinedProps(meta, populate, options);
 
@@ -1227,7 +1227,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
   /**
    * @internal
    */
-  mapPropToFieldNames<T extends object>(qb: QueryBuilder<T>, prop: EntityProperty<T>, tableAlias?: string): Field<T>[] {
+  mapPropToFieldNames<T extends object>(qb: QueryBuilder<T, any, any, any>, prop: EntityProperty<T>, tableAlias?: string): Field<T>[] {
     const aliased = this.platform.quoteIdentifier(tableAlias ? `${tableAlias}__${prop.fieldNames[0]}` : prop.fieldNames[0]);
 
     if (tableAlias && prop.customTypes?.some(type => type?.convertToJSValueSQL)) {
@@ -1263,10 +1263,10 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
   }
 
   /** @internal */
-  createQueryBuilder<T extends object>(entityName: EntityName<T> | QueryBuilder<T>, ctx?: Transaction<Knex.Transaction>, preferredConnectionType?: ConnectionType, convertCustomTypes?: boolean, loggerContext?: LoggingOptions, alias?: string, em?: SqlEntityManager): QueryBuilder<T> {
+  createQueryBuilder<T extends object>(entityName: EntityName<T> | QueryBuilder<T, any, any, any>, ctx?: Transaction<Knex.Transaction>, preferredConnectionType?: ConnectionType, convertCustomTypes?: boolean, loggerContext?: LoggingOptions, alias?: string, em?: SqlEntityManager): QueryBuilder<T, any, any, any> {
     // do not compute the connectionType if EM is provided as it will be computed from it in the QB later on
     const connectionType = em ? preferredConnectionType : this.resolveConnectionType({ ctx, connectionType: preferredConnectionType });
-    const qb = new QueryBuilder<T>(
+    const qb = new QueryBuilder<T, any, any, any>(
       entityName,
       this.metadata,
       this,
@@ -1373,7 +1373,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
     return { $and: [options.populateWhere, where] } as ObjectQuery<T>;
   }
 
-  protected buildOrderBy<T extends object>(qb: QueryBuilder<T>, meta: EntityMetadata<T>, populate: PopulateOptions<T>[], options: Pick<FindOptions<any>, 'strategy' | 'orderBy' | 'populateOrderBy'>): QueryOrderMap<T>[] {
+  protected buildOrderBy<T extends object>(qb: QueryBuilder<T, any, any, any>, meta: EntityMetadata<T>, populate: PopulateOptions<T>[], options: Pick<FindOptions<any>, 'strategy' | 'orderBy' | 'populateOrderBy'>): QueryOrderMap<T>[] {
     const joinedProps = this.joinedProps(meta, populate, options);
     // `options._populateWhere` is a copy of the value provided by user with a fallback to the global config option
     // as `options.populateWhere` will be always recomputed to respect filters
@@ -1385,7 +1385,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
     return [...Utils.asArray(options.orderBy), ...populateOrderBy, ...joinedPropsOrderBy] as QueryOrderMap<T>[];
   }
 
-  protected buildPopulateOrderBy<T extends object>(qb: QueryBuilder<T>, meta: EntityMetadata<T>, populateOrderBy: QueryOrderMap<T>[], parentPath: string, explicit: boolean, parentAlias = qb.alias): QueryOrderMap<T>[] {
+  protected buildPopulateOrderBy<T extends object>(qb: QueryBuilder<T, any, any, any>, meta: EntityMetadata<T>, populateOrderBy: QueryOrderMap<T>[], parentPath: string, explicit: boolean, parentAlias = qb.alias): QueryOrderMap<T>[] {
     const orderBy: QueryOrderMap<T>[] = [];
 
     for (let i = 0; i < populateOrderBy.length; i++) {
@@ -1451,7 +1451,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
     return orderBy;
   }
 
-  protected buildJoinedPropsOrderBy<T extends object>(qb: QueryBuilder<T>, meta: EntityMetadata<T>, populate: PopulateOptions<T>[], options?: Pick<FindOptions<any>, 'strategy' | 'orderBy' | 'populateOrderBy'>, parentPath?: string): QueryOrderMap<T>[] {
+  protected buildJoinedPropsOrderBy<T extends object>(qb: QueryBuilder<T, any, any, any>, meta: EntityMetadata<T>, populate: PopulateOptions<T>[], options?: Pick<FindOptions<any>, 'strategy' | 'orderBy' | 'populateOrderBy'>, parentPath?: string): QueryOrderMap<T>[] {
     const orderBy: QueryOrderMap<T>[] = [];
     const joinedProps = this.joinedProps(meta, populate, options);
 
@@ -1520,7 +1520,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
     return ret;
   }
 
-  protected processField<T extends object>(meta: EntityMetadata<T>, prop: EntityProperty<T> | undefined, field: string, ret: Field<T>[], populate: PopulateOptions<T>[], joinedProps: PopulateOptions<T>[], qb: QueryBuilder<T>): void {
+  protected processField<T extends object>(meta: EntityMetadata<T>, prop: EntityProperty<T> | undefined, field: string, ret: Field<T>[], populate: PopulateOptions<T>[], joinedProps: PopulateOptions<T>[], qb: QueryBuilder<T, any, any, any>): void {
     if (!prop || (prop.kind === ReferenceKind.ONE_TO_ONE && !prop.owner)) {
       return;
     }
@@ -1550,7 +1550,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
     ret.push(prop.name);
   }
 
-  protected buildFields<T extends object>(meta: EntityMetadata<T>, populate: PopulateOptions<T>[], joinedProps: PopulateOptions<T>[], qb: QueryBuilder<T>, alias: string, options: Pick<FindOptions<T, any, any, any>, 'strategy' | 'fields' | 'exclude'>): Field<T>[] {
+  protected buildFields<T extends object>(meta: EntityMetadata<T>, populate: PopulateOptions<T>[], joinedProps: PopulateOptions<T>[], qb: QueryBuilder<T, any, any, any>, alias: string, options: Pick<FindOptions<T, any, any, any>, 'strategy' | 'fields' | 'exclude'>): Field<T>[] {
     const lazyProps = meta.props.filter(prop => prop.lazy && !populate.some(p => p.field === prop.name || p.all));
     const hasLazyFormulas = meta.props.some(p => p.lazy && p.formula);
     const requiresSQLConversion = meta.props.some(p => p.customType?.convertToJSValueSQL && p.persist !== false);

--- a/packages/knex/src/SqlEntityManager.ts
+++ b/packages/knex/src/SqlEntityManager.ts
@@ -23,15 +23,15 @@ export class SqlEntityManager<Driver extends AbstractSqlDriver = AbstractSqlDriv
   /**
    * Creates a QueryBuilder instance
    */
-  createQueryBuilder<T extends object>(entityName: EntityName<T> | QueryBuilder<T>, alias?: string, type?: ConnectionType, loggerContext?: LoggingOptions): QueryBuilder<T> {
+  createQueryBuilder<Entity extends object, RootAlias extends string = never>(entityName: EntityName<Entity> | QueryBuilder<Entity>, alias?: RootAlias, type?: ConnectionType, loggerContext?: LoggingOptions): QueryBuilder<Entity, RootAlias> {
     const context = this.getContext(false);
-    return this.driver.createQueryBuilder(entityName, context.getTransactionContext(), type, true, loggerContext ?? context.loggerContext, alias, this);
+    return this.driver.createQueryBuilder(entityName as EntityName<Entity>, context.getTransactionContext(), type, true, loggerContext ?? context.loggerContext, alias, this) as any;
   }
 
   /**
    * Shortcut for `createQueryBuilder()`
    */
-  qb<T extends object>(entityName: EntityName<T>, alias?: string, type?: ConnectionType, loggerContext?: LoggingOptions) {
+  qb<Entity extends object, RootAlias extends string = never>(entityName: EntityName<Entity>, alias?: RootAlias, type?: ConnectionType, loggerContext?: LoggingOptions) {
     return this.createQueryBuilder(entityName, alias, type, loggerContext);
   }
 

--- a/packages/knex/src/SqlEntityRepository.ts
+++ b/packages/knex/src/SqlEntityRepository.ts
@@ -3,24 +3,26 @@ import { EntityRepository, type ConnectionType, type EntityName } from '@mikro-o
 import type { SqlEntityManager } from './SqlEntityManager';
 import type { QueryBuilder } from './query';
 
-export class SqlEntityRepository<T extends object> extends EntityRepository<T> {
+export class SqlEntityRepository<Entity extends object> extends EntityRepository<Entity> {
 
-  constructor(protected override readonly em: SqlEntityManager,
-              entityName: EntityName<T>) {
+  constructor(
+    protected override readonly em: SqlEntityManager,
+    entityName: EntityName<Entity>,
+  ) {
     super(em, entityName);
   }
 
   /**
    * Creates a QueryBuilder instance
    */
-  createQueryBuilder(alias?: string): QueryBuilder<T> {
+  createQueryBuilder<RootAlias extends string = never>(alias?: RootAlias): QueryBuilder<Entity, RootAlias> {
     return this.getEntityManager().createQueryBuilder(this.entityName, alias);
   }
 
   /**
    * Shortcut for `createQueryBuilder()`
    */
-  qb(alias?: string): QueryBuilder<T> {
+  qb<RootAlias extends string = never>(alias?: RootAlias): QueryBuilder<Entity, RootAlias> {
     return this.createQueryBuilder(alias);
   }
 

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -93,9 +93,9 @@ type AddToHint<RootAlias, Context, Field extends string> = GetAlias<Field> exten
 
 export type ModifyHint<RootAlias, Context, Hint extends string, Field extends string> = Hint | AddToHint<RootAlias, Context, Field>;
 
-export type ModifyContext<Entity extends object, Context, Field extends string, Alias extends string> = IsNever<Context> extends true
+export type ModifyContext<Entity extends object, Context, Field extends string, Alias extends string> = Compute<IsNever<Context> extends true
   ? AddToContext<GetType<Entity, object, Field>, object, Field, Alias>
-  : Compute<Context & AddToContext<GetType<Entity, Context, Field>, Context, Field, Alias>>;
+  : Context & AddToContext<GetType<Entity, Context, Field>, Context, Field, Alias>>;
 
 type EntityRelations<T> = EntityKey<T, true>;
 type AddAliasesFromContext<Context> = Context[keyof Context] extends infer Join
@@ -106,6 +106,7 @@ type AddAliasesFromContext<Context> = Context[keyof Context] extends infer Join
     : never
   : never;
 
+// TODO(v7): remove the `AnyString` and force people to keep the context on type level (either fluent interface or reassigning the QB)?
 export type QBField<Entity, RootAlias extends string, Context> = (EntityRelations<Entity> | `${RootAlias}.${EntityRelations<Entity>}` | AddAliasesFromContext<Context>) & {} | AnyString;
 
 /**

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -58,22 +58,26 @@ type AppendToHint<Parent extends string, Child extends string> = `${Parent}.${Ch
 type AddToContext<Context, Field extends string, Alias extends string> = { [K in Alias]: GetPath<Context, Field> };
 
 type GetPath<Context, Field extends string> = GetAlias<Field> extends infer Alias
-  ? Alias extends keyof Context
-    ? AppendToHint<Context[Alias] & string, GetPropName<Field>>
-    : GetPropName<Field>
-  : GetPropName<Field>;
-
-type AddToHint<RootAlias, Context, Field extends string> = GetAlias<Field> extends infer Alias
-  ? Alias extends RootAlias
+  ? IsNever<Alias> extends true
     ? GetPropName<Field>
     : Alias extends keyof Context
       ? AppendToHint<Context[Alias] & string, GetPropName<Field>>
       : GetPropName<Field>
+    : GetPropName<Field>;
+
+type AddToHint<RootAlias, Context, Field extends string> = GetAlias<Field> extends infer Alias
+  ? IsNever<Alias> extends true
+    ? GetPropName<Field>
+    : Alias extends RootAlias
+      ? GetPropName<Field>
+      : Alias extends keyof Context
+        ? AppendToHint<Context[Alias] & string, GetPropName<Field>>
+        : GetPropName<Field>
   : GetPropName<Field>;
 
-type ModifyHint<RootAlias, Context, Hint extends string, Field extends string> = Hint | AddToHint<RootAlias, Context, Field>;
+export type ModifyHint<RootAlias, Context, Hint extends string, Field extends string> = Hint | AddToHint<RootAlias, Context, Field>;
 
-type ModifyContext<Context, Field extends string, Alias extends string> = IsNever<Context> extends true
+export type ModifyContext<Context, Field extends string, Alias extends string> = IsNever<Context> extends true
   ? AddToContext<object, Field, Alias>
   : Compute<Context & AddToContext<Context, Field, Alias>>;
 

--- a/packages/mariadb/src/MariaDbDriver.ts
+++ b/packages/mariadb/src/MariaDbDriver.ts
@@ -51,10 +51,10 @@ export class MariaDbDriver extends AbstractSqlDriver<MariaDbConnection, MariaDbP
     return res;
   }
 
-  override createQueryBuilder<T extends AnyEntity<T>>(entityName: string, ctx?: Transaction<Knex.Transaction>, preferredConnectionType?: ConnectionType, convertCustomTypes?: boolean, loggerContext?: LoggingOptions, alias?: string, em?: SqlEntityManager): MariaDbQueryBuilder<T> {
+  override createQueryBuilder<T extends AnyEntity<T>>(entityName: string, ctx?: Transaction<Knex.Transaction>, preferredConnectionType?: ConnectionType, convertCustomTypes?: boolean, loggerContext?: LoggingOptions, alias?: string, em?: SqlEntityManager): MariaDbQueryBuilder<T, any, any, any> {
     // do not compute the connectionType if EM is provided as it will be computed from it in the QB later on
     const connectionType = em ? preferredConnectionType : this.resolveConnectionType({ ctx, connectionType: preferredConnectionType });
-    const qb = new MariaDbQueryBuilder<T>(entityName, this.metadata, this, ctx, alias, connectionType, em, loggerContext);
+    const qb = new MariaDbQueryBuilder<T, any, any, any>(entityName, this.metadata, this, ctx, alias, connectionType, em, loggerContext);
 
     if (!convertCustomTypes) {
       qb.unsetFlag(QueryFlag.CONVERT_CUSTOM_TYPES);

--- a/packages/mariadb/src/MariaDbQueryBuilder.ts
+++ b/packages/mariadb/src/MariaDbQueryBuilder.ts
@@ -12,7 +12,12 @@ import { QueryBuilder } from '@mikro-orm/knex';
 /**
  * @inheritDoc
  */
-export class MariaDbQueryBuilder<T extends object = AnyEntity> extends QueryBuilder<T> {
+export class MariaDbQueryBuilder<
+  Entity extends object = AnyEntity,
+  RootAlias extends string = never,
+  Hint extends string = never,
+  Context extends object = never,
+> extends QueryBuilder<Entity, RootAlias, Hint, Context> {
 
   protected override wrapPaginateSubQuery(meta: EntityMetadata): void {
     const pks = this.prepareFields(meta.primaryKeys, 'sub-query') as string[];
@@ -40,7 +45,7 @@ export class MariaDbQueryBuilder<T extends object = AnyEntity> extends QueryBuil
             continue;
           }
 
-          const [a, f] = this.helper.splitField(field as EntityKey<T>);
+          const [a, f] = this.helper.splitField(field as EntityKey<Entity>);
           const prop = this.helper.getProperty(f, a);
           const type = this.platform.castColumn(prop);
           const fieldName = this.helper.mapper(field, this.type, undefined, null);

--- a/packages/mssql/src/MsSqlDriver.ts
+++ b/packages/mssql/src/MsSqlDriver.ts
@@ -67,10 +67,10 @@ export class MsSqlDriver extends AbstractSqlDriver<MsSqlConnection> {
     return super.nativeInsertMany(entityName, data, options);
   }
 
-  override createQueryBuilder<T extends AnyEntity<T>>(entityName: string, ctx?: Transaction<Knex.Transaction>, preferredConnectionType?: ConnectionType, convertCustomTypes?: boolean, loggerContext?: LoggingOptions, alias?: string, em?: SqlEntityManager): MsSqlQueryBuilder<T> {
+  override createQueryBuilder<T extends AnyEntity<T>>(entityName: string, ctx?: Transaction<Knex.Transaction>, preferredConnectionType?: ConnectionType, convertCustomTypes?: boolean, loggerContext?: LoggingOptions, alias?: string, em?: SqlEntityManager): MsSqlQueryBuilder<T, any, any, any> {
     // do not compute the connectionType if EM is provided as it will be computed from it in the QB later on
     const connectionType = em ? preferredConnectionType : this.resolveConnectionType({ ctx, connectionType: preferredConnectionType });
-    const qb = new MsSqlQueryBuilder<T>(entityName, this.metadata, this, ctx, alias, connectionType, em, loggerContext);
+    const qb = new MsSqlQueryBuilder<T, any, any, any>(entityName, this.metadata, this, ctx, alias, connectionType, em, loggerContext);
 
     if (!convertCustomTypes) {
       qb.unsetFlag(QueryFlag.CONVERT_CUSTOM_TYPES);

--- a/packages/mssql/src/MsSqlQueryBuilder.ts
+++ b/packages/mssql/src/MsSqlQueryBuilder.ts
@@ -1,9 +1,14 @@
 import { type AnyEntity, QueryFlag, type RequiredEntityData, Utils } from '@mikro-orm/core';
 import { type InsertQueryBuilder, type Knex, QueryBuilder, QueryType } from '@mikro-orm/knex';
 
-export class MsSqlQueryBuilder<T extends AnyEntity<T> = AnyEntity> extends QueryBuilder<T> {
+export class MsSqlQueryBuilder<
+  Entity extends object = AnyEntity,
+  RootAlias extends string = never,
+  Hint extends string = never,
+  Context extends object = never,
+> extends QueryBuilder<Entity, RootAlias, Hint, Context> {
 
-  override insert(data: RequiredEntityData<T> | RequiredEntityData<T>[]): InsertQueryBuilder<T> {
+  override insert(data: RequiredEntityData<Entity> | RequiredEntityData<Entity>[]): InsertQueryBuilder<Entity> {
     this.checkIdentityInsert(data);
     return super.insert(data);
   }
@@ -46,7 +51,7 @@ export class MsSqlQueryBuilder<T extends AnyEntity<T> = AnyEntity> extends Query
     };
   }
 
-  private checkIdentityInsert(data: RequiredEntityData<T> | RequiredEntityData<T>[]) {
+  private checkIdentityInsert(data: RequiredEntityData<Entity> | RequiredEntityData<Entity>[]) {
     const meta = this.metadata.find(this.mainAlias.entityName);
 
     if (!meta) {

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -3007,6 +3007,7 @@ describe('QueryBuilder', () => {
 
       const qb5 = pg.em.createQueryBuilder(Author2, 'a');
       expect(() => qb5.leftJoinLateralAndSelect('a.books', 'sub', { author: sql.ref('a.id') })).toThrow('Lateral join can be used only with a sub-query.');
+      expect(() => qb5.leftJoinLateralAndSelect('a.books', 'sub')).toThrow('Lateral join can be used only with a sub-query.');
       pg.em.clear();
     }
 
@@ -3232,7 +3233,7 @@ describe('QueryBuilder', () => {
   test('aliased join condition', () => {
     const sql1 = orm.em.createQueryBuilder(Book2, 'b')
       .select('*')
-      .joinAndSelect('author', 'a')
+      .innerJoinAndSelect('author', 'a')
       .where({ 'a.born': '1990-03-23' })
       .getFormattedQuery();
     expect(sql1).toBe("select `b`.*, `a`.`id` as `a__id`, `a`.`created_at` as `a__created_at`, `a`.`updated_at` as `a__updated_at`, `a`.`name` as `a__name`, `a`.`email` as `a__email`, `a`.`age` as `a__age`, `a`.`terms_accepted` as `a__terms_accepted`, `a`.`optional` as `a__optional`, `a`.`identities` as `a__identities`, `a`.`born` as `a__born`, `a`.`born_time` as `a__born_time`, `a`.`favourite_book_uuid_pk` as `a__favourite_book_uuid_pk`, `a`.`favourite_author_id` as `a__favourite_author_id`, `a`.`identity` as `a__identity`, `b`.price * 1.19 as `price_taxed` from `book2` as `b` inner join `author2` as `a` on `b`.`author_id` = `a`.`id` where `a`.`born` = '1990-03-23'");

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -250,8 +250,8 @@ describe('QueryBuilder', () => {
   });
 
   test('select leftJoin 1:1 owner', async () => {
-    const qb = orm.em.createQueryBuilder(FooBar2, 'fb');
-    qb.select(['fb.*', 'fz.*'])
+    const qb = orm.em.createQueryBuilder(FooBar2, 'fb')
+      .select(['fb.*', 'fz.*'])
       .leftJoin('fb.baz', 'fz')
       .where({ 'fz.name': 'test 123' })
       .limit(2, 1);
@@ -3006,8 +3006,12 @@ describe('QueryBuilder', () => {
       pg.em.clear();
 
       const qb5 = pg.em.createQueryBuilder(Author2, 'a');
+      // @ts-expect-error
       expect(() => qb5.leftJoinLateralAndSelect('a.books', 'sub', { author: sql.ref('a.id') })).toThrow('Lateral join can be used only with a sub-query.');
+      // @ts-expect-error
       expect(() => qb5.leftJoinLateralAndSelect('a.books', 'sub')).toThrow('Lateral join can be used only with a sub-query.');
+      // @ts-expect-error
+      expect(() => qb5.leftJoinLateral('a.books', 'sub')).toThrow('Lateral join can be used only with a sub-query.');
       pg.em.clear();
     }
 

--- a/tests/features/entity-assigner/EntityAssigner.mysql.test.ts
+++ b/tests/features/entity-assigner/EntityAssigner.mysql.test.ts
@@ -1,4 +1,4 @@
-import type { MikroORM } from '@mikro-orm/core';
+import type { Loaded, MikroORM } from '@mikro-orm/core';
 import { Reference, wrap } from '@mikro-orm/core';
 import { MySqlDriver } from '@mikro-orm/mysql';
 import { initORMMySql } from '../../bootstrap';
@@ -229,7 +229,7 @@ describe('EntityAssignerMySql', () => {
         { title: 'b1' },
         { title: 'b2' },
       ],
-    });
+    }) as Loaded<Author2, 'books'>;
     entity.books.populated();
     const updated = wrap(entity).toObject();
     updated.books[0].title = 'updated name';

--- a/tests/features/result-cache/GH3294.test.ts
+++ b/tests/features/result-cache/GH3294.test.ts
@@ -76,8 +76,8 @@ describe('hidden properties are still included when cached (GH 3294)', () => {
     expect(mockLog.mock.calls).toHaveLength(1); // cache hit, no new query fired
 
     // Expect both hidden and not hidden props to be accessible in cached and uncached versions
-    expect(res1.map(e => ({ hidden: e.hiddenProp, notHidden: e.notHiddenProp }))).
-      toEqual(res2.map(e => ({ hidden: e.hiddenProp, notHidden: e.notHiddenProp })));
+    expect(res1.map(e => ({ hidden: e.hiddenProp, notHidden: e.notHiddenProp })))
+      .toEqual(res2.map(e => ({ hidden: e.hiddenProp, notHidden: e.notHiddenProp })));
   });
 
 });

--- a/tests/issues/GH222.test.ts
+++ b/tests/issues/GH222.test.ts
@@ -1,4 +1,15 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, OneToOne, PrimaryKey, Property, wrap } from '@mikro-orm/sqlite';
+import {
+  Collection,
+  EagerProps,
+  Entity,
+  ManyToOne,
+  MikroORM,
+  OneToMany,
+  OneToOne,
+  PrimaryKey,
+  Property,
+  wrap,
+} from '@mikro-orm/sqlite';
 
 @Entity()
 export class A {
@@ -16,6 +27,8 @@ export class A {
 
 @Entity()
 export class C {
+
+  [EagerProps]?: 'bCollection';
 
   @PrimaryKey({ type: Number })
   id!: number;

--- a/tests/issues/GH3812.test.ts
+++ b/tests/issues/GH3812.test.ts
@@ -1,14 +1,15 @@
 import {
   Collection,
   Entity,
+  MikroORM,
   ManyToOne,
   OneToMany,
   PrimaryKey,
   Property,
   Enum,
   wrap,
-} from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/sqlite';
+  Ref,
+} from '@mikro-orm/sqlite';
 import { v4 } from 'uuid';
 
 export abstract class BaseEntity {
@@ -49,6 +50,9 @@ export class Step extends BaseEntity {
   @Enum(() => StepType)
   type!: StepType;
 
+  @ManyToOne(() => Step, { ref: true, nullable: true })
+  subStep?: Ref<Step>;
+
 }
 
 @Entity()
@@ -68,8 +72,8 @@ export class Log extends BaseEntity {
   @ManyToOne(() => SerialNumber)
   serialNumber!: SerialNumber;
 
-  @ManyToOne()
-  step?: Step;
+  @ManyToOne(() => Step, { ref: true, nullable: true })
+  step?: Ref<Step>;
 
   @Property({ type: 'date', nullable: true })
   operationDate?: string | null;
@@ -137,6 +141,16 @@ test('GH 3812', async () => {
           number: '3',
           order: 0,
           type: StepType.ASSY,
+          subStep: {
+            id: '29b64d55-d583-44ed-8407-65968a150057',
+            createdAt: '2022-11-30T15:26:16.000Z',
+            updatedAt: '2022-11-30T15:26:16.000Z',
+            deletedAt: null,
+            name: 'INSP',
+            number: '20',
+            order: 3,
+            type: StepType.INSP,
+          },
         },
         operationDate: '2022-11-30',
         current: false,
@@ -157,6 +171,16 @@ test('GH 3812', async () => {
           number: '50',
           order: 1,
           type: StepType.ASSY,
+          subStep: {
+            id: '19b64d55-d583-44ed-8407-65968a150057',
+            createdAt: '2022-11-30T15:26:16.000Z',
+            updatedAt: '2022-11-30T15:26:16.000Z',
+            deletedAt: null,
+            name: 'INSP',
+            number: '10',
+            order: 2,
+            type: StepType.INSP,
+          },
         },
         operationDate: '2022-11-30',
         current: false,
@@ -169,21 +193,22 @@ test('GH 3812', async () => {
   orm.em.clear();
 
   // with EM
-  const res1 = await orm.em.find(SerialNumber, {}, { populate: ['logs.step'] });
+  const res1 = await orm.em.find(SerialNumber, {}, { populate: ['logs.step.subStep'] });
   expect(res1).toHaveLength(1);
   expect(wrap(res1[0]).toJSON().logs[0].serialNumber).toBe('559fccf7-11f0-4e5a-8e15-ae29b98ddeb3');
   expect(wrap(res1[0]).toJSON().logs[0].step?.name).toBe('ASSY');
 
   orm.em.clear();
 
-  // with QB
   const res2 = await orm.em
     .createQueryBuilder(SerialNumber, 'sn')
     .select('*')
     .leftJoinAndSelect('sn.logs', 'l')
     .leftJoinAndSelect('l.step', 's')
+    .leftJoinAndSelect('s.subStep', 's2')
     .getResultList();
   expect(res2).toHaveLength(1);
   expect(wrap(res2[0]).toJSON().logs[0].serialNumber).toBe('559fccf7-11f0-4e5a-8e15-ae29b98ddeb3');
   expect(wrap(res2[0]).toJSON().logs[0].step?.name).toBe('ASSY');
+  expect(wrap(res2[0]).toJSON().logs[0].step?.subStep?.name).toBe('INSP');
 });

--- a/tests/issues/GH3812.test.ts
+++ b/tests/issues/GH3812.test.ts
@@ -202,12 +202,14 @@ test('GH 3812', async () => {
 
   orm.em.clear();
 
-  type T11 = ModifyHint<'sn', never, never, 'logs'>;
-  type T12 = ModifyHint<'sn', { l: ['logs', 'l', Log] }, 'logs', 'l.step'>;
+  type T10 = ModifyHint<'sn', { l: ['logs', 'l', Log] }, 'logs', 'l.step', true>;
+  type T11 = ModifyHint<'sn', never, never, 'logs', true>;
+  type T12 = ModifyHint<'sn', { l: ['logs', 'l', Log] }, 'logs', 'l.step', true>;
   type T13 = ModifyHint<'sn', { l: ['logs', 'l', Log]; s: ['logs.step', 's', Step] }, 'logs' | 'logs.step', 's.subStep'>;
-  type T21 = ModifyContext<SerialNumber, never, 'logs', 'l'>;
-  type T22 = ModifyContext<Log, { l: ['logs', 'l', Log] }, 'l.step', 's'>;
-  type T23 = ModifyContext<Step, { l: ['logs', 'l', Log]; s: ['logs.step', 's', Step] }, 's.subStep', 's2'>;
+  type T20 = ModifyContext<SerialNumber, never, 'logs', 'l', false>;
+  type T21 = ModifyContext<SerialNumber, never, 'logs', 'l', true>;
+  type T22 = ModifyContext<Log, { l: ['logs', 'l', Log, false] }, 'l.step', 's'>;
+  type T23 = ModifyContext<Step, { l: ['logs', 'l', Log, false]; s: ['logs.step', 's', Step, true] }, 's.subStep', 's2'>;
   // type T31 = AddAliasesFromContext<{ l: ['logs', 'l', Log]; s: ['logs.step', 's', Step]; s2: ['logs.step.subStep', 's2', Step] }>;
   // type T32 = CleanKeys<Log, keyof Log, true>;
   // type T33 = EntityRelations<Log>;

--- a/tests/issues/GH3812.test.ts
+++ b/tests/issues/GH3812.test.ts
@@ -203,11 +203,18 @@ test('GH 3812', async () => {
   orm.em.clear();
 
   type T11 = ModifyHint<'sn', never, never, 'logs'>;
-  type T12 = ModifyHint<'sn', { l: 'logs' }, 'logs', 'l.step'>;
-  type T13 = ModifyHint<'sn', { l: 'logs'; s: 'logs.step' }, 'logs' | 'logs.step', 's.subStep'>;
-  type T21 = ModifyContext<never, 'logs', 'l'>;
-  type T22 = ModifyContext<{ l: 'logs' }, 'l.step', 's'>;
-  type T23 = ModifyContext<{ l: 'logs'; s: 'logs.step' }, 's.subStep', 's2'>;
+  type T12 = ModifyHint<'sn', { l: ['logs', 'l', Log] }, 'logs', 'l.step'>;
+  type T13 = ModifyHint<'sn', { l: ['logs', 'l', Log]; s: ['logs.step', 's', Step] }, 'logs' | 'logs.step', 's.subStep'>;
+  type T21 = ModifyContext<SerialNumber, never, 'logs', 'l'>;
+  type T22 = ModifyContext<Log, { l: ['logs', 'l', Log] }, 'l.step', 's'>;
+  type T23 = ModifyContext<Step, { l: ['logs', 'l', Log]; s: ['logs.step', 's', Step] }, 's.subStep', 's2'>;
+  // type T31 = AddAliasesFromContext<{ l: ['logs', 'l', Log]; s: ['logs.step', 's', Step]; s2: ['logs.step.subStep', 's2', Step] }>;
+  // type T32 = CleanKeys<Log, keyof Log, true>;
+  // type T33 = EntityRelations<Log>;
+  // type T41 = GetType<SerialNumber, object, 'sn.logs'>;
+  // type T42 = GetType<SerialNumber, { l: ['logs', 'l', Log]; s: ['logs.step', 's', Step] }, 'l.step'>;
+  // type T43 = GetType<SerialNumber, { l: ['logs', 'l', Log]; s: ['logs.step', 's', Step] }, 's.subStep'>;
+  // type T51 = QBField<SerialNumber, 'sn', { l: ['logs', 'l', Log]; s: ['logs.step', 's', Step]; s2: ['logs.step.subStep', 's2', Step] }>;
 
   const res2 = await orm.em
     .createQueryBuilder(SerialNumber, 'sn')

--- a/tests/issues/GH3812.test.ts
+++ b/tests/issues/GH3812.test.ts
@@ -2,6 +2,8 @@ import {
   Collection,
   Entity,
   MikroORM,
+  ModifyContext,
+  ModifyHint,
   ManyToOne,
   OneToMany,
   PrimaryKey,
@@ -199,6 +201,13 @@ test('GH 3812', async () => {
   expect(wrap(res1[0]).toJSON().logs[0].step?.name).toBe('ASSY');
 
   orm.em.clear();
+
+  type T11 = ModifyHint<'sn', never, never, 'logs'>;
+  type T12 = ModifyHint<'sn', { l: 'logs' }, 'logs', 'l.step'>;
+  type T13 = ModifyHint<'sn', { l: 'logs'; s: 'logs.step' }, 'logs' | 'logs.step', 's.subStep'>;
+  type T21 = ModifyContext<never, 'logs', 'l'>;
+  type T22 = ModifyContext<{ l: 'logs' }, 'l.step', 's'>;
+  type T23 = ModifyContext<{ l: 'logs'; s: 'logs.step' }, 's.subStep', 's2'>;
 
   const res2 = await orm.em
     .createQueryBuilder(SerialNumber, 'sn')

--- a/tests/issues/GH4741.test.ts
+++ b/tests/issues/GH4741.test.ts
@@ -104,16 +104,15 @@ beforeEach(async () => {
 test(`GH4741 issue (1/3)`, async () => {
   const em = orm.em.fork();
   const qb = em.createQueryBuilder(Outer, 'o');
-
   qb.select('*');
-  qb.leftJoinAndSelect('o.activeDivision', 'ad');
-  qb.leftJoinAndSelect('ad.inners', 'ai');
-  qb.leftJoinAndSelect('ai.geometry', 'g');
+  const qb2 = qb.leftJoinAndSelect('o.activeDivision', 'ad');
+  const qb3 = qb2.leftJoinAndSelect('ad.inners', 'ai');
+  const qb4 = qb3.leftJoinAndSelect('ai.geometry', 'g');
 
   const q = qb.getKnexQuery().toSQL();
   expect(q.sql).toBe('select `o`.*, `ad`.`id` as `ad__id`, `ad`.`outer_id` as `ad__outer_id`, `ai`.`id` as `ai__id`, `ai`.`geometry_id` as `ai__geometry_id`, `ai`.`division_id` as `ai__division_id`, `g`.`id` as `g__id` from `outer` as `o` left join `division` as `ad` on `o`.`active_division_id` = `ad`.`id` left join `inner` as `ai` on `ad`.`id` = `ai`.`division_id` left join `geometry` as `g` on `ai`.`geometry_id` = `g`.`id`');
 
-  const res = await qb.getResult();
+  const res = await qb4.getResult();
   expect(res.length).toBe(1);
 
   const outer = res[0];

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -88,14 +88,14 @@ describe('check typings', () => {
   });
 
   test('EntityDTO', async () => {
-    const b = { author: { books: [{}], identities: [''] } } as unknown as EntityDTO<Loaded<Book2, 'publisher'>>;
+    const b = { author: { books: [{}], identities: [''] } } as unknown as EntityDTO<Loaded<Book2, 'publisher' | 'author.books'>>;
     const b1 = b.author.name;
     const b2 = b.test?.name;
     const b3 = b.test?.book?.author.books2;
     const b4 = b.author.books[0].tags;
     const b5 = b.publisher?.name;
     const b6 = b.publisher?.tests;
-    const b7 = b.author.favouriteBook?.tags[0].name;
+    const b7: bigint | undefined = b.author.favouriteBook?.tags[0];
     const b8: number = b.author.identities!.length;
     const b9: string[] = b.author.identities!.slice();
     const b10: string[] = b.author.identities!.filter(i => i);


### PR DESCRIPTION
```ts
const authors = await em.createQueryBuilder(Author, 'a')
  .leftJoinAndSelect('a.books', 'b')
  .leftJoinAndSelect('b.tags', 't')
  .leftJoinAndSelect('b.pulisher', 'p');

// authors is of type `Loaded<Author, 'books' | 'books.tags' | 'books.publisher'>[]`
```