### PR TITLE
fix(postgres): cockroachdb may not require unmarshallArray

### DIFF
--- a/packages/postgresql/src/PostgreSqlSchemaHelper.ts
+++ b/packages/postgresql/src/PostgreSqlSchemaHelper.ts
@@ -318,10 +318,15 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
         name = row.schema_name + '.' + name;
       }
 
+      let items = row.enum_value;
+      if (!Array.isArray(items)) {
+        items = this.platform.unmarshallArray(row.enum_value);
+      }
+
       o[name] = {
         name: row.enum_name,
         schema: row.schema_name,
-        items: this.platform.unmarshallArray(row.enum_value),
+        items,
       };
 
       return o;


### PR DESCRIPTION
This PR fixes an issue I had when using the migration tool using CockroachDB.

When running migration:create or similar, any existing enums are fetched from the database. For some reason with CockroachDB, Knex or the driver automatically deserializes the array, so `unmarshallArray` will fail.