### PR TITLE
typescript type support in where clause with subquery

### DIFF
--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -183,7 +183,7 @@ export type ExpandQuery<T> = T extends object
 export type EntityProps<T> = { -readonly [K in EntityKey<T>]?: T[K] };
 export type ObjectQuery<T> = OperatorMap<T> & FilterObject<T>;
 export type FilterQuery<T> =
-  | ObjectQuery<T>
+  | QBFilterQuery<T>
   | NonNullable<ExpandScalar<Primary<T>>>
   | NonNullable<EntityProps<T> & OperatorMap<T>>
   | FilterQuery<T>[];


### PR DESCRIPTION
typescript type support subquery in where clause like below code.
```
  const users = await em.find(User, {
    id: {
      $in: subQuery,
    },
  });
```

I change only ObjectQuery to QBFilterQuery

QBFilterQuery definition is 
```
type QBFilterQuery<T = any> = ObjectQuery<T> | Dictionary;
```