### PR TITLE
perf(knex): revamp mergeJoinedResult algorithm to boost perfs

### DIFF
--- a/packages/knex/src/AbstractSqlDriver.ts
+++ b/packages/knex/src/AbstractSqlDriver.ts
@@ -1112,40 +1112,66 @@ export abstract class AbstractSqlDriver<Connection extends AbstractSqlConnection
    * @internal
    */
   mergeJoinedResult<T extends object>(rawResults: EntityData<T>[], meta: EntityMetadata<T>, joinedProps: PopulateOptions<T>[]): EntityData<T>[] {
+    if (rawResults.length <= 1) {
+      return rawResults;
+    }
+
     const res: EntityData<T>[] = [];
-    const map: Dictionary<Dictionary> = {};
+    const map: Dictionary<EntityData<T>> = {};
+    const collectionsToMerge: Dictionary<Dictionary<EntityData<T>[]>> = {};
+
+    const hints = joinedProps.map(hint => {
+      const [propName, ref] = hint.field.split(':', 2) as [EntityKey<T>, string | undefined];
+      return { propName, ref, children: hint.children };
+    });
 
     for (const item of rawResults) {
       const pk = Utils.getCompositeKeyHash(item, meta);
 
       if (map[pk]) {
-        for (const hint of joinedProps) {
-          const [propName, ref] = hint.field.split(':', 2) as [EntityKey<T>, string | undefined];
-          const prop = meta.properties[propName];
-
+        for (const { propName } of hints) {
           if (!item[propName]) {
             continue;
           }
 
-          if ([ReferenceKind.ONE_TO_MANY, ReferenceKind.MANY_TO_MANY].includes(prop.kind) && ref) {
-            map[pk][propName] = [...map[pk][propName], ...(item[propName] as T[])];
-            continue;
-          }
-
-          switch (prop.kind) {
-            case ReferenceKind.ONE_TO_MANY:
-            case ReferenceKind.MANY_TO_MANY:
-              map[pk][propName] = this.mergeJoinedResult<T>([...map[pk][propName], ...(item[propName] as T[])], prop.targetMeta!, hint.children as any ?? []);
-              break;
-            case ReferenceKind.MANY_TO_ONE:
-            case ReferenceKind.ONE_TO_ONE:
-              map[pk][propName] = this.mergeJoinedResult<T>([map[pk][propName], item[propName]], prop.targetMeta!, hint.children as any ?? [])[0];
-              break;
-          }
+          collectionsToMerge[pk] ??= {};
+          collectionsToMerge[pk][propName] ??= [map[pk][propName] as EntityData<T>];
+          collectionsToMerge[pk][propName].push(item[propName] as EntityData<T>);
         }
       } else {
         map[pk] = item;
         res.push(item);
+      }
+    }
+
+    for (const pk in collectionsToMerge) {
+      const entity = map[pk];
+      const collections = collectionsToMerge[pk];
+
+      for (const { propName, ref, children } of hints) {
+
+        if (!collections[propName]) {
+          continue;
+        }
+
+        const prop = meta.properties[propName];
+        const items = collections[propName].flat() as EntityData<T>[];
+
+        if ([ReferenceKind.ONE_TO_MANY, ReferenceKind.MANY_TO_MANY].includes(prop.kind) && ref) {
+          entity[propName] = items as EntityDataValue<T>;
+          continue;
+        }
+
+        switch (prop.kind) {
+          case ReferenceKind.ONE_TO_MANY:
+          case ReferenceKind.MANY_TO_MANY:
+            entity[propName] = this.mergeJoinedResult(items, prop.targetMeta!, children as any ?? []) as EntityDataValue<T>;
+            break;
+          case ReferenceKind.MANY_TO_ONE:
+          case ReferenceKind.ONE_TO_ONE:
+            entity[propName] = this.mergeJoinedResult(items, prop.targetMeta!, children as any ?? [])[0] as EntityDataValue<T>;
+            break;
+        }
       }
     }
 

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -2472,6 +2472,28 @@ describe('EntityManagerPostgre', () => {
     console.timeEnd('perf: populate many 1:m collections');
   });
 
+  // this should run in ~200ms (when running single test locally)
+  test('perf: populating a large one to many collection using JOINED strategy', async () => {
+    const author = new Author2('Jon Snow', `snow@wall.st`);
+    const books = [];
+
+    for (let i = 1; i <= 5000; i++) {
+      books.push(new Book2(`My Life on The Wall, part ${i}`, author));
+    }
+
+    await orm.em.insert(author);
+    await orm.em.insertMany(books);
+
+    orm.em.clear();
+
+    console.time('perf: findOne with options.populate on a large 1:m collection in JOINED strategy');
+    await orm.em.findOne(Author2, author.id, {
+      populate: ['books2'],
+      strategy: LoadStrategy.JOINED,
+    });
+    console.timeEnd('perf: findOne with options.populate on a large 1:m collection in JOINED strategy');
+  });
+
   // this should run in ~70ms (when running single test locally)
   test('perf: one to many via em.create()', async () => {
     const books = [] as Book2[];


### PR DESCRIPTION
**TL;DR**: Optimize `mergeJoinedResult` for JOINED strategy to prevent quadratic performance on large collections

🚧 **Problem**

When populating large collections in JOINED strategy, query result processing becomes prohibitively slow as the collection size grows.
On a findOne by primary key populating a 5k items collection, it takes ~6 seconds on my machine (MacBook Pro, Apple M1 Pro, 32 GB RAM).

By digging into it, I found the cause to be the `AbstractSqlDriver.prototype.mergeJoinedResult` method in the `knex` package .

Profiling showed ~12.5 million loop iterations, indicating an O(n²) like behavior due to nested loops inside the merge logic.
This leads to high CPU usage and increased memory pressure during result assembly.

Example reproduction (included in PR tests):
```ts
const author = new Author2("Jon Snow", `snow@wall.st`);
const books = [];

for (let i = 1; i <= 5000; i++) {
  books.push(new Book2(`My Life on The Wall, part ${i}`, author));
}

await orm.em.insert(author);
await orm.em.insertMany(books);

orm.em.clear();

console.time("perf: findOne with options.populate on a large 1:m collection in JOINED strategy");
await orm.em.findOne(Author2, author.id, {
  populate: ["books2"],
  strategy: LoadStrategy.JOINED,
});
console.timeEnd("perf: findOne with options.populate on a large 1:m collection in JOINED strategy");

```

✅ **Solution**

Refactored `mergeJoinedResult` to use a two-pass approach. This reduce the loop count from ~12.5 million to ~10 thousand in the above scenario.
Performance improves from ~6 seconds to ~200 ms, lowering complexity from O(n²) to roughly O(2n) per recursion level.

_This is my first contribution, so please forgive me in advance if I’ve overlooked something. In any case, thanks for the incredible work made with MikroORM 🚀._