### PR TITLE
fix: using raw fragment with bigint type (postgres/msql)

### DIFF
--- a/docs/docs/entity-manager.md
+++ b/docs/docs/entity-manager.md
@@ -440,6 +440,8 @@ user.lastOrderNumber = order.number; // throws, it could resolve to a different 
 JSON.stringify(order); // throws, raw value cannot be serialized
 ```
 
+Using `raw()` with BigInt type currently only works with PostgresQL and MySQL.
+
 ## Upsert
 
 We can use `em.upsert()` create or update the entity, based on whether it is already present in the database. This method performs an `insert on conflict merge` query ensuring the database is in sync, returning a managed entity instance. The method accepts either `entityName` together with the entity `data`, or just entity instance.

--- a/docs/versioned_docs/version-6.3/entity-manager.md
+++ b/docs/versioned_docs/version-6.3/entity-manager.md
@@ -440,6 +440,8 @@ user.lastOrderNumber = order.number; // throws, it could resolve to a different 
 JSON.stringify(order); // throws, raw value cannot be serialized
 ```
 
+Using `raw()` with BigInt type currently only works with PostgresQL and MySQL.
+
 ## Upsert
 
 We can use `em.upsert()` create or update the entity, based on whether it is already present in the database. This method performs an `insert on conflict merge` query ensuring the database is in sync, returning a managed entity instance. The method accepts either `entityName` together with the entity `data`, or just entity instance.

--- a/packages/core/src/types/BigIntType.ts
+++ b/packages/core/src/types/BigIntType.ts
@@ -1,6 +1,7 @@
 import { Type } from './Type';
 import type { Platform } from '../platforms';
 import type { EntityProperty } from '../typings';
+import { RawQueryFragment } from '..';
 
 /**
  * This type will automatically convert string values returned from the database to native JS bigints (default)
@@ -16,7 +17,9 @@ export class BigIntType extends Type<string | bigint | number | null | undefined
     if (value == null) {
       return value as null | undefined;
     }
-
+    if ((value as any) instanceof RawQueryFragment) {
+      return value as any;
+    }
     return '' + value;
   }
 

--- a/tests/features/raw-queries/raw-bigint.test.ts
+++ b/tests/features/raw-queries/raw-bigint.test.ts
@@ -1,0 +1,101 @@
+import {
+  BigIntType,
+  Entity,
+  MikroORM,
+  PrimaryKey,
+  Property,
+  Options,
+  raw,
+} from '@mikro-orm/core';
+import { PLATFORMS } from '../../bootstrap';
+
+@Entity()
+class Commission {
+
+  @PrimaryKey({ name: '_id' })
+  id!: number;
+
+  @Property({ type: 'int', default: 0 })
+  age?: number;
+
+  @Property({ type: new BigIntType('bigint'), default: 0 })
+  pending?: bigint;
+
+  @Property({ type: new BigIntType('bigint'), default: 0 })
+  total?: number;
+
+  @Property({ type: new BigIntType('string'), default: 0 })
+  withdrawn?: string;
+
+}
+
+describe.each([
+  // "sqlite",
+  // "better-sqlite",
+  'mysql',
+  'postgresql',
+  // "mongo",
+] as const)('raw bigint (%s)', type => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    const options: Options = {};
+
+    if (type === 'mysql') {
+      options.port = 3308;
+    }
+    orm = await MikroORM.init({
+      entities: [Commission],
+      dbName: type.includes('sqlite') ? ':memory:' : 'raw_bigint',
+      driver: PLATFORMS[type],
+      ...options,
+    });
+    await orm.schema.refreshDatabase();
+
+    orm.em.create(Commission, {
+      id: 1,
+      age: 0,
+      pending: BigInt(1000),
+      total: 1000,
+      withdrawn: '1000',
+    });
+    await orm.em.flush();
+    orm.em.clear();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('append raw to bigint', async () => {
+    const commission = (await orm.em.findOne(Commission, 1))!;
+
+    commission.age = raw(`age + 10`);
+    commission.pending = raw(`pending + 3000`);
+    commission.total = raw(`total + 5000`);
+    commission.withdrawn = raw(`withdrawn + 9000`);
+
+    await orm.em.persistAndFlush(commission);
+
+    expect(commission.age).toBe(10);
+    expect(commission.pending).toBe(BigInt(4000));
+    expect(commission.total).toBe(6000);
+    expect(commission.withdrawn).toBe('10000');
+  });
+
+  test('append raw to bigint from reference', async () => {
+    const commission = await orm.em.getReference(Commission, 1);
+
+    commission.age = raw(`age + 10`);
+    commission.pending = raw(`pending + 6000`);
+    commission.total = raw(`total + 4000`);
+    commission.withdrawn = raw(`withdrawn + 2000`);
+
+    await orm.em.persistAndFlush(commission);
+
+    expect(commission.age).toBe(20);
+    expect(commission.pending).toBe(BigInt(10000));
+    expect(commission.total).toBe(10000);
+    expect(commission.withdrawn).toBe('12000');
+  });
+});


### PR DESCRIPTION
When using atomic raw update with bigint column, it will cause error.
```ts
   // BigIntType.js
    convertToDatabaseValue(value) {
        if (value == null) {
            return value;
        }
        return '' + value;
    }
```
The `return '' + value;` trigger `valueOf` on raw so it throws an error, the fix will check if the value is an instance of RawFragment then it will directly return that value without trigger `valueOf`
This PR fix only works with PostgresQL and MySQL.