### PR TITLE
fix(tests): Force docker to use AMD64 version of mssql as ARM64 has been suspended

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
 
   mssql:
     image: mcr.microsoft.com/azure-sql-edge:latest
+    platform: linux/amd64
     restart: always
     ports:
       - "1433:1433"


### PR DESCRIPTION
Closes: https://github.com/mikro-orm/mikro-orm/issues/6627