### PR TITLE
fix(core): properly detect when Windows imports need patching

### DIFF
--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -1096,8 +1096,8 @@ export class Utils {
       } catch {
         // ignore
       }
-      // For some reason, ".ts" files do not work with "file://" URLs on Windows.
-      if (id.endsWith('.ts')) {
+      // If the extension is not registered, we need to fall back to a file path.
+      if (require.extensions && !require.extensions[extname(id)]) {
         id = fileURLToPath(id);
       }
     }


### PR DESCRIPTION
When the extension is not registered, paths are needed, both in ESM and in CJS.
When the extension is registered, file URLs are OK regardless of ESM or CJS. When the extension is registered, paths are OK in CJS, but not in ESM, which is what the original patching was meant to be doing.