### PR TITLE
Introducing MikroORM Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ TypeScript ORM for Node.js based on Data Mapper, [Unit of Work](https://mikro-or
 [![Coverage Status](https://img.shields.io/coveralls/mikro-orm/mikro-orm.svg)](https://coveralls.io/r/mikro-orm/mikro-orm?branch=master)
 [![Maintainability](https://api.codeclimate.com/v1/badges/27999651d3adc47cfa40/maintainability)](https://codeclimate.com/github/mikro-orm/mikro-orm/maintainability)
 [![Build Status](https://github.com/mikro-orm/mikro-orm/workflows/tests/badge.svg?branch=master)](https://github.com/mikro-orm/mikro-orm/actions?workflow=tests)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20MikroORM%20Guru-006BFF)](https://gurubase.io/g/mikroorm)
 
 ## 🤔 Unit of What?
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [MikroORM Guru](https://gurubase.io/g/mikroorm) to Gurubase. MikroORM Guru uses the data from this repo and data from the [docs](https://mikro-orm.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "MikroORM Guru", which highlights that MikroORM now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable MikroORM Guru in Gurubase, just let me know that's totally fine.
