### PR TITLE
test: generate code coverage only on node 22

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,9 +156,17 @@ jobs:
         uses: SimenB/github-actions-cpu-cores@v2
 
       - name: Test
+        if: matrix.node-version < 22
         run: |
-          yarn coverage --max-workers ${{ steps.cpu-cores.outputs.count }} > COVERAGE_RESULT
-          echo "$(cat COVERAGE_RESULT)"
+          yarn test --max-workers ${{ steps.cpu-cores.outputs.count }}
+          git status && git diff
+        env:
+          RETRY_TESTS: 1
+
+      - name: Coverage
+        if: matrix.node-version == 22
+        run: |
+          yarn coverage --max-workers ${{ steps.cpu-cores.outputs.count }}
           git status && git diff
         env:
           RETRY_TESTS: 1


### PR DESCRIPTION
Since the perf improvements in node 22 are quite significant, this should lower the overall CI time spent in tests in the slower node versions.