### PR TITLE
feat(core): improved configuration loaders

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,9 @@ module.exports = {
     'es2020': true,
     'node': true,
   },
+  globals: {
+    NodeJS: true // So ESLint will no complain about NodeJS namespace
+  },
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/eslint-recommended',

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-commitlint --edit $1
+yarn commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-lint-staged
+yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "guid-typescript": "1.0.9",
     "husky": "9.1.7",
     "jest": "29.7.0",
+    "jiti": "2.4.2",
     "lerna": "8.1.9",
     "lint-staged": "15.3.0",
     "mongodb": "6.12.0",
@@ -134,6 +135,7 @@
     "rimraf": "6.0.1",
     "ts-jest": "29.2.0",
     "ts-node": "10.9.2",
+    "tsx": "4.19.2",
     "typescript": "5.7.3",
     "uuid": "11.0.4"
   },

--- a/packages/core/src/utils/loader.ts
+++ b/packages/core/src/utils/loader.ts
@@ -1,0 +1,157 @@
+import { join, isAbsolute } from 'node:path';
+
+import { tryModule, TryModuleError, requireDefault, Utils } from './Utils';
+import type { Settings } from './ConfigurationLoader';
+import type { Options } from './Configuration';
+
+/**
+ * A set of supported TypeScript loaders
+ */
+export type Loaders = 'ts-node' | 'jiti' | 'tsx' | 'auto' | 'native' | false | null | undefined;
+
+interface Loader {
+  name: string;
+  import(specifier: string): Promise<Options>;
+}
+
+type LoaderFactory = (projectRoot: string, cliSettings: Settings) => Promise<Loader>;
+
+const createLoaderFactory = (fn: LoaderFactory): LoaderFactory => fn;
+
+const createNativeLoader = createLoaderFactory(async () => ({
+  name: 'import',
+  import: async specifier => requireDefault(await import(specifier)), // TODO: Handle module not found errors and report if the specifier is .ts file
+}));
+
+/**
+ * Creates loader factory for [`ts-node`](https://www.npmjs.com/package/ts-node).
+ *
+ * Note: Unlike the other loaders, this will *register* ts-node as `require` hook.
+ */
+const createTsNodeLoader = createLoaderFactory(async (root, settings) => {
+  const name = 'ts-node';
+  const loader: Loader = {
+    name,
+    import: async specifier => requireDefault(await import(specifier)),
+  };
+
+  // If ts-node is already registered, we can just return the loader
+  if (Utils.detectTsNode()) {
+    return loader;
+  }
+
+  const tsNode = requireDefault(await tryModule(import('ts-node'), {
+    specifier: name,
+  }));
+
+  const configPath = settings.tsConfigPath || 'tsconfig.json';
+  const tsConfigPath = isAbsolute(configPath) ? configPath : join(process.cwd(), configPath);
+
+  const { options } = tsNode.register({
+    cwd: root,
+    project: tsConfigPath,
+    transpileOnly: true,
+    compilerOptions: {
+      module: 'nodenext',
+      moduleResolution: 'nodenext',
+    },
+  }).config;
+
+  // Register tsconfig-paths to support custom module resolution
+  if (Utils.isObject(options.paths) && Object.keys(options.paths).length > 0) {
+    const paths = requireDefault(await tryModule(import('tsconfig-paths'), {
+      specifier: 'tsconfig-paths',
+    }));
+
+    paths.register({
+      baseUrl: options.baseUrl ?? '.',
+      paths: options.paths,
+    });
+  }
+
+  return loader;
+});
+
+/**
+ * Creates loader factory for [`jiti`](https://www.npmjs.com/package/jiti) transpiler
+ */
+const createJitiLoader = createLoaderFactory(async root => {
+  const name = 'jiti';
+
+  const { createJiti } = await tryModule(import('jiti'), {
+    specifier: name,
+  });
+
+  const jiti = createJiti(root);
+
+  return {
+    name,
+    import: specifier => jiti.import(specifier, {
+      default: true,
+    }),
+  };
+});
+
+/**
+ * Creates loader factory for [`tsx`](https://www.npmjs.com/package/tsx) transpiler
+ */
+const createTsxLoader = createLoaderFactory(async root => {
+  const name = 'tsx';
+
+  const { tsImport } = await tryModule(import('tsx/esm/api'), {
+    specifier: name,
+  });
+
+  return {
+    name,
+    import: async specifier => requireDefault(await tsImport(specifier, root)),
+  };
+});
+
+const factories = [createTsNodeLoader, createJitiLoader, createTsxLoader];
+
+/**
+ * Auto detects available transpiler by iterating over the internal `factories` array (see above) and creating each loader from the list.
+ *
+ * If a loader factory throws `TryModuleError` that means there's no transpiler for this package installed.
+ *
+ * If no loader has been successfully created, it will return native loader and let the runtime to deal with config loading.
+ */
+export const createAutoLoader = createLoaderFactory(async (root, settings) => {
+  for (const createLoader of factories) {
+    try {
+      return await createLoader(root, settings);
+    } catch (error) {
+      if (!(error instanceof TryModuleError)) {
+        throw error;
+      }
+    }
+  }
+
+  return createNativeLoader(root, settings);
+});
+
+/**
+ * Creates a loader depending on given `settings.loader` value.
+ *
+ * If no loader specified, it will auto-detect whatever transpiler is installed within the project's `node_modules` by importing it via `import()`.
+ */
+export const createLoader = createLoaderFactory((root, settings) => {
+  if (settings.alwaysAllowTs || settings.preferTs === false || settings.useTsNode === false) {
+    return createNativeLoader(root, settings);
+  }
+
+  switch (settings.loader) {
+    case 'ts-node':
+      return createTsNodeLoader(root, settings);
+    case 'jiti':
+      return createJitiLoader(root, settings);
+    case 'tsx':
+      return createTsxLoader(root, settings);
+    case 'native':
+    case false:
+      return createNativeLoader(root, settings);
+    default:
+      return createAutoLoader(root, settings);
+  }
+});

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { ObjectId } from 'bson';
-import { EntityMetadata, MikroORM, sql, compareObjects, Utils } from '@mikro-orm/core';
+import { EntityMetadata, MikroORM, sql, compareObjects, Utils, requireDefault, tryModule, TryModuleError } from '@mikro-orm/core';
 import { Author } from './entities';
 import { initORMMongo, BASE_DIR } from './bootstrap';
 import FooBar from './entities/FooBar';
@@ -661,6 +661,48 @@ describe('Utils', () => {
   test('removeDuplicates', () => {
     expect(Utils.removeDuplicates(['foo', 'bar', 'foo', 'bar2'])).toEqual(['foo', 'bar', 'bar2']);
     expect(Utils.removeDuplicates([{ v: 'foo' }, { v: 'bar' }, { v: 'foo' }, { v: 'bar2' }])).toEqual([{ v: 'foo' }, { v: 'bar' }, { v: 'bar2' }]);
+  });
+
+  describe('requireDefault', () => {
+    test('returns a value from default property', () => {
+      expect(requireDefault({ default: 'foo' })).toBe('foo');
+    });
+
+    test('returns value as is if no default property exist', () => {
+      expect(requireDefault({ test: 'foo' })).toEqual({ test: 'foo' });
+    });
+  });
+
+  describe('tryModule', () => {
+    test('resolves a promise', async () => {
+      await expect(tryModule(Promise.resolve('noop'), {
+        specifier: 'noop',
+      })).resolves.toBe('noop');
+    });
+
+    test('throws if the promise rejects with ERR_MODULE_NOT_FOUND code', async () => {
+      class ErrnoException extends Error implements NodeJS.ErrnoException {
+
+        readonly code = 'ERR_MODULE_NOT_FOUND';
+
+      }
+
+      const expectedMessage = 'Unable to import module "noop"';
+      const expectedCause = new ErrnoException("Can't find a module");
+
+      try {
+        await tryModule(Promise.reject(expectedCause), {
+          specifier: 'noop',
+        });
+      } catch (error) {
+        const actual = error as TryModuleError;
+
+        expect(actual).toBeInstanceOf(TryModuleError);
+        expect(actual.message).toBe(expectedMessage);
+        expect(actual.cause).toBe(expectedCause); // make sure the value references the same object, we don't care about shape of the object
+        expect(actual.specifier).toBe('noop');
+      }
+    });
   });
 
   afterAll(async () => orm.close(true));

--- a/yarn.lock
+++ b/yarn.lock
@@ -828,6 +828,174 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/aix-ppc64@npm:0.23.1"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/android-arm64@npm:0.23.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/android-arm@npm:0.23.1"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/android-x64@npm:0.23.1"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/darwin-arm64@npm:0.23.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/darwin-x64@npm:0.23.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/freebsd-arm64@npm:0.23.1"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/freebsd-x64@npm:0.23.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-arm64@npm:0.23.1"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-arm@npm:0.23.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-ia32@npm:0.23.1"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-loong64@npm:0.23.1"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-mips64el@npm:0.23.1"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-ppc64@npm:0.23.1"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-riscv64@npm:0.23.1"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-s390x@npm:0.23.1"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-x64@npm:0.23.1"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/netbsd-x64@npm:0.23.1"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/openbsd-arm64@npm:0.23.1"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/openbsd-x64@npm:0.23.1"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/sunos-x64@npm:0.23.1"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/win32-arm64@npm:0.23.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/win32-ia32@npm:0.23.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/win32-x64@npm:0.23.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0":
   version: 4.4.0
   resolution: "@eslint-community/eslint-utils@npm:4.4.0"
@@ -1617,6 +1785,7 @@ __metadata:
     guid-typescript: "npm:1.0.9"
     husky: "npm:9.1.7"
     jest: "npm:29.7.0"
+    jiti: "npm:2.4.2"
     lerna: "npm:8.1.9"
     lint-staged: "npm:15.3.0"
     mongodb: "npm:6.12.0"
@@ -1624,6 +1793,7 @@ __metadata:
     rimraf: "npm:6.0.1"
     ts-jest: "npm:29.2.0"
     ts-node: "npm:10.9.2"
+    tsx: "npm:4.19.2"
     typescript: "npm:5.7.3"
     uuid: "npm:11.0.4"
   languageName: unknown
@@ -4827,6 +4997,89 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild@npm:~0.23.0":
+  version: 0.23.1
+  resolution: "esbuild@npm:0.23.1"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.23.1"
+    "@esbuild/android-arm": "npm:0.23.1"
+    "@esbuild/android-arm64": "npm:0.23.1"
+    "@esbuild/android-x64": "npm:0.23.1"
+    "@esbuild/darwin-arm64": "npm:0.23.1"
+    "@esbuild/darwin-x64": "npm:0.23.1"
+    "@esbuild/freebsd-arm64": "npm:0.23.1"
+    "@esbuild/freebsd-x64": "npm:0.23.1"
+    "@esbuild/linux-arm": "npm:0.23.1"
+    "@esbuild/linux-arm64": "npm:0.23.1"
+    "@esbuild/linux-ia32": "npm:0.23.1"
+    "@esbuild/linux-loong64": "npm:0.23.1"
+    "@esbuild/linux-mips64el": "npm:0.23.1"
+    "@esbuild/linux-ppc64": "npm:0.23.1"
+    "@esbuild/linux-riscv64": "npm:0.23.1"
+    "@esbuild/linux-s390x": "npm:0.23.1"
+    "@esbuild/linux-x64": "npm:0.23.1"
+    "@esbuild/netbsd-x64": "npm:0.23.1"
+    "@esbuild/openbsd-arm64": "npm:0.23.1"
+    "@esbuild/openbsd-x64": "npm:0.23.1"
+    "@esbuild/sunos-x64": "npm:0.23.1"
+    "@esbuild/win32-arm64": "npm:0.23.1"
+    "@esbuild/win32-ia32": "npm:0.23.1"
+    "@esbuild/win32-x64": "npm:0.23.1"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10/f55fbd0bfb0f86ce67a6d2c6f6780729d536c330999ecb9f5a38d578fb9fda820acbbc67d6d1d377eed8fed50fc38f14ff9cb014f86dafab94269a7fb2177018
+  languageName: node
+  linkType: hard
+
 "escalade@npm:^3.1.1, escalade@npm:^3.1.2":
   version: 3.1.2
   resolution: "escalade@npm:3.1.2"
@@ -5487,7 +5740,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.3.2":
+"fsevents@npm:^2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -5497,7 +5750,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A^2.3.2#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A^2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
   version: 2.3.3
   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
@@ -5659,6 +5912,15 @@ __metadata:
     es-errors: "npm:^1.3.0"
     get-intrinsic: "npm:^1.2.4"
   checksum: 10/e1cb53bc211f9dbe9691a4f97a46837a553c4e7caadd0488dc24ac694db8a390b93edd412b48dcdd0b4bbb4c595de1709effc75fc87c0839deedc6968f5bd973
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.7.5":
+  version: 4.8.1
+  resolution: "get-tsconfig@npm:4.8.1"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 10/3fb5a8ad57b9633eaea085d81661e9e5c9f78b35d8f8689eaf8b8b45a2a3ebf3b3422266d4d7df765e308cc1e6231648d114803ab3d018332e29916f2c1de036
   languageName: node
   linkType: hard
 
@@ -7255,7 +7517,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jiti@npm:^2.4.1":
+"jiti@npm:2.4.2, jiti@npm:^2.4.1":
   version: 2.4.2
   resolution: "jiti@npm:2.4.2"
   bin:
@@ -10275,6 +10537,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve-pkg-maps@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-pkg-maps@npm:1.0.0"
+  checksum: 10/0763150adf303040c304009231314d1e84c6e5ebfa2d82b7d94e96a6e82bacd1dcc0b58ae257315f3c8adb89a91d8d0f12928241cba2df1680fbe6f60bf99b0e
+  languageName: node
+  linkType: hard
+
 "resolve.exports@npm:^2.0.0":
   version: 2.0.2
   resolution: "resolve.exports@npm:2.0.2"
@@ -11446,6 +11715,22 @@ __metadata:
   version: 1.0.1
   resolution: "tsqlstring@npm:1.0.1"
   checksum: 10/5047eed92724027951775bed6c41e45c36ffc25508d48deb477e3b17c3283c07d4f7b9d215cbf2ac57de9248a5168943c75f5b36598b270870d4d80e8092fe68
+  languageName: node
+  linkType: hard
+
+"tsx@npm:4.19.2":
+  version: 4.19.2
+  resolution: "tsx@npm:4.19.2"
+  dependencies:
+    esbuild: "npm:~0.23.0"
+    fsevents: "npm:~2.3.3"
+    get-tsconfig: "npm:^4.7.5"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: 10/4c5610ed1fb2f80d766681f8ac7827e1e8118dfe354c18f74800691f3ef1e9ed676a29842ab818806bcf8613cdc97c6af84b5645e768ddb7f4b0527b9100deda
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Details

This PR implements improves configuration loading with support for new transpilers, like [jiti](https://www.npmjs.com/package/jiti) and [tsx](https://www.npmjs.com/package/tsx). It also includes documentation updates, reflecting these changes. This PR also deprecates some of the old CLI settings: `useTsNode`, `preferTs`, and `alwaysAllowTs` in favor of a single new option called `loader`, and this new option allows to opt-in to a specific transpiler, or use auto-detection (the default), or opt-out to runtime's native `import()` (when set to either false or `native`).

### Notable changes

- [x] Implement new loaders: `ts-node`, `jiti`, `tsx`, and `native`;
- [x] Add new type-safe ESM utilities:
  - [x] `tryModule` - it resolves a promise, returned by `import()` and catches the errors with the `ERR_MODULE_NOT_FOUND` code, then wraps it into a `TryModuleError`, so it can be handled later. Unlike existent utilities (Utils.dynamicImport and Utils.tryRequire), the resulting value has correct types (though it only supports the `import()` - it can be easily modified to support `require()` function as well);
  - [x] `requireDefault` - resolves the `default` member from a module's exports while also providing correct types;
- [x] Add in-code documentation for CLI Settings interface;
- [x] Deprecate `useTsNode`, `preferTs`, and `alwaysAllowTs` in favor of `loaders`;
- [ ] Integrate loaders into `ConfigurationLoader` class;
- [ ] Add tests for loaders and `ConfigurationLoader` integration;

I also updated git hooks to use local binaries of `lint-staged` and `commitlint`, because there's no point to have those installed globally (yarn can pick up both local and global installations), nor to assume everyone has these by default.
