### PR TITLE
fix(mssql): account for quotes in table names

### DIFF
--- a/packages/mssql/src/MsSqlSchemaHelper.ts
+++ b/packages/mssql/src/MsSqlSchemaHelper.ts
@@ -90,7 +90,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       inner join sys.columns sc on sc.name = ic.column_name and sc.object_id = object_id(ic.table_schema + '.' + ic.table_name)
       left join sys.computed_columns cmp on cmp.name = ic.column_name and cmp.object_id = object_id(ic.table_schema + '.' + ic.table_name)
       left join sys.extended_properties t4 on t4.major_id = object_id(ic.table_schema + '.' + ic.table_name) and t4.name = 'MS_Description' and t4.minor_id = sc.column_id
-      where table_name in (${tables.map(t => this.platform.quoteValue(t.table_name.replaceAll(`'`, `''`)))})
+      where table_name in (${tables.map(t => this.platform.quoteValue(t.table_name))})
       order by ordinal_position`;
     const allColumns = await connection.execute<any[]>(sql);
     const str = (val?: string | number) => val != null ? '' + val : val;
@@ -146,7 +146,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       inner join sys.columns col on ic.object_id = col.object_id and ic.column_id = col.column_id
       inner join sys.tables t on ind.object_id = t.object_id
       where
-      t.name in (${tables.map(t => this.platform.quoteValue(t.table_name.replaceAll(`'`, `''`))).join(', ')})
+      t.name in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(', ')})
       order by t.name, ind.name, ind.index_id`;
     const allIndexes = await connection.execute<any[]>(sql);
     const ret = {} as Dictionary;
@@ -198,7 +198,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       from information_schema.constraint_column_usage ccu
       inner join information_schema.referential_constraints rc on ccu.constraint_name = rc.constraint_name and rc.constraint_schema = ccu.constraint_schema
       inner join information_schema.key_column_usage kcu on kcu.constraint_name = rc.unique_constraint_name and rc.unique_constraint_schema = kcu.constraint_schema
-      where (${tables.map(t => `(ccu.table_name = '${t.table_name.replaceAll(`'`, `''`)}' and ccu.table_schema = '${t.schema_name}')`).join(' or ')})
+      where (${tables.map(t => `(ccu.table_name = ${this.platform.quoteValue(t.table_name)} and ccu.table_schema = '${t.schema_name}')`).join(' or ')})
       order by kcu.table_schema, kcu.table_name, kcu.ordinal_position, kcu.constraint_name`;
     const allFks = await connection.execute<any[]>(sql);
     const ret = {} as Dictionary;
@@ -254,7 +254,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       from sys.check_constraints con
       left outer join sys.objects t on con.parent_object_id = t.object_id
       left outer join sys.all_columns col on con.parent_column_id = col.column_id and con.parent_object_id = col.object_id
-      where (${tables.map(t => `t.name = '${t.table_name.replaceAll(`'`, `''`)}' and schema_name(t.schema_id) = '${t.schema_name}'`).join(' or ')})
+      where (${tables.map(t => `t.name = ${this.platform.quoteValue(t.table_name)} and schema_name(t.schema_id) = '${t.schema_name}'`).join(' or ')})
       order by con.name`;
   }
 

--- a/packages/mssql/src/MsSqlSchemaHelper.ts
+++ b/packages/mssql/src/MsSqlSchemaHelper.ts
@@ -90,7 +90,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       inner join sys.columns sc on sc.name = ic.column_name and sc.object_id = object_id(ic.table_schema + '.' + ic.table_name)
       left join sys.computed_columns cmp on cmp.name = ic.column_name and cmp.object_id = object_id(ic.table_schema + '.' + ic.table_name)
       left join sys.extended_properties t4 on t4.major_id = object_id(ic.table_schema + '.' + ic.table_name) and t4.name = 'MS_Description' and t4.minor_id = sc.column_id
-      where table_name in (${tables.map(t => this.platform.quoteValue(t.table_name))})
+      where table_name in (${tables.map(t => this.platform.quoteValue(t.table_name.replaceAll(`'`, `''`)))})
       order by ordinal_position`;
     const allColumns = await connection.execute<any[]>(sql);
     const str = (val?: string | number) => val != null ? '' + val : val;
@@ -146,7 +146,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       inner join sys.columns col on ic.object_id = col.object_id and ic.column_id = col.column_id
       inner join sys.tables t on ind.object_id = t.object_id
       where
-      t.name in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(', ')})
+      t.name in (${tables.map(t => this.platform.quoteValue(t.table_name.replaceAll(`'`, `''`))).join(', ')})
       order by t.name, ind.name, ind.index_id`;
     const allIndexes = await connection.execute<any[]>(sql);
     const ret = {} as Dictionary;
@@ -198,7 +198,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       from information_schema.constraint_column_usage ccu
       inner join information_schema.referential_constraints rc on ccu.constraint_name = rc.constraint_name and rc.constraint_schema = ccu.constraint_schema
       inner join information_schema.key_column_usage kcu on kcu.constraint_name = rc.unique_constraint_name and rc.unique_constraint_schema = kcu.constraint_schema
-      where (${tables.map(t => `(ccu.table_name = '${t.table_name}' and ccu.table_schema = '${t.schema_name}')`).join(' or ')})
+      where (${tables.map(t => `(ccu.table_name = '${t.table_name.replaceAll(`'`, `''`)}' and ccu.table_schema = '${t.schema_name}')`).join(' or ')})
       order by kcu.table_schema, kcu.table_name, kcu.ordinal_position, kcu.constraint_name`;
     const allFks = await connection.execute<any[]>(sql);
     const ret = {} as Dictionary;
@@ -254,7 +254,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       from sys.check_constraints con
       left outer join sys.objects t on con.parent_object_id = t.object_id
       left outer join sys.all_columns col on con.parent_column_id = col.column_id and con.parent_object_id = col.object_id
-      where (${tables.map(t => `t.name = '${t.table_name}' and schema_name(t.schema_id) = '${t.schema_name}'`).join(' or ')})
+      where (${tables.map(t => `t.name = '${t.table_name.replaceAll(`'`, `''`)}' and schema_name(t.schema_id) = '${t.schema_name}'`).join(' or ')})
       order by con.name`;
   }
 


### PR DESCRIPTION
This fixes invalid sql produced by `MsSqlSchemaHelper` for tables with quote char in the name.