### PR TITLE
fix(core): rename `tsNode` option to `preferTs`

### DIFF
--- a/docs/docs/guide/03-project-setup.md
+++ b/docs/docs/guide/03-project-setup.md
@@ -229,7 +229,7 @@ export async function initTestApp(port: number) {
     dbName: ':memory:',
     // this will ensure the ORM discovers TS entities, with ts-node, ts-jest and vitest
     // it will be inferred automatically, but we are using vitest here
-    // tsNode: true,
+    // preferTs: true,
   });
 
   // create the schema so we can use the database

--- a/docs/docs/metadata-providers.md
+++ b/docs/docs/metadata-providers.md
@@ -23,7 +23,7 @@ await MikroORM.init({
 });
 ```
 
-If we use folder-based discovery, we should specify paths to the compiled entities via `entities` as well as paths to the TS source files of those entities via `entitiesTs`. When we run the ORM via `ts-node`, the latter will be used automatically, or if we explicitly pass `tsNode: true` in the config. Note that `tsNode: true` should not be part of production config.
+If we use folder-based discovery, we should specify paths to the compiled entities via `entities` as well as paths to the TS source files of those entities via `entitiesTs`. When we run the ORM via `ts-node`, the latter will be used automatically, or if we explicitly pass `preferTs: true` in the config. Note that `preferTs: true` should not be part of production config.
 
 > When running via `node`, `.d.ts` files are used to obtain the type, so we need to ship them in the production build. TS source files are no longer needed (since v4). Be sure to enable `compilerOptions.declaration` in our `tsconfig.json`.
 

--- a/packages/cli/src/CLIConfigurator.ts
+++ b/packages/cli/src/CLIConfigurator.ts
@@ -54,10 +54,10 @@ export class CLIConfigurator {
     const version = Utils.getORMVersion();
 
     if (settings.useTsNode !== false) {
-      const tsNode = ConfigurationLoader.registerTsNode(settings.tsConfigPath);
+      const preferTs = ConfigurationLoader.registerTsNode(settings.tsConfigPath);
 
       /* istanbul ignore if */
-      if (!tsNode) {
+      if (!preferTs) {
         process.env.MIKRO_ORM_CLI_USE_TS_NODE ??= '0';
       }
     }

--- a/packages/cli/src/CLIHelper.ts
+++ b/packages/cli/src/CLIHelper.ts
@@ -32,7 +32,7 @@ export class CLIHelper {
     options.set('connect', false);
 
     if (settings.useTsNode !== false) {
-      options.set('tsNode', true);
+      options.set('preferTs', true);
     }
 
     // The only times when we don't care to have a warning about no entities is also the time when we ignore entities.

--- a/packages/cli/src/commands/DebugCommand.ts
+++ b/packages/cli/src/commands/DebugCommand.ts
@@ -43,10 +43,11 @@ export class DebugCommand implements BaseCommand {
         CLIHelper.dump(` - ${colors.yellow(`database connection failed (${isConnected})`)}`);
       }
 
-      const tsNode = config.get('tsNode');
-      if ([true, false].includes(tsNode as boolean)) {
-        const warning = tsNode ? ' (this value should be set to `false` when running compiled code!)' : '';
-        CLIHelper.dump(` - \`tsNode\` flag explicitly set to ${tsNode}, will use \`entities${tsNode ? 'Ts' : ''}\` array${warning}`);
+      const preferTs = config.get('preferTs');
+
+      if ([true, false].includes(preferTs as boolean)) {
+        const warning = preferTs ? ' (this value should be set to `false` when running compiled code!)' : '';
+        CLIHelper.dump(` - \`preferTs\` flag explicitly set to ${preferTs}, will use \`entities${preferTs ? 'Ts' : ''}\` array${warning}`);
       }
 
       const entities = config.get('entities', []);
@@ -54,7 +55,7 @@ export class DebugCommand implements BaseCommand {
       if (entities.length > 0) {
         const refs = entities.filter(p => !Utils.isString(p));
         const paths = entities.filter(p => Utils.isString(p));
-        const will = !config.get('tsNode') ? 'will' : 'could';
+        const will = !config.get('preferTs') ? 'will' : 'could';
         CLIHelper.dump(` - ${will} use \`entities\` array (contains ${refs.length} references and ${paths.length} paths)`);
 
         if (paths.length > 0) {
@@ -68,7 +69,7 @@ export class DebugCommand implements BaseCommand {
         const refs = entitiesTs.filter(p => !Utils.isString(p));
         const paths = entitiesTs.filter(p => Utils.isString(p));
         /* istanbul ignore next */
-        const will = config.get('tsNode') ? 'will' : 'could';
+        const will = config.get('preferTs') ? 'will' : 'could';
         CLIHelper.dump(` - ${will} use \`entitiesTs\` array (contains ${refs.length} references and ${paths.length} paths)`);
 
         /* istanbul ignore else */

--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -221,12 +221,12 @@ export class MikroORM<D extends IDatabaseDriver = IDatabaseDriver, EM extends En
   }
 
   async discoverEntities(): Promise<void> {
-    this.metadata = await this.discovery.discover(this.config.get('tsNode'));
+    this.metadata = await this.discovery.discover(this.config.get('preferTs'));
     this.createEntityManager();
   }
 
   discoverEntitiesSync(): void {
-    this.metadata = this.discovery.discoverSync(this.config.get('tsNode'));
+    this.metadata = this.discovery.discoverSync(this.config.get('preferTs'));
     this.createEntityManager();
   }
 

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -174,13 +174,13 @@ export class MetadataDiscovery {
     });
   }
 
-  private findEntities(preferTsNode: boolean, sync: true): EntityMetadata[];
-  private findEntities(preferTsNode: boolean, sync?: false): Promise<EntityMetadata[]>;
-  private findEntities(preferTsNode: boolean, sync = false): EntityMetadata[] | Promise<EntityMetadata[]> {
+  private findEntities(preferTs: boolean, sync: true): EntityMetadata[];
+  private findEntities(preferTs: boolean, sync?: false): Promise<EntityMetadata[]>;
+  private findEntities(preferTs: boolean, sync = false): EntityMetadata[] | Promise<EntityMetadata[]> {
     this.discovered.length = 0;
 
     const options = this.config.get('discovery');
-    const key = (preferTsNode && this.config.get('tsNode', Utils.detectTsNode()) && this.config.get('entitiesTs').length > 0) ? 'entitiesTs' : 'entities';
+    const key = (preferTs && this.config.get('preferTs', Utils.detectTsNode()) && this.config.get('entitiesTs').length > 0) ? 'entitiesTs' : 'entities';
     const paths = this.config.get(key).filter(item => Utils.isString(item)) as string[];
     const refs = this.config.get(key).filter(item => !Utils.isString(item)) as Constructor<AnyEntity>[];
 

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -178,6 +178,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver, EM exten
 
     this.options = Utils.mergeConfig({}, Configuration.DEFAULTS, options);
     this.options.baseDir = Utils.absolutePath(this.options.baseDir);
+    this.options.preferTs ??= options.tsNode;
 
     if (validate) {
       this.validateOptions();
@@ -405,6 +406,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver, EM exten
 
   private sync(): void {
     process.env.MIKRO_ORM_COLORS = '' + this.options.colors;
+    this.options.tsNode = this.options.preferTs;
     this.logger.setDebugMode(this.options.debug);
   }
 
@@ -612,6 +614,13 @@ export interface MikroORMOptions<D extends IDatabaseDriver = IDatabaseDriver, EM
   debug: boolean | LoggerNamespace[];
   ignoreDeprecations: boolean | string[];
   highlighter: Highlighter;
+  /**
+   * Using this option, you can force the ORM to use the TS options regardless of whether the TypeScript support
+   * is detected or not. This effectively means using `entitiesTs` for discovery and `pathTs` for migrations and
+   * seeders. Should be used only for tests and stay disabled for production builds.
+   */
+  preferTs?: boolean;
+  /** @deprecated use `preferTs` instead */
   tsNode?: boolean;
   baseDir: string;
   migrations: MigrationsOptions;

--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -171,7 +171,6 @@ export class ConfigurationLoader {
   }
 
   static getConfigPaths(): string[] {
-
     const paths: string[] = [];
     const settings = ConfigurationLoader.getSettings();
 

--- a/packages/migrations-mongodb/src/Migrator.ts
+++ b/packages/migrations-mongodb/src/Migrator.ts
@@ -38,7 +38,7 @@ export class Migrator implements IMigrator {
     this.options = this.config.get('migrations');
 
     /* istanbul ignore next */
-    const key = (this.config.get('tsNode', Utils.detectTsNode()) && this.options.pathTs) ? 'pathTs' : 'path';
+    const key = (this.config.get('preferTs', Utils.detectTsNode()) && this.options.pathTs) ? 'pathTs' : 'path';
     this.absolutePath = Utils.absolutePath(this.options[key]!, this.config.get('baseDir'));
     this.createUmzug();
   }

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -51,7 +51,7 @@ export class Migrator implements IMigrator {
     this.options = this.config.get('migrations');
 
     /* istanbul ignore next */
-    const key = (this.config.get('tsNode', Utils.detectTsNode()) && this.options.pathTs) ? 'pathTs' : 'path';
+    const key = (this.config.get('preferTs', Utils.detectTsNode()) && this.options.pathTs) ? 'pathTs' : 'path';
     this.absolutePath = Utils.absolutePath(this.options[key]!, this.config.get('baseDir'));
     // for snapshots, we always want to use the path based on `emit` option, regardless of whether we run in ts-node context
     /* istanbul ignore next */

--- a/packages/seeder/src/SeedManager.ts
+++ b/packages/seeder/src/SeedManager.ts
@@ -23,7 +23,7 @@ export class SeedManager implements ISeedManager {
     this.em = this.em.fork();
     this.config.set('persistOnCreate', true);
     /* istanbul ignore next */
-    const key = (this.config.get('tsNode', Utils.detectTsNode()) && this.options.pathTs) ? 'pathTs' : 'path';
+    const key = (this.config.get('preferTs', Utils.detectTsNode()) && this.options.pathTs) ? 'pathTs' : 'path';
     this.absolutePath = Utils.absolutePath(this.options[key]!, this.config.get('baseDir'));
   }
 

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -66,7 +66,7 @@ export async function initORMMongo(replicaSet = false, overrideOptions: Partial<
 
   const orm = await MikroORM.init({
     entities: ['entities'],
-    tsNode: false,
+    preferTs: false,
     clientUrl,
     baseDir: BASE_DIR,
     logger: i => i,

--- a/tests/features/cli/DebugCommand.test.ts
+++ b/tests/features/cli/DebugCommand.test.ts
@@ -65,7 +65,7 @@ describe('DebugCommand', () => {
       [' - driver dependencies:'],
       [`   - mongodb ${await CLIHelper.getModuleVersion('mongodb')}`],
       [' - database connection successful'],
-      [' - `tsNode` flag explicitly set to true, will use `entitiesTs` array (this value should be set to `false` when running compiled code!)'],
+      [' - `preferTs` flag explicitly set to true, will use `entitiesTs` array (this value should be set to `false` when running compiled code!)'],
       [' - could use `entities` array (contains 0 references and 2 paths)'],
       [`   - ${Utils.normalizePath(process.cwd() + '/dist/entities-1') } (found)`],
       [`   - ${Utils.normalizePath(process.cwd() + '/dist/entities-2') } (not found)`],
@@ -89,7 +89,7 @@ describe('DebugCommand', () => {
       [' - driver dependencies:'],
       [`   - mongodb ${await CLIHelper.getModuleVersion('mongodb')}`],
       [' - database connection successful'],
-      [' - `tsNode` flag explicitly set to false, will use `entities` array'],
+      [' - `preferTs` flag explicitly set to false, will use `entities` array'],
       [' - will use `entities` array (contains 2 references and 0 paths)'],
     ]);
 
@@ -120,7 +120,7 @@ describe('DebugCommand', () => {
       [' - driver dependencies:'],
       [`   - mongodb ${await CLIHelper.getModuleVersion('mongodb')}`],
       [' - database connection successful'],
-      [' - `tsNode` flag explicitly set to false, will use `entities` array'],
+      [' - `preferTs` flag explicitly set to false, will use `entities` array'],
       [' - will use `entities` array (contains 2 references and 0 paths)'],
     ]);
 

--- a/tests/features/reflection/TsMorphMetadataProvider.test.ts
+++ b/tests/features/reflection/TsMorphMetadataProvider.test.ts
@@ -29,7 +29,7 @@ describe('TsMorphMetadataProvider', () => {
   test('should load entities based on .d.ts files', async () => {
     const orm = await MikroORM.init({
       entities: ['./entities-compiled'],
-      tsNode: false,
+      preferTs: false,
       baseDir: __dirname,
       clientUrl: 'mongodb://localhost:27017/mikro-orm-test',
       metadataCache: { enabled: false },
@@ -45,7 +45,7 @@ describe('TsMorphMetadataProvider', () => {
     const options: Options = {
       entities: ['./entities-compiled-error'],
       entitiesTs: ['./entities-compiled-error'],
-      tsNode: false,
+      preferTs: false,
       baseDir: __dirname,
       clientUrl: 'mongodb://localhost:27017/mikro-orm-test',
       metadataCache: { enabled: false },


### PR DESCRIPTION
The name `tsNode` was confusing and rather a relic from the past. The purpose of this option was always the same, telling the ORM that TS is supported, regardless of its auto-detection thinking something else.

The old `tsNode` name is still supported for backwards compatibility.