### PR TITLE
refactor: the Type.getType() method now returns the concrete type passed

### DIFF
--- a/packages/core/src/types/Type.ts
+++ b/packages/core/src/types/Type.ts
@@ -92,7 +92,7 @@ export abstract class Type<JSType = string, DBType = JSType> {
     return prop.columnTypes?.[0] ?? platform.getTextTypeDeclarationSQL(prop);
   }
 
-  static getType<JSType, DBType = JSType>(cls: Constructor<Type<JSType, DBType>>): Type<JSType, DBType> {
+  static getType<JSType, DBType = JSType, TypeClass extends Constructor<Type<JSType, DBType>> = Constructor<Type<JSType, DBType>>>(cls: TypeClass): InstanceType<TypeClass> {
     const key = cls.name;
 
     if (!Type.types.has(key)) {

--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -2,7 +2,6 @@ import {
   AbstractSqlPlatform,
   type Dictionary,
   type EntityMetadata,
-  type EntityProperty,
   type IDatabaseDriver,
   type EntityManager,
   type MikroORM,
@@ -95,7 +94,7 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
 
   override getEnumTypeDeclarationSQL(column: { items?: unknown[]; fieldNames: string[]; length?: number; unsigned?: boolean; autoincrement?: boolean }): string {
     if (column.items?.every(item => Utils.isString(item))) {
-      return Type.getType(UnicodeStringType).getColumnType({ length: 100, ...column } as EntityProperty, this);
+      return Type.getType(UnicodeStringType).getColumnType({ length: 100, ...column });
     }
 
     /* istanbul ignore next */

--- a/tests/features/schema-generator/SchemaGenerator.postgres.test.ts
+++ b/tests/features/schema-generator/SchemaGenerator.postgres.test.ts
@@ -325,7 +325,7 @@ describe('SchemaGenerator [postgres]', () => {
     // test changing a column to tsvector and adding an index
     meta.get('Book2').properties.title.defaultRaw = undefined;
     meta.get('Book2').properties.title.customType = Type.getType(FullTextType);
-    meta.get('Book2').properties.title.columnTypes[0] = Type.getType(FullTextType).getColumnType(meta.get('Book2').properties.title, orm.em.getPlatform());
+    meta.get('Book2').properties.title.columnTypes[0] = Type.getType(FullTextType).getColumnType();
     meta.get('Book2').indexes.push({ type: 'fulltext', properties: ['title'] });
 
     diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });


### PR DESCRIPTION
One broken usage in MsSqlPlatform and in SchemaGenerator.postgres.test.ts are fixed to work with it.