### PR TITLE
fix(core): fix same-second dates diffing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,6 +157,7 @@ jobs:
       - name: Init docker
         run: |
           docker compose up -d
+          sleep 5
 
       - name: Set CC Required env vars
         run: export GIT_BRANCH=$GITHUB_HEAD_REF && export GIT_COMMIT_SHA=$(git rev-parse origin/$GITHUB_HEAD_REF)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,10 +139,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Init docker
-        run: |
-          docker compose up -d
-
       - name: Enable corepack
         run: |
           corepack enable
@@ -157,6 +153,10 @@ jobs:
 
       - name: Install
         run: yarn
+
+      - name: Init docker
+        run: |
+          docker compose up -d
 
       - name: Set CC Required env vars
         run: export GIT_BRANCH=$GITHUB_HEAD_REF && export GIT_COMMIT_SHA=$(git rev-parse origin/$GITHUB_HEAD_REF)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,6 +139,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Init docker
+        run: |
+          docker compose up -d
+
       - name: Enable corepack
         run: |
           corepack enable
@@ -153,11 +157,6 @@ jobs:
 
       - name: Install
         run: yarn
-
-      - name: Init docker
-        run: |
-          docker compose up -d
-          sleep 10
 
       - name: Set CC Required env vars
         run: export GIT_BRANCH=$GITHUB_HEAD_REF && export GIT_COMMIT_SHA=$(git rev-parse origin/$GITHUB_HEAD_REF)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Init docker
         run: |
           docker compose up -d
-          sleep 5
+          sleep 10
 
       - name: Set CC Required env vars
         run: export GIT_BRANCH=$GITHUB_HEAD_REF && export GIT_COMMIT_SHA=$(git rev-parse origin/$GITHUB_HEAD_REF)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,8 @@ services:
       MSSQL_SA_PASSWORD: Root.Root
       MSSQL_TELEMETRY_ENABLED: 0
       ACCEPT_EULA: 1
+    healthcheck:
+      test: /opt/mssql-tools/bin/sqlcmd -S mssql -U sa -P 'Root.Root' -Q 'select 1'
 
 volumes:
   mysql8:

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -61,10 +61,13 @@ export function compareObjects(a: any, b: any) {
     return a.sql === b.sql && compareArrays(a.params, b.params);
   }
 
+  if ((a instanceof Date && b instanceof Date)) {
+    return a.toISOString() === b.toISOString();
+  }
+
   if (
     (typeof a === 'function' && typeof b === 'function') ||
     (typeof a === 'object' && a.client && ['Ref', 'Raw'].includes(a.constructor.name) && typeof b === 'object' && b.client && ['Ref', 'Raw'].includes(b.constructor.name)) || // knex qb
-    (a instanceof Date && b instanceof Date) ||
     (a instanceof RegExp && b instanceof RegExp) ||
     (a instanceof String && b instanceof String) ||
     (a instanceof Number && b instanceof Number)

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -88,6 +88,7 @@ describe('Utils', () => {
     expect(compareObjects(sql`select 1`, sql`select 1`)).toBe(true);
     expect(compareObjects(sql`select ${1}`, sql`select ${1}`)).toBe(true);
     expect(compareObjects(sql`select ${1}`, sql`select ${2}`)).toBe(false);
+    expect(compareObjects(new Date('2024-10-01T08:54:48.651Z'), new Date('2024-10-01T08:54:48.676Z'))).toBe(false);
     expect(Utils.equals(NaN, NaN)).toBe(true);
   });
 

--- a/tests/features/embeddables/GH2391-2.test.ts
+++ b/tests/features/embeddables/GH2391-2.test.ts
@@ -119,7 +119,7 @@ describe('onCreate and onUpdate in embeddables (GH 2283 and 2391)', () => {
     const tmp1 = line.fooAudit1.archived = new Date(1698010995749);
     await orm.em.flush();
     expect(mock).toHaveBeenCalledTimes(3);
-    expect(mock.mock.calls[1][0]).toMatch('update `my_entity` set `foo_audit1_archivedAt` = 1698010995749, `foo_audit1_updated_at` = 1698010995749, `foo_audit1_nested_audit1_updated_at` = 1698010995749 where `id` = 1');
+    expect(mock.mock.calls[1][0]).toMatch('update `my_entity` set `foo_audit1_archivedAt` = 1698010995749, `foo_audit1_updated_at` = 1698010995749, `foo_audit1_nested_audit1_updated_at` = 1698010995749, `bar_audit2` = \'{"updatedAt":"2023-10-22T21:43:15.749Z","created":"2023-10-22T21:43:15.740Z","nestedAudit1":{"updatedAt":"2023-10-22T21:43:15.749Z","created":"2023-10-22T21:43:15.740Z"}}\' where `id` = 1');
     mock.mockReset();
 
     const tmp2 = line.barAudit2.archived = new Date(1698010995750);

--- a/tests/features/embeddables/GH2391.test.ts
+++ b/tests/features/embeddables/GH2391.test.ts
@@ -92,7 +92,7 @@ describe('onCreate and onUpdate in embeddables (GH 2283 and 2391)', () => {
     const tmp1 = line.audit1.archived = new Date();
     await orm.em.flush();
     expect(mock).toHaveBeenCalledTimes(3);
-    expect(mock.mock.calls[1][0]).toMatch('update `my_entity` set `audit1_archived` = ?, `audit1_updated` = ?, `audit1_nested_audit1_updated` = ? where `id` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('update `my_entity` set `audit1_archived` = ?, `audit1_updated` = ?, `audit1_nested_audit1_updated` = ?, `audit2` = ? where `id` = ?');
     mock.mockReset();
 
     const tmp2 = line.audit2.archived = new Date();


### PR DESCRIPTION
This small PR fixes a minor regression that I think was introduced in https://github.com/mikro-orm/mikro-orm/commit/55df57ff1aa84e5d45188d849ba09e91ae6d3642.

## Issue
When updating an entity and changing a date property to another one very close to it (by a difference in microseconds), the change is not persisted in the database. Indeed, diffing dates by comparing the `toString()` output doesn't give enough precision to compare microseconds shifts. Example:
- `toString()` output: `Tue Oct 01 2024 08:54:48 GMT+0000 (Coordinated Universal Time)`
- `toISOString()` output: `2024-10-01T08:54:48.651Z`

Two dates can have the same `toString()` output even though their `toISOString()` output is different.

The impact is low and probably only concerns the test scenarios: It's rare to persist the same entity twice in the same second without changing anything other than a date.

## Fix
In this PR I'm switching the dates comparison to use `toISOString()` and adding a new unit test.