### PR TITLE
fix(entity-generator): support complex enum names and values

### DIFF
--- a/docs/docs/naming-strategy.md
+++ b/docs/docs/naming-strategy.md
@@ -76,6 +76,18 @@ Return a column name for a property (used in `EntityGenerator`).
 
 ---
 
+#### `NamingStrategy.getEnumClassName(columnName: string, tableName: string, schemaName?: string): string`
+
+Return an enum class name for a column (used in `EntityGenerator`).
+
+---
+
+#### `NamingStrategy.enumValueToEnumProperty(enumValue: string, columnName: string, tableName: string, schemaName?: string): string`
+
+Return an enum property name for an enum value (used in `EntityGenerator`).
+
+---
+
 #### `NamingStrategy.referenceColumnName(): string`
 
 Return the default reference column name.

--- a/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
+++ b/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
@@ -61,6 +61,20 @@ export abstract class AbstractNamingStrategy implements NamingStrategy {
     return propName;
   }
 
+  /**
+   * @inheritDoc
+   */
+  getEnumClassName(columnName: string, tableName: string, schemaName?: string): string {
+    return this.getEntityName(`${tableName}_${columnName}`, schemaName);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  enumValueToEnumProperty(enumValue: string, columnName: string, tableName: string, schemaName?: string): string {
+    return enumValue.toUpperCase();
+  }
+
   aliasName(entityName: string, index: number): string {
     // Take only the first letter of the prefix to keep character counts down since some engines have character limits
     return entityName.charAt(0).toLowerCase() + index;

--- a/packages/core/src/naming-strategy/NamingStrategy.ts
+++ b/packages/core/src/naming-strategy/NamingStrategy.ts
@@ -21,6 +21,29 @@ export interface NamingStrategy {
   propertyToColumnName(propertyName: string, object?: boolean): string;
 
   /**
+   * Get an enum class name.
+   *
+   * @param columnName The column name which has the enum.
+   * @param tableName The table name of the column.
+   * @param schemaName The schema name of the column.
+   *
+   * @return A new class name that will be used for the enum.
+   */
+  getEnumClassName(columnName: string, tableName: string, schemaName?: string): string;
+
+  /**
+   * Get an enum option name for a given enum value.
+   *
+   * @param enumValue The enum value to generate a name for.
+   * @param columnName The column name which has the enum.
+   * @param tableName The table name of the column.
+   * @param schemaName The schema name of the column.
+   *
+   * @return The name of the enum property that will hold the value.
+   */
+  enumValueToEnumProperty(enumValue: string, columnName: string, tableName: string, schemaName?: string): string;
+
+  /**
    * Return a name of the entity class based on database table name (used in `EntityGenerator`).
    * Default implementation ignores the schema name.
    */

--- a/packages/entity-generator/src/EntitySchemaSourceFile.ts
+++ b/packages/entity-generator/src/EntitySchemaSourceFile.ts
@@ -32,8 +32,7 @@ export class EntitySchemaSourceFile extends SourceFile {
       props.push(this.getPropertyDefinition(prop, 2));
 
       if (prop.enum) {
-        const enumClassName = this.namingStrategy.getClassName(this.meta.collection + '_' + prop.fieldNames[0], '_');
-        enumDefinitions.push(this.getEnumClassDefinition(enumClassName, prop.items as string[], 2));
+        enumDefinitions.push(this.getEnumClassDefinition(prop, 2));
       }
 
       if (prop.eager) {

--- a/packages/entity-generator/src/SourceFile.ts
+++ b/packages/entity-generator/src/SourceFile.ts
@@ -110,8 +110,7 @@ export class SourceFile {
       classBody += '\n';
 
       if (prop.enum) {
-        const enumClassName = this.namingStrategy.getClassName(this.meta.collection + '_' + prop.fieldNames[0], '_');
-        enumDefinitions.push(this.getEnumClassDefinition(enumClassName, prop.items as string[], 2));
+        enumDefinitions.push(this.getEnumClassDefinition(prop, 2));
       }
 
       if (prop.eager) {
@@ -282,12 +281,15 @@ export class SourceFile {
     return `${padding}${ret} = ${propType === 'string' ? this.quote('' + prop.default) : prop.default};\n`;
   }
 
-  protected getEnumClassDefinition(enumClassName: string, enumValues: string[], padLeft: number): string {
+  protected getEnumClassDefinition(prop: EntityProperty, padLeft: number): string {
+    const enumClassName = this.namingStrategy.getEnumClassName(prop.fieldNames[0], this.meta.collection, this.meta.schema);
     const padding = ' '.repeat(padLeft);
     let ret = `export enum ${enumClassName} {\n`;
 
+    const enumValues = prop.items as string[];
     for (const enumValue of enumValues) {
-      ret += `${padding}${enumValue.toUpperCase()} = '${enumValue}',\n`;
+      const enumName = this.namingStrategy.enumValueToEnumProperty(enumValue, prop.fieldNames[0], this.meta.collection, this.meta.schema);
+      ret += `${padding}${identifierRegex.test(enumName) ? enumName : this.quote(enumName)} = ${this.quote(enumValue)},\n`;
     }
 
     ret += '}\n';

--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -760,8 +760,7 @@ export class DatabaseTable {
     // If this column is using an enum.
     if (column.enumItems?.length) {
       // We will create a new enum name for this type and set it as the property type as well.
-      // The enum name will be a concatenation of the table name and the column name.
-      return namingStrategy.getClassName(this.name + '_' + column.name, '_');
+      return namingStrategy.getEnumClassName(column.name, this.name, this.schema);
     }
 
     return column.mappedType?.runtimeType ?? 'unknown';

--- a/tests/features/entity-generator/OddTableNames.mysql.test.ts
+++ b/tests/features/entity-generator/OddTableNames.mysql.test.ts
@@ -21,6 +21,7 @@ COLLATE = utf8mb4_0900_ai_ci;
 
 CREATE TABLE IF NOT EXISTS \`odd_table_names_example:100%\`.\`*misc\` (
   \`@ref\` INT UNSIGNED NOT NULL,
+  \`type\` ENUM('application/svg+xml', 'image/png'),
   PRIMARY KEY (\`@ref\`),
   CONSTRAINT \`fk_*misc_50% of stuff\`
     FOREIGN KEY (\`@ref\`)

--- a/tests/features/entity-generator/__snapshots__/OddTableNames.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OddTableNames.mysql.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`odd_table_names_example:100% entitySchema=false: mysql 1`] = `
 [
-  "import { Entity, OneToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, Enum, OneToOne, PrimaryKeyProp } from '@mikro-orm/core';
 import { E50$37$32of$32stuff } from './E50$37$32of$32stuff';
 
 @Entity({ tableName: '*misc' })
@@ -13,6 +13,14 @@ export class E_$42misc {
   @OneToOne({ entity: () => E50$37$32of$32stuff, fieldName: '@ref', primary: true })
   '@ref'!: E50$37$32of$32stuff;
 
+  @Enum({ items: () => E_$42miscType, nullable: true })
+  type?: E_$42miscType;
+
+}
+
+export enum E_$42miscType {
+  'APPLICATION/SVG+XML' = 'application/svg+xml',
+  'IMAGE/PNG' = 'image/png',
 }
 ",
   "import { Entity, Index, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
@@ -112,6 +120,12 @@ import { E50$37$32of$32stuff } from './E50$37$32of$32stuff';
 export class E_$42misc {
   [PrimaryKeyProp]?: '@ref';
   '@ref'!: E50$37$32of$32stuff;
+  type?: E_$42miscType;
+}
+
+export enum E_$42miscType {
+  'APPLICATION/SVG+XML' = 'application/svg+xml',
+  'IMAGE/PNG' = 'image/png',
 }
 
 export const E_$42miscSchema = new EntitySchema({
@@ -124,6 +138,7 @@ export const E_$42miscSchema = new EntitySchema({
       entity: () => E50$37$32of$32stuff,
       fieldName: '@ref',
     },
+    type: { enum: true, items: () => E_$42miscType, nullable: true },
   },
 });
 ",


### PR DESCRIPTION
Enum options that are invalid JS identifiers get the property treatment (independent of naming strategy), and the enum name itself gets the entity name treatment.

Two new NamingStrategy methods have been added to optionally adjust the default behaivour. getEnumClassName() and enumValueToEnumProperty().