### PR TITLE
fix(core/utils): compare invalid dates

### DIFF
--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -62,7 +62,7 @@ export function compareObjects(a: any, b: any) {
   }
 
   if ((a instanceof Date && b instanceof Date)) {
-    return a.toISOString() === b.toISOString();
+    return a.toString() === b.toString() && (isNaN(a.getTime()) || a.toISOString() === b.toISOString());
   }
 
   if (

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -90,8 +90,8 @@ describe('Utils', () => {
     expect(compareObjects(sql`select ${1}`, sql`select ${2}`)).toBe(false);
     expect(compareObjects(new Date('2024-10-01T08:54:48.651Z'), new Date('2024-10-01T08:54:48.651Z'))).toBe(true);
     expect(compareObjects(new Date('2024-10-01T08:54:48.651Z'), new Date('2024-10-01T08:54:48.676Z'))).toBe(false);
-    expect(compareObjects(new Date('2024-10-01T08:54:48.651Z'), new Date('invalid'))).toBe(false);
-    expect(compareObjects(new Date('invalid one'), new Date('invalid two'))).toBe(true);
+    expect(compareObjects(new Date('2024-10-01T08:54:48.651Z'), new Date(NaN))).toBe(false);
+    expect(compareObjects(new Date(NaN), new Date(NaN))).toBe(true);
     expect(Utils.equals(NaN, NaN)).toBe(true);
   });
 

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -88,7 +88,10 @@ describe('Utils', () => {
     expect(compareObjects(sql`select 1`, sql`select 1`)).toBe(true);
     expect(compareObjects(sql`select ${1}`, sql`select ${1}`)).toBe(true);
     expect(compareObjects(sql`select ${1}`, sql`select ${2}`)).toBe(false);
+    expect(compareObjects(new Date('2024-10-01T08:54:48.651Z'), new Date('2024-10-01T08:54:48.651Z'))).toBe(true);
     expect(compareObjects(new Date('2024-10-01T08:54:48.651Z'), new Date('2024-10-01T08:54:48.676Z'))).toBe(false);
+    expect(compareObjects(new Date('2024-10-01T08:54:48.651Z'), new Date('invalid'))).toBe(false);
+    expect(compareObjects(new Date('invalid one'), new Date('invalid two'))).toBe(true);
     expect(Utils.equals(NaN, NaN)).toBe(true);
   });
 


### PR DESCRIPTION
This PR fixes an issue I introduced in https://github.com/mikro-orm/mikro-orm/pull/6094

Using `toISOString()` on an invalid date throws a [RangeError exception](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString#exceptions). We should test if the date is valid before comparing it with `toISOString()`.