### PR TITLE
docs: fix the dataloader reference in usage

### DIFF
--- a/docs/docs/dataloaders.md
+++ b/docs/docs/dataloaders.md
@@ -12,14 +12,14 @@ In the current version, MikroORM is able to automatically batch [references](./g
 Dataloaders are disabled by default, but they can be easily enabled globally:
 
 ```ts
-import { Dataloader } from '@mikro-orm/core';
+import { DataloaderType } from '@mikro-orm/core';
 
 MikroORM.init({
-  dataloader: Dataloader.ALL,
+  dataloader: DataloaderType.ALL,
 });
 ```
 
-`Dataloader.REFERENCE` enables the dataloader for [References](./guide/05-type-safety.md#reference-wrapper), `Dataloader.COLLECTION` enables it for [Collections](./collections.md) while `Dataloader.ALL` enables it for both. A boolean value is also supported to enable/disable all of them.
+`DataloaderType.REFERENCE` enables the dataloader for [References](./guide/05-type-safety.md#reference-wrapper), `DataloaderType.COLLECTION` enables it for [Collections](./collections.md) while `DataloaderType.ALL` enables it for both. A boolean value is also supported to enable/disable all of them.
 
 The dataloader can also be enabled per-query via the `load()` method options of `Reference` or `Collection` class.
 


### PR DESCRIPTION
![Screenshot 2024-06-20 at 19 03 33](https://github.com/mikro-orm/mikro-orm/assets/2366668/85845fa4-97ad-4efe-8519-11fa467893e5)

I just found that `Dataloader` should be `DataloaderType` in the docs example.