### PR TITLE
feat(mongo): include MikroORM version in MongoDB handshake

### DIFF
--- a/packages/mongodb/src/MongoConnection.ts
+++ b/packages/mongodb/src/MongoConnection.ts
@@ -147,6 +147,12 @@ export class MongoConnection extends Connection {
       ret.maxPoolSize = pool.max;
     }
 
+    const version = Utils.getORMVersion();
+    ret.driverInfo = {
+      name: 'MikroORM',
+      version: version
+    }
+    
     return Utils.mergeConfig(ret, this.config.get('driverOptions'));
   }
 

--- a/packages/mongodb/src/MongoConnection.ts
+++ b/packages/mongodb/src/MongoConnection.ts
@@ -147,10 +147,9 @@ export class MongoConnection extends Connection {
       ret.maxPoolSize = pool.max;
     }
 
-    const version = Utils.getORMVersion();
     ret.driverInfo = {
       name: 'MikroORM',
-      version: version
+      version: Utils.getORMVersion(),
     }
     
     return Utils.mergeConfig(ret, this.config.get('driverOptions'));

--- a/packages/mongodb/src/MongoConnection.ts
+++ b/packages/mongodb/src/MongoConnection.ts
@@ -150,8 +150,8 @@ export class MongoConnection extends Connection {
     ret.driverInfo = {
       name: 'MikroORM',
       version: Utils.getORMVersion(),
-    }
-    
+    };
+
     return Utils.mergeConfig(ret, this.config.get('driverOptions'));
   }
 

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -600,8 +600,8 @@ describe('EntityManagerMongo', () => {
   test('should use user and password as connection options', async () => {
     const config = new Configuration({ driver: MongoDriver, user: 'usr', password: 'pw' } as any, false);
     const connection = new MongoConnection(config);
-    await expect(connection.getConnectionOptions()).toEqual({
-      auth: { username: 'usr', password: 'pw' },
+    await expect(connection.getConnectionOptions().auth).toEqual({
+      { username: 'usr', password: 'pw' },
     });
   });
 

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -600,9 +600,7 @@ describe('EntityManagerMongo', () => {
   test('should use user and password as connection options', async () => {
     const config = new Configuration({ driver: MongoDriver, user: 'usr', password: 'pw' } as any, false);
     const connection = new MongoConnection(config);
-    await expect(connection.getConnectionOptions().auth).toEqual({
-      { username: 'usr', password: 'pw' },
-    });
+    await expect(connection.getConnectionOptions().auth).toEqual({ username: 'usr', password: 'pw' });
   });
 
   test('using $exists operator', async () => {


### PR DESCRIPTION
The PR incorporates MongoDB's [wrapping client library](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md#supporting-wrapping-libraries) specification for the connection handshake to allow library details to be included in the metadata written to `mongos` or `mongod` logs.

For example, this change would allow server-side logs such as the following:

> {"t":{"$date":"2024-01-27T23:10:40.108Z"},"s":"I","c":"NETWORK","id":51800,"ctx":"conn16235","msg":"client metadata","attr":{"remote":"127.0.0.1:1094","client":"conn16235","doc":{"driver":{`"name":"nodejs|MikroORM"`,`"version":"6.12.0|6.4.2"`},"platform":"Node.js v18.18.2, LE","os":{"name":"linux","architecture":"x64","version":"5.15.133+","type":"Linux"}}}}

For anyone hosting clusters with connections coming from different applications this can help differentiate connections and facilitate log analysis.