### PR TITLE
fix(typings): enhance branded type definitions for `Opt`, `Hidden`, `Config` and `RequiredNullable`

### DIFF
--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -74,22 +74,46 @@ export const EagerProps = Symbol('EagerProps');
 export const HiddenProps = Symbol('HiddenProps');
 export const Config = Symbol('Config');
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-declare const __optional: unique symbol;
+export type Opt<T = unknown> = T & Opt.Brand;
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export declare namespace Opt {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const __optional: unique symbol;
+  export interface Brand {
+      [__optional]?: 1;
+  }
+}
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-declare const __requiredNullable: unique symbol;
+export type RequiredNullable<T = never> = (T & RequiredNullable.Brand) | null;
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export declare namespace RequiredNullable {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const __requiredNullable: unique symbol;
+  export interface Brand {
+      [__requiredNullable]?: 1;
+  }
+}
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-declare const __hidden: unique symbol;
+export type Hidden<T = unknown> = T & Hidden.Brand;
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export declare namespace Hidden {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const __hidden: unique symbol;
+  export interface Brand {
+      [__hidden]?: 1;
+  }
+}
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-declare const __config: unique symbol;
+export type DefineConfig<T extends TypeConfig> = T & DefineConfig.Brand;
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export declare namespace DefineConfig {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const __config: unique symbol;
+  export interface Brand {
+      [__config]?: 1;
+  }
+}
 
-export type Opt<T = unknown> = T & { [__optional]?: 1 };
-export type RequiredNullable<T = never> = (T & { [__requiredNullable]?: 1 }) | null;
-export type Hidden<T = unknown> = T & { [__hidden]?: 1 };
-export type DefineConfig<T extends TypeConfig> = T & { [__config]?: 1 };
 export type CleanTypeConfig<T> = Compute<Pick<T, Extract<keyof T, keyof TypeConfig>>>;
 
 export interface TypeConfig {
@@ -308,7 +332,7 @@ export type EntityDataProp<T, C extends boolean> = T extends Date
 
 export type RequiredEntityDataProp<T, O, C extends boolean> = T extends Date
   ? string | Date
-    : Exclude<T, null> extends { [__requiredNullable]?: 1 }
+    : Exclude<T, null> extends RequiredNullable.Brand
     ? T | null
       : T extends Scalar
       ? T
@@ -341,7 +365,7 @@ export type RequiredEntityDataNested<T, O, C extends boolean> = T extends any[]
 
 type ExplicitlyOptionalProps<T> = (T extends { [OptionalProps]?: infer K } ? K : never) | ({ [K in keyof T]: T[K] extends Opt ? K : never }[keyof T] & {});
 type NullableKeys<T, V = null> = { [K in keyof T]: V extends T[K] ? K : never }[keyof T];
-type RequiredNullableKeys<T> = { [K in keyof T]: Exclude<T[K], null> extends { [__requiredNullable]?: 1 } ? K : never }[keyof T];
+type RequiredNullableKeys<T> = { [K in keyof T]: Exclude<T[K], null> extends RequiredNullable.Brand ? K : never }[keyof T];
 type ProbablyOptionalProps<T> = PrimaryProperty<T> | ExplicitlyOptionalProps<T> | Exclude<NonNullable<NullableKeys<T, null | undefined>>, RequiredNullableKeys<T>>;
 
 type IsOptional<T, K extends keyof T, I> = T[K] extends Collection<any, any>


### PR DESCRIPTION
This PR will fix https://github.com/mikro-orm/mikro-orm/issues/6882

In the current implementation, for the following entity:
```ts
import { defineEntity, type InferEntity } from '@mikro-orm/core';

export const User = defineEntity({
  name: 'User',
  tableName: 'user',
  properties: (p) => ({
    id: p.integer().primary().autoincrement(),
    name: p.string(),
    email: p.string().unique(),
    bio: p.string().nullable(true).default(null),
  }),
});

export type IUser = InferEntity<typeof User>;
```
`IUser` will be inferred as:

```ts
type IUser = {
    id: number;
    name: string;
    email: string;
    bio: string & {
        [__optional]?: 1;
    };
}
```

With the improved brand type, `IUser` will be inferred as:
```ts
type IUser = {
    id: number;
    name: string;
    email: string;
    bio: string & Opt.Brand;
}
```