### PR TITLE
docs(guide): add missing generics

### DIFF
--- a/docs/docs/guide/04-advanced.md
+++ b/docs/docs/guide/04-advanced.md
@@ -507,7 +507,7 @@ The code is getting a bit messy, let's use [`em.create()`](/api/core/class/Entit
 -const user = new User(body.fullName, body.email, body.password);
 -user.bio = body.bio ?? '';
 -user.social = body.social as Social;
-+const user = db.user.create(request.body as RequiredEntityData);
++const user = db.user.create(request.body as RequiredEntityData<User>);
 await db.em.persist(user).flush();
 ```
 

--- a/docs/versioned_docs/version-6.3/guide/04-advanced.md
+++ b/docs/versioned_docs/version-6.3/guide/04-advanced.md
@@ -507,7 +507,7 @@ The code is getting a bit messy, let's use [`em.create()`](/api/core/class/Entit
 -const user = new User(body.fullName, body.email, body.password);
 -user.bio = body.bio ?? '';
 -user.social = body.social as Social;
-+const user = db.user.create(request.body as RequiredEntityData);
++const user = db.user.create(request.body as RequiredEntityData<User>);
 await db.em.persist(user).flush();
 ```
 


### PR DESCRIPTION
fix "Generic type 'RequiredEntityData' requires between 1 and 3 type arguments." errors in docs