### PR TITLE
feat(core): prevent conversion of `many` entities in `oneToMany` from `extractConstructorParams`

### DIFF
--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -407,12 +407,14 @@ export class EntityFactory {
         const tmp = { ...data };
 
         for (const prop of meta.props) {
-          if (prop.kind !== ReferenceKind.ONE_TO_MANY && options.convertCustomTypes && prop.customType && tmp[prop.name] != null) {
-            if ([ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind) && Utils.isPlainObject(tmp[prop.name]) && !Utils.extractPK(tmp[prop.name], meta.properties[prop.name].targetMeta, true)) {
-              tmp[prop.name] = Reference.wrapReference(this.create(meta.properties[prop.name].type, tmp[prop.name]!, options), prop);
-            } else {
-              tmp[prop.name] = prop.customType.convertToJSValue(tmp[prop.name], this.platform) as any;
-            }
+          if (!options.convertCustomTypes || !prop.customType || tmp[prop.name] == null) {
+            continue;
+          }
+
+          if ([ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind) && Utils.isPlainObject(tmp[prop.name]) && !Utils.extractPK(tmp[prop.name], meta.properties[prop.name].targetMeta, true)) {
+            tmp[prop.name] = Reference.wrapReference(this.create(meta.properties[prop.name].type, tmp[prop.name]!, options), prop);
+          } else if (prop.kind === ReferenceKind.SCALAR) {
+            tmp[prop.name] = prop.customType.convertToJSValue(tmp[prop.name], this.platform) as any;
           }
         }
 

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -407,7 +407,7 @@ export class EntityFactory {
         const tmp = { ...data };
 
         for (const prop of meta.props) {
-          if (options.convertCustomTypes && prop.customType && tmp[prop.name] != null) {
+          if (prop.kind !== ReferenceKind.ONE_TO_MANY && options.convertCustomTypes && prop.customType && tmp[prop.name] != null) {
             if ([ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind) && Utils.isPlainObject(tmp[prop.name]) && !Utils.extractPK(tmp[prop.name], meta.properties[prop.name].targetMeta, true)) {
               tmp[prop.name] = Reference.wrapReference(this.create(meta.properties[prop.name].type, tmp[prop.name]!, options), prop);
             } else {

--- a/tests/issues/GH6092.test.ts
+++ b/tests/issues/GH6092.test.ts
@@ -1,0 +1,55 @@
+import { Entity, PrimaryKey, MikroORM, OneToMany, Collection, ManyToOne } from '@mikro-orm/sqlite';
+
+@Entity()
+class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @OneToMany(() => Comment, comment => comment.user)
+  comments = new Collection<Comment>(this);
+
+  toForceHandleCommentsProp: Comment[] = [];
+
+  constructor(props?: { comments: Comment[] }) {
+    this.toForceHandleCommentsProp = props?.comments ? props.comments : [];
+  }
+
+}
+
+@Entity()
+export class Comment {
+
+  @PrimaryKey()
+  id!: bigint;
+
+  @ManyToOne()
+  user!: User;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [User, Comment],
+    forceEntityConstructor: true,
+  });
+  await orm.schema.createSchema();
+});
+
+afterAll(async () => {
+  await orm.close();
+});
+
+test('GH6092', async () => {
+  const user = new User();
+  user.comments.add(new Comment(), new Comment());
+  await orm.em.persistAndFlush(user);
+  orm.em.clear();
+
+  const users = await orm.em.findAll(User, { populate: ['comments'] });
+  expect(users[0].comments.count()).toBe(2);
+  expect(users[0].toForceHandleCommentsProp.length).toBe(2);
+});


### PR DESCRIPTION
Return value of `extractConstructorParams` appears to be passed only as an argument to the Entity constructor.
In typical use cases, entities in many relationships should only be accessed through a Collection.
However, in special situations where `forceEntityConstructor: true`, users can handle it directly in the constructor.

Closes #6092 