### PR TITLE
refactor: make `ConfigurationLoader.getConfiguration()` backwards compatible

### DIFF
--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -55,7 +55,8 @@ describe('CLIHelper', () => {
         case 'mikro-orm-factory.config.js': return (contextName: string) => (contextName === 'boom' ? undefined : Object.assign(
           {},
           config,
-          { dbName: `tenant_${contextName}`,
+          {
+            dbName: `tenant_${contextName}`,
             logger: message => {
               loggerMessages.push(message);
             },

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -40,6 +40,7 @@ describe('CLIHelper', () => {
   let readJSONMock: jest.SpyInstance;
   let dynamicImportMock: jest.SpyInstance;
   let requireFromMock: jest.SpyInstance;
+  const loggerMessages: string[] = [];
 
   beforeEach(() => {
     const config = { driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] } satisfies Options<MongoDriver>;
@@ -54,7 +55,11 @@ describe('CLIHelper', () => {
         case 'mikro-orm-factory.config.js': return (contextName: string) => (contextName === 'boom' ? undefined : Object.assign(
           {},
           config,
-          { dbName: `tenant_${contextName}` } satisfies Options<MongoDriver>,
+          { dbName: `tenant_${contextName}`,
+            logger: message => {
+              loggerMessages.push(message);
+            },
+          } satisfies Options<MongoDriver>,
         ));
         case 'mikro-orm-array.config.js': return [
           config,
@@ -105,6 +110,7 @@ describe('CLIHelper', () => {
     readJSONMock.mockRestore();
     dynamicImportMock.mockRestore();
     requireFromMock.mockRestore();
+    loggerMessages.length = 0;
   });
 
   test('configures yargs instance', async () => {
@@ -691,7 +697,11 @@ Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
     await MikroORM.init();
     expect(messages[0]).toBe('[deprecated] (D0001) Path for config file was inferred from the command line arguments. Instead, you should set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init.');
     messages.length = 0;
-
     configMock.mockRestore();
+
+    pathExistsMock.mockImplementation(path => (path as string).endsWith('/mikro-orm-factory.config.js'));
+    (global as any).process.argv = ['node', 'start.js', '--config=./mikro-orm-factory.config.js'];
+    expect(await ConfigurationLoader.getConfiguration(true)).toBeInstanceOf(Configuration);
+    expect(loggerMessages).toStrictEqual(['[deprecated] (D0001) Path for config file was inferred from the command line arguments. Instead, you should set the MIKRO_ORM_CLI_CONFIG environment variable to specify the path, or if you really must use the command line arguments, import the config manually based on them, and pass it to init.']);
   });
 });


### PR DESCRIPTION
If true is explicitly given at the first argument, it will trigger the legacy behavior, where `--config` is also searched for in `process.argv`.

If left without arguments, the new default is used, which is still mostly compatible, except `--config` is not searched in `process.argv`.

In either situation, the paths to search for default to the result of `ConfigurationLoader.getConfigPaths()`.