### PR TITLE
perf(schema): filter tables before fetching table details

### DIFF
--- a/packages/entity-generator/src/EntityGenerator.ts
+++ b/packages/entity-generator/src/EntityGenerator.ts
@@ -81,7 +81,7 @@ export class EntityGenerator {
   private async getEntityMetadata(schema: DatabaseSchema, options: GenerateOptions) {
     const metadata = schema.getTables()
       .filter(table => !options.schema || table.schema === options.schema)
-      .sort((a, b) => a.name!.localeCompare(b.name!))
+      .sort((a, b) => `${a.schema}.${a.name}`.localeCompare(`${b.schema}.${b.name}`))
       .map(table => {
         const skipColumns = options.skipColumns?.[table.getShortestName()];
         if (skipColumns) {

--- a/packages/entity-generator/src/EntityGenerator.ts
+++ b/packages/entity-generator/src/EntityGenerator.ts
@@ -48,7 +48,7 @@ export class EntityGenerator {
 
   async generate(options: GenerateOptions = {}): Promise<string[]> {
     options = Utils.mergeConfig({}, this.config.get('entityGenerator'), options);
-    const schema = await DatabaseSchema.create(this.connection, this.platform, this.config);
+    const schema = await DatabaseSchema.create(this.connection, this.platform, this.config, undefined, undefined, options.takeTables, options.skipTables);
     const metadata = await this.getEntityMetadata(schema, options);
     const defaultPath = `${this.config.get('baseDir')}/generated-entities`;
     const baseDir = Utils.normalizePath(options.path ?? defaultPath);
@@ -79,7 +79,7 @@ export class EntityGenerator {
   }
 
   private async getEntityMetadata(schema: DatabaseSchema, options: GenerateOptions) {
-    let metadata = schema.getTables()
+    const metadata = schema.getTables()
       .filter(table => !options.schema || table.schema === options.schema)
       .sort((a, b) => a.name!.localeCompare(b.name!))
       .map(table => {
@@ -96,7 +96,7 @@ export class EntityGenerator {
 
     for (const meta of metadata) {
       for (const prop of meta.relations) {
-        if (!this.isTableNameAllowed(prop.referencedTableName, options)) {
+        if (!metadata.some(otherMeta => prop.referencedTableName === otherMeta.collection || prop.referencedTableName === `${otherMeta.schema ?? schema.name}.${otherMeta.collection}`)) {
           prop.kind = ReferenceKind.SCALAR;
           const mappedTypes = prop.columnTypes.map((t, i) => this.platform.getMappedType(t));
 
@@ -106,8 +106,6 @@ export class EntityGenerator {
         }
       }
     }
-
-    metadata = metadata.filter(table => this.isTableNameAllowed(table.tableName, options));
 
     await options.onInitialMetadata?.(metadata, this.platform);
 
@@ -152,13 +150,6 @@ export class EntityGenerator {
     return typeof nameToMatch === 'string'
       ? name.toLocaleLowerCase() === nameToMatch.toLocaleLowerCase()
       : nameToMatch.test(name);
-  }
-
-  private isTableNameAllowed(tableName: string, { takeTables, skipTables }: GenerateOptions) {
-    return (
-      (takeTables?.some(tableNameToMatch => this.matchName(tableName, tableNameToMatch)) ?? true) &&
-      !(skipTables?.some(tableNameToMatch => this.matchName(tableName, tableNameToMatch)) ?? false)
-    );
   }
 
   private detectManyToManyRelations(metadata: EntityMetadata[], onlyPurePivotTables: boolean, readOnlyPivotTables: boolean, outputPurePivotTables: boolean): void {

--- a/packages/knex/src/schema/DatabaseSchema.ts
+++ b/packages/knex/src/schema/DatabaseSchema.ts
@@ -144,7 +144,6 @@ export class DatabaseSchema {
     return (meta.schema === '*' ? schema : meta.schema) ?? config.get('schema');
   }
 
-
   private static matchName(name: string, nameToMatch: string | RegExp) {
     return typeof nameToMatch === 'string'
       ? name.toLocaleLowerCase() === nameToMatch.toLocaleLowerCase()

--- a/packages/knex/src/schema/DatabaseSchema.ts
+++ b/packages/knex/src/schema/DatabaseSchema.ts
@@ -72,13 +72,13 @@ export class DatabaseSchema {
     return [...this.namespaces];
   }
 
-  static async create(connection: AbstractSqlConnection, platform: AbstractSqlPlatform, config: Configuration, schemaName?: string, schemas?: string[]): Promise<DatabaseSchema> {
+  static async create(connection: AbstractSqlConnection, platform: AbstractSqlPlatform, config: Configuration, schemaName?: string, schemas?: string[], takeTables?: (string | RegExp)[], skipTables?: (string | RegExp)[]): Promise<DatabaseSchema> {
     const schema = new DatabaseSchema(platform, schemaName ?? config.get('schema') ?? platform.getDefaultSchemaName());
     const allTables = await connection.execute<Table[]>(platform.getSchemaHelper()!.getListTablesSQL());
     const parts = config.get('migrations').tableName!.split('.');
     const migrationsTableName = parts[1] ?? parts[0];
     const migrationsSchemaName = parts.length > 1 ? parts[0] : config.get('schema', platform.getDefaultSchemaName());
-    const tables = allTables.filter(t => t.table_name !== migrationsTableName || (t.schema_name && t.schema_name !== migrationsSchemaName));
+    const tables = allTables.filter(t => this.isTableNameAllowed(t.table_name, takeTables, skipTables) && (t.table_name !== migrationsTableName || (t.schema_name && t.schema_name !== migrationsSchemaName)));
     await platform.getSchemaHelper()!.loadInformationSchema(schema, connection, tables, schemas && schemas.length > 0 ? schemas : undefined);
 
     return schema;
@@ -142,6 +142,20 @@ export class DatabaseSchema {
 
   private static getSchemaName(meta: EntityMetadata, config: Configuration, schema?: string): string | undefined {
     return (meta.schema === '*' ? schema : meta.schema) ?? config.get('schema');
+  }
+
+
+  private static matchName(name: string, nameToMatch: string | RegExp) {
+    return typeof nameToMatch === 'string'
+      ? name.toLocaleLowerCase() === nameToMatch.toLocaleLowerCase()
+      : nameToMatch.test(name);
+  }
+
+  private static isTableNameAllowed(tableName: string, takeTables?: (string | RegExp)[], skipTables?: (string | RegExp)[]) {
+    return (
+      (takeTables?.some(tableNameToMatch => this.matchName(tableName, tableNameToMatch)) ?? true) &&
+      !(skipTables?.some(tableNameToMatch => this.matchName(tableName, tableNameToMatch)) ?? false)
+    );
   }
 
   private static shouldHaveColumn(meta: EntityMetadata, prop: EntityProperty): boolean {

--- a/tests/features/custom-order/custom-order.mssql.test.ts
+++ b/tests/features/custom-order/custom-order.mssql.test.ts
@@ -82,7 +82,7 @@ const createWithDifficulty = (label: string, difficulty?: Difficulty) => {
   return t;
 };
 
-describe('custom order [sqlite]', () => {
+describe('custom order [mssql]', () => {
 
   let orm: MikroORM;
 

--- a/tests/features/entity-generator/EntityGenerator.postgres.test.ts
+++ b/tests/features/entity-generator/EntityGenerator.postgres.test.ts
@@ -73,7 +73,7 @@ describe('EntityGenerator', () => {
       save: true,
       path: './temp/entities-pg-skipTables',
       skipTables: ['test2', 'test2_bars'],
-      skipColumns: { 'public.book2': ['price'] },
+      skipColumns: { 'public.book2': ['price'], 'public.foo_baz2': [/^nam.$/] },
     });
     expect(dump).toMatchSnapshot('postgres-entity-dump-skipTables');
     await expect(pathExists('./temp/entities-pg-skipTables/Author2.ts')).resolves.toBe(true);

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
@@ -36,6 +36,24 @@ export enum Publisher2Type2 {
 
 exports[`EntityGenerator generate entities from schema [postgres]: postgres-entity-dump 1`] = `
 [
+  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+import { Label2 } from './Label2';
+import { Test2 } from './Test2';
+
+@Entity({ tableName: 'label2_tests', schema: 'label_schema' })
+export class Label2Tests {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne({ entity: () => Label2, updateRule: 'cascade', deleteRule: 'cascade' })
+  label2!: Label2;
+
+  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
+  test2!: Test2;
+
+}
+",
   "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
@@ -305,24 +323,6 @@ export class Label2 {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
-import { Label2 } from './Label2';
-import { Test2 } from './Test2';
-
-@Entity({ tableName: 'label2_tests', schema: 'label_schema' })
-export class Label2Tests {
-
-  @PrimaryKey()
-  id!: number;
-
-  @ManyToOne({ entity: () => Label2, updateRule: 'cascade', deleteRule: 'cascade' })
-  label2!: Label2;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
-  test2!: Test2;
-
-}
-",
   "import { Entity, Enum, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
@@ -431,6 +431,24 @@ export class Test2 {
 
 exports[`EntityGenerator generate entities from schema with forceUndefined = false [postgres]: postgres-entity-dump 1`] = `
 [
+  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+import { Label2 } from './Label2';
+import { Test2 } from './Test2';
+
+@Entity({ tableName: 'label2_tests', schema: 'label_schema' })
+export class Label2Tests {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne({ entity: () => Label2, updateRule: 'cascade', deleteRule: 'cascade' })
+  label2!: Label2;
+
+  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
+  test2!: Test2;
+
+}
+",
   "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
@@ -700,24 +718,6 @@ export class Label2 {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
-import { Label2 } from './Label2';
-import { Test2 } from './Test2';
-
-@Entity({ tableName: 'label2_tests', schema: 'label_schema' })
-export class Label2Tests {
-
-  @PrimaryKey()
-  id!: number;
-
-  @ManyToOne({ entity: () => Label2, updateRule: 'cascade', deleteRule: 'cascade' })
-  label2!: Label2;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
-  test2!: Test2;
-
-}
-",
   "import { Entity, Enum, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
@@ -826,6 +826,24 @@ export class Test2 {
 
 exports[`EntityGenerator generate entities from schema with forceUndefined = false and undefinedDefaults = true [postgres]: postgres-entity-dump 1`] = `
 [
+  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+import { Label2 } from './Label2';
+import { Test2 } from './Test2';
+
+@Entity({ tableName: 'label2_tests', schema: 'label_schema' })
+export class Label2Tests {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne({ entity: () => Label2, updateRule: 'cascade', deleteRule: 'cascade' })
+  label2!: Label2;
+
+  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
+  test2!: Test2;
+
+}
+",
   "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
@@ -1095,24 +1113,6 @@ export class Label2 {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
-import { Label2 } from './Label2';
-import { Test2 } from './Test2';
-
-@Entity({ tableName: 'label2_tests', schema: 'label_schema' })
-export class Label2Tests {
-
-  @PrimaryKey()
-  id!: number;
-
-  @ManyToOne({ entity: () => Label2, updateRule: 'cascade', deleteRule: 'cascade' })
-  label2!: Label2;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
-  test2!: Test2;
-
-}
-",
   "import { Entity, Enum, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
@@ -1221,6 +1221,23 @@ export class Test2 {
 
 exports[`EntityGenerator skipTables [postgres]: postgres-entity-dump-skipTables 1`] = `
 [
+  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Label2 } from './Label2';
+
+@Entity({ tableName: 'label2_tests', schema: 'label_schema' })
+export class Label2Tests {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne({ entity: () => Label2, updateRule: 'cascade', deleteRule: 'cascade' })
+  label2!: Label2;
+
+  @Property({ fieldName: 'test2_id' })
+  test2!: number;
+
+}
+",
   "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
@@ -1480,23 +1497,6 @@ export class Label2 {
 
   @Property()
   name!: string;
-
-}
-",
-  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import { Label2 } from './Label2';
-
-@Entity({ tableName: 'label2_tests', schema: 'label_schema' })
-export class Label2Tests {
-
-  @PrimaryKey()
-  id!: number;
-
-  @ManyToOne({ entity: () => Label2, updateRule: 'cascade', deleteRule: 'cascade' })
-  label2!: Label2;
-
-  @Property({ fieldName: 'test2_id' })
-  test2!: number;
 
 }
 ",

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
@@ -1373,8 +1373,7 @@ export class Book2Tags {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
-import { Test2 } from './Test2';
+  "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Configuration2 {
@@ -1384,8 +1383,8 @@ export class Configuration2 {
   @PrimaryKey()
   property!: string;
 
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', primary: true })
-  test!: Test2;
+  @PrimaryKey({ fieldName: 'test_id' })
+  test!: number;
 
   @Property()
   value!: string;
@@ -1487,9 +1486,8 @@ export class Label2 {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { Label2 } from './Label2';
-import { Test2 } from './Test2';
 
 @Entity({ tableName: 'label2_tests', schema: 'label_schema' })
 export class Label2Tests {
@@ -1500,8 +1498,8 @@ export class Label2Tests {
   @ManyToOne({ entity: () => Label2, updateRule: 'cascade', deleteRule: 'cascade' })
   label2!: Label2;
 
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
-  test2!: Test2;
+  @Property({ fieldName: 'test2_id' })
+  test2!: number;
 
 }
 ",
@@ -1559,9 +1557,8 @@ export enum Publisher2Enum5 {
   A = 'a',
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
-import { Test2 } from './Test2';
 
 @Entity({ tableName: 'publisher2_tests' })
 export class Publisher2Tests {
@@ -1572,8 +1569,8 @@ export class Publisher2Tests {
   @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade' })
   publisher2!: Publisher2;
 
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
-  test2!: Test2;
+  @Property({ fieldName: 'test2_id' })
+  test2!: number;
 
 }
 ",
@@ -1582,7 +1579,7 @@ export class Publisher2Tests {
 
 exports[`EntityGenerator takeTables [postgres]: postgres-entity-dump-takeTables 1`] = `
 [
-  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 
 @Entity()
 export class FooBar2 {
@@ -1599,8 +1596,9 @@ export class FooBar2 {
   @Property({ fieldName: 'baz_id', nullable: true, unique: true })
   baz?: number;
 
-  @Property({ fieldName: 'foo_bar_id', nullable: true, unique: true })
-  fooBar?: number;
+  @Unique({ name: 'foo_bar2_foo_bar_id_unique' })
+  @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  fooBar?: FooBar2;
 
   @Property({ type: 'datetime', length: 0, defaultRaw: \`current_timestamp(0)\` })
   version!: Date & Opt;
@@ -1619,7 +1617,7 @@ export class FooBar2 {
 
 }
 ",
-  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Test2 {
@@ -1633,8 +1631,8 @@ export class Test2 {
   @Property({ fieldName: 'book_uuid_pk', type: 'uuid', nullable: true, unique: true })
   book?: string;
 
-  @Property({ fieldName: 'parent_id', nullable: true })
-  parent?: number;
+  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  parent?: Test2;
 
   @Property({ type: 'integer' })
   version: number & Opt = 1;
@@ -1649,7 +1647,7 @@ export class Test2 {
 
 exports[`EntityGenerator takeTables and skipTables [postgres]: postgres-entity-dump-takeTables-skipTables 1`] = `
 [
-  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity()
 export class Test2 {
@@ -1663,8 +1661,8 @@ export class Test2 {
   @Property({ fieldName: 'book_uuid_pk', type: 'uuid', nullable: true, unique: true })
   book?: string;
 
-  @Property({ fieldName: 'parent_id', nullable: true })
-  parent?: number;
+  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  parent?: Test2;
 
   @Property({ type: 'integer' })
   version: number & Opt = 1;

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
@@ -1440,9 +1440,6 @@ export class FooBaz2 {
   id!: number;
 
   @Property()
-  name!: string;
-
-  @Property()
   code!: string;
 
   @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })

--- a/tests/features/entity-generator/__snapshots__/OddTableNames.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OddTableNames.mysql.test.ts.snap
@@ -32,8 +32,7 @@ export enum E_$42miscEnum {
   'A+B' = 'a+b',
 }
 ",
-  "import { Entity, Index, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
-import { Table$39s$32name$32has$32apostrophe$44$32also$32$96$32this } from './Table$39s$32name$32has$32apostrophe$44$32also$32$96$32this';
+  "import { Entity, Index, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
 @Entity({ tableName: '123_table_name' })
 @Index({ name: 'dollar\\'s index', properties: ['$$', '$$infer'] })
@@ -47,8 +46,8 @@ export class E123TableName {
   @Property()
   $$!: bigint;
 
-  @ManyToOne({ entity: () => Table$39s$32name$32has$32apostrophe$44$32also$32$96$32this, fieldName: 'prototype', index: 'fk_123_table_name_table\\'s name has apostrophe, also\` this_idx' })
-  prototype!: Table$39s$32name$32has$32apostrophe$44$32also$32$96$32this;
+  @Property({ length: 45, index: 'fk_123_table_name_table\\'s name has apostrophe, also\` this_idx' })
+  prototype!: string;
 
   @Property({ fieldName: 'oh_captain__my___captain', type: 'string' })
   ohCaptainMyCaptain: string & Opt = 'test';
@@ -160,13 +159,12 @@ export const E_$42miscSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
-import { Table$39s$32name$32has$32apostrophe$44$32also$32$96$32this } from './Table$39s$32name$32has$32apostrophe$44$32also$32$96$32this';
 
 export class E123TableName {
   [PrimaryKeyProp]?: '$';
   $!: number;
   $$!: bigint;
-  prototype!: Table$39s$32name$32has$32apostrophe$44$32also$32$96$32this;
+  prototype!: string;
   ohCaptainMyCaptain: string & Opt = 'test';
   infer!: string;
   $$infer!: string;
@@ -181,9 +179,8 @@ export const E123TableNameSchema = new EntitySchema({
     $: { primary: true, type: 'integer', unsigned: false, autoincrement: false },
     $$: { type: 'bigint' },
     prototype: {
-      kind: 'm:1',
-      entity: () => Table$39s$32name$32has$32apostrophe$44$32also$32$96$32this,
-      fieldName: 'prototype',
+      type: 'string',
+      length: 45,
       index: 'fk_123_table_name_table\\'s name has apostrophe, also\` this_idx',
     },
     ohCaptainMyCaptain: { type: 'string', fieldName: 'oh_captain__my___captain' },

--- a/tests/features/entity-generator/__snapshots__/OddTableNames.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OddTableNames.postgres.test.ts.snap
@@ -65,6 +65,19 @@ export class E50$37$32of$32stuff {
 
 }
 ",
+  "import { Entity, OneToOne, PrimaryKeyProp } from '@mikro-orm/core';
+import { E_$42misc } from './E_$42misc';
+
+@Entity({ tableName: 'this+that', schema: 'odd table_names_example:100%' })
+export class This$43that {
+
+  [PrimaryKeyProp]?: '80OfStuff';
+
+  @OneToOne({ entity: () => E_$42misc, fieldName: '80 of stuff', primary: true })
+  '80OfStuff'!: E_$42misc;
+
+}
+",
   "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity({ tableName: 'ns___subns__the_name', schema: 'odd_identifier\\'s_example\\'s_second' })
@@ -97,19 +110,6 @@ export class Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this {
 
   @Property({ length: 45, nullable: true })
   \`'derive\`?: string;
-
-}
-",
-  "import { Entity, OneToOne, PrimaryKeyProp } from '@mikro-orm/core';
-import { E_$42misc } from './E_$42misc';
-
-@Entity({ tableName: 'this+that', schema: 'odd table_names_example:100%' })
-export class This$43that {
-
-  [PrimaryKeyProp]?: '80OfStuff';
-
-  @OneToOne({ entity: () => E_$42misc, fieldName: '80 of stuff', primary: true })
-  '80OfStuff'!: E_$42misc;
 
 }
 ",
@@ -207,6 +207,28 @@ export const E50$37$32of$32stuffSchema = new EntitySchema({
   },
 });
 ",
+  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { E_$42misc } from './E_$42misc';
+
+export class This$43that {
+  [PrimaryKeyProp]?: '80OfStuff';
+  '80OfStuff'!: E_$42misc;
+}
+
+export const This$43thatSchema = new EntitySchema({
+  class: This$43that,
+  tableName: 'this+that',
+  schema: 'odd table_names_example:100%',
+  properties: {
+    '80OfStuff': {
+      primary: true,
+      kind: '1:1',
+      entity: () => E_$42misc,
+      fieldName: '80 of stuff',
+    },
+  },
+});
+",
   "import { EntitySchema } from '@mikro-orm/core';
 
 export class NsSubnsTheName {
@@ -252,28 +274,6 @@ export const Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32thisSchema
       type: 'string',
       length: 45,
       nullable: true,
-    },
-  },
-});
-",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
-import { E_$42misc } from './E_$42misc';
-
-export class This$43that {
-  [PrimaryKeyProp]?: '80OfStuff';
-  '80OfStuff'!: E_$42misc;
-}
-
-export const This$43thatSchema = new EntitySchema({
-  class: This$43that,
-  tableName: 'this+that',
-  schema: 'odd table_names_example:100%',
-  properties: {
-    '80OfStuff': {
-      primary: true,
-      kind: '1:1',
-      entity: () => E_$42misc,
-      fieldName: '80 of stuff',
     },
   },
 });

--- a/tests/features/entity-generator/__snapshots__/multple-schemas.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/multple-schemas.postgres.test.ts.snap
@@ -4,44 +4,6 @@ exports[`multiple schemas with same table name 1 1`] = `
 [
   "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity({ tableName: 'test', schema: 'schema1' })
-export class Schema1Test {
-
-  @PrimaryKey({ autoincrement: false })
-  id!: bigint;
-
-  @Property({ length: -1, nullable: true })
-  name?: string;
-
-  @Property({ nullable: true })
-  created?: Date;
-
-  @ManyToOne({ entity: () => Schema1Test, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  test?: Schema1Test;
-
-}
-",
-  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
-
-@Entity({ tableName: 'test', schema: 'schema2' })
-export class Schema2Test {
-
-  @PrimaryKey({ autoincrement: false })
-  id!: bigint;
-
-  @Property({ length: -1, nullable: true })
-  name?: string;
-
-  @Property({ nullable: true })
-  created?: Date;
-
-  @ManyToOne({ entity: () => Schema2Test, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  test?: Schema2Test;
-
-}
-",
-  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
-
 @Entity()
 export class Test {
 
@@ -59,11 +21,6 @@ export class Test {
 
 }
 ",
-]
-`;
-
-exports[`multiple schemas with same table name 2 1`] = `
-[
   "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity({ tableName: 'test', schema: 'schema1' })
@@ -102,6 +59,11 @@ export class Schema2Test {
 
 }
 ",
+]
+`;
+
+exports[`multiple schemas with same table name 2 1`] = `
+[
   "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity({ tableName: 'test' })
@@ -118,6 +80,44 @@ export class PublicTest {
 
   @ManyToOne({ entity: () => PublicTest, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   test?: PublicTest;
+
+}
+",
+  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'test', schema: 'schema1' })
+export class Schema1Test {
+
+  @PrimaryKey({ autoincrement: false })
+  id!: bigint;
+
+  @Property({ length: -1, nullable: true })
+  name?: string;
+
+  @Property({ nullable: true })
+  created?: Date;
+
+  @ManyToOne({ entity: () => Schema1Test, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  test?: Schema1Test;
+
+}
+",
+  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'test', schema: 'schema2' })
+export class Schema2Test {
+
+  @PrimaryKey({ autoincrement: false })
+  id!: bigint;
+
+  @Property({ length: -1, nullable: true })
+  name?: string;
+
+  @Property({ nullable: true })
+  created?: Date;
+
+  @ManyToOne({ entity: () => Schema2Test, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  test?: Schema2Test;
 
 }
 ",

--- a/tests/features/multiple-schemas/__snapshots__/multiple-schemas.mssql.test.ts.snap
+++ b/tests/features/multiple-schemas/__snapshots__/multiple-schemas.mssql.test.ts.snap
@@ -1,5 +1,211 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`multiple connected schemas in postgres generate entities for all schemas 1`] = `
+[
+  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { BookTag } from './BookTag';
+
+@Entity({ schema: 'n2' })
+export class Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+  @Property({ fieldName: 'author_id', nullable: true })
+  author?: number;
+
+  @ManyToOne({ entity: () => Book, nullable: true })
+  basedOn?: Book;
+
+  @ManyToMany({ entity: () => BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  tags = new Collection<BookTag>(this);
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ schema: 'n2' })
+export class BookTag {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+}
+",
+  "import { Entity, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+
+@Entity({ schema: 'n1' })
+export class Author {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Unique({ name: 'author_mentor_id_unique', expression: 'create unique index [author_mentor_id_unique] on [author] (where ([mentor_id] IS NOT NULL))' })
+  @OneToOne({ entity: () => Author, nullable: true })
+  mentor?: Author;
+
+}
+",
+  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Author } from './Author';
+import { N2BookTag } from './N2BookTag';
+
+@Entity({ tableName: 'book', schema: 'n2' })
+export class N2Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
+  author?: Author;
+
+  @ManyToOne({ entity: () => N2Book, nullable: true })
+  basedOn?: N2Book;
+
+  @ManyToMany({ entity: () => N2BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  tags = new Collection<N2BookTag>(this);
+
+}
+",
+  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Author } from './Author';
+import { N3BookTag } from './N3BookTag';
+
+@Entity({ tableName: 'book', schema: 'n3' })
+export class N3Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
+  author?: Author;
+
+  @ManyToOne({ entity: () => N3Book, nullable: true })
+  basedOn?: N3Book;
+
+  @ManyToMany({ entity: () => N3BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  tags = new Collection<N3BookTag>(this);
+
+}
+",
+  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Author } from './Author';
+import { N4BookTag } from './N4BookTag';
+
+@Entity({ tableName: 'book', schema: 'n4' })
+export class N4Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
+  author?: Author;
+
+  @ManyToOne({ entity: () => N4Book, nullable: true })
+  basedOn?: N4Book;
+
+  @ManyToMany({ entity: () => N4BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  tags = new Collection<N4BookTag>(this);
+
+}
+",
+  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Author } from './Author';
+import { N5BookTag } from './N5BookTag';
+
+@Entity({ tableName: 'book', schema: 'n5' })
+export class N5Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
+  author?: Author;
+
+  @ManyToOne({ entity: () => N5Book, nullable: true })
+  basedOn?: N5Book;
+
+  @ManyToMany({ entity: () => N5BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  tags = new Collection<N5BookTag>(this);
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'book_tag', schema: 'n2' })
+export class N2BookTag {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'book_tag', schema: 'n3' })
+export class N3BookTag {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'book_tag', schema: 'n4' })
+export class N4BookTag {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'book_tag', schema: 'n5' })
+export class N5BookTag {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+}
+",
+]
+`;
+
 exports[`multiple connected schemas in postgres generate entities for given schema only 1`] = `
 [
   "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';

--- a/tests/features/multiple-schemas/__snapshots__/multiple-schemas.mssql.test.ts.snap
+++ b/tests/features/multiple-schemas/__snapshots__/multiple-schemas.mssql.test.ts.snap
@@ -3,7 +3,6 @@
 exports[`multiple connected schemas in postgres generate entities for given schema only 1`] = `
 [
   "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import { Author } from './Author';
 import { BookTag } from './BookTag';
 
 @Entity({ schema: 'n2' })
@@ -15,8 +14,8 @@ export class Book {
   @Property({ nullable: true })
   name?: string;
 
-  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  author?: Author;
+  @Property({ fieldName: 'author_id', nullable: true })
+  author?: number;
 
   @ManyToOne({ entity: () => Book, nullable: true })
   basedOn?: Book;

--- a/tests/features/multiple-schemas/__snapshots__/multiple-schemas.mssql.test.ts.snap
+++ b/tests/features/multiple-schemas/__snapshots__/multiple-schemas.mssql.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`multiple connected schemas in postgres generate entities for all schemas 1`] = `
+exports[`multiple connected schemas in mssql generate entities for all schemas 1`] = `
 [
   "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { BookTag } from './BookTag';
@@ -206,7 +206,7 @@ export class N5BookTag {
 ]
 `;
 
-exports[`multiple connected schemas in postgres generate entities for given schema only 1`] = `
+exports[`multiple connected schemas in mssql generate entities for given schema only 1`] = `
 [
   "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { BookTag } from './BookTag';

--- a/tests/features/multiple-schemas/__snapshots__/multiple-schemas.mssql.test.ts.snap
+++ b/tests/features/multiple-schemas/__snapshots__/multiple-schemas.mssql.test.ts.snap
@@ -2,42 +2,6 @@
 
 exports[`multiple connected schemas in mssql generate entities for all schemas 1`] = `
 [
-  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import { BookTag } from './BookTag';
-
-@Entity({ schema: 'n2' })
-export class Book {
-
-  @PrimaryKey()
-  id!: number;
-
-  @Property({ nullable: true })
-  name?: string;
-
-  @Property({ fieldName: 'author_id', nullable: true })
-  author?: number;
-
-  @ManyToOne({ entity: () => Book, nullable: true })
-  basedOn?: Book;
-
-  @ManyToMany({ entity: () => BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
-  tags = new Collection<BookTag>(this);
-
-}
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
-
-@Entity({ schema: 'n2' })
-export class BookTag {
-
-  @PrimaryKey()
-  id!: number;
-
-  @Property({ nullable: true })
-  name?: string;
-
-}
-",
   "import { Entity, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 
 @Entity({ schema: 'n1' })

--- a/tests/features/multiple-schemas/__snapshots__/multiple-schemas.mssql.test.ts.snap
+++ b/tests/features/multiple-schemas/__snapshots__/multiple-schemas.mssql.test.ts.snap
@@ -79,6 +79,19 @@ export class N2Book {
 
 }
 ",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'book_tag', schema: 'n2' })
+export class N2BookTag {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+}
+",
   "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { Author } from './Author';
 import { N3BookTag } from './N3BookTag';
@@ -100,6 +113,19 @@ export class N3Book {
 
   @ManyToMany({ entity: () => N3BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
   tags = new Collection<N3BookTag>(this);
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'book_tag', schema: 'n3' })
+export class N3BookTag {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
 
 }
 ",
@@ -127,6 +153,19 @@ export class N4Book {
 
 }
 ",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'book_tag', schema: 'n4' })
+export class N4BookTag {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+}
+",
   "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { Author } from './Author';
 import { N5BookTag } from './N5BookTag';
@@ -148,45 +187,6 @@ export class N5Book {
 
   @ManyToMany({ entity: () => N5BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
   tags = new Collection<N5BookTag>(this);
-
-}
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
-
-@Entity({ tableName: 'book_tag', schema: 'n2' })
-export class N2BookTag {
-
-  @PrimaryKey()
-  id!: number;
-
-  @Property({ nullable: true })
-  name?: string;
-
-}
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
-
-@Entity({ tableName: 'book_tag', schema: 'n3' })
-export class N3BookTag {
-
-  @PrimaryKey()
-  id!: number;
-
-  @Property({ nullable: true })
-  name?: string;
-
-}
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
-
-@Entity({ tableName: 'book_tag', schema: 'n4' })
-export class N4BookTag {
-
-  @PrimaryKey()
-  id!: number;
-
-  @Property({ nullable: true })
-  name?: string;
 
 }
 ",

--- a/tests/features/multiple-schemas/__snapshots__/multiple-schemas.postgres.test.ts.snap
+++ b/tests/features/multiple-schemas/__snapshots__/multiple-schemas.postgres.test.ts.snap
@@ -1,5 +1,211 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`multiple connected schemas in postgres generate entities for all schemas 1`] = `
+[
+  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { BookTag } from './BookTag';
+
+@Entity({ schema: 'n2' })
+export class Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+  @Property({ fieldName: 'author_id', nullable: true })
+  author?: number;
+
+  @ManyToOne({ entity: () => Book, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  basedOn?: Book;
+
+  @ManyToMany({ entity: () => BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  tags = new Collection<BookTag>(this);
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ schema: 'n2' })
+export class BookTag {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+}
+",
+  "import { Entity, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+
+@Entity({ schema: 'n1' })
+export class Author {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Unique({ name: 'author_mentor_id_unique' })
+  @OneToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  mentor?: Author;
+
+}
+",
+  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Author } from './Author';
+import { N2BookTag } from './N2BookTag';
+
+@Entity({ tableName: 'book', schema: 'n2' })
+export class N2Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
+  author?: Author;
+
+  @ManyToOne({ entity: () => N2Book, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  basedOn?: N2Book;
+
+  @ManyToMany({ entity: () => N2BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  tags = new Collection<N2BookTag>(this);
+
+}
+",
+  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Author } from './Author';
+import { N4BookTag } from './N4BookTag';
+
+@Entity({ tableName: 'book', schema: 'n4' })
+export class N4Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
+  author?: Author;
+
+  @ManyToOne({ entity: () => N4Book, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  basedOn?: N4Book;
+
+  @ManyToMany({ entity: () => N4BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  tags = new Collection<N4BookTag>(this);
+
+}
+",
+  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Author } from './Author';
+import { N5BookTag } from './N5BookTag';
+
+@Entity({ tableName: 'book', schema: 'n5' })
+export class N5Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
+  author?: Author;
+
+  @ManyToOne({ entity: () => N5Book, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  basedOn?: N5Book;
+
+  @ManyToMany({ entity: () => N5BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  tags = new Collection<N5BookTag>(this);
+
+}
+",
+  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Author } from './Author';
+import { N3BookTag } from './N3BookTag';
+
+@Entity({ tableName: 'book', schema: 'n3' })
+export class N3Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
+  author?: Author;
+
+  @ManyToOne({ entity: () => N3Book, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  basedOn?: N3Book;
+
+  @ManyToMany({ entity: () => N3BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  tags = new Collection<N3BookTag>(this);
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'book_tag', schema: 'n5' })
+export class N5BookTag {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'book_tag', schema: 'n2' })
+export class N2BookTag {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'book_tag', schema: 'n3' })
+export class N3BookTag {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'book_tag', schema: 'n4' })
+export class N4BookTag {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+}
+",
+]
+`;
+
 exports[`multiple connected schemas in postgres generate entities for given schema only 1`] = `
 [
   "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';

--- a/tests/features/multiple-schemas/__snapshots__/multiple-schemas.postgres.test.ts.snap
+++ b/tests/features/multiple-schemas/__snapshots__/multiple-schemas.postgres.test.ts.snap
@@ -2,42 +2,6 @@
 
 exports[`multiple connected schemas in postgres generate entities for all schemas 1`] = `
 [
-  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import { BookTag } from './BookTag';
-
-@Entity({ schema: 'n2' })
-export class Book {
-
-  @PrimaryKey()
-  id!: number;
-
-  @Property({ nullable: true })
-  name?: string;
-
-  @Property({ fieldName: 'author_id', nullable: true })
-  author?: number;
-
-  @ManyToOne({ entity: () => Book, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  basedOn?: Book;
-
-  @ManyToMany({ entity: () => BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
-  tags = new Collection<BookTag>(this);
-
-}
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
-
-@Entity({ schema: 'n2' })
-export class BookTag {
-
-  @PrimaryKey()
-  id!: number;
-
-  @Property({ nullable: true })
-  name?: string;
-
-}
-",
   "import { Entity, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 
 @Entity({ schema: 'n1' })
@@ -79,51 +43,16 @@ export class N2Book {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import { Author } from './Author';
-import { N4BookTag } from './N4BookTag';
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity({ tableName: 'book', schema: 'n4' })
-export class N4Book {
+@Entity({ tableName: 'book_tag', schema: 'n2' })
+export class N2BookTag {
 
   @PrimaryKey()
   id!: number;
 
   @Property({ nullable: true })
   name?: string;
-
-  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  author?: Author;
-
-  @ManyToOne({ entity: () => N4Book, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  basedOn?: N4Book;
-
-  @ManyToMany({ entity: () => N4BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
-  tags = new Collection<N4BookTag>(this);
-
-}
-",
-  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import { Author } from './Author';
-import { N5BookTag } from './N5BookTag';
-
-@Entity({ tableName: 'book', schema: 'n5' })
-export class N5Book {
-
-  @PrimaryKey()
-  id!: number;
-
-  @Property({ nullable: true })
-  name?: string;
-
-  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  author?: Author;
-
-  @ManyToOne({ entity: () => N5Book, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  basedOn?: N5Book;
-
-  @ManyToMany({ entity: () => N5BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
-  tags = new Collection<N5BookTag>(this);
 
 }
 ",
@@ -153,32 +82,6 @@ export class N3Book {
 ",
   "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity({ tableName: 'book_tag', schema: 'n5' })
-export class N5BookTag {
-
-  @PrimaryKey()
-  id!: number;
-
-  @Property({ nullable: true })
-  name?: string;
-
-}
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
-
-@Entity({ tableName: 'book_tag', schema: 'n2' })
-export class N2BookTag {
-
-  @PrimaryKey()
-  id!: number;
-
-  @Property({ nullable: true })
-  name?: string;
-
-}
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
-
 @Entity({ tableName: 'book_tag', schema: 'n3' })
 export class N3BookTag {
 
@@ -190,10 +93,71 @@ export class N3BookTag {
 
 }
 ",
+  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Author } from './Author';
+import { N4BookTag } from './N4BookTag';
+
+@Entity({ tableName: 'book', schema: 'n4' })
+export class N4Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
+  author?: Author;
+
+  @ManyToOne({ entity: () => N4Book, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  basedOn?: N4Book;
+
+  @ManyToMany({ entity: () => N4BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  tags = new Collection<N4BookTag>(this);
+
+}
+",
   "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity({ tableName: 'book_tag', schema: 'n4' })
 export class N4BookTag {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+}
+",
+  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Author } from './Author';
+import { N5BookTag } from './N5BookTag';
+
+@Entity({ tableName: 'book', schema: 'n5' })
+export class N5Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
+  author?: Author;
+
+  @ManyToOne({ entity: () => N5Book, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  basedOn?: N5Book;
+
+  @ManyToMany({ entity: () => N5BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  tags = new Collection<N5BookTag>(this);
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'book_tag', schema: 'n5' })
+export class N5BookTag {
 
   @PrimaryKey()
   id!: number;

--- a/tests/features/multiple-schemas/__snapshots__/multiple-schemas.postgres.test.ts.snap
+++ b/tests/features/multiple-schemas/__snapshots__/multiple-schemas.postgres.test.ts.snap
@@ -3,7 +3,6 @@
 exports[`multiple connected schemas in postgres generate entities for given schema only 1`] = `
 [
   "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import { Author } from './Author';
 import { BookTag } from './BookTag';
 
 @Entity({ schema: 'n2' })
@@ -15,8 +14,8 @@ export class Book {
   @Property({ nullable: true })
   name?: string;
 
-  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  author?: Author;
+  @Property({ fieldName: 'author_id', nullable: true })
+  author?: number;
 
   @ManyToOne({ entity: () => Book, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
   basedOn?: Book;

--- a/tests/features/multiple-schemas/multiple-schemas.mssql.test.ts
+++ b/tests/features/multiple-schemas/multiple-schemas.mssql.test.ts
@@ -50,7 +50,7 @@ export class Book extends BaseEntity {
 
 }
 
-describe('multiple connected schemas in postgres', () => {
+describe('multiple connected schemas in mssql', () => {
 
   let orm: MikroORM;
 

--- a/tests/features/multiple-schemas/multiple-schemas.mssql.test.ts
+++ b/tests/features/multiple-schemas/multiple-schemas.mssql.test.ts
@@ -54,7 +54,7 @@ describe('multiple connected schemas in mssql', () => {
 
   let orm: MikroORM;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     orm = await MikroORM.init({
       entities: [Author, Book, BookTag],
       dbName: `mikro_orm_test_multi_schemas`,
@@ -82,16 +82,8 @@ describe('multiple connected schemas in mssql', () => {
     orm.config.set('schema', 'n2'); // set the schema so we can work with book entities without options param
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await orm.close(true);
-  });
-
-  beforeEach(async () => {
-    await orm.schema.clearDatabase();
-    await orm.schema.clearDatabase({ schema: 'n3' });
-    await orm.schema.clearDatabase({ schema: 'n4' });
-    await orm.schema.clearDatabase({ schema: 'n5' });
-    await orm.em.qb(Author).truncate();
   });
 
   // if we have schema specified on entity level, it only exists in that schema

--- a/tests/features/multiple-schemas/multiple-schemas.mssql.test.ts
+++ b/tests/features/multiple-schemas/multiple-schemas.mssql.test.ts
@@ -377,6 +377,12 @@ describe('multiple connected schemas in postgres', () => {
     expect(entities).toMatchSnapshot();
   });
 
+  test('generate entities for all schemas', async () => {
+    const generator = orm.getEntityGenerator();
+    const entities = await generator.generate();
+    expect(entities).toMatchSnapshot();
+  });
+
   test('use different schema via options in em.insert/Many', async () => {
     const mock = mockLogger(orm);
 

--- a/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
+++ b/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
@@ -55,7 +55,7 @@ describe('multiple connected schemas in postgres', () => {
 
   let orm: MikroORM<PostgreSqlDriver>;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     orm = await MikroORM.init({
       entities: [Author, Book, BookTag],
       dbName: `mikro_orm_test_multi_schemas`,
@@ -79,21 +79,8 @@ describe('multiple connected schemas in postgres', () => {
     orm.config.set('schema', 'n2'); // set the schema so we can work with book entities without options param
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await orm.close(true);
-  });
-
-  beforeEach(async () => {
-    await orm.em.createQueryBuilder(Author).truncate().execute(); // schema from metadata
-    await orm.em.createQueryBuilder(Book).truncate().execute(); // current schema from config
-    await orm.em.createQueryBuilder(Book).withSchema('n3').truncate().execute();
-    await orm.em.createQueryBuilder(Book).withSchema('n4').truncate().execute();
-    await orm.em.createQueryBuilder(Book).withSchema('n5').truncate().execute();
-    await orm.em.createQueryBuilder(BookTag).truncate().execute(); // current schema from config
-    await orm.em.createQueryBuilder(BookTag).withSchema('n3').truncate().execute();
-    await orm.em.createQueryBuilder(BookTag).withSchema('n4').truncate().execute();
-    await orm.em.createQueryBuilder(BookTag).withSchema('n5').truncate().execute();
-    orm.em.clear();
   });
 
   // if we have schema specified on entity level, it only exists in that schema
@@ -372,15 +359,15 @@ describe('multiple connected schemas in postgres', () => {
     });
   });
 
-  test('generate entities for given schema only', async () => {
-    const generator = orm.getEntityGenerator();
-    const entities = await generator.generate({ schema: 'n2' });
-    expect(entities).toMatchSnapshot();
-  });
-
   test('generate entities for all schemas', async () => {
     const generator = orm.getEntityGenerator();
     const entities = await generator.generate();
+    expect(entities).toMatchSnapshot();
+  });
+
+  test('generate entities for given schema only', async () => {
+    const generator = orm.getEntityGenerator();
+    const entities = await generator.generate({ schema: 'n2' });
     expect(entities).toMatchSnapshot();
   });
 

--- a/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
+++ b/tests/features/multiple-schemas/multiple-schemas.postgres.test.ts
@@ -378,6 +378,12 @@ describe('multiple connected schemas in postgres', () => {
     expect(entities).toMatchSnapshot();
   });
 
+  test('generate entities for all schemas', async () => {
+    const generator = orm.getEntityGenerator();
+    const entities = await generator.generate();
+    expect(entities).toMatchSnapshot();
+  });
+
   test('use different schema via options in em.insert/Many', async () => {
     const mock = mockLogger(orm);
 

--- a/tests/features/truncate/truncate.mssql.test.ts
+++ b/tests/features/truncate/truncate.mssql.test.ts
@@ -1,0 +1,60 @@
+import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/mssql';
+
+
+@Entity()
+class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+}
+
+describe('truncate [mssql]', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [User],
+      dbName: 'truncate',
+      password: 'Root.Root',
+    });
+    await orm.schema.refreshDatabase();
+  });
+
+  beforeEach(async () => {
+    await orm.schema.clearDatabase();
+  });
+
+  afterAll(() => orm.close(true));
+
+  test('truncates table and resets identity value', async () => {
+
+    await orm.em.persistAndFlush([
+      orm.em.create(User, { name: 'u1' }),
+      orm.em.create(User, { name: 'u2' }),
+      orm.em.create(User, { name: 'u3' }),
+    ]);
+
+    const [{ identity: identityBefore }] = await orm.em
+      .getKnex()
+      .raw(`SELECT IDENT_CURRENT('user') AS [identity]`);
+
+    await orm.em.createQueryBuilder(User).truncate().execute();
+
+    const [{ identity: identityAfter }] = await orm.em
+      .getKnex()
+      .raw(`SELECT IDENT_CURRENT('user') AS [identity]`);
+
+    const users = await orm.em.find(User, {});
+
+    expect(users.length).toBe(0);
+    expect(identityBefore).toBe(3);
+    expect(identityAfter).toBe(0);
+
+  });
+
+});

--- a/tests/features/truncate/truncate.mssql.test.ts
+++ b/tests/features/truncate/truncate.mssql.test.ts
@@ -1,6 +1,5 @@
 import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/mssql';
 
-
 @Entity()
 class User {
 
@@ -39,14 +38,12 @@ describe('truncate [mssql]', () => {
     ]);
 
     const [{ identity: identityBefore }] = await orm.em
-      .getKnex()
-      .raw(`SELECT IDENT_CURRENT('user') AS [identity]`);
+      .execute(`SELECT IDENT_CURRENT('user') AS [identity]`);
 
     await orm.em.createQueryBuilder(User).truncate().execute();
 
     const [{ identity: identityAfter }] = await orm.em
-      .getKnex()
-      .raw(`SELECT IDENT_CURRENT('user') AS [identity]`);
+      .execute(`SELECT IDENT_CURRENT('user') AS [identity]`);
 
     const users = await orm.em.find(User, {});
 

--- a/tests/features/truncate/truncate.mysql.test.ts
+++ b/tests/features/truncate/truncate.mysql.test.ts
@@ -1,6 +1,5 @@
 import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/mysql';
 
-
 @Entity()
 class User {
 

--- a/tests/features/truncate/truncate.postgresql.test.ts
+++ b/tests/features/truncate/truncate.postgresql.test.ts
@@ -1,6 +1,5 @@
 import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/postgresql';
 
-
 @Entity()
 class User {
 
@@ -37,25 +36,16 @@ describe('truncate [postgresql]', () => {
       orm.em.create(User, { name: 'u3' }),
     ]);
 
-    const {
-      rows: [{ identitySequence }],
-    } = await orm.em
-      .getKnex()
-      .raw(`SELECT pg_get_serial_sequence('user', 'id') AS "identitySequence"`);
+    const [{ identitySequence }] = await orm.em
+      .execute(`SELECT pg_get_serial_sequence('user', 'id') AS "identitySequence"`);
 
-    const {
-      rows: [{ identity: identityBefore }],
-    } = await orm.em
-      .getKnex()
-      .raw(`SELECT last_value AS "identity" FROM ${identitySequence}`);
+    const [{ identity: identityBefore }] = await orm.em
+      .execute(`SELECT last_value AS "identity" FROM ${identitySequence}`);
 
     await orm.em.createQueryBuilder(User).truncate().execute();
 
-    const {
-      rows: [{ identity: identityAfter }],
-    } = await orm.em
-      .getKnex()
-      .raw(`SELECT last_value AS "identity" FROM ${identitySequence}`);
+    const [{ identity: identityAfter }] = await orm.em
+      .execute(`SELECT last_value AS "identity" FROM ${identitySequence}`);
 
     const users = await orm.em.find(User, {});
 

--- a/tests/features/truncate/truncate.sqlite.test.ts
+++ b/tests/features/truncate/truncate.sqlite.test.ts
@@ -1,6 +1,5 @@
 import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
-
 @Entity()
 class User {
 


### PR DESCRIPTION
This moves table filtering from after retrieving all table details (i.e. columns, foreign keys, etc.) to after retrieving a list of tables as described in #5900.

Closes #5900