### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/docs/schema-generator.md
+++ b/docs/docs/schema-generator.md
@@ -107,7 +107,7 @@ $ ts-node create-schema
 
 When using generated columns, we'll get a perpetual diff on every `SchemaGenerator` run unless we set `ignoreSchemaChanges` to ignore changes to `type` and `extra`.
 
-See the [SQL Generated columns](./defining-entities.md#SQL Generated columns) section for more details.
+See the [SQL Generated columns](./defining-entities.md#sql-generated-columns) section for more details.
 
 ## Limitations of SQLite
 

--- a/docs/versioned_docs/version-5.9/schema-generator.md
+++ b/docs/versioned_docs/version-5.9/schema-generator.md
@@ -107,7 +107,7 @@ $ ts-node create-schema
 
 When using generated columns, we'll get a perpetual diff on every `SchemaGenerator` run unless we set `ignoreSchemaChanges` to ignore changes to `type` and `extra`.
 
-See the [SQL Generated columns](./defining-entities.md#SQL Generated columns) section for more details.
+See the [SQL Generated columns](./defining-entities.md#sql-generated-columns) section for more details.
 
 ## Limitations of SQLite
 

--- a/docs/versioned_docs/version-6.0/schema-generator.md
+++ b/docs/versioned_docs/version-6.0/schema-generator.md
@@ -107,7 +107,7 @@ $ ts-node create-schema
 
 When using generated columns, we'll get a perpetual diff on every `SchemaGenerator` run unless we set `ignoreSchemaChanges` to ignore changes to `type` and `extra`.
 
-See the [SQL Generated columns](./defining-entities.md#SQL Generated columns) section for more details.
+See the [SQL Generated columns](./defining-entities.md#sql-generated-columns) section for more details.
 
 ## Limitations of SQLite
 

--- a/docs/versioned_docs/version-6.1/schema-generator.md
+++ b/docs/versioned_docs/version-6.1/schema-generator.md
@@ -107,7 +107,7 @@ $ ts-node create-schema
 
 When using generated columns, we'll get a perpetual diff on every `SchemaGenerator` run unless we set `ignoreSchemaChanges` to ignore changes to `type` and `extra`.
 
-See the [SQL Generated columns](./defining-entities.md#SQL Generated columns) section for more details.
+See the [SQL Generated columns](./defining-entities.md#sql-generated-columns) section for more details.
 
 ## Limitations of SQLite
 

--- a/docs/versioned_docs/version-6.2/schema-generator.md
+++ b/docs/versioned_docs/version-6.2/schema-generator.md
@@ -107,7 +107,7 @@ $ ts-node create-schema
 
 When using generated columns, we'll get a perpetual diff on every `SchemaGenerator` run unless we set `ignoreSchemaChanges` to ignore changes to `type` and `extra`.
 
-See the [SQL Generated columns](./defining-entities.md#SQL Generated columns) section for more details.
+See the [SQL Generated columns](./defining-entities.md#sql-generated-columns) section for more details.
 
 ## Limitations of SQLite
 


### PR DESCRIPTION
I noticed this broken link on this page: https://mikro-orm.io/docs/schema-generator#ignoring-specific-column-changes

I have not tried to generate the docs with this change, so feel free to do that to verify the fix.
