### PR TITLE
fix(postgres): respect `timezone` option and interpret `timestamp` columns in UTC by default

### DIFF
--- a/packages/core/src/hydration/ObjectHydrator.ts
+++ b/packages/core/src/hydration/ObjectHydrator.ts
@@ -100,7 +100,7 @@ export class ObjectHydrator extends Hydrator {
         );
       } else if (prop.runtimeType === 'boolean') {
         ret.push(`    entity${entityKey} = !!data${dataKey};`);
-      } else if (prop.runtimeType === 'Date') {
+      } else if (prop.runtimeType === 'Date' && !this.platform.isNumericProperty(prop)) {
         ret.push(`    if (data${dataKey} instanceof Date) {`);
         ret.push(`      entity${entityKey} = data${dataKey};`);
 

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1132,7 +1132,7 @@ export class MetadataDiscovery {
   private initAutoincrement(meta: EntityMetadata): void {
     const pks = meta.getPrimaryProps();
 
-    if (pks.length === 1 && this.isNumericProperty(pks[0])) {
+    if (pks.length === 1 && this.platform.isNumericProperty(pks[0])) {
       /* istanbul ignore next */
       pks[0].autoincrement ??= true;
     }
@@ -1504,7 +1504,7 @@ export class MetadataDiscovery {
       return;
     }
 
-    prop.unsigned ??= (prop.primary || prop.unsigned) && this.isNumericProperty(prop) && this.platform.supportsUnsigned();
+    prop.unsigned ??= (prop.primary || prop.unsigned) && this.platform.isNumericProperty(prop) && this.platform.supportsUnsigned();
   }
 
   private initIndexes(meta: EntityMetadata, prop: EntityProperty): void {
@@ -1513,15 +1513,6 @@ export class MetadataDiscovery {
     if (prop.kind === ReferenceKind.MANY_TO_ONE && this.platform.indexForeignKeys() && !hasIndex) {
       prop.index ??= true;
     }
-  }
-
-  private isNumericProperty(prop: EntityProperty): boolean {
-    if (prop.customType) {
-      return this.platform.isNumericColumn(prop.customType);
-    }
-
-    const numericMappedType = prop.columnTypes?.[0] && this.platform.isNumericColumn(this.platform.getMappedType(prop.columnTypes[0]));
-    return numericMappedType || prop.type === 'number' || this.platform.isBigIntProperty(prop);
   }
 
   private async getEntityClassOrSchema(path: string, name: string) {

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -551,6 +551,11 @@ export abstract class Platform {
     return this.timezone;
   }
 
+  isNumericProperty(prop: EntityProperty, ignoreCustomType = false): boolean {
+    const numericMappedType = prop.columnTypes?.[0] && this.isNumericColumn(this.getMappedType(prop.columnTypes[0]));
+    return numericMappedType || prop.type === 'number' || this.isBigIntProperty(prop);
+  }
+
   isNumericColumn(mappedType: Type<unknown>): boolean {
     return [IntegerType, SmallIntType, BigIntType, TinyIntType].some(t => mappedType instanceof t);
   }

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -95,7 +95,6 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver, EM exten
     persistOnCreate: true,
     forceEntityConstructor: false,
     forceUndefined: false,
-    forceUtcTimezone: false,
     ensureDatabase: true,
     ensureIndexes: false,
     batchSize: 300,
@@ -569,7 +568,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver, EM
   persistOnCreate: boolean;
   forceEntityConstructor: boolean | (Constructor<AnyEntity> | string)[];
   forceUndefined: boolean;
-  forceUtcTimezone: boolean;
+  forceUtcTimezone?: boolean;
   timezone?: string;
   ensureDatabase: boolean | EnsureDatabaseOptions;
   ensureIndexes: boolean;

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -363,7 +363,7 @@ export class EntityComparator {
         lines.push(`    ret${this.wrap(prop.name)} = ${this.propName(prop.fieldNames[0])} == null ? ${this.propName(prop.fieldNames[0])} : !!${this.propName(prop.fieldNames[0])};`);
         lines.push(`    ${this.propName(prop.fieldNames[0], 'mapped')} = true;`);
         lines.push(`  }`);
-      } else if (prop.runtimeType === 'Date') {
+      } else if (prop.runtimeType === 'Date' && !this.platform.isNumericProperty(prop)) {
         lines.push(`  if (typeof ${this.propName(prop.fieldNames[0])} !== 'undefined') {`);
         context.set('parseDate', (value: string | number) => this.platform.parseDate(value as string));
         parseDate('ret' + this.wrap(prop.name), this.propName(prop.fieldNames[0]));

--- a/packages/mssql/src/MsSqlConnection.ts
+++ b/packages/mssql/src/MsSqlConnection.ts
@@ -25,7 +25,7 @@ export class MsSqlConnection extends AbstractSqlConnection {
       options: {
         enableArithAbort: true,
         fallbackToDefaultDb: true,
-        useUTC: this.config.get('forceUtcTimezone'),
+        useUTC: this.config.get('forceUtcTimezone', false),
       },
     };
 

--- a/tests/features/custom-types/GH5540.postgres.test.ts
+++ b/tests/features/custom-types/GH5540.postgres.test.ts
@@ -29,6 +29,7 @@ class TimestampType extends Type<JSType, DBType> {
     if (value == null) {
       return value;
     }
+
     return new Date(Number(value));
   }
 

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
@@ -334,8 +334,10 @@ exports[`embedded entities in postgres diffing 2`] = `
             } else if (typeof data.profile1_identity_links[idx_8].createdAt !== 'undefined') {
               if (data.profile1_identity_links[idx_8].createdAt instanceof Date) {
                 entity.profile1.identity.links[idx_8].createdAt = data.profile1_identity_links[idx_8].createdAt;
-              } else {
+              } else if (typeof data.profile1_identity_links[idx_8].createdAt === 'number' || data.profile1_identity_links[idx_8].createdAt.includes('+')) {
                 entity.profile1.identity.links[idx_8].createdAt = new Date(data.profile1_identity_links[idx_8].createdAt);
+              } else {
+                entity.profile1.identity.links[idx_8].createdAt = new Date(data.profile1_identity_links[idx_8].createdAt + 'Z');
               }
             }
             if (data.profile1_identity_links[idx_8].meta != null) {
@@ -509,8 +511,10 @@ exports[`embedded entities in postgres diffing 2`] = `
             } else if (typeof data.profile1_identity.links[idx_21].createdAt !== 'undefined') {
               if (data.profile1_identity.links[idx_21].createdAt instanceof Date) {
                 entity.profile1.identity.links[idx_21].createdAt = data.profile1_identity.links[idx_21].createdAt;
-              } else {
+              } else if (typeof data.profile1_identity.links[idx_21].createdAt === 'number' || data.profile1_identity.links[idx_21].createdAt.includes('+')) {
                 entity.profile1.identity.links[idx_21].createdAt = new Date(data.profile1_identity.links[idx_21].createdAt);
+              } else {
+                entity.profile1.identity.links[idx_21].createdAt = new Date(data.profile1_identity.links[idx_21].createdAt + 'Z');
               }
             }
             if (data.profile1_identity.links[idx_21].meta != null) {
@@ -711,8 +715,10 @@ exports[`embedded entities in postgres diffing 2`] = `
             } else if (typeof data.profile1_identity_links[idx_35].createdAt !== 'undefined') {
               if (data.profile1_identity_links[idx_35].createdAt instanceof Date) {
                 entity.profile1.identity.links[idx_35].createdAt = data.profile1_identity_links[idx_35].createdAt;
-              } else {
+              } else if (typeof data.profile1_identity_links[idx_35].createdAt === 'number' || data.profile1_identity_links[idx_35].createdAt.includes('+')) {
                 entity.profile1.identity.links[idx_35].createdAt = new Date(data.profile1_identity_links[idx_35].createdAt);
+              } else {
+                entity.profile1.identity.links[idx_35].createdAt = new Date(data.profile1_identity_links[idx_35].createdAt + 'Z');
               }
             }
             if (data.profile1_identity_links[idx_35].meta != null) {
@@ -886,8 +892,10 @@ exports[`embedded entities in postgres diffing 2`] = `
             } else if (typeof data.profile1.identity.links[idx_48].createdAt !== 'undefined') {
               if (data.profile1.identity.links[idx_48].createdAt instanceof Date) {
                 entity.profile1.identity.links[idx_48].createdAt = data.profile1.identity.links[idx_48].createdAt;
-              } else {
+              } else if (typeof data.profile1.identity.links[idx_48].createdAt === 'number' || data.profile1.identity.links[idx_48].createdAt.includes('+')) {
                 entity.profile1.identity.links[idx_48].createdAt = new Date(data.profile1.identity.links[idx_48].createdAt);
+              } else {
+                entity.profile1.identity.links[idx_48].createdAt = new Date(data.profile1.identity.links[idx_48].createdAt + 'Z');
               }
             }
             if (data.profile1.identity.links[idx_48].meta != null) {
@@ -1052,8 +1060,10 @@ exports[`embedded entities in postgres diffing 2`] = `
             } else if (typeof data.profile2.identity.links[idx_60].createdAt !== 'undefined') {
               if (data.profile2.identity.links[idx_60].createdAt instanceof Date) {
                 entity.profile2.identity.links[idx_60].createdAt = data.profile2.identity.links[idx_60].createdAt;
-              } else {
+              } else if (typeof data.profile2.identity.links[idx_60].createdAt === 'number' || data.profile2.identity.links[idx_60].createdAt.includes('+')) {
                 entity.profile2.identity.links[idx_60].createdAt = new Date(data.profile2.identity.links[idx_60].createdAt);
+              } else {
+                entity.profile2.identity.links[idx_60].createdAt = new Date(data.profile2.identity.links[idx_60].createdAt + 'Z');
               }
             }
             if (data.profile2.identity.links[idx_60].meta != null) {

--- a/tests/features/upsert/GH4242.test.ts
+++ b/tests/features/upsert/GH4242.test.ts
@@ -1,5 +1,5 @@
 import { Entity, ManyToOne, PrimaryKey, Property, Ref, Reference, SimpleLogger, sql, Unique } from '@mikro-orm/core';
-import { MikroORM } from '@mikro-orm/postgresql';
+import { MikroORM, PostgreSqlPlatform } from '@mikro-orm/postgresql';
 import { mockLogger } from '../../helpers';
 
 @Entity()
@@ -58,6 +58,10 @@ beforeEach(async () => {
   await orm.schema.clearDatabase();
 });
 
+function formatDate(date: Date) {
+  return (orm.em.getPlatform() as PostgreSqlPlatform).formatDate(date);
+}
+
 test('4242 1/4', async () => {
   const mock = mockLogger(orm);
 
@@ -101,7 +105,7 @@ test('4242 1/4', async () => {
     tenantWorkflowId: 1,
   }]);
   expect(mock.mock.calls).toEqual([
-    [`[query] insert into "d" ("tenant_workflow_id", "updated_at") values (1, '${date.toISOString()}') on conflict ("tenant_workflow_id") do update set "updated_at" = excluded."updated_at" returning "id", "optional"`],
+    [`[query] insert into "d" ("tenant_workflow_id", "updated_at") values (1, '${formatDate(date)}') on conflict ("tenant_workflow_id") do update set "updated_at" = excluded."updated_at" returning "id", "optional"`],
   ]);
   mock.mockReset();
 });
@@ -170,7 +174,7 @@ test('4242 3/4', async () => {
     tenantWorkflowId: 1,
   });
   expect(mock.mock.calls).toEqual([
-    [`[query] insert into "d" ("tenant_workflow_id", "updated_at") values (1, '${date.toISOString()}') on conflict ("tenant_workflow_id") do update set "updated_at" = excluded."updated_at" returning "id", "optional"`],
+    [`[query] insert into "d" ("tenant_workflow_id", "updated_at") values (1, '${formatDate(date)}') on conflict ("tenant_workflow_id") do update set "updated_at" = excluded."updated_at" returning "id", "optional"`],
   ]);
   mock.mockReset();
 });

--- a/tests/issues/GH5591.test.ts
+++ b/tests/issues/GH5591.test.ts
@@ -1,0 +1,55 @@
+import { Entity, IDatabaseDriver, MikroORM, PrimaryKey, Property, SimpleLogger, Utils } from '@mikro-orm/core';
+import { PLATFORMS } from '../bootstrap';
+
+@Entity()
+class Test {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ columnType: 'timestamp' })
+  date1!: Date;
+
+  @Property()
+  date2!: Date;
+
+}
+
+const options = {
+  'sqlite': { dbName: ':memory:' },
+  'better-sqlite': { dbName: ':memory:' },
+  'postgresql': { dbName: 'mikro_orm_upsert_5591' },
+  'postgresql2': { dbName: 'mikro_orm_upsert_5591', forceUtcTimezone: false },
+  'mysql': { dbName: 'mikro_orm_upsert_5591', port: 3308 },
+};
+
+describe.each(Utils.keys(options))('GH #5591 [%s]', type => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init<IDatabaseDriver>({
+      entities: [Test],
+      driver: PLATFORMS[type.replace(/\d+$/, '') as keyof typeof PLATFORMS],
+      loggerFactory: SimpleLogger.create,
+      ...options[type],
+    });
+    await orm.schema.refreshDatabase();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('timestamp without timezone', async () => {
+    const testEntity = orm.em.create(Test, {
+      date1: new Date('2024-08-01T17:00:00.000Z'),
+      date2: new Date('2024-08-01T17:00:00.000Z'),
+    });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const managedEntity = await orm.em.findOneOrFail(Test, testEntity.id);
+    expect(managedEntity.date1.toISOString()).toBe('2024-08-01T17:00:00.000Z');
+    expect(managedEntity.date2.toISOString()).toBe('2024-08-01T17:00:00.000Z');
+  });
+});


### PR DESCRIPTION
Postgres driver always used to write dates as UTC, but it was parsing them back in local timezone by default. Now it properly respects the `forceUtcTimezone` and `timezone` options. The postgres driver defaults to `forceUtcTimezone: true` since it used to be writing everything in UTC anyway. 

Other drivers behave differently, notably MySQL and MSSQL use `forceUtcTimezone: false` by default, changing that would be breaking, but we might want to normalize this in v7.

This also improves the processing of properties with a custom type and a runtime type `Date`, those used to be always converted during result mapping, now we only do such conversion if the custom type is not a numeric type like int/bigint.

Closes #5591