### PR TITLE
docs: update link for lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ There is also auto-generated [CHANGELOG.md](CHANGELOG.md) file based on commit m
 - [Using `QueryBuilder`](https://mikro-orm.io/docs/query-builder)
 - [Preloading Deeply Nested Structures via populate](https://mikro-orm.io/docs/nested-populate)
 - [Property Validation](https://mikro-orm.io/docs/property-validation)
-- [Lifecycle Hooks](https://mikro-orm.io/docs/lifecycle-hooks)
+- [Lifecycle Hooks](https://mikro-orm.io/docs/events#hooks)
 - [Vanilla JS Support](https://mikro-orm.io/docs/usage-with-js)
 - [Schema Generator](https://mikro-orm.io/docs/schema-generator)
 - [Entity Generator](https://mikro-orm.io/docs/entity-generator)


### PR DESCRIPTION
Current link is broken: https://mikro-orm.io/docs/lifecycle-hooks