### PR TITLE
docs: fix `make` method usage example in seeding section

### DIFF
--- a/docs/docs/seeding.md
+++ b/docs/docs/seeding.md
@@ -201,11 +201,17 @@ const authors = new AuthorFactory(orm.em).make(5);
 
 #### Overriding attributes
 
-If you would like to override some of the default values of your factories, you may pass an object to the make method. Only the specified attributes will be replaced while the rest of the attributes remain set to their default values as specified by the factory.
+If you would like to override some of the default values of your factories, you may pass an object to the `make` method. Only the specified attributes will be replaced while the rest of the attributes remain set to their default values as specified by the factory.
 
 ```ts
-const author = new AuthorFactory(orm.em).make({
+// Make a single author
+const author = new AuthorFactory(orm.em).makeOne({
   name: 'John Snow',
+});
+
+// Make 5 authors
+const authors = new AuthorFactory(orm.em).make(5, {
+  name: 'John Snow'
 });
 ```
 

--- a/docs/docs/seeding.md
+++ b/docs/docs/seeding.md
@@ -211,7 +211,7 @@ const author = new AuthorFactory(orm.em).makeOne({
 
 // Make 5 authors
 const authors = new AuthorFactory(orm.em).make(5, {
-  name: 'John Snow'
+  name: 'John Snow',
 });
 ```
 

--- a/docs/versioned_docs/version-6.3/seeding.md
+++ b/docs/versioned_docs/version-6.3/seeding.md
@@ -201,10 +201,16 @@ const authors = new AuthorFactory(orm.em).make(5);
 
 #### Overriding attributes
 
-If you would like to override some of the default values of your factories, you may pass an object to the make method. Only the specified attributes will be replaced while the rest of the attributes remain set to their default values as specified by the factory.
+If you would like to override some of the default values of your factories, you may pass an object to the `make` method. Only the specified attributes will be replaced while the rest of the attributes remain set to their default values as specified by the factory.
 
 ```ts
-const author = new AuthorFactory(orm.em).make({
+// Make a single author
+const author = new AuthorFactory(orm.em).makeOne({
+  name: 'John Snow',
+});
+
+// Make 5 authors
+const authors = new AuthorFactory(orm.em).make(5, {
   name: 'John Snow',
 });
 ```


### PR DESCRIPTION
Hello, this is just fixing a typo in the docs. The `make` method requires a number as its first argument, but the documents do not include that.

I added correct examples for `make` and `makeOne`, similar to the existing examples for `create` and `createOne` below it.