### PR TITLE
feat(core): improve typings for `@Entity`, `@Index` and `@Unique` decorators

### DIFF
--- a/packages/core/src/decorators/Entity.ts
+++ b/packages/core/src/decorators/Entity.ts
@@ -1,6 +1,6 @@
 import { MetadataStorage } from '../metadata';
 import { Utils } from '../utils';
-import type { Constructor, Dictionary, EntityClass, FilterQuery } from '../typings';
+import type { AnyString, Constructor, Dictionary, EntityClass, FilterQuery } from '../typings';
 import type { FindOptions } from '../drivers/IDatabaseDriver';
 
 export function Entity<T extends EntityClass<unknown>>(options: EntityOptions<T> = {}) {
@@ -19,7 +19,7 @@ export type EntityOptions<T> = {
   tableName?: string;
   schema?: string;
   collection?: string;
-  discriminatorColumn?: T extends EntityClass<infer P> ? keyof P : string;
+  discriminatorColumn?: (T extends EntityClass<infer P> ? keyof P : string) | AnyString;
   discriminatorMap?: Dictionary<string>;
   discriminatorValue?: number | string;
   forceConstructor?: boolean;

--- a/packages/core/src/decorators/Entity.ts
+++ b/packages/core/src/decorators/Entity.ts
@@ -1,19 +1,17 @@
 import { MetadataStorage } from '../metadata';
 import { Utils } from '../utils';
-import type { Constructor, Dictionary, FilterQuery } from '../typings';
+import type { Constructor, Dictionary, EntityClass, FilterQuery } from '../typings';
 import type { FindOptions } from '../drivers/IDatabaseDriver';
 
-export function Entity(options: EntityOptions<any> = {}) {
-  return function <T>(target: T & Dictionary) {
+export function Entity<T extends EntityClass<unknown>>(options: EntityOptions<T> = {}) {
+  return function (target: T) {
     const meta = MetadataStorage.getMetadataFromDecorator(target);
     Utils.mergeConfig(meta, options);
-    meta.class = target as unknown as Constructor<T>;
+    meta.class = target;
 
     if (!options.abstract || meta.discriminatorColumn) {
       meta.name = target.name;
     }
-
-    return target;
   };
 }
 
@@ -21,7 +19,7 @@ export type EntityOptions<T> = {
   tableName?: string;
   schema?: string;
   collection?: string;
-  discriminatorColumn?: string;
+  discriminatorColumn?: T extends EntityClass<infer P> ? keyof P : string;
   discriminatorMap?: Dictionary<string>;
   discriminatorValue?: number | string;
   forceConstructor?: boolean;

--- a/packages/core/src/decorators/Indexed.ts
+++ b/packages/core/src/decorators/Indexed.ts
@@ -1,9 +1,9 @@
 import { MetadataStorage } from '../metadata';
-import type { EntityClass, Dictionary } from '../typings';
+import type { EntityClass, Dictionary, AutoPath } from '../typings';
 import { Utils } from '../utils/Utils';
 import type { DeferMode } from '../enums';
 
-function createDecorator<T extends object>(options: IndexOptions<T> | UniqueOptions<T>, unique: boolean) {
+function createDecorator<T extends object>(options: IndexOptions<T, string> | UniqueOptions<T, string>, unique: boolean) {
   return function (target: T, propertyName?: T extends EntityClass<unknown> ? undefined : keyof T) {
     const meta = MetadataStorage.getMetadataFromDecorator(propertyName ? target.constructor : target);
     options.properties ??= propertyName;
@@ -18,26 +18,27 @@ function createDecorator<T extends object>(options: IndexOptions<T> | UniqueOpti
   };
 }
 
-export function Index<T extends object>(options: IndexOptions<T> = {}) {
+export function Index<T extends object, H extends string>(options: IndexOptions<T, H> = {}) {
   return createDecorator(options, false);
 }
 
-export function Unique<T extends object>(options: UniqueOptions<T> = {}) {
+export function Unique<T extends object, H extends string>(options: UniqueOptions<T, H> = {}) {
   return createDecorator(options, true);
 }
 
-type Properties<T> = keyof T | (keyof T)[];
-interface BaseOptions<T> {
+type MaybeArray<T> = T | T[];
+type Properties<T, H extends string> = MaybeArray<AutoPath<T, H>>;
+interface BaseOptions<T, H extends string> {
   name?: string;
-  properties?: T extends EntityClass<infer P> ? Properties<P> : Properties<T>;
+  properties?: (T extends EntityClass<infer P> ? Properties<P, H> : Properties<T, H>);
   options?: Dictionary;
   expression?: string;
 }
 
-export interface UniqueOptions<T> extends BaseOptions<T> {
+export interface UniqueOptions<T, H extends string = string> extends BaseOptions<T, H> {
   deferMode?: DeferMode | `${DeferMode}`;
 }
 
-export interface IndexOptions<T> extends BaseOptions<T> {
+export interface IndexOptions<T, H extends string = string> extends BaseOptions<T, H> {
   type?: string;
 }

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -236,11 +236,11 @@ export class EntitySchema<Entity = any, Base = never> {
     this.addProperty(name, type, prop);
   }
 
-  addIndex(options: IndexOptions<Entity>): void {
+  addIndex<Key extends string>(options: IndexOptions<Entity, Key>): void {
     this._meta.indexes.push(options as any);
   }
 
-  addUnique(options: UniqueOptions<Entity>): void {
+  addUnique<Key extends string>(options: UniqueOptions<Entity, Key>): void {
     this._meta.uniques.push(options as any);
   }
 

--- a/packages/entity-generator/src/SourceFile.ts
+++ b/packages/entity-generator/src/SourceFile.ts
@@ -131,32 +131,41 @@ export class SourceFile {
 
   protected getIndexOptions(index: EntityMetadata['indexes'][number], isAtEntityLevel = true) {
     const indexOpt: IndexOptions<Dictionary> = {};
+
     if (typeof index.name === 'string') {
       indexOpt.name = this.quote(index.name);
     }
+
     if (index.expression) {
       indexOpt.expression = this.quote(index.expression);
     }
+
     if (isAtEntityLevel && index.properties) {
-      indexOpt.properties = Utils.asArray(index.properties).map(prop => this.quote('' + prop));
+      indexOpt.properties = Utils.asArray(index.properties).map(prop => this.quote('' + prop)) as never[];
     }
+
     return indexOpt;
   }
 
   protected getUniqueOptions(index: EntityMetadata['uniques'][number], isAtEntityLevel = true) {
     const uniqueOpt: UniqueOptions<Dictionary> = {};
+
     if (typeof index.name === 'string') {
       uniqueOpt.name = this.quote(index.name);
     }
+
     if (index.expression) {
       uniqueOpt.expression = this.quote(index.expression);
     }
+
     if (isAtEntityLevel && index.properties) {
-      uniqueOpt.properties = Utils.asArray(index.properties).map(prop => this.quote('' + prop));
+      uniqueOpt.properties = Utils.asArray(index.properties).map(prop => this.quote('' + prop)) as never[];
     }
+
     if (index.deferMode) {
       uniqueOpt.deferMode = `${this.referenceCoreImport('DeferMode')}.INITIALLY_${index.deferMode.toUpperCase()}` as DeferMode;
     }
+
     return uniqueOpt;
   }
 

--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -4,7 +4,6 @@ import {
   DecimalType,
   type DeferMode,
   type Dictionary,
-  type EntityKey,
   type EntityMetadata,
   type EntityProperty,
   EntitySchema,
@@ -239,7 +238,7 @@ export class DatabaseTable {
     );
 
     for (const index of potentiallyUnmappedIndexes) {
-      const ret: UniqueOptions<Dictionary<EntityKey>> & { properties?: string[] } = {
+      const ret: UniqueOptions<any> = {
         name: index.keyName,
         deferMode: index.deferMode,
         expression: index.expression,
@@ -249,11 +248,12 @@ export class DatabaseTable {
       if (isTrivial) {
         // Index is for FK. Map to the FK prop and move on.
         const fkForIndex = fkIndexes.get(index);
+
         if (fkForIndex && !fkForIndex.fk.columnNames.some(col => !index.columnNames.includes(col))) {
-          ret.properties = [this.getPropertyName(namingStrategy, fkForIndex.baseName, fkForIndex.fk)];
+          ret.properties = [this.getPropertyName(namingStrategy, fkForIndex.baseName, fkForIndex.fk) as never];
           const map = index.unique ? compositeFkUniques : compositeFkIndexes;
-          if (typeof map[ret.properties[0]] === 'undefined') {
-            map[ret.properties[0]] = index;
+          if (typeof map[ret.properties![0]] === 'undefined') {
+            map[ret.properties![0]] = index;
             continue;
           }
         }
@@ -265,7 +265,8 @@ export class DatabaseTable {
       if (typeof properties === 'undefined') {
         ret.expression ??= schemaHelper.getCreateIndexSQL(this.name, index);
       } else {
-        ret.properties ??= properties;
+        ret.properties ??= properties as any;
+
         // If the index is for one property that is not a FK prop, map to the column prop and move on.
         if (properties.length === 1 && isTrivial && !fksOnStandaloneProps.has(properties[0])) {
           const map = index.unique ? compositeFkUniques : compositeFkIndexes;


### PR DESCRIPTION
hi! this PR improves the typings for these decorator options:
- `@Entity` → `discriminatorColumn`
- `@Index`, `@Unique` → `properties`

so that they only accept property keys from the decorated class, instead of just any string.

this particular example is pretty cool, as it shows how this supersedes the runtime [`unknownIndexProperty`](https://github.com/mikro-orm/mikro-orm/blob/a6c48fd1b436edcd2bcead74ebfec42bb65da043/packages/core/src/errors.ts#L214) error (at least in simple cases where every property is a @​Property):

```ts
@Unique({ properties: ["platform_id" }) // Type '"platform_id"' is not assignable to type 'keyof Thing'. Did you mean '"platformID"'?
@Unique({ properties: ["platform", "platformID"] }) // good
class Thing { id: number, platform: string, platformID: number }
```

there are minor side effects to this change (which i'm happy to explain), but i don't think they should be a problem