### PR TITLE
fix(entity-generator): output all DB related info even for virtual properties

### DIFF
--- a/packages/entity-generator/src/SourceFile.ts
+++ b/packages/entity-generator/src/SourceFile.ts
@@ -557,8 +557,7 @@ export class SourceFile {
 
     // For enum properties, we don't need a column type
     // or the property length or other information in the decorator.
-    // Non-persistent properties also don't need any of that additional information.
-    if (prop.enum || !prop.persist) {
+    if (prop.enum) {
       return;
     }
 

--- a/tests/features/entity-generator/__snapshots__/AmbiguousFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/AmbiguousFks.mysql.test.ts.snap
@@ -47,14 +47,14 @@ export class ProductColors {
   @ManyToOne({ entity: () => Colors, fieldName: 'color_id', primary: true })
   color!: Colors;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   colorId!: number;
 
   @ManyToOne({ entity: () => Products, fieldName: 'product_id', primary: true, index: 'fk_product_colors_products1_idx' })
   product!: Products;
 
   @Index({ name: 'fk_product_colors_products1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, autoincrement: true, persist: false })
   productId!: number;
 
 }
@@ -68,14 +68,14 @@ export class ProductCountries {
 
   [PrimaryKeyProp]?: ['product', 'countries'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @ManyToOne({ entity: () => ProductSizes, fieldName: 'product_id', primary: true, index: 'fk_product_countries_product_sizes1_idx' })
   product!: ProductSizes;
 
   @Index({ name: 'fk_product_countries_product_sizes1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @ManyToOne({ entity: () => Countries, fieldName: 'country', primary: true })
@@ -97,7 +97,7 @@ export class ProductSizes {
   @OneToOne({ entity: () => Products, fieldName: 'product_id', primary: true })
   product!: Products;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property({ type: 'smallint', unsigned: true })
@@ -140,29 +140,29 @@ export class Sales {
   @PrimaryKey()
   saleId!: number;
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @Index({ name: 'product_id_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @ManyToOne({ entity: () => ProductColors, fieldNames: ['color_id', 'product_id'], nullable: true, index: 'fk_sales_product_colors1_idx' })
   color?: ProductColors;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   colorId?: number;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ type: 'smallint', unsigned: true, nullable: true, persist: false })
   size?: number;
 
   @ManyToOne({ entity: () => SellerProducts, fieldNames: ['seller_id', 'exchanged_product_id'], nullable: true, index: 'fk_sales_seller_products2_idx' })
   exchanged?: SellerProducts;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   exchangedProductId?: number;
 
   @ManyToOne({ entity: () => ProductCountries, fieldNames: ['country', 'product_id'], index: 'fk_sales_product_countries1_idx' })
@@ -188,14 +188,14 @@ export class SellerCountries {
 
   [PrimaryKeyProp]?: ['seller', 'countries'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @ManyToOne({ entity: () => Sellers, fieldName: 'seller_id', primary: true, index: 'fk_seller_countries_sellers1_idx' })
   seller!: Sellers;
 
   @Index({ name: 'fk_seller_countries_sellers1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @ManyToOne({ entity: () => Countries, fieldName: 'country', primary: true })
@@ -215,14 +215,14 @@ export class SellerProducts {
   @ManyToOne({ entity: () => Sellers, fieldName: 'seller_id', primary: true })
   seller!: Sellers;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @ManyToOne({ entity: () => Products, fieldName: 'product_id', primary: true, index: 'fk_seller_products_products1_idx' })
   product!: Products;
 
   @Index({ name: 'fk_seller_products_products1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
 }
@@ -320,7 +320,7 @@ export const ProductColorsSchema = new EntitySchema({
       entity: () => Colors,
       fieldName: 'color_id',
     },
-    colorId: { type: 'integer', persist: false },
+    colorId: { type: 'integer', unsigned: true, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -330,6 +330,8 @@ export const ProductColorsSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
+      autoincrement: true,
       persist: false,
       index: 'fk_product_colors_products1_idx',
     },
@@ -351,7 +353,7 @@ export class ProductCountries {
 export const ProductCountriesSchema = new EntitySchema({
   class: ProductCountries,
   properties: {
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -361,6 +363,7 @@ export const ProductCountriesSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_product_countries_product_sizes1_idx',
     },
@@ -398,7 +401,7 @@ export const ProductSizesSchema = new EntitySchema({
       entity: () => Products,
       fieldName: 'product_id',
     },
-    productId: { type: 'integer', persist: false },
+    productId: { type: 'integer', unsigned: true, persist: false },
     size: { type: 'smallint', unsigned: true },
     productCountries: {
       kind: 'm:n',
@@ -461,9 +464,14 @@ export const SalesSchema = new EntitySchema({
   ],
   properties: {
     saleId: { primary: true, type: 'integer' },
-    country: { type: 'character', persist: false },
-    sellerId: { type: 'integer', persist: false },
-    productId: { type: 'integer', persist: false, index: 'product_id_idx' },
+    country: { type: 'character', length: 2, persist: false },
+    sellerId: { type: 'integer', unsigned: true, persist: false },
+    productId: {
+      type: 'integer',
+      unsigned: true,
+      persist: false,
+      index: 'product_id_idx',
+    },
     color: {
       kind: 'm:1',
       entity: () => ProductColors,
@@ -471,8 +479,8 @@ export const SalesSchema = new EntitySchema({
       nullable: true,
       index: 'fk_sales_product_colors1_idx',
     },
-    colorId: { type: 'integer', nullable: true, persist: false },
-    size: { type: 'smallint', nullable: true, persist: false },
+    colorId: { type: 'integer', unsigned: true, nullable: true, persist: false },
+    size: { type: 'smallint', unsigned: true, nullable: true, persist: false },
     exchanged: {
       kind: 'm:1',
       entity: () => SellerProducts,
@@ -480,7 +488,12 @@ export const SalesSchema = new EntitySchema({
       nullable: true,
       index: 'fk_sales_seller_products2_idx',
     },
-    exchangedProductId: { type: 'integer', nullable: true, persist: false },
+    exchangedProductId: {
+      type: 'integer',
+      unsigned: true,
+      nullable: true,
+      persist: false,
+    },
     productCountries: {
       kind: 'm:1',
       entity: () => ProductCountries,
@@ -524,7 +537,7 @@ export class SellerCountries {
 export const SellerCountriesSchema = new EntitySchema({
   class: SellerCountries,
   properties: {
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     seller: {
       primary: true,
       kind: 'm:1',
@@ -534,6 +547,7 @@ export const SellerCountriesSchema = new EntitySchema({
     },
     sellerId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_seller_countries_sellers1_idx',
     },
@@ -567,7 +581,7 @@ export const SellerProductsSchema = new EntitySchema({
       entity: () => Sellers,
       fieldName: 'seller_id',
     },
-    sellerId: { type: 'integer', persist: false },
+    sellerId: { type: 'integer', unsigned: true, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -577,6 +591,7 @@ export const SellerProductsSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_seller_products_products1_idx',
     },
@@ -671,14 +686,14 @@ export class ProductColors {
   @ManyToOne({ entity: () => Colors, ref: true, fieldName: 'color_id', primary: true })
   color!: Ref<Colors>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   colorId!: number;
 
   @ManyToOne({ entity: () => Products, ref: true, fieldName: 'product_id', primary: true, index: 'fk_product_colors_products1_idx' })
   product!: Ref<Products>;
 
   @Index({ name: 'fk_product_colors_products1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, autoincrement: true, persist: false })
   productId!: number;
 
 }
@@ -692,14 +707,14 @@ export class ProductCountries {
 
   [PrimaryKeyProp]?: ['product', 'countries'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @ManyToOne({ entity: () => ProductSizes, ref: true, fieldName: 'product_id', primary: true, index: 'fk_product_countries_product_sizes1_idx' })
   product!: Ref<ProductSizes>;
 
   @Index({ name: 'fk_product_countries_product_sizes1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @ManyToOne({ entity: () => Countries, ref: true, fieldName: 'country', primary: true })
@@ -721,7 +736,7 @@ export class ProductSizes {
   @OneToOne({ entity: () => Products, ref: true, fieldName: 'product_id', primary: true })
   product!: Ref<Products>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property({ type: 'smallint', unsigned: true })
@@ -764,29 +779,29 @@ export class Sales {
   @PrimaryKey()
   saleId!: number;
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @Index({ name: 'product_id_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @ManyToOne({ entity: () => ProductColors, ref: true, fieldNames: ['color_id', 'product_id'], nullable: true, index: 'fk_sales_product_colors1_idx' })
   color?: Ref<ProductColors>;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   colorId?: number;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ type: 'smallint', unsigned: true, nullable: true, persist: false })
   size?: number;
 
   @ManyToOne({ entity: () => SellerProducts, ref: true, fieldNames: ['seller_id', 'exchanged_product_id'], nullable: true, index: 'fk_sales_seller_products2_idx' })
   exchanged?: Ref<SellerProducts>;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   exchangedProductId?: number;
 
   @ManyToOne({ entity: () => ProductCountries, ref: true, fieldNames: ['country', 'product_id'], index: 'fk_sales_product_countries1_idx' })
@@ -812,14 +827,14 @@ export class SellerCountries {
 
   [PrimaryKeyProp]?: ['seller', 'countries'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @ManyToOne({ entity: () => Sellers, ref: true, fieldName: 'seller_id', primary: true, index: 'fk_seller_countries_sellers1_idx' })
   seller!: Ref<Sellers>;
 
   @Index({ name: 'fk_seller_countries_sellers1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @ManyToOne({ entity: () => Countries, ref: true, fieldName: 'country', primary: true })
@@ -839,14 +854,14 @@ export class SellerProducts {
   @ManyToOne({ entity: () => Sellers, ref: true, fieldName: 'seller_id', primary: true })
   seller!: Ref<Sellers>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @ManyToOne({ entity: () => Products, ref: true, fieldName: 'product_id', primary: true, index: 'fk_seller_products_products1_idx' })
   product!: Ref<Products>;
 
   @Index({ name: 'fk_seller_products_products1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
 }
@@ -945,7 +960,7 @@ export const ProductColorsSchema = new EntitySchema({
       ref: true,
       fieldName: 'color_id',
     },
-    colorId: { type: 'integer', persist: false },
+    colorId: { type: 'integer', unsigned: true, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -956,6 +971,8 @@ export const ProductColorsSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
+      autoincrement: true,
       persist: false,
       index: 'fk_product_colors_products1_idx',
     },
@@ -977,7 +994,7 @@ export class ProductCountries {
 export const ProductCountriesSchema = new EntitySchema({
   class: ProductCountries,
   properties: {
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -988,6 +1005,7 @@ export const ProductCountriesSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_product_countries_product_sizes1_idx',
     },
@@ -1027,7 +1045,7 @@ export const ProductSizesSchema = new EntitySchema({
       ref: true,
       fieldName: 'product_id',
     },
-    productId: { type: 'integer', persist: false },
+    productId: { type: 'integer', unsigned: true, persist: false },
     size: { type: 'smallint', unsigned: true },
     productCountries: {
       kind: 'm:n',
@@ -1090,9 +1108,14 @@ export const SalesSchema = new EntitySchema({
   ],
   properties: {
     saleId: { primary: true, type: 'integer' },
-    country: { type: 'character', persist: false },
-    sellerId: { type: 'integer', persist: false },
-    productId: { type: 'integer', persist: false, index: 'product_id_idx' },
+    country: { type: 'character', length: 2, persist: false },
+    sellerId: { type: 'integer', unsigned: true, persist: false },
+    productId: {
+      type: 'integer',
+      unsigned: true,
+      persist: false,
+      index: 'product_id_idx',
+    },
     color: {
       kind: 'm:1',
       entity: () => ProductColors,
@@ -1101,8 +1124,8 @@ export const SalesSchema = new EntitySchema({
       nullable: true,
       index: 'fk_sales_product_colors1_idx',
     },
-    colorId: { type: 'integer', nullable: true, persist: false },
-    size: { type: 'smallint', nullable: true, persist: false },
+    colorId: { type: 'integer', unsigned: true, nullable: true, persist: false },
+    size: { type: 'smallint', unsigned: true, nullable: true, persist: false },
     exchanged: {
       kind: 'm:1',
       entity: () => SellerProducts,
@@ -1111,7 +1134,12 @@ export const SalesSchema = new EntitySchema({
       nullable: true,
       index: 'fk_sales_seller_products2_idx',
     },
-    exchangedProductId: { type: 'integer', nullable: true, persist: false },
+    exchangedProductId: {
+      type: 'integer',
+      unsigned: true,
+      nullable: true,
+      persist: false,
+    },
     productCountries: {
       kind: 'm:1',
       entity: () => ProductCountries,
@@ -1159,7 +1187,7 @@ export class SellerCountries {
 export const SellerCountriesSchema = new EntitySchema({
   class: SellerCountries,
   properties: {
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     seller: {
       primary: true,
       kind: 'm:1',
@@ -1170,6 +1198,7 @@ export const SellerCountriesSchema = new EntitySchema({
     },
     sellerId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_seller_countries_sellers1_idx',
     },
@@ -1205,7 +1234,7 @@ export const SellerProductsSchema = new EntitySchema({
       ref: true,
       fieldName: 'seller_id',
     },
-    sellerId: { type: 'integer', persist: false },
+    sellerId: { type: 'integer', unsigned: true, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -1216,6 +1245,7 @@ export const SellerProductsSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_seller_products_products1_idx',
     },
@@ -1330,14 +1360,14 @@ export class ProductColors {
   @ManyToOne({ entity: () => Colors, fieldName: 'color_id', primary: true })
   color!: Colors;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   colorId!: number;
 
   @ManyToOne({ entity: () => Products, fieldName: 'product_id', primary: true, index: 'fk_product_colors_products1_idx' })
   product!: Products;
 
   @Index({ name: 'fk_product_colors_products1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, autoincrement: true, persist: false })
   productId!: number;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'color' })
@@ -1355,14 +1385,14 @@ export class ProductCountries {
 
   [PrimaryKeyProp]?: ['product', 'countries'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @ManyToOne({ entity: () => ProductSizes, fieldName: 'product_id', primary: true, index: 'fk_product_countries_product_sizes1_idx' })
   product!: ProductSizes;
 
   @Index({ name: 'fk_product_countries_product_sizes1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @ManyToOne({ entity: () => Countries, fieldName: 'country', primary: true })
@@ -1388,7 +1418,7 @@ export class ProductSizes {
   @OneToOne({ entity: () => Products, fieldName: 'product_id', primary: true })
   product!: Products;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property({ type: 'smallint', unsigned: true })
@@ -1457,29 +1487,29 @@ export class Sales {
   @PrimaryKey()
   saleId!: number;
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @Index({ name: 'product_id_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @ManyToOne({ entity: () => ProductColors, fieldNames: ['color_id', 'product_id'], nullable: true, index: 'fk_sales_product_colors1_idx' })
   color?: ProductColors;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   colorId?: number;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ type: 'smallint', unsigned: true, nullable: true, persist: false })
   size?: number;
 
   @ManyToOne({ entity: () => SellerProducts, fieldNames: ['seller_id', 'exchanged_product_id'], nullable: true, index: 'fk_sales_seller_products2_idx' })
   exchanged?: SellerProducts;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   exchangedProductId?: number;
 
   @ManyToOne({ entity: () => ProductCountries, fieldNames: ['country', 'product_id'], index: 'fk_sales_product_countries1_idx' })
@@ -1506,14 +1536,14 @@ export class SellerCountries {
 
   [PrimaryKeyProp]?: ['seller', 'countries'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @ManyToOne({ entity: () => Sellers, fieldName: 'seller_id', primary: true, index: 'fk_seller_countries_sellers1_idx' })
   seller!: Sellers;
 
   @Index({ name: 'fk_seller_countries_sellers1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @ManyToOne({ entity: () => Countries, fieldName: 'country', primary: true })
@@ -1537,14 +1567,14 @@ export class SellerProducts {
   @ManyToOne({ entity: () => Sellers, fieldName: 'seller_id', primary: true })
   seller!: Sellers;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @ManyToOne({ entity: () => Products, fieldName: 'product_id', primary: true, index: 'fk_seller_products_products1_idx' })
   product!: Products;
 
   @Index({ name: 'fk_seller_products_products1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'exchanged' })
@@ -1690,7 +1720,7 @@ export const ProductColorsSchema = new EntitySchema({
       entity: () => Colors,
       fieldName: 'color_id',
     },
-    colorId: { type: 'integer', persist: false },
+    colorId: { type: 'integer', unsigned: true, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -1700,6 +1730,8 @@ export const ProductColorsSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
+      autoincrement: true,
       persist: false,
       index: 'fk_product_colors_products1_idx',
     },
@@ -1724,7 +1756,7 @@ export class ProductCountries {
 export const ProductCountriesSchema = new EntitySchema({
   class: ProductCountries,
   properties: {
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -1734,6 +1766,7 @@ export const ProductCountriesSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_product_countries_product_sizes1_idx',
     },
@@ -1779,7 +1812,7 @@ export const ProductSizesSchema = new EntitySchema({
       entity: () => Products,
       fieldName: 'product_id',
     },
-    productId: { type: 'integer', persist: false },
+    productId: { type: 'integer', unsigned: true, persist: false },
     size: { type: 'smallint', unsigned: true },
     productCountries: {
       kind: 'm:n',
@@ -1883,9 +1916,14 @@ export const SalesSchema = new EntitySchema({
   ],
   properties: {
     saleId: { primary: true, type: 'integer' },
-    country: { type: 'character', persist: false },
-    sellerId: { type: 'integer', persist: false },
-    productId: { type: 'integer', persist: false, index: 'product_id_idx' },
+    country: { type: 'character', length: 2, persist: false },
+    sellerId: { type: 'integer', unsigned: true, persist: false },
+    productId: {
+      type: 'integer',
+      unsigned: true,
+      persist: false,
+      index: 'product_id_idx',
+    },
     color: {
       kind: 'm:1',
       entity: () => ProductColors,
@@ -1893,8 +1931,8 @@ export const SalesSchema = new EntitySchema({
       nullable: true,
       index: 'fk_sales_product_colors1_idx',
     },
-    colorId: { type: 'integer', nullable: true, persist: false },
-    size: { type: 'smallint', nullable: true, persist: false },
+    colorId: { type: 'integer', unsigned: true, nullable: true, persist: false },
+    size: { type: 'smallint', unsigned: true, nullable: true, persist: false },
     exchanged: {
       kind: 'm:1',
       entity: () => SellerProducts,
@@ -1902,7 +1940,12 @@ export const SalesSchema = new EntitySchema({
       nullable: true,
       index: 'fk_sales_seller_products2_idx',
     },
-    exchangedProductId: { type: 'integer', nullable: true, persist: false },
+    exchangedProductId: {
+      type: 'integer',
+      unsigned: true,
+      nullable: true,
+      persist: false,
+    },
     productCountries: {
       kind: 'm:1',
       entity: () => ProductCountries,
@@ -1948,7 +1991,7 @@ export class SellerCountries {
 export const SellerCountriesSchema = new EntitySchema({
   class: SellerCountries,
   properties: {
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     seller: {
       primary: true,
       kind: 'm:1',
@@ -1958,6 +2001,7 @@ export const SellerCountriesSchema = new EntitySchema({
     },
     sellerId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_seller_countries_sellers1_idx',
     },
@@ -1999,7 +2043,7 @@ export const SellerProductsSchema = new EntitySchema({
       entity: () => Sellers,
       fieldName: 'seller_id',
     },
-    sellerId: { type: 'integer', persist: false },
+    sellerId: { type: 'integer', unsigned: true, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -2009,6 +2053,7 @@ export const SellerProductsSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_seller_products_products1_idx',
     },
@@ -2141,14 +2186,14 @@ export class ProductColors {
   @ManyToOne({ entity: () => Colors, ref: true, fieldName: 'color_id', primary: true })
   color!: Ref<Colors>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   colorId!: number;
 
   @ManyToOne({ entity: () => Products, ref: true, fieldName: 'product_id', primary: true, index: 'fk_product_colors_products1_idx' })
   product!: Ref<Products>;
 
   @Index({ name: 'fk_product_colors_products1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, autoincrement: true, persist: false })
   productId!: number;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'color' })
@@ -2166,14 +2211,14 @@ export class ProductCountries {
 
   [PrimaryKeyProp]?: ['product', 'countries'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @ManyToOne({ entity: () => ProductSizes, ref: true, fieldName: 'product_id', primary: true, index: 'fk_product_countries_product_sizes1_idx' })
   product!: Ref<ProductSizes>;
 
   @Index({ name: 'fk_product_countries_product_sizes1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @ManyToOne({ entity: () => Countries, ref: true, fieldName: 'country', primary: true })
@@ -2199,7 +2244,7 @@ export class ProductSizes {
   @OneToOne({ entity: () => Products, ref: true, fieldName: 'product_id', primary: true })
   product!: Ref<Products>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property({ type: 'smallint', unsigned: true })
@@ -2268,29 +2313,29 @@ export class Sales {
   @PrimaryKey()
   saleId!: number;
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @Index({ name: 'product_id_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @ManyToOne({ entity: () => ProductColors, ref: true, fieldNames: ['color_id', 'product_id'], nullable: true, index: 'fk_sales_product_colors1_idx' })
   color?: Ref<ProductColors>;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   colorId?: number;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ type: 'smallint', unsigned: true, nullable: true, persist: false })
   size?: number;
 
   @ManyToOne({ entity: () => SellerProducts, ref: true, fieldNames: ['seller_id', 'exchanged_product_id'], nullable: true, index: 'fk_sales_seller_products2_idx' })
   exchanged?: Ref<SellerProducts>;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   exchangedProductId?: number;
 
   @ManyToOne({ entity: () => ProductCountries, ref: true, fieldNames: ['country', 'product_id'], index: 'fk_sales_product_countries1_idx' })
@@ -2317,14 +2362,14 @@ export class SellerCountries {
 
   [PrimaryKeyProp]?: ['seller', 'countries'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @ManyToOne({ entity: () => Sellers, ref: true, fieldName: 'seller_id', primary: true, index: 'fk_seller_countries_sellers1_idx' })
   seller!: Ref<Sellers>;
 
   @Index({ name: 'fk_seller_countries_sellers1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @ManyToOne({ entity: () => Countries, ref: true, fieldName: 'country', primary: true })
@@ -2348,14 +2393,14 @@ export class SellerProducts {
   @ManyToOne({ entity: () => Sellers, ref: true, fieldName: 'seller_id', primary: true })
   seller!: Ref<Sellers>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @ManyToOne({ entity: () => Products, ref: true, fieldName: 'product_id', primary: true, index: 'fk_seller_products_products1_idx' })
   product!: Ref<Products>;
 
   @Index({ name: 'fk_seller_products_products1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @OneToMany({ entity: () => Sales, mappedBy: 'exchanged' })
@@ -2502,7 +2547,7 @@ export const ProductColorsSchema = new EntitySchema({
       ref: true,
       fieldName: 'color_id',
     },
-    colorId: { type: 'integer', persist: false },
+    colorId: { type: 'integer', unsigned: true, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -2513,6 +2558,8 @@ export const ProductColorsSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
+      autoincrement: true,
       persist: false,
       index: 'fk_product_colors_products1_idx',
     },
@@ -2537,7 +2584,7 @@ export class ProductCountries {
 export const ProductCountriesSchema = new EntitySchema({
   class: ProductCountries,
   properties: {
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -2548,6 +2595,7 @@ export const ProductCountriesSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_product_countries_product_sizes1_idx',
     },
@@ -2595,7 +2643,7 @@ export const ProductSizesSchema = new EntitySchema({
       ref: true,
       fieldName: 'product_id',
     },
-    productId: { type: 'integer', persist: false },
+    productId: { type: 'integer', unsigned: true, persist: false },
     size: { type: 'smallint', unsigned: true },
     productCountries: {
       kind: 'm:n',
@@ -2704,9 +2752,14 @@ export const SalesSchema = new EntitySchema({
   ],
   properties: {
     saleId: { primary: true, type: 'integer' },
-    country: { type: 'character', persist: false },
-    sellerId: { type: 'integer', persist: false },
-    productId: { type: 'integer', persist: false, index: 'product_id_idx' },
+    country: { type: 'character', length: 2, persist: false },
+    sellerId: { type: 'integer', unsigned: true, persist: false },
+    productId: {
+      type: 'integer',
+      unsigned: true,
+      persist: false,
+      index: 'product_id_idx',
+    },
     color: {
       kind: 'm:1',
       entity: () => ProductColors,
@@ -2715,8 +2768,8 @@ export const SalesSchema = new EntitySchema({
       nullable: true,
       index: 'fk_sales_product_colors1_idx',
     },
-    colorId: { type: 'integer', nullable: true, persist: false },
-    size: { type: 'smallint', nullable: true, persist: false },
+    colorId: { type: 'integer', unsigned: true, nullable: true, persist: false },
+    size: { type: 'smallint', unsigned: true, nullable: true, persist: false },
     exchanged: {
       kind: 'm:1',
       entity: () => SellerProducts,
@@ -2725,7 +2778,12 @@ export const SalesSchema = new EntitySchema({
       nullable: true,
       index: 'fk_sales_seller_products2_idx',
     },
-    exchangedProductId: { type: 'integer', nullable: true, persist: false },
+    exchangedProductId: {
+      type: 'integer',
+      unsigned: true,
+      nullable: true,
+      persist: false,
+    },
     productCountries: {
       kind: 'm:1',
       entity: () => ProductCountries,
@@ -2775,7 +2833,7 @@ export class SellerCountries {
 export const SellerCountriesSchema = new EntitySchema({
   class: SellerCountries,
   properties: {
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     seller: {
       primary: true,
       kind: 'm:1',
@@ -2786,6 +2844,7 @@ export const SellerCountriesSchema = new EntitySchema({
     },
     sellerId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_seller_countries_sellers1_idx',
     },
@@ -2829,7 +2888,7 @@ export const SellerProductsSchema = new EntitySchema({
       ref: true,
       fieldName: 'seller_id',
     },
-    sellerId: { type: 'integer', persist: false },
+    sellerId: { type: 'integer', unsigned: true, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -2840,6 +2899,7 @@ export const SellerProductsSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_seller_products_products1_idx',
     },

--- a/tests/features/entity-generator/__snapshots__/FkIndexSelection.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/FkIndexSelection.mysql.test.ts.snap
@@ -51,7 +51,7 @@ export class Users {
   @Property({ nullable: true, persist: false })
   favoriteCarBrand?: string;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ columnType: 'year', nullable: true, persist: false })
   favoriteCarYear?: unknown;
 
   @Property({ nullable: true, persist: false })
@@ -130,7 +130,12 @@ export const UsersSchema = new EntitySchema({
       index: 'fk_users_fashionable_colors1_idx',
     },
     favoriteCarBrand: { type: 'string', nullable: true, persist: false },
-    favoriteCarYear: { type: 'unknown', nullable: true, persist: false },
+    favoriteCarYear: {
+      type: 'unknown',
+      columnType: 'year',
+      nullable: true,
+      persist: false,
+    },
     favoriteColor: { type: 'string', nullable: true, persist: false },
     favoriteBook: { type: 'string', nullable: true },
   },
@@ -190,7 +195,7 @@ export class Users {
   @Property({ nullable: true, persist: false })
   favoriteCarBrand?: string;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ columnType: 'year', nullable: true, persist: false })
   favoriteCarYear?: unknown;
 
   @Property({ nullable: true, persist: false })
@@ -270,7 +275,12 @@ export const UsersSchema = new EntitySchema({
       index: 'fk_users_fashionable_colors1_idx',
     },
     favoriteCarBrand: { type: 'string', nullable: true, persist: false },
-    favoriteCarYear: { type: 'unknown', nullable: true, persist: false },
+    favoriteCarYear: {
+      type: 'unknown',
+      columnType: 'year',
+      nullable: true,
+      persist: false,
+    },
     favoriteColor: { type: 'string', nullable: true, persist: false },
     favoriteBook: { type: 'string', nullable: true },
   },
@@ -334,7 +344,7 @@ export class Users {
   @Property({ nullable: true, persist: false })
   favoriteCarBrand?: string;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ columnType: 'year', nullable: true, persist: false })
   favoriteCarYear?: unknown;
 
   @Property({ nullable: true, persist: false })
@@ -416,7 +426,12 @@ export const UsersSchema = new EntitySchema({
       index: 'fk_users_fashionable_colors1_idx',
     },
     favoriteCarBrand: { type: 'string', nullable: true, persist: false },
-    favoriteCarYear: { type: 'unknown', nullable: true, persist: false },
+    favoriteCarYear: {
+      type: 'unknown',
+      columnType: 'year',
+      nullable: true,
+      persist: false,
+    },
     favoriteColor: { type: 'string', nullable: true, persist: false },
     favoriteBook: { type: 'string', nullable: true },
   },
@@ -480,7 +495,7 @@ export class Users {
   @Property({ nullable: true, persist: false })
   favoriteCarBrand?: string;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ columnType: 'year', nullable: true, persist: false })
   favoriteCarYear?: unknown;
 
   @Property({ nullable: true, persist: false })
@@ -563,7 +578,12 @@ export const UsersSchema = new EntitySchema({
       index: 'fk_users_fashionable_colors1_idx',
     },
     favoriteCarBrand: { type: 'string', nullable: true, persist: false },
-    favoriteCarYear: { type: 'unknown', nullable: true, persist: false },
+    favoriteCarYear: {
+      type: 'unknown',
+      columnType: 'year',
+      nullable: true,
+      persist: false,
+    },
     favoriteColor: { type: 'string', nullable: true, persist: false },
     favoriteBook: { type: 'string', nullable: true },
   },
@@ -1156,7 +1176,7 @@ export class Users {
   @ManyToOne({ entity: () => FashionableColors, fieldNames: ['favorite_car_year', 'favorite_color'], nullable: true, index: 'fk_users_fashionable_colors1_idx' })
   favorite?: FashionableColors;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ columnType: 'year', nullable: true, persist: false })
   favoriteCarYear?: unknown;
 
   @Property({ nullable: true })
@@ -1235,7 +1255,12 @@ export const UsersSchema = new EntitySchema({
       nullable: true,
       index: 'fk_users_fashionable_colors1_idx',
     },
-    favoriteCarYear: { type: 'unknown', nullable: true, persist: false },
+    favoriteCarYear: {
+      type: 'unknown',
+      columnType: 'year',
+      nullable: true,
+      persist: false,
+    },
     favoriteBook: { type: 'string', nullable: true },
   },
 });
@@ -1291,7 +1316,7 @@ export class Users {
   @ManyToOne({ entity: () => FashionableColors, ref: true, fieldNames: ['favorite_car_year', 'favorite_color'], nullable: true, index: 'fk_users_fashionable_colors1_idx' })
   favorite?: Ref<FashionableColors>;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ columnType: 'year', nullable: true, persist: false })
   favoriteCarYear?: unknown;
 
   @Property({ nullable: true })
@@ -1371,7 +1396,12 @@ export const UsersSchema = new EntitySchema({
       nullable: true,
       index: 'fk_users_fashionable_colors1_idx',
     },
-    favoriteCarYear: { type: 'unknown', nullable: true, persist: false },
+    favoriteCarYear: {
+      type: 'unknown',
+      columnType: 'year',
+      nullable: true,
+      persist: false,
+    },
     favoriteBook: { type: 'string', nullable: true },
   },
 });
@@ -1431,7 +1461,7 @@ export class Users {
   @ManyToOne({ entity: () => FashionableColors, fieldNames: ['favorite_car_year', 'favorite_color'], nullable: true, index: 'fk_users_fashionable_colors1_idx' })
   favorite?: FashionableColors;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ columnType: 'year', nullable: true, persist: false })
   favoriteCarYear?: unknown;
 
   @Property({ nullable: true })
@@ -1513,7 +1543,12 @@ export const UsersSchema = new EntitySchema({
       nullable: true,
       index: 'fk_users_fashionable_colors1_idx',
     },
-    favoriteCarYear: { type: 'unknown', nullable: true, persist: false },
+    favoriteCarYear: {
+      type: 'unknown',
+      columnType: 'year',
+      nullable: true,
+      persist: false,
+    },
     favoriteBook: { type: 'string', nullable: true },
   },
 });
@@ -1573,7 +1608,7 @@ export class Users {
   @ManyToOne({ entity: () => FashionableColors, ref: true, fieldNames: ['favorite_car_year', 'favorite_color'], nullable: true, index: 'fk_users_fashionable_colors1_idx' })
   favorite?: Ref<FashionableColors>;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ columnType: 'year', nullable: true, persist: false })
   favoriteCarYear?: unknown;
 
   @Property({ nullable: true })
@@ -1656,7 +1691,12 @@ export const UsersSchema = new EntitySchema({
       nullable: true,
       index: 'fk_users_fashionable_colors1_idx',
     },
-    favoriteCarYear: { type: 'unknown', nullable: true, persist: false },
+    favoriteCarYear: {
+      type: 'unknown',
+      columnType: 'year',
+      nullable: true,
+      persist: false,
+    },
     favoriteBook: { type: 'string', nullable: true },
   },
 });

--- a/tests/features/entity-generator/__snapshots__/FkSharedWithColumn.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/FkSharedWithColumn.mysql.test.ts.snap
@@ -22,7 +22,7 @@ export class LegalUserCountries {
 
   [PrimaryKeyProp]?: 'countries';
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @OneToOne({ entity: () => Countries, fieldName: 'country', primary: true })
@@ -43,11 +43,11 @@ export class Users {
   userId!: number;
 
   @Index({ name: 'fk_users_countries_idx' })
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   userCountry!: string;
 
   @Index({ name: 'fk_users_countries1_idx' })
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   userCountryBorn!: string;
 
   @ManyToOne({ entity: () => Countries, fieldName: 'user_country', index: 'fk_users_countries_idx' })
@@ -92,7 +92,7 @@ export class LegalUserCountries {
 export const LegalUserCountriesSchema = new EntitySchema({
   class: LegalUserCountries,
   properties: {
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     countries: {
       primary: true,
       kind: '1:1',
@@ -122,11 +122,13 @@ export const UsersSchema = new EntitySchema({
     userId: { primary: true, type: 'integer' },
     userCountry: {
       type: 'character',
+      length: 2,
       persist: false,
       index: 'fk_users_countries_idx',
     },
     userCountryBorn: {
       type: 'character',
+      length: 2,
       persist: false,
       index: 'fk_users_countries1_idx',
     },
@@ -178,7 +180,7 @@ export class LegalUserCountries {
 
   [PrimaryKeyProp]?: 'countries';
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @OneToOne({ entity: () => Countries, ref: true, fieldName: 'country', primary: true })
@@ -199,11 +201,11 @@ export class Users {
   userId!: number;
 
   @Index({ name: 'fk_users_countries_idx' })
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   userCountry!: string;
 
   @Index({ name: 'fk_users_countries1_idx' })
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   userCountryBorn!: string;
 
   @ManyToOne({ entity: () => Countries, ref: true, fieldName: 'user_country', index: 'fk_users_countries_idx' })
@@ -248,7 +250,7 @@ export class LegalUserCountries {
 export const LegalUserCountriesSchema = new EntitySchema({
   class: LegalUserCountries,
   properties: {
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     countries: {
       primary: true,
       kind: '1:1',
@@ -279,11 +281,13 @@ export const UsersSchema = new EntitySchema({
     userId: { primary: true, type: 'integer' },
     userCountry: {
       type: 'character',
+      length: 2,
       persist: false,
       index: 'fk_users_countries_idx',
     },
     userCountryBorn: {
       type: 'character',
+      length: 2,
       persist: false,
       index: 'fk_users_countries1_idx',
     },
@@ -350,7 +354,7 @@ export class LegalUserCountries {
 
   [PrimaryKeyProp]?: 'countries';
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @OneToOne({ entity: () => Countries, fieldName: 'country', primary: true })
@@ -374,11 +378,11 @@ export class Users {
   userId!: number;
 
   @Index({ name: 'fk_users_countries_idx' })
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   userCountry!: string;
 
   @Index({ name: 'fk_users_countries1_idx' })
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   userCountryBorn!: string;
 
   @ManyToOne({ entity: () => Countries, fieldName: 'user_country', index: 'fk_users_countries_idx' })
@@ -445,7 +449,7 @@ export class LegalUserCountries {
 export const LegalUserCountriesSchema = new EntitySchema({
   class: LegalUserCountries,
   properties: {
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     countries: {
       primary: true,
       kind: '1:1',
@@ -480,11 +484,13 @@ export const UsersSchema = new EntitySchema({
     userId: { primary: true, type: 'integer' },
     userCountry: {
       type: 'character',
+      length: 2,
       persist: false,
       index: 'fk_users_countries_idx',
     },
     userCountryBorn: {
       type: 'character',
+      length: 2,
       persist: false,
       index: 'fk_users_countries1_idx',
     },
@@ -548,7 +554,7 @@ export class LegalUserCountries {
 
   [PrimaryKeyProp]?: 'countries';
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @OneToOne({ entity: () => Countries, ref: true, fieldName: 'country', primary: true })
@@ -572,11 +578,11 @@ export class Users {
   userId!: number;
 
   @Index({ name: 'fk_users_countries_idx' })
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   userCountry!: string;
 
   @Index({ name: 'fk_users_countries1_idx' })
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   userCountryBorn!: string;
 
   @ManyToOne({ entity: () => Countries, ref: true, fieldName: 'user_country', index: 'fk_users_countries_idx' })
@@ -644,7 +650,7 @@ export class LegalUserCountries {
 export const LegalUserCountriesSchema = new EntitySchema({
   class: LegalUserCountries,
   properties: {
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     countries: {
       primary: true,
       kind: '1:1',
@@ -680,11 +686,13 @@ export const UsersSchema = new EntitySchema({
     userId: { primary: true, type: 'integer' },
     userCountry: {
       type: 'character',
+      length: 2,
       persist: false,
       index: 'fk_users_countries_idx',
     },
     userCountryBorn: {
       type: 'character',
+      length: 2,
       persist: false,
       index: 'fk_users_countries1_idx',
     },

--- a/tests/features/entity-generator/__snapshots__/FksWithDefaults.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/FksWithDefaults.mysql.test.ts.snap
@@ -25,7 +25,7 @@ export class WalletContents {
 
   [PrimaryKeyProp]?: 'walletMeta';
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   id!: number;
 
   @Property({ type: 'decimal', precision: 10, scale: 2 })
@@ -45,10 +45,10 @@ export class WalletMeta {
   @PrimaryKey()
   id!: number;
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 3, persist: false })
   currency: string & Opt = 'EUR';
 
-  @Property({ persist: false })
+  @Property({ type: 'character', persist: false })
   type: string & Opt = 'A';
 
   @ManyToOne({ entity: () => WalletType, fieldNames: ['currency', 'type'], index: 'fk_wallet_wallet_type_idx' })
@@ -64,7 +64,7 @@ export class WalletType {
 
   [PrimaryKeyProp]?: ['type', 'fkWalletTypeCurrency1'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 3, persist: false })
   currency: string & Opt = 'EUR';
 
   @PrimaryKey({ type: 'character' })
@@ -109,7 +109,7 @@ export class WalletContents {
 export const WalletContentsSchema = new EntitySchema({
   class: WalletContents,
   properties: {
-    id: { type: 'integer', persist: false },
+    id: { type: 'integer', unsigned: true, persist: false },
     balance: { type: 'decimal', precision: 10, scale: 2 },
     walletMeta: {
       primary: true,
@@ -134,7 +134,7 @@ export const WalletMetaSchema = new EntitySchema({
   class: WalletMeta,
   properties: {
     id: { primary: true, type: 'integer' },
-    currency: { type: 'character', persist: false },
+    currency: { type: 'character', length: 3, persist: false },
     type: { type: 'character', persist: false },
     walletType: {
       kind: 'm:1',
@@ -158,7 +158,7 @@ export class WalletType {
 export const WalletTypeSchema = new EntitySchema({
   class: WalletType,
   properties: {
-    currency: { type: 'character', persist: false },
+    currency: { type: 'character', length: 3, persist: false },
     type: { primary: true, type: 'character' },
     fkWalletTypeCurrency1: {
       primary: true,
@@ -197,7 +197,7 @@ export class WalletContents {
 
   [PrimaryKeyProp]?: 'walletMeta';
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   id!: number;
 
   @Property({ type: 'decimal', precision: 10, scale: 2 })
@@ -217,10 +217,10 @@ export class WalletMeta {
   @PrimaryKey()
   id!: number;
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 3, persist: false })
   currency: string & Opt = 'EUR';
 
-  @Property({ persist: false })
+  @Property({ type: 'character', persist: false })
   type: string & Opt = 'A';
 
   @ManyToOne({ entity: () => WalletType, fieldNames: ['currency', 'type'], index: 'fk_wallet_wallet_type_idx' })
@@ -236,7 +236,7 @@ export class WalletType {
 
   [PrimaryKeyProp]?: ['type', 'fkWalletTypeCurrency1'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 3, persist: false })
   currency: string & Opt = 'EUR';
 
   @PrimaryKey({ type: 'character' })
@@ -281,7 +281,7 @@ export class WalletContents {
 export const WalletContentsSchema = new EntitySchema({
   class: WalletContents,
   properties: {
-    id: { type: 'integer', persist: false },
+    id: { type: 'integer', unsigned: true, persist: false },
     balance: { type: 'decimal', precision: 10, scale: 2 },
     walletMeta: {
       primary: true,
@@ -306,7 +306,7 @@ export const WalletMetaSchema = new EntitySchema({
   class: WalletMeta,
   properties: {
     id: { primary: true, type: 'integer' },
-    currency: { type: 'character', persist: false },
+    currency: { type: 'character', length: 3, persist: false },
     type: { type: 'character', persist: false },
     walletType: {
       kind: 'm:1',
@@ -330,7 +330,7 @@ export class WalletType {
 export const WalletTypeSchema = new EntitySchema({
   class: WalletType,
   properties: {
-    currency: { type: 'character', persist: false },
+    currency: { type: 'character', length: 3, persist: false },
     type: { primary: true, type: 'character' },
     fkWalletTypeCurrency1: {
       primary: true,
@@ -369,7 +369,7 @@ export class WalletContents {
 
   [PrimaryKeyProp]?: 'walletMeta';
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   id!: number;
 
   @Property({ type: 'decimal', precision: 10, scale: 2 })
@@ -389,10 +389,10 @@ export class WalletMeta {
   @PrimaryKey()
   id!: number;
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 3, persist: false })
   currency: string & Opt = 'EUR';
 
-  @Property({ persist: false })
+  @Property({ type: 'character', persist: false })
   type: string & Opt = 'A';
 
   @ManyToOne({ entity: () => WalletType, ref: true, fieldNames: ['currency', 'type'], index: 'fk_wallet_wallet_type_idx' })
@@ -408,7 +408,7 @@ export class WalletType {
 
   [PrimaryKeyProp]?: ['type', 'fkWalletTypeCurrency1'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 3, persist: false })
   currency: string & Opt = 'EUR';
 
   @PrimaryKey({ type: 'character' })
@@ -453,7 +453,7 @@ export class WalletContents {
 export const WalletContentsSchema = new EntitySchema({
   class: WalletContents,
   properties: {
-    id: { type: 'integer', persist: false },
+    id: { type: 'integer', unsigned: true, persist: false },
     balance: { type: 'decimal', precision: 10, scale: 2 },
     walletMeta: {
       primary: true,
@@ -479,7 +479,7 @@ export const WalletMetaSchema = new EntitySchema({
   class: WalletMeta,
   properties: {
     id: { primary: true, type: 'integer' },
-    currency: { type: 'character', persist: false },
+    currency: { type: 'character', length: 3, persist: false },
     type: { type: 'character', persist: false },
     walletType: {
       kind: 'm:1',
@@ -504,7 +504,7 @@ export class WalletType {
 export const WalletTypeSchema = new EntitySchema({
   class: WalletType,
   properties: {
-    currency: { type: 'character', persist: false },
+    currency: { type: 'character', length: 3, persist: false },
     type: { primary: true, type: 'character' },
     fkWalletTypeCurrency1: {
       primary: true,
@@ -545,7 +545,7 @@ export class WalletContents {
 
   [PrimaryKeyProp]?: 'walletMeta';
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   id!: number;
 
   @Property({ type: 'decimal', precision: 10, scale: 2 })
@@ -565,10 +565,10 @@ export class WalletMeta {
   @PrimaryKey()
   id!: number;
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 3, persist: false })
   currency: string & Opt = 'EUR';
 
-  @Property({ persist: false })
+  @Property({ type: 'character', persist: false })
   type: string & Opt = 'A';
 
   @ManyToOne({ entity: () => WalletType, ref: true, fieldNames: ['currency', 'type'], index: 'fk_wallet_wallet_type_idx' })
@@ -584,7 +584,7 @@ export class WalletType {
 
   [PrimaryKeyProp]?: ['type', 'fkWalletTypeCurrency1'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 3, persist: false })
   currency: string & Opt = 'EUR';
 
   @PrimaryKey({ type: 'character' })
@@ -629,7 +629,7 @@ export class WalletContents {
 export const WalletContentsSchema = new EntitySchema({
   class: WalletContents,
   properties: {
-    id: { type: 'integer', persist: false },
+    id: { type: 'integer', unsigned: true, persist: false },
     balance: { type: 'decimal', precision: 10, scale: 2 },
     walletMeta: {
       primary: true,
@@ -655,7 +655,7 @@ export const WalletMetaSchema = new EntitySchema({
   class: WalletMeta,
   properties: {
     id: { primary: true, type: 'integer' },
-    currency: { type: 'character', persist: false },
+    currency: { type: 'character', length: 3, persist: false },
     type: { type: 'character', persist: false },
     walletType: {
       kind: 'm:1',
@@ -680,7 +680,7 @@ export class WalletType {
 export const WalletTypeSchema = new EntitySchema({
   class: WalletType,
   properties: {
-    currency: { type: 'character', persist: false },
+    currency: { type: 'character', length: 3, persist: false },
     type: { primary: true, type: 'character' },
     fkWalletTypeCurrency1: {
       primary: true,
@@ -725,7 +725,7 @@ export class WalletContents {
 
   [PrimaryKeyProp]?: 'walletMeta';
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   id!: number;
 
   @Property({ type: 'decimal', precision: 10, scale: 2 })
@@ -746,10 +746,10 @@ export class WalletMeta {
   @PrimaryKey()
   id!: number;
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 3, persist: false })
   currency: string & Opt = 'EUR';
 
-  @Property({ persist: false })
+  @Property({ type: 'character', persist: false })
   type: string & Opt = 'A';
 
   @ManyToOne({ entity: () => WalletType, fieldNames: ['currency', 'type'], index: 'fk_wallet_wallet_type_idx' })
@@ -769,7 +769,7 @@ export class WalletType {
 
   [PrimaryKeyProp]?: ['type', 'fkWalletTypeCurrency1'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 3, persist: false })
   currency: string & Opt = 'EUR';
 
   @PrimaryKey({ type: 'character' })
@@ -824,7 +824,7 @@ export class WalletContents {
 export const WalletContentsSchema = new EntitySchema({
   class: WalletContents,
   properties: {
-    id: { type: 'integer', persist: false },
+    id: { type: 'integer', unsigned: true, persist: false },
     balance: { type: 'decimal', precision: 10, scale: 2 },
     walletMeta: {
       primary: true,
@@ -851,7 +851,7 @@ export const WalletMetaSchema = new EntitySchema({
   class: WalletMeta,
   properties: {
     id: { primary: true, type: 'integer' },
-    currency: { type: 'character', persist: false },
+    currency: { type: 'character', length: 3, persist: false },
     type: { type: 'character', persist: false },
     walletType: {
       kind: 'm:1',
@@ -882,7 +882,7 @@ export class WalletType {
 export const WalletTypeSchema = new EntitySchema({
   class: WalletType,
   properties: {
-    currency: { type: 'character', persist: false },
+    currency: { type: 'character', length: 3, persist: false },
     type: { primary: true, type: 'character' },
     fkWalletTypeCurrency1: {
       primary: true,
@@ -930,7 +930,7 @@ export class WalletContents {
 
   [PrimaryKeyProp]?: 'walletMeta';
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   id!: number;
 
   @Property({ type: 'decimal', precision: 10, scale: 2 })
@@ -951,10 +951,10 @@ export class WalletMeta {
   @PrimaryKey()
   id!: number;
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 3, persist: false })
   currency: string & Opt = 'EUR';
 
-  @Property({ persist: false })
+  @Property({ type: 'character', persist: false })
   type: string & Opt = 'A';
 
   @ManyToOne({ entity: () => WalletType, fieldNames: ['currency', 'type'], index: 'fk_wallet_wallet_type_idx' })
@@ -974,7 +974,7 @@ export class WalletType {
 
   [PrimaryKeyProp]?: ['type', 'fkWalletTypeCurrency1'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 3, persist: false })
   currency: string & Opt = 'EUR';
 
   @PrimaryKey({ type: 'character' })
@@ -1029,7 +1029,7 @@ export class WalletContents {
 export const WalletContentsSchema = new EntitySchema({
   class: WalletContents,
   properties: {
-    id: { type: 'integer', persist: false },
+    id: { type: 'integer', unsigned: true, persist: false },
     balance: { type: 'decimal', precision: 10, scale: 2 },
     walletMeta: {
       primary: true,
@@ -1056,7 +1056,7 @@ export const WalletMetaSchema = new EntitySchema({
   class: WalletMeta,
   properties: {
     id: { primary: true, type: 'integer' },
-    currency: { type: 'character', persist: false },
+    currency: { type: 'character', length: 3, persist: false },
     type: { type: 'character', persist: false },
     walletType: {
       kind: 'm:1',
@@ -1087,7 +1087,7 @@ export class WalletType {
 export const WalletTypeSchema = new EntitySchema({
   class: WalletType,
   properties: {
-    currency: { type: 'character', persist: false },
+    currency: { type: 'character', length: 3, persist: false },
     type: { primary: true, type: 'character' },
     fkWalletTypeCurrency1: {
       primary: true,
@@ -1135,7 +1135,7 @@ export class WalletContents {
 
   [PrimaryKeyProp]?: 'walletMeta';
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   id!: number;
 
   @Property({ type: 'decimal', precision: 10, scale: 2 })
@@ -1156,10 +1156,10 @@ export class WalletMeta {
   @PrimaryKey()
   id!: number;
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 3, persist: false })
   currency: string & Opt = 'EUR';
 
-  @Property({ persist: false })
+  @Property({ type: 'character', persist: false })
   type: string & Opt = 'A';
 
   @ManyToOne({ entity: () => WalletType, ref: true, fieldNames: ['currency', 'type'], index: 'fk_wallet_wallet_type_idx' })
@@ -1179,7 +1179,7 @@ export class WalletType {
 
   [PrimaryKeyProp]?: ['type', 'fkWalletTypeCurrency1'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 3, persist: false })
   currency: string & Opt = 'EUR';
 
   @PrimaryKey({ type: 'character' })
@@ -1234,7 +1234,7 @@ export class WalletContents {
 export const WalletContentsSchema = new EntitySchema({
   class: WalletContents,
   properties: {
-    id: { type: 'integer', persist: false },
+    id: { type: 'integer', unsigned: true, persist: false },
     balance: { type: 'decimal', precision: 10, scale: 2 },
     walletMeta: {
       primary: true,
@@ -1262,7 +1262,7 @@ export const WalletMetaSchema = new EntitySchema({
   class: WalletMeta,
   properties: {
     id: { primary: true, type: 'integer' },
-    currency: { type: 'character', persist: false },
+    currency: { type: 'character', length: 3, persist: false },
     type: { type: 'character', persist: false },
     walletType: {
       kind: 'm:1',
@@ -1295,7 +1295,7 @@ export class WalletType {
 export const WalletTypeSchema = new EntitySchema({
   class: WalletType,
   properties: {
-    currency: { type: 'character', persist: false },
+    currency: { type: 'character', length: 3, persist: false },
     type: { primary: true, type: 'character' },
     fkWalletTypeCurrency1: {
       primary: true,
@@ -1345,7 +1345,7 @@ export class WalletContents {
 
   [PrimaryKeyProp]?: 'walletMeta';
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   id!: number;
 
   @Property({ type: 'decimal', precision: 10, scale: 2 })
@@ -1366,10 +1366,10 @@ export class WalletMeta {
   @PrimaryKey()
   id!: number;
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 3, persist: false })
   currency: string & Opt = 'EUR';
 
-  @Property({ persist: false })
+  @Property({ type: 'character', persist: false })
   type: string & Opt = 'A';
 
   @ManyToOne({ entity: () => WalletType, ref: true, fieldNames: ['currency', 'type'], index: 'fk_wallet_wallet_type_idx' })
@@ -1389,7 +1389,7 @@ export class WalletType {
 
   [PrimaryKeyProp]?: ['type', 'fkWalletTypeCurrency1'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 3, persist: false })
   currency: string & Opt = 'EUR';
 
   @PrimaryKey({ type: 'character' })
@@ -1444,7 +1444,7 @@ export class WalletContents {
 export const WalletContentsSchema = new EntitySchema({
   class: WalletContents,
   properties: {
-    id: { type: 'integer', persist: false },
+    id: { type: 'integer', unsigned: true, persist: false },
     balance: { type: 'decimal', precision: 10, scale: 2 },
     walletMeta: {
       primary: true,
@@ -1472,7 +1472,7 @@ export const WalletMetaSchema = new EntitySchema({
   class: WalletMeta,
   properties: {
     id: { primary: true, type: 'integer' },
-    currency: { type: 'character', persist: false },
+    currency: { type: 'character', length: 3, persist: false },
     type: { type: 'character', persist: false },
     walletType: {
       kind: 'm:1',
@@ -1505,7 +1505,7 @@ export class WalletType {
 export const WalletTypeSchema = new EntitySchema({
   class: WalletType,
   properties: {
-    currency: { type: 'character', persist: false },
+    currency: { type: 'character', length: 3, persist: false },
     type: { primary: true, type: 'character' },
     fkWalletTypeCurrency1: {
       primary: true,

--- a/tests/features/entity-generator/__snapshots__/NonCompositeAmbiguousFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/NonCompositeAmbiguousFks.mysql.test.ts.snap
@@ -13,7 +13,7 @@ export class DeliverableProducts {
   @OneToOne({ entity: () => Products, fieldName: 'product_id', primary: true })
   product!: Products;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property()
@@ -48,7 +48,7 @@ export class ManufacturedProducts {
   @OneToOne({ entity: () => Products, fieldName: 'product_id', primary: true })
   product!: Products;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property()
@@ -81,7 +81,7 @@ export class ShippableProducts {
 
   [PrimaryKeyProp]?: ['deliverableProducts', 'fkShippableProductsManufacturedProducts', 'fkShippableProductsManufacturedProducts1'];
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Index({ name: 'fk_shippable_products_destinations1_idx' })
@@ -126,7 +126,7 @@ export const DeliverableProductsSchema = new EntitySchema({
       entity: () => Products,
       fieldName: 'product_id',
     },
-    productId: { type: 'integer', persist: false },
+    productId: { type: 'integer', unsigned: true, persist: false },
     startingAt: { type: 'datetime' },
   },
 });
@@ -166,7 +166,7 @@ export const ManufacturedProductsSchema = new EntitySchema({
       entity: () => Products,
       fieldName: 'product_id',
     },
-    productId: { type: 'integer', persist: false },
+    productId: { type: 'integer', unsigned: true, persist: false },
     place: { type: 'string' },
   },
 });
@@ -205,7 +205,7 @@ export class ShippableProducts {
 export const ShippableProductsSchema = new EntitySchema({
   class: ShippableProducts,
   properties: {
-    productId: { type: 'integer', persist: false },
+    productId: { type: 'integer', unsigned: true, persist: false },
     destination: {
       type: 'string',
       persist: false,
@@ -254,7 +254,7 @@ export class DeliverableProducts {
   @OneToOne({ entity: () => Products, ref: true, fieldName: 'product_id', primary: true })
   product!: Ref<Products>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property()
@@ -289,7 +289,7 @@ export class ManufacturedProducts {
   @OneToOne({ entity: () => Products, ref: true, fieldName: 'product_id', primary: true })
   product!: Ref<Products>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property()
@@ -322,7 +322,7 @@ export class ShippableProducts {
 
   [PrimaryKeyProp]?: ['deliverableProducts', 'fkShippableProductsManufacturedProducts', 'fkShippableProductsManufacturedProducts1'];
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Index({ name: 'fk_shippable_products_destinations1_idx' })
@@ -368,7 +368,7 @@ export const DeliverableProductsSchema = new EntitySchema({
       ref: true,
       fieldName: 'product_id',
     },
-    productId: { type: 'integer', persist: false },
+    productId: { type: 'integer', unsigned: true, persist: false },
     startingAt: { type: 'datetime' },
   },
 });
@@ -409,7 +409,7 @@ export const ManufacturedProductsSchema = new EntitySchema({
       ref: true,
       fieldName: 'product_id',
     },
-    productId: { type: 'integer', persist: false },
+    productId: { type: 'integer', unsigned: true, persist: false },
     place: { type: 'string' },
   },
 });
@@ -448,7 +448,7 @@ export class ShippableProducts {
 export const ShippableProductsSchema = new EntitySchema({
   class: ShippableProducts,
   properties: {
-    productId: { type: 'integer', persist: false },
+    productId: { type: 'integer', unsigned: true, persist: false },
     destination: {
       type: 'string',
       persist: false,
@@ -502,7 +502,7 @@ export class DeliverableProducts {
   @OneToOne({ entity: () => Products, fieldName: 'product_id', primary: true })
   product!: Products;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property()
@@ -545,7 +545,7 @@ export class ManufacturedProducts {
   @OneToOne({ entity: () => Products, fieldName: 'product_id', primary: true })
   product!: Products;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property()
@@ -592,7 +592,7 @@ export class ShippableProducts {
 
   [PrimaryKeyProp]?: ['deliverableProducts', 'fkShippableProductsManufacturedProducts', 'fkShippableProductsManufacturedProducts1'];
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Index({ name: 'fk_shippable_products_destinations1_idx' })
@@ -639,7 +639,7 @@ export const DeliverableProductsSchema = new EntitySchema({
       entity: () => Products,
       fieldName: 'product_id',
     },
-    productId: { type: 'integer', persist: false },
+    productId: { type: 'integer', unsigned: true, persist: false },
     startingAt: { type: 'datetime' },
     shippableProductsCollection: {
       kind: '1:m',
@@ -694,7 +694,7 @@ export const ManufacturedProductsSchema = new EntitySchema({
       entity: () => Products,
       fieldName: 'product_id',
     },
-    productId: { type: 'integer', persist: false },
+    productId: { type: 'integer', unsigned: true, persist: false },
     place: { type: 'string' },
     shippableProductsCollection: {
       kind: '1:m',
@@ -757,7 +757,7 @@ export class ShippableProducts {
 export const ShippableProductsSchema = new EntitySchema({
   class: ShippableProducts,
   properties: {
-    productId: { type: 'integer', persist: false },
+    productId: { type: 'integer', unsigned: true, persist: false },
     destination: {
       type: 'string',
       persist: false,
@@ -807,7 +807,7 @@ export class DeliverableProducts {
   @OneToOne({ entity: () => Products, ref: true, fieldName: 'product_id', primary: true })
   product!: Ref<Products>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property()
@@ -850,7 +850,7 @@ export class ManufacturedProducts {
   @OneToOne({ entity: () => Products, ref: true, fieldName: 'product_id', primary: true })
   product!: Ref<Products>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property()
@@ -897,7 +897,7 @@ export class ShippableProducts {
 
   [PrimaryKeyProp]?: ['deliverableProducts', 'fkShippableProductsManufacturedProducts', 'fkShippableProductsManufacturedProducts1'];
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Index({ name: 'fk_shippable_products_destinations1_idx' })
@@ -945,7 +945,7 @@ export const DeliverableProductsSchema = new EntitySchema({
       ref: true,
       fieldName: 'product_id',
     },
-    productId: { type: 'integer', persist: false },
+    productId: { type: 'integer', unsigned: true, persist: false },
     startingAt: { type: 'datetime' },
     shippableProductsCollection: {
       kind: '1:m',
@@ -1001,7 +1001,7 @@ export const ManufacturedProductsSchema = new EntitySchema({
       ref: true,
       fieldName: 'product_id',
     },
-    productId: { type: 'integer', persist: false },
+    productId: { type: 'integer', unsigned: true, persist: false },
     place: { type: 'string' },
     shippableProductsCollection: {
       kind: '1:m',
@@ -1066,7 +1066,7 @@ export class ShippableProducts {
 export const ShippableProductsSchema = new EntitySchema({
   class: ShippableProducts,
   properties: {
-    productId: { type: 'integer', persist: false },
+    productId: { type: 'integer', unsigned: true, persist: false },
     destination: {
       type: 'string',
       persist: false,

--- a/tests/features/entity-generator/__snapshots__/NullableFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/NullableFks.mysql.test.ts.snap
@@ -14,28 +14,28 @@ export class EmailSendingLogs {
   @PrimaryKey()
   logId!: number;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   senderId!: number;
 
   @ManyToOne({ entity: () => RecepientEmails, fieldNames: ['recepient_id', 'recepient_email_id'], index: 'fk_email_sending_logs_recepient_emails1_idx' })
   recepient!: RecepientEmails;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   recepientId!: number;
 
   @ManyToOne({ entity: () => SenderEmails, fieldNames: ['sender_id', 'sender_email_id'], index: 'fk_email_sending_logs_sender_emails1_idx' })
   sender!: SenderEmails;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   senderEmailId!: number;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   recepientEmailId!: number;
 
   @ManyToOne({ entity: () => SenderEmails, fieldNames: ['sender_id', 'reply_email_id'], nullable: true, index: 'fk_email_sending_logs_sender_emails2_idx' })
   reply?: SenderEmails;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   replyEmailId?: number;
 
   @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
@@ -71,14 +71,14 @@ export class RecepientEmails {
   @ManyToOne({ entity: () => Recepients, fieldName: 'recepient_id', primary: true })
   recepient!: Recepients;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   recepientId!: number;
 
   @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_recepient_emails_emails1_idx' })
   email!: Emails;
 
   @Index({ name: 'fk_recepient_emails_emails1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   emailId!: number;
 
 }
@@ -115,14 +115,14 @@ export class SenderEmails {
   @ManyToOne({ entity: () => Senders, fieldName: 'sender_id', primary: true })
   sender!: Senders;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   senderId!: number;
 
   @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_sender_emails_emails1_idx' })
   email!: Emails;
 
   @Index({ name: 'fk_sender_emails_emails1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   emailId!: number;
 
 }
@@ -174,22 +174,22 @@ export const EmailSendingLogsSchema = new EntitySchema({
   class: EmailSendingLogs,
   properties: {
     logId: { primary: true, type: 'integer' },
-    senderId: { type: 'integer', persist: false },
+    senderId: { type: 'integer', unsigned: true, persist: false },
     recepient: {
       kind: 'm:1',
       entity: () => RecepientEmails,
       fieldNames: ['recepient_id', 'recepient_email_id'],
       index: 'fk_email_sending_logs_recepient_emails1_idx',
     },
-    recepientId: { type: 'integer', persist: false },
+    recepientId: { type: 'integer', unsigned: true, persist: false },
     sender: {
       kind: 'm:1',
       entity: () => SenderEmails,
       fieldNames: ['sender_id', 'sender_email_id'],
       index: 'fk_email_sending_logs_sender_emails1_idx',
     },
-    senderEmailId: { type: 'integer', persist: false },
-    recepientEmailId: { type: 'integer', persist: false },
+    senderEmailId: { type: 'integer', unsigned: true, persist: false },
+    recepientEmailId: { type: 'integer', unsigned: true, persist: false },
     reply: {
       kind: 'm:1',
       entity: () => SenderEmails,
@@ -197,7 +197,12 @@ export const EmailSendingLogsSchema = new EntitySchema({
       nullable: true,
       index: 'fk_email_sending_logs_sender_emails2_idx',
     },
-    replyEmailId: { type: 'integer', nullable: true, persist: false },
+    replyEmailId: {
+      type: 'integer',
+      unsigned: true,
+      nullable: true,
+      persist: false,
+    },
     createdAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
   },
 });
@@ -239,7 +244,7 @@ export const RecepientEmailsSchema = new EntitySchema({
       entity: () => Recepients,
       fieldName: 'recepient_id',
     },
-    recepientId: { type: 'integer', persist: false },
+    recepientId: { type: 'integer', unsigned: true, persist: false },
     email: {
       primary: true,
       kind: 'm:1',
@@ -249,6 +254,7 @@ export const RecepientEmailsSchema = new EntitySchema({
     },
     emailId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_recepient_emails_emails1_idx',
     },
@@ -303,7 +309,7 @@ export const SenderEmailsSchema = new EntitySchema({
       entity: () => Senders,
       fieldName: 'sender_id',
     },
-    senderId: { type: 'integer', persist: false },
+    senderId: { type: 'integer', unsigned: true, persist: false },
     email: {
       primary: true,
       kind: 'm:1',
@@ -313,6 +319,7 @@ export const SenderEmailsSchema = new EntitySchema({
     },
     emailId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_sender_emails_emails1_idx',
     },
@@ -363,28 +370,28 @@ export class EmailSendingLogs {
   @PrimaryKey()
   logId!: number;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   senderId!: number;
 
   @ManyToOne({ entity: () => RecepientEmails, ref: true, fieldNames: ['recepient_id', 'recepient_email_id'], index: 'fk_email_sending_logs_recepient_emails1_idx' })
   recepient!: Ref<RecepientEmails>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   recepientId!: number;
 
   @ManyToOne({ entity: () => SenderEmails, ref: true, fieldNames: ['sender_id', 'sender_email_id'], index: 'fk_email_sending_logs_sender_emails1_idx' })
   sender!: Ref<SenderEmails>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   senderEmailId!: number;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   recepientEmailId!: number;
 
   @ManyToOne({ entity: () => SenderEmails, ref: true, fieldNames: ['sender_id', 'reply_email_id'], nullable: true, index: 'fk_email_sending_logs_sender_emails2_idx' })
   reply?: Ref<SenderEmails>;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   replyEmailId?: number;
 
   @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
@@ -420,14 +427,14 @@ export class RecepientEmails {
   @ManyToOne({ entity: () => Recepients, ref: true, fieldName: 'recepient_id', primary: true })
   recepient!: Ref<Recepients>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   recepientId!: number;
 
   @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_recepient_emails_emails1_idx' })
   email!: Ref<Emails>;
 
   @Index({ name: 'fk_recepient_emails_emails1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   emailId!: number;
 
 }
@@ -464,14 +471,14 @@ export class SenderEmails {
   @ManyToOne({ entity: () => Senders, ref: true, fieldName: 'sender_id', primary: true })
   sender!: Ref<Senders>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   senderId!: number;
 
   @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_sender_emails_emails1_idx' })
   email!: Ref<Emails>;
 
   @Index({ name: 'fk_sender_emails_emails1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   emailId!: number;
 
 }
@@ -523,7 +530,7 @@ export const EmailSendingLogsSchema = new EntitySchema({
   class: EmailSendingLogs,
   properties: {
     logId: { primary: true, type: 'integer' },
-    senderId: { type: 'integer', persist: false },
+    senderId: { type: 'integer', unsigned: true, persist: false },
     recepient: {
       kind: 'm:1',
       entity: () => RecepientEmails,
@@ -531,7 +538,7 @@ export const EmailSendingLogsSchema = new EntitySchema({
       fieldNames: ['recepient_id', 'recepient_email_id'],
       index: 'fk_email_sending_logs_recepient_emails1_idx',
     },
-    recepientId: { type: 'integer', persist: false },
+    recepientId: { type: 'integer', unsigned: true, persist: false },
     sender: {
       kind: 'm:1',
       entity: () => SenderEmails,
@@ -539,8 +546,8 @@ export const EmailSendingLogsSchema = new EntitySchema({
       fieldNames: ['sender_id', 'sender_email_id'],
       index: 'fk_email_sending_logs_sender_emails1_idx',
     },
-    senderEmailId: { type: 'integer', persist: false },
-    recepientEmailId: { type: 'integer', persist: false },
+    senderEmailId: { type: 'integer', unsigned: true, persist: false },
+    recepientEmailId: { type: 'integer', unsigned: true, persist: false },
     reply: {
       kind: 'm:1',
       entity: () => SenderEmails,
@@ -549,7 +556,12 @@ export const EmailSendingLogsSchema = new EntitySchema({
       nullable: true,
       index: 'fk_email_sending_logs_sender_emails2_idx',
     },
-    replyEmailId: { type: 'integer', nullable: true, persist: false },
+    replyEmailId: {
+      type: 'integer',
+      unsigned: true,
+      nullable: true,
+      persist: false,
+    },
     createdAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
   },
 });
@@ -592,7 +604,7 @@ export const RecepientEmailsSchema = new EntitySchema({
       ref: true,
       fieldName: 'recepient_id',
     },
-    recepientId: { type: 'integer', persist: false },
+    recepientId: { type: 'integer', unsigned: true, persist: false },
     email: {
       primary: true,
       kind: 'm:1',
@@ -603,6 +615,7 @@ export const RecepientEmailsSchema = new EntitySchema({
     },
     emailId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_recepient_emails_emails1_idx',
     },
@@ -658,7 +671,7 @@ export const SenderEmailsSchema = new EntitySchema({
       ref: true,
       fieldName: 'sender_id',
     },
-    senderId: { type: 'integer', persist: false },
+    senderId: { type: 'integer', unsigned: true, persist: false },
     email: {
       primary: true,
       kind: 'm:1',
@@ -669,6 +682,7 @@ export const SenderEmailsSchema = new EntitySchema({
     },
     emailId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_sender_emails_emails1_idx',
     },
@@ -719,28 +733,28 @@ export class EmailSendingLogs {
   @PrimaryKey()
   logId!: number;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   senderId!: number;
 
   @ManyToOne({ entity: () => RecepientEmails, fieldNames: ['recepient_id', 'recepient_email_id'], index: 'fk_email_sending_logs_recepient_emails1_idx' })
   recepient!: RecepientEmails;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   recepientId!: number;
 
   @ManyToOne({ entity: () => SenderEmails, fieldNames: ['sender_id', 'sender_email_id'], index: 'fk_email_sending_logs_sender_emails1_idx' })
   sender!: SenderEmails;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   senderEmailId!: number;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   recepientEmailId!: number;
 
   @ManyToOne({ entity: () => SenderEmails, fieldNames: ['sender_id', 'reply_email_id'], nullable: true, index: 'fk_email_sending_logs_sender_emails2_idx' })
   reply?: SenderEmails;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   replyEmailId?: number;
 
   @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
@@ -793,14 +807,14 @@ export class RecepientEmails {
   @ManyToOne({ entity: () => Recepients, fieldName: 'recepient_id', primary: true })
   recepient!: Recepients;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   recepientId!: number;
 
   @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_recepient_emails_emails1_idx' })
   email!: Emails;
 
   @Index({ name: 'fk_recepient_emails_emails1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   emailId!: number;
 
   @OneToMany({ entity: () => EmailSendingLogs, mappedBy: 'recepient' })
@@ -844,14 +858,14 @@ export class SenderEmails {
   @ManyToOne({ entity: () => Senders, fieldName: 'sender_id', primary: true })
   sender!: Senders;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   senderId!: number;
 
   @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_sender_emails_emails1_idx' })
   email!: Emails;
 
   @Index({ name: 'fk_sender_emails_emails1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   emailId!: number;
 
   @OneToMany({ entity: () => EmailSendingLogs, mappedBy: 'sender' })
@@ -912,22 +926,22 @@ export const EmailSendingLogsSchema = new EntitySchema({
   class: EmailSendingLogs,
   properties: {
     logId: { primary: true, type: 'integer' },
-    senderId: { type: 'integer', persist: false },
+    senderId: { type: 'integer', unsigned: true, persist: false },
     recepient: {
       kind: 'm:1',
       entity: () => RecepientEmails,
       fieldNames: ['recepient_id', 'recepient_email_id'],
       index: 'fk_email_sending_logs_recepient_emails1_idx',
     },
-    recepientId: { type: 'integer', persist: false },
+    recepientId: { type: 'integer', unsigned: true, persist: false },
     sender: {
       kind: 'm:1',
       entity: () => SenderEmails,
       fieldNames: ['sender_id', 'sender_email_id'],
       index: 'fk_email_sending_logs_sender_emails1_idx',
     },
-    senderEmailId: { type: 'integer', persist: false },
-    recepientEmailId: { type: 'integer', persist: false },
+    senderEmailId: { type: 'integer', unsigned: true, persist: false },
+    recepientEmailId: { type: 'integer', unsigned: true, persist: false },
     reply: {
       kind: 'm:1',
       entity: () => SenderEmails,
@@ -935,7 +949,12 @@ export const EmailSendingLogsSchema = new EntitySchema({
       nullable: true,
       index: 'fk_email_sending_logs_sender_emails2_idx',
     },
-    replyEmailId: { type: 'integer', nullable: true, persist: false },
+    replyEmailId: {
+      type: 'integer',
+      unsigned: true,
+      nullable: true,
+      persist: false,
+    },
     createdAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
   },
 });
@@ -1007,7 +1026,7 @@ export const RecepientEmailsSchema = new EntitySchema({
       entity: () => Recepients,
       fieldName: 'recepient_id',
     },
-    recepientId: { type: 'integer', persist: false },
+    recepientId: { type: 'integer', unsigned: true, persist: false },
     email: {
       primary: true,
       kind: 'm:1',
@@ -1017,6 +1036,7 @@ export const RecepientEmailsSchema = new EntitySchema({
     },
     emailId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_recepient_emails_emails1_idx',
     },
@@ -1085,7 +1105,7 @@ export const SenderEmailsSchema = new EntitySchema({
       entity: () => Senders,
       fieldName: 'sender_id',
     },
-    senderId: { type: 'integer', persist: false },
+    senderId: { type: 'integer', unsigned: true, persist: false },
     email: {
       primary: true,
       kind: 'm:1',
@@ -1095,6 +1115,7 @@ export const SenderEmailsSchema = new EntitySchema({
     },
     emailId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_sender_emails_emails1_idx',
     },
@@ -1161,28 +1182,28 @@ export class EmailSendingLogs {
   @PrimaryKey()
   logId!: number;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   senderId!: number;
 
   @ManyToOne({ entity: () => RecepientEmails, ref: true, fieldNames: ['recepient_id', 'recepient_email_id'], index: 'fk_email_sending_logs_recepient_emails1_idx' })
   recepient!: Ref<RecepientEmails>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   recepientId!: number;
 
   @ManyToOne({ entity: () => SenderEmails, ref: true, fieldNames: ['sender_id', 'sender_email_id'], index: 'fk_email_sending_logs_sender_emails1_idx' })
   sender!: Ref<SenderEmails>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   senderEmailId!: number;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   recepientEmailId!: number;
 
   @ManyToOne({ entity: () => SenderEmails, ref: true, fieldNames: ['sender_id', 'reply_email_id'], nullable: true, index: 'fk_email_sending_logs_sender_emails2_idx' })
   reply?: Ref<SenderEmails>;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   replyEmailId?: number;
 
   @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
@@ -1235,14 +1256,14 @@ export class RecepientEmails {
   @ManyToOne({ entity: () => Recepients, ref: true, fieldName: 'recepient_id', primary: true })
   recepient!: Ref<Recepients>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   recepientId!: number;
 
   @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_recepient_emails_emails1_idx' })
   email!: Ref<Emails>;
 
   @Index({ name: 'fk_recepient_emails_emails1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   emailId!: number;
 
   @OneToMany({ entity: () => EmailSendingLogs, mappedBy: 'recepient' })
@@ -1286,14 +1307,14 @@ export class SenderEmails {
   @ManyToOne({ entity: () => Senders, ref: true, fieldName: 'sender_id', primary: true })
   sender!: Ref<Senders>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   senderId!: number;
 
   @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_sender_emails_emails1_idx' })
   email!: Ref<Emails>;
 
   @Index({ name: 'fk_sender_emails_emails1_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   emailId!: number;
 
   @OneToMany({ entity: () => EmailSendingLogs, mappedBy: 'sender' })
@@ -1354,7 +1375,7 @@ export const EmailSendingLogsSchema = new EntitySchema({
   class: EmailSendingLogs,
   properties: {
     logId: { primary: true, type: 'integer' },
-    senderId: { type: 'integer', persist: false },
+    senderId: { type: 'integer', unsigned: true, persist: false },
     recepient: {
       kind: 'm:1',
       entity: () => RecepientEmails,
@@ -1362,7 +1383,7 @@ export const EmailSendingLogsSchema = new EntitySchema({
       fieldNames: ['recepient_id', 'recepient_email_id'],
       index: 'fk_email_sending_logs_recepient_emails1_idx',
     },
-    recepientId: { type: 'integer', persist: false },
+    recepientId: { type: 'integer', unsigned: true, persist: false },
     sender: {
       kind: 'm:1',
       entity: () => SenderEmails,
@@ -1370,8 +1391,8 @@ export const EmailSendingLogsSchema = new EntitySchema({
       fieldNames: ['sender_id', 'sender_email_id'],
       index: 'fk_email_sending_logs_sender_emails1_idx',
     },
-    senderEmailId: { type: 'integer', persist: false },
-    recepientEmailId: { type: 'integer', persist: false },
+    senderEmailId: { type: 'integer', unsigned: true, persist: false },
+    recepientEmailId: { type: 'integer', unsigned: true, persist: false },
     reply: {
       kind: 'm:1',
       entity: () => SenderEmails,
@@ -1380,7 +1401,12 @@ export const EmailSendingLogsSchema = new EntitySchema({
       nullable: true,
       index: 'fk_email_sending_logs_sender_emails2_idx',
     },
-    replyEmailId: { type: 'integer', nullable: true, persist: false },
+    replyEmailId: {
+      type: 'integer',
+      unsigned: true,
+      nullable: true,
+      persist: false,
+    },
     createdAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
   },
 });
@@ -1453,7 +1479,7 @@ export const RecepientEmailsSchema = new EntitySchema({
       ref: true,
       fieldName: 'recepient_id',
     },
-    recepientId: { type: 'integer', persist: false },
+    recepientId: { type: 'integer', unsigned: true, persist: false },
     email: {
       primary: true,
       kind: 'm:1',
@@ -1464,6 +1490,7 @@ export const RecepientEmailsSchema = new EntitySchema({
     },
     emailId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_recepient_emails_emails1_idx',
     },
@@ -1533,7 +1560,7 @@ export const SenderEmailsSchema = new EntitySchema({
       ref: true,
       fieldName: 'sender_id',
     },
-    senderId: { type: 'integer', persist: false },
+    senderId: { type: 'integer', unsigned: true, persist: false },
     email: {
       primary: true,
       kind: 'm:1',
@@ -1544,6 +1571,7 @@ export const SenderEmailsSchema = new EntitySchema({
     },
     emailId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_sender_emails_emails1_idx',
     },

--- a/tests/features/entity-generator/__snapshots__/OverlapFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OverlapFks.mysql.test.ts.snap
@@ -25,14 +25,14 @@ export class ProductCountryMap {
 
   [PrimaryKeyProp]?: ['product', 'countries'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @ManyToOne({ entity: () => Products, fieldName: 'product_id', primary: true, index: 'fk_product_country_map_products1' })
   product!: Products;
 
   @Index({ name: 'fk_product_country_map_products1' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property({ type: 'boolean' })
@@ -55,14 +55,14 @@ export class ProductSellers {
   @ManyToOne({ entity: () => Sellers, fieldName: 'seller_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   seller!: Sellers;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @ManyToOne({ entity: () => Products, fieldName: 'product_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_product_sellers_products1' })
   product!: Products;
 
   @Index({ name: 'fk_product_sellers_products1' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property({ type: 'boolean' })
@@ -109,17 +109,17 @@ export class Sales {
   @PrimaryKey()
   saleId!: number;
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @ManyToOne({ entity: () => ProductSellers, fieldNames: ['seller_id', 'product_id'], updateRule: 'cascade', index: 'fk_sales_product_sellers1_idx' })
   seller!: ProductSellers;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @Index({ name: 'product_id_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property({ type: 'decimal', precision: 10, scale: 2 })
@@ -196,7 +196,7 @@ export const ProductCountryMapSchema = new EntitySchema({
     { name: 'primary_reindex_idx', properties: ['countries', 'productId'] },
   ],
   properties: {
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -206,6 +206,7 @@ export const ProductCountryMapSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_product_country_map_products1',
     },
@@ -243,7 +244,7 @@ export const ProductSellersSchema = new EntitySchema({
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
-    sellerId: { type: 'integer', persist: false },
+    sellerId: { type: 'integer', unsigned: true, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -255,6 +256,7 @@ export const ProductSellersSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_product_sellers_products1',
     },
@@ -313,7 +315,7 @@ export const SalesSchema = new EntitySchema({
   class: Sales,
   properties: {
     saleId: { primary: true, type: 'integer' },
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     seller: {
       kind: 'm:1',
       entity: () => ProductSellers,
@@ -321,8 +323,13 @@ export const SalesSchema = new EntitySchema({
       updateRule: 'cascade',
       index: 'fk_sales_product_sellers1_idx',
     },
-    sellerId: { type: 'integer', persist: false },
-    productId: { type: 'integer', persist: false, index: 'product_id_idx' },
+    sellerId: { type: 'integer', unsigned: true, persist: false },
+    productId: {
+      type: 'integer',
+      unsigned: true,
+      persist: false,
+      index: 'product_id_idx',
+    },
     singularPrice: { type: 'decimal', precision: 10, scale: 2 },
     quantitySold: { type: 'integer', unsigned: true },
     productCountryMap: {
@@ -390,14 +397,14 @@ export class ProductCountryMap {
 
   [PrimaryKeyProp]?: ['product', 'countries'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @ManyToOne({ entity: () => Products, ref: true, fieldName: 'product_id', primary: true, index: 'fk_product_country_map_products1' })
   product!: Ref<Products>;
 
   @Index({ name: 'fk_product_country_map_products1' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property({ type: 'boolean' })
@@ -420,14 +427,14 @@ export class ProductSellers {
   @ManyToOne({ entity: () => Sellers, ref: true, fieldName: 'seller_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   seller!: Ref<Sellers>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @ManyToOne({ entity: () => Products, ref: true, fieldName: 'product_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_product_sellers_products1' })
   product!: Ref<Products>;
 
   @Index({ name: 'fk_product_sellers_products1' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property({ type: 'boolean' })
@@ -474,17 +481,17 @@ export class Sales {
   @PrimaryKey()
   saleId!: number;
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @ManyToOne({ entity: () => ProductSellers, ref: true, fieldNames: ['seller_id', 'product_id'], updateRule: 'cascade', index: 'fk_sales_product_sellers1_idx' })
   seller!: Ref<ProductSellers>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @Index({ name: 'product_id_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property({ type: 'decimal', precision: 10, scale: 2 })
@@ -561,7 +568,7 @@ export const ProductCountryMapSchema = new EntitySchema({
     { name: 'primary_reindex_idx', properties: ['countries', 'productId'] },
   ],
   properties: {
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -572,6 +579,7 @@ export const ProductCountryMapSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_product_country_map_products1',
     },
@@ -611,7 +619,7 @@ export const ProductSellersSchema = new EntitySchema({
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
-    sellerId: { type: 'integer', persist: false },
+    sellerId: { type: 'integer', unsigned: true, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -624,6 +632,7 @@ export const ProductSellersSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_product_sellers_products1',
     },
@@ -682,7 +691,7 @@ export const SalesSchema = new EntitySchema({
   class: Sales,
   properties: {
     saleId: { primary: true, type: 'integer' },
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     seller: {
       kind: 'm:1',
       entity: () => ProductSellers,
@@ -691,8 +700,13 @@ export const SalesSchema = new EntitySchema({
       updateRule: 'cascade',
       index: 'fk_sales_product_sellers1_idx',
     },
-    sellerId: { type: 'integer', persist: false },
-    productId: { type: 'integer', persist: false, index: 'product_id_idx' },
+    sellerId: { type: 'integer', unsigned: true, persist: false },
+    productId: {
+      type: 'integer',
+      unsigned: true,
+      persist: false,
+      index: 'product_id_idx',
+    },
     singularPrice: { type: 'decimal', precision: 10, scale: 2 },
     quantitySold: { type: 'integer', unsigned: true },
     productCountryMap: {
@@ -770,14 +784,14 @@ export class ProductCountryMap {
 
   [PrimaryKeyProp]?: ['product', 'countries'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @ManyToOne({ entity: () => Products, fieldName: 'product_id', primary: true, index: 'fk_product_country_map_products1' })
   product!: Products;
 
   @Index({ name: 'fk_product_country_map_products1' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property({ type: 'boolean' })
@@ -804,14 +818,14 @@ export class ProductSellers {
   @ManyToOne({ entity: () => Sellers, fieldName: 'seller_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   seller!: Sellers;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @ManyToOne({ entity: () => Products, fieldName: 'product_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_product_sellers_products1' })
   product!: Products;
 
   @Index({ name: 'fk_product_sellers_products1' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property({ type: 'boolean' })
@@ -872,17 +886,17 @@ export class Sales {
   @PrimaryKey()
   saleId!: number;
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @ManyToOne({ entity: () => ProductSellers, fieldNames: ['seller_id', 'product_id'], updateRule: 'cascade', index: 'fk_sales_product_sellers1_idx' })
   seller!: ProductSellers;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @Index({ name: 'product_id_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property({ type: 'decimal', precision: 10, scale: 2 })
@@ -978,7 +992,7 @@ export const ProductCountryMapSchema = new EntitySchema({
     { name: 'primary_reindex_idx', properties: ['countries', 'productId'] },
   ],
   properties: {
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -988,6 +1002,7 @@ export const ProductCountryMapSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_product_country_map_products1',
     },
@@ -1032,7 +1047,7 @@ export const ProductSellersSchema = new EntitySchema({
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
-    sellerId: { type: 'integer', persist: false },
+    sellerId: { type: 'integer', unsigned: true, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -1044,6 +1059,7 @@ export const ProductSellersSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_product_sellers_products1',
     },
@@ -1123,7 +1139,7 @@ export const SalesSchema = new EntitySchema({
   class: Sales,
   properties: {
     saleId: { primary: true, type: 'integer' },
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     seller: {
       kind: 'm:1',
       entity: () => ProductSellers,
@@ -1131,8 +1147,13 @@ export const SalesSchema = new EntitySchema({
       updateRule: 'cascade',
       index: 'fk_sales_product_sellers1_idx',
     },
-    sellerId: { type: 'integer', persist: false },
-    productId: { type: 'integer', persist: false, index: 'product_id_idx' },
+    sellerId: { type: 'integer', unsigned: true, persist: false },
+    productId: {
+      type: 'integer',
+      unsigned: true,
+      persist: false,
+      index: 'product_id_idx',
+    },
     singularPrice: { type: 'decimal', precision: 10, scale: 2 },
     quantitySold: { type: 'integer', unsigned: true },
     productCountryMap: {
@@ -1215,14 +1236,14 @@ export class ProductCountryMap {
 
   [PrimaryKeyProp]?: ['product', 'countries'];
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @ManyToOne({ entity: () => Products, ref: true, fieldName: 'product_id', primary: true, index: 'fk_product_country_map_products1' })
   product!: Ref<Products>;
 
   @Index({ name: 'fk_product_country_map_products1' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property({ type: 'boolean' })
@@ -1249,14 +1270,14 @@ export class ProductSellers {
   @ManyToOne({ entity: () => Sellers, ref: true, fieldName: 'seller_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   seller!: Ref<Sellers>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @ManyToOne({ entity: () => Products, ref: true, fieldName: 'product_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_product_sellers_products1' })
   product!: Ref<Products>;
 
   @Index({ name: 'fk_product_sellers_products1' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property({ type: 'boolean' })
@@ -1317,17 +1338,17 @@ export class Sales {
   @PrimaryKey()
   saleId!: number;
 
-  @Property({ persist: false })
+  @Property({ type: 'character', length: 2, persist: false })
   country!: string;
 
   @ManyToOne({ entity: () => ProductSellers, ref: true, fieldNames: ['seller_id', 'product_id'], updateRule: 'cascade', index: 'fk_sales_product_sellers1_idx' })
   seller!: Ref<ProductSellers>;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   sellerId!: number;
 
   @Index({ name: 'product_id_idx' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   productId!: number;
 
   @Property({ type: 'decimal', precision: 10, scale: 2 })
@@ -1423,7 +1444,7 @@ export const ProductCountryMapSchema = new EntitySchema({
     { name: 'primary_reindex_idx', properties: ['countries', 'productId'] },
   ],
   properties: {
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -1434,6 +1455,7 @@ export const ProductCountryMapSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_product_country_map_products1',
     },
@@ -1480,7 +1502,7 @@ export const ProductSellersSchema = new EntitySchema({
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
-    sellerId: { type: 'integer', persist: false },
+    sellerId: { type: 'integer', unsigned: true, persist: false },
     product: {
       primary: true,
       kind: 'm:1',
@@ -1493,6 +1515,7 @@ export const ProductSellersSchema = new EntitySchema({
     },
     productId: {
       type: 'integer',
+      unsigned: true,
       persist: false,
       index: 'fk_product_sellers_products1',
     },
@@ -1572,7 +1595,7 @@ export const SalesSchema = new EntitySchema({
   class: Sales,
   properties: {
     saleId: { primary: true, type: 'integer' },
-    country: { type: 'character', persist: false },
+    country: { type: 'character', length: 2, persist: false },
     seller: {
       kind: 'm:1',
       entity: () => ProductSellers,
@@ -1581,8 +1604,13 @@ export const SalesSchema = new EntitySchema({
       updateRule: 'cascade',
       index: 'fk_sales_product_sellers1_idx',
     },
-    sellerId: { type: 'integer', persist: false },
-    productId: { type: 'integer', persist: false, index: 'product_id_idx' },
+    sellerId: { type: 'integer', unsigned: true, persist: false },
+    productId: {
+      type: 'integer',
+      unsigned: true,
+      persist: false,
+      index: 'product_id_idx',
+    },
     singularPrice: { type: 'decimal', precision: 10, scale: 2 },
     quantitySold: { type: 'integer', unsigned: true },
     productCountryMap: {

--- a/tests/features/entity-generator/__snapshots__/ScalarPropsForFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/ScalarPropsForFks.mysql.test.ts.snap
@@ -13,7 +13,7 @@ export class Address2 {
   @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
   author!: Author2;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   authorId!: number;
 
   @Property({ comment: 'This is address property' })
@@ -72,14 +72,14 @@ export class Author2 {
   favouriteBook?: Book2;
 
   @Index({ name: 'author2_favourite_book_uuid_pk_index' })
-  @Property({ nullable: true, persist: false })
+  @Property({ length: 36, nullable: true, persist: false })
   favouriteBookUuidPk?: string;
 
   @ManyToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   favouriteAuthor?: Author2;
 
   @Index({ name: 'author2_favourite_author_id_index' })
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   favouriteAuthorId?: number;
 
   @Property({ type: 'json', nullable: true })
@@ -118,14 +118,14 @@ export class BaseUser2 {
   favouriteEmployee?: BaseUser2;
 
   @Index({ name: 'base_user2_favourite_employee_id_index' })
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   favouriteEmployeeId?: number;
 
   @OneToOne({ entity: () => BaseUser2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   favouriteManager?: BaseUser2;
 
   @Unique({ name: 'base_user2_favourite_manager_id_unique' })
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   favouriteManagerId?: number;
 
   @Unique({ name: 'base_user2_employee_prop_unique' })
@@ -196,14 +196,14 @@ export class Book2 {
   author!: Author2;
 
   @Index({ name: 'book2_author_id_index' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   authorId!: number;
 
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
   publisher?: Publisher2;
 
   @Index({ name: 'book2_publisher_id_index' })
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   publisherId?: number;
 
   @Property({ type: 'string', nullable: true })
@@ -230,14 +230,14 @@ export class Book2Tags {
   book2!: Book2;
 
   @Index({ name: 'book2_tags_book2_uuid_pk_index' })
-  @Property({ fieldName: 'book2_uuid_pk', persist: false })
+  @Property({ fieldName: 'book2_uuid_pk', length: 36, persist: false })
   book2UuidPk!: string;
 
   @ManyToOne({ entity: () => BookTag2, updateRule: 'cascade', deleteRule: 'cascade' })
   bookTag2!: BookTag2;
 
   @Index({ name: 'book2_tags_book_tag2_id_index' })
-  @Property({ fieldName: 'book_tag2_id', persist: false })
+  @Property({ fieldName: 'book_tag2_id', unsigned: true, persist: false })
   bookTag2Id!: bigint;
 
 }
@@ -257,10 +257,10 @@ export class CarOwner2 {
   @ManyToOne({ entity: () => Car2, updateRule: 'cascade' })
   car!: Car2;
 
-  @Property({ persist: false })
+  @Property({ length: 100, persist: false })
   carName!: string;
 
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   carYear!: number;
 
 }
@@ -300,7 +300,7 @@ export class Configuration2 {
   test!: Test2;
 
   @Index({ name: 'configuration2_test_id_index' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   testId!: number;
 
   @Property()
@@ -337,14 +337,14 @@ export class FooBar2 {
   baz?: FooBaz2;
 
   @Unique({ name: 'foo_bar2_baz_id_unique' })
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   bazId?: number;
 
   @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   fooBar?: FooBar2;
 
   @Unique({ name: 'foo_bar2_foo_bar_id_unique' })
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   fooBarId?: number;
 
   @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
@@ -396,14 +396,14 @@ export class FooParam2 {
   bar!: FooBar2;
 
   @Index({ name: 'foo_param2_bar_id_index' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   barId!: number;
 
   @ManyToOne({ entity: () => FooBaz2, updateRule: 'cascade', primary: true })
   baz!: FooBaz2;
 
   @Index({ name: 'foo_param2_baz_id_index' })
-  @Property({ persist: false })
+  @Property({ unsigned: true, persist: false })
   bazId!: number;
 
   @Property()
@@ -482,14 +482,14 @@ export class Publisher2Tests {
   publisher2!: Publisher2;
 
   @Index({ name: 'publisher2_tests_publisher2_id_index' })
-  @Property({ fieldName: 'publisher2_id', persist: false })
+  @Property({ fieldName: 'publisher2_id', unsigned: true, persist: false })
   publisher2Id!: number;
 
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
   test2!: Test2;
 
   @Index({ name: 'publisher2_tests_test2_id_index' })
-  @Property({ fieldName: 'test2_id', persist: false })
+  @Property({ fieldName: 'test2_id', unsigned: true, persist: false })
   test2Id!: number;
 
 }
@@ -527,21 +527,21 @@ export class Test2 {
   book?: Book2;
 
   @Unique({ name: 'test2_book_uuid_pk_unique' })
-  @Property({ nullable: true, persist: false })
+  @Property({ length: 36, nullable: true, persist: false })
   bookUuidPk?: string;
 
   @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   parent?: Test2;
 
   @Index({ name: 'test2_parent_id_index' })
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   parentId?: number;
 
   @Property({ type: 'integer' })
   version: number & Opt = 1;
 
   @Unique({ name: 'test2_foo___bar_unique' })
-  @Property({ fieldName: 'foo___bar', nullable: true, persist: false })
+  @Property({ fieldName: 'foo___bar', unsigned: true, nullable: true, persist: false })
   fooBar?: number;
 
   @Property({ fieldName: 'foo___baz', unsigned: true, nullable: true })
@@ -576,10 +576,10 @@ export class User2 {
   @OneToOne({ entity: () => Car2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   favouriteCar?: Car2;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ length: 100, nullable: true, persist: false })
   favouriteCarName?: string;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   favouriteCarYear?: number;
 
   @ManyToMany({ entity: () => Car2, joinColumns: ['user2_first_name', 'user2_last_name'], inverseJoinColumns: ['car2_name', 'car2_year'] })
@@ -1088,10 +1088,10 @@ export class User2 {
   @OneToOne({ entity: () => Car2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   favouriteCar?: Car2;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ length: 100, nullable: true, persist: false })
   favouriteCarName?: string;
 
-  @Property({ nullable: true, persist: false })
+  @Property({ unsigned: true, nullable: true, persist: false })
   favouriteCarYear?: number;
 
   @ManyToMany({ entity: () => Car2, joinColumns: ['user2_first_name', 'user2_last_name'], inverseJoinColumns: ['car2_name', 'car2_year'] })


### PR DESCRIPTION
The extra information may be useful to custom types.
In the case of the "type" option, it's also required to skip runtime type inference.