### PR TITLE
Reproduction for issue #6855

### DIFF
--- a/tests/issues/GH6855.test.ts
+++ b/tests/issues/GH6855.test.ts
@@ -100,11 +100,6 @@ beforeAll(async () => {
       pageLength: 1,
     },
   ]);
-
-  // Crucial, the entities we just created cannot be found in the identity map
-  // or they will be properly initialised already.
-  await orm.em.flush();
-  orm.em.clear();
 });
 
 afterAll(async () => {


### PR DESCRIPTION
Adds reproduction for #6855, a difference in behaviour between `ref()` and `em.getReference()`.