### PR TITLE
fix(core): fix CreateRequestContext not working with callback returning EntityManager

### DIFF
--- a/packages/core/src/decorators/CreateRequestContext.ts
+++ b/packages/core/src/decorators/CreateRequestContext.ts
@@ -17,11 +17,11 @@ export function CreateRequestContext<T>(getContext?: MikroORM | Promise<MikroORM
       let em: unknown;
 
       if (typeof getContext === 'function') {
-        orm = await (getContext(this) ?? (this as any).orm);
-        em = await (getContext(this) ?? (this as any).em);
+        const context = await getContext(this)
+        orm = context ?? await (this as any).orm;
+        em = context ?? await (this as any).em;
       } else if (getContext) {
-        orm = await getContext;
-        em = await getContext;
+        orm = em = await getContext;
       } else {
         orm = await (this as any).orm;
         em = await (this as any).em;

--- a/packages/core/src/decorators/CreateRequestContext.ts
+++ b/packages/core/src/decorators/CreateRequestContext.ts
@@ -17,7 +17,7 @@ export function CreateRequestContext<T>(getContext?: MikroORM | Promise<MikroORM
       let em: unknown;
 
       if (typeof getContext === 'function') {
-        const context = await getContext(this)
+        const context = await getContext(this);
         orm = context ?? await (this as any).orm;
         em = context ?? await (this as any).em;
       } else if (getContext) {

--- a/packages/core/src/decorators/CreateRequestContext.ts
+++ b/packages/core/src/decorators/CreateRequestContext.ts
@@ -18,8 +18,10 @@ export function CreateRequestContext<T>(getContext?: MikroORM | Promise<MikroORM
 
       if (typeof getContext === 'function') {
         orm = await (getContext(this) ?? (this as any).orm);
+        em = await (getContext(this) ?? (this as any).em);
       } else if (getContext) {
         orm = await getContext;
+        em = await getContext;
       } else {
         orm = await (this as any).orm;
         em = await (this as any).em;


### PR DESCRIPTION
I've noticed that there was an existing PR addressing the same issue (https://github.com/mikro-orm/mikro-orm/pull/5423) which hasn't been merged yet. Therefore, I've created this PR to address the issue.

According to [the documentation](https://github.com/mikro-orm/mikro-orm/blob/623ee3a9768a88184c8b249250135b891261886a/docs/docs/identity-map.md?plain=1#L132), `CreateRequestContext` or `EnsureRequestContext` should support a callback that returns an `EntityManager` instance, but currently, it does not.

This PR updates `CreateRequestContext` to support a callback that returns an `EntityManager` instance.

The following code does not work with the current implementation, but this PR resolves the issue:

```ts
export class Service {
  constructor(private readonly em: EntityManager) {}

  @CreateRequestContext((self: Service) => self.em)
  async doSomething() {
  }
}
```