### PR TITLE
feat(logger): add slow query logging support

### DIFF
--- a/packages/core/src/connections/Connection.ts
+++ b/packages/core/src/connections/Connection.ts
@@ -158,8 +158,10 @@ export abstract class Connection {
   }
 
   protected logQuery(query: string, context: LogContext = {}): void {
+    const isSlowQuery = typeof context.took === 'number' && context.took >= 200;
+
     this.logger.logQuery({
-      level: 'info',
+      level: isSlowQuery ? 'warning' : 'info',
       connection: {
         type: this.type,
         name: this.options.name || this.config.get('name') || this.options.host,

--- a/packages/core/src/logging/Logger.ts
+++ b/packages/core/src/logging/Logger.ts
@@ -31,7 +31,7 @@ export interface Logger {
 
 }
 
-export type LoggerNamespace = 'query' | 'query-params' | 'schema' | 'discovery' | 'info' | 'deprecated';
+export type LoggerNamespace = 'query' | 'query-params' | 'schema' | 'discovery' | 'info' | 'deprecated' | 'slowQuery';
 
 export interface LogContext extends Dictionary {
   query?: string;


### PR DESCRIPTION
closes #4695 

- Introduced a new logging namespace - `slowQuery`
- Logging all the Queries that takes beyond the configurable threshold of **>=200** ms. 
- Modified the log level to 'warning` for the slow queries. 
- Highlighting the meta data color of slow queries to yellow 

This is my first contribution to Mikro ORM, i do not have a lot of experience with typescript either, i tried to do this while learning the same. So please feel free to let me know if i missed some nuances, i'm happy to address the feedback. 