### PR TITLE
fix(mssql): do not escape as many charecters

### DIFF
--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -35,7 +35,7 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
   override init(orm: MikroORM): void {
     super.init(orm);
     // do not double escape backslash inside strings
-    SqlString.CHARS_GLOBAL_REGEXP = /[\0\b\f\t\r\v\x1a']/g; // eslint-disable-line no-control-regex
+    SqlString.CHARS_GLOBAL_REGEXP = /[\0\b\x1a']/g; // eslint-disable-line no-control-regex
   }
 
   override usesOutputStatement(): boolean {

--- a/tests/platforms/GH5811.test.ts
+++ b/tests/platforms/GH5811.test.ts
@@ -32,10 +32,10 @@ afterAll(async () => {
 });
 
 test('MsSql should not encode newline', async () => {
-  const originalComment = new Comment('foo\nbar');
+  const originalComment = new Comment('foo\nnew\thtab\vvtab\rreturn');
   await orm.em.persistAndFlush(originalComment);
   orm.em.clear();
 
   const comment = await orm.em.findOne(Comment, { id: originalComment.id });
-  expect(comment?.content).toEqual('foo\nbar');
+  expect(comment?.content).toEqual('foo\nnew\thtab\vvtab\rreturn');
 });


### PR DESCRIPTION
The fix for mikro-orm#5811 solved new line but there are other escape characters that when escaped don't persist correctly in mssql.