### PR TITLE
test: add test for entity removal in parallel forks

### DIFF
--- a/tests/issues/entity-removal-parallel-forks.test.ts
+++ b/tests/issues/entity-removal-parallel-forks.test.ts
@@ -1,0 +1,41 @@
+import { MikroORM } from '@mikro-orm/core';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+import { initORMSqlite } from '../bootstrap';
+
+const { Author3, Book3, BookTag3, Publisher3, Test3, BaseEntity4 } = require('../entities-js/index');
+
+let orm: MikroORM<SqliteDriver>;
+
+beforeAll(async () => {
+  orm = await initORMSqlite();
+  await orm.schema.ensureDatabase();
+  await orm.schema.refreshDatabase();
+});
+
+beforeEach(async () => {
+  await orm.schema.clearDatabase();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('if multiple forks are created in parallel, an entity can be removed in one fork without being re-persisted in another', async () => {
+  const entity = new Author3.entity('test author', 'test@test.com');
+  await orm.em.persistAndFlush(entity);
+
+  const fork1 = orm.em.fork({ clear: false });
+  const fork2 = orm.em.fork({ clear: false });
+
+  fork1.remove(entity);
+  await fork1.flush();
+
+  const countAfterDelete = await orm.em.count(Author3.entity, { id: entity.id });
+  expect(countAfterDelete).toBe(0);
+
+  const anotherEntity = new Publisher3.entity('test publisher');
+  await fork2.persistAndFlush(anotherEntity);
+
+  const countAfterSecondFlush = await orm.em.count(Author3.entity, { id: entity.id });
+  expect(countAfterSecondFlush).toBe(0);
+});


### PR DESCRIPTION
After battling for a few hours, I think I've found a bug in Mikro ORM.

Basically we have a complex web app that has separate event consumers running in parallel, each doing its' own thing.

Think of it as running a `Promise.all(...)` on a few promises, where each promise is running code in its own EM fork, via the `EntityManager#transactional(...)` callback.

Now, we've noticed that if we remove an entity in one of such forks, the entity gets unintentionally repersisted whenever `.flush()` is called in any other forks (e.g. when their `.transactional()` callback comes to an end).

I've wrote a test case that reproduces this.

@B4nan , any idea what can we do about this?

It seems to be a serious blocker to us, because:

- it may cause our app to randomly not to work as we wished. we've met this issue accidentally, because some validations in the entity have started failing when it had been repersisted after being deleted; and it took us a good half of day to find the root cause. i'm afraid we'll meet this issue many more times in the future.
- I can't find of a workaround? we definitely want transaction wrapping and forking for each of our event consumer's code.