### PR TITLE
refactor(cli): made the CLI explicitly pass the config path from the arg, or else infer it once

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -581,6 +581,18 @@ MikroORM.init({
 });
 ```
 
+## Deprecation warnings
+
+By default, doing something that is deprecated will result in a deprecation warning being logged. The default logger will in turn show it on the console.
+
+You can ignore all or only specific deprecation warnings. See [Logging's section on deprecation warnings](./logging.md#deprecation-warnings) for details.
+
+The full list of deprecation errors:
+
+| label | message                                                                                                                                                                                                                                                                            |
+|-------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| D001  | Path for config file was inferred from the command line arguments. Instead, you should set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init. |
+
 ## Using environment variables
 
 Since v4.5 it is possible to set most of the ORM options via environment variables. By default `.env` file from the root directory is loaded - it is also possible to set full path to the env file you want to use via `MIKRO_ORM_ENV` environment variable.

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -591,7 +591,7 @@ The full list of deprecation errors:
 
 | label | message                                                                                                                                                                                                                                                                            |
 |-------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| D001  | Path for config file was inferred from the command line arguments. Instead, you should set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init. |
+| D001  | Path for config file was inferred from the command line arguments. Instead, you should set the `MIKRO_ORM_CLI_CONFIG` environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init. |
 
 ## Using environment variables
 

--- a/docs/docs/logging.md
+++ b/docs/docs/logging.md
@@ -63,7 +63,7 @@ You can ignore all deprecation warnings by setting `ignoreDeprecations` to `true
 
 ```ts
 return MikroORM.init({
-    ignoreDeprecations: true, // now no deprecations will be logged, though you may be surprised when upgrading
+  ignoreDeprecations: true, // now no deprecations will be logged, though you may be surprised when upgrading
 });
 ```
 
@@ -71,7 +71,7 @@ When you are actively trying to remove deprecation warnings in preparation for a
 
 ```ts
 return MikroORM.init({
-    ignoreDeprecations: ['D0001'], // ignore deprecation with label "D0001", but show others if they pop up
+  ignoreDeprecations: ['D0001'], // ignore deprecation with label "D0001", but show others if they pop up
 });
 ```
 

--- a/docs/docs/logging.md
+++ b/docs/docs/logging.md
@@ -49,9 +49,33 @@ return MikroORM.init({
 });
 ```
 
-Currently, there are 5 namespaces – `query`, `query-params`, `schema`, `discovery` and `info`.
+Currently, there are 6 namespaces – `query`, `query-params`, `schema`, `discovery`, `info` and `deprecated`.
 
 If you provide `query-params` then you must also provide `query` in order for it to take effect.
+
+## Deprecation warnings
+
+Even without `debugMode` enabled, the default logger will show `deprecated` messages in console.
+
+When something is deprecated, it means there is an intention for it to be removed in a future version. The deprecation message should suggest alternatives for you that you should switch to before migrating to a major version.
+
+You can ignore all deprecation warnings by setting `ignoreDeprecations` to `true`
+
+```ts
+return MikroORM.init({
+    ignoreDeprecations: true, // now no deprecations will be logged, though you may be surprised when upgrading
+});
+```
+
+When you are actively trying to remove deprecation warnings in preparation for an upgrade, you would likely want to tackle them one at a time. You can ignore only specific deprecation warnings you can't deal with right now, while still being alerted of others you didn't know about. To do this, list the deprecation warnings you want to ignore, e.g.
+
+```ts
+return MikroORM.init({
+    ignoreDeprecations: ['D0001'], // ignore deprecation with label "D0001", but show others if they pop up
+});
+```
+
+You can see a list of deprecation errors in [Configuration's section on deprecated warnings](./configuration.md#deprecation-warnings).
 
 ## Highlighters
 

--- a/packages/cli/src/CLIConfigurator.ts
+++ b/packages/cli/src/CLIConfigurator.ts
@@ -33,6 +33,7 @@ export class CLIConfigurator {
       .example('$0 schema:update --run', 'Runs schema synchronization')
       .option('config', {
         type: 'string',
+        array: true,
         desc: `Set path to the ORM configuration file`,
       })
       .alias('v', 'version')

--- a/packages/cli/src/CLIHelper.ts
+++ b/packages/cli/src/CLIHelper.ts
@@ -7,18 +7,23 @@ import { colors, ConfigurationLoader, MikroORM, Utils, type Configuration, type 
  */
 export class CLIHelper {
 
-  static async getConfiguration<D extends IDatabaseDriver = IDatabaseDriver>(validate = true, options: Partial<Options> = {}): Promise<Configuration<D>> {
+  static async getConfiguration<D extends IDatabaseDriver = IDatabaseDriver>(configPaths?: string[], options: Partial<Options<D>> = {}, validate = true): Promise<Configuration<D>> {
     const deps = ConfigurationLoader.getORMPackages();
 
     if (!deps.has('@mikro-orm/cli') && !process.env.MIKRO_ORM_ALLOW_GLOBAL_CLI) {
       throw new Error('@mikro-orm/cli needs to be installed as a local dependency!');
     }
 
-    return ConfigurationLoader.getConfiguration(validate, options);
+    ConfigurationLoader.commonJSCompat(options);
+    ConfigurationLoader.registerDotenv(options);
+
+    configPaths ??= ConfigurationLoader.getConfigPaths();
+
+    return ConfigurationLoader.getConfiguration(configPaths, options, validate);
   }
 
-  static async getORM(warnWhenNoEntities?: boolean, opts: Partial<Options> = {}): Promise<MikroORM> {
-    const options = await CLIHelper.getConfiguration(warnWhenNoEntities, opts);
+  static async getORM<D extends IDatabaseDriver = IDatabaseDriver>(config?: string, opts: Partial<Options<D>> = {}, validate?: boolean): Promise<MikroORM<D>> {
+    const options = await CLIHelper.getConfiguration((typeof config !== 'undefined') ? [config] : undefined, opts, validate);
     const settings = ConfigurationLoader.getSettings();
     options.set('allowGlobalContext', true);
     options.set('debug', !!settings.verbose);
@@ -29,20 +34,23 @@ export class CLIHelper {
       options.set('tsNode', true);
     }
 
-    if (Utils.isDefined(warnWhenNoEntities)) {
-      options.get('discovery').warnWhenNoEntities = warnWhenNoEntities;
+    // The only times when we don't care to have a warning about no entities is also the time when we ignore entities.
+    if (opts.discovery?.warnWhenNoEntities === false) {
+      options.set('entities', []);
+      options.set('entitiesTs', []);
     }
 
     return MikroORM.init(options.getAll());
   }
 
-  static async isDBConnected(reason = false): Promise<boolean | string> {
+  static async isDBConnected(config: Configuration, reason?: false): Promise<boolean>;
+  static async isDBConnected(config: Configuration, reason: true): Promise<true | string>;
+  static async isDBConnected(config: Configuration, reason = false): Promise<boolean | string> {
     try {
-      const config = await CLIHelper.getConfiguration();
       await config.getDriver().connect();
       const isConnected = await config.getDriver().getConnection().checkConnection();
       await config.getDriver().close();
-      return isConnected.reason && reason ? isConnected.reason : isConnected.ok;
+      return isConnected.ok || (reason ? isConnected.reason : false);
     } catch {
       return false;
     }
@@ -52,9 +60,8 @@ export class CLIHelper {
     return process.versions.node;
   }
 
-  static async getDriverDependencies(): Promise<string[]> {
+  static getDriverDependencies(config: Configuration): string[] {
     try {
-      const config = await CLIHelper.getConfiguration();
       return config.getDriver().getDependencies();
     } catch {
       return [];
@@ -81,12 +88,6 @@ export class CLIHelper {
     CLIHelper.dump(`   - node ${colors.green(CLIHelper.getNodeVersion())}`);
 
     if (pathExistsSync(process.cwd() + '/package.json')) {
-      const drivers = await CLIHelper.getDriverDependencies();
-
-      for (const driver of drivers) {
-        CLIHelper.dump(`   - ${driver} ${await CLIHelper.getModuleVersion(driver)}`);
-      }
-
       /* istanbul ignore next */
       if (process.versions.bun) {
         CLIHelper.dump(`   - typescript via bun`);

--- a/packages/cli/src/CLIHelper.ts
+++ b/packages/cli/src/CLIHelper.ts
@@ -22,8 +22,8 @@ export class CLIHelper {
     return ConfigurationLoader.getConfiguration(configPaths, options, validate);
   }
 
-  static async getORM<D extends IDatabaseDriver = IDatabaseDriver>(config?: string, opts: Partial<Options<D>> = {}, validate?: boolean): Promise<MikroORM<D>> {
-    const options = await CLIHelper.getConfiguration((typeof config !== 'undefined') ? [config] : undefined, opts, validate);
+  static async getORM<D extends IDatabaseDriver = IDatabaseDriver>(configPaths?: string[], opts: Partial<Options<D>> = {}, validate?: boolean): Promise<MikroORM<D>> {
+    const options = await CLIHelper.getConfiguration(configPaths, opts, validate);
     const settings = ConfigurationLoader.getSettings();
     options.set('allowGlobalContext', true);
     options.set('debug', !!settings.verbose);

--- a/packages/cli/src/commands/ClearCacheCommand.ts
+++ b/packages/cli/src/commands/ClearCacheCommand.ts
@@ -12,7 +12,9 @@ export class ClearCacheCommand implements BaseCommand {
    * @inheritDoc
    */
   async handler(args: ArgumentsCamelCase<BaseArgs>) {
-    const config = await CLIHelper.getConfiguration();
+    const config = await CLIHelper.getConfiguration(
+      (typeof args.config !== 'undefined') ? [args.config] : undefined,
+    );
 
     if (!config.get('metadataCache').enabled) {
       CLIHelper.dump(colors.red('Metadata cache is disabled in your configuration. Set cache.enabled to true to use this command.'));

--- a/packages/cli/src/commands/ClearCacheCommand.ts
+++ b/packages/cli/src/commands/ClearCacheCommand.ts
@@ -12,9 +12,7 @@ export class ClearCacheCommand implements BaseCommand {
    * @inheritDoc
    */
   async handler(args: ArgumentsCamelCase<BaseArgs>) {
-    const config = await CLIHelper.getConfiguration(
-      (typeof args.config !== 'undefined') ? [args.config] : undefined,
-    );
+    const config = await CLIHelper.getConfiguration(args.config);
 
     if (!config.get('metadataCache').enabled) {
       CLIHelper.dump(colors.red('Metadata cache is disabled in your configuration. Set cache.enabled to true to use this command.'));

--- a/packages/cli/src/commands/CreateDatabaseCommand.ts
+++ b/packages/cli/src/commands/CreateDatabaseCommand.ts
@@ -1,5 +1,4 @@
 import type { ArgumentsCamelCase } from 'yargs';
-import type { MikroORM } from '@mikro-orm/core';
 import type { AbstractSqlDriver } from '@mikro-orm/knex';
 import type { BaseArgs, BaseCommand } from '../CLIConfigurator';
 import { CLIHelper } from '../CLIHelper';
@@ -13,7 +12,7 @@ export class CreateDatabaseCommand implements BaseCommand {
    * @inheritDoc
    */
   async handler(args: ArgumentsCamelCase<BaseArgs>) {
-    const orm = await CLIHelper.getORM() as MikroORM<AbstractSqlDriver>;
+    const orm = await CLIHelper.getORM<AbstractSqlDriver>(args.config);
 
     const schemaGenerator = orm.getSchemaGenerator();
     await schemaGenerator.ensureDatabase();

--- a/packages/cli/src/commands/CreateSeederCommand.ts
+++ b/packages/cli/src/commands/CreateSeederCommand.ts
@@ -12,8 +12,8 @@ export class CreateSeederCommand implements BaseCommand<CreateSeederCommandArgs>
   builder = (args: Argv<BaseArgs>) => {
     args.positional('seeder', {
       describe: 'Name for the seeder class. (e.g. "test" will generate "TestSeeder" or "TestSeeder" will generate "TestSeeder")',
+      demandOption: true,
     });
-    args.demandOption('seeder');
     return args as Argv<CreateSeederCommandArgs>;
   };
 
@@ -22,7 +22,7 @@ export class CreateSeederCommand implements BaseCommand<CreateSeederCommandArgs>
    */
   async handler(args: ArgumentsCamelCase<CreateSeederCommandArgs>) {
     const className = CreateSeederCommand.getSeederClassName(args.seeder);
-    const orm = await CLIHelper.getORM();
+    const orm = await CLIHelper.getORM(args.config);
     const seeder = orm.getSeeder();
     const path = await seeder.createSeeder(className);
     CLIHelper.dump(colors.green(`Seeder ${args.seeder} successfully created at ${path}`));

--- a/packages/cli/src/commands/DatabaseSeedCommand.ts
+++ b/packages/cli/src/commands/DatabaseSeedCommand.ts
@@ -22,7 +22,7 @@ export class DatabaseSeedCommand implements BaseCommand<DatabaseSeedArgs> {
    * @inheritDoc
    */
   async handler(args: ArgumentsCamelCase<DatabaseSeedArgs>) {
-    const orm = await CLIHelper.getORM();
+    const orm = await CLIHelper.getORM(args.config);
     const className = args.class ?? orm.config.get('seeder').defaultSeeder!;
     await orm.getSeeder().seedString(className);
     CLIHelper.dump(colors.green(`Seeder ${className} successfully executed`));

--- a/packages/cli/src/commands/DebugCommand.ts
+++ b/packages/cli/src/commands/DebugCommand.ts
@@ -20,15 +20,21 @@ export class DebugCommand implements BaseCommand {
       CLIHelper.dump(' - ts-node ' + colors.green('enabled'));
     }
 
-    const configPaths = CLIHelper.getConfigPaths();
+    const configPaths = (typeof args.config !== 'undefined') ? [args.config] : CLIHelper.getConfigPaths();
     CLIHelper.dump(' - searched config paths:');
     await DebugCommand.checkPaths(configPaths, 'yellow');
 
     try {
-      const config = await CLIHelper.getConfiguration();
+      const config = await CLIHelper.getConfiguration(configPaths);
       CLIHelper.dump(` - configuration ${colors.green('found')}`);
+      const drivers = CLIHelper.getDriverDependencies(config);
 
-      const isConnected = await CLIHelper.isDBConnected(true);
+      CLIHelper.dump(' - driver dependencies:');
+      for (const driver of drivers) {
+        CLIHelper.dump(`   - ${driver} ${await CLIHelper.getModuleVersion(driver)}`);
+      }
+
+      const isConnected = await CLIHelper.isDBConnected(config, true);
 
       if (isConnected === true) {
         CLIHelper.dump(` - ${colors.green('database connection successful')}`);

--- a/packages/cli/src/commands/DebugCommand.ts
+++ b/packages/cli/src/commands/DebugCommand.ts
@@ -20,7 +20,7 @@ export class DebugCommand implements BaseCommand {
       CLIHelper.dump(' - ts-node ' + colors.green('enabled'));
     }
 
-    const configPaths = (typeof args.config !== 'undefined') ? [args.config] : CLIHelper.getConfigPaths();
+    const configPaths = args.config ?? CLIHelper.getConfigPaths();
     CLIHelper.dump(' - searched config paths:');
     await DebugCommand.checkPaths(configPaths, 'yellow');
 

--- a/packages/cli/src/commands/GenerateCacheCommand.ts
+++ b/packages/cli/src/commands/GenerateCacheCommand.ts
@@ -27,7 +27,7 @@ export class GenerateCacheCommand implements BaseCommand<CacheArgs> {
   async handler(args: ArgumentsCamelCase<CacheArgs>) {
     const options = args.combined ? { combined: './metadata.json' } : {};
     const config = await CLIHelper.getConfiguration(
-      (typeof args.config !== 'undefined') ? [args.config] : undefined,
+      args.config,
       {
         metadataCache: { enabled: true, adapter: FileCacheAdapter, options },
       },

--- a/packages/cli/src/commands/GenerateCacheCommand.ts
+++ b/packages/cli/src/commands/GenerateCacheCommand.ts
@@ -26,9 +26,12 @@ export class GenerateCacheCommand implements BaseCommand<CacheArgs> {
    */
   async handler(args: ArgumentsCamelCase<CacheArgs>) {
     const options = args.combined ? { combined: './metadata.json' } : {};
-    const config = await CLIHelper.getConfiguration(true, {
-      metadataCache: { enabled: true, adapter: FileCacheAdapter, options },
-    });
+    const config = await CLIHelper.getConfiguration(
+      (typeof args.config !== 'undefined') ? [args.config] : undefined,
+      {
+        metadataCache: { enabled: true, adapter: FileCacheAdapter, options },
+      },
+    );
 
     config.getMetadataCacheAdapter().clear();
     config.set('logger', CLIHelper.dump.bind(null));

--- a/packages/cli/src/commands/GenerateEntitiesCommand.ts
+++ b/packages/cli/src/commands/GenerateEntitiesCommand.ts
@@ -44,7 +44,7 @@ export class GenerateEntitiesCommand implements BaseCommand<GenerateEntitiesArgs
       return CLIHelper.showHelp();
     }
 
-    const orm = await CLIHelper.getORM(false);
+    const orm = await CLIHelper.getORM(args.config, { discovery: { warnWhenNoEntities: false } });
     const dump = await orm.entityGenerator.generate({
       save: args.save,
       path: args.path,

--- a/packages/cli/src/commands/ImportCommand.ts
+++ b/packages/cli/src/commands/ImportCommand.ts
@@ -1,10 +1,12 @@
-import { colors, type MikroORM } from '@mikro-orm/core';
+import { colors } from '@mikro-orm/core';
 import type { AbstractSqlDriver } from '@mikro-orm/knex';
 import type { ArgumentsCamelCase } from 'yargs';
 import type { BaseArgs, BaseCommand } from '../CLIConfigurator';
 import { CLIHelper } from '../CLIHelper';
 
-export class ImportCommand implements BaseCommand {
+type ImportArgs = BaseArgs & { file: string };
+
+export class ImportCommand implements BaseCommand<ImportArgs> {
 
   command = 'database:import <file>';
   describe = 'Imports the SQL file to the database';
@@ -12,9 +14,9 @@ export class ImportCommand implements BaseCommand {
   /**
    * @inheritDoc
    */
-  async handler(args: ArgumentsCamelCase<BaseArgs>) {
-    const orm = await CLIHelper.getORM() as MikroORM<AbstractSqlDriver>;
-    await orm.em.getConnection().loadFile(args.file as string);
+  async handler(args: ArgumentsCamelCase<ImportArgs>) {
+    const orm = await CLIHelper.getORM<AbstractSqlDriver>(args.config, { multipleStatements: true });
+    await orm.em.getConnection().loadFile(args.file);
     CLIHelper.dump(colors.green(`File ${args.file} successfully imported`));
     await orm.close(true);
   }

--- a/packages/cli/src/commands/MigrationCommandFactory.ts
+++ b/packages/cli/src/commands/MigrationCommandFactory.ts
@@ -92,8 +92,8 @@ export class MigrationCommandFactory {
 
   static async handleMigrationCommand(args: ArgumentsCamelCase<Opts>, method: MigratorMethod): Promise<void> {
     // to be able to run have a master transaction, but run marked migrations outside of it, we need a second connection
-    const options = { pool: { min: 1, max: 2 } } as Options;
-    const orm = await CLIHelper.getORM(undefined, options);
+    const options = { pool: { min: 1, max: 2 } } satisfies Options;
+    const orm = await CLIHelper.getORM(args.config, options);
     const migrator = orm.getMigrator();
 
     switch (method) {

--- a/packages/cli/src/commands/SchemaCommandFactory.ts
+++ b/packages/cli/src/commands/SchemaCommandFactory.ts
@@ -96,7 +96,7 @@ export class SchemaCommandFactory {
       return CLIHelper.showHelp();
     }
 
-    const orm = await CLIHelper.getORM();
+    const orm = await CLIHelper.getORM(args.config);
     const generator = orm.getSchemaGenerator();
     const params = { wrap: args.fkChecks == null ? undefined : !args.fkChecks, ...args };
 

--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -38,7 +38,7 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver, EM extends En
       const config = (await ConfigurationLoader.getConfiguration<D, EM>(configPathFromArg ?? ConfigurationLoader.getConfigPaths()));
       options = config.getAll();
       if (configPathFromArg) {
-        config.getLogger().warn('deprecated', 'Path for config file was inferred from the command line arguments. This is deprecated. Set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init.', { label: 'MikroORM:0001' });
+        config.getLogger().warn('deprecated', 'Path for config file was inferred from the command line arguments. Instead, you should set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init.', { label: 'D0001' });
       }
     }
 

--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -38,7 +38,7 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver, EM extends En
       const config = (await ConfigurationLoader.getConfiguration<D, EM>(configPathFromArg ?? ConfigurationLoader.getConfigPaths()));
       options = config.getAll();
       if (configPathFromArg) {
-        config.getLogger().warn('deprecated', 'Path for config file was inferred from the command line arguments. This is deprecated. Set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init.');
+        config.getLogger().warn('deprecated', 'Path for config file was inferred from the command line arguments. This is deprecated. Set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init.', { label: 'MikroORM:0001' });
       }
     }
 

--- a/packages/core/src/connections/Connection.ts
+++ b/packages/core/src/connections/Connection.ts
@@ -44,7 +44,7 @@ export abstract class Connection {
   /**
    * Are we connected to the database
    */
-  abstract checkConnection(): Promise<{ ok: boolean; reason?: string; error?: Error }>;
+  abstract checkConnection(): Promise<{ ok: true } | { ok: false; reason: string; error?: Error }>;
 
   /**
    * Closes the database connection (aka disconnect)

--- a/packages/core/src/logging/DefaultLogger.ts
+++ b/packages/core/src/logging/DefaultLogger.ts
@@ -70,7 +70,10 @@ export class DefaultLogger implements Logger {
     const debugMode = context?.debugMode ?? this.debugMode;
 
     if (namespace === 'deprecated') {
-      return !this.options.ignoreDeprecations;
+      const { ignoreDeprecations = false } = this.options;
+      return Array.isArray(ignoreDeprecations)
+        ? !ignoreDeprecations.includes(context?.label ?? '')
+        : !ignoreDeprecations;
     }
 
     return !!debugMode && (!Array.isArray(debugMode) || debugMode.includes(namespace));

--- a/packages/core/src/logging/DefaultLogger.ts
+++ b/packages/core/src/logging/DefaultLogger.ts
@@ -10,7 +10,7 @@ export class DefaultLogger implements Logger {
   private readonly highlighter?: Highlighter;
 
   constructor(private readonly options: LoggerOptions) {
-    this.debugMode = this.options.debugMode ?? ['deprecated'];
+    this.debugMode = this.options.debugMode ?? false;
     this.writer = this.options.writer;
     this.usesReplicas = this.options.usesReplicas;
     this.highlighter = this.options.highlighter;
@@ -68,6 +68,10 @@ export class DefaultLogger implements Logger {
   isEnabled(namespace: LoggerNamespace, context?: LogContext) {
     if (context?.enabled !== undefined) { return context.enabled; }
     const debugMode = context?.debugMode ?? this.debugMode;
+
+    if (namespace === 'deprecated') {
+      return !this.options.ignoreDeprecations;
+    }
 
     return !!debugMode && (!Array.isArray(debugMode) || debugMode.includes(namespace));
   }

--- a/packages/core/src/logging/DefaultLogger.ts
+++ b/packages/core/src/logging/DefaultLogger.ts
@@ -10,7 +10,7 @@ export class DefaultLogger implements Logger {
   private readonly highlighter?: Highlighter;
 
   constructor(private readonly options: LoggerOptions) {
-    this.debugMode = this.options.debugMode ?? false;
+    this.debugMode = this.options.debugMode ?? ['deprecated'];
     this.writer = this.options.writer;
     this.usesReplicas = this.options.usesReplicas;
     this.highlighter = this.options.highlighter;

--- a/packages/core/src/logging/Logger.ts
+++ b/packages/core/src/logging/Logger.ts
@@ -52,6 +52,7 @@ export interface LogContext extends Dictionary {
 export interface LoggerOptions {
   writer: (message: string) => void;
   debugMode?: boolean | LoggerNamespace[];
+  ignoreDeprecations?: boolean;
   highlighter?: Highlighter;
   usesReplicas?: boolean;
 }

--- a/packages/core/src/logging/Logger.ts
+++ b/packages/core/src/logging/Logger.ts
@@ -31,7 +31,7 @@ export interface Logger {
 
 }
 
-export type LoggerNamespace = 'query' | 'query-params' | 'schema' | 'discovery' | 'info';
+export type LoggerNamespace = 'query' | 'query-params' | 'schema' | 'discovery' | 'info' | 'deprecated';
 
 export interface LogContext extends Dictionary {
   query?: string;

--- a/packages/core/src/logging/Logger.ts
+++ b/packages/core/src/logging/Logger.ts
@@ -52,7 +52,7 @@ export interface LogContext extends Dictionary {
 export interface LoggerOptions {
   writer: (message: string) => void;
   debugMode?: boolean | LoggerNamespace[];
-  ignoreDeprecations?: boolean;
+  ignoreDeprecations?: boolean | string[];
   highlighter?: Highlighter;
   usesReplicas?: boolean;
 }

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -103,6 +103,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver, EM exten
     ensureIndexes: false,
     batchSize: 300,
     debug: false,
+    ignoreDeprecations: false,
     verbose: false,
     driverOptions: {},
     migrations: {
@@ -185,6 +186,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver, EM exten
     this.options.loggerFactory ??= DefaultLogger.create;
     this.logger = this.options.loggerFactory({
       debugMode: this.options.debug,
+      ignoreDeprecations: this.options.ignoreDeprecations,
       usesReplicas: (this.options.replicas?.length ?? 0) > 0,
       highlighter: this.options.highlighter,
       writer: this.options.logger,
@@ -608,6 +610,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver, EM
   findOneOrFailHandler: (entityName: string, where: Dictionary | IPrimaryKey) => Error;
   findExactlyOneOrFailHandler: (entityName: string, where: Dictionary | IPrimaryKey) => Error;
   debug: boolean | LoggerNamespace[];
+  ignoreDeprecations: boolean | string[];
   highlighter: Highlighter;
   tsNode?: boolean;
   baseDir: string;

--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -15,10 +15,7 @@ import { Utils } from './Utils';
  */
 export class ConfigurationLoader {
 
-  static async getConfiguration<D extends IDatabaseDriver = IDatabaseDriver, EM extends D[typeof EntityManagerType] & EntityManager = EntityManager>(validate = true, options: Partial<Options> = {}): Promise<Configuration<D, EM>> {
-    this.commonJSCompat(options);
-    this.registerDotenv(options);
-    const paths = this.getConfigPaths();
+  static async getConfiguration<D extends IDatabaseDriver = IDatabaseDriver, EM extends D[typeof EntityManagerType] & EntityManager = EntityManager>(paths: string[], options: Partial<Options> = {}, validate = true): Promise<Configuration<D, EM>> {
     const env = this.loadEnvironmentVars();
 
     for (let path of paths) {
@@ -87,13 +84,17 @@ export class ConfigurationLoader {
     return settings;
   }
 
-  static getConfigPaths(): string[] {
+  static configPathsFromArg() {
     const options = Utils.parseArgs();
     const configArgName = process.env.MIKRO_ORM_CONFIG_ARG_NAME ?? 'config';
 
     if (options[configArgName]) {
-      return [options[configArgName]];
+      return [options[configArgName]] as string[];
     }
+    return undefined;
+  }
+
+  static getConfigPaths(): string[] {
 
     const paths: string[] = [];
     const settings = ConfigurationLoader.getSettings();

--- a/packages/knex/src/AbstractSqlConnection.ts
+++ b/packages/knex/src/AbstractSqlConnection.ts
@@ -69,7 +69,7 @@ export abstract class AbstractSqlConnection extends Connection {
   /**
    * @inheritDoc
    */
-  async checkConnection(): Promise<{ ok: boolean; reason?: string; error?: Error }> {
+  async checkConnection(): Promise<{ ok: true } | { ok: false; reason: string; error?: Error }> {
     try {
       await this.getKnex().raw('select 1');
       return { ok: true };

--- a/packages/mongodb/src/MongoConnection.ts
+++ b/packages/mongodb/src/MongoConnection.ts
@@ -89,10 +89,12 @@ export class MongoConnection extends Connection {
     }
   }
 
-  async checkConnection(): Promise<{ ok: boolean; reason?: string; error?: Error }> {
+  async checkConnection(): Promise<{ ok: true } | { ok: false; reason: string; error?: Error }> {
     try {
       const res = await this.db?.command({ ping: 1 });
-      return { ok: !!res.ok };
+      return res.ok
+        ? { ok: true }
+        : { ok: false, reason: 'Ping reply does not feature "ok" property, or it evaluates to "false"' };
     } catch (error: any) {
       return { ok: false, reason: error.message, error };
     }

--- a/tests/Connection.test.ts
+++ b/tests/Connection.test.ts
@@ -27,7 +27,7 @@ class CustomConnection extends Connection {
     return false;
   }
 
-  async checkConnection(): Promise<{ ok: boolean; reason?: string; error?: Error }> {
+  async checkConnection(): Promise<{ ok: true } | { ok: false; reason: string; error?: Error }> {
     return { ok: false, reason: 'foo' };
   }
 

--- a/tests/EntityManager.mongo2.test.ts
+++ b/tests/EntityManager.mongo2.test.ts
@@ -29,6 +29,17 @@ describe('EntityManagerMongo2', () => {
     expect(await orm.checkConnection()).toEqual({
       ok: true,
     });
+
+    const commandMock = jest
+      .spyOn(orm.config.getDriver().getConnection().getDb(), 'command')
+      .mockReturnValue(Promise.resolve({ error: 'boom!' }));
+    expect(await orm.isConnected()).toBe(false);
+    expect(await orm.checkConnection()).toEqual({
+      ok: false,
+      reason: 'Ping reply does not feature "ok" property, or it evaluates to "false"',
+    });
+    expect(commandMock).toHaveBeenCalledTimes(2);
+    commandMock.mockRestore();
   });
 
   test('loaded references and collections', async () => {

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -553,19 +553,19 @@ Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
         },
       }))));
     await MikroORM.init();
-    expect(messages[0]).toBe('[deprecated] Path for config file was inferred from the command line arguments. This is deprecated. Set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init.');
+    expect(messages[0]).toBe('[deprecated] (MikroORM:0001) Path for config file was inferred from the command line arguments. This is deprecated. Set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init.');
     messages.length = 0;
 
     (global as any).process.argv = ['node', 'start.js', '--config=./override2/orm-config.ts'];
     expect(ConfigurationLoader.configPathsFromArg()).toEqual(['./override2/orm-config.ts']);
     await MikroORM.init();
-    expect(messages[0]).toBe('[deprecated] Path for config file was inferred from the command line arguments. This is deprecated. Set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init.');
+    expect(messages[0]).toBe('[deprecated] (MikroORM:0001) Path for config file was inferred from the command line arguments. This is deprecated. Set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init.');
     messages.length = 0;
 
     (global as any).process.argv = ['npx', 'mikro-orm', 'debug', '--config', './override3/orm-config.ts'];
     expect(ConfigurationLoader.configPathsFromArg()).toEqual(['./override3/orm-config.ts']);
     await MikroORM.init();
-    expect(messages[0]).toBe('[deprecated] Path for config file was inferred from the command line arguments. This is deprecated. Set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init.');
+    expect(messages[0]).toBe('[deprecated] (MikroORM:0001) Path for config file was inferred from the command line arguments. This is deprecated. Set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init.');
     messages.length = 0;
 
     configMock.mockRestore();

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -553,19 +553,19 @@ Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
         },
       }))));
     await MikroORM.init();
-    expect(messages[0]).toBe('[deprecated] (MikroORM:0001) Path for config file was inferred from the command line arguments. This is deprecated. Set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init.');
+    expect(messages[0]).toBe('[deprecated] (D0001) Path for config file was inferred from the command line arguments. Instead, you should set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init.');
     messages.length = 0;
 
     (global as any).process.argv = ['node', 'start.js', '--config=./override2/orm-config.ts'];
     expect(ConfigurationLoader.configPathsFromArg()).toEqual(['./override2/orm-config.ts']);
     await MikroORM.init();
-    expect(messages[0]).toBe('[deprecated] (MikroORM:0001) Path for config file was inferred from the command line arguments. This is deprecated. Set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init.');
+    expect(messages[0]).toBe('[deprecated] (D0001) Path for config file was inferred from the command line arguments. Instead, you should set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init.');
     messages.length = 0;
 
-    (global as any).process.argv = ['npx', 'mikro-orm', 'debug', '--config', './override3/orm-config.ts'];
+    (global as any).process.argv = ['npm', 'start', '--config', './override3/orm-config.ts'];
     expect(ConfigurationLoader.configPathsFromArg()).toEqual(['./override3/orm-config.ts']);
     await MikroORM.init();
-    expect(messages[0]).toBe('[deprecated] (MikroORM:0001) Path for config file was inferred from the command line arguments. This is deprecated. Set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init.');
+    expect(messages[0]).toBe('[deprecated] (D0001) Path for config file was inferred from the command line arguments. Instead, you should set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init.');
     messages.length = 0;
 
     configMock.mockRestore();

--- a/tests/features/cli/CreateSeederCommand.test.ts
+++ b/tests/features/cli/CreateSeederCommand.test.ts
@@ -29,12 +29,12 @@ describe('CreateSeederCommand', () => {
     const cmd = new CreateSeederCommand();
     const mockPositional = jest.fn();
     const mockDemand = jest.fn();
-    const args = { positional: mockPositional, demandOption: mockDemand };
+    const args = { positional: mockPositional };
     cmd.builder(args as any);
     expect(mockPositional).toHaveBeenCalledWith('seeder', {
+      demandOption: true,
       describe: 'Name for the seeder class. (e.g. "test" will generate "TestSeeder" or "TestSeeder" will generate "TestSeeder")',
     });
-    expect(mockDemand).toHaveBeenCalledWith('seeder');
 
     await expect(cmd.handler({ seeder: 'DatabaseSeeder' } as any)).resolves.toBeUndefined();
     expect(createSeederMock).toHaveBeenCalledTimes(1);

--- a/tests/features/logging/Logger.test.ts
+++ b/tests/features/logging/Logger.test.ts
@@ -15,11 +15,22 @@ describe('Logger', () => {
 
   describe('DefaultLogger', () => {
 
-    test('should have debug mode disabled by default', async () => {
+    test('should have debug mode disabled by default, except for deprecated', async () => {
       const logger = new DefaultLogger({ writer: mockWriter });
+      expect(logger.debugMode).toStrictEqual(['deprecated']);
+      logger.log('discovery', 'test debug msg');
+      logger.log('info', 'test info msg');
+      expect(mockWriter).toHaveBeenCalledTimes(0);
+      logger.log('deprecated', 'test deprecation msg');
+      expect(mockWriter).toHaveBeenCalledTimes(1);
+    });
+
+    test('should have debug mode not print anything when fully disabled', async () => {
+      const logger = new DefaultLogger({ writer: mockWriter, debugMode: false });
       expect(logger.debugMode).toBe(false);
       logger.log('discovery', 'test debug msg');
       logger.log('info', 'test info msg');
+      logger.log('deprecated', 'test deprecation msg');
       expect(mockWriter).toHaveBeenCalledTimes(0);
     });
 
@@ -32,6 +43,8 @@ describe('Logger', () => {
       expect(mockWriter).toHaveBeenCalledTimes(2);
       logger.log('query', 'test query msg');
       expect(mockWriter).toHaveBeenCalledTimes(3);
+      logger.log('deprecated', 'test deprecation msg');
+      expect(mockWriter).toHaveBeenCalledTimes(4);
     });
 
     test('should not print debug messages when given namespace not enabled', async () => {
@@ -40,6 +53,8 @@ describe('Logger', () => {
       logger.log('discovery', 'test debug msg');
       expect(mockWriter).toHaveBeenCalledTimes(0);
       logger.log('info', 'test info msg');
+      expect(mockWriter).toHaveBeenCalledTimes(0);
+      logger.log('deprecated', 'test deprecation msg');
       expect(mockWriter).toHaveBeenCalledTimes(0);
       logger.log('query', 'test query msg');
       expect(mockWriter).toHaveBeenCalledTimes(1);

--- a/tests/features/logging/Logger.test.ts
+++ b/tests/features/logging/Logger.test.ts
@@ -15,9 +15,9 @@ describe('Logger', () => {
 
   describe('DefaultLogger', () => {
 
-    test('should have debug mode disabled by default, except for deprecated', async () => {
+    test('should have debug mode disabled by default, but still output deprecated', async () => {
       const logger = new DefaultLogger({ writer: mockWriter });
-      expect(logger.debugMode).toStrictEqual(['deprecated']);
+      expect(logger.debugMode).toBe(false);
       logger.log('discovery', 'test debug msg');
       logger.log('info', 'test info msg');
       expect(mockWriter).toHaveBeenCalledTimes(0);
@@ -25,13 +25,33 @@ describe('Logger', () => {
       expect(mockWriter).toHaveBeenCalledTimes(1);
     });
 
-    test('should have debug mode not print anything when fully disabled', async () => {
+    test('should have debug mode not print anything when disabled, except deprecated', async () => {
       const logger = new DefaultLogger({ writer: mockWriter, debugMode: false });
+      expect(logger.debugMode).toBe(false);
+      logger.log('discovery', 'test debug msg');
+      logger.log('info', 'test info msg');
+      expect(mockWriter).toHaveBeenCalledTimes(0);
+      logger.log('deprecated', 'test deprecation msg');
+      expect(mockWriter).toHaveBeenCalledTimes(1);
+    });
+
+    test('should have debug mode not print anything when debugMode is false and ignoreDeprecations is true', async () => {
+      const logger = new DefaultLogger({ writer: mockWriter, debugMode: false, ignoreDeprecations: true });
       expect(logger.debugMode).toBe(false);
       logger.log('discovery', 'test debug msg');
       logger.log('info', 'test info msg');
       logger.log('deprecated', 'test deprecation msg');
       expect(mockWriter).toHaveBeenCalledTimes(0);
+    });
+
+    test('should have debug mode not print deprecated when ignoreDeprecations is set to true', async () => {
+      const logger = new DefaultLogger({ writer: mockWriter, debugMode: true, ignoreDeprecations: true });
+      expect(logger.debugMode).toBe(true);
+      logger.log('deprecated', 'test deprecation msg');
+      expect(mockWriter).toHaveBeenCalledTimes(0);
+      logger.log('discovery', 'test debug msg');
+      logger.log('info', 'test info msg');
+      expect(mockWriter).toHaveBeenCalledTimes(2);
     });
 
     test('should print debug messages when debug mode enabled', async () => {
@@ -54,14 +74,14 @@ describe('Logger', () => {
       expect(mockWriter).toHaveBeenCalledTimes(0);
       logger.log('info', 'test info msg');
       expect(mockWriter).toHaveBeenCalledTimes(0);
-      logger.log('deprecated', 'test deprecation msg');
-      expect(mockWriter).toHaveBeenCalledTimes(0);
       logger.log('query', 'test query msg');
       expect(mockWriter).toHaveBeenCalledTimes(1);
       logger.error('query', 'test error msg');
       expect(mockWriter).toHaveBeenCalledTimes(2);
       logger.warn('query', 'test warning msg');
       expect(mockWriter).toHaveBeenCalledTimes(3);
+      logger.log('deprecated', 'test deprecation msg');
+      expect(mockWriter).toHaveBeenCalledTimes(4);
     });
 
     test('should print labels correctly', () => {

--- a/tests/features/logging/Logger.test.ts
+++ b/tests/features/logging/Logger.test.ts
@@ -35,6 +35,17 @@ describe('Logger', () => {
       expect(mockWriter).toHaveBeenCalledTimes(1);
     });
 
+    test('should only ignore deprecations with specific labels', async () => {
+      const logger = new DefaultLogger({ writer: mockWriter, debugMode: false, ignoreDeprecations: ['ignoreMe'] });
+      expect(logger.debugMode).toBe(false);
+      logger.log('discovery', 'test debug msg');
+      logger.log('info', 'test info msg');
+      logger.log('deprecated', 'test deprecation msg', { label: 'ignoreMe' });
+      expect(mockWriter).toHaveBeenCalledTimes(0);
+      logger.log('deprecated', 'test deprecation msg', { label: 'DoNotIgnoreMe' });
+      expect(mockWriter).toHaveBeenCalledTimes(1);
+    });
+
     test('should have debug mode not print anything when debugMode is false and ignoreDeprecations is true', async () => {
       const logger = new DefaultLogger({ writer: mockWriter, debugMode: false, ignoreDeprecations: true });
       expect(logger.debugMode).toBe(false);


### PR DESCRIPTION
The output of debug is adjusted as a consequence of the config being a passed dependency. Driver dependency versions are going to be shown if a config is found, independently of whether a package.json was found.

The config is always validated, even during entity generation. When warnings about missing entities are disabled, the entities options are also set to empty arrays, to avoid the old / additional entities' meta data influencing the entity generation.

If the config path is automatically inferred from a CLI argument during MikroORM.init(), a deprecation warning is logged.