### PR TITLE
feat(postgres): allow specifying deferred mode on unique constraints

### DIFF
--- a/docs/docs/decorators.md
+++ b/docs/docs/decorators.md
@@ -166,11 +166,12 @@ Use `@Index()` to create an index, or `@Unique()` to create unique constraint. Y
 
 See [Defining Entities](./defining-entities.md#indexes).
 
-| Parameter    | Type                       | Optional | Description                                                                                              |
-|--------------|----------------------------|----------|----------------------------------------------------------------------------------------------------------|
-| `name`       | `string`                   | yes      | index name                                                                                               |
-| `properties` | `string` &#124; `string[]` | yes      | list of properties, required when using on entity level                                                  |
-| `type`       | `string`                   | yes      | index type, not available for `@Unique()`. Use `fulltext` to enable support for the `$fulltext` operator |
+| Parameter     | Type                          | Optional | Description                                                                                              |
+|---------------|-------------------------------|----------|----------------------------------------------------------------------------------------------------------|
+| `name`        | `string`                      | yes      | index name                                                                                               |
+| `properties`  | `string` &#124; `string[]`    | yes      | list of properties, required when using on entity level                                                  |
+| `type`        | `string`                      | yes      | index type, not available for `@Unique()`. Use `fulltext` to enable support for the `$fulltext` operator |
+| `deferMode`   | `immediate` &#124; `deferred` | yes      | only for postgres unique constraints                                                                     |
 
 ```ts
 @Entity()
@@ -260,6 +261,7 @@ See [Defining Entities](./relationships.md#manytoone) for more examples.
 | `primary`    | `boolean`                                     | yes      | Use this relation as primary key.                                                                                                                           |
 | `deleteRule` | `string`                                      | yes      | [Referential integrity](./cascading.md#declarative-referential-integrity).                                                                                  |
 | `updateRule` | `string`                                      | yes      | [Referential integrity](./cascading.md#declarative-referential-integrity).                                                                                  |
+| `deferMode`  | `immediate` &#124; `deferred`                 | yes      | only for postgres unique constraints                                                                                                                        |
 
 ```ts
 @ManyToOne()
@@ -294,6 +296,7 @@ See [Defining Entities](./relationships.md#onetoone) for more examples, includin
 | `primary`       | `boolean`                                     | yes      | Use this relation as primary key.                                                                                                                           |
 | `deleteRule`    | `string`                                      | yes      | [Referential integrity](./cascading.md#declarative-referential-integrity).                                                                                  |
 | `updateRule`    | `string`                                      | yes      | [Referential integrity](./cascading.md#declarative-referential-integrity).                                                                                  |
+| `deferMode`     | `immediate` &#124; `deferred`                 | yes      | only for postgres unique constraints                                                                                                                        |
 
 ```ts
 // when none of `owner/inverseBy/mappedBy` is provided, it will be considered owning side

--- a/packages/core/src/decorators/Indexed.ts
+++ b/packages/core/src/decorators/Indexed.ts
@@ -1,6 +1,7 @@
 import { MetadataStorage } from '../metadata';
 import type { AnyEntity, Dictionary } from '../typings';
 import { Utils } from '../utils/Utils';
+import type { DeferMode } from '../enums';
 
 function createDecorator<T>(options: IndexOptions<T> | UniqueOptions<T>, unique: boolean) {
   return function (target: AnyEntity, propertyName?: string) {
@@ -25,13 +26,17 @@ export function Unique<T>(options: UniqueOptions<T> = {}) {
   return createDecorator(options, true);
 }
 
-export interface UniqueOptions<T> {
+interface BaseOptions<T> {
   name?: string;
   properties?: keyof T | (keyof T)[];
   options?: Dictionary;
   expression?: string;
 }
 
-export interface IndexOptions<T> extends UniqueOptions<T> {
+export interface UniqueOptions<T> extends BaseOptions<T> {
+  deferMode?: DeferMode | `${DeferMode}`;
+}
+
+export interface IndexOptions<T> extends BaseOptions<T> {
   type?: string;
 }

--- a/packages/core/src/decorators/ManyToOne.ts
+++ b/packages/core/src/decorators/ManyToOne.ts
@@ -30,5 +30,5 @@ export interface ManyToOneOptions<Owner, Target> extends ReferenceOptions<Owner,
   referencedColumnNames?: string[];
   deleteRule?: 'cascade' | 'no action' | 'set null' | 'set default' | AnyString;
   updateRule?: 'cascade' | 'no action' | 'set null' | 'set default' | AnyString;
-  deferMode?: DeferMode;
+  deferMode?: DeferMode | `${DeferMode}`;
 }

--- a/packages/core/src/decorators/OneToOne.ts
+++ b/packages/core/src/decorators/OneToOne.ts
@@ -20,5 +20,5 @@ export interface OneToOneOptions<Owner, Target> extends Partial<Omit<OneToManyOp
   mapToPk?: boolean;
   deleteRule?: 'cascade' | 'no action' | 'set null' | 'set default' | AnyString;
   updateRule?: 'cascade' | 'no action' | 'set null' | 'set default' | AnyString;
-  deferMode?: DeferMode;
+  deferMode?: DeferMode | `${DeferMode}`;
 }

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -725,7 +725,7 @@ export interface EntityMetadata<T = any> {
   hydrateProps: EntityProperty<T>[]; // for Hydrator
   uniqueProps: EntityProperty<T>[];
   indexes: { properties: EntityKey<T> | EntityKey<T>[]; name?: string; type?: string; options?: Dictionary; expression?: string }[];
-  uniques: { properties: EntityKey<T> | EntityKey<T>[]; name?: string; options?: Dictionary; expression?: string }[];
+  uniques: { properties: EntityKey<T> | EntityKey<T>[]; name?: string; options?: Dictionary; expression?: string; deferMode?: DeferMode }[];
   checks: CheckConstraint<T>[];
   repository: () => EntityClass<EntityRepository<any>>;
   hooks: { [K in EventType]?: (keyof T | EventSubscriber<T>[EventType])[] };

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -613,7 +613,10 @@ export class UnitOfWork {
     }
 
     // when changing a unique nullable property (or a 1:1 relation), we can't do it in a single query as it would cause unique constraint violations
-    const uniqueProps = changeSet.meta.uniqueProps.filter(prop => prop.nullable && changeSet.payload[prop.name] != null);
+    const uniqueProps = changeSet.meta.uniqueProps.filter(prop => {
+      return (prop.nullable || changeSet.type !== ChangeSetType.CREATE)
+        && changeSet.payload[prop.name] != null;
+    });
     this.scheduleExtraUpdate(changeSet, uniqueProps);
 
     return changeSet.type === ChangeSetType.UPDATE && !Utils.hasObjectKeys(changeSet.payload);

--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -3,6 +3,7 @@ import {
   type Configuration,
   DateTimeType,
   DecimalType,
+  type DeferMode,
   type Dictionary,
   type EntityKey,
   type EntityMetadata,
@@ -802,6 +803,7 @@ export class DatabaseTable {
     name?: string;
     type?: string;
     expression?: string;
+    deferMode?: DeferMode;
     options?: Dictionary;
   }, type: 'index' | 'unique' | 'primary') {
     const properties = Utils.unique(Utils.flatten(Utils.asArray(index.properties).map(prop => {
@@ -840,6 +842,7 @@ export class DatabaseTable {
       type: index.type,
       expression: index.expression,
       options: index.options,
+      deferMode: index.deferMode,
     });
   }
 

--- a/packages/postgresql/src/PostgreSqlSchemaHelper.ts
+++ b/packages/postgresql/src/PostgreSqlSchemaHelper.ts
@@ -111,6 +111,10 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
         primary: index.primary,
       };
 
+      if (index.condeferrable) {
+        indexDef.deferMode = index.condeferred ? DeferMode.INITIALLY_DEFERRED : DeferMode.INITIALLY_IMMEDIATE;
+      }
+
       if (index.index_def.some((col: string) => col.match(/[(): ,"'`]/)) || index.expression?.match(/ where /i)) {
         indexDef.expression = index.expression;
       }
@@ -571,7 +575,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
   }
 
   private getIndexesSQL(tables: Table[]): string {
-    return `select indrelid::regclass as table_name, ns.nspname as schema_name, relname as constraint_name, idx.indisunique as unique, idx.indisprimary as primary, contype,
+    return `select indrelid::regclass as table_name, ns.nspname as schema_name, relname as constraint_name, idx.indisunique as unique, idx.indisprimary as primary, contype, condeferrable, condeferred,
       array(
         select pg_get_indexdef(idx.indexrelid, k + 1, true)
         from generate_subscripts(idx.indkey, 1) as k

--- a/tests/features/deferrable-constraints/__snapshots__/compound-deferrable-constraint.test.ts.snap
+++ b/tests/features/deferrable-constraints/__snapshots__/compound-deferrable-constraint.test.ts.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`schema diffing 1`] = `
+"set names 'utf8';
+set session_replication_role = 'replica';
+
+create table "product_category" ("id" serial primary key, "rank" numeric not null default 0, "parent_category_id" integer null);
+alter table "product_category" add constraint "product_category_parent_category_id_rank_unique" unique ("parent_category_id", "rank") deferrable initially deferred;
+
+alter table "product_category" add constraint "product_category_parent_category_id_foreign" foreign key ("parent_category_id") references "product_category" ("id") on update cascade on delete set null;
+
+set session_replication_role = 'origin';
+"
+`;
+
+exports[`schema diffing 2`] = `
+"set names 'utf8';
+set session_replication_role = 'replica';
+
+alter table "product_category" drop constraint "product_category_parent_category_id_rank_unique";
+
+alter table "product_category" add constraint "product_category_parent_category_id_rank_unique" unique ("parent_category_id", "rank");
+
+set session_replication_role = 'origin';
+"
+`;
+
+exports[`schema diffing 3`] = `
+"set names 'utf8';
+set session_replication_role = 'replica';
+
+alter table "product_category" drop constraint "product_category_parent_category_id_rank_unique";
+
+alter table "product_category" add constraint "product_category_parent_category_id_rank_unique" unique ("parent_category_id", "rank") deferrable initially immediate;
+
+set session_replication_role = 'origin';
+"
+`;

--- a/tests/features/deferrable-constraints/compound-deferrable-constraint.test.ts
+++ b/tests/features/deferrable-constraints/compound-deferrable-constraint.test.ts
@@ -1,0 +1,90 @@
+import { DeferMode, Entity, ManyToOne, MikroORM, PrimaryKey, Property, Unique } from '@mikro-orm/postgresql';
+
+@Entity()
+@Unique({
+  properties: ['parent_category_id', 'rank'],
+  deferMode: 'deferred',
+})
+class ProductCategory {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ columnType: 'numeric', nullable: false, default: 0 })
+  rank: number;
+
+  @ManyToOne(() => ProductCategory, {
+    columnType: 'integer',
+    fieldName: 'parent_category_id',
+    nullable: true,
+    mapToPk: true,
+  })
+  parent_category_id?: number | null;
+
+  constructor(rank: number) {
+    this.rank = rank;
+  }
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: 'test-db',
+    entities: [ProductCategory],
+  });
+  await orm.schema.refreshDatabase();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('schema diffing', async () => {
+  const sql = await orm.schema.getCreateSchemaSQL();
+  expect(sql).toMatchSnapshot();
+  const diff = await orm.schema.getUpdateSchemaSQL();
+  expect(diff).toBe('');
+  delete orm.getMetadata(ProductCategory).uniques[0].deferMode;
+  const diff2 = await orm.schema.getUpdateSchemaSQL();
+  expect(diff2).toMatchSnapshot();
+  orm.getMetadata(ProductCategory).uniques[0].deferMode = DeferMode.INITIALLY_IMMEDIATE;
+  const diff3 = await orm.schema.getUpdateSchemaSQL();
+  expect(diff3).toMatchSnapshot();
+});
+
+test('basic CRUD example', async () => {
+  const parent = orm.em.create(ProductCategory, {
+    rank: 1,
+    parent_category_id: null,
+  });
+
+  await orm.em.flush();
+
+  orm.em.create(ProductCategory, {
+    rank: 1,
+    parent_category_id: parent.id,
+  });
+  orm.em.create(ProductCategory, {
+    rank: 2,
+    parent_category_id: parent.id,
+  });
+
+  await orm.em.flush();
+
+  await orm.em.fork().transactional(async em => {
+    const [, cat1, cat2] = await orm.em.findAll(ProductCategory, {});
+
+    cat1.rank = 2;
+    em.persist(cat1);
+
+    cat2.rank = 1;
+    em.persist(cat2);
+  });
+
+  const [, cat1, cat2] = await orm.em.fork().findAll(ProductCategory, {});
+
+  expect(cat1.rank).toEqual(2);
+  expect(cat2.rank).toEqual(1);
+});


### PR DESCRIPTION
Allows specifying `deferMode` on a unique constraint to get around issues with batch updates mainly.