### PR TITLE
fix: correctly map raw result fields to entity properties with @Property({ name: 'x_name' })

### DIFF
--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -432,7 +432,7 @@ export class EntityComparator {
       mapEntityProperties(meta);
     }
 
-    lines.push(`  for (let k in result) { if (Object.hasOwn(result, k) && !mapped[k]) ret[k] = result[k]; }`);
+    lines.push(`  for (let k in result) { if (Object.hasOwn(result, k) && !mapped[k] && ret[k] === undefined) ret[k] = result[k]; }`);
 
     const code = `// compiled mapper for entity ${meta.className}\n`
       + `return function(result) {\n  const ret = {};\n${lines.join('\n')}\n  return ret;\n}`;

--- a/tests/features/embeddables/__snapshots__/GH2391-2.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/GH2391-2.test.ts.snap
@@ -60,7 +60,7 @@ exports[`onCreate and onUpdate in embeddables (GH 2283 and 2391) result mapper 1
     ret.barAudit2 = result.bar_audit2 == null ? result.bar_audit2 : mapEmbeddedResult_0(result.bar_audit2);
     mapped.bar_audit2 = true;
   }
-  for (let k in result) { if (Object.hasOwn(result, k) && !mapped[k]) ret[k] = result[k]; }
+  for (let k in result) { if (Object.hasOwn(result, k) && !mapped[k] && ret[k] === undefined) ret[k] = result[k]; }
   return ret;
 }"
 `;

--- a/tests/features/embeddables/__snapshots__/GH2391.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/GH2391.test.ts.snap
@@ -60,7 +60,7 @@ exports[`onCreate and onUpdate in embeddables (GH 2283 and 2391) result mapper 1
     ret.audit2 = result.audit2 == null ? result.audit2 : mapEmbeddedResult_0(result.audit2);
     mapped.audit2 = true;
   }
-  for (let k in result) { if (Object.hasOwn(result, k) && !mapped[k]) ret[k] = result[k]; }
+  for (let k in result) { if (Object.hasOwn(result, k) && !mapped[k] && ret[k] === undefined) ret[k] = result[k]; }
   return ret;
 }"
 `;

--- a/tests/issues/GH6861.test.ts
+++ b/tests/issues/GH6861.test.ts
@@ -25,8 +25,6 @@ beforeAll(async () => {
   orm = await MikroORM.init({
     dbName: ':memory:',
     entities: [User],
-    debug: ['query', 'query-params'],
-    allowGlobalContext: true, // only for testing
   });
   await orm.schema.refreshDatabase();
   await orm.em.execute('alter table "user" add column name text');

--- a/tests/issues/GH6861.test.ts
+++ b/tests/issues/GH6861.test.ts
@@ -1,0 +1,46 @@
+import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
+
+@Entity()
+class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ name: 'name_tmp' })
+  name: string;
+
+  @Property({ unique: true })
+  email: string;
+
+  constructor(name: string, email: string) {
+    this.name = name;
+    this.email = email;
+  }
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [User],
+    debug: ['query', 'query-params'],
+    allowGlobalContext: true, // only for testing
+  });
+  await orm.schema.refreshDatabase();
+  await orm.em.execute('alter table "user" add column name text');
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('should persist and retrieve user by email and mapped name property', async () => {
+  orm.em.create(User, { name: 'Foo', email: 'foo' });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const user = await orm.em.findOneOrFail(User, { email: 'foo' });
+  expect(user.name).toBe('Foo');
+});


### PR DESCRIPTION
reproduction repo – https://github.com/isaryy/mapped-field-overwrite-reproduction

closes #6861 