### PR TITLE
fix(mongo): fix persisting objects like `ObjectID` in JSON properties

### DIFF
--- a/packages/core/src/utils/clone.ts
+++ b/packages/core/src/utils/clone.ts
@@ -133,7 +133,7 @@ export function clone<T>(parent: T, respectCustomCloneMethod = true): T {
         attrs = getPropertyDescriptor(proto, i);
       }
 
-      if (attrs && attrs.set == null) {
+      if (attrs && typeof attrs.get === 'function' && attrs.set == null) {
         continue;
       }
 

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -1,8 +1,9 @@
 import { ObjectId } from 'bson';
 import {
- Platform, MongoNamingStrategy, Utils, ReferenceKind, MetadataError, type
-  IPrimaryKey, type Primary, type NamingStrategy, type Constructor, type EntityRepository, type EntityProperty, type
-  PopulateOptions, type EntityMetadata, type IDatabaseDriver, type EntityManager, type Configuration, type MikroORM } from '@mikro-orm/core';
+  Platform, MongoNamingStrategy, Utils, ReferenceKind, MetadataError, type
+    IPrimaryKey, type Primary, type NamingStrategy, type Constructor, type EntityRepository, type EntityProperty, type
+    PopulateOptions, type EntityMetadata, type IDatabaseDriver, type EntityManager, type Configuration, type MikroORM,
+} from '@mikro-orm/core';
 import { MongoExceptionConverter } from './MongoExceptionConverter';
 import { MongoEntityRepository } from './MongoEntityRepository';
 import { MongoSchemaGenerator } from './MongoSchemaGenerator';
@@ -18,7 +19,7 @@ export class MongoPlatform extends Platform {
     super.setConfig(config);
   }
 
-  override getNamingStrategy(): { new(): NamingStrategy} {
+  override getNamingStrategy(): { new(): NamingStrategy } {
     return MongoNamingStrategy;
   }
 
@@ -79,7 +80,7 @@ export class MongoPlatform extends Platform {
   }
 
   override convertJsonToDatabaseValue(value: unknown): unknown {
-    return structuredClone(value);
+    return Utils.copy(value);
   }
 
   override convertJsonToJSValue(value: unknown, prop: EntityProperty): unknown {

--- a/tests/issues/GH6091.test.ts
+++ b/tests/issues/GH6091.test.ts
@@ -1,0 +1,53 @@
+import { Entity, MikroORM, ObjectId, PrimaryKey, Property, SerializedPrimaryKey } from '@mikro-orm/mongodb';
+
+interface Event {
+  name: string;
+  actorId: ObjectId;
+}
+
+@Entity()
+class User {
+
+  @PrimaryKey()
+  _id!: ObjectId;
+
+  @SerializedPrimaryKey()
+  id!: string;
+
+  @Property({ unique: true })
+  email!: string;
+
+  @Property({ type: 'json' })
+  events: Event[] = [];
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: '6091',
+    entities: [User],
+    driverOptions: {},
+  });
+  await orm.schema.refreshDatabase();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('MongoDB driver should persist ObjectID in JSON properties', async () => {
+  const actorId = new ObjectId();
+  orm.em.create(User, {
+    email: 'foo',
+    events: [{ name: 'creation', actorId }],
+  });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const user = await orm.em.findOneOrFail(User, { email: 'foo' });
+  expect(user.events.length).toBe(1);
+  expect(user.events[0].name).toBe('creation');
+  expect(user.events[0].actorId.equals(actorId)).toBe(true);
+});


### PR DESCRIPTION
This PR fixes a regression introduced in v6.3.11.

After upgrading from v6.3.10 to v6.3.11, ObjectID subproperties of JSON properties are not persisted in the MongoDB database.

The fix reverts the change in 55df57ff1aa84e5d45188d849ba09e91ae6d3642 that uses `structuredClone` instead of `Utils.clone()` to convert JSON to database values in the MongoDB driver. Unfortunately, `structuredClone` doesn't clone non-built-in classes (see [supported types](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#javascript_types)).

I've added a condition to `Utils.clone` to continue supporting both tests:
- [should copy child object even though getter property is dynamically injected](https://github.com/mikro-orm/mikro-orm/blob/f48e5443f3fe3539d24a53dcb6a82f280e3999ee/tests/Utils.test.ts#L159)
- [should populate a json property that contains a default value in its prototype at entity update](https://github.com/mikro-orm/mikro-orm/blob/f48e5443f3fe3539d24a53dcb6a82f280e3999ee/tests/features/custom-types/GH6050.test.ts#L56)

Related issues:
- https://github.com/mikro-orm/mikro-orm/issues/6050
- https://github.com/mikro-orm/mikro-orm/issues/6078