### PR TITLE
feat(core): allow passing `raw()` into `onConflictFields` of upsert methods

### DIFF
--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -11,6 +11,7 @@ import type { EntityManager } from '../EntityManager';
 import type { DriverException } from '../exceptions';
 import type { Configuration } from '../utils/Configuration';
 import type { LoggingOptions, LogContext } from '../logging';
+import type { RawQueryFragment } from '../utils/RawQueryFragment';
 
 export const EntityManagerType = Symbol('EntityManagerType');
 
@@ -179,7 +180,7 @@ export interface NativeInsertUpdateManyOptions<T> extends NativeInsertUpdateOpti
 }
 
 export interface UpsertOptions<Entity> extends Omit<NativeInsertUpdateOptions<Entity>, 'upsert'> {
-  onConflictFields?: (keyof Entity)[];
+  onConflictFields?: (keyof Entity)[] | RawQueryFragment;
   onConflictAction?: 'ignore' | 'merge';
   onConflictMergeFields?: (keyof Entity)[];
   onConflictExcludeFields?: (keyof Entity)[];

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -1304,7 +1304,7 @@ export class Utils {
     return Object.entries(obj) as [keyof T, T[keyof T]][];
   }
 
-  static isRawSql(value: unknown): value is { sql: string; params: unknown[]; use: () => void } {
+  static isRawSql<T = { sql: string; params: unknown[]; use: () => void }>(value: unknown): value is T {
     return isRawSql(value);
   }
 

--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -179,7 +179,7 @@ export class QueryBuilder<
   protected _groupBy: Field<Entity>[] = [];
   protected _having: Dictionary = {};
   protected _returning?: Field<Entity>[];
-  protected _onConflict?: { fields: string[]; ignore?: boolean; merge?: EntityData<Entity> | Field<Entity>[]; where?: QBFilterQuery<Entity> }[];
+  protected _onConflict?: { fields: string[] | RawQueryFragment; ignore?: boolean; merge?: EntityData<Entity> | Field<Entity>[]; where?: QBFilterQuery<Entity> }[];
   protected _limit?: number;
   protected _offset?: number;
   protected _distinctOn?: string[];
@@ -573,11 +573,13 @@ export class QueryBuilder<
     this.ensureNotFinalized();
     this._onConflict ??= [];
     this._onConflict.push({
-      fields: Utils.asArray(fields).flatMap(f => {
-        const key = f.toString() as EntityKey<Entity>;
-        /* istanbul ignore next */
-        return meta.properties[key]?.fieldNames ?? [key];
-      }),
+      fields: Utils.isRawSql<RawQueryFragment>(fields)
+        ? fields
+        : Utils.asArray(fields).flatMap(f => {
+          const key = f.toString() as EntityKey<Entity>;
+          /* istanbul ignore next */
+          return meta.properties[key]?.fieldNames ?? [key];
+        }),
     });
     return this as InsertQueryBuilder<Entity>;
   }

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -162,7 +162,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     /* istanbul ignore next */
     const rename = (field: keyof T) => meta ? (meta.properties[field as string]?.fieldNames[0] as keyof T ?? field) : field;
 
-    if (options.onConflictFields) {
+    if (options.onConflictFields && Array.isArray(options.onConflictFields)) {
       options.onConflictFields = options.onConflictFields.map(rename);
     }
 
@@ -192,7 +192,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     /* istanbul ignore next */
     const rename = (field: keyof T) => meta ? (meta.properties[field as string]?.fieldNames[0] as keyof T ?? field) : field;
 
-    if (options.onConflictFields) {
+    if (options.onConflictFields && Array.isArray(options.onConflictFields)) {
       options.onConflictFields = options.onConflictFields.map(rename);
     }
 

--- a/tests/features/upsert/GH5668.test.ts
+++ b/tests/features/upsert/GH5668.test.ts
@@ -1,0 +1,76 @@
+import { Entity, MikroORM, PrimaryKey, Property, sql, Unique } from '@mikro-orm/sqlite';
+
+@Entity()
+@Unique({
+  name: 'a_null',
+  expression: 'create unique index a_null on `a` (`z`, `y`) where `x` is null',
+})
+@Unique({
+  name: 'a_non_null',
+  expression: 'create unique index a_non_null on `a` (`z`, `y`, `x`) where `x` is not null',
+})
+class A {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  x?: string;
+
+  @Property()
+  y!: string;
+
+  @Property()
+  z!: string;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [A],
+  });
+  await orm.schema.refreshDatabase();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('5668', async () => {
+  const em = orm.em.fork();
+
+  await orm.em.insertMany(A, [
+    { y: 'y1', z: 'z1' },
+    { y: 'y2', z: 'z2', x: 'x2' },
+  ]);
+
+  await orm.em.fork().upsert(
+    A,
+    { y: 'y1', z: 'z1' },
+    {
+      onConflictFields: sql`(z, y) where x is null`,
+      onConflictAction: 'merge',
+      onConflictMergeFields: ['z'],
+    },
+  );
+
+  await orm.em.fork().upsertMany(
+    A,
+    [{ y: 'y1', z: 'z1' }],
+    {
+      onConflictFields: sql`(z, y) where x is null`,
+      onConflictAction: 'ignore',
+      onConflictMergeFields: ['z'],
+    },
+  );
+
+  await orm.em.fork().qb(A)
+    .insert({ y: 'y1', z: 'z1' })
+    .onConflict(sql`(z, y) where x is null`)
+    .merge()
+    .returning('id')
+    .execute();
+});


### PR DESCRIPTION
```ts
await em.upsert(
  A,
  { y: 'y1', z: 'z1' },
  {
    onConflictFields: sql`(z, y) where x is null`,
    onConflictAction: 'ignore',
    onConflictMergeFields: ['z'],
  },
);
```

Closes #5668