### PR TITLE
refactor: group tables by schema to load information schema

### DIFF
--- a/packages/knex/src/schema/SchemaHelper.ts
+++ b/packages/knex/src/schema/SchemaHelper.ts
@@ -511,7 +511,7 @@ export abstract class SchemaHelper {
   }
 
   getTablesGroupedBySchemas(tables: Table[]): Map<string | undefined, Table[]> {
-    const tablesBySchema = tables.reduce((acc, table) => {
+    return tables.reduce((acc, table) => {
       const schemaTables = acc.get(table.schema_name);
       if (!schemaTables) {
         acc.set(table.schema_name, [table]);
@@ -520,8 +520,6 @@ export abstract class SchemaHelper {
       schemaTables.push(table);
       return acc;
     }, new Map<string | undefined, Table[]>());
-
-    return tablesBySchema;
   }
 
   async getAlterTable?(changedTable: TableDifference, wrap?: boolean): Promise<string>;

--- a/packages/knex/src/schema/SchemaHelper.ts
+++ b/packages/knex/src/schema/SchemaHelper.ts
@@ -510,6 +510,20 @@ export abstract class SchemaHelper {
     return builder;
   }
 
+  getTablesGroupedBySchemas(tables: Table[]): Map<string | undefined, Table[]> {
+    const tablesBySchema = tables.reduce((acc, table) => {
+      const schemaTables = acc.get(table.schema_name);
+      if (!schemaTables) {
+        acc.set(table.schema_name, [table]);
+        return acc;
+      }
+      schemaTables.push(table);
+      return acc;
+    }, new Map<string | undefined, Table[]>());
+
+    return tablesBySchema;
+  }
+
   async getAlterTable?(changedTable: TableDifference, wrap?: boolean): Promise<string>;
 
   get knex(): Knex {

--- a/packages/mssql/src/MsSqlSchemaHelper.ts
+++ b/packages/mssql/src/MsSqlSchemaHelper.ts
@@ -301,15 +301,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       return;
     }
 
-    const tablesBySchema = tables.reduce((acc, table) => {
-      const schemaTables = acc.get(table.schema_name);
-      if (!schemaTables) {
-        acc.set(table.schema_name, [table]);
-        return acc;
-      }
-      schemaTables.push(table);
-      return acc;
-    }, new Map<string | undefined, Table[]>());
+    const tablesBySchema = this.getTablesGroupedBySchemas(tables);
 
     const columns = await this.getAllColumns(connection, tablesBySchema);
     const indexes = await this.getAllIndexes(connection, tablesBySchema);

--- a/packages/postgresql/src/PostgreSqlSchemaHelper.ts
+++ b/packages/postgresql/src/PostgreSqlSchemaHelper.ts
@@ -80,15 +80,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
       return;
     }
 
-    const tablesBySchema = tables.reduce((acc, table) => {
-      const schemaTables = acc.get(table.schema_name);
-      if (!schemaTables) {
-        acc.set(table.schema_name, [table]);
-        return acc;
-      }
-      schemaTables.push(table);
-      return acc;
-    }, new Map<string | undefined, Table[]>());
+    const tablesBySchema = this.getTablesGroupedBySchemas(tables);
 
     const columns = await this.getAllColumns(connection, tablesBySchema, nativeEnums);
     const indexes = await this.getAllIndexes(connection, tables);


### PR DESCRIPTION
This changes `MsSqlSchemaHelper` and `PostgreSqlSchemaHelper` to group tables by schema name and use `IN` operator for table names instead of using `OR` for every schema/table combo, e.g.

```sql
WHERE (
  (ccu.table_name = 'seals' and ccu.table_schema = 'mammals')
OR (ccu.table_name = 'owls' and ccu.table_schema = 'birds')
OR (ccu.table_name = 'parrots' and ccu.table_schema = 'birds')
)

```

becomes

```sql
WHERE (
  (ccu.table_name IN ('seals') and ccu.table_schema = 'mammals')
OR (ccu.table_name IN('owls','parrots') and ccu.table_schema = 'birds')
)

```

This doesn't change the current behavior, yet it makes the entity generator faster (at least for large databases) when multiple tables belong to the same schema (which is almost always the case).