### PR TITLE
fix(core): prevent stack overflow errors when using SELECT_IN populate strategy on lots of entities

### DIFF
--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -618,16 +618,21 @@ export class EntityLoader {
 
     if (prop.kind === ReferenceKind.ONE_TO_MANY) {
       return filtered.map(e => (e[prop.name] as unknown as Collection<Entity, AnyEntity>).owner);
-    } else if (prop.kind === ReferenceKind.MANY_TO_MANY && prop.owner) {
+    }
+
+    if (prop.kind === ReferenceKind.MANY_TO_MANY && prop.owner) {
       return filtered.reduce((a, b) => {
         a.push(...(b[prop.name] as Collection<AnyEntity>).getItems());
         return a;
       }, [] as AnyEntity[]);
-    } else if (prop.kind === ReferenceKind.MANY_TO_MANY) { // inverse side
-      return filtered as AnyEntity[];
-    } else { // MANY_TO_ONE or ONE_TO_ONE
-      return this.filterReferences(entities, prop.name, options, ref) as AnyEntity[];
     }
+
+    if (prop.kind === ReferenceKind.MANY_TO_MANY) { // inverse side
+      return filtered as AnyEntity[];
+    }
+
+    // MANY_TO_ONE or ONE_TO_ONE
+    return this.filterReferences(entities, prop.name, options, ref) as AnyEntity[];
   }
 
   private filterCollections<Entity extends object>(entities: Entity[], field: keyof Entity, options: Required<EntityLoaderOptions<Entity>>, ref?: string | boolean): Entity[] {

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -615,22 +615,19 @@ export class EntityLoader {
 
   private getChildReferences<Entity extends object>(entities: Entity[], prop: EntityProperty<Entity>, options: Required<EntityLoaderOptions<Entity>>, ref: boolean): AnyEntity[] {
     const filtered = this.filterCollections(entities, prop.name, options, ref);
-    const children: AnyEntity[] = [];
 
     if (prop.kind === ReferenceKind.ONE_TO_MANY) {
-      children.push(...filtered.map(e => (e[prop.name] as unknown as Collection<Entity, AnyEntity>).owner));
+      return filtered.map(e => (e[prop.name] as unknown as Collection<Entity, AnyEntity>).owner);
     } else if (prop.kind === ReferenceKind.MANY_TO_MANY && prop.owner) {
-      children.push(...filtered.reduce((a, b) => {
+      return filtered.reduce((a, b) => {
         a.push(...(b[prop.name] as Collection<AnyEntity>).getItems());
         return a;
-      }, [] as AnyEntity[]));
+      }, [] as AnyEntity[]);
     } else if (prop.kind === ReferenceKind.MANY_TO_MANY) { // inverse side
-      children.push(...filtered as AnyEntity[]);
+      return filtered as AnyEntity[];
     } else { // MANY_TO_ONE or ONE_TO_ONE
-      children.push(...this.filterReferences(entities, prop.name, options, ref) as AnyEntity[]);
+      return this.filterReferences(entities, prop.name, options, ref) as AnyEntity[];
     }
-
-    return children;
   }
 
   private filterCollections<Entity extends object>(entities: Entity[], field: keyof Entity, options: Required<EntityLoaderOptions<Entity>>, ref?: string | boolean): Entity[] {

--- a/tests/issues/GH6874.test.ts
+++ b/tests/issues/GH6874.test.ts
@@ -1,0 +1,69 @@
+import {
+  Collection,
+  Entity,
+  LoadStrategy,
+  ManyToOne,
+  MikroORM,
+  OneToMany,
+  PrimaryKey,
+  Property,
+} from '@mikro-orm/sqlite';
+
+@Entity()
+class Post {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title: string;
+
+  @OneToMany(() => Comment, comment => comment.post)
+  comments = new Collection<Comment>(this);
+
+  constructor(title: string) {
+    this.title = title;
+  }
+
+}
+
+@Entity()
+class Comment {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Post)
+  post!: Post;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Post, Comment],
+  });
+  await orm.schema.refreshDatabase();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('stack overflow when getting entities with nested relationships', async () => {
+  const posts = [];
+
+  for (let i = 0; i < 125000; i++) {
+    posts.push({ title: `Post ${i}` });
+  }
+
+  await orm.em.insertMany(Post, posts);
+
+  // This will cause a max call stack error in EntityLoader.getChildReferences
+  await orm.em.findAll(Post, {
+    populate: ['comments'],
+    strategy: LoadStrategy.SELECT_IN, // Also fails for LoadStrategy.BALANCED
+  });
+});


### PR DESCRIPTION
- When getting entities and populating child references with `SELECT_IN` and `BALANCED` strategies, a max call stack error is triggered due to `.push` and `...` being used in conjunction in `getChildReferences` for larger datasets (>100k entities). 
- This is because using push and spread adds each array element onto `.push`'s method parameters and, in turn, the call stack. 
```
children.push(...array) --> children.push(array[0], array[1], ... array[n)) // stack overflow.  
```

I've been able to reproduce this in this repo: https://github.com/kitopang/mikro-orm-populate-strategy-bug