### PR TITLE
fix(query-builder): skip branching on to-one joins

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
   mssql:
     image: mcr.microsoft.com/mssql/server:2025-CTP2.0-ubuntu-22.04
     restart: always
+    platform: linux/amd64
     ports:
       - '1433:1433'
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,6 @@ services:
   mssql:
     image: mcr.microsoft.com/mssql/server:2025-CTP2.0-ubuntu-22.04
     restart: always
-    platform: linux/amd64
     ports:
       - '1433:1433'
     environment:

--- a/packages/knex/src/query/ObjectCriteriaNode.ts
+++ b/packages/knex/src/query/ObjectCriteriaNode.ts
@@ -92,9 +92,10 @@ export class ObjectCriteriaNode<T extends object> extends CriteriaNode<T> {
       const virtual = childNode.prop?.persist === false && !childNode.prop?.formula;
       // if key is missing, we are inside group operator and we need to prefix with alias
       const primaryKey = this.key && this.metadata.find(this.entityName)!.primaryKeys.includes(field);
+      const isToOne = childNode.prop && [ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(childNode.prop.kind);
 
       if (childNode.shouldInline(payload)) {
-        const childAlias = qb.getAliasForJoinPath(childNode.getPath(), options);
+        const childAlias = qb.getAliasForJoinPath(childNode.getPath(), { preferNoBranch: isToOne, ...options });
         const a = qb.helper.isTableNameAliasRequired(qb.type) ? alias : undefined;
         this.inlineChildPayload(o, payload, field as EntityKey, a, childAlias);
       } else if (childNode.shouldRename(payload)) {

--- a/tests/issues/GH6824.test.ts
+++ b/tests/issues/GH6824.test.ts
@@ -1,0 +1,228 @@
+import {
+  Collection,
+  Entity,
+  ManyToOne,
+  MikroORM,
+  OneToMany,
+  OneToOne,
+  PrimaryKey,
+  Property,
+  Ref,
+} from '@mikro-orm/sqlite';
+
+@Entity()
+class Organisation {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+}
+
+@Entity()
+class User {
+
+  @ManyToOne({
+    entity: () => Organisation,
+    fieldName: 'org_id',
+    primary: true,
+    ref: true,
+  })
+  org!: Ref<Organisation>;
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToOne({
+    entity: () => Profile,
+    ref: true,
+    fieldNames: ['org_id', 'profile_id'],
+    ownColumns: ['profile_id'],
+  })
+  profile!: Ref<Profile>;
+
+  @ManyToOne({
+    entity: () => Workspace,
+    fieldNames: ['org_id', 'workspace_id'],
+    ownColumns: ['workspace_id'],
+    ref: true,
+  })
+  workspace!: Ref<Workspace>;
+
+  @OneToOne({
+    entity: () => UserRequest,
+    mappedBy: ur => ur.user,
+    ref: true,
+  })
+  request?: Ref<UserRequest>;
+
+}
+
+@Entity()
+class Profile {
+
+  @ManyToOne({
+    entity: () => Organisation,
+    fieldName: 'org_id',
+    primary: true,
+    ref: true,
+  })
+  org!: Ref<Organisation>;
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToOne({
+    entity: () => User,
+    mappedBy: u => u.profile,
+    ref: true,
+  })
+  user?: Ref<User>;
+
+}
+
+@Entity()
+class Workspace {
+
+  @ManyToOne({
+    entity: () => Organisation,
+    fieldName: 'org_id',
+    primary: true,
+    ref: true,
+  })
+  org!: Ref<Organisation>;
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToMany({
+    entity: () => User,
+    mappedBy: u => u.workspace,
+    ref: true,
+  })
+  users = new Collection<User>(this);
+
+}
+
+@Entity()
+class UserRequest {
+
+  @ManyToOne({
+    entity: () => Organisation,
+    fieldName: 'org_id',
+    primary: true,
+    ref: true,
+  })
+  org!: Ref<Organisation>;
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToOne({
+    entity: () => User,
+    ref: true,
+    fieldNames: ['org_id', 'user_id'],
+    ownColumns: ['user_id'],
+  })
+  user!: Ref<User>;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Organisation, User, Profile, UserRequest],
+    debug: ['query', 'query-params'],
+    allowGlobalContext: true, // only for testing
+  });
+
+  await orm.schema.refreshDatabase({ dropDb: true });
+
+  const org = orm.em.create(Organisation, { id: 1, name: 'org1' });
+
+  const workspace = orm.em.create(Workspace, {
+    org,
+    id: 10,
+    name: 'workspace1',
+  });
+
+  const profile = orm.em.create(Profile, {
+    org,
+    id: 11,
+    name: 'profile1',
+  });
+
+  const user = orm.em.create(User, {
+    org,
+    id: 12,
+    name: 'user1',
+    profile,
+    workspace,
+  });
+
+  orm.em.create(UserRequest, {
+    org,
+    id: 13,
+    name: 'userRequest1',
+    user,
+  });
+
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+afterEach(() => {
+  orm.em.clear();
+});
+
+test('partial composite foreign key from non-owning side, (1:1)', async () => {
+  const user = await orm.em.findOneOrFail(User, {
+    request: {
+      id: 13,
+    },
+  });
+
+  expect(user.name).toBe('user1');
+});
+
+test('partial composite foreign key from non-owning side (1:m)', async () => {
+  const user = await orm.em.findOneOrFail(Workspace, {
+    users: {
+      id: 12,
+    },
+  });
+
+  expect(user.name).toBe('workspace1');
+});
+
+test('partial composite foreign key from non-owning side (1:1, nested)', async () => {
+  const profile = await orm.em.findOneOrFail(Profile, {
+    user: {
+      request: {
+        id: 13,
+      },
+    },
+  });
+
+  expect(profile.name).toBe('profile1');
+});

--- a/tests/issues/GH6824.test.ts
+++ b/tests/issues/GH6824.test.ts
@@ -148,8 +148,6 @@ beforeAll(async () => {
   orm = await MikroORM.init({
     dbName: ':memory:',
     entities: [Organisation, User, Profile, UserRequest],
-    debug: ['query', 'query-params'],
-    allowGlobalContext: true, // only for testing
   });
 
   await orm.schema.refreshDatabase({ dropDb: true });


### PR DESCRIPTION
- Set preferNoBranch to true if relationship is :1. This allows the child alias to be correctly matched.

Closes #6824 