### PR TITLE
feat(core): upsert managed entities

### DIFF
--- a/docs/docs/entity-manager.md
+++ b/docs/docs/entity-manager.md
@@ -459,8 +459,6 @@ const author = await em.upsert(Author, { email: 'foo@bar.com', age: 33 });
 
 Depending on the driver support, this will either use a returning query, or a separate select query, to fetch the primary key if it's missing from the `data`.
 
-If the entity is already present in current context, there won't be any queries - instead, the entity data will be assigned and an explicit `flush` will be required for those changes to be persisted.
-
 You can also use detached entity instance, after the `em.upsert()` call it will become managed.
 
 ```ts

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -881,7 +881,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     if (Utils.isEntity(data)) {
       entity = data as Entity;
 
-      if (helper(entity).__managed && helper(entity).__em === em) {
+      if (helper(entity).__managed && helper(entity).__em === em && !this.config.get('upsertManaged')) {
         em.entityFactory.mergeData(meta, entity, data, { initialized: true });
         return entity;
       }
@@ -892,7 +892,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
       data = Utils.copy(QueryHelper.processParams(data));
       where = Utils.extractPK(data, meta) as FilterQuery<Entity>;
 
-      if (where) {
+      if (where && !this.config.get('upsertManaged')) {
         const exists = em.unitOfWork.getById<Entity>(entityName, where as Primary<Entity>, options.schema);
 
         if (exists) {
@@ -1045,7 +1045,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
       if (Utils.isEntity(row)) {
         const entity = row as Entity;
 
-        if (helper(entity).__managed && helper(entity).__em === em) {
+        if (helper(entity).__managed && helper(entity).__em === em && !this.config.get('upsertManaged')) {
           em.entityFactory.mergeData(meta, entity, row, { initialized: true });
           entities.set(entity, row);
           entitiesByData.set(row, entity);
@@ -1058,7 +1058,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
         row = data[i] = Utils.copy(QueryHelper.processParams(row));
         where = Utils.extractPK(row, meta) as FilterQuery<Entity>;
 
-        if (where) {
+        if (where && !this.config.get('upsertManaged')) {
           const exists = em.unitOfWork.getById<Entity>(entityName, where as Primary<Entity>, options.schema);
 
           if (exists) {

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -95,6 +95,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver, EM exten
       mergeEmbeddedProperties: true,
     },
     persistOnCreate: true,
+    upsertManaged: true,
     forceEntityConstructor: false,
     forceUndefined: false,
     ensureDatabase: true,
@@ -574,6 +575,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver, EM
   };
   assign: AssignOptions<boolean>;
   persistOnCreate: boolean;
+  upsertManaged: boolean;
   forceEntityConstructor: boolean | (Constructor<AnyEntity> | string)[];
   forceUndefined: boolean;
   forceUtcTimezone?: boolean;

--- a/tests/features/upsert/GH3667.test.ts
+++ b/tests/features/upsert/GH3667.test.ts
@@ -35,7 +35,6 @@ test('GH issue 3667', async () => {
   await orm.em.flush();
 
   await orm.em.repo(User).upsert({ id: 1, name: 'john' });
-  await orm.em.flush();
 
   await orm.em.refresh(user1);
   expect(user1.name).toEqual('john');
@@ -44,9 +43,7 @@ test('GH issue 3667', async () => {
     ['[query] begin'],
     ['[query] insert into `user` (`id`) select null as `id` returning `id`'],
     ['[query] commit'],
-    ['[query] begin'],
-    ["[query] update `user` set `name` = 'john' where `id` = 1"],
-    ['[query] commit'],
+    ["[query] insert into `user` (`id`, `name`) values (1, 'john') on conflict (`id`) do update set `name` = excluded.`name`"],
     ['[query] select `u0`.* from `user` as `u0` where `u0`.`id` = 1 limit 1'],
   ]);
 });

--- a/tests/features/upsert/GH3787-2.test.ts
+++ b/tests/features/upsert/GH3787-2.test.ts
@@ -103,8 +103,6 @@ test('upsertMany with managed entity calls assign', async () => {
     ['[query] begin'],
     [`[query] insert into \`my_entity1\` (\`id\`, \`field\`) values (1, '{"firstName":"John","lastName":"Doe"}')`],
     ['[query] commit'],
-    ['[query] begin'],
-    [`[query] update \`my_entity1\` set \`field\` = '{"firstName":"123","lastName":"Doe"}' where \`id\` = 1`],
-    ['[query] commit'],
+    ['[query] insert into `my_entity1` (`field`, `id`) values (\'{"firstName":"123","lastName":"Doe"}\', 1) on conflict (`id`) do update set `field` = excluded.`field` returning `id`'],
   ]);
 });

--- a/tests/features/upsert/upsert-managed.test.ts
+++ b/tests/features/upsert/upsert-managed.test.ts
@@ -1,0 +1,92 @@
+import { Entity, PrimaryKey, Property, SimpleLogger } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/sqlite';
+import { mockLogger } from '../../helpers';
+
+@Entity()
+class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property()
+  email!: string;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [User],
+    loggerFactory: SimpleLogger.create,
+  });
+  await orm.schema.createSchema();
+});
+
+beforeEach(async () => {
+  await orm.schema.clearDatabase();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('upsert managed entity', async () => {
+  const user1 = orm.em.create(User, { id: 1, name: 'John', email: 'foo' });
+  orm.em.persist(user1);
+  await orm.em.flush();
+
+  const mock = mockLogger(orm);
+  const u1 = await orm.em.upsert(User, { id: 1, name: 'Paul', email: 'bar' });
+  expect(u1).toBe(user1);
+  expect(user1.name).toEqual('Paul');
+  expect(user1.email).toEqual('bar');
+
+  const [u2] = await orm.em.upsertMany(User, [{ id: 1, name: 'Ringo', email: 'baz' }]);
+  expect(u2).toBe(user1);
+  expect(user1.name).toEqual('Ringo');
+  expect(user1.email).toEqual('baz');
+
+  expect(mock.mock.calls).toEqual([
+    ["[query] insert into `user` (`email`, `id`, `name`) values ('bar', 1, 'Paul') on conflict (`id`) do update set `name` = excluded.`name`, `email` = excluded.`email`"],
+    ["[query] insert into `user` (`email`, `id`, `name`) values ('baz', 1, 'Ringo') on conflict (`id`) do update set `name` = excluded.`name`, `email` = excluded.`email` returning `id`"],
+  ]);
+});
+
+test('upsert managed disabled', async () => {
+  orm.config.set('upsertManaged', false);
+  const user1 = orm.em.create(User, { id: 1, name: 'John', email: 'foo' });
+  orm.em.persist(user1);
+  await orm.em.flush();
+
+  const mock = mockLogger(orm);
+  const u1 = await orm.em.upsert(User, { id: 1, name: 'Paul', email: 'bar' });
+  expect(u1).toBe(user1);
+  expect(user1.name).toEqual('Paul');
+  expect(user1.email).toEqual('bar');
+  expect(mock.mock.calls).toEqual([]);
+  await orm.em.flush();
+
+  mock.mockReset();
+  const [u2] = await orm.em.upsertMany(User, [{ id: 1, name: 'Ringo', email: 'baz' }]);
+  expect(u2).toBe(user1);
+  expect(user1.name).toEqual('Ringo');
+  expect(user1.email).toEqual('baz');
+  expect(mock.mock.calls).toEqual([]);
+  await orm.em.flush();
+
+  mock.mockReset();
+  const u3 = orm.em.create(User, { id: 1, name: 'Ringo', email: 'baz' });
+  const u4 = await orm.em.upsert(u3);
+  const [u5] = await orm.em.upsertMany([u3]);
+  expect(u4).toBe(user1);
+  expect(u5).toBe(user1);
+  expect(user1.name).toEqual('Ringo');
+  expect(user1.email).toEqual('baz');
+  expect(mock.mock.calls).toEqual([]);
+  await orm.em.flush();
+});

--- a/tests/features/upsert/upsert.mssql.test.ts
+++ b/tests/features/upsert/upsert.mssql.test.ts
@@ -196,8 +196,6 @@ async function assert(author: Author, mock: jest.Mock) {
   expect(author22).toBe(authors[1]);
   expect(author32).toBe(authors[2]);
   expect(author22.age).toBe(321);
-  expect(mock).not.toHaveBeenCalled();
-  await orm.em.flush();
   await orm.em.refresh(author22);
   expect(author22.age).toBe(321);
 }
@@ -228,8 +226,6 @@ async function assertFooBars(fooBars: FooBar[], mock: jest.Mock) {
   expect(fooBar22).toBe(fooBarsReloaded[1]);
   expect(fooBar32).toBe(fooBarsReloaded[2]);
   expect(fooBar22.propName).toBe('12345');
-  expect(mock).not.toHaveBeenCalled();
-  await orm.em.flush();
   await orm.em.refresh(fooBar22);
   expect(fooBar22.propName).toBe('12345');
 }

--- a/tests/features/upsert/upsert.test.ts
+++ b/tests/features/upsert/upsert.test.ts
@@ -228,8 +228,6 @@ describe.each(Utils.keys(options))('em.upsert [%s]',  type => {
     expect(author22).toBe(authors[1]);
     expect(author32).toBe(authors[2]);
     expect(author22.age).toBe(321);
-    expect(mock).not.toHaveBeenCalled();
-    await orm.em.flush();
     await orm.em.refresh(author22);
     expect(author22.age).toBe(321);
   }
@@ -257,8 +255,6 @@ describe.each(Utils.keys(options))('em.upsert [%s]',  type => {
     expect(fooBar22).toBe(fooBarsReloaded[1]);
     expect(fooBar32).toBe(fooBarsReloaded[2]);
     expect(fooBar22.propName).toBe('12345');
-    expect(mock).not.toHaveBeenCalled();
-    await orm.em.flush();
     await orm.em.refresh(fooBar22);
     expect(fooBar22.propName).toBe('12345');
   }


### PR DESCRIPTION
Previously, if you tried to upsert a managed entity, the call was interpreted as `assign`, and an explicit `flush` was required to persist those changes to the database. Now the upsert query is always issued regardless of the entity being managed or not.

To opt in to the previous behavior, use `upsertManaged: false` in the ORM config.

Closes #6055