### PR TITLE
fix(query-builder): ensure cached `execute('get')` returns a single result instead of an array

### DIFF
--- a/packages/knex/src/query/QueryBuilder.ts
+++ b/packages/knex/src/query/QueryBuilder.ts
@@ -971,11 +971,12 @@ export class QueryBuilder<
       mapped = [this.driver.mapResult<Entity>(res, meta, joinedProps, this)!];
     }
 
-    await this.em?.storeCache(this._cache, cached!, mapped);
-
     if (method === 'get') {
+      await this.em?.storeCache(this._cache, cached!, mapped[0]);
       return mapped[0] as U;
     }
+
+    await this.em?.storeCache(this._cache, cached!, mapped);
 
     return mapped as U;
   }

--- a/tests/issues/GH6083.test.ts
+++ b/tests/issues/GH6083.test.ts
@@ -1,0 +1,47 @@
+import { Entity, MikroORM, PrimaryKey } from '@mikro-orm/postgresql';
+
+@Entity()
+class User {
+
+  @PrimaryKey()
+  userId!: string;
+
+  constructor(userId: string) {
+    this.userId = userId;
+  }
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({ entities: [User], dbName: '6083' });
+  await orm.schema.refreshDatabase();
+});
+
+afterAll(async () => {
+  await orm.schema.dropDatabase();
+  await orm.close(true);
+});
+
+test('check schema', async () => {
+  await orm.em.insertMany([
+    new User('6083-1'),
+    new User('6083-2'),
+    new User('6083-3'),
+  ]);
+
+  await orm.em.createQueryBuilder(User)
+    .select('userId')
+    .where({ userId: '6083-2' })
+    .cache([`6083`, 6083])
+    .execute('get');
+
+  const result = await orm.em.createQueryBuilder(User)
+    .select('userId')
+    .where({ userId: '6083-1' })
+    .cache([`6083`, 6083])
+    .execute('get');
+
+  expect(result).toMatchSnapshot();
+});

--- a/tests/issues/GH6083.test.ts
+++ b/tests/issues/GH6083.test.ts
@@ -32,16 +32,16 @@ test('check schema', async () => {
   ]);
 
   await orm.em.createQueryBuilder(User)
-    .select('userId')
-    .where({ userId: '6083-2' })
-    .cache([`6083`, 6083])
-    .execute('get');
+      .select('userId')
+      .where({ userId: '6083-2' })
+      .cache([`6083`, 6083])
+      .execute('get');
 
   const result = await orm.em.createQueryBuilder(User)
-    .select('userId')
-    .where({ userId: '6083-1' })
-    .cache([`6083`, 6083])
-    .execute('get');
+      .select('userId')
+      .where({ userId: '6083-1' })
+      .cache([`6083`, 6083])
+      .execute('get');
 
-  expect(result).toMatchSnapshot();
+  expect(result).toEqual({ userId: '6083-2' });
 });

--- a/tests/issues/__snapshots__/GH6083.test.ts.snap
+++ b/tests/issues/__snapshots__/GH6083.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`check schema 1`] = `
+{
+  "userId": "6083-2",
+}
+`;

--- a/tests/issues/__snapshots__/GH6083.test.ts.snap
+++ b/tests/issues/__snapshots__/GH6083.test.ts.snap
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`check schema 1`] = `
-{
-  "userId": "6083-2",
-}
-`;


### PR DESCRIPTION
The result of the first cached execute('get') is guaranteed to be a single object,
so I modified it to ensure that the data stored in or retrieved from the cache is a single object.
When there is no result, it will be `null` rather than an array containing `null`.

Closes #6083 