### PR TITLE
fix(core): skip TS support detection via `require.extensions`

### DIFF
--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -801,8 +801,7 @@ export class Utils {
       || !!process.env.VITEST // check if vitest is used
       || !!process.versions.bun // check if bun is used
       || process.argv.slice(1).some(arg => arg.includes('ts-node')) // registering ts-node runner
-      || process.execArgv.some(arg => arg === 'ts-node/esm') // check for ts-node/esm module loader
-      || (require.extensions && !!require.extensions['.ts']); // check if the extension is registered
+      || process.execArgv.some(arg => arg === 'ts-node/esm'); // check for ts-node/esm module loader
   }
 
   /**


### PR DESCRIPTION
This check was problematic because of Node.js type stripping uses it now too, and it does fail to parse decorators.

It was already removed from v7, but since the type stripping will be backported to Node.js 22, I am removing it from v6 too, otherwise things break when executing the compiled code.

Related to https://github.com/nodejs/node/pull/57298#issuecomment-2703430792