### PR TITLE
Change MikroORM CLI installation command

### DIFF
--- a/docs/versioned_docs/version-6.5/quick-start.md
+++ b/docs/versioned_docs/version-6.5/quick-start.md
@@ -250,7 +250,7 @@ MikroORM ships with a number of command line tools that are very helpful during 
 
 ```sh
 # install the CLI package first!
-$ yarn add @mikro-orm/cli
+$ yarn add --dev @mikro-orm/cli
 
 # manually
 $ node node_modules/.bin/mikro-orm


### PR DESCRIPTION
Updated installation command for MikroORM CLI to use --dev flag.