### PR TITLE
Removed items still appear in the reloaded collection (if prior to that they've been removed in a clean transaction)

### DIFF
--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -197,7 +197,7 @@ export async function initORMMsSql(additionalOptions: Partial<Options<MsSqlDrive
   return orm;
 }
 
-export async function initORMSqlite() {
+export async function initORMSqlite(options?: Partial<Options<SqliteDriver>>) {
   const orm = await MikroORM.init<SqliteDriver>({
     entities: [Author3, Book3, BookTag3, Publisher3, Test3, BaseEntity4],
     dbName: ':memory:',
@@ -211,6 +211,7 @@ export async function initORMSqlite() {
     persistOnCreate: false,
     ignoreUndefinedInQuery: true,
     extensions: [Migrator, SeedManager, EntityGenerator],
+    ...options,
   });
 
   const connection = orm.em.getConnection();

--- a/tests/issues/item-removal-in-clean-transaction.test.ts
+++ b/tests/issues/item-removal-in-clean-transaction.test.ts
@@ -1,4 +1,4 @@
-import { MikroORM } from '@mikro-orm/core';
+import { DataloaderType, MikroORM } from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 import { initORMSqlite } from '../bootstrap';
 
@@ -7,7 +7,9 @@ const { Author3, Book3, BookTag3, Publisher3, Test3, BaseEntity4 } = require('..
 let orm: MikroORM<SqliteDriver>;
 
 beforeAll(async () => {
-  orm = await initORMSqlite();
+  orm = await initORMSqlite({
+    dataloader: DataloaderType.ALL,
+  });
   await orm.schema.ensureDatabase();
   await orm.schema.refreshDatabase();
 });
@@ -43,7 +45,7 @@ test('collection item can be removed in a clean transaction, and afterwards the 
   const booksBeforeReload: { title: string }[] = author.books.getItems();
   expect(booksBeforeReload.map(b => b.title)).toEqual(['book 1', 'book 2', 'book 3']);
 
-  const booksAfterReload: { title: string }[] = await author.books.loadItems({ reload: true });
+  const booksAfterReload: { title: string }[] = await author.books.loadItems({ refresh: true });
   expect(booksAfterReload.map(b => b.title)).toEqual([
     'book 2',
     'book 3',

--- a/tests/issues/item-removal-in-clean-transaction.test.ts
+++ b/tests/issues/item-removal-in-clean-transaction.test.ts
@@ -1,0 +1,51 @@
+import { MikroORM } from '@mikro-orm/core';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+import { initORMSqlite } from '../bootstrap';
+
+const { Author3, Book3, BookTag3, Publisher3, Test3, BaseEntity4 } = require('../entities-js/index');
+
+let orm: MikroORM<SqliteDriver>;
+
+beforeAll(async () => {
+  orm = await initORMSqlite();
+  await orm.schema.ensureDatabase();
+  await orm.schema.refreshDatabase();
+});
+
+beforeEach(async () => {
+  await orm.schema.clearDatabase();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('collection item can be removed in a clean transaction, and afterwards the collection can be retrieved with the remaining items reloaded', async () => {
+  const author = new Author3.entity('test author', 'test@test.com');
+  await orm.em.persistAndFlush(author);
+
+  const book1 = new Book3.entity('book 1', author);
+  const book2 = new Book3.entity('book 2', author);
+  const book3 = new Book3.entity('book 3', author);
+  await orm.em.persistAndFlush([book1, book2, book3]);
+
+  await orm.em.transactional(async em => {
+    const book = await em.findOneOrFail(Book3.entity, { title: 'book 1' });
+    await em.removeAndFlush(book);
+
+    const nestedAuthor: any = await em.findOneOrFail(Author3.entity, { id: author.id });
+    const books: { title: string }[] = await nestedAuthor.books.loadItems();
+    expect(books.map(b => b.title)).toEqual(['book 2', 'book 3']);
+  }, { clear: true });
+
+  expect(await orm.em.findOne(Book3.entity, { title: 'book 1' })).toBeNull();
+
+  const booksBeforeReload: { title: string }[] = author.books.getItems();
+  expect(booksBeforeReload.map(b => b.title)).toEqual(['book 1', 'book 2', 'book 3']);
+
+  const booksAfterReload: { title: string }[] = await author.books.loadItems({ reload: true });
+  expect(booksAfterReload.map(b => b.title)).toEqual([
+    'book 2',
+    'book 3',
+  ]);
+});


### PR DESCRIPTION
After the discussion in https://github.com/mikro-orm/mikro-orm/pull/6762 , I'm now replacing all `@Transactional()` calls in my codebase to be `@Transactional({ clear: true })` .

However, now I've met another strange behaviour (perhaps unrelated completely to that other ticket). 

After removing an entity in the transaction, I am still getting that entity in another entity's collection when calling `.loadItems({ refresh: true })` , even though the entity does not exist in the database anymore.

Am I doing something wrong, or is it MikroORM incorrectly not reloading the collection when asked to?

Note: If I remove `clear: true` transaction option, then the test passes.