### PR TITLE
feat(seeder): make `.each()` function receive `index: number` argument

### DIFF
--- a/packages/seeder/src/Factory.ts
+++ b/packages/seeder/src/Factory.ts
@@ -3,7 +3,7 @@ import type { RequiredEntityData, EntityData, EntityManager, Constructor } from 
 export abstract class Factory<T extends object> {
 
   abstract readonly model: Constructor<T>;
-  private eachFunction?: (entity: T) => void;
+  private eachFunction?: (entity: T, index: number) => void;
 
   constructor(protected readonly em: EntityManager) { }
 
@@ -13,15 +13,13 @@ export abstract class Factory<T extends object> {
    * Make a single entity instance, without persisting it.
    * @param overrideParameters Object specifying what default attributes of the entity factory should be overridden
    */
-  makeEntity(overrideParameters?: EntityData<T>): T {
+  makeEntity(overrideParameters?: EntityData<T>, index = 0): T {
     const entity = this.em.create(this.model, {
       ...this.definition(),
       ...overrideParameters,
     } as unknown as RequiredEntityData<T>, { persist: false });
 
-    if (this.eachFunction) {
-      this.eachFunction(entity);
-    }
+    this.eachFunction?.(entity, index);
 
     return entity;
   }
@@ -42,8 +40,8 @@ export abstract class Factory<T extends object> {
    * @param overrideParameters Object specifying what default attributes of the entity factory should be overridden
    */
   make(amount: number, overrideParameters?: EntityData<T>): T[] {
-    const entities = [...Array(amount)].map(() => {
-      return this.makeEntity(overrideParameters);
+    const entities = [...Array(amount)].map((_, index) => {
+      return this.makeEntity(overrideParameters, index);
     });
     this.em.persist(entities);
     return entities;
@@ -75,7 +73,7 @@ export abstract class Factory<T extends object> {
    * In case of `createOne` or `create` it is applied before the entity is persisted
    * @param eachFunction The function that is applied on every entity
    */
-  each(eachFunction: (entity: T) => void) {
+  each(eachFunction: (entity: T, index: number) => void) {
     this.eachFunction = eachFunction;
     return this;
   }

--- a/tests/features/seeder/factory.test.ts
+++ b/tests/features/seeder/factory.test.ts
@@ -38,7 +38,6 @@ export class HouseFactory extends Factory<House> {
 }
 
 describe('Factory', () => {
-
   let orm: MikroORM;
   let persistSpy: SpyInstance;
   let flushSpy: SpyInstance;
@@ -62,7 +61,7 @@ describe('Factory', () => {
     flushSpy.mockClear();
   });
 
-  test('that a factory can make a single instance of an entity without saving it in the database', async () => {
+  test('a factory can make a single instance of an entity without saving it in the database', async () => {
     const project = new ProjectFactory(orm.em).makeOne();
     expect(project).toBeInstanceOf(Project);
     expect(project.id).toBeUndefined();
@@ -70,7 +69,7 @@ describe('Factory', () => {
     expect(flushSpy).not.toHaveBeenCalled();
   });
 
-  test('that a factory can create a single instance of an entity and save it in the database', async () => {
+  test('a factory can create a single instance of an entity and save it in the database', async () => {
     const projectSaved = await new ProjectFactory(orm.em).createOne();
     expect(persistSpy).toHaveBeenCalled();
     expect(flushSpy).toHaveBeenCalled();
@@ -78,7 +77,7 @@ describe('Factory', () => {
     expect(projectSaved.id).toBeDefined();
   });
 
-  test('that a factory can make multiple instances of an entity without saving them in the database', async () => {
+  test('a factory can make multiple instances of an entity without saving them in the database', async () => {
     const projects = new ProjectFactory(orm.em).make(5);
     expect(projects).toBeInstanceOf(Array);
     expect(persistSpy).toHaveBeenCalledTimes(1);
@@ -86,7 +85,7 @@ describe('Factory', () => {
     expect(projects.length).toBe(5);
   });
 
-  test('that a factory can create multiple instances of an entity and save them in the database', async () => {
+  test('a factory can create multiple instances of an entity and save them in the database', async () => {
     const projectSaved = await new ProjectFactory(orm.em).create(5);
     expect(persistSpy).toHaveBeenCalledTimes(1);
     expect(flushSpy).toHaveBeenCalledTimes(1);
@@ -94,18 +93,17 @@ describe('Factory', () => {
     expect(projectSaved.length).toBe(5);
   });
 
-  test('that properties of the factory can be overwritten', async () => {
+  test('properties of the factory can be overwritten', async () => {
     const projectDefault = new ProjectFactory(orm.em).makeOne();
     expect(projectDefault.worth).toBe(120000);
 
-    const project = new ProjectFactory(orm.em)
-      .makeOne({
-        worth: 36,
-      });
+    const project = new ProjectFactory(orm.em).makeOne({
+      worth: 36,
+    });
     expect(project.worth).toBe(36);
   });
 
-  test('that relations can be populated on an entity', async () => {
+  test('relations can be populated on an entity', async () => {
     const project = new ProjectFactory(orm.em)
       .each((p: Project) => {
         p.houses.set(new HouseFactory(orm.em).make(2));
@@ -114,7 +112,7 @@ describe('Factory', () => {
     expect(project.houses.count()).toBe(2);
   });
 
-  test('that relations can be populated on an entity and saved at once', async () => {
+  test('relations can be populated on an entity and saved at once', async () => {
     const project = await new ProjectFactory(orm.em)
       .each((p: Project) => {
         p.houses.set(new HouseFactory(orm.em).make(2));
@@ -123,5 +121,14 @@ describe('Factory', () => {
     expect(project.houses.count()).toBe(2);
     expect(project.id).toBeDefined();
     expect(project.houses.getItems()[0].id).toBeDefined();
+  });
+
+  test('index is passed to the `.each()` function', async () => {
+    const projects = await new ProjectFactory(orm.em)
+      .each((p: Project, i: number) => {
+        p.houses.set(new HouseFactory(orm.em).make(i));
+      })
+      .create(3);
+    expect(projects.map(p => p.houses.count())).toEqual([0, 1, 2]);
   });
 });


### PR DESCRIPTION
Sometimes I want to dynamically assign different params to my seeded entities, depending on their index.

Example:

```ts
const participants = await new TournamentParticipantFactory(em)
      .each((p, i) => {
        p.seed = i + 1;
      })
      .create(16, {
        tournament,
      });
```

Without this, I have to write something like

```ts
const participants = await new TournamentParticipantFactory(em)
      .create(16, {
        tournament,
      });
participants.forEach((p, i) => { p.seed = i + 1; });
await em.persistAndFlush(participants);
```

This in part resolves https://github.com/mikro-orm/mikro-orm/discussions/3002 .