### PR TITLE
fix(schema): ensure `CREATE TABLE` DDL for `tinyint/smallint/mediumint` primary keys

### DIFF
--- a/packages/knex/src/dialects/mysql/MySqlColumnCompiler.ts
+++ b/packages/knex/src/dialects/mysql/MySqlColumnCompiler.ts
@@ -1,18 +1,25 @@
 // @ts-ignore
 import BaseMySqlColumnCompiler from 'knex/lib/dialects/mysql/schema/mysql-columncompiler';
+import type { IncrementOptions } from '../../typings';
 
 export class MySqlColumnCompiler extends BaseMySqlColumnCompiler {
 
   // we need the old behaviour to be able to add auto_increment to a column that is already PK
-  increments(this: any, options = { primaryKey: true, unsigned: true }) {
-    const type = options.unsigned ? 'int unsigned' : 'int';
-    return `${type} not null auto_increment` + (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '');
+  increments(options: IncrementOptions) {
+    return this.generateDDL(options);
   }
 
   /* istanbul ignore next */
-  bigincrements(this: any, options = { primaryKey: true, unsigned: true }) {
-    const type = options.unsigned ? 'bigint unsigned' : 'bigint';
-    return `${type} not null auto_increment` + (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '');
+  bigincrements(options: IncrementOptions) {
+    return this.generateDDL(options);
+  }
+
+  private generateDDL(this: any, options: IncrementOptions = {}) {
+    const { primaryKey = true, unsigned = true, type = 'int' } = options;
+    return type
+      + (unsigned ? ' unsigned' : '')
+      + ' not null auto_increment'
+      + (this.tableCompiler._canBeAddPrimaryKey({ primaryKey }) ? ' primary key' : '');
   }
 
 }

--- a/packages/knex/src/dialects/mysql/MySqlSchemaHelper.ts
+++ b/packages/knex/src/dialects/mysql/MySqlSchemaHelper.ts
@@ -4,7 +4,6 @@ import { EnumType, StringType, TextType, type Dictionary, type Type } from '@mik
 import type { AbstractSqlConnection } from '../../AbstractSqlConnection';
 import { SchemaHelper } from '../../schema/SchemaHelper';
 import type { DatabaseSchema } from '../../schema/DatabaseSchema';
-import type { DatabaseTable } from '../../schema/DatabaseTable';
 
 export class MySqlSchemaHelper extends SchemaHelper {
 
@@ -252,14 +251,6 @@ export class MySqlSchemaHelper extends SchemaHelper {
     const columnName = this.platform.quoteIdentifier(to.name);
 
     return `alter table ${tableName} modify ${columnName} ${this.getColumnDeclarationSQL(to)}`;
-  }
-
-  override createTableColumn(table: Knex.TableBuilder, column: Column, fromTable: DatabaseTable, changedProperties?: Set<string>) {
-    return super.createTableColumn(table, column, fromTable, changedProperties);
-  }
-
-  override configureColumn(column: Column, col: Knex.ColumnBuilder, knex: Knex, changedProperties?: Set<string>) {
-    return super.configureColumn(column, col, knex, changedProperties);
   }
 
   private getColumnDeclarationSQL(col: Column, addPrimary = false): string {

--- a/packages/knex/src/dialects/mysql/MySqlSchemaHelper.ts
+++ b/packages/knex/src/dialects/mysql/MySqlSchemaHelper.ts
@@ -1,6 +1,6 @@
 import type { Knex } from 'knex';
 import type { CheckDef, Column, IndexDef, TableDifference, Table, ForeignKey } from '../../typings';
-import { EnumType, StringType, TextType, MediumIntType, type Dictionary, type Type } from '@mikro-orm/core';
+import { EnumType, StringType, TextType, type Dictionary, type Type } from '@mikro-orm/core';
 import type { AbstractSqlConnection } from '../../AbstractSqlConnection';
 import { SchemaHelper } from '../../schema/SchemaHelper';
 import type { DatabaseSchema } from '../../schema/DatabaseSchema';
@@ -255,18 +255,10 @@ export class MySqlSchemaHelper extends SchemaHelper {
   }
 
   override createTableColumn(table: Knex.TableBuilder, column: Column, fromTable: DatabaseTable, changedProperties?: Set<string>) {
-    if (column.mappedType instanceof MediumIntType) {
-      return table.specificType(column.name, this.getColumnDeclarationSQL(column, true));
-    }
-
     return super.createTableColumn(table, column, fromTable, changedProperties);
   }
 
   override configureColumn(column: Column, col: Knex.ColumnBuilder, knex: Knex, changedProperties?: Set<string>) {
-    if (column.mappedType instanceof MediumIntType) {
-      return col;
-    }
-
     return super.configureColumn(column, col, knex, changedProperties);
   }
 

--- a/packages/knex/src/schema/SchemaHelper.ts
+++ b/packages/knex/src/schema/SchemaHelper.ts
@@ -178,10 +178,10 @@ export abstract class SchemaHelper {
       const primaryKey = !changedProperties && !this.hasNonDefaultPrimaryKeyName(fromTable);
 
       if (column.mappedType instanceof BigIntType) {
-        return table.bigIncrements(column.name, { primaryKey, unsigned: column.unsigned });
+        return table.bigIncrements(column.name, { primaryKey, unsigned: column.unsigned, type: column.type });
       }
 
-      return table.increments(column.name, { primaryKey, unsigned: column.unsigned });
+      return table.increments(column.name, { primaryKey, unsigned: column.unsigned, type: column.type });
     }
 
     if (column.mappedType instanceof EnumType && column.enumItems?.every(item => Utils.isString(item))) {

--- a/packages/knex/src/typings.ts
+++ b/packages/knex/src/typings.ts
@@ -205,13 +205,9 @@ export interface ICriteriaNode<T extends object> {
   getPivotPath(path: string): string;
 }
 
+export type IncrementOptions = { primaryKey?: boolean; unsigned?: boolean; type?: Column['type'] };
+
 export interface ExpandedTableBuilder extends Knex.TableBuilder {
-  increments(
-    columnName?: string,
-    options?: { primaryKey?: boolean; unsigned?: boolean }
-  ): Knex.ColumnBuilder;
-  bigIncrements(
-    columnName?: string,
-    options?: { primaryKey?: boolean; unsigned?: boolean }
-  ): Knex.ColumnBuilder;
+  increments(columnName?: string, options?: IncrementOptions,): Knex.ColumnBuilder;
+  bigIncrements(columnName?: string, options?: IncrementOptions,): Knex.ColumnBuilder;
 }

--- a/tests/features/schema-generator/SchemaGenerator.mysql.test.ts
+++ b/tests/features/schema-generator/SchemaGenerator.mysql.test.ts
@@ -70,7 +70,7 @@ describe('SchemaGenerator', () => {
           name: 'id',
           type: 'number',
           fieldNames: ['id'],
-          columnTypes: ['int unsigned auto_increment'],
+          columnTypes: ['int'],
           autoincrement: true,
         },
         createdAt: {

--- a/tests/features/schema-generator/__snapshots__/GH3230.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/GH3230.test.ts.snap
@@ -3,9 +3,9 @@
 exports[`mediumint column type in mysql as FK 1`] = `
 "set names utf8mb4;
 
-create table \`author\` (\`id\` mediumint unsigned auto_increment not null primary key, \`name\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+create table \`author\` (\`id\` mediumint unsigned not null auto_increment primary key, \`name\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
 
-create table \`book\` (\`book_id\` mediumint unsigned auto_increment not null primary key, \`title\` varchar(255) not null, \`author_id\` mediumint unsigned not null) default character set utf8mb4 engine = InnoDB;
+create table \`book\` (\`book_id\` mediumint unsigned not null auto_increment primary key, \`title\` varchar(255) not null, \`author_id\` mediumint unsigned not null) default character set utf8mb4 engine = InnoDB;
 alter table \`book\` add index \`book_author_id_index\`(\`author_id\`);
 
 alter table \`book\` add constraint \`book_author_id_foreign\` foreign key (\`author_id\`) references \`author\` (\`id\`) on update cascade;

--- a/tests/issues/GH5996.test.ts
+++ b/tests/issues/GH5996.test.ts
@@ -1,0 +1,72 @@
+import { EntitySchema, type EntitySchemaMetadata, MikroORM, type Options } from '@mikro-orm/core';
+import { MikroORM as MySqlORM } from '@mikro-orm/mysql';
+import { MikroORM as MariaDbORM } from '@mikro-orm/mariadb';
+
+type Key = 'tinyint' | 'smallint' | 'mediumint';
+
+type Property = { id: number };
+
+const entity: Record<Key, EntitySchemaMetadata<Property>> = {
+  tinyint: {
+    name: 'entity',
+    properties: { id: { primary: true, type: 'tinyint' } },
+  },
+  smallint: {
+    name: 'entity',
+    properties: { id: { primary: true, type: 'smallint' } },
+  },
+  mediumint: {
+    name: 'entity',
+    properties: { id: { primary: true, type: 'mediumint' } },
+  },
+};
+
+let orm: MikroORM;
+
+afterEach(async () => {
+  await orm.close(true);
+});
+
+describe('MySQL supports tinyint/smallint/mediumint primary keys', () => {
+  const dbInfo: Options = { dbName: 'GH5996-mysql', port: 3308 };
+
+  test('Should be tinyint.', async () => {
+    orm = await MySqlORM.init({ entities: [new EntitySchema(entity.tinyint)], ...dbInfo });
+    const sql1 = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql1).toMatch(/^create table `entity` \(`id` tinyint unsigned not null auto_increment primary key\).*/);
+  });
+
+  test('Should be smallint.', async () => {
+    orm = await MySqlORM.init({ entities: [new EntitySchema(entity.smallint)], ...dbInfo });
+    const sql1 = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql1).toMatch(/^create table `entity` \(`id` smallint unsigned not null auto_increment primary key\).*/);
+  });
+
+  test('Should be mediumint.', async () => {
+    orm = await MySqlORM.init({ entities: [new EntitySchema(entity.mediumint)], ...dbInfo });
+    const sql1 = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql1).toMatch(/^create table `entity` \(`id` mediumint unsigned not null auto_increment primary key\).*/);
+  });
+});
+
+describe('MariaDB supports tinyint/smallint/mediumint primary keys', () => {
+  const dbInfo: Options = { dbName: 'GH5996-mariadb', port: 3309 };
+
+  test('Should be tinyint.', async () => {
+    orm = await MariaDbORM.init({ entities: [new EntitySchema(entity.tinyint)], ...dbInfo });
+    const sql1 = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql1).toMatch(/^create table `entity` \(`id` tinyint unsigned not null auto_increment primary key\).*/);
+  });
+
+  test('Should be smallint.', async () => {
+    orm = await MariaDbORM.init({ entities: [new EntitySchema(entity.smallint)], ...dbInfo });
+    const sql1 = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql1).toMatch(/^create table `entity` \(`id` smallint unsigned not null auto_increment primary key\).*/);
+  });
+
+  test('Should be mediumint.', async () => {
+    orm = await MariaDbORM.init({ entities: [new EntitySchema(entity.mediumint)], ...dbInfo });
+    const sql1 = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql1).toMatch(/^create table `entity` \(`id` mediumint unsigned not null auto_increment primary key\).*/);
+  });
+});

--- a/tests/issues/GH6057.test.ts
+++ b/tests/issues/GH6057.test.ts
@@ -1,4 +1,4 @@
-import { EntitySchema, type EntitySchemaMetadata, type Options } from '@mikro-orm/core';
+import { EntitySchema, type EntitySchemaMetadata, MikroORM, type Options } from '@mikro-orm/core';
 import { MikroORM as MySqlORM } from '@mikro-orm/mysql';
 import { MikroORM as MariaDbORM } from '@mikro-orm/mariadb';
 
@@ -34,53 +34,53 @@ const entity: Record<Key, EntitySchemaMetadata<Property>> = {
   },
 };
 
+let orm: MikroORM;
+
+afterEach(async () => {
+  await orm.close(true);
+});
+
 describe('MySQL supports unsigned increment primary keys.', () => {
   const dbInfo: Options = { dbName: 'GH6057-mysql', port: 3308 };
 
   test('Should be signed bigint.', async () => {
     const signedBigintRegex = /^create table `entity` \(`id` bigint not null auto_increment primary key\).*/;
 
-    const orm1 = await MySqlORM.init({ entities: [new EntitySchema(entity.bigint1)], ...dbInfo });
-    const sql1 = await orm1.schema.getCreateSchemaSQL({ wrap: false });
+    orm = await MySqlORM.init({ entities: [new EntitySchema(entity.bigint1)], ...dbInfo });
+    const sql1 = await orm.schema.getCreateSchemaSQL({ wrap: false });
     expect(sql1).toMatch(signedBigintRegex);
-    await orm1.close();
   });
 
   test('Should be unsigned bigint.', async () => {
     const unsignedBigintRegex = /^create table `entity` \(`id` bigint unsigned not null auto_increment primary key\).*/;
 
-    const orm2 = await MySqlORM.init({ entities: [new EntitySchema(entity.bigint2)], ...dbInfo });
-    const sql2 = await orm2.schema.getCreateSchemaSQL({ wrap: false });
+    orm = await MySqlORM.init({ entities: [new EntitySchema(entity.bigint2)], ...dbInfo });
+    const sql2 = await orm.schema.getCreateSchemaSQL({ wrap: false });
     expect(sql2).toMatch(unsignedBigintRegex);
-    await orm2.close();
 
-    const orm3 = await MySqlORM.init({ entities: [new EntitySchema(entity.bigint3)], ...dbInfo });
-    const sql3 = await orm3.schema.getCreateSchemaSQL({ wrap: false });
+    orm = await MySqlORM.init({ entities: [new EntitySchema(entity.bigint3)], ...dbInfo });
+    const sql3 = await orm.schema.getCreateSchemaSQL({ wrap: false });
     expect(sql3).toMatch(unsignedBigintRegex);
-    await orm3.close();
   });
 
   test('Should be signed int.', async () => {
     const signedIntRegex = /^create table `entity` \(`id` int not null auto_increment primary key\).*/;
 
-    const orm4 = await MySqlORM.init({ entities: [new EntitySchema(entity.number1)], ...dbInfo });
-    const sql4 = await orm4.schema.getCreateSchemaSQL({ wrap: false });
+    orm = await MySqlORM.init({ entities: [new EntitySchema(entity.number1)], ...dbInfo });
+    const sql4 = await orm.schema.getCreateSchemaSQL({ wrap: false });
     expect(sql4).toMatch(signedIntRegex);
-    await orm4.close();
   });
 
   test('Should be unsigned int.', async () => {
     const unsignedIntRegex = /^create table `entity` \(`id` int unsigned not null auto_increment primary key\).*/;
 
-    const orm5 = await MySqlORM.init({ entities: [new EntitySchema(entity.number2)], ...dbInfo });
-    const sql5 = await orm5.schema.getCreateSchemaSQL({ wrap: false });
+    orm = await MySqlORM.init({ entities: [new EntitySchema(entity.number2)], ...dbInfo });
+    const sql5 = await orm.schema.getCreateSchemaSQL({ wrap: false });
     expect(sql5).toMatch(unsignedIntRegex);
-    await orm5.close();
 
-    const orm6 = await MySqlORM.init({ entities: [new EntitySchema(entity.number3)], ...dbInfo });
-    const sql6 = await orm6.schema.getCreateSchemaSQL({ wrap: false });
+    orm = await MySqlORM.init({ entities: [new EntitySchema(entity.number3)], ...dbInfo });
+    const sql6 = await orm.schema.getCreateSchemaSQL({ wrap: false });
     expect(sql6).toMatch(unsignedIntRegex);
-    await orm6.close();
   });
 });
 
@@ -90,46 +90,40 @@ describe('MariaDB supports unsigned increment primary keys.', () => {
   test('Should be signed bigint.', async () => {
     const signedBigintRegex = /^create table `entity` \(`id` bigint not null auto_increment primary key\).*/;
 
-    const orm1 = await MariaDbORM.init({ entities: [new EntitySchema(entity.bigint1)], ...dbInfo });
-    const sql1 = await orm1.schema.getCreateSchemaSQL({ wrap: false });
+    orm = await MariaDbORM.init({ entities: [new EntitySchema(entity.bigint1)], ...dbInfo });
+    const sql1 = await orm.schema.getCreateSchemaSQL({ wrap: false });
     expect(sql1).toMatch(signedBigintRegex);
-    await orm1.close();
   });
 
   test('Should be unsigned bigint.', async () => {
     const unsignedBigintRegex = /^create table `entity` \(`id` bigint unsigned not null auto_increment primary key\).*/;
 
-    const orm2 = await MariaDbORM.init({ entities: [new EntitySchema(entity.bigint2)], ...dbInfo });
-    const sql2 = await orm2.schema.getCreateSchemaSQL({ wrap: false });
+    orm = await MariaDbORM.init({ entities: [new EntitySchema(entity.bigint2)], ...dbInfo });
+    const sql2 = await orm.schema.getCreateSchemaSQL({ wrap: false });
     expect(sql2).toMatch(unsignedBigintRegex);
-    await orm2.close();
 
-    const orm3 = await MariaDbORM.init({ entities: [new EntitySchema(entity.bigint3)], ...dbInfo });
-    const sql3 = await orm3.schema.getCreateSchemaSQL({ wrap: false });
+    orm = await MariaDbORM.init({ entities: [new EntitySchema(entity.bigint3)], ...dbInfo });
+    const sql3 = await orm.schema.getCreateSchemaSQL({ wrap: false });
     expect(sql3).toMatch(unsignedBigintRegex);
-    await orm3.close();
   });
 
   test('Should be signed int.', async () => {
     const signedIntRegex = /^create table `entity` \(`id` int not null auto_increment primary key\).*/;
 
-    const orm4 = await MariaDbORM.init({ entities: [new EntitySchema(entity.number1)], ...dbInfo });
-    const sql4 = await orm4.schema.getCreateSchemaSQL({ wrap: false });
+    orm = await MariaDbORM.init({ entities: [new EntitySchema(entity.number1)], ...dbInfo });
+    const sql4 = await orm.schema.getCreateSchemaSQL({ wrap: false });
     expect(sql4).toMatch(signedIntRegex);
-    await orm4.close();
   });
 
   test('Should be unsigned int.', async () => {
     const unsignedIntRegex = /^create table `entity` \(`id` int unsigned not null auto_increment primary key\).*/;
 
-    const orm5 = await MariaDbORM.init({ entities: [new EntitySchema(entity.number2)], ...dbInfo });
-    const sql5 = await orm5.schema.getCreateSchemaSQL({ wrap: false });
+    orm = await MariaDbORM.init({ entities: [new EntitySchema(entity.number2)], ...dbInfo });
+    const sql5 = await orm.schema.getCreateSchemaSQL({ wrap: false });
     expect(sql5).toMatch(unsignedIntRegex);
-    await orm5.close();
 
-    const orm6 = await MariaDbORM.init({ entities: [new EntitySchema(entity.number3)], ...dbInfo });
-    const sql6 = await orm6.schema.getCreateSchemaSQL({ wrap: false });
+    orm = await MariaDbORM.init({ entities: [new EntitySchema(entity.number3)], ...dbInfo });
+    const sql6 = await orm.schema.getCreateSchemaSQL({ wrap: false });
     expect(sql6).toMatch(unsignedIntRegex);
-    await orm6.close();
   });
 });


### PR DESCRIPTION
Modified the handling of `tinyint/smallint/mediumint` primary keys to be consistent with `int/bigint`.
This involved removing branching code specific to `MediumIntType` and making minor adjustments to existing test code.