### PR TITLE
docs: add jsdoc to make it clear that ArrayCollection.add() is idempotent

### DIFF
--- a/packages/core/src/entity/ArrayCollection.ts
+++ b/packages/core/src/entity/ArrayCollection.ts
@@ -65,6 +65,9 @@ export class ArrayCollection<T extends object, O extends object> {
     }) as unknown as U[];
   }
 
+  /**
+   * Adds one or more entities to the collection.
+   */
   add(entity: T | Reference<T> | Iterable<T | Reference<T>>, ...entities: (T | Reference<T>)[]): void {
     entities = Utils.asArray(entity).concat(entities);
 
@@ -92,6 +95,9 @@ export class ArrayCollection<T extends object, O extends object> {
     }
   }
 
+  /**
+   * Replaces the current collection items with the provided items.
+   */
   set(items: Iterable<T | Reference<T>>): void {
     if (!this.initialized) {
       this.initialized = true;

--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -159,6 +159,9 @@ export class Collection<T extends object, O extends object = object> extends Arr
     return super.toJSON() as unknown as EntityDTO<TT>[];
   }
 
+  /**
+   * @inheritDoc
+   */
   override add<TT extends T>(entity: TT | Reference<TT> | Iterable<TT | Reference<TT>>, ...entities: (TT | Reference<TT>)[]): void {
     entities = Utils.asArray(entity).concat(entities);
     const unwrapped = entities.map(i => Reference.unwrapReference(i)) as T[];


### PR DESCRIPTION
Just starting with MikroOrm.

I found some places where there is no jsdoc not documentation, e.g for those two methods, I had to check source code to know if I need to do `if (collection.contains())` before adding an item or not.