### PR TITLE
feat(core): add `RequiredNullable` helper type

### DIFF
--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -394,20 +394,64 @@ properties: {
 
 To make a nullable field required in methods like `em.create()` (i.e. you cannot omit the property), use `RequiredNullable` type. Such property needs to be provided explicitly in the `em.create()` method, but will accept a `null` value.
 
-```ts title='book.entity.ts'
-export class Book extends BaseEntity {
 
-  @Property()
-  title: RequiredNullable<string>;
+<Tabs
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'defineEntity', value: 'define-entity'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="reflect-metadata">
 
-  // ...
-
-}
+```ts title='./entities/Book.ts'
+@Property()
+title: RequiredNullable<string>;
 
 em.create(Book, { title: "Alice in Wonderland" }); // ok
 em.create(Book, { title: null }); // ok
 em.create(Book, {}); // compile error: missing title
 ```
+
+  </TabItem>
+  <TabItem value="ts-morph">
+
+```ts title='./entities/Book.ts'
+@Property()
+title: RequiredNullable<string>;
+
+em.create(Book, { title: "Alice in Wonderland" }); // ok
+em.create(Book, { title: null }); // ok
+em.create(Book, {}); // compile error: missing title
+```
+
+  </TabItem>
+  <TabItem value="define-entity">
+
+```ts title='./entities/Book.ts'
+// TODO
+
+em.create(Book, { title: "Alice in Wonderland" }); // ok
+em.create(Book, { title: null }); // ok
+em.create(Book, {}); // compile error: missing title
+```
+
+  </TabItem>
+  <TabItem value="entity-schema">
+
+```ts title="./entities/Author.ts"
+// TODO
+
+em.create(Book, { title: "Alice in Wonderland" }); // ok
+em.create(Book, { title: null }); // ok
+em.create(Book, {}); // compile error: missing title
+```
+
+  </TabItem>
+</Tabs>
 
 ## Default values
 

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -392,6 +392,23 @@ properties: {
   </TabItem>
 </Tabs>
 
+To make a nullable field required (i.e. you cannot omit the property), use `RequiredNull`:
+
+```ts title='book.entity.ts'
+export class Book extends BaseEntity {
+
+  @Property()
+  title: string | RequiredNull;
+
+  // ...
+
+}
+
+em.create(Book, { title: "Alice in Wonderland" }); // ok
+em.create(Book, { title: null }); // ok
+em.create(Book, {}); // compile error: missing description
+```
+
 ## Default values
 
 We can set default value of a property in 2 ways:

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -392,13 +392,13 @@ properties: {
   </TabItem>
 </Tabs>
 
-To make a nullable field required (i.e. you cannot omit the property), use `RequiredNull`:
+To make a nullable field required (i.e. you cannot omit the property), use `RequiredNullable`:
 
 ```ts title='book.entity.ts'
 export class Book extends BaseEntity {
 
   @Property()
-  title: string | RequiredNull;
+  title: RequiredNullable<string>;
 
   // ...
 

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -392,7 +392,7 @@ properties: {
   </TabItem>
 </Tabs>
 
-To make a nullable field required (i.e. you cannot omit the property), use `RequiredNullable`:
+To make a nullable field required in methods like `em.create()` (i.e. you cannot omit the property), use `RequiredNullable` type. Such property needs to be provided explicitly in the `em.create()` method, but will accept a `null` value.
 
 ```ts title='book.entity.ts'
 export class Book extends BaseEntity {

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -406,7 +406,7 @@ export class Book extends BaseEntity {
 
 em.create(Book, { title: "Alice in Wonderland" }); // ok
 em.create(Book, { title: null }); // ok
-em.create(Book, {}); // compile error: missing description
+em.create(Book, {}); // compile error: missing title
 ```
 
 ## Default values

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -408,8 +408,10 @@ To make a nullable field required in methods like `em.create()` (i.e. you cannot
   <TabItem value="reflect-metadata">
 
 ```ts title='./entities/Book.ts'
-@Property()
-title: RequiredNullable<string>;
+class Book {
+  @Property()
+  title!: RequiredNullable<string>;
+}
 
 em.create(Book, { title: "Alice in Wonderland" }); // ok
 em.create(Book, { title: null }); // ok
@@ -420,8 +422,10 @@ em.create(Book, {}); // compile error: missing title
   <TabItem value="ts-morph">
 
 ```ts title='./entities/Book.ts'
-@Property()
-title: RequiredNullable<string>;
+class Book {
+  @Property()
+  title!: RequiredNullable<string>;
+}
 
 em.create(Book, { title: "Alice in Wonderland" }); // ok
 em.create(Book, { title: null }); // ok
@@ -432,7 +436,12 @@ em.create(Book, {}); // compile error: missing title
   <TabItem value="define-entity">
 
 ```ts title='./entities/Book.ts'
-// TODO
+const Book = defineEntity({
+  name: 'Book',
+  properties: p => ({
+    title: p.string().$type<RequiredNullable<string>>(),
+  }),
+});
 
 em.create(Book, { title: "Alice in Wonderland" }); // ok
 em.create(Book, { title: null }); // ok
@@ -443,7 +452,16 @@ em.create(Book, {}); // compile error: missing title
   <TabItem value="entity-schema">
 
 ```ts title="./entities/Author.ts"
-// TODO
+class Book {
+  title!: RequiredNullable<string>;
+}
+
+const schema = new EntitySchema({
+  class: Book,
+  properties: {
+    title: { type: 'string' },
+  },
+});
 
 em.create(Book, { title: "Alice in Wonderland" }); // ok
 em.create(Book, { title: null }); // ok

--- a/docs/docs/guide/02-relationships.md
+++ b/docs/docs/guide/02-relationships.md
@@ -373,6 +373,23 @@ export class Article extends BaseEntity {
 }
 ```
 
+By default, any nullable properties are optional when creating an instance of an entity. To make a nullable field required (i.e. you cannot omit the property), use `RequiredNull`:
+
+```ts title='article.entity.ts'
+export class Article extends BaseEntity {
+
+  @Property({ length: 1000 })
+  description: string | RequiredNull;
+
+  // ...
+
+}
+
+em.create(Article, { description: "Description!" }); // ok
+em.create(Article, { description: null }); // ok
+em.create(Article, {}); // compile error: missing description
+```
+
 ## Populating relationships
 
 What if we want to fetch the `Article` together with the `author` relation? We can use `populate` hints for that:

--- a/docs/docs/guide/02-relationships.md
+++ b/docs/docs/guide/02-relationships.md
@@ -373,13 +373,13 @@ export class Article extends BaseEntity {
 }
 ```
 
-By default, any nullable properties are optional when creating an instance of an entity. To make a nullable field required (i.e. you cannot omit the property), use `RequiredNull`:
+By default, any nullable properties are optional when creating an instance of an entity. To make a nullable field required (i.e. you cannot omit the property), use `RequiredNullable`:
 
 ```ts title='article.entity.ts'
 export class Article extends BaseEntity {
 
   @Property({ length: 1000 })
-  description: string | RequiredNull;
+  description: RequiredNullable<string>;
 
   // ...
 

--- a/docs/docs/guide/02-relationships.md
+++ b/docs/docs/guide/02-relationships.md
@@ -308,7 +308,7 @@ Unfortunately not, you will see TypeScript error like this one:
 Property '[OptionalProps]' in type 'Article' is not assignable to the same property in base type 'BaseEntity'.
   Type '"slug" | "description" | undefined' is not assignable to type '"createdAt" | "updatedAt" | undefined'.
     Type '"slug"' is not assignable to type '"createdAt" | "updatedAt" | undefined'. ts(2416)
- ```
+```
 
 #### Generics to the rescue!
 
@@ -373,7 +373,7 @@ export class Article extends BaseEntity {
 }
 ```
 
-By default, any nullable properties are optional when creating an instance of an entity. To make a nullable field required (i.e. you cannot omit the property), use `RequiredNullable`:
+To make a nullable field required in methods like `em.create()` (i.e. you cannot omit the property), use `RequiredNullable` type. Such property needs to be provided explicitly in the `em.create()` method, but will accept a `null` value.
 
 ```ts title='article.entity.ts'
 export class Article extends BaseEntity {

--- a/docs/versioned_docs/version-6.1/guide/02-relationships.md
+++ b/docs/versioned_docs/version-6.1/guide/02-relationships.md
@@ -371,6 +371,23 @@ export class Article extends BaseEntity {
 }
 ```
 
+By default, any nullable properties are optional when creating an instance of an entity. To make a nullable field required (i.e. you cannot omit the property), use `RequiredNull`:
+
+```ts title='article.entity.ts'
+export class Article extends BaseEntity {
+
+  @Property({ length: 1000 })
+  description: string | RequiredNull;
+
+  // ...
+
+}
+
+em.create(Article, { description: "Description!" }); // ok
+em.create(Article, { description: null }); // ok
+em.create(Article, {}); // compile error: missing description
+```
+
 ## Populating relationships
 
 What if we want to fetch the `Article` together with the `author` relation? We can use `populate` hints for that:

--- a/docs/versioned_docs/version-6.1/guide/02-relationships.md
+++ b/docs/versioned_docs/version-6.1/guide/02-relationships.md
@@ -371,23 +371,6 @@ export class Article extends BaseEntity {
 }
 ```
 
-By default, any nullable properties are optional when creating an instance of an entity. To make a nullable field required (i.e. you cannot omit the property), use `RequiredNull`:
-
-```ts title='article.entity.ts'
-export class Article extends BaseEntity {
-
-  @Property({ length: 1000 })
-  description: string | RequiredNull;
-
-  // ...
-
-}
-
-em.create(Article, { description: "Description!" }); // ok
-em.create(Article, { description: null }); // ok
-em.create(Article, {}); // compile error: missing description
-```
-
 ## Populating relationships
 
 What if we want to fetch the `Article` together with the `author` relation? We can use `populate` hints for that:

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -304,23 +304,23 @@ export type EntityDataProp<T, C extends boolean> = T extends Date
 
 export type RequiredEntityDataProp<T, O, C extends boolean> = T extends Date
   ? string | Date
-  : { [__requiredNullable]?: 1 } extends T
-  ? T | null
-  : T extends Scalar
-    ? T
-    : T extends { __runtime?: infer Runtime; __raw?: infer Raw }
-      ? (C extends true ? Raw : Runtime)
-      : T extends Reference<infer U>
-        ? RequiredEntityDataNested<U, O, C>
-        : T extends ScalarReference<infer U>
-          ? RequiredEntityDataProp<U, O, C>
-          : T extends Collection<infer U, any>
-            ? U | U[] | RequiredEntityDataNested<U, O, C> | RequiredEntityDataNested<U, O, C>[]
-            : T extends readonly (infer U)[]
-              ? U extends NonArrayObject
-                ? U | U[] | RequiredEntityDataNested<U, O, C> | RequiredEntityDataNested<U, O, C>[]
-                : U[] | RequiredEntityDataNested<U, O, C>[]
-              : RequiredEntityDataNested<T, O, C>;
+    : { [__requiredNullable]?: 1 } extends T
+    ? T | null
+      : T extends Scalar
+      ? T
+      : T extends { __runtime?: infer Runtime; __raw?: infer Raw }
+        ? (C extends true ? Raw : Runtime)
+        : T extends Reference<infer U>
+          ? RequiredEntityDataNested<U, O, C>
+          : T extends ScalarReference<infer U>
+            ? RequiredEntityDataProp<U, O, C>
+            : T extends Collection<infer U, any>
+              ? U | U[] | RequiredEntityDataNested<U, O, C> | RequiredEntityDataNested<U, O, C>[]
+              : T extends readonly (infer U)[]
+                ? U extends NonArrayObject
+                  ? U | U[] | RequiredEntityDataNested<U, O, C> | RequiredEntityDataNested<U, O, C>[]
+                  : U[] | RequiredEntityDataNested<U, O, C>[]
+                : RequiredEntityDataNested<T, O, C>;
 
 export type EntityDataNested<T, C extends boolean = false> = T extends undefined
   ? never
@@ -337,14 +337,13 @@ export type RequiredEntityDataNested<T, O, C extends boolean> = T extends any[]
 
 type ExplicitlyOptionalProps<T> = (T extends { [OptionalProps]?: infer K } ? K : never) | ({ [K in keyof T]: T[K] extends Opt ? K : never }[keyof T] & {});
 type NullableKeys<T, V = null> = { [K in keyof T]: V extends T[K] ? K : never }[keyof T];
-type ProbablyOptionalProps<T> = PrimaryProperty<T> | ExplicitlyOptionalProps<T> | NonNullable<NullableKeys<T, null | undefined>>;
+type RequiredNullableKeys<T> = { [K in keyof T]: { [__requiredNullable]?: 1 } extends T[K] ? K : never }[keyof T];
+type ProbablyOptionalProps<T> = PrimaryProperty<T> | ExplicitlyOptionalProps<T> | Exclude<NonNullable<NullableKeys<T, null | undefined>>, RequiredNullableKeys<T>>;
 
 type IsOptional<T, K extends keyof T, I> = T[K] extends Collection<any, any>
   ? true
   : ExtractType<T[K]> extends I
     ? true
-    : { [__requiredNullable]?: 1 } extends T[K]
-    ? false
     : K extends ProbablyOptionalProps<T>
       ? true
       : false;
@@ -1092,8 +1091,6 @@ export type ExpandProperty<T> = T extends Reference<infer U>
 type LoadedLoadable<T, E extends object> =
   T extends Collection<any, any>
   ? LoadedCollection<E>
-  : { [__requiredNullable]?: 1 } extends T
-  ? T | null
   : T extends Reference<any>
     ? T & LoadedReference<E> // intersect with T (which is `Ref`) to include the PK props
     : T extends ScalarReference<infer U>

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -304,8 +304,8 @@ export type EntityDataProp<T, C extends boolean> = T extends Date
 
 export type RequiredEntityDataProp<T, O, C extends boolean> = T extends Date
   ? string | Date
-  : T extends RequiredNullable<infer U>
-  ? U | null
+  : { [__requiredNull]?: 1 } extends T
+  ? T | null
   : T extends Scalar
     ? T
     : T extends { __runtime?: infer Runtime; __raw?: infer Raw }
@@ -343,8 +343,8 @@ type IsOptional<T, K extends keyof T, I> = T[K] extends Collection<any, any>
   ? true
   : ExtractType<T[K]> extends I
     ? true
-    : T extends RequiredNullable
-      ? false
+    : { [__requiredNull]?: 1 } extends T[K]
+    ? false
     : K extends ProbablyOptionalProps<T>
       ? true
       : false;
@@ -1092,8 +1092,8 @@ export type ExpandProperty<T> = T extends Reference<infer U>
 type LoadedLoadable<T, E extends object> =
   T extends Collection<any, any>
   ? LoadedCollection<E>
-  : T extends RequiredNullable<infer U>
-  ? U | null
+  : { [__requiredNull]?: 1 } extends T
+  ? T | null
   : T extends Reference<any>
     ? T & LoadedReference<E> // intersect with T (which is `Ref`) to include the PK props
     : T extends ScalarReference<infer U>

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -78,7 +78,7 @@ export const Config = Symbol('Config');
 declare const __optional: unique symbol;
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-declare const __requiredNull: unique symbol;
+declare const __requiredNullable: unique symbol;
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 declare const __hidden: unique symbol;
@@ -87,7 +87,7 @@ declare const __hidden: unique symbol;
 declare const __config: unique symbol;
 
 export type Opt<T = unknown> = T & { [__optional]?: 1 };
-export type RequiredNullable<T = never> = T | null | { [__requiredNull]?: 1 };
+export type RequiredNullable<T = never> = T | null | { [__requiredNullable]?: 1 };
 export type Hidden<T = unknown> = T & { [__hidden]?: 1 };
 export type DefineConfig<T extends TypeConfig> = T & { [__config]?: 1 };
 export type CleanTypeConfig<T> = Compute<Pick<T, Extract<keyof T, keyof TypeConfig>>>;
@@ -304,7 +304,7 @@ export type EntityDataProp<T, C extends boolean> = T extends Date
 
 export type RequiredEntityDataProp<T, O, C extends boolean> = T extends Date
   ? string | Date
-  : { [__requiredNull]?: 1 } extends T
+  : { [__requiredNullable]?: 1 } extends T
   ? T | null
   : T extends Scalar
     ? T
@@ -343,7 +343,7 @@ type IsOptional<T, K extends keyof T, I> = T[K] extends Collection<any, any>
   ? true
   : ExtractType<T[K]> extends I
     ? true
-    : { [__requiredNull]?: 1 } extends T[K]
+    : { [__requiredNullable]?: 1 } extends T[K]
     ? false
     : K extends ProbablyOptionalProps<T>
       ? true
@@ -1092,7 +1092,7 @@ export type ExpandProperty<T> = T extends Reference<infer U>
 type LoadedLoadable<T, E extends object> =
   T extends Collection<any, any>
   ? LoadedCollection<E>
-  : { [__requiredNull]?: 1 } extends T
+  : { [__requiredNullable]?: 1 } extends T
   ? T | null
   : T extends Reference<any>
     ? T & LoadedReference<E> // intersect with T (which is `Ref`) to include the PK props

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -87,7 +87,7 @@ declare const __hidden: unique symbol;
 declare const __config: unique symbol;
 
 export type Opt<T = unknown> = T & { [__optional]?: 1 };
-export type RequiredNullable<T = never> = T | null | { [__requiredNullable]?: 1 };
+export type RequiredNullable<T = never> = (T & { [__requiredNullable]?: 1 }) | null;
 export type Hidden<T = unknown> = T & { [__hidden]?: 1 };
 export type DefineConfig<T extends TypeConfig> = T & { [__config]?: 1 };
 export type CleanTypeConfig<T> = Compute<Pick<T, Extract<keyof T, keyof TypeConfig>>>;
@@ -304,7 +304,7 @@ export type EntityDataProp<T, C extends boolean> = T extends Date
 
 export type RequiredEntityDataProp<T, O, C extends boolean> = T extends Date
   ? string | Date
-    : { [__requiredNullable]?: 1 } extends T
+    : Exclude<T, null> extends { [__requiredNullable]?: 1 }
     ? T | null
       : T extends Scalar
       ? T
@@ -337,7 +337,7 @@ export type RequiredEntityDataNested<T, O, C extends boolean> = T extends any[]
 
 type ExplicitlyOptionalProps<T> = (T extends { [OptionalProps]?: infer K } ? K : never) | ({ [K in keyof T]: T[K] extends Opt ? K : never }[keyof T] & {});
 type NullableKeys<T, V = null> = { [K in keyof T]: V extends T[K] ? K : never }[keyof T];
-type RequiredNullableKeys<T> = { [K in keyof T]: { [__requiredNullable]?: 1 } extends T[K] ? K : never }[keyof T];
+type RequiredNullableKeys<T> = { [K in keyof T]: Exclude<T[K], null> extends { [__requiredNullable]?: 1 } ? K : never }[keyof T];
 type ProbablyOptionalProps<T> = PrimaryProperty<T> | ExplicitlyOptionalProps<T> | Exclude<NonNullable<NullableKeys<T, null | undefined>>, RequiredNullableKeys<T>>;
 
 type IsOptional<T, K extends keyof T, I> = T[K] extends Collection<any, any>

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -87,7 +87,7 @@ declare const __hidden: unique symbol;
 declare const __config: unique symbol;
 
 export type Opt<T = unknown> = T & { [__optional]?: 1 };
-export type RequiredNullable<T> = T | null | { [__requiredNull]?: 1 };
+export type RequiredNullable<T = never> = T | null | { [__requiredNull]?: 1 };
 export type Hidden<T = unknown> = T & { [__hidden]?: 1 };
 export type DefineConfig<T extends TypeConfig> = T & { [__config]?: 1 };
 export type CleanTypeConfig<T> = Compute<Pick<T, Extract<keyof T, keyof TypeConfig>>>;
@@ -343,7 +343,7 @@ type IsOptional<T, K extends keyof T, I> = T[K] extends Collection<any, any>
   ? true
   : ExtractType<T[K]> extends I
     ? true
-    : T extends RequiredNullable<any>
+    : T extends RequiredNullable
       ? false
     : K extends ProbablyOptionalProps<T>
       ? true
@@ -1197,11 +1197,9 @@ export type FromEntityType<T> = T extends LoadedEntityType<infer U> ? U : T;
 type LoadedInternal<T, L extends string = never, F extends string = '*', E extends string = never> =
   [F] extends ['*']
     ? IsNever<E> extends true
-      ? TransformRequiredNulls<T> & { [K in keyof T as IsPrefixed<T, K, ExpandHint<T, L>>]: LoadedProp<NonNullable<T[K]>, Suffix<K, L>, Suffix<K, F>, Suffix<K, E>> | AddOptional<T[K]>; }
+      ? T & { [K in keyof T as IsPrefixed<T, K, ExpandHint<T, L>>]: LoadedProp<NonNullable<T[K]>, Suffix<K, L>, Suffix<K, F>, Suffix<K, E>> | AddOptional<T[K]>; }
       : { [K in keyof T as IsPrefixed<T, K, ExpandHint<T, L>, E>]: LoadedProp<NonNullable<T[K]>, Suffix<K, L>, Suffix<K, F>, Suffix<K, E>> | AddOptional<T[K]>; }
     : Selected<T, L, F>;
-
-type TransformRequiredNulls<T> = { [K in keyof T]: T[K] extends RequiredNullable<infer U> ? U | null : T[K] };
 
 /**
  * Represents entity with its loaded relations (`populate` hint) and selected properties (`fields` hint).

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1032,7 +1032,7 @@ describe('check typings', () => {
     }
   });
 
-  test('RequiredNull', () => {
+  test('RequiredNullable', () => {
 
     class User {
 
@@ -1050,5 +1050,11 @@ describe('check typings', () => {
     em.create(User, { requiredNullableString: 'some string' });
     em.create(User, { requiredNullableString: null });
 
+    const user = { requiredNullableString: '' } as User;
+
+    user.requiredNullableString?.toString();
+
+    // @ts-expect-error
+    user.requiredNullableString.toString();
   });
 });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -23,6 +23,7 @@ import type {
   Primary,
   PrimaryKeyProp,
   ExpandQuery,
+  RequiredNullable,
 } from '../packages/core/src/typings';
 import type { Author2, Book2, BookTag2, Car2, FooBar2, FooParam2, Publisher2, User2 } from './entities-sql';
 import type { Author, Book } from './entities';
@@ -1031,4 +1032,23 @@ describe('check typings', () => {
     }
   });
 
+  test('RequiredNull', () => {
+
+    class User {
+
+      id!: number;
+      nullableString!: string | null;
+      requiredNullableString!: RequiredNullable<string>;
+
+    }
+
+    const em = { create: jest.fn() as any } as EntityManager;
+
+    // @ts-expect-error
+    em.create(User, { });
+
+    em.create(User, { requiredNullableString: 'some string' });
+    em.create(User, { requiredNullableString: null });
+
+  });
 });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1052,9 +1052,22 @@ describe('check typings', () => {
 
     const user = { requiredNullableString: '' } as User;
 
-    user.requiredNullableString?.toString();
-
     // @ts-expect-error
     user.requiredNullableString.toString();
+
+    user.requiredNullableString?.toString();
+
+    const s1: string | null = user.requiredNullableString;
+    void s1; // so no unused variable error for `s`
+
+    const loadedUser = { requiredNullableString: '' } as Loaded<User>;
+
+    // @ts-expect-error
+    loadedUser.requiredNullableString.toString();
+
+    loadedUser.requiredNullableString?.toString();
+
+    const s2: string | null = user.requiredNullableString;
+    void s2; // so no unused variable error for `s`
   });
 });


### PR DESCRIPTION
Followup from https://github.com/mikro-orm/mikro-orm/discussions/6744#discussioncomment-13766303

This PR adds a type `RequiredNullable ` that can be used to make an entity field nullable, but still require the user to supply a value (`null` or otherwise) when instantiating 

```ts
export class Article extends BaseEntity {

  @Property({ length: 1000 })
  description: RequiredNullable<string>;

  // ...

}

em.create(Article, { description: "Description!" }); // ok
em.create(Article, { description: null }); // ok
em.create(Article, {}); // compile error: missing description
```