### PR TITLE
fix(sql): correctly handle lazy scalar properties with custom types

### DIFF
--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -1673,17 +1673,20 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
     }
 
     if (ret.length > 0 && !hasExplicitFields && addFormulas) {
-      meta.props
-        .filter(prop => prop.formula && !lazyProps.includes(prop))
-        .forEach(prop => {
+      for (const prop of meta.props) {
+        if (lazyProps.includes(prop)) {
+          continue;
+        }
+
+        if (prop.formula) {
           const a = this.platform.quoteIdentifier(alias);
           const aliased = this.platform.quoteIdentifier(prop.fieldNames[0]);
           ret.push(raw(`${prop.formula!(a)} as ${aliased}`));
-        });
-
-      meta.props
-        .filter(prop => !prop.object && (prop.hasConvertToDatabaseValueSQL || prop.hasConvertToJSValueSQL))
-        .forEach(prop => ret.push(prop.name));
+        }
+        if (!prop.object && (prop.hasConvertToDatabaseValueSQL || prop.hasConvertToJSValueSQL)) {
+          ret.push(prop.name);
+        }
+      }
     }
 
     // add joined relations after the root entity fields

--- a/tests/issues/GH6715.test.ts
+++ b/tests/issues/GH6715.test.ts
@@ -1,0 +1,85 @@
+import { Entity, MikroORM, PrimaryKey, Property, Type } from '@mikro-orm/postgresql';
+import { mockLogger } from '../bootstrap';
+
+type GeoPoint = {
+  lat: number;
+  lng: number;
+};
+class GeoPointType extends Type<GeoPoint | undefined, string | undefined> {
+
+  override convertToDatabaseValue(value: GeoPoint | undefined) {
+    return value ? `point(${value.lat} ${value.lng})` : value;
+  }
+
+  override convertToJSValue(value: string | undefined) {
+    const m = value?.match(/point\((-?\d+(\.\d+)?) (-?\d+(\.\d+)?)\)/i);
+    return m ? { lat: +m[1], lng: +m[3] } : undefined;
+  }
+
+  override convertToJSValueSQL(key: string) {
+    return `ST_AsText(${key})`;
+  }
+
+  override convertToDatabaseValueSQL(key: string) {
+    return `ST_PointFromText(${key})`;
+  }
+
+  override getColumnType() {
+    return 'geometry(Point)';
+  }
+
+}
+
+@Entity()
+class Place {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: GeoPointType, lazy: true })
+  location!: GeoPoint;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Place],
+    dbName: 'GHxxxx',
+    port: 5433,
+  });
+
+  await orm.schema.execute('create extension if not exists postgis');
+  await orm.schema.refreshDatabase();
+});
+beforeEach(async () => {
+  await orm.schema.clearDatabase();
+});
+afterAll(async () => {
+  await orm.schema.dropDatabase();
+  await orm.close(true);
+});
+
+
+test('should handle lazy scalar properties with custom types correctly', async () => {
+  const place = orm.em.create(Place, { id: 1, location: { lat: 2, lng: 3 } });
+
+  await orm.em.flush();
+  orm.em.clear();
+
+  const mock = mockLogger(orm, ['query']);
+
+  const r1 = await orm.em.find(Place, {});
+  expect(r1[0]).toEqual({ id: 1 });
+  expect(mock.mock.calls[0][0]).toMatch('select "p0"."id" from "place" as "p0"');
+
+  orm.em.clear();
+  mock.mockClear();
+
+  const r2 = await orm.em.find(Place, {}, { populate: ['location'] });
+  expect(r2[0]).toEqual({ id: 1, location: { lat: 2, lng: 3 } });
+  expect(mock.mock.calls[0][0]).toMatch('select "p0".*, ST_AsText("p0"."location") as "location" from "place" as "p0"');
+});
+
+

--- a/tests/issues/GH6715.test.ts
+++ b/tests/issues/GH6715.test.ts
@@ -46,15 +46,12 @@ let orm: MikroORM;
 beforeAll(async () => {
   orm = await MikroORM.init({
     entities: [Place],
-    dbName: 'GHxxxx',
+    dbName: '6715',
     port: 5433,
   });
 
   await orm.schema.execute('create extension if not exists postgis');
   await orm.schema.refreshDatabase();
-});
-beforeEach(async () => {
-  await orm.schema.clearDatabase();
 });
 afterAll(async () => {
   await orm.schema.dropDatabase();


### PR DESCRIPTION
This PR fixes lazy support for custom type properties, which were always selected even if not explicitly populated.