### PR TITLE
docs: fix typo in Foreign keys and `forceObject` title

### DIFF
--- a/docs/docs/serializing.md
+++ b/docs/docs/serializing.md
@@ -124,7 +124,7 @@ Primary keys are automatically included. If you want to hide them, you have two 
 - use `hidden: true` in the property options
 - use `serialization: { includePrimaryKeys: false }` in the ORM config
 
-### Foreign keys are `forceObject`
+### Foreign keys and `forceObject`
 
 Unpopulated relations are serialized as foreign key values, e.g. `{ author: 1 }`, if you want to enforce objects, e.g. `{ author: { id: 1 } }`, use `serialization: { forceObject: true }` in your ORM config.
 

--- a/docs/versioned_docs/version-6.0/serializing.md
+++ b/docs/versioned_docs/version-6.0/serializing.md
@@ -155,7 +155,7 @@ Primary keys are automatically included. If you want to hide them, you have two 
 - use `hidden: true` in the property options
 - use `serialization: { includePrimaryKeys: false }` in the ORM config
 
-### Foreign keys are `forceObject`
+### Foreign keys and `forceObject`
 
 Unpopulated relations are serialized as foreign key values, e.g. `{ author: 1 }`, if you want to enforce objects, e.g. `{ author: { id: 1 } }`, use `serialization: { forceObject: true }` in your ORM config.
 

--- a/docs/versioned_docs/version-6.1/serializing.md
+++ b/docs/versioned_docs/version-6.1/serializing.md
@@ -155,7 +155,7 @@ Primary keys are automatically included. If you want to hide them, you have two 
 - use `hidden: true` in the property options
 - use `serialization: { includePrimaryKeys: false }` in the ORM config
 
-### Foreign keys are `forceObject`
+### Foreign keys and `forceObject`
 
 Unpopulated relations are serialized as foreign key values, e.g. `{ author: 1 }`, if you want to enforce objects, e.g. `{ author: { id: 1 } }`, use `serialization: { forceObject: true }` in your ORM config.
 

--- a/docs/versioned_docs/version-6.2/serializing.md
+++ b/docs/versioned_docs/version-6.2/serializing.md
@@ -155,7 +155,7 @@ Primary keys are automatically included. If you want to hide them, you have two 
 - use `hidden: true` in the property options
 - use `serialization: { includePrimaryKeys: false }` in the ORM config
 
-### Foreign keys are `forceObject`
+### Foreign keys and `forceObject`
 
 Unpopulated relations are serialized as foreign key values, e.g. `{ author: 1 }`, if you want to enforce objects, e.g. `{ author: { id: 1 } }`, use `serialization: { forceObject: true }` in your ORM config.
 

--- a/docs/versioned_docs/version-6.3/serializing.md
+++ b/docs/versioned_docs/version-6.3/serializing.md
@@ -155,7 +155,7 @@ Primary keys are automatically included. If you want to hide them, you have two 
 - use `hidden: true` in the property options
 - use `serialization: { includePrimaryKeys: false }` in the ORM config
 
-### Foreign keys are `forceObject`
+### Foreign keys and `forceObject`
 
 Unpopulated relations are serialized as foreign key values, e.g. `{ author: 1 }`, if you want to enforce objects, e.g. `{ author: { id: 1 } }`, use `serialization: { forceObject: true }` in your ORM config.
 

--- a/docs/versioned_docs/version-6.4/serializing.md
+++ b/docs/versioned_docs/version-6.4/serializing.md
@@ -124,7 +124,7 @@ Primary keys are automatically included. If you want to hide them, you have two 
 - use `hidden: true` in the property options
 - use `serialization: { includePrimaryKeys: false }` in the ORM config
 
-### Foreign keys are `forceObject`
+### Foreign keys and `forceObject`
 
 Unpopulated relations are serialized as foreign key values, e.g. `{ author: 1 }`, if you want to enforce objects, e.g. `{ author: { id: 1 } }`, use `serialization: { forceObject: true }` in your ORM config.
 


### PR DESCRIPTION
Very minor fix.
I believe the title "Foreign keys are `forceObject`" must be a typo, because it does not make sense to me.
I think the intended title is "Foreign keys _and_ `forceObject`".