### PR TITLE
fix(entity-generator): fixed default values for enums

### DIFF
--- a/packages/entity-generator/src/SourceFile.ts
+++ b/packages/entity-generator/src/SourceFile.ts
@@ -260,7 +260,8 @@ export class SourceFile {
     }
 
     if (prop.enum && typeof prop.default === 'string') {
-      return `${padding}${ret} = ${propType}.${prop.default.toUpperCase()};\n`;
+      const enumVal = this.namingStrategy.enumValueToEnumProperty(prop.default, prop.fieldNames[0], this.meta.collection, this.meta.schema);
+      return `${padding}${ret} = ${propType}${identifierRegex.test(enumVal) ? `.${enumVal}` : `[${this.quote(enumVal)}]`};\n`;
     }
 
     return `${padding}${ret} = ${propType === 'string' ? this.quote('' + prop.default) : prop.default};\n`;

--- a/tests/features/entity-generator/OddTableNames.mysql.test.ts
+++ b/tests/features/entity-generator/OddTableNames.mysql.test.ts
@@ -22,6 +22,7 @@ COLLATE = utf8mb4_0900_ai_ci;
 CREATE TABLE IF NOT EXISTS \`odd_table_names_example:100%\`.\`*misc\` (
   \`@ref\` INT UNSIGNED NOT NULL,
   \`type\` ENUM('application/svg+xml', 'image/png'),
+  \`enum\` ENUM('a', 'b', 'a+b') DEFAULT 'a+b',
   PRIMARY KEY (\`@ref\`),
   CONSTRAINT \`fk_*misc_50% of stuff\`
     FOREIGN KEY (\`@ref\`)

--- a/tests/features/entity-generator/__snapshots__/OddTableNames.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OddTableNames.mysql.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`odd_table_names_example:100% entitySchema=false: mysql 1`] = `
 [
-  "import { Entity, Enum, OneToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, Enum, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { E50$37$32of$32stuff } from './E50$37$32of$32stuff';
 
 @Entity({ tableName: '*misc' })
@@ -16,11 +16,20 @@ export class E_$42misc {
   @Enum({ items: () => E_$42miscType, nullable: true })
   type?: E_$42miscType;
 
+  @Enum({ items: () => E_$42miscEnum, nullable: true })
+  enum?: E_$42miscEnum & Opt = E_$42miscEnum['A+B'];
+
 }
 
 export enum E_$42miscType {
   'APPLICATION/SVG+XML' = 'application/svg+xml',
   'IMAGE/PNG' = 'image/png',
+}
+
+export enum E_$42miscEnum {
+  A = 'a',
+  B = 'b',
+  'A+B' = 'a+b',
 }
 ",
   "import { Entity, Index, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
@@ -114,18 +123,25 @@ export class This$43that {
 
 exports[`odd_table_names_example:100% entitySchema=true: mysql 1`] = `
 [
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { E50$37$32of$32stuff } from './E50$37$32of$32stuff';
 
 export class E_$42misc {
   [PrimaryKeyProp]?: '@ref';
   '@ref'!: E50$37$32of$32stuff;
   type?: E_$42miscType;
+  enum?: E_$42miscEnum & Opt = E_$42miscEnum['A+B'];
 }
 
 export enum E_$42miscType {
   'APPLICATION/SVG+XML' = 'application/svg+xml',
   'IMAGE/PNG' = 'image/png',
+}
+
+export enum E_$42miscEnum {
+  A = 'a',
+  B = 'b',
+  'A+B' = 'a+b',
 }
 
 export const E_$42miscSchema = new EntitySchema({
@@ -139,6 +155,7 @@ export const E_$42miscSchema = new EntitySchema({
       fieldName: '@ref',
     },
     type: { enum: true, items: () => E_$42miscType, nullable: true },
+    enum: { enum: true, items: () => E_$42miscEnum, nullable: true },
   },
 });
 ",


### PR DESCRIPTION
The naming strategy is now consulted for the default value option names.

Independent of the naming strategy, if the resulting option name is not a valid identifier, it will be used via "array access".