### PR TITLE
feat(core): check for ORM extensions dynamically

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -133,6 +133,8 @@ export default defineConfig({
 
 > The `SchemaGenerator` (as well as `MongoSchemaGenerator`) is registered automatically as it does not require any 3rd party dependencies to be installed.
 
+Since v6.3, the extensions are again checked dynamically if not explicitly registered, so it should be enough to have the given package (e.g. `@mikro-orm/seeder`) installed as in v5.
+
 ## Driver
 
 To select driver, you can either use `type` option, or provide the driver class reference.

--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -264,41 +264,21 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver, EM extends En
    * Gets the EntityGenerator.
    */
   getEntityGenerator<T extends IEntityGenerator = IEntityGenerator>(): T {
-    const extension = this.config.getExtension<T>('@mikro-orm/entity-generator');
-
-    if (extension) {
-      return extension;
-    }
-
-    throw new Error(`EntityGenerator extension not registered.`);
+    return this.driver.getPlatform().getExtension('EntityGenerator', '@mikro-orm/entity-generator', '@mikro-orm/entity-generator', this.em);
   }
 
   /**
    * Gets the Migrator.
    */
   getMigrator<T extends IMigrator = IMigrator>(): T {
-    const extension = this.config.getExtension<T>('@mikro-orm/migrator');
-
-    if (extension) {
-      return extension;
-    }
-
-    /* istanbul ignore next */
-    throw new Error(`Migrator extension not registered.`);
+    return this.driver.getPlatform().getExtension('Migrator', '@mikro-orm/migrator', '@mikro-orm/migrations', this.em);
   }
 
   /**
    * Gets the SeedManager
    */
   getSeeder<T extends ISeedManager = ISeedManager>(): T {
-    const extension = this.config.getExtension<T>('@mikro-orm/seeder');
-
-    if (extension) {
-      return extension;
-    }
-
-    /* istanbul ignore next */
-    throw new Error(`SeedManager extension not registered.`);
+    return this.driver.getPlatform().getExtension('SeedManager', '@mikro-orm/seeder', '@mikro-orm/seeder', this.em);
   }
 
   /**

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -406,12 +406,13 @@ export abstract class Platform {
       return extension;
     }
 
+    /* istanbul ignore next */
     const module = Utils.tryRequire({
       module: moduleName,
       warning: `Please install ${moduleName} package.`,
     });
 
-    /* istanbul ignore else */
+    /* istanbul ignore next */
     if (module) {
       return this.config.getCachedService(module[extensionName], em);
     }

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -399,6 +399,27 @@ export abstract class Platform {
     // no extensions by default
   }
 
+  getExtension<T>(extensionName: string, extensionKey: string, moduleName: string, em: EntityManager): T {
+    const extension = this.config.getExtension<T>(extensionKey);
+
+    if (extension) {
+      return extension;
+    }
+
+    const module = Utils.tryRequire({
+      module: moduleName,
+      warning: `Please install ${moduleName} package.`,
+    });
+
+    /* istanbul ignore else */
+    if (module) {
+      return this.config.getCachedService(module[extensionName], em);
+    }
+
+    /* istanbul ignore next */
+    throw new Error(`${extensionName} extension not registered.`);
+  }
+
   /* istanbul ignore next: kept for type inference only */
   getSchemaGenerator(driver: IDatabaseDriver, em?: EntityManager): ISchemaGenerator {
     throw new Error(`${driver.constructor.name} does not support SchemaGenerator`);

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -34,13 +34,14 @@ export class MongoPlatform extends Platform {
   /** @inheritDoc */
   override getExtension<T>(extensionName: string, extensionKey: string, moduleName: string, em: EntityManager): T {
     if (extensionName === 'EntityGenerator') {
-      throw new Error('EntityGenerator is not support for this driver.');
+      throw new Error('EntityGenerator is not supported for this driver.');
     }
 
     if (extensionName === 'Migrator') {
       return super.getExtension('Migrator', '@mikro-orm/migrator', '@mikro-orm/migrations-mongodb', em);
     }
 
+    /* istanbul ignore next */
     return super.getExtension(extensionName, extensionKey, moduleName, em);
   }
 

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -31,6 +31,19 @@ export class MongoPlatform extends Platform {
     MongoSchemaGenerator.register(orm);
   }
 
+  /** @inheritDoc */
+  override getExtension<T>(extensionName: string, extensionKey: string, moduleName: string, em: EntityManager): T {
+    if (extensionName === 'EntityGenerator') {
+      throw new Error('EntityGenerator is not support for this driver.');
+    }
+
+    if (extensionName === 'Migrator') {
+      return super.getExtension('Migrator', '@mikro-orm/migrator', '@mikro-orm/migrations-mongodb', em);
+    }
+
+    return super.getExtension(extensionName, extensionKey, moduleName, em);
+  }
+
   /* istanbul ignore next: kept for type inference only */
   override getSchemaGenerator(driver: IDatabaseDriver, em?: EntityManager): MongoSchemaGenerator {
     return new MongoSchemaGenerator(em ?? driver as any);

--- a/tests/features/entity-generator/EntityGenerator.test.ts
+++ b/tests/features/entity-generator/EntityGenerator.test.ts
@@ -7,7 +7,7 @@ describe('EntityGenerator', () => {
 
   test('not supported [mongodb]', async () => {
     const orm = await MikroORM.init({ driver: MongoDriver, dbName: 'mikro-orm-test', discovery: { warnWhenNoEntities: false }, connect: false });
-    expect(() => orm.entityGenerator).toThrow('EntityGenerator extension not registered.');
+    expect(() => orm.entityGenerator).toThrow('EntityGenerator is not support for this driver.');
   });
 
   test('generate entities from schema [sqlite]', async () => {

--- a/tests/features/entity-generator/EntityGenerator.test.ts
+++ b/tests/features/entity-generator/EntityGenerator.test.ts
@@ -7,7 +7,7 @@ describe('EntityGenerator', () => {
 
   test('not supported [mongodb]', async () => {
     const orm = await MikroORM.init({ driver: MongoDriver, dbName: 'mikro-orm-test', discovery: { warnWhenNoEntities: false }, connect: false });
-    expect(() => orm.entityGenerator).toThrow('EntityGenerator is not support for this driver.');
+    expect(() => orm.entityGenerator).toThrow('EntityGenerator is not supported for this driver.');
   });
 
   test('generate entities from schema [sqlite]', async () => {


### PR DESCRIPTION
The extensions are now again checked dynamically if not explicitly registered, so it should be enough to have the given package (e.g. `@mikro-orm/seeder`) installed as in v5.