### PR TITLE
fix(entity-generator): primary keys that are foreign keys or enums are now generated correctly

### DIFF
--- a/packages/entity-generator/src/EntitySchemaSourceFile.ts
+++ b/packages/entity-generator/src/EntitySchemaSourceFile.ts
@@ -27,7 +27,7 @@ export class EntitySchemaSourceFile extends SourceFile {
     for (const prop of Object.values(this.meta.properties)) {
       props.push(this.getPropertyDefinition(prop, 2));
 
-      if (prop.enum) {
+      if (prop.enum && (typeof prop.kind === 'undefined' || prop.kind === ReferenceKind.SCALAR)) {
         enumDefinitions.push(this.getEnumClassDefinition(prop, 2));
       }
 
@@ -153,11 +153,6 @@ export class EntitySchemaSourceFile extends SourceFile {
       this.getForeignKeyDecoratorOptions(options, prop);
     }
 
-    if (prop.enum) {
-      options.enum = true;
-      options.items = `() => ${prop.runtimeType}`;
-    }
-
     if (prop.formula) {
       options.formula = `${prop.formula}`;
     }
@@ -205,7 +200,10 @@ export class EntitySchemaSourceFile extends SourceFile {
   }
 
   protected override getScalarPropertyDecoratorOptions(options: Dictionary, prop: EntityProperty): void {
-    if (prop.kind === ReferenceKind.SCALAR && !prop.enum) {
+    if (prop.enum) {
+      options.enum = true;
+      options.items = `() => ${prop.runtimeType}`;
+    } else {
       options.type = this.quote(prop.type);
     }
 

--- a/tests/features/entity-generator/OddPkTypes.mysql.test.ts
+++ b/tests/features/entity-generator/OddPkTypes.mysql.test.ts
@@ -1,0 +1,84 @@
+import { MikroORM } from '@mikro-orm/mysql';
+import { EntityGenerator } from '@mikro-orm/entity-generator';
+import { remove } from 'fs-extra';
+
+let orm: MikroORM;
+
+const schemaName = 'complex_pks_example';
+const schema = `
+
+CREATE TABLE IF NOT EXISTS \`worktime\` (
+  \`weekday\` ENUM('Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday') NOT NULL,
+  \`from\` TIME NOT NULL,
+  \`to\` TIME NOT NULL,
+  PRIMARY KEY (\`weekday\`))
+ENGINE = InnoDB
+COMMENT = 'Worktime. If a day is holiday, remove the row.';
+
+CREATE TABLE IF NOT EXISTS \`events\` (
+  \`weekday\` ENUM('Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday') NOT NULL,
+  \`at\` TIME NOT NULL,
+  \`what\` VARCHAR(255) NOT NULL,
+  PRIMARY KEY (\`weekday\`, \`at\`),
+  CONSTRAINT \`fk_events_worktime\`
+    FOREIGN KEY (\`weekday\`)
+    REFERENCES \`worktime\` (\`weekday\`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS \`event_details\` (
+  \`weekday\` ENUM('Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday') NOT NULL,
+  \`at\` TIME NOT NULL,
+  \`more_info\` TEXT NULL,
+  PRIMARY KEY (\`weekday\`, \`at\`),
+  CONSTRAINT \`fk_event_details_events1\`
+    FOREIGN KEY (\`weekday\` , \`at\`)
+    REFERENCES \`events\` (\`weekday\` , \`at\`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+ENGINE = InnoDB;
+`;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: schemaName,
+    port: 3308,
+    discovery: { warnWhenNoEntities: false },
+    extensions: [EntityGenerator],
+    multipleStatements: true,
+    ensureDatabase: false,
+  });
+
+  if (await orm.schema.ensureDatabase()) {
+    await orm.schema.execute(schema);
+  }
+
+  await orm.close(true);
+});
+
+beforeEach(async () => {
+  orm = await MikroORM.init({
+    dbName: schemaName,
+    port: 3308,
+    discovery: { warnWhenNoEntities: false },
+    extensions: [EntityGenerator],
+    multipleStatements: true,
+  });
+});
+
+afterEach(async () => {
+  await orm.close(true);
+});
+
+describe(schemaName, () => {
+  test.each([true, false])('entitySchema=%s', async entitySchema => {
+    orm.config.get('entityGenerator').entitySchema = entitySchema;
+    const dump = await orm.entityGenerator.generate({
+      save: true,
+      path: './temp/entities-oddPkTypes',
+    });
+    expect(dump).toMatchSnapshot('mysql');
+    await remove('./temp/entities-oddPkTypes');
+  });
+});

--- a/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
@@ -796,6 +796,7 @@ export const Author2Schema = new EntitySchema({
       nullable: true,
     },
     secondsSinceLastModified: {
+      type: 'integer',
       formula: alias => \`TIMESTAMPDIFF(SECONDS, NOW(), \${alias}.updated_at)\`,
       lazy: true,
     },
@@ -1426,8 +1427,8 @@ export class IdentitiesContainer {
 export const IdentitiesContainerSchema = new EntitySchema({
   class: IdentitiesContainer,
   properties: {
-    github: {  },
-    local: {  },
+    github: { type: 'string' },
+    local: { type: 'integer' },
   },
 });
 ",
@@ -2285,6 +2286,7 @@ export const Author2Schema = new EntitySchema({
       nullable: true,
     },
     secondsSinceLastModified: {
+      type: 'integer',
       formula: alias => \`TIMESTAMPDIFF(SECONDS, NOW(), \${alias}.updated_at)\`,
       lazy: true,
     },
@@ -2956,8 +2958,8 @@ export class IdentitiesContainer {
 export const IdentitiesContainerSchema = new EntitySchema({
   class: IdentitiesContainer,
   properties: {
-    github: {  },
-    local: {  },
+    github: { type: 'string' },
+    local: { type: 'integer' },
   },
 });
 ",

--- a/tests/features/entity-generator/__snapshots__/OddPkTypes.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OddPkTypes.mysql.test.ts.snap
@@ -1,0 +1,166 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`complex_pks_example entitySchema=false: mysql 1`] = `
+[
+  "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+import { Events } from './Events';
+
+@Entity()
+export class EventDetails {
+
+  [PrimaryKeyProp]?: 'weekday';
+
+  @OneToOne({ entity: () => Events, fieldNames: ['weekday', 'at'], primary: true })
+  weekday!: Events;
+
+  @Property({ type: 'text', length: 65535, nullable: true })
+  moreInfo?: string;
+
+}
+
+export enum EventDetailsWeekday {
+  MONDAY = 'Monday',
+  TUESDAY = 'Tuesday',
+  WEDNESDAY = 'Wednesday',
+  THURSDAY = 'Thursday',
+  FRIDAY = 'Friday',
+  SATURDAY = 'Saturday',
+  SUNDAY = 'Sunday',
+}
+",
+  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+import { Worktime } from './Worktime';
+
+@Entity()
+export class Events {
+
+  [PrimaryKeyProp]?: ['weekday', 'at'];
+
+  @ManyToOne({ entity: () => Worktime, fieldName: 'weekday', primary: true })
+  weekday!: Worktime;
+
+  @PrimaryKey({ type: 'time' })
+  at!: string;
+
+  @Property({ length: 255 })
+  what!: string;
+
+}
+
+export enum EventsWeekday {
+  MONDAY = 'Monday',
+  TUESDAY = 'Tuesday',
+  WEDNESDAY = 'Wednesday',
+  THURSDAY = 'Thursday',
+  FRIDAY = 'Friday',
+  SATURDAY = 'Saturday',
+  SUNDAY = 'Sunday',
+}
+",
+  "import { Entity, Enum, PrimaryKeyProp, Property } from '@mikro-orm/core';
+
+@Entity()
+export class Worktime {
+
+  [PrimaryKeyProp]?: 'weekday';
+
+  @Enum({ items: () => WorktimeWeekday, primary: true })
+  weekday!: WorktimeWeekday;
+
+  @Property({ type: 'time' })
+  from!: string;
+
+  @Property({ type: 'time' })
+  to!: string;
+
+}
+
+export enum WorktimeWeekday {
+  MONDAY = 'Monday',
+  TUESDAY = 'Tuesday',
+  WEDNESDAY = 'Wednesday',
+  THURSDAY = 'Thursday',
+  FRIDAY = 'Friday',
+  SATURDAY = 'Saturday',
+  SUNDAY = 'Sunday',
+}
+",
+]
+`;
+
+exports[`complex_pks_example entitySchema=true: mysql 1`] = `
+[
+  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Events } from './Events';
+
+export class EventDetails {
+  [PrimaryKeyProp]?: 'weekday';
+  weekday!: Events;
+  moreInfo?: string;
+}
+
+export const EventDetailsSchema = new EntitySchema({
+  class: EventDetails,
+  properties: {
+    weekday: {
+      primary: true,
+      kind: '1:1',
+      entity: () => Events,
+      fieldNames: [
+        'weekday',
+        'at'
+      ],
+    },
+    moreInfo: { type: 'text', length: 65535, nullable: true },
+  },
+});
+",
+  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Worktime } from './Worktime';
+
+export class Events {
+  [PrimaryKeyProp]?: ['weekday', 'at'];
+  weekday!: Worktime;
+  at!: string;
+  what!: string;
+}
+
+export const EventsSchema = new EntitySchema({
+  class: Events,
+  properties: {
+    weekday: { primary: true, kind: 'm:1', entity: () => Worktime, fieldName: 'weekday' },
+    at: { primary: true, type: 'time' },
+    what: { type: 'string', length: 255 },
+  },
+});
+",
+  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+
+export class Worktime {
+  [PrimaryKeyProp]?: 'weekday';
+  weekday!: WorktimeWeekday;
+  from!: string;
+  to!: string;
+}
+
+export enum WorktimeWeekday {
+  MONDAY = 'Monday',
+  TUESDAY = 'Tuesday',
+  WEDNESDAY = 'Wednesday',
+  THURSDAY = 'Thursday',
+  FRIDAY = 'Friday',
+  SATURDAY = 'Saturday',
+  SUNDAY = 'Sunday',
+}
+
+export const WorktimeSchema = new EntitySchema({
+  class: Worktime,
+  properties: {
+    weekday: { primary: true, enum: true, items: () => WorktimeWeekday },
+    from: { type: 'time' },
+    to: { type: 'time' },
+  },
+});
+",
+]
+`;


### PR DESCRIPTION
Previously, PKs that are not scalar would miss the "primary" option in the output, and enums would use the PrimaryKey decorator instead of the Enum decorator.

Also, FKs that are refs to enum columns would previously create a brand new enum class in each ref. Now, only the "origin" column gets the enum class, and other references use the entity class.