### PR TITLE
fix(schema): properly handle array defaults

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1307,12 +1307,8 @@ export class MetadataDiscovery {
       return;
     }
 
-    if (Array.isArray(prop.default)) {
-      if (prop.customType instanceof ArrayType) {
-        val = prop.customType.convertToDatabaseValue(prop.default, this.platform)!;
-      } else if (prop.kind === ReferenceKind.EMBEDDED && prop.array) {
-        val = this.platform.convertJsonToDatabaseValue(prop.default) as string;
-      }
+    if (Array.isArray(prop.default) && prop.customType) {
+      val = prop.customType.convertToDatabaseValue(prop.default, this.platform)!;
     }
 
     prop.defaultRaw = typeof val === 'string' ? `'${val}'` : '' + val;
@@ -1368,6 +1364,10 @@ export class MetadataDiscovery {
     }
 
     if (prop.kind === ReferenceKind.SCALAR && !prop.customType && prop.columnTypes && ['json', 'jsonb'].includes(prop.columnTypes[0])) {
+      prop.customType = new JsonType();
+    }
+
+    if (prop.kind === ReferenceKind.EMBEDDED && !prop.customType && (prop.object || prop.array)) {
       prop.customType = new JsonType();
     }
 

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1307,8 +1307,12 @@ export class MetadataDiscovery {
       return;
     }
 
-    if (prop.customType instanceof ArrayType && Array.isArray(prop.default)) {
-      val = prop.customType.convertToDatabaseValue(prop.default, this.platform)!;
+    if (Array.isArray(prop.default)) {
+      if (prop.customType instanceof ArrayType) {
+        val = prop.customType.convertToDatabaseValue(prop.default, this.platform)!;
+      } else if (prop.kind === ReferenceKind.EMBEDDED && prop.array) {
+        val = this.platform.convertJsonToDatabaseValue(prop.default) as string;
+      }
     }
 
     prop.defaultRaw = typeof val === 'string' ? `'${val}'` : '' + val;

--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -166,7 +166,7 @@ export class QueryHelper {
 
       const isJsonProperty = prop?.customType instanceof JsonType && Utils.isPlainObject(value) && !platform.isRaw(value) && Object.keys(value)[0] !== '$eq';
 
-      if (isJsonProperty) {
+      if (isJsonProperty && prop?.kind !== ReferenceKind.EMBEDDED) {
         return this.processJsonCondition<T>(o as FilterQuery<T>, value as EntityValue<T>, [prop.fieldNames[0]] as EntityKey<T>[], platform, aliased);
       }
 

--- a/packages/knex/src/query/CriteriaNodeFactory.ts
+++ b/packages/knex/src/query/CriteriaNodeFactory.ts
@@ -72,8 +72,9 @@ export class CriteriaNodeFactory {
   static createObjectItemNode<T extends object>(metadata: MetadataStorage, entityName: string, node: ICriteriaNode<T>, payload: Dictionary, key: EntityKey<T>, meta?: EntityMetadata<T>) {
     const prop = meta?.properties[key];
     const childEntity = prop && prop.kind !== ReferenceKind.SCALAR ? prop.type : entityName;
+    const isNotEmbedded = prop?.kind !== ReferenceKind.EMBEDDED;
 
-    if (prop?.customType instanceof JsonType) {
+    if (isNotEmbedded && prop?.customType instanceof JsonType) {
       return this.createScalarNode(metadata, childEntity, payload[key], node, key);
     }
 
@@ -81,7 +82,7 @@ export class CriteriaNodeFactory {
       throw ValidationError.cannotUseGroupOperatorsInsideScalars(entityName, prop.name, payload);
     }
 
-    if (prop?.kind !== ReferenceKind.EMBEDDED) {
+    if (isNotEmbedded) {
       return this.createNode(metadata, childEntity, payload[key], node, key);
     }
 

--- a/tests/features/schema-generator/__snapshots__/diffing-default-values.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/diffing-default-values.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`diffing default values (GH #2385) string defaults do not produce additional diffs [mariadb] 1`] = `
 "set names utf8mb4;
 
-create table \`foo1\` (\`id\` int unsigned not null auto_increment primary key, \`bar0\` varchar(255) not null default 'test', \`bar1\` varchar(255) not null default 'test', \`num\` int not null default 1, \`bool\` tinyint(1) not null default true, \`bar2\` datetime not null default current_timestamp, \`bar3\` datetime(6) not null default current_timestamp(6), \`metadata\` json not null default '{"value":42}') default character set utf8mb4 engine = InnoDB;
+create table \`foo1\` (\`id\` int unsigned not null auto_increment primary key, \`bar0\` varchar(255) not null default 'test', \`bar1\` varchar(255) not null default 'test', \`num\` int not null default 1, \`bool\` tinyint(1) not null default true, \`bar2\` datetime not null default current_timestamp, \`bar3\` datetime(6) not null default current_timestamp(6), \`metadata\` json not null default ('{"value":42}')) default character set utf8mb4 engine = InnoDB;
 
 "
 `;

--- a/tests/issues/GH6688.test.ts
+++ b/tests/issues/GH6688.test.ts
@@ -38,6 +38,7 @@ const options = {
   'mysql': { dbName: 'default_array_values', port: 3308 },
   'mariadb': { dbName: 'default_array_values', port: 3309 },
   'postgresql': { dbName: 'default_array_values' },
+  'mssql': { dbName: 'default_array_values', password: 'Root.Root' },
 };
 
 describe.each(Utils.keys(options))('default array values [%s]', type => {

--- a/tests/issues/GH6688.test.ts
+++ b/tests/issues/GH6688.test.ts
@@ -1,0 +1,65 @@
+import { Entity, PrimaryKey, Property, MikroORM, t, Embeddable, Embedded, Opt, Enum, Utils, AbstractSqlDriver } from '@mikro-orm/knex';
+import { PLATFORMS } from '../bootstrap';
+
+enum EnumItems {
+  A = 'a',
+  B = 'b',
+  C = 'c',
+}
+
+@Embeddable()
+class Account {
+
+  @Property()
+  type!: string;
+
+}
+
+@Entity()
+class A {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: t.array, nullable: false, default: ['en'] })
+  languages: Opt<string[]> = ['en'];
+
+  @Embedded(() => Account, { array: true, default: [] })
+  accounts: Opt<Account[]> = [];
+
+  @Enum({ items: () => EnumItems, array: true, default: [] })
+  items: Opt<EnumItems[]> = [];
+
+}
+
+const options = {
+  'sqlite': { dbName: ':memory:' },
+  'better-sqlite': { dbName: ':memory:' },
+  'mysql': { dbName: 'default_array_values', port: 3308 },
+  'mariadb': { dbName: 'default_array_values', port: 3309 },
+  'postgresql': { dbName: 'default_array_values' },
+};
+
+describe.each(Utils.keys(options))('default array values [%s]', type => {
+  let orm: MikroORM<AbstractSqlDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init<AbstractSqlDriver>({
+      entities: [A],
+      driver: PLATFORMS[type],
+      ...options[type],
+    });
+
+    await orm.schema.ensureDatabase();
+  });
+
+  afterAll(() => orm.close(true));
+
+  afterEach(() => orm.schema.dropSchema());
+
+  test('database default when using arrays', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+    expect(sql).toMatchSnapshot();
+    await orm.schema.execute(sql);
+  });
+});

--- a/tests/issues/__snapshots__/GH6688.test.ts.snap
+++ b/tests/issues/__snapshots__/GH6688.test.ts.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`default array values [better-sqlite] database default when using arrays 1`] = `
+"create table \`a\` (\`id\` integer not null primary key autoincrement, \`languages\` text not null default 'en', \`accounts\` json not null default '[]', \`items\` text not null default '');
+
+"
+`;
+
+exports[`default array values [mariadb] database default when using arrays 1`] = `
+"set names utf8mb4;
+
+create table \`a\` (\`id\` int unsigned not null auto_increment primary key, \`languages\` text not null default ('en'), \`accounts\` json not null default ('[]'), \`items\` text not null default ('')) default character set utf8mb4 engine = InnoDB;
+
+"
+`;
+
+exports[`default array values [mysql] database default when using arrays 1`] = `
+"set names utf8mb4;
+
+create table \`a\` (\`id\` int unsigned not null auto_increment primary key, \`languages\` text not null default ('en'), \`accounts\` json not null default ('[]'), \`items\` text not null default ('')) default character set utf8mb4 engine = InnoDB;
+
+"
+`;
+
+exports[`default array values [postgresql] database default when using arrays 1`] = `
+"set names 'utf8';
+
+create table "a" ("id" serial primary key, "languages" text[] not null default '{en}', "accounts" jsonb not null default '[]', "items" text[] not null default '{}');
+
+"
+`;
+
+exports[`default array values [sqlite] database default when using arrays 1`] = `
+"create table \`a\` (\`id\` integer not null primary key autoincrement, \`languages\` text not null default 'en', \`accounts\` json not null default '[]', \`items\` text not null default '');
+
+"
+`;

--- a/tests/issues/__snapshots__/GH6688.test.ts.snap
+++ b/tests/issues/__snapshots__/GH6688.test.ts.snap
@@ -14,6 +14,12 @@ create table \`a\` (\`id\` int unsigned not null auto_increment primary key, \`l
 "
 `;
 
+exports[`default array values [mssql] database default when using arrays 1`] = `
+"CREATE TABLE [a] ([id] int identity(1,1) not null primary key, [languages] text not null CONSTRAINT [a_languages_default] DEFAULT 'en', [accounts] nvarchar(max) not null CONSTRAINT [a_accounts_default] DEFAULT '[]', [items] text not null CONSTRAINT [a_items_default] DEFAULT '');
+
+"
+`;
+
 exports[`default array values [mysql] database default when using arrays 1`] = `
 "set names utf8mb4;
 


### PR DESCRIPTION
Fixes #6688. While testing across all databases, MySQL was failing with the following error:

```sql
DriverException: create table `a` (
  `id` int unsigned not null auto_increment primary key,
  `languages` text not null default 'en',
  `accounts` json not null default '[]',
  `items` text not null default ''
) default character set utf8mb4 engine = InnoDB;
- BLOB, TEXT, GEOMETRY or JSON column 'languages' can't have a default value
```
See: https://dev.mysql.com/doc/refman/9.0/en/data-type-defaults.html

> The [BLOB](https://dev.mysql.com/doc/refman/9.0/en/blob.html), [TEXT](https://dev.mysql.com/doc/refman/9.0/en/blob.html), GEOMETRY, and [JSON](https://dev.mysql.com/doc/refman/9.0/en/json.html) data types can be assigned a default value only if the value is written as an expression, even if the expression value is a literal

Fixed by wrapping the default value in an expression when the column type is one of the types mentioned above.
