### PR TITLE
fix(mongo): support partial loading of M:N owning sides

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -2074,11 +2074,13 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
       const pruneToOneRelations = (meta: EntityMetadata, fields: string[]): string[] => {
         const ret: string[] = [];
 
-        for (const field of fields) {
+        for (let field of fields) {
           if (field === PopulatePath.ALL || field.startsWith(`${PopulatePath.ALL}.`)) {
             ret.push(...meta.props.filter(prop => prop.lazy || [ReferenceKind.SCALAR, ReferenceKind.EMBEDDED].includes(prop.kind)).map(prop => prop.name));
             continue;
           }
+
+          field = field.split(':')[0];
 
           if (!field.includes('.') && ![ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(meta.properties[field].kind)) {
             ret.push(field);

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -182,6 +182,14 @@ export class EntityLoader {
     const meta = this.metadata.find<Entity>(entityName)!;
     const prop = meta.properties[field];
 
+    if (prop.kind === ReferenceKind.MANY_TO_MANY && prop.owner && !this.driver.getPlatform().usesPivotTable()) {
+      const filtered = entities.filter(e => !(e[prop.name] as Collection<any>)?.isInitialized());
+
+      if (filtered.length > 0) {
+        await this.populateScalar(meta, filtered, options, prop);
+      }
+    }
+
     if (prop.kind === ReferenceKind.SCALAR && prop.lazy) {
       const filtered = entities.filter(e => options.refresh || (prop.ref ? !(e[prop.name] as ScalarReference<any>)?.isInitialized() : e[prop.name] === undefined));
 
@@ -189,16 +197,7 @@ export class EntityLoader {
         return entities as AnyEntity[];
       }
 
-      const pk = Utils.getPrimaryKeyHash(meta.primaryKeys) as FilterKey<Entity>;
-      const ids = Utils.unique(filtered.map(e => Utils.getPrimaryKeyValues(e, meta.primaryKeys, true)));
-      const where = this.mergePrimaryCondition<Entity>(ids as Entity[], pk, options, meta, this.metadata, this.driver.getPlatform());
-      const { filters, convertCustomTypes, lockMode, strategy, populateWhere, connectionType, logging } = options;
-
-      await this.em.find(meta.className, where, {
-        filters, convertCustomTypes, lockMode, strategy, populateWhere, connectionType, logging,
-        fields: [prop.name] as never,
-        populate: [],
-      });
+      await this.populateScalar(meta, filtered, options, prop);
 
       return entities as AnyEntity[];
     }
@@ -221,6 +220,19 @@ export class EntityLoader {
     this.initializeCollections<Entity>(filtered, prop, field, data, innerOrderBy.length > 0);
 
     return data;
+  }
+
+  private async populateScalar<Entity>(meta: EntityMetadata<Entity>, filtered: Entity[], options: Required<EntityLoaderOptions<Entity>>, prop: EntityProperty<Entity>) {
+    const pk = Utils.getPrimaryKeyHash(meta.primaryKeys) as FilterKey<Entity>;
+    const ids = Utils.unique(filtered.map(e => Utils.getPrimaryKeyValues(e, meta.primaryKeys, true)));
+    const where = this.mergePrimaryCondition<Entity>(ids as Entity[], pk, options, meta, this.metadata, this.driver.getPlatform());
+    const { filters, convertCustomTypes, lockMode, strategy, populateWhere, connectionType, logging } = options;
+
+    await this.em.find(meta.className, where, {
+      filters, convertCustomTypes, lockMode, strategy, populateWhere, connectionType, logging,
+      fields: [prop.name] as never,
+      populate: [],
+    });
   }
 
   private initializeCollections<Entity extends object>(filtered: Entity[], prop: EntityProperty, field: keyof Entity, children: AnyEntity[], customOrder: boolean): void {

--- a/packages/core/src/hydration/ObjectHydrator.ts
+++ b/packages/core/src/hydration/ObjectHydrator.ts
@@ -203,9 +203,16 @@ export class ObjectHydrator extends Hydrator {
       ret.push(`    }`);
       ret.push(`  } else if (!entity${entityKey} && data${dataKey} instanceof Collection) {`);
       ret.push(`    entity${entityKey} = data${dataKey};`);
+
+      if (!this.platform.usesPivotTable() && prop.owner && prop.kind === ReferenceKind.MANY_TO_MANY) {
+        ret.push(`  } else if (!entity${entityKey} && Array.isArray(data${dataKey})) {`);
+        const items = this.platform.usesPivotTable() || !prop.owner ? 'undefined' : '[]';
+        ret.push(`    const coll = Collection.create(entity, '${prop.name}', ${items}, !!data${dataKey} || newEntity);`);
+        ret.push(`    coll.setDirty(false);`);
+      }
+
       ret.push(`  } else if (!entity${entityKey}) {`);
-      const items = this.platform.usesPivotTable() || !prop.owner ? 'undefined' : '[]';
-      ret.push(`    const coll = Collection.create(entity, '${prop.name}', ${items}, !!data${dataKey} || newEntity);`);
+      ret.push(`    const coll = Collection.create(entity, '${prop.name}', undefined, newEntity);`);
       ret.push(`    coll.setDirty(false);`);
       ret.push(`  }`);
 

--- a/packages/core/src/unit-of-work/ChangeSetComputer.ts
+++ b/packages/core/src/unit-of-work/ChangeSetComputer.ts
@@ -175,16 +175,14 @@ export class ChangeSetComputer {
   private processToMany<T extends object>(prop: EntityProperty<T>, changeSet: ChangeSet<T>): void {
     const target = changeSet.entity[prop.name] as Collection<any>;
 
-    if (!target.isDirty()) {
+    if (!target.isDirty() && changeSet.type !== ChangeSetType.CREATE) {
       return;
     }
 
     this.collectionUpdates.add(target);
 
-    if (prop.owner || target.getItems(false).filter(item => !item.__helper!.__initialized).length > 0) {
-      if (!this.platform.usesPivotTable()) {
-        changeSet.payload[prop.name] = target.getItems(false).map((item: AnyEntity) => item.__helper!.__identifier ?? item.__helper!.getPrimaryKey());
-      }
+    if (prop.owner && !this.platform.usesPivotTable()) {
+      changeSet.payload[prop.name] = target.getItems(false).map((item: AnyEntity) => item.__helper!.__identifier ?? item.__helper!.getPrimaryKey());
     }
   }
 

--- a/tests/EntityFactory.test.ts
+++ b/tests/EntityFactory.test.ts
@@ -222,7 +222,7 @@ describe('EntityFactory', () => {
 
     expect(mock.mock.calls).toHaveLength(3);
     expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('book-tag'\)\.insertMany\(\[ { name: 't1' } ], {}\);/);
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('author'\)\.insertMany\(\[ { createdAt: ISODate\('.*'\), updatedAt: ISODate\('.*'\), foo: 'bar', name: 'Jon', email: 'jon@snow\.com', termsAccepted: false } ], {}\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('author'\)\.insertMany\(\[ { createdAt: ISODate\('.*'\), updatedAt: ISODate\('.*'\), foo: 'bar', name: 'Jon', email: 'jon@snow\.com', termsAccepted: false, friends: \[] } ], {}\);/);
     expect(mock.mock.calls[2][0]).toMatch(/db\.getCollection\('books-table'\)\.insertMany\(\[ { createdAt: ISODate\('.*'\), title: 'B1', author: ObjectId\('.*'\), publisher: ObjectId\('5b0d19b28b21c648c2c8a600'\), tags: \[ ObjectId\('.*'\), ObjectId\('5b0d19b28b21c648c2c8a601'\) ] } ], {}\);/);
 
     orm.em.clear();
@@ -251,7 +251,7 @@ describe('EntityFactory', () => {
 
     expect(mock.mock.calls.length).toBe(3);
     expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('book-tag'\)\.insertMany\(\[ { name: 't1' } ], {}\);/);
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('author'\)\.insertMany\(\[ { createdAt: ISODate\('.*'\), updatedAt: ISODate\('.*'\), foo: 'bar', name: 'Jon', email: 'jon2@snow\.com', termsAccepted: false } ], {}\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('author'\)\.insertMany\(\[ { createdAt: ISODate\('.*'\), updatedAt: ISODate\('.*'\), foo: 'bar', name: 'Jon', email: 'jon2@snow\.com', termsAccepted: false, friends: \[] } ], {}\);/);
     expect(mock.mock.calls[2][0]).toMatch(/db\.getCollection\('books-table'\)\.insertMany\(\[ { createdAt: ISODate\('.*'\), title: 'B1', author: ObjectId\('.*'\), publisher: ObjectId\('5b0d19b28b21c648c2c8a600'\), tags: \[ ObjectId\('.*'\), ObjectId\('5b0d19b28b21c648c2c8a601'\) ] } ], {}\);/);
   });
 

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -1659,7 +1659,7 @@ describe('EntityManagerMongo', () => {
     // check fired queries
     expect(mock.mock.calls.length).toBe(4);
     expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('author'\)\.insertMany\(\[ { createdAt: ISODate\('.*'\), updatedAt: ISODate\('.*'\), foo: '.*', name: '.*', email: '.*', termsAccepted: .* } ], {}\);/);
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.insertMany\(\[ { createdAt: ISODate\('.*'\), title: 'b1', author: ObjectId\('.*'\) }, { createdAt: ISODate\('.*'\), title: 'b2', author: ObjectId\('.*'\) }, { createdAt: ISODate\('.*'\), title: 'b3', author: ObjectId\('.*'\) } ], {}\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.insertMany\(\[ { createdAt: ISODate\('.*'\), title: 'b1', author: ObjectId\('.*'\), tags: \[] }, { createdAt: ISODate\('.*'\), title: 'b2', author: ObjectId\('.*'\), tags: \[] }, { createdAt: ISODate\('.*'\), title: 'b3', author: ObjectId\('.*'\), tags: \[] } ], {}\);/);
     expect(mock.mock.calls[2][0]).toMatch(/db\.getCollection\('author'\)\.updateMany\({ _id: ObjectId\('.*'\) }, { '\$set': { favouriteAuthor: ObjectId\('.*'\), updatedAt: ISODate\('.*'\) } }, {}\);/);
     expect(mock.mock.calls[3][0]).toMatch(/db\.getCollection\('author'\)\.find\(.*\)\.toArray\(\);/);
   });
@@ -1828,7 +1828,6 @@ describe('EntityManagerMongo', () => {
   test('automatically fix array of PKs instead of collection when flushing (m:n)', async () => {
     const mock = mockLogger(orm);
 
-
     const author = new Author('Jon Snow', 'snow@wall.st');
     const book = new Book('B123', author);
     await orm.em.persistAndFlush(book);
@@ -1850,8 +1849,8 @@ describe('EntityManagerMongo', () => {
     expect(book.tags.isDirty()).toBe(true);
 
     await orm.em.flush();
-    expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('author'\)\.insertMany\(\[ { createdAt: ISODate\(.*\), updatedAt: ISODate\(.*\), foo: 'bar', name: 'Jon Snow', email: 'snow@wall\.st', termsAccepted: false } ], {}\);/);
-    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.insertMany\(\[ { createdAt: ISODate\('.*'\), title: 'B123', author: ObjectId\('.*'\) } ], {}\);/);
+    expect(mock.mock.calls[0][0]).toMatch(/db\.getCollection\('author'\)\.insertMany\(\[ { createdAt: ISODate\(.*\), updatedAt: ISODate\(.*\), foo: 'bar', name: 'Jon Snow', email: 'snow@wall\.st', termsAccepted: false, friends: \[] } ], {}\);/);
+    expect(mock.mock.calls[1][0]).toMatch(/db\.getCollection\('books-table'\)\.insertMany\(\[ { createdAt: ISODate\('.*'\), title: 'B123', author: ObjectId\('.*'\), tags: \[] } ], {}\);/);
     expect(mock.mock.calls[2][0]).toMatch(/db\.getCollection\('books-table'\)\.updateMany\({ _id: ObjectId\('.*'\) }, { '\$set': { tags: \[ ObjectId\('0000007b5c9c61c332380f78'\), ObjectId\('0000007b5c9c61c332380f79'\) ] } }, {}\);/);
   });
 
@@ -1971,7 +1970,7 @@ describe('EntityManagerMongo', () => {
     await orm.em.persistAndFlush(author);
 
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch(/\[90m\[query] \[39mdb\[0m.\[0mgetCollection\(\[33m'author'\[39m\)\[0m.\[0minsertMany\(\[ \{ createdAt: ISODate\('.*'\), updatedAt: ISODate\(.*\), foo: 'bar', name: 'Jon Snow', email: 'snow@wall.st', age: 30, termsAccepted: false } ], \{}\);\[90m \[took \d+ ms]\[39m/);
+    expect(mock.mock.calls[0][0]).toMatch(/\[90m\[query] \[39mdb\[0m.\[0mgetCollection\(\[33m'author'\[39m\)\[0m.\[0minsertMany\(\[ \{ createdAt: ISODate\('.*'\), updatedAt: ISODate\(.*\), foo: 'bar', name: 'Jon Snow', email: 'snow@wall.st', age: 30, termsAccepted: false, friends: \[] } ], \{}\);\[90m \[took \d+ ms]\[39m/);
 
     Object.assign(orm.config.getLogger(), { highlighter: new NullHighlighter() });
   });

--- a/tests/features/partial-loading/m-n-owners.mongo.test.ts
+++ b/tests/features/partial-loading/m-n-owners.mongo.test.ts
@@ -1,0 +1,93 @@
+import { Entity, MikroORM, ObjectId, PrimaryKey, Property, ManyToMany, Collection } from '@mikro-orm/mongodb';
+
+@Entity()
+class Author {
+
+  @PrimaryKey()
+  _id!: ObjectId;
+
+  @Property()
+  name!: string;
+
+  @ManyToMany(() => Book)
+  books = new Collection<Book, Author>(this);
+
+}
+
+@Entity()
+class Book {
+
+  @PrimaryKey()
+  _id!: ObjectId;
+
+  @Property()
+  title!: string;
+
+  @ManyToMany(() => Author, 'books')
+  authors = new Collection<Author, Book>(this);
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: '123',
+    entities: [Author, Book],
+  });
+  await orm.schema.refreshDatabase();
+
+  orm.em.create(Author, {
+    name: 'Arthur C. Clark',
+    books: [
+      { title: "Childhood's End" },
+      { title: '2001: A Space Odyssey' },
+      { title: 'Rendezvous with Rama' },
+    ],
+  });
+
+  await orm.em.flush();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+beforeEach(async () => {
+  orm.em.clear();
+});
+
+test('m:n collections on owning side and partial loading 1 [mongo]', async () => {
+  const authors = await orm.em.findAll(Author, { fields: ['name'] });
+  // @ts-expect-error
+  expect(authors[0].books.isInitialized()).toBe(false);
+
+  const a1 = await orm.em.populate(authors, ['books:ref']);
+  expect(a1[0].books.isInitialized()).toBe(true);
+  expect(a1[0].books.isInitialized(true)).toBe(false);
+
+  const a2 = await orm.em.populate(authors, ['books']);
+  expect(a2[0].books.isInitialized()).toBe(true);
+  expect(a2[0].books.isInitialized(true)).toBe(true);
+});
+
+test('m:n collections on owning side and partial loading 2 [mongo]', async () => {
+  const authors = await orm.em.findAll(Author, { fields: ['name', 'books'], populate: [] });
+  expect(authors[0].books.isInitialized()).toBe(true);
+  expect(authors[0].books.isInitialized(true)).toBe(false);
+  expect(authors[0].books).toHaveLength(3);
+});
+
+test('m:n collections on owning side and partial loading 3 [mongo]', async () => {
+  const authors = await orm.em.findAll(Author, { fields: ['name', 'books'], populate: ['books:ref'] });
+  expect(authors[0].books.isInitialized()).toBe(true);
+  expect(authors[0].books.isInitialized(true)).toBe(false);
+  expect(authors[0].books).toHaveLength(3);
+});
+
+test('m:n collections on owning side and partial loading 4 [mongo]', async () => {
+  const authors = await orm.em.findAll(Author, { fields: ['name', 'books'] });
+  expect(authors[0].books.isInitialized()).toBe(true);
+  expect(authors[0].books.isInitialized(true)).toBe(true);
+  expect(authors[0].books).toHaveLength(3);
+});


### PR DESCRIPTION
This resolves several things for mongo specific M:N implementation, which uses array properties on owning sides.
- new entities with empty collections are now property saves with `[]` value
- partial loading without the collection property will result in not initialized collection
- `em.populate` can be used to load such relation without the initial value