### PR TITLE
feat(seeder): pass params to `.definition()` function as argument

### DIFF
--- a/docs/docs/seeding.md
+++ b/docs/docs/seeding.md
@@ -295,7 +295,7 @@ export class AuthorFactory extends Factory<
   }
 }
 
-# Finally
+// Finally
 new AuthorFactory(em).createOne({ booksCount: 4 })
 ```
 

--- a/docs/docs/seeding.md
+++ b/docs/docs/seeding.md
@@ -243,7 +243,11 @@ const authors = await new AuthorFactory(orm.em).create(5, {
 
 ### Factory relationships
 
-It is nice to create large quantities of data for one entity, but most of the time you will want to create data for multiple entities and also have relations between them. For that you can use the `each` method which can be chained on a factory. The `each` method can be called with a function that transforms output entity from the factory before returning it. Let's look at some examples of the different relations.
+It is nice to create large quantities of data for one entity, but most of the time you will want to create data for multiple entities and also have relations between them.
+
+#### Defining relations via `.each()`
+
+For that you can use the `each` method which can be chained on a factory. The `each` method can be called with a function that transforms output entity from the factory before returning it. Let's look at some examples of the different relations.
 
 #### ManyToOne and OneToOne relations
 
@@ -259,6 +263,40 @@ const books: Book[] = new BookFactory(orm.em).each(book => {
 const books: Book[] = new BookFactory(orm.em).each(book => {
   book.owners.set(new OwnerFactory(orm.em).make(5));
 }).make(5);
+```
+
+#### Defining relations via `.definition()`
+
+Alternatively you can build the nested entities inside of the `definition` method. If needed, this method can accept additional params that need not to be a part of the entity schema.
+
+```ts
+export class AuthorFactory extends Factory<
+  AuthorEntity,
+  EntityData<AuthorEntity> & { booksCount?: number }
+> {
+  model = AuthorEntity;
+
+  async definition(
+    params?: EntityData<AuthorEntity> & { booksCount?: number }
+  ): EntityData<AuthorEntity> {
+    const name = params.name ?? faker.person.findName();
+    const books = params.books ?? (
+      [...Array(params?.booksCount ?? 0)].map((v, i) =>
+        new BookFactory(this.em).makeEntity({
+          title: `${name} Trilogy - Part ${i + 1}`
+        })
+      )
+    );
+    return {
+      ...params,
+      name,
+      books
+    };
+  }
+}
+
+# Finally
+new AuthorFactory(em).createOne({ booksCount: 4 })
 ```
 
 ## Use with CLI

--- a/packages/seeder/src/Factory.ts
+++ b/packages/seeder/src/Factory.ts
@@ -1,23 +1,36 @@
-import type { RequiredEntityData, EntityData, EntityManager, Constructor } from '@mikro-orm/core';
+import type {
+  RequiredEntityData,
+  EntityData,
+  EntityManager,
+  Constructor,
+} from '@mikro-orm/core';
 
-export abstract class Factory<T extends object> {
+export abstract class Factory<TEntity extends object, TInput = EntityData<TEntity>> {
 
-  abstract readonly model: Constructor<T>;
-  private eachFunction?: (entity: T, index: number) => void;
+  abstract readonly model: Constructor<TEntity>;
+  private eachFunction?: (entity: TEntity, index: number) => void;
 
-  constructor(protected readonly em: EntityManager) { }
+  constructor(protected readonly em: EntityManager) {}
 
-  protected abstract definition(): EntityData<T>;
+  protected abstract definition(input?: TInput): EntityData<TEntity>;
 
   /**
    * Make a single entity instance, without persisting it.
-   * @param overrideParameters Object specifying what default attributes of the entity factory should be overridden
+   * @param input Object specifying what default attributes of the entity factory should be overridden
    */
-  makeEntity(overrideParameters?: EntityData<T>, index = 0): T {
-    const entity = this.em.create(this.model, {
-      ...this.definition(),
-      ...overrideParameters,
-    } as unknown as RequiredEntityData<T>, { persist: false });
+  makeEntity(input?: TInput, index = 0): TEntity {
+    const data =
+      this.definition.length === 0
+        ? {
+            ...this.definition(),
+            ...input,
+          }
+        : this.definition(input);
+    const entity = this.em.create(
+      this.model,
+      data as unknown as RequiredEntityData<TEntity>,
+      { persist: false },
+    );
 
     this.eachFunction?.(entity, index);
 
@@ -26,10 +39,10 @@ export abstract class Factory<T extends object> {
 
   /**
    * Make a single entity and persist (not flush)
-   * @param overrideParameters Object specifying what default attributes of the entity factory should be overridden
+   * @param input Object specifying what default attributes of the entity factory should be overridden
    */
-  makeOne(overrideParameters?: EntityData<T>): T {
-    const entity = this.makeEntity(overrideParameters);
+  makeOne(input?: TInput): TEntity {
+    const entity = this.makeEntity(input);
     this.em.persist(entity);
     return entity;
   }
@@ -37,11 +50,11 @@ export abstract class Factory<T extends object> {
   /**
    * Make multiple entities and then persist them (not flush)
    * @param amount Number of entities that should be generated
-   * @param overrideParameters Object specifying what default attributes of the entity factory should be overridden
+   * @param input Object specifying what default attributes of the entity factory should be overridden
    */
-  make(amount: number, overrideParameters?: EntityData<T>): T[] {
+  make(amount: number, input?: TInput): TEntity[] {
     const entities = [...Array(amount)].map((_, index) => {
-      return this.makeEntity(overrideParameters, index);
+      return this.makeEntity(input, index);
     });
     this.em.persist(entities);
     return entities;
@@ -49,10 +62,10 @@ export abstract class Factory<T extends object> {
 
   /**
    * Create (and flush) a single entity
-   * @param overrideParameters Object specifying what default attributes of the entity factory should be overridden
+   * @param input Object specifying what default attributes of the entity factory should be overridden
    */
-  async createOne(overrideParameters?: EntityData<T>): Promise<T> {
-    const entity = this.makeOne(overrideParameters);
+  async createOne(input?: TInput): Promise<TEntity> {
+    const entity = this.makeOne(input);
     await this.em.flush();
     return entity;
   }
@@ -60,10 +73,10 @@ export abstract class Factory<T extends object> {
   /**
    * Create (and flush) multiple entities
    * @param amount Number of entities that should be generated
-   * @param overrideParameters Object specifying what default attributes of the entity factory should be overridden
+   * @param input Object specifying what default attributes of the entity factory should be overridden
    */
-  async create(amount: number, overrideParameters?: EntityData<T>): Promise<T[]> {
-    const entities = this.make(amount, overrideParameters);
+  async create(amount: number, input?: TInput): Promise<TEntity[]> {
+    const entities = this.make(amount, input);
     await this.em.flush();
     return entities;
   }
@@ -73,7 +86,7 @@ export abstract class Factory<T extends object> {
    * In case of `createOne` or `create` it is applied before the entity is persisted
    * @param eachFunction The function that is applied on every entity
    */
-  each(eachFunction: (entity: T, index: number) => void) {
+  each(eachFunction: (entity: TEntity, index: number) => void) {
     this.eachFunction = eachFunction;
     return this;
   }

--- a/tests/features/seeder/factory.test.ts
+++ b/tests/features/seeder/factory.test.ts
@@ -29,9 +29,26 @@ export class HouseFactory extends Factory<House> {
 
   model = House;
 
-  definition(): Partial<House> {
+  definition(input?: EntityData<House>): EntityData<House> {
     return {
       address: 'addr',
+      ...input,
+    };
+  }
+
+}
+
+export class MaybeMansionFactory extends Factory<
+  House,
+  EntityData<House> & { mansion: boolean }
+> {
+
+  model = House;
+
+  definition(input: EntityData<House> & { mansion: boolean }) {
+    return {
+      ...(input.mansion ? { address: 'mansion street' } : {}),
+      ...input,
     };
   }
 
@@ -130,5 +147,17 @@ describe('Factory', () => {
       })
       .create(3);
     expect(projects.map(p => p.houses.count())).toEqual([0, 1, 2]);
+  });
+
+  test("a factory can have custom input params on which it bases its' definition", async () => {
+    const project = await new ProjectFactory(orm.em).createOne();
+    const house = await new MaybeMansionFactory(orm.em).createOne({
+      project: { id: project.id },
+      mansion: true,
+    });
+    expect(house).toMatchObject({
+      project,
+      address: 'mansion street',
+    });
   });
 });


### PR DESCRIPTION
Some of my entities have a lot of attributes, that can have a lot of combinations. It would be nice if I could pass a property to the `.definition()` method (when making or creating an entity), so that I can dynamically define how a generated entity should look like.

Example usage:

```ts
export class TournamentFactory extends Factory<
  TournamentEntity,
  EntityData<TournamentEntity> & { groupsCount?: number }
> {
  model = TournamentEntity;

  async definition(
    params?: EntityData<TournamentEntity> & { groupsCount?: number }
  ): EntityData<TournamentEntity> {
    return {
      name: "XXX Olympic Games",
      ...params,
      groups: params.groups ?? [...Array(params?.groupsCount ?? 0)].map((v, i) =>
        new TournamentGroupFactory(this.em).makeEntity({
          number: i + 1,
        })
      ),
    };
  }
}

// Final usage

new TournamentFactory(em).createOne({ groupsCount: 4 }) // creates a tournament with four groups
```

Without this, I currently have :

- to create dozens of classes (e.g. `FourGroupsTournamentFactory` `EightGroupsTournamentFactory`), or
- use `.each()`, but that doesn't scale, as I'd prefer to keep the above logic written only once, in my factory class, or
- do some wrappers around the factory, like `createTournament(em, { groupsCount: 4 })`, which becomes a factory-wrapper for another factory.