### PR TITLE
fix(mssql): fix creating migrations due to a missing helper method

### DIFF
--- a/packages/mssql/src/MsSqlSchemaHelper.ts
+++ b/packages/mssql/src/MsSqlSchemaHelper.ts
@@ -50,6 +50,14 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       left join sys.extended_properties ep on ep.major_id = t.id and ep.name = 'MS_Description' and ep.minor_id = 0`;
   }
 
+  override async getNamespaces(
+    connection: AbstractSqlConnection,
+  ): Promise<string[]> {
+    const sql = `SELECT name AS schema_name FROM sys.schemas ORDER BY name`;
+    const res = await connection.execute<{ schema_name: string }[]>(sql);
+    return res.map(row => row.schema_name);
+  }
+
   override normalizeDefaultValue(defaultValue: string, length: number, defaultValues: Dictionary<string[]> = {}, stripQuotes = false) {
     let match = defaultValue?.match(/^\((.*)\)$/);
 

--- a/packages/mssql/src/MsSqlSchemaHelper.ts
+++ b/packages/mssql/src/MsSqlSchemaHelper.ts
@@ -50,10 +50,8 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       left join sys.extended_properties ep on ep.major_id = t.id and ep.name = 'MS_Description' and ep.minor_id = 0`;
   }
 
-  override async getNamespaces(
-    connection: AbstractSqlConnection,
-  ): Promise<string[]> {
-    const sql = `SELECT name AS schema_name FROM sys.schemas ORDER BY name`;
+  override async getNamespaces(connection: AbstractSqlConnection): Promise<string[]> {
+    const sql = `select name as schema_name from sys.schemas order by name`;
     const res = await connection.execute<{ schema_name: string }[]>(sql);
     return res.map(row => row.schema_name);
   }


### PR DESCRIPTION
This is linked with the issue closes #5633 

I have overriden the method `getNamespaces` inside the MSSqlSchemaHelper so that we can dynamically get the namespaces present in the MSSQL connection that was configured with the Mikroorm instance of the application.

I have tested this query with migration files that migrate the database up and I was able to successfully do that.
To be precise was able to run these commands successfully and the changes were reflected in the DB:

```sh
mikro-orm migration:create --initial
mikro-orm migration:create && mikro-orm migration:up
mikro-orm migration:down #If required to reduce the version of migration is also successful
```

Please let me know whether this looks good and I am up for any changes or refinements. Thank you