### PR TITLE
feat: add entityname as argument for filters

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -545,7 +545,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
           throw new Error(`No arguments provided for filter '${filter.name}'`);
         }
 
-        cond = await filter.cond(args, type, this, findOptions);
+        cond = await filter.cond(args, type, this, findOptions, entityName);
       } else {
         cond = filter.cond;
       }

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -976,7 +976,7 @@ export interface MigrationObject {
 
 export type FilterDef = {
   name: string;
-  cond: Dictionary | ((args: Dictionary, type: 'read' | 'update' | 'delete', em: any, options?: FindOptions<any, any, any, any> | FindOneOptions<any, any, any, any>) => Dictionary | Promise<Dictionary>);
+  cond: Dictionary | ((args: Dictionary, type: 'read' | 'update' | 'delete', em: any, options?: FindOptions<any, any, any, any> | FindOneOptions<any, any, any, any>, entityName?: EntityName<any>) => Dictionary | Promise<Dictionary>);
   default?: boolean;
   entity?: string[];
   args?: boolean;


### PR DESCRIPTION
This PR adds an extra argument to the filters condition function.

When you execute a relational query, a filter function is executed multiple times. By using the entity name, you can deduce which layer the filter is applied to.