### PR TITLE
fix(schema): ensure `unsigned: false` works for primary keys

### DIFF
--- a/packages/knex/src/dialects/mysql/MySqlColumnCompiler.ts
+++ b/packages/knex/src/dialects/mysql/MySqlColumnCompiler.ts
@@ -4,13 +4,15 @@ import BaseMySqlColumnCompiler from 'knex/lib/dialects/mysql/schema/mysql-column
 export class MySqlColumnCompiler extends BaseMySqlColumnCompiler {
 
   // we need the old behaviour to be able to add auto_increment to a column that is already PK
-  increments(this: any, options = { primaryKey: true }) {
-    return 'int unsigned not null auto_increment' + (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '');
+  increments(this: any, options = { primaryKey: true, unsigned: true }) {
+    const type = options.unsigned ? 'int unsigned' : 'int';
+    return `${type} not null auto_increment` + (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '');
   }
 
   /* istanbul ignore next */
-  bigincrements(this: any, options = { primaryKey: true }) {
-    return 'bigint unsigned not null auto_increment' + (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '');
+  bigincrements(this: any, options = { primaryKey: true, unsigned: true }) {
+    const type = options.unsigned ? 'bigint unsigned' : 'bigint';
+    return `${type} not null auto_increment` + (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '');
   }
 
 }

--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -127,11 +127,7 @@ export class DatabaseTable {
         extra: prop.extra,
         ignoreSchemaChanges: prop.ignoreSchemaChanges,
       };
-
-      if (this.columns[field].unsigned === undefined) {
-        this.columns[field].unsigned = this.columns[field].autoincrement;
-      }
-
+      this.columns[field].unsigned ??= this.columns[field].autoincrement;
       const defaultValue = this.platform.getSchemaHelper()!.normalizeDefaultValue(prop.defaultRaw!, prop.length);
       this.columns[field].default = defaultValue as string;
     });

--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -127,7 +127,11 @@ export class DatabaseTable {
         extra: prop.extra,
         ignoreSchemaChanges: prop.ignoreSchemaChanges,
       };
-      this.columns[field].unsigned ||= this.columns[field].autoincrement;
+
+      if (this.columns[field].unsigned === undefined) {
+        this.columns[field].unsigned = this.columns[field].autoincrement;
+      }
+
       const defaultValue = this.platform.getSchemaHelper()!.normalizeDefaultValue(prop.defaultRaw!, prop.length);
       this.columns[field].default = defaultValue as string;
     });

--- a/packages/knex/src/schema/SchemaHelper.ts
+++ b/packages/knex/src/schema/SchemaHelper.ts
@@ -9,7 +9,7 @@ import {
 import type { Knex } from 'knex';
 import type { AbstractSqlConnection } from '../AbstractSqlConnection';
 import type { AbstractSqlPlatform } from '../AbstractSqlPlatform';
-import type { CheckDef, Column, ForeignKey, IndexDef, Table, TableDifference } from '../typings';
+import type { CheckDef, Column, ExpandedTableBuilder, ForeignKey, IndexDef, Table, TableDifference } from '../typings';
 import type { DatabaseSchema } from './DatabaseSchema';
 import type { DatabaseTable } from './DatabaseTable';
 
@@ -171,17 +171,17 @@ export abstract class SchemaHelper {
     return pkIndex?.keyName !== defaultName;
   }
 
-  createTableColumn(table: Knex.TableBuilder, column: Column, fromTable: DatabaseTable, changedProperties?: Set<string>, alter?: boolean): Knex.ColumnBuilder | undefined {
+  createTableColumn(table: ExpandedTableBuilder, column: Column, fromTable: DatabaseTable, changedProperties?: Set<string>, alter?: boolean): Knex.ColumnBuilder | undefined {
     const compositePK = fromTable.getPrimaryKey()?.composite;
 
     if (column.autoincrement && !column.generated && !compositePK && (!changedProperties || changedProperties.has('autoincrement') || changedProperties.has('type'))) {
       const primaryKey = !changedProperties && !this.hasNonDefaultPrimaryKeyName(fromTable);
 
       if (column.mappedType instanceof BigIntType) {
-        return table.bigIncrements(column.name, { primaryKey });
+        return table.bigIncrements(column.name, { primaryKey, unsigned: column.unsigned });
       }
 
-      return table.increments(column.name, { primaryKey });
+      return table.increments(column.name, { primaryKey, unsigned: column.unsigned });
     }
 
     if (column.mappedType instanceof EnumType && column.enumItems?.every(item => Utils.isString(item))) {

--- a/packages/knex/src/typings.ts
+++ b/packages/knex/src/typings.ts
@@ -204,3 +204,14 @@ export interface ICriteriaNode<T extends object> {
   getPath(addIndex?: boolean): string;
   getPivotPath(path: string): string;
 }
+
+export interface ExpandedTableBuilder extends Knex.TableBuilder {
+  increments(
+    columnName?: string,
+    options?: { primaryKey?: boolean; unsigned?: boolean }
+  ): Knex.ColumnBuilder;
+  bigIncrements(
+    columnName?: string,
+    options?: { primaryKey?: boolean; unsigned?: boolean }
+  ): Knex.ColumnBuilder;
+}

--- a/tests/issues/GH6057.test.ts
+++ b/tests/issues/GH6057.test.ts
@@ -1,0 +1,165 @@
+import type { EntitySchemaMetadata } from '@mikro-orm/core';
+import { MikroORM as MySqlORM, EntitySchema as MySqlSchema } from '@mikro-orm/mysql';
+import { MikroORM as SqliteORM, EntitySchema as SqliteSchema } from '@mikro-orm/sqlite';
+import { MikroORM as PostgreSqlORM, EntitySchema as PostgreSqlSchema } from '@mikro-orm/postgresql';
+
+type Key = 'bigint1' | 'bigint2' | 'bigint3' | 'number1' | 'number2' | 'number3';
+type Property = { id: number };
+
+const entity: Record<Key, EntitySchemaMetadata<Property>> = {
+  bigint1: {
+    name: 'entity',
+    properties: { id: { primary: true, type: 'bigint', unsigned: false } },
+  },
+  bigint2: {
+    name: 'entity',
+    properties: { id: { primary: true, type: 'bigint', unsigned: true } },
+  },
+  bigint3: {
+    name: 'entity',
+    properties: { id: { primary: true, type: 'bigint' } },
+  },
+
+  number1: {
+    name: 'entity',
+    properties: { id: { primary: true, type: 'number', unsigned: false } },
+  },
+  number2: {
+    name: 'entity',
+    properties: { id: { primary: true, type: 'number', unsigned: true } },
+  },
+  number3: {
+    name: 'entity',
+    properties: { id: { primary: true, type: 'number' } },
+  },
+};
+
+describe('MySql support unsigned increment pk.', () => {
+  const dbInfo = { dbName: 'GH6057', port: 3308 };
+
+  test('Should be non-unsigned bigint.', async () => {
+    const nonUnsignedBigintRegex = /^create table `entity` \(`id` bigint not null auto_increment primary key\).*/;
+
+    const orm1 = await MySqlORM.init({ entities: [new MySqlSchema(entity.bigint1)], ...dbInfo });
+    const sql1 = await orm1.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql1).toMatch(nonUnsignedBigintRegex);
+    await orm1.close();
+  });
+
+  test('Should be unsigned bigint.', async () => {
+    const unsignedBigintRegex = /^create table `entity` \(`id` bigint unsigned not null auto_increment primary key\).*/;
+
+    const orm2 = await MySqlORM.init({ entities: [new MySqlSchema(entity.bigint2)], ...dbInfo });
+    const sql2 = await orm2.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql2).toMatch(unsignedBigintRegex);
+    await orm2.close();
+
+    const orm3 = await MySqlORM.init({ entities: [new MySqlSchema(entity.bigint3)], ...dbInfo });
+    const sql3 = await orm3.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql3).toMatch(unsignedBigintRegex);
+    await orm3.close();
+  });
+
+  test('Should be non-unsigned int.', async () => {
+    const nonUnsignedIntRegex = /^create table `entity` \(`id` int not null auto_increment primary key\).*/;
+
+    const orm4 = await MySqlORM.init({ entities: [new MySqlSchema(entity.number1)], ...dbInfo });
+    const sql4 = await orm4.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql4).toMatch(nonUnsignedIntRegex);
+    await orm4.close();
+  });
+
+  test('Should be unsigned int.', async () => {
+    const unsignedIntRegex = /^create table `entity` \(`id` int unsigned not null auto_increment primary key\).*/;
+
+    const orm5 = await MySqlORM.init({ entities: [new MySqlSchema(entity.number2)], ...dbInfo });
+    const sql5 = await orm5.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql5).toMatch(unsignedIntRegex);
+    await orm5.close();
+
+    const orm6 = await MySqlORM.init({ entities: [new MySqlSchema(entity.number3)], ...dbInfo });
+    const sql6 = await orm6.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql6).toMatch(unsignedIntRegex);
+    await orm6.close();
+  });
+});
+
+describe('Sqlite not support unsigned increment pk.', () => {
+  const dbInfo = { dbName: 'GH6057' };
+
+  test('Should be non-unsigned integer.', async () => {
+    const nonUnsignedIntegerRegex = /^create table `entity` \(`id` integer not null primary key autoincrement\).*/;
+
+    const orm1 = await SqliteORM.init({ entities: [new SqliteSchema(entity.bigint1)], ...dbInfo });
+    const sql1 = await orm1.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql1).toMatch(nonUnsignedIntegerRegex);
+    await orm1.close();
+
+    const orm2 = await SqliteORM.init({ entities: [new SqliteSchema(entity.bigint2)], ...dbInfo });
+    const sql2 = await orm2.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql2).toMatch(nonUnsignedIntegerRegex);
+    await orm2.close();
+
+    const orm3 = await SqliteORM.init({ entities: [new SqliteSchema(entity.bigint3)], ...dbInfo });
+    const sql3 = await orm3.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql3).toMatch(nonUnsignedIntegerRegex);
+    await orm3.close();
+
+    const orm4 = await SqliteORM.init({ entities: [new SqliteSchema(entity.number1)], ...dbInfo });
+    const sql4 = await orm4.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql4).toMatch(nonUnsignedIntegerRegex);
+    await orm4.close();
+
+    const orm5 = await SqliteORM.init({ entities: [new SqliteSchema(entity.number2)], ...dbInfo });
+    const sql5 = await orm5.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql5).toMatch(nonUnsignedIntegerRegex);
+    await orm5.close();
+
+    const orm6 = await SqliteORM.init({ entities: [new SqliteSchema(entity.number3)], ...dbInfo });
+    const sql6 = await orm6.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql6).toMatch(nonUnsignedIntegerRegex);
+    await orm6.close();
+  });
+});
+
+describe('PostgreSql not support unsigned increment pk.', () => {
+  const dbInfo = { dbName: 'GH6057' };
+
+  test('Should be non-unsigned bigserial.', async () => {
+    const nonUnsignedBigserialRegex = /^create table "entity" \("id" bigserial primary key\);.*/;
+
+    const orm1 = await PostgreSqlORM.init({ entities: [new PostgreSqlSchema(entity.bigint1)], ...dbInfo });
+    const sql1 = await orm1.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql1.trim()).toMatch(nonUnsignedBigserialRegex);
+    await orm1.close();
+
+    const orm2 = await PostgreSqlORM.init({ entities: [new PostgreSqlSchema(entity.bigint2)], ...dbInfo });
+    const sql2 = await orm2.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql2.trim()).toMatch(nonUnsignedBigserialRegex);
+    await orm2.close();
+
+    const orm3 = await PostgreSqlORM.init({ entities: [new PostgreSqlSchema(entity.bigint3)], ...dbInfo });
+    const sql3 = await orm3.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql3.trim()).toMatch(nonUnsignedBigserialRegex);
+    await orm3.close();
+  });
+
+  test('Should be non-unsigned serial.', async () => {
+    const nonUnsignedSerialRegex = /^create table "entity" \("id" serial primary key\);.*/;
+
+    const orm4 = await PostgreSqlORM.init({ entities: [new PostgreSqlSchema(entity.number1)], ...dbInfo });
+    const sql4 = await orm4.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql4.trim()).toMatch(nonUnsignedSerialRegex);
+    await orm4.close();
+
+    const orm5 = await PostgreSqlORM.init({ entities: [new PostgreSqlSchema(entity.number2)], ...dbInfo });
+    const sql5 = await orm5.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql5.trim()).toMatch(nonUnsignedSerialRegex);
+    await orm5.close();
+
+    const orm6 = await PostgreSqlORM.init({ entities: [new PostgreSqlSchema(entity.number3)], ...dbInfo });
+    const sql6 = await orm6.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql6.trim()).toMatch(nonUnsignedSerialRegex);
+    await orm6.close();
+  });
+});

--- a/tests/issues/GH6057.test.ts
+++ b/tests/issues/GH6057.test.ts
@@ -85,7 +85,7 @@ describe('MySql support unsigned increment pk.', () => {
 });
 
 describe('Sqlite not support unsigned increment pk.', () => {
-  const dbInfo = { dbName: 'GH6057' };
+  const dbInfo = { dbName: ':memory:' };
 
   test('Should be non-unsigned integer.', async () => {
     const nonUnsignedIntegerRegex = /^create table `entity` \(`id` integer not null primary key autoincrement\).*/;

--- a/tests/issues/GH6057.test.ts
+++ b/tests/issues/GH6057.test.ts
@@ -1,9 +1,9 @@
-import type { EntitySchemaMetadata } from '@mikro-orm/core';
-import { MikroORM as MySqlORM, EntitySchema as MySqlSchema } from '@mikro-orm/mysql';
-import { MikroORM as SqliteORM, EntitySchema as SqliteSchema } from '@mikro-orm/sqlite';
-import { MikroORM as PostgreSqlORM, EntitySchema as PostgreSqlSchema } from '@mikro-orm/postgresql';
+import { EntitySchema, type EntitySchemaMetadata, type Options } from '@mikro-orm/core';
+import { MikroORM as MySqlORM } from '@mikro-orm/mysql';
+import { MikroORM as MariaDbORM } from '@mikro-orm/mariadb';
 
 type Key = 'bigint1' | 'bigint2' | 'bigint3' | 'number1' | 'number2' | 'number3';
+
 type Property = { id: number };
 
 const entity: Record<Key, EntitySchemaMetadata<Property>> = {
@@ -34,132 +34,102 @@ const entity: Record<Key, EntitySchemaMetadata<Property>> = {
   },
 };
 
-describe('MySql support unsigned increment pk.', () => {
-  const dbInfo = { dbName: 'GH6057', port: 3308 };
+describe('MySQL supports unsigned increment primary keys.', () => {
+  const dbInfo: Options = { dbName: 'GH6057-mysql', port: 3308 };
 
-  test('Should be non-unsigned bigint.', async () => {
-    const nonUnsignedBigintRegex = /^create table `entity` \(`id` bigint not null auto_increment primary key\).*/;
+  test('Should be signed bigint.', async () => {
+    const signedBigintRegex = /^create table `entity` \(`id` bigint not null auto_increment primary key\).*/;
 
-    const orm1 = await MySqlORM.init({ entities: [new MySqlSchema(entity.bigint1)], ...dbInfo });
+    const orm1 = await MySqlORM.init({ entities: [new EntitySchema(entity.bigint1)], ...dbInfo });
     const sql1 = await orm1.schema.getCreateSchemaSQL({ wrap: false });
-    expect(sql1).toMatch(nonUnsignedBigintRegex);
+    expect(sql1).toMatch(signedBigintRegex);
     await orm1.close();
   });
 
   test('Should be unsigned bigint.', async () => {
     const unsignedBigintRegex = /^create table `entity` \(`id` bigint unsigned not null auto_increment primary key\).*/;
 
-    const orm2 = await MySqlORM.init({ entities: [new MySqlSchema(entity.bigint2)], ...dbInfo });
+    const orm2 = await MySqlORM.init({ entities: [new EntitySchema(entity.bigint2)], ...dbInfo });
     const sql2 = await orm2.schema.getCreateSchemaSQL({ wrap: false });
     expect(sql2).toMatch(unsignedBigintRegex);
     await orm2.close();
 
-    const orm3 = await MySqlORM.init({ entities: [new MySqlSchema(entity.bigint3)], ...dbInfo });
+    const orm3 = await MySqlORM.init({ entities: [new EntitySchema(entity.bigint3)], ...dbInfo });
     const sql3 = await orm3.schema.getCreateSchemaSQL({ wrap: false });
     expect(sql3).toMatch(unsignedBigintRegex);
     await orm3.close();
   });
 
-  test('Should be non-unsigned int.', async () => {
-    const nonUnsignedIntRegex = /^create table `entity` \(`id` int not null auto_increment primary key\).*/;
+  test('Should be signed int.', async () => {
+    const signedIntRegex = /^create table `entity` \(`id` int not null auto_increment primary key\).*/;
 
-    const orm4 = await MySqlORM.init({ entities: [new MySqlSchema(entity.number1)], ...dbInfo });
+    const orm4 = await MySqlORM.init({ entities: [new EntitySchema(entity.number1)], ...dbInfo });
     const sql4 = await orm4.schema.getCreateSchemaSQL({ wrap: false });
-    expect(sql4).toMatch(nonUnsignedIntRegex);
+    expect(sql4).toMatch(signedIntRegex);
     await orm4.close();
   });
 
   test('Should be unsigned int.', async () => {
     const unsignedIntRegex = /^create table `entity` \(`id` int unsigned not null auto_increment primary key\).*/;
 
-    const orm5 = await MySqlORM.init({ entities: [new MySqlSchema(entity.number2)], ...dbInfo });
+    const orm5 = await MySqlORM.init({ entities: [new EntitySchema(entity.number2)], ...dbInfo });
     const sql5 = await orm5.schema.getCreateSchemaSQL({ wrap: false });
     expect(sql5).toMatch(unsignedIntRegex);
     await orm5.close();
 
-    const orm6 = await MySqlORM.init({ entities: [new MySqlSchema(entity.number3)], ...dbInfo });
+    const orm6 = await MySqlORM.init({ entities: [new EntitySchema(entity.number3)], ...dbInfo });
     const sql6 = await orm6.schema.getCreateSchemaSQL({ wrap: false });
     expect(sql6).toMatch(unsignedIntRegex);
     await orm6.close();
   });
 });
 
-describe('Sqlite not support unsigned increment pk.', () => {
-  const dbInfo = { dbName: ':memory:' };
+describe('MariaDB supports unsigned increment primary keys.', () => {
+  const dbInfo: Options = { dbName: 'GH6057-mariadb', port: 3309 };
 
-  test('Should be non-unsigned integer.', async () => {
-    const nonUnsignedIntegerRegex = /^create table `entity` \(`id` integer not null primary key autoincrement\).*/;
+  test('Should be signed bigint.', async () => {
+    const signedBigintRegex = /^create table `entity` \(`id` bigint not null auto_increment primary key\).*/;
 
-    const orm1 = await SqliteORM.init({ entities: [new SqliteSchema(entity.bigint1)], ...dbInfo });
+    const orm1 = await MariaDbORM.init({ entities: [new EntitySchema(entity.bigint1)], ...dbInfo });
     const sql1 = await orm1.schema.getCreateSchemaSQL({ wrap: false });
-    expect(sql1).toMatch(nonUnsignedIntegerRegex);
+    expect(sql1).toMatch(signedBigintRegex);
     await orm1.close();
-
-    const orm2 = await SqliteORM.init({ entities: [new SqliteSchema(entity.bigint2)], ...dbInfo });
-    const sql2 = await orm2.schema.getCreateSchemaSQL({ wrap: false });
-    expect(sql2).toMatch(nonUnsignedIntegerRegex);
-    await orm2.close();
-
-    const orm3 = await SqliteORM.init({ entities: [new SqliteSchema(entity.bigint3)], ...dbInfo });
-    const sql3 = await orm3.schema.getCreateSchemaSQL({ wrap: false });
-    expect(sql3).toMatch(nonUnsignedIntegerRegex);
-    await orm3.close();
-
-    const orm4 = await SqliteORM.init({ entities: [new SqliteSchema(entity.number1)], ...dbInfo });
-    const sql4 = await orm4.schema.getCreateSchemaSQL({ wrap: false });
-    expect(sql4).toMatch(nonUnsignedIntegerRegex);
-    await orm4.close();
-
-    const orm5 = await SqliteORM.init({ entities: [new SqliteSchema(entity.number2)], ...dbInfo });
-    const sql5 = await orm5.schema.getCreateSchemaSQL({ wrap: false });
-    expect(sql5).toMatch(nonUnsignedIntegerRegex);
-    await orm5.close();
-
-    const orm6 = await SqliteORM.init({ entities: [new SqliteSchema(entity.number3)], ...dbInfo });
-    const sql6 = await orm6.schema.getCreateSchemaSQL({ wrap: false });
-    expect(sql6).toMatch(nonUnsignedIntegerRegex);
-    await orm6.close();
   });
-});
 
-describe('PostgreSql not support unsigned increment pk.', () => {
-  const dbInfo = { dbName: 'GH6057' };
+  test('Should be unsigned bigint.', async () => {
+    const unsignedBigintRegex = /^create table `entity` \(`id` bigint unsigned not null auto_increment primary key\).*/;
 
-  test('Should be non-unsigned bigserial.', async () => {
-    const nonUnsignedBigserialRegex = /^create table "entity" \("id" bigserial primary key\);.*/;
-
-    const orm1 = await PostgreSqlORM.init({ entities: [new PostgreSqlSchema(entity.bigint1)], ...dbInfo });
-    const sql1 = await orm1.schema.getCreateSchemaSQL({ wrap: false });
-    expect(sql1.trim()).toMatch(nonUnsignedBigserialRegex);
-    await orm1.close();
-
-    const orm2 = await PostgreSqlORM.init({ entities: [new PostgreSqlSchema(entity.bigint2)], ...dbInfo });
+    const orm2 = await MariaDbORM.init({ entities: [new EntitySchema(entity.bigint2)], ...dbInfo });
     const sql2 = await orm2.schema.getCreateSchemaSQL({ wrap: false });
-    expect(sql2.trim()).toMatch(nonUnsignedBigserialRegex);
+    expect(sql2).toMatch(unsignedBigintRegex);
     await orm2.close();
 
-    const orm3 = await PostgreSqlORM.init({ entities: [new PostgreSqlSchema(entity.bigint3)], ...dbInfo });
+    const orm3 = await MariaDbORM.init({ entities: [new EntitySchema(entity.bigint3)], ...dbInfo });
     const sql3 = await orm3.schema.getCreateSchemaSQL({ wrap: false });
-    expect(sql3.trim()).toMatch(nonUnsignedBigserialRegex);
+    expect(sql3).toMatch(unsignedBigintRegex);
     await orm3.close();
   });
 
-  test('Should be non-unsigned serial.', async () => {
-    const nonUnsignedSerialRegex = /^create table "entity" \("id" serial primary key\);.*/;
+  test('Should be signed int.', async () => {
+    const signedIntRegex = /^create table `entity` \(`id` int not null auto_increment primary key\).*/;
 
-    const orm4 = await PostgreSqlORM.init({ entities: [new PostgreSqlSchema(entity.number1)], ...dbInfo });
+    const orm4 = await MariaDbORM.init({ entities: [new EntitySchema(entity.number1)], ...dbInfo });
     const sql4 = await orm4.schema.getCreateSchemaSQL({ wrap: false });
-    expect(sql4.trim()).toMatch(nonUnsignedSerialRegex);
+    expect(sql4).toMatch(signedIntRegex);
     await orm4.close();
+  });
 
-    const orm5 = await PostgreSqlORM.init({ entities: [new PostgreSqlSchema(entity.number2)], ...dbInfo });
+  test('Should be unsigned int.', async () => {
+    const unsignedIntRegex = /^create table `entity` \(`id` int unsigned not null auto_increment primary key\).*/;
+
+    const orm5 = await MariaDbORM.init({ entities: [new EntitySchema(entity.number2)], ...dbInfo });
     const sql5 = await orm5.schema.getCreateSchemaSQL({ wrap: false });
-    expect(sql5.trim()).toMatch(nonUnsignedSerialRegex);
+    expect(sql5).toMatch(unsignedIntRegex);
     await orm5.close();
 
-    const orm6 = await PostgreSqlORM.init({ entities: [new PostgreSqlSchema(entity.number3)], ...dbInfo });
+    const orm6 = await MariaDbORM.init({ entities: [new EntitySchema(entity.number3)], ...dbInfo });
     const sql6 = await orm6.schema.getCreateSchemaSQL({ wrap: false });
-    expect(sql6.trim()).toMatch(nonUnsignedSerialRegex);
+    expect(sql6).toMatch(unsignedIntRegex);
     await orm6.close();
   });
 });


### PR DESCRIPTION
Support for the unsigned attribute on auto-incrementing primary keys seems to be a special case that is likely only supported by MySQL.
Previous source code seemed to be designed to generate DDL for MySQL without considering unsigned property, similar to how it handles schema generation for other databases.

In scenarios where the unsigned option needs to be passed, the code relied on the external knex package's types.
To address this, I modified the code to extend these types.
Initially, I attempted to override interface types within namespace using `declare module`, but encountered type conflicts.
As a solution, I chose to inherit from the existing TableBuilder interface.

Closes #6057