### PR TITLE
fix(core): implement joined filters via `populateFilter` option, separately from `populateWhere`

### DIFF
--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -118,22 +118,59 @@ export interface FindOptions<
   Fields extends string = PopulatePath.ALL,
   Excludes extends string = never,
 > extends LoadHint<Entity, Hint, Fields, Excludes> {
+  /**
+   * Where condition for populated relations. This will have no effect on the root entity.
+   * With `select-in` strategy, this is applied only to the populate queries.
+   * With `joined` strategy, those are applied as `join on` conditions.
+   * When you use a nested condition on a to-many relation, it will produce a nested inner join,
+   * discarding the collection items based on the child condition.
+   */
   populateWhere?: ObjectQuery<Entity> | PopulateHint | `${PopulateHint}`;
+
+  /**
+   * Filter condition for populated relations. This is similar to `populateWhere`, but will produce a `left join`
+   * when nesting the condition. This is used for implementation of joined filters.
+   */
+  populateFilter?: ObjectQuery<Entity> | PopulateHint | `${PopulateHint}`;
+
+  /** Used for ordering of the populate queries. If not specified, the value of `options.orderBy` is used. */
   populateOrderBy?: OrderDefinition<Entity>;
+
+  /** Ordering of the results.Can be an object or array of objects, keys are property names, values are ordering (asc/desc) */
   orderBy?: OrderDefinition<Entity>;
+
+  /** Control result caching for this query. Result cache is by default disabled, not to be confused with the identity map. */
   cache?: boolean | number | [string, number];
+
+  /**
+   * Limit the number of returned results. If you try to use limit/offset on a query that joins a to-many relation, pagination mechanism
+   * will be triggered, resulting in a subquery condition, to apply this limit only to the root entities
+   * instead of the cartesian product you get from a database in this case.
+   */
   limit?: number;
+
+  /**
+   * Sets the offset. If you try to use limit/offset on a query that joins a to-many relation, pagination mechanism
+   * will be triggered, resulting in a subquery condition, to apply this limit only to the root entities
+   * instead of the cartesian product you get from a database in this case.
+   */
   offset?: number;
+
   /** Fetch items `before` this cursor. */
   before?: string | { startCursor: string | null } | FilterObject<Entity>;
+
   /** Fetch items `after` this cursor. */
   after?: string | { endCursor: string | null } | FilterObject<Entity>;
+
   /** Fetch `first` N items. */
   first?: number;
+
   /** Fetch `last` N items. */
   last?: number;
+
   /** Fetch one more item than `first`/`last`, enabled automatically in `em.findByCursor` to check if there is a next page. */
   overfetch?: boolean;
+
   refresh?: boolean;
   convertCustomTypes?: boolean;
   disableIdentityMap?: boolean;

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -112,7 +112,11 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
     qb.__populateWhere = (options as Dictionary)._populateWhere;
     qb.select(fields)
       // only add populateWhere if we are populate-joining, as this will be used to add `on` conditions
-      .populate(populate, joinedProps.length > 0 ? populateWhere : undefined)
+      .populate(
+        populate,
+        joinedProps.length > 0 ? populateWhere : undefined,
+        joinedProps.length > 0 ? options.populateFilter : undefined,
+      )
       .where(where)
       .groupBy(options.groupBy!)
       .having(options.having!)

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -1867,7 +1867,7 @@ describe('EntityManagerMySql', () => {
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`perex` as `b1__perex`, `b1`.`price` as `b1__price`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id` ' +
       'from `book_tag2` as `b0` ' +
       'left join (`book_to_tag_unordered` as `b2` ' +
-      'inner join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` and `b1`.`author_id` is not null and `b1`.`title` != ?) on `b0`.`id` = `b2`.`book_tag2_id` ' +
+      'inner join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` and `b1`.`title` != ? and `b1`.`author_id` is not null) on `b0`.`id` = `b2`.`book_tag2_id` ' +
       'where `b1`.`title` != ? ' +
       'order by `b0`.`name` asc');
   });

--- a/tests/features/__snapshots__/dataloader.test.ts.snap
+++ b/tests/features/__snapshots__/dataloader.test.ts.snap
@@ -50,7 +50,7 @@ exports[`Dataloader Collection.load 1`] = `
     "[query] select \`m0\`.* from \`message\` as \`m0\` where (\`m0\`.\`chat_owner_id\`, \`m0\`.\`chat_recipient_id\`) in ( values (1, 2), (1, 3))",
   ],
   [
-    "[query] select \`a0\`.*, \`b1\`.\`id\` as \`b1__id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`email\` as \`b1__email\` from \`author\` as \`a0\` left join (\`author_buddies\` as \`a2\` inner join \`author\` as \`b1\` on \`a2\`.\`author_1_id\` = \`b1\`.\`id\` and \`b1\`.\`age\` < 80) on \`a0\`.\`id\` = \`a2\`.\`author_2_id\` left join \`author_buddies\` as \`a3\` on \`a0\`.\`id\` = \`a3\`.\`author_2_id\` where \`a0\`.\`age\` < 80 and \`a3\`.\`author_1_id\` in (1, 2, 3)",
+    "[query] select \`a0\`.*, \`b1\`.\`id\` as \`b1__id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`email\` as \`b1__email\` from \`author\` as \`a0\` left join \`author_buddies\` as \`a2\` on \`a0\`.\`id\` = \`a2\`.\`author_2_id\` left join \`author\` as \`b1\` on \`a2\`.\`author_1_id\` = \`b1\`.\`id\` and \`b1\`.\`age\` < 80 left join \`author_buddies\` as \`a3\` on \`a0\`.\`id\` = \`a3\`.\`author_2_id\` where \`a0\`.\`age\` < 80 and \`a3\`.\`author_1_id\` in (1, 2, 3)",
   ],
   [
     "[query] select \`b0\`.*, \`a1\`.\`id\` as \`a1__id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where (\`b0\`.\`author_id\` in (1, 2, 3) or \`b0\`.\`publisher_id\` in (1, 2))",
@@ -105,7 +105,7 @@ exports[`Dataloader Dataloader can be globally enabled for Collections with true
     "[query] select \`m0\`.* from \`message\` as \`m0\` where (\`m0\`.\`chat_owner_id\`, \`m0\`.\`chat_recipient_id\`) in ( values (1, 2), (1, 3))",
   ],
   [
-    "[query] select \`a0\`.*, \`b1\`.\`id\` as \`b1__id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`email\` as \`b1__email\` from \`author\` as \`a0\` left join (\`author_buddies\` as \`a2\` inner join \`author\` as \`b1\` on \`a2\`.\`author_1_id\` = \`b1\`.\`id\` and \`b1\`.\`age\` < 80) on \`a0\`.\`id\` = \`a2\`.\`author_2_id\` left join \`author_buddies\` as \`a3\` on \`a0\`.\`id\` = \`a3\`.\`author_2_id\` where \`a0\`.\`age\` < 80 and \`a3\`.\`author_1_id\` in (1, 2, 3)",
+    "[query] select \`a0\`.*, \`b1\`.\`id\` as \`b1__id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`email\` as \`b1__email\` from \`author\` as \`a0\` left join \`author_buddies\` as \`a2\` on \`a0\`.\`id\` = \`a2\`.\`author_2_id\` left join \`author\` as \`b1\` on \`a2\`.\`author_1_id\` = \`b1\`.\`id\` and \`b1\`.\`age\` < 80 left join \`author_buddies\` as \`a3\` on \`a0\`.\`id\` = \`a3\`.\`author_2_id\` where \`a0\`.\`age\` < 80 and \`a3\`.\`author_1_id\` in (1, 2, 3)",
   ],
   [
     "[query] select \`b0\`.*, \`a1\`.\`id\` as \`a1__id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where (\`b0\`.\`author_id\` in (1, 2, 3) or \`b0\`.\`publisher_id\` in (1, 2))",
@@ -252,7 +252,7 @@ exports[`Dataloader getColBatchLoadFn 1`] = `
     "[query] select \`m0\`.* from \`message\` as \`m0\` where (\`m0\`.\`chat_owner_id\`, \`m0\`.\`chat_recipient_id\`) in ( values (1, 2), (1, 3))",
   ],
   [
-    "[query] select \`a0\`.*, \`b1\`.\`id\` as \`b1__id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`email\` as \`b1__email\` from \`author\` as \`a0\` left join (\`author_buddies\` as \`a2\` inner join \`author\` as \`b1\` on \`a2\`.\`author_1_id\` = \`b1\`.\`id\` and \`b1\`.\`age\` < 80) on \`a0\`.\`id\` = \`a2\`.\`author_2_id\` left join \`author_buddies\` as \`a3\` on \`a0\`.\`id\` = \`a3\`.\`author_2_id\` where \`a0\`.\`age\` < 80 and \`a3\`.\`author_1_id\` in (1, 2, 3)",
+    "[query] select \`a0\`.*, \`b1\`.\`id\` as \`b1__id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`email\` as \`b1__email\` from \`author\` as \`a0\` left join \`author_buddies\` as \`a2\` on \`a0\`.\`id\` = \`a2\`.\`author_2_id\` left join \`author\` as \`b1\` on \`a2\`.\`author_1_id\` = \`b1\`.\`id\` and \`b1\`.\`age\` < 80 left join \`author_buddies\` as \`a3\` on \`a0\`.\`id\` = \`a3\`.\`author_2_id\` where \`a0\`.\`age\` < 80 and \`a3\`.\`author_1_id\` in (1, 2, 3)",
   ],
   [
     "[query] select \`b0\`.*, \`a1\`.\`id\` as \`a1__id\` from \`book\` as \`b0\` inner join \`author\` as \`a1\` on \`b0\`.\`author_id\` = \`a1\`.\`id\` and \`a1\`.\`age\` < 80 where (\`b0\`.\`author_id\` in (1, 2, 3) or \`b0\`.\`publisher_id\` in (1, 2))",

--- a/tests/features/embeddables/GH5325.test.ts
+++ b/tests/features/embeddables/GH5325.test.ts
@@ -175,8 +175,8 @@ test('5325', async () => {
     ['[query] commit'],
     ['[query] select `d0`.*, `d1`.`id` as `d1__id`, `d1`.`entity_state` as `d1__entity_state`, `d1`.`drug_info_ingredients` as `d1__drug_info_ingredients`, `d1`.`clinic_id` as `d1__clinic_id` ' +
     'from `drug` as `d0` ' +
-    'left join (`drug_info` as `d1` left join `ingredient` as `i2` on json_extract(`d1`.`drug_info_ingredients`, \'$.ingredient_id\') = `i2`.`id` and `i2`.`entity_state` = \'Available\') on `d0`.`drug_info_id` = `d1`.`id` and `d1`.`entity_state` = \'Available\' ' +
+    "left join `drug_info` as `d1` on `d0`.`drug_info_id` = `d1`.`id` and `d1`.`entity_state` = 'Available' left join `ingredient` as `i2` on json_extract(`d1`.`drug_info_ingredients`, '$.ingredient_id') = `i2`.`id` and `i2`.`entity_state` = 'Available' " +
     'where `d0`.`entity_state` = \'Available\''],
-    ["[query] select `i0`.* from `ingredient` as `i0` where `i0`.`entity_state` = 'Available' and `i0`.`id` in ('11', '22') and `i0`.`entity_state` = 'Available'"],
+    ["[query] select `i0`.* from `ingredient` as `i0` where `i0`.`entity_state` = 'Available' and `i0`.`id` in ('11', '22')"],
   ]);
 });

--- a/tests/features/filters/filters.postgres.test.ts
+++ b/tests/features/filters/filters.postgres.test.ts
@@ -197,7 +197,9 @@ describe('filters [postgres]', () => {
     const e2 = await orm.em.findOneOrFail(Employee, employee.id, { populate: ['benefits.details'], strategy: 'joined' });
     expect(mock.mock.calls[0][0]).toMatch('select "e0".*, "b1"."id" as "b1__id", "b1"."benefit_status" as "b1__benefit_status", "b1"."name" as "b1__name", "d3"."id" as "d3__id", "d3"."description" as "d3__description", "d3"."benefit_id" as "d3__benefit_id", "d3"."active" as "d3__active" ' +
       'from "employee" as "e0" ' +
-      'left join ("employee_benefits" as "e2" inner join ("public"."benefit" as "b1" left join "public"."benefit_detail" as "d3" on "b1"."id" = "d3"."benefit_id" and "d3"."active" = $1) on "e2"."benefit_id" = "b1"."id" and "b1"."benefit_status" = $2) on "e0"."id" = "e2"."employee_id" ' +
+      'left join "employee_benefits" as "e2" on "e0"."id" = "e2"."employee_id" ' +
+      'left join "public"."benefit" as "b1" on "e2"."benefit_id" = "b1"."id" and "b1"."benefit_status" = $1 ' +
+      'left join "benefit_detail" as "d3" on "b1"."id" = "d3"."benefit_id" and "d3"."active" = $2 ' +
       'where "e0"."id" = $3');
     expect(e2.benefits).toHaveLength(1);
     expect(e2.benefits[0].details).toHaveLength(1);

--- a/tests/features/joined-strategy.postgre.test.ts
+++ b/tests/features/joined-strategy.postgre.test.ts
@@ -423,7 +423,8 @@ describe('Joined loading strategy', () => {
       '"p4"."id" as "p4__id", "p4"."name" as "p4__name", "p4"."type" as "p4__type", "p4"."type2" as "p4__type2", "p4"."enum1" as "p4__enum1", "p4"."enum2" as "p4__enum2", "p4"."enum3" as "p4__enum3", "p4"."enum4" as "p4__enum4", "p4"."enum5" as "p4__enum5", ' +
       '"t5"."id" as "t5__id", "t5"."name" as "t5__name", "t5"."book_uuid_pk" as "t5__book_uuid_pk", "t5"."parent_id" as "t5__parent_id", "t5"."version" as "t5__version" ' +
       'from "book_tag2" as "b0" ' +
-      'left join ("book2_tags" as "b2" inner join "public"."book2" as "b1" on "b2"."book2_uuid_pk" = "b1"."uuid_pk" and "b1"."author_id" is not null) on "b0"."id" = "b2"."book_tag2_id" ' +
+      'left join "book2_tags" as "b2" on "b0"."id" = "b2"."book_tag2_id" ' +
+      'left join "public"."book2" as "b1" on "b2"."book2_uuid_pk" = "b1"."uuid_pk" and "b1"."author_id" is not null ' +
       'left join "author2" as "a3" on "b1"."author_id" = "a3"."id" ' +
       'left join "publisher2" as "p4" on "b1"."publisher_id" = "p4"."id" ' +
       'left join "publisher2_tests" as "p6" on "p4"."id" = "p6"."publisher2_id" ' +
@@ -508,11 +509,12 @@ describe('Joined loading strategy', () => {
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed", ' +
       '"a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "a1"."identity" as "a1__identity", ' +
-      '"f2"."uuid_pk" as "f2__uuid_pk", "f2"."created_at" as "f2__created_at", "f2"."isbn" as "f2__isbn", "f2"."title" as "f2__title", "f2"."price" as "f2__price", "f2".price * 1.19 as "f2__price_taxed", "f2"."double" as "f2__double", "f2"."meta" as "f2__meta", "f2"."author_id" as "f2__author_id", "f2"."publisher_id" as "f2__publisher_id", ' +
-      '"a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", "a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", "a3"."identity" as "a3__identity" ' +
+      '"f2"."uuid_pk" as "f2__uuid_pk", "f2"."created_at" as "f2__created_at", "f2"."isbn" as "f2__isbn", "f2"."title" as "f2__title", "f2"."price" as "f2__price", "f2".price * 1.19 as "f2__price_taxed", "f2"."double" as "f2__double", "f2"."meta" as "f2__meta", "f2"."author_id" as "f2__author_id", "f2"."publisher_id" as "f2__publisher_id", "a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", ' +
+      '"a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", "a3"."identity" as "a3__identity" ' +
       'from "book2" as "b0" ' +
       // populateHint: all
-      'left join ("author2" as "a1" left join "book2" as "f2" on "a1"."favourite_book_uuid_pk" = "f2"."uuid_pk" and "f2"."author_id" is not null) on "b0"."author_id" = "a1"."id" ' +
+      'left join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
+      'left join "book2" as "f2" on "a1"."favourite_book_uuid_pk" = "f2"."uuid_pk" and "f2"."author_id" is not null ' +
       'left join "author2" as "a3" on "f2"."author_id" = "a3"."id" ' +
       // where joins
       'left join "author2" as "a4" on "b0"."author_id" = "a4"."id" ' +
@@ -544,7 +546,8 @@ describe('Joined loading strategy', () => {
       '"f2"."uuid_pk" as "f2__uuid_pk", "f2"."created_at" as "f2__created_at", "f2"."isbn" as "f2__isbn", "f2"."title" as "f2__title", "f2"."price" as "f2__price", "f2".price * 1.19 as "f2__price_taxed", "f2"."double" as "f2__double", "f2"."meta" as "f2__meta", "f2"."author_id" as "f2__author_id", "f2"."publisher_id" as "f2__publisher_id", ' +
       '"a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", "a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", "a3"."identity" as "a3__identity" ' +
       'from "book2" as "b0" ' +
-      'left join ("author2" as "a1" left join ("book2" as "f2" left join "author2" as "a3" on "f2"."author_id" = "a3"."id" and "a3"."name" = $1) on "a1"."favourite_book_uuid_pk" = "f2"."uuid_pk" and "f2"."author_id" is not null) on "b0"."author_id" = "a1"."id" ' +
+      'left join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
+      'left join ("book2" as "f2" left join "author2" as "a3" on "f2"."author_id" = "a3"."id" and "a3"."name" = $1) on "a1"."favourite_book_uuid_pk" = "f2"."uuid_pk" and "f2"."author_id" is not null ' +
       'where "b0"."author_id" is not null and "a3"."name" = $2');
   });
 

--- a/tests/issues/GHx16.test.ts
+++ b/tests/issues/GHx16.test.ts
@@ -1,0 +1,85 @@
+import { Collection, Entity, Filter, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
+
+@Filter({ name: 'softDelete', cond: { removedAt: null }, default: true })
+@Entity()
+class MicroCloud {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 6, nullable: true })
+  removedAt?: Date;
+
+}
+
+@Entity()
+class DatacenterTask {
+
+  @PrimaryKey()
+  id!: number;
+
+  @OneToMany(() => DatacenterTaskDevice, x => x.datacenterTask)
+  datacenterTaskDevices = new Collection<DatacenterTaskDevice>(this);
+
+}
+
+@Entity()
+class DatacenterTaskDevice {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => DatacenterTask)
+  datacenterTask!: DatacenterTask;
+
+  @ManyToOne(() => MicroCloud, { nullable: true })
+  microCloud?: MicroCloud;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [DatacenterTaskDevice],
+    dbName: ':memory:',
+    populateWhere: 'infer',
+    forceUndefined: true,
+  });
+  await orm.schema.createSchema();
+});
+
+afterAll(() => orm.close(true));
+
+test('filters and nested populate of to-many relations', async () => {
+  orm.em.create(DatacenterTask, {
+    datacenterTaskDevices: [
+      {
+        microCloud: undefined,
+      },
+      {
+        microCloud: {},
+      },
+    ],
+  });
+
+  await orm.em.flush();
+  orm.em.clear();
+
+  const datacenterTask1 = await orm.em.findOneOrFail(DatacenterTask, 1, {
+    populate: ['datacenterTaskDevices'],
+  });
+
+  // Should be 2 devices
+  expect(datacenterTask1.datacenterTaskDevices).toHaveLength(2);
+  orm.em.clear();
+
+  const datacenterTask2 = await orm.em.findOneOrFail(DatacenterTask, 1, {
+    populate: ['datacenterTaskDevices.microCloud'],
+    // populateWhere: { datacenterTaskDevices: { microCloud: { removedAt: null } } },
+    // populateFilter: { datacenterTaskDevices: { microCloud: { removedAt: null } } },
+  });
+
+  // Should be 2 devices, even if some does not have (nullable field) microCloud
+  expect(datacenterTask2.datacenterTaskDevices).toHaveLength(2);
+});


### PR DESCRIPTION
#5893 introduced the concept of nested inner joins, used for the `populateWhere` conditions when the parent is a to-many relation. This ensures the collection items are discarded if they conflict with the child condition. While it makes sense for the `populateWhere` to behave this way, we also use this option internally for filters on joined relations, and there we can't just discard items because the children are not correct.

This PR introduces new `populateFilter` option, which is now used for the joined filters and will produce simple `left join`s, unlike the `populateWhere` option.