### PR TITLE
feat(core): add `onQuery` hook

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -247,6 +247,37 @@ MikroORM.init({
 });
 ```
 
+### `onQuery` hook and observability
+
+Sometimes you might want to alter the generated queries. One use case for that might be adding contextual query hints to allow observability. Before a more native approach is added to the ORM, you can use the `onQuery` hook to modify all the queries by hand. The hook will be fired for every query before its execution.
+
+```ts
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const ctx = new AsyncLocalStorage();
+
+// provide the necessary data to the store in some middleware
+app.use((req, res, next) => {
+  const store = { endpoint: req.url };
+  ctx.run(store, next);
+});
+
+MikroORM.init({
+  onQuery: (sql: string, params: unknown[]) => {
+    const store = ctx.getStore();
+
+    if (!store) {
+      return sql;
+    }
+
+    // your function that generates the necessary query hint
+    const hint = createQueryHint(store);
+
+    return sql + hint;
+  },
+});
+```
+
 ## Naming Strategy
 
 When mapping your entities to database tables and columns, their names will be defined by naming strategy. There are 3 basic naming strategies you can choose from:

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -81,6 +81,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver, EM exten
     populateWhere: PopulateHint.ALL,
     connect: true,
     ignoreUndefinedInQuery: false,
+    onQuery: sql => sql,
     autoJoinOneToOneOwner: true,
     autoJoinRefsForFilters: true,
     propagationOnPrototype: true,
@@ -564,6 +565,7 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver, EM
   connect: boolean;
   verbose: boolean;
   ignoreUndefinedInQuery?: boolean;
+  onQuery: (sql: string, params: unknown[]) => string;
   autoJoinOneToOneOwner: boolean;
   autoJoinRefsForFilters: boolean;
   propagationOnPrototype: boolean;

--- a/packages/knex/src/AbstractSqlConnection.ts
+++ b/packages/knex/src/AbstractSqlConnection.ts
@@ -150,6 +150,7 @@ export abstract class AbstractSqlConnection extends Connection {
       params = q.bindings as any[];
     }
 
+    queryOrKnex = this.config.get('onQuery')(queryOrKnex, params);
     const formatted = this.platform.formatQuery(queryOrKnex, params);
     const sql = this.getSql(queryOrKnex, formatted, loggerContext);
     return this.executeQuery<T>(sql, async () => {

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -190,10 +190,10 @@ describe('EntityManagerPostgre', () => {
       { name: 'test 3', tests: [1, 5, 2], type: PublisherType.GLOBAL, type2: PublisherType2.LOCAL },
     ]);
 
-    expect(mock.mock.calls[0][0]).toMatch('insert into "publisher2" ("name", "type", "type2") values ($1, $2, $3), ($4, $5, $6), ($7, $8, $9) returning "id"');
-    expect(mock.mock.calls[1][0]).toMatch('insert into "publisher2_tests" ("test2_id", "publisher2_id") values ($1, $2), ($3, $4), ($5, $6)');
-    expect(mock.mock.calls[2][0]).toMatch('insert into "publisher2_tests" ("test2_id", "publisher2_id") values ($1, $2), ($3, $4)');
-    expect(mock.mock.calls[3][0]).toMatch('insert into "publisher2_tests" ("test2_id", "publisher2_id") values ($1, $2), ($3, $4), ($5, $6)');
+    expect(mock.mock.calls[0][0]).toMatch('/* foo */ insert into "publisher2" ("name", "type", "type2") values ($1, $2, $3), ($4, $5, $6), ($7, $8, $9) returning "id"');
+    expect(mock.mock.calls[1][0]).toMatch('/* foo */ insert into "publisher2_tests" ("test2_id", "publisher2_id") values ($1, $2), ($3, $4), ($5, $6)');
+    expect(mock.mock.calls[2][0]).toMatch('/* foo */ insert into "publisher2_tests" ("test2_id", "publisher2_id") values ($1, $2), ($3, $4)');
+    expect(mock.mock.calls[3][0]).toMatch('/* foo */ insert into "publisher2_tests" ("test2_id", "publisher2_id") values ($1, $2), ($3, $4), ($5, $6)');
 
     // postgres returns all the ids based on returning clause
     expect(res).toMatchObject({ insertId: 1, affectedRows: 3, row: { id: 1 }, rows: [ { id: 1 }, { id: 2 }, { id: 3 } ] });

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -158,6 +158,7 @@ export async function initORMPostgreSql(loadStrategy = LoadStrategy.SELECT_IN, e
     loadStrategy,
     subscribers: [Test2Subscriber],
     extensions: [Migrator, SeedManager, EntityGenerator],
+    onQuery: sql => `/* foo */ ${sql}`,
   });
 
   await orm.schema.ensureDatabase();


### PR DESCRIPTION
Sometimes you might want to alter the generated queries. One use case for that might be adding contextual query hints to allow observability. Before a more native approach is added to the ORM, you can use the `onQuery` hook to modify all the queries by hand. The hook will be fired for every query before its execution.

```ts
import { AsyncLocalStorage } from 'node:async_hooks';

const ctx = new AsyncLocalStorage();

// provide the necessary data to the store in some middleware
app.use((req, res, next) => {
  const store = { endpoint: req.url };
  ctx.run(store, next);
});

MikroORM.init({
  onQuery: (sql: string, params: unknown[]) => {
    const store = ctx.getStore();

    if (!store) {
      return sql;
    }

    // your function that generates the necessary query hint
    const hint = createQueryHint(store);

    return sql + hint;
  },
});
```