### PR TITLE
fix(migrations): support multiline strings in `addSql()`

### DIFF
--- a/packages/migrations/src/MigrationGenerator.ts
+++ b/packages/migrations/src/MigrationGenerator.ts
@@ -31,7 +31,7 @@ export abstract class MigrationGenerator implements IMigrationGenerator {
   createStatement(sql: string, padLeft: number): string {
     if (sql) {
       const padding = ' '.repeat(padLeft);
-      return `${padding}this.addSql('${sql.replace(/['\\]/g, '\\\'')}');\n`;
+      return `${padding}this.addSql(\`${sql.replace(/[`$\\]/g, '\\$&')}\`);\n`;
     }
 
     return '\n';

--- a/tests/features/migrations/__snapshots__/Migrator.mssql.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.mssql.test.ts.snap
@@ -7,89 +7,89 @@ exports[`Migrator (mssql) generate initial migration: initial-migration-dump 1`]
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('if (schema_id(\\'custom\\') is null) begin exec (\\'create schema [custom] authorization [dbo]\\') end;');
-    this.addSql('CREATE TABLE [custom].[book_tag2] ([id] bigint identity(1,1) not null primary key, [name] nvarchar(50) not null);');
+    this.addSql(\`if (schema_id('custom') is null) begin exec ('create schema [custom] authorization [dbo]') end;\`);
+    this.addSql(\`CREATE TABLE [custom].[book_tag2] ([id] bigint identity(1,1) not null primary key, [name] nvarchar(50) not null);\`);
 
-    this.addSql('CREATE TABLE [custom].[foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null CONSTRAINT [foo_baz2_version_default] DEFAULT current_timestamp);');
+    this.addSql(\`CREATE TABLE [custom].[foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null CONSTRAINT [foo_baz2_version_default] DEFAULT current_timestamp);\`);
 
-    this.addSql('CREATE TABLE [custom].[foo_bar2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null CONSTRAINT [foo_bar2_version_default] DEFAULT current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);');
-    this.addSql('CREATE UNIQUE INDEX [foo_bar2_baz_id_unique] ON [custom].[foo_bar2] ([baz_id]) WHERE [baz_id] IS NOT NULL;');
-    this.addSql('CREATE UNIQUE INDEX [foo_bar2_foo_bar_id_unique] ON [custom].[foo_bar2] ([foo_bar_id]) WHERE [foo_bar_id] IS NOT NULL;');
+    this.addSql(\`CREATE TABLE [custom].[foo_bar2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null CONSTRAINT [foo_bar2_version_default] DEFAULT current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);\`);
+    this.addSql(\`CREATE UNIQUE INDEX [foo_bar2_baz_id_unique] ON [custom].[foo_bar2] ([baz_id]) WHERE [baz_id] IS NOT NULL;\`);
+    this.addSql(\`CREATE UNIQUE INDEX [foo_bar2_foo_bar_id_unique] ON [custom].[foo_bar2] ([foo_bar_id]) WHERE [foo_bar_id] IS NOT NULL;\`);
 
-    this.addSql('CREATE TABLE [custom].[foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, CONSTRAINT [foo_param2_pkey] PRIMARY KEY ([bar_id], [baz_id]));');
+    this.addSql(\`CREATE TABLE [custom].[foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, CONSTRAINT [foo_param2_pkey] PRIMARY KEY ([bar_id], [baz_id]));\`);
 
-    this.addSql('CREATE TABLE [custom].[publisher2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null CONSTRAINT [publisher2_name_default] DEFAULT \\'asd\\', [type] nvarchar(100) check ([type] in (\\'local\\', \\'global\\')) not null CONSTRAINT [publisher2_type_default] DEFAULT \\'local\\', [type2] nvarchar(100) check ([type2] in (\\'LOCAL\\', \\'GLOBAL\\')) not null CONSTRAINT [publisher2_type2_default] DEFAULT \\'LOCAL\\', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) check ([enum4] in (\\'a\\', \\'b\\', \\'c\\')) null);');
+    this.addSql(\`CREATE TABLE [custom].[publisher2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null CONSTRAINT [publisher2_name_default] DEFAULT 'asd', [type] nvarchar(100) check ([type] in ('local', 'global')) not null CONSTRAINT [publisher2_type_default] DEFAULT 'local', [type2] nvarchar(100) check ([type2] in ('LOCAL', 'GLOBAL')) not null CONSTRAINT [publisher2_type2_default] DEFAULT 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) check ([enum4] in ('a', 'b', 'c')) null);\`);
 
-    this.addSql('CREATE TABLE [custom].[author2] ([id] int identity(1,1) not null primary key, [created_at] datetime2(3) not null CONSTRAINT [author2_created_at_default] DEFAULT current_timestamp, [updated_at] datetime2(3) not null CONSTRAINT [author2_updated_at_default] DEFAULT current_timestamp, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [age] int null, [terms_accepted] bit not null CONSTRAINT [author2_terms_accepted_default] DEFAULT 0, [optional] bit null, [identities] text null, [born] date null, [born_time] time null, [favourite_book_uuid_pk] uniqueidentifier null, [favourite_author_id] int null);');
-    this.addSql('CREATE INDEX [custom_email_index_name] ON [custom].[author2] ([email]);');
-    this.addSql('CREATE UNIQUE INDEX [custom_email_unique_name] ON [custom].[author2] ([email]) WHERE [email] IS NOT NULL;');
-    this.addSql('CREATE INDEX [author2_terms_accepted_index] ON [custom].[author2] ([terms_accepted]);');
-    this.addSql('CREATE INDEX [author2_born_index] ON [custom].[author2] ([born]);');
-    this.addSql('CREATE INDEX [born_time_idx] ON [custom].[author2] ([born_time]);');
-    this.addSql('CREATE INDEX [custom_idx_name_123] ON [custom].[author2] ([name]);');
-    this.addSql('CREATE INDEX [author2_name_age_index] ON [custom].[author2] ([name], [age]);');
-    this.addSql('CREATE UNIQUE INDEX [author2_name_email_unique] ON [custom].[author2] ([name], [email]) WHERE [name] IS NOT NULL AND [email] IS NOT NULL;');
+    this.addSql(\`CREATE TABLE [custom].[author2] ([id] int identity(1,1) not null primary key, [created_at] datetime2(3) not null CONSTRAINT [author2_created_at_default] DEFAULT current_timestamp, [updated_at] datetime2(3) not null CONSTRAINT [author2_updated_at_default] DEFAULT current_timestamp, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [age] int null, [terms_accepted] bit not null CONSTRAINT [author2_terms_accepted_default] DEFAULT 0, [optional] bit null, [identities] text null, [born] date null, [born_time] time null, [favourite_book_uuid_pk] uniqueidentifier null, [favourite_author_id] int null);\`);
+    this.addSql(\`CREATE INDEX [custom_email_index_name] ON [custom].[author2] ([email]);\`);
+    this.addSql(\`CREATE UNIQUE INDEX [custom_email_unique_name] ON [custom].[author2] ([email]) WHERE [email] IS NOT NULL;\`);
+    this.addSql(\`CREATE INDEX [author2_terms_accepted_index] ON [custom].[author2] ([terms_accepted]);\`);
+    this.addSql(\`CREATE INDEX [author2_born_index] ON [custom].[author2] ([born]);\`);
+    this.addSql(\`CREATE INDEX [born_time_idx] ON [custom].[author2] ([born_time]);\`);
+    this.addSql(\`CREATE INDEX [custom_idx_name_123] ON [custom].[author2] ([name]);\`);
+    this.addSql(\`CREATE INDEX [author2_name_age_index] ON [custom].[author2] ([name], [age]);\`);
+    this.addSql(\`CREATE UNIQUE INDEX [author2_name_email_unique] ON [custom].[author2] ([name], [email]) WHERE [name] IS NOT NULL AND [email] IS NOT NULL;\`);
 
-    this.addSql('CREATE TABLE [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null CONSTRAINT [book2_created_at_default] DEFAULT current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null CONSTRAINT [book2_title_default] DEFAULT \\'\\', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, CONSTRAINT [book2_pkey] PRIMARY KEY ([uuid_pk]));');
-    this.addSql('CREATE UNIQUE INDEX [book2_isbn_unique] ON [custom].[book2] ([isbn]) WHERE [isbn] IS NOT NULL;');
+    this.addSql(\`CREATE TABLE [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null CONSTRAINT [book2_created_at_default] DEFAULT current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null CONSTRAINT [book2_title_default] DEFAULT '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, CONSTRAINT [book2_pkey] PRIMARY KEY ([uuid_pk]));\`);
+    this.addSql(\`CREATE UNIQUE INDEX [book2_isbn_unique] ON [custom].[book2] ([isbn]) WHERE [isbn] IS NOT NULL;\`);
 
-    this.addSql('CREATE TABLE [custom].[book2_tags] ([order] int identity(1,1) not null primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);');
+    this.addSql(\`CREATE TABLE [custom].[book2_tags] ([order] int identity(1,1) not null primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);\`);
 
-    this.addSql('CREATE TABLE [custom].[book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, CONSTRAINT [book_to_tag_unordered_pkey] PRIMARY KEY ([book2_uuid_pk], [book_tag2_id]));');
+    this.addSql(\`CREATE TABLE [custom].[book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, CONSTRAINT [book_to_tag_unordered_pkey] PRIMARY KEY ([book2_uuid_pk], [book_tag2_id]));\`);
 
-    this.addSql('CREATE TABLE [custom].[author2_following] ([author2_1_id] int not null, [author2_2_id] int not null, CONSTRAINT [author2_following_pkey] PRIMARY KEY ([author2_1_id], [author2_2_id]));');
+    this.addSql(\`CREATE TABLE [custom].[author2_following] ([author2_1_id] int not null, [author2_2_id] int not null, CONSTRAINT [author2_following_pkey] PRIMARY KEY ([author2_1_id], [author2_2_id]));\`);
 
-    this.addSql('CREATE TABLE [custom].[author_to_friend] ([author2_1_id] int not null, [author2_2_id] int not null, CONSTRAINT [author_to_friend_pkey] PRIMARY KEY ([author2_1_id], [author2_2_id]));');
+    this.addSql(\`CREATE TABLE [custom].[author_to_friend] ([author2_1_id] int not null, [author2_2_id] int not null, CONSTRAINT [author_to_friend_pkey] PRIMARY KEY ([author2_1_id], [author2_2_id]));\`);
 
-    this.addSql('CREATE TABLE [custom].[address2] ([author_id] int not null, [value] nvarchar(255) not null, CONSTRAINT [address2_pkey] PRIMARY KEY ([author_id]));');
-    this.addSql('IF EXISTS(SELECT * FROM sys.fn_listextendedproperty(N\\'MS_Description\\', N\\'Schema\\', N\\'custom\\', N\\'Table\\', N\\'address2\\', NULL, NULL))');
-    this.addSql('  EXEC sys.sp_updateextendedproperty N\\'MS_Description\\', N\\'This is address table\\', N\\'Schema\\', N\\'custom\\', N\\'Table\\', N\\'address2\\'');
-    this.addSql('ELSE');
-    this.addSql('  EXEC sys.sp_addextendedproperty N\\'MS_Description\\', N\\'This is address table\\', N\\'Schema\\', N\\'custom\\', N\\'Table\\', N\\'address2\\';');
-    this.addSql('IF EXISTS(SELECT * FROM sys.fn_listextendedproperty(N\\'MS_Description\\', N\\'Schema\\', N\\'custom\\', N\\'Table\\', N\\'address2\\', N\\'Column\\', N\\'value\\'))');
-    this.addSql('  EXEC sys.sp_updateextendedproperty N\\'MS_Description\\', N\\'This is address property\\', N\\'Schema\\', N\\'custom\\', N\\'Table\\', N\\'address2\\', N\\'Column\\', N\\'value\\'');
-    this.addSql('ELSE');
-    this.addSql('  EXEC sys.sp_addextendedproperty N\\'MS_Description\\', N\\'This is address property\\', N\\'Schema\\', N\\'custom\\', N\\'Table\\', N\\'address2\\', N\\'Column\\', N\\'value\\';');
+    this.addSql(\`CREATE TABLE [custom].[address2] ([author_id] int not null, [value] nvarchar(255) not null, CONSTRAINT [address2_pkey] PRIMARY KEY ([author_id]));\`);
+    this.addSql(\`IF EXISTS(SELECT * FROM sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'custom', N'Table', N'address2', NULL, NULL))\`);
+    this.addSql(\`  EXEC sys.sp_updateextendedproperty N'MS_Description', N'This is address table', N'Schema', N'custom', N'Table', N'address2'\`);
+    this.addSql(\`ELSE\`);
+    this.addSql(\`  EXEC sys.sp_addextendedproperty N'MS_Description', N'This is address table', N'Schema', N'custom', N'Table', N'address2';\`);
+    this.addSql(\`IF EXISTS(SELECT * FROM sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'custom', N'Table', N'address2', N'Column', N'value'))\`);
+    this.addSql(\`  EXEC sys.sp_updateextendedproperty N'MS_Description', N'This is address property', N'Schema', N'custom', N'Table', N'address2', N'Column', N'value'\`);
+    this.addSql(\`ELSE\`);
+    this.addSql(\`  EXEC sys.sp_addextendedproperty N'MS_Description', N'This is address property', N'Schema', N'custom', N'Table', N'address2', N'Column', N'value';\`);
 
-    this.addSql('CREATE TABLE [custom].[test2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) null, [book_uuid_pk] uniqueidentifier null, [version] int not null CONSTRAINT [test2_version_default] DEFAULT 1);');
-    this.addSql('CREATE UNIQUE INDEX [test2_book_uuid_pk_unique] ON [custom].[test2] ([book_uuid_pk]) WHERE [book_uuid_pk] IS NOT NULL;');
+    this.addSql(\`CREATE TABLE [custom].[test2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) null, [book_uuid_pk] uniqueidentifier null, [version] int not null CONSTRAINT [test2_version_default] DEFAULT 1);\`);
+    this.addSql(\`CREATE UNIQUE INDEX [test2_book_uuid_pk_unique] ON [custom].[test2] ([book_uuid_pk]) WHERE [book_uuid_pk] IS NOT NULL;\`);
 
-    this.addSql('CREATE TABLE [custom].[publisher2_tests] ([id] int identity(1,1) not null primary key, [publisher2_id] int not null, [test2_id] int not null);');
+    this.addSql(\`CREATE TABLE [custom].[publisher2_tests] ([id] int identity(1,1) not null primary key, [publisher2_id] int not null, [test2_id] int not null);\`);
 
-    this.addSql('CREATE TABLE [custom].[configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, CONSTRAINT [configuration2_pkey] PRIMARY KEY ([property], [test_id]));');
+    this.addSql(\`CREATE TABLE [custom].[configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, CONSTRAINT [configuration2_pkey] PRIMARY KEY ([property], [test_id]));\`);
 
-    this.addSql('alter table [custom].[foo_bar2] add constraint [foo_bar2_baz_id_foreign] foreign key ([baz_id]) references [custom].[foo_baz2] ([id]) on update cascade on delete set null;');
-    this.addSql('alter table [custom].[foo_bar2] add constraint [foo_bar2_foo_bar_id_foreign] foreign key ([foo_bar_id]) references [custom].[foo_bar2] ([id]);');
+    this.addSql(\`alter table [custom].[foo_bar2] add constraint [foo_bar2_baz_id_foreign] foreign key ([baz_id]) references [custom].[foo_baz2] ([id]) on update cascade on delete set null;\`);
+    this.addSql(\`alter table [custom].[foo_bar2] add constraint [foo_bar2_foo_bar_id_foreign] foreign key ([foo_bar_id]) references [custom].[foo_bar2] ([id]);\`);
 
-    this.addSql('alter table [custom].[foo_param2] add constraint [foo_param2_bar_id_foreign] foreign key ([bar_id]) references [custom].[foo_bar2] ([id]) on update cascade;');
-    this.addSql('alter table [custom].[foo_param2] add constraint [foo_param2_baz_id_foreign] foreign key ([baz_id]) references [custom].[foo_baz2] ([id]) on update no action on delete no action;');
+    this.addSql(\`alter table [custom].[foo_param2] add constraint [foo_param2_bar_id_foreign] foreign key ([bar_id]) references [custom].[foo_bar2] ([id]) on update cascade;\`);
+    this.addSql(\`alter table [custom].[foo_param2] add constraint [foo_param2_baz_id_foreign] foreign key ([baz_id]) references [custom].[foo_baz2] ([id]) on update no action on delete no action;\`);
 
-    this.addSql('alter table [custom].[author2] add constraint [author2_favourite_book_uuid_pk_foreign] foreign key ([favourite_book_uuid_pk]) references [custom].[book2] ([uuid_pk]) on update no action on delete cascade;');
-    this.addSql('alter table [custom].[author2] add constraint [author2_favourite_author_id_foreign] foreign key ([favourite_author_id]) references [custom].[author2] ([id]);');
+    this.addSql(\`alter table [custom].[author2] add constraint [author2_favourite_book_uuid_pk_foreign] foreign key ([favourite_book_uuid_pk]) references [custom].[book2] ([uuid_pk]) on update no action on delete cascade;\`);
+    this.addSql(\`alter table [custom].[author2] add constraint [author2_favourite_author_id_foreign] foreign key ([favourite_author_id]) references [custom].[author2] ([id]);\`);
 
-    this.addSql('alter table [custom].[book2] add constraint [book2_author_id_foreign] foreign key ([author_id]) references [custom].[author2] ([id]);');
-    this.addSql('alter table [custom].[book2] add constraint [book2_publisher_id_foreign] foreign key ([publisher_id]) references [custom].[publisher2] ([id]) on update cascade on delete cascade;');
+    this.addSql(\`alter table [custom].[book2] add constraint [book2_author_id_foreign] foreign key ([author_id]) references [custom].[author2] ([id]);\`);
+    this.addSql(\`alter table [custom].[book2] add constraint [book2_publisher_id_foreign] foreign key ([publisher_id]) references [custom].[publisher2] ([id]) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table [custom].[book2_tags] add constraint [book2_tags_book2_uuid_pk_foreign] foreign key ([book2_uuid_pk]) references [custom].[book2] ([uuid_pk]) on update cascade on delete cascade;');
-    this.addSql('alter table [custom].[book2_tags] add constraint [book2_tags_book_tag2_id_foreign] foreign key ([book_tag2_id]) references [custom].[book_tag2] ([id]) on update cascade on delete cascade;');
+    this.addSql(\`alter table [custom].[book2_tags] add constraint [book2_tags_book2_uuid_pk_foreign] foreign key ([book2_uuid_pk]) references [custom].[book2] ([uuid_pk]) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table [custom].[book2_tags] add constraint [book2_tags_book_tag2_id_foreign] foreign key ([book_tag2_id]) references [custom].[book_tag2] ([id]) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table [custom].[book_to_tag_unordered] add constraint [book_to_tag_unordered_book2_uuid_pk_foreign] foreign key ([book2_uuid_pk]) references [custom].[book2] ([uuid_pk]) on update cascade on delete cascade;');
-    this.addSql('alter table [custom].[book_to_tag_unordered] add constraint [book_to_tag_unordered_book_tag2_id_foreign] foreign key ([book_tag2_id]) references [custom].[book_tag2] ([id]) on update cascade on delete cascade;');
+    this.addSql(\`alter table [custom].[book_to_tag_unordered] add constraint [book_to_tag_unordered_book2_uuid_pk_foreign] foreign key ([book2_uuid_pk]) references [custom].[book2] ([uuid_pk]) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table [custom].[book_to_tag_unordered] add constraint [book_to_tag_unordered_book_tag2_id_foreign] foreign key ([book_tag2_id]) references [custom].[book_tag2] ([id]) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table [custom].[author2_following] add constraint [author2_following_author2_1_id_foreign] foreign key ([author2_1_id]) references [custom].[author2] ([id]) on update no action on delete no action;');
-    this.addSql('alter table [custom].[author2_following] add constraint [author2_following_author2_2_id_foreign] foreign key ([author2_2_id]) references [custom].[author2] ([id]) on update no action on delete no action;');
+    this.addSql(\`alter table [custom].[author2_following] add constraint [author2_following_author2_1_id_foreign] foreign key ([author2_1_id]) references [custom].[author2] ([id]) on update no action on delete no action;\`);
+    this.addSql(\`alter table [custom].[author2_following] add constraint [author2_following_author2_2_id_foreign] foreign key ([author2_2_id]) references [custom].[author2] ([id]) on update no action on delete no action;\`);
 
-    this.addSql('alter table [custom].[author_to_friend] add constraint [author_to_friend_author2_1_id_foreign] foreign key ([author2_1_id]) references [custom].[author2] ([id]) on update no action on delete no action;');
-    this.addSql('alter table [custom].[author_to_friend] add constraint [author_to_friend_author2_2_id_foreign] foreign key ([author2_2_id]) references [custom].[author2] ([id]) on update no action on delete no action;');
+    this.addSql(\`alter table [custom].[author_to_friend] add constraint [author_to_friend_author2_1_id_foreign] foreign key ([author2_1_id]) references [custom].[author2] ([id]) on update no action on delete no action;\`);
+    this.addSql(\`alter table [custom].[author_to_friend] add constraint [author_to_friend_author2_2_id_foreign] foreign key ([author2_2_id]) references [custom].[author2] ([id]) on update no action on delete no action;\`);
 
-    this.addSql('alter table [custom].[address2] add constraint [address2_author_id_foreign] foreign key ([author_id]) references [custom].[author2] ([id]) on update cascade on delete cascade;');
+    this.addSql(\`alter table [custom].[address2] add constraint [address2_author_id_foreign] foreign key ([author_id]) references [custom].[author2] ([id]) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table [custom].[test2] add constraint [test2_book_uuid_pk_foreign] foreign key ([book_uuid_pk]) references [custom].[book2] ([uuid_pk]) on delete no action;');
+    this.addSql(\`alter table [custom].[test2] add constraint [test2_book_uuid_pk_foreign] foreign key ([book_uuid_pk]) references [custom].[book2] ([uuid_pk]) on delete no action;\`);
 
-    this.addSql('alter table [custom].[publisher2_tests] add constraint [publisher2_tests_publisher2_id_foreign] foreign key ([publisher2_id]) references [custom].[publisher2] ([id]) on update cascade on delete cascade;');
-    this.addSql('alter table [custom].[publisher2_tests] add constraint [publisher2_tests_test2_id_foreign] foreign key ([test2_id]) references [custom].[test2] ([id]) on update cascade on delete cascade;');
+    this.addSql(\`alter table [custom].[publisher2_tests] add constraint [publisher2_tests_publisher2_id_foreign] foreign key ([publisher2_id]) references [custom].[publisher2] ([id]) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table [custom].[publisher2_tests] add constraint [publisher2_tests_test2_id_foreign] foreign key ([test2_id]) references [custom].[test2] ([id]) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table [custom].[configuration2] add constraint [configuration2_test_id_foreign] foreign key ([test_id]) references [custom].[test2] ([id]) on update cascade;');
+    this.addSql(\`alter table [custom].[configuration2] add constraint [configuration2_test_id_foreign] foreign key ([test_id]) references [custom].[test2] ([id]) on update cascade;\`);
   }
 
 }
@@ -193,89 +193,89 @@ exports[`Migrator (mssql) generate initial migration: initial-migration-dump 2`]
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('if (schema_id(\\'custom\\') is null) begin exec (\\'create schema [custom] authorization [dbo]\\') end;');
-    this.addSql('CREATE TABLE [custom].[book_tag2] ([id] bigint identity(1,1) not null primary key, [name] nvarchar(50) not null);');
+    this.addSql(\`if (schema_id('custom') is null) begin exec ('create schema [custom] authorization [dbo]') end;\`);
+    this.addSql(\`CREATE TABLE [custom].[book_tag2] ([id] bigint identity(1,1) not null primary key, [name] nvarchar(50) not null);\`);
 
-    this.addSql('CREATE TABLE [custom].[foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null CONSTRAINT [foo_baz2_version_default] DEFAULT current_timestamp);');
+    this.addSql(\`CREATE TABLE [custom].[foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null CONSTRAINT [foo_baz2_version_default] DEFAULT current_timestamp);\`);
 
-    this.addSql('CREATE TABLE [custom].[foo_bar2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null CONSTRAINT [foo_bar2_version_default] DEFAULT current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);');
-    this.addSql('CREATE UNIQUE INDEX [foo_bar2_baz_id_unique] ON [custom].[foo_bar2] ([baz_id]) WHERE [baz_id] IS NOT NULL;');
-    this.addSql('CREATE UNIQUE INDEX [foo_bar2_foo_bar_id_unique] ON [custom].[foo_bar2] ([foo_bar_id]) WHERE [foo_bar_id] IS NOT NULL;');
+    this.addSql(\`CREATE TABLE [custom].[foo_bar2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null CONSTRAINT [foo_bar2_version_default] DEFAULT current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);\`);
+    this.addSql(\`CREATE UNIQUE INDEX [foo_bar2_baz_id_unique] ON [custom].[foo_bar2] ([baz_id]) WHERE [baz_id] IS NOT NULL;\`);
+    this.addSql(\`CREATE UNIQUE INDEX [foo_bar2_foo_bar_id_unique] ON [custom].[foo_bar2] ([foo_bar_id]) WHERE [foo_bar_id] IS NOT NULL;\`);
 
-    this.addSql('CREATE TABLE [custom].[foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, CONSTRAINT [foo_param2_pkey] PRIMARY KEY ([bar_id], [baz_id]));');
+    this.addSql(\`CREATE TABLE [custom].[foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, CONSTRAINT [foo_param2_pkey] PRIMARY KEY ([bar_id], [baz_id]));\`);
 
-    this.addSql('CREATE TABLE [custom].[publisher2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null CONSTRAINT [publisher2_name_default] DEFAULT \\'asd\\', [type] nvarchar(100) check ([type] in (\\'local\\', \\'global\\')) not null CONSTRAINT [publisher2_type_default] DEFAULT \\'local\\', [type2] nvarchar(100) check ([type2] in (\\'LOCAL\\', \\'GLOBAL\\')) not null CONSTRAINT [publisher2_type2_default] DEFAULT \\'LOCAL\\', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) check ([enum4] in (\\'a\\', \\'b\\', \\'c\\')) null);');
+    this.addSql(\`CREATE TABLE [custom].[publisher2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null CONSTRAINT [publisher2_name_default] DEFAULT 'asd', [type] nvarchar(100) check ([type] in ('local', 'global')) not null CONSTRAINT [publisher2_type_default] DEFAULT 'local', [type2] nvarchar(100) check ([type2] in ('LOCAL', 'GLOBAL')) not null CONSTRAINT [publisher2_type2_default] DEFAULT 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) check ([enum4] in ('a', 'b', 'c')) null);\`);
 
-    this.addSql('CREATE TABLE [custom].[author2] ([id] int identity(1,1) not null primary key, [created_at] datetime2(3) not null CONSTRAINT [author2_created_at_default] DEFAULT current_timestamp, [updated_at] datetime2(3) not null CONSTRAINT [author2_updated_at_default] DEFAULT current_timestamp, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [age] int null, [terms_accepted] bit not null CONSTRAINT [author2_terms_accepted_default] DEFAULT 0, [optional] bit null, [identities] text null, [born] date null, [born_time] time null, [favourite_book_uuid_pk] uniqueidentifier null, [favourite_author_id] int null);');
-    this.addSql('CREATE INDEX [custom_email_index_name] ON [custom].[author2] ([email]);');
-    this.addSql('CREATE UNIQUE INDEX [custom_email_unique_name] ON [custom].[author2] ([email]) WHERE [email] IS NOT NULL;');
-    this.addSql('CREATE INDEX [author2_terms_accepted_index] ON [custom].[author2] ([terms_accepted]);');
-    this.addSql('CREATE INDEX [author2_born_index] ON [custom].[author2] ([born]);');
-    this.addSql('CREATE INDEX [born_time_idx] ON [custom].[author2] ([born_time]);');
-    this.addSql('CREATE INDEX [custom_idx_name_123] ON [custom].[author2] ([name]);');
-    this.addSql('CREATE INDEX [author2_name_age_index] ON [custom].[author2] ([name], [age]);');
-    this.addSql('CREATE UNIQUE INDEX [author2_name_email_unique] ON [custom].[author2] ([name], [email]) WHERE [name] IS NOT NULL AND [email] IS NOT NULL;');
+    this.addSql(\`CREATE TABLE [custom].[author2] ([id] int identity(1,1) not null primary key, [created_at] datetime2(3) not null CONSTRAINT [author2_created_at_default] DEFAULT current_timestamp, [updated_at] datetime2(3) not null CONSTRAINT [author2_updated_at_default] DEFAULT current_timestamp, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [age] int null, [terms_accepted] bit not null CONSTRAINT [author2_terms_accepted_default] DEFAULT 0, [optional] bit null, [identities] text null, [born] date null, [born_time] time null, [favourite_book_uuid_pk] uniqueidentifier null, [favourite_author_id] int null);\`);
+    this.addSql(\`CREATE INDEX [custom_email_index_name] ON [custom].[author2] ([email]);\`);
+    this.addSql(\`CREATE UNIQUE INDEX [custom_email_unique_name] ON [custom].[author2] ([email]) WHERE [email] IS NOT NULL;\`);
+    this.addSql(\`CREATE INDEX [author2_terms_accepted_index] ON [custom].[author2] ([terms_accepted]);\`);
+    this.addSql(\`CREATE INDEX [author2_born_index] ON [custom].[author2] ([born]);\`);
+    this.addSql(\`CREATE INDEX [born_time_idx] ON [custom].[author2] ([born_time]);\`);
+    this.addSql(\`CREATE INDEX [custom_idx_name_123] ON [custom].[author2] ([name]);\`);
+    this.addSql(\`CREATE INDEX [author2_name_age_index] ON [custom].[author2] ([name], [age]);\`);
+    this.addSql(\`CREATE UNIQUE INDEX [author2_name_email_unique] ON [custom].[author2] ([name], [email]) WHERE [name] IS NOT NULL AND [email] IS NOT NULL;\`);
 
-    this.addSql('CREATE TABLE [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null CONSTRAINT [book2_created_at_default] DEFAULT current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null CONSTRAINT [book2_title_default] DEFAULT \\'\\', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, CONSTRAINT [book2_pkey] PRIMARY KEY ([uuid_pk]));');
-    this.addSql('CREATE UNIQUE INDEX [book2_isbn_unique] ON [custom].[book2] ([isbn]) WHERE [isbn] IS NOT NULL;');
+    this.addSql(\`CREATE TABLE [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null CONSTRAINT [book2_created_at_default] DEFAULT current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null CONSTRAINT [book2_title_default] DEFAULT '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, CONSTRAINT [book2_pkey] PRIMARY KEY ([uuid_pk]));\`);
+    this.addSql(\`CREATE UNIQUE INDEX [book2_isbn_unique] ON [custom].[book2] ([isbn]) WHERE [isbn] IS NOT NULL;\`);
 
-    this.addSql('CREATE TABLE [custom].[book2_tags] ([order] int identity(1,1) not null primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);');
+    this.addSql(\`CREATE TABLE [custom].[book2_tags] ([order] int identity(1,1) not null primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);\`);
 
-    this.addSql('CREATE TABLE [custom].[book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, CONSTRAINT [book_to_tag_unordered_pkey] PRIMARY KEY ([book2_uuid_pk], [book_tag2_id]));');
+    this.addSql(\`CREATE TABLE [custom].[book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, CONSTRAINT [book_to_tag_unordered_pkey] PRIMARY KEY ([book2_uuid_pk], [book_tag2_id]));\`);
 
-    this.addSql('CREATE TABLE [custom].[author2_following] ([author2_1_id] int not null, [author2_2_id] int not null, CONSTRAINT [author2_following_pkey] PRIMARY KEY ([author2_1_id], [author2_2_id]));');
+    this.addSql(\`CREATE TABLE [custom].[author2_following] ([author2_1_id] int not null, [author2_2_id] int not null, CONSTRAINT [author2_following_pkey] PRIMARY KEY ([author2_1_id], [author2_2_id]));\`);
 
-    this.addSql('CREATE TABLE [custom].[author_to_friend] ([author2_1_id] int not null, [author2_2_id] int not null, CONSTRAINT [author_to_friend_pkey] PRIMARY KEY ([author2_1_id], [author2_2_id]));');
+    this.addSql(\`CREATE TABLE [custom].[author_to_friend] ([author2_1_id] int not null, [author2_2_id] int not null, CONSTRAINT [author_to_friend_pkey] PRIMARY KEY ([author2_1_id], [author2_2_id]));\`);
 
-    this.addSql('CREATE TABLE [custom].[address2] ([author_id] int not null, [value] nvarchar(255) not null, CONSTRAINT [address2_pkey] PRIMARY KEY ([author_id]));');
-    this.addSql('IF EXISTS(SELECT * FROM sys.fn_listextendedproperty(N\\'MS_Description\\', N\\'Schema\\', N\\'custom\\', N\\'Table\\', N\\'address2\\', NULL, NULL))');
-    this.addSql('  EXEC sys.sp_updateextendedproperty N\\'MS_Description\\', N\\'This is address table\\', N\\'Schema\\', N\\'custom\\', N\\'Table\\', N\\'address2\\'');
-    this.addSql('ELSE');
-    this.addSql('  EXEC sys.sp_addextendedproperty N\\'MS_Description\\', N\\'This is address table\\', N\\'Schema\\', N\\'custom\\', N\\'Table\\', N\\'address2\\';');
-    this.addSql('IF EXISTS(SELECT * FROM sys.fn_listextendedproperty(N\\'MS_Description\\', N\\'Schema\\', N\\'custom\\', N\\'Table\\', N\\'address2\\', N\\'Column\\', N\\'value\\'))');
-    this.addSql('  EXEC sys.sp_updateextendedproperty N\\'MS_Description\\', N\\'This is address property\\', N\\'Schema\\', N\\'custom\\', N\\'Table\\', N\\'address2\\', N\\'Column\\', N\\'value\\'');
-    this.addSql('ELSE');
-    this.addSql('  EXEC sys.sp_addextendedproperty N\\'MS_Description\\', N\\'This is address property\\', N\\'Schema\\', N\\'custom\\', N\\'Table\\', N\\'address2\\', N\\'Column\\', N\\'value\\';');
+    this.addSql(\`CREATE TABLE [custom].[address2] ([author_id] int not null, [value] nvarchar(255) not null, CONSTRAINT [address2_pkey] PRIMARY KEY ([author_id]));\`);
+    this.addSql(\`IF EXISTS(SELECT * FROM sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'custom', N'Table', N'address2', NULL, NULL))\`);
+    this.addSql(\`  EXEC sys.sp_updateextendedproperty N'MS_Description', N'This is address table', N'Schema', N'custom', N'Table', N'address2'\`);
+    this.addSql(\`ELSE\`);
+    this.addSql(\`  EXEC sys.sp_addextendedproperty N'MS_Description', N'This is address table', N'Schema', N'custom', N'Table', N'address2';\`);
+    this.addSql(\`IF EXISTS(SELECT * FROM sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'custom', N'Table', N'address2', N'Column', N'value'))\`);
+    this.addSql(\`  EXEC sys.sp_updateextendedproperty N'MS_Description', N'This is address property', N'Schema', N'custom', N'Table', N'address2', N'Column', N'value'\`);
+    this.addSql(\`ELSE\`);
+    this.addSql(\`  EXEC sys.sp_addextendedproperty N'MS_Description', N'This is address property', N'Schema', N'custom', N'Table', N'address2', N'Column', N'value';\`);
 
-    this.addSql('CREATE TABLE [custom].[test2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) null, [book_uuid_pk] uniqueidentifier null, [version] int not null CONSTRAINT [test2_version_default] DEFAULT 1);');
-    this.addSql('CREATE UNIQUE INDEX [test2_book_uuid_pk_unique] ON [custom].[test2] ([book_uuid_pk]) WHERE [book_uuid_pk] IS NOT NULL;');
+    this.addSql(\`CREATE TABLE [custom].[test2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) null, [book_uuid_pk] uniqueidentifier null, [version] int not null CONSTRAINT [test2_version_default] DEFAULT 1);\`);
+    this.addSql(\`CREATE UNIQUE INDEX [test2_book_uuid_pk_unique] ON [custom].[test2] ([book_uuid_pk]) WHERE [book_uuid_pk] IS NOT NULL;\`);
 
-    this.addSql('CREATE TABLE [custom].[publisher2_tests] ([id] int identity(1,1) not null primary key, [publisher2_id] int not null, [test2_id] int not null);');
+    this.addSql(\`CREATE TABLE [custom].[publisher2_tests] ([id] int identity(1,1) not null primary key, [publisher2_id] int not null, [test2_id] int not null);\`);
 
-    this.addSql('CREATE TABLE [custom].[configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, CONSTRAINT [configuration2_pkey] PRIMARY KEY ([property], [test_id]));');
+    this.addSql(\`CREATE TABLE [custom].[configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, CONSTRAINT [configuration2_pkey] PRIMARY KEY ([property], [test_id]));\`);
 
-    this.addSql('alter table [custom].[foo_bar2] add constraint [foo_bar2_baz_id_foreign] foreign key ([baz_id]) references [custom].[foo_baz2] ([id]) on update cascade on delete set null;');
-    this.addSql('alter table [custom].[foo_bar2] add constraint [foo_bar2_foo_bar_id_foreign] foreign key ([foo_bar_id]) references [custom].[foo_bar2] ([id]);');
+    this.addSql(\`alter table [custom].[foo_bar2] add constraint [foo_bar2_baz_id_foreign] foreign key ([baz_id]) references [custom].[foo_baz2] ([id]) on update cascade on delete set null;\`);
+    this.addSql(\`alter table [custom].[foo_bar2] add constraint [foo_bar2_foo_bar_id_foreign] foreign key ([foo_bar_id]) references [custom].[foo_bar2] ([id]);\`);
 
-    this.addSql('alter table [custom].[foo_param2] add constraint [foo_param2_bar_id_foreign] foreign key ([bar_id]) references [custom].[foo_bar2] ([id]) on update cascade;');
-    this.addSql('alter table [custom].[foo_param2] add constraint [foo_param2_baz_id_foreign] foreign key ([baz_id]) references [custom].[foo_baz2] ([id]) on update no action on delete no action;');
+    this.addSql(\`alter table [custom].[foo_param2] add constraint [foo_param2_bar_id_foreign] foreign key ([bar_id]) references [custom].[foo_bar2] ([id]) on update cascade;\`);
+    this.addSql(\`alter table [custom].[foo_param2] add constraint [foo_param2_baz_id_foreign] foreign key ([baz_id]) references [custom].[foo_baz2] ([id]) on update no action on delete no action;\`);
 
-    this.addSql('alter table [custom].[author2] add constraint [author2_favourite_book_uuid_pk_foreign] foreign key ([favourite_book_uuid_pk]) references [custom].[book2] ([uuid_pk]) on update no action on delete cascade;');
-    this.addSql('alter table [custom].[author2] add constraint [author2_favourite_author_id_foreign] foreign key ([favourite_author_id]) references [custom].[author2] ([id]);');
+    this.addSql(\`alter table [custom].[author2] add constraint [author2_favourite_book_uuid_pk_foreign] foreign key ([favourite_book_uuid_pk]) references [custom].[book2] ([uuid_pk]) on update no action on delete cascade;\`);
+    this.addSql(\`alter table [custom].[author2] add constraint [author2_favourite_author_id_foreign] foreign key ([favourite_author_id]) references [custom].[author2] ([id]);\`);
 
-    this.addSql('alter table [custom].[book2] add constraint [book2_author_id_foreign] foreign key ([author_id]) references [custom].[author2] ([id]);');
-    this.addSql('alter table [custom].[book2] add constraint [book2_publisher_id_foreign] foreign key ([publisher_id]) references [custom].[publisher2] ([id]) on update cascade on delete cascade;');
+    this.addSql(\`alter table [custom].[book2] add constraint [book2_author_id_foreign] foreign key ([author_id]) references [custom].[author2] ([id]);\`);
+    this.addSql(\`alter table [custom].[book2] add constraint [book2_publisher_id_foreign] foreign key ([publisher_id]) references [custom].[publisher2] ([id]) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table [custom].[book2_tags] add constraint [book2_tags_book2_uuid_pk_foreign] foreign key ([book2_uuid_pk]) references [custom].[book2] ([uuid_pk]) on update cascade on delete cascade;');
-    this.addSql('alter table [custom].[book2_tags] add constraint [book2_tags_book_tag2_id_foreign] foreign key ([book_tag2_id]) references [custom].[book_tag2] ([id]) on update cascade on delete cascade;');
+    this.addSql(\`alter table [custom].[book2_tags] add constraint [book2_tags_book2_uuid_pk_foreign] foreign key ([book2_uuid_pk]) references [custom].[book2] ([uuid_pk]) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table [custom].[book2_tags] add constraint [book2_tags_book_tag2_id_foreign] foreign key ([book_tag2_id]) references [custom].[book_tag2] ([id]) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table [custom].[book_to_tag_unordered] add constraint [book_to_tag_unordered_book2_uuid_pk_foreign] foreign key ([book2_uuid_pk]) references [custom].[book2] ([uuid_pk]) on update cascade on delete cascade;');
-    this.addSql('alter table [custom].[book_to_tag_unordered] add constraint [book_to_tag_unordered_book_tag2_id_foreign] foreign key ([book_tag2_id]) references [custom].[book_tag2] ([id]) on update cascade on delete cascade;');
+    this.addSql(\`alter table [custom].[book_to_tag_unordered] add constraint [book_to_tag_unordered_book2_uuid_pk_foreign] foreign key ([book2_uuid_pk]) references [custom].[book2] ([uuid_pk]) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table [custom].[book_to_tag_unordered] add constraint [book_to_tag_unordered_book_tag2_id_foreign] foreign key ([book_tag2_id]) references [custom].[book_tag2] ([id]) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table [custom].[author2_following] add constraint [author2_following_author2_1_id_foreign] foreign key ([author2_1_id]) references [custom].[author2] ([id]) on update no action on delete no action;');
-    this.addSql('alter table [custom].[author2_following] add constraint [author2_following_author2_2_id_foreign] foreign key ([author2_2_id]) references [custom].[author2] ([id]) on update no action on delete no action;');
+    this.addSql(\`alter table [custom].[author2_following] add constraint [author2_following_author2_1_id_foreign] foreign key ([author2_1_id]) references [custom].[author2] ([id]) on update no action on delete no action;\`);
+    this.addSql(\`alter table [custom].[author2_following] add constraint [author2_following_author2_2_id_foreign] foreign key ([author2_2_id]) references [custom].[author2] ([id]) on update no action on delete no action;\`);
 
-    this.addSql('alter table [custom].[author_to_friend] add constraint [author_to_friend_author2_1_id_foreign] foreign key ([author2_1_id]) references [custom].[author2] ([id]) on update no action on delete no action;');
-    this.addSql('alter table [custom].[author_to_friend] add constraint [author_to_friend_author2_2_id_foreign] foreign key ([author2_2_id]) references [custom].[author2] ([id]) on update no action on delete no action;');
+    this.addSql(\`alter table [custom].[author_to_friend] add constraint [author_to_friend_author2_1_id_foreign] foreign key ([author2_1_id]) references [custom].[author2] ([id]) on update no action on delete no action;\`);
+    this.addSql(\`alter table [custom].[author_to_friend] add constraint [author_to_friend_author2_2_id_foreign] foreign key ([author2_2_id]) references [custom].[author2] ([id]) on update no action on delete no action;\`);
 
-    this.addSql('alter table [custom].[address2] add constraint [address2_author_id_foreign] foreign key ([author_id]) references [custom].[author2] ([id]) on update cascade on delete cascade;');
+    this.addSql(\`alter table [custom].[address2] add constraint [address2_author_id_foreign] foreign key ([author_id]) references [custom].[author2] ([id]) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table [custom].[test2] add constraint [test2_book_uuid_pk_foreign] foreign key ([book_uuid_pk]) references [custom].[book2] ([uuid_pk]) on delete no action;');
+    this.addSql(\`alter table [custom].[test2] add constraint [test2_book_uuid_pk_foreign] foreign key ([book_uuid_pk]) references [custom].[book2] ([uuid_pk]) on delete no action;\`);
 
-    this.addSql('alter table [custom].[publisher2_tests] add constraint [publisher2_tests_publisher2_id_foreign] foreign key ([publisher2_id]) references [custom].[publisher2] ([id]) on update cascade on delete cascade;');
-    this.addSql('alter table [custom].[publisher2_tests] add constraint [publisher2_tests_test2_id_foreign] foreign key ([test2_id]) references [custom].[test2] ([id]) on update cascade on delete cascade;');
+    this.addSql(\`alter table [custom].[publisher2_tests] add constraint [publisher2_tests_publisher2_id_foreign] foreign key ([publisher2_id]) references [custom].[publisher2] ([id]) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table [custom].[publisher2_tests] add constraint [publisher2_tests_test2_id_foreign] foreign key ([test2_id]) references [custom].[test2] ([id]) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table [custom].[configuration2] add constraint [configuration2_test_id_foreign] foreign key ([test_id]) references [custom].[test2] ([id]) on update cascade;');
+    this.addSql(\`alter table [custom].[configuration2] add constraint [configuration2_test_id_foreign] foreign key ([test_id]) references [custom].[test2] ([id]) on update cascade;\`);
   }
 
 }
@@ -381,24 +381,24 @@ const { Migration } = require('@mikro-orm/migrations');
 class Migration20191013214813 extends Migration {
 
   async up() {
-    this.addSql('alter table [custom].[book2] alter column [double] nvarchar(max);');
+    this.addSql(\`alter table [custom].[book2] alter column [double] nvarchar(max);\`);
 
-    this.addSql('declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = \\'custom\\' and tables.name = \\'book2\\' and all_columns.name = \\'foo\\') if @constraint0 is not null exec(\\'alter table [custom].[book2] drop constraint \\' + @constraint0);');
-    this.addSql('alter table [custom].[book2] drop column [foo];');
+    this.addSql(\`declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = 'custom' and tables.name = 'book2' and all_columns.name = 'foo') if @constraint0 is not null exec('alter table [custom].[book2] drop constraint ' + @constraint0);\`);
+    this.addSql(\`alter table [custom].[book2] drop column [foo];\`);
 
-    this.addSql('alter table [custom].[book2] alter column [double] float(53);');
+    this.addSql(\`alter table [custom].[book2] alter column [double] float(53);\`);
 
-    this.addSql('declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = \\'custom\\' and tables.name = \\'test2\\' and all_columns.name = \\'path\\') if @constraint0 is not null exec(\\'alter table [custom].[test2] drop constraint \\' + @constraint0);');
-    this.addSql('alter table [custom].[test2] drop column [path];');
+    this.addSql(\`declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = 'custom' and tables.name = 'test2' and all_columns.name = 'path') if @constraint0 is not null exec('alter table [custom].[test2] drop constraint ' + @constraint0);\`);
+    this.addSql(\`alter table [custom].[test2] drop column [path];\`);
   }
 
   async down() {
-    this.addSql('alter table [custom].[book2] alter column [double] nvarchar(max);');
+    this.addSql(\`alter table [custom].[book2] alter column [double] nvarchar(max);\`);
 
-    this.addSql('alter table [custom].[book2] add [foo] varchar(1) null CONSTRAINT [book2_foo_default] DEFAULT \\'lol\\';');
-    this.addSql('alter table [custom].[book2] alter column [double] numeric(18,0);');
+    this.addSql(\`alter table [custom].[book2] add [foo] varchar(1) null CONSTRAINT [book2_foo_default] DEFAULT 'lol';\`);
+    this.addSql(\`alter table [custom].[book2] alter column [double] numeric(18,0);\`);
 
-    this.addSql('alter table [custom].[test2] add [path] text null CONSTRAINT [test2_path_default] DEFAULT \\'NULL\\';');
+    this.addSql(\`alter table [custom].[test2] add [path] text null CONSTRAINT [test2_path_default] DEFAULT 'NULL';\`);
   }
 
 }
@@ -438,24 +438,24 @@ import { Migration } from '@mikro-orm/migrations';
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('alter table [custom].[book2] alter column [double] nvarchar(max);');
+    this.addSql(\`alter table [custom].[book2] alter column [double] nvarchar(max);\`);
 
-    this.addSql('declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = \\'custom\\' and tables.name = \\'book2\\' and all_columns.name = \\'foo\\') if @constraint0 is not null exec(\\'alter table [custom].[book2] drop constraint \\' + @constraint0);');
-    this.addSql('alter table [custom].[book2] drop column [foo];');
+    this.addSql(\`declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = 'custom' and tables.name = 'book2' and all_columns.name = 'foo') if @constraint0 is not null exec('alter table [custom].[book2] drop constraint ' + @constraint0);\`);
+    this.addSql(\`alter table [custom].[book2] drop column [foo];\`);
 
-    this.addSql('alter table [custom].[book2] alter column [double] float(53);');
+    this.addSql(\`alter table [custom].[book2] alter column [double] float(53);\`);
 
-    this.addSql('declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = \\'custom\\' and tables.name = \\'test2\\' and all_columns.name = \\'path\\') if @constraint0 is not null exec(\\'alter table [custom].[test2] drop constraint \\' + @constraint0);');
-    this.addSql('alter table [custom].[test2] drop column [path];');
+    this.addSql(\`declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = 'custom' and tables.name = 'test2' and all_columns.name = 'path') if @constraint0 is not null exec('alter table [custom].[test2] drop constraint ' + @constraint0);\`);
+    this.addSql(\`alter table [custom].[test2] drop column [path];\`);
   }
 
   override async down(): Promise<void> {
-    this.addSql('alter table [custom].[book2] alter column [double] nvarchar(max);');
+    this.addSql(\`alter table [custom].[book2] alter column [double] nvarchar(max);\`);
 
-    this.addSql('alter table [custom].[book2] add [foo] varchar(1) null CONSTRAINT [book2_foo_default] DEFAULT \\'lol\\';');
-    this.addSql('alter table [custom].[book2] alter column [double] numeric(18,0);');
+    this.addSql(\`alter table [custom].[book2] add [foo] varchar(1) null CONSTRAINT [book2_foo_default] DEFAULT 'lol';\`);
+    this.addSql(\`alter table [custom].[book2] alter column [double] numeric(18,0);\`);
 
-    this.addSql('alter table [custom].[test2] add [path] text null CONSTRAINT [test2_path_default] DEFAULT \\'NULL\\';');
+    this.addSql(\`alter table [custom].[test2] add [path] text null CONSTRAINT [test2_path_default] DEFAULT 'NULL';\`);
   }
 
 }
@@ -492,24 +492,24 @@ exports[`Migrator (mssql) generate migration with custom name with name option: 
 export class Migration20191013214813_custom_name extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('alter table [custom].[book2] alter column [double] nvarchar(max);');
+    this.addSql(\`alter table [custom].[book2] alter column [double] nvarchar(max);\`);
 
-    this.addSql('declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = \\'custom\\' and tables.name = \\'book2\\' and all_columns.name = \\'foo\\') if @constraint0 is not null exec(\\'alter table [custom].[book2] drop constraint \\' + @constraint0);');
-    this.addSql('alter table [custom].[book2] drop column [foo];');
+    this.addSql(\`declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = 'custom' and tables.name = 'book2' and all_columns.name = 'foo') if @constraint0 is not null exec('alter table [custom].[book2] drop constraint ' + @constraint0);\`);
+    this.addSql(\`alter table [custom].[book2] drop column [foo];\`);
 
-    this.addSql('alter table [custom].[book2] alter column [double] float(53);');
+    this.addSql(\`alter table [custom].[book2] alter column [double] float(53);\`);
 
-    this.addSql('declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = \\'custom\\' and tables.name = \\'test2\\' and all_columns.name = \\'path\\') if @constraint0 is not null exec(\\'alter table [custom].[test2] drop constraint \\' + @constraint0);');
-    this.addSql('alter table [custom].[test2] drop column [path];');
+    this.addSql(\`declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = 'custom' and tables.name = 'test2' and all_columns.name = 'path') if @constraint0 is not null exec('alter table [custom].[test2] drop constraint ' + @constraint0);\`);
+    this.addSql(\`alter table [custom].[test2] drop column [path];\`);
   }
 
   override async down(): Promise<void> {
-    this.addSql('alter table [custom].[book2] alter column [double] nvarchar(max);');
+    this.addSql(\`alter table [custom].[book2] alter column [double] nvarchar(max);\`);
 
-    this.addSql('alter table [custom].[book2] add [foo] varchar(1) null CONSTRAINT [book2_foo_default] DEFAULT \\'lol\\';');
-    this.addSql('alter table [custom].[book2] alter column [double] numeric(18,0);');
+    this.addSql(\`alter table [custom].[book2] add [foo] varchar(1) null CONSTRAINT [book2_foo_default] DEFAULT 'lol';\`);
+    this.addSql(\`alter table [custom].[book2] alter column [double] numeric(18,0);\`);
 
-    this.addSql('alter table [custom].[test2] add [path] text null CONSTRAINT [test2_path_default] DEFAULT \\'NULL\\';');
+    this.addSql(\`alter table [custom].[test2] add [path] text null CONSTRAINT [test2_path_default] DEFAULT 'NULL';\`);
   }
 
 }
@@ -546,24 +546,24 @@ exports[`Migrator (mssql) generate migration with custom name: migration-dump 1`
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('alter table [custom].[book2] alter column [double] nvarchar(max);');
+    this.addSql(\`alter table [custom].[book2] alter column [double] nvarchar(max);\`);
 
-    this.addSql('declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = \\'custom\\' and tables.name = \\'book2\\' and all_columns.name = \\'foo\\') if @constraint0 is not null exec(\\'alter table [custom].[book2] drop constraint \\' + @constraint0);');
-    this.addSql('alter table [custom].[book2] drop column [foo];');
+    this.addSql(\`declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = 'custom' and tables.name = 'book2' and all_columns.name = 'foo') if @constraint0 is not null exec('alter table [custom].[book2] drop constraint ' + @constraint0);\`);
+    this.addSql(\`alter table [custom].[book2] drop column [foo];\`);
 
-    this.addSql('alter table [custom].[book2] alter column [double] float(53);');
+    this.addSql(\`alter table [custom].[book2] alter column [double] float(53);\`);
 
-    this.addSql('declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = \\'custom\\' and tables.name = \\'test2\\' and all_columns.name = \\'path\\') if @constraint0 is not null exec(\\'alter table [custom].[test2] drop constraint \\' + @constraint0);');
-    this.addSql('alter table [custom].[test2] drop column [path];');
+    this.addSql(\`declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = 'custom' and tables.name = 'test2' and all_columns.name = 'path') if @constraint0 is not null exec('alter table [custom].[test2] drop constraint ' + @constraint0);\`);
+    this.addSql(\`alter table [custom].[test2] drop column [path];\`);
   }
 
   override async down(): Promise<void> {
-    this.addSql('alter table [custom].[book2] alter column [double] nvarchar(max);');
+    this.addSql(\`alter table [custom].[book2] alter column [double] nvarchar(max);\`);
 
-    this.addSql('alter table [custom].[book2] add [foo] varchar(1) null CONSTRAINT [book2_foo_default] DEFAULT \\'lol\\';');
-    this.addSql('alter table [custom].[book2] alter column [double] numeric(18,0);');
+    this.addSql(\`alter table [custom].[book2] add [foo] varchar(1) null CONSTRAINT [book2_foo_default] DEFAULT 'lol';\`);
+    this.addSql(\`alter table [custom].[book2] alter column [double] numeric(18,0);\`);
 
-    this.addSql('alter table [custom].[test2] add [path] text null CONSTRAINT [test2_path_default] DEFAULT \\'NULL\\';');
+    this.addSql(\`alter table [custom].[test2] add [path] text null CONSTRAINT [test2_path_default] DEFAULT 'NULL';\`);
   }
 
 }
@@ -600,24 +600,24 @@ exports[`Migrator (mssql) generate migration with snapshot: migration-snapshot-d
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('alter table [custom].[book2] alter column [double] nvarchar(max);');
+    this.addSql(\`alter table [custom].[book2] alter column [double] nvarchar(max);\`);
 
-    this.addSql('declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = \\'custom\\' and tables.name = \\'book2\\' and all_columns.name = \\'foo\\') if @constraint0 is not null exec(\\'alter table [custom].[book2] drop constraint \\' + @constraint0);');
-    this.addSql('alter table [custom].[book2] drop column [foo];');
+    this.addSql(\`declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = 'custom' and tables.name = 'book2' and all_columns.name = 'foo') if @constraint0 is not null exec('alter table [custom].[book2] drop constraint ' + @constraint0);\`);
+    this.addSql(\`alter table [custom].[book2] drop column [foo];\`);
 
-    this.addSql('alter table [custom].[book2] alter column [double] float(53);');
+    this.addSql(\`alter table [custom].[book2] alter column [double] float(53);\`);
 
-    this.addSql('declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = \\'custom\\' and tables.name = \\'test2\\' and all_columns.name = \\'path\\') if @constraint0 is not null exec(\\'alter table [custom].[test2] drop constraint \\' + @constraint0);');
-    this.addSql('alter table [custom].[test2] drop column [path];');
+    this.addSql(\`declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = 'custom' and tables.name = 'test2' and all_columns.name = 'path') if @constraint0 is not null exec('alter table [custom].[test2] drop constraint ' + @constraint0);\`);
+    this.addSql(\`alter table [custom].[test2] drop column [path];\`);
   }
 
   override async down(): Promise<void> {
-    this.addSql('alter table [custom].[book2] alter column [double] nvarchar(max);');
+    this.addSql(\`alter table [custom].[book2] alter column [double] nvarchar(max);\`);
 
-    this.addSql('alter table [custom].[book2] add [foo] varchar(1) null CONSTRAINT [book2_foo_default] DEFAULT \\'lol\\';');
-    this.addSql('alter table [custom].[book2] alter column [double] numeric(18,0);');
+    this.addSql(\`alter table [custom].[book2] add [foo] varchar(1) null CONSTRAINT [book2_foo_default] DEFAULT 'lol';\`);
+    this.addSql(\`alter table [custom].[book2] alter column [double] numeric(18,0);\`);
 
-    this.addSql('alter table [custom].[test2] add [path] text null CONSTRAINT [test2_path_default] DEFAULT \\'NULL\\';');
+    this.addSql(\`alter table [custom].[test2] add [path] text null CONSTRAINT [test2_path_default] DEFAULT 'NULL';\`);
   }
 
 }
@@ -665,24 +665,24 @@ exports[`Migrator (mssql) generate schema migration: migration-dump 1`] = `
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('alter table [custom].[book2] alter column [double] nvarchar(max);');
+    this.addSql(\`alter table [custom].[book2] alter column [double] nvarchar(max);\`);
 
-    this.addSql('declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = \\'custom\\' and tables.name = \\'book2\\' and all_columns.name = \\'foo\\') if @constraint0 is not null exec(\\'alter table [custom].[book2] drop constraint \\' + @constraint0);');
-    this.addSql('alter table [custom].[book2] drop column [foo];');
+    this.addSql(\`declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = 'custom' and tables.name = 'book2' and all_columns.name = 'foo') if @constraint0 is not null exec('alter table [custom].[book2] drop constraint ' + @constraint0);\`);
+    this.addSql(\`alter table [custom].[book2] drop column [foo];\`);
 
-    this.addSql('alter table [custom].[book2] alter column [double] float(53);');
+    this.addSql(\`alter table [custom].[book2] alter column [double] float(53);\`);
 
-    this.addSql('declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = \\'custom\\' and tables.name = \\'test2\\' and all_columns.name = \\'path\\') if @constraint0 is not null exec(\\'alter table [custom].[test2] drop constraint \\' + @constraint0);');
-    this.addSql('alter table [custom].[test2] drop column [path];');
+    this.addSql(\`declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = 'custom' and tables.name = 'test2' and all_columns.name = 'path') if @constraint0 is not null exec('alter table [custom].[test2] drop constraint ' + @constraint0);\`);
+    this.addSql(\`alter table [custom].[test2] drop column [path];\`);
   }
 
   override async down(): Promise<void> {
-    this.addSql('alter table [custom].[book2] alter column [double] nvarchar(max);');
+    this.addSql(\`alter table [custom].[book2] alter column [double] nvarchar(max);\`);
 
-    this.addSql('alter table [custom].[book2] add [foo] varchar(1) null CONSTRAINT [book2_foo_default] DEFAULT \\'lol\\';');
-    this.addSql('alter table [custom].[book2] alter column [double] numeric(18,0);');
+    this.addSql(\`alter table [custom].[book2] add [foo] varchar(1) null CONSTRAINT [book2_foo_default] DEFAULT 'lol';\`);
+    this.addSql(\`alter table [custom].[book2] alter column [double] numeric(18,0);\`);
 
-    this.addSql('alter table [custom].[test2] add [path] text null CONSTRAINT [test2_path_default] DEFAULT \\'NULL\\';');
+    this.addSql(\`alter table [custom].[test2] add [path] text null CONSTRAINT [test2_path_default] DEFAULT 'NULL';\`);
   }
 
 }

--- a/tests/features/migrations/__snapshots__/Migrator.postgres.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.postgres.test.ts.snap
@@ -7,90 +7,90 @@ exports[`Migrator (postgres) generate initial migration: initial-migration-dump 
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('create schema if not exists "custom";');
-    this.addSql('create table "custom"."book_tag2" ("id" bigserial primary key, "name" varchar(50) not null);');
+    this.addSql(\`create schema if not exists "custom";\`);
+    this.addSql(\`create table "custom"."book_tag2" ("id" bigserial primary key, "name" varchar(50) not null);\`);
 
-    this.addSql('create table "custom"."foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "code" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));');
+    this.addSql(\`create table "custom"."foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "code" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));\`);
 
-    this.addSql('create table "custom"."foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int null, "foo_bar_id" int null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "blob2" bytea null, "array" text[] null, "object_property" jsonb null);');
-    this.addSql('alter table "custom"."foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");');
-    this.addSql('alter table "custom"."foo_bar2" add constraint "foo_bar2_foo_bar_id_unique" unique ("foo_bar_id");');
+    this.addSql(\`create table "custom"."foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int null, "foo_bar_id" int null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "blob2" bytea null, "array" text[] null, "object_property" jsonb null);\`);
+    this.addSql(\`alter table "custom"."foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");\`);
+    this.addSql(\`alter table "custom"."foo_bar2" add constraint "foo_bar2_foo_bar_id_unique" unique ("foo_bar_id");\`);
 
-    this.addSql('create table "custom"."foo_param2" ("bar_id" int not null, "baz_id" int not null, "value" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3), constraint "foo_param2_pkey" primary key ("bar_id", "baz_id"));');
+    this.addSql(\`create table "custom"."foo_param2" ("bar_id" int not null, "baz_id" int not null, "value" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3), constraint "foo_param2_pkey" primary key ("bar_id", "baz_id"));\`);
 
-    this.addSql('create table "custom"."publisher2" ("id" serial primary key, "name" varchar(255) not null default \\'asd\\', "type" text check ("type" in (\\'local\\', \\'global\\')) not null default \\'local\\', "type2" text check ("type2" in (\\'LOCAL\\', \\'GLOBAL\\')) not null default \\'LOCAL\\', "enum1" smallint null, "enum2" smallint null, "enum3" smallint null, "enum4" text check ("enum4" in (\\'a\\', \\'b\\', \\'c\\')) null, "enum5" text check ("enum5" in (\\'a\\')) null);');
+    this.addSql(\`create table "custom"."publisher2" ("id" serial primary key, "name" varchar(255) not null default 'asd', "type" text check ("type" in ('local', 'global')) not null default 'local', "type2" text check ("type2" in ('LOCAL', 'GLOBAL')) not null default 'LOCAL', "enum1" smallint null, "enum2" smallint null, "enum3" smallint null, "enum4" text check ("enum4" in ('a', 'b', 'c')) null, "enum5" text check ("enum5" in ('a')) null);\`);
 
-    this.addSql('create table "custom"."author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), "updated_at" timestamptz(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int null, "terms_accepted" boolean not null default false, "optional" boolean null, "identities" text[] null, "born" date null, "born_time" time(0) null, "favourite_book_uuid_pk" uuid null, "favourite_author_id" int null, "identity" jsonb null);');
-    this.addSql('create index "custom_email_index_name" on "custom"."author2" ("email");');
-    this.addSql('alter table "custom"."author2" add constraint "custom_email_unique_name" unique ("email");');
-    this.addSql('create index "author2_terms_accepted_index" on "custom"."author2" ("terms_accepted");');
-    this.addSql('create index "author2_born_index" on "custom"."author2" ("born");');
-    this.addSql('create index "born_time_idx" on "custom"."author2" ("born_time");');
-    this.addSql('create index "custom_idx_name_123" on "custom"."author2" ("name");');
-    this.addSql('create index "author2_name_age_index" on "custom"."author2" ("name", "age");');
-    this.addSql('alter table "custom"."author2" add constraint "author2_name_email_unique" unique ("name", "email");');
+    this.addSql(\`create table "custom"."author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), "updated_at" timestamptz(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int null, "terms_accepted" boolean not null default false, "optional" boolean null, "identities" text[] null, "born" date null, "born_time" time(0) null, "favourite_book_uuid_pk" uuid null, "favourite_author_id" int null, "identity" jsonb null);\`);
+    this.addSql(\`create index "custom_email_index_name" on "custom"."author2" ("email");\`);
+    this.addSql(\`alter table "custom"."author2" add constraint "custom_email_unique_name" unique ("email");\`);
+    this.addSql(\`create index "author2_terms_accepted_index" on "custom"."author2" ("terms_accepted");\`);
+    this.addSql(\`create index "author2_born_index" on "custom"."author2" ("born");\`);
+    this.addSql(\`create index "born_time_idx" on "custom"."author2" ("born_time");\`);
+    this.addSql(\`create index "custom_idx_name_123" on "custom"."author2" ("name");\`);
+    this.addSql(\`create index "author2_name_age_index" on "custom"."author2" ("name", "age");\`);
+    this.addSql(\`alter table "custom"."author2" add constraint "author2_name_email_unique" unique ("name", "email");\`);
 
-    this.addSql('create table "custom"."book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "isbn" char(13) null, "title" varchar(255) null default \\'\\', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));');
-    this.addSql('alter table "custom"."book2" add constraint "book2_isbn_unique" unique ("isbn");');
-    this.addSql('create index "book2_title_index" on "custom"."book2" using gin(to_tsvector(\\'simple\\', "title"));');
+    this.addSql(\`create table "custom"."book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "isbn" char(13) null, "title" varchar(255) null default '', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));\`);
+    this.addSql(\`alter table "custom"."book2" add constraint "book2_isbn_unique" unique ("isbn");\`);
+    this.addSql(\`create index "book2_title_index" on "custom"."book2" using gin(to_tsvector('simple', "title"));\`);
 
-    this.addSql('create table "custom"."book2_tags" ("order" serial primary key, "book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null);');
+    this.addSql(\`create table "custom"."book2_tags" ("order" serial primary key, "book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null);\`);
 
-    this.addSql('create table "custom"."book_to_tag_unordered" ("book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null, constraint "book_to_tag_unordered_pkey" primary key ("book2_uuid_pk", "book_tag2_id"));');
+    this.addSql(\`create table "custom"."book_to_tag_unordered" ("book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null, constraint "book_to_tag_unordered_pkey" primary key ("book2_uuid_pk", "book_tag2_id"));\`);
 
-    this.addSql('create table "custom"."author2_following" ("author2_1_id" int not null, "author2_2_id" int not null, constraint "author2_following_pkey" primary key ("author2_1_id", "author2_2_id"));');
+    this.addSql(\`create table "custom"."author2_following" ("author2_1_id" int not null, "author2_2_id" int not null, constraint "author2_following_pkey" primary key ("author2_1_id", "author2_2_id"));\`);
 
-    this.addSql('create table "custom"."author_to_friend" ("author2_1_id" int not null, "author2_2_id" int not null, constraint "author_to_friend_pkey" primary key ("author2_1_id", "author2_2_id"));');
+    this.addSql(\`create table "custom"."author_to_friend" ("author2_1_id" int not null, "author2_2_id" int not null, constraint "author_to_friend_pkey" primary key ("author2_1_id", "author2_2_id"));\`);
 
-    this.addSql('create table "custom"."address2" ("author_id" int not null, "value" varchar(255) not null, constraint "address2_pkey" primary key ("author_id"));');
-    this.addSql('comment on table "custom"."address2" is \\'This is address table\\';');
-    this.addSql('comment on column "custom"."address2"."value" is \\'This is address property\\';');
+    this.addSql(\`create table "custom"."address2" ("author_id" int not null, "value" varchar(255) not null, constraint "address2_pkey" primary key ("author_id"));\`);
+    this.addSql(\`comment on table "custom"."address2" is 'This is address table';\`);
+    this.addSql(\`comment on column "custom"."address2"."value" is 'This is address property';\`);
 
-    this.addSql('create table "custom"."test2" ("id" serial primary key, "name" varchar(255) null, "book_uuid_pk" uuid null, "parent_id" int null, "version" int not null default 1);');
-    this.addSql('alter table "custom"."test2" add constraint "test2_book_uuid_pk_unique" unique ("book_uuid_pk");');
+    this.addSql(\`create table "custom"."test2" ("id" serial primary key, "name" varchar(255) null, "book_uuid_pk" uuid null, "parent_id" int null, "version" int not null default 1);\`);
+    this.addSql(\`alter table "custom"."test2" add constraint "test2_book_uuid_pk_unique" unique ("book_uuid_pk");\`);
 
-    this.addSql('create table "custom"."publisher2_tests" ("id" serial primary key, "publisher2_id" int not null, "test2_id" int not null);');
+    this.addSql(\`create table "custom"."publisher2_tests" ("id" serial primary key, "publisher2_id" int not null, "test2_id" int not null);\`);
 
-    this.addSql('create table "custom"."configuration2" ("property" varchar(255) not null, "test_id" int not null, "value" varchar(255) not null, constraint "configuration2_pkey" primary key ("property", "test_id"));');
+    this.addSql(\`create table "custom"."configuration2" ("property" varchar(255) not null, "test_id" int not null, "value" varchar(255) not null, constraint "configuration2_pkey" primary key ("property", "test_id"));\`);
 
-    this.addSql('create table "custom"."test2_bars" ("test2_id" int not null, "foo_bar2_id" int not null, constraint "test2_bars_pkey" primary key ("test2_id", "foo_bar2_id"));');
+    this.addSql(\`create table "custom"."test2_bars" ("test2_id" int not null, "foo_bar2_id" int not null, constraint "test2_bars_pkey" primary key ("test2_id", "foo_bar2_id"));\`);
 
-    this.addSql('alter table "custom"."foo_bar2" add constraint "foo_bar2_baz_id_foreign" foreign key ("baz_id") references "custom"."foo_baz2" ("id") on update cascade on delete set null;');
-    this.addSql('alter table "custom"."foo_bar2" add constraint "foo_bar2_foo_bar_id_foreign" foreign key ("foo_bar_id") references "custom"."foo_bar2" ("id") on update cascade on delete set null;');
+    this.addSql(\`alter table "custom"."foo_bar2" add constraint "foo_bar2_baz_id_foreign" foreign key ("baz_id") references "custom"."foo_baz2" ("id") on update cascade on delete set null;\`);
+    this.addSql(\`alter table "custom"."foo_bar2" add constraint "foo_bar2_foo_bar_id_foreign" foreign key ("foo_bar_id") references "custom"."foo_bar2" ("id") on update cascade on delete set null;\`);
 
-    this.addSql('alter table "custom"."foo_param2" add constraint "foo_param2_bar_id_foreign" foreign key ("bar_id") references "custom"."foo_bar2" ("id") on update cascade;');
-    this.addSql('alter table "custom"."foo_param2" add constraint "foo_param2_baz_id_foreign" foreign key ("baz_id") references "custom"."foo_baz2" ("id") on update cascade;');
+    this.addSql(\`alter table "custom"."foo_param2" add constraint "foo_param2_bar_id_foreign" foreign key ("bar_id") references "custom"."foo_bar2" ("id") on update cascade;\`);
+    this.addSql(\`alter table "custom"."foo_param2" add constraint "foo_param2_baz_id_foreign" foreign key ("baz_id") references "custom"."foo_baz2" ("id") on update cascade;\`);
 
-    this.addSql('alter table "custom"."author2" add constraint "author2_favourite_book_uuid_pk_foreign" foreign key ("favourite_book_uuid_pk") references "custom"."book2" ("uuid_pk") on update no action on delete cascade;');
-    this.addSql('alter table "custom"."author2" add constraint "author2_favourite_author_id_foreign" foreign key ("favourite_author_id") references "custom"."author2" ("id") on update cascade on delete set null;');
+    this.addSql(\`alter table "custom"."author2" add constraint "author2_favourite_book_uuid_pk_foreign" foreign key ("favourite_book_uuid_pk") references "custom"."book2" ("uuid_pk") on update no action on delete cascade;\`);
+    this.addSql(\`alter table "custom"."author2" add constraint "author2_favourite_author_id_foreign" foreign key ("favourite_author_id") references "custom"."author2" ("id") on update cascade on delete set null;\`);
 
-    this.addSql('alter table "custom"."book2" add constraint "book2_author_id_foreign" foreign key ("author_id") references "custom"."author2" ("id");');
-    this.addSql('alter table "custom"."book2" add constraint "book2_publisher_id_foreign" foreign key ("publisher_id") references "custom"."publisher2" ("id") on update cascade on delete cascade;');
+    this.addSql(\`alter table "custom"."book2" add constraint "book2_author_id_foreign" foreign key ("author_id") references "custom"."author2" ("id");\`);
+    this.addSql(\`alter table "custom"."book2" add constraint "book2_publisher_id_foreign" foreign key ("publisher_id") references "custom"."publisher2" ("id") on update cascade on delete cascade;\`);
 
-    this.addSql('alter table "custom"."book2_tags" add constraint "book2_tags_book2_uuid_pk_foreign" foreign key ("book2_uuid_pk") references "custom"."book2" ("uuid_pk") on update cascade on delete cascade;');
-    this.addSql('alter table "custom"."book2_tags" add constraint "book2_tags_book_tag2_id_foreign" foreign key ("book_tag2_id") references "custom"."book_tag2" ("id") on update cascade on delete cascade;');
+    this.addSql(\`alter table "custom"."book2_tags" add constraint "book2_tags_book2_uuid_pk_foreign" foreign key ("book2_uuid_pk") references "custom"."book2" ("uuid_pk") on update cascade on delete cascade;\`);
+    this.addSql(\`alter table "custom"."book2_tags" add constraint "book2_tags_book_tag2_id_foreign" foreign key ("book_tag2_id") references "custom"."book_tag2" ("id") on update cascade on delete cascade;\`);
 
-    this.addSql('alter table "custom"."book_to_tag_unordered" add constraint "book_to_tag_unordered_book2_uuid_pk_foreign" foreign key ("book2_uuid_pk") references "custom"."book2" ("uuid_pk") on update cascade on delete cascade;');
-    this.addSql('alter table "custom"."book_to_tag_unordered" add constraint "book_to_tag_unordered_book_tag2_id_foreign" foreign key ("book_tag2_id") references "custom"."book_tag2" ("id") on update cascade on delete cascade;');
+    this.addSql(\`alter table "custom"."book_to_tag_unordered" add constraint "book_to_tag_unordered_book2_uuid_pk_foreign" foreign key ("book2_uuid_pk") references "custom"."book2" ("uuid_pk") on update cascade on delete cascade;\`);
+    this.addSql(\`alter table "custom"."book_to_tag_unordered" add constraint "book_to_tag_unordered_book_tag2_id_foreign" foreign key ("book_tag2_id") references "custom"."book_tag2" ("id") on update cascade on delete cascade;\`);
 
-    this.addSql('alter table "custom"."author2_following" add constraint "author2_following_author2_1_id_foreign" foreign key ("author2_1_id") references "custom"."author2" ("id") on update cascade on delete cascade;');
-    this.addSql('alter table "custom"."author2_following" add constraint "author2_following_author2_2_id_foreign" foreign key ("author2_2_id") references "custom"."author2" ("id") on update cascade on delete cascade;');
+    this.addSql(\`alter table "custom"."author2_following" add constraint "author2_following_author2_1_id_foreign" foreign key ("author2_1_id") references "custom"."author2" ("id") on update cascade on delete cascade;\`);
+    this.addSql(\`alter table "custom"."author2_following" add constraint "author2_following_author2_2_id_foreign" foreign key ("author2_2_id") references "custom"."author2" ("id") on update cascade on delete cascade;\`);
 
-    this.addSql('alter table "custom"."author_to_friend" add constraint "author_to_friend_author2_1_id_foreign" foreign key ("author2_1_id") references "custom"."author2" ("id") on update cascade on delete cascade;');
-    this.addSql('alter table "custom"."author_to_friend" add constraint "author_to_friend_author2_2_id_foreign" foreign key ("author2_2_id") references "custom"."author2" ("id") on update cascade on delete cascade;');
+    this.addSql(\`alter table "custom"."author_to_friend" add constraint "author_to_friend_author2_1_id_foreign" foreign key ("author2_1_id") references "custom"."author2" ("id") on update cascade on delete cascade;\`);
+    this.addSql(\`alter table "custom"."author_to_friend" add constraint "author_to_friend_author2_2_id_foreign" foreign key ("author2_2_id") references "custom"."author2" ("id") on update cascade on delete cascade;\`);
 
-    this.addSql('alter table "custom"."address2" add constraint "address2_author_id_foreign" foreign key ("author_id") references "custom"."author2" ("id") on update cascade on delete cascade;');
+    this.addSql(\`alter table "custom"."address2" add constraint "address2_author_id_foreign" foreign key ("author_id") references "custom"."author2" ("id") on update cascade on delete cascade;\`);
 
-    this.addSql('alter table "custom"."test2" add constraint "test2_book_uuid_pk_foreign" foreign key ("book_uuid_pk") references "custom"."book2" ("uuid_pk") on delete set null;');
-    this.addSql('alter table "custom"."test2" add constraint "test2_parent_id_foreign" foreign key ("parent_id") references "custom"."test2" ("id") on update cascade on delete set null;');
+    this.addSql(\`alter table "custom"."test2" add constraint "test2_book_uuid_pk_foreign" foreign key ("book_uuid_pk") references "custom"."book2" ("uuid_pk") on delete set null;\`);
+    this.addSql(\`alter table "custom"."test2" add constraint "test2_parent_id_foreign" foreign key ("parent_id") references "custom"."test2" ("id") on update cascade on delete set null;\`);
 
-    this.addSql('alter table "custom"."publisher2_tests" add constraint "publisher2_tests_publisher2_id_foreign" foreign key ("publisher2_id") references "custom"."publisher2" ("id") on update cascade on delete cascade;');
-    this.addSql('alter table "custom"."publisher2_tests" add constraint "publisher2_tests_test2_id_foreign" foreign key ("test2_id") references "custom"."test2" ("id") on update cascade on delete cascade;');
+    this.addSql(\`alter table "custom"."publisher2_tests" add constraint "publisher2_tests_publisher2_id_foreign" foreign key ("publisher2_id") references "custom"."publisher2" ("id") on update cascade on delete cascade;\`);
+    this.addSql(\`alter table "custom"."publisher2_tests" add constraint "publisher2_tests_test2_id_foreign" foreign key ("test2_id") references "custom"."test2" ("id") on update cascade on delete cascade;\`);
 
-    this.addSql('alter table "custom"."configuration2" add constraint "configuration2_test_id_foreign" foreign key ("test_id") references "custom"."test2" ("id") on update cascade;');
+    this.addSql(\`alter table "custom"."configuration2" add constraint "configuration2_test_id_foreign" foreign key ("test_id") references "custom"."test2" ("id") on update cascade;\`);
 
-    this.addSql('alter table "custom"."test2_bars" add constraint "test2_bars_test2_id_foreign" foreign key ("test2_id") references "custom"."test2" ("id") on update cascade on delete cascade;');
-    this.addSql('alter table "custom"."test2_bars" add constraint "test2_bars_foo_bar2_id_foreign" foreign key ("foo_bar2_id") references "custom"."foo_bar2" ("id") on update cascade on delete cascade;');
+    this.addSql(\`alter table "custom"."test2_bars" add constraint "test2_bars_test2_id_foreign" foreign key ("test2_id") references "custom"."test2" ("id") on update cascade on delete cascade;\`);
+    this.addSql(\`alter table "custom"."test2_bars" add constraint "test2_bars_foo_bar2_id_foreign" foreign key ("foo_bar2_id") references "custom"."foo_bar2" ("id") on update cascade on delete cascade;\`);
   }
 
 }
@@ -195,90 +195,90 @@ exports[`Migrator (postgres) generate initial migration: initial-migration-dump 
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('create schema if not exists "custom";');
-    this.addSql('create table "custom"."book_tag2" ("id" bigserial primary key, "name" varchar(50) not null);');
+    this.addSql(\`create schema if not exists "custom";\`);
+    this.addSql(\`create table "custom"."book_tag2" ("id" bigserial primary key, "name" varchar(50) not null);\`);
 
-    this.addSql('create table "custom"."foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "code" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));');
+    this.addSql(\`create table "custom"."foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "code" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));\`);
 
-    this.addSql('create table "custom"."foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int null, "foo_bar_id" int null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "blob2" bytea null, "array" text[] null, "object_property" jsonb null);');
-    this.addSql('alter table "custom"."foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");');
-    this.addSql('alter table "custom"."foo_bar2" add constraint "foo_bar2_foo_bar_id_unique" unique ("foo_bar_id");');
+    this.addSql(\`create table "custom"."foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int null, "foo_bar_id" int null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "blob2" bytea null, "array" text[] null, "object_property" jsonb null);\`);
+    this.addSql(\`alter table "custom"."foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");\`);
+    this.addSql(\`alter table "custom"."foo_bar2" add constraint "foo_bar2_foo_bar_id_unique" unique ("foo_bar_id");\`);
 
-    this.addSql('create table "custom"."foo_param2" ("bar_id" int not null, "baz_id" int not null, "value" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3), constraint "foo_param2_pkey" primary key ("bar_id", "baz_id"));');
+    this.addSql(\`create table "custom"."foo_param2" ("bar_id" int not null, "baz_id" int not null, "value" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3), constraint "foo_param2_pkey" primary key ("bar_id", "baz_id"));\`);
 
-    this.addSql('create table "custom"."publisher2" ("id" serial primary key, "name" varchar(255) not null default \\'asd\\', "type" text check ("type" in (\\'local\\', \\'global\\')) not null default \\'local\\', "type2" text check ("type2" in (\\'LOCAL\\', \\'GLOBAL\\')) not null default \\'LOCAL\\', "enum1" smallint null, "enum2" smallint null, "enum3" smallint null, "enum4" text check ("enum4" in (\\'a\\', \\'b\\', \\'c\\')) null, "enum5" text check ("enum5" in (\\'a\\')) null);');
+    this.addSql(\`create table "custom"."publisher2" ("id" serial primary key, "name" varchar(255) not null default 'asd', "type" text check ("type" in ('local', 'global')) not null default 'local', "type2" text check ("type2" in ('LOCAL', 'GLOBAL')) not null default 'LOCAL', "enum1" smallint null, "enum2" smallint null, "enum3" smallint null, "enum4" text check ("enum4" in ('a', 'b', 'c')) null, "enum5" text check ("enum5" in ('a')) null);\`);
 
-    this.addSql('create table "custom"."author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), "updated_at" timestamptz(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int null, "terms_accepted" boolean not null default false, "optional" boolean null, "identities" text[] null, "born" date null, "born_time" time(0) null, "favourite_book_uuid_pk" uuid null, "favourite_author_id" int null, "identity" jsonb null);');
-    this.addSql('create index "custom_email_index_name" on "custom"."author2" ("email");');
-    this.addSql('alter table "custom"."author2" add constraint "custom_email_unique_name" unique ("email");');
-    this.addSql('create index "author2_terms_accepted_index" on "custom"."author2" ("terms_accepted");');
-    this.addSql('create index "author2_born_index" on "custom"."author2" ("born");');
-    this.addSql('create index "born_time_idx" on "custom"."author2" ("born_time");');
-    this.addSql('create index "custom_idx_name_123" on "custom"."author2" ("name");');
-    this.addSql('create index "author2_name_age_index" on "custom"."author2" ("name", "age");');
-    this.addSql('alter table "custom"."author2" add constraint "author2_name_email_unique" unique ("name", "email");');
+    this.addSql(\`create table "custom"."author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), "updated_at" timestamptz(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int null, "terms_accepted" boolean not null default false, "optional" boolean null, "identities" text[] null, "born" date null, "born_time" time(0) null, "favourite_book_uuid_pk" uuid null, "favourite_author_id" int null, "identity" jsonb null);\`);
+    this.addSql(\`create index "custom_email_index_name" on "custom"."author2" ("email");\`);
+    this.addSql(\`alter table "custom"."author2" add constraint "custom_email_unique_name" unique ("email");\`);
+    this.addSql(\`create index "author2_terms_accepted_index" on "custom"."author2" ("terms_accepted");\`);
+    this.addSql(\`create index "author2_born_index" on "custom"."author2" ("born");\`);
+    this.addSql(\`create index "born_time_idx" on "custom"."author2" ("born_time");\`);
+    this.addSql(\`create index "custom_idx_name_123" on "custom"."author2" ("name");\`);
+    this.addSql(\`create index "author2_name_age_index" on "custom"."author2" ("name", "age");\`);
+    this.addSql(\`alter table "custom"."author2" add constraint "author2_name_email_unique" unique ("name", "email");\`);
 
-    this.addSql('create table "custom"."book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "isbn" char(13) null, "title" varchar(255) null default \\'\\', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));');
-    this.addSql('alter table "custom"."book2" add constraint "book2_isbn_unique" unique ("isbn");');
-    this.addSql('create index "book2_title_index" on "custom"."book2" using gin(to_tsvector(\\'simple\\', "title"));');
+    this.addSql(\`create table "custom"."book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "isbn" char(13) null, "title" varchar(255) null default '', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, constraint "book2_pkey" primary key ("uuid_pk"));\`);
+    this.addSql(\`alter table "custom"."book2" add constraint "book2_isbn_unique" unique ("isbn");\`);
+    this.addSql(\`create index "book2_title_index" on "custom"."book2" using gin(to_tsvector('simple', "title"));\`);
 
-    this.addSql('create table "custom"."book2_tags" ("order" serial primary key, "book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null);');
+    this.addSql(\`create table "custom"."book2_tags" ("order" serial primary key, "book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null);\`);
 
-    this.addSql('create table "custom"."book_to_tag_unordered" ("book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null, constraint "book_to_tag_unordered_pkey" primary key ("book2_uuid_pk", "book_tag2_id"));');
+    this.addSql(\`create table "custom"."book_to_tag_unordered" ("book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null, constraint "book_to_tag_unordered_pkey" primary key ("book2_uuid_pk", "book_tag2_id"));\`);
 
-    this.addSql('create table "custom"."author2_following" ("author2_1_id" int not null, "author2_2_id" int not null, constraint "author2_following_pkey" primary key ("author2_1_id", "author2_2_id"));');
+    this.addSql(\`create table "custom"."author2_following" ("author2_1_id" int not null, "author2_2_id" int not null, constraint "author2_following_pkey" primary key ("author2_1_id", "author2_2_id"));\`);
 
-    this.addSql('create table "custom"."author_to_friend" ("author2_1_id" int not null, "author2_2_id" int not null, constraint "author_to_friend_pkey" primary key ("author2_1_id", "author2_2_id"));');
+    this.addSql(\`create table "custom"."author_to_friend" ("author2_1_id" int not null, "author2_2_id" int not null, constraint "author_to_friend_pkey" primary key ("author2_1_id", "author2_2_id"));\`);
 
-    this.addSql('create table "custom"."address2" ("author_id" int not null, "value" varchar(255) not null, constraint "address2_pkey" primary key ("author_id"));');
-    this.addSql('comment on table "custom"."address2" is \\'This is address table\\';');
-    this.addSql('comment on column "custom"."address2"."value" is \\'This is address property\\';');
+    this.addSql(\`create table "custom"."address2" ("author_id" int not null, "value" varchar(255) not null, constraint "address2_pkey" primary key ("author_id"));\`);
+    this.addSql(\`comment on table "custom"."address2" is 'This is address table';\`);
+    this.addSql(\`comment on column "custom"."address2"."value" is 'This is address property';\`);
 
-    this.addSql('create table "custom"."test2" ("id" serial primary key, "name" varchar(255) null, "book_uuid_pk" uuid null, "parent_id" int null, "version" int not null default 1);');
-    this.addSql('alter table "custom"."test2" add constraint "test2_book_uuid_pk_unique" unique ("book_uuid_pk");');
+    this.addSql(\`create table "custom"."test2" ("id" serial primary key, "name" varchar(255) null, "book_uuid_pk" uuid null, "parent_id" int null, "version" int not null default 1);\`);
+    this.addSql(\`alter table "custom"."test2" add constraint "test2_book_uuid_pk_unique" unique ("book_uuid_pk");\`);
 
-    this.addSql('create table "custom"."publisher2_tests" ("id" serial primary key, "publisher2_id" int not null, "test2_id" int not null);');
+    this.addSql(\`create table "custom"."publisher2_tests" ("id" serial primary key, "publisher2_id" int not null, "test2_id" int not null);\`);
 
-    this.addSql('create table "custom"."configuration2" ("property" varchar(255) not null, "test_id" int not null, "value" varchar(255) not null, constraint "configuration2_pkey" primary key ("property", "test_id"));');
+    this.addSql(\`create table "custom"."configuration2" ("property" varchar(255) not null, "test_id" int not null, "value" varchar(255) not null, constraint "configuration2_pkey" primary key ("property", "test_id"));\`);
 
-    this.addSql('create table "custom"."test2_bars" ("test2_id" int not null, "foo_bar2_id" int not null, constraint "test2_bars_pkey" primary key ("test2_id", "foo_bar2_id"));');
+    this.addSql(\`create table "custom"."test2_bars" ("test2_id" int not null, "foo_bar2_id" int not null, constraint "test2_bars_pkey" primary key ("test2_id", "foo_bar2_id"));\`);
 
-    this.addSql('alter table "custom"."foo_bar2" add constraint "foo_bar2_baz_id_foreign" foreign key ("baz_id") references "custom"."foo_baz2" ("id") on update cascade on delete set null;');
-    this.addSql('alter table "custom"."foo_bar2" add constraint "foo_bar2_foo_bar_id_foreign" foreign key ("foo_bar_id") references "custom"."foo_bar2" ("id") on update cascade on delete set null;');
+    this.addSql(\`alter table "custom"."foo_bar2" add constraint "foo_bar2_baz_id_foreign" foreign key ("baz_id") references "custom"."foo_baz2" ("id") on update cascade on delete set null;\`);
+    this.addSql(\`alter table "custom"."foo_bar2" add constraint "foo_bar2_foo_bar_id_foreign" foreign key ("foo_bar_id") references "custom"."foo_bar2" ("id") on update cascade on delete set null;\`);
 
-    this.addSql('alter table "custom"."foo_param2" add constraint "foo_param2_bar_id_foreign" foreign key ("bar_id") references "custom"."foo_bar2" ("id") on update cascade;');
-    this.addSql('alter table "custom"."foo_param2" add constraint "foo_param2_baz_id_foreign" foreign key ("baz_id") references "custom"."foo_baz2" ("id") on update cascade;');
+    this.addSql(\`alter table "custom"."foo_param2" add constraint "foo_param2_bar_id_foreign" foreign key ("bar_id") references "custom"."foo_bar2" ("id") on update cascade;\`);
+    this.addSql(\`alter table "custom"."foo_param2" add constraint "foo_param2_baz_id_foreign" foreign key ("baz_id") references "custom"."foo_baz2" ("id") on update cascade;\`);
 
-    this.addSql('alter table "custom"."author2" add constraint "author2_favourite_book_uuid_pk_foreign" foreign key ("favourite_book_uuid_pk") references "custom"."book2" ("uuid_pk") on update no action on delete cascade;');
-    this.addSql('alter table "custom"."author2" add constraint "author2_favourite_author_id_foreign" foreign key ("favourite_author_id") references "custom"."author2" ("id") on update cascade on delete set null;');
+    this.addSql(\`alter table "custom"."author2" add constraint "author2_favourite_book_uuid_pk_foreign" foreign key ("favourite_book_uuid_pk") references "custom"."book2" ("uuid_pk") on update no action on delete cascade;\`);
+    this.addSql(\`alter table "custom"."author2" add constraint "author2_favourite_author_id_foreign" foreign key ("favourite_author_id") references "custom"."author2" ("id") on update cascade on delete set null;\`);
 
-    this.addSql('alter table "custom"."book2" add constraint "book2_author_id_foreign" foreign key ("author_id") references "custom"."author2" ("id");');
-    this.addSql('alter table "custom"."book2" add constraint "book2_publisher_id_foreign" foreign key ("publisher_id") references "custom"."publisher2" ("id") on update cascade on delete cascade;');
+    this.addSql(\`alter table "custom"."book2" add constraint "book2_author_id_foreign" foreign key ("author_id") references "custom"."author2" ("id");\`);
+    this.addSql(\`alter table "custom"."book2" add constraint "book2_publisher_id_foreign" foreign key ("publisher_id") references "custom"."publisher2" ("id") on update cascade on delete cascade;\`);
 
-    this.addSql('alter table "custom"."book2_tags" add constraint "book2_tags_book2_uuid_pk_foreign" foreign key ("book2_uuid_pk") references "custom"."book2" ("uuid_pk") on update cascade on delete cascade;');
-    this.addSql('alter table "custom"."book2_tags" add constraint "book2_tags_book_tag2_id_foreign" foreign key ("book_tag2_id") references "custom"."book_tag2" ("id") on update cascade on delete cascade;');
+    this.addSql(\`alter table "custom"."book2_tags" add constraint "book2_tags_book2_uuid_pk_foreign" foreign key ("book2_uuid_pk") references "custom"."book2" ("uuid_pk") on update cascade on delete cascade;\`);
+    this.addSql(\`alter table "custom"."book2_tags" add constraint "book2_tags_book_tag2_id_foreign" foreign key ("book_tag2_id") references "custom"."book_tag2" ("id") on update cascade on delete cascade;\`);
 
-    this.addSql('alter table "custom"."book_to_tag_unordered" add constraint "book_to_tag_unordered_book2_uuid_pk_foreign" foreign key ("book2_uuid_pk") references "custom"."book2" ("uuid_pk") on update cascade on delete cascade;');
-    this.addSql('alter table "custom"."book_to_tag_unordered" add constraint "book_to_tag_unordered_book_tag2_id_foreign" foreign key ("book_tag2_id") references "custom"."book_tag2" ("id") on update cascade on delete cascade;');
+    this.addSql(\`alter table "custom"."book_to_tag_unordered" add constraint "book_to_tag_unordered_book2_uuid_pk_foreign" foreign key ("book2_uuid_pk") references "custom"."book2" ("uuid_pk") on update cascade on delete cascade;\`);
+    this.addSql(\`alter table "custom"."book_to_tag_unordered" add constraint "book_to_tag_unordered_book_tag2_id_foreign" foreign key ("book_tag2_id") references "custom"."book_tag2" ("id") on update cascade on delete cascade;\`);
 
-    this.addSql('alter table "custom"."author2_following" add constraint "author2_following_author2_1_id_foreign" foreign key ("author2_1_id") references "custom"."author2" ("id") on update cascade on delete cascade;');
-    this.addSql('alter table "custom"."author2_following" add constraint "author2_following_author2_2_id_foreign" foreign key ("author2_2_id") references "custom"."author2" ("id") on update cascade on delete cascade;');
+    this.addSql(\`alter table "custom"."author2_following" add constraint "author2_following_author2_1_id_foreign" foreign key ("author2_1_id") references "custom"."author2" ("id") on update cascade on delete cascade;\`);
+    this.addSql(\`alter table "custom"."author2_following" add constraint "author2_following_author2_2_id_foreign" foreign key ("author2_2_id") references "custom"."author2" ("id") on update cascade on delete cascade;\`);
 
-    this.addSql('alter table "custom"."author_to_friend" add constraint "author_to_friend_author2_1_id_foreign" foreign key ("author2_1_id") references "custom"."author2" ("id") on update cascade on delete cascade;');
-    this.addSql('alter table "custom"."author_to_friend" add constraint "author_to_friend_author2_2_id_foreign" foreign key ("author2_2_id") references "custom"."author2" ("id") on update cascade on delete cascade;');
+    this.addSql(\`alter table "custom"."author_to_friend" add constraint "author_to_friend_author2_1_id_foreign" foreign key ("author2_1_id") references "custom"."author2" ("id") on update cascade on delete cascade;\`);
+    this.addSql(\`alter table "custom"."author_to_friend" add constraint "author_to_friend_author2_2_id_foreign" foreign key ("author2_2_id") references "custom"."author2" ("id") on update cascade on delete cascade;\`);
 
-    this.addSql('alter table "custom"."address2" add constraint "address2_author_id_foreign" foreign key ("author_id") references "custom"."author2" ("id") on update cascade on delete cascade;');
+    this.addSql(\`alter table "custom"."address2" add constraint "address2_author_id_foreign" foreign key ("author_id") references "custom"."author2" ("id") on update cascade on delete cascade;\`);
 
-    this.addSql('alter table "custom"."test2" add constraint "test2_book_uuid_pk_foreign" foreign key ("book_uuid_pk") references "custom"."book2" ("uuid_pk") on delete set null;');
-    this.addSql('alter table "custom"."test2" add constraint "test2_parent_id_foreign" foreign key ("parent_id") references "custom"."test2" ("id") on update cascade on delete set null;');
+    this.addSql(\`alter table "custom"."test2" add constraint "test2_book_uuid_pk_foreign" foreign key ("book_uuid_pk") references "custom"."book2" ("uuid_pk") on delete set null;\`);
+    this.addSql(\`alter table "custom"."test2" add constraint "test2_parent_id_foreign" foreign key ("parent_id") references "custom"."test2" ("id") on update cascade on delete set null;\`);
 
-    this.addSql('alter table "custom"."publisher2_tests" add constraint "publisher2_tests_publisher2_id_foreign" foreign key ("publisher2_id") references "custom"."publisher2" ("id") on update cascade on delete cascade;');
-    this.addSql('alter table "custom"."publisher2_tests" add constraint "publisher2_tests_test2_id_foreign" foreign key ("test2_id") references "custom"."test2" ("id") on update cascade on delete cascade;');
+    this.addSql(\`alter table "custom"."publisher2_tests" add constraint "publisher2_tests_publisher2_id_foreign" foreign key ("publisher2_id") references "custom"."publisher2" ("id") on update cascade on delete cascade;\`);
+    this.addSql(\`alter table "custom"."publisher2_tests" add constraint "publisher2_tests_test2_id_foreign" foreign key ("test2_id") references "custom"."test2" ("id") on update cascade on delete cascade;\`);
 
-    this.addSql('alter table "custom"."configuration2" add constraint "configuration2_test_id_foreign" foreign key ("test_id") references "custom"."test2" ("id") on update cascade;');
+    this.addSql(\`alter table "custom"."configuration2" add constraint "configuration2_test_id_foreign" foreign key ("test_id") references "custom"."test2" ("id") on update cascade;\`);
 
-    this.addSql('alter table "custom"."test2_bars" add constraint "test2_bars_test2_id_foreign" foreign key ("test2_id") references "custom"."test2" ("id") on update cascade on delete cascade;');
-    this.addSql('alter table "custom"."test2_bars" add constraint "test2_bars_foo_bar2_id_foreign" foreign key ("foo_bar2_id") references "custom"."foo_bar2" ("id") on update cascade on delete cascade;');
+    this.addSql(\`alter table "custom"."test2_bars" add constraint "test2_bars_test2_id_foreign" foreign key ("test2_id") references "custom"."test2" ("id") on update cascade on delete cascade;\`);
+    this.addSql(\`alter table "custom"."test2_bars" add constraint "test2_bars_foo_bar2_id_foreign" foreign key ("foo_bar2_id") references "custom"."foo_bar2" ("id") on update cascade on delete cascade;\`);
   }
 
 }
@@ -385,18 +385,18 @@ const { Migration } = require('@mikro-orm/migrations');
 class Migration20191013214813 extends Migration {
 
   async up() {
-    this.addSql('alter table "custom"."book2" drop column "foo";');
+    this.addSql(\`alter table "custom"."book2" drop column "foo";\`);
 
-    this.addSql('alter table "custom"."book2" alter column "double" type double precision using ("double"::double precision);');
+    this.addSql(\`alter table "custom"."book2" alter column "double" type double precision using ("double"::double precision);\`);
 
-    this.addSql('alter table "custom"."test2" drop column "path";');
+    this.addSql(\`alter table "custom"."test2" drop column "path";\`);
   }
 
   async down() {
-    this.addSql('alter table "custom"."book2" add column "foo" varchar null default \\'lol\\';');
-    this.addSql('alter table "custom"."book2" alter column "double" type numeric using ("double"::numeric);');
+    this.addSql(\`alter table "custom"."book2" add column "foo" varchar null default 'lol';\`);
+    this.addSql(\`alter table "custom"."book2" alter column "double" type numeric using ("double"::numeric);\`);
 
-    this.addSql('alter table "custom"."test2" add column "path" polygon null;');
+    this.addSql(\`alter table "custom"."test2" add column "path" polygon null;\`);
   }
 
 }
@@ -430,18 +430,18 @@ import { Migration } from '@mikro-orm/migrations';
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('alter table "custom"."book2" drop column "foo";');
+    this.addSql(\`alter table "custom"."book2" drop column "foo";\`);
 
-    this.addSql('alter table "custom"."book2" alter column "double" type double precision using ("double"::double precision);');
+    this.addSql(\`alter table "custom"."book2" alter column "double" type double precision using ("double"::double precision);\`);
 
-    this.addSql('alter table "custom"."test2" drop column "path";');
+    this.addSql(\`alter table "custom"."test2" drop column "path";\`);
   }
 
   override async down(): Promise<void> {
-    this.addSql('alter table "custom"."book2" add column "foo" varchar null default \\'lol\\';');
-    this.addSql('alter table "custom"."book2" alter column "double" type numeric using ("double"::numeric);');
+    this.addSql(\`alter table "custom"."book2" add column "foo" varchar null default 'lol';\`);
+    this.addSql(\`alter table "custom"."book2" alter column "double" type numeric using ("double"::numeric);\`);
 
-    this.addSql('alter table "custom"."test2" add column "path" polygon null;');
+    this.addSql(\`alter table "custom"."test2" add column "path" polygon null;\`);
   }
 
 }
@@ -472,18 +472,18 @@ exports[`Migrator (postgres) generate migration with custom name with name optio
 export class Migration20191013214813_custom_name extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('alter table "custom"."book2" drop column "foo";');
+    this.addSql(\`alter table "custom"."book2" drop column "foo";\`);
 
-    this.addSql('alter table "custom"."book2" alter column "double" type double precision using ("double"::double precision);');
+    this.addSql(\`alter table "custom"."book2" alter column "double" type double precision using ("double"::double precision);\`);
 
-    this.addSql('alter table "custom"."test2" drop column "path";');
+    this.addSql(\`alter table "custom"."test2" drop column "path";\`);
   }
 
   override async down(): Promise<void> {
-    this.addSql('alter table "custom"."book2" add column "foo" varchar null default \\'lol\\';');
-    this.addSql('alter table "custom"."book2" alter column "double" type numeric using ("double"::numeric);');
+    this.addSql(\`alter table "custom"."book2" add column "foo" varchar null default 'lol';\`);
+    this.addSql(\`alter table "custom"."book2" alter column "double" type numeric using ("double"::numeric);\`);
 
-    this.addSql('alter table "custom"."test2" add column "path" polygon null;');
+    this.addSql(\`alter table "custom"."test2" add column "path" polygon null;\`);
   }
 
 }
@@ -514,18 +514,18 @@ exports[`Migrator (postgres) generate migration with custom name: migration-dump
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('alter table "custom"."book2" drop column "foo";');
+    this.addSql(\`alter table "custom"."book2" drop column "foo";\`);
 
-    this.addSql('alter table "custom"."book2" alter column "double" type double precision using ("double"::double precision);');
+    this.addSql(\`alter table "custom"."book2" alter column "double" type double precision using ("double"::double precision);\`);
 
-    this.addSql('alter table "custom"."test2" drop column "path";');
+    this.addSql(\`alter table "custom"."test2" drop column "path";\`);
   }
 
   override async down(): Promise<void> {
-    this.addSql('alter table "custom"."book2" add column "foo" varchar null default \\'lol\\';');
-    this.addSql('alter table "custom"."book2" alter column "double" type numeric using ("double"::numeric);');
+    this.addSql(\`alter table "custom"."book2" add column "foo" varchar null default 'lol';\`);
+    this.addSql(\`alter table "custom"."book2" alter column "double" type numeric using ("double"::numeric);\`);
 
-    this.addSql('alter table "custom"."test2" add column "path" polygon null;');
+    this.addSql(\`alter table "custom"."test2" add column "path" polygon null;\`);
   }
 
 }
@@ -556,18 +556,18 @@ exports[`Migrator (postgres) generate migration with snapshot: migration-snapsho
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('alter table "custom"."book2" drop column "foo";');
+    this.addSql(\`alter table "custom"."book2" drop column "foo";\`);
 
-    this.addSql('alter table "custom"."book2" alter column "double" type double precision using ("double"::double precision);');
+    this.addSql(\`alter table "custom"."book2" alter column "double" type double precision using ("double"::double precision);\`);
 
-    this.addSql('alter table "custom"."test2" drop column "path";');
+    this.addSql(\`alter table "custom"."test2" drop column "path";\`);
   }
 
   override async down(): Promise<void> {
-    this.addSql('alter table "custom"."book2" add column "foo" varchar null default \\'lol\\';');
-    this.addSql('alter table "custom"."book2" alter column "double" type numeric using ("double"::numeric);');
+    this.addSql(\`alter table "custom"."book2" add column "foo" varchar null default 'lol';\`);
+    this.addSql(\`alter table "custom"."book2" alter column "double" type numeric using ("double"::numeric);\`);
 
-    this.addSql('alter table "custom"."test2" add column "path" polygon null;');
+    this.addSql(\`alter table "custom"."test2" add column "path" polygon null;\`);
   }
 
 }
@@ -609,18 +609,18 @@ exports[`Migrator (postgres) generate schema migration: migration-dump 1`] = `
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('alter table "custom"."book2" drop column "foo";');
+    this.addSql(\`alter table "custom"."book2" drop column "foo";\`);
 
-    this.addSql('alter table "custom"."book2" alter column "double" type double precision using ("double"::double precision);');
+    this.addSql(\`alter table "custom"."book2" alter column "double" type double precision using ("double"::double precision);\`);
 
-    this.addSql('alter table "custom"."test2" drop column "path";');
+    this.addSql(\`alter table "custom"."test2" drop column "path";\`);
   }
 
   override async down(): Promise<void> {
-    this.addSql('alter table "custom"."book2" add column "foo" varchar null default \\'lol\\';');
-    this.addSql('alter table "custom"."book2" alter column "double" type numeric using ("double"::numeric);');
+    this.addSql(\`alter table "custom"."book2" add column "foo" varchar null default 'lol';\`);
+    this.addSql(\`alter table "custom"."book2" alter column "double" type numeric using ("double"::numeric);\`);
 
-    this.addSql('alter table "custom"."test2" add column "path" polygon null;');
+    this.addSql(\`alter table "custom"."test2" add column "path" polygon null;\`);
   }
 
 }

--- a/tests/features/migrations/__snapshots__/Migrator.sqlite.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.sqlite.test.ts.snap
@@ -7,37 +7,37 @@ exports[`Migrator (sqlite) generate initial migration: initial-migration-dump 1`
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('create table \`book_tag4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null, \`version\` datetime not null default current_timestamp);');
+    this.addSql(\`create table \\\`book_tag4\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`created_at\\\` datetime null, \\\`updated_at\\\` datetime null, \\\`name\\\` text not null, \\\`version\\\` datetime not null default current_timestamp);\`);
 
-    this.addSql('create table \`foo_baz4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null, \`version\` datetime not null default current_timestamp);');
+    this.addSql(\`create table \\\`foo_baz4\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`created_at\\\` datetime null, \\\`updated_at\\\` datetime null, \\\`name\\\` text not null, \\\`version\\\` datetime not null default current_timestamp);\`);
 
-    this.addSql('create table \`foo_bar4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null default \\'asd\\', \`baz_id\` integer null, \`foo_bar_id\` integer null, \`version\` integer not null default 1, \`blob\` blob null, \`blob2\` blob null, \`array\` text null, \`object\` json null, constraint \`foo_bar4_baz_id_foreign\` foreign key(\`baz_id\`) references \`foo_baz4\`(\`id\`) on delete set null on update cascade, constraint \`foo_bar4_foo_bar_id_foreign\` foreign key(\`foo_bar_id\`) references \`foo_bar4\`(\`id\`) on delete set null on update cascade);');
-    this.addSql('create unique index \`foo_bar4_baz_id_unique\` on \`foo_bar4\` (\`baz_id\`);');
-    this.addSql('create unique index \`foo_bar4_foo_bar_id_unique\` on \`foo_bar4\` (\`foo_bar_id\`);');
+    this.addSql(\`create table \\\`foo_bar4\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`created_at\\\` datetime null, \\\`updated_at\\\` datetime null, \\\`name\\\` text not null default 'asd', \\\`baz_id\\\` integer null, \\\`foo_bar_id\\\` integer null, \\\`version\\\` integer not null default 1, \\\`blob\\\` blob null, \\\`blob2\\\` blob null, \\\`array\\\` text null, \\\`object\\\` json null, constraint \\\`foo_bar4_baz_id_foreign\\\` foreign key(\\\`baz_id\\\`) references \\\`foo_baz4\\\`(\\\`id\\\`) on delete set null on update cascade, constraint \\\`foo_bar4_foo_bar_id_foreign\\\` foreign key(\\\`foo_bar_id\\\`) references \\\`foo_bar4\\\`(\\\`id\\\`) on delete set null on update cascade);\`);
+    this.addSql(\`create unique index \\\`foo_bar4_baz_id_unique\\\` on \\\`foo_bar4\\\` (\\\`baz_id\\\`);\`);
+    this.addSql(\`create unique index \\\`foo_bar4_foo_bar_id_unique\\\` on \\\`foo_bar4\\\` (\\\`foo_bar_id\\\`);\`);
 
-    this.addSql('create table \`publisher4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null default \\'asd\\', \`type\` text check (\`type\` in (\\'local\\', \\'global\\')) not null default \\'local\\', \`enum3\` integer null);');
+    this.addSql(\`create table \\\`publisher4\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`created_at\\\` datetime null, \\\`updated_at\\\` datetime null, \\\`name\\\` text not null default 'asd', \\\`type\\\` text check (\\\`type\\\` in ('local', 'global')) not null default 'local', \\\`enum3\\\` integer null);\`);
 
-    this.addSql('create table \`book4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`title\` text not null, \`price\` real null, \`author_id\` integer null, \`publisher_id\` integer null, \`meta\` json null, constraint \`book4_author_id_foreign\` foreign key(\`author_id\`) references \`author4\`(\`id\`) on delete set null on update cascade, constraint \`book4_publisher_id_foreign\` foreign key(\`publisher_id\`) references \`publisher4\`(\`id\`) on delete set null on update cascade);');
-    this.addSql('create index \`book4_author_id_index\` on \`book4\` (\`author_id\`);');
-    this.addSql('create index \`book4_publisher_id_index\` on \`book4\` (\`publisher_id\`);');
+    this.addSql(\`create table \\\`book4\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`created_at\\\` datetime null, \\\`updated_at\\\` datetime null, \\\`title\\\` text not null, \\\`price\\\` real null, \\\`author_id\\\` integer null, \\\`publisher_id\\\` integer null, \\\`meta\\\` json null, constraint \\\`book4_author_id_foreign\\\` foreign key(\\\`author_id\\\`) references \\\`author4\\\`(\\\`id\\\`) on delete set null on update cascade, constraint \\\`book4_publisher_id_foreign\\\` foreign key(\\\`publisher_id\\\`) references \\\`publisher4\\\`(\\\`id\\\`) on delete set null on update cascade);\`);
+    this.addSql(\`create index \\\`book4_author_id_index\\\` on \\\`book4\\\` (\\\`author_id\\\`);\`);
+    this.addSql(\`create index \\\`book4_publisher_id_index\\\` on \\\`book4\\\` (\\\`publisher_id\\\`);\`);
 
-    this.addSql('create table \`author4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null, \`email\` text not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` date(3) null, \`born_time\` time(3) null, \`favourite_book_id\` integer null, \`identity\` json null, constraint \`author4_favourite_book_id_foreign\` foreign key(\`favourite_book_id\`) references \`book4\`(\`id\`) on delete set null on update cascade);');
-    this.addSql('create unique index \`author4_email_unique\` on \`author4\` (\`email\`);');
-    this.addSql('create index \`author4_favourite_book_id_index\` on \`author4\` (\`favourite_book_id\`);');
+    this.addSql(\`create table \\\`author4\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`created_at\\\` datetime null, \\\`updated_at\\\` datetime null, \\\`name\\\` text not null, \\\`email\\\` text not null, \\\`age\\\` integer null, \\\`terms_accepted\\\` integer not null default 0, \\\`identities\\\` text null, \\\`born\\\` date(3) null, \\\`born_time\\\` time(3) null, \\\`favourite_book_id\\\` integer null, \\\`identity\\\` json null, constraint \\\`author4_favourite_book_id_foreign\\\` foreign key(\\\`favourite_book_id\\\`) references \\\`book4\\\`(\\\`id\\\`) on delete set null on update cascade);\`);
+    this.addSql(\`create unique index \\\`author4_email_unique\\\` on \\\`author4\\\` (\\\`email\\\`);\`);
+    this.addSql(\`create index \\\`author4_favourite_book_id_index\\\` on \\\`author4\\\` (\\\`favourite_book_id\\\`);\`);
 
-    this.addSql('create table \`tags_ordered\` (\`id\` integer not null primary key autoincrement, \`book4_id\` integer not null, \`book_tag4_id\` integer not null, constraint \`tags_ordered_book4_id_foreign\` foreign key(\`book4_id\`) references \`book4\`(\`id\`) on delete cascade on update cascade, constraint \`tags_ordered_book_tag4_id_foreign\` foreign key(\`book_tag4_id\`) references \`book_tag4\`(\`id\`) on delete cascade on update cascade);');
-    this.addSql('create index \`tags_ordered_book4_id_index\` on \`tags_ordered\` (\`book4_id\`);');
-    this.addSql('create index \`tags_ordered_book_tag4_id_index\` on \`tags_ordered\` (\`book_tag4_id\`);');
+    this.addSql(\`create table \\\`tags_ordered\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`book4_id\\\` integer not null, \\\`book_tag4_id\\\` integer not null, constraint \\\`tags_ordered_book4_id_foreign\\\` foreign key(\\\`book4_id\\\`) references \\\`book4\\\`(\\\`id\\\`) on delete cascade on update cascade, constraint \\\`tags_ordered_book_tag4_id_foreign\\\` foreign key(\\\`book_tag4_id\\\`) references \\\`book_tag4\\\`(\\\`id\\\`) on delete cascade on update cascade);\`);
+    this.addSql(\`create index \\\`tags_ordered_book4_id_index\\\` on \\\`tags_ordered\\\` (\\\`book4_id\\\`);\`);
+    this.addSql(\`create index \\\`tags_ordered_book_tag4_id_index\\\` on \\\`tags_ordered\\\` (\\\`book_tag4_id\\\`);\`);
 
-    this.addSql('create table \`tags_unordered\` (\`book4_id\` integer not null, \`book_tag4_id\` integer not null, constraint \`tags_unordered_book4_id_foreign\` foreign key(\`book4_id\`) references \`book4\`(\`id\`) on delete cascade on update cascade, constraint \`tags_unordered_book_tag4_id_foreign\` foreign key(\`book_tag4_id\`) references \`book_tag4\`(\`id\`) on delete cascade on update cascade, primary key (\`book4_id\`, \`book_tag4_id\`));');
-    this.addSql('create index \`tags_unordered_book4_id_index\` on \`tags_unordered\` (\`book4_id\`);');
-    this.addSql('create index \`tags_unordered_book_tag4_id_index\` on \`tags_unordered\` (\`book_tag4_id\`);');
+    this.addSql(\`create table \\\`tags_unordered\\\` (\\\`book4_id\\\` integer not null, \\\`book_tag4_id\\\` integer not null, constraint \\\`tags_unordered_book4_id_foreign\\\` foreign key(\\\`book4_id\\\`) references \\\`book4\\\`(\\\`id\\\`) on delete cascade on update cascade, constraint \\\`tags_unordered_book_tag4_id_foreign\\\` foreign key(\\\`book_tag4_id\\\`) references \\\`book_tag4\\\`(\\\`id\\\`) on delete cascade on update cascade, primary key (\\\`book4_id\\\`, \\\`book_tag4_id\\\`));\`);
+    this.addSql(\`create index \\\`tags_unordered_book4_id_index\\\` on \\\`tags_unordered\\\` (\\\`book4_id\\\`);\`);
+    this.addSql(\`create index \\\`tags_unordered_book_tag4_id_index\\\` on \\\`tags_unordered\\\` (\\\`book_tag4_id\\\`);\`);
 
-    this.addSql('create table \`test4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text null, \`version\` integer not null default 1);');
+    this.addSql(\`create table \\\`test4\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`created_at\\\` datetime null, \\\`updated_at\\\` datetime null, \\\`name\\\` text null, \\\`version\\\` integer not null default 1);\`);
 
-    this.addSql('create table \`publisher4_tests\` (\`id\` integer not null primary key autoincrement, \`publisher4_id\` integer not null, \`test4_id\` integer not null, constraint \`publisher4_tests_publisher4_id_foreign\` foreign key(\`publisher4_id\`) references \`publisher4\`(\`id\`) on delete cascade on update cascade, constraint \`publisher4_tests_test4_id_foreign\` foreign key(\`test4_id\`) references \`test4\`(\`id\`) on delete cascade on update cascade);');
-    this.addSql('create index \`publisher4_tests_publisher4_id_index\` on \`publisher4_tests\` (\`publisher4_id\`);');
-    this.addSql('create index \`publisher4_tests_test4_id_index\` on \`publisher4_tests\` (\`test4_id\`);');
+    this.addSql(\`create table \\\`publisher4_tests\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`publisher4_id\\\` integer not null, \\\`test4_id\\\` integer not null, constraint \\\`publisher4_tests_publisher4_id_foreign\\\` foreign key(\\\`publisher4_id\\\`) references \\\`publisher4\\\`(\\\`id\\\`) on delete cascade on update cascade, constraint \\\`publisher4_tests_test4_id_foreign\\\` foreign key(\\\`test4_id\\\`) references \\\`test4\\\`(\\\`id\\\`) on delete cascade on update cascade);\`);
+    this.addSql(\`create index \\\`publisher4_tests_publisher4_id_index\\\` on \\\`publisher4_tests\\\` (\\\`publisher4_id\\\`);\`);
+    this.addSql(\`create index \\\`publisher4_tests_test4_id_index\\\` on \\\`publisher4_tests\\\` (\\\`test4_id\\\`);\`);
   }
 
 }
@@ -89,37 +89,37 @@ exports[`Migrator (sqlite) generate initial migration: initial-migration-dump 2`
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('create table \`book_tag4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null, \`version\` datetime not null default current_timestamp);');
+    this.addSql(\`create table \\\`book_tag4\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`created_at\\\` datetime null, \\\`updated_at\\\` datetime null, \\\`name\\\` text not null, \\\`version\\\` datetime not null default current_timestamp);\`);
 
-    this.addSql('create table \`foo_baz4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null, \`version\` datetime not null default current_timestamp);');
+    this.addSql(\`create table \\\`foo_baz4\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`created_at\\\` datetime null, \\\`updated_at\\\` datetime null, \\\`name\\\` text not null, \\\`version\\\` datetime not null default current_timestamp);\`);
 
-    this.addSql('create table \`foo_bar4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null default \\'asd\\', \`baz_id\` integer null, \`foo_bar_id\` integer null, \`version\` integer not null default 1, \`blob\` blob null, \`blob2\` blob null, \`array\` text null, \`object\` json null, constraint \`foo_bar4_baz_id_foreign\` foreign key(\`baz_id\`) references \`foo_baz4\`(\`id\`) on delete set null on update cascade, constraint \`foo_bar4_foo_bar_id_foreign\` foreign key(\`foo_bar_id\`) references \`foo_bar4\`(\`id\`) on delete set null on update cascade);');
-    this.addSql('create unique index \`foo_bar4_baz_id_unique\` on \`foo_bar4\` (\`baz_id\`);');
-    this.addSql('create unique index \`foo_bar4_foo_bar_id_unique\` on \`foo_bar4\` (\`foo_bar_id\`);');
+    this.addSql(\`create table \\\`foo_bar4\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`created_at\\\` datetime null, \\\`updated_at\\\` datetime null, \\\`name\\\` text not null default 'asd', \\\`baz_id\\\` integer null, \\\`foo_bar_id\\\` integer null, \\\`version\\\` integer not null default 1, \\\`blob\\\` blob null, \\\`blob2\\\` blob null, \\\`array\\\` text null, \\\`object\\\` json null, constraint \\\`foo_bar4_baz_id_foreign\\\` foreign key(\\\`baz_id\\\`) references \\\`foo_baz4\\\`(\\\`id\\\`) on delete set null on update cascade, constraint \\\`foo_bar4_foo_bar_id_foreign\\\` foreign key(\\\`foo_bar_id\\\`) references \\\`foo_bar4\\\`(\\\`id\\\`) on delete set null on update cascade);\`);
+    this.addSql(\`create unique index \\\`foo_bar4_baz_id_unique\\\` on \\\`foo_bar4\\\` (\\\`baz_id\\\`);\`);
+    this.addSql(\`create unique index \\\`foo_bar4_foo_bar_id_unique\\\` on \\\`foo_bar4\\\` (\\\`foo_bar_id\\\`);\`);
 
-    this.addSql('create table \`publisher4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null default \\'asd\\', \`type\` text check (\`type\` in (\\'local\\', \\'global\\')) not null default \\'local\\', \`enum3\` integer null);');
+    this.addSql(\`create table \\\`publisher4\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`created_at\\\` datetime null, \\\`updated_at\\\` datetime null, \\\`name\\\` text not null default 'asd', \\\`type\\\` text check (\\\`type\\\` in ('local', 'global')) not null default 'local', \\\`enum3\\\` integer null);\`);
 
-    this.addSql('create table \`book4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`title\` text not null, \`price\` real null, \`author_id\` integer null, \`publisher_id\` integer null, \`meta\` json null, constraint \`book4_author_id_foreign\` foreign key(\`author_id\`) references \`author4\`(\`id\`) on delete set null on update cascade, constraint \`book4_publisher_id_foreign\` foreign key(\`publisher_id\`) references \`publisher4\`(\`id\`) on delete set null on update cascade);');
-    this.addSql('create index \`book4_author_id_index\` on \`book4\` (\`author_id\`);');
-    this.addSql('create index \`book4_publisher_id_index\` on \`book4\` (\`publisher_id\`);');
+    this.addSql(\`create table \\\`book4\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`created_at\\\` datetime null, \\\`updated_at\\\` datetime null, \\\`title\\\` text not null, \\\`price\\\` real null, \\\`author_id\\\` integer null, \\\`publisher_id\\\` integer null, \\\`meta\\\` json null, constraint \\\`book4_author_id_foreign\\\` foreign key(\\\`author_id\\\`) references \\\`author4\\\`(\\\`id\\\`) on delete set null on update cascade, constraint \\\`book4_publisher_id_foreign\\\` foreign key(\\\`publisher_id\\\`) references \\\`publisher4\\\`(\\\`id\\\`) on delete set null on update cascade);\`);
+    this.addSql(\`create index \\\`book4_author_id_index\\\` on \\\`book4\\\` (\\\`author_id\\\`);\`);
+    this.addSql(\`create index \\\`book4_publisher_id_index\\\` on \\\`book4\\\` (\\\`publisher_id\\\`);\`);
 
-    this.addSql('create table \`author4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null, \`email\` text not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` date(3) null, \`born_time\` time(3) null, \`favourite_book_id\` integer null, \`identity\` json null, constraint \`author4_favourite_book_id_foreign\` foreign key(\`favourite_book_id\`) references \`book4\`(\`id\`) on delete set null on update cascade);');
-    this.addSql('create unique index \`author4_email_unique\` on \`author4\` (\`email\`);');
-    this.addSql('create index \`author4_favourite_book_id_index\` on \`author4\` (\`favourite_book_id\`);');
+    this.addSql(\`create table \\\`author4\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`created_at\\\` datetime null, \\\`updated_at\\\` datetime null, \\\`name\\\` text not null, \\\`email\\\` text not null, \\\`age\\\` integer null, \\\`terms_accepted\\\` integer not null default 0, \\\`identities\\\` text null, \\\`born\\\` date(3) null, \\\`born_time\\\` time(3) null, \\\`favourite_book_id\\\` integer null, \\\`identity\\\` json null, constraint \\\`author4_favourite_book_id_foreign\\\` foreign key(\\\`favourite_book_id\\\`) references \\\`book4\\\`(\\\`id\\\`) on delete set null on update cascade);\`);
+    this.addSql(\`create unique index \\\`author4_email_unique\\\` on \\\`author4\\\` (\\\`email\\\`);\`);
+    this.addSql(\`create index \\\`author4_favourite_book_id_index\\\` on \\\`author4\\\` (\\\`favourite_book_id\\\`);\`);
 
-    this.addSql('create table \`tags_ordered\` (\`id\` integer not null primary key autoincrement, \`book4_id\` integer not null, \`book_tag4_id\` integer not null, constraint \`tags_ordered_book4_id_foreign\` foreign key(\`book4_id\`) references \`book4\`(\`id\`) on delete cascade on update cascade, constraint \`tags_ordered_book_tag4_id_foreign\` foreign key(\`book_tag4_id\`) references \`book_tag4\`(\`id\`) on delete cascade on update cascade);');
-    this.addSql('create index \`tags_ordered_book4_id_index\` on \`tags_ordered\` (\`book4_id\`);');
-    this.addSql('create index \`tags_ordered_book_tag4_id_index\` on \`tags_ordered\` (\`book_tag4_id\`);');
+    this.addSql(\`create table \\\`tags_ordered\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`book4_id\\\` integer not null, \\\`book_tag4_id\\\` integer not null, constraint \\\`tags_ordered_book4_id_foreign\\\` foreign key(\\\`book4_id\\\`) references \\\`book4\\\`(\\\`id\\\`) on delete cascade on update cascade, constraint \\\`tags_ordered_book_tag4_id_foreign\\\` foreign key(\\\`book_tag4_id\\\`) references \\\`book_tag4\\\`(\\\`id\\\`) on delete cascade on update cascade);\`);
+    this.addSql(\`create index \\\`tags_ordered_book4_id_index\\\` on \\\`tags_ordered\\\` (\\\`book4_id\\\`);\`);
+    this.addSql(\`create index \\\`tags_ordered_book_tag4_id_index\\\` on \\\`tags_ordered\\\` (\\\`book_tag4_id\\\`);\`);
 
-    this.addSql('create table \`tags_unordered\` (\`book4_id\` integer not null, \`book_tag4_id\` integer not null, constraint \`tags_unordered_book4_id_foreign\` foreign key(\`book4_id\`) references \`book4\`(\`id\`) on delete cascade on update cascade, constraint \`tags_unordered_book_tag4_id_foreign\` foreign key(\`book_tag4_id\`) references \`book_tag4\`(\`id\`) on delete cascade on update cascade, primary key (\`book4_id\`, \`book_tag4_id\`));');
-    this.addSql('create index \`tags_unordered_book4_id_index\` on \`tags_unordered\` (\`book4_id\`);');
-    this.addSql('create index \`tags_unordered_book_tag4_id_index\` on \`tags_unordered\` (\`book_tag4_id\`);');
+    this.addSql(\`create table \\\`tags_unordered\\\` (\\\`book4_id\\\` integer not null, \\\`book_tag4_id\\\` integer not null, constraint \\\`tags_unordered_book4_id_foreign\\\` foreign key(\\\`book4_id\\\`) references \\\`book4\\\`(\\\`id\\\`) on delete cascade on update cascade, constraint \\\`tags_unordered_book_tag4_id_foreign\\\` foreign key(\\\`book_tag4_id\\\`) references \\\`book_tag4\\\`(\\\`id\\\`) on delete cascade on update cascade, primary key (\\\`book4_id\\\`, \\\`book_tag4_id\\\`));\`);
+    this.addSql(\`create index \\\`tags_unordered_book4_id_index\\\` on \\\`tags_unordered\\\` (\\\`book4_id\\\`);\`);
+    this.addSql(\`create index \\\`tags_unordered_book_tag4_id_index\\\` on \\\`tags_unordered\\\` (\\\`book_tag4_id\\\`);\`);
 
-    this.addSql('create table \`test4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text null, \`version\` integer not null default 1);');
+    this.addSql(\`create table \\\`test4\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`created_at\\\` datetime null, \\\`updated_at\\\` datetime null, \\\`name\\\` text null, \\\`version\\\` integer not null default 1);\`);
 
-    this.addSql('create table \`publisher4_tests\` (\`id\` integer not null primary key autoincrement, \`publisher4_id\` integer not null, \`test4_id\` integer not null, constraint \`publisher4_tests_publisher4_id_foreign\` foreign key(\`publisher4_id\`) references \`publisher4\`(\`id\`) on delete cascade on update cascade, constraint \`publisher4_tests_test4_id_foreign\` foreign key(\`test4_id\`) references \`test4\`(\`id\`) on delete cascade on update cascade);');
-    this.addSql('create index \`publisher4_tests_publisher4_id_index\` on \`publisher4_tests\` (\`publisher4_id\`);');
-    this.addSql('create index \`publisher4_tests_test4_id_index\` on \`publisher4_tests\` (\`test4_id\`);');
+    this.addSql(\`create table \\\`publisher4_tests\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`publisher4_id\\\` integer not null, \\\`test4_id\\\` integer not null, constraint \\\`publisher4_tests_publisher4_id_foreign\\\` foreign key(\\\`publisher4_id\\\`) references \\\`publisher4\\\`(\\\`id\\\`) on delete cascade on update cascade, constraint \\\`publisher4_tests_test4_id_foreign\\\` foreign key(\\\`test4_id\\\`) references \\\`test4\\\`(\\\`id\\\`) on delete cascade on update cascade);\`);
+    this.addSql(\`create index \\\`publisher4_tests_publisher4_id_index\\\` on \\\`publisher4_tests\\\` (\\\`publisher4_id\\\`);\`);
+    this.addSql(\`create index \\\`publisher4_tests_test4_id_index\\\` on \\\`publisher4_tests\\\` (\\\`test4_id\\\`);\`);
   }
 
 }

--- a/tests/features/migrations/__snapshots__/Migrator.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.test.ts.snap
@@ -31,11 +31,11 @@ exports[`Migrator blank initial migration can be created if no entity metadata i
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('select 1');
+    this.addSql(\`select 1\`);
   }
 
   override async down(): Promise<void> {
-    this.addSql('select 1');
+    this.addSql(\`select 1\`);
   }
 
 }
@@ -59,148 +59,148 @@ exports[`Migrator do not log a migration if the schema does not exist yet: initi
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('create table \`base_user2\` (\`id\` int unsigned not null auto_increment primary key, \`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`type\` enum(\\'employee\\', \\'manager\\', \\'owner\\') not null, \`owner_prop\` varchar(255) null, \`favourite_employee_id\` int unsigned null, \`favourite_manager_id\` int unsigned null, \`employee_prop\` int null, \`manager_prop\` varchar(255) null) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`base_user2\` add index \`base_user2_type_index\`(\`type\`);');
-    this.addSql('alter table \`base_user2\` add index \`base_user2_favourite_employee_id_index\`(\`favourite_employee_id\`);');
-    this.addSql('alter table \`base_user2\` add unique \`base_user2_favourite_manager_id_unique\`(\`favourite_manager_id\`);');
-    this.addSql('alter table \`base_user2\` add unique \`base_user2_employee_prop_unique\`(\`employee_prop\`);');
+    this.addSql(\`create table \\\`base_user2\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`first_name\\\` varchar(100) not null, \\\`last_name\\\` varchar(100) not null, \\\`type\\\` enum('employee', 'manager', 'owner') not null, \\\`owner_prop\\\` varchar(255) null, \\\`favourite_employee_id\\\` int unsigned null, \\\`favourite_manager_id\\\` int unsigned null, \\\`employee_prop\\\` int null, \\\`manager_prop\\\` varchar(255) null) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`base_user2\\\` add index \\\`base_user2_type_index\\\`(\\\`type\\\`);\`);
+    this.addSql(\`alter table \\\`base_user2\\\` add index \\\`base_user2_favourite_employee_id_index\\\`(\\\`favourite_employee_id\\\`);\`);
+    this.addSql(\`alter table \\\`base_user2\\\` add unique \\\`base_user2_favourite_manager_id_unique\\\`(\\\`favourite_manager_id\\\`);\`);
+    this.addSql(\`alter table \\\`base_user2\\\` add unique \\\`base_user2_employee_prop_unique\\\`(\\\`employee_prop\\\`);\`);
 
-    this.addSql('create table \`book_tag2\` (\`id\` bigint unsigned not null auto_increment primary key, \`name\` varchar(50) not null) default character set utf8mb4 engine = InnoDB;');
+    this.addSql(\`create table \\\`book_tag2\\\` (\\\`id\\\` bigint unsigned not null auto_increment primary key, \\\`name\\\` varchar(50) not null) default character set utf8mb4 engine = InnoDB;\`);
 
-    this.addSql('create table \`car2\` (\`name\` varchar(100) not null, \`year\` int unsigned not null, \`price\` int not null, primary key (\`name\`, \`year\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`car2\` add index \`car2_name_index\`(\`name\`);');
-    this.addSql('alter table \`car2\` add index \`car2_year_index\`(\`year\`);');
+    this.addSql(\`create table \\\`car2\\\` (\\\`name\\\` varchar(100) not null, \\\`year\\\` int unsigned not null, \\\`price\\\` int not null, primary key (\\\`name\\\`, \\\`year\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`car2\\\` add index \\\`car2_name_index\\\`(\\\`name\\\`);\`);
+    this.addSql(\`alter table \\\`car2\\\` add index \\\`car2_year_index\\\`(\\\`year\\\`);\`);
 
-    this.addSql('create table \`car_owner2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`car_name\` varchar(100) not null, \`car_year\` int unsigned not null) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`car_owner2\` add index \`car_owner2_car_name_car_year_index\`(\`car_name\`, \`car_year\`);');
+    this.addSql(\`create table \\\`car_owner2\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`name\\\` varchar(255) not null, \\\`car_name\\\` varchar(100) not null, \\\`car_year\\\` int unsigned not null) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`car_owner2\\\` add index \\\`car_owner2_car_name_car_year_index\\\`(\\\`car_name\\\`, \\\`car_year\\\`);\`);
 
-    this.addSql('create table \`dummy2\` (\`id\` int unsigned not null auto_increment primary key) default character set utf8mb4 engine = InnoDB;');
+    this.addSql(\`create table \\\`dummy2\\\` (\\\`id\\\` int unsigned not null auto_increment primary key) default character set utf8mb4 engine = InnoDB;\`);
 
-    this.addSql('create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`code\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;');
+    this.addSql(\`create table \\\`foo_baz2\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`name\\\` varchar(255) not null, \\\`code\\\` varchar(255) not null, \\\`version\\\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;\`);
 
-    this.addSql('create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`name with space\` varchar(255) null, \`baz_id\` int unsigned null, \`foo_bar_id\` int unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`blob2\` blob null, \`array\` text null, \`object_property\` json null) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);');
-    this.addSql('alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);');
+    this.addSql(\`create table \\\`foo_bar2\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`name\\\` varchar(255) not null, \\\`name with space\\\` varchar(255) null, \\\`baz_id\\\` int unsigned null, \\\`foo_bar_id\\\` int unsigned null, \\\`version\\\` datetime not null default current_timestamp, \\\`blob\\\` blob null, \\\`blob2\\\` blob null, \\\`array\\\` text null, \\\`object_property\\\` json null) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`foo_bar2\\\` add unique \\\`foo_bar2_baz_id_unique\\\`(\\\`baz_id\\\`);\`);
+    this.addSql(\`alter table \\\`foo_bar2\\\` add unique \\\`foo_bar2_foo_bar_id_unique\\\`(\\\`foo_bar_id\\\`);\`);
 
-    this.addSql('create table \`foo_param2\` (\`bar_id\` int unsigned not null, \`baz_id\` int unsigned not null, \`value\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3), primary key (\`bar_id\`, \`baz_id\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);');
-    this.addSql('alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);');
+    this.addSql(\`create table \\\`foo_param2\\\` (\\\`bar_id\\\` int unsigned not null, \\\`baz_id\\\` int unsigned not null, \\\`value\\\` varchar(255) not null, \\\`version\\\` datetime(3) not null default current_timestamp(3), primary key (\\\`bar_id\\\`, \\\`baz_id\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`foo_param2\\\` add index \\\`foo_param2_bar_id_index\\\`(\\\`bar_id\\\`);\`);
+    this.addSql(\`alter table \\\`foo_param2\\\` add index \\\`foo_param2_baz_id_index\\\`(\\\`baz_id\\\`);\`);
 
-    this.addSql('create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null default \\'asd\\', \`type\` enum(\\'local\\', \\'global\\') not null default \\'local\\', \`type2\` enum(\\'LOCAL\\', \\'GLOBAL\\') not null default \\'LOCAL\\', \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum(\\'a\\', \\'b\\', \\'c\\') null, \`enum5\` enum(\\'a\\') null) default character set utf8mb4 engine = InnoDB;');
+    this.addSql(\`create table \\\`publisher2\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`name\\\` varchar(255) not null default 'asd', \\\`type\\\` enum('local', 'global') not null default 'local', \\\`type2\\\` enum('LOCAL', 'GLOBAL') not null default 'LOCAL', \\\`enum1\\\` tinyint null, \\\`enum2\\\` tinyint null, \\\`enum3\\\` tinyint null, \\\`enum4\\\` enum('a', 'b', 'c') null, \\\`enum5\\\` enum('a') null) default character set utf8mb4 engine = InnoDB;\`);
 
-    this.addSql('create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int unsigned null, \`identity\` json null) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`author2\` add index \`custom_email_index_name\`(\`email\`);');
-    this.addSql('alter table \`author2\` add unique \`custom_email_unique_name\`(\`email\`);');
-    this.addSql('alter table \`author2\` add index \`author2_terms_accepted_index\`(\`terms_accepted\`);');
-    this.addSql('alter table \`author2\` add index \`author2_born_index\`(\`born\`);');
-    this.addSql('alter table \`author2\` add index \`born_time_idx\`(\`born_time\`);');
-    this.addSql('alter table \`author2\` add index \`author2_favourite_book_uuid_pk_index\`(\`favourite_book_uuid_pk\`);');
-    this.addSql('alter table \`author2\` add index \`author2_favourite_author_id_index\`(\`favourite_author_id\`);');
-    this.addSql('alter table \`author2\` add index \`custom_idx_name_123\`(\`name\`);');
-    this.addSql('alter table \`author2\` add index \`author2_name_age_index\`(\`name\`, \`age\`);');
-    this.addSql('alter table \`author2\` add unique \`author2_name_email_unique\`(\`name\`, \`email\`);');
+    this.addSql(\`create table \\\`author2\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`created_at\\\` datetime(3) not null default current_timestamp(3), \\\`updated_at\\\` datetime(3) not null default current_timestamp(3), \\\`name\\\` varchar(255) not null, \\\`email\\\` varchar(255) not null, \\\`age\\\` int null default null, \\\`terms_accepted\\\` tinyint(1) not null default false, \\\`optional\\\` tinyint(1) null, \\\`identities\\\` text null, \\\`born\\\` date null, \\\`born_time\\\` time null, \\\`favourite_book_uuid_pk\\\` varchar(36) null, \\\`favourite_author_id\\\` int unsigned null, \\\`identity\\\` json null) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`author2\\\` add index \\\`custom_email_index_name\\\`(\\\`email\\\`);\`);
+    this.addSql(\`alter table \\\`author2\\\` add unique \\\`custom_email_unique_name\\\`(\\\`email\\\`);\`);
+    this.addSql(\`alter table \\\`author2\\\` add index \\\`author2_terms_accepted_index\\\`(\\\`terms_accepted\\\`);\`);
+    this.addSql(\`alter table \\\`author2\\\` add index \\\`author2_born_index\\\`(\\\`born\\\`);\`);
+    this.addSql(\`alter table \\\`author2\\\` add index \\\`born_time_idx\\\`(\\\`born_time\\\`);\`);
+    this.addSql(\`alter table \\\`author2\\\` add index \\\`author2_favourite_book_uuid_pk_index\\\`(\\\`favourite_book_uuid_pk\\\`);\`);
+    this.addSql(\`alter table \\\`author2\\\` add index \\\`author2_favourite_author_id_index\\\`(\\\`favourite_author_id\\\`);\`);
+    this.addSql(\`alter table \\\`author2\\\` add index \\\`custom_idx_name_123\\\`(\\\`name\\\`);\`);
+    this.addSql(\`alter table \\\`author2\\\` add index \\\`author2_name_age_index\\\`(\\\`name\\\`, \\\`age\\\`);\`);
+    this.addSql(\`alter table \\\`author2\\\` add unique \\\`author2_name_email_unique\\\`(\\\`name\\\`, \\\`email\\\`);\`);
 
-    this.addSql('create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`isbn\` char(13) null, \`title\` varchar(255) null default \\'\\', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`book2\` add unique \`book2_isbn_unique\`(\`isbn\`);');
-    this.addSql('alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);');
-    this.addSql('alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);');
-    this.addSql('alter table \`book2\` add fulltext index \`book2_title_index\`(\`title\`);');
+    this.addSql(\`create table \\\`book2\\\` (\\\`uuid_pk\\\` varchar(36) not null, \\\`created_at\\\` datetime(3) not null default current_timestamp(3), \\\`isbn\\\` char(13) null, \\\`title\\\` varchar(255) null default '', \\\`perex\\\` text null, \\\`price\\\` numeric(8,2) null, \\\`double\\\` double null, \\\`meta\\\` json null, \\\`author_id\\\` int unsigned not null, \\\`publisher_id\\\` int unsigned null, primary key (\\\`uuid_pk\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`book2\\\` add unique \\\`book2_isbn_unique\\\`(\\\`isbn\\\`);\`);
+    this.addSql(\`alter table \\\`book2\\\` add index \\\`book2_author_id_index\\\`(\\\`author_id\\\`);\`);
+    this.addSql(\`alter table \\\`book2\\\` add index \\\`book2_publisher_id_index\\\`(\\\`publisher_id\\\`);\`);
+    this.addSql(\`alter table \\\`book2\\\` add fulltext index \\\`book2_title_index\\\`(\\\`title\\\`);\`);
 
-    this.addSql('create table \`book2_tags\` (\`order\` int unsigned not null auto_increment primary key, \`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`book2_tags\` add index \`book2_tags_book2_uuid_pk_index\`(\`book2_uuid_pk\`);');
-    this.addSql('alter table \`book2_tags\` add index \`book2_tags_book_tag2_id_index\`(\`book_tag2_id\`);');
+    this.addSql(\`create table \\\`book2_tags\\\` (\\\`order\\\` int unsigned not null auto_increment primary key, \\\`book2_uuid_pk\\\` varchar(36) not null, \\\`book_tag2_id\\\` bigint unsigned not null) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`book2_tags\\\` add index \\\`book2_tags_book2_uuid_pk_index\\\`(\\\`book2_uuid_pk\\\`);\`);
+    this.addSql(\`alter table \\\`book2_tags\\\` add index \\\`book2_tags_book_tag2_id_index\\\`(\\\`book_tag2_id\\\`);\`);
 
-    this.addSql('create table \`book_to_tag_unordered\` (\`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null, primary key (\`book2_uuid_pk\`, \`book_tag2_id\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book2_uuid_pk_index\`(\`book2_uuid_pk\`);');
-    this.addSql('alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book_tag2_id_index\`(\`book_tag2_id\`);');
+    this.addSql(\`create table \\\`book_to_tag_unordered\\\` (\\\`book2_uuid_pk\\\` varchar(36) not null, \\\`book_tag2_id\\\` bigint unsigned not null, primary key (\\\`book2_uuid_pk\\\`, \\\`book_tag2_id\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`book_to_tag_unordered\\\` add index \\\`book_to_tag_unordered_book2_uuid_pk_index\\\`(\\\`book2_uuid_pk\\\`);\`);
+    this.addSql(\`alter table \\\`book_to_tag_unordered\\\` add index \\\`book_to_tag_unordered_book_tag2_id_index\\\`(\\\`book_tag2_id\\\`);\`);
 
-    this.addSql('create table \`author2_following\` (\`author2_1_id\` int unsigned not null, \`author2_2_id\` int unsigned not null, primary key (\`author2_1_id\`, \`author2_2_id\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`author2_following\` add index \`author2_following_author2_1_id_index\`(\`author2_1_id\`);');
-    this.addSql('alter table \`author2_following\` add index \`author2_following_author2_2_id_index\`(\`author2_2_id\`);');
+    this.addSql(\`create table \\\`author2_following\\\` (\\\`author2_1_id\\\` int unsigned not null, \\\`author2_2_id\\\` int unsigned not null, primary key (\\\`author2_1_id\\\`, \\\`author2_2_id\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`author2_following\\\` add index \\\`author2_following_author2_1_id_index\\\`(\\\`author2_1_id\\\`);\`);
+    this.addSql(\`alter table \\\`author2_following\\\` add index \\\`author2_following_author2_2_id_index\\\`(\\\`author2_2_id\\\`);\`);
 
-    this.addSql('create table \`author_to_friend\` (\`author2_1_id\` int unsigned not null, \`author2_2_id\` int unsigned not null, primary key (\`author2_1_id\`, \`author2_2_id\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`author_to_friend\` add index \`author_to_friend_author2_1_id_index\`(\`author2_1_id\`);');
-    this.addSql('alter table \`author_to_friend\` add index \`author_to_friend_author2_2_id_index\`(\`author2_2_id\`);');
+    this.addSql(\`create table \\\`author_to_friend\\\` (\\\`author2_1_id\\\` int unsigned not null, \\\`author2_2_id\\\` int unsigned not null, primary key (\\\`author2_1_id\\\`, \\\`author2_2_id\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`author_to_friend\\\` add index \\\`author_to_friend_author2_1_id_index\\\`(\\\`author2_1_id\\\`);\`);
+    this.addSql(\`alter table \\\`author_to_friend\\\` add index \\\`author_to_friend_author2_2_id_index\\\`(\\\`author2_2_id\\\`);\`);
 
-    this.addSql('create table \`address2\` (\`author_id\` int unsigned not null, \`value\` varchar(255) not null comment \\'This is address property\\', primary key (\`author_id\`)) default character set utf8mb4 engine = InnoDB comment = \\'This is address table\\';');
+    this.addSql(\`create table \\\`address2\\\` (\\\`author_id\\\` int unsigned not null, \\\`value\\\` varchar(255) not null comment 'This is address property', primary key (\\\`author_id\\\`)) default character set utf8mb4 engine = InnoDB comment = 'This is address table';\`);
 
-    this.addSql('create table \`sandwich\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`price\` int not null) default character set utf8mb4 engine = InnoDB;');
+    this.addSql(\`create table \\\`sandwich\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`name\\\` varchar(255) not null, \\\`price\\\` int not null) default character set utf8mb4 engine = InnoDB;\`);
 
-    this.addSql('create table \`test2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) null, \`book_uuid_pk\` varchar(36) null, \`parent_id\` int unsigned null, \`version\` int not null default 1) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`test2\` add unique \`test2_book_uuid_pk_unique\`(\`book_uuid_pk\`);');
-    this.addSql('alter table \`test2\` add index \`test2_parent_id_index\`(\`parent_id\`);');
+    this.addSql(\`create table \\\`test2\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`name\\\` varchar(255) null, \\\`book_uuid_pk\\\` varchar(36) null, \\\`parent_id\\\` int unsigned null, \\\`version\\\` int not null default 1) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`test2\\\` add unique \\\`test2_book_uuid_pk_unique\\\`(\\\`book_uuid_pk\\\`);\`);
+    this.addSql(\`alter table \\\`test2\\\` add index \\\`test2_parent_id_index\\\`(\\\`parent_id\\\`);\`);
 
-    this.addSql('create table \`publisher2_tests\` (\`id\` int unsigned not null auto_increment primary key, \`publisher2_id\` int unsigned not null, \`test2_id\` int unsigned not null) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`publisher2_tests\` add index \`publisher2_tests_publisher2_id_index\`(\`publisher2_id\`);');
-    this.addSql('alter table \`publisher2_tests\` add index \`publisher2_tests_test2_id_index\`(\`test2_id\`);');
+    this.addSql(\`create table \\\`publisher2_tests\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`publisher2_id\\\` int unsigned not null, \\\`test2_id\\\` int unsigned not null) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`publisher2_tests\\\` add index \\\`publisher2_tests_publisher2_id_index\\\`(\\\`publisher2_id\\\`);\`);
+    this.addSql(\`alter table \\\`publisher2_tests\\\` add index \\\`publisher2_tests_test2_id_index\\\`(\\\`test2_id\\\`);\`);
 
-    this.addSql('create table \`configuration2\` (\`property\` varchar(255) not null, \`test_id\` int unsigned not null, \`value\` varchar(255) not null, primary key (\`property\`, \`test_id\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`configuration2\` add index \`configuration2_test_id_index\`(\`test_id\`);');
+    this.addSql(\`create table \\\`configuration2\\\` (\\\`property\\\` varchar(255) not null, \\\`test_id\\\` int unsigned not null, \\\`value\\\` varchar(255) not null, primary key (\\\`property\\\`, \\\`test_id\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`configuration2\\\` add index \\\`configuration2_test_id_index\\\`(\\\`test_id\\\`);\`);
 
-    this.addSql('create table \`test2_bars\` (\`test2_id\` int unsigned not null, \`foo_bar2_id\` int unsigned not null, primary key (\`test2_id\`, \`foo_bar2_id\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`test2_bars\` add index \`test2_bars_test2_id_index\`(\`test2_id\`);');
-    this.addSql('alter table \`test2_bars\` add index \`test2_bars_foo_bar2_id_index\`(\`foo_bar2_id\`);');
+    this.addSql(\`create table \\\`test2_bars\\\` (\\\`test2_id\\\` int unsigned not null, \\\`foo_bar2_id\\\` int unsigned not null, primary key (\\\`test2_id\\\`, \\\`foo_bar2_id\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`test2_bars\\\` add index \\\`test2_bars_test2_id_index\\\`(\\\`test2_id\\\`);\`);
+    this.addSql(\`alter table \\\`test2_bars\\\` add index \\\`test2_bars_foo_bar2_id_index\\\`(\\\`foo_bar2_id\\\`);\`);
 
-    this.addSql('create table \`user2\` (\`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`foo\` int null, \`favourite_car_name\` varchar(100) null, \`favourite_car_year\` int unsigned null, primary key (\`first_name\`, \`last_name\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`user2\` add unique \`user2_favourite_car_name_favourite_car_year_unique\`(\`favourite_car_name\`, \`favourite_car_year\`);');
+    this.addSql(\`create table \\\`user2\\\` (\\\`first_name\\\` varchar(100) not null, \\\`last_name\\\` varchar(100) not null, \\\`foo\\\` int null, \\\`favourite_car_name\\\` varchar(100) null, \\\`favourite_car_year\\\` int unsigned null, primary key (\\\`first_name\\\`, \\\`last_name\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`user2\\\` add unique \\\`user2_favourite_car_name_favourite_car_year_unique\\\`(\\\`favourite_car_name\\\`, \\\`favourite_car_year\\\`);\`);
 
-    this.addSql('create table \`user2_cars\` (\`user2_first_name\` varchar(100) not null, \`user2_last_name\` varchar(100) not null, \`car2_name\` varchar(100) not null, \`car2_year\` int unsigned not null, primary key (\`user2_first_name\`, \`user2_last_name\`, \`car2_name\`, \`car2_year\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`user2_cars\` add index \`user2_cars_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);');
-    this.addSql('alter table \`user2_cars\` add index \`user2_cars_car2_name_car2_year_index\`(\`car2_name\`, \`car2_year\`);');
+    this.addSql(\`create table \\\`user2_cars\\\` (\\\`user2_first_name\\\` varchar(100) not null, \\\`user2_last_name\\\` varchar(100) not null, \\\`car2_name\\\` varchar(100) not null, \\\`car2_year\\\` int unsigned not null, primary key (\\\`user2_first_name\\\`, \\\`user2_last_name\\\`, \\\`car2_name\\\`, \\\`car2_year\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`user2_cars\\\` add index \\\`user2_cars_user2_first_name_user2_last_name_index\\\`(\\\`user2_first_name\\\`, \\\`user2_last_name\\\`);\`);
+    this.addSql(\`alter table \\\`user2_cars\\\` add index \\\`user2_cars_car2_name_car2_year_index\\\`(\\\`car2_name\\\`, \\\`car2_year\\\`);\`);
 
-    this.addSql('create table \`user2_sandwiches\` (\`user2_first_name\` varchar(100) not null, \`user2_last_name\` varchar(100) not null, \`sandwich_id\` int unsigned not null, primary key (\`user2_first_name\`, \`user2_last_name\`, \`sandwich_id\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`user2_sandwiches\` add index \`user2_sandwiches_sandwich_id_index\`(\`sandwich_id\`);');
-    this.addSql('alter table \`user2_sandwiches\` add index \`user2_sandwiches_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);');
+    this.addSql(\`create table \\\`user2_sandwiches\\\` (\\\`user2_first_name\\\` varchar(100) not null, \\\`user2_last_name\\\` varchar(100) not null, \\\`sandwich_id\\\` int unsigned not null, primary key (\\\`user2_first_name\\\`, \\\`user2_last_name\\\`, \\\`sandwich_id\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`user2_sandwiches\\\` add index \\\`user2_sandwiches_sandwich_id_index\\\`(\\\`sandwich_id\\\`);\`);
+    this.addSql(\`alter table \\\`user2_sandwiches\\\` add index \\\`user2_sandwiches_user2_first_name_user2_last_name_index\\\`(\\\`user2_first_name\\\`, \\\`user2_last_name\\\`);\`);
 
-    this.addSql('alter table \`base_user2\` add constraint \`base_user2_favourite_employee_id_foreign\` foreign key (\`favourite_employee_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;');
-    this.addSql('alter table \`base_user2\` add constraint \`base_user2_favourite_manager_id_foreign\` foreign key (\`favourite_manager_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;');
+    this.addSql(\`alter table \\\`base_user2\\\` add constraint \\\`base_user2_favourite_employee_id_foreign\\\` foreign key (\\\`favourite_employee_id\\\`) references \\\`base_user2\\\` (\\\`id\\\`) on update cascade on delete set null;\`);
+    this.addSql(\`alter table \\\`base_user2\\\` add constraint \\\`base_user2_favourite_manager_id_foreign\\\` foreign key (\\\`favourite_manager_id\\\`) references \\\`base_user2\\\` (\\\`id\\\`) on update cascade on delete set null;\`);
 
-    this.addSql('alter table \`car_owner2\` add constraint \`car_owner2_car_name_car_year_foreign\` foreign key (\`car_name\`, \`car_year\`) references \`car2\` (\`name\`, \`year\`) on update cascade;');
+    this.addSql(\`alter table \\\`car_owner2\\\` add constraint \\\`car_owner2_car_name_car_year_foreign\\\` foreign key (\\\`car_name\\\`, \\\`car_year\\\`) references \\\`car2\\\` (\\\`name\\\`, \\\`year\\\`) on update cascade;\`);
 
-    this.addSql('alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;');
-    this.addSql('alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;');
+    this.addSql(\`alter table \\\`foo_bar2\\\` add constraint \\\`foo_bar2_baz_id_foreign\\\` foreign key (\\\`baz_id\\\`) references \\\`foo_baz2\\\` (\\\`id\\\`) on update cascade on delete set null;\`);
+    this.addSql(\`alter table \\\`foo_bar2\\\` add constraint \\\`foo_bar2_foo_bar_id_foreign\\\` foreign key (\\\`foo_bar_id\\\`) references \\\`foo_bar2\\\` (\\\`id\\\`) on update cascade on delete set null;\`);
 
-    this.addSql('alter table \`foo_param2\` add constraint \`foo_param2_bar_id_foreign\` foreign key (\`bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade;');
-    this.addSql('alter table \`foo_param2\` add constraint \`foo_param2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade;');
+    this.addSql(\`alter table \\\`foo_param2\\\` add constraint \\\`foo_param2_bar_id_foreign\\\` foreign key (\\\`bar_id\\\`) references \\\`foo_bar2\\\` (\\\`id\\\`) on update cascade;\`);
+    this.addSql(\`alter table \\\`foo_param2\\\` add constraint \\\`foo_param2_baz_id_foreign\\\` foreign key (\\\`baz_id\\\`) references \\\`foo_baz2\\\` (\\\`id\\\`) on update cascade;\`);
 
-    this.addSql('alter table \`author2\` add constraint \`author2_favourite_book_uuid_pk_foreign\` foreign key (\`favourite_book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update no action on delete cascade;');
-    this.addSql('alter table \`author2\` add constraint \`author2_favourite_author_id_foreign\` foreign key (\`favourite_author_id\`) references \`author2\` (\`id\`) on update cascade on delete set null;');
+    this.addSql(\`alter table \\\`author2\\\` add constraint \\\`author2_favourite_book_uuid_pk_foreign\\\` foreign key (\\\`favourite_book_uuid_pk\\\`) references \\\`book2\\\` (\\\`uuid_pk\\\`) on update no action on delete cascade;\`);
+    this.addSql(\`alter table \\\`author2\\\` add constraint \\\`author2_favourite_author_id_foreign\\\` foreign key (\\\`favourite_author_id\\\`) references \\\`author2\\\` (\\\`id\\\`) on update cascade on delete set null;\`);
 
-    this.addSql('alter table \`book2\` add constraint \`book2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`);');
-    this.addSql('alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key (\`publisher_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`book2\\\` add constraint \\\`book2_author_id_foreign\\\` foreign key (\\\`author_id\\\`) references \\\`author2\\\` (\\\`id\\\`);\`);
+    this.addSql(\`alter table \\\`book2\\\` add constraint \\\`book2_publisher_id_foreign\\\` foreign key (\\\`publisher_id\\\`) references \\\`publisher2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table \`book2_tags\` add constraint \`book2_tags_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;');
-    this.addSql('alter table \`book2_tags\` add constraint \`book2_tags_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`book2_tags\\\` add constraint \\\`book2_tags_book2_uuid_pk_foreign\\\` foreign key (\\\`book2_uuid_pk\\\`) references \\\`book2\\\` (\\\`uuid_pk\\\`) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table \\\`book2_tags\\\` add constraint \\\`book2_tags_book_tag2_id_foreign\\\` foreign key (\\\`book_tag2_id\\\`) references \\\`book_tag2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table \`book_to_tag_unordered\` add constraint \`book_to_tag_unordered_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;');
-    this.addSql('alter table \`book_to_tag_unordered\` add constraint \`book_to_tag_unordered_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`book_to_tag_unordered\\\` add constraint \\\`book_to_tag_unordered_book2_uuid_pk_foreign\\\` foreign key (\\\`book2_uuid_pk\\\`) references \\\`book2\\\` (\\\`uuid_pk\\\`) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table \\\`book_to_tag_unordered\\\` add constraint \\\`book_to_tag_unordered_book_tag2_id_foreign\\\` foreign key (\\\`book_tag2_id\\\`) references \\\`book_tag2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table \`author2_following\` add constraint \`author2_following_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;');
-    this.addSql('alter table \`author2_following\` add constraint \`author2_following_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`author2_following\\\` add constraint \\\`author2_following_author2_1_id_foreign\\\` foreign key (\\\`author2_1_id\\\`) references \\\`author2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table \\\`author2_following\\\` add constraint \\\`author2_following_author2_2_id_foreign\\\` foreign key (\\\`author2_2_id\\\`) references \\\`author2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table \`author_to_friend\` add constraint \`author_to_friend_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;');
-    this.addSql('alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`author_to_friend\\\` add constraint \\\`author_to_friend_author2_1_id_foreign\\\` foreign key (\\\`author2_1_id\\\`) references \\\`author2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table \\\`author_to_friend\\\` add constraint \\\`author_to_friend_author2_2_id_foreign\\\` foreign key (\\\`author2_2_id\\\`) references \\\`author2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table \`address2\` add constraint \`address2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`address2\\\` add constraint \\\`address2_author_id_foreign\\\` foreign key (\\\`author_id\\\`) references \\\`author2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table \`test2\` add constraint \`test2_book_uuid_pk_foreign\` foreign key (\`book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on delete set null;');
-    this.addSql('alter table \`test2\` add constraint \`test2_parent_id_foreign\` foreign key (\`parent_id\`) references \`test2\` (\`id\`) on update cascade on delete set null;');
+    this.addSql(\`alter table \\\`test2\\\` add constraint \\\`test2_book_uuid_pk_foreign\\\` foreign key (\\\`book_uuid_pk\\\`) references \\\`book2\\\` (\\\`uuid_pk\\\`) on delete set null;\`);
+    this.addSql(\`alter table \\\`test2\\\` add constraint \\\`test2_parent_id_foreign\\\` foreign key (\\\`parent_id\\\`) references \\\`test2\\\` (\\\`id\\\`) on update cascade on delete set null;\`);
 
-    this.addSql('alter table \`publisher2_tests\` add constraint \`publisher2_tests_publisher2_id_foreign\` foreign key (\`publisher2_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;');
-    this.addSql('alter table \`publisher2_tests\` add constraint \`publisher2_tests_test2_id_foreign\` foreign key (\`test2_id\`) references \`test2\` (\`id\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`publisher2_tests\\\` add constraint \\\`publisher2_tests_publisher2_id_foreign\\\` foreign key (\\\`publisher2_id\\\`) references \\\`publisher2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table \\\`publisher2_tests\\\` add constraint \\\`publisher2_tests_test2_id_foreign\\\` foreign key (\\\`test2_id\\\`) references \\\`test2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table \`configuration2\` add constraint \`configuration2_test_id_foreign\` foreign key (\`test_id\`) references \`test2\` (\`id\`) on update cascade;');
+    this.addSql(\`alter table \\\`configuration2\\\` add constraint \\\`configuration2_test_id_foreign\\\` foreign key (\\\`test_id\\\`) references \\\`test2\\\` (\\\`id\\\`) on update cascade;\`);
 
-    this.addSql('alter table \`test2_bars\` add constraint \`test2_bars_test2_id_foreign\` foreign key (\`test2_id\`) references \`test2\` (\`id\`) on update cascade on delete cascade;');
-    this.addSql('alter table \`test2_bars\` add constraint \`test2_bars_foo_bar2_id_foreign\` foreign key (\`foo_bar2_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`test2_bars\\\` add constraint \\\`test2_bars_test2_id_foreign\\\` foreign key (\\\`test2_id\\\`) references \\\`test2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table \\\`test2_bars\\\` add constraint \\\`test2_bars_foo_bar2_id_foreign\\\` foreign key (\\\`foo_bar2_id\\\`) references \\\`foo_bar2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table \`user2\` add constraint \`user2_favourite_car_name_favourite_car_year_foreign\` foreign key (\`favourite_car_name\`, \`favourite_car_year\`) references \`car2\` (\`name\`, \`year\`) on update cascade on delete set null;');
+    this.addSql(\`alter table \\\`user2\\\` add constraint \\\`user2_favourite_car_name_favourite_car_year_foreign\\\` foreign key (\\\`favourite_car_name\\\`, \\\`favourite_car_year\\\`) references \\\`car2\\\` (\\\`name\\\`, \\\`year\\\`) on update cascade on delete set null;\`);
 
-    this.addSql('alter table \`user2_cars\` add constraint \`user2_cars_user2_first_name_user2_last_name_foreign\` foreign key (\`user2_first_name\`, \`user2_last_name\`) references \`user2\` (\`first_name\`, \`last_name\`) on update cascade on delete cascade;');
-    this.addSql('alter table \`user2_cars\` add constraint \`user2_cars_car2_name_car2_year_foreign\` foreign key (\`car2_name\`, \`car2_year\`) references \`car2\` (\`name\`, \`year\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`user2_cars\\\` add constraint \\\`user2_cars_user2_first_name_user2_last_name_foreign\\\` foreign key (\\\`user2_first_name\\\`, \\\`user2_last_name\\\`) references \\\`user2\\\` (\\\`first_name\\\`, \\\`last_name\\\`) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table \\\`user2_cars\\\` add constraint \\\`user2_cars_car2_name_car2_year_foreign\\\` foreign key (\\\`car2_name\\\`, \\\`car2_year\\\`) references \\\`car2\\\` (\\\`name\\\`, \\\`year\\\`) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_user2_first_name_user2_last_name_foreign\` foreign key (\`user2_first_name\`, \`user2_last_name\`) references \`user2\` (\`first_name\`, \`last_name\`) on update cascade on delete cascade;');
-    this.addSql('alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_sandwich_id_foreign\` foreign key (\`sandwich_id\`) references \`sandwich\` (\`id\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`user2_sandwiches\\\` add constraint \\\`user2_sandwiches_user2_first_name_user2_last_name_foreign\\\` foreign key (\\\`user2_first_name\\\`, \\\`user2_last_name\\\`) references \\\`user2\\\` (\\\`first_name\\\`, \\\`last_name\\\`) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table \\\`user2_sandwiches\\\` add constraint \\\`user2_sandwiches_sandwich_id_foreign\\\` foreign key (\\\`sandwich_id\\\`) references \\\`sandwich\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
   }
 
 }
@@ -365,20 +365,20 @@ const { Migration } = require('@mikro-orm/migrations');
 class Migration20191013214813 extends Migration {
 
   async up() {
-    this.addSql('alter table \`test2\` drop foreign key \`test2_foo___bar_foreign\`;');
+    this.addSql(\`alter table \\\`test2\\\` drop foreign key \\\`test2_foo___bar_foreign\\\`;\`);
 
-    this.addSql('alter table \`book2\` drop column \`foo\`;');
+    this.addSql(\`alter table \\\`book2\\\` drop column \\\`foo\\\`;\`);
 
-    this.addSql('alter table \`test2\` drop index \`test2_foo___bar_unique\`;');
-    this.addSql('alter table \`test2\` drop column \`foo___bar\`, drop column \`foo___baz\`;');
+    this.addSql(\`alter table \\\`test2\\\` drop index \\\`test2_foo___bar_unique\\\`;\`);
+    this.addSql(\`alter table \\\`test2\\\` drop column \\\`foo___bar\\\`, drop column \\\`foo___baz\\\`;\`);
   }
 
   async down() {
-    this.addSql('alter table \`book2\` add \`foo\` varchar(255) null default \\'lol\\';');
+    this.addSql(\`alter table \\\`book2\\\` add \\\`foo\\\` varchar(255) null default 'lol';\`);
 
-    this.addSql('alter table \`test2\` add \`foo___bar\` int unsigned null, add \`foo___baz\` int unsigned null;');
-    this.addSql('alter table \`test2\` add constraint \`test2_foo___bar_foreign\` foreign key (\`foo___bar\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;');
-    this.addSql('alter table \`test2\` add unique \`test2_foo___bar_unique\`(\`foo___bar\`);');
+    this.addSql(\`alter table \\\`test2\\\` add \\\`foo___bar\\\` int unsigned null, add \\\`foo___baz\\\` int unsigned null;\`);
+    this.addSql(\`alter table \\\`test2\\\` add constraint \\\`test2_foo___bar_foreign\\\` foreign key (\\\`foo___bar\\\`) references \\\`foo_bar2\\\` (\\\`id\\\`) on update cascade on delete set null;\`);
+    this.addSql(\`alter table \\\`test2\\\` add unique \\\`test2_foo___bar_unique\\\`(\\\`foo___bar\\\`);\`);
   }
 
 }
@@ -414,20 +414,20 @@ const { Migration } = require('@mikro-orm/migrations');
 class Migration20191013214813 extends Migration {
 
   async up() {
-    this.addSql('alter table \`test2\` drop foreign key \`test2_foo___bar_foreign\`;');
+    this.addSql(\`alter table \\\`test2\\\` drop foreign key \\\`test2_foo___bar_foreign\\\`;\`);
 
-    this.addSql('alter table \`book2\` drop column \`foo\`;');
+    this.addSql(\`alter table \\\`book2\\\` drop column \\\`foo\\\`;\`);
 
-    this.addSql('alter table \`test2\` drop index \`test2_foo___bar_unique\`;');
-    this.addSql('alter table \`test2\` drop column \`foo___bar\`, drop column \`foo___baz\`;');
+    this.addSql(\`alter table \\\`test2\\\` drop index \\\`test2_foo___bar_unique\\\`;\`);
+    this.addSql(\`alter table \\\`test2\\\` drop column \\\`foo___bar\\\`, drop column \\\`foo___baz\\\`;\`);
   }
 
   async down() {
-    this.addSql('alter table \`book2\` add \`foo\` varchar(255) null default \\'lol\\';');
+    this.addSql(\`alter table \\\`book2\\\` add \\\`foo\\\` varchar(255) null default 'lol';\`);
 
-    this.addSql('alter table \`test2\` add \`foo___bar\` int unsigned null, add \`foo___baz\` int unsigned null;');
-    this.addSql('alter table \`test2\` add constraint \`test2_foo___bar_foreign\` foreign key (\`foo___bar\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;');
-    this.addSql('alter table \`test2\` add unique \`test2_foo___bar_unique\`(\`foo___bar\`);');
+    this.addSql(\`alter table \\\`test2\\\` add \\\`foo___bar\\\` int unsigned null, add \\\`foo___baz\\\` int unsigned null;\`);
+    this.addSql(\`alter table \\\`test2\\\` add constraint \\\`test2_foo___bar_foreign\\\` foreign key (\\\`foo___bar\\\`) references \\\`foo_bar2\\\` (\\\`id\\\`) on update cascade on delete set null;\`);
+    this.addSql(\`alter table \\\`test2\\\` add unique \\\`test2_foo___bar_unique\\\`(\\\`foo___bar\\\`);\`);
   }
 
 }
@@ -461,20 +461,20 @@ exports[`Migrator generate migration with custom name: migration-dump 1`] = `
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('alter table \`test2\` drop foreign key \`test2_foo___bar_foreign\`;');
+    this.addSql(\`alter table \\\`test2\\\` drop foreign key \\\`test2_foo___bar_foreign\\\`;\`);
 
-    this.addSql('alter table \`book2\` drop column \`foo\`;');
+    this.addSql(\`alter table \\\`book2\\\` drop column \\\`foo\\\`;\`);
 
-    this.addSql('alter table \`test2\` drop index \`test2_foo___bar_unique\`;');
-    this.addSql('alter table \`test2\` drop column \`foo___bar\`, drop column \`foo___baz\`;');
+    this.addSql(\`alter table \\\`test2\\\` drop index \\\`test2_foo___bar_unique\\\`;\`);
+    this.addSql(\`alter table \\\`test2\\\` drop column \\\`foo___bar\\\`, drop column \\\`foo___baz\\\`;\`);
   }
 
   override async down(): Promise<void> {
-    this.addSql('alter table \`book2\` add \`foo\` varchar(255) null default \\'lol\\';');
+    this.addSql(\`alter table \\\`book2\\\` add \\\`foo\\\` varchar(255) null default 'lol';\`);
 
-    this.addSql('alter table \`test2\` add \`foo___bar\` int unsigned null, add \`foo___baz\` int unsigned null;');
-    this.addSql('alter table \`test2\` add constraint \`test2_foo___bar_foreign\` foreign key (\`foo___bar\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;');
-    this.addSql('alter table \`test2\` add unique \`test2_foo___bar_unique\`(\`foo___bar\`);');
+    this.addSql(\`alter table \\\`test2\\\` add \\\`foo___bar\\\` int unsigned null, add \\\`foo___baz\\\` int unsigned null;\`);
+    this.addSql(\`alter table \\\`test2\\\` add constraint \\\`test2_foo___bar_foreign\\\` foreign key (\\\`foo___bar\\\`) references \\\`foo_bar2\\\` (\\\`id\\\`) on update cascade on delete set null;\`);
+    this.addSql(\`alter table \\\`test2\\\` add unique \\\`test2_foo___bar_unique\\\`(\\\`foo___bar\\\`);\`);
   }
 
 }
@@ -507,20 +507,20 @@ exports[`Migrator generate schema migration: migration-dump 1`] = `
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('alter table \`test2\` drop foreign key \`test2_foo___bar_foreign\`;');
+    this.addSql(\`alter table \\\`test2\\\` drop foreign key \\\`test2_foo___bar_foreign\\\`;\`);
 
-    this.addSql('alter table \`book2\` drop column \`foo\`;');
+    this.addSql(\`alter table \\\`book2\\\` drop column \\\`foo\\\`;\`);
 
-    this.addSql('alter table \`test2\` drop index \`test2_foo___bar_unique\`;');
-    this.addSql('alter table \`test2\` drop column \`foo___bar\`, drop column \`foo___baz\`;');
+    this.addSql(\`alter table \\\`test2\\\` drop index \\\`test2_foo___bar_unique\\\`;\`);
+    this.addSql(\`alter table \\\`test2\\\` drop column \\\`foo___bar\\\`, drop column \\\`foo___baz\\\`;\`);
   }
 
   override async down(): Promise<void> {
-    this.addSql('alter table \`book2\` add \`foo\` varchar(255) null default \\'lol\\';');
+    this.addSql(\`alter table \\\`book2\\\` add \\\`foo\\\` varchar(255) null default 'lol';\`);
 
-    this.addSql('alter table \`test2\` add \`foo___bar\` int unsigned null, add \`foo___baz\` int unsigned null;');
-    this.addSql('alter table \`test2\` add constraint \`test2_foo___bar_foreign\` foreign key (\`foo___bar\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;');
-    this.addSql('alter table \`test2\` add unique \`test2_foo___bar_unique\`(\`foo___bar\`);');
+    this.addSql(\`alter table \\\`test2\\\` add \\\`foo___bar\\\` int unsigned null, add \\\`foo___baz\\\` int unsigned null;\`);
+    this.addSql(\`alter table \\\`test2\\\` add constraint \\\`test2_foo___bar_foreign\\\` foreign key (\\\`foo___bar\\\`) references \\\`foo_bar2\\\` (\\\`id\\\`) on update cascade on delete set null;\`);
+    this.addSql(\`alter table \\\`test2\\\` add unique \\\`test2_foo___bar_unique\\\`(\\\`foo___bar\\\`);\`);
   }
 
 }
@@ -553,148 +553,148 @@ exports[`Migrator log a migration when the schema already exists: initial-migrat
 export class Migration20191013214813 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('create table \`base_user2\` (\`id\` int unsigned not null auto_increment primary key, \`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`type\` enum(\\'employee\\', \\'manager\\', \\'owner\\') not null, \`owner_prop\` varchar(255) null, \`favourite_employee_id\` int unsigned null, \`favourite_manager_id\` int unsigned null, \`employee_prop\` int null, \`manager_prop\` varchar(255) null) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`base_user2\` add index \`base_user2_type_index\`(\`type\`);');
-    this.addSql('alter table \`base_user2\` add index \`base_user2_favourite_employee_id_index\`(\`favourite_employee_id\`);');
-    this.addSql('alter table \`base_user2\` add unique \`base_user2_favourite_manager_id_unique\`(\`favourite_manager_id\`);');
-    this.addSql('alter table \`base_user2\` add unique \`base_user2_employee_prop_unique\`(\`employee_prop\`);');
+    this.addSql(\`create table \\\`base_user2\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`first_name\\\` varchar(100) not null, \\\`last_name\\\` varchar(100) not null, \\\`type\\\` enum('employee', 'manager', 'owner') not null, \\\`owner_prop\\\` varchar(255) null, \\\`favourite_employee_id\\\` int unsigned null, \\\`favourite_manager_id\\\` int unsigned null, \\\`employee_prop\\\` int null, \\\`manager_prop\\\` varchar(255) null) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`base_user2\\\` add index \\\`base_user2_type_index\\\`(\\\`type\\\`);\`);
+    this.addSql(\`alter table \\\`base_user2\\\` add index \\\`base_user2_favourite_employee_id_index\\\`(\\\`favourite_employee_id\\\`);\`);
+    this.addSql(\`alter table \\\`base_user2\\\` add unique \\\`base_user2_favourite_manager_id_unique\\\`(\\\`favourite_manager_id\\\`);\`);
+    this.addSql(\`alter table \\\`base_user2\\\` add unique \\\`base_user2_employee_prop_unique\\\`(\\\`employee_prop\\\`);\`);
 
-    this.addSql('create table \`book_tag2\` (\`id\` bigint unsigned not null auto_increment primary key, \`name\` varchar(50) not null) default character set utf8mb4 engine = InnoDB;');
+    this.addSql(\`create table \\\`book_tag2\\\` (\\\`id\\\` bigint unsigned not null auto_increment primary key, \\\`name\\\` varchar(50) not null) default character set utf8mb4 engine = InnoDB;\`);
 
-    this.addSql('create table \`car2\` (\`name\` varchar(100) not null, \`year\` int unsigned not null, \`price\` int not null, primary key (\`name\`, \`year\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`car2\` add index \`car2_name_index\`(\`name\`);');
-    this.addSql('alter table \`car2\` add index \`car2_year_index\`(\`year\`);');
+    this.addSql(\`create table \\\`car2\\\` (\\\`name\\\` varchar(100) not null, \\\`year\\\` int unsigned not null, \\\`price\\\` int not null, primary key (\\\`name\\\`, \\\`year\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`car2\\\` add index \\\`car2_name_index\\\`(\\\`name\\\`);\`);
+    this.addSql(\`alter table \\\`car2\\\` add index \\\`car2_year_index\\\`(\\\`year\\\`);\`);
 
-    this.addSql('create table \`car_owner2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`car_name\` varchar(100) not null, \`car_year\` int unsigned not null) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`car_owner2\` add index \`car_owner2_car_name_car_year_index\`(\`car_name\`, \`car_year\`);');
+    this.addSql(\`create table \\\`car_owner2\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`name\\\` varchar(255) not null, \\\`car_name\\\` varchar(100) not null, \\\`car_year\\\` int unsigned not null) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`car_owner2\\\` add index \\\`car_owner2_car_name_car_year_index\\\`(\\\`car_name\\\`, \\\`car_year\\\`);\`);
 
-    this.addSql('create table \`dummy2\` (\`id\` int unsigned not null auto_increment primary key) default character set utf8mb4 engine = InnoDB;');
+    this.addSql(\`create table \\\`dummy2\\\` (\\\`id\\\` int unsigned not null auto_increment primary key) default character set utf8mb4 engine = InnoDB;\`);
 
-    this.addSql('create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`code\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;');
+    this.addSql(\`create table \\\`foo_baz2\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`name\\\` varchar(255) not null, \\\`code\\\` varchar(255) not null, \\\`version\\\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;\`);
 
-    this.addSql('create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`name with space\` varchar(255) null, \`baz_id\` int unsigned null, \`foo_bar_id\` int unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`blob2\` blob null, \`array\` text null, \`object_property\` json null) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);');
-    this.addSql('alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);');
+    this.addSql(\`create table \\\`foo_bar2\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`name\\\` varchar(255) not null, \\\`name with space\\\` varchar(255) null, \\\`baz_id\\\` int unsigned null, \\\`foo_bar_id\\\` int unsigned null, \\\`version\\\` datetime not null default current_timestamp, \\\`blob\\\` blob null, \\\`blob2\\\` blob null, \\\`array\\\` text null, \\\`object_property\\\` json null) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`foo_bar2\\\` add unique \\\`foo_bar2_baz_id_unique\\\`(\\\`baz_id\\\`);\`);
+    this.addSql(\`alter table \\\`foo_bar2\\\` add unique \\\`foo_bar2_foo_bar_id_unique\\\`(\\\`foo_bar_id\\\`);\`);
 
-    this.addSql('create table \`foo_param2\` (\`bar_id\` int unsigned not null, \`baz_id\` int unsigned not null, \`value\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3), primary key (\`bar_id\`, \`baz_id\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`foo_param2\` add index \`foo_param2_bar_id_index\`(\`bar_id\`);');
-    this.addSql('alter table \`foo_param2\` add index \`foo_param2_baz_id_index\`(\`baz_id\`);');
+    this.addSql(\`create table \\\`foo_param2\\\` (\\\`bar_id\\\` int unsigned not null, \\\`baz_id\\\` int unsigned not null, \\\`value\\\` varchar(255) not null, \\\`version\\\` datetime(3) not null default current_timestamp(3), primary key (\\\`bar_id\\\`, \\\`baz_id\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`foo_param2\\\` add index \\\`foo_param2_bar_id_index\\\`(\\\`bar_id\\\`);\`);
+    this.addSql(\`alter table \\\`foo_param2\\\` add index \\\`foo_param2_baz_id_index\\\`(\\\`baz_id\\\`);\`);
 
-    this.addSql('create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null default \\'asd\\', \`type\` enum(\\'local\\', \\'global\\') not null default \\'local\\', \`type2\` enum(\\'LOCAL\\', \\'GLOBAL\\') not null default \\'LOCAL\\', \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum(\\'a\\', \\'b\\', \\'c\\') null, \`enum5\` enum(\\'a\\') null) default character set utf8mb4 engine = InnoDB;');
+    this.addSql(\`create table \\\`publisher2\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`name\\\` varchar(255) not null default 'asd', \\\`type\\\` enum('local', 'global') not null default 'local', \\\`type2\\\` enum('LOCAL', 'GLOBAL') not null default 'LOCAL', \\\`enum1\\\` tinyint null, \\\`enum2\\\` tinyint null, \\\`enum3\\\` tinyint null, \\\`enum4\\\` enum('a', 'b', 'c') null, \\\`enum5\\\` enum('a') null) default character set utf8mb4 engine = InnoDB;\`);
 
-    this.addSql('create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int null default null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int unsigned null, \`identity\` json null) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`author2\` add index \`custom_email_index_name\`(\`email\`);');
-    this.addSql('alter table \`author2\` add unique \`custom_email_unique_name\`(\`email\`);');
-    this.addSql('alter table \`author2\` add index \`author2_terms_accepted_index\`(\`terms_accepted\`);');
-    this.addSql('alter table \`author2\` add index \`author2_born_index\`(\`born\`);');
-    this.addSql('alter table \`author2\` add index \`born_time_idx\`(\`born_time\`);');
-    this.addSql('alter table \`author2\` add index \`author2_favourite_book_uuid_pk_index\`(\`favourite_book_uuid_pk\`);');
-    this.addSql('alter table \`author2\` add index \`author2_favourite_author_id_index\`(\`favourite_author_id\`);');
-    this.addSql('alter table \`author2\` add index \`custom_idx_name_123\`(\`name\`);');
-    this.addSql('alter table \`author2\` add index \`author2_name_age_index\`(\`name\`, \`age\`);');
-    this.addSql('alter table \`author2\` add unique \`author2_name_email_unique\`(\`name\`, \`email\`);');
+    this.addSql(\`create table \\\`author2\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`created_at\\\` datetime(3) not null default current_timestamp(3), \\\`updated_at\\\` datetime(3) not null default current_timestamp(3), \\\`name\\\` varchar(255) not null, \\\`email\\\` varchar(255) not null, \\\`age\\\` int null default null, \\\`terms_accepted\\\` tinyint(1) not null default false, \\\`optional\\\` tinyint(1) null, \\\`identities\\\` text null, \\\`born\\\` date null, \\\`born_time\\\` time null, \\\`favourite_book_uuid_pk\\\` varchar(36) null, \\\`favourite_author_id\\\` int unsigned null, \\\`identity\\\` json null) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`author2\\\` add index \\\`custom_email_index_name\\\`(\\\`email\\\`);\`);
+    this.addSql(\`alter table \\\`author2\\\` add unique \\\`custom_email_unique_name\\\`(\\\`email\\\`);\`);
+    this.addSql(\`alter table \\\`author2\\\` add index \\\`author2_terms_accepted_index\\\`(\\\`terms_accepted\\\`);\`);
+    this.addSql(\`alter table \\\`author2\\\` add index \\\`author2_born_index\\\`(\\\`born\\\`);\`);
+    this.addSql(\`alter table \\\`author2\\\` add index \\\`born_time_idx\\\`(\\\`born_time\\\`);\`);
+    this.addSql(\`alter table \\\`author2\\\` add index \\\`author2_favourite_book_uuid_pk_index\\\`(\\\`favourite_book_uuid_pk\\\`);\`);
+    this.addSql(\`alter table \\\`author2\\\` add index \\\`author2_favourite_author_id_index\\\`(\\\`favourite_author_id\\\`);\`);
+    this.addSql(\`alter table \\\`author2\\\` add index \\\`custom_idx_name_123\\\`(\\\`name\\\`);\`);
+    this.addSql(\`alter table \\\`author2\\\` add index \\\`author2_name_age_index\\\`(\\\`name\\\`, \\\`age\\\`);\`);
+    this.addSql(\`alter table \\\`author2\\\` add unique \\\`author2_name_email_unique\\\`(\\\`name\\\`, \\\`email\\\`);\`);
 
-    this.addSql('create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`isbn\` char(13) null, \`title\` varchar(255) null default \\'\\', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`book2\` add unique \`book2_isbn_unique\`(\`isbn\`);');
-    this.addSql('alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);');
-    this.addSql('alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);');
-    this.addSql('alter table \`book2\` add fulltext index \`book2_title_index\`(\`title\`);');
+    this.addSql(\`create table \\\`book2\\\` (\\\`uuid_pk\\\` varchar(36) not null, \\\`created_at\\\` datetime(3) not null default current_timestamp(3), \\\`isbn\\\` char(13) null, \\\`title\\\` varchar(255) null default '', \\\`perex\\\` text null, \\\`price\\\` numeric(8,2) null, \\\`double\\\` double null, \\\`meta\\\` json null, \\\`author_id\\\` int unsigned not null, \\\`publisher_id\\\` int unsigned null, primary key (\\\`uuid_pk\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`book2\\\` add unique \\\`book2_isbn_unique\\\`(\\\`isbn\\\`);\`);
+    this.addSql(\`alter table \\\`book2\\\` add index \\\`book2_author_id_index\\\`(\\\`author_id\\\`);\`);
+    this.addSql(\`alter table \\\`book2\\\` add index \\\`book2_publisher_id_index\\\`(\\\`publisher_id\\\`);\`);
+    this.addSql(\`alter table \\\`book2\\\` add fulltext index \\\`book2_title_index\\\`(\\\`title\\\`);\`);
 
-    this.addSql('create table \`book2_tags\` (\`order\` int unsigned not null auto_increment primary key, \`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`book2_tags\` add index \`book2_tags_book2_uuid_pk_index\`(\`book2_uuid_pk\`);');
-    this.addSql('alter table \`book2_tags\` add index \`book2_tags_book_tag2_id_index\`(\`book_tag2_id\`);');
+    this.addSql(\`create table \\\`book2_tags\\\` (\\\`order\\\` int unsigned not null auto_increment primary key, \\\`book2_uuid_pk\\\` varchar(36) not null, \\\`book_tag2_id\\\` bigint unsigned not null) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`book2_tags\\\` add index \\\`book2_tags_book2_uuid_pk_index\\\`(\\\`book2_uuid_pk\\\`);\`);
+    this.addSql(\`alter table \\\`book2_tags\\\` add index \\\`book2_tags_book_tag2_id_index\\\`(\\\`book_tag2_id\\\`);\`);
 
-    this.addSql('create table \`book_to_tag_unordered\` (\`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null, primary key (\`book2_uuid_pk\`, \`book_tag2_id\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book2_uuid_pk_index\`(\`book2_uuid_pk\`);');
-    this.addSql('alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book_tag2_id_index\`(\`book_tag2_id\`);');
+    this.addSql(\`create table \\\`book_to_tag_unordered\\\` (\\\`book2_uuid_pk\\\` varchar(36) not null, \\\`book_tag2_id\\\` bigint unsigned not null, primary key (\\\`book2_uuid_pk\\\`, \\\`book_tag2_id\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`book_to_tag_unordered\\\` add index \\\`book_to_tag_unordered_book2_uuid_pk_index\\\`(\\\`book2_uuid_pk\\\`);\`);
+    this.addSql(\`alter table \\\`book_to_tag_unordered\\\` add index \\\`book_to_tag_unordered_book_tag2_id_index\\\`(\\\`book_tag2_id\\\`);\`);
 
-    this.addSql('create table \`author2_following\` (\`author2_1_id\` int unsigned not null, \`author2_2_id\` int unsigned not null, primary key (\`author2_1_id\`, \`author2_2_id\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`author2_following\` add index \`author2_following_author2_1_id_index\`(\`author2_1_id\`);');
-    this.addSql('alter table \`author2_following\` add index \`author2_following_author2_2_id_index\`(\`author2_2_id\`);');
+    this.addSql(\`create table \\\`author2_following\\\` (\\\`author2_1_id\\\` int unsigned not null, \\\`author2_2_id\\\` int unsigned not null, primary key (\\\`author2_1_id\\\`, \\\`author2_2_id\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`author2_following\\\` add index \\\`author2_following_author2_1_id_index\\\`(\\\`author2_1_id\\\`);\`);
+    this.addSql(\`alter table \\\`author2_following\\\` add index \\\`author2_following_author2_2_id_index\\\`(\\\`author2_2_id\\\`);\`);
 
-    this.addSql('create table \`author_to_friend\` (\`author2_1_id\` int unsigned not null, \`author2_2_id\` int unsigned not null, primary key (\`author2_1_id\`, \`author2_2_id\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`author_to_friend\` add index \`author_to_friend_author2_1_id_index\`(\`author2_1_id\`);');
-    this.addSql('alter table \`author_to_friend\` add index \`author_to_friend_author2_2_id_index\`(\`author2_2_id\`);');
+    this.addSql(\`create table \\\`author_to_friend\\\` (\\\`author2_1_id\\\` int unsigned not null, \\\`author2_2_id\\\` int unsigned not null, primary key (\\\`author2_1_id\\\`, \\\`author2_2_id\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`author_to_friend\\\` add index \\\`author_to_friend_author2_1_id_index\\\`(\\\`author2_1_id\\\`);\`);
+    this.addSql(\`alter table \\\`author_to_friend\\\` add index \\\`author_to_friend_author2_2_id_index\\\`(\\\`author2_2_id\\\`);\`);
 
-    this.addSql('create table \`address2\` (\`author_id\` int unsigned not null, \`value\` varchar(255) not null comment \\'This is address property\\', primary key (\`author_id\`)) default character set utf8mb4 engine = InnoDB comment = \\'This is address table\\';');
+    this.addSql(\`create table \\\`address2\\\` (\\\`author_id\\\` int unsigned not null, \\\`value\\\` varchar(255) not null comment 'This is address property', primary key (\\\`author_id\\\`)) default character set utf8mb4 engine = InnoDB comment = 'This is address table';\`);
 
-    this.addSql('create table \`sandwich\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`price\` int not null) default character set utf8mb4 engine = InnoDB;');
+    this.addSql(\`create table \\\`sandwich\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`name\\\` varchar(255) not null, \\\`price\\\` int not null) default character set utf8mb4 engine = InnoDB;\`);
 
-    this.addSql('create table \`test2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) null, \`book_uuid_pk\` varchar(36) null, \`parent_id\` int unsigned null, \`version\` int not null default 1) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`test2\` add unique \`test2_book_uuid_pk_unique\`(\`book_uuid_pk\`);');
-    this.addSql('alter table \`test2\` add index \`test2_parent_id_index\`(\`parent_id\`);');
+    this.addSql(\`create table \\\`test2\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`name\\\` varchar(255) null, \\\`book_uuid_pk\\\` varchar(36) null, \\\`parent_id\\\` int unsigned null, \\\`version\\\` int not null default 1) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`test2\\\` add unique \\\`test2_book_uuid_pk_unique\\\`(\\\`book_uuid_pk\\\`);\`);
+    this.addSql(\`alter table \\\`test2\\\` add index \\\`test2_parent_id_index\\\`(\\\`parent_id\\\`);\`);
 
-    this.addSql('create table \`publisher2_tests\` (\`id\` int unsigned not null auto_increment primary key, \`publisher2_id\` int unsigned not null, \`test2_id\` int unsigned not null) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`publisher2_tests\` add index \`publisher2_tests_publisher2_id_index\`(\`publisher2_id\`);');
-    this.addSql('alter table \`publisher2_tests\` add index \`publisher2_tests_test2_id_index\`(\`test2_id\`);');
+    this.addSql(\`create table \\\`publisher2_tests\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`publisher2_id\\\` int unsigned not null, \\\`test2_id\\\` int unsigned not null) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`publisher2_tests\\\` add index \\\`publisher2_tests_publisher2_id_index\\\`(\\\`publisher2_id\\\`);\`);
+    this.addSql(\`alter table \\\`publisher2_tests\\\` add index \\\`publisher2_tests_test2_id_index\\\`(\\\`test2_id\\\`);\`);
 
-    this.addSql('create table \`configuration2\` (\`property\` varchar(255) not null, \`test_id\` int unsigned not null, \`value\` varchar(255) not null, primary key (\`property\`, \`test_id\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`configuration2\` add index \`configuration2_test_id_index\`(\`test_id\`);');
+    this.addSql(\`create table \\\`configuration2\\\` (\\\`property\\\` varchar(255) not null, \\\`test_id\\\` int unsigned not null, \\\`value\\\` varchar(255) not null, primary key (\\\`property\\\`, \\\`test_id\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`configuration2\\\` add index \\\`configuration2_test_id_index\\\`(\\\`test_id\\\`);\`);
 
-    this.addSql('create table \`test2_bars\` (\`test2_id\` int unsigned not null, \`foo_bar2_id\` int unsigned not null, primary key (\`test2_id\`, \`foo_bar2_id\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`test2_bars\` add index \`test2_bars_test2_id_index\`(\`test2_id\`);');
-    this.addSql('alter table \`test2_bars\` add index \`test2_bars_foo_bar2_id_index\`(\`foo_bar2_id\`);');
+    this.addSql(\`create table \\\`test2_bars\\\` (\\\`test2_id\\\` int unsigned not null, \\\`foo_bar2_id\\\` int unsigned not null, primary key (\\\`test2_id\\\`, \\\`foo_bar2_id\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`test2_bars\\\` add index \\\`test2_bars_test2_id_index\\\`(\\\`test2_id\\\`);\`);
+    this.addSql(\`alter table \\\`test2_bars\\\` add index \\\`test2_bars_foo_bar2_id_index\\\`(\\\`foo_bar2_id\\\`);\`);
 
-    this.addSql('create table \`user2\` (\`first_name\` varchar(100) not null, \`last_name\` varchar(100) not null, \`foo\` int null, \`favourite_car_name\` varchar(100) null, \`favourite_car_year\` int unsigned null, primary key (\`first_name\`, \`last_name\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`user2\` add unique \`user2_favourite_car_name_favourite_car_year_unique\`(\`favourite_car_name\`, \`favourite_car_year\`);');
+    this.addSql(\`create table \\\`user2\\\` (\\\`first_name\\\` varchar(100) not null, \\\`last_name\\\` varchar(100) not null, \\\`foo\\\` int null, \\\`favourite_car_name\\\` varchar(100) null, \\\`favourite_car_year\\\` int unsigned null, primary key (\\\`first_name\\\`, \\\`last_name\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`user2\\\` add unique \\\`user2_favourite_car_name_favourite_car_year_unique\\\`(\\\`favourite_car_name\\\`, \\\`favourite_car_year\\\`);\`);
 
-    this.addSql('create table \`user2_cars\` (\`user2_first_name\` varchar(100) not null, \`user2_last_name\` varchar(100) not null, \`car2_name\` varchar(100) not null, \`car2_year\` int unsigned not null, primary key (\`user2_first_name\`, \`user2_last_name\`, \`car2_name\`, \`car2_year\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`user2_cars\` add index \`user2_cars_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);');
-    this.addSql('alter table \`user2_cars\` add index \`user2_cars_car2_name_car2_year_index\`(\`car2_name\`, \`car2_year\`);');
+    this.addSql(\`create table \\\`user2_cars\\\` (\\\`user2_first_name\\\` varchar(100) not null, \\\`user2_last_name\\\` varchar(100) not null, \\\`car2_name\\\` varchar(100) not null, \\\`car2_year\\\` int unsigned not null, primary key (\\\`user2_first_name\\\`, \\\`user2_last_name\\\`, \\\`car2_name\\\`, \\\`car2_year\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`user2_cars\\\` add index \\\`user2_cars_user2_first_name_user2_last_name_index\\\`(\\\`user2_first_name\\\`, \\\`user2_last_name\\\`);\`);
+    this.addSql(\`alter table \\\`user2_cars\\\` add index \\\`user2_cars_car2_name_car2_year_index\\\`(\\\`car2_name\\\`, \\\`car2_year\\\`);\`);
 
-    this.addSql('create table \`user2_sandwiches\` (\`user2_first_name\` varchar(100) not null, \`user2_last_name\` varchar(100) not null, \`sandwich_id\` int unsigned not null, primary key (\`user2_first_name\`, \`user2_last_name\`, \`sandwich_id\`)) default character set utf8mb4 engine = InnoDB;');
-    this.addSql('alter table \`user2_sandwiches\` add index \`user2_sandwiches_sandwich_id_index\`(\`sandwich_id\`);');
-    this.addSql('alter table \`user2_sandwiches\` add index \`user2_sandwiches_user2_first_name_user2_last_name_index\`(\`user2_first_name\`, \`user2_last_name\`);');
+    this.addSql(\`create table \\\`user2_sandwiches\\\` (\\\`user2_first_name\\\` varchar(100) not null, \\\`user2_last_name\\\` varchar(100) not null, \\\`sandwich_id\\\` int unsigned not null, primary key (\\\`user2_first_name\\\`, \\\`user2_last_name\\\`, \\\`sandwich_id\\\`)) default character set utf8mb4 engine = InnoDB;\`);
+    this.addSql(\`alter table \\\`user2_sandwiches\\\` add index \\\`user2_sandwiches_sandwich_id_index\\\`(\\\`sandwich_id\\\`);\`);
+    this.addSql(\`alter table \\\`user2_sandwiches\\\` add index \\\`user2_sandwiches_user2_first_name_user2_last_name_index\\\`(\\\`user2_first_name\\\`, \\\`user2_last_name\\\`);\`);
 
-    this.addSql('alter table \`base_user2\` add constraint \`base_user2_favourite_employee_id_foreign\` foreign key (\`favourite_employee_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;');
-    this.addSql('alter table \`base_user2\` add constraint \`base_user2_favourite_manager_id_foreign\` foreign key (\`favourite_manager_id\`) references \`base_user2\` (\`id\`) on update cascade on delete set null;');
+    this.addSql(\`alter table \\\`base_user2\\\` add constraint \\\`base_user2_favourite_employee_id_foreign\\\` foreign key (\\\`favourite_employee_id\\\`) references \\\`base_user2\\\` (\\\`id\\\`) on update cascade on delete set null;\`);
+    this.addSql(\`alter table \\\`base_user2\\\` add constraint \\\`base_user2_favourite_manager_id_foreign\\\` foreign key (\\\`favourite_manager_id\\\`) references \\\`base_user2\\\` (\\\`id\\\`) on update cascade on delete set null;\`);
 
-    this.addSql('alter table \`car_owner2\` add constraint \`car_owner2_car_name_car_year_foreign\` foreign key (\`car_name\`, \`car_year\`) references \`car2\` (\`name\`, \`year\`) on update cascade;');
+    this.addSql(\`alter table \\\`car_owner2\\\` add constraint \\\`car_owner2_car_name_car_year_foreign\\\` foreign key (\\\`car_name\\\`, \\\`car_year\\\`) references \\\`car2\\\` (\\\`name\\\`, \\\`year\\\`) on update cascade;\`);
 
-    this.addSql('alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;');
-    this.addSql('alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;');
+    this.addSql(\`alter table \\\`foo_bar2\\\` add constraint \\\`foo_bar2_baz_id_foreign\\\` foreign key (\\\`baz_id\\\`) references \\\`foo_baz2\\\` (\\\`id\\\`) on update cascade on delete set null;\`);
+    this.addSql(\`alter table \\\`foo_bar2\\\` add constraint \\\`foo_bar2_foo_bar_id_foreign\\\` foreign key (\\\`foo_bar_id\\\`) references \\\`foo_bar2\\\` (\\\`id\\\`) on update cascade on delete set null;\`);
 
-    this.addSql('alter table \`foo_param2\` add constraint \`foo_param2_bar_id_foreign\` foreign key (\`bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade;');
-    this.addSql('alter table \`foo_param2\` add constraint \`foo_param2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade;');
+    this.addSql(\`alter table \\\`foo_param2\\\` add constraint \\\`foo_param2_bar_id_foreign\\\` foreign key (\\\`bar_id\\\`) references \\\`foo_bar2\\\` (\\\`id\\\`) on update cascade;\`);
+    this.addSql(\`alter table \\\`foo_param2\\\` add constraint \\\`foo_param2_baz_id_foreign\\\` foreign key (\\\`baz_id\\\`) references \\\`foo_baz2\\\` (\\\`id\\\`) on update cascade;\`);
 
-    this.addSql('alter table \`author2\` add constraint \`author2_favourite_book_uuid_pk_foreign\` foreign key (\`favourite_book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update no action on delete cascade;');
-    this.addSql('alter table \`author2\` add constraint \`author2_favourite_author_id_foreign\` foreign key (\`favourite_author_id\`) references \`author2\` (\`id\`) on update cascade on delete set null;');
+    this.addSql(\`alter table \\\`author2\\\` add constraint \\\`author2_favourite_book_uuid_pk_foreign\\\` foreign key (\\\`favourite_book_uuid_pk\\\`) references \\\`book2\\\` (\\\`uuid_pk\\\`) on update no action on delete cascade;\`);
+    this.addSql(\`alter table \\\`author2\\\` add constraint \\\`author2_favourite_author_id_foreign\\\` foreign key (\\\`favourite_author_id\\\`) references \\\`author2\\\` (\\\`id\\\`) on update cascade on delete set null;\`);
 
-    this.addSql('alter table \`book2\` add constraint \`book2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`);');
-    this.addSql('alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key (\`publisher_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`book2\\\` add constraint \\\`book2_author_id_foreign\\\` foreign key (\\\`author_id\\\`) references \\\`author2\\\` (\\\`id\\\`);\`);
+    this.addSql(\`alter table \\\`book2\\\` add constraint \\\`book2_publisher_id_foreign\\\` foreign key (\\\`publisher_id\\\`) references \\\`publisher2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table \`book2_tags\` add constraint \`book2_tags_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;');
-    this.addSql('alter table \`book2_tags\` add constraint \`book2_tags_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`book2_tags\\\` add constraint \\\`book2_tags_book2_uuid_pk_foreign\\\` foreign key (\\\`book2_uuid_pk\\\`) references \\\`book2\\\` (\\\`uuid_pk\\\`) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table \\\`book2_tags\\\` add constraint \\\`book2_tags_book_tag2_id_foreign\\\` foreign key (\\\`book_tag2_id\\\`) references \\\`book_tag2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table \`book_to_tag_unordered\` add constraint \`book_to_tag_unordered_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;');
-    this.addSql('alter table \`book_to_tag_unordered\` add constraint \`book_to_tag_unordered_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`book_to_tag_unordered\\\` add constraint \\\`book_to_tag_unordered_book2_uuid_pk_foreign\\\` foreign key (\\\`book2_uuid_pk\\\`) references \\\`book2\\\` (\\\`uuid_pk\\\`) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table \\\`book_to_tag_unordered\\\` add constraint \\\`book_to_tag_unordered_book_tag2_id_foreign\\\` foreign key (\\\`book_tag2_id\\\`) references \\\`book_tag2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table \`author2_following\` add constraint \`author2_following_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;');
-    this.addSql('alter table \`author2_following\` add constraint \`author2_following_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`author2_following\\\` add constraint \\\`author2_following_author2_1_id_foreign\\\` foreign key (\\\`author2_1_id\\\`) references \\\`author2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table \\\`author2_following\\\` add constraint \\\`author2_following_author2_2_id_foreign\\\` foreign key (\\\`author2_2_id\\\`) references \\\`author2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table \`author_to_friend\` add constraint \`author_to_friend_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;');
-    this.addSql('alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`author_to_friend\\\` add constraint \\\`author_to_friend_author2_1_id_foreign\\\` foreign key (\\\`author2_1_id\\\`) references \\\`author2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table \\\`author_to_friend\\\` add constraint \\\`author_to_friend_author2_2_id_foreign\\\` foreign key (\\\`author2_2_id\\\`) references \\\`author2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table \`address2\` add constraint \`address2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`address2\\\` add constraint \\\`address2_author_id_foreign\\\` foreign key (\\\`author_id\\\`) references \\\`author2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table \`test2\` add constraint \`test2_book_uuid_pk_foreign\` foreign key (\`book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on delete set null;');
-    this.addSql('alter table \`test2\` add constraint \`test2_parent_id_foreign\` foreign key (\`parent_id\`) references \`test2\` (\`id\`) on update cascade on delete set null;');
+    this.addSql(\`alter table \\\`test2\\\` add constraint \\\`test2_book_uuid_pk_foreign\\\` foreign key (\\\`book_uuid_pk\\\`) references \\\`book2\\\` (\\\`uuid_pk\\\`) on delete set null;\`);
+    this.addSql(\`alter table \\\`test2\\\` add constraint \\\`test2_parent_id_foreign\\\` foreign key (\\\`parent_id\\\`) references \\\`test2\\\` (\\\`id\\\`) on update cascade on delete set null;\`);
 
-    this.addSql('alter table \`publisher2_tests\` add constraint \`publisher2_tests_publisher2_id_foreign\` foreign key (\`publisher2_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;');
-    this.addSql('alter table \`publisher2_tests\` add constraint \`publisher2_tests_test2_id_foreign\` foreign key (\`test2_id\`) references \`test2\` (\`id\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`publisher2_tests\\\` add constraint \\\`publisher2_tests_publisher2_id_foreign\\\` foreign key (\\\`publisher2_id\\\`) references \\\`publisher2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table \\\`publisher2_tests\\\` add constraint \\\`publisher2_tests_test2_id_foreign\\\` foreign key (\\\`test2_id\\\`) references \\\`test2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table \`configuration2\` add constraint \`configuration2_test_id_foreign\` foreign key (\`test_id\`) references \`test2\` (\`id\`) on update cascade;');
+    this.addSql(\`alter table \\\`configuration2\\\` add constraint \\\`configuration2_test_id_foreign\\\` foreign key (\\\`test_id\\\`) references \\\`test2\\\` (\\\`id\\\`) on update cascade;\`);
 
-    this.addSql('alter table \`test2_bars\` add constraint \`test2_bars_test2_id_foreign\` foreign key (\`test2_id\`) references \`test2\` (\`id\`) on update cascade on delete cascade;');
-    this.addSql('alter table \`test2_bars\` add constraint \`test2_bars_foo_bar2_id_foreign\` foreign key (\`foo_bar2_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`test2_bars\\\` add constraint \\\`test2_bars_test2_id_foreign\\\` foreign key (\\\`test2_id\\\`) references \\\`test2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table \\\`test2_bars\\\` add constraint \\\`test2_bars_foo_bar2_id_foreign\\\` foreign key (\\\`foo_bar2_id\\\`) references \\\`foo_bar2\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table \`user2\` add constraint \`user2_favourite_car_name_favourite_car_year_foreign\` foreign key (\`favourite_car_name\`, \`favourite_car_year\`) references \`car2\` (\`name\`, \`year\`) on update cascade on delete set null;');
+    this.addSql(\`alter table \\\`user2\\\` add constraint \\\`user2_favourite_car_name_favourite_car_year_foreign\\\` foreign key (\\\`favourite_car_name\\\`, \\\`favourite_car_year\\\`) references \\\`car2\\\` (\\\`name\\\`, \\\`year\\\`) on update cascade on delete set null;\`);
 
-    this.addSql('alter table \`user2_cars\` add constraint \`user2_cars_user2_first_name_user2_last_name_foreign\` foreign key (\`user2_first_name\`, \`user2_last_name\`) references \`user2\` (\`first_name\`, \`last_name\`) on update cascade on delete cascade;');
-    this.addSql('alter table \`user2_cars\` add constraint \`user2_cars_car2_name_car2_year_foreign\` foreign key (\`car2_name\`, \`car2_year\`) references \`car2\` (\`name\`, \`year\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`user2_cars\\\` add constraint \\\`user2_cars_user2_first_name_user2_last_name_foreign\\\` foreign key (\\\`user2_first_name\\\`, \\\`user2_last_name\\\`) references \\\`user2\\\` (\\\`first_name\\\`, \\\`last_name\\\`) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table \\\`user2_cars\\\` add constraint \\\`user2_cars_car2_name_car2_year_foreign\\\` foreign key (\\\`car2_name\\\`, \\\`car2_year\\\`) references \\\`car2\\\` (\\\`name\\\`, \\\`year\\\`) on update cascade on delete cascade;\`);
 
-    this.addSql('alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_user2_first_name_user2_last_name_foreign\` foreign key (\`user2_first_name\`, \`user2_last_name\`) references \`user2\` (\`first_name\`, \`last_name\`) on update cascade on delete cascade;');
-    this.addSql('alter table \`user2_sandwiches\` add constraint \`user2_sandwiches_sandwich_id_foreign\` foreign key (\`sandwich_id\`) references \`sandwich\` (\`id\`) on update cascade on delete cascade;');
+    this.addSql(\`alter table \\\`user2_sandwiches\\\` add constraint \\\`user2_sandwiches_user2_first_name_user2_last_name_foreign\\\` foreign key (\\\`user2_first_name\\\`, \\\`user2_last_name\\\`) references \\\`user2\\\` (\\\`first_name\\\`, \\\`last_name\\\`) on update cascade on delete cascade;\`);
+    this.addSql(\`alter table \\\`user2_sandwiches\\\` add constraint \\\`user2_sandwiches_sandwich_id_foreign\\\` foreign key (\\\`sandwich_id\\\`) references \\\`sandwich\\\` (\\\`id\\\`) on update cascade on delete cascade;\`);
   }
 
 }
@@ -857,20 +857,20 @@ exports[`Migrator snapshot should not be updated when custom migration fileName 
 export class Migration20191013214813_with-custom-name extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql('alter table \`test2\` drop foreign key \`test2_foo___bar_foreign\`;');
+    this.addSql(\`alter table \\\`test2\\\` drop foreign key \\\`test2_foo___bar_foreign\\\`;\`);
 
-    this.addSql('alter table \`book2\` drop column \`foo\`;');
+    this.addSql(\`alter table \\\`book2\\\` drop column \\\`foo\\\`;\`);
 
-    this.addSql('alter table \`test2\` drop index \`test2_foo___bar_unique\`;');
-    this.addSql('alter table \`test2\` drop column \`foo___bar\`, drop column \`foo___baz\`;');
+    this.addSql(\`alter table \\\`test2\\\` drop index \\\`test2_foo___bar_unique\\\`;\`);
+    this.addSql(\`alter table \\\`test2\\\` drop column \\\`foo___bar\\\`, drop column \\\`foo___baz\\\`;\`);
   }
 
   override async down(): Promise<void> {
-    this.addSql('alter table \`book2\` add \`foo\` varchar(255) null default \\'lol\\';');
+    this.addSql(\`alter table \\\`book2\\\` add \\\`foo\\\` varchar(255) null default 'lol';\`);
 
-    this.addSql('alter table \`test2\` add \`foo___bar\` int unsigned null, add \`foo___baz\` int unsigned null;');
-    this.addSql('alter table \`test2\` add constraint \`test2_foo___bar_foreign\` foreign key (\`foo___bar\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;');
-    this.addSql('alter table \`test2\` add unique \`test2_foo___bar_unique\`(\`foo___bar\`);');
+    this.addSql(\`alter table \\\`test2\\\` add \\\`foo___bar\\\` int unsigned null, add \\\`foo___baz\\\` int unsigned null;\`);
+    this.addSql(\`alter table \\\`test2\\\` add constraint \\\`test2_foo___bar_foreign\\\` foreign key (\\\`foo___bar\\\`) references \\\`foo_bar2\\\` (\\\`id\\\`) on update cascade on delete set null;\`);
+    this.addSql(\`alter table \\\`test2\\\` add unique \\\`test2_foo___bar_unique\\\`(\\\`foo___bar\\\`);\`);
   }
 
 }


### PR DESCRIPTION
This enables better handling of multi line SQL statements, which users can produce with customization of MigrationGenerator that result in a single statement spanning multiple lines.

Related to #6015