### PR TITLE
feat(mssql): add support for raw query fragments with TVPs

### DIFF
--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -494,6 +494,18 @@ export abstract class Platform {
     return value;
   }
 
+  shouldBindParamWithKnex(value: any): boolean {
+    return false;
+  }
+
+  formatValue(value: any): string {
+    if (this.shouldBindParamWithKnex(value)) {
+      return '?';
+    }
+
+    return this.quoteValue(value);
+  }
+
   formatQuery(sql: string, params: readonly any[]): string {
     if (params.length === 0) {
       return sql;
@@ -509,7 +521,7 @@ export abstract class Platform {
         ret += this.quoteIdentifier(params[j++]);
         pos = 2;
       } else {
-        ret += this.quoteValue(params[j++]);
+        ret += this.formatValue(params[j++]);
         pos = 1;
       }
     }
@@ -529,7 +541,7 @@ export abstract class Platform {
         ret += sql.substring(pos, idx) + this.quoteIdentifier(params[j++]);
         pos = idx + 2;
       } else {
-        ret += sql.substring(pos, idx) + this.quoteValue(params[j++]);
+        ret += sql.substring(pos, idx) + this.formatValue(params[j++]);
         pos = idx + 1;
       }
     }

--- a/packages/knex/src/AbstractSqlConnection.ts
+++ b/packages/knex/src/AbstractSqlConnection.ts
@@ -151,10 +151,11 @@ export abstract class AbstractSqlConnection extends Connection {
     }
 
     queryOrKnex = this.config.get('onQuery')(queryOrKnex, params);
+    const paramsToBindWithKnex = this.getParamsToBindWithKnex(params);
     const formatted = this.platform.formatQuery(queryOrKnex, params);
     const sql = this.getSql(queryOrKnex, formatted, loggerContext);
     return this.executeQuery<T>(sql, async () => {
-      const query = this.getKnex().raw(formatted);
+      const query = this.getKnex().raw(formatted, paramsToBindWithKnex);
 
       if (ctx) {
         query.transacting(ctx);
@@ -177,6 +178,10 @@ export abstract class AbstractSqlConnection extends Connection {
       /* istanbul ignore next */
       throw this.platform.getExceptionConverter().convertException(e as Error);
     }
+  }
+
+  protected getParamsToBindWithKnex(params: unknown[]): unknown[] {
+    return params.filter(param => this.platform.shouldBindParamWithKnex(param));
   }
 
   protected createKnexClient(type: string): Knex {

--- a/packages/mssql/src/MsSqlDriver.ts
+++ b/packages/mssql/src/MsSqlDriver.ts
@@ -1,14 +1,11 @@
 import {
   type AnyEntity,
   type Configuration,
-  type Connection,
   type ConnectionType,
   type Dictionary,
   type EntityDictionary,
   type EntityKey,
-  type EntityManager,
   type EntityProperty,
-  type IDatabaseDriver,
   type LoggingOptions,
   type NativeInsertUpdateManyOptions,
   QueryFlag,
@@ -22,12 +19,7 @@ import { MsSqlPlatform } from './MsSqlPlatform';
 import { MsSqlQueryBuilder } from './MsSqlQueryBuilder';
 import { isTVP } from './utils/is-tvp';
 
-function patchConfig(
-  config: Configuration<
-    IDatabaseDriver<Connection>,
-    EntityManager<IDatabaseDriver<Connection>>
-  >,
-) {
+function patchConfig(config: Configuration) {
   const driverOptions: Dictionary = config.get('driverOptions', {});
   driverOptions.connection ??= {};
   driverOptions.connection.options ??= {};

--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -21,6 +21,7 @@ import { MsSqlExceptionConverter } from './MsSqlExceptionConverter';
 import { MsSqlSchemaGenerator } from './MsSqlSchemaGenerator';
 import { UnicodeCharacterType } from './UnicodeCharacterType';
 import { UnicodeString, UnicodeStringType } from './UnicodeStringType';
+import { isTVP } from './utils/is-tvp';
 
 export class MsSqlPlatform extends AbstractSqlPlatform {
 
@@ -221,6 +222,10 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
 
   override quoteIdentifier(id: string): string {
     return `[${id.replace('.', `].[`)}]`;
+  }
+
+  override shouldBindParamWithKnex(value: any): boolean {
+    return isTVP(value);
   }
 
   override escape(value: any): string {

--- a/packages/mssql/src/utils/is-tvp.ts
+++ b/packages/mssql/src/utils/is-tvp.ts
@@ -1,8 +1,5 @@
+import { TYPES } from 'tedious';
+
 export function isTVP(value: any): boolean {
-  return (
-    value != null &&
-    typeof value === 'object' &&
-    Array.isArray(value.columns) &&
-    Array.isArray(value.rows)
-  );
+  return value != null && typeof value === 'object' && value.type === TYPES.TVP;
 }

--- a/packages/mssql/src/utils/is-tvp.ts
+++ b/packages/mssql/src/utils/is-tvp.ts
@@ -1,0 +1,8 @@
+export function isTVP(value: any): boolean {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    Array.isArray(value.columns) &&
+    Array.isArray(value.rows)
+  );
+}

--- a/tests/features/raw-queries/knex-bound-params.mssql.test.ts
+++ b/tests/features/raw-queries/knex-bound-params.mssql.test.ts
@@ -1,0 +1,73 @@
+import { Entity, MikroORM, PrimaryKey, Property, raw } from '@mikro-orm/mssql';
+import { TYPES } from 'tedious';
+
+@Entity()
+class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = MikroORM.initSync({
+    entities: [User],
+    dbName: `knex-bound-params`,
+    password: 'Root.Root',
+  });
+
+  await orm.schema.refreshDatabase();
+
+  const users = [
+    orm.em.create(User, { id: 1, name: 'John' }),
+    orm.em.create(User, { id: 2, name: 'Jane' }),
+    orm.em.create(User, { id: 3, name: 'Jack' }),
+  ];
+
+  await orm.em.persistAndFlush(users);
+  await orm.em.getConnection().execute(`DROP TYPE IF EXISTS IdTvp;`);
+  await orm.em.getConnection().execute(`
+    CREATE TYPE IdTvp AS TABLE
+    (
+      id INT
+    );
+  `);
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('executes raw query with TVP', async () => {
+  const users = await orm.em.find(
+    User,
+    {
+      [raw(alias => `${alias}.id`)]: {
+        $in: raw('SELECT id FROM :UserIDs', {
+          UserIDs: {
+            type: TYPES.TVP,
+            value: {
+              name: 'IdTvp',
+              columns: [{ name: 'id', type: TYPES.Int }],
+              rows: [[1], [3]],
+            },
+          },
+        }),
+      },
+    },
+    {
+      orderBy: {
+        id: 'asc',
+      },
+    },
+  );
+
+  expect(users.length).toBe(2);
+  expect(users[0].name).toEqual('John');
+  expect(users[1].name).toEqual('Jack');
+});


### PR DESCRIPTION
This adds support for passing table-valued parameters (TVPs) to raw query fragments when using MsSql driver.
Currently, objects used to construct TVP by tedious are stringified to JSON as any other object.

Table-valued parameters allow multi-column comparisons without the need for dynamic generation of conditions with ORs between, and makes the query shorter, in some cases improving the performance.


I know that knex dependency removal is planned for the next major version, but the changes here are very simple, so I think it can be easily rewritten for the new knex-less solution.