### PR TITLE
fix(core): detect path from decorator for each class only once

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -329,7 +329,7 @@ export class MetadataDiscovery {
     return entity as EntityClass<T>;
   }
 
-  private getSchema<T>(entity: Constructor<T> | EntitySchema<T>, filepath?: string): EntitySchema<T> {
+  private getSchema<T>(entity: (Constructor<T> & { [MetadataStorage.PATH_SYMBOL]?: string }) | EntitySchema<T>, filepath?: string): EntitySchema<T> {
     if (entity instanceof EntitySchema) {
       if (filepath) {
         // initialize global metadata for given entity
@@ -339,7 +339,7 @@ export class MetadataDiscovery {
       return entity;
     }
 
-    const path = (entity as Dictionary).__path;
+    const path = entity[MetadataStorage.PATH_SYMBOL];
 
     if (path) {
       const meta = Utils.copy(MetadataStorage.getMetadata(entity.name, path), false);

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -798,7 +798,7 @@ export class Utils {
       // here we handle bun which stack is different from nodejs so we search for reflect-metadata
       const reflectLine = stack.findIndex(line => Utils.normalizePath(line).includes('node_modules/reflect-metadata/Reflect.js'));
 
-      if (reflectLine === -1 || reflectLine + 1 > stack.length || !stack[reflectLine + 1].includes('bun:wrap')) {
+      if (reflectLine === -1 || reflectLine + 2 >= stack.length || !stack[reflectLine + 1].includes('bun:wrap')) {
         return name;
       }
 
@@ -807,10 +807,6 @@ export class Utils {
 
     if (stack[line].includes('Reflect.decorate')) {
       line++;
-    }
-
-    if (stack[line].match(/DecorateProperty|DecorateConstructor/)) {
-      line += 2;
     }
 
     if (Utils.normalizePath(stack[line]).includes('node_modules/tslib/tslib')) {

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -493,6 +493,16 @@ describe('Utils', () => {
       '    at moduleEvaluation (:1:11)',
       '    at <anonymous> (:2:1)',
     ])).toBe('Book');
+
+    // invalid stack trace - not complete
+    expect(Utils.lookupPathFromDecorator('Book', [
+      'Error',
+      '    at lookupPathFromDecorator (/home/ruby/workspace/bun-playground/node_modules/@mikro-orm/core/utils/Utils.js:400:33)',
+      '    at getMetadataFromDecorator (/home/ruby/workspace/bun-playground/node_modules/@mikro-orm/core/metadata/MetadataStorage.js:27:57)',
+      '    at <anonymous> (/home/ruby/workspace/bun-playground/node_modules/@mikro-orm/core/decorators/Entity.js:4:71)',
+      '    at DecorateConstructor (/home/ruby/workspace/bun-playground/node_modules/reflect-metadata/Reflect.js:171:61)',
+      '    at A (bun:wrap:1:2617)',
+    ])).toBe('Book');
   });
 
   test('lookup path from decorator on windows', () => {


### PR DESCRIPTION
### Fix for bun path detection
Related discussion here: https://github.com/mikro-orm/mikro-orm/discussions/5496
In [this commit](https://github.com/mikro-orm/mikro-orm/commit/271ff7dfe95ded8f2821b7a97a10ddfe409b1513) you changed the condition because of coverage. This is incorrect because it guards against going out of stack array bounds - I have added the test for this case. Also, I removed no longer needed condition.

### Performance
Before the changes, the path was detected for every used decorator on the class and overwritten. This is not needed because the path used as a key should be stable and should not change for a given class. So I introduced the new symbol `MetadataStorage.PATH_SYMBOL`, which will hold the path and check if it exists for a given class using `Object.hasOwn` (this also works for class inheritance so the path is not taken from the base class but defined for each child).

Moreover, as a side effect, this also allows defining a path on the class by the developer (maybe in cases like when Bun was not working), but it should not be needed and used only as a workaround:

```typescript
import { Entity, MetadataStorage } from '@mikro-orm/core';

@Entity()
class User {
  static [MetadataStorage.PATH_SYMBOL] = import.meta.filename // or __filename for commonjs

  @PrimaryKey()
  id!: number;

  @Property()
  username!: string;
}
```