### PR TITLE
feat(entity-generator): pass through `orderBy` option to the output

### DIFF
--- a/packages/entity-generator/src/SourceFile.ts
+++ b/packages/entity-generator/src/SourceFile.ts
@@ -770,6 +770,10 @@ export class SourceFile {
     this.entityImports.add(prop.type);
     options.entity = `() => ${prop.type}`;
 
+    if (prop.orderBy) {
+      options.orderBy = JSON.stringify(prop.orderBy);
+    }
+
     if (prop.mappedBy) {
       options.mappedBy = this.quote(prop.mappedBy);
       return;
@@ -808,6 +812,9 @@ export class SourceFile {
     this.entityImports.add(prop.type);
     options.entity = `() => ${prop.type}`;
     options.mappedBy = this.quote(prop.mappedBy);
+    if (prop.orderBy) {
+      options.orderBy = JSON.stringify(prop.orderBy);
+    }
   }
 
   protected getEmbeddedPropertyDeclarationOptions(options: Dictionary, prop: EntityProperty) {

--- a/tests/features/entity-generator/MetadataHooks.mysql.test.ts
+++ b/tests/features/entity-generator/MetadataHooks.mysql.test.ts
@@ -281,6 +281,17 @@ const processedMetadataProcessor: GenerateOptions['onProcessedMetadata'] = (meta
 
       };
     }
+
+    if (entity.className === 'BookTag2') {
+      entity.props.forEach(prop => {
+        if (
+          prop.name === 'bookToTagUnorderedInverse' ||
+          prop.name === 'book2TagsCollection'
+        ) {
+          prop.orderBy = { name: 'asc' };
+        }
+      });
+    }
   });
 };
 

--- a/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
@@ -172,10 +172,10 @@ export class BookTag2 {
   @Property({ length: 50 })
   name!: string;
 
-  @ManyToMany({ entity: () => Book2, mappedBy: 'bookToTagUnordered' })
+  @ManyToMany({ entity: () => Book2, orderBy: {"name":"asc"}, mappedBy: 'bookToTagUnordered' })
   bookToTagUnorderedInverse = new Collection<Book2>(this);
 
-  @OneToMany({ entity: () => Book2Tags, mappedBy: 'bookTag2' })
+  @OneToMany({ entity: () => Book2Tags, mappedBy: 'bookTag2', orderBy: {"name":"asc"} })
   book2TagsCollection = new Collection<Book2Tags>(this);
 
 }
@@ -977,12 +977,14 @@ export const BookTag2Schema = new EntitySchema({
     bookToTagUnorderedInverse: {
       kind: 'm:n',
       entity: () => Book2,
+      orderBy: {"name":"asc"},
       mappedBy: 'bookToTagUnordered',
     },
     book2TagsCollection: {
       kind: '1:m',
       entity: () => Book2Tags,
       mappedBy: 'bookTag2',
+      orderBy: {"name":"asc"},
     },
   },
 });
@@ -1837,10 +1839,10 @@ export class BookTag2 {
   @Property({ length: 50 })
   name!: string;
 
-  @ManyToMany({ entity: () => Book2, mappedBy: 'bookToTagUnordered' })
+  @ManyToMany({ entity: () => Book2, orderBy: {"name":"asc"}, mappedBy: 'bookToTagUnordered' })
   bookToTagUnorderedInverse = new Collection<Book2>(this);
 
-  @OneToMany({ entity: () => Book2Tags, mappedBy: 'bookTag2' })
+  @OneToMany({ entity: () => Book2Tags, mappedBy: 'bookTag2', orderBy: {"name":"asc"} })
   book2TagsCollection = new Collection<Book2Tags>(this);
 
 }
@@ -2654,12 +2656,14 @@ export const BookTag2Schema = new EntitySchema({
     bookToTagUnorderedInverse: {
       kind: 'm:n',
       entity: () => Book2,
+      orderBy: {"name":"asc"},
       mappedBy: 'bookToTagUnordered',
     },
     book2TagsCollection: {
       kind: '1:m',
       entity: () => Book2Tags,
       mappedBy: 'bookTag2',
+      orderBy: {"name":"asc"},
     },
   },
 });
@@ -3533,10 +3537,10 @@ export class BookTag2 {
   @Property({ length: 50 })
   name!: string;
 
-  @ManyToMany({ entity: () => Book2, mappedBy: 'bookToTagUnordered' })
+  @ManyToMany({ entity: () => Book2, orderBy: {"name":"asc"}, mappedBy: 'bookToTagUnordered' })
   bookToTagUnorderedInverse = new Collection<Book2>(this);
 
-  @OneToMany({ entity: () => Book2Tags, mappedBy: 'bookTag2' })
+  @OneToMany({ entity: () => Book2Tags, mappedBy: 'bookTag2', orderBy: {"name":"asc"} })
   book2TagsCollection = new Collection<Book2Tags>(this);
 
 }
@@ -4338,12 +4342,14 @@ export const BookTag2Schema = new EntitySchema({
     bookToTagUnorderedInverse: {
       kind: 'm:n',
       entity: () => Book2,
+      orderBy: {"name":"asc"},
       mappedBy: 'bookToTagUnordered',
     },
     book2TagsCollection: {
       kind: '1:m',
       entity: () => Book2Tags,
       mappedBy: 'bookTag2',
+      orderBy: {"name":"asc"},
     },
   },
 });
@@ -5198,10 +5204,10 @@ export class BookTag2 {
   @Property({ length: 50 })
   name!: string;
 
-  @ManyToMany({ entity: () => Book2, mappedBy: 'bookToTagUnordered' })
+  @ManyToMany({ entity: () => Book2, orderBy: {"name":"asc"}, mappedBy: 'bookToTagUnordered' })
   bookToTagUnorderedInverse = new Collection<Book2>(this);
 
-  @OneToMany({ entity: () => Book2Tags, mappedBy: 'bookTag2' })
+  @OneToMany({ entity: () => Book2Tags, mappedBy: 'bookTag2', orderBy: {"name":"asc"} })
   book2TagsCollection = new Collection<Book2Tags>(this);
 
 }
@@ -6015,12 +6021,14 @@ export const BookTag2Schema = new EntitySchema({
     bookToTagUnorderedInverse: {
       kind: 'm:n',
       entity: () => Book2,
+      orderBy: {"name":"asc"},
       mappedBy: 'bookToTagUnordered',
     },
     book2TagsCollection: {
       kind: '1:m',
       entity: () => Book2Tags,
       mappedBy: 'bookTag2',
+      orderBy: {"name":"asc"},
     },
   },
 });


### PR DESCRIPTION
I am using entity generator to maintain source code of my entities, and also I'd like to provide `orderBy` option for some of my collections.

Currently one can alter a lot of entities' code through the `onProcessedMetadata` callback - but just not the `orderBy` option, as it is never saved to the generated code output.

This PR fixes it - allowing to specify `orderBy` option for some of the relations in the metadata callbacks, so that it's later placed in the generated entities code.