### PR TITLE
feat(schema): allow disabling foreign key constraint creation, per relation

### DIFF
--- a/docs/docs/relationships.md
+++ b/docs/docs/relationships.md
@@ -197,3 +197,28 @@ export class Book {
 
 }
 ```
+
+## Disabling foreign key constraint creation
+
+If you need to disable the creation of the underlying SQL foreign key constraint for a specific relation, you can set `createForeignKeyConstraint` to `false` on the relation on the owning side.
+
+```ts
+@Entity()
+export class Book {
+
+  @ManyToOne(() => Author, { createForeignKeyConstraint: false })
+  author1: Author;
+
+}
+```
+
+Note that if you globally disable the creation of all foreign key contraints by setting `createForeignKeyConstraints` to `false`, then no foreign key constraint is created whatsoever on any relation.
+
+```ts
+const orm = await MikroORM.init({
+  ...
+  schemaGenerator: {
+    createForeignKeyConstraints: false,
+  },
+});
+```

--- a/packages/core/src/decorators/ManyToMany.ts
+++ b/packages/core/src/decorators/ManyToMany.ts
@@ -71,4 +71,7 @@ export interface ManyToManyOptions<Owner, Target> extends ReferenceOptions<Owner
 
   /** What to do when the reference to the target entity gets updated. */
   updateRule?: 'cascade' | 'no action' | 'set null' | 'set default' | AnyString;
+
+  /** Enable/disable foreign key constraint creation on this relation */
+  createForeignKeyConstraint?: boolean;
 }

--- a/packages/core/src/decorators/ManyToOne.ts
+++ b/packages/core/src/decorators/ManyToOne.ts
@@ -56,6 +56,9 @@ export interface ManyToOneOptions<Owner, Target> extends ReferenceOptions<Owner,
   /** Set the constraint type. Immediate constraints are checked for each statement, while deferred ones are only checked at the end of the transaction. Only for postgres unique constraints. */
   deferMode?: DeferMode | `${DeferMode}`;
 
+  /** Enable/disable foreign key constraint creation on this relation */
+  createForeignKeyConstraint?: boolean;
+
   /** Set a custom foreign key constraint name, overriding NamingStrategy.indexName(). */
   foreignKeyName?: string;
 }

--- a/packages/core/src/decorators/OneToOne.ts
+++ b/packages/core/src/decorators/OneToOne.ts
@@ -42,4 +42,7 @@ export interface OneToOneOptions<Owner, Target> extends Partial<Omit<OneToManyOp
 
   /** Set a custom foreign key constraint name, overriding NamingStrategy.indexName(). */
   foreignKeyName?: string;
+
+  /** Enable/disable foreign key constraint creation on this relation */
+  createForeignKeyConstraint?: boolean;
 }

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -175,6 +175,9 @@ export class EntitySchema<Entity = any, Base = never> {
       prop.joinColumns = prop.fieldNames;
     }
 
+    // By default, the foreign key constraint is created on the relation
+    Utils.defaultValue(prop, 'createForeignKeyConstraint', true);
+
     this.addProperty(name, type, prop);
   }
 
@@ -187,6 +190,9 @@ export class EntitySchema<Entity = any, Base = never> {
 
     if (options.owner) {
       Utils.renameKey(options, 'mappedBy', 'inversedBy');
+
+      // By default, the foreign key constraint is created on the relation
+      Utils.defaultValue(options, 'createForeignKeyConstraint', true);
     }
 
     const prop = this.createProperty(ReferenceKind.MANY_TO_MANY, options);
@@ -203,8 +209,13 @@ export class EntitySchema<Entity = any, Base = never> {
     Utils.defaultValue(prop, 'owner', !!prop.inversedBy || !prop.mappedBy);
     Utils.defaultValue(prop, 'unique', prop.owner);
 
-    if (prop.owner && options.mappedBy) {
-      Utils.renameKey(prop, 'mappedBy', 'inversedBy');
+    if (prop.owner) {
+      if (options.mappedBy) {
+        Utils.renameKey(prop, 'mappedBy', 'inversedBy');
+      }
+
+      // By default, the foreign key constraint is created on the relation
+      Utils.defaultValue(prop, 'createForeignKeyConstraint', true);
     }
 
     if (prop.joinColumns && !prop.fieldNames) {

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -51,8 +51,8 @@ export class MetadataDiscovery {
   private readonly discovered: EntityMetadata[] = [];
 
   constructor(private readonly metadata: MetadataStorage,
-    private readonly platform: Platform,
-    private readonly config: Configuration) {
+              private readonly platform: Platform,
+              private readonly config: Configuration) {
     this.namingStrategy = this.config.getNamingStrategy();
     this.metadataProvider = this.config.getMetadataProvider();
     this.cache = this.config.getMetadataCacheAdapter();

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -51,8 +51,8 @@ export class MetadataDiscovery {
   private readonly discovered: EntityMetadata[] = [];
 
   constructor(private readonly metadata: MetadataStorage,
-              private readonly platform: Platform,
-              private readonly config: Configuration) {
+    private readonly platform: Platform,
+    private readonly config: Configuration) {
     this.namingStrategy = this.config.getNamingStrategy();
     this.metadataProvider = this.config.getMetadataProvider();
     this.cache = this.config.getMetadataCacheAdapter();
@@ -826,6 +826,7 @@ export class MetadataDiscovery {
       autoincrement: false,
       updateRule: prop.updateRule,
       deleteRule: prop.deleteRule,
+      createForeignKeyConstraint: prop.createForeignKeyConstraint,
     } as EntityProperty;
 
     if (selfReferencing && !this.platform.supportsMultipleCascadePaths()) {

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -528,6 +528,7 @@ export interface EntityProperty<Owner = any, Target = any> {
   optional?: boolean; // for ts-morph
   ignoreSchemaChanges?: ('type' | 'extra' | 'default')[];
   deferMode?: DeferMode;
+  createForeignKeyConstraint: boolean; // To enable/disable foreign-key constraint creation, per relation
   foreignKeyName?: string;
 }
 

--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -32,8 +32,8 @@ export class DatabaseTable {
   public comment?: string;
 
   constructor(private readonly platform: AbstractSqlPlatform,
-    readonly name: string,
-    readonly schema?: string) {
+              readonly name: string,
+              readonly schema?: string) {
     Object.defineProperties(this, {
       platform: { enumerable: false, writable: true },
     });

--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -32,8 +32,8 @@ export class DatabaseTable {
   public comment?: string;
 
   constructor(private readonly platform: AbstractSqlPlatform,
-              readonly name: string,
-              readonly schema?: string) {
+    readonly name: string,
+    readonly schema?: string) {
     Object.defineProperties(this, {
       platform: { enumerable: false, writable: true },
     });
@@ -150,6 +150,7 @@ export class DatabaseTable {
         localTableName: this.getShortestName(),
         referencedColumnNames: prop.referencedColumnNames,
         referencedTableName: schema ? `${schema}.${prop.referencedTableName}` : prop.referencedTableName,
+        createForeignKeyConstraint: prop.createForeignKeyConstraint,
       };
 
       const cascade = prop.cascade.includes(Cascade.REMOVE) || prop.cascade.includes(Cascade.ALL);
@@ -232,14 +233,14 @@ export class DatabaseTable {
     const compositeFkUniques: Dictionary<Pick<IndexDef, 'keyName'>> = {};
 
     const potentiallyUnmappedIndexes = this.indexes.filter(index =>
-        !index.primary // Skip primary index. Whether it's in use by scalar column or FK, it's already mapped.
-        && (index.columnNames.length > 1 // All composite indexes are to be mapped to entity decorators or FK props.
-          || skippedColumnNames.includes(index.columnNames[0]) // Non-composite indexes for skipped columns are to be mapped as entity decorators.
-          || index.deferMode || index.expression // Non-trivial non-composite indexes will be declared at the entity's metadata, though later outputted in the property
-          || !(index.columnNames[0] in columnFks) // Trivial non-composite indexes for scalar props are to be mapped to the column.
-        )
-        // ignore indexes that don't have all column names (this can happen in sqlite where there is no way to infer this for expressions)
-        && !(index.columnNames.some(col => !col) && !index.expression),
+      !index.primary // Skip primary index. Whether it's in use by scalar column or FK, it's already mapped.
+      && (index.columnNames.length > 1 // All composite indexes are to be mapped to entity decorators or FK props.
+        || skippedColumnNames.includes(index.columnNames[0]) // Non-composite indexes for skipped columns are to be mapped as entity decorators.
+        || index.deferMode || index.expression // Non-trivial non-composite indexes will be declared at the entity's metadata, though later outputted in the property
+        || !(index.columnNames[0] in columnFks) // Trivial non-composite indexes for scalar props are to be mapped to the column.
+      )
+      // ignore indexes that don't have all column names (this can happen in sqlite where there is no way to infer this for expressions)
+      && !(index.columnNames.some(col => !col) && !index.expression),
     );
 
     for (const index of potentiallyUnmappedIndexes) {
@@ -475,8 +476,8 @@ export class DatabaseTable {
         return columnsInFks.includes(column.name)
           && !fksOnColumnProps.has(column.name)
           && (column.nullable
-              ? columnFks[column.name].some(fk => !fk.columnNames.some(fkColumnName => fkColumnName !== column.name && this.getColumn(fkColumnName)?.nullable))
-              : columnFks[column.name].some(fk => !nullableForeignKeys.has(fk))
+            ? columnFks[column.name].some(fk => !fk.columnNames.some(fkColumnName => fkColumnName !== column.name && this.getColumn(fkColumnName)?.nullable))
+            : columnFks[column.name].some(fk => !nullableForeignKeys.has(fk))
           );
       },
     };

--- a/packages/knex/src/schema/SchemaHelper.ts
+++ b/packages/knex/src/schema/SchemaHelper.ts
@@ -420,7 +420,7 @@ export abstract class SchemaHelper {
   }
 
   createForeignKey(table: Knex.CreateTableBuilder, foreignKey: ForeignKey, schema?: string) {
-    if (!this.options.createForeignKeyConstraints) {
+    if (!this.options.createForeignKeyConstraints || !foreignKey.createForeignKeyConstraint) {
       return;
     }
 

--- a/packages/knex/src/typings.ts
+++ b/packages/knex/src/typings.ts
@@ -81,6 +81,7 @@ export interface ForeignKey {
   updateRule?: string;
   deleteRule?: string;
   deferMode?: DeferMode;
+  createForeignKeyConstraint: boolean;
 }
 
 export interface IndexDef {

--- a/tests/features/createForeignKeyConstraint/__snapshots__/createForeignKeyConstraint.mysql.test.ts.snap
+++ b/tests/features/createForeignKeyConstraint/__snapshots__/createForeignKeyConstraint.mysql.test.ts.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createForeignKeyConstraint [mysql] create SQL schema (with global createForeignKeyConstraints set to false): createSchemaSQL-dump 1`] = `
+"set names utf8mb4;
+
+create table \`author\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+
+create table \`author_following\` (\`author_1_id\` int unsigned not null, \`author_2_id\` int unsigned not null, primary key (\`author_1_id\`, \`author_2_id\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`author_following\` add index \`author_following_author_1_id_index\`(\`author_1_id\`);
+alter table \`author_following\` add index \`author_following_author_2_id_index\`(\`author_2_id\`);
+
+create table \`author_address\` (\`author_id\` int unsigned not null, \`value\` varchar(255) not null, primary key (\`author_id\`)) default character set utf8mb4 engine = InnoDB;
+
+create table \`book_tag\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+
+create table \`publisher\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+
+create table \`book\` (\`id\` int unsigned not null auto_increment primary key, \`title\` varchar(255) not null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`book\` add index \`book_author_id_index\`(\`author_id\`);
+alter table \`book\` add index \`book_publisher_id_index\`(\`publisher_id\`);
+
+create table \`book_tags\` (\`book_id\` int unsigned not null, \`book_tag_id\` int unsigned not null, primary key (\`book_id\`, \`book_tag_id\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`book_tags\` add index \`book_tags_book_id_index\`(\`book_id\`);
+alter table \`book_tags\` add index \`book_tags_book_tag_id_index\`(\`book_tag_id\`);
+
+create table \`publisher_address\` (\`publisher_id\` int unsigned not null, \`value\` varchar(255) not null, primary key (\`publisher_id\`)) default character set utf8mb4 engine = InnoDB;
+
+"
+`;
+
+exports[`createForeignKeyConstraint [mysql] create SQL schema: createSchemaSQL-dump 1`] = `
+"set names utf8mb4;
+
+create table \`author\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+
+create table \`author_following\` (\`author_1_id\` int unsigned not null, \`author_2_id\` int unsigned not null, primary key (\`author_1_id\`, \`author_2_id\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`author_following\` add index \`author_following_author_1_id_index\`(\`author_1_id\`);
+alter table \`author_following\` add index \`author_following_author_2_id_index\`(\`author_2_id\`);
+
+create table \`author_address\` (\`author_id\` int unsigned not null, \`value\` varchar(255) not null, primary key (\`author_id\`)) default character set utf8mb4 engine = InnoDB;
+
+create table \`book_tag\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+
+create table \`publisher\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null) default character set utf8mb4 engine = InnoDB;
+
+create table \`book\` (\`id\` int unsigned not null auto_increment primary key, \`title\` varchar(255) not null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`book\` add index \`book_author_id_index\`(\`author_id\`);
+alter table \`book\` add index \`book_publisher_id_index\`(\`publisher_id\`);
+
+create table \`book_tags\` (\`book_id\` int unsigned not null, \`book_tag_id\` int unsigned not null, primary key (\`book_id\`, \`book_tag_id\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`book_tags\` add index \`book_tags_book_id_index\`(\`book_id\`);
+alter table \`book_tags\` add index \`book_tags_book_tag_id_index\`(\`book_tag_id\`);
+
+create table \`publisher_address\` (\`publisher_id\` int unsigned not null, \`value\` varchar(255) not null, primary key (\`publisher_id\`)) default character set utf8mb4 engine = InnoDB;
+
+alter table \`author_following\` add constraint \`author_following_author_1_id_foreign\` foreign key (\`author_1_id\`) references \`author\` (\`id\`) on update cascade on delete cascade;
+alter table \`author_following\` add constraint \`author_following_author_2_id_foreign\` foreign key (\`author_2_id\`) references \`author\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`author_address\` add constraint \`author_address_author_id_foreign\` foreign key (\`author_id\`) references \`author\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`book\` add constraint \`book_author_id_foreign\` foreign key (\`author_id\`) references \`author\` (\`id\`) on update cascade;
+
+"
+`;

--- a/tests/features/createForeignKeyConstraint/__snapshots__/createForeignKeyConstraint.postgres.test.ts.snap
+++ b/tests/features/createForeignKeyConstraint/__snapshots__/createForeignKeyConstraint.postgres.test.ts.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createForeignKeyConstraint [postgres] create SQL schema (with global createForeignKeyConstraints set to false): createSchemaSQL-dump 1`] = `
+"set names 'utf8';
+
+create table "author" ("id" serial primary key, "name" varchar(255) not null);
+
+create table "author_following" ("author_1_id" int not null, "author_2_id" int not null, constraint "author_following_pkey" primary key ("author_1_id", "author_2_id"));
+
+create table "author_address" ("author_id" int not null, "value" varchar(255) not null, constraint "author_address_pkey" primary key ("author_id"));
+
+create table "book_tag" ("id" serial primary key, "name" varchar(255) not null);
+
+create table "publisher" ("id" serial primary key, "name" varchar(255) not null);
+
+create table "book" ("id" serial primary key, "title" varchar(255) not null, "author_id" int not null, "publisher_id" int not null);
+
+create table "book_tags" ("book_id" int not null, "book_tag_id" int not null, constraint "book_tags_pkey" primary key ("book_id", "book_tag_id"));
+
+create table "publisher_address" ("publisher_id" int not null, "value" varchar(255) not null, constraint "publisher_address_pkey" primary key ("publisher_id"));
+
+"
+`;
+
+exports[`createForeignKeyConstraint [postgres] create SQL schema: createSchemaSQL-dump 1`] = `
+"set names 'utf8';
+
+create table "author" ("id" serial primary key, "name" varchar(255) not null);
+
+create table "author_following" ("author_1_id" int not null, "author_2_id" int not null, constraint "author_following_pkey" primary key ("author_1_id", "author_2_id"));
+
+create table "author_address" ("author_id" int not null, "value" varchar(255) not null, constraint "author_address_pkey" primary key ("author_id"));
+
+create table "book_tag" ("id" serial primary key, "name" varchar(255) not null);
+
+create table "publisher" ("id" serial primary key, "name" varchar(255) not null);
+
+create table "book" ("id" serial primary key, "title" varchar(255) not null, "author_id" int not null, "publisher_id" int not null);
+
+create table "book_tags" ("book_id" int not null, "book_tag_id" int not null, constraint "book_tags_pkey" primary key ("book_id", "book_tag_id"));
+
+create table "publisher_address" ("publisher_id" int not null, "value" varchar(255) not null, constraint "publisher_address_pkey" primary key ("publisher_id"));
+
+alter table "author_following" add constraint "author_following_author_1_id_foreign" foreign key ("author_1_id") references "author" ("id") on update cascade on delete cascade;
+alter table "author_following" add constraint "author_following_author_2_id_foreign" foreign key ("author_2_id") references "author" ("id") on update cascade on delete cascade;
+
+alter table "author_address" add constraint "author_address_author_id_foreign" foreign key ("author_id") references "author" ("id") on update cascade on delete cascade;
+
+alter table "book" add constraint "book_author_id_foreign" foreign key ("author_id") references "author" ("id") on update cascade;
+
+"
+`;

--- a/tests/features/createForeignKeyConstraint/createForeignKeyConstraint.mysql.test.ts
+++ b/tests/features/createForeignKeyConstraint/createForeignKeyConstraint.mysql.test.ts
@@ -1,0 +1,64 @@
+import { MikroORM } from '@mikro-orm/core';
+import { MySqlDriver } from '@mikro-orm/mysql';
+import { Author } from './entities/Author';
+import { AuthorAddress } from './entities/AuthorAddress';
+import { BaseEntity } from './entities/BaseEntity';
+import { Book } from './entities/Book';
+import { BookTag } from './entities/BookTag';
+import { Publisher } from './entities/Publisher';
+import { PublisherAddress } from './entities/PublisherAddress';
+import { v4 } from 'uuid';
+
+describe('createForeignKeyConstraint [mysql]', () => {
+
+  test('create SQL schema', async () => {
+
+    /**
+    * In this test, some foreign key constraints creations are disabled, on
+    * some specific OneToOne, ManyToOne, ManyToMany relations (aka when
+    * "createForeignKeyConstraint" is set to false on the owning side of
+    * the relation).
+    */
+
+    const orm = await MikroORM.init({
+      entities: [Author, AuthorAddress, BaseEntity, Book, BookTag, Publisher, PublisherAddress],
+      dbName: `db-${v4()}`, // random db name
+      port: 3308,
+      driver: MySqlDriver,
+    });
+
+    const createDump = await orm.schema.getCreateSchemaSQL();
+    expect(createDump).toMatchSnapshot('createSchemaSQL-dump');
+
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+  test('create SQL schema (with global createForeignKeyConstraints set to false)', async () => {
+
+    /**
+    * In this test, all foreign key constraints creations are disabled (aka when
+    * "createForeignKeyConstraints" is set to false at the global level).
+    *
+    * This disables all foreign key constraints creations, even if
+    * "createForeignKeyConstraint" is set to true on a given relation.
+    */
+
+    const orm = await MikroORM.init({
+      entities: [Author, AuthorAddress, BaseEntity, Book, BookTag, Publisher, PublisherAddress],
+      dbName: `db-${v4()}`, // random db name
+      port: 3308,
+      driver: MySqlDriver,
+      schemaGenerator: {
+        createForeignKeyConstraints: false,
+      },
+    });
+
+    const createDump = await orm.schema.getCreateSchemaSQL();
+    expect(createDump).toMatchSnapshot('createSchemaSQL-dump');
+
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+});

--- a/tests/features/createForeignKeyConstraint/createForeignKeyConstraint.mysql.test.ts
+++ b/tests/features/createForeignKeyConstraint/createForeignKeyConstraint.mysql.test.ts
@@ -14,11 +14,11 @@ describe('createForeignKeyConstraint [mysql]', () => {
   test('create SQL schema', async () => {
 
     /**
-    * In this test, some foreign key constraints creations are disabled, on
-    * some specific OneToOne, ManyToOne, ManyToMany relations (aka when
-    * "createForeignKeyConstraint" is set to false on the owning side of
-    * the relation).
-    */
+     * In this test, some foreign key constraints creations are disabled, on
+     * some specific OneToOne, ManyToOne, ManyToMany relations (aka when
+     * "createForeignKeyConstraint" is set to false on the owning side of
+     * the relation).
+     */
 
     const orm = await MikroORM.init({
       entities: [Author, AuthorAddress, BaseEntity, Book, BookTag, Publisher, PublisherAddress],
@@ -37,12 +37,12 @@ describe('createForeignKeyConstraint [mysql]', () => {
   test('create SQL schema (with global createForeignKeyConstraints set to false)', async () => {
 
     /**
-    * In this test, all foreign key constraints creations are disabled (aka when
-    * "createForeignKeyConstraints" is set to false at the global level).
-    *
-    * This disables all foreign key constraints creations, even if
-    * "createForeignKeyConstraint" is set to true on a given relation.
-    */
+     * In this test, all foreign key constraints creations are disabled (aka when
+     * "createForeignKeyConstraints" is set to false at the global level).
+     *
+     * This disables all foreign key constraints creations, even if
+     * "createForeignKeyConstraint" is set to true on a given relation.
+     */
 
     const orm = await MikroORM.init({
       entities: [Author, AuthorAddress, BaseEntity, Book, BookTag, Publisher, PublisherAddress],

--- a/tests/features/createForeignKeyConstraint/createForeignKeyConstraint.postgres.test.ts
+++ b/tests/features/createForeignKeyConstraint/createForeignKeyConstraint.postgres.test.ts
@@ -1,0 +1,64 @@
+import { MikroORM } from '@mikro-orm/core';
+import { Author } from './entities/Author';
+import { AuthorAddress } from './entities/AuthorAddress';
+import { BaseEntity } from './entities/BaseEntity';
+import { Book } from './entities/Book';
+import { BookTag } from './entities/BookTag';
+import { Publisher } from './entities/Publisher';
+import { PublisherAddress } from './entities/PublisherAddress';
+import { v4 } from 'uuid';
+import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+
+describe('createForeignKeyConstraint [postgres]', () => {
+
+  test('create SQL schema', async () => {
+
+    /**
+    * In this test, some foreign key constraints creations are disabled, on
+    * some specific OneToOne, ManyToOne, ManyToMany relations (aka when
+    * "createForeignKeyConstraint" is set to false on the owning side of
+    * the relation).
+    */
+
+    const orm = await MikroORM.init({
+      entities: [Author, AuthorAddress, BaseEntity, Book, BookTag, Publisher, PublisherAddress],
+      dbName: `db-${v4()}`, // random db name
+      port: 5432,
+      driver: PostgreSqlDriver,
+    });
+
+    const createDump = await orm.schema.getCreateSchemaSQL();
+    expect(createDump).toMatchSnapshot('createSchemaSQL-dump');
+
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+  test('create SQL schema (with global createForeignKeyConstraints set to false)', async () => {
+
+    /**
+    * In this test, all foreign key constraints creations are disabled (aka when
+    * "createForeignKeyConstraints" is set to false at the global level).
+    *
+    * This disables all foreign key constraints creations, even if
+    * "createForeignKeyConstraint" is set to true on a given relation.
+    */
+
+    const orm = await MikroORM.init({
+      entities: [Author, AuthorAddress, BaseEntity, Book, BookTag, Publisher, PublisherAddress],
+      dbName: `db-${v4()}`, // random db name
+      port: 5432,
+      driver: PostgreSqlDriver,
+      schemaGenerator: {
+        createForeignKeyConstraints: false,
+      },
+    });
+
+    const createDump = await orm.schema.getCreateSchemaSQL();
+    expect(createDump).toMatchSnapshot('createSchemaSQL-dump');
+
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+});

--- a/tests/features/createForeignKeyConstraint/createForeignKeyConstraint.postgres.test.ts
+++ b/tests/features/createForeignKeyConstraint/createForeignKeyConstraint.postgres.test.ts
@@ -14,11 +14,11 @@ describe('createForeignKeyConstraint [postgres]', () => {
   test('create SQL schema', async () => {
 
     /**
-    * In this test, some foreign key constraints creations are disabled, on
-    * some specific OneToOne, ManyToOne, ManyToMany relations (aka when
-    * "createForeignKeyConstraint" is set to false on the owning side of
-    * the relation).
-    */
+     * In this test, some foreign key constraints creations are disabled, on
+     * some specific OneToOne, ManyToOne, ManyToMany relations (aka when
+     * "createForeignKeyConstraint" is set to false on the owning side of
+     * the relation).
+     */
 
     const orm = await MikroORM.init({
       entities: [Author, AuthorAddress, BaseEntity, Book, BookTag, Publisher, PublisherAddress],
@@ -37,12 +37,12 @@ describe('createForeignKeyConstraint [postgres]', () => {
   test('create SQL schema (with global createForeignKeyConstraints set to false)', async () => {
 
     /**
-    * In this test, all foreign key constraints creations are disabled (aka when
-    * "createForeignKeyConstraints" is set to false at the global level).
-    *
-    * This disables all foreign key constraints creations, even if
-    * "createForeignKeyConstraint" is set to true on a given relation.
-    */
+     * In this test, all foreign key constraints creations are disabled (aka when
+     * "createForeignKeyConstraints" is set to false at the global level).
+     *
+     * This disables all foreign key constraints creations, even if
+     * "createForeignKeyConstraint" is set to true on a given relation.
+     */
 
     const orm = await MikroORM.init({
       entities: [Author, AuthorAddress, BaseEntity, Book, BookTag, Publisher, PublisherAddress],

--- a/tests/features/createForeignKeyConstraint/entities/Author.ts
+++ b/tests/features/createForeignKeyConstraint/entities/Author.ts
@@ -1,0 +1,37 @@
+import {
+  Collection,
+  Entity,
+  OneToMany,
+  Property,
+  ManyToMany,
+  OneToOne,
+} from '@mikro-orm/core';
+import { Book } from './Book';
+import { BaseEntity } from './BaseEntity';
+import { AuthorAddress } from './AuthorAddress';
+
+@Entity()
+export class Author extends BaseEntity {
+
+  @Property()
+  name: string;
+
+  @OneToMany({ entity: () => Book, mappedBy: 'author' })
+  books = new Collection<Book>(this);
+
+  @OneToOne({ entity: () => AuthorAddress, mappedBy: 'author' })
+  address: AuthorAddress;
+
+  @ManyToMany({ entity: () => Author })
+  following = new Collection<Author>(this);
+
+  @ManyToMany({ entity: () => Author, mappedBy: 'following' })
+  followers = new Collection<Author>(this);
+
+  constructor(name: string, address: AuthorAddress) {
+    super();
+    this.name = name;
+    this.address = address;
+  }
+
+}

--- a/tests/features/createForeignKeyConstraint/entities/AuthorAddress.ts
+++ b/tests/features/createForeignKeyConstraint/entities/AuthorAddress.ts
@@ -1,0 +1,18 @@
+import { Entity, Property, OneToOne } from '@mikro-orm/core';
+import { Author } from './Author';
+
+@Entity()
+export class AuthorAddress {
+
+  @OneToOne({ entity: () => Author, primary: true })
+  author: Author;
+
+  @Property()
+  value: string;
+
+  constructor(author: Author, value: string) {
+    this.author = author;
+    this.value = value;
+  }
+
+}

--- a/tests/features/createForeignKeyConstraint/entities/BaseEntity.ts
+++ b/tests/features/createForeignKeyConstraint/entities/BaseEntity.ts
@@ -1,0 +1,8 @@
+import { PrimaryKey } from '@mikro-orm/core';
+
+export abstract class BaseEntity {
+
+  @PrimaryKey()
+  id!: number;
+
+}

--- a/tests/features/createForeignKeyConstraint/entities/Book.ts
+++ b/tests/features/createForeignKeyConstraint/entities/Book.ts
@@ -1,0 +1,35 @@
+import {
+  Collection,
+  Entity,
+  ManyToMany,
+  ManyToOne,
+  Property,
+} from '@mikro-orm/core';
+import { Publisher } from './Publisher';
+import { BookTag } from './BookTag';
+import { BaseEntity } from './BaseEntity';
+import { Author } from './Author';
+
+@Entity()
+export class Book extends BaseEntity {
+
+  @Property()
+  title: string;
+
+  @ManyToOne({ entity: () => Author })
+  author: Author;
+
+  @ManyToOne({ entity: () => Publisher, createForeignKeyConstraint: false })
+  publisher: Publisher;
+
+  @ManyToMany({ entity: () => BookTag, createForeignKeyConstraint: false })
+  tags = new Collection<BookTag>(this);
+
+  constructor(title: string, author: Author, publisher: Publisher) {
+    super();
+    this.title = title;
+    this.author = author;
+    this.publisher = publisher;
+  }
+
+}

--- a/tests/features/createForeignKeyConstraint/entities/BookTag.ts
+++ b/tests/features/createForeignKeyConstraint/entities/BookTag.ts
@@ -1,0 +1,19 @@
+import { Collection, Entity, ManyToMany, Property } from '@mikro-orm/core';
+import { Book } from './Book';
+import { BaseEntity } from './BaseEntity';
+
+@Entity()
+export class BookTag extends BaseEntity {
+
+  @Property()
+  name: string;
+
+  @ManyToMany({ entity: () => Book, mappedBy: 'tags' })
+  books = new Collection<Book>(this);
+
+  constructor(name: string) {
+    super();
+    this.name = name;
+  }
+
+}

--- a/tests/features/createForeignKeyConstraint/entities/Publisher.ts
+++ b/tests/features/createForeignKeyConstraint/entities/Publisher.ts
@@ -1,0 +1,24 @@
+import { Collection, Entity, OneToMany, OneToOne, Property } from '@mikro-orm/core';
+import { Book } from './Book';
+import { BaseEntity } from './BaseEntity';
+import { PublisherAddress } from './PublisherAddress';
+
+@Entity()
+export class Publisher extends BaseEntity {
+
+  @Property()
+  name: string;
+
+  @OneToOne({ entity: () => PublisherAddress, mappedBy: 'publisher' })
+  address: PublisherAddress;
+
+  @OneToMany({ entity: () => Book, mappedBy: 'publisher' })
+  books = new Collection<Book>(this);
+
+  constructor(name: string, address: PublisherAddress) {
+    super();
+    this.name = name;
+    this.address = address;
+  }
+
+}

--- a/tests/features/createForeignKeyConstraint/entities/PublisherAddress.ts
+++ b/tests/features/createForeignKeyConstraint/entities/PublisherAddress.ts
@@ -1,0 +1,18 @@
+import { Entity, Property, OneToOne } from '@mikro-orm/core';
+import { Publisher } from './Publisher';
+
+@Entity()
+export class PublisherAddress {
+
+  @OneToOne({ entity: () => Publisher, primary: true, createForeignKeyConstraint: false })
+  publisher: Publisher;
+
+  @Property()
+  value: string;
+
+  constructor(publisher: Publisher, value: string) {
+    this.publisher = publisher;
+    this.value = value;
+  }
+
+}


### PR DESCRIPTION
This PR follows my comment [here](https://github.com/mikro-orm/mikro-orm/issues/2548#issuecomment-2765607556) regarding the possibility to disable foreign key constraint, per relation.

This work complements what had been previously done in fcdb236.

Being able to disable foreign key creation on specific relations is useful when using DDD (Domain Driven Design) philosophy to design your app. Inside a DDD aggregate, entities are linked to each other by object references, and at the DB level we want to have strong integrity using foreign key constraint. Now for cross-aggregate links, we usually want to use _soft references_, meaning at the db level we just want an id referencing another entity but without the foreign key constraint.

Down the road it allows to implement eventual consistency between aggregates when we delete data from the db. Having foreign keys everywhere is sometimes too strict of a design. There is good literature on the subject [here](https://stackoverflow.com/a/1077696), for those interested to dive into the subject.

Hence the proposed PR here.

Please find below some explanations about how to use the feature implemented in the PR.

If you need to disable the creation of the underlying SQL foreign key constraint for a specific relation, you can now set `createForeignKeyConstraint` to `false` on the relation on the owning side.

```ts
@Entity()
export class Book {

  @ManyToOne(() => Author, { createForeignKeyConstraint: false })
  author1: Author;

}
```

This option is valid to be set on `ManyToOne`, `OneToOne`, and `ManyToMany` relations.

Note that if you globally disable the creation of all foreign key contraints by setting `createForeignKeyConstraints` to `false`, then no foreign key constraint is created whatsoever on any relation.

```ts
const orm = await MikroORM.init({
  ...
  schemaGenerator: {
    createForeignKeyConstraints: false,
  },
});
```