### PR TITLE
Pin mssql container to a non-latest 2025 version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
 
   mssql:
-    image: mcr.microsoft.com/mssql/server:2025-latest
+    image: mcr.microsoft.com/mssql/server:2025-CTP2.0-ubuntu-22.04
     restart: always
     ports:
       - '1433:1433'
@@ -63,7 +63,7 @@ services:
       test: /opt/mssql-tools/bin/sqlcmd -S mssql -U sa -P 'Root.Root' -Q 'select 1'
 
   waitmssql:
-    image: mcr.microsoft.com/mssql/server:2025-latest
+    image: mcr.microsoft.com/mssql/server:2025-CTP2.0-ubuntu-22.04
     links:
       - mssql
     depends_on:


### PR DESCRIPTION
Running

```
docker compose up -d
yarn test
```

yields broken tests because of a failing MSSQL docker container. The container is reporting `no such file or directory` (last line of the output). The version prior to latest works fine and all tests pass.

Given the other database containers are version pinned, this one probably should be too. 

In this case `latest` === `mcr.microsoft.com/mssql/server:2025-CTP2.1-ubuntu-22.04`.

```
2025-07-11 16:13:14 This program has encountered a fatal error and cannot continue running at Fri Jul 11 21:13:14 2025
2025-07-11 16:13:14 The following diagnostic information is available:
2025-07-11 16:13:14 
2025-07-11 16:13:14          Reason: 0x00000006
2025-07-11 16:13:14         Message: PROCESS_FAULT_FLAGS_UNHANDLED_EXCEPTION: The process [sqlservr.exe ] has encountered an unhandled exception.
2025-07-11 16:13:14         Address: 0x3fffb485dad8
2025-07-11 16:13:14     Stack Trace:
2025-07-11 16:13:14                  file://package6/windows/system32/sqlpal.dll+0x000000000000A5F2
2025-07-11 16:13:14                  file://package6/windows/system32/sqlpal.dll+0x0000000000008F66
2025-07-11 16:13:14                  file://package6/windows/system32/sqlpal.dll+0x000000000005D848
2025-07-11 16:13:14                  file://package6/windows/system32/sqlpal.dll+0x000000000005DAD8
2025-07-11 16:13:14                  file://package6/windows/system32/sqlpal.dll+0x000000000005D73C
2025-07-11 16:13:14                  file://package6/windows/system32/sqlpal.dll+0x0000000000002B74
2025-07-11 16:13:14                  file://package6/windows/system32/sqlpal.dll+0x000000000012178B
2025-07-11 16:13:14                  file:///windows/system32/ntdll.dll+0x00000000001033BF
2025-07-11 16:13:14                  file:///windows/system32/ntdll.dll+0x000000000002EDD1
2025-07-11 16:13:14                  file:///windows/system32/ntdll.dll+0x000000000002F21B
2025-07-11 16:13:14                  file:///windows/system32/ntdll.dll+0x000000000010A879
2025-07-11 16:13:14                  file:///windows/system32/ntdll.dll+0x00000000000F3D66
2025-07-11 16:13:14                  file:///windows/system32/ntdll.dll+0x0000000000107F9F
2025-07-11 16:13:14                  file:///windows/system32/ntdll.dll+0x00000000000A2E7E
2025-07-11 16:13:14                  file:///windows/system32/ntdll.dll+0x0000000000106F9E
2025-07-11 16:13:14                  file:///binn/sqllang.dll+0x00000000003D2EC7
2025-07-11 16:13:14         Process: 11 - sqlservr
2025-07-11 16:13:14          Thread: 17 (application thread 0x3bc)
2025-07-11 16:13:14     Instance Id: 4f3b6c37-bef2-4d57-9189-ed7e2e6b8f25
2025-07-11 16:13:14        Crash Id: fe091694-a6ff-446f-8a4d-0398324d631f
2025-07-11 16:13:14     Build stamp: 96b8b2f422b4b799d8798c6e8180f8ae0afae51e6e9203cc3313295af5eecea3
2025-07-11 16:13:14    Distribution: Ubuntu 22.04.5 LTS
2025-07-11 16:13:14      Processors: 12
2025-07-11 16:13:14    Total Memory: 16748662784 bytes
2025-07-11 16:13:14       Timestamp: Fri Jul 11 21:13:14 2025
2025-07-11 16:13:14      Last errno: 2
2025-07-11 16:13:14 Last errno text: No such file or directory
```