### PR TITLE
docs(example): add missing mikro-orm section to package.json

### DIFF
--- a/docs/docs/guide/01-first-entity.md
+++ b/docs/docs/guide/01-first-entity.md
@@ -164,7 +164,10 @@ Save this file into `src/mikro-orm.config.ts`, so it will get compiled together 
 {
   "type": "module",
   "dependencies": { ... },
-  "devDependencies": { ... }
+  "devDependencies": { ... },
+  "mikro-orm": {
+    "useTsNode": true
+  }
 }
 ```
 


### PR DESCRIPTION
The documentation mentions that adding the mikro-orm section to package.json enables TypeScript support for the CLI. However, the actual example code does not include this section.

Based on the information provided in [Checkpoint 1](https://stackblitz.com/edit/mikro-orm-getting-started-guide-cp-1?file=package.json), I have added the necessary mikro-orm configuration to the package.json example to ensure consistency and correctness.