### PR TITLE
fix(entity-generator): output entity and prop comments

### DIFF
--- a/packages/knex/src/dialects/mysql/MySqlSchemaHelper.ts
+++ b/packages/knex/src/dialects/mysql/MySqlSchemaHelper.ts
@@ -99,7 +99,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
       nullif(table_schema, schema()) as schema_name,
       column_name as column_name,
       column_default as column_default,
-      column_comment as column_comment,
+      nullif(column_comment, '') as column_comment,
       is_nullable as is_nullable,
       data_type as data_type,
       column_type as column_type,

--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -228,7 +228,7 @@ export class DatabaseTable {
     } = this.foreignKeysToProps(namingStrategy, scalarPropertiesForRelations);
 
     const name = namingStrategy.getEntityName(this.name, this.schema);
-    const schema = new EntitySchema({ name, collection: this.name, schema: this.schema });
+    const schema = new EntitySchema({ name, collection: this.name, schema: this.schema, comment: this.comment });
 
     const compositeFkIndexes: Dictionary<{ keyName: string }> = {};
     const compositeFkUniques: Dictionary<{ keyName: string }> = {};
@@ -639,6 +639,7 @@ export class DatabaseTable {
       columnOptions.length = column.length;
       columnOptions.precision = column.precision;
       columnOptions.scale = column.scale;
+      columnOptions.comment = column.comment;
       columnOptions.enum = !!column.enumItems?.length;
       columnOptions.items = column.enumItems;
     }
@@ -706,6 +707,7 @@ export class DatabaseTable {
       length: column.length,
       precision: column.precision,
       scale: column.scale,
+      comment: column.comment,
       index: index ? index.keyName : undefined,
       unique: unique ? unique.keyName : undefined,
       enum: !!column.enumItems?.length,

--- a/packages/knex/src/schema/SchemaHelper.ts
+++ b/packages/knex/src/schema/SchemaHelper.ts
@@ -88,8 +88,7 @@ export abstract class SchemaHelper {
 
   async loadInformationSchema(schema: DatabaseSchema, connection: AbstractSqlConnection, tables: Table[], schemas?: string[]): Promise<void> {
     for (const t of tables) {
-      const table = schema.addTable(t.table_name, t.schema_name);
-      table.comment = t.table_comment;
+      const table = schema.addTable(t.table_name, t.schema_name, t.table_comment);
       const cols = await this.getColumns(connection, table.name, table.schema);
       const indexes = await this.getIndexes(connection, table.name, table.schema);
       const checks = await this.getChecks(connection, table.name, table.schema, cols);

--- a/packages/mariadb/src/MariaDbSchemaHelper.ts
+++ b/packages/mariadb/src/MariaDbSchemaHelper.ts
@@ -63,7 +63,7 @@ export class MariaDbSchemaHelper extends MySqlSchemaHelper {
       nullif(table_schema, schema()) as schema_name,
       column_name as column_name,
       column_default as column_default,
-      column_comment as column_comment,
+      nullif(column_comment, '') as column_comment,
       is_nullable as is_nullable,
       data_type as data_type,
       column_type as column_type,

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.mssql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.mssql.test.ts.snap
@@ -5,7 +5,7 @@ exports[`EntityGenerator generate entities from schema [mssql]: mssql-entity-dum
   "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity()
+@Entity({ comment: 'This is address table' })
 export class Address2 {
 
   [PrimaryKeyProp]?: 'author';
@@ -13,7 +13,7 @@ export class Address2 {
   @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   author!: Author2;
 
-  @Property({ length: 255 })
+  @Property({ length: 255, comment: 'This is address property' })
   value!: string;
 
 }

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.mysql.test.ts.snap
@@ -47,6 +47,7 @@ export class Address2 {
 
 export const Address2Schema = new EntitySchema({
   class: Address2,
+  comment: 'This is address table',
   properties: {
     author: {
       primary: true,
@@ -56,7 +57,7 @@ export const Address2Schema = new EntitySchema({
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
-    value: { type: 'string', length: 255 },
+    value: { type: 'string', length: 255, comment: 'This is address property' },
   },
 });
 ",
@@ -807,6 +808,7 @@ export class Address2 {
 
 export const Address2Schema = new EntitySchema({
   class: Address2,
+  comment: 'This is address table',
   properties: {
     author: {
       primary: true,
@@ -816,7 +818,7 @@ export const Address2Schema = new EntitySchema({
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
-    value: { type: 'string', length: 255 },
+    value: { type: 'string', length: 255, comment: 'This is address property' },
   },
 });
 ",
@@ -1463,7 +1465,7 @@ exports[`EntityGenerator generate entities from schema [mysql]: mysql-entity-dum
   "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity()
+@Entity({ comment: 'This is address table' })
 export class Address2 {
 
   [PrimaryKeyProp]?: 'author';
@@ -1471,7 +1473,7 @@ export class Address2 {
   @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   author!: Author2;
 
-  @Property({ length: 255 })
+  @Property({ length: 255, comment: 'This is address property' })
   value!: string;
 
 }
@@ -1965,7 +1967,7 @@ exports[`EntityGenerator generate entities with bidirectional relations [mysql]:
   "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity()
+@Entity({ comment: 'This is address table' })
 export class Address2 {
 
   [PrimaryKeyProp]?: 'author';
@@ -1973,7 +1975,7 @@ export class Address2 {
   @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   author!: Author2;
 
-  @Property({ length: 255 })
+  @Property({ length: 255, comment: 'This is address property' })
   value!: string;
 
 }
@@ -2553,7 +2555,7 @@ exports[`EntityGenerator generate entities with bidirectional relations and refe
   "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity()
+@Entity({ comment: 'This is address table' })
 export class Address2 {
 
   [PrimaryKeyProp]?: 'author';
@@ -2561,7 +2563,7 @@ export class Address2 {
   @OneToOne({ entity: () => Author2, ref: true, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   author!: Ref<Author2>;
 
-  @Property({ length: 255 })
+  @Property({ length: 255, comment: 'This is address property' })
   value!: string;
 
 }
@@ -3141,7 +3143,7 @@ exports[`EntityGenerator generate entities with reference wrappers and named imp
   "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2.js';
 
-@Entity()
+@Entity({ comment: 'This is address table' })
 export class Address2 {
 
   [PrimaryKeyProp]?: 'author';
@@ -3149,7 +3151,7 @@ export class Address2 {
   @OneToOne({ entity: () => Author2, ref: true, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   author!: Ref<Author2>;
 
-  @Property({ length: 255 })
+  @Property({ length: 255, comment: 'This is address property' })
   value!: string;
 
 }
@@ -3697,7 +3699,7 @@ exports[`EntityGenerator skipTables [mysql]: mysql-entity-dump-skipTables 1`] = 
   "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity()
+@Entity({ comment: 'This is address table' })
 export class Address2 {
 
   [PrimaryKeyProp]?: 'author';
@@ -3705,7 +3707,7 @@ export class Address2 {
   @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   author!: Author2;
 
-  @Property({ length: 255 })
+  @Property({ length: 255, comment: 'This is address property' })
   value!: string;
 
 }

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
@@ -39,7 +39,7 @@ exports[`EntityGenerator generate entities from schema [postgres]: postgres-enti
   "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity()
+@Entity({ comment: 'This is address table' })
 export class Address2 {
 
   [PrimaryKeyProp]?: 'author';
@@ -47,7 +47,7 @@ export class Address2 {
   @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   author!: Author2;
 
-  @Property({ length: 255 })
+  @Property({ length: 255, comment: 'This is address property' })
   value!: string;
 
 }
@@ -436,7 +436,7 @@ exports[`EntityGenerator skipTables [postgres]: postgres-entity-dump-skipTables 
   "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity()
+@Entity({ comment: 'This is address table' })
 export class Address2 {
 
   [PrimaryKeyProp]?: 'author';
@@ -444,7 +444,7 @@ export class Address2 {
   @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   author!: Author2;
 
-  @Property({ length: 255 })
+  @Property({ length: 255, comment: 'This is address property' })
   value!: string;
 
 }

--- a/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
@@ -5,7 +5,7 @@ exports[`MetadataHooks [mysql] identifiedReferences=false metadata hooks with de
   "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity()
+@Entity({ comment: 'This is address table' })
 export class Address2 {
 
   [PrimaryKeyProp]?: 'author';
@@ -13,7 +13,7 @@ export class Address2 {
   @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   author!: Author2;
 
-  @Property({ length: 255 })
+  @Property({ length: 255, comment: 'This is address property' })
   value!: string;
 
 }
@@ -689,6 +689,7 @@ export class Address2 {
 
 export const Address2Schema = new EntitySchema({
   class: Address2,
+  comment: 'This is address table',
   properties: {
     author: {
       primary: true,
@@ -697,7 +698,7 @@ export const Address2Schema = new EntitySchema({
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
-    value: { type: 'string', length: 255 },
+    value: { type: 'string', length: 255, comment: 'This is address property' },
   },
 });
 ",
@@ -1606,7 +1607,7 @@ exports[`MetadataHooks [mysql] identifiedReferences=true metadata hooks with dec
   "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity()
+@Entity({ comment: 'This is address table' })
 export class Address2 {
 
   [PrimaryKeyProp]?: 'author';
@@ -1614,7 +1615,7 @@ export class Address2 {
   @OneToOne({ entity: () => Author2, ref: true, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   author!: Ref<Author2>;
 
-  @Property({ length: 255 })
+  @Property({ length: 255, comment: 'This is address property' })
   value!: string;
 
 }
@@ -2290,6 +2291,7 @@ export class Address2 {
 
 export const Address2Schema = new EntitySchema({
   class: Address2,
+  comment: 'This is address table',
   properties: {
     author: {
       primary: true,
@@ -2299,7 +2301,7 @@ export const Address2Schema = new EntitySchema({
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
-    value: { type: 'string', length: 255 },
+    value: { type: 'string', length: 255, comment: 'This is address property' },
   },
 });
 ",

--- a/tests/features/entity-generator/__snapshots__/OddPkTypes.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OddPkTypes.mysql.test.ts.snap
@@ -59,7 +59,7 @@ export enum EventsWeekday {
 ",
   "import { Entity, Enum, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
-@Entity()
+@Entity({ comment: 'Worktime. If a day is holiday, remove the row.' })
 export class Worktime {
 
   [PrimaryKeyProp]?: 'weekday';
@@ -157,6 +157,7 @@ export enum WorktimeWeekday {
 
 export const WorktimeSchema = new EntitySchema({
   class: Worktime,
+  comment: 'Worktime. If a day is holiday, remove the row.',
   properties: {
     weekday: { primary: true, enum: true, items: () => WorktimeWeekday },
     from: { type: 'time' },

--- a/tests/features/entity-generator/__snapshots__/ScalarPropsForFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/ScalarPropsForFks.mysql.test.ts.snap
@@ -5,7 +5,7 @@ exports[`ScalarPropsForFks generate entities with columns for all foreign key pr
   "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity()
+@Entity({ comment: 'This is address table' })
 export class Address2 {
 
   [PrimaryKeyProp]?: 'author';
@@ -16,7 +16,7 @@ export class Address2 {
   @Property({ persist: false })
   authorId!: number;
 
-  @Property({ length: 255 })
+  @Property({ length: 255, comment: 'This is address property' })
   value!: string;
 
 }
@@ -594,7 +594,7 @@ exports[`ScalarPropsForFks generate entities with columns for some foreign key p
   "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity()
+@Entity({ comment: 'This is address table' })
 export class Address2 {
 
   [PrimaryKeyProp]?: 'author';
@@ -602,7 +602,7 @@ export class Address2 {
   @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   author!: Author2;
 
-  @Property({ length: 255 })
+  @Property({ length: 255, comment: 'This is address property' })
   value!: string;
 
 }


### PR DESCRIPTION
Note that MySQL and MariaDB populate an empty string in columns, always, even when none was defined. For them, empty comments on columns are turned into nulls.