### PR TITLE
fix(mssql): add proper support for MSSQL's native "varchar" type

### DIFF
--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -2,6 +2,7 @@ import {
   AbstractSqlPlatform,
   type Dictionary,
   type EntityMetadata,
+  type EntityProperty,
   type IDatabaseDriver,
   type EntityManager,
   type MikroORM,
@@ -92,9 +93,9 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
     return 'nvarchar(max)';
   }
 
-  override getEnumTypeDeclarationSQL(column: { fieldNames: string[]; items?: unknown[]; length?: number }): string {
+  override getEnumTypeDeclarationSQL(column: { items?: unknown[]; fieldNames: string[]; length?: number; unsigned?: boolean; autoincrement?: boolean }): string {
     if (column.items?.every(item => Utils.isString(item))) {
-      return this.getVarcharTypeDeclarationSQL({ length: 100, ...column });
+      return Type.getType(UnicodeStringType).getColumnType({ length: 100, ...column } as EntityProperty, this);
     }
 
     /* istanbul ignore next */
@@ -122,10 +123,6 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
 
   override getDefaultSchemaName(): string | undefined {
     return 'dbo';
-  }
-
-  override getVarcharTypeDeclarationSQL(column: { length?: number }): string {
-    return `nvarchar(${column.length ?? 255})`;
   }
 
   override getUuidTypeDeclarationSQL(column: { length?: number }): string {

--- a/packages/mssql/src/UnicodeStringType.ts
+++ b/packages/mssql/src/UnicodeStringType.ts
@@ -1,4 +1,4 @@
-import { Type, type EntityProperty } from '@mikro-orm/core';
+import { Type } from '@mikro-orm/core';
 
 export class UnicodeString {
 
@@ -26,7 +26,7 @@ export class UnicodeString {
 
 export class UnicodeStringType extends Type<string | null, string | null> {
 
-  override getColumnType(prop: EntityProperty) {
+  override getColumnType(prop: { length?: number }) {
     const length = prop.length === -1 ? 'max' : (prop.length ?? 255);
     return `nvarchar(${length})`;
   }

--- a/tests/EntityHelper.mysql.test.ts
+++ b/tests/EntityHelper.mysql.test.ts
@@ -50,6 +50,7 @@ describe('EntityHelperMySql', () => {
         }, // circular reference breaks the cycle
         id: 1,
         name: 'fz',
+        code: 'fz',
         version: a.baz!.version,
       },
       fooBar: null,
@@ -91,6 +92,7 @@ describe('EntityHelperMySql', () => {
         }, // circular reference breaks the cycle
         id: 1,
         name: 'fz',
+        code: 'fz',
         version: a.baz!.version,
       },
       fooBar: null,

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -293,7 +293,7 @@ describe('QueryBuilder', () => {
       .where({ 'fz.name': 'baz' })
       .limit(1);
     const sql = 'select `fb1`.*, ' +
-      '`fz`.`id` as `fz__id`, `fz`.`name` as `fz__name`, `fz`.`version` as `fz__version`, ' +
+      '`fz`.`id` as `fz__id`, `fz`.`name` as `fz__name`, `fz`.`code` as `fz__code`, `fz`.`version` as `fz__version`, ' +
       '`fb2`.`id` as `fb2__id`, `fb2`.`name` as `fb2__name`, `fb2`.`name with space` as `fb2__name with space`, `fb2`.`baz_id` as `fb2__baz_id`, `fb2`.`foo_bar_id` as `fb2__foo_bar_id`, `fb2`.`version` as `fb2__version`, `fb2`.`blob` as `fb2__blob`, `fb2`.`blob2` as `fb2__blob2`, `fb2`.`array` as `fb2__array`, `fb2`.`object_property` as `fb2__object_property`, (select 123) as `fb2__random`, ' +
       '(select 123) as `random` from `foo_bar2` as `fb1` ' +
       'inner join `foo_baz2` as `fz` on `fb1`.`baz_id` = `fz`.`id` ' +
@@ -313,7 +313,7 @@ describe('QueryBuilder', () => {
       .setFlag(QueryFlag.PAGINATE)
       .limit(1);
     const sql = 'select `fb1`.*, ' +
-      '`fz`.`id` as `fz__id`, `fz`.`name` as `fz__name`, `fz`.`version` as `fz__version`, ' +
+      '`fz`.`id` as `fz__id`, `fz`.`name` as `fz__name`, `fz`.`code` as `fz__code`, `fz`.`version` as `fz__version`, ' +
       '`fb2`.`id` as `fb2__id`, `fb2`.`name` as `fb2__name`, `fb2`.`name with space` as `fb2__name with space`, `fb2`.`baz_id` as `fb2__baz_id`, `fb2`.`foo_bar_id` as `fb2__foo_bar_id`, `fb2`.`version` as `fb2__version`, `fb2`.`blob` as `fb2__blob`, `fb2`.`blob2` as `fb2__blob2`, `fb2`.`array` as `fb2__array`, `fb2`.`object_property` as `fb2__object_property`, (select 123) as `fb2__random`, ' +
       '(select 123) as `random` from `foo_bar2` as `fb1` ' +
       'inner join `foo_baz2` as `fz` on `fb1`.`baz_id` = `fz`.`id` ' +
@@ -2639,7 +2639,7 @@ describe('QueryBuilder', () => {
         .where({ 'fz.name': 'baz' })
         .limit(1);
       const sql = 'select distinct on ("fb1"."id") "fb1".*, ' +
-        '"fz"."id" as "fz__id", "fz"."name" as "fz__name", "fz"."version" as "fz__version", ' +
+        '"fz"."id" as "fz__id", "fz"."name" as "fz__name", "fz"."code" as "fz__code", "fz"."version" as "fz__version", ' +
         '"fb2"."id" as "fb2__id", "fb2"."name" as "fb2__name", "fb2"."name with space" as "fb2__name with space", "fb2"."baz_id" as "fb2__baz_id", "fb2"."foo_bar_id" as "fb2__foo_bar_id", "fb2"."version" as "fb2__version", "fb2"."blob" as "fb2__blob", "fb2"."blob2" as "fb2__blob2", "fb2"."array" as "fb2__array", "fb2"."object_property" as "fb2__object_property", (select 123) as "fb2__random", ' +
         '(select 123) as "random" from "foo_bar2" as "fb1" ' +
         'inner join "foo_baz2" as "fz" on "fb1"."baz_id" = "fz"."id" ' +
@@ -2706,7 +2706,7 @@ describe('QueryBuilder', () => {
         .where({ 'fz.name': 'baz' })
         .limit(1);
       const sql = 'select distinct "fb1".*, ' +
-        '"fz"."id" as "fz__id", "fz"."name" as "fz__name", "fz"."version" as "fz__version", ' +
+        '"fz"."id" as "fz__id", "fz"."name" as "fz__name", "fz"."code" as "fz__code", "fz"."version" as "fz__version", ' +
         '"fb2"."id" as "fb2__id", "fb2"."name" as "fb2__name", "fb2"."name with space" as "fb2__name with space", "fb2"."baz_id" as "fb2__baz_id", "fb2"."foo_bar_id" as "fb2__foo_bar_id", "fb2"."version" as "fb2__version", "fb2"."blob" as "fb2__blob", "fb2"."blob2" as "fb2__blob2", "fb2"."array" as "fb2__array", "fb2"."object_property" as "fb2__object_property", (select 123) as "fb2__random", ' +
         '(select 123) as "random" from "foo_bar2" as "fb1" ' +
         'inner join "foo_baz2" as "fz" on "fb1"."baz_id" = "fz"."id" ' +

--- a/tests/entities-mssql/FooBaz2.ts
+++ b/tests/entities-mssql/FooBaz2.ts
@@ -10,6 +10,9 @@ export class FooBaz2 {
   @Property()
   name: string;
 
+  @Property({ type: 'varchar' })
+  code: string;
+
   @OneToOne(() => FooBar2, 'baz', { lazy: true })
   bar?: FooBar2;
 
@@ -18,6 +21,7 @@ export class FooBaz2 {
 
   constructor(name: string) {
     this.name = name;
+    this.code = name;
   }
 
 }

--- a/tests/entities-sql/FooBaz2.ts
+++ b/tests/entities-sql/FooBaz2.ts
@@ -10,6 +10,9 @@ export class FooBaz2 {
   @Property()
   name: string;
 
+  @Property({ type: 'varchar' })
+  code: string;
+
   @OneToOne(() => FooBar2, 'baz', { nullable: true })
   bar?: FooBar2;
 
@@ -18,6 +21,7 @@ export class FooBaz2 {
 
   constructor(name: string) {
     this.name = name;
+    this.code = name;
   }
 
 }

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.mssql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.mssql.test.ts.snap
@@ -305,6 +305,9 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
+  @Property({ type: 'string', columnType: 'varchar(255)' })
+  code!: string;
+
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp\` })
   version!: Date & Opt;
 

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.mysql.test.ts.snap
@@ -511,6 +511,7 @@ import { FooParam2 } from './FooParam2';
 export class FooBaz2 {
   id!: number;
   name!: string;
+  code!: string;
   version!: Date & Opt;
   bazInverse = new Collection<FooParam2>(this);
 }
@@ -520,6 +521,7 @@ export const FooBaz2Schema = new EntitySchema({
   properties: {
     id: { primary: true, type: 'integer' },
     name: { type: 'string', length: 255 },
+    code: { type: 'string', length: 255 },
     version: { type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` },
     bazInverse: { kind: '1:m', entity: () => FooParam2, mappedBy: 'baz' },
   },
@@ -1183,6 +1185,7 @@ export const FooBar2Schema = new EntitySchema({
 export class FooBaz2 {
   id!: number;
   name!: string;
+  code!: string;
   version!: Date & Opt;
 }
 
@@ -1191,6 +1194,7 @@ export const FooBaz2Schema = new EntitySchema({
   properties: {
     id: { primary: true, type: 'integer' },
     name: { type: 'string', length: 255 },
+    code: { type: 'string', length: 255 },
     version: { type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` },
   },
 });
@@ -1772,6 +1776,9 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
+  @Property({ length: 255 })
+  code!: string;
+
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
@@ -2330,6 +2337,9 @@ export class FooBaz2 {
 
   @Property({ length: 255 })
   name!: string;
+
+  @Property({ length: 255 })
+  code!: string;
 
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
@@ -2916,6 +2926,9 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
+  @Property({ length: 255 })
+  code!: string;
+
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
@@ -3440,6 +3453,9 @@ export class FooBaz2 {
 
   @Property({ length: 255 })
   name!: string;
+
+  @Property({ length: 255 })
+  code!: string;
 
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
@@ -3990,6 +4006,9 @@ export class FooBaz2 {
 
   @Property({ length: 255 })
   name!: string;
+
+  @Property({ length: 255 })
+  code!: string;
 
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
@@ -264,6 +264,9 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
+  @Property({ length: 255 })
+  code!: string;
+
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
@@ -654,6 +657,9 @@ export class FooBaz2 {
 
   @Property({ length: 255 })
   name!: string;
+
+  @Property({ length: 255 })
+  code!: string;
 
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;

--- a/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
@@ -391,6 +391,9 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
+  @Property({ length: 255 })
+  code!: string;
+
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
@@ -1191,6 +1194,7 @@ import { FooParam2 } from './FooParam2';
 export class FooBaz2 {
   id!: number;
   name!: string;
+  code!: string;
   version!: Date & Opt;
   bazInverse = new Collection<FooParam2>(this);
 }
@@ -1200,6 +1204,7 @@ export const FooBaz2Schema = new EntitySchema({
   properties: {
     id: { primary: true, type: 'integer' },
     name: { type: 'string', length: 255 },
+    code: { type: 'string', length: 255 },
     version: { type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` },
     bazInverse: { kind: '1:m', entity: () => FooParam2, mappedBy: 'baz' },
   },
@@ -1986,6 +1991,9 @@ export class FooBaz2 {
 
   @Property({ length: 255 })
   name!: string;
+
+  @Property({ length: 255 })
+  code!: string;
 
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
@@ -2806,6 +2814,7 @@ import { FooParam2 } from './FooParam2';
 export class FooBaz2 {
   id!: number;
   name!: string;
+  code!: string;
   version!: Date & Opt;
   bazInverse = new Collection<FooParam2>(this);
 }
@@ -2815,6 +2824,7 @@ export const FooBaz2Schema = new EntitySchema({
   properties: {
     id: { primary: true, type: 'integer' },
     name: { type: 'string', length: 255 },
+    code: { type: 'string', length: 255 },
     version: { type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` },
     bazInverse: { kind: '1:m', entity: () => FooParam2, mappedBy: 'baz' },
   },

--- a/tests/features/entity-generator/__snapshots__/ScalarPropsForFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/ScalarPropsForFks.mysql.test.ts.snap
@@ -371,6 +371,9 @@ export class FooBaz2 {
   @Property({ length: 255 })
   name!: string;
 
+  @Property({ length: 255 })
+  code!: string;
+
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
 
@@ -903,6 +906,9 @@ export class FooBaz2 {
 
   @Property({ length: 255 })
   name!: string;
+
+  @Property({ length: 255 })
+  code!: string;
 
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;

--- a/tests/features/migrations/__snapshots__/Migrator.mssql.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.mssql.test.ts.snap
@@ -10,7 +10,7 @@ export class Migration20191013214813 extends Migration {
     this.addSql('if (schema_id(\\'custom\\') is null) begin exec (\\'create schema [custom] authorization [dbo]\\') end;');
     this.addSql('CREATE TABLE [custom].[book_tag2] ([id] bigint identity(1,1) not null primary key, [name] nvarchar(50) not null);');
 
-    this.addSql('CREATE TABLE [custom].[foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [version] datetime2(3) not null CONSTRAINT [foo_baz2_version_default] DEFAULT current_timestamp);');
+    this.addSql('CREATE TABLE [custom].[foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null CONSTRAINT [foo_baz2_version_default] DEFAULT current_timestamp);');
 
     this.addSql('CREATE TABLE [custom].[foo_bar2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null CONSTRAINT [foo_bar2_version_default] DEFAULT current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);');
     this.addSql('CREATE UNIQUE INDEX [foo_bar2_baz_id_unique] ON [custom].[foo_bar2] ([baz_id]) WHERE [baz_id] IS NOT NULL;');
@@ -99,7 +99,7 @@ export class Migration20191013214813 extends Migration {
       "if (schema_id('custom') is null) begin exec ('create schema [custom] authorization [dbo]') end;",
       "CREATE TABLE [custom].[book_tag2] ([id] bigint identity(1,1) not null primary key, [name] nvarchar(50) not null);",
       "",
-      "CREATE TABLE [custom].[foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [version] datetime2(3) not null CONSTRAINT [foo_baz2_version_default] DEFAULT current_timestamp);",
+      "CREATE TABLE [custom].[foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null CONSTRAINT [foo_baz2_version_default] DEFAULT current_timestamp);",
       "",
       "CREATE TABLE [custom].[foo_bar2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null CONSTRAINT [foo_bar2_version_default] DEFAULT current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);",
       "CREATE UNIQUE INDEX [foo_bar2_baz_id_unique] ON [custom].[foo_bar2] ([baz_id]) WHERE [baz_id] IS NOT NULL;",
@@ -194,7 +194,7 @@ export class Migration20191013214813 extends Migration {
     this.addSql('if (schema_id(\\'custom\\') is null) begin exec (\\'create schema [custom] authorization [dbo]\\') end;');
     this.addSql('CREATE TABLE [custom].[book_tag2] ([id] bigint identity(1,1) not null primary key, [name] nvarchar(50) not null);');
 
-    this.addSql('CREATE TABLE [custom].[foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [version] datetime2(3) not null CONSTRAINT [foo_baz2_version_default] DEFAULT current_timestamp);');
+    this.addSql('CREATE TABLE [custom].[foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null CONSTRAINT [foo_baz2_version_default] DEFAULT current_timestamp);');
 
     this.addSql('CREATE TABLE [custom].[foo_bar2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null CONSTRAINT [foo_bar2_version_default] DEFAULT current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);');
     this.addSql('CREATE UNIQUE INDEX [foo_bar2_baz_id_unique] ON [custom].[foo_bar2] ([baz_id]) WHERE [baz_id] IS NOT NULL;');
@@ -283,7 +283,7 @@ export class Migration20191013214813 extends Migration {
       "if (schema_id('custom') is null) begin exec ('create schema [custom] authorization [dbo]') end;",
       "CREATE TABLE [custom].[book_tag2] ([id] bigint identity(1,1) not null primary key, [name] nvarchar(50) not null);",
       "",
-      "CREATE TABLE [custom].[foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [version] datetime2(3) not null CONSTRAINT [foo_baz2_version_default] DEFAULT current_timestamp);",
+      "CREATE TABLE [custom].[foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null CONSTRAINT [foo_baz2_version_default] DEFAULT current_timestamp);",
       "",
       "CREATE TABLE [custom].[foo_bar2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null CONSTRAINT [foo_bar2_version_default] DEFAULT current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);",
       "CREATE UNIQUE INDEX [foo_bar2_baz_id_unique] ON [custom].[foo_bar2] ([baz_id]) WHERE [baz_id] IS NOT NULL;",

--- a/tests/features/migrations/__snapshots__/Migrator.postgres.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.postgres.test.ts.snap
@@ -10,7 +10,7 @@ export class Migration20191013214813 extends Migration {
     this.addSql('create schema if not exists "custom";');
     this.addSql('create table "custom"."book_tag2" ("id" bigserial primary key, "name" varchar(50) not null);');
 
-    this.addSql('create table "custom"."foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));');
+    this.addSql('create table "custom"."foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "code" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));');
 
     this.addSql('create table "custom"."foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int null, "foo_bar_id" int null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "blob2" bytea null, "array" text[] null, "object_property" jsonb null);');
     this.addSql('alter table "custom"."foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");');
@@ -100,7 +100,7 @@ export class Migration20191013214813 extends Migration {
       "create schema if not exists "custom";",
       "create table "custom"."book_tag2" ("id" bigserial primary key, "name" varchar(50) not null);",
       "",
-      "create table "custom"."foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));",
+      "create table "custom"."foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "code" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));",
       "",
       "create table "custom"."foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int null, "foo_bar_id" int null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "blob2" bytea null, "array" text[] null, "object_property" jsonb null);",
       "alter table "custom"."foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");",
@@ -196,7 +196,7 @@ export class Migration20191013214813 extends Migration {
     this.addSql('create schema if not exists "custom";');
     this.addSql('create table "custom"."book_tag2" ("id" bigserial primary key, "name" varchar(50) not null);');
 
-    this.addSql('create table "custom"."foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));');
+    this.addSql('create table "custom"."foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "code" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));');
 
     this.addSql('create table "custom"."foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int null, "foo_bar_id" int null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "blob2" bytea null, "array" text[] null, "object_property" jsonb null);');
     this.addSql('alter table "custom"."foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");');
@@ -286,7 +286,7 @@ export class Migration20191013214813 extends Migration {
       "create schema if not exists "custom";",
       "create table "custom"."book_tag2" ("id" bigserial primary key, "name" varchar(50) not null);",
       "",
-      "create table "custom"."foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));",
+      "create table "custom"."foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "code" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));",
       "",
       "create table "custom"."foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int null, "foo_bar_id" int null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "blob2" bytea null, "array" text[] null, "object_property" jsonb null);",
       "alter table "custom"."foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");",

--- a/tests/features/migrations/__snapshots__/Migrator.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.test.ts.snap
@@ -52,7 +52,7 @@ export class Migration20191013214813 extends Migration {
 
     this.addSql('create table \`dummy2\` (\`id\` int unsigned not null auto_increment primary key) default character set utf8mb4 engine = InnoDB;');
 
-    this.addSql('create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;');
+    this.addSql('create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`code\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;');
 
     this.addSql('create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`name with space\` varchar(255) null, \`baz_id\` int unsigned null, \`foo_bar_id\` int unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`blob2\` blob null, \`array\` text null, \`object_property\` json null) default character set utf8mb4 engine = InnoDB;');
     this.addSql('alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);');
@@ -200,7 +200,7 @@ export class Migration20191013214813 extends Migration {
       "",
       "create table \`dummy2\` (\`id\` int unsigned not null auto_increment primary key) default character set utf8mb4 engine = InnoDB;",
       "",
-      "create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;",
+      "create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`code\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;",
       "",
       "create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`name with space\` varchar(255) null, \`baz_id\` int unsigned null, \`foo_bar_id\` int unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`blob2\` blob null, \`array\` text null, \`object_property\` json null) default character set utf8mb4 engine = InnoDB;",
       "alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);",
@@ -544,7 +544,7 @@ export class Migration20191013214813 extends Migration {
 
     this.addSql('create table \`dummy2\` (\`id\` int unsigned not null auto_increment primary key) default character set utf8mb4 engine = InnoDB;');
 
-    this.addSql('create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;');
+    this.addSql('create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`code\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;');
 
     this.addSql('create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`name with space\` varchar(255) null, \`baz_id\` int unsigned null, \`foo_bar_id\` int unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`blob2\` blob null, \`array\` text null, \`object_property\` json null) default character set utf8mb4 engine = InnoDB;');
     this.addSql('alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);');
@@ -692,7 +692,7 @@ export class Migration20191013214813 extends Migration {
       "",
       "create table \`dummy2\` (\`id\` int unsigned not null auto_increment primary key) default character set utf8mb4 engine = InnoDB;",
       "",
-      "create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;",
+      "create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`code\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;",
       "",
       "create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`name with space\` varchar(255) null, \`baz_id\` int unsigned null, \`foo_bar_id\` int unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`blob2\` blob null, \`array\` text null, \`object_property\` json null) default character set utf8mb4 engine = InnoDB;",
       "alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);",

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.mariadb.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.mariadb.test.ts.snap
@@ -21,7 +21,7 @@ alter table \`car_owner2\` add index \`car_owner2_car_name_car_year_index\`(\`ca
 
 create table \`dummy2\` (\`id\` int unsigned not null auto_increment primary key) default character set utf8mb4 engine = InnoDB;
 
-create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
+create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`code\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
 
 create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`name with space\` varchar(255) null, \`baz_id\` int unsigned null, \`foo_bar_id\` int unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`blob2\` blob null, \`array\` text null, \`object_property\` json null) default character set utf8mb4 engine = InnoDB;
 alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.mssql.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.mssql.test.ts.snap
@@ -18,7 +18,7 @@ CREATE INDEX [car_owner2_car_name_car_year_index] ON [car_owner2] ([car_name], [
 
 CREATE TABLE [dummy2] ([id] int identity(1,1) not null primary key);
 
-CREATE TABLE [foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [version] datetime2(3) not null CONSTRAINT [foo_baz2_version_default] DEFAULT current_timestamp);
+CREATE TABLE [foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null CONSTRAINT [foo_baz2_version_default] DEFAULT current_timestamp);
 
 CREATE TABLE [foo_bar2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null CONSTRAINT [foo_bar2_version_default] DEFAULT current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);
 CREATE UNIQUE INDEX [foo_bar2_baz_id_unique] ON [foo_bar2] ([baz_id]) WHERE [baz_id] IS NOT NULL;

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.mysql.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.mysql.test.ts.snap
@@ -21,7 +21,7 @@ alter table \`car_owner2\` add index \`car_owner2_car_name_car_year_index\`(\`ca
 
 create table \`dummy2\` (\`id\` int unsigned not null auto_increment primary key) default character set utf8mb4 engine = InnoDB;
 
-create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
+create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`code\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
 
 create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`name with space\` varchar(255) null, \`baz_id\` int unsigned null, \`foo_bar_id\` int unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`blob2\` blob null, \`array\` text null, \`object_property\` json null) default character set utf8mb4 engine = InnoDB;
 alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.mysql2.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.mysql2.test.ts.snap
@@ -18,7 +18,7 @@ alter table \`car_owner2\` add index \`car_owner2_car_name_car_year_index\`(\`ca
 
 create table \`dummy2\` (\`id\` int unsigned not null auto_increment primary key) default character set utf8mb4 engine = InnoDB;
 
-create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
+create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`code\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
 
 create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`name with space\` varchar(255) null, \`baz_id\` int unsigned null, \`foo_bar_id\` int unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`blob2\` blob null, \`array\` text null, \`object_property\` json null) default character set utf8mb4 engine = InnoDB;
 alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.postgres.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.postgres.test.ts.snap
@@ -7,7 +7,7 @@ set session_replication_role = 'replica';
 create schema if not exists "label_schema";
 create table "book_tag2" ("id" bigserial primary key, "name" varchar(50) not null);
 
-create table "foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
+create table "foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "code" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
 
 create table "foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int null, "foo_bar_id" int null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "blob2" bytea null, "array" text[] null, "object_property" jsonb null);
 alter table "foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");
@@ -135,7 +135,7 @@ set session_replication_role = 'replica';
 create schema if not exists "label_schema";
 create table "book_tag2" ("id" bigserial primary key, "name" varchar(50) not null);
 
-create table "foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
+create table "foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "code" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
 
 create table "foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int null, "foo_bar_id" int null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "blob2" bytea null, "array" text[] null, "object_property" jsonb null);
 alter table "foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");

--- a/tests/features/schema-generator/__snapshots__/custom-type-mapping.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/custom-type-mapping.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`changing default type mapping (GH 3066) 1`] = `
 "create table "book_tag2" ("id" bigserial primary key, "name" text not null);
 
-create table "foo_baz2" ("id" serial primary key, "name" text not null, "version" timestamptz(3) not null default current_timestamp(3));
+create table "foo_baz2" ("id" serial primary key, "name" text not null, "code" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
 
 create table "foo_bar2" ("id" serial primary key, "name" text not null, "name with space" text null, "baz_id" int null, "foo_bar_id" int null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "blob2" bytea null, "array" text[] null, "object_property" jsonb null);
 alter table "foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");

--- a/tests/features/virtual-entities/__snapshots__/virtual-entities.postgres.test.ts.snap
+++ b/tests/features/virtual-entities/__snapshots__/virtual-entities.postgres.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`virtual entities (sqlite) schema 1`] = `
 "create table "book_tag2" ("id" bigserial primary key, "name" varchar(50) not null);
 
-create table "foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
+create table "foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "code" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
 
 create table "foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int null, "foo_bar_id" int null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "blob2" bytea null, "array" text[] null, "object_property" jsonb null);
 alter table "foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");

--- a/tests/mssql-schema.sql
+++ b/tests/mssql-schema.sql
@@ -31,7 +31,7 @@ CREATE TABLE [publisher2] ([id] int identity(1,1) not null primary key, [name] n
 
 CREATE TABLE [label2] ([uuid] uniqueidentifier not null, [name] nvarchar(255) not null, CONSTRAINT [label2_pkey] PRIMARY KEY ([uuid]));
 
-CREATE TABLE [foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [version] datetime not null default current_timestamp);
+CREATE TABLE [foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime not null default current_timestamp);
 
 CREATE TABLE [foo_bar2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(3) not null default current_timestamp, [blob] varbinary(max) null, [array] text null, [object] text null);
 CREATE UNIQUE INDEX [foo_bar2_baz_id_unique] ON [foo_bar2] ([baz_id]) WHERE [baz_id] IS NOT NULL;
@@ -57,7 +57,7 @@ CREATE TABLE [user2_cars] ([user2_first_name] nvarchar(100) not null, [user2_las
 
 CREATE TABLE [book_tag2] ([id] bigint identity(1,1) not null primary key, [name] nvarchar(50) not null);
 
-CREATE TABLE [base_user2] ([id] int identity(1,1) not null primary key, [first_name] nvarchar(100) not null, [last_name] nvarchar(100) not null, [type] varchar(100) check ([type] in ('employee', 'manager', 'owner')) not null, [owner_prop] nvarchar(255) null, [favourite_employee_id] int null, [favourite_manager_id] int null, [employee_prop] int null, [manager_prop] nvarchar(255) null);
+CREATE TABLE [base_user2] ([id] int identity(1,1) not null primary key, [first_name] nvarchar(100) not null, [last_name] nvarchar(100) not null, [type] nvarchar(100) check ([type] in ('employee', 'manager', 'owner')) not null, [owner_prop] nvarchar(255) null, [favourite_employee_id] int null, [favourite_manager_id] int null, [employee_prop] int null, [manager_prop] nvarchar(255) null);
 CREATE INDEX [base_user2_type_index] ON [base_user2] ([type]);
 CREATE UNIQUE INDEX [base_user2_favourite_manager_id_unique] ON [base_user2] ([favourite_manager_id]) WHERE [favourite_manager_id] IS NOT NULL;
 

--- a/tests/mysql-schema.sql
+++ b/tests/mysql-schema.sql
@@ -39,7 +39,7 @@ create table `sandwich` (`id` int(10) unsigned not null auto_increment primary k
 
 create table `publisher2` (`id` int(10) unsigned not null auto_increment primary key, `name` varchar(255) not null default 'asd', `type` enum('local', 'global') not null default 'local', `type2` enum('LOCAL', 'GLOBAL') not null default 'LOCAL', `enum1` tinyint null, `enum2` tinyint null, `enum3` tinyint null, `enum4` enum('a', 'b', 'c') null, `enum5` enum('a') null) default character set utf8mb4 engine = InnoDB;
 
-create table `foo_baz2` (`id` int(10) unsigned not null auto_increment primary key, `name` varchar(255) not null, `version` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
+create table `foo_baz2` (`id` int(10) unsigned not null auto_increment primary key, `name` varchar(255) not null, `code` varchar(255) not null, `version` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
 
 create table `foo_bar2` (`id` int(10) unsigned not null auto_increment primary key, `name` varchar(255) not null, `name with space` varchar(255) null, `baz_id` int(10) unsigned null, `foo_bar_id` int(10) unsigned null, `version` datetime not null default current_timestamp, `blob` blob null, `blob2` blob null, `array` text null, `object_property` json null) default character set utf8mb4 engine = InnoDB;
 alter table `foo_bar2` add unique `foo_bar2_baz_id_unique`(`baz_id`);

--- a/tests/postgre-schema.sql
+++ b/tests/postgre-schema.sql
@@ -31,7 +31,7 @@ create schema if not exists "label_schema";
 create table "label2" ("uuid" uuid not null, "name" varchar(255) not null);
 alter table "label2" add constraint "label2_pkey" primary key ("uuid");
 
-create table "foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
+create table "foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "code" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
 
 create table "foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int4 null, "foo_bar_id" int4 null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "blob2" bytea null, "array" text[] null, "object_property" jsonb null);
 alter table "foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");


### PR DESCRIPTION
Previously, specifying "type: 'varchar'" on a property was treated as aliasing it to "nvarchar" for schema diffing and entity generation purposes, without wrapping it up as UnicodeString at runtime.

Now, it is using MSSQL's native "varchar" for schema diffing / entity generation purposes. Those values are not wrapped up in the UnicodeString wrapper at runtime, as before.

For other drivers, "varchar" still means "varchar if supported" (sqlite still aliases to "text").