### PR TITLE
fix(mssql): handle mapping for order by expressions with nulls first/last

### DIFF
--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -250,30 +250,18 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
   }
 
   override getOrderByExpression(column: string, direction: QueryOrder): string[] {
-    const ret: string[] = [];
-
     switch (direction.toUpperCase()) {
-      case QueryOrder.ASC:
-        ret.push(`${column} asc`);
-        break;
-      case QueryOrder.DESC:
-        ret.push(`${column} desc`);
-        break;
       case QueryOrder.ASC_NULLS_FIRST:
-        ret.push(`case when ${column} is null then 0 else 1 end, ${column} asc`);
-        break;
+        return `case when ${column} is null then 0 else 1 end, ${column} asc`;
       case QueryOrder.ASC_NULLS_LAST:
-        ret.push(`case when ${column} is null then 1 else 0 end, ${column} asc`);
-        break;
+        return `case when ${column} is null then 1 else 0 end, ${column} asc`;
       case QueryOrder.DESC_NULLS_FIRST:
-        ret.push(`case when ${column} is null then 0 else 1 end, ${column} desc`);
-        break;
+        return `case when ${column} is null then 0 else 1 end, ${column} desc`;
       case QueryOrder.DESC_NULLS_LAST:
-        ret.push(`case when ${column} is null then 1 else 0 end, ${column} desc`);
-        break;
+        return `case when ${column} is null then 1 else 0 end, ${column} desc`;
+      default:
+        return `${column} ${direction.toLowerCase()}`;
     }
-
-    return ret;
   }
 
 }

--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -252,15 +252,15 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
   override getOrderByExpression(column: string, direction: QueryOrder): string[] {
     switch (direction.toUpperCase()) {
       case QueryOrder.ASC_NULLS_FIRST:
-        return `case when ${column} is null then 0 else 1 end, ${column} asc`;
+        return [`case when ${column} is null then 0 else 1 end, ${column} asc`];
       case QueryOrder.ASC_NULLS_LAST:
-        return `case when ${column} is null then 1 else 0 end, ${column} asc`;
+        return [`case when ${column} is null then 1 else 0 end, ${column} asc`];
       case QueryOrder.DESC_NULLS_FIRST:
-        return `case when ${column} is null then 0 else 1 end, ${column} desc`;
+        return [`case when ${column} is null then 0 else 1 end, ${column} desc`];
       case QueryOrder.DESC_NULLS_LAST:
-        return `case when ${column} is null then 1 else 0 end, ${column} desc`;
+        return [`case when ${column} is null then 1 else 0 end, ${column} desc`];
       default:
-        return `${column} ${direction.toLowerCase()}`;
+        return [`${column} ${direction.toLowerCase()}`];
     }
   }
 

--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -13,6 +13,7 @@ import {
   type IPrimaryKey,
   DoubleType,
   FloatType,
+  QueryOrder,
 } from '@mikro-orm/knex';
 // @ts-expect-error no types available
 import SqlString from 'tsqlstring';
@@ -246,6 +247,33 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
 
   override allowsComparingTuples() {
     return false;
+  }
+
+  override getOrderByExpression(column: string, direction: QueryOrder): string[] {
+    const ret: string[] = [];
+
+    switch (direction.toUpperCase()) {
+      case QueryOrder.ASC:
+        ret.push(`${column} asc`);
+        break;
+      case QueryOrder.DESC:
+        ret.push(`${column} desc`);
+        break;
+      case QueryOrder.ASC_NULLS_FIRST:
+        ret.push(`case when ${column} is null then 0 else 1 end, ${column} asc`);
+        break;
+      case QueryOrder.ASC_NULLS_LAST:
+        ret.push(`case when ${column} is null then 1 else 0 end, ${column} asc`);
+        break;
+      case QueryOrder.DESC_NULLS_FIRST:
+        ret.push(`case when ${column} is null then 0 else 1 end, ${column} desc`);
+        break;
+      case QueryOrder.DESC_NULLS_LAST:
+        ret.push(`case when ${column} is null then 1 else 0 end, ${column} desc`);
+        break;
+    }
+
+    return ret;
   }
 
 }

--- a/tests/platforms/order-by.test.ts
+++ b/tests/platforms/order-by.test.ts
@@ -1,0 +1,152 @@
+import { Entity, IDatabaseDriver, PrimaryKey, Property, QueryOrder, SimpleLogger, Utils } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/core';
+import { mockLogger } from '../helpers';
+import { PLATFORMS } from '../bootstrap';
+
+@Entity()
+class Test {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 255, nullable: true })
+  value?: string | null;
+
+}
+
+const options = {
+  'sqlite': { dbName: ':memory:' },
+  'libsql': { dbName: ':memory:' },
+  'better-sqlite': { dbName: ':memory:' },
+  'mysql': { port: 3308 },
+  'mariadb': { port: 3309 },
+  'mssql': { password: 'Root.Root' },
+  'postgresql': {},
+};
+
+describe.each(Utils.keys(options))('Order by [%s]', type => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init<IDatabaseDriver>({
+      entities: [Test],
+      driver: PLATFORMS[type],
+      dbName: 'order-by',
+      loggerFactory: SimpleLogger.create,
+      ...options[type],
+    });
+
+    await orm.schema.refreshDatabase();
+  });
+
+  beforeEach(() => orm.schema.clearDatabase());
+
+  afterAll(() => orm.close(true));
+
+  test(`order-by`, async () => {
+    // Shouldn't be escaped.
+    const test = new Test();
+    test.value = null;
+
+    // Should be escaped.
+    const test2 = new Test();
+    test2.value = 'foo';
+
+    // Should be escaped twice.
+    const test3 = new Test();
+    test3.value = 'bar';
+
+    orm.em.persist(test);
+    orm.em.persist(test2);
+    orm.em.persist(test3);
+
+    await orm.em.flush();
+
+    const mock = mockLogger(orm, ['query', 'query-params']);
+
+    await orm.em.getRepository(Test).find({},
+      {
+        orderBy: {
+          value: QueryOrder.ASC,
+        },
+    });
+
+    await orm.em.getRepository(Test).find({},
+      {
+        orderBy: {
+          value: QueryOrder.DESC,
+        },
+      },
+    );
+
+    await orm.em.getRepository(Test).find({},
+      {
+        orderBy: {
+          value: QueryOrder.ASC_NULLS_FIRST,
+        },
+      },
+    );
+
+    await orm.em.getRepository(Test).find({},
+      {
+        orderBy: {
+          value: QueryOrder.ASC_NULLS_LAST,
+        },
+      },
+    );
+
+    await orm.em.getRepository(Test).find({},
+      {
+        orderBy: {
+          value: QueryOrder.DESC_NULLS_FIRST,
+        },
+      },
+    );
+
+    await orm.em.getRepository(Test).find({},
+      {
+        orderBy: {
+          value: QueryOrder.DESC_NULLS_LAST,
+        },
+      },
+    );
+
+    switch (type) {
+      case 'sqlite':
+      case 'libsql':
+      case 'better-sqlite':
+        expect(mock.mock.calls[0][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` asc');
+        expect(mock.mock.calls[1][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` desc');
+        expect(mock.mock.calls[2][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` asc nulls first');
+        expect(mock.mock.calls[3][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` asc nulls last');
+        expect(mock.mock.calls[4][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` desc nulls first');
+        expect(mock.mock.calls[5][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` desc nulls last');
+        break;
+      case 'mysql':
+      case 'mariadb':
+        expect(mock.mock.calls[0][0]).toMatch('[query] select `t0`.* from `test` as `t0`');
+        expect(mock.mock.calls[1][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` desc');
+        expect(mock.mock.calls[2][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` is not null, `t0`.`value` asc');
+        expect(mock.mock.calls[3][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` is null, `t0`.`value` asc');
+        expect(mock.mock.calls[4][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` is not null, `t0`.`value` desc');
+        expect(mock.mock.calls[5][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` is null, `t0`.`value` desc');
+        break;
+      case 'mssql':
+        expect(mock.mock.calls[0][0]).toMatch('[query] select [t0].* from [test] as [t0]');
+        expect(mock.mock.calls[1][0]).toMatch('[query] select [t0].* from [test] as [t0] order by [t0].[value] desc');
+        expect(mock.mock.calls[2][0]).toMatch('[query] select [t0].* from [test] as [t0] order by case when [t0].[value] is null then 0 else 1 end, [t0].[value] asc');
+        expect(mock.mock.calls[3][0]).toMatch('[query] select [t0].* from [test] as [t0] order by case when [t0].[value] is null then 1 else 0 end, [t0].[value] asc');
+        expect(mock.mock.calls[4][0]).toMatch('[query] select [t0].* from [test] as [t0] order by case when [t0].[value] is null then 0 else 1 end, [t0].[value] desc');
+        expect(mock.mock.calls[5][0]).toMatch('[query] select [t0].* from [test] as [t0] order by case when [t0].[value] is null then 1 else 0 end, [t0].[value] desc');
+        break;
+      case 'postgresql':
+        expect(mock.mock.calls[0][0]).toMatch('[query] select "t0".* from "test" as "t0" order by "t0"."value" asc');
+        expect(mock.mock.calls[1][0]).toMatch('[query] select "t0".* from "test" as "t0" order by "t0"."value" desc');
+        expect(mock.mock.calls[2][0]).toMatch('[query] select "t0".* from "test" as "t0" order by "t0"."value" asc nulls first');
+        expect(mock.mock.calls[3][0]).toMatch('[query] select "t0".* from "test" as "t0" order by "t0"."value" asc nulls last');
+        expect(mock.mock.calls[4][0]).toMatch('[query] select "t0".* from "test" as "t0" order by "t0"."value" desc nulls first');
+        expect(mock.mock.calls[5][0]).toMatch('[query] select "t0".* from "test" as "t0" order by "t0"."value" desc nulls last');
+        break;
+    }
+  });
+});

--- a/tests/platforms/order-by.test.ts
+++ b/tests/platforms/order-by.test.ts
@@ -15,10 +15,10 @@ class Test {
 }
 
 const options = {
-  'mysql': { port: 3308 },
-  'mariadb': { port: 3309 },
-  'mssql': { password: 'Root.Root' },
-  'postgresql': {},
+  mysql: { port: 3308 },
+  mariadb: { port: 3309 },
+  mssql: { password: 'Root.Root' },
+  postgresql: {},
 };
 
 describe.each(Utils.keys(options))('Order by [%s]', type => {

--- a/tests/platforms/order-by.test.ts
+++ b/tests/platforms/order-by.test.ts
@@ -15,6 +15,8 @@ class Test {
 }
 
 const options = {
+  sqlite: { dbName: ':memory:' },
+  libsql: { dbName: ':memory:' },
   mysql: { port: 3308 },
   mariadb: { port: 3309 },
   mssql: { password: 'Root.Root' },
@@ -43,54 +45,52 @@ describe.each(Utils.keys(options))('Order by [%s]', type => {
   test(`order-by`, async () => {
     const mock = mockLogger(orm, ['query', 'query-params']);
 
-    await orm.em.findAll(Test,
-      {
-        orderBy: {
-          value: QueryOrder.ASC,
-        },
+    await orm.em.findAll(Test, {
+      orderBy: {
+        value: QueryOrder.ASC,
+      },
     });
 
-    await orm.em.findAll(Test,
-      {
-        orderBy: {
-          value: QueryOrder.DESC,
-        },
+    await orm.em.findAll(Test, {
+      orderBy: {
+        value: QueryOrder.DESC,
       },
-    );
+    });
 
-    await orm.em.findAll(Test,
-      {
-        orderBy: {
-          value: QueryOrder.ASC_NULLS_FIRST,
-        },
+    await orm.em.findAll(Test, {
+      orderBy: {
+        value: QueryOrder.ASC_NULLS_FIRST,
       },
-    );
+    });
 
-    await orm.em.findAll(Test,
-      {
-        orderBy: {
-          value: QueryOrder.ASC_NULLS_LAST,
-        },
+    await orm.em.findAll(Test, {
+      orderBy: {
+        value: QueryOrder.ASC_NULLS_LAST,
       },
-    );
+    });
 
-    await orm.em.findAll(Test,
-      {
-        orderBy: {
-          value: QueryOrder.DESC_NULLS_FIRST,
-        },
+    await orm.em.findAll(Test, {
+      orderBy: {
+        value: QueryOrder.DESC_NULLS_FIRST,
       },
-    );
+    });
 
-    await orm.em.findAll(Test,
-      {
-        orderBy: {
-          value: QueryOrder.DESC_NULLS_LAST,
-        },
+    await orm.em.findAll(Test, {
+      orderBy: {
+        value: QueryOrder.DESC_NULLS_LAST,
       },
-    );
+    });
 
     switch (type) {
+      case 'sqlite':
+      case 'libsql':
+        expect(mock.mock.calls[0][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` asc');
+        expect(mock.mock.calls[1][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` desc');
+        expect(mock.mock.calls[2][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` asc nulls first');
+        expect(mock.mock.calls[3][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` asc nulls last');
+        expect(mock.mock.calls[4][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` desc nulls first');
+        expect(mock.mock.calls[5][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` desc nulls last');
+        break;
       case 'mysql':
       case 'mariadb':
         expect(mock.mock.calls[0][0]).toMatch('[query] select `t0`.* from `test` as `t0`');

--- a/tests/platforms/order-by.test.ts
+++ b/tests/platforms/order-by.test.ts
@@ -15,9 +15,6 @@ class Test {
 }
 
 const options = {
-  'sqlite': { dbName: ':memory:' },
-  'libsql': { dbName: ':memory:' },
-  'better-sqlite': { dbName: ':memory:' },
   'mysql': { port: 3308 },
   'mariadb': { port: 3309 },
   'mssql': { password: 'Root.Root' },
@@ -44,34 +41,16 @@ describe.each(Utils.keys(options))('Order by [%s]', type => {
   afterAll(() => orm.close(true));
 
   test(`order-by`, async () => {
-    // Shouldn't be escaped.
-    const test = new Test();
-    test.value = null;
-
-    // Should be escaped.
-    const test2 = new Test();
-    test2.value = 'foo';
-
-    // Should be escaped twice.
-    const test3 = new Test();
-    test3.value = 'bar';
-
-    orm.em.persist(test);
-    orm.em.persist(test2);
-    orm.em.persist(test3);
-
-    await orm.em.flush();
-
     const mock = mockLogger(orm, ['query', 'query-params']);
 
-    await orm.em.getRepository(Test).find({},
+    await orm.em.findAll(Test,
       {
         orderBy: {
           value: QueryOrder.ASC,
         },
     });
 
-    await orm.em.getRepository(Test).find({},
+    await orm.em.findAll(Test,
       {
         orderBy: {
           value: QueryOrder.DESC,
@@ -79,7 +58,7 @@ describe.each(Utils.keys(options))('Order by [%s]', type => {
       },
     );
 
-    await orm.em.getRepository(Test).find({},
+    await orm.em.findAll(Test,
       {
         orderBy: {
           value: QueryOrder.ASC_NULLS_FIRST,
@@ -87,7 +66,7 @@ describe.each(Utils.keys(options))('Order by [%s]', type => {
       },
     );
 
-    await orm.em.getRepository(Test).find({},
+    await orm.em.findAll(Test,
       {
         orderBy: {
           value: QueryOrder.ASC_NULLS_LAST,
@@ -95,7 +74,7 @@ describe.each(Utils.keys(options))('Order by [%s]', type => {
       },
     );
 
-    await orm.em.getRepository(Test).find({},
+    await orm.em.findAll(Test,
       {
         orderBy: {
           value: QueryOrder.DESC_NULLS_FIRST,
@@ -103,7 +82,7 @@ describe.each(Utils.keys(options))('Order by [%s]', type => {
       },
     );
 
-    await orm.em.getRepository(Test).find({},
+    await orm.em.findAll(Test,
       {
         orderBy: {
           value: QueryOrder.DESC_NULLS_LAST,
@@ -112,16 +91,6 @@ describe.each(Utils.keys(options))('Order by [%s]', type => {
     );
 
     switch (type) {
-      case 'sqlite':
-      case 'libsql':
-      case 'better-sqlite':
-        expect(mock.mock.calls[0][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` asc');
-        expect(mock.mock.calls[1][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` desc');
-        expect(mock.mock.calls[2][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` asc nulls first');
-        expect(mock.mock.calls[3][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` asc nulls last');
-        expect(mock.mock.calls[4][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` desc nulls first');
-        expect(mock.mock.calls[5][0]).toMatch('[query] select `t0`.* from `test` as `t0` order by `t0`.`value` desc nulls last');
-        break;
       case 'mysql':
       case 'mariadb':
         expect(mock.mock.calls[0][0]).toMatch('[query] select `t0`.* from `test` as `t0`');


### PR DESCRIPTION
This PR fixes an issue with order by with nulls first and nulls last