### PR TITLE
docs: Update 02-relationships.md

### DIFF
--- a/docs/docs/guide/02-relationships.md
+++ b/docs/docs/guide/02-relationships.md
@@ -166,8 +166,10 @@ em.clear();
 
 // create the article instance
 const article = em.create(Article, {
-  title: 'Foo is Bar',
+  slug: 'foo',
+  title: 'Foo',
   text: 'Lorem impsum dolor sit amet',
+  description: 'Foo is bar',
   author: user.id,
 });
 

--- a/docs/versioned_docs/version-6.4/guide/02-relationships.md
+++ b/docs/versioned_docs/version-6.4/guide/02-relationships.md
@@ -166,8 +166,10 @@ em.clear();
 
 // create the article instance
 const article = em.create(Article, {
-  title: 'Foo is Bar',
+  slug: 'foo',
+  title: 'Foo',
   text: 'Lorem impsum dolor sit amet',
+  description: 'Foo is bar',
   author: user.id,
 });
 


### PR DESCRIPTION
Respect the definite assignment assertion operator in the entity 'Article'. Without assigning the previously missing class variables, TypeScript complains about the same.

Closes https://github.com/mikro-orm/guide/issues/5