### PR TITLE
fix(core): respect Collection property `orderBy` when dataloader is enabled

### DIFF
--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -300,7 +300,7 @@ export class Collection<T extends object, O extends object = object> extends Arr
     if (options.dataloader ?? [DataloaderType.ALL, DataloaderType.COLLECTION].includes(DataloaderUtils.getDataloaderType(em.config.get('dataloader')))) {
       const order = [...this.items]; // copy order of references
       const orderBy = this.createOrderBy(options.orderBy);
-      const customOrder = !!orderBy;
+      const customOrder = orderBy.length > 0;
       // eslint-disable-next-line dot-notation
       const items: TT[] = await em['colLoader'].load([
         this,

--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -299,9 +299,13 @@ export class Collection<T extends object, O extends object = object> extends Arr
 
     if (options.dataloader ?? [DataloaderType.ALL, DataloaderType.COLLECTION].includes(DataloaderUtils.getDataloaderType(em.config.get('dataloader')))) {
       const order = [...this.items]; // copy order of references
-      const customOrder = !!options.orderBy;
+      const orderBy = this.createOrderBy(options.orderBy);
+      const customOrder = !!orderBy;
       // eslint-disable-next-line dot-notation
-      const items: TT[] = await em['colLoader'].load([this, options]);
+      const items: TT[] = await em['colLoader'].load([
+        this,
+        { ...options, orderBy },
+      ]);
 
       if (!customOrder) {
         this.reorderItems(items, order);

--- a/tests/features/collection/collection-order.test.ts
+++ b/tests/features/collection/collection-order.test.ts
@@ -1,0 +1,79 @@
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, SimpleLogger } from '@mikro-orm/better-sqlite';
+
+@Entity()
+class Author {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name: string;
+
+  @OneToMany(() => Book, b => b.author, { orderBy: { title: 'asc' } })
+  books = new Collection<Book>(this);
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+}
+
+@Entity()
+class Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToOne(() => Author)
+  author!: Author;
+
+
+  constructor(author: Author, title: string) {
+    this.author = author;
+    this.title = title;
+  }
+
+}
+
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Author],
+    dbName: ':memory:',
+    loggerFactory: SimpleLogger.create,
+  });
+
+  await orm.schema.createSchema();
+  await createEntities();
+});
+
+beforeEach(() => orm.em.clear());
+afterAll(() => orm.close(true));
+
+async function createEntities() {
+  const author = new Author('john');
+  author.books.add(
+    new Book(author, 'a'),
+    new Book(author, 'c'),
+    new Book(author, 'b'),
+  );
+  await orm.em.fork().persistAndFlush(author);
+}
+
+describe.each([true, false])('dataloader=%s', dataloader => {
+  beforeEach(() => orm.config.set('dataloader', dataloader));
+
+  test('collection is loaded using the default order if orderBy option is not passed', async () => {
+    const author = await orm.em.findOneOrFail(Author, { name: 'john' });
+    expect((await author.books.loadItems()).map(b => b.title)).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+});

--- a/tests/features/collection/collection-order.test.ts
+++ b/tests/features/collection/collection-order.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, SimpleLogger } from '@mikro-orm/better-sqlite';
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/sqlite';
 
 @Entity()
 class Author {
@@ -45,7 +45,6 @@ beforeAll(async () => {
   orm = await MikroORM.init({
     entities: [Author],
     dbName: ':memory:',
-    loggerFactory: SimpleLogger.create,
   });
 
   await orm.schema.createSchema();


### PR DESCRIPTION
After adding default `orderBy` to my collection in the entity class `@OneToMany(...)` decorator, I noticed that my collections are sometimes sorted correctly and sometimes not at all.

Upon debugging it appeared that this happens only if `dataloader` is enabled (and it is, in my case).

This PR fixes it, making the `Collection#loadItems` load items in the default order (rather than none) also when dataloader is enabled. (Currently, it happens only when it is disabled.)