### PR TITLE
feat(entity-generator): repository class reference can be added from hooks

### DIFF
--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -736,6 +736,7 @@ export interface EntityMetadata<T = any> {
   indexes: { properties: EntityKey<T> | EntityKey<T>[]; name?: string; type?: string; options?: Dictionary; expression?: string }[];
   uniques: { properties: EntityKey<T> | EntityKey<T>[]; name?: string; options?: Dictionary; expression?: string; deferMode?: DeferMode }[];
   checks: CheckConstraint<T>[];
+  repositoryClass?: string; // for EntityGenerator
   repository: () => EntityClass<EntityRepository<any>>;
   hooks: { [K in EventType]?: (keyof T | EventSubscriber<T>[EventType])[] };
   prototype: T;

--- a/packages/entity-generator/src/SourceFile.ts
+++ b/packages/entity-generator/src/SourceFile.ts
@@ -90,6 +90,11 @@ export class SourceFile {
       classHead += `\n${' '.repeat(2)}[${this.referenceCoreImport('Config')}]?: ${this.referenceCoreImport('DefineConfig')}<${this.serializeObject(defineConfigTypeSettings)}>;\n\n`;
     }
 
+    if (this.meta.repositoryClass) {
+      this.entityImports.add(this.meta.repositoryClass);
+      classHead += `\n${' '.repeat(2)}[${this.referenceCoreImport('EntityRepositoryType')}]?: ${this.meta.repositoryClass};\n`;
+    }
+
     const enumDefinitions: string[] = [];
     const eagerProperties: EntityProperty<any>[] = [];
     const primaryProps: EntityProperty<any>[] = [];
@@ -361,6 +366,11 @@ export class SourceFile {
       options.expression = this.quote(this.meta.expression);
     } else if (typeof this.meta.expression === 'function') {
       options.expression = `${this.meta.expression}`;
+    }
+
+    if (this.meta.repositoryClass) {
+      this.entityImports.add(this.meta.repositoryClass);
+      options.repository = `() => ${this.meta.repositoryClass}` as unknown as typeof options.repository;
     }
 
     if (this.meta.comment) {

--- a/tests/features/entity-generator/MetadataHooks.mysql.test.ts
+++ b/tests/features/entity-generator/MetadataHooks.mysql.test.ts
@@ -223,6 +223,7 @@ const processedMetadataProcessor: GenerateOptions['onProcessedMetadata'] = (meta
     }
 
     if (entity.className === 'User2') {
+      entity.repositoryClass = 'Users2Repository';
       entity.properties.favouriteCar.mapToPk = true;
     }
 

--- a/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
@@ -585,12 +585,15 @@ export class Test2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, EntityRepositoryType, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './Sandwich';
+import { Users2Repository } from './Users2Repository';
 
-@Entity()
+@Entity({ repository: () => Users2Repository })
 export class User2 {
+
+  [EntityRepositoryType]?: Users2Repository;
 
   [PrimaryKeyProp]?: ['firstName', 'lastName'];
 
@@ -1460,6 +1463,7 @@ export const Test2Schema = new EntitySchema({
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './Sandwich';
+import { Users2Repository } from './Users2Repository';
 
 export class User2 {
   [PrimaryKeyProp]?: ['firstName', 'lastName'];
@@ -1473,6 +1477,7 @@ export class User2 {
 
 export const User2Schema = new EntitySchema({
   class: User2,
+  repository: () => Users2Repository,
   properties: {
     firstName: { primary: true, type: 'string', length: 100 },
     lastName: { primary: true, type: 'string', length: 100 },
@@ -2214,12 +2219,15 @@ export class Test2 {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
+  "import { Collection, Entity, EntityRepositoryType, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './Sandwich';
+import { Users2Repository } from './Users2Repository';
 
-@Entity()
+@Entity({ repository: () => Users2Repository })
 export class User2 {
+
+  [EntityRepositoryType]?: Users2Repository;
 
   [PrimaryKeyProp]?: ['firstName', 'lastName'];
 
@@ -3119,6 +3127,7 @@ export const Test2Schema = new EntitySchema({
   "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './Sandwich';
+import { Users2Repository } from './Users2Repository';
 
 export class User2 {
   [PrimaryKeyProp]?: ['firstName', 'lastName'];
@@ -3132,6 +3141,7 @@ export class User2 {
 
 export const User2Schema = new EntitySchema({
   class: User2,
+  repository: () => Users2Repository,
   properties: {
     firstName: { primary: true, type: 'string', length: 100 },
     lastName: { primary: true, type: 'string', length: 100 },


### PR DESCRIPTION
Adding a new option repositoryClass to the meta data will produce a repository factory function, and a EntityRepositoryType symbol.

Repository classes themselves are not generated (yet). This is merely creating a reference to a class the user is responsible for creating, akin to a custom type reference.