### PR TITLE
feat(core): validate non-persistent relations are not composite

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -258,6 +258,10 @@ export class MetadataError<T extends AnyEntity = AnyEntity> extends ValidationEr
     return this.fromMessage(meta, prop, `targets abstract entity ${prop.type}. Maybe you forgot to put @Entity() decorator on the ${prop.type} class?`);
   }
 
+  static nonPersistentCompositeProp(meta: EntityMetadata, prop: EntityProperty) {
+    return this.fromMessage(meta, prop, `is non-persistent relation which targets composite primary key. This is not supported and will cause issues, 'persist: false' should be added to the properties representing single columns instead.`);
+  }
+
   static propertyTargetsEntityType(meta: EntityMetadata, prop: EntityProperty, target: EntityMetadata) {
     /* istanbul ignore next */
     const suggestion = target.embeddable ? 'Embedded' : 'ManyToOne';

--- a/packages/core/src/metadata/MetadataValidator.ts
+++ b/packages/core/src/metadata/MetadataValidator.ts
@@ -49,7 +49,7 @@ export class MetadataValidator {
 
     for (const prop of Utils.values(meta.properties)) {
       if (prop.kind !== ReferenceKind.SCALAR) {
-        this.validateReference(meta, prop, metadata);
+        this.validateReference(meta, prop, metadata, options);
         this.validateBidirectional(meta, prop, metadata);
       } else if (metadata.has(prop.type)) {
         throw MetadataError.propertyTargetsEntityType(meta, prop, metadata.get(prop.type));
@@ -119,7 +119,7 @@ export class MetadataValidator {
     });
   }
 
-  private validateReference(meta: EntityMetadata, prop: EntityProperty, metadata: MetadataStorage): void {
+  private validateReference(meta: EntityMetadata, prop: EntityProperty, metadata: MetadataStorage, options: MetadataDiscoveryOptions): void {
     // references do have types
     if (!prop.type) {
       throw MetadataError.fromWrongTypeDefinition(meta, prop);
@@ -132,6 +132,10 @@ export class MetadataValidator {
 
     if (metadata.find(prop.type)!.abstract && !metadata.find(prop.type)!.discriminatorColumn) {
       throw MetadataError.targetIsAbstract(meta, prop);
+    }
+
+    if (prop.persist === false && metadata.find(prop.type)!.compositePK && options.checkNonPersistentCompositeProps) {
+      throw MetadataError.nonPersistentCompositeProp(meta, prop);
     }
   }
 

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -57,9 +57,10 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver, EM exten
       requireEntitiesArray: false,
       checkDuplicateTableNames: true,
       checkDuplicateFieldNames: true,
+      checkDuplicateEntities: true,
+      checkNonPersistentCompositeProps: true,
       alwaysAnalyseProperties: true,
       disableDynamicFileAccess: false,
-      checkDuplicateEntities: true,
       inferDefaultValues: true,
     },
     strict: false,
@@ -545,11 +546,12 @@ export interface MetadataDiscoveryOptions {
   requireEntitiesArray?: boolean;
   checkDuplicateTableNames?: boolean;
   checkDuplicateFieldNames?: boolean;
+  checkDuplicateEntities?: boolean;
+  checkNonPersistentCompositeProps?: boolean;
   alwaysAnalyseProperties?: boolean;
   disableDynamicFileAccess?: boolean;
   inferDefaultValues?: boolean;
   getMappedType?: (type: string, platform: Platform) => Type<unknown> | undefined;
-  checkDuplicateEntities?: boolean;
   onMetadata?: (meta: EntityMetadata, platform: Platform) => MaybePromise<void>;
   afterDiscovered?: (storage: MetadataStorage, platform: Platform) => MaybePromise<void>;
   tsConfigPath?: string;


### PR DESCRIPTION
Adding `persist: false` to relations is supported, but rather discouraged, it was designed to be used on scalars instead. Using it on a relation targeting composite PK will cause issues and is now disallowed. You can opt out of this validation via `checkNonPersistentCompositeProps` discovery option.