### PR TITLE
fix(sqlite): fix altering tables via malformed temp table

### DIFF
--- a/packages/knex/src/schema/SqlSchemaGenerator.ts
+++ b/packages/knex/src/schema/SqlSchemaGenerator.ts
@@ -3,7 +3,6 @@ import {
   AbstractSchemaGenerator,
   type ClearDatabaseOptions,
   type CreateSchemaOptions,
-  type Dictionary,
   type DropSchemaOptions,
   type EnsureDatabaseOptions,
   type ISchemaGenerator,
@@ -12,7 +11,7 @@ import {
   type UpdateSchemaOptions,
   Utils,
 } from '@mikro-orm/core';
-import type { CheckDef, ForeignKey, IndexDef, SchemaDifference, TableDifference } from '../typings';
+import type { CheckDef, IndexDef, SchemaDifference, TableDifference } from '../typings';
 import { DatabaseSchema } from './DatabaseSchema';
 import type { DatabaseTable } from './DatabaseTable';
 import type { AbstractSqlDriver } from '../AbstractSqlDriver';
@@ -89,7 +88,7 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
       }
 
       const sql = this.helper.getCreateNamespaceSQL(namespace);
-      ret += await this.dump(this.knex.schema.raw(sql), '\n');
+      ret += await this.dump(sql, '\n');
     }
 
     if (this.platform.supportsNativeEnums()) {
@@ -104,16 +103,16 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
         created.push(enumName);
 
         const sql = this.helper.getCreateNativeEnumSQL(enumOptions.name, enumOptions.items, this.getSchemaName(enumOptions, options));
-        ret += await this.dump(this.knex.schema.raw(sql), '\n');
+        ret += await this.dump(sql, '\n');
       }
     }
 
     for (const tableDef of toSchema.getTables()) {
-      ret += await this.dump(this.createTable(tableDef));
+      ret += await this.dump(this.helper.createTable(tableDef));
     }
 
     for (const tableDef of toSchema.getTables()) {
-      ret += await this.dump(this.createSchemaBuilder(tableDef.schema).alterTable(tableDef.name, table => this.createForeignKeys(table, tableDef, options.schema)));
+      ret += await this.dump(this.helper.createSchemaBuilder(tableDef.schema).alterTable(tableDef.name, table => this.createForeignKeys(table, tableDef, options.schema)));
     }
 
     return this.wrapSchema(ret, { wrap });
@@ -172,7 +171,7 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
 
       if (!this.platform.usesCascadeStatement() && table && (!wrap || options.dropForeignKeys)) {
         for (const fk of Object.values(table.getForeignKeys())) {
-          const builder = this.createSchemaBuilder(table.schema).alterTable(table.name, tbl => {
+          const builder = this.helper.createSchemaBuilder(table.schema).alterTable(table.name, tbl => {
             tbl.dropForeign(fk.columnNames, fk.constraintName);
           });
           ret += await this.dump(builder, '\n');
@@ -187,7 +186,7 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
     if (this.platform.supportsNativeEnums()) {
       for (const columnName of Object.keys(schema.getNativeEnums())) {
         const sql = this.helper.getDropNativeEnumSQL(columnName, options.schema ?? this.config.get('schema'));
-        ret += await this.dump(this.knex.schema.raw(sql), '\n');
+        ret += await this.dump(sql, '\n');
       }
     }
 
@@ -254,32 +253,32 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
     if (this.platform.supportsSchemas()) {
       for (const newNamespace of schemaDiff.newNamespaces) {
         const sql = this.helper.getCreateNamespaceSQL(newNamespace);
-        ret += await this.dump(this.knex.schema.raw(sql), '\n');
+        ret += await this.dump(sql, '\n');
       }
     }
 
     if (this.platform.supportsNativeEnums()) {
       for (const newNativeEnum of schemaDiff.newNativeEnums) {
         const sql = this.helper.getCreateNativeEnumSQL(newNativeEnum.name, newNativeEnum.items, this.getSchemaName(newNativeEnum, options));
-        ret += await this.dump(this.knex.schema.raw(sql), '\n');
+        ret += await this.dump(sql, '\n');
       }
     }
 
     if (!options.safe) {
       for (const orphanedForeignKey of schemaDiff.orphanedForeignKeys) {
-        const [schemaName, tableName] = this.splitTableName(orphanedForeignKey.localTableName);
-        ret += await this.dump(this.createSchemaBuilder(schemaName).alterTable(tableName, table => {
+        const [schemaName, tableName] = this.helper.splitTableName(orphanedForeignKey.localTableName);
+        ret += await this.dump(this.helper.createSchemaBuilder(schemaName).alterTable(tableName, table => {
           return table.dropForeign(orphanedForeignKey.columnNames, orphanedForeignKey.constraintName);
         }));
       }
     }
 
     for (const newTable of Object.values(schemaDiff.newTables)) {
-      ret += await this.dump(this.createTable(newTable, true));
+      ret += await this.dump(this.helper.createTable(newTable, true));
     }
 
     for (const newTable of Object.values(schemaDiff.newTables)) {
-      ret += await this.dump(this.createSchemaBuilder(newTable.schema).alterTable(newTable.name, table => {
+      ret += await this.dump(this.helper.createSchemaBuilder(newTable.schema).alterTable(newTable.name, table => {
         this.createForeignKeys(table, newTable, options.schema);
       }));
     }
@@ -298,7 +297,13 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
 
     for (const changedTable of Object.values(schemaDiff.changedTables)) {
       for (const builder of this.alterTable(changedTable, options.safe!)) {
-        ret += await this.dump(builder);
+        let diff = await this.dump(builder);
+
+        if (diff.includes('CREATE TABLE `_knex_temp_alter') && this.helper.getAlterTable) {
+          diff = await this.helper.getAlterTable(changedTable, options.wrap);
+        }
+
+        ret += diff;
       }
     }
 
@@ -311,60 +316,18 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
     if (!options.safe && this.platform.supportsNativeEnums()) {
       for (const removedNativeEnum of schemaDiff.removedNativeEnums) {
         const sql = this.helper.getDropNativeEnumSQL(removedNativeEnum.name, removedNativeEnum.schema);
-        ret += await this.dump(this.knex.schema.raw(sql), '\n');
+        ret += await this.dump(sql, '\n');
       }
     }
 
     if (options.dropTables && !options.safe) {
       for (const removedNamespace of schemaDiff.removedNamespaces) {
         const sql = this.helper.getDropNamespaceSQL(removedNamespace);
-        ret += await this.dump(this.knex.schema.raw(sql), '\n');
+        ret += await this.dump(sql, '\n');
       }
     }
 
     return this.wrapSchema(ret, options);
-  }
-
-  private getReferencedTableName(referencedTableName: string, schema?: string) {
-    const [schemaName, tableName] = this.splitTableName(referencedTableName);
-    schema = schemaName ?? schema ?? this.config.get('schema');
-
-    /* istanbul ignore next */
-    if (schema && schemaName === '*') {
-      return `${schema}.${referencedTableName.replace(/^\*\./, '')}`;
-    }
-
-    if (!schemaName || schemaName === this.platform.getDefaultSchemaName()) {
-      return tableName;
-    }
-
-    return `${schemaName}.${tableName}`;
-  }
-
-  private createForeignKey(table: Knex.CreateTableBuilder, foreignKey: ForeignKey, schema?: string) {
-    if (!this.options.createForeignKeyConstraints) {
-      return;
-    }
-
-    const builder = table
-      .foreign(foreignKey.columnNames, foreignKey.constraintName)
-      .references(foreignKey.referencedColumnNames)
-      .inTable(this.getReferencedTableName(foreignKey.referencedTableName, schema))
-      .withKeyName(foreignKey.constraintName);
-
-    if (foreignKey.localTableName !== foreignKey.referencedTableName || this.platform.supportsMultipleCascadePaths()) {
-      if (foreignKey.updateRule) {
-        builder.onUpdate(foreignKey.updateRule);
-      }
-
-      if (foreignKey.deleteRule) {
-        builder.onDelete(foreignKey.deleteRule);
-      }
-    }
-
-    if (foreignKey.deferMode) {
-      builder.deferrable(foreignKey.deferMode);
-    }
   }
 
   /**
@@ -374,9 +337,9 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
     const ret: Knex.SchemaBuilder[] = [];
     const push = (sql: string) => sql ? ret.push(this.knex.schema.raw(sql)) : undefined;
     push(this.helper.getPreAlterTable(diff, safe));
-    const [schemaName, tableName] = this.splitTableName(diff.name);
+    const [schemaName, tableName] = this.helper.splitTableName(diff.name);
 
-    ret.push(this.createSchemaBuilder(schemaName).alterTable(tableName, table => {
+    ret.push(this.helper.createSchemaBuilder(schemaName).alterTable(tableName, table => {
       for (const foreignKey of Object.values(diff.removedForeignKeys)) {
         table.dropForeign(foreignKey.columnNames, foreignKey.constraintName);
       }
@@ -397,17 +360,9 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
     return ret;
   }
 
-  private splitTableName(name: string): [string | undefined, string] {
-    const parts = name.split('.');
-    const tableName = parts.pop()!;
-    const schemaName = parts.pop();
-
-    return [schemaName, tableName];
-  }
-
   private alterTable(diff: TableDifference, safe: boolean): Knex.SchemaBuilder[] {
     const ret: Knex.SchemaBuilder[] = [];
-    const [schemaName, tableName] = this.splitTableName(diff.name);
+    const [schemaName, tableName] = this.helper.splitTableName(diff.name);
 
     if (this.platform.supportsNativeEnums()) {
       const changedNativeEnums: [enumName: string, itemsNew: string[], itemsOld: string[]][] = [];
@@ -432,7 +387,7 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
       });
     }
 
-    ret.push(this.createSchemaBuilder(schemaName).alterTable(tableName, table => {
+    ret.push(this.helper.createSchemaBuilder(schemaName).alterTable(tableName, table => {
       for (const index of Object.values(diff.removedIndexes)) {
         this.dropIndex(table, index);
       }
@@ -455,7 +410,7 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
       }
     }));
 
-    ret.push(this.createSchemaBuilder(schemaName).alterTable(tableName, table => {
+    ret.push(this.helper.createSchemaBuilder(schemaName).alterTable(tableName, table => {
       for (const column of Object.values(diff.addedColumns)) {
         const col = this.helper.createTableColumn(table, column, diff.fromTable, undefined, true)!;
         this.helper.configureColumn(column, col, this.knex);
@@ -464,7 +419,7 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
         if (foreignKey && this.options.createForeignKeyConstraints) {
           delete diff.addedForeignKeys[foreignKey.constraintName];
           const builder = col.references(foreignKey.referencedColumnNames[0])
-            .inTable(this.getReferencedTableName(foreignKey.referencedTableName))
+            .inTable(this.helper.getReferencedTableName(foreignKey.referencedTableName))
             .withKeyName(foreignKey.constraintName)
             .onUpdate(foreignKey.updateRule!)
             .onDelete(foreignKey.deleteRule!);
@@ -508,36 +463,36 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
       }
 
       for (const foreignKey of Object.values(diff.addedForeignKeys)) {
-        this.createForeignKey(table, foreignKey);
+        this.helper.createForeignKey(table, foreignKey, undefined);
       }
 
       for (const foreignKey of Object.values(diff.changedForeignKeys)) {
-        this.createForeignKey(table, foreignKey);
+        this.helper.createForeignKey(table, foreignKey, undefined);
       }
 
       for (const index of Object.values(diff.addedIndexes)) {
-        this.createIndex(table, index, diff.toTable);
+        this.helper.createIndex(table, index, diff.toTable);
       }
 
       for (const index of Object.values(diff.changedIndexes)) {
-        this.createIndex(table, index, diff.toTable, true);
+        this.helper.createIndex(table, index, diff.toTable, true);
       }
 
       for (const [oldIndexName, index] of Object.entries(diff.renamedIndexes)) {
         if (index.unique) {
           this.dropIndex(table, index, oldIndexName);
-          this.createIndex(table, index, diff.toTable);
+          this.helper.createIndex(table, index, diff.toTable);
         } else {
           this.helper.pushTableQuery(table, this.helper.getRenameIndexSQL(diff.name, index, oldIndexName));
         }
       }
 
       for (const check of Object.values(diff.addedChecks)) {
-        this.createCheck(table, check);
+        this.helper.createCheck(table, check);
       }
 
       for (const check of Object.values(diff.changedChecks)) {
-        this.createCheck(table, check);
+        this.helper.createCheck(table, check);
       }
 
       if ('changedComment' in diff) {
@@ -621,82 +576,6 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
     return ret;
   }
 
-  private createSchemaBuilder(schema?: string): Knex.SchemaBuilder {
-    const builder = this.knex.schema;
-
-    if (schema && schema !== this.platform.getDefaultSchemaName()) {
-      builder.withSchema(schema);
-    }
-
-    return builder;
-  }
-
-  private createTable(tableDef: DatabaseTable, alter?: boolean): Knex.SchemaBuilder {
-    return this.createSchemaBuilder(tableDef.schema).createTable(tableDef.name, table => {
-      tableDef.getColumns().forEach(column => {
-        const col = this.helper.createTableColumn(table, column, tableDef, undefined, alter)!;
-        this.helper.configureColumn(column, col, this.knex);
-      });
-
-      for (const index of tableDef.getIndexes()) {
-        const createPrimary = !tableDef.getColumns().some(c => c.autoincrement && c.primary) || this.helper.hasNonDefaultPrimaryKeyName(tableDef);
-        this.createIndex(table, index, tableDef, createPrimary);
-      }
-
-      for (const check of tableDef.getChecks()) {
-        this.createCheck(table, check);
-      }
-
-      if (tableDef.comment) {
-        const comment = this.platform.quoteValue(tableDef.comment).replace(/^'|'$/g, '');
-        table.comment(comment);
-      }
-
-      if (!this.helper.supportsSchemaConstraints()) {
-        for (const fk of Object.values(tableDef.getForeignKeys())) {
-          this.createForeignKey(table, fk);
-        }
-      }
-
-      this.helper.finalizeTable(table, this.config.get('charset'), this.config.get('collate'));
-    });
-  }
-
-  private createIndex(table: Knex.CreateTableBuilder, index: IndexDef, tableDef: DatabaseTable, createPrimary = false) {
-    if (index.primary && !createPrimary) {
-      return;
-    }
-
-    if (index.primary) {
-      const keyName = this.helper.hasNonDefaultPrimaryKeyName(tableDef) ? index.keyName : undefined;
-      table.primary(index.columnNames, keyName);
-    } else if (index.unique) {
-      // JSON columns can have unique index but not unique constraint, and we need to distinguish those, so we can properly drop them
-      if (index.columnNames.some(column => column.includes('.'))) {
-        const columns = this.platform.getJsonIndexDefinition(index);
-        table.index(columns.map(column => this.knex.raw(column)), index.keyName, { indexType: 'unique' });
-      } else {
-        table.unique(index.columnNames, { indexName: index.keyName, deferrable: index.deferMode });
-      }
-    } else if (index.expression) {
-      this.helper.pushTableQuery(table, index.expression);
-    } else if (index.type === 'fulltext') {
-      const columns = index.columnNames.map(name => ({ name, type: tableDef.getColumn(name)!.type }));
-
-      if (this.platform.supportsCreatingFullTextIndex()) {
-        this.helper.pushTableQuery(table, this.platform.getFullTextIndexExpression(index.keyName, tableDef.schema, tableDef.name, columns));
-      }
-    } else {
-      // JSON columns can have unique index but not unique constraint, and we need to distinguish those, so we can properly drop them
-      if (index.columnNames.some(column => column.includes('.'))) {
-        const columns = this.platform.getJsonIndexDefinition(index);
-        table.index(columns.map(column => this.knex.raw(column)), index.keyName, index.type as Dictionary);
-      } else {
-        table.index(index.columnNames, index.keyName, index.type as Dictionary);
-      }
-    }
-  }
-
   private dropIndex(table: Knex.CreateTableBuilder, index: IndexDef, oldIndexName = index.keyName) {
     if (index.primary) {
       table.dropPrimary(oldIndexName);
@@ -707,16 +586,12 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
     }
   }
 
-  private createCheck(table: Knex.CreateTableBuilder, check: CheckDef) {
-    table.check(check.expression as string, {}, check.name);
-  }
-
   private dropCheck(table: Knex.CreateTableBuilder, check: CheckDef) {
     table.dropChecks(check.name);
   }
 
   private dropTable(name: string, schema?: string): Knex.SchemaBuilder {
-    let builder = this.createSchemaBuilder(schema).dropTableIfExists(name);
+    let builder = this.helper.createSchemaBuilder(schema).dropTableIfExists(name);
 
     if (this.platform.usesCascadeStatement()) {
       builder = this.knex.schema.raw(builder.toQuery() + ' cascade');
@@ -731,22 +606,12 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
     }
 
     for (const fk of Object.values(tableDef.getForeignKeys())) {
-      this.createForeignKey(table, fk, schema);
+      this.helper.createForeignKey(table, fk, schema);
     }
   }
 
-  private async dump(builder: Knex.SchemaBuilder, append = '\n\n'): Promise<string> {
-    const sql = await builder.generateDdlCommands();
-    const queries = [...sql.pre, ...sql.sql, ...sql.post];
-
-    if (queries.length === 0) {
-      return '';
-    }
-
-    const dump = `${queries.map(q => typeof q === 'object' ? (q as Dictionary).sql : q).join(';\n')};${append}`;
-    const tmp = dump.replace(/pragma table_.+/ig, '').replace(/\n\n+/g, '\n').trim();
-
-    return tmp ? tmp + append : '';
+  private async dump(builder: Knex.SchemaBuilder | string, append = '\n\n'): Promise<string> {
+    return this.helper.dump(builder, append);
   }
 
   private get knex() {

--- a/tests/features/schema-generator/GH2959.test.ts
+++ b/tests/features/schema-generator/GH2959.test.ts
@@ -1,7 +1,8 @@
 import { Entity, ManyToOne, MikroORM, PrimaryKey } from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
-@Entity() export class Foo {
+@Entity()
+class Foo {
 
   @PrimaryKey()
   id!: number;
@@ -11,7 +12,8 @@ import { SqliteDriver } from '@mikro-orm/sqlite';
 
 }
 
-@Entity() export class Bar {
+@Entity()
+class Bar {
 
   @ManyToOne()
   foo!: Foo;

--- a/tests/features/schema-generator/SchemaGenerator.sqlite.test.ts
+++ b/tests/features/schema-generator/SchemaGenerator.sqlite.test.ts
@@ -35,4 +35,15 @@ describe('SchemaGenerator [sqlite]', () => {
     await orm.close(true);
   });
 
+  test('alter enum [sqlite]', async () => {
+    const orm = await initORMSqlite();
+    await orm.schema.dropSchema();
+
+    const updateDump = await orm.schema.getUpdateSchemaSQL();
+    expect(updateDump).toMatchSnapshot('sqlite-update-empty-schema-dump');
+    await orm.schema.execute(updateDump, { wrap: true });
+
+    await orm.close(true);
+  });
+
 });

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.sqlite.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.sqlite.test.ts.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SchemaGenerator [sqlite] alter enum [sqlite]: sqlite-update-empty-schema-dump 1`] = `
+"pragma foreign_keys = off;
+
+create table \`book_tag3\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`version\` datetime not null default current_timestamp);
+
+create table \`publisher3\` (\`id\` integer not null primary key autoincrement, \`name\` text not null default 'asd', \`type\` PublisherType not null default 'local');
+
+create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null, \`email\` text not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` date(3) null, \`born_time\` time(3) null, \`favourite_book_id\` integer null, constraint \`author3_favourite_book_id_foreign\` foreign key(\`favourite_book_id\`) references \`book3\`(\`id\`) on delete set null on update cascade);
+create unique index \`author3_email_unique\` on \`author3\` (\`email\`);
+create index \`author3_favourite_book_id_index\` on \`author3\` (\`favourite_book_id\`);
+create index \`author3_name_favourite_book_id_index\` on \`author3\` (\`name\`, \`favourite_book_id\`);
+
+create table \`book3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`title\` text not null default '', \`author_id\` integer not null, \`publisher_id\` integer null, constraint \`book3_author_id_foreign\` foreign key(\`author_id\`) references \`author3\`(\`id\`) on update cascade, constraint \`book3_publisher_id_foreign\` foreign key(\`publisher_id\`) references \`publisher3\`(\`id\`) on delete set null on update cascade);
+create index \`book3_author_id_index\` on \`book3\` (\`author_id\`);
+create index \`book3_publisher_id_index\` on \`book3\` (\`publisher_id\`);
+
+create table \`book3_tags\` (\`id\` integer not null primary key autoincrement, \`book3_id\` integer not null, \`book_tag3_id\` integer not null, constraint \`book3_tags_book3_id_foreign\` foreign key(\`book3_id\`) references \`book3\`(\`id\`) on delete cascade on update cascade, constraint \`book3_tags_book_tag3_id_foreign\` foreign key(\`book_tag3_id\`) references \`book_tag3\`(\`id\`) on delete cascade on update cascade);
+create index \`book3_tags_book3_id_index\` on \`book3_tags\` (\`book3_id\`);
+create index \`book3_tags_book_tag3_id_index\` on \`book3_tags\` (\`book_tag3_id\`);
+
+create table \`test3\` (\`id\` integer not null primary key autoincrement, \`name\` text null, \`version\` integer not null default 1);
+
+create table \`publisher3_tests\` (\`id\` integer not null primary key autoincrement, \`publisher3_id\` integer not null, \`test3_id\` integer not null, constraint \`publisher3_tests_publisher3_id_foreign\` foreign key(\`publisher3_id\`) references \`publisher3\`(\`id\`) on delete cascade on update cascade, constraint \`publisher3_tests_test3_id_foreign\` foreign key(\`test3_id\`) references \`test3\`(\`id\`) on delete cascade on update cascade);
+create index \`publisher3_tests_publisher3_id_index\` on \`publisher3_tests\` (\`publisher3_id\`);
+create index \`publisher3_tests_test3_id_index\` on \`publisher3_tests\` (\`test3_id\`);
+
+pragma foreign_keys = on;
+"
+`;
+
 exports[`SchemaGenerator [sqlite] generate schema from metadata [sqlite]: sqlite-create-schema-dump 1`] = `
 "pragma foreign_keys = off;
 

--- a/tests/features/schema-generator/__snapshots__/enum-diffing.sqlite.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/enum-diffing.sqlite.test.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GH #5672 1`] = `
+"pragma foreign_keys = off;
+create table \`author__temp_alter\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`some_enum\` text check (\`some_enum\` in ('Foo', 'Bar', 'Baz')) not null);
+insert into \`author__temp_alter\` select * from \`author\`;
+drop table \`author\`;
+alter table \`author__temp_alter\` rename to \`author\`;
+pragma foreign_keys = on;"
+`;

--- a/tests/features/schema-generator/enum-diffing.sqlite.test.ts
+++ b/tests/features/schema-generator/enum-diffing.sqlite.test.ts
@@ -1,0 +1,56 @@
+import { Entity, Enum, MikroORM, PrimaryKey, Property } from '@mikro-orm/libsql';
+
+enum SomeEnum {
+  FOO = 'Foo',
+  BAR = 'Bar',
+}
+
+enum SomeEnum2 {
+  FOO = 'Foo',
+  BAR = 'Bar',
+  BAZ = 'Baz',
+}
+
+@Entity({ tableName: 'author' })
+class Author0 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Enum(() => SomeEnum)
+  someEnum!: SomeEnum;
+
+}
+
+@Entity({ tableName: 'author' })
+class Author1 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Enum({ items: () => SomeEnum2 })
+  someEnum!: SomeEnum2;
+
+}
+
+test('GH #5672', async () => {
+  const orm = await MikroORM.init({
+    entities: [Author0],
+    dbName: `:memory:`,
+  });
+  await orm.schema.refreshDatabase();
+
+  orm.getMetadata().reset('Author0');
+  await orm.discoverEntity([Author1]);
+  const diff1 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+  expect(diff1.trim()).toMatchSnapshot();
+  await orm.schema.execute(diff1);
+
+  await orm.close(true);
+});


### PR DESCRIPTION
This replaces the knex implementation which is dependent on the current state, which was wrong on its own, since the state might not be matching the metadata we have (e.g. when generating migration against a snapshot).

Closes #5672