### PR TITLE
feat(libsql): support connecting to remote turso database

### DIFF
--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -29,7 +29,7 @@ npm install @mikro-orm/core @mikro-orm/sqlite
 # for better-sqlite
 npm install @mikro-orm/core @mikro-orm/better-sqlite
 
-# for libsql
+# for libsql/turso
 npm install @mikro-orm/core @mikro-orm/libsql
 
 # for mssql

--- a/docs/docs/usage-with-sql.md
+++ b/docs/docs/usage-with-sql.md
@@ -24,7 +24,7 @@ npm install @mikro-orm/core @mikro-orm/sqlite
 # for better-sqlite
 npm install @mikro-orm/core @mikro-orm/better-sqlite
 
-# for libsql
+# for libsql/turso
 npm install @mikro-orm/core @mikro-orm/libsql
 
 # for mssql
@@ -213,6 +213,36 @@ const orm = await MikroORM.init({
     afterCreate: (conn: any, done: any) => {
       conn.loadExtension('/.../sqlean-macos-arm64/sqlean');
       done(null, conn);
+    },
+  },
+});
+```
+
+## Using Turso database
+
+To be able to connect to a remote [Turso](https://docs.turso.tech/introduction) database, you need to use the `@mikro-orm/libsql` driver. Use the `password` option to set the `authToken`.
+
+```ts
+import { defineConfig } from '@mikro-orm/libsql';
+
+export default defineConfig({
+  dbName: process.env.LIBSQL_URL,
+  password: process.env.LIBSQL_AUTH_TOKEN,
+});
+```
+
+To set the additional options like `syncUrl` or `syncPeriod`, use the `driverOptions.connection`:
+
+```ts
+import { defineConfig } from '@mikro-orm/libsql';
+
+export default defineConfig({
+  dbName: 'local.db',
+  password: process.env.LIBSQL_AUTH_TOKEN,
+  driverOptions: {
+    connection: {
+      syncUrl: process.env.LIBSQL_URL,
+      syncPeriod: 0.5, // 500ms
     },
   },
 });

--- a/docs/versioned_docs/version-6.2/quick-start.md
+++ b/docs/versioned_docs/version-6.2/quick-start.md
@@ -29,7 +29,7 @@ npm install @mikro-orm/core @mikro-orm/sqlite
 # for better-sqlite
 npm install @mikro-orm/core @mikro-orm/better-sqlite
 
-# for libsql
+# for libsql/turso
 npm install @mikro-orm/core @mikro-orm/libsql
 
 # for mssql

--- a/docs/versioned_docs/version-6.2/usage-with-sql.md
+++ b/docs/versioned_docs/version-6.2/usage-with-sql.md
@@ -24,7 +24,7 @@ npm install @mikro-orm/core @mikro-orm/sqlite
 # for better-sqlite
 npm install @mikro-orm/core @mikro-orm/better-sqlite
 
-# for libsql
+# for libsql/turso
 npm install @mikro-orm/core @mikro-orm/libsql
 
 # for mssql

--- a/packages/knex/src/dialects/sqlite/LibSqlKnexDialect.ts
+++ b/packages/knex/src/dialects/sqlite/LibSqlKnexDialect.ts
@@ -11,9 +11,91 @@ export class LibSqlKnexDialect extends MonkeyPatchable.BetterSqlite3Dialect {
     return require('libsql');
   }
 
+  async _query(this: any, connection: any, obj: any) {
+    /* istanbul ignore next */
+    if (!obj.sql) {
+      throw new Error('The query is empty');
+    }
+
+    /* istanbul ignore next */
+    if (!connection) {
+      throw new Error('No connection provided');
+    }
+
+    const callMethod = this.getCallMethod(obj);
+    const statement = connection.prepare(obj.sql);
+    const bindings = this._formatBindings(obj.bindings);
+    const response = await statement[callMethod](bindings);
+    obj.response = response;
+    obj.context = {
+      lastID: response.lastInsertRowid,
+      changes: response.changes,
+    };
+
+    return obj;
+  }
+
+  async acquireRawConnection(this: any) {
+    const connection = new this.driver(this.connectionSettings.filename, {
+      ...this.connectionSettings,
+    });
+    connection.__created = Date.now();
+
+    return connection;
+  }
+
   tableCompiler() {
     // eslint-disable-next-line prefer-rest-params
     return new (SqliteTableCompiler as any)(this, ...arguments);
+  }
+
+  validateConnection(connection: any) {
+    if (connection.memory) {
+      return true;
+    }
+
+    /* istanbul ignore next */
+    return connection.__created > Date.now() - 10_000;
+  }
+
+  private getCallMethod(obj: any): string {
+    if (obj.method === 'raw') {
+      const query = obj.sql.trim().toLowerCase();
+
+      if ((query.startsWith('insert into') || query.startsWith('update ')) && query.includes(' returning ')) {
+        return 'all';
+      }
+
+      if (this.isRunQuery(query)) {
+        return 'run';
+      }
+    }
+
+    /* istanbul ignore next */
+    switch (obj.method) {
+      case 'insert':
+      case 'update':
+        return obj.returning ? 'all' : 'run';
+      case 'counter':
+      case 'del':
+        return 'run';
+      default:
+        return 'all';
+    }
+  }
+
+  private isRunQuery(query: string): boolean {
+    query = query.trim().toLowerCase();
+
+    /* istanbul ignore next */
+    if ((query.startsWith('insert into') || query.startsWith('update ')) && query.includes(' returning ')) {
+      return false;
+    }
+
+    return query.startsWith('insert into') ||
+      query.startsWith('update') ||
+      query.startsWith('delete') ||
+      query.startsWith('truncate');
   }
 
 }

--- a/packages/libsql/src/LibSqlConnection.ts
+++ b/packages/libsql/src/LibSqlConnection.ts
@@ -1,10 +1,22 @@
-import { LibSqlKnexDialect, BaseSqliteConnection } from '@mikro-orm/knex';
+import { LibSqlKnexDialect, BaseSqliteConnection, Utils, type Knex } from '@mikro-orm/knex';
 
 export class LibSqlConnection extends BaseSqliteConnection {
 
   override createKnex() {
     this.client = this.createKnexClient(LibSqlKnexDialect as any);
     this.connected = true;
+  }
+
+  protected override getKnexOptions(type: string): Knex.Config {
+    return Utils.mergeConfig({
+      client: type,
+      connection: {
+        filename: this.config.get('dbName'),
+        authToken: this.config.get('password'),
+      },
+      pool: this.config.get('pool'),
+      useNullAsDefault: true,
+    }, this.config.get('driverOptions'));
   }
 
 }


### PR DESCRIPTION
To be able to connect to a remote [Turso](https://docs.turso.tech/introduction) database, you need to use the `@mikro-orm/libsql` driver. Use the `password` option to set the `authToken`.

```ts
import { defineConfig } from '@mikro-orm/libsql';

export default defineConfig({
  dbName: process.env.LIBSQL_URL,
  password: process.env.LIBSQL_AUTH_TOKEN,
});
```

To set the additional options like `syncUrl` or `syncPeriod`, use the `driverOptions.connection`:

```ts
import { defineConfig } from '@mikro-orm/libsql';

export default defineConfig({
  dbName: 'local.db',
  password: process.env.LIBSQL_AUTH_TOKEN,
  driverOptions: {
    connection: {
      syncUrl: process.env.LIBSQL_URL,
      syncPeriod: 0.5, // 500ms
    },
  },
});
```