### PR TITLE
feat(defineEntity): support for composite keys

### DIFF
--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -887,11 +887,9 @@ export function defineEntity<Properties extends Record<string, any>, const PK ex
   }): EntitySchema<InferEntityFromProperties<Properties, PK>, never> {
   const { properties: propertiesOrGetter, primaryKeys, ...options } = meta;
   const propertyOptions = typeof propertiesOrGetter === 'function' ? propertiesOrGetter(propertyBuilders) : propertiesOrGetter;
-  const properties: Record<string, PropertyOptions<any>> = {};
 
-  const values = new Map<string, any>();
   const originKeys = Object.keys(propertyOptions);
-  let orderedKeys: string[] = originKeys;
+  let orderedKeys = originKeys;
   if (primaryKeys?.length) {
     orderedKeys = [];
     for (const pk of primaryKeys) {
@@ -905,7 +903,8 @@ export function defineEntity<Properties extends Record<string, any>, const PK ex
       }
     }
   }
-
+  const properties: Record<string, PropertyOptions<any>> = {};
+  const values = new Map<string, any>();
   for (const key of orderedKeys) {
     const builder = (propertyOptions as Record<string, any>)[key];
     if (typeof builder === 'function') {

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -1,4 +1,4 @@
-import { Cascade, Collection, defineEntity, EntityData, EntityDTO, EntityMetadata, EntityName, EntitySchema, Hidden, InferEntity, IType, Opt, Ref, Reference, RequiredEntityData, ScalarReference, Type, types } from '@mikro-orm/core';
+import { Cascade, Collection, defineEntity, EntityData, EntityDTO, EntityMetadata, EntityName, EntitySchema, Hidden, InferEntity, IType, Opt, PrimaryKeyProp, Ref, Reference, RequiredEntityData, ScalarReference, Type, types } from '@mikro-orm/core';
 import { IsExact, assert } from 'conditional-type-checks';
 import { ObjectId } from 'bson';
 
@@ -38,6 +38,33 @@ describe('defineEntity', () => {
 
     type IBook = InferEntity<typeof Book>;
     assert<IsExact<IBook, { _id: ObjectId; id: string; title: string; tags: string[] }>>(true);
+  });
+
+  it('should define entity with primary keys', () => {
+    const Foo = defineEntity({
+      name: 'Foo',
+      properties: p => ({
+        id: p.integer().primary(),
+      }),
+      primaryKeys: ['id'],
+    });
+
+    expect(Foo.init().meta.primaryKeys).toEqual(['id']);
+    type IFoo = InferEntity<typeof Foo>;
+    assert<IsExact<IFoo, { id: number; [PrimaryKeyProp]?: ['id'] }>>(true);
+
+    const Bar = defineEntity({
+      name: 'Bar',
+      properties: p => ({
+        lastName: p.string(),
+        firstName: p.string(),
+      }),
+      primaryKeys: ['firstName', 'lastName'],
+    });
+
+    expect(Bar.init().meta.primaryKeys).toEqual(['firstName', 'lastName']);
+    type IBar = InferEntity<typeof Bar>;
+    assert<IsExact<IBar, { firstName: string; lastName: string; [PrimaryKeyProp]?: ['firstName', 'lastName'] }>>(true);
   });
 
   it('should be able to custom types with $type', async () => {


### PR DESCRIPTION
This PR implements support for composite primary keys when defining entities using `defineEntity`:

```ts
export const Car = defineEntity({
  name: 'Car',
  properties: p => ({
    name: p.string(),
    year: p.integer(),
  }),
  primaryKeys: ['name', 'year'],
});
```

`Car` will be inferred as:

```ts
type ICar = {
    name: string;
    year: number;
    [PrimaryKeyProp]?: ["name", "year"] | undefined;
}
```