### PR TITLE
fix(postgres): respect `deferMode` option in 1:1 relations

### DIFF
--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -199,6 +199,7 @@ export class DatabaseTable {
         constraint: !prop.fieldNames.some((d: string) => d.includes('.')),
         primary: false,
         unique: true,
+        deferMode: prop.deferMode,
       });
     }
   }

--- a/packages/knex/src/schema/SchemaComparator.ts
+++ b/packages/knex/src/schema/SchemaComparator.ts
@@ -607,7 +607,7 @@ export class SchemaComparator {
       return true;
     }
 
-    return index1.primary === index2.primary && index1.unique === index2.unique;
+    return index1.primary === index2.primary && index1.unique === index2.unique && index1.deferMode === index2.deferMode;
   }
 
   diffExpression(expr1: string, expr2: string): boolean {

--- a/packages/knex/src/typings.ts
+++ b/packages/knex/src/typings.ts
@@ -92,6 +92,7 @@ export interface IndexDef {
   expression?: string; // allows using custom sql expressions
   options?: Dictionary; // for driver specific options
   type?: string | Readonly<{ indexType?: string; storageEngineIndexType?: 'hash' | 'btree'; predicate?: Knex.QueryBuilder }>; // for back compatibility mainly, to allow using knex's `index.type` option (e.g. gin index)
+  deferMode?: DeferMode;
 }
 
 export interface CheckDef<T = unknown> {

--- a/packages/postgresql/src/PostgreSqlSchemaHelper.ts
+++ b/packages/postgresql/src/PostgreSqlSchemaHelper.ts
@@ -115,6 +115,10 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
         indexDef.expression = index.expression;
       }
 
+      if (index.deferrable) {
+        indexDef.deferMode = index.initially_deferred ? DeferMode.INITIALLY_DEFERRED : DeferMode.INITIALLY_IMMEDIATE;
+      }
+
       ret[key] ??= [];
       ret[key].push(indexDef);
     }
@@ -573,7 +577,9 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
         from generate_subscripts(idx.indkey, 1) as k
         order by k
       ) as index_def,
-      pg_get_indexdef(idx.indexrelid) as expression
+      pg_get_indexdef(idx.indexrelid) as expression,
+      c.condeferrable as deferrable,
+      c.condeferred as initially_deferred
       from pg_index idx
       join pg_class as i on i.oid = idx.indexrelid
       join pg_namespace as ns on i.relnamespace = ns.oid

--- a/tests/features/schema-generator/__snapshots__/fk-diffing.postgres.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/fk-diffing.postgres.test.ts.snap
@@ -54,23 +54,36 @@ alter table "book" drop column "author2_id", drop column "based_on_id";
 exports[`updating tables with FKs in postgres schema generator updates foreign keys on deferrable change 1`] = `
 "alter table "book" drop constraint "book_author1_pk_foreign";
 
+alter table "book" add column "author2_pk" int not null;
+alter table "book" add constraint "book_author2_pk_foreign" foreign key ("author2_pk") references "author" ("pk") on update cascade deferrable initially deferred ;
 alter table "book" add constraint "book_author1_pk_foreign" foreign key ("author1_pk") references "author" ("pk") on update cascade deferrable initially deferred ;
+alter table "book" add constraint "book_author2_pk_unique" unique ("author2_pk") deferrable initially deferred;
 
 "
 `;
 
 exports[`updating tables with FKs in postgres schema generator updates foreign keys on deferrable change 2`] = `
 "alter table "book" drop constraint "book_author1_pk_foreign";
+alter table "book" drop constraint "book_author2_pk_foreign";
+
+alter table "book" drop constraint "book_author2_pk_unique";
 
 alter table "book" add constraint "book_author1_pk_foreign" foreign key ("author1_pk") references "author" ("pk") on update cascade deferrable initially immediate ;
+alter table "book" add constraint "book_author2_pk_foreign" foreign key ("author2_pk") references "author" ("pk") on update cascade deferrable initially immediate ;
+alter table "book" add constraint "book_author2_pk_unique" unique ("author2_pk") deferrable initially immediate;
 
 "
 `;
 
 exports[`updating tables with FKs in postgres schema generator updates foreign keys on deferrable change 3`] = `
 "alter table "book" drop constraint "book_author1_pk_foreign";
+alter table "book" drop constraint "book_author2_pk_foreign";
+
+alter table "book" drop constraint "book_author2_pk_unique";
 
 alter table "book" add constraint "book_author1_pk_foreign" foreign key ("author1_pk") references "author" ("pk") on update cascade;
+alter table "book" add constraint "book_author2_pk_foreign" foreign key ("author2_pk") references "author" ("pk") on update cascade;
+alter table "book" add constraint "book_author2_pk_unique" unique ("author2_pk");
 
 "
 `;

--- a/tests/features/schema-generator/fk-diffing.postgres.test.ts
+++ b/tests/features/schema-generator/fk-diffing.postgres.test.ts
@@ -1,4 +1,12 @@
-import { DeferMode, Entity, ManyToOne, MikroORM, PrimaryKey, Property } from '@mikro-orm/core';
+import {
+  DeferMode,
+  Entity,
+  ManyToOne,
+  MikroORM,
+  OneToOne,
+  PrimaryKey,
+  Property,
+} from '@mikro-orm/core';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 
 @Entity({ tableName: 'author' })
@@ -105,6 +113,9 @@ export class Book4 {
   @ManyToOne(() => Author1)
   author1!: Author1;
 
+  @OneToOne(() => Author1)
+  author2!: Author1;
+
 }
 
 @Entity({ tableName: 'book' })
@@ -116,6 +127,9 @@ export class Book41 {
   @ManyToOne(() => Author1, { deferMode: DeferMode.INITIALLY_DEFERRED })
   author1!: Author1;
 
+  @OneToOne(() => Author1, { deferMode: DeferMode.INITIALLY_DEFERRED })
+  author2!: Author1;
+
 }
 
 @Entity({ tableName: 'book' })
@@ -126,6 +140,9 @@ export class Book42 {
 
   @ManyToOne(() => Author1, { deferMode: DeferMode.INITIALLY_IMMEDIATE })
   author1!: Author1;
+
+  @OneToOne(() => Author1, { deferMode: DeferMode.INITIALLY_IMMEDIATE })
+  author2!: Author1;
 
 }
 


### PR DESCRIPTION
In my initial implementation on `deferMode` for 1:m and 1:1 I overlooked the unique constraint which is created for 1:1 relations. This PR corrects this and also applies the selected `deferMode` to the unique constraint.

This PR also lays the framework for potentially using `deferMode` on custom unique constraints, though that is not critical since those could already be created through the `expression` prop.

If this PR looks fine, I'd appreciate a quick bugfix release after you had time to merge it, since this is currently a showstopper in one of my projects and I can't find a workaround :)