### PR TITLE
feat(core): allow upserting without a unique value

### DIFF
--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -429,8 +429,8 @@ export class ChangeSetPersister {
    * No need to handle composite keys here as they need to be set upfront.
    * We do need to map to the change set payload too, as it will be used in the originalEntityData for new entities.
    */
-  mapReturnedValues<T extends object>(entity: T, payload: EntityDictionary<T>, row: Dictionary | undefined, meta: EntityMetadata<T>): void {
-    if (this.usesReturningStatement && row && Utils.hasObjectKeys(row)) {
+  mapReturnedValues<T extends object>(entity: T, payload: EntityDictionary<T>, row: Dictionary | undefined, meta: EntityMetadata<T>, upsert = false): void {
+    if ((this.usesReturningStatement || upsert) && row && Utils.hasObjectKeys(row)) {
       const mapped = this.comparator.mapResult<T>(meta.className, row as EntityDictionary<T>);
       this.hydrator.hydrate(entity, meta, mapped, this.factory, 'full', false, true);
       Object.assign(payload, mapped); // merge to the changeset payload, so it gets saved to the entity snapshot

--- a/packages/mariadb/src/MariaDbDriver.ts
+++ b/packages/mariadb/src/MariaDbDriver.ts
@@ -8,6 +8,10 @@ import {
   type QueryResult,
   type Transaction,
   QueryFlag,
+  type FilterQuery,
+  type UpsertManyOptions,
+  Utils,
+  type EntityKey, Dictionary,
 } from '@mikro-orm/core';
 import { AbstractSqlDriver, type Knex, type SqlEntityManager } from '@mikro-orm/knex';
 import { MariaDbConnection } from './MariaDbConnection';
@@ -46,6 +50,34 @@ export class MariaDbDriver extends AbstractSqlDriver<MariaDbConnection, MariaDbP
     const ctx = options.ctx;
     const autoIncrementIncrement = await this.getAutoIncrementIncrement(ctx);
     data.forEach((item, idx) => res.rows![idx] = { [pks[0]]: item[pks[0]] ?? res.insertId as number + (idx * autoIncrementIncrement) });
+    res.row = res.rows![0];
+
+    return res;
+  }
+
+  override async nativeUpdateMany<T extends object>(entityName: string, where: FilterQuery<T>[], data: EntityDictionary<T>[], options: NativeInsertUpdateManyOptions<T> & UpsertManyOptions<T> = {}): Promise<QueryResult<T>> {
+    const res = await super.nativeUpdateMany(entityName, where, data, options);
+    const pks = this.getPrimaryKeyFields(entityName);
+    const ctx = options.ctx;
+    const autoIncrementIncrement = await this.getAutoIncrementIncrement(ctx);
+    let i = 0;
+
+    const rows = where.map(cond => {
+      if (res.insertId != null && Utils.isEmpty(cond)) {
+        return { [pks[0]]: res.insertId as number + (i++ * autoIncrementIncrement) };
+      }
+
+      if (cond[pks[0] as EntityKey] == null) {
+        return undefined;
+      }
+
+      return { [pks[0]]: cond[pks[0] as EntityKey] };
+    });
+
+    if (rows.every(i => i !== undefined)) {
+      res.rows = rows as Dictionary[];
+    }
+
     res.row = res.rows![0];
 
     return res;

--- a/packages/mongodb/src/MongoConnection.ts
+++ b/packages/mongodb/src/MongoConnection.ts
@@ -336,8 +336,14 @@ export class MongoConnection extends Connection {
           const doc = this.createUpdatePayload(row, upsertOptions) as Dictionary;
 
           if (upsert) {
-            query += log(() => `bulk.find(${this.logObject(cond)}).upsert().update(${this.logObject(doc)});\n`);
-            bulk.find(cond).upsert().update(doc);
+            if (Utils.isEmpty(cond)) {
+              query += log(() => `bulk.insert(${this.logObject(row)});\n`);
+              bulk.insert(row);
+            } else {
+              query += log(() => `bulk.find(${this.logObject(cond)}).upsert().update(${this.logObject(doc)});\n`);
+              bulk.find(cond).upsert().update(doc);
+            }
+
             return;
           }
 

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -204,7 +204,22 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
       options.onConflictExcludeFields = options.onConflictExcludeFields.map(rename);
     }
 
-    return this.rethrow(this.getConnection('write').bulkUpdateMany<T>(entityName, where as object[], data as object[], options.ctx, options.upsert, options));
+    /* istanbul ignore next */
+    const pk = meta?.getPrimaryProps()[0].fieldNames[0] ?? '_id';
+    const res = await this.rethrow(this.getConnection('write').bulkUpdateMany<T>(entityName, where as object[], data as object[], options.ctx, options.upsert, options));
+
+    if (res.insertedIds) {
+      let i = 0;
+      res.rows = where.map(cond => {
+        if (Utils.isEmpty(cond)) {
+          return { [pk]: res.insertedIds![i++] };
+        }
+
+        return { [pk]: cond[pk as EntityKey] };
+      });
+    }
+
+    return res;
   }
 
   async nativeDelete<T extends object>(entityName: string, where: FilterQuery<T>, options: { ctx?: Transaction<ClientSession> } = {}): Promise<QueryResult<T>> {

--- a/tests/features/upsert/GH3787-2.test.ts
+++ b/tests/features/upsert/GH3787-2.test.ts
@@ -108,8 +108,3 @@ test('upsertMany with managed entity calls assign', async () => {
     ['[query] commit'],
   ]);
 });
-
-test('validation', async () => {
-  await expect(orm.em.upsert(MyEntity1, {})).rejects.toThrow('Unique property value required for upsert, provide one of: id');
-  await expect(orm.em.upsertMany(MyEntity1, [{}])).rejects.toThrow('Unique property value required for upsert, provide one of: id');
-});

--- a/tests/features/upsert/GH4153.test.ts
+++ b/tests/features/upsert/GH4153.test.ts
@@ -1,5 +1,5 @@
-import { Entity, PrimaryKey, Property, Unique } from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/mysql';
+import { MikroORM, Entity, PrimaryKey, Property, Unique, Utils, IDatabaseDriver } from '@mikro-orm/core';
+import { PLATFORMS } from '../../bootstrap';
 
 @Entity()
 @Unique({ properties: ['uniq1', 'uniq2'] })
@@ -19,37 +19,45 @@ class MyEntity1 {
 
 }
 
-let orm: MikroORM;
+const options = {
+  mysql: { port: 3308 },
+  mariadb: { port: 3309 },
+};
 
-beforeAll(async () => {
-  orm = await MikroORM.init({
-    dbName: 'mikro_4153',
-    port: 3308,
-    entities: [MyEntity1],
+describe.each(Utils.keys(options))('GH 4153 [%s]',  type => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init<IDatabaseDriver>({
+      dbName: 'mikro_4153',
+      driver: PLATFORMS[type],
+      ...options[type],
+      entities: [MyEntity1],
+    });
+    await orm.schema.refreshDatabase();
   });
-  await orm.schema.refreshDatabase();
-});
 
-afterAll(() => orm.close(true));
+  afterAll(() => orm.close(true));
 
-test('mapping PKs after upsert based on unique properties', async () => {
-  await orm.em.insertMany(MyEntity1, [
-    { id: 1, uniq1: 1, uniq2: 1, name: 'first' },
-    { id: 2, uniq1: 2, uniq2: 1, name: 'second' },
-  ]);
+  test('mapping PKs after upsert based on unique properties', async () => {
+    await orm.em.insertMany(MyEntity1, [
+      { id: 1, uniq1: 1, uniq2: 1, name: 'first' },
+      { id: 2, uniq1: 2, uniq2: 1, name: 'second' },
+    ]);
 
-  const entity1 = new MyEntity1();
-  entity1.uniq1 = 1;
-  entity1.uniq2 = 1;
-  entity1.name = 'first updated';
+    const entity1 = new MyEntity1();
+    entity1.uniq1 = 1;
+    entity1.uniq2 = 1;
+    entity1.name = 'first updated';
 
-  const entity2 = new MyEntity1();
-  entity2.uniq1 = 2;
-  entity2.uniq2 = 1;
-  entity2.name = 'second updated';
+    const entity2 = new MyEntity1();
+    entity2.uniq1 = 2;
+    entity2.uniq2 = 1;
+    entity2.name = 'second updated';
 
-  const result = await orm.em.upsertMany([entity2, entity1]);
+    const result = await orm.em.upsertMany([entity2, entity1]);
 
-  expect(result.find(v => v.uniq1 === 1 && v.uniq2 === 1)!.id).toBe(1);
-  expect(result.find(v => v.uniq1 === 2 && v.uniq2 === 1)!.id).toBe(2);
+    expect(result.find(v => v.uniq1 === 1 && v.uniq2 === 1)!.id).toBe(1);
+    expect(result.find(v => v.uniq1 === 2 && v.uniq2 === 1)!.id).toBe(2);
+  });
 });

--- a/tests/features/upsert/__snapshots__/upsert-without-unique-values.test.ts.snap
+++ b/tests/features/upsert/__snapshots__/upsert-without-unique-values.test.ts.snap
@@ -1,0 +1,76 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`em.upsert without unique values [better-sqlite] em.upsert() without unique values: better-sqlite 1`] = `
+[
+  [
+    "[query] insert into \`book\` (\`title\`) values ('foo 1') on conflict (\`id\`) do update set \`title\` = excluded.\`title\` returning \`id\`",
+  ],
+  [
+    "[query] insert into \`book\` (\`id\`, \`title\`) select 1 as \`id\`, 'foo 12' as \`title\` union all select NULL as \`id\`, 'foo 2' as \`title\` union all select NULL as \`id\`, 'foo 3' as \`title\` where true on conflict (\`id\`) do update set \`title\` = excluded.\`title\` returning \`id\`",
+  ],
+]
+`;
+
+exports[`em.upsert without unique values [mariadb] em.upsert() without unique values: mariadb 1`] = `
+[
+  [
+    "[query] insert into \`book\` (\`title\`) values ('foo 1') on duplicate key update \`title\` = values(\`title\`)",
+  ],
+  [
+    "[query] select \`b0\`.\`id\` from \`book\` as \`b0\` where \`b0\`.\`id\` = 1 limit 1",
+  ],
+  [
+    "[query] insert into \`book\` (\`id\`, \`title\`) values (1, 'foo 12'), (DEFAULT, 'foo 2'), (DEFAULT, 'foo 3') on duplicate key update \`title\` = values(\`title\`)",
+  ],
+]
+`;
+
+exports[`em.upsert without unique values [mongo] em.upsert() without unique values: mongo 1`] = `
+[
+  [
+    "[query] db.getCollection('mongo-book').updateMany({}, { '$set': { title: 'foo 1' } }, { upsert: true });",
+  ],
+  [
+    "[query] db.getCollection('mongo-book').find({}, { projection: { id: 1 } }).limit(1).toArray();",
+  ],
+  [
+    "[query] bulk = db.getCollection('mongo-book').initializeUnorderedBulkOp({ upsert: true });bulk.find({ _id: ObjectId('[generated-object-id]') }).upsert().update({ '$set': { _id: ObjectId('[generated-object-id]'), title: 'foo 12' } });bulk.insert({ title: 'foo 2' });bulk.insert({ title: 'foo 3' });bulk.execute()",
+  ],
+]
+`;
+
+exports[`em.upsert without unique values [mysql] em.upsert() without unique values: mysql 1`] = `
+[
+  [
+    "[query] insert into \`book\` (\`title\`) values ('foo 1') on duplicate key update \`title\` = values(\`title\`)",
+  ],
+  [
+    "[query] select \`b0\`.\`id\` from \`book\` as \`b0\` where \`b0\`.\`id\` = 1 limit 1",
+  ],
+  [
+    "[query] insert into \`book\` (\`id\`, \`title\`) values (1, 'foo 12'), (DEFAULT, 'foo 2'), (DEFAULT, 'foo 3') on duplicate key update \`title\` = values(\`title\`)",
+  ],
+]
+`;
+
+exports[`em.upsert without unique values [postgresql] em.upsert() without unique values: postgresql 1`] = `
+[
+  [
+    "[query] insert into "book" ("title") values ('foo 1') on conflict ("id") do update set "title" = excluded."title" returning "id"",
+  ],
+  [
+    "[query] insert into "book" ("id", "title") values (1, 'foo 12'), (DEFAULT, 'foo 2'), (DEFAULT, 'foo 3') on conflict ("id") do update set "title" = excluded."title" returning "id"",
+  ],
+]
+`;
+
+exports[`em.upsert without unique values [sqlite] em.upsert() without unique values: sqlite 1`] = `
+[
+  [
+    "[query] insert into \`book\` (\`title\`) values ('foo 1') on conflict (\`id\`) do update set \`title\` = excluded.\`title\` returning \`id\`",
+  ],
+  [
+    "[query] insert into \`book\` (\`id\`, \`title\`) select 1 as \`id\`, 'foo 12' as \`title\` union all select NULL as \`id\`, 'foo 2' as \`title\` union all select NULL as \`id\`, 'foo 3' as \`title\` where true on conflict (\`id\`) do update set \`title\` = excluded.\`title\` returning \`id\`",
+  ],
+]
+`;

--- a/tests/features/upsert/upsert-without-unique-values.test.ts
+++ b/tests/features/upsert/upsert-without-unique-values.test.ts
@@ -1,0 +1,122 @@
+import { Entity, IDatabaseDriver, MikroORM, PrimaryKey, Property, SimpleLogger, Utils } from '@mikro-orm/core';
+import { MongoDriver, ObjectId } from '@mikro-orm/mongodb';
+import { mockLogger, PLATFORMS } from '../../bootstrap';
+
+@Entity()
+class Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+}
+
+@Entity()
+class MongoBook {
+
+  @PrimaryKey({ name: '_id' })
+  id!: ObjectId;
+
+  @Property()
+  title!: string;
+
+}
+
+const options = {
+  'sqlite': { dbName: ':memory:' },
+  'better-sqlite': { dbName: ':memory:' },
+  'mysql': { dbName: 'mikro_orm_upsert2', port: 3308 },
+  'mariadb': { dbName: 'mikro_orm_upsert2', port: 3309 },
+  'postgresql': { dbName: 'mikro_orm_upsert2' },
+};
+
+describe.each(Utils.keys(options))('em.upsert without unique values [%s]',  type => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init<IDatabaseDriver>({
+      driver: PLATFORMS[type],
+      entities: [Book],
+      loggerFactory: options => new SimpleLogger(options),
+      ...options[type],
+    });
+    await orm.schema.refreshDatabase();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('em.upsert() without unique values', async () => {
+    const mock = mockLogger(orm);
+
+    const b1 = await orm.em.upsert(Book, {
+      title: 'foo 1',
+    });
+    expect(b1.id).toBe(1);
+    orm.em.clear();
+
+    const books = await orm.em.upsertMany(Book, [
+      { id: b1.id, title: 'foo 12' },
+      { title: 'foo 2' },
+      { title: 'foo 3' },
+    ]);
+
+    expect(books).toHaveLength(3);
+    expect(books[0].id).toBe(1);
+    expect(books[0].title).toBe('foo 12');
+    expect(books[1].title).toBe('foo 2');
+    expect(books[1].id).toBe(2);
+    expect(books[2].title).toBe('foo 3');
+    expect(books[2].id).toBe(3);
+
+    expect(mock.mock.calls).toMatchSnapshot(type);
+  });
+});
+
+describe('em.upsert without unique values [mongo]', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init<IDatabaseDriver>({
+      driver: MongoDriver,
+      entities: [MongoBook],
+      dbName: 'mikro_orm_upsert2',
+      loggerFactory: options => new SimpleLogger(options),
+    });
+    await orm.schema.refreshDatabase();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('em.upsert() without unique values', async () => {
+    const mock = mockLogger(orm);
+
+    const b1 = await orm.em.upsert(MongoBook, {
+      title: 'foo 1',
+    });
+    expect(b1.id).toBeInstanceOf(ObjectId);
+    orm.em.clear();
+
+    const books = await orm.em.upsertMany(MongoBook, [
+      { id: b1.id, title: 'foo 12' },
+      { title: 'foo 2' },
+      { title: 'foo 3' },
+    ]);
+
+    expect(books).toHaveLength(3);
+    expect(books[0].id).toBeInstanceOf(ObjectId);
+    expect(books[0].title).toBe('foo 12');
+    expect(books[1].id).toBeInstanceOf(ObjectId);
+    expect(books[1].title).toBe('foo 2');
+    expect(books[2].id).toBeInstanceOf(ObjectId);
+    expect(books[2].title).toBe('foo 3');
+
+    mock.mock.calls[2][0] = mock.mock.calls[2][0].replaceAll(b1.id, '[generated-object-id]');
+    expect(mock.mock.calls).toMatchSnapshot('mongo');
+  });
+});


### PR DESCRIPTION
`em.upsert` and `em.upsertMany` no longer enforce a unique value in the payload. An insert with a default PK value is issued in such a case.