### PR TITLE
feat(core): implement "character" type (DB type "char")

### DIFF
--- a/docs/docs/custom-types.md
+++ b/docs/docs/custom-types.md
@@ -311,10 +311,13 @@ export const types = {
   double: DoubleType,
   boolean: BooleanType,
   decimal: DecimalType,
+  character: CharacterType,
   string: StringType,
   uuid: UuidType,
   text: TextType,
-};
+  interval: IntervalType,
+  unknown: UnknownType,
+} as const;
 ```
 
 ### ArrayType

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -7,8 +7,30 @@ import type { EntityManager } from '../EntityManager';
 import type { Configuration } from '../utils/Configuration';
 import type { IDatabaseDriver } from '../drivers/IDatabaseDriver';
 import {
-  ArrayType, BigIntType, BlobType, Uint8ArrayType, BooleanType, DateType, DecimalType, DoubleType, JsonType, SmallIntType, TimeType,
-  TinyIntType, Type, UuidType, StringType, IntegerType, FloatType, DateTimeType, TextType, EnumType, UnknownType, MediumIntType, IntervalType,
+  ArrayType,
+  BigIntType,
+  BlobType,
+  Uint8ArrayType,
+  BooleanType,
+  CharacterType,
+  DateType,
+  DecimalType,
+  DoubleType,
+  JsonType,
+  SmallIntType,
+  TimeType,
+  TinyIntType,
+  Type,
+  UuidType,
+  StringType,
+  IntegerType,
+  FloatType,
+  DateTimeType,
+  TextType,
+  EnumType,
+  UnknownType,
+  MediumIntType,
+  IntervalType,
 } from '../types';
 import { parseJsonSafe, Utils } from '../utils/Utils';
 import { ReferenceKind } from '../enums';
@@ -131,6 +153,10 @@ export abstract class Platform {
     return 255;
   }
 
+  getDefaultCharLength(): number {
+    return 1;
+  }
+
   getDateTypeDeclarationSQL(length?: number): string {
     return 'date' + (length ? `(${length})` : '');
   }
@@ -203,6 +229,10 @@ export abstract class Platform {
     return 'bigint';
   }
 
+  getCharTypeDeclarationSQL(column: { length?: number }): string {
+    return `char(${column.length ?? this.getDefaultCharLength()})`;
+  }
+
   getVarcharTypeDeclarationSQL(column: { length?: number }): string {
     return `varchar(${column.length ?? this.getDefaultVarcharLength()})`;
   }
@@ -258,6 +288,8 @@ export abstract class Platform {
     }
 
     switch (this.extractSimpleType(type)) {
+      case 'character':
+      case 'char': return Type.getType(CharacterType);
       case 'string':
       case 'varchar': return Type.getType(StringType);
       case 'interval': return Type.getType(IntervalType);

--- a/packages/core/src/types/CharacterType.ts
+++ b/packages/core/src/types/CharacterType.ts
@@ -1,0 +1,15 @@
+import { StringType } from './StringType';
+import type { Platform } from '../platforms';
+import type { EntityProperty } from '../typings';
+
+export class CharacterType extends StringType {
+
+  override getColumnType(prop: EntityProperty, platform: Platform) {
+    return platform.getCharTypeDeclarationSQL(prop);
+  }
+
+  override getDefaultLength(platform: Platform): number {
+    return platform.getDefaultCharLength();
+  }
+
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,32 +1,33 @@
-import { Type, TransformContext, IType } from './Type';
-import { DateType } from './DateType';
-import { TimeType } from './TimeType';
-import { DateTimeType } from './DateTimeType';
+import { ArrayType } from './ArrayType';
 import { BigIntType } from './BigIntType';
 import { BlobType } from './BlobType';
-import { Uint8ArrayType } from './Uint8ArrayType';
-import { ArrayType } from './ArrayType';
+import { BooleanType } from './BooleanType';
+import { DateTimeType } from './DateTimeType';
+import { DateType } from './DateType';
+import { DecimalType } from './DecimalType';
+import { DoubleType } from './DoubleType';
 import { EnumArrayType } from './EnumArrayType';
 import { EnumType } from './EnumType';
-import { JsonType } from './JsonType';
-import { IntegerType } from './IntegerType';
-import { SmallIntType } from './SmallIntType';
-import { TinyIntType } from './TinyIntType';
-import { MediumIntType } from './MediumIntType';
+import { CharacterType } from './CharacterType';
 import { FloatType } from './FloatType';
-import { DoubleType } from './DoubleType';
-import { BooleanType } from './BooleanType';
-import { DecimalType } from './DecimalType';
-import { StringType } from './StringType';
-import { UuidType } from './UuidType';
-import { TextType } from './TextType';
+import { IntegerType } from './IntegerType';
 import { IntervalType } from './IntervalType';
+import { JsonType } from './JsonType';
+import { MediumIntType } from './MediumIntType';
+import { SmallIntType } from './SmallIntType';
+import { StringType } from './StringType';
+import { TextType } from './TextType';
+import { TimeType } from './TimeType';
+import { TinyIntType } from './TinyIntType';
+import { IType, TransformContext, Type } from './Type';
+import { Uint8ArrayType } from './Uint8ArrayType';
 import { UnknownType } from './UnknownType';
+import { UuidType } from './UuidType';
 
 export {
   Type, DateType, TimeType, DateTimeType, BigIntType, BlobType, Uint8ArrayType, ArrayType, EnumArrayType, EnumType,
   JsonType, IntegerType, SmallIntType, TinyIntType, MediumIntType, FloatType, DoubleType, BooleanType, DecimalType,
-  StringType, UuidType, TextType, UnknownType, TransformContext, IntervalType, IType,
+  StringType, UuidType, TextType, UnknownType, TransformContext, IntervalType, IType, CharacterType,
 };
 
 export const types = {
@@ -48,6 +49,7 @@ export const types = {
   double: DoubleType,
   boolean: BooleanType,
   decimal: DecimalType,
+  character: CharacterType,
   string: StringType,
   uuid: UuidType,
   text: TextType,

--- a/packages/knex/src/dialects/sqlite/BaseSqlitePlatform.ts
+++ b/packages/knex/src/dialects/sqlite/BaseSqlitePlatform.ts
@@ -48,6 +48,10 @@ export abstract class BaseSqlitePlatform extends AbstractSqlPlatform {
     return 'integer';
   }
 
+  override getCharTypeDeclarationSQL(column: { length?: number }): string {
+    return 'text';
+  }
+
   override getVarcharTypeDeclarationSQL(column: { length?: number }): string {
     return 'text';
   }

--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -18,6 +18,7 @@ import SqlString from 'tsqlstring';
 import { MsSqlSchemaHelper } from './MsSqlSchemaHelper';
 import { MsSqlExceptionConverter } from './MsSqlExceptionConverter';
 import { MsSqlSchemaGenerator } from './MsSqlSchemaGenerator';
+import { UnicodeCharacterType } from './UnicodeCharacterType';
 import { UnicodeString, UnicodeStringType } from './UnicodeStringType';
 
 export class MsSqlPlatform extends AbstractSqlPlatform {
@@ -92,9 +93,16 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
     return 'nvarchar(max)';
   }
 
+  override getVarcharTypeDeclarationSQL(column: { length?: number }): string {
+    if (column.length === -1) {
+      return 'varchar(max)';
+    }
+    return super.getVarcharTypeDeclarationSQL(column);
+  }
+
   override getEnumTypeDeclarationSQL(column: { items?: unknown[]; fieldNames: string[]; length?: number; unsigned?: boolean; autoincrement?: boolean }): string {
     if (column.items?.every(item => Utils.isString(item))) {
-      return Type.getType(UnicodeStringType).getColumnType({ length: 100, ...column });
+      return Type.getType(UnicodeStringType).getColumnType({ length: 100, ...column }, this);
     }
 
     /* istanbul ignore next */
@@ -106,6 +114,9 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
 
     if (normalizedType !== 'uuid' && ['string', 'nvarchar'].includes(normalizedType)) {
       return Type.getType(UnicodeStringType);
+    }
+    if (['character', 'nchar'].includes(normalizedType)) {
+      return Type.getType(UnicodeCharacterType);
     }
 
     const map = {

--- a/packages/mssql/src/MsSqlSchemaHelper.ts
+++ b/packages/mssql/src/MsSqlSchemaHelper.ts
@@ -438,7 +438,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       return;
     }
 
-    if (match[2] === 'max' && ['varchar', 'nvarchar'].includes(match[1])) {
+    if (match[2] === 'max') {
       return -1;
     }
 

--- a/packages/mssql/src/UnicodeCharacterType.ts
+++ b/packages/mssql/src/UnicodeCharacterType.ts
@@ -1,0 +1,16 @@
+import type { Platform, EntityProperty } from '@mikro-orm/core';
+
+import { UnicodeStringType } from './UnicodeStringType';
+
+export class UnicodeCharacterType extends UnicodeStringType {
+
+  override getColumnType(prop: EntityProperty, platform: Platform) {
+    const length = prop.length === -1 ? 'max' : (prop.length ?? this.getDefaultLength(platform));
+    return `nchar(${length})`;
+  }
+
+  override getDefaultLength(platform: Platform): number {
+    return platform.getDefaultCharLength();
+  }
+
+}

--- a/packages/mssql/src/UnicodeStringType.ts
+++ b/packages/mssql/src/UnicodeStringType.ts
@@ -1,4 +1,4 @@
-import { Type } from '@mikro-orm/core';
+import { type Platform, Type } from '@mikro-orm/core';
 
 export class UnicodeString {
 
@@ -26,8 +26,8 @@ export class UnicodeString {
 
 export class UnicodeStringType extends Type<string | null, string | null> {
 
-  override getColumnType(prop: { length?: number }) {
-    const length = prop.length === -1 ? 'max' : (prop.length ?? 255);
+  override getColumnType(prop: { length?: number }, platform: Platform) {
+    const length = prop.length === -1 ? 'max' : (prop.length ?? this.getDefaultLength(platform));
     return `nvarchar(${length})`;
   }
 
@@ -54,6 +54,10 @@ export class UnicodeStringType extends Type<string | null, string | null> {
 
   override toJSON(value: string | null | UnicodeString): string | null {
     return this.convertToJSValue(value);
+  }
+
+  override getDefaultLength(platform: Platform): number {
+    return platform.getDefaultVarcharLength();
   }
 
 }

--- a/packages/postgresql/src/PostgreSqlPlatform.ts
+++ b/packages/postgresql/src/PostgreSqlPlatform.ts
@@ -192,6 +192,13 @@ export class PostgreSqlPlatform extends AbstractSqlPlatform {
     return super.getVarcharTypeDeclarationSQL(column);
   }
 
+  override getCharTypeDeclarationSQL(column: { length?: number }): string {
+    if (column.length === -1) {
+      return 'char';
+    }
+    return super.getCharTypeDeclarationSQL(column);
+  }
+
   override getBlobDeclarationSQL(): string {
     return 'bytea';
   }
@@ -295,6 +302,7 @@ export class PostgreSqlPlatform extends AbstractSqlPlatform {
       'bytea': 'blob',
       'jsonb': 'json',
       'character varying': 'varchar',
+      'bpchar': 'character',
     };
 
     return super.getDefaultMappedType(map[normalizedType as keyof typeof map] ?? type);

--- a/packages/postgresql/src/PostgreSqlSchemaHelper.ts
+++ b/packages/postgresql/src/PostgreSqlSchemaHelper.ts
@@ -641,6 +641,9 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
       switch (match[1]) {
         case 'character varying':
         case 'varchar':
+        case 'bpchar':
+        case 'char':
+        case 'character':
           return -1;
         case 'interval':
         case 'time':

--- a/tests/EntityManager.mssql.test.ts
+++ b/tests/EntityManager.mssql.test.ts
@@ -1022,7 +1022,7 @@ describe('EntityManagerMsSql', () => {
     expect(res).toHaveLength(1);
     expect(res[0].books.length).toBe(3);
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toMatch('select [a0].*, [b1].[uuid_pk] as [b1__uuid_pk], [b1].[created_at] as [b1__created_at], [b1].[title] as [b1__title], [b1].[perex] as [b1__perex], [b1].[price] as [b1__price], ([b1].[price] * 1.19) as [b1__price_taxed], [b1].[double] as [b1__double], [b1].[meta] as [b1__meta], [b1].[author_id] as [b1__author_id], [b1].[publisher_id] as [b1__publisher_id], [f2].[uuid_pk] as [f2__uuid_pk] ' +
+    expect(mock.mock.calls[0][0]).toMatch('select [a0].*, [b1].[uuid_pk] as [b1__uuid_pk], [b1].[created_at] as [b1__created_at], [b1].[isbn] as [b1__isbn], [b1].[title] as [b1__title], [b1].[perex] as [b1__perex], [b1].[price] as [b1__price], ([b1].[price] * 1.19) as [b1__price_taxed], [b1].[double] as [b1__double], [b1].[meta] as [b1__meta], [b1].[author_id] as [b1__author_id], [b1].[publisher_id] as [b1__publisher_id], [f2].[uuid_pk] as [f2__uuid_pk] ' +
       'from [author2] as [a0] ' +
       'left join [book2] as [b1] on [a0].[id] = [b1].[author_id] and [b1].[author_id] is not null ' +
       'left join [book2] as [f2] on [a0].[favourite_book_uuid_pk] = [f2].[uuid_pk] and [f2].[author_id] is not null ' +

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -2566,7 +2566,7 @@ describe('EntityManagerMySql', () => {
     const b = await orm.em.findOneOrFail(Book2, { author: { name: 'God' } }, { strategy: 'select-in' });
     expect(b.price).toBe(1000.00);
     expect(b.priceTaxed).toBe('1190.0000');
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
       'from `book2` as `b0` ' +
       'left join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
       'left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` ' +
@@ -2617,7 +2617,7 @@ describe('EntityManagerMySql', () => {
     const b = await orm.em.fork().findOneOrFail(Book2, { priceTaxed: '1190.0000' }, { strategy: 'select-in' });
     expect(b.price).toBe(1000.00);
     expect(b.priceTaxed).toBe('1190.0000');
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.price * 1.19 = ? limit ?');
@@ -2630,7 +2630,7 @@ describe('EntityManagerMySql', () => {
       'left join `book2` as `b1` on `a0`.`favourite_book_uuid_pk` = `b1`.`uuid_pk` ' +
       'left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` ' +
       'where `b1`.price * 1.19 = ?');
-    expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`author_id` in (?) ' +
@@ -2644,7 +2644,7 @@ describe('EntityManagerMySql', () => {
       'left join `book2` as `b1` on `a0`.`favourite_book_uuid_pk` = `b1`.`uuid_pk` ' +
       'left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` ' +
       'where `b1`.price * 1.19 = ?');
-    expect(mock.mock.calls[4][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[4][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`author_id` in (?) ' +

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -395,12 +395,12 @@ describe('EntityManagerPostgre', () => {
     await em.commit();
 
     expect(mock.mock.calls[0][0]).toMatch(`begin`);
-    expect(mock.mock.calls[1][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."uuid_pk" = $1 limit $2`);
+    expect(mock.mock.calls[1][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."uuid_pk" = $1 limit $2`);
     expect(mock.mock.calls[2][0]).toMatch(`select "p0".* from "publisher2" as "p0" where "p0"."id" = $1 limit $2 for update`);
     expect(mock.mock.calls[3][0]).toMatch(`select "t1".*, "p0"."test2_id" as "fk__test2_id", "p0"."publisher2_id" as "fk__publisher2_id" from "publisher2_tests" as "p0" inner join "public"."test2" as "t1" on "p0"."test2_id" = "t1"."id" where "p0"."publisher2_id" in ($1) order by "p0"."id" asc for update`);
     expect(mock.mock.calls[4][0]).toMatch(`savepoint trx`);
     expect(mock.mock.calls[5][0]).toMatch(`release savepoint trx`);
-    expect(mock.mock.calls[6][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."publisher_id" in ($1) for update`);
+    expect(mock.mock.calls[6][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."publisher_id" in ($1) for update`);
     expect(mock.mock.calls[7][0]).toMatch(`commit`);
   });
 
@@ -927,7 +927,7 @@ describe('EntityManagerPostgre', () => {
     });
     expect(mock.mock.calls.length).toBe(3);
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed", "a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "a1"."identity" as "a1__identity" from "book2" as "b0" left join "author2" as "a1" on "b0"."author_id" = "a1"."id" where "b0"."author_id" is not null for update of "b0" skip locked');
+    expect(mock.mock.calls[1][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed", "a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "a1"."identity" as "a1__identity" from "book2" as "b0" left join "author2" as "a1" on "b0"."author_id" = "a1"."id" where "b0"."author_id" is not null for update of "b0" skip locked');
     expect(mock.mock.calls[2][0]).toMatch('commit');
   });
 
@@ -945,7 +945,7 @@ describe('EntityManagerPostgre', () => {
     });
     expect(mock.mock.calls.length).toBe(5);
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null for update skip locked`);
+    expect(mock.mock.calls[1][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null for update skip locked`);
     expect(mock.mock.calls[2][0]).toMatch(`select "a0".* from "author2" as "a0" where "a0"."id" in ($1) and "a0"."id" is not null for update skip locked`);
     expect(mock.mock.calls[3][0]).toMatch(`select "b1".*, "b0"."book_tag2_id" as "fk__book_tag2_id", "b0"."book2_uuid_pk" as "fk__book2_uuid_pk" from "book2_tags" as "b0" inner join "public"."book_tag2" as "b1" on "b0"."book_tag2_id" = "b1"."id" where "b0"."book2_uuid_pk" in ($1, $2, $3) order by "b0"."order" asc for update skip locked`);
     expect(mock.mock.calls[4][0]).toMatch('commit');
@@ -1554,7 +1554,7 @@ describe('EntityManagerPostgre', () => {
       'new book',
     ]);
 
-    expect(mock.mock.calls[0][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."author_id" in ($1) order by "b0"."title" asc`);
+    expect(mock.mock.calls[0][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."author_id" in ($1) order by "b0"."title" asc`);
     expect(mock.mock.calls[1][0]).toMatch(`begin`);
     expect(mock.mock.calls[2][0]).toMatch(`insert into "book2" ("uuid_pk", "created_at", "title", "price", "author_id") values ($1, $2, $3, $4, $5)`);
     expect(mock.mock.calls[3][0]).toMatch(`commit`);
@@ -2053,7 +2053,7 @@ describe('EntityManagerPostgre', () => {
     });
     expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed", ' +
       '"a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "a1"."identity" as "a1__identity", ' +
-      '"b2"."uuid_pk" as "b2__uuid_pk", "b2"."created_at" as "b2__created_at", "b2"."title" as "b2__title", "b2"."price" as "b2__price", "b2".price * 1.19 as "b2__price_taxed", "b2"."double" as "b2__double", "b2"."meta" as "b2__meta", "b2"."author_id" as "b2__author_id", "b2"."publisher_id" as "b2__publisher_id", ' +
+      '"b2"."uuid_pk" as "b2__uuid_pk", "b2"."created_at" as "b2__created_at", "b2"."isbn" as "b2__isbn", "b2"."title" as "b2__title", "b2"."price" as "b2__price", "b2".price * 1.19 as "b2__price_taxed", "b2"."double" as "b2__double", "b2"."meta" as "b2__meta", "b2"."author_id" as "b2__author_id", "b2"."publisher_id" as "b2__publisher_id", ' +
       '"a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", "a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", "a3"."identity" as "a3__identity" ' +
       'from "book2" as "b0" ' +
       'left join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
@@ -2066,9 +2066,9 @@ describe('EntityManagerPostgre', () => {
     const res4 = await orm.em.find(Book2, { author: { favouriteBook: { $or: [{ author: { name: 'Jon Snow' } }] } } }, { populate: ['$infer'] });
     expect(res4).toHaveLength(3);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed", ' +
       '"a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "a1"."identity" as "a1__identity", ' +
-      '"b2"."uuid_pk" as "b2__uuid_pk", "b2"."created_at" as "b2__created_at", "b2"."title" as "b2__title", "b2"."price" as "b2__price", "b2".price * 1.19 as "b2__price_taxed", "b2"."double" as "b2__double", "b2"."meta" as "b2__meta", "b2"."author_id" as "b2__author_id", "b2"."publisher_id" as "b2__publisher_id", ' +
+      '"b2"."uuid_pk" as "b2__uuid_pk", "b2"."created_at" as "b2__created_at", "b2"."isbn" as "b2__isbn", "b2"."title" as "b2__title", "b2"."price" as "b2__price", "b2".price * 1.19 as "b2__price_taxed", "b2"."double" as "b2__double", "b2"."meta" as "b2__meta", "b2"."author_id" as "b2__author_id", "b2"."publisher_id" as "b2__publisher_id", ' +
       '"a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", "a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", "a3"."identity" as "a3__identity" ' +
       'from "book2" as "b0" ' +
       'left join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -1715,7 +1715,7 @@ describe('QueryBuilder', () => {
       .limit(10, 5);
     await qb;
 
-    const sql = 'select `p`.*, `b`.`uuid_pk` as `b__uuid_pk`, `b`.`created_at` as `b__created_at`, `b`.`title` as `b__title`, `b`.`price` as `b__price`, `b`.price * 1.19 as `b__price_taxed`, `b`.`double` as `b__double`, `b`.`meta` as `b__meta`, `b`.`author_id` as `b__author_id`, `b`.`publisher_id` as `b__publisher_id`, ' +
+    const sql = 'select `p`.*, `b`.`uuid_pk` as `b__uuid_pk`, `b`.`created_at` as `b__created_at`, `b`.`isbn` as `b__isbn`, `b`.`title` as `b__title`, `b`.`price` as `b__price`, `b`.price * 1.19 as `b__price_taxed`, `b`.`double` as `b__double`, `b`.`meta` as `b__meta`, `b`.`author_id` as `b__author_id`, `b`.`publisher_id` as `b__publisher_id`, ' +
       '`a`.`id` as `a__id`, `a`.`created_at` as `a__created_at`, `a`.`updated_at` as `a__updated_at`, `a`.`name` as `a__name`, `a`.`email` as `a__email`, `a`.`age` as `a__age`, `a`.`terms_accepted` as `a__terms_accepted`, `a`.`optional` as `a__optional`, `a`.`identities` as `a__identities`, `a`.`born` as `a__born`, `a`.`born_time` as `a__born_time`, `a`.`favourite_book_uuid_pk` as `a__favourite_book_uuid_pk`, `a`.`favourite_author_id` as `a__favourite_author_id`, `a`.`identity` as `a__identity`, ' +
       '`t`.`id` as `t__id`, `t`.`name` as `t__name` ' +
       'from `publisher2` as `p` ' +
@@ -2147,7 +2147,7 @@ describe('QueryBuilder', () => {
       .leftJoinAndSelect(['a.books', qb1.getKnexQuery()], 'sub')
       .leftJoinAndSelect('sub.tags', 't')
       .where({ 'sub.title': /^foo/ });
-    expect(qb4.getFormattedQuery()).toEqual('select `a`.*, `sub`.`uuid_pk` as `sub__uuid_pk`, `sub`.`created_at` as `sub__created_at`, `sub`.`title` as `sub__title`, `sub`.`price` as `sub__price`, `sub`.price * 1.19 as `sub__price_taxed`, `sub`.`double` as `sub__double`, `sub`.`meta` as `sub__meta`, `sub`.`author_id` as `sub__author_id`, `sub`.`publisher_id` as `sub__publisher_id`, `t`.`id` as `t__id`, `t`.`name` as `t__name` from `author2` as `a` left join (select `b`.*, `b`.price * 1.19 as `price_taxed` from `book2` as `b` order by `b`.`title` asc limit 1) as `sub` on `a`.`id` = `sub`.`author_id` left join `book2_tags` as `e1` on `sub`.`uuid_pk` = `e1`.`book2_uuid_pk` left join `book_tag2` as `t` on `e1`.`book_tag2_id` = `t`.`id` where `sub`.`title` like \'foo%\'');
+    expect(qb4.getFormattedQuery()).toEqual('select `a`.*, `sub`.`uuid_pk` as `sub__uuid_pk`, `sub`.`created_at` as `sub__created_at`, `sub`.`isbn` as `sub__isbn`, `sub`.`title` as `sub__title`, `sub`.`price` as `sub__price`, `sub`.price * 1.19 as `sub__price_taxed`, `sub`.`double` as `sub__double`, `sub`.`meta` as `sub__meta`, `sub`.`author_id` as `sub__author_id`, `sub`.`publisher_id` as `sub__publisher_id`, `t`.`id` as `t__id`, `t`.`name` as `t__name` from `author2` as `a` left join (select `b`.*, `b`.price * 1.19 as `price_taxed` from `book2` as `b` order by `b`.`title` asc limit 1) as `sub` on `a`.`id` = `sub`.`author_id` left join `book2_tags` as `e1` on `sub`.`uuid_pk` = `e1`.`book2_uuid_pk` left join `book_tag2` as `t` on `e1`.`book_tag2_id` = `t`.`id` where `sub`.`title` like \'foo%\'');
     const res4 = await qb4.getResult();
     expect(res4).toHaveLength(1);
     expect(res4[0]).toMatchObject({
@@ -2168,7 +2168,7 @@ describe('QueryBuilder', () => {
     qb5.select(['*', 'sub.*'])
       .leftJoinAndSelect('a.books', 'sub')
       .where({ 'sub.title': /^foo/ });
-    expect(qb5.getFormattedQuery()).toEqual('select `a`.*, `sub`.*, `sub`.`uuid_pk` as `sub__uuid_pk`, `sub`.`created_at` as `sub__created_at`, `sub`.`title` as `sub__title`, `sub`.`price` as `sub__price`, `sub`.price * 1.19 as `sub__price_taxed`, `sub`.`double` as `sub__double`, `sub`.`meta` as `sub__meta`, `sub`.`author_id` as `sub__author_id`, `sub`.`publisher_id` as `sub__publisher_id` from `author2` as `a` left join `book2` as `sub` on `a`.`id` = `sub`.`author_id` where `sub`.`title` like \'foo%\'');
+    expect(qb5.getFormattedQuery()).toEqual('select `a`.*, `sub`.*, `sub`.`uuid_pk` as `sub__uuid_pk`, `sub`.`created_at` as `sub__created_at`, `sub`.`isbn` as `sub__isbn`, `sub`.`title` as `sub__title`, `sub`.`price` as `sub__price`, `sub`.price * 1.19 as `sub__price_taxed`, `sub`.`double` as `sub__double`, `sub`.`meta` as `sub__meta`, `sub`.`author_id` as `sub__author_id`, `sub`.`publisher_id` as `sub__publisher_id` from `author2` as `a` left join `book2` as `sub` on `a`.`id` = `sub`.`author_id` where `sub`.`title` like \'foo%\'');
     const res5 = await qb5.getResult();
     expect(res5).toHaveLength(1);
     expect(res5[0].books).toHaveLength(2);
@@ -2180,7 +2180,7 @@ describe('QueryBuilder', () => {
       .leftJoinAndSelect(['a.books', qb1.getKnexQuery()], 'sub')
       .leftJoinAndSelect('sub.tags', 't')
       .where({ 'sub.title': /^foo/ });
-    expect(qb6.getFormattedQuery()).toEqual('select `a`.*, `sub`.`uuid_pk` as `sub__uuid_pk`, `sub`.`created_at` as `sub__created_at`, `sub`.`title` as `sub__title`, `sub`.`price` as `sub__price`, `sub`.price * 1.19 as `sub__price_taxed`, `sub`.`double` as `sub__double`, `sub`.`meta` as `sub__meta`, `sub`.`author_id` as `sub__author_id`, `sub`.`publisher_id` as `sub__publisher_id`, `t`.`id` as `t__id`, `t`.`name` as `t__name` from `author2` as `a` left join (select `b`.*, `b`.price * 1.19 as `price_taxed` from `book2` as `b` order by `b`.`title` asc limit 1) as `sub` on `a`.`id` = `sub`.`author_id` left join `book2_tags` as `e1` on `sub`.`uuid_pk` = `e1`.`book2_uuid_pk` left join `book_tag2` as `t` on `e1`.`book_tag2_id` = `t`.`id` where `sub`.`title` like \'foo%\'');
+    expect(qb6.getFormattedQuery()).toEqual('select `a`.*, `sub`.`uuid_pk` as `sub__uuid_pk`, `sub`.`created_at` as `sub__created_at`, `sub`.`isbn` as `sub__isbn`, `sub`.`title` as `sub__title`, `sub`.`price` as `sub__price`, `sub`.price * 1.19 as `sub__price_taxed`, `sub`.`double` as `sub__double`, `sub`.`meta` as `sub__meta`, `sub`.`author_id` as `sub__author_id`, `sub`.`publisher_id` as `sub__publisher_id`, `t`.`id` as `t__id`, `t`.`name` as `t__name` from `author2` as `a` left join (select `b`.*, `b`.price * 1.19 as `price_taxed` from `book2` as `b` order by `b`.`title` asc limit 1) as `sub` on `a`.`id` = `sub`.`author_id` left join `book2_tags` as `e1` on `sub`.`uuid_pk` = `e1`.`book2_uuid_pk` left join `book_tag2` as `t` on `e1`.`book_tag2_id` = `t`.`id` where `sub`.`title` like \'foo%\'');
     const res6 = await qb6.getResult();
     expect(res6).toHaveLength(1);
     expect(res6[0]).toMatchObject({
@@ -2996,7 +2996,7 @@ describe('QueryBuilder', () => {
         .innerJoinLateralAndSelect(['a.books', qb1.getKnexQuery()], 'sub')
         .leftJoinAndSelect('sub.tags', 't')
         .where({ 'sub.title': /^foo/ });
-      expect(qb4.getFormattedQuery()).toEqual('select "a".*, "sub"."uuid_pk" as "sub__uuid_pk", "sub"."created_at" as "sub__created_at", "sub"."title" as "sub__title", "sub"."price" as "sub__price", "sub".price * 1.19 as "sub__price_taxed", "sub"."double" as "sub__double", "sub"."meta" as "sub__meta", "sub"."author_id" as "sub__author_id", "sub"."publisher_id" as "sub__publisher_id", "t"."id" as "t__id", "t"."name" as "t__name" from "author2" as "a" inner join lateral (select "b".*, "b".price * 1.19 as "price_taxed" from "book2" as "b" order by "b"."title" asc limit 1) as "sub" on "a"."id" = "sub"."author_id" left join "book2_tags" as "b1" on "sub"."uuid_pk" = "b1"."book2_uuid_pk" left join "public"."book_tag2" as "t" on "b1"."book_tag2_id" = "t"."id" where "sub"."title" like \'foo%\'');
+      expect(qb4.getFormattedQuery()).toEqual('select "a".*, "sub"."uuid_pk" as "sub__uuid_pk", "sub"."created_at" as "sub__created_at", "sub"."isbn" as "sub__isbn", "sub"."title" as "sub__title", "sub"."price" as "sub__price", "sub".price * 1.19 as "sub__price_taxed", "sub"."double" as "sub__double", "sub"."meta" as "sub__meta", "sub"."author_id" as "sub__author_id", "sub"."publisher_id" as "sub__publisher_id", "t"."id" as "t__id", "t"."name" as "t__name" from "author2" as "a" inner join lateral (select "b".*, "b".price * 1.19 as "price_taxed" from "book2" as "b" order by "b"."title" asc limit 1) as "sub" on "a"."id" = "sub"."author_id" left join "book2_tags" as "b1" on "sub"."uuid_pk" = "b1"."book2_uuid_pk" left join "public"."book_tag2" as "t" on "b1"."book_tag2_id" = "t"."id" where "sub"."title" like \'foo%\'');
       const res4 = await qb4.getResult();
       expect(res4).toHaveLength(1);
       expect(res4[0]).toMatchObject({
@@ -3268,14 +3268,14 @@ describe('QueryBuilder', () => {
   });
 
   test('sub-query order-by fields are always fully qualified', () => {
-    const expected = 'select `e0`.*, `books`.`uuid_pk` as `books__uuid_pk`, `books`.`created_at` as `books__created_at`, `books`.`title` as `books__title`, `books`.`price` as `books__price`, `books`.price * 1.19 as `books__price_taxed`, `books`.`double` as `books__double`, `books`.`meta` as `books__meta`, `books`.`author_id` as `books__author_id`, `books`.`publisher_id` as `books__publisher_id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` where `e0`.`id` in (select `e0`.`id` from (select `e0`.`id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` group by `e0`.`id` order by min(`e0`.`id`) desc limit 10) as `e0`) order by `e0`.`id` desc';
+    const expected = 'select `e0`.*, `books`.`uuid_pk` as `books__uuid_pk`, `books`.`created_at` as `books__created_at`, `books`.`isbn` as `books__isbn`, `books`.`title` as `books__title`, `books`.`price` as `books__price`, `books`.price * 1.19 as `books__price_taxed`, `books`.`double` as `books__double`, `books`.`meta` as `books__meta`, `books`.`author_id` as `books__author_id`, `books`.`publisher_id` as `books__publisher_id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` where `e0`.`id` in (select `e0`.`id` from (select `e0`.`id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` group by `e0`.`id` order by min(`e0`.`id`) desc limit 10) as `e0`) order by `e0`.`id` desc';
     const sql = orm.em.createQueryBuilder(Author2).select('*').joinAndSelect('books', 'books').orderBy({ id: QueryOrder.DESC }).limit(10).getFormattedQuery();
     expect(sql).toBe(expected);
   });
 
   test(`sub-query order-by fields should not include 'as'`, async () => {
     const sql = orm.em.createQueryBuilder(Author2).select('*').joinAndSelect('books', 'books').orderBy([{ books: { priceTaxed: QueryOrder.DESC } }, { id: QueryOrder.DESC }]).limit(10).getFormattedQuery();
-    expect(sql).toBe('select `e0`.*, `books`.`uuid_pk` as `books__uuid_pk`, `books`.`created_at` as `books__created_at`, `books`.`title` as `books__title`, `books`.`price` as `books__price`, `books`.price * 1.19 as `books__price_taxed`, `books`.`double` as `books__double`, `books`.`meta` as `books__meta`, `books`.`author_id` as `books__author_id`, `books`.`publisher_id` as `books__publisher_id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` where `e0`.`id` in (select `e0`.`id` from (select `e0`.`id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` group by `e0`.`id` order by min(`books`.price * 1.19) desc, min(`e0`.`id`) desc limit 10) as `e0`) order by `books`.price * 1.19 desc, `e0`.`id` desc');
+    expect(sql).toBe('select `e0`.*, `books`.`uuid_pk` as `books__uuid_pk`, `books`.`created_at` as `books__created_at`, `books`.`isbn` as `books__isbn`, `books`.`title` as `books__title`, `books`.`price` as `books__price`, `books`.price * 1.19 as `books__price_taxed`, `books`.`double` as `books__double`, `books`.`meta` as `books__meta`, `books`.`author_id` as `books__author_id`, `books`.`publisher_id` as `books__publisher_id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` where `e0`.`id` in (select `e0`.`id` from (select `e0`.`id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` group by `e0`.`id` order by min(`books`.price * 1.19) desc, min(`e0`.`id`) desc limit 10) as `e0`) order by `books`.price * 1.19 desc, `e0`.`id` desc');
   });
 
   test(`sub-query group-by fields should not include 'as'`, async () => {

--- a/tests/entities-mssql/Book2.ts
+++ b/tests/entities-mssql/Book2.ts
@@ -1,5 +1,22 @@
 import { v4 } from 'uuid';
-import { Cascade, Collection, Entity, Filter, Formula, Ref, JsonType, ManyToMany, ManyToOne, OneToOne, OptionalProps, PrimaryKey, Property, QueryOrder, t } from '@mikro-orm/core';
+import {
+  Cascade,
+  Collection,
+  Entity,
+  Filter,
+  Formula,
+  Ref,
+  JsonType,
+  ManyToMany,
+  ManyToOne,
+  OneToOne,
+  OptionalProps,
+  PrimaryKey,
+  Property,
+  QueryOrder,
+  t,
+  Unique,
+} from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
@@ -19,6 +36,10 @@ export class Book2 {
 
   @Property({ defaultRaw: 'current_timestamp', length: 3 })
   createdAt: Date = new Date();
+
+  @Unique()
+  @Property({ type: 'character', length: 13, nullable: true })
+  isbn?: string;
 
   @Property({ nullable: true, default: '' })
   title?: string;

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -18,6 +18,7 @@ import {
   rel,
   t,
   sql,
+  Unique,
 } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Author2 } from './Author2';
@@ -38,6 +39,10 @@ export class Book2 {
 
   @Property({ default: sql.now(3), length: 3 })
   createdAt = new Date();
+
+  @Unique()
+  @Property({ type: 'character', length: 13, nullable: true })
+  isbn?: string;
 
   @Index({ type: 'fulltext' })
   @Property({ nullable: true, default: '' })
@@ -73,13 +78,16 @@ export class Book2 {
   @ManyToMany(() => BookTag2, undefined, { pivotTable: 'book_to_tag_unordered', orderBy: { name: QueryOrder.ASC } })
   tagsUnordered = new Collection<BookTag2>(this);
 
-  constructor(title: string, author: number | Author2, price?: number, publisher?: number | Publisher2) {
+  constructor(title: string, author: number | Author2, price?: number, isbn?: string, publisher?: number | Publisher2) {
     this.title = title;
     this.author = rel(Author2, author);
     this.publisher = ref(Publisher2, publisher);
 
     if (price) {
       this.price = price;
+    }
+    if (isbn) {
+      this.isbn = isbn;
     }
   }
 

--- a/tests/features/embeddables/__snapshots__/embeddable-custom-types.postgres.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/embeddable-custom-types.postgres.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`embedded entities with custom types schema: embeddables custom types 1 1`] = `
-"create table "parent" ("id" serial primary key, "nested_some_value" varchar not null, "nested_deep_some_value" varchar not null, "nested2" jsonb not null, "after" int null, "some_value" varchar null);
+"create table "parent" ("id" serial primary key, "nested_some_value" varchar(255) not null, "nested_deep_some_value" varchar(255) not null, "nested2" jsonb not null, "after" int null, "some_value" varchar(255) null);
 
 create table "user" ("id" serial primary key, "savings_amount" numeric(14,2) not null, "views" double precision null, "after" int null);
 

--- a/tests/features/embeddables/embeddable-custom-types.postgres.test.ts
+++ b/tests/features/embeddables/embeddable-custom-types.postgres.test.ts
@@ -14,7 +14,7 @@ export class AlwaysConvertsToAbc extends Type<string, string> {
   }
 
   override getColumnType(): string {
-    return 'varchar';
+    return 'varchar(255)';
   }
 
 }

--- a/tests/features/entity-generator/__snapshots__/AmbiguousFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/AmbiguousFks.mysql.test.ts.snap
@@ -30,8 +30,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'country';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  country!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  country!: string;
 
 }
 ",
@@ -69,7 +69,7 @@ export class ProductCountries {
   [PrimaryKeyProp]?: ['product', 'countries'];
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @ManyToOne({ entity: () => ProductSizes, fieldName: 'product_id', primary: true, index: 'fk_product_countries_product_sizes1_idx' })
   product!: ProductSizes;
@@ -141,7 +141,7 @@ export class Sales {
   saleId!: number;
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @Property({ persist: false })
   sellerId!: number;
@@ -189,7 +189,7 @@ export class SellerCountries {
   [PrimaryKeyProp]?: ['seller', 'countries'];
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @ManyToOne({ entity: () => Sellers, fieldName: 'seller_id', primary: true, index: 'fk_seller_countries_sellers1_idx' })
   seller!: Sellers;
@@ -289,13 +289,13 @@ export const ColorsSchema = new EntitySchema({
 
 export class Countries {
   [PrimaryKeyProp]?: 'country';
-  country!: unknown;
+  country!: string;
 }
 
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    country: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    country: { primary: true, type: 'character', length: 2 },
   },
 });
 ",
@@ -342,7 +342,7 @@ import { ProductSizes } from './ProductSizes';
 
 export class ProductCountries {
   [PrimaryKeyProp]?: ['product', 'countries'];
-  country!: unknown;
+  country!: string;
   product!: ProductSizes;
   productId!: number;
   countries!: Countries;
@@ -351,7 +351,7 @@ export class ProductCountries {
 export const ProductCountriesSchema = new EntitySchema({
   class: ProductCountries,
   properties: {
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -437,7 +437,7 @@ import { SellerProducts } from './SellerProducts';
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
   saleId!: number;
-  country!: unknown;
+  country!: string;
   sellerId!: number;
   productId!: number;
   color?: ProductColors;
@@ -461,7 +461,7 @@ export const SalesSchema = new EntitySchema({
   ],
   properties: {
     saleId: { primary: true, type: 'integer' },
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     sellerId: { type: 'integer', persist: false },
     productId: { type: 'integer', persist: false, index: 'product_id_idx' },
     color: {
@@ -515,7 +515,7 @@ import { Sellers } from './Sellers';
 
 export class SellerCountries {
   [PrimaryKeyProp]?: ['seller', 'countries'];
-  country!: unknown;
+  country!: string;
   seller!: Sellers;
   sellerId!: number;
   countries!: Countries;
@@ -524,7 +524,7 @@ export class SellerCountries {
 export const SellerCountriesSchema = new EntitySchema({
   class: SellerCountries,
   properties: {
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     seller: {
       primary: true,
       kind: 'm:1',
@@ -654,8 +654,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'country';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  country!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  country!: string;
 
 }
 ",
@@ -693,7 +693,7 @@ export class ProductCountries {
   [PrimaryKeyProp]?: ['product', 'countries'];
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @ManyToOne({ entity: () => ProductSizes, ref: true, fieldName: 'product_id', primary: true, index: 'fk_product_countries_product_sizes1_idx' })
   product!: Ref<ProductSizes>;
@@ -765,7 +765,7 @@ export class Sales {
   saleId!: number;
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @Property({ persist: false })
   sellerId!: number;
@@ -813,7 +813,7 @@ export class SellerCountries {
   [PrimaryKeyProp]?: ['seller', 'countries'];
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @ManyToOne({ entity: () => Sellers, ref: true, fieldName: 'seller_id', primary: true, index: 'fk_seller_countries_sellers1_idx' })
   seller!: Ref<Sellers>;
@@ -913,13 +913,13 @@ export const ColorsSchema = new EntitySchema({
 
 export class Countries {
   [PrimaryKeyProp]?: 'country';
-  country!: unknown;
+  country!: string;
 }
 
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    country: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    country: { primary: true, type: 'character', length: 2 },
   },
 });
 ",
@@ -968,7 +968,7 @@ import { ProductSizes } from './ProductSizes';
 
 export class ProductCountries {
   [PrimaryKeyProp]?: ['product', 'countries'];
-  country!: unknown;
+  country!: string;
   product!: Ref<ProductSizes>;
   productId!: number;
   countries!: Ref<Countries>;
@@ -977,7 +977,7 @@ export class ProductCountries {
 export const ProductCountriesSchema = new EntitySchema({
   class: ProductCountries,
   properties: {
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -1066,7 +1066,7 @@ import { SellerProducts } from './SellerProducts';
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
   saleId!: number;
-  country!: unknown;
+  country!: string;
   sellerId!: number;
   productId!: number;
   color?: Ref<ProductColors>;
@@ -1090,7 +1090,7 @@ export const SalesSchema = new EntitySchema({
   ],
   properties: {
     saleId: { primary: true, type: 'integer' },
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     sellerId: { type: 'integer', persist: false },
     productId: { type: 'integer', persist: false, index: 'product_id_idx' },
     color: {
@@ -1150,7 +1150,7 @@ import { Sellers } from './Sellers';
 
 export class SellerCountries {
   [PrimaryKeyProp]?: ['seller', 'countries'];
-  country!: unknown;
+  country!: string;
   seller!: Ref<Sellers>;
   sellerId!: number;
   countries!: Ref<Countries>;
@@ -1159,7 +1159,7 @@ export class SellerCountries {
 export const SellerCountriesSchema = new EntitySchema({
   class: SellerCountries,
   properties: {
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     seller: {
       primary: true,
       kind: 'm:1',
@@ -1299,8 +1299,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'country';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  country!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  country!: string;
 
   @OneToMany({ entity: () => SellerCountries, mappedBy: 'countries' })
   countriesInverse = new Collection<SellerCountries>(this);
@@ -1352,7 +1352,7 @@ export class ProductCountries {
   [PrimaryKeyProp]?: ['product', 'countries'];
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @ManyToOne({ entity: () => ProductSizes, fieldName: 'product_id', primary: true, index: 'fk_product_countries_product_sizes1_idx' })
   product!: ProductSizes;
@@ -1446,7 +1446,7 @@ export class Sales {
   saleId!: number;
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @Property({ persist: false })
   sellerId!: number;
@@ -1495,7 +1495,7 @@ export class SellerCountries {
   [PrimaryKeyProp]?: ['seller', 'countries'];
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @ManyToOne({ entity: () => Sellers, fieldName: 'seller_id', primary: true, index: 'fk_seller_countries_sellers1_idx' })
   seller!: Sellers;
@@ -1613,7 +1613,7 @@ import { Sellers } from './Sellers';
 
 export class Countries {
   [PrimaryKeyProp]?: 'country';
-  country!: unknown;
+  country!: string;
   countriesInverse = new Collection<SellerCountries>(this);
   productCountriesInverse = new Collection<ProductSizes>(this);
   sellerCountriesInverse = new Collection<Sellers>(this);
@@ -1622,7 +1622,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    country: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    country: { primary: true, type: 'character', length: 2 },
     countriesInverse: {
       kind: '1:m',
       entity: () => SellerCountries,
@@ -1688,7 +1688,7 @@ import { Sales } from './Sales';
 
 export class ProductCountries {
   [PrimaryKeyProp]?: ['product', 'countries'];
-  country!: unknown;
+  country!: string;
   product!: ProductSizes;
   productId!: number;
   countries!: Countries;
@@ -1698,7 +1698,7 @@ export class ProductCountries {
 export const ProductCountriesSchema = new EntitySchema({
   class: ProductCountries,
   properties: {
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -1823,7 +1823,7 @@ import { SellerProducts } from './SellerProducts';
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
   saleId!: number;
-  country!: unknown;
+  country!: string;
   sellerId!: number;
   productId!: number;
   color?: ProductColors;
@@ -1847,7 +1847,7 @@ export const SalesSchema = new EntitySchema({
   ],
   properties: {
     saleId: { primary: true, type: 'integer' },
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     sellerId: { type: 'integer', persist: false },
     productId: { type: 'integer', persist: false, index: 'product_id_idx' },
     color: {
@@ -1902,7 +1902,7 @@ import { Sellers } from './Sellers';
 
 export class SellerCountries {
   [PrimaryKeyProp]?: ['seller', 'countries'];
-  country!: unknown;
+  country!: string;
   seller!: Sellers;
   sellerId!: number;
   countries!: Countries;
@@ -1912,7 +1912,7 @@ export class SellerCountries {
 export const SellerCountriesSchema = new EntitySchema({
   class: SellerCountries,
   properties: {
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     seller: {
       primary: true,
       kind: 'm:1',
@@ -2068,8 +2068,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'country';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  country!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  country!: string;
 
   @OneToMany({ entity: () => SellerCountries, mappedBy: 'countries' })
   countriesInverse = new Collection<SellerCountries>(this);
@@ -2121,7 +2121,7 @@ export class ProductCountries {
   [PrimaryKeyProp]?: ['product', 'countries'];
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @ManyToOne({ entity: () => ProductSizes, ref: true, fieldName: 'product_id', primary: true, index: 'fk_product_countries_product_sizes1_idx' })
   product!: Ref<ProductSizes>;
@@ -2215,7 +2215,7 @@ export class Sales {
   saleId!: number;
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @Property({ persist: false })
   sellerId!: number;
@@ -2264,7 +2264,7 @@ export class SellerCountries {
   [PrimaryKeyProp]?: ['seller', 'countries'];
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @ManyToOne({ entity: () => Sellers, ref: true, fieldName: 'seller_id', primary: true, index: 'fk_seller_countries_sellers1_idx' })
   seller!: Ref<Sellers>;
@@ -2382,7 +2382,7 @@ import { Sellers } from './Sellers';
 
 export class Countries {
   [PrimaryKeyProp]?: 'country';
-  country!: unknown;
+  country!: string;
   countriesInverse = new Collection<SellerCountries>(this);
   productCountriesInverse = new Collection<ProductSizes>(this);
   sellerCountriesInverse = new Collection<Sellers>(this);
@@ -2391,7 +2391,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    country: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    country: { primary: true, type: 'character', length: 2 },
     countriesInverse: {
       kind: '1:m',
       entity: () => SellerCountries,
@@ -2459,7 +2459,7 @@ import { Sales } from './Sales';
 
 export class ProductCountries {
   [PrimaryKeyProp]?: ['product', 'countries'];
-  country!: unknown;
+  country!: string;
   product!: Ref<ProductSizes>;
   productId!: number;
   countries!: Ref<Countries>;
@@ -2469,7 +2469,7 @@ export class ProductCountries {
 export const ProductCountriesSchema = new EntitySchema({
   class: ProductCountries,
   properties: {
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -2597,7 +2597,7 @@ import { SellerProducts } from './SellerProducts';
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
   saleId!: number;
-  country!: unknown;
+  country!: string;
   sellerId!: number;
   productId!: number;
   color?: Ref<ProductColors>;
@@ -2621,7 +2621,7 @@ export const SalesSchema = new EntitySchema({
   ],
   properties: {
     saleId: { primary: true, type: 'integer' },
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     sellerId: { type: 'integer', persist: false },
     productId: { type: 'integer', persist: false, index: 'product_id_idx' },
     color: {
@@ -2682,7 +2682,7 @@ import { Sellers } from './Sellers';
 
 export class SellerCountries {
   [PrimaryKeyProp]?: ['seller', 'countries'];
-  country!: unknown;
+  country!: string;
   seller!: Ref<Sellers>;
   sellerId!: number;
   countries!: Ref<Countries>;
@@ -2692,7 +2692,7 @@ export class SellerCountries {
 export const SellerCountriesSchema = new EntitySchema({
   class: SellerCountries,
   properties: {
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     seller: {
       primary: true,
       kind: 'm:1',
@@ -2850,8 +2850,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'country';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  country!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  country!: string;
 
   @ManyToMany({ entity: () => ProductSizes, pivotTable: 'product_countries', pivotEntity: () => ProductCountries, joinColumn: 'country', inverseJoinColumn: 'product_id' })
   productCountries = new Collection<ProductSizes>(this);
@@ -3060,7 +3060,7 @@ import { Sellers } from './Sellers';
 
 export class Countries {
   [PrimaryKeyProp]?: 'country';
-  country!: unknown;
+  country!: string;
   productCountries = new Collection<ProductSizes>(this);
   sellerCountries = new Collection<Sellers>(this);
 }
@@ -3068,7 +3068,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    country: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    country: { primary: true, type: 'character', length: 2 },
     productCountries: {
       kind: 'm:n',
       entity: () => ProductSizes,
@@ -3383,8 +3383,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'country';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  country!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  country!: string;
 
   @ManyToMany({ entity: () => ProductSizes, pivotTable: 'product_countries', pivotEntity: () => ProductCountries, joinColumn: 'country', inverseJoinColumn: 'product_id' })
   productCountries = new Collection<ProductSizes>(this);
@@ -3593,7 +3593,7 @@ import { Sellers } from './Sellers';
 
 export class Countries {
   [PrimaryKeyProp]?: 'country';
-  country!: unknown;
+  country!: string;
   productCountries = new Collection<ProductSizes>(this);
   sellerCountries = new Collection<Sellers>(this);
 }
@@ -3601,7 +3601,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    country: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    country: { primary: true, type: 'character', length: 2 },
     productCountries: {
       kind: 'm:n',
       entity: () => ProductSizes,
@@ -3934,8 +3934,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'country';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  country!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  country!: string;
 
   @ManyToMany({ entity: () => ProductSizes, pivotTable: 'product_countries', pivotEntity: () => ProductCountries, joinColumn: 'country', inverseJoinColumn: 'product_id' })
   productCountries = new Collection<ProductSizes>(this);
@@ -4199,7 +4199,7 @@ import { Sellers } from './Sellers';
 
 export class Countries {
   [PrimaryKeyProp]?: 'country';
-  country!: unknown;
+  country!: string;
   productCountries = new Collection<ProductSizes>(this);
   sellerCountries = new Collection<Sellers>(this);
   countryInverse = new Collection<SellerCountries>(this);
@@ -4208,7 +4208,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    country: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    country: { primary: true, type: 'character', length: 2 },
     productCountries: {
       kind: 'm:n',
       entity: () => ProductSizes,
@@ -4608,8 +4608,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'country';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  country!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  country!: string;
 
   @ManyToMany({ entity: () => ProductSizes, pivotTable: 'product_countries', pivotEntity: () => ProductCountries, joinColumn: 'country', inverseJoinColumn: 'product_id' })
   productCountries = new Collection<ProductSizes>(this);
@@ -4873,7 +4873,7 @@ import { Sellers } from './Sellers';
 
 export class Countries {
   [PrimaryKeyProp]?: 'country';
-  country!: unknown;
+  country!: string;
   productCountries = new Collection<ProductSizes>(this);
   sellerCountries = new Collection<Sellers>(this);
   countryInverse = new Collection<SellerCountries>(this);
@@ -4882,7 +4882,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    country: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    country: { primary: true, type: 'character', length: 2 },
     productCountries: {
       kind: 'm:n',
       entity: () => ProductSizes,
@@ -5294,8 +5294,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'country';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  country!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  country!: string;
 
   @ManyToMany({ entity: () => ProductSizes, pivotTable: 'product_countries', pivotEntity: () => ProductCountries, joinColumn: 'country', inverseJoinColumn: 'product_id' })
   productCountries = new Collection<ProductSizes>(this);
@@ -5504,7 +5504,7 @@ import { Sellers } from './Sellers';
 
 export class Countries {
   [PrimaryKeyProp]?: 'country';
-  country!: unknown;
+  country!: string;
   productCountries = new Collection<ProductSizes>(this);
   sellerCountries = new Collection<Sellers>(this);
 }
@@ -5512,7 +5512,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    country: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    country: { primary: true, type: 'character', length: 2 },
     productCountries: {
       kind: 'm:n',
       entity: () => ProductSizes,
@@ -5827,8 +5827,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'country';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  country!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  country!: string;
 
   @ManyToMany({ entity: () => ProductSizes, pivotTable: 'product_countries', pivotEntity: () => ProductCountries, joinColumn: 'country', inverseJoinColumn: 'product_id' })
   productCountries = new Collection<ProductSizes>(this);
@@ -6037,7 +6037,7 @@ import { Sellers } from './Sellers';
 
 export class Countries {
   [PrimaryKeyProp]?: 'country';
-  country!: unknown;
+  country!: string;
   productCountries = new Collection<ProductSizes>(this);
   sellerCountries = new Collection<Sellers>(this);
 }
@@ -6045,7 +6045,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    country: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    country: { primary: true, type: 'character', length: 2 },
     productCountries: {
       kind: 'm:n',
       entity: () => ProductSizes,
@@ -6378,8 +6378,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'country';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  country!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  country!: string;
 
   @ManyToMany({ entity: () => ProductSizes, pivotTable: 'product_countries', pivotEntity: () => ProductCountries, joinColumn: 'country', inverseJoinColumn: 'product_id' })
   productCountries = new Collection<ProductSizes>(this);
@@ -6643,7 +6643,7 @@ import { Sellers } from './Sellers';
 
 export class Countries {
   [PrimaryKeyProp]?: 'country';
-  country!: unknown;
+  country!: string;
   productCountries = new Collection<ProductSizes>(this);
   sellerCountries = new Collection<Sellers>(this);
   countryInverse = new Collection<SellerCountries>(this);
@@ -6652,7 +6652,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    country: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    country: { primary: true, type: 'character', length: 2 },
     productCountries: {
       kind: 'm:n',
       entity: () => ProductSizes,
@@ -7052,8 +7052,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'country';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  country!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  country!: string;
 
   @ManyToMany({ entity: () => ProductSizes, pivotTable: 'product_countries', pivotEntity: () => ProductCountries, joinColumn: 'country', inverseJoinColumn: 'product_id' })
   productCountries = new Collection<ProductSizes>(this);
@@ -7317,7 +7317,7 @@ import { Sellers } from './Sellers';
 
 export class Countries {
   [PrimaryKeyProp]?: 'country';
-  country!: unknown;
+  country!: string;
   productCountries = new Collection<ProductSizes>(this);
   sellerCountries = new Collection<Sellers>(this);
   countryInverse = new Collection<SellerCountries>(this);
@@ -7326,7 +7326,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    country: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    country: { primary: true, type: 'character', length: 2 },
     productCountries: {
       kind: 'm:n',
       entity: () => ProductSizes,

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.mssql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.mssql.test.ts.snap
@@ -13,7 +13,7 @@ export class Address2 {
   @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   author!: Author2;
 
-  @Property({ length: 255, comment: 'This is address property' })
+  @Property({ comment: 'This is address property' })
   value!: string;
 
 }
@@ -37,12 +37,12 @@ export class Author2 {
   updatedAt!: Date & Opt;
 
   @Index({ name: 'custom_idx_name_123' })
-  @Property({ length: 255 })
+  @Property()
   name!: string;
 
   @Index({ name: 'custom_email_index_name' })
   @Unique({ name: 'custom_email_unique_name' })
-  @Property({ length: 255 })
+  @Property()
   email!: string;
 
   @Property({ nullable: true })
@@ -98,7 +98,7 @@ export class BaseUser2 {
   @Enum({ items: () => BaseUser2Type })
   type!: BaseUser2Type;
 
-  @Property({ length: 255, nullable: true })
+  @Property({ nullable: true })
   ownerProp?: string;
 
   @ManyToOne({ entity: () => BaseUser2, nullable: true })
@@ -110,7 +110,7 @@ export class BaseUser2 {
   @Property({ nullable: true })
   employeeProp?: number;
 
-  @Property({ length: 255, nullable: true })
+  @Property({ nullable: true })
   managerProp?: string;
 
 }
@@ -134,12 +134,13 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
 
 @Entity()
+@Unique({ name: 'book2_isbn_unique', expression: 'create unique index [book2_isbn_unique] on [book2] (where ([isbn] IS NOT NULL))' })
 export class Book2 {
 
   [PrimaryKeyProp]?: 'uuidPk';
@@ -150,7 +151,11 @@ export class Book2 {
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp\` })
   createdAt!: Date & Opt;
 
-  @Property({ length: 255, nullable: true })
+  @Unique({ name: 'book2_isbn_unique' })
+  @Property({ type: 'character', length: 13, nullable: true })
+  isbn?: string;
+
+  @Property({ nullable: true })
   title?: string;
 
   @Property({ type: 'text', length: 2147483647, nullable: true })
@@ -205,7 +210,7 @@ export class CarOwner2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255 })
+  @Property()
   name!: string;
 
   @ManyToOne({ entity: () => Car2, updateRule: 'cascade', index: true })
@@ -241,13 +246,13 @@ export class Configuration2 {
 
   [PrimaryKeyProp]?: ['property', 'test'];
 
-  @PrimaryKey({ length: 255 })
+  @PrimaryKey()
   property!: string;
 
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', primary: true })
   test!: Test2;
 
-  @Property({ length: 255 })
+  @Property()
   value!: string;
 
 }
@@ -271,7 +276,7 @@ export class FooBar2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255 })
+  @Property()
   name!: string;
 
   @OneToOne({ entity: () => FooBaz2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
@@ -302,7 +307,7 @@ export class FooBaz2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255 })
+  @Property()
   name!: string;
 
   @Property({ type: 'string', columnType: 'varchar(255)' })
@@ -328,7 +333,7 @@ export class FooParam2 {
   @ManyToOne({ entity: () => FooBaz2, primary: true })
   baz!: FooBaz2;
 
-  @Property({ length: 255 })
+  @Property()
   value!: string;
 
 }
@@ -341,7 +346,7 @@ export class Publisher2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ type: 'string', length: 255 })
+  @Property({ type: 'string' })
   name: string & Opt = 'asd';
 
   @Enum({ items: () => Publisher2Type })
@@ -406,7 +411,7 @@ export class Sandwich {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255 })
+  @Property()
   name!: string;
 
   @Property()
@@ -423,7 +428,7 @@ export class Test2 {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, nullable: true })
+  @Property({ nullable: true })
   name?: string;
 
   @OneToOne({ entity: () => Book2, nullable: true })

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.mysql.test.ts.snap
@@ -265,6 +265,7 @@ export class Book2 {
   [PrimaryKeyProp]?: 'uuidPk';
   uuidPk!: string;
   createdAt!: Date & Opt;
+  isbn?: string;
   title?: string;
   perex?: string;
   price?: string;
@@ -284,6 +285,12 @@ export const Book2Schema = new EntitySchema({
   properties: {
     uuidPk: { primary: true, type: 'string', length: 36 },
     createdAt: { type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` },
+    isbn: {
+      type: 'character',
+      length: 13,
+      nullable: true,
+      unique: 'book2_isbn_unique',
+    },
     title: { type: 'string', nullable: true, index: 'book2_title_index' },
     perex: { type: 'text', length: 65535, nullable: true },
     price: { type: 'decimal', precision: 8, scale: 2, nullable: true },
@@ -970,6 +977,7 @@ export class Book2 {
   [PrimaryKeyProp]?: 'uuidPk';
   uuidPk!: string;
   createdAt!: Date & Opt;
+  isbn?: string;
   title?: string;
   perex?: string;
   price?: string;
@@ -986,6 +994,12 @@ export const Book2Schema = new EntitySchema({
   properties: {
     uuidPk: { primary: true, type: 'string', length: 36 },
     createdAt: { type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` },
+    isbn: {
+      type: 'character',
+      length: 13,
+      nullable: true,
+      unique: 'book2_isbn_unique',
+    },
     title: { type: 'string', nullable: true, index: 'book2_title_index' },
     perex: { type: 'text', length: 65535, nullable: true },
     price: { type: 'decimal', precision: 8, scale: 2, nullable: true },
@@ -1583,7 +1597,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -1598,6 +1612,10 @@ export class Book2 {
 
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
+
+  @Unique({ name: 'book2_isbn_unique' })
+  @Property({ type: 'character', length: 13, nullable: true })
+  isbn?: string;
 
   @Index({ name: 'book2_title_index' })
   @Property({ nullable: true })
@@ -2111,7 +2129,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
@@ -2128,6 +2146,10 @@ export class Book2 {
 
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
+
+  @Unique({ name: 'book2_isbn_unique' })
+  @Property({ type: 'character', length: 13, nullable: true })
+  isbn?: string;
 
   @Index({ name: 'book2_title_index' })
   @Property({ nullable: true })
@@ -2699,7 +2721,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
@@ -2716,6 +2738,10 @@ export class Book2 {
 
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
+
+  @Unique({ name: 'book2_isbn_unique' })
+  @Property({ type: 'character', length: 13, nullable: true })
+  isbn?: string;
 
   @Index({ name: 'book2_title_index' })
   @Property({ nullable: true })
@@ -3261,7 +3287,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
 import { Author2 } from './Author2.js';
 import { BookTag2 } from './BookTag2.js';
 import { Publisher2 } from './Publisher2.js';
@@ -3276,6 +3302,10 @@ export class Book2 {
 
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
+
+  @Unique({ name: 'book2_isbn_unique' })
+  @Property({ type: 'character', length: 13, nullable: true })
+  isbn?: string;
 
   @Index({ name: 'book2_title_index' })
   @Property({ nullable: true })
@@ -3817,7 +3847,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -3832,6 +3862,10 @@ export class Book2 {
 
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
+
+  @Unique({ name: 'book2_isbn_unique' })
+  @Property({ type: 'character', length: 13, nullable: true })
+  isbn?: string;
 
   @Index({ name: 'book2_title_index' })
   @Property({ nullable: true })

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
@@ -129,7 +129,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -144,6 +144,10 @@ export class Book2 {
 
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
+
+  @Unique({ name: 'book_isbn_unique' })
+  @Property({ type: 'character', length: 13, nullable: true })
+  isbn?: string;
 
   @Property({ type: 'string', nullable: true })
   title?: string & Opt = '';
@@ -524,7 +528,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -539,6 +543,10 @@ export class Book2 {
 
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
+
+  @Unique({ name: 'book_isbn_unique' })
+  @Property({ type: 'character', length: 13, nullable: true })
+  isbn?: string;
 
   @Property({ type: 'string', nullable: true })
   title?: string & Opt = '';

--- a/tests/features/entity-generator/__snapshots__/FkSharedWithColumn.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/FkSharedWithColumn.mysql.test.ts.snap
@@ -9,8 +9,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
 }
 ",
@@ -23,7 +23,7 @@ export class LegalUserCountries {
   [PrimaryKeyProp]?: 'countries';
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @OneToOne({ entity: () => Countries, fieldName: 'country', primary: true })
   countries!: Countries;
@@ -44,11 +44,11 @@ export class Users {
 
   @Index({ name: 'fk_users_countries_idx' })
   @Property({ persist: false })
-  userCountry!: unknown;
+  userCountry!: string;
 
   @Index({ name: 'fk_users_countries1_idx' })
   @Property({ persist: false })
-  userCountryBorn!: unknown;
+  userCountryBorn!: string;
 
   @ManyToOne({ entity: () => Countries, fieldName: 'user_country', index: 'fk_users_countries_idx' })
   fkUserCountry!: Countries;
@@ -70,13 +70,13 @@ exports[`fk_shared_with_column_example scalarPropertiesForRelations=always bidir
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
 }
 
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
   },
 });
 ",
@@ -85,14 +85,14 @@ import { Countries } from './Countries';
 
 export class LegalUserCountries {
   [PrimaryKeyProp]?: 'countries';
-  country!: unknown;
+  country!: string;
   countries!: Countries;
 }
 
 export const LegalUserCountriesSchema = new EntitySchema({
   class: LegalUserCountries,
   properties: {
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     countries: {
       primary: true,
       kind: '1:1',
@@ -109,8 +109,8 @@ import { LegalUserCountries } from './LegalUserCountries';
 export class Users {
   [PrimaryKeyProp]?: 'userId';
   userId!: number;
-  userCountry!: unknown;
-  userCountryBorn!: unknown;
+  userCountry!: string;
+  userCountryBorn!: string;
   fkUserCountry!: Countries;
   legalUserCountries!: LegalUserCountries;
   fkUserCountryBorn!: Countries;
@@ -121,12 +121,12 @@ export const UsersSchema = new EntitySchema({
   properties: {
     userId: { primary: true, type: 'integer' },
     userCountry: {
-      type: 'unknown',
+      type: 'character',
       persist: false,
       index: 'fk_users_countries_idx',
     },
     userCountryBorn: {
-      type: 'unknown',
+      type: 'character',
       persist: false,
       index: 'fk_users_countries1_idx',
     },
@@ -165,8 +165,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
 }
 ",
@@ -179,7 +179,7 @@ export class LegalUserCountries {
   [PrimaryKeyProp]?: 'countries';
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @OneToOne({ entity: () => Countries, ref: true, fieldName: 'country', primary: true })
   countries!: Ref<Countries>;
@@ -200,11 +200,11 @@ export class Users {
 
   @Index({ name: 'fk_users_countries_idx' })
   @Property({ persist: false })
-  userCountry!: unknown;
+  userCountry!: string;
 
   @Index({ name: 'fk_users_countries1_idx' })
   @Property({ persist: false })
-  userCountryBorn!: unknown;
+  userCountryBorn!: string;
 
   @ManyToOne({ entity: () => Countries, ref: true, fieldName: 'user_country', index: 'fk_users_countries_idx' })
   fkUserCountry!: Ref<Countries>;
@@ -226,13 +226,13 @@ exports[`fk_shared_with_column_example scalarPropertiesForRelations=always bidir
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
 }
 
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
   },
 });
 ",
@@ -241,14 +241,14 @@ import { Countries } from './Countries';
 
 export class LegalUserCountries {
   [PrimaryKeyProp]?: 'countries';
-  country!: unknown;
+  country!: string;
   countries!: Ref<Countries>;
 }
 
 export const LegalUserCountriesSchema = new EntitySchema({
   class: LegalUserCountries,
   properties: {
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     countries: {
       primary: true,
       kind: '1:1',
@@ -266,8 +266,8 @@ import { LegalUserCountries } from './LegalUserCountries';
 export class Users {
   [PrimaryKeyProp]?: 'userId';
   userId!: number;
-  userCountry!: unknown;
-  userCountryBorn!: unknown;
+  userCountry!: string;
+  userCountryBorn!: string;
   fkUserCountry!: Ref<Countries>;
   legalUserCountries!: Ref<LegalUserCountries>;
   fkUserCountryBorn!: Ref<Countries>;
@@ -278,12 +278,12 @@ export const UsersSchema = new EntitySchema({
   properties: {
     userId: { primary: true, type: 'integer' },
     userCountry: {
-      type: 'unknown',
+      type: 'character',
       persist: false,
       index: 'fk_users_countries_idx',
     },
     userCountryBorn: {
-      type: 'unknown',
+      type: 'character',
       persist: false,
       index: 'fk_users_countries1_idx',
     },
@@ -327,8 +327,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
   @OneToOne({ entity: () => LegalUserCountries, mappedBy: 'countries' })
   countriesInverse?: LegalUserCountries;
@@ -351,7 +351,7 @@ export class LegalUserCountries {
   [PrimaryKeyProp]?: 'countries';
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @OneToOne({ entity: () => Countries, fieldName: 'country', primary: true })
   countries!: Countries;
@@ -375,11 +375,11 @@ export class Users {
 
   @Index({ name: 'fk_users_countries_idx' })
   @Property({ persist: false })
-  userCountry!: unknown;
+  userCountry!: string;
 
   @Index({ name: 'fk_users_countries1_idx' })
   @Property({ persist: false })
-  userCountryBorn!: unknown;
+  userCountryBorn!: string;
 
   @ManyToOne({ entity: () => Countries, fieldName: 'user_country', index: 'fk_users_countries_idx' })
   fkUserCountry!: Countries;
@@ -403,7 +403,7 @@ import { Users } from './Users';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
   countriesInverse?: LegalUserCountries;
   fkUserCountryInverse = new Collection<Users>(this);
   fkUserCountryBornInverse = new Collection<Users>(this);
@@ -412,7 +412,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
     countriesInverse: {
       kind: '1:1',
       entity: () => LegalUserCountries,
@@ -437,7 +437,7 @@ import { Users } from './Users';
 
 export class LegalUserCountries {
   [PrimaryKeyProp]?: 'countries';
-  country!: unknown;
+  country!: string;
   countries!: Countries;
   legalUserCountriesInverse = new Collection<Users>(this);
 }
@@ -445,7 +445,7 @@ export class LegalUserCountries {
 export const LegalUserCountriesSchema = new EntitySchema({
   class: LegalUserCountries,
   properties: {
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     countries: {
       primary: true,
       kind: '1:1',
@@ -467,8 +467,8 @@ import { LegalUserCountries } from './LegalUserCountries';
 export class Users {
   [PrimaryKeyProp]?: 'userId';
   userId!: number;
-  userCountry!: unknown;
-  userCountryBorn!: unknown;
+  userCountry!: string;
+  userCountryBorn!: string;
   fkUserCountry!: Countries;
   legalUserCountries!: LegalUserCountries;
   fkUserCountryBorn!: Countries;
@@ -479,12 +479,12 @@ export const UsersSchema = new EntitySchema({
   properties: {
     userId: { primary: true, type: 'integer' },
     userCountry: {
-      type: 'unknown',
+      type: 'character',
       persist: false,
       index: 'fk_users_countries_idx',
     },
     userCountryBorn: {
-      type: 'unknown',
+      type: 'character',
       persist: false,
       index: 'fk_users_countries1_idx',
     },
@@ -525,8 +525,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
   @OneToOne({ entity: () => LegalUserCountries, ref: true, mappedBy: 'countries' })
   countriesInverse?: Ref<LegalUserCountries>;
@@ -549,7 +549,7 @@ export class LegalUserCountries {
   [PrimaryKeyProp]?: 'countries';
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @OneToOne({ entity: () => Countries, ref: true, fieldName: 'country', primary: true })
   countries!: Ref<Countries>;
@@ -573,11 +573,11 @@ export class Users {
 
   @Index({ name: 'fk_users_countries_idx' })
   @Property({ persist: false })
-  userCountry!: unknown;
+  userCountry!: string;
 
   @Index({ name: 'fk_users_countries1_idx' })
   @Property({ persist: false })
-  userCountryBorn!: unknown;
+  userCountryBorn!: string;
 
   @ManyToOne({ entity: () => Countries, ref: true, fieldName: 'user_country', index: 'fk_users_countries_idx' })
   fkUserCountry!: Ref<Countries>;
@@ -601,7 +601,7 @@ import { Users } from './Users';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
   countriesInverse?: Ref<LegalUserCountries>;
   fkUserCountryInverse = new Collection<Users>(this);
   fkUserCountryBornInverse = new Collection<Users>(this);
@@ -610,7 +610,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
     countriesInverse: {
       kind: '1:1',
       entity: () => LegalUserCountries,
@@ -636,7 +636,7 @@ import { Users } from './Users';
 
 export class LegalUserCountries {
   [PrimaryKeyProp]?: 'countries';
-  country!: unknown;
+  country!: string;
   countries!: Ref<Countries>;
   legalUserCountriesInverse = new Collection<Users>(this);
 }
@@ -644,7 +644,7 @@ export class LegalUserCountries {
 export const LegalUserCountriesSchema = new EntitySchema({
   class: LegalUserCountries,
   properties: {
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     countries: {
       primary: true,
       kind: '1:1',
@@ -667,8 +667,8 @@ import { LegalUserCountries } from './LegalUserCountries';
 export class Users {
   [PrimaryKeyProp]?: 'userId';
   userId!: number;
-  userCountry!: unknown;
-  userCountryBorn!: unknown;
+  userCountry!: string;
+  userCountryBorn!: string;
   fkUserCountry!: Ref<Countries>;
   legalUserCountries!: Ref<LegalUserCountries>;
   fkUserCountryBorn!: Ref<Countries>;
@@ -679,12 +679,12 @@ export const UsersSchema = new EntitySchema({
   properties: {
     userId: { primary: true, type: 'integer' },
     userCountry: {
-      type: 'unknown',
+      type: 'character',
       persist: false,
       index: 'fk_users_countries_idx',
     },
     userCountryBorn: {
-      type: 'unknown',
+      type: 'character',
       persist: false,
       index: 'fk_users_countries1_idx',
     },
@@ -726,8 +726,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
 }
 ",
@@ -776,13 +776,13 @@ exports[`fk_shared_with_column_example scalarPropertiesForRelations=never bidire
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
 }
 
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
   },
 });
 ",
@@ -857,8 +857,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
 }
 ",
@@ -907,13 +907,13 @@ exports[`fk_shared_with_column_example scalarPropertiesForRelations=never bidire
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
 }
 
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
   },
 });
 ",
@@ -994,8 +994,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
   @OneToOne({ entity: () => LegalUserCountries, mappedBy: 'country' })
   countryInverse?: LegalUserCountries;
@@ -1059,7 +1059,7 @@ import { Users } from './Users';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
   countryInverse?: LegalUserCountries;
   userCountryBornInverse = new Collection<Users>(this);
   fkUserCountryInverse = new Collection<Users>(this);
@@ -1068,7 +1068,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
     countryInverse: {
       kind: '1:1',
       entity: () => LegalUserCountries,
@@ -1167,8 +1167,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
   @OneToOne({ entity: () => LegalUserCountries, ref: true, mappedBy: 'country' })
   countryInverse?: Ref<LegalUserCountries>;
@@ -1232,7 +1232,7 @@ import { Users } from './Users';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
   countryInverse?: Ref<LegalUserCountries>;
   userCountryBornInverse = new Collection<Users>(this);
   fkUserCountryInverse = new Collection<Users>(this);
@@ -1241,7 +1241,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
     countryInverse: {
       kind: '1:1',
       entity: () => LegalUserCountries,
@@ -1343,8 +1343,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
 }
 ",
@@ -1393,13 +1393,13 @@ exports[`fk_shared_with_column_example scalarPropertiesForRelations=smart bidire
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
 }
 
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
   },
 });
 ",
@@ -1474,8 +1474,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
 }
 ",
@@ -1524,13 +1524,13 @@ exports[`fk_shared_with_column_example scalarPropertiesForRelations=smart bidire
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
 }
 
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
   },
 });
 ",
@@ -1611,8 +1611,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
   @OneToOne({ entity: () => LegalUserCountries, mappedBy: 'country' })
   countryInverse?: LegalUserCountries;
@@ -1676,7 +1676,7 @@ import { Users } from './Users';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
   countryInverse?: LegalUserCountries;
   userCountryBornInverse = new Collection<Users>(this);
   fkUserCountryInverse = new Collection<Users>(this);
@@ -1685,7 +1685,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
     countryInverse: {
       kind: '1:1',
       entity: () => LegalUserCountries,
@@ -1784,8 +1784,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
   @OneToOne({ entity: () => LegalUserCountries, ref: true, mappedBy: 'country' })
   countryInverse?: Ref<LegalUserCountries>;
@@ -1849,7 +1849,7 @@ import { Users } from './Users';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
   countryInverse?: Ref<LegalUserCountries>;
   userCountryBornInverse = new Collection<Users>(this);
   fkUserCountryInverse = new Collection<Users>(this);
@@ -1858,7 +1858,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
     countryInverse: {
       kind: '1:1',
       entity: () => LegalUserCountries,

--- a/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
@@ -174,7 +174,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, type IType, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, type IType, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
@@ -192,6 +192,10 @@ export class Book2 {
 
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
+
+  @Unique({ name: 'book2_isbn_unique' })
+  @Property({ type: 'character', length: 13, nullable: true })
+  isbn?: string;
 
   @Index({ name: 'book2_title_index' })
   @Property({ nullable: true })
@@ -954,6 +958,7 @@ export class Book2 {
   [PrimaryKeyProp]?: 'uuidPk';
   uuidPk!: string;
   createdAt!: Date & Opt;
+  isbn?: string;
   title?: string;
   perex?: string;
   price?: string;
@@ -973,6 +978,12 @@ export const Book2Schema = new EntitySchema({
   properties: {
     uuidPk: { primary: true, type: 'uuid', length: 36 },
     createdAt: { type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` },
+    isbn: {
+      type: 'character',
+      length: 13,
+      nullable: true,
+      unique: 'book2_isbn_unique',
+    },
     title: { type: 'string', nullable: true, index: 'book2_title_index' },
     perex: { type: 'text', length: 65535, nullable: true },
     price: { type: 'decimal', precision: 8, scale: 2, nullable: true },
@@ -1758,7 +1769,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, type IType, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, type IType, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
@@ -1776,6 +1787,10 @@ export class Book2 {
 
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
+
+  @Unique({ name: 'book2_isbn_unique' })
+  @Property({ type: 'character', length: 13, nullable: true })
+  isbn?: string;
 
   @Index({ name: 'book2_title_index' })
   @Property({ nullable: true })
@@ -2545,6 +2560,7 @@ export class Book2 {
   [PrimaryKeyProp]?: 'uuidPk';
   uuidPk!: string;
   createdAt!: Date & Opt;
+  isbn?: string;
   title?: string;
   perex?: string;
   price?: string;
@@ -2564,6 +2580,12 @@ export const Book2Schema = new EntitySchema({
   properties: {
     uuidPk: { primary: true, type: 'uuid', length: 36 },
     createdAt: { type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` },
+    isbn: {
+      type: 'character',
+      length: 13,
+      nullable: true,
+      unique: 'book2_isbn_unique',
+    },
     title: { type: 'string', nullable: true, index: 'book2_title_index' },
     perex: { type: 'text', length: 65535, nullable: true },
     price: { type: 'decimal', precision: 8, scale: 2, nullable: true },

--- a/tests/features/entity-generator/__snapshots__/OverlapFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OverlapFks.mysql.test.ts.snap
@@ -9,8 +9,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
 }
 ",
@@ -26,7 +26,7 @@ export class ProductCountryMap {
   [PrimaryKeyProp]?: ['product', 'countries'];
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @ManyToOne({ entity: () => Products, fieldName: 'product_id', primary: true, index: 'fk_product_country_map_products1' })
   product!: Products;
@@ -110,7 +110,7 @@ export class Sales {
   saleId!: number;
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @ManyToOne({ entity: () => ProductSellers, fieldNames: ['seller_id', 'product_id'], updateRule: 'cascade', index: 'fk_sales_product_sellers1_idx' })
   seller!: ProductSellers;
@@ -163,13 +163,13 @@ exports[`overlap_fk_example scalarPropertiesForRelations=always bidirectionalRel
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
 }
 
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
   },
 });
 ",
@@ -179,7 +179,7 @@ import { Products } from './Products';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['product', 'countries'];
-  country!: unknown;
+  country!: string;
   product!: Products;
   productId!: number;
   isCurrentlyAllowed: boolean & Opt = false;
@@ -196,7 +196,7 @@ export const ProductCountryMapSchema = new EntitySchema({
     { name: 'primary_reindex_idx', properties: ['countries', 'productId'] },
   ],
   properties: {
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -300,7 +300,7 @@ import { ProductSellers } from './ProductSellers';
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
   saleId!: number;
-  country!: unknown;
+  country!: string;
   seller!: ProductSellers;
   sellerId!: number;
   productId!: number;
@@ -313,7 +313,7 @@ export const SalesSchema = new EntitySchema({
   class: Sales,
   properties: {
     saleId: { primary: true, type: 'integer' },
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     seller: {
       kind: 'm:1',
       entity: () => ProductSellers,
@@ -374,8 +374,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
 }
 ",
@@ -391,7 +391,7 @@ export class ProductCountryMap {
   [PrimaryKeyProp]?: ['product', 'countries'];
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @ManyToOne({ entity: () => Products, ref: true, fieldName: 'product_id', primary: true, index: 'fk_product_country_map_products1' })
   product!: Ref<Products>;
@@ -475,7 +475,7 @@ export class Sales {
   saleId!: number;
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @ManyToOne({ entity: () => ProductSellers, ref: true, fieldNames: ['seller_id', 'product_id'], updateRule: 'cascade', index: 'fk_sales_product_sellers1_idx' })
   seller!: Ref<ProductSellers>;
@@ -528,13 +528,13 @@ exports[`overlap_fk_example scalarPropertiesForRelations=always bidirectionalRel
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
 }
 
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
   },
 });
 ",
@@ -544,7 +544,7 @@ import { Products } from './Products';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['product', 'countries'];
-  country!: unknown;
+  country!: string;
   product!: Ref<Products>;
   productId!: number;
   isCurrentlyAllowed: boolean & Opt = false;
@@ -561,7 +561,7 @@ export const ProductCountryMapSchema = new EntitySchema({
     { name: 'primary_reindex_idx', properties: ['countries', 'productId'] },
   ],
   properties: {
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -669,7 +669,7 @@ import { ProductSellers } from './ProductSellers';
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
   saleId!: number;
-  country!: unknown;
+  country!: string;
   seller!: Ref<ProductSellers>;
   sellerId!: number;
   productId!: number;
@@ -682,7 +682,7 @@ export const SalesSchema = new EntitySchema({
   class: Sales,
   properties: {
     saleId: { primary: true, type: 'integer' },
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     seller: {
       kind: 'm:1',
       entity: () => ProductSellers,
@@ -747,8 +747,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
   @OneToMany({ entity: () => ProductCountryMap, mappedBy: 'countries' })
   countriesInverse = new Collection<ProductCountryMap>(this);
@@ -771,7 +771,7 @@ export class ProductCountryMap {
   [PrimaryKeyProp]?: ['product', 'countries'];
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @ManyToOne({ entity: () => Products, fieldName: 'product_id', primary: true, index: 'fk_product_country_map_products1' })
   product!: Products;
@@ -870,7 +870,7 @@ export class Sales {
   saleId!: number;
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @ManyToOne({ entity: () => ProductSellers, fieldNames: ['seller_id', 'product_id'], updateRule: 'cascade', index: 'fk_sales_product_sellers1_idx' })
   seller!: ProductSellers;
@@ -928,7 +928,7 @@ import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
   countriesInverse = new Collection<ProductCountryMap>(this);
   productCountryMapInverse = new Collection<Products>(this);
 }
@@ -936,7 +936,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
     countriesInverse: {
       kind: '1:m',
       entity: () => ProductCountryMap,
@@ -957,7 +957,7 @@ import { Sales } from './Sales';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['product', 'countries'];
-  country!: unknown;
+  country!: string;
   product!: Products;
   productId!: number;
   isCurrentlyAllowed: boolean & Opt = false;
@@ -975,7 +975,7 @@ export const ProductCountryMapSchema = new EntitySchema({
     { name: 'primary_reindex_idx', properties: ['countries', 'productId'] },
   ],
   properties: {
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -1101,7 +1101,7 @@ import { ProductSellers } from './ProductSellers';
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
   saleId!: number;
-  country!: unknown;
+  country!: string;
   seller!: ProductSellers;
   sellerId!: number;
   productId!: number;
@@ -1114,7 +1114,7 @@ export const SalesSchema = new EntitySchema({
   class: Sales,
   properties: {
     saleId: { primary: true, type: 'integer' },
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     seller: {
       kind: 'm:1',
       entity: () => ProductSellers,
@@ -1183,8 +1183,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
   @OneToMany({ entity: () => ProductCountryMap, mappedBy: 'countries' })
   countriesInverse = new Collection<ProductCountryMap>(this);
@@ -1207,7 +1207,7 @@ export class ProductCountryMap {
   [PrimaryKeyProp]?: ['product', 'countries'];
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @ManyToOne({ entity: () => Products, ref: true, fieldName: 'product_id', primary: true, index: 'fk_product_country_map_products1' })
   product!: Ref<Products>;
@@ -1306,7 +1306,7 @@ export class Sales {
   saleId!: number;
 
   @Property({ persist: false })
-  country!: unknown;
+  country!: string;
 
   @ManyToOne({ entity: () => ProductSellers, ref: true, fieldNames: ['seller_id', 'product_id'], updateRule: 'cascade', index: 'fk_sales_product_sellers1_idx' })
   seller!: Ref<ProductSellers>;
@@ -1364,7 +1364,7 @@ import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
   countriesInverse = new Collection<ProductCountryMap>(this);
   productCountryMapInverse = new Collection<Products>(this);
 }
@@ -1372,7 +1372,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
     countriesInverse: {
       kind: '1:m',
       entity: () => ProductCountryMap,
@@ -1393,7 +1393,7 @@ import { Sales } from './Sales';
 
 export class ProductCountryMap {
   [PrimaryKeyProp]?: ['product', 'countries'];
-  country!: unknown;
+  country!: string;
   product!: Ref<Products>;
   productId!: number;
   isCurrentlyAllowed: boolean & Opt = false;
@@ -1411,7 +1411,7 @@ export const ProductCountryMapSchema = new EntitySchema({
     { name: 'primary_reindex_idx', properties: ['countries', 'productId'] },
   ],
   properties: {
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -1541,7 +1541,7 @@ import { ProductSellers } from './ProductSellers';
 export class Sales {
   [PrimaryKeyProp]?: 'saleId';
   saleId!: number;
-  country!: unknown;
+  country!: string;
   seller!: Ref<ProductSellers>;
   sellerId!: number;
   productId!: number;
@@ -1554,7 +1554,7 @@ export const SalesSchema = new EntitySchema({
   class: Sales,
   properties: {
     saleId: { primary: true, type: 'integer' },
-    country: { type: 'unknown', persist: false },
+    country: { type: 'character', persist: false },
     seller: {
       kind: 'm:1',
       entity: () => ProductSellers,
@@ -1625,8 +1625,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
   @ManyToMany({ entity: () => Products, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'country', inverseJoinColumn: 'product_id' })
   productCountryMap = new Collection<Products>(this);
@@ -1756,14 +1756,14 @@ import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
   productCountryMap = new Collection<Products>(this);
 }
 
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
     productCountryMap: {
       kind: 'm:n',
       entity: () => Products,
@@ -1948,8 +1948,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
   @ManyToMany({ entity: () => Products, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'country', inverseJoinColumn: 'product_id' })
   productCountryMap = new Collection<Products>(this);
@@ -2079,14 +2079,14 @@ import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
   productCountryMap = new Collection<Products>(this);
 }
 
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
     productCountryMap: {
       kind: 'm:n',
       entity: () => Products,
@@ -2277,8 +2277,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
   @ManyToMany({ entity: () => Products, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'country', inverseJoinColumn: 'product_id' })
   productCountryMap = new Collection<Products>(this);
@@ -2434,7 +2434,7 @@ import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
   productCountryMap = new Collection<Products>(this);
   countryInverse = new Collection<ProductCountryMap>(this);
 }
@@ -2442,7 +2442,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
     productCountryMap: {
       kind: 'm:n',
       entity: () => Products,
@@ -2665,8 +2665,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
   @ManyToMany({ entity: () => Products, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'country', inverseJoinColumn: 'product_id' })
   productCountryMap = new Collection<Products>(this);
@@ -2822,7 +2822,7 @@ import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
   productCountryMap = new Collection<Products>(this);
   countryInverse = new Collection<ProductCountryMap>(this);
 }
@@ -2830,7 +2830,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
     productCountryMap: {
       kind: 'm:n',
       entity: () => Products,
@@ -3059,8 +3059,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
   @ManyToMany({ entity: () => Products, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'country', inverseJoinColumn: 'product_id' })
   productCountryMap = new Collection<Products>(this);
@@ -3190,14 +3190,14 @@ import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
   productCountryMap = new Collection<Products>(this);
 }
 
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
     productCountryMap: {
       kind: 'm:n',
       entity: () => Products,
@@ -3382,8 +3382,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
   @ManyToMany({ entity: () => Products, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'country', inverseJoinColumn: 'product_id' })
   productCountryMap = new Collection<Products>(this);
@@ -3513,14 +3513,14 @@ import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
   productCountryMap = new Collection<Products>(this);
 }
 
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
     productCountryMap: {
       kind: 'm:n',
       entity: () => Products,
@@ -3711,8 +3711,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
   @ManyToMany({ entity: () => Products, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'country', inverseJoinColumn: 'product_id' })
   productCountryMap = new Collection<Products>(this);
@@ -3868,7 +3868,7 @@ import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
   productCountryMap = new Collection<Products>(this);
   countryInverse = new Collection<ProductCountryMap>(this);
 }
@@ -3876,7 +3876,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
     productCountryMap: {
       kind: 'm:n',
       entity: () => Products,
@@ -4099,8 +4099,8 @@ export class Countries {
 
   [PrimaryKeyProp]?: 'code';
 
-  @PrimaryKey({ columnType: 'char(2)' })
-  code!: unknown;
+  @PrimaryKey({ type: 'character', length: 2 })
+  code!: string;
 
   @ManyToMany({ entity: () => Products, pivotTable: 'product_country_map', pivotEntity: () => ProductCountryMap, joinColumn: 'country', inverseJoinColumn: 'product_id' })
   productCountryMap = new Collection<Products>(this);
@@ -4256,7 +4256,7 @@ import { Products } from './Products';
 
 export class Countries {
   [PrimaryKeyProp]?: 'code';
-  code!: unknown;
+  code!: string;
   productCountryMap = new Collection<Products>(this);
   countryInverse = new Collection<ProductCountryMap>(this);
 }
@@ -4264,7 +4264,7 @@ export class Countries {
 export const CountriesSchema = new EntitySchema({
   class: Countries,
   properties: {
-    code: { primary: true, type: 'unknown', columnType: 'char(2)' },
+    code: { primary: true, type: 'character', length: 2 },
     productCountryMap: {
       kind: 'm:n',
       entity: () => Products,

--- a/tests/features/entity-generator/__snapshots__/ScalarPropsForFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/ScalarPropsForFks.mysql.test.ts.snap
@@ -156,7 +156,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -171,6 +171,10 @@ export class Book2 {
 
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
+
+  @Unique({ name: 'book2_isbn_unique' })
+  @Property({ type: 'character', length: 13, nullable: true })
+  isbn?: string;
 
   @Index({ name: 'book2_title_index' })
   @Property({ nullable: true })
@@ -726,7 +730,7 @@ export class BookTag2 {
 
 }
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
@@ -741,6 +745,10 @@ export class Book2 {
 
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
+
+  @Unique({ name: 'book2_isbn_unique' })
+  @Property({ type: 'character', length: 13, nullable: true })
+  isbn?: string;
 
   @Index({ name: 'book2_title_index' })
   @Property({ nullable: true })

--- a/tests/features/entity-generator/__snapshots__/character-types.mssql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/character-types.mssql.test.ts.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`character-types 1`] = `
+[
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity()
+export class Test {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: 'string', columnType: 'varchar(max)', nullable: true })
+  firstName?: string;
+
+  @Property({ type: 'string', columnType: 'char(1)', nullable: true })
+  middleInitial?: string;
+
+  @Property({ type: 'string', columnType: 'varchar(255)', nullable: true })
+  lastName?: string;
+
+  @Property({ type: 'character', nullable: true })
+  gender?: string;
+
+  @Property({ type: 'character', length: 2, nullable: true })
+  currency?: string;
+
+  @Property({ type: 'string', columnType: 'varchar(45)', nullable: true })
+  locale?: string;
+
+  @Property({ type: 'string', columnType: 'char(2)', nullable: true })
+  bloodType?: string;
+
+  @Property({ type: 'string', columnType: 'char(1)', nullable: true })
+  motherInitial?: string;
+
+  @Property({ type: 'string', columnType: 'varchar(1)', nullable: true })
+  spouceInitial?: string;
+
+  @Property({ length: -1, nullable: true })
+  notes?: string;
+
+  @Property({ length: 1, nullable: true })
+  favoriteLetter?: string;
+
+  @Property({ length: 10, nullable: true })
+  governmentId?: string;
+
+  @Property({ nullable: true })
+  descr?: string;
+
+  @Property({ type: 'character', nullable: true })
+  fatherInitial?: string;
+
+  @Property({ type: 'string', columnType: 'varchar(1)', nullable: true })
+  fatherInGroup?: string;
+
+  @Property({ length: 1, nullable: true })
+  memberInGroup?: string;
+
+}
+",
+]
+`;

--- a/tests/features/entity-generator/__snapshots__/character-types.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/character-types.postgres.test.ts.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`character-types 1`] = `
+[
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity()
+export class Test {
+
+  @PrimaryKey({ autoincrement: false })
+  id!: bigint;
+
+  @Property({ length: -1, nullable: true })
+  firstName?: string;
+
+  @Property({ type: 'character', nullable: true })
+  middleInitial?: string;
+
+  @Property({ nullable: true })
+  lastName?: string;
+
+  @Property({ type: 'character', nullable: true })
+  gender?: string;
+
+  @Property({ type: 'character', length: 2, nullable: true })
+  currency?: string;
+
+  @Property({ length: 45, nullable: true })
+  locale?: string;
+
+  @Property({ type: 'character', length: 2, nullable: true })
+  bloodType?: string;
+
+  @Property({ type: 'character', nullable: true })
+  motherInitial?: string;
+
+  @Property({ length: 1, nullable: true })
+  spouceInitial?: string;
+
+  @Property({ type: 'character', length: -1, nullable: true })
+  notes?: string;
+
+  @Property({ type: 'character', nullable: true })
+  favoriteLetter?: string;
+
+  @Property({ type: 'character', length: 10, nullable: true })
+  governmentId?: string;
+
+  @Property({ type: 'character', nullable: true })
+  description?: string;
+
+}
+",
+]
+`;

--- a/tests/features/entity-generator/character-types.mssql.test.ts
+++ b/tests/features/entity-generator/character-types.mssql.test.ts
@@ -1,0 +1,44 @@
+import { MikroORM } from '@mikro-orm/mssql';
+import { EntityGenerator } from '@mikro-orm/entity-generator';
+
+const schema = `
+  CREATE TABLE [test] (
+    [id] int identity(1,1) not null primary key,
+    [first_name] varchar(max),
+    [middle_initial] char,
+    [last_name] varchar(255),
+    [gender] nchar(1),
+    [currency] nchar(2),
+    [locale] varchar(45),
+    [blood_type] char(2),
+    [mother_initial] char(1),
+    [spouce_initial] varchar(1),
+    [notes] nvarchar(max),
+    [favorite_letter] nvarchar(1),
+    [government_id] nvarchar(10),
+    [descr] nvarchar(255),
+    [father_initial] nchar,
+    [father_in_group] varchar,
+    [member_in_group] nvarchar
+  );
+`;
+
+test('character-types', async () => {
+  const orm = await MikroORM.init({
+    dbName: 'character-types-test',
+    password: 'Root.Root',
+    discovery: {
+      warnWhenNoEntities: false,
+    },
+    ensureDatabase: false,
+    extensions: [EntityGenerator],
+  });
+
+  if (await orm.schema.ensureDatabase({ create: true })) {
+    await orm.schema.execute(schema);
+  }
+
+  const dump = await orm.entityGenerator.generate();
+  expect(dump).toMatchSnapshot();
+  await orm.close(true);
+});

--- a/tests/features/entity-generator/character-types.postgres.test.ts
+++ b/tests/features/entity-generator/character-types.postgres.test.ts
@@ -1,0 +1,52 @@
+import { MikroORM, UnderscoreNamingStrategy } from '@mikro-orm/postgresql';
+import { EntityGenerator } from '@mikro-orm/entity-generator';
+
+const schema = `
+  create table "test" (
+    "id" int8 not null,
+    "first_name" varchar,
+    "middle_initial" character,
+    "last_name" varchar(255),
+    "gender" character(1),
+    "currency" character(2),
+    "locale" varchar(45),
+    "blood_type" char(2),
+    "mother_initial" char(1),
+    "spouce_initial" varchar(1),
+    "notes" bpchar,
+    "favorite_letter" bpchar(1),
+    "government_id" bpchar(10),
+    "description" char,
+    primary key ("id")
+  );
+`;
+
+test('character-types', async () => {
+  const orm = await MikroORM.init({
+    dbName: 'character-types-test',
+    discovery: {
+      warnWhenNoEntities: false,
+    },
+    ensureDatabase: false,
+    extensions: [EntityGenerator],
+    namingStrategy: class extends UnderscoreNamingStrategy {
+
+      getEntityName(tableName: string, schemaName?: string): string {
+        if (schemaName !== 'public') {
+          return super.getClassName(`${schemaName}_${tableName}`, '_');
+        }
+
+        return super.getClassName(tableName, '_');
+      }
+
+    },
+  });
+
+  if (await orm.schema.ensureDatabase({ create: true })) {
+    await orm.schema.execute(schema);
+  }
+
+  const dump = await orm.entityGenerator.generate();
+  expect(dump).toMatchSnapshot();
+  await orm.close(true);
+});

--- a/tests/features/filters/filters.mysql.test.ts
+++ b/tests/features/filters/filters.mysql.test.ts
@@ -46,7 +46,7 @@ describe('filters [mysql]', () => {
     const books2 = await orm.em.find(Book2, { title: '123' }, {
       filters: { hasAuthor: false, long: true, writtenBy: { name: 'God' } },
     });
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
       'from `book2` as `b0` ' +
       'left join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
       'left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` ' +
@@ -55,7 +55,7 @@ describe('filters [mysql]', () => {
     const books3 = await orm.em.find(Book2, { title: '123' }, {
       filters: false,
     });
-    expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`title` = \'123\'');
@@ -63,7 +63,7 @@ describe('filters [mysql]', () => {
     const books4 = await orm.em.find(Book2, { title: '123' }, {
       filters: true,
     });
-    expect(mock.mock.calls[3][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[3][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`title` = \'123\'');
@@ -71,7 +71,7 @@ describe('filters [mysql]', () => {
     const b1 = await orm.em.findOne(Book2, '123', {
       filters: { long: true },
     });
-    expect(mock.mock.calls[4][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[4][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and length(perex) > 10000 and `b0`.`uuid_pk` = \'123\' limit 1');
@@ -79,7 +79,7 @@ describe('filters [mysql]', () => {
     const b2 = await orm.em.findOne(Book2, { author: { name: 'Jon' } }, {
       filters: { hasAuthor: false, long: true },
     });
-    expect(mock.mock.calls[5][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
+    expect(mock.mock.calls[5][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
       'from `book2` as `b0` ' +
       'left join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
       'left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` ' +
@@ -144,7 +144,7 @@ describe('filters [mysql]', () => {
     const books2 = await orm.em.find(Book2, { title: '123' }, {
       filters: { hasAuthor: false, long: true, writtenBy: { name: 'God' } },
     });
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
       'from `book2` as `b0` ' +
       'left join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
       'left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` ' +
@@ -153,7 +153,7 @@ describe('filters [mysql]', () => {
     const books3 = await orm.em.find(Book2, { title: '123' }, {
       filters: false,
     });
-    expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`title` = \'123\'');
@@ -161,7 +161,7 @@ describe('filters [mysql]', () => {
     const books4 = await orm.em.find(Book2, { title: '123' }, {
       filters: true,
     });
-    expect(mock.mock.calls[3][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[3][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`title` = \'123\'');
@@ -169,7 +169,7 @@ describe('filters [mysql]', () => {
     const b1 = await orm.em.findOne(Book2, '123', {
       filters: { long: true },
     });
-    expect(mock.mock.calls[4][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[4][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and length(perex) > 10000 and `b0`.`uuid_pk` = \'123\' limit 1');
@@ -177,7 +177,7 @@ describe('filters [mysql]', () => {
     const b2 = await orm.em.findOne(Book2, { author: { name: 'Jon' } }, {
       filters: { hasAuthor: false, long: true },
     });
-    expect(mock.mock.calls[5][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
+    expect(mock.mock.calls[5][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
       'from `book2` as `b0` ' +
       'left join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
       'left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` ' +

--- a/tests/features/joined-strategy.postgre.test.ts
+++ b/tests/features/joined-strategy.postgre.test.ts
@@ -113,7 +113,7 @@ describe('Joined loading strategy', () => {
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books2.perex'] });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
       '"f2"."uuid_pk" as "f2__uuid_pk" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
@@ -126,7 +126,7 @@ describe('Joined loading strategy', () => {
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books2'] });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
       '"f2"."uuid_pk" as "f2__uuid_pk" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
@@ -139,7 +139,7 @@ describe('Joined loading strategy', () => {
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books'], filters: false });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" ' +
       'where "a0"."id" = $1');
@@ -149,7 +149,7 @@ describe('Joined loading strategy', () => {
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books.perex'] });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
       '"f2"."uuid_pk" as "f2__uuid_pk" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
@@ -175,7 +175,7 @@ describe('Joined loading strategy', () => {
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books2.perex'], filters: false });
     expect(mock.mock.calls).toHaveLength(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" ' +
       'where "a0"."id" = $1');
@@ -185,7 +185,7 @@ describe('Joined loading strategy', () => {
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books2'] });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
       '"f2"."uuid_pk" as "f2__uuid_pk" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
@@ -197,7 +197,7 @@ describe('Joined loading strategy', () => {
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books'], strategy: LoadStrategy.JOINED });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
       '"f2"."uuid_pk" as "f2__uuid_pk" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
@@ -209,7 +209,7 @@ describe('Joined loading strategy', () => {
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books.perex'] });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
       '"f2"."uuid_pk" as "f2__uuid_pk" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
@@ -243,7 +243,7 @@ describe('Joined loading strategy', () => {
     mock.mock.calls.length = 0;
     const books = await orm.em.find(Book2, {}, { populate: ['tags'], strategy: LoadStrategy.JOINED, orderBy: { tags: { name: 'desc' } } });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed", ' +
       '"t1"."id" as "t1__id", "t1"."name" as "t1__name" ' +
       'from "book2" as "b0" ' +
       'left join "book2_tags" as "b2" on "b0"."uuid_pk" = "b2"."book2_uuid_pk" ' +
@@ -418,7 +418,7 @@ describe('Joined loading strategy', () => {
     });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "b0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
       '"a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", "a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", "a3"."identity" as "a3__identity", ' +
       '"p4"."id" as "p4__id", "p4"."name" as "p4__name", "p4"."type" as "p4__type", "p4"."type2" as "p4__type2", "p4"."enum1" as "p4__enum1", "p4"."enum2" as "p4__enum2", "p4"."enum3" as "p4__enum3", "p4"."enum4" as "p4__enum4", "p4"."enum5" as "p4__enum5", ' +
       '"t5"."id" as "t5__id", "t5"."name" as "t5__name", "t5"."book_uuid_pk" as "t5__book_uuid_pk", "t5"."parent_id" as "t5__parent_id", "t5"."version" as "t5__version" ' +
@@ -509,7 +509,7 @@ describe('Joined loading strategy', () => {
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed", ' +
       '"a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "a1"."identity" as "a1__identity", ' +
-      '"f2"."uuid_pk" as "f2__uuid_pk", "f2"."created_at" as "f2__created_at", "f2"."title" as "f2__title", "f2"."price" as "f2__price", "f2".price * 1.19 as "f2__price_taxed", "f2"."double" as "f2__double", "f2"."meta" as "f2__meta", "f2"."author_id" as "f2__author_id", "f2"."publisher_id" as "f2__publisher_id", ' +
+      '"f2"."uuid_pk" as "f2__uuid_pk", "f2"."created_at" as "f2__created_at", "f2"."isbn" as "f2__isbn", "f2"."title" as "f2__title", "f2"."price" as "f2__price", "f2".price * 1.19 as "f2__price_taxed", "f2"."double" as "f2__double", "f2"."meta" as "f2__meta", "f2"."author_id" as "f2__author_id", "f2"."publisher_id" as "f2__publisher_id", ' +
       '"a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", "a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", "a3"."identity" as "a3__identity" ' +
       'from "book2" as "b0" ' +
       // populateHint: all
@@ -543,7 +543,7 @@ describe('Joined loading strategy', () => {
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed", ' +
       '"a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "a1"."identity" as "a1__identity", ' +
-      '"f2"."uuid_pk" as "f2__uuid_pk", "f2"."created_at" as "f2__created_at", "f2"."title" as "f2__title", "f2"."price" as "f2__price", "f2".price * 1.19 as "f2__price_taxed", "f2"."double" as "f2__double", "f2"."meta" as "f2__meta", "f2"."author_id" as "f2__author_id", "f2"."publisher_id" as "f2__publisher_id", ' +
+      '"f2"."uuid_pk" as "f2__uuid_pk", "f2"."created_at" as "f2__created_at", "f2"."isbn" as "f2__isbn", "f2"."title" as "f2__title", "f2"."price" as "f2__price", "f2".price * 1.19 as "f2__price_taxed", "f2"."double" as "f2__double", "f2"."meta" as "f2__meta", "f2"."author_id" as "f2__author_id", "f2"."publisher_id" as "f2__publisher_id", ' +
       '"a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", "a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", "a3"."identity" as "a3__identity" ' +
       'from "book2" as "b0" left join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
       'left join "book2" as "f2" on "a1"."favourite_book_uuid_pk" = "f2"."uuid_pk" and "f2"."author_id" is not null ' +

--- a/tests/features/lazy-scalar-properties/lazy-scalar-properties.mysql.test.ts
+++ b/tests/features/lazy-scalar-properties/lazy-scalar-properties.mysql.test.ts
@@ -31,7 +31,7 @@ describe('lazy scalar properties (mysql)', () => {
     expect(r1[0].books[0].perex?.unwrap()).toBe('123');
     expect(mock.mock.calls).toHaveLength(3);
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `a1`.`author_id` as `a1__author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id`');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`author_id` in (?) ' +
@@ -57,7 +57,7 @@ describe('lazy scalar properties (mysql)', () => {
     await expect(r3!.books[0].perex?.load()).resolves.toBe('123');
     expect(mock.mock.calls).toHaveLength(3);
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `a1`.`author_id` as `a1__author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id`');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`author_id` in (?) ' +
@@ -92,7 +92,7 @@ describe('lazy scalar properties (mysql)', () => {
     await wrap(r1[0]).populate(['books.perex']);
     expect(r1[0].books[0].perex?.unwrap()).toBe('123');
     expect(mock.mock.calls).toHaveLength(2);
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`title` as `b1__title`, `b1`.`price` as `b1__price`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`price` as `b1__price`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` ' +
       'from `author2` as `a0` ' +
       'left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null ' +
       'left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` ' +
@@ -103,7 +103,7 @@ describe('lazy scalar properties (mysql)', () => {
     const r2 = await orm.em.find(Author2, {}, { populate: ['books.perex'] });
     expect(r2[0].books[0].perex?.get()).toBe('123');
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`title` as `b1__title`, `b1`.`perex` as `b1__perex`, `b1`.`price` as `b1__price`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`perex` as `b1__perex`, `b1`.`price` as `b1__price`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` ' +
       'from `author2` as `a0` ' +
       'left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null ' +
       'left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` ' +
@@ -115,7 +115,7 @@ describe('lazy scalar properties (mysql)', () => {
     expect(r3!.books[0].perex?.unwrap()).not.toBe('123');
     await expect(r3!.books[0].perex?.load()).resolves.toBe('123');
     expect(mock.mock.calls).toHaveLength(2);
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`title` as `b1__title`, `b1`.`price` as `b1__price`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` from `author2` as `a0` left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` where `a0`.`id` = ? order by `b1`.`title` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`price` as `b1__price`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` from `author2` as `a0` left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` where `a0`.`id` = ? order by `b1`.`title` asc');
     expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`perex` from `book2` as `b0` where `b0`.`author_id` is not null and `b0`.`uuid_pk` in (?)');
 
     orm.em.clear();
@@ -123,7 +123,7 @@ describe('lazy scalar properties (mysql)', () => {
     const r4 = await orm.em.findOne(Author2, book.author, { populate: ['books.perex'] });
     expect(r4!.books[0].perex?.$).toBe('123');
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`title` as `b1__title`, `b1`.`perex` as `b1__perex`, `b1`.`price` as `b1__price`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` from `author2` as `a0` left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` where `a0`.`id` = ? order by `b1`.`title` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`perex` as `b1__perex`, `b1`.`price` as `b1__price`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` from `author2` as `a0` left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` where `a0`.`id` = ? order by `b1`.`title` asc');
   });
 
   test('em.populate() respects lazy scalar properties', async () => {
@@ -142,7 +142,7 @@ describe('lazy scalar properties (mysql)', () => {
 
     expect(mock.mock.calls).toHaveLength(3);
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `a1`.`author_id` as `a1__author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id`');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`author_id` is not null and `b0`.`author_id` in (?) order by `b0`.`title` asc');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`author_id` is not null and `b0`.`author_id` in (?) order by `b0`.`title` asc');
     expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`perex` from `book2` as `b0` where `b0`.`author_id` is not null and `b0`.`uuid_pk` in (?)');
 
     mock.mockReset();

--- a/tests/features/migrations/__snapshots__/Migrator.mssql.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.mssql.test.ts.snap
@@ -30,7 +30,8 @@ export class Migration20191013214813 extends Migration {
     this.addSql('CREATE INDEX [author2_name_age_index] ON [custom].[author2] ([name], [age]);');
     this.addSql('CREATE UNIQUE INDEX [author2_name_email_unique] ON [custom].[author2] ([name], [email]) WHERE [name] IS NOT NULL AND [email] IS NOT NULL;');
 
-    this.addSql('CREATE TABLE [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null CONSTRAINT [book2_created_at_default] DEFAULT current_timestamp, [title] nvarchar(255) null CONSTRAINT [book2_title_default] DEFAULT \\'\\', [perex] text null, [price] numeric(8,2) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, CONSTRAINT [book2_pkey] PRIMARY KEY ([uuid_pk]));');
+    this.addSql('CREATE TABLE [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null CONSTRAINT [book2_created_at_default] DEFAULT current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null CONSTRAINT [book2_title_default] DEFAULT \\'\\', [perex] text null, [price] numeric(8,2) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, CONSTRAINT [book2_pkey] PRIMARY KEY ([uuid_pk]));');
+    this.addSql('CREATE UNIQUE INDEX [book2_isbn_unique] ON [custom].[book2] ([isbn]) WHERE [isbn] IS NOT NULL;');
 
     this.addSql('CREATE TABLE [custom].[book2_tags] ([order] int identity(1,1) not null primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);');
 
@@ -119,7 +120,8 @@ export class Migration20191013214813 extends Migration {
       "CREATE INDEX [author2_name_age_index] ON [custom].[author2] ([name], [age]);",
       "CREATE UNIQUE INDEX [author2_name_email_unique] ON [custom].[author2] ([name], [email]) WHERE [name] IS NOT NULL AND [email] IS NOT NULL;",
       "",
-      "CREATE TABLE [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null CONSTRAINT [book2_created_at_default] DEFAULT current_timestamp, [title] nvarchar(255) null CONSTRAINT [book2_title_default] DEFAULT '', [perex] text null, [price] numeric(8,2) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, CONSTRAINT [book2_pkey] PRIMARY KEY ([uuid_pk]));",
+      "CREATE TABLE [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null CONSTRAINT [book2_created_at_default] DEFAULT current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null CONSTRAINT [book2_title_default] DEFAULT '', [perex] text null, [price] numeric(8,2) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, CONSTRAINT [book2_pkey] PRIMARY KEY ([uuid_pk]));",
+      "CREATE UNIQUE INDEX [book2_isbn_unique] ON [custom].[book2] ([isbn]) WHERE [isbn] IS NOT NULL;",
       "",
       "CREATE TABLE [custom].[book2_tags] ([order] int identity(1,1) not null primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);",
       "",
@@ -214,7 +216,8 @@ export class Migration20191013214813 extends Migration {
     this.addSql('CREATE INDEX [author2_name_age_index] ON [custom].[author2] ([name], [age]);');
     this.addSql('CREATE UNIQUE INDEX [author2_name_email_unique] ON [custom].[author2] ([name], [email]) WHERE [name] IS NOT NULL AND [email] IS NOT NULL;');
 
-    this.addSql('CREATE TABLE [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null CONSTRAINT [book2_created_at_default] DEFAULT current_timestamp, [title] nvarchar(255) null CONSTRAINT [book2_title_default] DEFAULT \\'\\', [perex] text null, [price] numeric(8,2) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, CONSTRAINT [book2_pkey] PRIMARY KEY ([uuid_pk]));');
+    this.addSql('CREATE TABLE [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null CONSTRAINT [book2_created_at_default] DEFAULT current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null CONSTRAINT [book2_title_default] DEFAULT \\'\\', [perex] text null, [price] numeric(8,2) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, CONSTRAINT [book2_pkey] PRIMARY KEY ([uuid_pk]));');
+    this.addSql('CREATE UNIQUE INDEX [book2_isbn_unique] ON [custom].[book2] ([isbn]) WHERE [isbn] IS NOT NULL;');
 
     this.addSql('CREATE TABLE [custom].[book2_tags] ([order] int identity(1,1) not null primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);');
 
@@ -303,7 +306,8 @@ export class Migration20191013214813 extends Migration {
       "CREATE INDEX [author2_name_age_index] ON [custom].[author2] ([name], [age]);",
       "CREATE UNIQUE INDEX [author2_name_email_unique] ON [custom].[author2] ([name], [email]) WHERE [name] IS NOT NULL AND [email] IS NOT NULL;",
       "",
-      "CREATE TABLE [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null CONSTRAINT [book2_created_at_default] DEFAULT current_timestamp, [title] nvarchar(255) null CONSTRAINT [book2_title_default] DEFAULT '', [perex] text null, [price] numeric(8,2) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, CONSTRAINT [book2_pkey] PRIMARY KEY ([uuid_pk]));",
+      "CREATE TABLE [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null CONSTRAINT [book2_created_at_default] DEFAULT current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null CONSTRAINT [book2_title_default] DEFAULT '', [perex] text null, [price] numeric(8,2) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, CONSTRAINT [book2_pkey] PRIMARY KEY ([uuid_pk]));",
+      "CREATE UNIQUE INDEX [book2_isbn_unique] ON [custom].[book2] ([isbn]) WHERE [isbn] IS NOT NULL;",
       "",
       "CREATE TABLE [custom].[book2_tags] ([order] int identity(1,1) not null primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);",
       "",

--- a/tests/features/migrations/__snapshots__/Migrator.postgres.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.postgres.test.ts.snap
@@ -30,7 +30,8 @@ export class Migration20191013214813 extends Migration {
     this.addSql('create index "author2_name_age_index" on "custom"."author2" ("name", "age");');
     this.addSql('alter table "custom"."author2" add constraint "author2_name_email_unique" unique ("name", "email");');
 
-    this.addSql('create table "custom"."book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "title" varchar(255) null default \\'\\', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));');
+    this.addSql('create table "custom"."book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "isbn" char(13) null, "title" varchar(255) null default \\'\\', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));');
+    this.addSql('alter table "custom"."book2" add constraint "book2_isbn_unique" unique ("isbn");');
     this.addSql('create index "book2_title_index" on "custom"."book2" using gin(to_tsvector(\\'simple\\', "title"));');
 
     this.addSql('create table "custom"."book2_tags" ("order" serial primary key, "book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null);');
@@ -120,7 +121,8 @@ export class Migration20191013214813 extends Migration {
       "create index "author2_name_age_index" on "custom"."author2" ("name", "age");",
       "alter table "custom"."author2" add constraint "author2_name_email_unique" unique ("name", "email");",
       "",
-      "create table "custom"."book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "title" varchar(255) null default '', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));",
+      "create table "custom"."book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "isbn" char(13) null, "title" varchar(255) null default '', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));",
+      "alter table "custom"."book2" add constraint "book2_isbn_unique" unique ("isbn");",
       "create index "book2_title_index" on "custom"."book2" using gin(to_tsvector('simple', "title"));",
       "",
       "create table "custom"."book2_tags" ("order" serial primary key, "book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null);",
@@ -216,7 +218,8 @@ export class Migration20191013214813 extends Migration {
     this.addSql('create index "author2_name_age_index" on "custom"."author2" ("name", "age");');
     this.addSql('alter table "custom"."author2" add constraint "author2_name_email_unique" unique ("name", "email");');
 
-    this.addSql('create table "custom"."book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "title" varchar(255) null default \\'\\', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));');
+    this.addSql('create table "custom"."book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "isbn" char(13) null, "title" varchar(255) null default \\'\\', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));');
+    this.addSql('alter table "custom"."book2" add constraint "book2_isbn_unique" unique ("isbn");');
     this.addSql('create index "book2_title_index" on "custom"."book2" using gin(to_tsvector(\\'simple\\', "title"));');
 
     this.addSql('create table "custom"."book2_tags" ("order" serial primary key, "book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null);');
@@ -306,7 +309,8 @@ export class Migration20191013214813 extends Migration {
       "create index "author2_name_age_index" on "custom"."author2" ("name", "age");",
       "alter table "custom"."author2" add constraint "author2_name_email_unique" unique ("name", "email");",
       "",
-      "create table "custom"."book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "title" varchar(255) null default '', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));",
+      "create table "custom"."book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "isbn" char(13) null, "title" varchar(255) null default '', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));",
+      "alter table "custom"."book2" add constraint "book2_isbn_unique" unique ("isbn");",
       "create index "book2_title_index" on "custom"."book2" using gin(to_tsvector('simple', "title"));",
       "",
       "create table "custom"."book2_tags" ("order" serial primary key, "book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null);",

--- a/tests/features/migrations/__snapshots__/Migrator.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.test.ts.snap
@@ -76,7 +76,8 @@ export class Migration20191013214813 extends Migration {
     this.addSql('alter table \`author2\` add index \`author2_name_age_index\`(\`name\`, \`age\`);');
     this.addSql('alter table \`author2\` add unique \`author2_name_email_unique\`(\`name\`, \`email\`);');
 
-    this.addSql('create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`title\` varchar(255) null default \\'\\', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;');
+    this.addSql('create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`isbn\` char(13) null, \`title\` varchar(255) null default \\'\\', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;');
+    this.addSql('alter table \`book2\` add unique \`book2_isbn_unique\`(\`isbn\`);');
     this.addSql('alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);');
     this.addSql('alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);');
     this.addSql('alter table \`book2\` add fulltext index \`book2_title_index\`(\`title\`);');
@@ -224,7 +225,8 @@ export class Migration20191013214813 extends Migration {
       "alter table \`author2\` add index \`author2_name_age_index\`(\`name\`, \`age\`);",
       "alter table \`author2\` add unique \`author2_name_email_unique\`(\`name\`, \`email\`);",
       "",
-      "create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`title\` varchar(255) null default '', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;",
+      "create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`isbn\` char(13) null, \`title\` varchar(255) null default '', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;",
+      "alter table \`book2\` add unique \`book2_isbn_unique\`(\`isbn\`);",
       "alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);",
       "alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);",
       "alter table \`book2\` add fulltext index \`book2_title_index\`(\`title\`);",
@@ -568,7 +570,8 @@ export class Migration20191013214813 extends Migration {
     this.addSql('alter table \`author2\` add index \`author2_name_age_index\`(\`name\`, \`age\`);');
     this.addSql('alter table \`author2\` add unique \`author2_name_email_unique\`(\`name\`, \`email\`);');
 
-    this.addSql('create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`title\` varchar(255) null default \\'\\', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;');
+    this.addSql('create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`isbn\` char(13) null, \`title\` varchar(255) null default \\'\\', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;');
+    this.addSql('alter table \`book2\` add unique \`book2_isbn_unique\`(\`isbn\`);');
     this.addSql('alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);');
     this.addSql('alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);');
     this.addSql('alter table \`book2\` add fulltext index \`book2_title_index\`(\`title\`);');
@@ -716,7 +719,8 @@ export class Migration20191013214813 extends Migration {
       "alter table \`author2\` add index \`author2_name_age_index\`(\`name\`, \`age\`);",
       "alter table \`author2\` add unique \`author2_name_email_unique\`(\`name\`, \`email\`);",
       "",
-      "create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`title\` varchar(255) null default '', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;",
+      "create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`isbn\` char(13) null, \`title\` varchar(255) null default '', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;",
+      "alter table \`book2\` add unique \`book2_isbn_unique\`(\`isbn\`);",
       "alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);",
       "alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);",
       "alter table \`book2\` add fulltext index \`book2_title_index\`(\`title\`);",

--- a/tests/features/multiple-schemas/__snapshots__/multiple-schemas.mssql.test.ts.snap
+++ b/tests/features/multiple-schemas/__snapshots__/multiple-schemas.mssql.test.ts.snap
@@ -12,7 +12,7 @@ export class Book {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, nullable: true })
+  @Property({ nullable: true })
   name?: string;
 
   @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
@@ -34,7 +34,7 @@ export class BookTag {
   @PrimaryKey()
   id!: number;
 
-  @Property({ length: 255, nullable: true })
+  @Property({ nullable: true })
   name?: string;
 
 }

--- a/tests/features/partial-loading/partial-loading-exclude.mysql.test.ts
+++ b/tests/features/partial-loading/partial-loading-exclude.mysql.test.ts
@@ -125,7 +125,7 @@ describe('partial loading via `exclude` (mysql)', () => {
     expect(r1[0].books[0].author).toBeDefined();
     expect(mock.mock.calls).toHaveLength(2);
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `a0`.`created_at`, `a0`.`updated_at`, `a0`.`email`, `a0`.`age`, `a0`.`terms_accepted`, `a0`.`optional`, `a0`.`identities`, `a0`.`born`, `a0`.`born_time`, `a0`.`favourite_book_uuid_pk`, `a0`.`favourite_author_id`, `a0`.`identity`, `a1`.`author_id` as `a1__author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id` where `a0`.`id` = ?');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`author_id` is not null and `b0`.`author_id` in (?) order by `b0`.`title` asc');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`author_id` is not null and `b0`.`author_id` in (?) order by `b0`.`title` asc');
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -136,7 +136,7 @@ describe('partial loading via `exclude` (mysql)', () => {
     expect(r0[0].name).toBeUndefined();
     expect(r0[0].books[0].uuid).toBe(god.books[0].uuid);
     expect(r0[0].books[0].title).toBe('Bible 1');
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `a0`.`created_at`, `a0`.`updated_at`, `a0`.`email`, `a0`.`age`, `a0`.`terms_accepted`, `a0`.`optional`, `a0`.`identities`, `a0`.`born`, `a0`.`born_time`, `a0`.`favourite_book_uuid_pk`, `a0`.`favourite_author_id`, `a0`.`identity`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`title` as `b1__title`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` from `author2` as `a0` left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` where `a0`.`id` = ? order by `b1`.`title` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `a0`.`created_at`, `a0`.`updated_at`, `a0`.`email`, `a0`.`age`, `a0`.`terms_accepted`, `a0`.`optional`, `a0`.`identities`, `a0`.`born`, `a0`.`born_time`, `a0`.`favourite_book_uuid_pk`, `a0`.`favourite_author_id`, `a0`.`identity`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` from `author2` as `a0` left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` where `a0`.`id` = ? order by `b1`.`title` asc');
     // @ts-expect-error
     expect(r0[0].books[0].price).toBeUndefined();
     expect(r0[0].books[0].author).toBeDefined();
@@ -183,7 +183,7 @@ describe('partial loading via `exclude` (mysql)', () => {
     // @ts-expect-error
     expect(r1[0].author.name).toBeUndefined();
     expect(r1[0].author.email).toBeDefined();
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `a1`.`id` as `a1__id`, `a1`.`created_at` as `a1__created_at`, `a1`.`updated_at` as `a1__updated_at`, `a1`.`email` as `a1__email`, `a1`.`age` as `a1__age`, `a1`.`terms_accepted` as `a1__terms_accepted`, `a1`.`optional` as `a1__optional`, `a1`.`identities` as `a1__identities`, `a1`.`born` as `a1__born`, `a1`.`born_time` as `a1__born_time`, `a1`.`favourite_book_uuid_pk` as `a1__favourite_book_uuid_pk`, `a1`.`favourite_author_id` as `a1__favourite_author_id`, `a1`.`identity` as `a1__identity`, `t2`.`id` as `t2__id` from `book2` as `b0` left join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` where `b0`.`uuid_pk` = ?');
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `a1`.`id` as `a1__id`, `a1`.`created_at` as `a1__created_at`, `a1`.`updated_at` as `a1__updated_at`, `a1`.`email` as `a1__email`, `a1`.`age` as `a1__age`, `a1`.`terms_accepted` as `a1__terms_accepted`, `a1`.`optional` as `a1__optional`, `a1`.`identities` as `a1__identities`, `a1`.`born` as `a1__born`, `a1`.`born_time` as `a1__born_time`, `a1`.`favourite_book_uuid_pk` as `a1__favourite_book_uuid_pk`, `a1`.`favourite_author_id` as `a1__favourite_author_id`, `a1`.`identity` as `a1__identity`, `t2`.`id` as `t2__id` from `book2` as `b0` left join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` where `b0`.`uuid_pk` = ?');
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -203,7 +203,7 @@ describe('partial loading via `exclude` (mysql)', () => {
     // @ts-expect-error
     expect(r2[0].author.name).toBeUndefined();
     expect(r2[0].author.email).toBeDefined();
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`title`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`uuid_pk` = ?');
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`uuid_pk` = ?');
     expect(mock.mock.calls[1][0]).toMatch('select `a0`.`id`, `a0`.`created_at`, `a0`.`updated_at`, `a0`.`email`, `a0`.`age`, `a0`.`terms_accepted`, `a0`.`optional`, `a0`.`identities`, `a0`.`born`, `a0`.`born_time`, `a0`.`favourite_book_uuid_pk`, `a0`.`favourite_author_id`, `a0`.`identity`, `a1`.`author_id` as `a1__author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id` where `a0`.`id` in (?)');
     orm.em.clear();
     mock.mock.calls.length = 0;
@@ -226,7 +226,7 @@ describe('partial loading via `exclude` (mysql)', () => {
     expect(r1[0].books[0].price).toBeUndefined();
     // @ts-expect-error
     expect(r1[0].books[0].author).toBeUndefined();
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`title` as `b1__title`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`publisher_id` as `b1__publisher_id` from `book_tag2` as `b0` left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` order by `b2`.`order` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`publisher_id` as `b1__publisher_id` from `book_tag2` as `b0` left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` order by `b2`.`order` asc');
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -244,7 +244,7 @@ describe('partial loading via `exclude` (mysql)', () => {
     // @ts-expect-error
     expect(r2[0].books[0].author).toBeUndefined();
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name` from `book_tag2` as `b0` where `b0`.`name` = ?');
-    expect(mock.mock.calls[1][0]).toMatch('select `b1`.price * 1.19 as `price_taxed`, `b1`.`publisher_id`, `b1`.`meta`, `b1`.`double`, `b1`.`title`, `b1`.`created_at`, `b1`.`uuid_pk`, `b0`.`book_tag2_id` as `fk__book_tag2_id`, `b0`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `b2`.`id` as `b2__id` from `book2_tags` as `b0` inner join `book2` as `b1` on `b0`.`book2_uuid_pk` = `b1`.`uuid_pk` left join `test2` as `b2` on `b1`.`uuid_pk` = `b2`.`book_uuid_pk` where `b0`.`book_tag2_id` in (?) order by `b0`.`order` asc');
+    expect(mock.mock.calls[1][0]).toMatch('select `b1`.price * 1.19 as `price_taxed`, `b1`.`publisher_id`, `b1`.`meta`, `b1`.`double`, `b1`.`title`, `b1`.`isbn`, `b1`.`created_at`, `b1`.`uuid_pk`, `b0`.`book_tag2_id` as `fk__book_tag2_id`, `b0`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `b2`.`id` as `b2__id` from `book2_tags` as `b0` inner join `book2` as `b1` on `b0`.`book2_uuid_pk` = `b1`.`uuid_pk` left join `test2` as `b2` on `b1`.`uuid_pk` = `b2`.`book_uuid_pk` where `b0`.`book_tag2_id` in (?) order by `b0`.`order` asc');
   });
 
   test('partial nested loading (m:n -> m:1)', async () => {
@@ -268,7 +268,7 @@ describe('partial loading via `exclude` (mysql)', () => {
     expect(r1[0].books[0].author.name).toBeUndefined();
     expect(r1[0].books[0].author.email).toBe(god.email);
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name` from `book_tag2` as `b0`');
-    expect(mock.mock.calls[1][0]).toMatch('select `b1`.price * 1.19 as `price_taxed`, `b1`.`publisher_id`, `b1`.`author_id`, `b1`.`meta`, `b1`.`double`, `b1`.`title`, `b1`.`created_at`, `b1`.`uuid_pk`, `b0`.`book_tag2_id` as `fk__book_tag2_id`, `b0`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `b2`.`id` as `b2__id` from `book2_tags` as `b0` inner join `book2` as `b1` on `b0`.`book2_uuid_pk` = `b1`.`uuid_pk` left join `test2` as `b2` on `b1`.`uuid_pk` = `b2`.`book_uuid_pk` where `b0`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) order by `b0`.`order` asc');
+    expect(mock.mock.calls[1][0]).toMatch('select `b1`.price * 1.19 as `price_taxed`, `b1`.`publisher_id`, `b1`.`author_id`, `b1`.`meta`, `b1`.`double`, `b1`.`title`, `b1`.`isbn`, `b1`.`created_at`, `b1`.`uuid_pk`, `b0`.`book_tag2_id` as `fk__book_tag2_id`, `b0`.`book2_uuid_pk` as `fk__book2_uuid_pk`, `b2`.`id` as `b2__id` from `book2_tags` as `b0` inner join `book2` as `b1` on `b0`.`book2_uuid_pk` = `b1`.`uuid_pk` left join `test2` as `b2` on `b1`.`uuid_pk` = `b2`.`book_uuid_pk` where `b0`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) order by `b0`.`order` asc');
     expect(mock.mock.calls[2][0]).toMatch('select `a0`.`id`, `a0`.`created_at`, `a0`.`updated_at`, `a0`.`email`, `a0`.`age`, `a0`.`terms_accepted`, `a0`.`optional`, `a0`.`identities`, `a0`.`born`, `a0`.`born_time`, `a0`.`favourite_book_uuid_pk`, `a0`.`favourite_author_id`, `a0`.`identity`, `a1`.`author_id` as `a1__author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id` where `a0`.`id` in (?)');
     orm.em.clear();
     mock.mock.calls.length = 0;
@@ -290,7 +290,7 @@ describe('partial loading via `exclude` (mysql)', () => {
     expect(r2[0].books[0].author.name).toBeUndefined();
     expect(r2[0].books[0].author.email).toBe(god.email);
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`title` as `b1__title`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a3`.`id` as `a3__id`, `a3`.`created_at` as `a3__created_at`, `a3`.`updated_at` as `a3__updated_at`, `a3`.`email` as `a3__email`, `a3`.`age` as `a3__age`, `a3`.`terms_accepted` as `a3__terms_accepted`, `a3`.`optional` as `a3__optional`, `a3`.`identities` as `a3__identities`, `a3`.`born` as `a3__born`, `a3`.`born_time` as `a3__born_time`, `a3`.`favourite_book_uuid_pk` as `a3__favourite_book_uuid_pk`, `a3`.`favourite_author_id` as `a3__favourite_author_id`, `a3`.`identity` as `a3__identity` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a3`.`id` as `a3__id`, `a3`.`created_at` as `a3__created_at`, `a3`.`updated_at` as `a3__updated_at`, `a3`.`email` as `a3__email`, `a3`.`age` as `a3__age`, `a3`.`terms_accepted` as `a3__terms_accepted`, `a3`.`optional` as `a3__optional`, `a3`.`identities` as `a3__identities`, `a3`.`born` as `a3__born`, `a3`.`born_time` as `a3__born_time`, `a3`.`favourite_book_uuid_pk` as `a3__favourite_book_uuid_pk`, `a3`.`favourite_author_id` as `a3__favourite_author_id`, `a3`.`identity` as `a3__identity` ' +
       'from `book_tag2` as `b0` ' +
       'left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` ' +
       'left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` ' +

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.mariadb.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.mariadb.test.ts.snap
@@ -45,7 +45,8 @@ alter table \`author2\` add index \`custom_idx_name_123\`(\`name\`);
 alter table \`author2\` add index \`author2_name_age_index\`(\`name\`, \`age\`);
 alter table \`author2\` add unique \`author2_name_email_unique\`(\`name\`, \`email\`);
 
-create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`title\` varchar(255) null default '', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;
+create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`isbn\` char(13) null, \`title\` varchar(255) null default '', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`book2\` add unique \`book2_isbn_unique\`(\`isbn\`);
 alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);
 alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);
 alter table \`book2\` add fulltext index \`book2_title_index\`(\`title\`);

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.mssql.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.mssql.test.ts.snap
@@ -38,7 +38,8 @@ CREATE INDEX [custom_idx_name_123] ON [author2] ([name]);
 CREATE INDEX [author2_name_age_index] ON [author2] ([name], [age]);
 CREATE UNIQUE INDEX [author2_name_email_unique] ON [author2] ([name], [email]) WHERE [name] IS NOT NULL AND [email] IS NOT NULL;
 
-CREATE TABLE [book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null CONSTRAINT [book2_created_at_default] DEFAULT current_timestamp, [title] nvarchar(255) null CONSTRAINT [book2_title_default] DEFAULT '', [perex] text null, [price] numeric(8,2) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, CONSTRAINT [book2_pkey] PRIMARY KEY ([uuid_pk]));
+CREATE TABLE [book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null CONSTRAINT [book2_created_at_default] DEFAULT current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null CONSTRAINT [book2_title_default] DEFAULT '', [perex] text null, [price] numeric(8,2) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, CONSTRAINT [book2_pkey] PRIMARY KEY ([uuid_pk]));
+CREATE UNIQUE INDEX [book2_isbn_unique] ON [book2] ([isbn]) WHERE [isbn] IS NOT NULL;
 
 CREATE TABLE [book2_tags] ([order] int identity(1,1) not null primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);
 

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.mysql.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.mysql.test.ts.snap
@@ -45,7 +45,8 @@ alter table \`author2\` add index \`custom_idx_name_123\`(\`name\`);
 alter table \`author2\` add index \`author2_name_age_index\`(\`name\`, \`age\`);
 alter table \`author2\` add unique \`author2_name_email_unique\`(\`name\`, \`email\`);
 
-create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`title\` varchar(255) null default '', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;
+create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`isbn\` char(13) null, \`title\` varchar(255) null default '', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`book2\` add unique \`book2_isbn_unique\`(\`isbn\`);
 alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);
 alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);
 alter table \`book2\` add fulltext index \`book2_title_index\`(\`title\`);

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.mysql2.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.mysql2.test.ts.snap
@@ -42,7 +42,8 @@ alter table \`author2\` add index \`custom_idx_name_123\`(\`name\`);
 alter table \`author2\` add index \`author2_name_age_index\`(\`name\`, \`age\`);
 alter table \`author2\` add unique \`author2_name_email_unique\`(\`name\`, \`email\`);
 
-create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`title\` varchar(255) null default '', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;
+create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`isbn\` char(13) null, \`title\` varchar(255) null default '', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`book2\` add unique \`book2_isbn_unique\`(\`isbn\`);
 alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);
 alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);
 alter table \`book2\` add fulltext index \`book2_title_index\`(\`title\`);
@@ -217,7 +218,8 @@ alter table \`author2\` add index \`custom_idx_name_123\`(\`name\`);
 alter table \`author2\` add index \`author2_name_age_index\`(\`name\`, \`age\`);
 alter table \`author2\` add unique \`author2_name_email_unique\`(\`name\`, \`email\`);
 
-create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`title\` varchar(255) null default '', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;
+create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`isbn\` char(13) null, \`title\` varchar(255) null default '', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`book2\` add unique \`book2_isbn_unique\`(\`isbn\`);
 alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);
 alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);
 alter table \`book2\` add fulltext index \`book2_title_index\`(\`title\`);

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.postgres.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.postgres.test.ts.snap
@@ -29,7 +29,8 @@ create index "custom_idx_name_123" on "author2" ("name");
 create index "author2_name_age_index" on "author2" ("name", "age");
 alter table "author2" add constraint "author2_name_email_unique" unique ("name", "email");
 
-create table "book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "title" varchar(255) null default '', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));
+create table "book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "isbn" char(13) null, "title" varchar(255) null default '', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));
+alter table "book2" add constraint "book2_isbn_unique" unique ("isbn");
 create index "book2_title_index" on "public"."book2" using gin(to_tsvector('simple', "title"));
 
 create table "book2_tags" ("order" serial primary key, "book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null);
@@ -157,7 +158,8 @@ create index "custom_idx_name_123" on "author2" ("name");
 create index "author2_name_age_index" on "author2" ("name", "age");
 alter table "author2" add constraint "author2_name_email_unique" unique ("name", "email");
 
-create table "book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "title" varchar(255) null default '', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));
+create table "book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "isbn" char(13) null, "title" varchar(255) null default '', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));
+alter table "book2" add constraint "book2_isbn_unique" unique ("isbn");
 create index "book2_title_index" on "public"."book2" using gin(to_tsvector('simple', "title"));
 
 create table "book2_tags" ("order" serial primary key, "book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null);

--- a/tests/features/schema-generator/__snapshots__/custom-type-mapping.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/custom-type-mapping.test.ts.snap
@@ -21,7 +21,8 @@ create index "custom_idx_name_123" on "author2" ("name");
 create index "author2_name_age_index" on "author2" ("name", "age");
 alter table "author2" add constraint "author2_name_email_unique" unique ("name", "email");
 
-create table "book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "title" text null default '', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));
+create table "book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "isbn" char(13) null, "title" text null default '', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));
+alter table "book2" add constraint "book2_isbn_unique" unique ("isbn");
 create index "book2_title_index" on "public"."book2" using gin(to_tsvector('simple', "title"));
 
 create table "book2_tags" ("order" serial primary key, "book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null);

--- a/tests/features/virtual-entities/__snapshots__/virtual-entities.postgres.test.ts.snap
+++ b/tests/features/virtual-entities/__snapshots__/virtual-entities.postgres.test.ts.snap
@@ -21,7 +21,8 @@ create index "custom_idx_name_123" on "author2" ("name");
 create index "author2_name_age_index" on "author2" ("name", "age");
 alter table "author2" add constraint "author2_name_email_unique" unique ("name", "email");
 
-create table "book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "title" varchar(255) null default '', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));
+create table "book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "isbn" char(13) null, "title" varchar(255) null default '', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));
+alter table "book2" add constraint "book2_isbn_unique" unique ("isbn");
 create index "book2_title_index" on "public"."book2" using gin(to_tsvector('simple', "title"));
 
 create table "book2_tags" ("order" serial primary key, "book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null);

--- a/tests/mssql-schema.sql
+++ b/tests/mssql-schema.sql
@@ -71,7 +71,8 @@ CREATE INDEX [custom_idx_name_123] ON [author2] ([name]);
 CREATE INDEX [author2_name_age_index] ON [author2] ([name], [age]);
 CREATE UNIQUE INDEX [author2_name_email_unique] ON [author2] ([name], [email]) WHERE [name] IS NOT NULL AND [email] IS NOT NULL;
 
-CREATE TABLE [book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null CONSTRAINT [book2_created_at_default] default current_timestamp, [title] nvarchar(255) null CONSTRAINT [book2_title_default] default '', [perex] text null, [price] float(24) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, CONSTRAINT [book2_pkey] PRIMARY KEY ([uuid_pk]));
+CREATE TABLE [book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null CONSTRAINT [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null CONSTRAINT [book2_title_default] default '', [perex] text null, [price] float(24) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, CONSTRAINT [book2_pkey] PRIMARY KEY ([uuid_pk]));
+CREATE UNIQUE INDEX [book2_isbn_unique] ON [book2] ([isbn]) WHERE [isbn] IS NOT NULL;
 
 CREATE TABLE [test2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) null, [book_uuid_pk] uniqueidentifier null, [version] int not null default 1);
 CREATE UNIQUE INDEX [test2_book_uuid_pk_unique] ON [test2] ([book_uuid_pk]) WHERE [book_uuid_pk] IS NOT NULL;

--- a/tests/mysql-schema.sql
+++ b/tests/mysql-schema.sql
@@ -94,8 +94,9 @@ alter table `author2` add index `custom_idx_name_123`(`name`);
 alter table `author2` add index `author2_name_age_index`(`name`, `age`);
 alter table `author2` add unique `author2_name_email_unique`(`name`, `email`);
 
-create table `book2` (`uuid_pk` varchar(36) not null, `created_at` datetime(3) not null default current_timestamp(3), `title` varchar(255) null default '', `perex` text null, `price` decimal(8, 2) null, `double` double null, `meta` json null, `author_id` int(10) unsigned not null, `publisher_id` int(10) unsigned null, `foo` varchar(255) null default 'lol') default character set utf8mb4 engine = InnoDB;
+create table `book2` (`uuid_pk` varchar(36) not null, `created_at` datetime(3) not null default current_timestamp(3), `isbn` char(13) null, `title` varchar(255) null default '', `perex` text null, `price` decimal(8, 2) null, `double` double null, `meta` json null, `author_id` int(10) unsigned not null, `publisher_id` int(10) unsigned null, `foo` varchar(255) null default 'lol') default character set utf8mb4 engine = InnoDB;
 alter table `book2` add primary key `book2_pkey`(`uuid_pk`);
+alter table `book2` add unique `book2_isbn_unique`(`isbn`);
 alter table `book2` add index `book2_author_id_index`(`author_id`);
 alter table `book2` add index `book2_publisher_id_index`(`publisher_id`);
 alter table `book2` add fulltext index `book2_title_index`(`title`);

--- a/tests/postgre-schema.sql
+++ b/tests/postgre-schema.sql
@@ -59,8 +59,9 @@ comment on table "address2" is 'This is address table';
 comment on column "address2"."value" is 'This is address property';
 alter table "address2" add constraint "address2_pkey" primary key ("author_id");
 
-create table "book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "title" varchar(255) null default '', "perex" text null, "price" numeric(8, 2) null, "double" numeric null, "meta" jsonb null, "author_id" int4 not null, "publisher_id" int4 null, "foo" varchar(255) null default 'lol');
+create table "book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "isbn" char(13) null, "title" varchar(255) null default '', "perex" text null, "price" numeric(8, 2) null, "double" numeric null, "meta" jsonb null, "author_id" int4 not null, "publisher_id" int4 null, "foo" varchar(255) null default 'lol');
 alter table "book2" add constraint "book2_pkey" primary key ("uuid_pk");
+alter table "book2" add constraint "book_isbn_unique" unique ("isbn");
 
 create table "test2" ("id" serial primary key, "name" varchar(255) null, "book_uuid_pk" uuid null, "parent_id" int4 null, "version" int4 not null default 1, "path" polygon null);
 alter table "test2" add constraint "test2_book_uuid_pk_unique" unique ("book_uuid_pk");


### PR DESCRIPTION
The name "character" was picked to be different from the regular "char" type,
while still having precedent (that being alias of "char" in postgresql).

The char length is set to default of 1, to avoid excessive memory usage,
while still providing a default, as required.

For sqlite, this type is aliased to "text", just like "string".
For mssql, "character" is aliased to "nchar", to be consistent with "string" being "nvarchar",
while "char" means the native "char" type,
to be consistent with "varchar" meaning the native "varchar".
For postgresql, the "bpchar" type is also supported as an alias to "char"/"character".
