### PR TITLE
fix(core): correctly handle populate of `mapToPk` relations

### DIFF
--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -223,7 +223,7 @@ export class EntityLoader {
     }
 
     const where = await this.extractChildCondition(options, prop);
-    const data = await this.findChildren<Entity>(entities, prop, populate, { ...options, where, orderBy: innerOrderBy! }, !!ref);
+    const data = await this.findChildren<Entity>(entities, prop, populate, { ...options, where, orderBy: innerOrderBy! }, !!(ref || prop.mapToPk));
     this.initializeCollections<Entity>(filtered, prop, field, data, innerOrderBy.length > 0);
 
     return data;

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -376,7 +376,8 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
           }
         });
 
-      const targetProps = ref
+      const mapToPk = !!(ref || prop.mapToPk);
+      const targetProps = mapToPk
         ? meta2.getPrimaryProps()
         : meta2.props.filter(prop => this.platform.shouldHaveColumn(prop, hint.children as any || []));
       const tz = this.platform.getTimezone();
@@ -419,7 +420,7 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
         prop.fieldNames.map(name => delete root![`${relationAlias}__${name}` as EntityKey<T>]);
       }
 
-      if (ref) {
+      if (mapToPk) {
         const tmp = Object.values(relationPojo);
         /* istanbul ignore next */
         relationPojo = (meta2.compositePK ? tmp : tmp[0]) as EntityData<T>;
@@ -1243,9 +1244,9 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
 
       const childExclude = exclude ? Utils.extractChildElements(exclude as string[], prop.name) : exclude;
 
-      if (!ref) {
+      if (!ref && !prop.mapToPk) {
         fields.push(...this.getFieldsForJoinedLoad(qb, meta2, childExplicitFields.length === 0 ? undefined : childExplicitFields, childExclude, hint.children as any, options, tableAlias, path, count));
-      } else if (hint.filter) {
+      } else if (hint.filter || prop.mapToPk) {
         fields.push(...prop.referencedColumnNames!.map(col => qb.helper.mapper(`${tableAlias}.${col}`, qb.type, undefined, `${tableAlias}__${col}`)));
       }
     }

--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -1114,6 +1114,11 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
         return true;
       }
 
+      // skip redundant joins for 1:1 owner population hints when using `mapToPk`
+      if (prop.kind === ReferenceKind.ONE_TO_ONE && prop.mapToPk && prop.owner) {
+        return false;
+      }
+
       if ((options?.strategy || hint.strategy || prop.strategy || this.config.get('loadStrategy')) !== LoadStrategy.JOINED) {
         // force joined strategy for explicit 1:1 owner populate hint as it would require a join anyway
         return prop.kind === ReferenceKind.ONE_TO_ONE && !prop.owner;

--- a/tests/features/unit-of-work/map-to-pk.test.ts
+++ b/tests/features/unit-of-work/map-to-pk.test.ts
@@ -79,7 +79,7 @@ describe('mapToPk', () => {
   });
 
   afterAll(async () => {
-    await orm.close();
+    await orm.close(true);
   });
 
   beforeEach(async () => {
@@ -148,6 +148,7 @@ describe('mapToPk', () => {
     await orm.em.persistAndFlush(t3);
     orm.em.clear();
 
+    const mock = mockLogger(orm, ['query', 'query-params']);
     // owning side
     const team = await orm.em.findOneOrFail(
       Team,
@@ -166,6 +167,10 @@ describe('mapToPk', () => {
     );
 
     expect(order.owningTeam).toBe(t3.id);
+    expect(mock.mock.calls).toHaveLength(2);
+    expect(mock.mock.calls[0][0]).toMatch("select `t0`.* from `team` as `t0` where `t0`.`id` = 'team1' limit 1");
+    expect(mock.mock.calls[1][0]).toMatch("select `o0`.*, `o1`.`id` as `o1__id` from `order` as `o0` left join `team` as `o1` on `o0`.`id` = `o1`.`current_order_id` where `o0`.`id` = 'order1' limit 1");
+    mock.mockReset();
   });
 
   test.each(Object.values(LoadStrategy))('mapToPk works with populate using "%s" strategy (compositePK)', async strategy => {


### PR DESCRIPTION
### The Problem

Related issue: [#6265](https://github.com/mikro-orm/mikro-orm/pull/6265). Before the changes, populating a `mapToPk` relation did not extract just the key; instead, the entire entity object was assigned to the property.

### The Solution

I have added tests for both simple and composite primary keys. While adding tests for the `select-in` loading strategy, I noticed that the second query (for loading the primary key entity) is not executed. This makes sense because the keys are already selected.  

This led me to reconsider whether we should use a join for the `joined` strategy, as the keys are already present on the owning entity. 

**Select-in strategy:**

```sql
select `t0`.* 
from `team` as `t0` 
where `t0`.`id` = 'team1' 
limit 1
```
**Joined strategy:**

```sql
select `t0`.*, `c1`.`id` as `c1__id`
from `team` as `t0`
-- this join is redundant
left join `order` as `c1` on `t0`.`current_order_id` = `c1`.`id`
where `t0`.`id` = 'team1'
limit 1
```

EDIT: I have also added a test for the inverse side of a 1:1 relation using `mapToPk` to verify that it works as expected. Another redundant populate query was being made to the `Team` entity, which I addressed as well.

```sql
select `o0`.*, `o1`.`id` as `o1__id`
from `order` as `o0`
left join `team` as `o1` on `o0`.`id` = `o1`.`current_order_id`
where `o0`.`id` = 'order1'
limit 1
-- this populate query is redundant because we do not want the full entity
select `t0`.*
from `team` as `t0`
where `t0`.`current_order_id` in ('order1')
```
