### PR TITLE
fix(knex): update `PoolConfig` interface to match what knex supports

### DIFF
--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -509,7 +509,7 @@ export interface SeederOptions {
 
 export interface PoolConfig {
   name?: string;
-  afterCreate?: (...a: unknown[]) => unknown;
+  afterCreate?: Function;
   min?: number;
   max?: number;
   refreshIdle?: boolean;
@@ -519,16 +519,12 @@ export interface PoolConfig {
   priorityRange?: number;
   log?: (message: string, logLevel: string) => void;
 
-  // generic-pool v3 configs
-  maxWaitingClients?: number;
-  testOnBorrow?: boolean;
+  // tarn configs
+  propagateCreateError?: boolean;
+  createRetryIntervalMillis?: number;
+  createTimeoutMillis?: number;
+  destroyTimeoutMillis?: number;
   acquireTimeoutMillis?: number;
-  fifo?: boolean;
-  autostart?: boolean;
-  evictionRunIntervalMillis?: number;
-  numTestsPerRun?: number;
-  softIdleTimeoutMillis?: number;
-  Promise?: any;
 }
 
 export interface MetadataDiscoveryOptions {


### PR DESCRIPTION
Knex moved to tarn.js way back (https://github.com/knex/knex/issues/4395), this type hasn't kept up

The current type includes options which will prevent the pool from starting up as tarn validates the provided options (`evictionRunIntervalMillis`) and is missing options which can be useful 