### PR TITLE
fix(core): respect nullability of wrapped types for ScalarReference's

### DIFF
--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -1112,7 +1112,7 @@ const user = await em.findOne(User, 1);
 const passwordHash = await user.passwordHash.load();
 ```
 
-For object-like types, if you choose to use the reference wrappers, you should use the `ScalarReference<T>` type explicitly. For example, you might want to lazily load a large JSON value:
+For object-like types, if you choose to use the reference wrappers, you should use the `ScalarRef<T>` type explicitly. For example, you might want to lazily load a large JSON value:
 
 ```ts
 @Property({ type: 'json', nullable: true, lazy: true, ref: true })

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -1135,10 +1135,6 @@ const populatedReport = await em.populate(report, ['reportParameters']);
 // Logs `null`
 console.log(populatedReport.reportParameters.$); 
 ```
-
-
-
-
 ## Virtual Properties
 
 We can define our properties as virtual, either as a method, or via JavaScript `get/set`.

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -1100,19 +1100,41 @@ const b2 = await em.find(Book, 1, { populate: ['text'] }); // this will load the
 
 ### `ScalarReference` wrapper
 
-Similarly to the `Reference` wrapper, we can also wrap lazy scalars with `Ref` into a `ScalarReference` object.
+Similarly to the `Reference` wrapper, we can also wrap lazy scalars with `Ref` into a `ScalarReference` object. The `Ref` type automatically resolves to `ScalarReference` for non-object types, so the below is correct:
 
 ```ts
 @Property({ lazy: true, ref: true })
 passwordHash!: Ref<string>;
 ```
 
-The `Ref` type automatically resolves to `ScalarReference` for non-object types. You can use it explicitly if you want to wrap an object scalar property (e.g. JSON value).
-
 ```ts
 const user = await em.findOne(User, 1);
 const passwordHash = await user.passwordHash.load();
 ```
+
+For object-like types, if you choose to use the reference wrappers, you should use the `ScalarReference<T>` type explicitly. For example, you might want to lazily load a large JSON value:
+
+```ts
+@Property({ type: 'json', nullable: true, lazy: true, ref: true })
+reportParameters!: ScalarReference<ReportParameters | null>; // ReportParameters is an example class, imagine it defined elsewhere.
+```
+
+Keep in mind that once a scalar value is managed through a ScalarReference, accessing it through MikroORM managed objects will always return the Reference wrapper. That can be confusing in case the property is also `nullable`, since the Reference will always be truthy. In such cases, you should inform the type system of the nullability of the property through `ScalarReference<T>`'s type parameter as demonstrated above. Below is an example of how it works:
+
+```ts
+// Say Report of id "1" has no reportParameters in the Database.
+const report = await em.findOne(Report, 1);
+if (report.reportParameters) {
+  console.log(report.reportParameters); // Logs Ref<?>, not the actual value. **Would always run***.
+  //@ts-expect-error $/.get() is not available until the reference has been loaded.
+  // const mistake = report.reportParameters.$
+}
+const populatedReport = await em.populate(report, ['reportParameters']);
+console.log(populatedReport.reportParameters.$); // Logs `null`
+```
+
+
+
 
 ## Virtual Properties
 

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -1135,6 +1135,7 @@ const populatedReport = await em.populate(report, ['reportParameters']);
 // Logs `null`
 console.log(populatedReport.reportParameters.$); 
 ```
+
 ## Virtual Properties
 
 We can define our properties as virtual, either as a method, or via JavaScript `get/set`.

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -1116,7 +1116,7 @@ For object-like types, if you choose to use the reference wrappers, you should u
 
 ```ts
 @Property({ type: 'json', nullable: true, lazy: true, ref: true })
-// ReportParameters is an example class, imagine it defined elsewhere.
+// ReportParameters is an object type, imagine it defined elsewhere.
 reportParameters!: ScalarReference<ReportParameters | null>; 
 ```
 

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -1116,21 +1116,24 @@ For object-like types, if you choose to use the reference wrappers, you should u
 
 ```ts
 @Property({ type: 'json', nullable: true, lazy: true, ref: true })
-reportParameters!: ScalarReference<ReportParameters | null>; // ReportParameters is an example class, imagine it defined elsewhere.
+// ReportParameters is an example class, imagine it defined elsewhere.
+reportParameters!: ScalarReference<ReportParameters | null>; 
 ```
 
-Keep in mind that once a scalar value is managed through a ScalarReference, accessing it through MikroORM managed objects will always return the Reference wrapper. That can be confusing in case the property is also `nullable`, since the Reference will always be truthy. In such cases, you should inform the type system of the nullability of the property through `ScalarReference<T>`'s type parameter as demonstrated above. Below is an example of how it works:
+Keep in mind that once a scalar value is managed through a `ScalarReference`, accessing it through MikroORM managed objects will always return the `Reference` wrapper. That can be confusing in case the property is also `nullable`, since the `Reference` will always be truthy. In such cases, you should inform the type system of the nullability of the property through `ScalarReference<T>`'s type parameter as demonstrated above. Below is an example of how it all works:
 
 ```ts
 // Say Report of id "1" has no reportParameters in the Database.
 const report = await em.findOne(Report, 1);
 if (report.reportParameters) {
-  console.log(report.reportParameters); // Logs Ref<?>, not the actual value. **Would always run***.
+  // Logs Ref<?>, not the actual value. **Would always run***.
+  console.log(report.reportParameters); 
   //@ts-expect-error $/.get() is not available until the reference has been loaded.
   // const mistake = report.reportParameters.$
 }
 const populatedReport = await em.populate(report, ['reportParameters']);
-console.log(populatedReport.reportParameters.$); // Logs `null`
+// Logs `null`
+console.log(populatedReport.reportParameters.$); 
 ```
 
 

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -1120,7 +1120,7 @@ For object-like types, if you choose to use the reference wrappers, you should u
 reportParameters!: ScalarReference<ReportParameters | null>; 
 ```
 
-Keep in mind that once a scalar value is managed through a `ScalarReference`, accessing it through MikroORM managed objects will always return the `Reference` wrapper. That can be confusing in case the property is also `nullable`, since the `Reference` will always be truthy. In such cases, you should inform the type system of the nullability of the property through `ScalarReference<T>`'s type parameter as demonstrated above. Below is an example of how it all works:
+Keep in mind that once a scalar value is managed through a `ScalarReference`, accessing it through MikroORM managed objects will always return the `ScalarReference` wrapper. That can be confusing in case the property is also `nullable`, since the `ScalarReference` will always be truthy. In such cases, you should inform the type system of the nullability of the property through `ScalarReference<T>`'s type parameter as demonstrated above. Below is an example of how it all works:
 
 ```ts
 // Say Report of id "1" has no reportParameters in the Database.

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -1117,7 +1117,7 @@ For object-like types, if you choose to use the reference wrappers, you should u
 ```ts
 @Property({ type: 'json', nullable: true, lazy: true, ref: true })
 // ReportParameters is an object type, imagine it defined elsewhere.
-reportParameters!: ScalarReference<ReportParameters | null>; 
+reportParameters!: ScalarRef<ReportParameters | null>; 
 ```
 
 Keep in mind that once a scalar value is managed through a `ScalarReference`, accessing it through MikroORM managed objects will always return the `ScalarReference` wrapper. That can be confusing in case the property is also `nullable`, since the `ScalarReference` will always be truthy. In such cases, you should inform the type system of the nullability of the property through `ScalarReference<T>`'s type parameter as demonstrated above. Below is an example of how it all works:

--- a/docs/docs/guide/05-type-safety.md
+++ b/docs/docs/guide/05-type-safety.md
@@ -146,7 +146,7 @@ For object-like types, if you choose to use the reference wrappers, you should u
 reportParameters!: ScalarReference<ReportParameters | null>; 
 ```
 
-Keep in mind that once a scalar value is managed through a `ScalarReference`, accessing it through MikroORM managed objects will always return the `Reference` wrapper. That can be confusing in case the property is also `nullable`, since the `Reference` will always be truthy. In such cases, you should inform the type system of the nullability of the property through `ScalarReference<T>`'s type parameter as demonstrated above. Below is an example of how it all works:
+Keep in mind that once a scalar value is managed through a `ScalarReference`, accessing it through MikroORM managed objects will always return the `ScalarReference` wrapper. That can be confusing in case the property is also `nullable`, since the `ScalarReference` will always be truthy. In such cases, you should inform the type system of the nullability of the property through `ScalarReference<T>`'s type parameter as demonstrated above. Below is an example of how it all works:
 
 ```ts
 // Say Report of id "1" has no reportParameters in the Database.

--- a/docs/docs/guide/05-type-safety.md
+++ b/docs/docs/guide/05-type-safety.md
@@ -143,7 +143,7 @@ For object-like types, if you choose to use the reference wrappers, you should u
 ```ts
 @Property({ type: 'json', nullable: true, lazy: true, ref: true })
 // ReportParameters is an object type, imagine it defined elsewhere.
-reportParameters!: ScalarReference<ReportParameters | null>; 
+reportParameters!: ScalarRef<ReportParameters | null>; 
 ```
 
 Keep in mind that once a scalar value is managed through a `ScalarReference`, accessing it through MikroORM managed objects will always return the `ScalarReference` wrapper. That can be confusing in case the property is also `nullable`, since the `ScalarReference` will always be truthy. In such cases, you should inform the type system of the nullability of the property through `ScalarReference<T>`'s type parameter as demonstrated above. Below is an example of how it all works:

--- a/docs/docs/guide/05-type-safety.md
+++ b/docs/docs/guide/05-type-safety.md
@@ -138,7 +138,7 @@ const user = await em.findOne(User, 1);
 const passwordHash = await user.passwordHash.load();
 ```
 
-For object-like types, if you choose to use the reference wrappers, you should use the `ScalarReference<T>` type explicitly. For example, you might want to lazily load a large JSON value:
+For object-like types, if you choose to use the reference wrappers, you should use the `ScalarRef<T>` type explicitly. For example, you might want to lazily load a large JSON value:
 
 ```ts
 @Property({ type: 'json', nullable: true, lazy: true, ref: true })

--- a/docs/docs/guide/05-type-safety.md
+++ b/docs/docs/guide/05-type-safety.md
@@ -142,7 +142,7 @@ For object-like types, if you choose to use the reference wrappers, you should u
 
 ```ts
 @Property({ type: 'json', nullable: true, lazy: true, ref: true })
-// ReportParameters is an example class, imagine it defined elsewhere.
+// ReportParameters is an object type, imagine it defined elsewhere.
 reportParameters!: ScalarReference<ReportParameters | null>; 
 ```
 

--- a/docs/docs/type-safe-relations.md
+++ b/docs/docs/type-safe-relations.md
@@ -194,7 +194,7 @@ const user = await em.findOne(User, 1);
 const passwordHash = await user.passwordHash.load();
 ```
 
-For object-like types, if you choose to use the reference wrappers, you should use the `ScalarReference<T>` type explicitly. For example, you might want to lazily load a large JSON value:
+For object-like types, if you choose to use the reference wrappers, you should use the `ScalarRef<T>` type explicitly. For example, you might want to lazily load a large JSON value:
 
 ```ts
 @Property({ type: 'json', nullable: true, lazy: true, ref: true })

--- a/docs/docs/type-safe-relations.md
+++ b/docs/docs/type-safe-relations.md
@@ -198,7 +198,7 @@ For object-like types, if you choose to use the reference wrappers, you should u
 
 ```ts
 @Property({ type: 'json', nullable: true, lazy: true, ref: true })
-// ReportParameters is an example class, imagine it defined elsewhere.
+// ReportParameters is an object type, imagine it defined elsewhere.
 reportParameters!: ScalarReference<ReportParameters | null>; 
 ```
 

--- a/docs/docs/type-safe-relations.md
+++ b/docs/docs/type-safe-relations.md
@@ -199,7 +199,7 @@ For object-like types, if you choose to use the reference wrappers, you should u
 ```ts
 @Property({ type: 'json', nullable: true, lazy: true, ref: true })
 // ReportParameters is an object type, imagine it defined elsewhere.
-reportParameters!: ScalarReference<ReportParameters | null>; 
+reportParameters!: ScalarRef<ReportParameters | null>; 
 ```
 
 Keep in mind that once a scalar value is managed through a `ScalarReference`, accessing it through MikroORM managed objects will always return the `ScalarReference` wrapper. That can be confusing in case the property is also `nullable`, since the `ScalarReference` will always be truthy. In such cases, you should inform the type system of the nullability of the property through `ScalarReference<T>`'s type parameter as demonstrated above. Below is an example of how it all works:

--- a/docs/docs/type-safe-relations.md
+++ b/docs/docs/type-safe-relations.md
@@ -182,16 +182,40 @@ await book2.author.load(); // no additional query, already loaded
 
 Similarly to the `Reference` wrapper, we can also wrap scalars with `Ref` into a `ScalarReference` object. This is handy for lazy scalar properties.
 
+The `Ref` type automatically resolves to `ScalarReference` for non-object types, so the below is correct:
+
 ```ts
 @Property({ lazy: true, ref: true })
 passwordHash!: Ref<string>;
 ```
 
-The `Ref` type automatically resolves to `ScalarReference` for non-object types. You can use it explicitly if you want to wrap an object scalar property (e.g. JSON value).
-
 ```ts
 const user = await em.findOne(User, 1);
 const passwordHash = await user.passwordHash.load();
+```
+
+For object-like types, if you choose to use the reference wrappers, you should use the `ScalarReference<T>` type explicitly. For example, you might want to lazily load a large JSON value:
+
+```ts
+@Property({ type: 'json', nullable: true, lazy: true, ref: true })
+// ReportParameters is an example class, imagine it defined elsewhere.
+reportParameters!: ScalarReference<ReportParameters | null>; 
+```
+
+Keep in mind that once a scalar value is managed through a `ScalarReference`, accessing it through MikroORM managed objects will always return the `Reference` wrapper. That can be confusing in case the property is also `nullable`, since the `Reference` will always be truthy. In such cases, you should inform the type system of the nullability of the property through `ScalarReference<T>`'s type parameter as demonstrated above. Below is an example of how it all works:
+
+```ts
+// Say Report of id "1" has no reportParameters in the Database.
+const report = await em.findOne(Report, 1);
+if (report.reportParameters) {
+  // Logs Ref<?>, not the actual value. **Would always run***.
+  console.log(report.reportParameters); 
+  //@ts-expect-error $/.get() is not available until the reference has been loaded.
+  // const mistake = report.reportParameters.$
+}
+const populatedReport = await em.populate(report, ['reportParameters']);
+// Logs `null`
+console.log(populatedReport.reportParameters.$); 
 ```
 
 ## `Loaded` type

--- a/docs/docs/type-safe-relations.md
+++ b/docs/docs/type-safe-relations.md
@@ -202,7 +202,7 @@ For object-like types, if you choose to use the reference wrappers, you should u
 reportParameters!: ScalarReference<ReportParameters | null>; 
 ```
 
-Keep in mind that once a scalar value is managed through a `ScalarReference`, accessing it through MikroORM managed objects will always return the `Reference` wrapper. That can be confusing in case the property is also `nullable`, since the `Reference` will always be truthy. In such cases, you should inform the type system of the nullability of the property through `ScalarReference<T>`'s type parameter as demonstrated above. Below is an example of how it all works:
+Keep in mind that once a scalar value is managed through a `ScalarReference`, accessing it through MikroORM managed objects will always return the `ScalarReference` wrapper. That can be confusing in case the property is also `nullable`, since the `ScalarReference` will always be truthy. In such cases, you should inform the type system of the nullability of the property through `ScalarReference<T>`'s type parameter as demonstrated above. Below is an example of how it all works:
 
 ```ts
 // Say Report of id "1" has no reportParameters in the Database.

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1128,9 +1128,9 @@ export interface LoadedReference<T> extends Reference<NonNullable<T>> {
   get(): NonNullable<T>;
 }
 
-export interface LoadedScalarReference<T> extends ScalarReference<NonNullable<T>> {
-  $: NonNullable<T>;
-  get(): NonNullable<T>;
+export interface LoadedScalarReference<T> extends ScalarReference<T> {
+  $: T;
+  get(): T;
 }
 
 export interface LoadedCollection<T extends object> extends Collection<T> {


### PR DESCRIPTION
If one is to use a ScalarReference to get type-safe access to a lazily loaded scalar value it should be possible to encode in the types that the scalar may be null in the database. Currently, ScalarReferences, when de-referenced through `.get()` or `.$` are typed with "NonNullable" variants of their wrapped types. That non-nullability is not reflected at runtime, which opens up code that perfectly type-checks to runtime exceptions because of null reference accesses. This is demonstrated in this reproduction: https://github.com/ropbastos/mikro-orm-reproduction

Briefly linking the "fixed" version of the library with my companies project I didn't see any types that looked wrong, and all tests still pass, so I'm creating this PR. However, I'm aware the NonNullable helpers are pretty explicit about their intent 😅. I'm not sure what I'm trying to do makes sense/why were they added in the first place, but in the off-chance that they are there by mistake (or they ceased to make sense), I've already done the small work of removing them 🙏

Here is a discussion I opened when I first encountered an error of the type represented in the reproduction repository: https://github.com/mikro-orm/mikro-orm/discussions/5711