### PR TITLE
refactor(knex): moved better-sqlite, libsql and mariadb dialects into their packages

### DIFF
--- a/packages/better-sqlite/src/BetterSqliteConnection.ts
+++ b/packages/better-sqlite/src/BetterSqliteConnection.ts
@@ -1,4 +1,5 @@
-import { BetterSqliteKnexDialect, BaseSqliteConnection } from '@mikro-orm/knex';
+import { BaseSqliteConnection } from '@mikro-orm/knex';
+import { BetterSqliteKnexDialect } from './BetterSqliteKnexDialect';
 
 export class BetterSqliteConnection extends BaseSqliteConnection {
 

--- a/packages/better-sqlite/src/BetterSqliteKnexDialect.ts
+++ b/packages/better-sqlite/src/BetterSqliteKnexDialect.ts
@@ -1,5 +1,4 @@
-import { SqliteTableCompiler } from './SqliteTableCompiler';
-import { MonkeyPatchable } from '../../MonkeyPatchable';
+import { MonkeyPatchable, SqliteTableCompiler } from '@mikro-orm/knex';
 
 export class BetterSqliteKnexDialect extends MonkeyPatchable.BetterSqlite3Dialect {
 

--- a/packages/knex/src/dialects/mysql/index.ts
+++ b/packages/knex/src/dialects/mysql/index.ts
@@ -1,4 +1,3 @@
-export * from './MariaDbKnexDialect';
 export * from './MySqlKnexDialect';
 export * from './MySqlConnection';
 export * from './MySqlExceptionConverter';

--- a/packages/knex/src/dialects/sqlite/index.ts
+++ b/packages/knex/src/dialects/sqlite/index.ts
@@ -2,6 +2,4 @@ export * from './BaseSqliteConnection';
 export * from './BaseSqlitePlatform';
 export * from './BaseSqliteSchemaHelper';
 export * from './SqliteTableCompiler';
-export * from './BetterSqliteKnexDialect';
-export * from './LibSqlKnexDialect';
 export * from './SqliteKnexDialect';

--- a/packages/libsql/src/LibSqlConnection.ts
+++ b/packages/libsql/src/LibSqlConnection.ts
@@ -1,4 +1,5 @@
-import { LibSqlKnexDialect, BaseSqliteConnection } from '@mikro-orm/knex';
+import { BaseSqliteConnection } from '@mikro-orm/knex';
+import { LibSqlKnexDialect } from './LibSqlKnexDialect';
 
 export class LibSqlConnection extends BaseSqliteConnection {
 

--- a/packages/libsql/src/LibSqlKnexDialect.ts
+++ b/packages/libsql/src/LibSqlKnexDialect.ts
@@ -1,5 +1,4 @@
-import { SqliteTableCompiler } from './SqliteTableCompiler';
-import { MonkeyPatchable } from '../../MonkeyPatchable';
+import { MonkeyPatchable, SqliteTableCompiler } from '@mikro-orm/knex';
 
 export class LibSqlKnexDialect extends MonkeyPatchable.BetterSqlite3Dialect {
 

--- a/packages/mariadb/src/MariaDbConnection.ts
+++ b/packages/mariadb/src/MariaDbConnection.ts
@@ -1,5 +1,6 @@
 import type { QueryConfig } from 'mariadb';
-import { MySqlConnection, type Knex, MariaDbKnexDialect } from '@mikro-orm/knex';
+import { MySqlConnection, type Knex } from '@mikro-orm/knex';
+import { MariaDbKnexDialect } from './MariaDbKnexDialect';
 
 export class MariaDbConnection extends MySqlConnection {
 

--- a/packages/mariadb/src/MariaDbKnexDialect.ts
+++ b/packages/mariadb/src/MariaDbKnexDialect.ts
@@ -1,4 +1,4 @@
-import { MySqlKnexDialect } from './MySqlKnexDialect';
+import { MySqlKnexDialect } from '@mikro-orm/knex';
 
 export class MariaDbKnexDialect extends MySqlKnexDialect {
 


### PR DESCRIPTION
This allows tree shaking bundlers (e.g. Vite) to exclude those dialects' clients, when they are not in use, without needing an explicit config.