### PR TITLE
feat(seeder): make `Factory.em` protected

### DIFF
--- a/packages/seeder/src/Factory.ts
+++ b/packages/seeder/src/Factory.ts
@@ -5,7 +5,7 @@ export abstract class Factory<T extends object> {
   abstract readonly model: Constructor<T>;
   private eachFunction?: (entity: T) => void;
 
-  constructor(private readonly em: EntityManager) { }
+  constructor(protected readonly em: EntityManager) { }
 
   protected abstract definition(): EntityData<T>;
 


### PR DESCRIPTION
Currently when I am extending a `Factory` class, so that e.g. I can build definitions of child relations, I can't reuse other `Factory` classes, as they depend on `EntityManager`. Factory class access to the entity manager, but it is `private`. If it were `protected`, then I could reuse it.

For now I have to cheat TypeScript into thinking that `this.em: EntityManager` exists (and it does).

Example usage:

```ts
// organisation.factory.ts
import { faker } from '@faker-js/faker';
import { Factory } from '@mikro-orm/seeder';
import { OrganisationEntity } from '../entities/organisation.entity';
export class OrganisationFactory extends Factory<OrganisationEntity> {
  model = OrganisationEntity;
  definition(): Partial<OrganisationEntity> {
    return {
      name: faker.company.name(),
    };
  }
}

// event.factory.ts
import { faker } from '@faker-js/faker';
import { EntityData, EntityManager } from '@mikro-orm/core';
import { Factory } from '@mikro-orm/seeder';
import { EventEntity } from '../entities/event.entity';
import { OrganisationFactory } from './organisation.factory';
export class EventFactory extends Factory<EventEntity> {
  model = EventEntity;
  definition(): EntityData<EventEntity> {
    return {
      name: faker.lorem.words(),
      organisation: new OrganisationFactory(this.em).makeEntity(),
    };
  }
}
```

Currently I have to write the latter file like this:

```ts
// event.factory.ts (current workaround)
import { faker } from '@faker-js/faker';
import { EntityData, EntityManager } from '@mikro-orm/core';
import { Factory } from '@mikro-orm/seeder';
import { EventEntity } from '../entities/event.entity';
import { OrganisationFactory } from './organisation.factory';
export class EventFactory extends Factory<EventEntity> {
  model = EventEntity;
  constructor(private readonly _em: EntityManager) {
    super(_em);
  }
  definition(): EntityData<EventEntity> {
    return {
      name: faker.lorem.words(),
      organisation: new OrganisationFactory(this._em).makeEntity(),
    };
  }
}
```