### PR TITLE
docs(guide): resolve 'No entities found' error in test setup

### DIFF
--- a/docs/docs/guide/03-project-setup.md
+++ b/docs/docs/guide/03-project-setup.md
@@ -216,12 +216,12 @@ Let's create one more utility file before we get to the first test, and put it i
 ```ts title='utils.ts'
 import { bootstrap } from '../src/app.js';
 import { initORM } from '../src/db.js';
-import config from "../src/mikro-orm.config.js";
+import config from '../src/mikro-orm.config.js';
 
 export async function initTestApp(port: number) {
   // this will create all the ORM services and cache them
   const { orm } = await initORM({
-    // copy existing config options
+    // first, include the main config
     ...config,
     // no need for debug information, it would only pollute the logs
     debug: false,

--- a/docs/docs/guide/03-project-setup.md
+++ b/docs/docs/guide/03-project-setup.md
@@ -216,10 +216,13 @@ Let's create one more utility file before we get to the first test, and put it i
 ```ts title='utils.ts'
 import { bootstrap } from '../src/app.js';
 import { initORM } from '../src/db.js';
+import config from "../src/mikro-orm.config.js";
 
 export async function initTestApp(port: number) {
   // this will create all the ORM services and cache them
   const { orm } = await initORM({
+    // copy existing config options
+    ...config,
     // no need for debug information, it would only pollute the logs
     debug: false,
     // we will use in-memory database, this way we can easily parallelize our tests

--- a/docs/versioned_docs/version-6.3/guide/03-project-setup.md
+++ b/docs/versioned_docs/version-6.3/guide/03-project-setup.md
@@ -216,10 +216,13 @@ Let's create one more utility file before we get to the first test, and put it i
 ```ts title='utils.ts'
 import { bootstrap } from '../src/app.js';
 import { initORM } from '../src/db.js';
+import config from '../src/mikro-orm.config.js';
 
 export async function initTestApp(port: number) {
   // this will create all the ORM services and cache them
   const { orm } = await initORM({
+    // first, include the main config
+    ...config,
     // no need for debug information, it would only pollute the logs
     debug: false,
     // we will use in-memory database, this way we can easily parallelize our tests


### PR DESCRIPTION
The initial test setup was missing the `entities` option in the ORM configuration, leading to a 'No entities found' error. Updated `initTestApp` function to include the existing configuration from `mikro-orm.config.js` and override specific settings for testing.

- Imported the existing ORM configuration.
- Added `entities` option to the configuration for test environment.