### PR TITLE
fix(core): check proptotype chain while cloning

### DIFF
--- a/packages/core/src/utils/clone.ts
+++ b/packages/core/src/utils/clone.ts
@@ -7,6 +7,31 @@
 import { EventEmitter } from 'node:events';
 import { RawQueryFragment } from './RawQueryFragment';
 
+/**
+ * Get the property descriptor of a property on an object or its prototype chain.
+ *
+ * @param obj - The object to get the property descriptor from.
+ * @param prop - The property to get the descriptor for.
+ */
+function getPropertyDescriptor<T>(
+  obj: T,
+  prop: keyof T,
+): PropertyDescriptor | null {
+  const descriptor = Object.getOwnPropertyDescriptor(obj, prop);
+
+  if (descriptor) {
+    return descriptor;
+  }
+
+  const proto = Object.getPrototypeOf(obj);
+  if (proto) {
+    return getPropertyDescriptor(proto, prop as keyof typeof proto);
+  }
+
+  return null;
+}
+
+
 export function clone<T>(parent: T, respectCustomCloneMethod = true): T {
   const allParents: unknown[] = [];
   const allChildren: unknown[] = [];
@@ -105,7 +130,7 @@ export function clone<T>(parent: T, respectCustomCloneMethod = true): T {
       let attrs;
 
       if (proto) {
-        attrs = Object.getOwnPropertyDescriptor(proto, i);
+        attrs = getPropertyDescriptor(proto, i);
       }
 
       if (attrs && attrs.set == null) {
@@ -144,3 +169,4 @@ export function clone<T>(parent: T, respectCustomCloneMethod = true): T {
 
   return _clone(parent);
 }
+

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -133,27 +133,69 @@ describe('Utils', () => {
     expect(Utils.diff({ a: new ObjectId('00000001885f0a3cc37dc9f0') }, { a: new ObjectId('00000001885f0a3cc37dc9f0') })).toEqual({});
   });
 
-  test('copy', () => {
-    const a = { a: 'a', b: 'c' };
-    const b = Utils.copy(a);
-    b.a = 'b';
-    expect(a.a).toBe('a');
-    expect(b.a).toBe('b');
-    expect(Utils.copy(new Error('foo'))).toEqual(new Error('foo'));
-    expect(Utils.copy(/abc/gim)).toEqual(/abc/gim);
+  describe('copy', () => {
+    test('should copy simple object', () => {
+      const a = { a: 'a', b: 'c' };
+      const b = Utils.copy(a);
+      b.a = 'b';
+      expect(a.a).toBe('a');
+      expect(b.a).toBe('b');
+      expect(Utils.copy(new Error('foo'))).toEqual(new Error('foo'));
+      expect(Utils.copy(/abc/gim)).toEqual(/abc/gim);
 
-    const re = /a/;
-    re.lastIndex = 1;
-    expect(Utils.copy(re)).toEqual(re);
-    expect(Utils.copy(re).lastIndex).toEqual(re.lastIndex);
+      const re = /a/;
+      re.lastIndex = 1;
+      expect(Utils.copy(re)).toEqual(re);
+      expect(Utils.copy(re).lastIndex).toEqual(re.lastIndex);
 
-    const c = { a: 'a', b: 'c', inner: { foo: 'bar', p: Promise.resolve() } } as any;
-    const d = Utils.copy(c);
-    d.inner.lol = 'new';
-    expect(c.inner.lol).toBeUndefined();
-    expect(d.inner.lol).toBe('new');
-    expect(c.inner.p).toBeInstanceOf(Promise);
-  });
+      const c = { a: 'a', b: 'c', inner: { foo: 'bar', p: Promise.resolve() } } as any;
+      const d = Utils.copy(c);
+      d.inner.lol = 'new';
+      expect(c.inner.lol).toBeUndefined();
+      expect(d.inner.lol).toBe('new');
+      expect(c.inner.p).toBeInstanceOf(Promise);
+    });
+
+    it('should copy child object even though getter property is dynamically injected', () => {
+
+      function NameDecorator<T extends { new (...args: any[]): {} }>(constructor: T) {
+
+        return class extends constructor {
+
+          name = constructor.name;
+
+        };
+
+      }
+
+      class Parent {
+
+        constructor(
+          private readonly __name__: string,
+        ) {}
+
+        get name() {
+          return this.__name__;
+        }
+
+      }
+
+      @NameDecorator
+      class Child extends Parent {}
+
+      // given
+      const expected = 'child_name';
+      const child = new Child(expected);
+
+      // when
+      const copied = Utils.copy(child);
+
+      // then
+      expect(copied).toBeInstanceOf(Child);
+      expect(copied.name).toBe(expected);
+
+    })
+  })
 
   describe('stripRelativePath', () => {
     test('Remove single leading dot (./)', () => {

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -194,7 +194,7 @@ describe('Utils', () => {
       expect(copied).toBeInstanceOf(Child);
       expect(copied.name).toBe(expected);
 
-    })
+    });
   })
 
   describe('stripRelativePath', () => {

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -195,7 +195,7 @@ describe('Utils', () => {
       expect(copied.name).toBe(expected);
 
     });
-  })
+  });
 
   describe('stripRelativePath', () => {
     test('Remove single leading dot (./)', () => {


### PR DESCRIPTION
I'm using MikroORM 6.3.7 with Postgresql 14.

I'm using MikroORM with ts-jenum.
When I use [ts-jenum](https://github.com/reforms/ts-jenum) in MikroORM's where condition, following error occurs

```
Cannot set property enumName of [object Object] which has only a getter
TypeError: Cannot set property enumName of [object Object] which has only a getter
```

This issue was caused by the [following code](https://github.com/reforms/ts-jenum/blob/e1a45f54537ec5bd6abc258391e656e8c6339595/src/ts/jenum.ts#L181-L184). In the ts-jenum library, the “enumName” of the parent enum type has a getter but no setter implemented. Therefore, when [clone.ts tries to call the setter](https://github.com/mikro-orm/mikro-orm/blob/c0dacd8964786118d094fb6f88c3c136bcfa7115/packages/core/src/utils/clone.ts#L123), an error occurs.

I explored why this issue occurs. The problem arises in MikroORM’s “clone” function when using the `Object.getOwnPropertyDescriptor` function. `Object.getOwnPropertyDescriptor` inspects the properties of a JavaScript object but does not check the properties inherited from its prototype. Therefore, I removed the `Object.getOwnPropertyDescriptor` function in the clone operation and created a function that inspects the properties of the object as well as those inherited from the connected prototype.
