### PR TITLE
docs:  remove mention for manual typescript config in `package.json`

### DIFF
--- a/docs/docs/guide/01-first-entity.md
+++ b/docs/docs/guide/01-first-entity.md
@@ -181,7 +181,6 @@ This issue with dynamic imports can surface for both the CLI usage and `vitest`.
   "type": "module",
   "dependencies": { ... },
   "devDependencies": { ... },
-  "mikro-orm": { ... },
   "scripts": {
     "build": "tsc",
     "start": "node --no-warnings=ExperimentalWarning --loader ts-node/esm src/server.ts",

--- a/docs/docs/guide/01-first-entity.md
+++ b/docs/docs/guide/01-first-entity.md
@@ -156,7 +156,7 @@ export default defineConfig({
 });
 ```
 
-Save this file into `src/mikro-orm.config.ts`, so it will get compiled together with the rest of your app. Next, you need to tell the ORM to enable TypeScript support for CLI, via `mikro-orm` section in the `package.json` file.
+Save this file into `src/mikro-orm.config.ts`, so it will get compiled together with the rest of your app.
 
 > Alternatively, you can use `mikro-orm.config.js` file in the root of your project, such a file will get loaded automatically. Consult [the documentation](../quick-start#setting-up-the-commandline-tool) for more info.
 

--- a/docs/versioned_docs/version-6.3/guide/01-first-entity.md
+++ b/docs/versioned_docs/version-6.3/guide/01-first-entity.md
@@ -156,7 +156,7 @@ export default defineConfig({
 });
 ```
 
-Save this file into `src/mikro-orm.config.ts`, so it will get compiled together with the rest of your app. Next, you need to tell the ORM to enable TypeScript support for CLI, via `mikro-orm` section in the `package.json` file.
+Save this file into `src/mikro-orm.config.ts`, so it will get compiled together with the rest of your app.
 
 > Alternatively, you can use `mikro-orm.config.js` file in the root of your project, such a file will get loaded automatically. Consult [the documentation](../quick-start#setting-up-the-commandline-tool) for more info.
 
@@ -181,7 +181,6 @@ This issue with dynamic imports can surface for both the CLI usage and `vitest`.
   "type": "module",
   "dependencies": { ... },
   "devDependencies": { ... },
-  "mikro-orm": { ... },
   "scripts": {
     "build": "tsc",
     "start": "node --no-warnings=ExperimentalWarning --loader ts-node/esm src/server.ts",

--- a/docs/versioned_docs/version-6.4/guide/01-first-entity.md
+++ b/docs/versioned_docs/version-6.4/guide/01-first-entity.md
@@ -156,7 +156,7 @@ export default defineConfig({
 });
 ```
 
-Save this file into `src/mikro-orm.config.ts`, so it will get compiled together with the rest of your app. Next, you need to tell the ORM to enable TypeScript support for CLI, via `mikro-orm` section in the `package.json` file.
+Save this file into `src/mikro-orm.config.ts`, so it will get compiled together with the rest of your app.
 
 > Alternatively, you can use `mikro-orm.config.js` file in the root of your project, such a file will get loaded automatically. Consult [the documentation](../quick-start#setting-up-the-commandline-tool) for more info.
 
@@ -181,7 +181,6 @@ This issue with dynamic imports can surface for both the CLI usage and `vitest`.
   "type": "module",
   "dependencies": { ... },
   "devDependencies": { ... },
-  "mikro-orm": { ... },
   "scripts": {
     "build": "tsc",
     "start": "node --no-warnings=ExperimentalWarning --loader ts-node/esm src/server.ts",


### PR DESCRIPTION
Change was made in this PR: https://github.com/mikro-orm/mikro-orm/pull/5650 - the code sample was updated but not this sentence. Great package by the way, I'm new coming from EF Core that is also based on Data Mapper and really enjoying it so far.

I've gone through the entire guide now and don't see any other mentions of `mikro-orm` in `package.json`