### PR TITLE
perf(reflection): only consider entity files instead of evaluating the whole project

### DIFF
--- a/packages/reflection/src/TsMorphMetadataProvider.ts
+++ b/packages/reflection/src/TsMorphMetadataProvider.ts
@@ -213,6 +213,7 @@ export class TsMorphMetadataProvider extends MetadataProvider {
     try {
       this.project = new Project({
         tsConfigFilePath: Utils.normalizePath(process.cwd(), tsConfigFilePath),
+        skipAddingFilesFromTsConfig: true,
         compilerOptions: {
           strictNullChecks: true,
           module: ModuleKind.Node16,


### PR DESCRIPTION
This significantly reduces the time to initialize the TS project. We were previously checking all the files included in the tsconfig.json, which usually means the whole project. We add the entity files explicitly, so this shouldn't be needed.