### PR TITLE
fix(sql): correct cursor conditions application on virtual entities

### DIFF
--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -229,6 +229,8 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
       .comment(options.comments!)
       .hintComment(options.hintComments!);
 
+    qb.where(where);
+
     const { first, last, before, after } = options as FindByCursorOptions<T>;
     const isCursorPagination = [first, last, before, after].some(v => v != null);
 
@@ -244,8 +246,6 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
 
       qb.limit(options?.limit, options?.offset);
     }
-
-    qb.where(where);
 
     const kqb = qb.getKnexQuery(false).clear('select');
 

--- a/tests/features/cursor-based-pagination/virtual-entities.test.ts
+++ b/tests/features/cursor-based-pagination/virtual-entities.test.ts
@@ -1,0 +1,90 @@
+import { Entity, ManyToOne, MikroORM, PrimaryKey, Property, QueryOrder } from '@mikro-orm/sqlite';
+
+@Entity()
+class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property()
+  age!: number;
+
+}
+
+@Entity()
+class Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToOne(() => User)
+  owner!: User;
+
+}
+
+@Entity({
+  expression: `
+    SELECT "user".id, "user".name, "user".age, COUNT(b.id) AS book_count
+    FROM "user"
+           LEFT JOIN "book" b ON b.owner_id = "user".id
+    GROUP BY "user".id
+  `,
+})
+class UserBookSummary {
+
+  @Property()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property()
+  age!: number;
+
+  @Property()
+  bookCount!: number;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [User, Book, UserBookSummary],
+    dbName: ':memory:',
+  });
+  await orm.schema.refreshDatabase();
+  const em = orm.em;
+  const users = [
+    em.create(User, { name: 'Alice', age: 30 }),
+    em.create(User, { name: 'Bob', age: 24 }),
+    em.create(User, { name: 'Charlie', age: 28 }),
+    em.create(User, { name: 'David', age: 35 }),
+    em.create(User, { name: 'Eve', age: 22 }),
+  ];
+  em.create(Book, { title: 'The Great Gatsby', owner: users[0] });
+  em.create(Book, { title: '1984', owner: users[1] });
+  em.create(Book, { title: 'Brave New World', owner: users[2] });
+  em.create(Book, { title: 'To Kill a Mockingbird', owner: users[3] });
+  em.create(Book, { title: 'Moby Dick', owner: users[4] });
+  await em.flush();
+  em.clear();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('should correctly paginate virtual entities using cursors', async () => {
+    const firstResult = await orm.em.findByCursor(UserBookSummary, { name:{ $ne:'a' } }, { orderBy:{ id:QueryOrder.ASC }, first:3 });
+    expect(firstResult.endCursor).not.toBeNull();
+    const cursor = firstResult.endCursor!;
+    const finalResult = await orm.em.findByCursor(UserBookSummary, { name:{ $ne:'a' } }, { after:cursor, orderBy:{ id:QueryOrder.ASC }, first:2 });
+    expect(finalResult.items.map(item => item.id)).toEqual([4, 5]);
+});

--- a/tests/features/cursor-based-pagination/virtual-entities.test.ts
+++ b/tests/features/cursor-based-pagination/virtual-entities.test.ts
@@ -82,9 +82,9 @@ afterAll(async () => {
 });
 
 test('should correctly paginate virtual entities using cursors', async () => {
-    const firstResult = await orm.em.findByCursor(UserBookSummary, { name:{ $ne:'a' } }, { orderBy:{ id:QueryOrder.ASC }, first:3 });
-    expect(firstResult.endCursor).not.toBeNull();
-    const cursor = firstResult.endCursor!;
-    const finalResult = await orm.em.findByCursor(UserBookSummary, { name:{ $ne:'a' } }, { after:cursor, orderBy:{ id:QueryOrder.ASC }, first:2 });
-    expect(finalResult.items.map(item => item.id)).toEqual([4, 5]);
+  const firstResult = await orm.em.findByCursor(UserBookSummary, {}, { orderBy: { id: QueryOrder.ASC }, first: 3 });
+  expect(firstResult.endCursor).not.toBeNull();
+  const cursor = firstResult.endCursor!;
+  const finalResult = await orm.em.findByCursor(UserBookSummary, {}, { after: cursor, orderBy: { id: QueryOrder.ASC }, first: 2 });
+  expect(finalResult.items.map(item => item.id)).toEqual([4, 5]);
 });


### PR DESCRIPTION
Now we cannot use cursor-based pagination on virtual entities because  `qb.where` will override the `processCursorOptions` return where.

So I move the `qb.where(where)` to beginning.