### PR TITLE
fix(core): allow `em.transactional` handler to be synchronous

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1231,7 +1231,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Runs your callback wrapped inside a database transaction.
    */
-  async transactional<T>(cb: (em: this) => Promise<T>, options: TransactionOptions = {}): Promise<T> {
+  async transactional<T>(cb: (em: this) => T | Promise<T>, options: TransactionOptions = {}): Promise<T> {
     const em = this.getContext(false);
 
     if (this.disableTransactions || em.disableTransactions) {


### PR DESCRIPTION
Currently such code raises TS error:

```ts
    await this.em.transactional((em) => {
      worksheet.AcknowledgedDate = new Date();
      em.persist(worksheet);
    });
```

The error is the following:

```
Argument of type '(em: EntityManager<IDatabaseDriver<Connection>>) => void' is not assignable to parameter of type '(em: EntityManager<IDatabaseDriver<Connection>>) => Promise<unknown>'.
  Type 'void' is not assignable to type 'Promise<unknown>'.
```

Even though a very similar example is suggested in MikroORM docs ( https://mikro-orm.io/docs/transactions#approach-2-explicitly ).

This PR I guess would fix this.

